### PR TITLE
🌱 Use stable Flutter 3.47.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-flutter 3.47.0-0.4.pre-beta
+flutter 3.47.0-stable

--- a/client/README.md
+++ b/client/README.md
@@ -97,7 +97,7 @@ dart pub get
 (cd desktop && flutter run -d macos)
 ```
 
-The exact stable Flutter version is pinned in the repository root `.tool-versions`.
+The exact Flutter version is pinned in the repository root `.tool-versions`.
 
 ## Analyze And Test
 

--- a/client/README.md
+++ b/client/README.md
@@ -97,7 +97,7 @@ dart pub get
 (cd desktop && flutter run -d macos)
 ```
 
-The exact Flutter version is pinned in the repository root `.tool-versions`.
+The exact stable Flutter version is pinned in the repository root `.tool-versions`.
 
 ## Analyze And Test
 

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -1949,4 +1949,4 @@ packages:
     version: "2.2.4"
 sdks:
   dart: ">=3.13.0-0 <4.0.0"
-  flutter: ">=3.47.0-0.4.pre <3.48.0"
+  flutter: ">=3.47.0 <3.48.0"

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 environment:
   sdk: ^3.13.0-0
-  flutter: ">=3.47.0-0.4.pre <3.48.0"
+  flutter: ">=3.47.0 <3.48.0"
 
 workspace:
   - app

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,12 +4,12 @@ Thanks for your interest in Sesori. This repo contains the Bridge, the mobile cl
 
 ## Prerequisites
 
-- **asdf** — recommended for version management. The repo's [`.tool-versions`](../.tool-versions) pins the stable Flutter SDK and its bundled Dart SDK automatically.
+- **asdf** — recommended for version management. The repo's [`.tool-versions`](../.tool-versions) pins the Flutter SDK and its bundled Dart SDK automatically.
 - **Flutter** — used by the `client/` workspace.
 - **Dart SDK** — used by the `bridge/` workspace. It ships with the pinned Flutter version, so no separate install is needed.
 - **Make** — each workspace uses a Makefile for common tasks.
 
-Install the pinned stable Flutter version with asdf, then make sure `dart` is available from the Flutter install.
+Install the pinned Flutter version with asdf, then make sure `dart` is available from the Flutter install.
 
 ## Clone the repo
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,12 +4,12 @@ Thanks for your interest in Sesori. This repo contains the Bridge, the mobile cl
 
 ## Prerequisites
 
-- **asdf** — recommended for version management. The repo's [`.tool-versions`](../.tool-versions) pins the Flutter and Dart versions automatically.
+- **asdf** — recommended for version management. The repo's [`.tool-versions`](../.tool-versions) pins the stable Flutter SDK and its bundled Dart SDK automatically.
 - **Flutter** — used by the `client/` workspace.
 - **Dart SDK** — used by the `bridge/` workspace. It ships with the pinned Flutter version, so no separate install is needed.
 - **Make** — each workspace uses a Makefile for common tasks.
 
-Install the pinned Flutter version with asdf, then make sure `dart` is available from the Flutter install.
+Install the pinned stable Flutter version with asdf, then make sure `dart` is available from the Flutter install.
 
 ## Clone the repo
 


### PR DESCRIPTION
## Complexity

🌱 Trivial: updates the pinned Flutter channel label, matching SDK constraint, and setup documentation.

## What

- Pin Flutter to `3.47.0-stable` instead of the beta-qualified `3.47.0-0.4.pre-beta` build.
- Require stable Flutter 3.47.0 in the client workspace and regenerate its lockfile.
- Keep contributor documentation pointed at the authoritative Flutter SDK pin.

## Why

- Use the final stable Flutter 3.47.0 release consistently across tool resolution, package constraints, and setup guidance.

## Risk and test focus

- Low risk; this changes the repository toolchain selection and minimum Flutter constraint within the same 3.47.0 release line.
- No user-visible or database impact.
- Confirm local tool resolution selects Flutter 3.47.0 on the stable channel and all product targets compile.

## Expected result

- Contributors and CI resolve the stable Flutter 3.47.0 SDK from `.tool-versions`.
- The client workspace no longer accepts the earlier 3.47.0 prerelease SDK.

## Verification

- CI: bridge analyze/tests and native build smoke pass
- CI: mobile analyze/tests pass
- CI: desktop analyze/tests and macOS, Linux, and Windows builds pass
- `asdf current flutter`
- `flutter --version`
- `dart pub get` from `client/`
- `dart analyze --fatal-infos` from `client/app/`
- `dart analyze --fatal-infos` from `client/desktop/`
- `flutter build apk --debug` from `client/app/`
- `flutter build ios --config-only --release --no-codesign` from `client/app/`
- `make build-host` from `bridge/app/`

