### PR TITLE
🌱 [session-user-interaction-order] docs: simplify running session activity order [step 1/4]

### DIFF
--- a/.agents/skills/sesori-plan-maker/SKILL.md
+++ b/.agents/skills/sesori-plan-maker/SKILL.md
@@ -75,6 +75,37 @@ retirement.
 
 ## Evidence And Proportionality
 
+### Prefer Elegant, Low-State Designs
+
+- Before adding persistence or coordination, inspect existing fields, event
+  shapes, and relevant Git history. Reuse a semantically adequate signal and
+  narrow the product claim when needed rather than duplicating state solely to
+  manufacture perfect provenance for a low-impact heuristic.
+- Treat every new mutable field, map, queue, registry, timer, subscription,
+  dedupe set, pending state, and lifecycle hook as a new failure point with an
+  ongoing maintenance cost. Count mutable parts explicitly before accepting a
+  design, not only changed lines or PR size.
+- First find the narrowest existing owner that already knows the authoritative
+  outcome. Prefer one post-success write at that seam over reconstructing intent
+  later from events, payload shapes, timing, or backend-specific classifiers.
+- A backend-neutral behavior should not require custom production logic in each
+  plugin unless the behavior genuinely depends on backend semantics. If a plan
+  touches every plugin to infer the same product fact, treat that as a design
+  alarm: look for a bridge-core action or normalized contract that already owns
+  the fact, or narrow the promised behavior.
+- Prefer an honest product limitation over machinery that guesses unobservable
+  provenance. Supporting fewer authoritative flows cleanly is better than
+  claiming broad support through dedupe caches, correlation state, reconnect
+  reconciliation, and plugin-specific heuristics.
+- Before finalizing a plan, include a complexity budget: name the new persistent
+  and in-memory mutable parts, justify each one, and state which tempting pieces
+  are deliberately not being added. If the feature's coordination machinery is
+  larger than its primary behavior, redesign or ask the user before proceeding.
+- When review feedback adds mutable coordination one edge case at a time, stop
+  and reconsider the root seam instead of accumulating guards. Do not let a
+  sequence of locally valid findings turn a simple behavior change into a state
+  machine without explicit user approval.
+
 - Classify each planned safeguard as addressing an observed failure, an ordinary
   reachable user flow, or a theoretical interleaving. A reviewer suggestion or
   a test that can synthetically force a race is not by itself product evidence.

--- a/.plan/active/session-user-interaction-order/PLAN.md
+++ b/.plan/active/session-user-interaction-order/PLAN.md
@@ -194,28 +194,34 @@ its backend-specific evidence.
 
 Add `OpenCodeUserInteractionTracker` beside the existing OpenCode trackers. It
 owns the bounded message-envelope/part classifier, automatic-overflow
-suppression, and all classifier lifecycle state. It receives the existing
-`ActiveSessionTracker` as a required dependency for root/display attribution;
-it does not duplicate the session-parent graph.
+suppression, bridge-write correlation, and all classifier lifecycle state.
+`OpenCodeService` composes it with the existing `ActiveSessionTracker`, which
+remains the sole parent/display graph owner; the interaction tracker receives
+resolved root attribution rather than depending on its tracker peer directly.
 
-`OpenCodePlugin._handleRawSseEvent` remains a composition pipeline: after
-parsing and updating the existing service/tracker state, it delegates the raw
-`SseEventData` to `OpenCodeUserInteractionTracker`, forwards any returned
-neutral interaction fact, then continues existing presentation mapping.
-Classification still occurs before `SseEventMapper` erases raw part provenance.
+`OpenCodePlugin._handleRawSseEvent` parses once, delegates the raw event to
+`OpenCodeService`, forwards any returned neutral interaction fact, then
+continues existing presentation mapping. The service updates its trackers and
+classifies before `SseEventMapper` erases raw part provenance. Prompt, command,
+create-session, reconnect, and disposal paths likewise delegate interaction
+coordination to the service rather than sequencing tracker peers in the plugin.
 
-The same tracker also coordinates bridge-owned prompt/command acceptance. The
-plugin starts one bounded pending write before dispatch, raw classification may
-satisfy that write first, and successful API completion emits a null-timestamp
-fallback only when no matching raw fact was observed. Failed acceptance emits no
-fallback. This produces one fact in the ordinary path while covering the real
-disconnect window where OpenCode accepted the write but its envelope or part was
-lost before the fresh non-replaying SSE connection. Initial create-session turns
-use the same coordination after the backend session ID is known.
+The same tracker coordinates bridge-owned prompt/command acceptance by message
+identity. Generate an OpenCode-compatible message ID before dispatch and pass it
+through the existing optional `messageID` field on prompt and command payloads.
+The matching raw classification may satisfy that pending write first; successful
+API completion emits a null-timestamp fallback only when that exact message ID
+was not observed. Failed acceptance emits no fallback. A laptop-originated
+message cannot consume a Sesori write. This produces one fact in the ordinary
+path while covering the real disconnect window where OpenCode accepted the
+write but its envelope or part was lost before the fresh non-replaying SSE
+connection. Initial create-session turns use the same correlation after the
+backend session ID is known.
 
-- Keep at most one pending user envelope per session: message ID plus the
-  message creation timestamp. This state is bounded by the number of known
-  sessions, not transcript length.
+- Keep at most one pending user envelope and one most-recently classified
+  message ID per session. The latter rejects an immediate duplicate complete
+  envelope/part delivery after the pending envelope was consumed. State remains
+  bounded by known sessions, not transcript length.
 - A later part classifies only the matching pending envelope.
 - A root-session non-synthetic text/file/subtask prompt records one interaction.
   A child user prompt is not counted because OpenCode creates those for agent
@@ -228,11 +234,18 @@ use the same coordination after the backend session ID is known.
   envelope. Clear suppression when consumed or when compaction/status terminal
   evidence proves no replay remains, so a failed compaction cannot suppress a
   later genuine prompt.
+- A bridge-owned manual compact is one action. Its optional instruction prompt
+  receives the correlated message ID and is marked as compact guidance so its
+  raw text part cannot emit independently; successful summarize acceptance
+  satisfies the same pending action. The later manual `CompactionPart` is
+  coalesced with that action. A laptop-originated manual compact still emits
+  from its raw compaction part.
 - Remove pending/suppression state when the tracker observes session deletion;
   call its `reset` from the existing OpenCode reconnect/reset path and its
   `dispose` during plugin disposal. Do not add a transcript-sized dedupe set;
-  one envelope is consumed once, and bridge-write coordination emits at most one
-  fact for its accepted action.
+  one envelope is consumed once, the last classified ID rejects immediate
+  duplicate delivery, and correlated bridge-write coordination emits at most
+  one fact for its accepted action.
 - Raw `question.replied` and `question.rejected` events are authoritative and
   cover both Sesori and laptop replies.
 - Raw `permission.replied` is not authoritative: OpenCode emits the same event
@@ -477,8 +490,10 @@ existing merge seams is sufficient.
 |---|---|---|
 | Automatic compaction looks user-authored | Observed backend behavior | Classify raw OpenCode parts before mapping; test auto, continuation, and overflow replay |
 | Auto-approved/cancelled replies look manual | Ordinary reachable flow | Required permission origin plus manual-only plugin fact emission; cancellation methods emit no fact |
-| Duplicate backend events | Ordinary live-event flow | Plugin-local one-shot classification plus persisted monotonic conditional update and existing ordered write tail |
-| Accepted OpenCode write loses SSE pair | Ordinary disconnect window | Coordinate bridge write with raw observation and emit one successful null-time fallback only when raw did not satisfy it |
+| Duplicate OpenCode envelope/part delivery | Ordinary transport duplicate | Retain one most-recent classified message ID per session and consume each pending envelope once |
+| Accepted OpenCode write loses SSE pair | Ordinary disconnect window | Correlate with caller-supplied message ID and emit one successful null-time fallback only when that exact raw message did not satisfy it |
+| Concurrent laptop and Sesori writes | First-class multi-surface flow | Correlate pending bridge action by message ID; unrelated raw facts emit independently and cannot satisfy it |
+| Manual compact with instructions | Ordinary compact command flow | Mark the correlated no-reply instruction as compact guidance and coalesce it with summarize/manual-compaction evidence into one fact |
 | Backend clock rollback | Ordinary clock-adjustment flow | OpenCode uses null occurred-at and bridge monotonic stamping; known times remain only for authoritative plugin sources |
 | REST/SSE replacement race | Ordinary initial/in-flight refresh flow | Existing unseen tracker retains the patch; service maxes it at client replacement seams |
 | Reversed OpenCode message/part order | Theoretical against current upstream order | Accepted; no timer or history lookup. Missing one reorder self-heals on the next genuine interaction |
@@ -534,16 +549,18 @@ series.
 - Add the internal interaction event and required permission origin enum.
 - Update every registered plugin and all app/plugin call sites in lockstep.
 - Add `OpenCodeUserInteractionTracker` and implement pending-envelope
-  classification, bridge-write fallback coordination, lifecycle cleanup, and
-  automatic-compaction exclusions.
+  classification, message-ID-correlated bridge-write fallback, manual-compaction
+  coalescing, lifecycle cleanup, and automatic-compaction exclusions. Compose
+  it under `OpenCodeService` with resolved display attribution.
 - Add `CodexGeneratedContextValidator` plus
   `CodexUserInteractionTracker`, then implement Codex, ACP/Cursor, and Claude
   authoritative emission rules.
 - Add bridge event ID translation and explicit no-public-wire mapping.
 - Test prompt, command, initial turn, manual compaction, manual answer/decision,
   auto approval, cancellation, synthetic continuation, overflow replay, and
-  duplicate handling, backend clock rollback, and disconnect-between-acceptance-
-  and-SSE behavior at the owning boundaries.
+  duplicate handling, concurrent laptop/Sesori writes, instructed compaction,
+  backend clock rollback, and disconnect-between-acceptance-and-SSE behavior at
+  the owning boundaries.
 - No database, released wire, client, or user-visible behavior yet.
 
 **Changed-line target:** 1,050-1,500 lines. If complete production-plugin tests
@@ -653,7 +670,9 @@ Step 2:
   child-generated prompt exclusion, slash/subtask command, manual compaction,
   auto compaction, synthetic continuation, overflow replay, question
   reply/reject, manual versus automatic permission, bridge-write/raw one-fact
-  coordination, lost-SSE fallback, clock rollback, and bounded pending-state cleanup.
+  message-ID-correlated write/raw one-fact coordination, unrelated concurrent
+  laptop writes, immediate duplicate delivery, instructed-compaction
+  coalescing, lost-SSE fallback, clock rollback, and bounded pending-state cleanup.
 - `CodexGeneratedContextValidator` and `CodexUserInteractionTracker` tests: one
   first-lifecycle user-item fact, generated-context exclusion, bounded terminal
   cleanup, ordinary command, explicit manual compact, generic context compaction

--- a/.plan/active/session-user-interaction-order/PLAN.md
+++ b/.plan/active/session-user-interaction-order/PLAN.md
@@ -236,10 +236,10 @@ backend session ID is known.
   later genuine prompt.
 - A bridge-owned manual compact is one action. Its optional instruction prompt
   receives the correlated message ID and is marked as compact guidance so its
-  raw text part cannot emit independently; successful summarize acceptance
-  satisfies the same pending action. The later manual `CompactionPart` is
-  coalesced with that action. A laptop-originated manual compact still emits
-  from its raw compaction part.
+  raw text part cannot emit independently. Summarize has no upstream caller-ID,
+  so raw manual compactions never consume its bridge fallback. Emit that
+  fallback only when no raw manual compact was observed during the bridge call;
+  concurrent laptop compaction therefore cannot suppress a lost bridge fact.
 - Remove pending/suppression state when the tracker observes session deletion;
   call its `reset` from the existing OpenCode reconnect/reset path and its
   `dispose` during plugin disposal. Do not add a transcript-sized dedupe set;
@@ -247,10 +247,12 @@ backend session ID is known.
   duplicate delivery, and correlated bridge-write coordination emits at most
   one fact for its accepted action.
 - Raw `question.replied` and `question.rejected` events are authoritative and
-  cover both Sesori and laptop replies.
+  cover laptop replies. Bridge calls coordinate by request ID and emit a
+  successful-call fallback only when the exact raw event was not observed.
 - Raw `permission.replied` is not authoritative: OpenCode emits the same event
   for `always` cascades. Emit one fact only from a successful manual
-  `replyToPermission` call. Direct laptop permission decisions remain unknown.
+  `replyToPermission` 2xx outcome; a reconciled 404 returns not-accepted and
+  emits none. Direct laptop permission decisions remain unknown.
 
 This design relies on OpenCode's observed and generated API ordering:
 `message.updated` precedes its parts. It does not add a timer, delayed flush,
@@ -269,8 +271,9 @@ clock semantics make it authoritative.
 - The tracker emits once from the first app-server `userMessage` item lifecycle
   observation; that typed item is the authoritative prompt/command boundary and
   also covers another observable Codex surface. It keeps only in-flight
-  `(threadId, itemId)` keys: `item/started` emits and records, `item/completed`
-  removes and emits only if no start was observed. Turn terminal, thread delete,
+  `(threadId, itemId)` keys plus one latest completed item ID per thread:
+  `item/started` emits and records, `item/completed` removes and emits only if no
+  start or matching completion was observed. Turn terminal, thread delete,
   reconnect/reset, and disposal clear remaining keys. Do not emit again from
   `sendPrompt` or an ordinary `sendCommand` response.
 - Extract the existing private generated repository/context test into one pure
@@ -282,6 +285,8 @@ clock semantics make it authoritative.
   emit no fact.
 - Successful registry question/permission methods emit facts only for explicit
   manual calls. `cancelForSession` remains a no-fact cleanup path.
+- The tracker accepts notification, manual-compact, and manual-registry triggers;
+  `CodexPlugin` only delegates and forwards returned facts.
 - App-server user items have no reliable message timestamp, so these events use
   null `occurredAt` and bridge observation time.
 
@@ -403,8 +408,7 @@ For running sessions, compare:
    `lastUserInteractionAt ?? time.updated ?? 0`;
 2. a known interaction marker before an unknown marker when effective keys are
    equal;
-3. `time.updated` descending; and
-4. session ID ascending as a deterministic final tie-breaker.
+3. session ID ascending as a deterministic final tie-breaker.
 
 The `time.updated` fallback preserves useful behavior with old bridges and
 pre-migration sessions. Once a verified marker exists, later automatic backend
@@ -493,7 +497,8 @@ existing merge seams is sufficient.
 | Duplicate OpenCode envelope/part delivery | Ordinary transport duplicate | Retain one most-recent classified message ID per session and consume each pending envelope once |
 | Accepted OpenCode write loses SSE pair | Ordinary disconnect window | Correlate with caller-supplied message ID and emit one successful null-time fallback only when that exact raw message did not satisfy it |
 | Concurrent laptop and Sesori writes | First-class multi-surface flow | Correlate pending bridge action by message ID; unrelated raw facts emit independently and cannot satisfy it |
-| Manual compact with instructions | Ordinary compact command flow | Mark the correlated no-reply instruction as compact guidance and coalesce it with summarize/manual-compaction evidence into one fact |
+| Manual compact with instructions | Ordinary compact command flow | Mark guidance non-emitting; raw compact cannot consume fallback; fallback only when no raw compact was observed during the call |
+| OpenCode reply disconnect/reconciliation | Ordinary race flow | Request-ID fallback for accepted questions; reconciled permission 404 emits no fact |
 | Backend clock rollback | Ordinary clock-adjustment flow | OpenCode uses null occurred-at and bridge monotonic stamping; known times remain only for authoritative plugin sources |
 | REST/SSE replacement race | Ordinary initial/in-flight refresh flow | Existing unseen tracker retains the patch; service maxes it at client replacement seams |
 | Reversed OpenCode message/part order | Theoretical against current upstream order | Accepted; no timer or history lookup. Missing one reorder self-heals on the next genuine interaction |
@@ -669,14 +674,16 @@ Step 2:
 - `OpenCodeUserInteractionTracker` tests: ordinary root prompt/file prompt,
   child-generated prompt exclusion, slash/subtask command, manual compaction,
   auto compaction, synthetic continuation, overflow replay, question
-  reply/reject, manual versus automatic permission, bridge-write/raw one-fact
-  message-ID-correlated write/raw one-fact coordination, unrelated concurrent
+  reply/reject, manual versus automatic permission, message-ID-correlated
+  write/raw one-fact coordination, unrelated concurrent
   laptop writes, immediate duplicate delivery, instructed-compaction
-  coalescing, lost-SSE fallback, clock rollback, and bounded pending-state cleanup.
+  fallback, request-ID reply fallback, reconciled permission 404, clock rollback,
+  and bounded pending-state cleanup.
 - `CodexGeneratedContextValidator` and `CodexUserInteractionTracker` tests: one
-  first-lifecycle user-item fact, generated-context exclusion, bounded terminal
-  cleanup, ordinary command, explicit manual compact, generic context compaction
-  exclusion, manual registry replies, and cancellation exclusion.
+  first-lifecycle user-item fact, generated-context exclusion, duplicate
+  completion rejection, bounded terminal cleanup, ordinary command, explicit
+  manual compact, generic context compaction exclusion, manual registry replies,
+  and cancellation exclusion.
 - ACP/Cursor and Claude tests: accepted/failed prompt and command, initial turn,
   compact mapping, manual reply, cancellation/disposal exclusion.
 - Bridge app mapper tests: backend/stable IDs and display-root translation; no

--- a/.plan/active/session-user-interaction-order/PLAN.md
+++ b/.plan/active/session-user-interaction-order/PLAN.md
@@ -1,0 +1,733 @@
+# Running Session Interaction Order
+
+## Status
+
+- **Plan slug:** `session-user-interaction-order`
+- **Status:** Reviewed plan - architecture findings applied and current main revalidated
+- **Plan date:** 2026-08-13
+- **Repository:** `sesori-ai/sesori_apps_monorepo`
+- **Implementation base:** `main` at `88059e200`
+- **Implementation branch:** `session-order-ux-review`
+- **Delivery:** one plan PR, four implementation PRs, one regression-documentation
+  PR, and one verification/retirement PR
+
+This document and `TRACKER.md` are the implementation authority for the series.
+The fixed split keeps the backend-specific provenance, durable bridge state,
+released wire compatibility, and client behavior independently reviewable.
+
+## Goal
+
+Keep running root sessions promoted at the top of the project session list, but
+order that running prefix by the most recent genuine user interaction rather
+than alphabetically.
+
+Interactions that advance recency are:
+
+- an accepted user prompt, including a prompt created directly in an observable
+  backend surface;
+- an accepted slash command;
+- a manual question answer, question rejection, or permission decision; and
+- manual context compaction.
+
+Automatic compaction, generated continuation/replay prompts, automatic
+permission approval, cancellation cleanup, assistant activity, tool activity,
+and title/catalog updates must not advance the marker.
+
+The visible policy remains otherwise unchanged:
+
+- running means `mainAgentRunning || isRetrying || backgroundTaskCount > 0`;
+- awaiting-input alone does not promote a session into the running prefix;
+- non-running sessions remain ordered by `Session.time.updated` descending;
+- archived filtering remains unchanged; and
+- project ordering and the background-task child list do not change.
+
+## Success Criteria
+
+1. Running root sessions with known interaction markers appear in descending
+   user-interaction recency, regardless of title.
+2. A prompt, command, manual answer/rejection/permission decision, or manual
+   compaction advances the displayed root session promptly without a list
+   refetch.
+3. Automatic OpenCode compaction, including its synthetic continuation and
+   overflow replay messages, does not advance recency.
+4. Sesori permission auto-approval and plugin cancellation/teardown replies do
+   not advance recency.
+5. Observable backend/laptop-originated user interactions advance recency when
+   the owning plugin can prove human provenance; unsupported external-process
+   cases remain unknown rather than guessed.
+6. Existing databases add a nullable `last_user_interaction_at` column without
+   backfilling polluted `last_user_message_at` or backend `updated_at` values.
+7. The marker is monotonic across duplicate/replayed events, reconnects, bridge
+   restart, and clock rollback, using existing ordered pipelines rather than a
+   new lock or registry.
+8. REST session payloads and the existing `session.unseen_changed` live patch
+   carry the nullable marker additively. Old app/new bridge and new app/old
+   bridge combinations retain their current behavior.
+9. A stale REST or `session.updated` payload cannot replace a fresher live
+   marker already held by the session-list Cubit.
+10. Sessions whose marker is absent use `time.updated` as the compatibility
+    fallback. Equal keys have a deterministic ID tie-breaker.
+11. No backend identifier, interaction kind, prompt text, command name,
+    transcript content, path, or entity identifier is added to analytics or a
+    new public event.
+
+## Current Behavior And Evidence
+
+### Client ordering ownership
+
+- `SessionListService.visibleSessions` partitions running sessions using
+  `SessionActivityCalculator.isRunning`, alphabetizes the running prefix, then
+  appends the remaining sessions sorted by `time.updated` descending
+  (`client/module_core/lib/src/services/session_list_service.dart`).
+- `SessionActivityCalculator` deliberately excludes `awaitingInput` alone from
+  running (`client/module_core/lib/src/services/session_activity_calculator.dart`).
+- `SessionListCubit` owns the complete unbounded project list, applies REST and
+  live session updates, and re-runs `visibleSessions` whenever activity changes
+  (`client/module_core/lib/src/cubits/session_list/session_list_cubit.dart`).
+- The in-repository client sends `start: null, limit: null` to `POST /sessions`
+  (`client/module_core/lib/src/api/project_api.dart`). Server pagination remains
+  an API capability but does not define this screen's visible order.
+- The background-task child list is separately sorted by `time.updated`
+  (`SessionDetailCubit._sortChildrenByUpdatedDesc`) and is not part of this
+  root-list change.
+
+### Existing bridge timestamps are not an interaction source
+
+- `sessions_table.last_user_message_at` feeds released unseen-state behavior
+  (`SessionUnseenCalculator`) and is currently advanced by generic
+  user-shaped messages and question/permission reply events.
+- OpenCode represents both manual and automatic compaction as a user message.
+  `MessagePartMapper` intentionally renders both forms as `/compact`, so the
+  shared message shape no longer contains provenance.
+- OpenCode publishes `message.updated` before `message.part.updated`; only the
+  raw `CompactionPart.auto` on the later part distinguishes manual from
+  automatic compaction.
+- The generated OpenCode API models remain sourced from v1.17.7, while the
+  managed runtime is now pinned to v1.18.11. Revalidation against v1.18.11
+  confirms the same envelope-before-part order, `auto` provenance, synthetic
+  continuation, and overflow replay behavior used by this classifier.
+- OpenCode also creates synthetic user messages for compaction continuation,
+  plan-mode transitions, task-result injection, and shell bookkeeping. Overflow
+  compaction can replay an earlier user message with copied non-synthetic parts.
+- Existing released rows can therefore contain values unsuitable for ordering.
+  No valid historical backfill exists.
+
+### Existing seams can carry the new fact
+
+- `BridgePluginApi.events` is the backend-neutral plugin boundary for live
+  backend facts (`bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart`).
+- `SessionEventDispatcher` and `OrchestratorSession._processPluginEventInOrder`
+  already preserve per-plugin event order and generation fencing.
+- `SessionEventMapper` translates backend session IDs to stable bridge IDs and
+  already supports a distinct display/root session for child questions and
+  permissions.
+- `SessionUnseenService` already serializes low-volume session-list timestamp
+  writes, owns a monotonic clock, persists `last_user_message_at`, and emits the
+  existing cross-cutting `session.unseen_changed` list-state patch after a
+  commit.
+- Shared JSON generation omits nullable values and accepts missing nullable
+  keys, which provides additive old/new peer compatibility.
+
+### History decisions
+
+- PR #474 introduced a broad bridge-authored project/session activity summary.
+- PR #480 reverted that pipeline.
+- PR #482 established the current client-owned running prefix and alphabetical
+  running order.
+- This plan transmits one timestamp fact and keeps ordering in the client. It
+  does not restore `ActiveWorkSummaryService` or bridge-authored list snapshots.
+
+## Architecture
+
+### 1. Backend-neutral interaction fact
+
+Add one internal plugin event in
+`bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart`:
+
+```text
+BridgeSseSessionUserInteraction
+  sessionID: String
+  displaySessionId: String?
+  occurredAt: int?
+```
+
+Contract:
+
+- The event means the plugin has authoritative evidence that a human
+  interaction was accepted or observed.
+- `sessionID` is the backend session that owns the interaction.
+- `displaySessionId` is the backend root session whose row should move when a
+  child request is surfaced under that root. Flat plugins use the same session
+  ID; null means the plugin cannot resolve a distinct display root.
+- `occurredAt` is milliseconds since epoch when the backend supplies a reliable
+  interaction timestamp; null asks bridge core to stamp acceptance/observation
+  time.
+- The event deliberately carries no interaction kind or content. Every accepted
+  kind has identical ordering semantics, and exposing more detail would add no
+  client decision value.
+- `BridgeEventMapper` maps it to no direct public SSE event. It is consumed by
+  bridge core after backend-to-stable ID translation.
+
+Add a closed `PluginInteractionOrigin.manual/automatic` enum to the internal
+plugin interface and require it on `BridgePluginApi.replyToPermission`. The
+manual reply handler passes `manual`; `PermissionAutoApprovalService` passes
+`automatic`. Internal plugin contracts and all in-repository implementors update
+in lockstep; no compatibility shim or optional parameter is added.
+
+Question reply/rejection methods need no origin parameter because the only
+bridge-app callers are explicit user routes. Plugin cancellation and teardown
+paths remain separate and do not emit the interaction fact.
+
+`SessionEventMapper` translates both session identities. If either explicitly
+named backend ID has no durable binding, the existing pending-binding behavior
+holds or drops the event exactly like other session events. Persistence targets
+`displaySessionId ?? sessionID`; it does not walk ancestors, stamp both rows, or
+infer a family beyond the plugin's display attribution.
+
+### 2. Plugin provenance rules
+
+Every registered production plugin emits the same neutral event, but each owns
+its backend-specific evidence.
+
+#### OpenCode
+
+Add `OpenCodeUserInteractionTracker` beside the existing OpenCode trackers. It
+owns the bounded message-envelope/part classifier, automatic-overflow
+suppression, and all classifier lifecycle state. It receives the existing
+`ActiveSessionTracker` as a required dependency for root/display attribution;
+it does not duplicate the session-parent graph.
+
+`OpenCodePlugin._handleRawSseEvent` remains a composition pipeline: after
+parsing and updating the existing service/tracker state, it delegates the raw
+`SseEventData` to `OpenCodeUserInteractionTracker`, forwards any returned
+neutral interaction fact, then continues existing presentation mapping.
+Classification still occurs before `SseEventMapper` erases raw part provenance.
+
+- Keep at most one pending user envelope per session: message ID plus the
+  message creation timestamp. This state is bounded by the number of known
+  sessions, not transcript length.
+- A later part classifies only the matching pending envelope.
+- A root-session non-synthetic text/file/subtask prompt records one interaction.
+  A child user prompt is not counted because OpenCode creates those for agent
+  task sessions and Sesori exposes child detail as read-only.
+- `CompactionPart(auto: false)` records one manual interaction.
+- `CompactionPart(auto: true)` records none.
+- Synthetic text parts record none. This excludes auto-compaction continuation,
+  plan-mode transitions, background-result injection, and shell bookkeeping.
+- For automatic overflow compaction, suppress the next replay/continuation user
+  envelope. Clear suppression when consumed or when compaction/status terminal
+  evidence proves no replay remains, so a failed compaction cannot suppress a
+  later genuine prompt.
+- Remove pending/suppression state when the tracker observes session deletion;
+  call its `reset` from the existing OpenCode reconnect/reset path and its
+  `dispose` during plugin disposal. Do not add a transcript-sized dedupe set;
+  duplicate known-timestamp facts are rejected by the persisted monotonic write.
+- Raw `question.replied` and `question.rejected` events are authoritative and
+  cover both Sesori and laptop replies.
+- Raw `permission.replied` is not authoritative: OpenCode emits the same event
+  for `always` cascades. Emit one fact only from a successful manual
+  `replyToPermission` call. Direct laptop permission decisions remain unknown.
+
+This design relies on OpenCode's observed and generated API ordering:
+`message.updated` precedes its parts. It does not add a timer, delayed flush,
+history read, or content comparison for a theoretical reversed sequence.
+
+#### Codex
+
+- Add `CodexUserInteractionTracker` as the plugin-local owner of app-server user
+  item provenance. `CodexPlugin` delegates notifications and terminal lifecycle
+  signals to it and forwards returned neutral facts; `CodexEventMapper` remains
+  a presentation mapper.
+- The tracker emits once from the first app-server `userMessage` item lifecycle
+  observation; that typed item is the authoritative prompt/command boundary and
+  also covers another observable Codex surface. It keeps only in-flight
+  `(threadId, itemId)` keys: `item/started` emits and records, `item/completed`
+  removes and emits only if no start was observed. Turn terminal, thread delete,
+  reconnect/reset, and disposal clear remaining keys. Do not emit again from
+  `sendPrompt` or an ordinary `sendCommand` response.
+- Extract the existing private generated repository/context test into one pure
+  `CodexGeneratedContextValidator`. Inject that required dependency into both
+  `CodexUserInteractionTracker` and `CodexMessageRepository`; do not duplicate
+  wrapper strings or expose them outside the Codex plugin.
+- A successful `thread/compact/start` call emits one manual-compaction fact.
+  Generic `contextCompaction` notifications carry no manual/automatic origin and
+  emit no fact.
+- Successful registry question/permission methods emit facts only for explicit
+  manual calls. `cancelForSession` remains a no-fact cleanup path.
+- App-server user items have no reliable message timestamp, so these events use
+  null `occurredAt` and bridge observation time.
+
+#### Cursor / ACP
+
+- Emit after the existing prompt/command acceptance gate and for a non-empty
+  initial create-session turn.
+- Cursor's public `compact` command is counted once after acceptance even though
+  the adapter rewrites it to the backend `summarize` command.
+- Emit after successful manual registry answers/decisions; abort/dispose
+  cancellation emits no fact.
+- ACP drops backend `user_message_chunk` echoes and the bridge owns a separate
+  process, so interactions made in another laptop process are not observable and
+  remain unknown.
+
+#### Claude
+
+- Emit after `_enqueue` accepts a prompt/command and for a non-empty initial
+  create-session turn. A manually sent `/compact` is therefore counted as a
+  command.
+- Emit after successful manual registry answers/decisions; cancellation and
+  disposal emit no fact.
+- Do not infer interaction from generic Claude user frames, which can represent
+  internal tool-result/context traffic.
+- Separate laptop Claude CLI transcripts are not live-tailed by this plugin, so
+  those interactions remain unknown.
+
+OMP inherits the ACP implementation but is not registered in the production
+bridge at the plan date. Pi has protocol primitives but no `BridgePluginApi`
+implementation and is also excluded until registration. If registration changes
+before execution, re-evaluate the production matrix rather than hard-coding this
+historical list.
+
+### 3. Durable marker and monotonic write
+
+Add nullable `lastUserInteractionAt` to `SessionTable`/`SessionDto` and bump the
+Drift schema from v13 to v14.
+
+- The v13-to-v14 migration only adds the nullable column.
+- Existing rows remain null. Neither `last_user_message_at` nor `updated_at` is
+  an honest baseline.
+- Preserve the v13 snapshot and generate a new v14 schema snapshot, migration
+  steps, generated database source, and migration helper. Never hand-edit
+  generated files.
+- Catalog import/upsert preserves an existing marker and leaves new imported
+  rows null until an authoritative live fact arrives.
+- Existing session projection updates and placeholder/create UPSERTs omit the
+  column so they cannot erase it.
+
+Extend `SessionUnseenRepository`/`SessionUnseenService` rather than adding a
+parallel timestamp repository, service, stream, or lock. They already own the
+persisted user marker, monotonic timestamp source, ordered write tail, and
+session-list state patch.
+
+`recordUserInteraction` behavior:
+
+1. read the named stable session row;
+2. no-op if it does not exist;
+3. for a known `occurredAt`, no-op when it is not newer than the stored marker;
+4. for a null timestamp, stamp `max(local monotonic now, stored + 1)` so a new
+   accepted action still advances after clock rollback/restart;
+5. update only `last_user_interaction_at` with a conditional/monotonic DAO
+   write; and
+6. emit the committed session-list patch.
+
+This does not alter `last_activity_at`, `last_seen_at`, `last_user_message_at`,
+or the unseen formula. Generic message/reply unseen routing stays in place for
+released behavior, even where historical user-shaped backend events are broader
+than the new marker. Update the `lastUserMessageAt` comment to state that it is
+an unseen-specific legacy marker and must not be reused as authoritative
+interaction recency.
+
+The ordinary reachable duplicate/replay flow justifies monotonic persistence.
+No new cross-plugin queue, per-session mutex, event journal, or reconciliation
+job is needed because existing per-plugin processing and the global low-volume
+timestamp write tail already serialize the relevant operations.
+
+### 4. Additive REST and live transport
+
+Add `required int? lastUserInteractionAt` to the shared `Session` model and map
+the persisted field through every bridge catalog/detail/child/live session
+projection:
+
+- `SessionCatalogMapper` for database-only roots and children;
+- `PluginSessionMapper.enrichSharedSession` for plugin-enriched payloads; and
+- all direct `Session` construction call sites required by generated analysis.
+
+Add the same required nullable property to the existing
+`SesoriSseEvent.sessionUnseenChanged` variant. Update its documentation and the
+bridge `UnseenChange` typedef to describe a session-list state patch carrying
+unseen state plus interaction recency.
+
+- Every post-row patch carries the committed marker.
+- Delete patches carry null.
+- Old apps ignore the extra REST/SSE key.
+- New apps decode omission from old bridges as null.
+- Null values remain omitted by shared JSON generation.
+- Use dated compatibility comments with the actual release target at
+  implementation time.
+
+Do not create a dedicated public interaction event. Reusing the existing
+post-commit list-state patch avoids a second ordering relationship and unknown
+event behavior in older clients while keeping the internal provenance fact out
+of the released protocol.
+
+Do not change `Session.time.updated`, DAO root ordering, or session-list indexes.
+The client owns the activity-aware visible order and fetches the complete list.
+Changing server pagination would not be sufficient because the server query
+does not own live running state, and no current in-repository list consumer uses
+paged roots.
+
+### 5. Client merge and comparator
+
+`SessionListService` remains the sole visible-order policy owner.
+
+For running sessions, compare:
+
+1. effective interaction recency descending, where
+   `lastUserInteractionAt ?? time.updated ?? 0`;
+2. a known interaction marker before an unknown marker when effective keys are
+   equal;
+3. `time.updated` descending; and
+4. session ID ascending as a deterministic final tie-breaker.
+
+The `time.updated` fallback preserves useful behavior with old bridges and
+pre-migration sessions. Once a verified marker exists, later automatic backend
+updates cannot move that session because the comparator uses the marker instead.
+
+For non-running sessions, keep `time.updated` descending and add only the same
+deterministic ID tie-breaker. Do not change `SessionActivityCalculator`, project
+ordering, or child-task ordering.
+
+`SessionListService` owns every marker transformation:
+
+- `applyInteractionPatch` locates an already-held session and max-merges the
+  nullable live marker without manufacturing a missing session;
+- `applySessionUpdatedEvent` keeps the greater existing/new interaction marker
+  alongside its current PR metadata merge; and
+- `mergeRestSnapshot` treats fetched membership and ordinary fields as
+  authoritative while max-merging markers from matching sessions already held,
+  so an in-flight fetch cannot roll back a live patch.
+
+`SessionListCubit` only validates the SSE project/state, delegates
+`SesoriSessionUnseenChanged` to `applyInteractionPatch`, delegates successful
+REST replacement to `mergeRestSnapshot`, and re-runs `visibleSessions`.
+`SessionUnseenTracker` remains the authority for unseen booleans and ignores the
+additional property.
+
+No new long-lived tracker, Cubit generation, tick map, or optimistic interaction
+state is required. Bridge markers are monotonic, so a per-session max at the two
+existing merge seams is sufficient.
+
+## Compatibility
+
+### Wire
+
+- **New bridge, old app:** extra nullable properties on known REST/SSE shapes are
+  ignored; current updated-time/alphabetical behavior remains in that app.
+- **Old bridge, new app:** missing properties decode to null and running order
+  falls back to `time.updated`.
+- **New plugin fact, old app:** the internal fact never reaches the wire.
+- No request field, route, capability negotiation, or new public SSE variant is
+  added.
+
+### Database
+
+- Stable released databases migrate v13 to v14 by adding a nullable column.
+- No historical interaction is manufactured.
+- Existing unseen columns and values remain intact.
+- If another schema version lands on `main` before implementation, preserve it
+  and move this migration/snapshot to the next available version rather than
+  rewriting merged history.
+
+### Internal APIs
+
+- `BridgePluginApi` and plugin packages have no out-of-repository consumers and
+  update together. The new required permission origin has no fallback or shim.
+
+## Scope And Non-Goals
+
+- Do not restore `ActiveWorkSummaryService`, bridge-authored session ordering,
+  or project ordering by session activity.
+- Do not infer genuine interaction from `Session.time.updated`, generic shared
+  `MessageUser`, command completion, assistant output, tool output, session
+  status, or title changes when an authoritative marker is available.
+- Do not backfill the new column from existing timestamps or transcript history.
+- Do not redesign unseen state or clean polluted historical
+  `last_user_message_at` values.
+- Do not add live tailing to Claude/ACP processes or make unobservable laptop
+  interactions appear supported.
+- Do not add locks, timers, ancestry walks, content hashes, event journals,
+  background repair, server-side active sorting, or pagination/index changes.
+- Do not change child-session presentation or make child detail writable.
+- Do not add analytics. There is no product decision, reporting model, or
+  privacy-safe aggregate that requires tracking this ordering behavior; the
+  authoritative event would also risk turning session activity into telemetry.
+
+## Evidence And Accepted Risk
+
+| Concern | Evidence class | Planned safeguard / accepted behavior |
+|---|---|---|
+| Automatic compaction looks user-authored | Observed backend behavior | Classify raw OpenCode parts before mapping; test auto, continuation, and overflow replay |
+| Auto-approved/cancelled replies look manual | Ordinary reachable flow | Required permission origin plus manual-only plugin fact emission; cancellation methods emit no fact |
+| Duplicate/replayed backend events | Ordinary reconnect flow | Persisted monotonic conditional update and existing ordered write tail |
+| REST/SSE replacement race | Ordinary in-flight refresh flow | Max the marker at the two existing client replacement seams |
+| Reversed OpenCode message/part order | Theoretical against current upstream order | Accepted; no timer or history lookup. Missing one reorder self-heals on the next genuine interaction |
+| Direct laptop interaction in a separate ACP/Claude process | Unobservable by current architecture | Accepted limitation; keep marker unchanged rather than guess |
+| Direct OpenCode permission decision | Event cannot distinguish one choice from `always` cascade | Accepted limitation; only Sesori manual decisions count until upstream adds provenance |
+| Existing null markers after migration | Required honest migration state | Fall back to `time.updated` until the first authoritative interaction |
+| Paged third-party root requests | No current in-repository consumer and server lacks running state | Keep existing server order; visible app fetch remains complete and client-owned |
+
+## Cleanup Assessment
+
+Directly caused cleanup:
+
+- remove `_compareSessionsByTitleAndId` and the alphabetical-running-order tests
+  replaced by the recency comparator;
+- correct the `lastUserMessageAt` documentation so future work does not treat it
+  as authoritative interaction provenance; and
+- update `session.unseen_changed` naming documentation from unseen-only to the
+  cross-cutting session-list patch it becomes.
+
+Retained intentionally:
+
+- `last_user_message_at`, generic user-message unseen routing, and current
+  unseen tests remain required by released persisted unseen behavior;
+- `time.updated` remains the inactive order and compatibility fallback;
+- existing activity-summary and child-task calculations remain required; and
+- no larger obsolete service, cache, setting, job, or transport field is created
+  by this change.
+
+## Delivery Plan
+
+All steps use the existing `session-order-ux-review` branch/worktree. Before each
+implementation PR, synchronize with current `main` and preserve any schema
+versions already merged. Do not create another branch or worktree for this
+series.
+
+### Step 1/7 - Plan
+
+**Exact PR title:**
+`🌱 [session-user-interaction-order] docs: plan running session interaction order [step 1/7]`
+
+- Add this plan and tracker.
+- Record architecture review findings and direct corrections.
+- Validate exact titles, fixed denominator, scope, and `git diff --check`.
+- No production, generated, database, wire, or user-visible change.
+
+**Changed-line target:** 550-950 documentation lines.
+
+### Step 2/7 - Authoritative plugin facts
+
+**Exact PR title:**
+`🚧 [session-user-interaction-order] feat(plugins): report genuine user interactions [step 2/7]`
+
+- Add the internal interaction event and required permission origin enum.
+- Update every registered plugin and all app/plugin call sites in lockstep.
+- Add `OpenCodeUserInteractionTracker` and implement pending-envelope
+  classification, lifecycle cleanup, and automatic-compaction exclusions.
+- Add `CodexGeneratedContextValidator` plus
+  `CodexUserInteractionTracker`, then implement Codex, ACP/Cursor, and Claude
+  authoritative emission rules.
+- Add bridge event ID translation and explicit no-public-wire mapping.
+- Test prompt, command, initial turn, manual compaction, manual answer/decision,
+  auto approval, cancellation, synthetic continuation, overflow replay, and
+  duplicate-known-time behavior at the owning boundaries.
+- No database, released wire, client, or user-visible behavior yet.
+
+**Changed-line target:** 1,050-1,500 lines. If complete production-plugin tests
+would exceed the soft cap, split test-only follow-up is not acceptable because
+the contract must land verified; update the target with measured generated-free
+scope before opening the PR.
+
+### Step 3/7 - Persist interaction recency
+
+**Exact PR title:**
+`🚧 [session-user-interaction-order] feat(bridge): persist session interaction recency [step 3/7]`
+
+- Add the nullable Drift column and next schema migration with no backfill.
+- Generate schema snapshot, steps, database source, and migration helpers.
+- Preserve markers through catalog import and all session projection UPSERTs.
+- Extend the existing unseen repository/service with the monotonic
+  post-translation write and consume internal facts in the orchestrator.
+- Keep existing unseen timestamps/formula unchanged.
+- Test migration structure/null baseline, preservation, root/display
+  attribution, missing rows, known-time duplicate/no-regression, null-time clock
+  rollback, and auto-generated no-fact paths.
+- No released wire or client behavior yet.
+
+**Changed-line target:** 4,500-6,500 lines, explicitly above the 1,500-line soft
+cap because the required new Drift v14 JSON snapshot and generated Dart schema
+helper are additive files of several thousand lines. Hand-editing, omitting, or
+separating those generated migration artifacts would leave the persisted change
+unreviewable or invalid; non-generated production/test scope should remain
+localized.
+
+### Step 4/7 - Transport the marker
+
+**Exact PR title:**
+`⚙️ [session-user-interaction-order] feat(protocol): publish session interaction recency [step 4/7]`
+
+- Add the nullable shared `Session` and `session.unseen_changed` properties with
+  dated compatibility comments.
+- Regenerate shared Freezed/JSON source.
+- Map REST/detail/child/live session projections and post-commit list patches.
+- Verify null omission, missing-field decode, old/new peer behavior, delete null,
+  and committed-value delivery.
+- No ordering change in the client yet; old clients remain unaffected.
+
+**Changed-line target:** 700-1,300 lines including generated source and tests.
+
+### Step 5/7 - Apply client ordering
+
+**Exact PR title:**
+`⚙️ [session-user-interaction-order] feat(client): order running sessions by interaction [step 5/7]`
+
+- Replace alphabetical running order with the effective-recency comparator.
+- Add `SessionListService.applyInteractionPatch` and `mergeRestSnapshot`; preserve
+  max values across live patches, session updates, and in-flight REST
+  replacement while keeping the Cubit orchestration-only.
+- Keep awaiting-only, inactive, archived, project, and child ordering behavior
+  unchanged.
+- Add service/Cubit tests for marker order, null fallback, deterministic ties,
+  auto-update stability, live reordering, stale REST, old bridge payloads, and
+  project mismatch.
+- Verify both mobile and desktop downstream analysis because both consume
+  `module_core`, while noting the desktop shell has no catalog UI.
+
+**Changed-line target:** 350-750 lines.
+
+### Step 6/7 - Regression contract
+
+**Exact PR title:**
+`🌱 [session-user-interaction-order] docs: define session interaction order coverage [step 6/7]`
+
+- Reconcile `docs/regression/projects-and-sessions.md` with the root running
+  order, live marker, null fallback, and compatibility behavior.
+- Reconcile `docs/regression/session-turns.md` with genuine interaction
+  provenance, manual compaction, and automatic/cancellation exclusions.
+- Record the final registered-plugin and platform matrix discovered from the
+  implemented code.
+- No production, database, wire, generated, or user-visible change.
+
+**Changed-line target:** 50-180 lines.
+
+### Step 7/7 - Verify and retire
+
+**Exact PR title:**
+`🌱 [session-user-interaction-order] docs: verify and retire interaction ordering [step 7/7]`
+
+- Run the recorded L3 cumulative regression level through the matrix below.
+- Record automated and live/client evidence, limitations, versions, and cleanup
+  in the tracker without prompts, transcripts, paths, raw IDs, or logs.
+- Run final relevant analysis/tests only where the evidence changed since each
+  implementation PR; do not rerun an unchanged passing matrix for confidence.
+- Move the plan directory from `.plan/active/` to `.plan/completed/` only when
+  every required boundary passes. Partial, blocked, failed, or reduced coverage
+  keeps the plan active unless the user explicitly accepts and records a matrix
+  reduction.
+- No production, database, wire, generated, or new user-visible change.
+
+**Changed-line target:** 60-220 documentation lines.
+
+## Verification Plan
+
+### Focused automated verification
+
+Step 2:
+
+- `sesori_plugin_interface`: strict analysis and exhaustive event switches.
+- `OpenCodeUserInteractionTracker` tests: ordinary root prompt/file prompt,
+  child-generated prompt exclusion, slash/subtask command, manual compaction,
+  auto compaction, synthetic continuation, overflow replay, question
+  reply/reject, manual versus automatic permission, and bounded pending-state
+  cleanup.
+- `CodexGeneratedContextValidator` and `CodexUserInteractionTracker` tests: one
+  first-lifecycle user-item fact, generated-context exclusion, bounded terminal
+  cleanup, ordinary command, explicit manual compact, generic context compaction
+  exclusion, manual registry replies, and cancellation exclusion.
+- ACP/Cursor and Claude tests: accepted/failed prompt and command, initial turn,
+  compact mapping, manual reply, cancellation/disposal exclusion.
+- Bridge app mapper tests: backend/stable IDs and display-root translation; no
+  public mapping.
+
+Step 3:
+
+- Drift v13-to-v14 migration tests and schema validation.
+- DAO/repository/service tests for null baseline, preservation, monotonic writes,
+  missing rows, display-root targeting, and post-commit patch emission.
+- Orchestrator event processing test proving the internal fact persists but is
+  not directly enqueued as a wire event.
+
+Step 4:
+
+- Shared model round-trip and omitted-field compatibility tests.
+- Bridge catalog/detail/child/session-update mapper and route tests.
+- Existing unseen-change tests extended to assert the committed nullable marker.
+
+Step 5:
+
+- `client/module_core/test/services/session_list_service_test.dart`.
+- `client/module_core/test/cubits/session_list/session_list_cubit_test.dart`.
+- Focused connection/SSE parsing tests for the additive known-event property.
+- `dart analyze` in shared, changed bridge packages, `module_core`, mobile app,
+  and desktop shell as applicable.
+
+### Regression level and proof boundaries
+
+**Highest required level:** L3 Release, cumulative through L1 and L2.
+
+The behavior has independent proof boundaries:
+
+- **Automated:** plugin provenance classification, migration/persistence,
+  additive JSON compatibility, monotonic merge, and deterministic comparator.
+- **Live plugin:** real backend prompt/command/manual-compaction behavior and
+  automatic-compaction exclusion where supported.
+- **Client end to end:** a phone observes multiple running root sessions reorder
+  after genuine interactions while inactive/awaiting-only rows retain policy.
+
+### Required matrix
+
+- **Plugins:** every supporting registered production plugin at execution time.
+  At plan time: OpenCode, Codex, Cursor, and Claude.
+- **Interaction capabilities:** prompt and command for each plugin; manual
+  compaction and question/permission response where supported; automatic
+  compaction/auto-approval/cancellation exclusions where the plugin exposes
+  those flows.
+- **Backend-originated coverage:** OpenCode and Codex where the attached backend
+  stream can authoritatively observe another surface; ACP/Cursor and Claude are
+  explicitly limited to the bridge-owned process.
+- **Client platform:** one release-target phone platform for L3. The desktop
+  shell has no catalog surface, but downstream compile/analyze remains required.
+- **Bridge host:** one release-target host; no host-specific ordering claim.
+- **Peer compatibility:** current app with a pre-marker bridge fixture and
+  current bridge payload with a pre-marker app decoder/fixture where available.
+
+Any reduction to this matrix requires explicit user acceptance recorded here
+before retirement.
+
+## Expected PR Review Summaries
+
+Every implementation PR body must include the repository-required sections.
+Use these review focuses rather than duplicating the whole plan:
+
+- **Step 2 complexity:** complex - backend-specific provenance across the shared
+  plugin boundary, especially OpenCode compaction ordering.
+- **Step 2 risk/test focus:** false recency from generated messages, duplicate
+  facts, permission auto paths, and plugin lifecycle cleanup. No database or
+  released-wire impact; no user-visible change yet.
+- **Step 3 complexity:** complex - persisted nullable state, migration/codegen,
+  ordered event consumption, and monotonicity.
+- **Step 3 risk/test focus:** schema preservation, no dishonest backfill,
+  display-root attribution, and not changing unseen behavior. Database impact:
+  one nullable column; no user-visible change yet.
+- **Step 4 complexity:** moderate - additive shared REST/SSE contract and bridge
+  projections.
+- **Step 4 risk/test focus:** mixed-version decode/encode, null omission, and
+  committed-value delivery. No visible ordering change until Step 5.
+- **Step 5 complexity:** moderate - client ordering plus live/REST race-safe
+  merge.
+- **Step 5 risk/test focus:** running-prefix policy, fallback behavior, no churn,
+  and no project/child/inactive regression. User-visible impact: running sessions
+  reorder by genuine interaction.
+
+## Architecture Review
+
+- **Reviewer:** `architecture-plan-review`
+- **Reviewed scope:** complete `.plan/active/session-user-interaction-order/`
+  against current plugin, bridge, shared, database, and client architecture
+- **Initial verdict:** rejected with three actionable ownership findings
+- **Findings applied:** moved OpenCode classifier state from the top-level plugin
+  into `OpenCodeUserInteractionTracker`; named `CodexUserInteractionTracker` and
+  one shared `CodexGeneratedContextValidator` with bounded lifecycle; moved live
+  patch and REST max-merge policy from `SessionListCubit` into
+  `SessionListService`
+- **Re-review:** not run; repository policy applies valid concrete findings
+  directly without a second review merely to approve the corrections

--- a/.plan/active/session-user-interaction-order/PLAN.md
+++ b/.plan/active/session-user-interaction-order/PLAN.md
@@ -57,14 +57,15 @@ The visible policy remains otherwise unchanged:
    cases remain unknown rather than guessed.
 6. Existing databases add a nullable `last_user_interaction_at` column without
    backfilling polluted `last_user_message_at` or backend `updated_at` values.
-7. The marker is monotonic across duplicate/replayed events, reconnects, bridge
-   restart, and clock rollback, using existing ordered pipelines rather than a
-   new lock or registry.
+7. The marker is monotonic across duplicate events, reconnects, bridge restart,
+   and clock rollback, using existing ordered pipelines rather than a new lock
+   or registry. An accepted bridge-owned OpenCode write still records one fact
+   if its raw SSE envelope/part pair is lost during reconnect.
 8. REST session payloads and the existing `session.unseen_changed` live patch
    carry the nullable marker additively. Old app/new bridge and new app/old
    bridge combinations retain their current behavior.
 9. A stale REST or `session.updated` payload cannot replace a fresher live
-   marker already held by the session-list Cubit.
+   marker, including when the patch arrives during the initial REST load.
 10. Sessions whose marker is absent use `time.updated` as the compatibility
     fallback. Equal keys have a deterministic ID tie-breaker.
 11. No backend identifier, interaction kind, prompt text, command name,
@@ -203,6 +204,15 @@ parsing and updating the existing service/tracker state, it delegates the raw
 neutral interaction fact, then continues existing presentation mapping.
 Classification still occurs before `SseEventMapper` erases raw part provenance.
 
+The same tracker also coordinates bridge-owned prompt/command acceptance. The
+plugin starts one bounded pending write before dispatch, raw classification may
+satisfy that write first, and successful API completion emits a null-timestamp
+fallback only when no matching raw fact was observed. Failed acceptance emits no
+fallback. This produces one fact in the ordinary path while covering the real
+disconnect window where OpenCode accepted the write but its envelope or part was
+lost before the fresh non-replaying SSE connection. Initial create-session turns
+use the same coordination after the backend session ID is known.
+
 - Keep at most one pending user envelope per session: message ID plus the
   message creation timestamp. This state is bounded by the number of known
   sessions, not transcript length.
@@ -221,7 +231,8 @@ Classification still occurs before `SseEventMapper` erases raw part provenance.
 - Remove pending/suppression state when the tracker observes session deletion;
   call its `reset` from the existing OpenCode reconnect/reset path and its
   `dispose` during plugin disposal. Do not add a transcript-sized dedupe set;
-  duplicate known-timestamp facts are rejected by the persisted monotonic write.
+  one envelope is consumed once, and bridge-write coordination emits at most one
+  fact for its accepted action.
 - Raw `question.replied` and `question.rejected` events are authoritative and
   cover both Sesori and laptop replies.
 - Raw `permission.replied` is not authoritative: OpenCode emits the same event
@@ -231,6 +242,10 @@ Classification still occurs before `SseEventMapper` erases raw part provenance.
 This design relies on OpenCode's observed and generated API ordering:
 `message.updated` precedes its parts. It does not add a timer, delayed flush,
 history read, or content comparison for a theoretical reversed sequence.
+OpenCode facts use null `occurredAt`: interaction order is acceptance/observation
+order, and bridge stamping remains monotonic even when the backend clock rolls
+back. Other plugins may provide a known timestamp only where replay identity and
+clock semantics make it authoritative.
 
 #### Codex
 
@@ -393,14 +408,19 @@ ordering, or child-task ordering.
 - `applySessionUpdatedEvent` keeps the greater existing/new interaction marker
   alongside its current PR metadata merge; and
 - `mergeRestSnapshot` treats fetched membership and ordinary fields as
-  authoritative while max-merging markers from matching sessions already held,
-  so an in-flight fetch cannot roll back a live patch.
+  authoritative while max-merging markers from matching sessions already held
+  and from the existing `SessionUnseenTracker`, so an in-flight or initial fetch
+  cannot roll back a live patch.
 
 `SessionListCubit` only validates the SSE project/state, delegates
 `SesoriSessionUnseenChanged` to `applyInteractionPatch`, delegates successful
 REST replacement to `mergeRestSnapshot`, and re-runs `visibleSessions`.
-`SessionUnseenTracker` remains the authority for unseen booleans and ignores the
-additional property.
+`SessionUnseenTracker` remains the live list-state cache: extend its existing
+per-project tick and session map to retain the nullable marker from
+`SesoriSessionUnseenChanged` alongside unseen state. It performs no ordering or
+merge decision; `SessionListService` consumes its cached marker map. This reuses
+the tracker that already receives patches before a list Cubit is loaded rather
+than adding another long-lived owner.
 
 No new long-lived tracker, Cubit generation, tick map, or optimistic interaction
 state is required. Bridge markers are monotonic, so a per-session max at the two
@@ -457,8 +477,10 @@ existing merge seams is sufficient.
 |---|---|---|
 | Automatic compaction looks user-authored | Observed backend behavior | Classify raw OpenCode parts before mapping; test auto, continuation, and overflow replay |
 | Auto-approved/cancelled replies look manual | Ordinary reachable flow | Required permission origin plus manual-only plugin fact emission; cancellation methods emit no fact |
-| Duplicate/replayed backend events | Ordinary reconnect flow | Persisted monotonic conditional update and existing ordered write tail |
-| REST/SSE replacement race | Ordinary in-flight refresh flow | Max the marker at the two existing client replacement seams |
+| Duplicate backend events | Ordinary live-event flow | Plugin-local one-shot classification plus persisted monotonic conditional update and existing ordered write tail |
+| Accepted OpenCode write loses SSE pair | Ordinary disconnect window | Coordinate bridge write with raw observation and emit one successful null-time fallback only when raw did not satisfy it |
+| Backend clock rollback | Ordinary clock-adjustment flow | OpenCode uses null occurred-at and bridge monotonic stamping; known times remain only for authoritative plugin sources |
+| REST/SSE replacement race | Ordinary initial/in-flight refresh flow | Existing unseen tracker retains the patch; service maxes it at client replacement seams |
 | Reversed OpenCode message/part order | Theoretical against current upstream order | Accepted; no timer or history lookup. Missing one reorder self-heals on the next genuine interaction |
 | Direct laptop interaction in a separate ACP/Claude process | Unobservable by current architecture | Accepted limitation; keep marker unchanged rather than guess |
 | Direct OpenCode permission decision | Event cannot distinguish one choice from `always` cascade | Accepted limitation; only Sesori manual decisions count until upstream adds provenance |
@@ -502,7 +524,7 @@ series.
 - Validate exact titles, fixed denominator, scope, and `git diff --check`.
 - No production, generated, database, wire, or user-visible change.
 
-**Changed-line target:** 550-950 documentation lines.
+**Changed-line target:** 550-1,050 documentation lines.
 
 ### Step 2/7 - Authoritative plugin facts
 
@@ -512,14 +534,16 @@ series.
 - Add the internal interaction event and required permission origin enum.
 - Update every registered plugin and all app/plugin call sites in lockstep.
 - Add `OpenCodeUserInteractionTracker` and implement pending-envelope
-  classification, lifecycle cleanup, and automatic-compaction exclusions.
+  classification, bridge-write fallback coordination, lifecycle cleanup, and
+  automatic-compaction exclusions.
 - Add `CodexGeneratedContextValidator` plus
   `CodexUserInteractionTracker`, then implement Codex, ACP/Cursor, and Claude
   authoritative emission rules.
 - Add bridge event ID translation and explicit no-public-wire mapping.
 - Test prompt, command, initial turn, manual compaction, manual answer/decision,
   auto approval, cancellation, synthetic continuation, overflow replay, and
-  duplicate-known-time behavior at the owning boundaries.
+  duplicate handling, backend clock rollback, and disconnect-between-acceptance-
+  and-SSE behavior at the owning boundaries.
 - No database, released wire, client, or user-visible behavior yet.
 
 **Changed-line target:** 1,050-1,500 lines. If complete production-plugin tests
@@ -573,12 +597,13 @@ localized.
 - Replace alphabetical running order with the effective-recency comparator.
 - Add `SessionListService.applyInteractionPatch` and `mergeRestSnapshot`; preserve
   max values across live patches, session updates, and in-flight REST
-  replacement while keeping the Cubit orchestration-only.
+  replacement. Extend `SessionUnseenTracker`'s existing list-state cache so an
+  initial-load patch is retained while keeping the Cubit orchestration-only.
 - Keep awaiting-only, inactive, archived, project, and child ordering behavior
   unchanged.
 - Add service/Cubit tests for marker order, null fallback, deterministic ties,
-  auto-update stability, live reordering, stale REST, old bridge payloads, and
-  project mismatch.
+  auto-update stability, live reordering, initial/in-flight stale REST, old
+  bridge payloads, and project mismatch.
 - Verify both mobile and desktop downstream analysis because both consume
   `module_core`, while noting the desktop shell has no catalog UI.
 
@@ -627,8 +652,8 @@ Step 2:
 - `OpenCodeUserInteractionTracker` tests: ordinary root prompt/file prompt,
   child-generated prompt exclusion, slash/subtask command, manual compaction,
   auto compaction, synthetic continuation, overflow replay, question
-  reply/reject, manual versus automatic permission, and bounded pending-state
-  cleanup.
+  reply/reject, manual versus automatic permission, bridge-write/raw one-fact
+  coordination, lost-SSE fallback, clock rollback, and bounded pending-state cleanup.
 - `CodexGeneratedContextValidator` and `CodexUserInteractionTracker` tests: one
   first-lifecycle user-item fact, generated-context exclusion, bounded terminal
   cleanup, ordinary command, explicit manual compact, generic context compaction

--- a/.plan/active/session-user-interaction-order/PLAN.md
+++ b/.plan/active/session-user-interaction-order/PLAN.md
@@ -32,11 +32,14 @@ The visible policy otherwise remains unchanged:
 
 "User-side activity" deliberately means the bridge's existing unseen-state
 marker, not perfect human-origin provenance. It advances for normalized user
-messages and manual question/permission replies, and it excludes permission
-replies consumed by bridge auto-approval before normal event routing. A backend
-that represents automatic compaction or other generated input as a user message
-can advance it. This is accepted for a low-impact running-list heuristic rather
-than adding per-plugin inference and correlation state.
+messages and question/permission reply or rejection events, and it excludes
+permission replies consumed by bridge auto-approval before normal event routing.
+Lifecycle cleanup also emits those normalized events when abort, thread close,
+process exit, or disposal cancels pending input, so that cleanup can advance the
+marker without a human reply. A backend that represents automatic compaction or
+other generated input as a user message can also advance it. These are accepted
+for a low-impact running-list heuristic rather than adding per-plugin inference
+and correlation state.
 
 ## Complexity Budget
 
@@ -44,7 +47,9 @@ The implementation must stay within all of these constraints:
 
 - no database column, schema migration, or backfill;
 - no new bridge or client long-lived mutable state;
-- no plugin API or production plugin change;
+- no plugin API, classifier, or behavioral plugin change; mechanical shared
+  `Session` constructor updates pass null where a plugin builds a pre-enrichment
+  event payload;
 - no dispatcher flag, operation hook, backend classifier, message correlation,
   dedupe collection, timer, lock, registry, or lifecycle owner;
 - one existing persisted scalar projected additively onto existing REST and SSE
@@ -67,6 +72,10 @@ If implementation exceeds this budget, stop and ask before adding machinery.
   the service's strictly monotonic local timestamp.
 - Permission auto-approval replies are consumed in `Orchestrator` before mapping
   and therefore do not advance the marker.
+- ACP abort/dispose cleanup, Codex thread-close cleanup, and Claude process-exit
+  cleanup emit ordinary normalized reply/rejection events so open clients retire
+  pending input. Those events currently advance the same marker and are part of
+  its accepted lifecycle semantics.
 - Root REST projections already read the stored row but currently expose only
   the derived `unseen` boolean. The existing `session.unseen_changed` event is
   emitted after each relevant marker write but also omits the timestamp.
@@ -102,6 +111,9 @@ the source provides.
   fields from old bridges decode as null.
 - Plugin-originated session DTOs remain unaware of the field; bridge enrichment
   adds the durable value after the normalized plugin boundary.
+- Existing ACP and Codex mappers that directly construct shared `Session`
+  payloads pass `lastUserActivityAt: null`. These are required mechanical
+  constructor updates only; plugins neither derive nor own the marker.
 
 No write path changes. Existing timestamp ordering, idempotence, auto-approval
 filtering, and persistence preservation remain authoritative.
@@ -133,8 +145,11 @@ business logic.
 map and passes it with the current activity map to `SessionListService`.
 Its tracker subscription must call `_emitFiltered` so a committed activity
 patch re-runs the comparator even when the session was already running and no
-separate status event follows. Replace the current unseen-only callback behavior;
-do not add another subscription or stream.
+separate status event follows. Retain the existing `SessionListLoaded` guard
+before calling `_emitFiltered`: the tracker's seeded `BehaviorSubject` replays
+during initial loading and must not replace the loading state with an empty
+loaded list. Replace only the current loaded-state unseen update after that
+guard; do not add another subscription or stream.
 
 `SessionListService.visibleSessions` keeps its existing partition. For running
 roots, compare:
@@ -169,6 +184,10 @@ No new route, event variant, capability, or compatibility shim is added.
 - Automatic compaction or generated backend input normalized as a user message
   can move a running session. The marker is explicitly user-side activity, not a
   proof of human intent.
+- Lifecycle-generated permission replies and question rejections used to clear
+  pending UI can move a running session after abort, thread close, process exit,
+  or disposal. They retain their existing unseen-routing semantics; this plan
+  does not add plugin-specific origin metadata to distinguish them.
 - Markers carrying backend event times are comparable only when those backends
   share a sufficiently aligned clock domain. A remote or clock-skewed backend
   can pin one running session above or below genuinely newer activity from
@@ -229,6 +248,8 @@ branch or worktree is created.
 - Add nullable `lastUserActivityAt` to shared `Session` and
   `session.unseen_changed`, then regenerate shared source.
 - Project `last_user_message_at` through bridge REST and post-write patch seams.
+- Add required null arguments to existing ACP/Codex shared `Session`
+  constructors without changing plugin behavior or marker ownership.
 - Replace the existing unseen tracker value with typed session-list state while
   retaining its one cache/tick/subscription lifecycle.
 - Replace alphabetical running order with activity recency and stable ties.
@@ -273,10 +294,13 @@ Automated proof:
 - bridge catalog/detail projections and committed unseen patches carry the
   existing marker without changing any write or unseen formula;
 - permission auto-approval remains filtered before marker routing;
+- lifecycle-generated reply/rejection events retain their documented activity
+  semantics and clear pending input without new provenance state;
 - tracker live max-merge, REST replacement, optimistic unseen update, initial
   load, and in-flight fetch behavior retain the latest marker;
 - a tracker patch while the target is already running immediately re-runs the
-  visible comparator without waiting for another status event or refresh;
+  visible comparator without waiting for another status event or refresh, while
+  the initial replay remains guarded until `SessionListLoaded`;
 - running comparator, null fallback, deterministic ties, and unchanged inactive,
   awaiting-only, archived, project, and child ordering; and
 - Git diff proves no schema/migration or production plugin change.
@@ -291,7 +315,9 @@ End-to-end proof:
 - a current app decoding an omitted marker fixture uses the documented fallback.
 
 No every-plugin live matrix is required. Existing plugin event normalization is
-not changed or newly claimed by this work.
+not changed or newly claimed by this work. Focused mapper analysis/tests cover
+the mechanical null constructor updates in packages that directly build shared
+`Session` payloads.
 
 ## Architecture Review History
 

--- a/.plan/active/session-user-interaction-order/PLAN.md
+++ b/.plan/active/session-user-interaction-order/PLAN.md
@@ -1,790 +1,298 @@
-# Running Session Interaction Order
+# Running Session User-Activity Order
 
 ## Status
 
 - **Plan slug:** `session-user-interaction-order`
-- **Status:** Reviewed plan - architecture findings applied and current main revalidated
+- **Status:** Simplified after product and history review
 - **Plan date:** 2026-08-13
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Implementation base:** `main` at `88059e200`
-- **Implementation branch:** `session-order-ux-review`
-- **Delivery:** one plan PR, four implementation PRs, one regression-documentation
-  PR, and one verification/retirement PR
+- **Implementation branch/worktree:** `session-order-ux-review`
+- **Delivery:** four PRs: plan, implementation, regression contract,
+  verification/retirement
 
-This document and `TRACKER.md` are the implementation authority for the series.
-The fixed split keeps the backend-specific provenance, durable bridge state,
-released wire compatibility, and client behavior independently reviewable.
+This revision supersedes the earlier seven-step plugin-classifier design and the
+intermediate proposal for a second persisted interaction timestamp. The existing
+`last_user_message_at` marker is adequate for this session-list heuristic once
+its current semantics are stated honestly.
 
 ## Goal
 
-Keep running root sessions promoted at the top of the project session list, but
-order that running prefix by the most recent genuine user interaction rather
-than alphabetically.
+Keep running root sessions promoted at the top of a project's session list, but
+order that running prefix by the bridge's latest recorded user-side activity
+instead of alphabetically.
 
-Interactions that advance recency are:
-
-- an accepted user prompt, including a prompt created directly in an observable
-  backend surface;
-- an accepted slash command;
-- a manual question answer, question rejection, or permission decision; and
-- manual context compaction.
-
-Automatic compaction, generated continuation/replay prompts, automatic
-permission approval, cancellation cleanup, assistant activity, tool activity,
-and title/catalog updates must not advance the marker.
-
-The visible policy remains otherwise unchanged:
+The visible policy otherwise remains unchanged:
 
 - running means `mainAgentRunning || isRetrying || backgroundTaskCount > 0`;
-- awaiting-input alone does not promote a session into the running prefix;
-- non-running sessions remain ordered by `Session.time.updated` descending;
+- awaiting-input alone does not promote a session;
+- inactive sessions remain ordered by `Session.time.updated` descending;
 - archived filtering remains unchanged; and
-- project ordering and the background-task child list do not change.
+- project and child-task ordering remain unchanged.
 
-## Success Criteria
+"User-side activity" deliberately means the bridge's existing unseen-state
+marker, not perfect human-origin provenance. It advances for normalized user
+messages and manual question/permission replies, and it excludes permission
+replies consumed by bridge auto-approval before normal event routing. A backend
+that represents automatic compaction or other generated input as a user message
+can advance it. This is accepted for a low-impact running-list heuristic rather
+than adding per-plugin inference and correlation state.
 
-1. Running root sessions with known interaction markers appear in descending
-   user-interaction recency, regardless of title.
-2. A prompt, command, manual answer/rejection/permission decision, or manual
-   compaction advances the displayed root session promptly without a list
-   refetch.
-3. Automatic OpenCode compaction, including its synthetic continuation and
-   overflow replay messages, does not advance recency.
-4. Sesori permission auto-approval and plugin cancellation/teardown replies do
-   not advance recency.
-5. Observable backend/laptop-originated user interactions advance recency when
-   the owning plugin can prove human provenance; unsupported external-process
-   cases remain unknown rather than guessed.
-6. Existing databases add a nullable `last_user_interaction_at` column without
-   backfilling polluted `last_user_message_at` or backend `updated_at` values.
-7. The marker is monotonic across duplicate events, reconnects, bridge restart,
-   and clock rollback, using existing ordered pipelines rather than a new lock
-   or registry. An accepted bridge-owned OpenCode write still records one fact
-   if its raw SSE envelope/part pair is lost during reconnect.
-8. REST session payloads and the existing `session.unseen_changed` live patch
-   carry the nullable marker additively. Old app/new bridge and new app/old
-   bridge combinations retain their current behavior.
-9. A stale REST or `session.updated` payload cannot replace a fresher live
-   marker, including when the patch arrives during the initial REST load.
-10. Sessions whose marker is absent use `time.updated` as the compatibility
-    fallback. Equal keys have a deterministic ID tie-breaker.
-11. No backend identifier, interaction kind, prompt text, command name,
-    transcript content, path, or entity identifier is added to analytics or a
-    new public event.
+## Complexity Budget
 
-## Current Behavior And Evidence
+The implementation must stay within all of these constraints:
 
-### Client ordering ownership
+- no database column, schema migration, or backfill;
+- no new bridge or client long-lived mutable state;
+- no plugin API or production plugin change;
+- no dispatcher flag, operation hook, backend classifier, message correlation,
+  dedupe collection, timer, lock, registry, or lifecycle owner;
+- one existing persisted scalar projected additively onto existing REST and SSE
+  shapes; and
+- one client running-prefix comparator, using existing activity and list-state
+  delivery.
 
-- `SessionListService.visibleSessions` partitions running sessions using
+If implementation exceeds this budget, stop and ask before adding machinery.
+
+## Current Behavior And History
+
+- `SessionListService.visibleSessions` partitions running roots using
   `SessionActivityCalculator.isRunning`, alphabetizes the running prefix, then
-  appends the remaining sessions sorted by `time.updated` descending
-  (`client/module_core/lib/src/services/session_list_service.dart`).
-- `SessionActivityCalculator` deliberately excludes `awaitingInput` alone from
-  running (`client/module_core/lib/src/services/session_activity_calculator.dart`).
-- `SessionListCubit` owns the complete unbounded project list, applies REST and
-  live session updates, and re-runs `visibleSessions` whenever activity changes
-  (`client/module_core/lib/src/cubits/session_list/session_list_cubit.dart`).
-- The in-repository client sends `start: null, limit: null` to `POST /sessions`
-  (`client/module_core/lib/src/api/project_api.dart`). Server pagination remains
-  an API capability but does not define this screen's visible order.
-- The background-task child list is separately sorted by `time.updated`
-  (`SessionDetailCubit._sortChildrenByUpdatedDesc`) and is not part of this
-  root-list change.
+  appends inactive sessions by `time.updated` descending.
+- Session rows already persist nullable `last_user_message_at`. The bridge's
+  ordered `SessionUnseenService` writes it from normalized user messages and
+  manual question/permission replies.
+- User-message events with known creation times are idempotent: re-emissions at
+  or before the stored marker are skipped. Replies without a payload time use
+  the service's strictly monotonic local timestamp.
+- Permission auto-approval replies are consumed in `Orchestrator` before mapping
+  and therefore do not advance the marker.
+- Root REST projections already read the stored row but currently expose only
+  the derived `unseen` boolean. The existing `session.unseen_changed` event is
+  emitted after each relevant marker write but also omits the timestamp.
+- `SessionUnseenTracker` already caches that list-state patch, including events
+  received while a session-list REST request is in flight, and owns the existing
+  per-project tick that prevents an older REST seed from replacing live state.
+- PR #474 (`578970ae3`) previously reused `last_user_message_at`, but coupled it
+  to a bridge-authored project/session ordering service, retry timer, summary
+  snapshots, and cross-layer order flags. PR #480 (`c302c5df3`) reverted that
+  entire pipeline to restore prior ordering. PR #482 (`ddfd6d1a6`) then
+  established the current simpler client-owned running prefix. The historical
+  problem was the oversized ordering pipeline, not the persisted scalar.
 
-### Existing bridge timestamps are not an interaction source
+## Design
 
-- `sessions_table.last_user_message_at` feeds released unseen-state behavior
-  (`SessionUnseenCalculator`) and is currently advanced by generic
-  user-shaped messages and question/permission reply events.
-- OpenCode represents both manual and automatic compaction as a user message.
-  `MessagePartMapper` intentionally renders both forms as `/compact`, so the
-  shared message shape no longer contains provenance.
-- OpenCode publishes `message.updated` before `message.part.updated`; only the
-  raw `CompactionPart.auto` on the later part distinguishes manual from
-  automatic compaction.
-- The generated OpenCode API models remain sourced from v1.17.7, while the
-  managed runtime is now pinned to v1.18.11. Revalidation against v1.18.11
-  confirms the same envelope-before-part order, `auto` provenance, synthetic
-  continuation, and overflow replay behavior used by this classifier.
-- OpenCode also creates synthetic user messages for compaction continuation,
-  plan-mode transitions, task-result injection, and shell bookkeeping. Overflow
-  compaction can replay an earlier user message with copied non-synthetic parts.
-- Existing released rows can therefore contain values unsuitable for ordering.
-  No valid historical backfill exists.
+### Reuse the existing marker
 
-### Existing seams can carry the new fact
+Expose the stored row's `lastUserMessageAt` as required nullable
+`lastUserActivityAt` on shared `Session` and the existing
+`SesoriSseEvent.sessionUnseenChanged` variant.
 
-- `BridgePluginApi.events` is the backend-neutral plugin boundary for live
-  backend facts (`bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart`).
-- `SessionEventDispatcher` and `OrchestratorSession._processPluginEventInOrder`
-  already preserve per-plugin event order and generation fencing.
-- `SessionEventMapper` translates backend session IDs to stable bridge IDs and
-  already supports a distinct display/root session for child questions and
-  permissions.
-- `SessionUnseenService` already serializes low-volume session-list timestamp
-  writes, owns a monotonic clock, persists `last_user_message_at`, and emits the
-  existing cross-cutting `session.unseen_changed` list-state patch after a
-  commit.
-- Shared JSON generation omits nullable values and accepts missing nullable
-  keys, which provides additive old/new peer compatibility.
+The product-facing name describes how the value is used without renaming the
+released database column or changing unseen semantics. Do not add the misleading
+`lastUserInteractionAt` name, which would imply stronger human provenance than
+the source provides.
 
-### History decisions
+- `SessionCatalogMapper` and stored enrichment map `lastUserMessageAt` into the
+  shared field for root/detail projections.
+- `SessionUnseenService` includes the row's committed marker in `UnseenChange`;
+  the orchestrator adds it to the existing patch.
+- Delete patches carry null because the row no longer exists.
+- Shared null omission keeps new-bridge/old-app payloads additive, and missing
+  fields from old bridges decode as null.
+- Plugin-originated session DTOs remain unaware of the field; bridge enrichment
+  adds the durable value after the normalized plugin boundary.
 
-- PR #474 introduced a broad bridge-authored project/session activity summary.
-- PR #480 reverted that pipeline.
-- PR #482 established the current client-owned running prefix and alphabetical
-  running order.
-- This plan transmits one timestamp fact and keeps ordering in the client. It
-  does not restore `ActiveWorkSummaryService` or bridge-authored list snapshots.
+No write path changes. Existing timestamp ordering, idempotence, auto-approval
+filtering, and persistence preservation remain authoritative.
 
-## Architecture
+### Extend the existing list-state cache
 
-### 1. Backend-neutral interaction fact
+Extend `SessionUnseenTracker`'s per-session value from a bare unseen boolean to a
+small typed list-state value carrying:
 
-Add one internal plugin event in
-`bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart`:
+- `unseen`; and
+- nullable `lastUserActivityAt`.
 
-```text
-BridgeSseSessionUserInteraction
-  sessionID: String
-  displaySessionId: String?
-  occurredAt: int?
-```
+This is not another cache or state machine. It replaces the value already stored
+under the same project/session maps and reuses the same stream, subscription,
+tick, seeding, optimistic unseen update, and disposal lifecycle.
 
-Contract:
+Live patches replace `unseen` and max-merge a non-null activity timestamp with
+the cached timestamp. REST seeding replaces project membership only when the
+existing tick guard permits it and seeds each session's timestamp from the
+fetched `Session`. A local mark-read/unread changes only `unseen`, retaining the
+cached activity timestamp.
 
-- The event means the plugin has authoritative evidence that a human
-  interaction was accepted or observed.
-- `sessionID` is the backend session that owns the interaction.
-- `displaySessionId` is the backend root session whose row should move when a
-  child request is surfaced under that root. Flat plugins use the same session
-  ID; null means the plugin cannot resolve a distinct display root.
-- `occurredAt` is milliseconds since epoch when the backend supplies a reliable
-  interaction timestamp; null asks bridge core to stamp acceptance/observation
-  time.
-- The event deliberately carries no interaction kind or content. Every accepted
-  kind has identical ordering semantics, and exposing more detail would add no
-  client decision value.
-- `BridgeEventMapper` maps it to no direct public SSE event. It is consumed by
-  bridge core after backend-to-stable ID translation.
+The two test fake implementations update in lockstep; no product shell owns
+business logic.
 
-Add a closed `PluginInteractionOrigin.manual/automatic` enum to the internal
-plugin interface and require it on `BridgePluginApi.replyToPermission`. The
-manual reply handler passes `manual`; `PermissionAutoApprovalService` passes
-`automatic`. Internal plugin contracts and all in-repository implementors update
-in lockstep; no compatibility shim or optional parameter is added.
+### Client ordering
 
-Question reply/rejection methods need no origin parameter because the only
-bridge-app callers are explicit user routes. Plugin cancellation and teardown
-paths remain separate and do not emit the interaction fact.
+`SessionListCubit` continues orchestrating only. It reads the current tracker
+map and passes it with the current activity map to `SessionListService`.
 
-`SessionEventMapper` translates both session identities. If either explicitly
-named backend ID has no durable binding, the existing pending-binding behavior
-holds or drops the event exactly like other session events. Persistence targets
-`displaySessionId ?? sessionID`; it does not walk ancestors, stamp both rows, or
-infer a family beyond the plugin's display attribution.
+`SessionListService.visibleSessions` keeps its existing partition. For running
+roots, compare:
 
-### 2. Plugin provenance rules
+1. `lastUserActivityAt ?? session.time?.updated ?? 0`, descending; and
+2. session ID ascending for deterministic ties.
 
-Every registered production plugin emits the same neutral event, but each owns
-its backend-specific evidence.
+For inactive roots, retain `time.updated` descending and add the same ID
+tie-breaker. A running session with no marker therefore has useful old-bridge
+and pre-activity behavior without requiring a backfill. Once it has a marker,
+assistant/tool/title updates do not move it because the comparator prefers the
+marker over `time.updated`.
 
-#### OpenCode
-
-Add `OpenCodeUserInteractionTracker` beside the existing OpenCode trackers. It
-owns the bounded message-envelope/part classifier, automatic-overflow
-suppression, bridge-write correlation, and all classifier lifecycle state.
-`OpenCodeService` composes it with the existing `ActiveSessionTracker`, which
-remains the sole parent/display graph owner; the interaction tracker receives
-resolved root attribution rather than depending on its tracker peer directly.
-
-`OpenCodePlugin._handleRawSseEvent` parses once, delegates the raw event to
-`OpenCodeService`, forwards any returned neutral interaction fact, then
-continues existing presentation mapping. The service updates its trackers and
-classifies before `SseEventMapper` erases raw part provenance. Prompt, command,
-create-session, reconnect, and disposal paths likewise delegate interaction
-coordination to the service rather than sequencing tracker peers in the plugin.
-
-The same tracker coordinates bridge-owned prompt/command acceptance by message
-identity. Generate an OpenCode-compatible message ID before dispatch and pass it
-through the existing optional `messageID` field on prompt and command payloads.
-The matching raw classification may satisfy that pending write first; successful
-API completion emits a null-timestamp fallback only when that exact message ID
-was not observed. Failed acceptance emits no fallback. A laptop-originated
-message cannot consume a Sesori write. This produces one fact in the ordinary
-path while covering the real disconnect window where OpenCode accepted the
-write but its envelope or part was lost before the fresh non-replaying SSE
-connection. Initial create-session turns use the same correlation after the
-backend session ID is known.
-
-- Keep at most one pending user envelope and one most-recently classified
-  message ID per session. The latter rejects an immediate duplicate complete
-  envelope/part delivery after the pending envelope was consumed. State remains
-  bounded by known sessions, not transcript length.
-- A later part classifies only the matching pending envelope.
-- A root-session non-synthetic text/file/subtask prompt records one interaction.
-  A child user prompt is not counted because OpenCode creates those for agent
-  task sessions and Sesori exposes child detail as read-only.
-- `CompactionPart(auto: false)` records one manual interaction.
-- `CompactionPart(auto: true)` records none.
-- Synthetic text parts record none. This excludes auto-compaction continuation,
-  plan-mode transitions, background-result injection, and shell bookkeeping.
-- For automatic overflow compaction, suppress the next replay/continuation user
-  envelope. Clear suppression when consumed or when compaction/status terminal
-  evidence proves no replay remains, so a failed compaction cannot suppress a
-  later genuine prompt.
-- A bridge-owned manual compact is one action. Its optional instruction prompt
-  receives the correlated message ID and is marked as compact guidance so its
-  raw text part cannot emit independently. Summarize has no upstream caller-ID,
-  so no raw compaction can authoritatively satisfy its bridge fallback. Emit the
-  fallback for every accepted bridge compact; raw manual compactions remain
-  independent observable facts. This may produce duplicate same-session
-  evidence for one bridge compact, but cannot lose the accepted bridge action or
-  misattribute a concurrent laptop compact. Exact coalescing waits for upstream
-  summarize identity rather than guessing by timing.
-- Remove pending/suppression state when the tracker observes session deletion;
-  call its `reset` from the existing OpenCode reconnect/reset path and its
-  `dispose` during plugin disposal. Do not add a transcript-sized dedupe set;
-  one envelope is consumed once, the last classified ID rejects immediate
-  duplicate delivery, and correlated bridge-write coordination emits at most
-  one fact for its accepted action.
-- Raw `question.replied` and `question.rejected` events are authoritative and
-  cover laptop replies. Bridge calls coordinate by request ID and emit a
-  successful-call fallback only when the exact raw event was not observed. A
-  reconciled 404 returns not-accepted and emits no fallback.
-- Raw `permission.replied` is not authoritative: OpenCode emits the same event
-  for `always` cascades. Emit one fact only from a successful manual
-  `replyToPermission` 2xx outcome; a reconciled 404 returns not-accepted and
-  emits none. Direct laptop permission decisions remain unknown.
-
-This design relies on OpenCode's observed and generated API ordering:
-`message.updated` precedes its parts. It does not add a timer, delayed flush,
-history read, or content comparison for a theoretical reversed sequence.
-OpenCode facts use null `occurredAt`: interaction order is acceptance/observation
-order, and bridge stamping remains monotonic even when the backend clock rolls
-back. Other plugins may provide a known timestamp only where replay identity and
-clock semantics make it authoritative.
-
-#### Codex
-
-- Add `CodexUserInteractionTracker` as the plugin-local owner of app-server user
-  item provenance. `CodexPlugin` delegates notifications and terminal lifecycle
-  signals to it and forwards returned neutral facts; `CodexEventMapper` remains
-  a presentation mapper.
-- The tracker emits once from the first app-server `userMessage` item lifecycle
-  observation; that typed item is the authoritative prompt/command boundary and
-  also covers another observable Codex surface. It keeps only in-flight
-  `(threadId, itemId)` keys plus one latest completed item ID per thread:
-  `item/started` emits and records, `item/completed` removes and emits only if no
-  start or matching completion was observed. Turn terminal, thread delete,
-  reconnect/reset, and disposal clear remaining keys. Do not emit again from
-  `sendPrompt` or an ordinary `sendCommand` response.
-- Extract the existing private generated repository/context test into one pure
-  `CodexGeneratedContextValidator`. Inject that required dependency into both
-  `CodexUserInteractionTracker` and `CodexMessageRepository`; do not duplicate
-  wrapper strings or expose them outside the Codex plugin.
-- A successful `thread/compact/start` call emits one manual-compaction fact.
-  Generic `contextCompaction` notifications carry no manual/automatic origin and
-  emit no fact.
-- Successful registry question/permission methods emit facts only for explicit
-  manual calls. `cancelForSession` remains a no-fact cleanup path.
-- The tracker accepts notification, manual-compact, and manual-registry triggers;
-  `CodexPlugin` only delegates and forwards returned facts.
-- App-server user items have no reliable message timestamp, so these events use
-  null `occurredAt` and bridge observation time.
-
-#### Cursor / ACP
-
-- Emit after the existing prompt/command acceptance gate and for a non-empty
-  initial create-session turn.
-- Cursor's public `compact` command is counted once after acceptance even though
-  the adapter rewrites it to the backend `summarize` command.
-- Emit after successful manual registry answers/decisions; abort/dispose
-  cancellation emits no fact.
-- ACP drops backend `user_message_chunk` echoes and the bridge owns a separate
-  process, so interactions made in another laptop process are not observable and
-  remain unknown.
-
-#### Claude
-
-- Emit after `_enqueue` accepts a prompt/command and for a non-empty initial
-  create-session turn. A manually sent `/compact` is therefore counted as a
-  command.
-- Emit after successful manual registry answers/decisions; cancellation and
-  disposal emit no fact.
-- Do not infer interaction from generic Claude user frames, which can represent
-  internal tool-result/context traffic.
-- Separate laptop Claude CLI transcripts are not live-tailed by this plugin, so
-  those interactions remain unknown.
-
-OMP inherits the ACP implementation but is not registered in the production
-bridge at the plan date. Pi has protocol primitives but no `BridgePluginApi`
-implementation and is also excluded until registration. If registration changes
-before execution, re-evaluate the production matrix rather than hard-coding this
-historical list.
-
-### 3. Durable marker and monotonic write
-
-Add nullable `lastUserInteractionAt` to `SessionTable`/`SessionDto` and bump the
-Drift schema from v13 to v14.
-
-- The v13-to-v14 migration only adds the nullable column.
-- Existing rows remain null. Neither `last_user_message_at` nor `updated_at` is
-  an honest baseline.
-- Preserve the v13 snapshot and generate a new v14 schema snapshot, migration
-  steps, generated database source, and migration helper. Never hand-edit
-  generated files.
-- Catalog import/upsert preserves an existing marker and leaves new imported
-  rows null until an authoritative live fact arrives.
-- Existing session projection updates and placeholder/create UPSERTs omit the
-  column so they cannot erase it.
-
-Extend `SessionUnseenRepository`/`SessionUnseenService` rather than adding a
-parallel timestamp repository, service, stream, or lock. They already own the
-persisted user marker, monotonic timestamp source, ordered write tail, and
-session-list state patch.
-
-`recordUserInteraction` behavior:
-
-1. read the named stable session row;
-2. no-op if it does not exist;
-3. for a known `occurredAt`, no-op when it is not newer than the stored marker;
-4. for a null timestamp, stamp `max(local monotonic now, stored + 1)` so a new
-   accepted action still advances after clock rollback/restart;
-5. update only `last_user_interaction_at` with a conditional/monotonic DAO
-   write; and
-6. emit the committed session-list patch.
-
-This does not alter `last_activity_at`, `last_seen_at`, `last_user_message_at`,
-or the unseen formula. Generic message/reply unseen routing stays in place for
-released behavior, even where historical user-shaped backend events are broader
-than the new marker. Update the `lastUserMessageAt` comment to state that it is
-an unseen-specific legacy marker and must not be reused as authoritative
-interaction recency.
-
-The ordinary reachable duplicate/replay flow justifies monotonic persistence.
-No new cross-plugin queue, per-session mutex, event journal, or reconciliation
-job is needed because existing per-plugin processing and the global low-volume
-timestamp write tail already serialize the relevant operations.
-
-### 4. Additive REST and live transport
-
-Add `required int? lastUserInteractionAt` to the shared `Session` model and map
-the persisted field through every bridge catalog/detail/child/live session
-projection:
-
-- `SessionCatalogMapper` for database-only roots and children;
-- `PluginSessionMapper.enrichSharedSession` for plugin-enriched payloads; and
-- all direct `Session` construction call sites required by generated analysis.
-
-Add the same required nullable property to the existing
-`SesoriSseEvent.sessionUnseenChanged` variant. Update its documentation and the
-bridge `UnseenChange` typedef to describe a session-list state patch carrying
-unseen state plus interaction recency.
-
-- Every post-row patch carries the committed marker.
-- Delete patches carry null.
-- Old apps ignore the extra REST/SSE key.
-- New apps decode omission from old bridges as null.
-- Null values remain omitted by shared JSON generation.
-- Use dated compatibility comments with the actual release target at
-  implementation time.
-
-Do not create a dedicated public interaction event. Reusing the existing
-post-commit list-state patch avoids a second ordering relationship and unknown
-event behavior in older clients while keeping the internal provenance fact out
-of the released protocol.
-
-Do not change `Session.time.updated`, DAO root ordering, or session-list indexes.
-The client owns the activity-aware visible order and fetches the complete list.
-Changing server pagination would not be sufficient because the server query
-does not own live running state, and no current in-repository list consumer uses
-paged roots.
-
-### 5. Client merge and comparator
-
-`SessionListService` remains the sole visible-order policy owner.
-
-For running sessions, compare:
-
-1. effective interaction recency descending, where
-   `lastUserInteractionAt ?? time.updated ?? 0`;
-2. a known interaction marker before an unknown marker when effective keys are
-   equal;
-3. session ID ascending as a deterministic final tie-breaker.
-
-The `time.updated` fallback preserves useful behavior with old bridges and
-pre-migration sessions. Once a verified marker exists, later automatic backend
-updates cannot move that session because the comparator uses the marker instead.
-
-For non-running sessions, keep `time.updated` descending and add only the same
-deterministic ID tie-breaker. Do not change `SessionActivityCalculator`, project
-ordering, or child-task ordering.
-
-`SessionListService` owns every marker transformation:
-
-- `applyInteractionPatch` locates an already-held session and max-merges the
-  nullable live marker without manufacturing a missing session;
-- `applySessionUpdatedEvent` keeps the greater existing/new interaction marker
-  alongside its current PR metadata merge; and
-- `mergeRestSnapshot` treats fetched membership and ordinary fields as
-  authoritative while max-merging markers from matching sessions already held
-  and from the cached marker map supplied by the Cubit, so an in-flight or
-  initial fetch cannot roll back a live patch.
-
-`SessionListCubit` only validates the SSE project/state, delegates
-`SesoriSessionUnseenChanged` to `applyInteractionPatch`, delegates successful
-REST replacement to `mergeRestSnapshot`, and re-runs `visibleSessions`.
-`SessionUnseenTracker` remains the live list-state cache: extend its existing
-per-project tick and session map to retain the nullable marker from
-`SesoriSessionUnseenChanged` alongside unseen state. It performs no ordering or
-merge decision; `SessionListService` consumes its cached marker map. This reuses
-the tracker that already receives patches before a list Cubit is loaded rather
-than adding another long-lived owner. The Cubit reads that map and passes it to
-the service; peer Layer-3 collaborators do not depend on each other.
-
-No new long-lived tracker, Cubit generation, tick map, or optimistic interaction
-state is required. Bridge markers are monotonic, so a per-session max at the two
-existing merge seams is sufficient.
+Do not add optimistic interaction timestamps on send acceptance. The normalized
+event and existing patch are the authority; the list reorders when that event is
+committed, and reconnect/refresh self-heals a missed patch.
 
 ## Compatibility
 
-### Wire
+- **New bridge, old app:** extra nullable keys on known REST/SSE shapes are
+  ignored; that app retains its current alphabetical running order.
+- **Old bridge, new app:** omitted fields decode to null and running order falls
+  back to `time.updated`.
+- **Existing databases:** no migration; every current marker remains intact.
+- **Internal packages:** shared, bridge, and clients update together; no plugin
+  contract changes.
 
-- **New bridge, old app:** extra nullable properties on known REST/SSE shapes are
-  ignored; current updated-time/alphabetical behavior remains in that app.
-- **Old bridge, new app:** missing properties decode to null and running order
-  falls back to `time.updated`.
-- **New plugin fact, old app:** the internal fact never reaches the wire.
-- No request field, route, capability negotiation, or new public SSE variant is
-  added.
+No new route, event variant, capability, or compatibility shim is added.
 
-### Database
+## Accepted Limitations
 
-- Stable released databases migrate v13 to v14 by adding a nullable column.
-- No historical interaction is manufactured.
-- Existing unseen columns and values remain intact.
-- If another schema version lands on `main` before implementation, preserve it
-  and move this migration/snapshot to the next available version rather than
-  rewriting merged history.
+- Automatic compaction or generated backend input normalized as a user message
+  can move a running session. The marker is explicitly user-side activity, not a
+  proof of human intent.
+- Direct laptop/backend activity counts only when the backend exposes it through
+  the existing normalized user-message/reply events. No effort is made to infer
+  activity a bridge-owned process cannot observe.
+- A new app connected to an old bridge, and a session whose marker is still
+  null, falls back to `time.updated`.
+- A patch missed across disconnect reorders on the next relevant event or list
+  refresh; no replay repair or optimistic timestamp is added.
+- Server-paged third-party root requests retain server order. The current app
+  fetches the complete project list and owns activity-aware visible order.
 
-### Internal APIs
-
-- `BridgePluginApi` and plugin packages have no out-of-repository consumers and
-  update together. The new required permission origin has no fallback or shim.
-
-## Scope And Non-Goals
-
-- Do not restore `ActiveWorkSummaryService`, bridge-authored session ordering,
-  or project ordering by session activity.
-- Do not infer genuine interaction from `Session.time.updated`, generic shared
-  `MessageUser`, command completion, assistant output, tool output, session
-  status, or title changes when an authoritative marker is available.
-- Do not backfill the new column from existing timestamps or transcript history.
-- Do not redesign unseen state or clean polluted historical
-  `last_user_message_at` values.
-- Do not add live tailing to Claude/ACP processes or make unobservable laptop
-  interactions appear supported.
-- Do not add locks, timers, ancestry walks, content hashes, event journals,
-  background repair, server-side active sorting, or pagination/index changes.
-- Do not change child-session presentation or make child detail writable.
-- Do not add analytics. There is no product decision, reporting model, or
-  privacy-safe aggregate that requires tracking this ordering behavior; the
-  authoritative event would also risk turning session activity into telemetry.
-
-## Evidence And Accepted Risk
-
-| Concern | Evidence class | Planned safeguard / accepted behavior |
-|---|---|---|
-| Automatic compaction looks user-authored | Observed backend behavior | Classify raw OpenCode parts before mapping; test auto, continuation, and overflow replay |
-| Auto-approved/cancelled replies look manual | Ordinary reachable flow | Required permission origin plus manual-only plugin fact emission; cancellation methods emit no fact |
-| Duplicate OpenCode envelope/part delivery | Ordinary transport duplicate | Retain one most-recent classified message ID per session and consume each pending envelope once |
-| Accepted OpenCode write loses SSE pair | Ordinary disconnect window | Correlate with caller-supplied message ID and emit one successful null-time fallback only when that exact raw message did not satisfy it |
-| Concurrent laptop and Sesori writes | First-class multi-surface flow | Correlate pending bridge action by message ID; unrelated raw facts emit independently and cannot satisfy it |
-| Manual compact with instructions | Ordinary compact command flow | Mark guidance non-emitting; accepted bridge compact always emits fallback; raw compact remains independent until upstream exposes identity |
-| OpenCode reply disconnect/reconciliation | Ordinary race flow | Request-ID fallback for accepted questions; reconciled question/permission 404 emits no fact |
-| Backend clock rollback | Ordinary clock-adjustment flow | OpenCode uses null occurred-at and bridge monotonic stamping; known times remain only for authoritative plugin sources |
-| REST/SSE replacement race | Ordinary initial/in-flight refresh flow | Existing unseen tracker retains the patch; service maxes it at client replacement seams |
-| Reversed OpenCode message/part order | Theoretical against current upstream order | Accepted; no timer or history lookup. Missing one reorder self-heals on the next genuine interaction |
-| Direct laptop interaction in a separate ACP/Claude process | Unobservable by current architecture | Accepted limitation; keep marker unchanged rather than guess |
-| Direct OpenCode permission decision | Event cannot distinguish one choice from `always` cascade | Accepted limitation; only Sesori manual decisions count until upstream adds provenance |
-| Bridge OpenCode compact also arrives raw | Summarize exposes no caller identity | Accept duplicate same-session evidence rather than lose or misattribute either concurrent surface; remove when upstream identity exists |
-| Existing null markers after migration | Required honest migration state | Fall back to `time.updated` until the first authoritative interaction |
-| Paged third-party root requests | No current in-repository consumer and server lacks running state | Keep existing server order; visible app fetch remains complete and client-owned |
+These are bounded list-order effects with natural refresh recovery. They do not
+justify new persistence, classifier state, or cross-plugin coordination.
 
 ## Cleanup Assessment
 
-Directly caused cleanup:
+- Remove `_compareSessionsByTitleAndId` and replace alphabetical-running tests.
+- Update `session.unseen_changed` and tracker documentation to describe their
+  complete session-list state payload.
+- Keep `last_user_message_at`, its existing write logic, unseen calculations,
+  and persistence tests unchanged; they remain required production behavior.
+- Do not restore `ActiveWorkSummaryService`, `userInteractionOrdered`, project
+  reordering, or any prototype plugin event/origin changes.
 
-- remove `_compareSessionsByTitleAndId` and the alphabetical-running-order tests
-  replaced by the recency comparator;
-- correct the `lastUserMessageAt` documentation so future work does not treat it
-  as authoritative interaction provenance; and
-- update `session.unseen_changed` naming documentation from unseen-only to the
-  cross-cutting session-list patch it becomes.
-
-Retained intentionally:
-
-- `last_user_message_at`, generic user-message unseen routing, and current
-  unseen tests remain required by released persisted unseen behavior;
-- `time.updated` remains the inactive order and compatibility fallback;
-- existing activity-summary and child-task calculations remain required; and
-- no larger obsolete service, cache, setting, job, or transport field is created
-  by this change.
+No other service, cache, field, setting, job, or transport variant becomes
+obsolete.
 
 ## Delivery Plan
 
-All steps use the existing `session-order-ux-review` branch/worktree. Before each
-implementation PR, synchronize with current `main` and preserve any schema
-versions already merged. Do not create another branch or worktree for this
-series.
+All steps use the existing `session-order-ux-review` branch/worktree. No extra
+branch or worktree is created.
 
-### Step 1/7 - Plan
+### Step 1/4 - Plan
 
 **Exact PR title:**
-`🌱 [session-user-interaction-order] docs: plan running session interaction order [step 1/7]`
+`🌱 [session-user-interaction-order] docs: simplify running session activity order [step 1/4]`
 
-- Add this plan and tracker.
-- Record architecture review findings and direct corrections.
-- Validate exact titles, fixed denominator, scope, and `git diff --check`.
-- No production, generated, database, wire, or user-visible change.
-
-**Changed-line target:** 550-1,050 documentation lines.
-
-### Step 2/7 - Authoritative plugin facts
-
-**Exact PR title:**
-`🚧 [session-user-interaction-order] feat(plugins): report genuine user interactions [step 2/7]`
-
-- Add the internal interaction event and required permission origin enum.
-- Update every registered plugin and all app/plugin call sites in lockstep.
-- Add `OpenCodeUserInteractionTracker` and implement pending-envelope
-  classification, message-ID-correlated bridge-write fallback, manual-compaction
-  coalescing, lifecycle cleanup, and automatic-compaction exclusions. Compose
-  it under `OpenCodeService` with resolved display attribution.
-- Add `CodexGeneratedContextValidator` plus
-  `CodexUserInteractionTracker`, then implement Codex, ACP/Cursor, and Claude
-  authoritative emission rules.
-- Add bridge event ID translation and explicit no-public-wire mapping.
-- Test prompt, command, initial turn, manual compaction, manual answer/decision,
-  auto approval, cancellation, synthetic continuation, overflow replay, and
-  duplicate handling, concurrent laptop/Sesori writes, instructed compaction,
-  backend clock rollback, and disconnect-between-acceptance-and-SSE behavior at
-  the owning boundaries.
-- No database, released wire, client, or user-visible behavior yet.
-
-**Changed-line target:** 1,050-1,500 lines. If complete production-plugin tests
-would exceed the soft cap, split test-only follow-up is not acceptable because
-the contract must land verified; update the target with measured generated-free
-scope before opening the PR.
-
-### Step 3/7 - Persist interaction recency
-
-**Exact PR title:**
-`🚧 [session-user-interaction-order] feat(bridge): persist session interaction recency [step 3/7]`
-
-- Add the nullable Drift column and next schema migration with no backfill.
-- Generate schema snapshot, steps, database source, and migration helpers.
-- Preserve markers through catalog import and all session projection UPSERTs.
-- Extend the existing unseen repository/service with the monotonic
-  post-translation write and consume internal facts in the orchestrator.
-- Keep existing unseen timestamps/formula unchanged.
-- Test migration structure/null baseline, preservation, root/display
-  attribution, missing rows, known-time duplicate/no-regression, null-time clock
-  rollback, and auto-generated no-fact paths.
-- No released wire or client behavior yet.
-
-**Changed-line target:** 4,500-6,500 lines, explicitly above the 1,500-line soft
-cap because the required new Drift v14 JSON snapshot and generated Dart schema
-helper are additive files of several thousand lines. Hand-editing, omitting, or
-separating those generated migration artifacts would leave the persisted change
-unreviewable or invalid; non-generated production/test scope should remain
-localized.
-
-### Step 4/7 - Transport the marker
-
-**Exact PR title:**
-`⚙️ [session-user-interaction-order] feat(protocol): publish session interaction recency [step 4/7]`
-
-- Add the nullable shared `Session` and `session.unseen_changed` properties with
-  dated compatibility comments.
-- Regenerate shared Freezed/JSON source.
-- Map REST/detail/child/live session projections and post-commit list patches.
-- Verify null omission, missing-field decode, old/new peer behavior, delete null,
-  and committed-value delivery.
-- No ordering change in the client yet; old clients remain unaffected.
-
-**Changed-line target:** 700-1,300 lines including generated source and tests.
-
-### Step 5/7 - Apply client ordering
-
-**Exact PR title:**
-`⚙️ [session-user-interaction-order] feat(client): order running sessions by interaction [step 5/7]`
-
-- Replace alphabetical running order with the effective-recency comparator.
-- Add `SessionListService.applyInteractionPatch` and `mergeRestSnapshot`; preserve
-  max values across live patches, session updates, and in-flight REST
-  replacement. Extend `SessionUnseenTracker`'s existing list-state cache so an
-  initial-load patch is retained while keeping the Cubit orchestration-only.
-- Keep awaiting-only, inactive, archived, project, and child ordering behavior
-  unchanged.
-- Add service/Cubit tests for marker order, null fallback, deterministic ties,
-  auto-update stability, live reordering, initial/in-flight stale REST, old
-  bridge payloads, and project mismatch.
-- Verify both mobile and desktop downstream analysis because both consume
-  `module_core`, while noting the desktop shell has no catalog UI.
-
-**Changed-line target:** 350-750 lines.
-
-### Step 6/7 - Regression contract
-
-**Exact PR title:**
-`🌱 [session-user-interaction-order] docs: define session interaction order coverage [step 6/7]`
-
-- Reconcile `docs/regression/projects-and-sessions.md` with the root running
-  order, live marker, null fallback, and compatibility behavior.
-- Reconcile `docs/regression/session-turns.md` with genuine interaction
-  provenance, manual compaction, and automatic/cancellation exclusions.
-- Record the final registered-plugin and platform matrix discovered from the
-  implemented code.
+- Publish this revised plan and tracker.
+- Update the plan-maker skill to require existing-state/history inspection and
+  explicit mutable-part budgeting.
+- Record why the seven-step classifier design and second-scalar proposal were
+  superseded.
 - No production, database, wire, generated, or user-visible change.
 
-**Changed-line target:** 50-180 lines.
+**Changed-line target:** 350-650 documentation lines.
 
-### Step 7/7 - Verify and retire
+### Step 2/4 - Coherent implementation
 
 **Exact PR title:**
-`🌱 [session-user-interaction-order] docs: verify and retire interaction ordering [step 7/7]`
+`⚙️ [session-user-interaction-order] feat: order running sessions by user activity [step 2/4]`
 
-- Run the recorded L3 cumulative regression level through the matrix below.
-- Record automated and live/client evidence, limitations, versions, and cleanup
-  in the tracker without prompts, transcripts, paths, raw IDs, or logs.
-- Run final relevant analysis/tests only where the evidence changed since each
-  implementation PR; do not rerun an unchanged passing matrix for confidence.
-- Move the plan directory from `.plan/active/` to `.plan/completed/` only when
-  every required boundary passes. Partial, blocked, failed, or reduced coverage
-  keeps the plan active unless the user explicitly accepts and records a matrix
-  reduction.
+- Add nullable `lastUserActivityAt` to shared `Session` and
+  `session.unseen_changed`, then regenerate shared source.
+- Project `last_user_message_at` through bridge REST and post-write patch seams.
+- Replace the existing unseen tracker value with typed session-list state while
+  retaining its one cache/tick/subscription lifecycle.
+- Replace alphabetical running order with activity recency and stable ties.
+- Test additive JSON, bridge projections/patches, tracker retention, initial and
+  in-flight REST behavior, comparator fallback, and unchanged inactive/activity
+  policy.
+- Verify there is no database schema or production plugin diff.
+
+This is one coherent PR because transport without a consumer or a comparator
+without the bridge fact would be dead intermediate behavior. Generated shared
+source is expected; no Drift generation occurs.
+
+### Step 3/4 - Regression contract
+
+**Exact PR title:**
+`🌱 [session-user-interaction-order] docs: define running session activity coverage [step 3/4]`
+
+- Update `docs/regression/projects-and-sessions.md` with running-root activity
+  ordering, null fallback, live patching, and accepted generated-input semantics.
+- Update `docs/regression/session-turns.md` and
+  `docs/regression/questions-and-permissions.md` only where needed to identify
+  the existing normalized actions feeding the marker and auto-approval exclusion.
 - No production, database, wire, generated, or new user-visible change.
 
-**Changed-line target:** 60-220 documentation lines.
+### Step 4/4 - Verify and retire
 
-## Verification Plan
+**Exact PR title:**
+`🌱 [session-user-interaction-order] docs: verify and retire session activity ordering [step 4/4]`
 
-### Focused automated verification
+- Run cumulative L3 coverage below.
+- Record privacy-safe evidence and accepted limitations.
+- Move the plan to `.plan/completed/` only after required coverage passes.
 
-Step 2:
+## Verification
 
-- `sesori_plugin_interface`: strict analysis and exhaustive event switches.
-- `OpenCodeUserInteractionTracker` tests: ordinary root prompt/file prompt,
-  child-generated prompt exclusion, slash/subtask command, manual compaction,
-  auto compaction, synthetic continuation, overflow replay, question
-  reply/reject, manual versus automatic permission, message-ID-correlated
-  write/raw one-fact coordination, unrelated concurrent
-  laptop writes, immediate duplicate delivery, instructed-compaction
-  fallback, request-ID reply fallback, reconciled permission 404, clock rollback,
-  and bounded pending-state cleanup.
-- `CodexGeneratedContextValidator` and `CodexUserInteractionTracker` tests: one
-  first-lifecycle user-item fact, generated-context exclusion, duplicate
-  completion rejection, bounded terminal cleanup, ordinary command, explicit
-  manual compact, generic context compaction exclusion, manual registry replies,
-  and cancellation exclusion.
-- ACP/Cursor and Claude tests: accepted/failed prompt and command, initial turn,
-  compact mapping, manual reply, cancellation/disposal exclusion.
-- Bridge app mapper tests: backend/stable IDs and display-root translation; no
-  public mapping.
+**Highest required level:** L3 Release, cumulative through L1/L2.
 
-Step 3:
+Automated proof:
 
-- Drift v13-to-v14 migration tests and schema validation.
-- DAO/repository/service tests for null baseline, preservation, monotonic writes,
-  missing rows, display-root targeting, and post-commit patch emission.
-- Orchestrator event processing test proving the internal fact persists but is
-  not directly enqueued as a wire event.
+- shared `Session` and known SSE event omit null on encode and accept omission on
+  decode;
+- bridge catalog/detail projections and committed unseen patches carry the
+  existing marker without changing any write or unseen formula;
+- permission auto-approval remains filtered before marker routing;
+- tracker live max-merge, REST replacement, optimistic unseen update, initial
+  load, and in-flight fetch behavior retain the latest marker;
+- running comparator, null fallback, deterministic ties, and unchanged inactive,
+  awaiting-only, archived, project, and child ordering; and
+- Git diff proves no schema/migration or production plugin change.
 
-Step 4:
+End-to-end proof:
 
-- Shared model round-trip and omitted-field compatibility tests.
-- Bridge catalog/detail/child/session-update mapper and route tests.
-- Existing unseen-change tests extended to assert the committed nullable marker.
+- one release-target phone and bridge host;
+- one representative registered plugin, because ordering starts after the
+  existing normalized event boundary and no plugin changes;
+- two running roots reorder after user-side activity while an awaiting-only root
+  is not promoted and inactive rows retain updated-time order; and
+- a current app decoding an omitted marker fixture uses the documented fallback.
 
-Step 5:
+No every-plugin live matrix is required. Existing plugin event normalization is
+not changed or newly claimed by this work.
 
-- `client/module_core/test/services/session_list_service_test.dart`.
-- `client/module_core/test/cubits/session_list/session_list_cubit_test.dart`.
-- Focused connection/SSE parsing tests for the additive known-event property.
-- `dart analyze` in shared, changed bridge packages, `module_core`, mobile app,
-  and desktop shell as applicable.
+## Architecture Review History
 
-### Regression level and proof boundaries
+The initial seven-step plan received architecture review and then accumulated
+plugin-specific classifiers, correlation state, dedupe, reconnect handling, and
+an every-plugin matrix. The user rejected that direction on 2026-08-13 because
+the coordination machinery outweighed the list-ordering behavior.
 
-**Highest required level:** L3 Release, cumulative through L1 and L2.
-
-The behavior has independent proof boundaries:
-
-- **Automated:** plugin provenance classification, migration/persistence,
-  additive JSON compatibility, monotonic merge, and deterministic comparator.
-- **Live plugin:** real backend prompt/command/manual-compaction behavior and
-  automatic-compaction exclusion where supported.
-- **Client end to end:** a phone observes multiple running root sessions reorder
-  after genuine interactions while inactive/awaiting-only rows retain policy.
-
-### Required matrix
-
-- **Plugins:** every supporting registered production plugin at execution time.
-  At plan time: OpenCode, Codex, Cursor, and Claude.
-- **Interaction capabilities:** prompt and command for each plugin; manual
-  compaction and question/permission response where supported; automatic
-  compaction/auto-approval/cancellation exclusions where the plugin exposes
-  those flows.
-- **Backend-originated coverage:** OpenCode and Codex where the attached backend
-  stream can authoritatively observe another surface; ACP/Cursor and Claude are
-  explicitly limited to the bridge-owned process.
-- **Client platform:** one release-target phone platform for L3. The desktop
-  shell has no catalog surface, but downstream compile/analyze remains required.
-- **Bridge host:** one release-target host; no host-specific ordering claim.
-- **Peer compatibility:** current app with a pre-marker bridge fixture and
-  current bridge payload with a pre-marker app decoder/fixture where available.
-
-Any reduction to this matrix requires explicit user acceptance recorded here
-before retirement.
-
-## Expected PR Review Summaries
-
-Every implementation PR body must include the repository-required sections.
-Use these review focuses rather than duplicating the whole plan:
-
-- **Step 2 complexity:** complex - backend-specific provenance across the shared
-  plugin boundary, especially OpenCode compaction ordering.
-- **Step 2 risk/test focus:** false recency from generated messages, duplicate
-  facts, permission auto paths, and plugin lifecycle cleanup. No database or
-  released-wire impact; no user-visible change yet.
-- **Step 3 complexity:** complex - persisted nullable state, migration/codegen,
-  ordered event consumption, and monotonicity.
-- **Step 3 risk/test focus:** schema preservation, no dishonest backfill,
-  display-root attribution, and not changing unseen behavior. Database impact:
-  one nullable column; no user-visible change yet.
-- **Step 4 complexity:** moderate - additive shared REST/SSE contract and bridge
-  projections.
-- **Step 4 risk/test focus:** mixed-version decode/encode, null omission, and
-  committed-value delivery. No visible ordering change until Step 5.
-- **Step 5 complexity:** moderate - client ordering plus live/REST race-safe
-  merge.
-- **Step 5 risk/test focus:** running-prefix policy, fallback behavior, no churn,
-  and no project/child/inactive regression. User-visible impact: running sessions
-  reorder by genuine interaction.
-
-## Architecture Review
-
-- **Reviewer:** `architecture-plan-review`
-- **Reviewed scope:** complete `.plan/active/session-user-interaction-order/`
-  against current plugin, bridge, shared, database, and client architecture
-- **Initial verdict:** rejected with three actionable ownership findings
-- **Findings applied:** moved OpenCode classifier state from the top-level plugin
-  into `OpenCodeUserInteractionTracker`; named `CodexUserInteractionTracker` and
-  one shared `CodexGeneratedContextValidator` with bounded lifecycle; moved live
-  patch and REST max-merge policy from `SessionListCubit` into
-  `SessionListService`
-- **Re-review:** not run; repository policy applies valid concrete findings
-  directly without a second review merely to approve the corrections
+The first simplification removed plugin logic but introduced a second persisted
+scalar and bridge operation hooks. A subsequent history/data-flow audit found
+that PR #474 had already demonstrated reuse of `last_user_message_at`, and that
+current code still owns and maintains that field independently of the reverted
+ordering pipeline. This revision therefore removes the second scalar and all
+operation hooks. A fresh `architecture-plan-review` approved this revision on
+2026-08-13 with no findings. It confirmed bridge repository/service ownership,
+orchestrator SSE projection, existing tracker lifecycle ownership, client
+comparator ownership, and additive shared-wire compatibility.

--- a/.plan/active/session-user-interaction-order/PLAN.md
+++ b/.plan/active/session-user-interaction-order/PLAN.md
@@ -237,9 +237,12 @@ backend session ID is known.
 - A bridge-owned manual compact is one action. Its optional instruction prompt
   receives the correlated message ID and is marked as compact guidance so its
   raw text part cannot emit independently. Summarize has no upstream caller-ID,
-  so raw manual compactions never consume its bridge fallback. Emit that
-  fallback only when no raw manual compact was observed during the bridge call;
-  concurrent laptop compaction therefore cannot suppress a lost bridge fact.
+  so no raw compaction can authoritatively satisfy its bridge fallback. Emit the
+  fallback for every accepted bridge compact; raw manual compactions remain
+  independent observable facts. This may produce duplicate same-session
+  evidence for one bridge compact, but cannot lose the accepted bridge action or
+  misattribute a concurrent laptop compact. Exact coalescing waits for upstream
+  summarize identity rather than guessing by timing.
 - Remove pending/suppression state when the tracker observes session deletion;
   call its `reset` from the existing OpenCode reconnect/reset path and its
   `dispose` during plugin disposal. Do not add a transcript-sized dedupe set;
@@ -248,7 +251,8 @@ backend session ID is known.
   one fact for its accepted action.
 - Raw `question.replied` and `question.rejected` events are authoritative and
   cover laptop replies. Bridge calls coordinate by request ID and emit a
-  successful-call fallback only when the exact raw event was not observed.
+  successful-call fallback only when the exact raw event was not observed. A
+  reconciled 404 returns not-accepted and emits no fallback.
 - Raw `permission.replied` is not authoritative: OpenCode emits the same event
   for `always` cascades. Emit one fact only from a successful manual
   `replyToPermission` 2xx outcome; a reconciled 404 returns not-accepted and
@@ -426,8 +430,8 @@ ordering, or child-task ordering.
   alongside its current PR metadata merge; and
 - `mergeRestSnapshot` treats fetched membership and ordinary fields as
   authoritative while max-merging markers from matching sessions already held
-  and from the existing `SessionUnseenTracker`, so an in-flight or initial fetch
-  cannot roll back a live patch.
+  and from the cached marker map supplied by the Cubit, so an in-flight or
+  initial fetch cannot roll back a live patch.
 
 `SessionListCubit` only validates the SSE project/state, delegates
 `SesoriSessionUnseenChanged` to `applyInteractionPatch`, delegates successful
@@ -437,7 +441,8 @@ per-project tick and session map to retain the nullable marker from
 `SesoriSessionUnseenChanged` alongside unseen state. It performs no ordering or
 merge decision; `SessionListService` consumes its cached marker map. This reuses
 the tracker that already receives patches before a list Cubit is loaded rather
-than adding another long-lived owner.
+than adding another long-lived owner. The Cubit reads that map and passes it to
+the service; peer Layer-3 collaborators do not depend on each other.
 
 No new long-lived tracker, Cubit generation, tick map, or optimistic interaction
 state is required. Bridge markers are monotonic, so a per-session max at the two
@@ -497,13 +502,14 @@ existing merge seams is sufficient.
 | Duplicate OpenCode envelope/part delivery | Ordinary transport duplicate | Retain one most-recent classified message ID per session and consume each pending envelope once |
 | Accepted OpenCode write loses SSE pair | Ordinary disconnect window | Correlate with caller-supplied message ID and emit one successful null-time fallback only when that exact raw message did not satisfy it |
 | Concurrent laptop and Sesori writes | First-class multi-surface flow | Correlate pending bridge action by message ID; unrelated raw facts emit independently and cannot satisfy it |
-| Manual compact with instructions | Ordinary compact command flow | Mark guidance non-emitting; raw compact cannot consume fallback; fallback only when no raw compact was observed during the call |
-| OpenCode reply disconnect/reconciliation | Ordinary race flow | Request-ID fallback for accepted questions; reconciled permission 404 emits no fact |
+| Manual compact with instructions | Ordinary compact command flow | Mark guidance non-emitting; accepted bridge compact always emits fallback; raw compact remains independent until upstream exposes identity |
+| OpenCode reply disconnect/reconciliation | Ordinary race flow | Request-ID fallback for accepted questions; reconciled question/permission 404 emits no fact |
 | Backend clock rollback | Ordinary clock-adjustment flow | OpenCode uses null occurred-at and bridge monotonic stamping; known times remain only for authoritative plugin sources |
 | REST/SSE replacement race | Ordinary initial/in-flight refresh flow | Existing unseen tracker retains the patch; service maxes it at client replacement seams |
 | Reversed OpenCode message/part order | Theoretical against current upstream order | Accepted; no timer or history lookup. Missing one reorder self-heals on the next genuine interaction |
 | Direct laptop interaction in a separate ACP/Claude process | Unobservable by current architecture | Accepted limitation; keep marker unchanged rather than guess |
 | Direct OpenCode permission decision | Event cannot distinguish one choice from `always` cascade | Accepted limitation; only Sesori manual decisions count until upstream adds provenance |
+| Bridge OpenCode compact also arrives raw | Summarize exposes no caller identity | Accept duplicate same-session evidence rather than lose or misattribute either concurrent surface; remove when upstream identity exists |
 | Existing null markers after migration | Required honest migration state | Fall back to `time.updated` until the first authoritative interaction |
 | Paged third-party root requests | No current in-repository consumer and server lacks running state | Keep existing server order; visible app fetch remains complete and client-owned |
 

--- a/.plan/active/session-user-interaction-order/PLAN.md
+++ b/.plan/active/session-user-interaction-order/PLAN.md
@@ -131,6 +131,10 @@ business logic.
 
 `SessionListCubit` continues orchestrating only. It reads the current tracker
 map and passes it with the current activity map to `SessionListService`.
+Its tracker subscription must call `_emitFiltered` so a committed activity
+patch re-runs the comparator even when the session was already running and no
+separate status event follows. Replace the current unseen-only callback behavior;
+do not add another subscription or stream.
 
 `SessionListService.visibleSessions` keeps its existing partition. For running
 roots, compare:
@@ -165,6 +169,13 @@ No new route, event variant, capability, or compatibility shim is added.
 - Automatic compaction or generated backend input normalized as a user message
   can move a running session. The marker is explicitly user-side activity, not a
   proof of human intent.
+- Markers carrying backend event times are comparable only when those backends
+  share a sufficiently aligned clock domain. A remote or clock-skewed backend
+  can pin one running session above or below genuinely newer activity from
+  another clock domain. Existing within-session clamping protects unseen state,
+  not cross-session chronology. This bounded ordering limitation is accepted
+  instead of adding a second bridge-observation scalar or changing released
+  unseen timestamp semantics.
 - Direct laptop/backend activity counts only when the backend exposes it through
   the existing normalized user-message/reply events. No effort is made to infer
   activity a bridge-owned process cannot observe.
@@ -264,6 +275,8 @@ Automated proof:
 - permission auto-approval remains filtered before marker routing;
 - tracker live max-merge, REST replacement, optimistic unseen update, initial
   load, and in-flight fetch behavior retain the latest marker;
+- a tracker patch while the target is already running immediately re-runs the
+  visible comparator without waiting for another status event or refresh;
 - running comparator, null fallback, deterministic ties, and unchanged inactive,
   awaiting-only, archived, project, and child ordering; and
 - Git diff proves no schema/migration or production plugin change.

--- a/.plan/active/session-user-interaction-order/TRACKER.md
+++ b/.plan/active/session-user-interaction-order/TRACKER.md
@@ -1,4 +1,4 @@
-# Running Session Interaction Order: Tracker
+# Running Session User-Activity Order: Tracker
 
 ## Current State
 
@@ -6,241 +6,125 @@
 - **Implementation base:** `main` at `88059e200`
 - **Branch/worktree:** `session-order-ux-review`
 - **Plan PR:** [#865](https://github.com/sesori-ai/sesori_apps_monorepo/pull/865)
-- **Series state:** Step 1/7 in review; no implementation published
-- **Current step:** 1/7 open; Step 2/7 beginning locally
-- **Next action:** monitor Step 1 and implement authoritative plugin facts locally
-- **Source changes:** none
-- **Tests run:** none
+- **Series state:** Step 1/4 rewritten around existing persisted state
+- **Current step:** 1/4 in review; no production source published
+- **Next action:** publish revised plan/skill and update PR #865
+- **Production source changes published:** none
 
-## Locked Product Behavior
+## Simplicity Contract
+
+- [x] Zero new database columns or migrations.
+- [x] Zero plugin API or production plugin changes.
+- [x] Zero dispatcher flags or bridge operation hooks.
+- [x] Zero classifiers, correlation maps, dedupe collections, timers, locks,
+  registries, or new lifecycle owners.
+- [x] Reuse `last_user_message_at`, the existing unseen patch/cache/tick, and the
+  existing client activity partition.
+- [x] Name the transported fact `lastUserActivityAt`, not the stronger and
+  misleading `lastUserInteractionAt`.
+- [x] Accept generated user-side backend input as a bounded ordering heuristic.
+- [x] Any implementation breach of this contract requires user approval.
+
+## Locked Behavior
 
 - [x] Running roots remain promoted.
-- [x] Running means main-agent busy, retry, or at least one background task;
-  awaiting-input alone remains non-running.
-- [x] Running roots order by genuine interaction recency, not title.
-- [x] Prompt, slash command, manual answer/decision, and manual compaction count.
-- [x] Automatic compaction, generated continuation/replay, auto approval,
-  cancellation, assistant/tool/title activity do not count.
-- [x] Null markers fall back to `time.updated` for old bridges and migrated rows.
-- [x] Non-running, project, and child-task ordering remain unchanged.
-- [x] The client owns visible ordering; the bridge transmits timestamp facts.
-- [x] No analytics event is added.
-
-## Architecture Decisions
-
-- [x] One internal `BridgeSseSessionUserInteraction` fact carries backend
-  session, optional display root, and optional occurred-at timestamp.
-- [x] One required manual/automatic permission origin updates all internal
-  plugin implementors in lockstep.
-- [x] `OpenCodeUserInteractionTracker` owns raw message/part classifier state
-  before compaction provenance is erased, coordinates message-ID-correlated
-  bridge-write fallback under `OpenCodeService`, coalesces manual compact
-  guidance, and uses bridge monotonic observation time; the top-level plugin
-  delegates once.
-- [x] `CodexUserInteractionTracker` owns bounded first-user-item observation and
-  shares one `CodexGeneratedContextValidator` with history mapping; ACP/Cursor
-  and Claude use their accepted bridge-owned write paths.
-- [x] New nullable `last_user_interaction_at`; no backfill.
-- [x] Existing ordered plugin-event processing and unseen timestamp write tail
-  are reused; no new lock, tracker service, or bridge ordering snapshot.
-- [x] Existing `session.unseen_changed` becomes the additive post-commit
-  session-list patch; no new public SSE variant.
-- [x] `SessionListService` owns live/session-update/REST marker max merges;
-  `SessionUnseenTracker` retains initial-load patches and the Cubit only
-  validates, delegates, and emits.
-- [x] Existing unseen semantics and `last_user_message_at` are retained.
-
-## Accepted Limitations
-
-- [x] Direct laptop OpenCode permission replies are unknown because upstream
-  does not distinguish one manual decision from an `always` cascade.
-- [x] OpenCode summarize exposes no caller identity; an accepted bridge compact
-  always emits its fallback while raw manual compacts remain independent, so
-  duplicate same-session evidence is accepted rather than misattributing a
-  concurrent surface.
-- [x] Separate ACP/Cursor and Claude laptop processes are not observable by the
-  bridge-owned process.
-- [x] A theoretical OpenCode part-before-envelope sequence can miss one marker;
-  no timer/history lookup is added against current upstream ordering.
-- [x] Existing migrated rows remain null until a new authoritative interaction
-  and use updated-time fallback meanwhile.
-- [x] Server-paged root responses retain updated-time order; the current app
-  fetches the complete list and owns activity-aware visible order.
+- [x] Running means main-agent busy, retry, or background task; awaiting-only is
+  not running.
+- [x] Running roots order by existing user-side activity recency, then ID.
+- [x] Null marker falls back to `time.updated`.
+- [x] Inactive roots remain ordered by `time.updated`, then ID.
+- [x] Archived filtering and project/child ordering remain unchanged.
+- [x] Auto-approved permission replies remain excluded by current orchestrator
+  filtering.
+- [x] Automatic compaction/generated input can count when normalized as a user
+  message; no plugin inference is added.
+- [x] No analytics event.
 
 ## Delivery Steps
 
-| Done | Step | Exact PR title | Changed-line target | State |
-|---|---|---|---:|---|
-| [ ] | 1/7 | `🌱 [session-user-interaction-order] docs: plan running session interaction order [step 1/7]` | 550-1,050 | [PR #865](https://github.com/sesori-ai/sesori_apps_monorepo/pull/865) open |
-| [ ] | 2/7 | `🚧 [session-user-interaction-order] feat(plugins): report genuine user interactions [step 2/7]` | 1,050-1,500 | Pending |
-| [ ] | 3/7 | `🚧 [session-user-interaction-order] feat(bridge): persist session interaction recency [step 3/7]` | 4,500-6,500; generated migration cap exception | Pending |
-| [ ] | 4/7 | `⚙️ [session-user-interaction-order] feat(protocol): publish session interaction recency [step 4/7]` | 700-1,300 | Pending |
-| [ ] | 5/7 | `⚙️ [session-user-interaction-order] feat(client): order running sessions by interaction [step 5/7]` | 350-750 | Pending |
-| [ ] | 6/7 | `🌱 [session-user-interaction-order] docs: define session interaction order coverage [step 6/7]` | 50-180 | Pending |
-| [ ] | 7/7 | `🌱 [session-user-interaction-order] docs: verify and retire interaction ordering [step 7/7]` | 60-220 | Pending |
+| Done | Step | Exact PR title | State |
+|---|---|---|---|
+| [ ] | 1/4 | `🌱 [session-user-interaction-order] docs: simplify running session activity order [step 1/4]` | [PR #865](https://github.com/sesori-ai/sesori_apps_monorepo/pull/865) open; rewritten |
+| [ ] | 2/4 | `⚙️ [session-user-interaction-order] feat: order running sessions by user activity [step 2/4]` | Pending |
+| [ ] | 3/4 | `🌱 [session-user-interaction-order] docs: define running session activity coverage [step 3/4]` | Pending |
+| [ ] | 4/4 | `🌱 [session-user-interaction-order] docs: verify and retire session activity ordering [step 4/4]` | Pending |
 
 ## Step 1 Checklist
 
-- [x] Trace current client list ownership and running definition.
-- [x] Trace persisted unseen/user-message timestamps and prove they are unsafe
-  for ordering.
-- [x] Inspect OpenCode message/part and compaction ordering, including synthetic
-  continuation and overflow replay.
-- [x] Inspect all registered production plugin write/reply paths.
-- [x] Define additive REST/live compatibility and honest null migration.
-- [x] Define deterministic client fallback and merge behavior.
-- [x] Record cleanup, accepted limitations, L3 proof boundaries, and matrix.
-- [x] Fix exact seven-step titles and line targets.
-- [x] Run architecture plan review and apply valid findings.
-- [x] Run `git diff --check` and plan/tracker consistency validation.
-- [x] Commit, push, and open the Step 1 PR for the confirmed reviewed series.
+- [x] Trace current running-prefix ownership and live list update seams.
+- [x] Audit every write and projection of `last_user_message_at`.
+- [x] Inspect PRs #474, #480, and #482 and identify the reverted complexity.
+- [x] Confirm auto-approved permission replies are filtered before unseen routing.
+- [x] Supersede the seven-step plugin-classifier design.
+- [x] Supersede the second-scalar/dispatcher-hook proposal.
+- [x] Define a four-step, zero-new-state implementation and accepted semantics.
+- [x] Update plan-maker guidance with existing-state/history inspection.
+- [x] Run fresh architecture plan review and apply valid findings.
+- [x] Validate plan/tracker consistency and whitespace.
+- [ ] Commit, push, update PR #865 title/body, and resolve superseded discussion.
 
 ## Step 2 Checklist
 
-- [ ] Add typed internal interaction event and permission origin.
-- [ ] Update OpenCode, Codex, ACP/Cursor, Claude, bridge call sites, and test
-  fakes in lockstep.
-- [ ] Add `OpenCodeUserInteractionTracker` with bounded envelope/part classifier
-  message-ID-correlated bridge-write fallback coordination, compact coalescing,
-  and lifecycle cleanup under `OpenCodeService`.
-- [ ] Add `CodexGeneratedContextValidator` and bounded
-  `CodexUserInteractionTracker`; inject the validator into history mapping.
-- [ ] Route all Codex triggers through the tracker and reject duplicate completed
-  item notifications.
-- [ ] Prove automatic compaction continuation/overflow replay exclusions.
-- [ ] Prove one fact across ordinary raw delivery, lost-SSE fallback, and backend
-  clock rollback.
-- [ ] Prove concurrent laptop/Sesori writes cannot cross-satisfy, instructed
-  compact fallback always records acceptance, and immediate complete-message
-  duplicates are rejected.
-- [ ] Prove request-ID question fallback and reconciled question/permission 404
-  exclusion.
-- [ ] Prove manual versus automatic/cancelled reply behavior.
-- [ ] Prove internal event ID/display-root translation and no public wire event.
-- [ ] Run focused plugin/interface/app tests and strict analysis.
-- [ ] Run architecture implementation review.
+- [ ] Discard the stashed plugin event/origin prototype; do not restore it.
+- [ ] Add nullable `lastUserActivityAt` to shared `Session` and the existing
+  list-state patch; regenerate source.
+- [ ] Map existing persisted markers through bridge REST/detail and patch seams.
+- [ ] Replace tracker boolean values with typed unseen/activity list state while
+  retaining its existing cache, tick, subscription, and lifecycle.
+- [ ] Preserve marker values across live max-merge, REST seeding, and optimistic
+  unseen updates.
+- [ ] Replace alphabetical running order with activity/fallback recency and IDs.
+- [ ] Prove unchanged inactive, awaiting-only, archived, project, child, and
+  auto-approval behavior.
+- [ ] Prove no schema/migration or production plugin diff.
+- [ ] Run focused analysis/tests and architecture implementation review.
 
 ## Step 3 Checklist
 
-- [ ] Rebase schema version on current `main` without rewriting merged versions.
-- [ ] Add nullable column and no-backfill migration.
-- [ ] Generate all Drift snapshots/steps/source/helpers.
-- [ ] Preserve marker in import/projection/create paths.
-- [ ] Add monotonic repository/service write through existing ordered tail.
-- [ ] Consume translated facts without changing unseen formula or markers.
-- [ ] Test migration, null baseline, preservation, attribution, duplicates, and
-  clock rollback.
-- [ ] Run strict bridge app analysis/tests and architecture implementation review.
+- [ ] Update projects/sessions regression behavior and L3 exercise.
+- [ ] Reconcile turns and questions/permissions with existing marker inputs and
+  auto-approval exclusion without claiming perfect human provenance.
+- [ ] Record representative-plugin scope and generated-input limitation.
+- [ ] Validate documentation consistency and whitespace.
 
 ## Step 4 Checklist
 
-- [ ] Add required nullable shared REST and known-SSE properties with dated
-  compatibility comments.
-- [ ] Regenerate shared source.
-- [ ] Map root/detail/child/live projections and post-commit patches.
-- [ ] Test omitted null, missing old field, old/new peers, and delete null.
-- [ ] Run shared/bridge tests, strict analysis, and architecture implementation
-  review.
+- [ ] Run cumulative L3 automated and phone/bridge coverage.
+- [ ] Record omitted-marker fallback and live reorder evidence.
+- [ ] Keep plan active for partial/blocked/failed coverage unless explicitly
+  accepted by the user.
+- [ ] Move plan to `.plan/completed/` only after required coverage passes.
 
-## Step 5 Checklist
+## Decision Log
 
-- [ ] Replace alphabetical running comparator with effective interaction
-  recency and deterministic ties.
-- [ ] Preserve inactive, awaiting-only, archived, project, and child policies.
-- [ ] Add `SessionListService.applyInteractionPatch` and consume live marker
-  patches through it.
-- [ ] Extend `SessionUnseenTracker` to retain marker patches across initial load.
-- [ ] Add `SessionListService.mergeRestSnapshot` and max-merge session updates
-  at the service boundary.
-- [ ] Test new/old bridge, live reorder, stale fetch, auto-update stability, and
-  project mismatch.
-- [ ] Run module_core tests/analyze and affected mobile/desktop downstream
-  validation.
-- [ ] Run architecture implementation review.
-
-## Step 6 Checklist
-
-- [ ] Update `projects-and-sessions.md`.
-- [ ] Update `session-turns.md`.
-- [ ] Reconfirm registered plugin/platform matrix from production code.
-- [ ] Validate documentation consistency and `git diff --check`.
-
-## Step 7 Checklist
-
-- [ ] Run cumulative L3 coverage at automated, live-plugin, and phone boundaries.
-- [ ] Cover every supporting registered plugin and capability in the recorded
-  matrix.
-- [ ] Record privacy-safe evidence, versions, limitations, and cleanup.
-- [ ] Keep plan active for partial/blocked/failed coverage unless the user
-  explicitly accepts a reduction.
-- [ ] Move `.plan/active/session-user-interaction-order/` to `.plan/completed/`
-  only after required coverage passes.
-
-## Architecture Review
-
-- **Reviewer:** `architecture-plan-review`
-- **Reviewed scope:** complete `.plan/active/session-user-interaction-order/`
-  against current plugin, bridge, shared, database, and client architecture
-- **Initial verdict:** rejected with three actionable ownership findings
-- **Findings applied:** `OpenCodeUserInteractionTracker` now owns OpenCode
-  classifier state; `CodexUserInteractionTracker` plus one
-  `CodexGeneratedContextValidator` own Codex provenance; `SessionListService`
-  now owns all marker merge transformations
-- **Re-review:** not run; valid concrete findings were applied directly per
-  repository policy
+- **2026-08-13 initial plan:** seven steps with plugin facts, OpenCode/Codex
+  classifiers, permission-origin contract, per-plugin mutable state, a new
+  database marker, transport, client, regression, and retirement.
+- **2026-08-13 user complexity review:** user rejected plugin-specific code and
+  many mutable failure points for list ordering.
+- **2026-08-13 first simplification:** narrowed the promise to Sesori-owned
+  successful actions but still proposed a second scalar and dispatcher/create
+  hooks.
+- **2026-08-13 history audit:** PR #474 had already used
+  `last_user_message_at`; PR #480 reverted its bridge ordering service and
+  project-wide pipeline, not the underlying scalar. PR #482 established the
+  client-owned running prefix used today.
+- **2026-08-13 final simplification:** reuse the existing marker and current
+  list-state delivery. Accept its broader user-side-activity semantics rather
+  than recreating perfect origin provenance.
 
 ## Verification Log
 
-- **2026-08-13 discovery:** worktree clean on `session-order-ux-review`; no source
-  edits or tests before plan creation.
-- **2026-08-13 planning:** repository instructions, current client/bridge/shared
-  flow, registered plugins, generated OpenCode v1.17.7 models, upstream OpenCode
-  compaction implementation, relevant PR history, and regression contracts
-  inspected.
-- **2026-08-13 architecture review:** initial draft rejected on three concrete
-  ownership gaps. All were applied directly; no product scope, compatibility,
-  migration, PR lifecycle, or regression-matrix finding remained.
-- **2026-08-13 plan validation:** exact slug, seven-step denominator, titles,
-  ordering, line targets, architecture record, regression matrix, and cleanup
-  agree between plan and tracker. Both new files passed no-index whitespace
-  validation before publication. No Dart/Flutter suite was run for this
-  documentation-only work.
-- **2026-08-13 main refresh:** fast-forwarded the required branch/worktree from
-  `ec479cef5` to `88059e200`. Schema v13, the four-plugin registry, client running
-  comparator, and plan ownership seams remain unchanged. The bundled OpenCode
-  runtime advanced to v1.18.11; its source retains envelope-before-part
-  compaction events, manual/automatic provenance, synthetic continuation, and
-  overflow replay. Main's attachment-mapping and regression-copy changes do not
-  alter this plan. No architecture re-review was needed because no architecture
-  or product decision changed.
-- **2026-08-13 Step 1 publication:** committed the 929-line plan as `4be4705ce`,
-  pushed `session-order-ux-review`, and opened [PR #865](https://github.com/sesori-ai/sesori_apps_monorepo/pull/865).
-  The PR is mergeable and CI started successfully. Qodo reported only that its
-  review is pending; Cursor Bugbot reported its own usage limit, with no code or
-  plan finding.
-- **2026-08-13 Step 1 review:** accepted three concrete race/clock findings.
-  OpenCode now coordinates bridge-write fallback with raw observation and uses
-  bridge monotonic time; the existing unseen tracker retains marker patches
-  through initial REST load. The stale tracker-state finding was already fixed
-  in `c8aed9ee5`. Against merge base `88059e200`,
-  `git diff --numstat $(git merge-base origin/main HEAD) -- .plan/active/session-user-interaction-order/PLAN.md .plan/active/session-user-interaction-order/TRACKER.md`
-  reports PLAN `+790/-0` and TRACKER `+246/-0`, totaling `+1,036/-0` within the
-  revised 550-1,050 target. The same range passes
-  `git diff --check $(git merge-base origin/main HEAD) -- .plan/active/session-user-interaction-order/PLAN.md .plan/active/session-user-interaction-order/TRACKER.md`.
-- **2026-08-13 Step 1 second review:** consolidated four OpenCode comments at
-  their shared correlation seam. Upstream prompt and command payloads accept a
-  caller-supplied `messageID`; the service-owned tracker now uses it for exact
-  bridge-write/raw correlation, instructed-compaction coalescing, and bounded
-  immediate-duplicate rejection. Declined a broad unseen-owner rename because
-  those existing classes still own unseen behavior and only reuse their ordered
-  timestamp persistence seam; they do not become owners of the complete session
-  list-state invariant.
-- **2026-08-13 Step 1 third review:** clarified summarize's no-caller-ID
-  boundary, question fallback, permission 404 exclusion, Codex completion
-  idempotency/coordinator ownership, and stable equal-known-marker ties. The
-  repeated unseen-owner rename remains declined.
-- **2026-08-13 final bot follow-up:** recorded the honest summarize limitation:
-  accepted bridge compact fallback is unconditional and raw compacts remain
-  independent until upstream provides identity. Also excluded reconciled
-  question 404s and kept Layer-3 peers independent by having the Cubit pass the
-  tracker's cached marker map into `SessionListService`.
+- Original PR #865 was CI-green and bot-approved before redesign; the
+  `ready-for-human-review` label was withdrawn after the user's complexity
+  objection.
+- Current audit confirmed the worktree has only plan/tracker/skill edits; the
+  obsolete Step 2 plugin prototype remains isolated in stash
+  `wip step 2 before simplification redesign` and must not be restored.
+- No Dart/Flutter suite is required for this documentation/skill-only Step 1.
+- Repository skill changes require an OpenCode restart before this running
+  session consumes the updated instructions.
+- Fresh `architecture-plan-review` approved the zero-new-state revision with no
+  findings. It confirmed bridge repository/service ownership, orchestrator SSE
+  projection, existing tracker lifecycle ownership, client comparator
+  ownership, and additive shared-wire compatibility.

--- a/.plan/active/session-user-interaction-order/TRACKER.md
+++ b/.plan/active/session-user-interaction-order/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `session-user-interaction-order`
 - **Implementation base:** `main` at `88059e200`
 - **Branch/worktree:** `session-order-ux-review`
-- **Series state:** Reviewed plan; three architecture findings applied; current
-  main revalidated; no implementation started
-- **Current step:** 1/7 ready for publication
-- **Next action:** commit, push, and open the Step 1 plan PR
+- **Plan PR:** [#865](https://github.com/sesori-ai/sesori_apps_monorepo/pull/865)
+- **Series state:** Step 1/7 in review; no implementation published
+- **Current step:** 1/7 open; Step 2/7 beginning locally
+- **Next action:** monitor Step 1 and implement authoritative plugin facts locally
 - **Source changes:** none
 - **Tests run:** none
 
@@ -63,7 +63,7 @@
 
 | Done | Step | Exact PR title | Changed-line target | State |
 |---|---|---|---:|---|
-| [ ] | 1/7 | `🌱 [session-user-interaction-order] docs: plan running session interaction order [step 1/7]` | 550-950 | Reviewed and validated locally |
+| [ ] | 1/7 | `🌱 [session-user-interaction-order] docs: plan running session interaction order [step 1/7]` | 550-950 | [PR #865](https://github.com/sesori-ai/sesori_apps_monorepo/pull/865) open |
 | [ ] | 2/7 | `🚧 [session-user-interaction-order] feat(plugins): report genuine user interactions [step 2/7]` | 1,050-1,500 | Pending |
 | [ ] | 3/7 | `🚧 [session-user-interaction-order] feat(bridge): persist session interaction recency [step 3/7]` | 4,500-6,500; generated migration cap exception | Pending |
 | [ ] | 4/7 | `⚙️ [session-user-interaction-order] feat(protocol): publish session interaction recency [step 4/7]` | 700-1,300 | Pending |
@@ -85,7 +85,7 @@
 - [x] Fix exact seven-step titles and line targets.
 - [x] Run architecture plan review and apply valid findings.
 - [x] Run `git diff --check` and plan/tracker consistency validation.
-- [ ] Commit, push, and open the Step 1 PR for the confirmed reviewed series.
+- [x] Commit, push, and open the Step 1 PR for the confirmed reviewed series.
 
 ## Step 2 Checklist
 
@@ -194,3 +194,8 @@
   overflow replay. Main's attachment-mapping and regression-copy changes do not
   alter this plan. No architecture re-review was needed because no architecture
   or product decision changed.
+- **2026-08-13 Step 1 publication:** committed the 929-line plan as `4be4705ce`,
+  pushed `session-order-ux-review`, and opened [PR #865](https://github.com/sesori-ai/sesori_apps_monorepo/pull/865).
+  The PR is mergeable and CI started successfully. Qodo reported only that its
+  review is pending; Cursor Bugbot reported its own usage limit, with no code or
+  plan finding.

--- a/.plan/active/session-user-interaction-order/TRACKER.md
+++ b/.plan/active/session-user-interaction-order/TRACKER.md
@@ -33,9 +33,10 @@
 - [x] One required manual/automatic permission origin updates all internal
   plugin implementors in lockstep.
 - [x] `OpenCodeUserInteractionTracker` owns raw message/part classifier state
-  before compaction provenance is erased, coordinates one-fact bridge-write
-  fallback, and uses bridge monotonic observation time; the top-level plugin
-  delegates.
+  before compaction provenance is erased, coordinates message-ID-correlated
+  bridge-write fallback under `OpenCodeService`, coalesces manual compact
+  guidance, and uses bridge monotonic observation time; the top-level plugin
+  delegates once.
 - [x] `CodexUserInteractionTracker` owns bounded first-user-item observation and
   shares one `CodexGeneratedContextValidator` with history mapping; ACP/Cursor
   and Claude use their accepted bridge-owned write paths.
@@ -96,12 +97,15 @@
 - [ ] Update OpenCode, Codex, ACP/Cursor, Claude, bridge call sites, and test
   fakes in lockstep.
 - [ ] Add `OpenCodeUserInteractionTracker` with bounded envelope/part classifier
-  bridge-write fallback coordination, and lifecycle cleanup.
+  message-ID-correlated bridge-write fallback coordination, compact coalescing,
+  and lifecycle cleanup under `OpenCodeService`.
 - [ ] Add `CodexGeneratedContextValidator` and bounded
   `CodexUserInteractionTracker`; inject the validator into history mapping.
 - [ ] Prove automatic compaction continuation/overflow replay exclusions.
 - [ ] Prove one fact across ordinary raw delivery, lost-SSE fallback, and backend
   clock rollback.
+- [ ] Prove concurrent laptop/Sesori writes cannot cross-satisfy, instructed
+  compact emits once, and immediate complete-message duplicates are rejected.
 - [ ] Prove manual versus automatic/cancelled reply behavior.
 - [ ] Prove internal event ID/display-root translation and no public wire event.
 - [ ] Run focused plugin/interface/app tests and strict analysis.
@@ -211,6 +215,14 @@
   through initial REST load. The stale tracker-state finding was already fixed
   in `c8aed9ee5`. Against merge base `88059e200`,
   `git diff --numstat $(git merge-base origin/main HEAD) -- .plan/active/session-user-interaction-order/PLAN.md .plan/active/session-user-interaction-order/TRACKER.md`
-  reports PLAN `+758/-0` and TRACKER `+216/-0`, totaling `+974/-0` within the
+  reports PLAN `+777/-0` and TRACKER `+228/-0`, totaling `+1,005/-0` within the
   revised 550-1,050 target. The same range passes
   `git diff --check $(git merge-base origin/main HEAD) -- .plan/active/session-user-interaction-order/PLAN.md .plan/active/session-user-interaction-order/TRACKER.md`.
+- **2026-08-13 Step 1 second review:** consolidated four OpenCode comments at
+  their shared correlation seam. Upstream prompt and command payloads accept a
+  caller-supplied `messageID`; the service-owned tracker now uses it for exact
+  bridge-write/raw correlation, instructed-compaction coalescing, and bounded
+  immediate-duplicate rejection. Declined a broad unseen-owner rename because
+  those existing classes still own unseen behavior and only reuse their ordered
+  timestamp persistence seam; they do not become owners of the complete session
+  list-state invariant.

--- a/.plan/active/session-user-interaction-order/TRACKER.md
+++ b/.plan/active/session-user-interaction-order/TRACKER.md
@@ -101,11 +101,15 @@
   and lifecycle cleanup under `OpenCodeService`.
 - [ ] Add `CodexGeneratedContextValidator` and bounded
   `CodexUserInteractionTracker`; inject the validator into history mapping.
+- [ ] Route all Codex triggers through the tracker and reject duplicate completed
+  item notifications.
 - [ ] Prove automatic compaction continuation/overflow replay exclusions.
 - [ ] Prove one fact across ordinary raw delivery, lost-SSE fallback, and backend
   clock rollback.
 - [ ] Prove concurrent laptop/Sesori writes cannot cross-satisfy, instructed
-  compact emits once, and immediate complete-message duplicates are rejected.
+  compact fallback cannot be consumed by another raw compact, and immediate
+  complete-message duplicates are rejected.
+- [ ] Prove request-ID question fallback and reconciled permission 404 exclusion.
 - [ ] Prove manual versus automatic/cancelled reply behavior.
 - [ ] Prove internal event ID/display-root translation and no public wire event.
 - [ ] Run focused plugin/interface/app tests and strict analysis.
@@ -215,7 +219,7 @@
   through initial REST load. The stale tracker-state finding was already fixed
   in `c8aed9ee5`. Against merge base `88059e200`,
   `git diff --numstat $(git merge-base origin/main HEAD) -- .plan/active/session-user-interaction-order/PLAN.md .plan/active/session-user-interaction-order/TRACKER.md`
-  reports PLAN `+777/-0` and TRACKER `+228/-0`, totaling `+1,005/-0` within the
+  reports PLAN `+784/-0` and TRACKER `+236/-0`, totaling `+1,020/-0` within the
   revised 550-1,050 target. The same range passes
   `git diff --check $(git merge-base origin/main HEAD) -- .plan/active/session-user-interaction-order/PLAN.md .plan/active/session-user-interaction-order/TRACKER.md`.
 - **2026-08-13 Step 1 second review:** consolidated four OpenCode comments at
@@ -226,3 +230,7 @@
   those existing classes still own unseen behavior and only reuse their ordered
   timestamp persistence seam; they do not become owners of the complete session
   list-state invariant.
+- **2026-08-13 Step 1 third review:** clarified summarize's no-caller-ID
+  boundary, question fallback, permission 404 exclusion, Codex completion
+  idempotency/coordinator ownership, and stable equal-known-marker ties. The
+  repeated unseen-owner rename remains declined.

--- a/.plan/active/session-user-interaction-order/TRACKER.md
+++ b/.plan/active/session-user-interaction-order/TRACKER.md
@@ -131,8 +131,8 @@
 - Published the rewrite in `1ee36b9d0`, updated PR #865 to the exact four-step
   title and zero-new-state body, and confirmed GitHub has no unresolved inline
   review threads.
-- Against the current merge base, `git diff --numstat $(git merge-base
-  origin/main HEAD) HEAD -- .plan/active/session-user-interaction-order/PLAN.md
+- Against the Step 1 publication baseline, `git diff --numstat $(git merge-base
+  origin/main 49e762c8) 49e762c8 -- .plan/active/session-user-interaction-order/PLAN.md
   .plan/active/session-user-interaction-order/TRACKER.md
   .agents/skills/sesori-plan-maker/SKILL.md` reports PLAN `+298/-0`, TRACKER
   `+133/-0`, and skill `+31/-0`. The plan/tracker documentation total is 431

--- a/.plan/active/session-user-interaction-order/TRACKER.md
+++ b/.plan/active/session-user-interaction-order/TRACKER.md
@@ -152,10 +152,10 @@
 - Published the rewrite in `1ee36b9d0`, updated PR #865 to the exact four-step
   title and zero-new-state body, and confirmed GitHub has no unresolved inline
   review threads.
-- Against the Step 1 publication baseline, `git diff --numstat $(git merge-base
-  origin/main 49e762c8) 49e762c8 -- .plan/active/session-user-interaction-order/PLAN.md
+- Against the current Step 1 head, `git diff --numstat $(git merge-base
+  origin/main HEAD) HEAD -- .plan/active/session-user-interaction-order/PLAN.md
   .plan/active/session-user-interaction-order/TRACKER.md
-  .agents/skills/sesori-plan-maker/SKILL.md` reports PLAN `+298/-0`, TRACKER
-  `+133/-0`, and skill `+31/-0`. The plan/tracker documentation total is 431
+  .agents/skills/sesori-plan-maker/SKILL.md` reports PLAN `+337/-0`, TRACKER
+  `+161/-0`, and skill `+31/-0`. The plan/tracker documentation total is 498
   lines within the recorded 350-650 target; total Step 1 additions including the
-  skill are 462 lines. The same range passes `git diff --check`.
+  skill are 529 lines. The same range passes `git diff --check`.

--- a/.plan/active/session-user-interaction-order/TRACKER.md
+++ b/.plan/active/session-user-interaction-order/TRACKER.md
@@ -54,6 +54,10 @@
 
 - [x] Direct laptop OpenCode permission replies are unknown because upstream
   does not distinguish one manual decision from an `always` cascade.
+- [x] OpenCode summarize exposes no caller identity; an accepted bridge compact
+  always emits its fallback while raw manual compacts remain independent, so
+  duplicate same-session evidence is accepted rather than misattributing a
+  concurrent surface.
 - [x] Separate ACP/Cursor and Claude laptop processes are not observable by the
   bridge-owned process.
 - [x] A theoretical OpenCode part-before-envelope sequence can miss one marker;
@@ -107,9 +111,10 @@
 - [ ] Prove one fact across ordinary raw delivery, lost-SSE fallback, and backend
   clock rollback.
 - [ ] Prove concurrent laptop/Sesori writes cannot cross-satisfy, instructed
-  compact fallback cannot be consumed by another raw compact, and immediate
-  complete-message duplicates are rejected.
-- [ ] Prove request-ID question fallback and reconciled permission 404 exclusion.
+  compact fallback always records acceptance, and immediate complete-message
+  duplicates are rejected.
+- [ ] Prove request-ID question fallback and reconciled question/permission 404
+  exclusion.
 - [ ] Prove manual versus automatic/cancelled reply behavior.
 - [ ] Prove internal event ID/display-root translation and no public wire event.
 - [ ] Run focused plugin/interface/app tests and strict analysis.
@@ -219,7 +224,7 @@
   through initial REST load. The stale tracker-state finding was already fixed
   in `c8aed9ee5`. Against merge base `88059e200`,
   `git diff --numstat $(git merge-base origin/main HEAD) -- .plan/active/session-user-interaction-order/PLAN.md .plan/active/session-user-interaction-order/TRACKER.md`
-  reports PLAN `+784/-0` and TRACKER `+236/-0`, totaling `+1,020/-0` within the
+  reports PLAN `+790/-0` and TRACKER `+246/-0`, totaling `+1,036/-0` within the
   revised 550-1,050 target. The same range passes
   `git diff --check $(git merge-base origin/main HEAD) -- .plan/active/session-user-interaction-order/PLAN.md .plan/active/session-user-interaction-order/TRACKER.md`.
 - **2026-08-13 Step 1 second review:** consolidated four OpenCode comments at
@@ -234,3 +239,8 @@
   boundary, question fallback, permission 404 exclusion, Codex completion
   idempotency/coordinator ownership, and stable equal-known-marker ties. The
   repeated unseen-owner rename remains declined.
+- **2026-08-13 final bot follow-up:** recorded the honest summarize limitation:
+  accepted bridge compact fallback is unconditional and raw compacts remain
+  independent until upstream provides identity. Also excluded reconciled
+  question 404s and kept Layer-3 peers independent by having the Cubit pass the
+  tracker's cached marker map into `SessionListService`.

--- a/.plan/active/session-user-interaction-order/TRACKER.md
+++ b/.plan/active/session-user-interaction-order/TRACKER.md
@@ -14,7 +14,8 @@
 ## Simplicity Contract
 
 - [x] Zero new database columns or migrations.
-- [x] Zero plugin API or production plugin changes.
+- [x] Zero plugin API, classifier, or behavioral plugin changes; required
+  shared-`Session` constructors may receive mechanical null arguments.
 - [x] Zero dispatcher flags or bridge operation hooks.
 - [x] Zero classifiers, correlation maps, dedupe collections, timers, locks,
   registries, or new lifecycle owners.
@@ -36,6 +37,8 @@
 - [x] Archived filtering and project/child ordering remain unchanged.
 - [x] Auto-approved permission replies remain excluded by current orchestrator
   filtering.
+- [x] Lifecycle-generated reply/rejection events can count when abort, thread
+  close, process exit, or disposal clears pending input.
 - [x] Automatic compaction/generated input can count when normalized as a user
   message; no plugin inference is added.
 - [x] Cross-backend activity order assumes sufficiently aligned source clocks;
@@ -71,12 +74,16 @@
 - [ ] Add nullable `lastUserActivityAt` to shared `Session` and the existing
   list-state patch; regenerate source.
 - [ ] Map existing persisted markers through bridge REST/detail and patch seams.
+- [ ] Pass null through ACP/Codex shared `Session` constructors without deriving
+  or owning the bridge marker in plugin code.
 - [ ] Replace tracker boolean values with typed unseen/activity list state while
   retaining its existing cache, tick, subscription, and lifecycle.
 - [ ] Preserve marker values across live max-merge, REST seeding, and optimistic
   unseen updates.
 - [ ] Re-run `_emitFiltered` directly from the existing tracker subscription so
   an activity patch reorders an already-running session immediately.
+- [ ] Preserve the `SessionListLoaded` guard around that callback so seeded
+  tracker replay cannot replace initial loading with an empty loaded list.
 - [ ] Replace alphabetical running order with activity/fallback recency and IDs.
 - [ ] Prove unchanged inactive, awaiting-only, archived, project, child, and
   auto-approval behavior.
@@ -121,6 +128,11 @@
   marker would require the second persisted scalar this redesign intentionally
   removed; the effect is limited to running-list order and refresh cannot make
   incomparable clocks comparable.
+- **2026-08-13 lifecycle/constructor review:** recorded that existing plugin
+  lifecycle cancellation replies share the marker's normalized activity
+  semantics. Allowed required null arguments at ACP/Codex shared `Session`
+  constructors while preserving zero plugin behavior/classifier changes, and
+  retained the loaded-state guard around live re-filtering.
 
 ## Verification Log
 

--- a/.plan/active/session-user-interaction-order/TRACKER.md
+++ b/.plan/active/session-user-interaction-order/TRACKER.md
@@ -33,7 +33,9 @@
 - [x] One required manual/automatic permission origin updates all internal
   plugin implementors in lockstep.
 - [x] `OpenCodeUserInteractionTracker` owns raw message/part classifier state
-  before compaction provenance is erased; the top-level plugin delegates.
+  before compaction provenance is erased, coordinates one-fact bridge-write
+  fallback, and uses bridge monotonic observation time; the top-level plugin
+  delegates.
 - [x] `CodexUserInteractionTracker` owns bounded first-user-item observation and
   shares one `CodexGeneratedContextValidator` with history mapping; ACP/Cursor
   and Claude use their accepted bridge-owned write paths.
@@ -42,8 +44,9 @@
   are reused; no new lock, tracker service, or bridge ordering snapshot.
 - [x] Existing `session.unseen_changed` becomes the additive post-commit
   session-list patch; no new public SSE variant.
-- [x] `SessionListService` owns live/session-update/REST marker max merges; the
-  Cubit only validates, delegates, and emits.
+- [x] `SessionListService` owns live/session-update/REST marker max merges;
+  `SessionUnseenTracker` retains initial-load patches and the Cubit only
+  validates, delegates, and emits.
 - [x] Existing unseen semantics and `last_user_message_at` are retained.
 
 ## Accepted Limitations
@@ -63,7 +66,7 @@
 
 | Done | Step | Exact PR title | Changed-line target | State |
 |---|---|---|---:|---|
-| [ ] | 1/7 | `🌱 [session-user-interaction-order] docs: plan running session interaction order [step 1/7]` | 550-950 | [PR #865](https://github.com/sesori-ai/sesori_apps_monorepo/pull/865) open |
+| [ ] | 1/7 | `🌱 [session-user-interaction-order] docs: plan running session interaction order [step 1/7]` | 550-1,050 | [PR #865](https://github.com/sesori-ai/sesori_apps_monorepo/pull/865) open |
 | [ ] | 2/7 | `🚧 [session-user-interaction-order] feat(plugins): report genuine user interactions [step 2/7]` | 1,050-1,500 | Pending |
 | [ ] | 3/7 | `🚧 [session-user-interaction-order] feat(bridge): persist session interaction recency [step 3/7]` | 4,500-6,500; generated migration cap exception | Pending |
 | [ ] | 4/7 | `⚙️ [session-user-interaction-order] feat(protocol): publish session interaction recency [step 4/7]` | 700-1,300 | Pending |
@@ -93,10 +96,12 @@
 - [ ] Update OpenCode, Codex, ACP/Cursor, Claude, bridge call sites, and test
   fakes in lockstep.
 - [ ] Add `OpenCodeUserInteractionTracker` with bounded envelope/part classifier
-  and lifecycle cleanup.
+  bridge-write fallback coordination, and lifecycle cleanup.
 - [ ] Add `CodexGeneratedContextValidator` and bounded
   `CodexUserInteractionTracker`; inject the validator into history mapping.
 - [ ] Prove automatic compaction continuation/overflow replay exclusions.
+- [ ] Prove one fact across ordinary raw delivery, lost-SSE fallback, and backend
+  clock rollback.
 - [ ] Prove manual versus automatic/cancelled reply behavior.
 - [ ] Prove internal event ID/display-root translation and no public wire event.
 - [ ] Run focused plugin/interface/app tests and strict analysis.
@@ -131,6 +136,7 @@
 - [ ] Preserve inactive, awaiting-only, archived, project, and child policies.
 - [ ] Add `SessionListService.applyInteractionPatch` and consume live marker
   patches through it.
+- [ ] Extend `SessionUnseenTracker` to retain marker patches across initial load.
 - [ ] Add `SessionListService.mergeRestSnapshot` and max-merge session updates
   at the service boundary.
 - [ ] Test new/old bridge, live reorder, stale fetch, auto-update stability, and
@@ -183,9 +189,9 @@
   migration, PR lifecycle, or regression-matrix finding remained.
 - **2026-08-13 plan validation:** exact slug, seven-step denominator, titles,
   ordering, line targets, architecture record, regression matrix, and cleanup
-  agree between plan and tracker. Both new files pass no-index whitespace
-  validation; 929 documentation lines are within the revised 550-950 Step 1
-  target. No Dart/Flutter suite was run for this documentation-only work.
+  agree between plan and tracker. Both new files passed no-index whitespace
+  validation before publication. No Dart/Flutter suite was run for this
+  documentation-only work.
 - **2026-08-13 main refresh:** fast-forwarded the required branch/worktree from
   `ec479cef5` to `88059e200`. Schema v13, the four-plugin registry, client running
   comparator, and plan ownership seams remain unchanged. The bundled OpenCode
@@ -199,3 +205,12 @@
   The PR is mergeable and CI started successfully. Qodo reported only that its
   review is pending; Cursor Bugbot reported its own usage limit, with no code or
   plan finding.
+- **2026-08-13 Step 1 review:** accepted three concrete race/clock findings.
+  OpenCode now coordinates bridge-write fallback with raw observation and uses
+  bridge monotonic time; the existing unseen tracker retains marker patches
+  through initial REST load. The stale tracker-state finding was already fixed
+  in `c8aed9ee5`. Against merge base `88059e200`,
+  `git diff --numstat $(git merge-base origin/main HEAD) -- .plan/active/session-user-interaction-order/PLAN.md .plan/active/session-user-interaction-order/TRACKER.md`
+  reports PLAN `+758/-0` and TRACKER `+216/-0`, totaling `+974/-0` within the
+  revised 550-1,050 target. The same range passes
+  `git diff --check $(git merge-base origin/main HEAD) -- .plan/active/session-user-interaction-order/PLAN.md .plan/active/session-user-interaction-order/TRACKER.md`.

--- a/.plan/active/session-user-interaction-order/TRACKER.md
+++ b/.plan/active/session-user-interaction-order/TRACKER.md
@@ -38,6 +38,8 @@
   filtering.
 - [x] Automatic compaction/generated input can count when normalized as a user
   message; no plugin inference is added.
+- [x] Cross-backend activity order assumes sufficiently aligned source clocks;
+  skew is accepted instead of adding a bridge-observation scalar.
 - [x] No analytics event.
 
 ## Delivery Steps
@@ -73,6 +75,8 @@
   retaining its existing cache, tick, subscription, and lifecycle.
 - [ ] Preserve marker values across live max-merge, REST seeding, and optimistic
   unseen updates.
+- [ ] Re-run `_emitFiltered` directly from the existing tracker subscription so
+  an activity patch reorders an already-running session immediately.
 - [ ] Replace alphabetical running order with activity/fallback recency and IDs.
 - [ ] Prove unchanged inactive, awaiting-only, archived, project, child, and
   auto-approval behavior.
@@ -112,6 +116,11 @@
 - **2026-08-13 final simplification:** reuse the existing marker and current
   list-state delivery. Accept its broader user-side-activity semantics rather
   than recreating perfect origin provenance.
+- **2026-08-13 clock-domain review:** accepted that source-clock markers can
+  misorder sessions across skewed backends. A globally comparable observation
+  marker would require the second persisted scalar this redesign intentionally
+  removed; the effect is limited to running-list order and refresh cannot make
+  incomparable clocks comparable.
 
 ## Verification Log
 

--- a/.plan/active/session-user-interaction-order/TRACKER.md
+++ b/.plan/active/session-user-interaction-order/TRACKER.md
@@ -1,0 +1,196 @@
+# Running Session Interaction Order: Tracker
+
+## Current State
+
+- **Plan slug:** `session-user-interaction-order`
+- **Implementation base:** `main` at `88059e200`
+- **Branch/worktree:** `session-order-ux-review`
+- **Series state:** Reviewed plan; three architecture findings applied; current
+  main revalidated; no implementation started
+- **Current step:** 1/7 ready for publication
+- **Next action:** commit, push, and open the Step 1 plan PR
+- **Source changes:** none
+- **Tests run:** none
+
+## Locked Product Behavior
+
+- [x] Running roots remain promoted.
+- [x] Running means main-agent busy, retry, or at least one background task;
+  awaiting-input alone remains non-running.
+- [x] Running roots order by genuine interaction recency, not title.
+- [x] Prompt, slash command, manual answer/decision, and manual compaction count.
+- [x] Automatic compaction, generated continuation/replay, auto approval,
+  cancellation, assistant/tool/title activity do not count.
+- [x] Null markers fall back to `time.updated` for old bridges and migrated rows.
+- [x] Non-running, project, and child-task ordering remain unchanged.
+- [x] The client owns visible ordering; the bridge transmits timestamp facts.
+- [x] No analytics event is added.
+
+## Architecture Decisions
+
+- [x] One internal `BridgeSseSessionUserInteraction` fact carries backend
+  session, optional display root, and optional occurred-at timestamp.
+- [x] One required manual/automatic permission origin updates all internal
+  plugin implementors in lockstep.
+- [x] `OpenCodeUserInteractionTracker` owns raw message/part classifier state
+  before compaction provenance is erased; the top-level plugin delegates.
+- [x] `CodexUserInteractionTracker` owns bounded first-user-item observation and
+  shares one `CodexGeneratedContextValidator` with history mapping; ACP/Cursor
+  and Claude use their accepted bridge-owned write paths.
+- [x] New nullable `last_user_interaction_at`; no backfill.
+- [x] Existing ordered plugin-event processing and unseen timestamp write tail
+  are reused; no new lock, tracker service, or bridge ordering snapshot.
+- [x] Existing `session.unseen_changed` becomes the additive post-commit
+  session-list patch; no new public SSE variant.
+- [x] `SessionListService` owns live/session-update/REST marker max merges; the
+  Cubit only validates, delegates, and emits.
+- [x] Existing unseen semantics and `last_user_message_at` are retained.
+
+## Accepted Limitations
+
+- [x] Direct laptop OpenCode permission replies are unknown because upstream
+  does not distinguish one manual decision from an `always` cascade.
+- [x] Separate ACP/Cursor and Claude laptop processes are not observable by the
+  bridge-owned process.
+- [x] A theoretical OpenCode part-before-envelope sequence can miss one marker;
+  no timer/history lookup is added against current upstream ordering.
+- [x] Existing migrated rows remain null until a new authoritative interaction
+  and use updated-time fallback meanwhile.
+- [x] Server-paged root responses retain updated-time order; the current app
+  fetches the complete list and owns activity-aware visible order.
+
+## Delivery Steps
+
+| Done | Step | Exact PR title | Changed-line target | State |
+|---|---|---|---:|---|
+| [ ] | 1/7 | `🌱 [session-user-interaction-order] docs: plan running session interaction order [step 1/7]` | 550-950 | Reviewed and validated locally |
+| [ ] | 2/7 | `🚧 [session-user-interaction-order] feat(plugins): report genuine user interactions [step 2/7]` | 1,050-1,500 | Pending |
+| [ ] | 3/7 | `🚧 [session-user-interaction-order] feat(bridge): persist session interaction recency [step 3/7]` | 4,500-6,500; generated migration cap exception | Pending |
+| [ ] | 4/7 | `⚙️ [session-user-interaction-order] feat(protocol): publish session interaction recency [step 4/7]` | 700-1,300 | Pending |
+| [ ] | 5/7 | `⚙️ [session-user-interaction-order] feat(client): order running sessions by interaction [step 5/7]` | 350-750 | Pending |
+| [ ] | 6/7 | `🌱 [session-user-interaction-order] docs: define session interaction order coverage [step 6/7]` | 50-180 | Pending |
+| [ ] | 7/7 | `🌱 [session-user-interaction-order] docs: verify and retire interaction ordering [step 7/7]` | 60-220 | Pending |
+
+## Step 1 Checklist
+
+- [x] Trace current client list ownership and running definition.
+- [x] Trace persisted unseen/user-message timestamps and prove they are unsafe
+  for ordering.
+- [x] Inspect OpenCode message/part and compaction ordering, including synthetic
+  continuation and overflow replay.
+- [x] Inspect all registered production plugin write/reply paths.
+- [x] Define additive REST/live compatibility and honest null migration.
+- [x] Define deterministic client fallback and merge behavior.
+- [x] Record cleanup, accepted limitations, L3 proof boundaries, and matrix.
+- [x] Fix exact seven-step titles and line targets.
+- [x] Run architecture plan review and apply valid findings.
+- [x] Run `git diff --check` and plan/tracker consistency validation.
+- [ ] Commit, push, and open the Step 1 PR for the confirmed reviewed series.
+
+## Step 2 Checklist
+
+- [ ] Add typed internal interaction event and permission origin.
+- [ ] Update OpenCode, Codex, ACP/Cursor, Claude, bridge call sites, and test
+  fakes in lockstep.
+- [ ] Add `OpenCodeUserInteractionTracker` with bounded envelope/part classifier
+  and lifecycle cleanup.
+- [ ] Add `CodexGeneratedContextValidator` and bounded
+  `CodexUserInteractionTracker`; inject the validator into history mapping.
+- [ ] Prove automatic compaction continuation/overflow replay exclusions.
+- [ ] Prove manual versus automatic/cancelled reply behavior.
+- [ ] Prove internal event ID/display-root translation and no public wire event.
+- [ ] Run focused plugin/interface/app tests and strict analysis.
+- [ ] Run architecture implementation review.
+
+## Step 3 Checklist
+
+- [ ] Rebase schema version on current `main` without rewriting merged versions.
+- [ ] Add nullable column and no-backfill migration.
+- [ ] Generate all Drift snapshots/steps/source/helpers.
+- [ ] Preserve marker in import/projection/create paths.
+- [ ] Add monotonic repository/service write through existing ordered tail.
+- [ ] Consume translated facts without changing unseen formula or markers.
+- [ ] Test migration, null baseline, preservation, attribution, duplicates, and
+  clock rollback.
+- [ ] Run strict bridge app analysis/tests and architecture implementation review.
+
+## Step 4 Checklist
+
+- [ ] Add required nullable shared REST and known-SSE properties with dated
+  compatibility comments.
+- [ ] Regenerate shared source.
+- [ ] Map root/detail/child/live projections and post-commit patches.
+- [ ] Test omitted null, missing old field, old/new peers, and delete null.
+- [ ] Run shared/bridge tests, strict analysis, and architecture implementation
+  review.
+
+## Step 5 Checklist
+
+- [ ] Replace alphabetical running comparator with effective interaction
+  recency and deterministic ties.
+- [ ] Preserve inactive, awaiting-only, archived, project, and child policies.
+- [ ] Add `SessionListService.applyInteractionPatch` and consume live marker
+  patches through it.
+- [ ] Add `SessionListService.mergeRestSnapshot` and max-merge session updates
+  at the service boundary.
+- [ ] Test new/old bridge, live reorder, stale fetch, auto-update stability, and
+  project mismatch.
+- [ ] Run module_core tests/analyze and affected mobile/desktop downstream
+  validation.
+- [ ] Run architecture implementation review.
+
+## Step 6 Checklist
+
+- [ ] Update `projects-and-sessions.md`.
+- [ ] Update `session-turns.md`.
+- [ ] Reconfirm registered plugin/platform matrix from production code.
+- [ ] Validate documentation consistency and `git diff --check`.
+
+## Step 7 Checklist
+
+- [ ] Run cumulative L3 coverage at automated, live-plugin, and phone boundaries.
+- [ ] Cover every supporting registered plugin and capability in the recorded
+  matrix.
+- [ ] Record privacy-safe evidence, versions, limitations, and cleanup.
+- [ ] Keep plan active for partial/blocked/failed coverage unless the user
+  explicitly accepts a reduction.
+- [ ] Move `.plan/active/session-user-interaction-order/` to `.plan/completed/`
+  only after required coverage passes.
+
+## Architecture Review
+
+- **Reviewer:** `architecture-plan-review`
+- **Reviewed scope:** complete `.plan/active/session-user-interaction-order/`
+  against current plugin, bridge, shared, database, and client architecture
+- **Initial verdict:** rejected with three actionable ownership findings
+- **Findings applied:** `OpenCodeUserInteractionTracker` now owns OpenCode
+  classifier state; `CodexUserInteractionTracker` plus one
+  `CodexGeneratedContextValidator` own Codex provenance; `SessionListService`
+  now owns all marker merge transformations
+- **Re-review:** not run; valid concrete findings were applied directly per
+  repository policy
+
+## Verification Log
+
+- **2026-08-13 discovery:** worktree clean on `session-order-ux-review`; no source
+  edits or tests before plan creation.
+- **2026-08-13 planning:** repository instructions, current client/bridge/shared
+  flow, registered plugins, generated OpenCode v1.17.7 models, upstream OpenCode
+  compaction implementation, relevant PR history, and regression contracts
+  inspected.
+- **2026-08-13 architecture review:** initial draft rejected on three concrete
+  ownership gaps. All were applied directly; no product scope, compatibility,
+  migration, PR lifecycle, or regression-matrix finding remained.
+- **2026-08-13 plan validation:** exact slug, seven-step denominator, titles,
+  ordering, line targets, architecture record, regression matrix, and cleanup
+  agree between plan and tracker. Both new files pass no-index whitespace
+  validation; 929 documentation lines are within the revised 550-950 Step 1
+  target. No Dart/Flutter suite was run for this documentation-only work.
+- **2026-08-13 main refresh:** fast-forwarded the required branch/worktree from
+  `ec479cef5` to `88059e200`. Schema v13, the four-plugin registry, client running
+  comparator, and plan ownership seams remain unchanged. The bundled OpenCode
+  runtime advanced to v1.18.11; its source retains envelope-before-part
+  compaction events, manual/automatic provenance, synthetic continuation, and
+  overflow replay. Main's attachment-mapping and regression-copy changes do not
+  alter this plan. No architecture re-review was needed because no architecture
+  or product decision changed.

--- a/.plan/active/session-user-interaction-order/TRACKER.md
+++ b/.plan/active/session-user-interaction-order/TRACKER.md
@@ -61,7 +61,7 @@
 - [x] Update plan-maker guidance with existing-state/history inspection.
 - [x] Run fresh architecture plan review and apply valid findings.
 - [x] Validate plan/tracker consistency and whitespace.
-- [ ] Commit, push, update PR #865 title/body, and resolve superseded discussion.
+- [x] Commit, push, update PR #865 title/body, and resolve superseded discussion.
 
 ## Step 2 Checklist
 
@@ -128,3 +128,6 @@
   findings. It confirmed bridge repository/service ownership, orchestrator SSE
   projection, existing tracker lifecycle ownership, client comparator
   ownership, and additive shared-wire compatibility.
+- Published the rewrite in `1ee36b9d0`, updated PR #865 to the exact four-step
+  title and zero-new-state body, and confirmed GitHub has no unresolved inline
+  review threads.

--- a/.plan/active/session-user-interaction-order/TRACKER.md
+++ b/.plan/active/session-user-interaction-order/TRACKER.md
@@ -8,7 +8,7 @@
 - **Plan PR:** [#865](https://github.com/sesori-ai/sesori_apps_monorepo/pull/865)
 - **Series state:** Step 1/4 rewritten around existing persisted state
 - **Current step:** 1/4 in review; no production source published
-- **Next action:** publish revised plan/skill and update PR #865
+- **Next action:** monitor Step 1 review and merge readiness
 - **Production source changes published:** none
 
 ## Simplicity Contract
@@ -131,3 +131,10 @@
 - Published the rewrite in `1ee36b9d0`, updated PR #865 to the exact four-step
   title and zero-new-state body, and confirmed GitHub has no unresolved inline
   review threads.
+- Against the current merge base, `git diff --numstat $(git merge-base
+  origin/main HEAD) HEAD -- .plan/active/session-user-interaction-order/PLAN.md
+  .plan/active/session-user-interaction-order/TRACKER.md
+  .agents/skills/sesori-plan-maker/SKILL.md` reports PLAN `+298/-0`, TRACKER
+  `+133/-0`, and skill `+31/-0`. The plan/tracker documentation total is 431
+  lines within the recorded 350-650 target; total Step 1 additions including the
+  skill are 462 lines. The same range passes `git diff --check`.


### PR DESCRIPTION
## Complexity

🌱 Trivial. This PR changes only planning, tracking, and planning-skill documentation.

## What

- Replaces the seven-step plugin-classifier plan with a four-step, zero-new-state design.
- Reuses the existing persisted `last_user_message_at` as an honestly named `lastUserActivityAt` REST/SSE fact.
- Keeps ordering client-owned through the existing running partition, unseen patch/cache/tick, and one comparator.
- Updates the plan-maker skill to inspect existing state and Git history before adding persistence or coordination.

## Why

The previous design accumulated plugin classifiers, correlation maps, dedupe, lifecycle hooks, a new database marker, and an every-plugin matrix for a low-impact list-ordering heuristic. A history and data-flow audit showed that the existing marker is semantically adequate once the product claim is narrowed to user-side activity rather than perfect human-origin provenance.

## Risk and test focus

Risk is documentation-only. Review the accepted generated/lifecycle activity and cross-clock semantics, zero-new-state complexity budget, additive old/new peer behavior, guarded tracker seeding and live re-filter ownership, mechanical null mapper updates, unchanged inactive/project/child ordering, and representative-plugin L3 boundary.

## Expected result

No user-visible, database, wire, generated-code, or production behavior change. Reviewers receive a smaller implementation authority: no schema migration, plugin API/classifier/behavior change, dispatcher hooks, timers, registries, or new lifecycle owner. The eventual implementation may mechanically pass null at existing plugin-side shared `Session` constructors.

## Verification

- Audited every current `last_user_message_at` write/projection and the relevant client list-state flow.
- Inspected the implementation and reversion history in PRs #474, #480, and #482.
- Fresh `architecture-plan-review` approved the rewritten plan with no findings.
- `git diff --check` passed.
- Final merge-base numstat reports PLAN `+337/-0`, TRACKER `+161/-0`, and skill `+31/-0`; the 498-line plan/tracker documentation total is within the recorded 350-650 target.
- No Dart or Flutter suites were run for this documentation/skill-only change.
