### PR TITLE
⚙️ Preserve branches during session retirement

### DIFF
--- a/bridge/app/lib/src/bridge/api/git_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/git_cli_api.dart
@@ -508,18 +508,6 @@ class GitCliApi({
     return removed;
   }
 
-  Future<bool> deleteBranch({
-    required String projectPath,
-    required String branchName,
-    required bool force,
-  }) async {
-    final result = await runGit(
-      projectPath: projectPath,
-      arguments: ["branch", force ? "-D" : "-d", "--", branchName],
-    );
-    return result.exitCode == 0;
-  }
-
   Future<ProcessResult> runGit({required String projectPath, required List<String> arguments}) {
     return _processRunner.run("git", arguments, workingDirectory: projectPath);
   }

--- a/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
@@ -241,18 +241,6 @@ class WorktreeRepository({
     return removed;
   }
 
-  Future<bool> deleteBranch({
-    required String projectPath,
-    required String branchName,
-    required bool force,
-  }) async {
-    return await _gitApi.deleteBranch(
-      projectPath: projectPath,
-      branchName: branchName,
-      force: force,
-    );
-  }
-
   bool isValidWorktreePath({required String projectPath, required String worktreePath}) {
     final expectedPrefix = "$projectPath/$_worktreeDir/";
     return worktreePath.startsWith(expectedPrefix);

--- a/bridge/app/lib/src/bridge/routing/delete_session_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/delete_session_handler.dart
@@ -29,9 +29,12 @@ class DeleteSessionHandler({required final SessionDeletionService _sessionDeleti
       throw buildErrorResponse(request, 400, "empty session id");
     }
 
-    // COMPATIBILITY 2026-08-13 (v1.7.1): Published clients still send
-    // deleteBranch. It is intentionally ignored; remove the field from the
-    // request model when v1.7.1 clients are unsupported.
+    // COMPATIBILITY 2026-08-13 (v1.7.1): Published clients can request branch
+    // deletion. Reject it explicitly so they do not report unperformed cleanup
+    // as success; remove the field when v1.7.1 clients are unsupported.
+    if (body.deleteBranch) {
+      throw buildErrorResponse(request, 422, "branch cleanup is no longer supported");
+    }
     final cleanupResult = await _sessionDeletionService.deleteSession(
       sessionId: sessionId,
       deleteWorktree: body.deleteWorktree,

--- a/bridge/app/lib/src/bridge/routing/delete_session_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/delete_session_handler.dart
@@ -29,10 +29,12 @@ class DeleteSessionHandler({required final SessionDeletionService _sessionDeleti
       throw buildErrorResponse(request, 400, "empty session id");
     }
 
+    // COMPATIBILITY 2026-08-13 (v1.7.1): Published clients still send
+    // deleteBranch. It is intentionally ignored; remove the field from the
+    // request model when v1.7.1 clients are unsupported.
     final cleanupResult = await _sessionDeletionService.deleteSession(
       sessionId: sessionId,
       deleteWorktree: body.deleteWorktree,
-      deleteBranch: body.deleteBranch,
       force: body.force,
     );
     if (cleanupResult case CleanupRejected(:final rejection)) {

--- a/bridge/app/lib/src/bridge/routing/update_session_archive_status_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/update_session_archive_status_handler.dart
@@ -31,10 +31,13 @@ class UpdateSessionArchiveStatusHandler({
     if (sessionId.isEmpty) {
       throw buildErrorResponse(request, 400, "empty session id");
     }
+    // COMPATIBILITY 2026-08-13 (v1.7.1): Published clients can request branch
+    // deletion. Reject it explicitly so they do not report unperformed cleanup
+    // as success; remove the field when v1.7.1 clients are unsupported.
+    if (body.deleteBranch) {
+      throw buildErrorResponse(request, 422, "branch cleanup is no longer supported");
+    }
     try {
-      // COMPATIBILITY 2026-08-13 (v1.7.1): Published clients still send
-      // deleteBranch. It is intentionally ignored; remove the field from the
-      // request model when v1.7.1 clients are unsupported.
       final update = await _sessionLifecycleService.updateArchiveStatus(
         sessionId: sessionId,
         archived: body.archived,

--- a/bridge/app/lib/src/bridge/routing/update_session_archive_status_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/update_session_archive_status_handler.dart
@@ -32,11 +32,13 @@ class UpdateSessionArchiveStatusHandler({
       throw buildErrorResponse(request, 400, "empty session id");
     }
     try {
+      // COMPATIBILITY 2026-08-13 (v1.7.1): Published clients still send
+      // deleteBranch. It is intentionally ignored; remove the field from the
+      // request model when v1.7.1 clients are unsupported.
       final update = await _sessionLifecycleService.updateArchiveStatus(
         sessionId: sessionId,
         archived: body.archived,
         deleteWorktree: body.deleteWorktree,
-        deleteBranch: body.deleteBranch,
         force: body.force,
       );
       final session = update.session;

--- a/bridge/app/lib/src/bridge/services/session_deletion_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_deletion_service.dart
@@ -14,7 +14,6 @@ class SessionDeletionService({
   Future<CleanupResult> deleteSession({
     required String sessionId,
     required bool deleteWorktree,
-    required bool deleteBranch,
     required bool force,
   }) {
     // The two stores are coordinated here rather than inside
@@ -24,7 +23,6 @@ class SessionDeletionService({
       cleanup: () => _sessionLifecycleService.cleanupAlreadyReserved(
         sessionId: sessionId,
         deleteWorktree: deleteWorktree,
-        deleteBranch: deleteBranch,
         force: force,
       ),
       onDeleted: _purgeHistory,

--- a/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
@@ -112,7 +112,7 @@ class SessionLifecycleService({
       final deleted = await _worktreeService.deleteBranch(
         projectId: projectId,
         branchName: branchName,
-        force: force,
+        force: deleteWorktree || force,
       );
       if (!deleted &&
           await _worktreeService.branchExists(

--- a/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_lifecycle_service.dart
@@ -11,7 +11,7 @@ import "session_cleanup_result.dart";
 import "session_operation_dispatcher.dart";
 import "worktree_service.dart";
 
-enum SessionCleanupOperation() { removeWorktree, deleteBranch }
+enum SessionCleanupOperation() { removeWorktree }
 
 class SessionCleanupFailedException({
     required final String sessionId,
@@ -47,7 +47,6 @@ class SessionLifecycleService({
   Future<CleanupResult> cleanupAlreadyReserved({
     required String sessionId,
     required bool deleteWorktree,
-    required bool deleteBranch,
     required bool force,
   }) async {
     final storedSession = await _sessionRepository.requireRoutableStoredSession(
@@ -55,21 +54,20 @@ class SessionLifecycleService({
       operation: SessionOperation.cleanupSession,
     );
     final worktreePath = storedSession.worktreePath;
-    final branchName = storedSession.branchName;
-    if (!(deleteWorktree || deleteBranch) || worktreePath == null || branchName == null) {
+    if (!deleteWorktree || worktreePath == null) {
       return CleanupSuccess();
     }
 
     final projectId = storedSession.projectId;
 
     // Shared-worktree cleanup is forceable so the user can resolve a stalemate
-    // when multiple sessions point at the same worktree or branch.
+    // when multiple sessions point at the same worktree.
     if (!force) {
       final hasSharing = await _sessionRepository.hasOtherActiveSessionsSharing(
         sessionId: sessionId,
         projectId: projectId,
-        worktreePath: deleteWorktree ? worktreePath : null,
-        branchName: deleteBranch ? branchName : null,
+        worktreePath: worktreePath,
+        branchName: null,
       );
       if (hasSharing) {
         return CleanupRejected(
@@ -80,7 +78,7 @@ class SessionLifecycleService({
       }
     }
 
-    if (deleteWorktree && !force) {
+    if (!force) {
       final safety = await _worktreeService.checkWorktreeSafety(
         worktreePath: worktreePath,
       );
@@ -93,37 +91,17 @@ class SessionLifecycleService({
       }
     }
 
-    if (deleteWorktree) {
-      final removed = await _worktreeService.removeWorktree(
-        pluginId: storedSession.pluginId,
-        projectId: projectId,
-        worktreePath: worktreePath,
-        force: force,
+    final removed = await _worktreeService.removeWorktree(
+      pluginId: storedSession.pluginId,
+      projectId: projectId,
+      worktreePath: worktreePath,
+      force: force,
+    );
+    if (!removed && _filesystemRepository.classifyPath(path: worktreePath) != FilesystemEntityKind.notFound) {
+      throw SessionCleanupFailedException(
+        sessionId: sessionId,
+        operation: SessionCleanupOperation.removeWorktree,
       );
-      if (!removed && _filesystemRepository.classifyPath(path: worktreePath) != FilesystemEntityKind.notFound) {
-        throw SessionCleanupFailedException(
-          sessionId: sessionId,
-          operation: SessionCleanupOperation.removeWorktree,
-        );
-      }
-    }
-
-    if (deleteBranch) {
-      final deleted = await _worktreeService.deleteBranch(
-        projectId: projectId,
-        branchName: branchName,
-        force: deleteWorktree || force,
-      );
-      if (!deleted &&
-          await _worktreeService.branchExists(
-            projectId: projectId,
-            branchName: branchName,
-          )) {
-        throw SessionCleanupFailedException(
-          sessionId: sessionId,
-          operation: SessionCleanupOperation.deleteBranch,
-        );
-      }
     }
 
     return CleanupSuccess();
@@ -133,7 +111,6 @@ class SessionLifecycleService({
     required String sessionId,
     required bool archived,
     required bool deleteWorktree,
-    required bool deleteBranch,
     required bool force,
   }) {
     return _sessionOperationDispatcher.dispatch(
@@ -143,7 +120,6 @@ class SessionLifecycleService({
         sessionId: sessionId,
         archived: archived,
         deleteWorktree: deleteWorktree,
-        deleteBranch: deleteBranch,
         force: force,
       ),
     );
@@ -153,7 +129,6 @@ class SessionLifecycleService({
     required String sessionId,
     required bool archived,
     required bool deleteWorktree,
-    required bool deleteBranch,
     required bool force,
   }) async {
     // COMPATIBILITY 2026-08-07 (v1.7.0): published apps render Unarchive from
@@ -168,7 +143,6 @@ class SessionLifecycleService({
       session: await _doArchive(
         storedSession: storedSession,
         deleteWorktree: deleteWorktree,
-        deleteBranch: deleteBranch,
         force: force,
       ),
       changed: storedSession.archivedAt == null,
@@ -205,7 +179,6 @@ class SessionLifecycleService({
   Future<Session> _doArchive({
     required StoredSession storedSession,
     required bool deleteWorktree,
-    required bool deleteBranch,
     required bool force,
   }) async {
     final archivedAt = DateTime.now().millisecondsSinceEpoch;
@@ -218,7 +191,6 @@ class SessionLifecycleService({
     await _cleanupIfNeeded(
       storedSession: storedSession,
       deleteWorktree: deleteWorktree,
-      deleteBranch: deleteBranch,
       force: force,
     );
     await _sessionRepository.archiveStoredSession(
@@ -272,16 +244,14 @@ class SessionLifecycleService({
   Future<void> _cleanupIfNeeded({
     required StoredSession storedSession,
     required bool deleteWorktree,
-    required bool deleteBranch,
     required bool force,
   }) async {
-    if (!(deleteWorktree || deleteBranch)) {
+    if (!deleteWorktree) {
       return;
     }
     final cleanupResult = await cleanupAlreadyReserved(
       sessionId: storedSession.id,
       deleteWorktree: deleteWorktree,
-      deleteBranch: deleteBranch,
       force: force,
     );
     if (cleanupResult case CleanupRejected(:final rejection)) {

--- a/bridge/app/lib/src/bridge/services/worktree_service.dart
+++ b/bridge/app/lib/src/bridge/services/worktree_service.dart
@@ -194,18 +194,6 @@ class WorktreeService({required final WorktreeRepository _worktreeRepository}) {
     );
   }
 
-  Future<bool> deleteBranch({
-    required String projectId,
-    required String branchName,
-    required bool force,
-  }) async {
-    return await _worktreeRepository.deleteBranch(
-      projectPath: await _worktreeRepository.resolveProjectPath(projectId: projectId),
-      branchName: branchName,
-      force: force,
-    );
-  }
-
   Future<bool> branchExists({
     required String projectId,
     required String branchName,

--- a/bridge/app/test/bridge/routing/delete_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/delete_session_handler_test.dart
@@ -97,7 +97,7 @@ void main() {
       );
     });
 
-    test("1) deleteWorktree=false deleteBranch=false: plugin+db delete, no git ops", () async {
+    test("deleteWorktree=false: plugin+db delete, no git ops", () async {
       await _insertSession(
         db: db,
         sessionId: "s1",
@@ -124,7 +124,6 @@ void main() {
       expect(await db.sessionDao.getSession(sessionId: "s1"), isNull);
       expect(worktreeService.checkCallCount, equals(0));
       expect(worktreeService.removeCallCount, equals(0));
-      expect(worktreeService.deleteBranchCallCount, equals(0));
       expect(operationLog, equals(["pluginDelete"]));
     });
 
@@ -151,7 +150,6 @@ void main() {
       expect(plugin.lastDeleteSessionId, isNull);
       expect(worktreeService.checkCallCount, 0);
       expect(worktreeService.removeCallCount, 0);
-      expect(worktreeService.deleteBranchCallCount, 0);
     });
 
     test("2) deleteWorktree=true on clean worktree: safety check then plugin then worktree", () async {
@@ -184,7 +182,6 @@ void main() {
       expect(worktreeService.lastRemoveProjectId, equals("/repo"));
       expect(worktreeService.lastRemoveWorktreePath, equals("/repo/.worktrees/session-002"));
       expect(worktreeService.lastRemoveForce, isFalse);
-      expect(worktreeService.deleteBranchCallCount, equals(0));
       expect(plugin.lastDeleteSessionId, equals("s2"));
       expect(await db.sessionDao.getSession(sessionId: "s2"), isNull);
       expect(operationLog, equals(["checkSafety", "removeWorktree", "pluginDelete"]));
@@ -226,7 +223,7 @@ void main() {
       expect(operationLog, equals(["checkSafety", "removeWorktree"]));
     });
 
-    test("3) deleteBranch=true: deletes branch", () async {
+    test("legacy deleteBranch=true is ignored", () async {
       await _insertSession(
         db: db,
         sessionId: "s3",
@@ -251,16 +248,12 @@ void main() {
       expect(response, isA<SuccessEmptyResponse>());
       expect(worktreeService.checkCallCount, equals(0));
       expect(worktreeService.removeCallCount, equals(0));
-      expect(worktreeService.deleteBranchCallCount, equals(1));
-      expect(worktreeService.lastDeleteBranchProjectId, equals("/repo"));
-      expect(worktreeService.lastDeleteBranchName, equals("session-003"));
-      expect(worktreeService.lastDeleteBranchForce, isFalse);
       expect(plugin.lastDeleteSessionId, equals("s3"));
       expect(await db.sessionDao.getSession(sessionId: "s3"), isNull);
-      expect(operationLog, equals(["deleteBranch", "pluginDelete"]));
+      expect(operationLog, equals(["pluginDelete"]));
     });
 
-    test("4) deleteWorktree=true + deleteBranch=true: both cleanup operations run", () async {
+    test("deleteWorktree=true with legacy deleteBranch=true removes only worktree", () async {
       await _insertSession(
         db: db,
         sessionId: "s4",
@@ -286,11 +279,9 @@ void main() {
       expect(response, isA<SuccessEmptyResponse>());
       expect(worktreeService.checkCallCount, equals(1));
       expect(worktreeService.removeCallCount, equals(1));
-      expect(worktreeService.deleteBranchCallCount, equals(1));
-      expect(worktreeService.lastDeleteBranchForce, isTrue);
       expect(plugin.lastDeleteSessionId, equals("s4"));
       expect(await db.sessionDao.getSession(sessionId: "s4"), isNull);
-      expect(operationLog, equals(["checkSafety", "removeWorktree", "deleteBranch", "pluginDelete"]));
+      expect(operationLog, equals(["checkSafety", "removeWorktree", "pluginDelete"]));
     });
 
     test("5) deleteWorktree=true on dirty worktree, force=false: returns 409 rejection", () async {
@@ -323,7 +314,6 @@ void main() {
         throwsA(isA<RelayResponse>().having((r) => r.status, "status", equals(409))),
       );
       expect(worktreeService.removeCallCount, equals(0));
-      expect(worktreeService.deleteBranchCallCount, equals(0));
       expect(plugin.lastDeleteSessionId, isNull);
       expect(await db.sessionDao.getSession(sessionId: "s5"), isNotNull);
       expect(operationLog, equals(["checkSafety"]));
@@ -388,7 +378,6 @@ void main() {
       expect(response, isA<SuccessEmptyResponse>());
       expect(worktreeService.checkCallCount, equals(0));
       expect(worktreeService.removeCallCount, equals(0));
-      expect(worktreeService.deleteBranchCallCount, equals(0));
       expect(plugin.lastDeleteSessionId, equals("s7"));
       expect(await db.sessionDao.getSession(sessionId: "s7"), isNull);
       expect(operationLog, equals(["pluginDelete"]));
@@ -426,7 +415,6 @@ void main() {
       expect(plugin.lastDeleteSessionId, isNull);
       expect(worktreeService.checkCallCount, equals(0));
       expect(worktreeService.removeCallCount, equals(0));
-      expect(worktreeService.deleteBranchCallCount, equals(0));
       expect(await db.sessionDao.getSession(sessionId: "s9"), isNotNull);
       expect(operationLog, isEmpty);
     });
@@ -460,9 +448,8 @@ void main() {
 
       expect(worktreeService.checkCallCount, equals(1));
       expect(worktreeService.removeCallCount, equals(1));
-      expect(worktreeService.deleteBranchCallCount, equals(1));
       expect(await db.sessionDao.getSession(sessionId: "s10"), isNotNull);
-      expect(operationLog, equals(["checkSafety", "removeWorktree", "deleteBranch", "pluginDelete"]));
+      expect(operationLog, equals(["checkSafety", "removeWorktree", "pluginDelete"]));
     });
 
     test("11) plugin delete 404: tolerated, DB row still removed", () async {
@@ -551,19 +538,14 @@ class _FakeWorktreeService({required AppDatabase database, required final List<S
     extends WorktreeService {
   WorktreeSafetyResult safetyResult = WorktreeSafe();
   bool removeResult = true;
-  bool deleteBranchResult = true;
 
   int checkCallCount = 0;
   int removeCallCount = 0;
-  int deleteBranchCallCount = 0;
 
   String? lastCheckWorktreePath;
   String? lastRemoveProjectId;
   String? lastRemoveWorktreePath;
   bool? lastRemoveForce;
-  String? lastDeleteBranchProjectId;
-  String? lastDeleteBranchName;
-  bool? lastDeleteBranchForce;
 
   this
     : super(
@@ -601,20 +583,6 @@ class _FakeWorktreeService({required AppDatabase database, required final List<S
     lastRemoveWorktreePath = worktreePath;
     lastRemoveForce = force;
     return removeResult;
-  }
-
-  @override
-  Future<bool> deleteBranch({
-    required String projectId,
-    required String branchName,
-    required bool force,
-  }) async {
-    deleteBranchCallCount++;
-    operationLog.add("deleteBranch");
-    lastDeleteBranchProjectId = projectId;
-    lastDeleteBranchName = branchName;
-    lastDeleteBranchForce = force;
-    return deleteBranchResult;
   }
 }
 

--- a/bridge/app/test/bridge/routing/delete_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/delete_session_handler_test.dart
@@ -136,7 +136,7 @@ void main() {
             const DeleteSessionRequest(
               sessionId: "ghost",
               deleteWorktree: true,
-              deleteBranch: true,
+              deleteBranch: false,
               force: false,
             ).toJson(),
           ),
@@ -223,7 +223,7 @@ void main() {
       expect(operationLog, equals(["checkSafety", "removeWorktree"]));
     });
 
-    test("legacy deleteBranch=true is ignored", () async {
+    test("legacy deleteBranch=true is rejected before deletion", () async {
       await _insertSession(
         db: db,
         sessionId: "s3",
@@ -232,28 +232,30 @@ void main() {
         branchName: "session-003",
       );
 
-      final response = await handler.handle(
-        makeRequest("DELETE", "/session/delete"),
-        body: const DeleteSessionRequest(
-          sessionId: "s3",
-          deleteWorktree: false,
-          deleteBranch: true,
-          force: false,
+      await expectLater(
+        () => handler.handle(
+          makeRequest("DELETE", "/session/delete"),
+          body: const DeleteSessionRequest(
+            sessionId: "s3",
+            deleteWorktree: false,
+            deleteBranch: true,
+            force: false,
+          ),
+          pathParams: {},
+          queryParams: {},
+          fragment: null,
         ),
-        pathParams: {},
-        queryParams: {},
-        fragment: null,
+        throwsA(isA<RelayResponse>().having((response) => response.status, "status", 422)),
       );
 
-      expect(response, isA<SuccessEmptyResponse>());
       expect(worktreeService.checkCallCount, equals(0));
       expect(worktreeService.removeCallCount, equals(0));
-      expect(plugin.lastDeleteSessionId, equals("s3"));
-      expect(await db.sessionDao.getSession(sessionId: "s3"), isNull);
-      expect(operationLog, equals(["pluginDelete"]));
+      expect(plugin.lastDeleteSessionId, isNull);
+      expect(await db.sessionDao.getSession(sessionId: "s3"), isNotNull);
+      expect(operationLog, isEmpty);
     });
 
-    test("deleteWorktree=true with legacy deleteBranch=true removes only worktree", () async {
+    test("legacy combined cleanup is rejected before worktree removal", () async {
       await _insertSession(
         db: db,
         sessionId: "s4",
@@ -263,25 +265,27 @@ void main() {
       );
       worktreeService.safetyResult = WorktreeSafe();
 
-      final response = await handler.handle(
-        makeRequest("DELETE", "/session/delete"),
-        body: const DeleteSessionRequest(
-          sessionId: "s4",
-          deleteWorktree: true,
-          deleteBranch: true,
-          force: false,
+      await expectLater(
+        () => handler.handle(
+          makeRequest("DELETE", "/session/delete"),
+          body: const DeleteSessionRequest(
+            sessionId: "s4",
+            deleteWorktree: true,
+            deleteBranch: true,
+            force: false,
+          ),
+          pathParams: {},
+          queryParams: {},
+          fragment: null,
         ),
-        pathParams: {},
-        queryParams: {},
-        fragment: null,
+        throwsA(isA<RelayResponse>().having((response) => response.status, "status", 422)),
       );
 
-      expect(response, isA<SuccessEmptyResponse>());
-      expect(worktreeService.checkCallCount, equals(1));
-      expect(worktreeService.removeCallCount, equals(1));
-      expect(plugin.lastDeleteSessionId, equals("s4"));
-      expect(await db.sessionDao.getSession(sessionId: "s4"), isNull);
-      expect(operationLog, equals(["checkSafety", "removeWorktree", "pluginDelete"]));
+      expect(worktreeService.checkCallCount, isZero);
+      expect(worktreeService.removeCallCount, isZero);
+      expect(plugin.lastDeleteSessionId, isNull);
+      expect(await db.sessionDao.getSession(sessionId: "s4"), isNotNull);
+      expect(operationLog, isEmpty);
     });
 
     test("5) deleteWorktree=true on dirty worktree, force=false: returns 409 rejection", () async {
@@ -367,7 +371,7 @@ void main() {
         body: const DeleteSessionRequest(
           sessionId: "s7",
           deleteWorktree: true,
-          deleteBranch: true,
+          deleteBranch: false,
           force: false,
         ),
         pathParams: {},
@@ -401,7 +405,7 @@ void main() {
             const DeleteSessionRequest(
               sessionId: "s9",
               deleteWorktree: true,
-              deleteBranch: true,
+              deleteBranch: false,
               force: false,
             ).toJson(),
           ),
@@ -436,7 +440,7 @@ void main() {
           body: const DeleteSessionRequest(
             sessionId: "s10",
             deleteWorktree: true,
-            deleteBranch: true,
+            deleteBranch: false,
             force: false,
           ),
           pathParams: {},

--- a/bridge/app/test/bridge/routing/delete_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/delete_session_handler_test.dart
@@ -287,7 +287,7 @@ void main() {
       expect(worktreeService.checkCallCount, equals(1));
       expect(worktreeService.removeCallCount, equals(1));
       expect(worktreeService.deleteBranchCallCount, equals(1));
-      expect(worktreeService.lastDeleteBranchForce, isFalse);
+      expect(worktreeService.lastDeleteBranchForce, isTrue);
       expect(plugin.lastDeleteSessionId, equals("s4"));
       expect(await db.sessionDao.getSession(sessionId: "s4"), isNull);
       expect(operationLog, equals(["checkSafety", "removeWorktree", "deleteBranch", "pluginDelete"]));

--- a/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
+++ b/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
@@ -250,7 +250,7 @@ void main() {
       expect(persisted?.archivedAt, isNotNull);
     });
 
-    test("legacy deleteBranch=true is ignored while archiving", () async {
+    test("legacy deleteBranch=true is rejected before archiving", () async {
       await _insertSession(
         db: db,
         sessionId: "s1-legacy",
@@ -263,22 +263,25 @@ void main() {
         baseCommit: null,
       );
 
-      await handler.handle(
-        makeRequest("PATCH", "/session/update/archive"),
-        body: _archiveRequest(
-          sessionId: "s1-legacy",
-          archived: true,
-          deleteWorktree: false,
-          deleteBranch: true,
-          force: false,
+      await expectLater(
+        () => handler.handle(
+          makeRequest("PATCH", "/session/update/archive"),
+          body: _archiveRequest(
+            sessionId: "s1-legacy",
+            archived: true,
+            deleteWorktree: false,
+            deleteBranch: true,
+            force: false,
+          ),
+          pathParams: {},
+          queryParams: {},
+          fragment: null,
         ),
-        pathParams: {},
-        queryParams: {},
-        fragment: null,
+        throwsA(isA<RelayResponse>().having((response) => response.status, "status", 422)),
       );
 
       final persisted = await db.sessionDao.getSession(sessionId: "s1-legacy");
-      expect(persisted?.archivedAt, isNotNull);
+      expect(persisted?.archivedAt, isNull);
       expect(worktreeService.checkCallCount, isZero);
       expect(worktreeService.removeCallCount, isZero);
     });
@@ -458,7 +461,7 @@ void main() {
               sessionId: "missing",
               archived: true,
               deleteWorktree: true,
-              deleteBranch: true,
+              deleteBranch: false,
               force: false,
             ).toJson(),
           ),
@@ -497,7 +500,7 @@ void main() {
               sessionId: "stale-plugin-session",
               archived: true,
               deleteWorktree: true,
-              deleteBranch: true,
+              deleteBranch: false,
               force: false,
             ).toJson(),
           ),
@@ -680,7 +683,7 @@ void main() {
           sessionId: "s1",
           archived: true,
           deleteWorktree: true,
-          deleteBranch: true,
+          deleteBranch: false,
           force: false,
         ),
         pathParams: {},

--- a/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
+++ b/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
@@ -56,7 +56,7 @@ void main() {
           filesystemRepository: filesystemRepository,
           sessionOperationDispatcher: operationDispatcher,
           archivedSessionValidator: ArchivedSessionValidator(sessionRepository: sessionRepository),
-        chatHistoryService: createTestChatHistory().service,
+          chatHistoryService: createTestChatHistory().service,
         ),
         sessionUnseenService: unseenService = buildTestSessionUnseenService(db, plugin),
       );
@@ -152,7 +152,6 @@ void main() {
 
       expect(worktreeService.checkCallCount, equals(0));
       expect(worktreeService.removeCallCount, equals(0));
-      expect(worktreeService.deleteBranchCallCount, equals(0));
       final persisted = await db.sessionDao.getSession(sessionId: "s1");
       expect(persisted?.archivedAt, isNotNull);
       expect(result.id, equals("s1"));
@@ -251,40 +250,37 @@ void main() {
       expect(persisted?.archivedAt, isNotNull);
     });
 
-    test("failed branch deletion preserves the unarchived session for retry", () async {
+    test("legacy deleteBranch=true is ignored while archiving", () async {
       await _insertSession(
         db: db,
-        sessionId: "s1-failed",
+        sessionId: "s1-legacy",
         projectId: "/repo",
         isDedicated: true,
-        worktreePath: "/repo/.worktrees/session-001-failed",
-        branchName: "session-001-failed",
+        worktreePath: "/repo/.worktrees/session-001-legacy",
+        branchName: "session-001-legacy",
         baseBranch: null,
         archivedAt: null,
         baseCommit: null,
       );
-      worktreeService.deleteBranchResult = false;
 
-      await expectLater(
-        () => handler.handle(
-          makeRequest("PATCH", "/session/update/archive"),
-          body: _archiveRequest(
-            sessionId: "s1-failed",
-            archived: true,
-            deleteWorktree: false,
-            deleteBranch: true,
-            force: false,
-          ),
-          pathParams: {},
-          queryParams: {},
-          fragment: null,
+      await handler.handle(
+        makeRequest("PATCH", "/session/update/archive"),
+        body: _archiveRequest(
+          sessionId: "s1-legacy",
+          archived: true,
+          deleteWorktree: false,
+          deleteBranch: true,
+          force: false,
         ),
-        throwsA(isA<SessionCleanupFailedException>()),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
       );
 
-      final persisted = await db.sessionDao.getSession(sessionId: "s1-failed");
-      expect(persisted?.archivedAt, isNull);
-      expect(worktreeService.deleteBranchCallCount, equals(1));
+      final persisted = await db.sessionDao.getSession(sessionId: "s1-legacy");
+      expect(persisted?.archivedAt, isNotNull);
+      expect(worktreeService.checkCallCount, isZero);
+      expect(worktreeService.removeCallCount, isZero);
     });
 
     test("archive with cleanup on dirty worktree throws 409", () async {
@@ -476,7 +472,6 @@ void main() {
       expect(plugin.lastArchiveSessionId, isNull);
       expect(worktreeService.checkCallCount, 0);
       expect(worktreeService.removeCallCount, 0);
-      expect(worktreeService.deleteBranchCallCount, 0);
     });
 
     test("stored plugin mismatch returns 503 before plugin I/O or cleanup", () async {
@@ -516,7 +511,6 @@ void main() {
       expect(plugin.lastArchiveSessionId, isNull);
       expect(worktreeService.checkCallCount, 0);
       expect(worktreeService.removeCallCount, 0);
-      expect(worktreeService.deleteBranchCallCount, 0);
       expect((await db.sessionDao.getSession(sessionId: "stale-plugin-session"))?.archivedAt, isNull);
     });
 
@@ -696,7 +690,6 @@ void main() {
 
       expect(worktreeService.checkCallCount, equals(0));
       expect(worktreeService.removeCallCount, equals(0));
-      expect(worktreeService.deleteBranchCallCount, equals(0));
       final persisted = await db.sessionDao.getSession(sessionId: "s1");
       expect(persisted?.archivedAt, isNotNull);
     });
@@ -856,20 +849,15 @@ Future<void> _insertSession({
 class _FakeWorktreeService({required AppDatabase database}) extends WorktreeService {
   WorktreeSafetyResult safetyResult = WorktreeSafe();
   bool removeResult = true;
-  bool deleteBranchResult = true;
   bool branchExistsResult = true;
 
   int checkCallCount = 0;
   int removeCallCount = 0;
-  int deleteBranchCallCount = 0;
 
   String? lastCheckWorktreePath;
   String? lastRemoveProjectId;
   String? lastRemoveWorktreePath;
   bool? lastRemoveForce;
-  String? lastDeleteBranchProjectId;
-  String? lastDeleteBranchName;
-  bool? lastDeleteBranchForce;
 
   this
     : super(
@@ -905,19 +893,6 @@ class _FakeWorktreeService({required AppDatabase database}) extends WorktreeServ
     lastRemoveWorktreePath = worktreePath;
     lastRemoveForce = force;
     return removeResult;
-  }
-
-  @override
-  Future<bool> deleteBranch({
-    required String projectId,
-    required String branchName,
-    required bool force,
-  }) async {
-    deleteBranchCallCount++;
-    lastDeleteBranchProjectId = projectId;
-    lastDeleteBranchName = branchName;
-    lastDeleteBranchForce = force;
-    return deleteBranchResult;
   }
 
   @override

--- a/bridge/app/test/bridge/services/session_family_mutation_test.dart
+++ b/bridge/app/test/bridge/services/session_family_mutation_test.dart
@@ -130,7 +130,6 @@ void main() {
       final result = await fixture.deletions.deleteSession(
         sessionId: "root",
         deleteWorktree: true,
-        deleteBranch: false,
         force: false,
       );
 
@@ -243,7 +242,6 @@ class _Fixture() {
     final result = await deletions.deleteSession(
       sessionId: "root",
       deleteWorktree: false,
-      deleteBranch: false,
       force: false,
     );
     if (result is CleanupRejected) throw StateError("unexpected cleanup rejection");
@@ -254,7 +252,6 @@ class _Fixture() {
       sessionId: "root",
       archived: archived,
       deleteWorktree: false,
-      deleteBranch: false,
       force: false,
     );
   }
@@ -300,6 +297,7 @@ class _FamilyRepository() implements SessionRepository {
     if (record == null) throw StateError("missing test session $sessionId");
     record.archivedAt = archived ? 1 : null;
   }
+
   @override
   Future<SessionFamilyScope> resolveSessionFamily({
     required String sessionId,
@@ -464,9 +462,6 @@ class _FamilyWorktreeService() implements WorktreeService {
     required String worktreePath,
     required bool force,
   }) async => true;
-
-  @override
-  Future<bool> deleteBranch({required String projectId, required String branchName, required bool force}) async => true;
 
   @override
   Future<bool> branchExists({required String projectId, required String branchName}) async => false;

--- a/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
+++ b/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
@@ -62,14 +62,12 @@ void main() {
         worktreePath: "/repo/.worktrees/session-001",
         branchName: "session-001",
         deleteWorktree: false,
-        deleteBranch: false,
         force: false,
       );
 
       expect(result, isA<CleanupSuccess>());
       expect(worktreeService.checkCallCount, equals(0));
       expect(worktreeService.removeCallCount, equals(0));
-      expect(worktreeService.deleteBranchCallCount, equals(0));
     });
 
     test("missing root binding is an explicit not-found failure", () async {
@@ -77,7 +75,6 @@ void main() {
         service.cleanupAlreadyReserved(
           sessionId: "missing",
           deleteWorktree: true,
-          deleteBranch: true,
           force: false,
         ),
         throwsA(isA<PluginOperationException>().having((error) => error.isNotFound, "isNotFound", isTrue)),
@@ -85,7 +82,6 @@ void main() {
 
       expect(worktreeService.checkCallCount, isZero);
       expect(worktreeService.removeCallCount, isZero);
-      expect(worktreeService.deleteBranchCallCount, isZero);
     });
 
     test("plugin mismatch is rejected before archive cleanup or plugin I/O", () async {
@@ -109,7 +105,6 @@ void main() {
           sessionId: "s-mismatch",
           archived: true,
           deleteWorktree: true,
-          deleteBranch: true,
           force: true,
         ),
         throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 503)),
@@ -117,7 +112,6 @@ void main() {
 
       expect(worktreeService.checkCallCount, isZero);
       expect(worktreeService.removeCallCount, isZero);
-      expect(worktreeService.deleteBranchCallCount, isZero);
     });
 
     test("clean worktree removes worktree and returns success", () async {
@@ -130,7 +124,6 @@ void main() {
         worktreePath: "/repo/.worktrees/session-002",
         branchName: "session-002",
         deleteWorktree: true,
-        deleteBranch: false,
         force: false,
       );
 
@@ -138,7 +131,6 @@ void main() {
       expect(worktreeService.checkCallCount, equals(1));
       expect(worktreeService.removeCallCount, equals(1));
       expect(worktreeService.lastRemoveWorktreePath, equals("/repo/.worktrees/session-002"));
-      expect(worktreeService.deleteBranchCallCount, equals(0));
     });
 
     test("failed worktree removal throws instead of reporting success", () async {
@@ -157,7 +149,6 @@ void main() {
           worktreePath: worktree.path,
           branchName: "session-002-failed",
           deleteWorktree: true,
-          deleteBranch: false,
           force: false,
         ),
         throwsA(
@@ -168,48 +159,6 @@ void main() {
           ),
         ),
       );
-    });
-
-    test("identical retry continues branch cleanup after worktree was removed", () async {
-      worktreeService.safetyResult = WorktreeSafe();
-      worktreeService.deleteBranchResult = false;
-      final worktree = Directory.systemTemp.createTempSync("cleanup_retry_");
-      addTearDown(() {
-        if (worktree.existsSync()) worktree.deleteSync(recursive: true);
-      });
-
-      await expectLater(
-        () => _cleanup(
-          service: service,
-          sessionRepository: sessionRepository,
-          sessionId: "s2-retry",
-          worktreePath: worktree.path,
-          branchName: "session-002-retry",
-          deleteWorktree: true,
-          deleteBranch: true,
-          force: false,
-        ),
-        throwsA(isA<SessionCleanupFailedException>()),
-      );
-      worktree.deleteSync(recursive: true);
-      worktreeService.removeResult = false;
-      worktreeService.deleteBranchResult = true;
-
-      final retryResult = await _cleanup(
-        service: service,
-        sessionRepository: sessionRepository,
-        sessionId: "s2-retry",
-        worktreePath: worktree.path,
-        branchName: "session-002-retry",
-        deleteWorktree: true,
-        deleteBranch: true,
-        force: false,
-      );
-
-      expect(retryResult, isA<CleanupSuccess>());
-      expect(worktreeService.removeCallCount, equals(2));
-      expect(worktreeService.deleteBranchCallCount, equals(2));
-      expect(worktreeService.lastDeleteBranchForce, isTrue);
     });
 
     test("dirty worktree without force rejects with mapped issues", () async {
@@ -226,7 +175,6 @@ void main() {
         worktreePath: "/repo/.worktrees/session-003",
         branchName: "session-003",
         deleteWorktree: true,
-        deleteBranch: false,
         force: false,
       );
 
@@ -241,7 +189,6 @@ void main() {
         ),
       );
       expect(worktreeService.removeCallCount, equals(0));
-      expect(worktreeService.deleteBranchCallCount, equals(0));
     });
 
     test("dirty worktree with force skips safety check and succeeds", () async {
@@ -256,7 +203,6 @@ void main() {
         worktreePath: "/repo/.worktrees/session-004",
         branchName: "session-004",
         deleteWorktree: true,
-        deleteBranch: false,
         force: true,
       );
 
@@ -264,82 +210,6 @@ void main() {
       expect(worktreeService.checkCallCount, equals(0));
       expect(worktreeService.removeCallCount, equals(1));
       expect(worktreeService.lastRemoveForce, isTrue);
-    });
-
-    test("delete worktree and branch runs both operations", () async {
-      worktreeService.safetyResult = WorktreeSafe();
-
-      final result = await _cleanup(
-        service: service,
-        sessionRepository: sessionRepository,
-        sessionId: "s5",
-        worktreePath: "/repo/.worktrees/session-005",
-        branchName: "session-005",
-        deleteWorktree: true,
-        deleteBranch: true,
-        force: false,
-      );
-
-      expect(result, isA<CleanupSuccess>());
-      expect(worktreeService.checkCallCount, equals(1));
-      expect(worktreeService.removeCallCount, equals(1));
-      expect(worktreeService.deleteBranchCallCount, equals(1));
-      expect(worktreeService.lastDeleteBranchForce, isTrue);
-    });
-
-    test("failed branch deletion throws instead of reporting success", () async {
-      worktreeService.deleteBranchResult = false;
-
-      await expectLater(
-        () => _cleanup(
-          service: service,
-          sessionRepository: sessionRepository,
-          sessionId: "s5-failed",
-          worktreePath: "/repo/.worktrees/session-005-failed",
-          branchName: "session-005-failed",
-          deleteWorktree: false,
-          deleteBranch: true,
-          force: false,
-        ),
-        throwsA(
-          isA<SessionCleanupFailedException>().having(
-            (error) => error.operation,
-            "operation",
-            SessionCleanupOperation.deleteBranch,
-          ),
-        ),
-      );
-    });
-
-    test("identical retry accepts a branch that was already deleted", () async {
-      final firstResult = await _cleanup(
-        service: service,
-        sessionRepository: sessionRepository,
-        sessionId: "s5-retry",
-        worktreePath: "/repo/.worktrees/session-005-retry",
-        branchName: "session-005-retry",
-        deleteWorktree: false,
-        deleteBranch: true,
-        force: false,
-      );
-      expect(firstResult, isA<CleanupSuccess>());
-
-      worktreeService.deleteBranchResult = false;
-      worktreeService.branchExistsResult = false;
-      final retryResult = await _cleanup(
-        service: service,
-        sessionRepository: sessionRepository,
-        sessionId: "s5-retry",
-        worktreePath: "/repo/.worktrees/session-005-retry",
-        branchName: "session-005-retry",
-        deleteWorktree: false,
-        deleteBranch: true,
-        force: false,
-      );
-
-      expect(retryResult, isA<CleanupSuccess>());
-      expect(worktreeService.deleteBranchCallCount, equals(2));
-      expect(worktreeService.branchExistsCallCount, equals(1));
     });
 
     test("shared worktree rejected when force=false", () async {
@@ -352,7 +222,6 @@ void main() {
         worktreePath: "/repo/.worktrees/session-006",
         branchName: "session-006",
         deleteWorktree: true,
-        deleteBranch: true,
         force: false,
       );
 
@@ -362,7 +231,6 @@ void main() {
       expect(sessionRepository.hasSharingCallCount, equals(1));
       expect(worktreeService.checkCallCount, equals(0));
       expect(worktreeService.removeCallCount, equals(0));
-      expect(worktreeService.deleteBranchCallCount, equals(0));
     });
 
     test("force=true bypasses shared-worktree check and proceeds with cleanup", () async {
@@ -375,7 +243,6 @@ void main() {
         worktreePath: "/repo/.worktrees/session-006b",
         branchName: "session-006b",
         deleteWorktree: true,
-        deleteBranch: true,
         force: true,
       );
 
@@ -384,7 +251,6 @@ void main() {
       expect(result, isA<CleanupSuccess>());
       expect(sessionRepository.hasSharingCallCount, equals(0));
       expect(worktreeService.removeCallCount, equals(1));
-      expect(worktreeService.deleteBranchCallCount, equals(1));
     });
 
     test("no rejection when no other sessions share worktree", () async {
@@ -398,7 +264,6 @@ void main() {
         worktreePath: "/repo/.worktrees/session-007",
         branchName: "session-007",
         deleteWorktree: true,
-        deleteBranch: false,
         force: false,
       );
 
@@ -419,14 +284,12 @@ void main() {
         worktreePath: "/repo/.worktrees/session-008",
         branchName: "session-008",
         deleteWorktree: true,
-        deleteBranch: true,
         force: false,
       );
 
       expect(result, isA<CleanupSuccess>());
       expect(sessionRepository.hasSharingCallCount, equals(1));
       expect(worktreeService.removeCallCount, equals(1));
-      expect(worktreeService.deleteBranchCallCount, equals(1));
     });
   });
 
@@ -485,7 +348,6 @@ void main() {
         sessionId: "root-session",
         archived: true,
         deleteWorktree: false,
-        deleteBranch: false,
         force: false,
       );
       await Future<void>.delayed(Duration.zero);
@@ -509,7 +371,6 @@ void main() {
           sessionId: "root-session",
           archived: false,
           deleteWorktree: false,
-          deleteBranch: false,
           force: false,
         ),
         throwsA(
@@ -531,7 +392,6 @@ void main() {
         sessionId: "root-session",
         archived: false,
         deleteWorktree: false,
-        deleteBranch: false,
         force: false,
       );
 
@@ -549,7 +409,6 @@ Future<CleanupResult> _cleanup({
   required String worktreePath,
   required String branchName,
   required bool deleteWorktree,
-  required bool deleteBranch,
   required bool force,
 }) {
   sessionRepository.storedSession = StoredSession(
@@ -569,7 +428,6 @@ Future<CleanupResult> _cleanup({
   return service.cleanupAlreadyReserved(
     sessionId: sessionId,
     deleteWorktree: deleteWorktree,
-    deleteBranch: deleteBranch,
     force: force,
   );
 }
@@ -662,17 +520,12 @@ class _FakeSessionRepository() implements SessionRepository {
 class _FakeWorktreeService({required AppDatabase database}) extends WorktreeService {
   WorktreeSafetyResult safetyResult = WorktreeSafe();
   bool removeResult = true;
-  bool deleteBranchResult = true;
-  bool branchExistsResult = true;
 
   int checkCallCount = 0;
   int removeCallCount = 0;
-  int deleteBranchCallCount = 0;
-  int branchExistsCallCount = 0;
 
   String? lastRemoveWorktreePath;
   bool? lastRemoveForce;
-  bool? lastDeleteBranchForce;
 
   this
     : super(
@@ -706,26 +559,6 @@ class _FakeWorktreeService({required AppDatabase database}) extends WorktreeServ
     lastRemoveWorktreePath = worktreePath;
     lastRemoveForce = force;
     return removeResult;
-  }
-
-  @override
-  Future<bool> deleteBranch({
-    required String projectId,
-    required String branchName,
-    required bool force,
-  }) async {
-    deleteBranchCallCount++;
-    lastDeleteBranchForce = force;
-    return deleteBranchResult;
-  }
-
-  @override
-  Future<bool> branchExists({
-    required String projectId,
-    required String branchName,
-  }) async {
-    branchExistsCallCount++;
-    return branchExistsResult;
   }
 }
 

--- a/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
+++ b/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
@@ -187,7 +187,7 @@ void main() {
           branchName: "session-002-retry",
           deleteWorktree: true,
           deleteBranch: true,
-          force: true,
+          force: false,
         ),
         throwsA(isA<SessionCleanupFailedException>()),
       );
@@ -203,12 +203,13 @@ void main() {
         branchName: "session-002-retry",
         deleteWorktree: true,
         deleteBranch: true,
-        force: true,
+        force: false,
       );
 
       expect(retryResult, isA<CleanupSuccess>());
       expect(worktreeService.removeCallCount, equals(2));
       expect(worktreeService.deleteBranchCallCount, equals(2));
+      expect(worktreeService.lastDeleteBranchForce, isTrue);
     });
 
     test("dirty worktree without force rejects with mapped issues", () async {
@@ -283,7 +284,7 @@ void main() {
       expect(worktreeService.checkCallCount, equals(1));
       expect(worktreeService.removeCallCount, equals(1));
       expect(worktreeService.deleteBranchCallCount, equals(1));
-      expect(worktreeService.lastDeleteBranchForce, isFalse);
+      expect(worktreeService.lastDeleteBranchForce, isTrue);
     });
 
     test("failed branch deletion throws instead of reporting success", () async {

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -860,7 +860,7 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  // pruneWorktrees / removeWorktree / deleteBranch
+  // pruneWorktrees / removeWorktree
   // -------------------------------------------------------------------------
 
   group("WorktreeService lifecycle methods", () {
@@ -989,41 +989,6 @@ void main() {
       );
 
       expect(result, isFalse);
-    });
-
-    // deleteBranch (force: false)
-
-    test("deleteBranch(force: false): calls git branch -d <branch>", () async {
-      processRunner.enqueue(result: _ok());
-
-      final result = await service.deleteBranch(
-        projectId: _projectId,
-        branchName: "session-001",
-        force: false,
-      );
-
-      expect(result, isTrue);
-      expect(processRunner.invocations, hasLength(1));
-      final inv = processRunner.invocations.first;
-      expect(inv.arguments, equals(["branch", "-d", "--", "session-001"]));
-      expect(inv.workingDirectory, equals(_projectId));
-    });
-
-    // deleteBranch (force: true)
-
-    test("deleteBranch(force: true): calls git branch -D <branch>", () async {
-      processRunner.enqueue(result: _ok());
-
-      final result = await service.deleteBranch(
-        projectId: _projectId,
-        branchName: "session-001",
-        force: true,
-      );
-
-      expect(result, isTrue);
-      expect(processRunner.invocations, hasLength(1));
-      final inv = processRunner.invocations.first;
-      expect(inv.arguments, equals(["branch", "-D", "--", "session-001"]));
     });
   });
 }

--- a/client/app/lib/features/session_list/session_cleanup_dialogs.dart
+++ b/client/app/lib/features/session_list/session_cleanup_dialogs.dart
@@ -6,7 +6,7 @@ part of "session_list_action_dispatcher.dart";
 
 class const _DeleteSessionSheet({
   required final Session session,
-  required final void Function({required bool deleteWorktree, required bool deleteBranch}) onConfirm,
+  required final void Function({required bool deleteWorktree}) onConfirm,
 }) extends StatefulWidget {
   @override
   State<_DeleteSessionSheet> createState() => _DeleteSessionSheetState();
@@ -14,7 +14,6 @@ class const _DeleteSessionSheet({
 
 class _DeleteSessionSheetState() extends State<_DeleteSessionSheet> {
   bool _deleteWorktree = true;
-  bool _deleteBranch = true;
 
   @override
   Widget build(BuildContext context) {
@@ -49,14 +48,6 @@ class _DeleteSessionSheetState() extends State<_DeleteSessionSheet> {
                 controlAffinity: ListTileControlAffinity.leading,
                 contentPadding: EdgeInsets.zero,
               ),
-              CheckboxListTile(
-                value: _deleteBranch,
-                onChanged: (v) => setState(() => _deleteBranch = v ?? false),
-                title: Text(loc.sessionListDeleteBranchCheckbox),
-                dense: true,
-                controlAffinity: ListTileControlAffinity.leading,
-                contentPadding: EdgeInsets.zero,
-              ),
               const SizedBox(height: 12),
             ],
             Row(
@@ -73,7 +64,6 @@ class _DeleteSessionSheetState() extends State<_DeleteSessionSheet> {
                     context.pop();
                     widget.onConfirm(
                       deleteWorktree: hasWorktree && _deleteWorktree,
-                      deleteBranch: hasWorktree && _deleteBranch,
                     );
                   },
                   child: Text(loc.sessionListDeleteConfirmAction),
@@ -93,7 +83,7 @@ class _DeleteSessionSheetState() extends State<_DeleteSessionSheet> {
 
 class const _ArchiveSessionSheet({
   required final Session session,
-  required final void Function({required bool deleteWorktree, required bool deleteBranch}) onConfirm,
+  required final void Function({required bool deleteWorktree}) onConfirm,
 }) extends StatefulWidget {
   @override
   State<_ArchiveSessionSheet> createState() => _ArchiveSessionSheetState();
@@ -101,7 +91,6 @@ class const _ArchiveSessionSheet({
 
 class _ArchiveSessionSheetState() extends State<_ArchiveSessionSheet> {
   bool _deleteWorktree = true;
-  bool _deleteBranch = true;
 
   @override
   Widget build(BuildContext context) {
@@ -136,14 +125,6 @@ class _ArchiveSessionSheetState() extends State<_ArchiveSessionSheet> {
                 controlAffinity: ListTileControlAffinity.leading,
                 contentPadding: EdgeInsets.zero,
               ),
-              CheckboxListTile(
-                value: _deleteBranch,
-                onChanged: (v) => setState(() => _deleteBranch = v ?? false),
-                title: Text(loc.sessionListDeleteBranchCheckbox),
-                dense: true,
-                controlAffinity: ListTileControlAffinity.leading,
-                contentPadding: EdgeInsets.zero,
-              ),
               const SizedBox(height: 12),
             ],
             Row(
@@ -159,7 +140,6 @@ class _ArchiveSessionSheetState() extends State<_ArchiveSessionSheet> {
                     context.pop();
                     widget.onConfirm(
                       deleteWorktree: hasWorktree && _deleteWorktree,
-                      deleteBranch: hasWorktree && _deleteBranch,
                     );
                   },
                   child: Text(loc.sessionListArchiveConfirmAction),

--- a/client/app/lib/features/session_list/session_force_dialog.dart
+++ b/client/app/lib/features/session_list/session_force_dialog.dart
@@ -11,7 +11,6 @@ void _showForceDialog({
   required SessionCleanupRejection rejection,
   required bool isDelete,
   required bool deleteWorktree,
-  required bool deleteBranch,
 }) {
   final loc = context.loc;
 
@@ -60,7 +59,6 @@ void _showForceDialog({
                   cubit: cubit,
                   sessionId: sessionId,
                   deleteWorktree: deleteWorktree,
-                  deleteBranch: deleteBranch,
                   force: true,
                 );
               } else {
@@ -69,7 +67,6 @@ void _showForceDialog({
                   cubit: cubit,
                   sessionId: sessionId,
                   deleteWorktree: deleteWorktree,
-                  deleteBranch: deleteBranch,
                   force: true,
                 );
               }

--- a/client/app/lib/features/session_list/session_list_actions.dart
+++ b/client/app/lib/features/session_list/session_list_actions.dart
@@ -17,13 +17,12 @@ void _showArchiveSheet({
     title: context.loc.sessionListArchiveConfirmTitle,
     builder: (_) => _ArchiveSessionSheet(
       session: session,
-      onConfirm: ({required bool deleteWorktree, required bool deleteBranch}) {
+      onConfirm: ({required bool deleteWorktree}) {
         _archiveSession(
           context: context,
           cubit: cubit,
           sessionId: session.id,
           deleteWorktree: deleteWorktree,
-          deleteBranch: deleteBranch,
         );
       },
     ),
@@ -35,14 +34,12 @@ Future<void> _archiveSession({
   required SessionListCubit cubit,
   required String sessionId,
   bool deleteWorktree = true,
-  bool deleteBranch = true,
   bool force = false,
 }) async {
   final loc = context.loc;
   final success = await cubit.archiveSession(
     sessionId: sessionId,
     deleteWorktree: deleteWorktree,
-    deleteBranch: deleteBranch,
     force: force,
   );
   if (!context.mounted) return;
@@ -64,7 +61,6 @@ Future<void> _archiveSession({
       rejection: rejection,
       isDelete: false,
       deleteWorktree: deleteWorktree,
-      deleteBranch: deleteBranch,
     );
   } else {
     ScaffoldMessenger.of(context)
@@ -91,13 +87,12 @@ void _showDeleteSheet({
     title: context.loc.sessionListDeleteConfirmTitle,
     builder: (_) => _DeleteSessionSheet(
       session: session,
-      onConfirm: ({required bool deleteWorktree, required bool deleteBranch}) {
+      onConfirm: ({required bool deleteWorktree}) {
         _deleteSession(
           context: context,
           cubit: cubit,
           sessionId: session.id,
           deleteWorktree: deleteWorktree,
-          deleteBranch: deleteBranch,
         );
       },
     ),
@@ -109,14 +104,12 @@ Future<void> _deleteSession({
   required SessionListCubit cubit,
   required String sessionId,
   bool deleteWorktree = true,
-  bool deleteBranch = true,
   bool force = false,
 }) async {
   final loc = context.loc;
   final success = await cubit.deleteSession(
     sessionId: sessionId,
     deleteWorktree: deleteWorktree,
-    deleteBranch: deleteBranch,
     force: force,
   );
   if (!context.mounted) return;
@@ -139,7 +132,6 @@ Future<void> _deleteSession({
       rejection: rejection,
       isDelete: true,
       deleteWorktree: deleteWorktree,
-      deleteBranch: deleteBranch,
     );
   } else {
     ScaffoldMessenger.of(context)

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -822,7 +822,6 @@
   "newSessionOptionsUpdateFailedRetained": "Couldn’t update options. Previously cached options are still available.",
   "newSessionOptionsRefreshFailedUnavailable": "Refresh failed and no valid cached options remain. You can create with defaults.",
   "sessionListDeleteWorktreeCheckbox": "Delete worktree",
-  "sessionListDeleteBranchCheckbox": "Delete branch",
   "sessionDetailArchivedNotice": "This session is archived and read-only.",
   "sessionListArchiveConfirmTitle": "Archive session?",
   "sessionListArchiveConfirmMessage": "Archiving is permanent. This session becomes read-only — you can still read it, but you cannot reopen it, send prompts, or unarchive it.",

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -2839,12 +2839,6 @@ abstract class AppLocalizations {
   /// **'Delete worktree'**
   String get sessionListDeleteWorktreeCheckbox;
 
-  /// No description provided for @sessionListDeleteBranchCheckbox.
-  ///
-  /// In en, this message translates to:
-  /// **'Delete branch'**
-  String get sessionListDeleteBranchCheckbox;
-
   /// No description provided for @sessionDetailArchivedNotice.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -1,5 +1,6 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
+
 import 'app_localizations.dart';
 
 // ignore_for_file: type=lint
@@ -1491,9 +1492,6 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get sessionListDeleteWorktreeCheckbox => 'Delete worktree';
-
-  @override
-  String get sessionListDeleteBranchCheckbox => 'Delete branch';
 
   @override
   String get sessionDetailArchivedNotice => 'This session is archived and read-only.';

--- a/client/app/test/features/session_list/adaptive_session_list_navigation_test.dart
+++ b/client/app/test/features/session_list/adaptive_session_list_navigation_test.dart
@@ -414,7 +414,6 @@ void main() {
       () => harness.sessionRepository.deleteSession(
         sessionId: any(named: "sessionId"),
         deleteWorktree: any(named: "deleteWorktree"),
-        deleteBranch: any(named: "deleteBranch"),
         force: any(named: "force"),
       ),
     ).thenAnswer((_) async => ApiResponse<void>.success(null));
@@ -472,7 +471,6 @@ void main() {
       () => harness.sessionRepository.deleteSession(
         sessionId: any(named: "sessionId"),
         deleteWorktree: any(named: "deleteWorktree"),
-        deleteBranch: any(named: "deleteBranch"),
         force: any(named: "force"),
       ),
     ).thenAnswer((_) async => ApiResponse<void>.success(null));

--- a/client/app/test/features/session_list/session_lifecycle_ui_test.dart
+++ b/client/app/test/features/session_list/session_lifecycle_ui_test.dart
@@ -194,7 +194,6 @@ class const _TestDeleteSheet({required final Session session, required final Ses
 
 class _TestDeleteSheetState() extends State<_TestDeleteSheet> {
   bool _deleteWorktree = true;
-  bool _deleteBranch = true;
 
   @override
   Widget build(BuildContext context) {
@@ -212,12 +211,6 @@ class _TestDeleteSheetState() extends State<_TestDeleteSheet> {
             onChanged: (v) => setState(() => _deleteWorktree = v ?? false),
             title: Text(loc.sessionListDeleteWorktreeCheckbox),
           ),
-          CheckboxListTile(
-            key: const Key("delete-branch-checkbox"),
-            value: _deleteBranch,
-            onChanged: (v) => setState(() => _deleteBranch = v ?? false),
-            title: Text(loc.sessionListDeleteBranchCheckbox),
-          ),
           FilledButton(
             key: const Key("confirm-delete-button"),
             onPressed: () {
@@ -225,7 +218,6 @@ class _TestDeleteSheetState() extends State<_TestDeleteSheet> {
               widget.cubit.deleteSession(
                 sessionId: widget.session.id,
                 deleteWorktree: _deleteWorktree,
-                deleteBranch: _deleteBranch,
                 force: false,
               );
             },
@@ -245,7 +237,6 @@ class const _TestArchiveSheet({required final Session session, required final Se
 
 class _TestArchiveSheetState() extends State<_TestArchiveSheet> {
   bool _deleteWorktree = true;
-  bool _deleteBranch = true;
 
   @override
   Widget build(BuildContext context) {
@@ -263,12 +254,6 @@ class _TestArchiveSheetState() extends State<_TestArchiveSheet> {
             onChanged: (v) => setState(() => _deleteWorktree = v ?? false),
             title: Text(loc.sessionListDeleteWorktreeCheckbox),
           ),
-          CheckboxListTile(
-            key: const Key("archive-branch-checkbox"),
-            value: _deleteBranch,
-            onChanged: (v) => setState(() => _deleteBranch = v ?? false),
-            title: Text(loc.sessionListDeleteBranchCheckbox),
-          ),
           FilledButton(
             key: const Key("confirm-archive-button"),
             onPressed: () {
@@ -276,7 +261,6 @@ class _TestArchiveSheetState() extends State<_TestArchiveSheet> {
               widget.cubit.archiveSession(
                 sessionId: widget.session.id,
                 deleteWorktree: _deleteWorktree,
-                deleteBranch: _deleteBranch,
                 force: false,
               );
             },
@@ -371,7 +355,7 @@ void main() {
   // ---------------------------------------------------------------------------
 
   group("Delete bottom sheet", () {
-    testWidgets("shows checkboxes for delete worktree and branch", (tester) async {
+    testWidgets("shows delete worktree checkbox", (tester) async {
       final session = testSession(title: "My Session");
       when(() => mockCubit.state).thenReturn(
         SessionListState.loaded(sessions: [session], baseBranch: null, repoSlug: null),
@@ -387,9 +371,7 @@ void main() {
       await tester.tap(find.text("Delete"));
       await tester.pumpAndSettle();
 
-      // Verify checkboxes appear
       expect(find.text("Delete worktree"), findsOneWidget);
-      expect(find.text("Delete branch"), findsOneWidget);
       expect(find.text("Delete session?"), findsOneWidget);
     });
 
@@ -407,15 +389,10 @@ void main() {
       await tester.tap(find.text("Delete"));
       await tester.pumpAndSettle();
 
-      // Both checkboxes should be checked by default
       final worktreeCheckbox = tester.widget<CheckboxListTile>(
         find.byKey(const Key("delete-worktree-checkbox")),
       );
-      final branchCheckbox = tester.widget<CheckboxListTile>(
-        find.byKey(const Key("delete-branch-checkbox")),
-      );
       expect(worktreeCheckbox.value, isTrue);
-      expect(branchCheckbox.value, isTrue);
     });
 
     testWidgets("unchecking worktree checkbox and confirming passes false", (tester) async {
@@ -427,7 +404,6 @@ void main() {
         () => mockCubit.deleteSession(
           sessionId: any(named: "sessionId"),
           deleteWorktree: any(named: "deleteWorktree"),
-          deleteBranch: any(named: "deleteBranch"),
           force: any(named: "force"),
         ),
       ).thenAnswer((_) async => true);
@@ -452,7 +428,6 @@ void main() {
         () => mockCubit.deleteSession(
           sessionId: session.id,
           deleteWorktree: false,
-          deleteBranch: true,
           force: false,
         ),
       ).called(1);
@@ -480,7 +455,6 @@ void main() {
 
       expect(find.text("Archive session?"), findsOneWidget);
       expect(find.text("Delete worktree"), findsOneWidget);
-      expect(find.text("Delete branch"), findsOneWidget);
     });
 
     testWidgets("archive confirm calls cubit with checkbox values", (tester) async {
@@ -492,7 +466,6 @@ void main() {
         () => mockCubit.archiveSession(
           sessionId: any(named: "sessionId"),
           deleteWorktree: any(named: "deleteWorktree"),
-          deleteBranch: any(named: "deleteBranch"),
           force: any(named: "force"),
         ),
       ).thenAnswer((_) async => true);
@@ -505,8 +478,7 @@ void main() {
       await tester.tap(find.text("Archive"));
       await tester.pumpAndSettle();
 
-      // Uncheck branch
-      await tester.tap(find.byKey(const Key("archive-branch-checkbox")));
+      await tester.tap(find.byKey(const Key("archive-worktree-checkbox")));
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const Key("confirm-archive-button")));
@@ -515,8 +487,7 @@ void main() {
       verify(
         () => mockCubit.archiveSession(
           sessionId: session.id,
-          deleteWorktree: true,
-          deleteBranch: false,
+          deleteWorktree: false,
           force: false,
         ),
       ).called(1);

--- a/client/app/test/features/session_list/session_tile_menu_test.dart
+++ b/client/app/test/features/session_list/session_tile_menu_test.dart
@@ -119,7 +119,12 @@ void main() {
 
   testWidgets("Mark as unread dismisses the menu and marks the session", (tester) async {
     final session = testSession(title: "My Session");
-    when(() => cubit.markSessionSeen(sessionId: any(named: "sessionId"), read: any(named: "read"))).thenAnswer(
+    when(
+      () => cubit.markSessionSeen(
+        sessionId: any(named: "sessionId"),
+        read: any(named: "read"),
+      ),
+    ).thenAnswer(
       (_) async {},
     );
 
@@ -164,7 +169,6 @@ void main() {
       () => cubit.archiveSession(
         sessionId: any(named: "sessionId"),
         deleteWorktree: any(named: "deleteWorktree"),
-        deleteBranch: any(named: "deleteBranch"),
         force: any(named: "force"),
       ),
     ).thenAnswer((_) async {
@@ -251,7 +255,10 @@ void main() {
 
     expect(find.text("Delete").hitTestable(), findsNothing);
     verifyNever(
-      () => cubit.markSessionSeen(sessionId: any(named: "sessionId"), read: any(named: "read")),
+      () => cubit.markSessionSeen(
+        sessionId: any(named: "sessionId"),
+        read: any(named: "read"),
+      ),
     );
   });
 }

--- a/client/app/test/features/session_list/session_tile_swipe_test.dart
+++ b/client/app/test/features/session_list/session_tile_swipe_test.dart
@@ -112,7 +112,6 @@ void main() {
       () => cubit.archiveSession(
         sessionId: any(named: "sessionId"),
         deleteWorktree: any(named: "deleteWorktree"),
-        deleteBranch: any(named: "deleteBranch"),
         force: any(named: "force"),
       ),
     );
@@ -120,7 +119,6 @@ void main() {
       () => cubit.deleteSession(
         sessionId: any(named: "sessionId"),
         deleteWorktree: any(named: "deleteWorktree"),
-        deleteBranch: any(named: "deleteBranch"),
         force: any(named: "force"),
       ),
     );
@@ -134,7 +132,6 @@ void main() {
       () => cubit.archiveSession(
         sessionId: any(named: "sessionId"),
         deleteWorktree: any(named: "deleteWorktree"),
-        deleteBranch: any(named: "deleteBranch"),
         force: any(named: "force"),
       ),
     ).thenAnswer((_) async => true);
@@ -151,7 +148,6 @@ void main() {
       () => cubit.archiveSession(
         sessionId: any(named: "sessionId"),
         deleteWorktree: any(named: "deleteWorktree"),
-        deleteBranch: any(named: "deleteBranch"),
         force: any(named: "force"),
       ),
     );
@@ -163,7 +159,6 @@ void main() {
       () => cubit.archiveSession(
         sessionId: session.id,
         deleteWorktree: false,
-        deleteBranch: false,
         force: false,
       ),
     ).called(1);
@@ -178,7 +173,6 @@ void main() {
       () => cubit.archiveSession(
         sessionId: any(named: "sessionId"),
         deleteWorktree: any(named: "deleteWorktree"),
-        deleteBranch: any(named: "deleteBranch"),
         force: any(named: "force"),
       ),
     ).thenAnswer((_) async => true);
@@ -195,7 +189,6 @@ void main() {
       () => cubit.archiveSession(
         sessionId: session.id,
         deleteWorktree: false,
-        deleteBranch: false,
         force: false,
       ),
     ).called(1);
@@ -231,7 +224,6 @@ void main() {
       () => cubit.deleteSession(
         sessionId: any(named: "sessionId"),
         deleteWorktree: any(named: "deleteWorktree"),
-        deleteBranch: any(named: "deleteBranch"),
         force: any(named: "force"),
       ),
     );
@@ -253,7 +245,6 @@ void main() {
       () => cubit.deleteSession(
         sessionId: any(named: "sessionId"),
         deleteWorktree: any(named: "deleteWorktree"),
-        deleteBranch: any(named: "deleteBranch"),
         force: any(named: "force"),
       ),
     );

--- a/client/module_core/lib/src/api/session_api.dart
+++ b/client/module_core/lib/src/api/session_api.dart
@@ -126,7 +126,6 @@ class SessionApi({required final RelayHttpApiClient _client}) {
   Future<ApiResponse<Session>> archiveSession({
     required String sessionId,
     required bool deleteWorktree,
-    required bool deleteBranch,
     required bool force,
   }) async {
     final response = await _client.patch(
@@ -136,7 +135,9 @@ class SessionApi({required final RelayHttpApiClient _client}) {
         sessionId: sessionId,
         archived: true,
         deleteWorktree: deleteWorktree,
-        deleteBranch: deleteBranch,
+        // COMPATIBILITY 2026-08-13 (v1.7.1): Published bridges require this
+        // retired field. Remove it when v1.7.1 bridges are unsupported.
+        deleteBranch: false,
         force: force,
       ),
     );
@@ -156,7 +157,6 @@ class SessionApi({required final RelayHttpApiClient _client}) {
   Future<ApiResponse<void>> deleteSession({
     required String sessionId,
     required bool deleteWorktree,
-    required bool deleteBranch,
     required bool force,
   }) async {
     final response = await _client.delete(
@@ -165,7 +165,9 @@ class SessionApi({required final RelayHttpApiClient _client}) {
       body: DeleteSessionRequest(
         sessionId: sessionId,
         deleteWorktree: deleteWorktree,
-        deleteBranch: deleteBranch,
+        // COMPATIBILITY 2026-08-13 (v1.7.1): Published bridges require this
+        // retired field. Remove it when v1.7.1 bridges are unsupported.
+        deleteBranch: false,
         force: force,
       ),
     );

--- a/client/module_core/lib/src/capabilities/session/session_service.dart
+++ b/client/module_core/lib/src/capabilities/session/session_service.dart
@@ -10,13 +10,11 @@ class SessionService({required final SessionRepository _repository}) {
   Future<ApiResponse<Session>> archiveSession({
     required String sessionId,
     required bool deleteWorktree,
-    required bool deleteBranch,
     required bool force,
   }) {
     return _repository.archiveSession(
       sessionId: sessionId,
       deleteWorktree: deleteWorktree,
-      deleteBranch: deleteBranch,
       force: force,
     );
   }
@@ -28,13 +26,11 @@ class SessionService({required final SessionRepository _repository}) {
   Future<ApiResponse<void>> deleteSession({
     required String sessionId,
     required bool deleteWorktree,
-    required bool deleteBranch,
     required bool force,
   }) {
     return _repository.deleteSession(
       sessionId: sessionId,
       deleteWorktree: deleteWorktree,
-      deleteBranch: deleteBranch,
       force: force,
     );
   }

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -346,7 +346,6 @@ class SessionListCubit({
   Future<bool> archiveSession({
     required String sessionId,
     required bool deleteWorktree,
-    required bool deleteBranch,
     required bool force,
   }) async {
     if (state is! SessionListLoaded) return false;
@@ -376,7 +375,6 @@ class SessionListCubit({
       response = await _sessionService.archiveSession(
         sessionId: sessionId,
         deleteWorktree: deleteWorktree,
-        deleteBranch: deleteBranch,
         force: force,
       );
     } on SessionCleanupRejectedException catch (error) {
@@ -417,7 +415,6 @@ class SessionListCubit({
   Future<bool> deleteSession({
     required String sessionId,
     required bool deleteWorktree,
-    required bool deleteBranch,
     required bool force,
   }) async {
     if (state is! SessionListLoaded) return false;
@@ -441,7 +438,6 @@ class SessionListCubit({
       response = await _sessionService.deleteSession(
         sessionId: sessionId,
         deleteWorktree: deleteWorktree,
-        deleteBranch: deleteBranch,
         force: force,
       );
     } on SessionCleanupRejectedException catch (error) {

--- a/client/module_core/lib/src/repositories/session_repository.dart
+++ b/client/module_core/lib/src/repositories/session_repository.dart
@@ -14,13 +14,11 @@ class SessionRepository({
   Future<ApiResponse<Session>> archiveSession({
     required String sessionId,
     required bool deleteWorktree,
-    required bool deleteBranch,
     required bool force,
   }) {
     return _api.archiveSession(
       sessionId: sessionId,
       deleteWorktree: deleteWorktree,
-      deleteBranch: deleteBranch,
       force: force,
     );
   }
@@ -32,13 +30,11 @@ class SessionRepository({
   Future<ApiResponse<void>> deleteSession({
     required String sessionId,
     required bool deleteWorktree,
-    required bool deleteBranch,
     required bool force,
   }) {
     return _api.deleteSession(
       sessionId: sessionId,
       deleteWorktree: deleteWorktree,
-      deleteBranch: deleteBranch,
       force: force,
     );
   }

--- a/client/module_core/test/capabilities/session/session_service_test.dart
+++ b/client/module_core/test/capabilities/session/session_service_test.dart
@@ -44,7 +44,6 @@ void main() {
       await service.archiveSession(
         sessionId: "s1",
         deleteWorktree: true,
-        deleteBranch: false,
         force: true,
       );
 
@@ -75,7 +74,6 @@ void main() {
       await service.deleteSession(
         sessionId: "s1",
         deleteWorktree: true,
-        deleteBranch: true,
         force: false,
       );
 
@@ -86,7 +84,7 @@ void main() {
           body: const DeleteSessionRequest(
             sessionId: "s1",
             deleteWorktree: true,
-            deleteBranch: true,
+            deleteBranch: false,
             force: false,
           ),
         ),
@@ -117,7 +115,6 @@ void main() {
         () => service.deleteSession(
           sessionId: "s1",
           deleteWorktree: true,
-          deleteBranch: true,
           force: false,
         ),
         throwsA(

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -442,7 +442,6 @@ void main() {
           () => mockSessionService.archiveSession(
             sessionId: "s1",
             deleteWorktree: any(named: "deleteWorktree"),
-            deleteBranch: any(named: "deleteBranch"),
             force: any(named: "force"),
           ),
         ).thenAnswer((_) async => ApiResponse.success(testSession(id: "s1")));
@@ -454,7 +453,6 @@ void main() {
         final result = await cubit.archiveSession(
           sessionId: "s1",
           deleteWorktree: false,
-          deleteBranch: false,
           force: false,
         );
         expect(result, isTrue);
@@ -487,7 +485,6 @@ void main() {
           () => mockSessionService.archiveSession(
             sessionId: "s1",
             deleteWorktree: any(named: "deleteWorktree"),
-            deleteBranch: any(named: "deleteBranch"),
             force: any(named: "force"),
           ),
         ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
@@ -498,7 +495,6 @@ void main() {
         final result = await cubit.archiveSession(
           sessionId: "s1",
           deleteWorktree: false,
-          deleteBranch: false,
           force: false,
         );
         expect(result, isFalse);
@@ -533,7 +529,6 @@ void main() {
           () => mockSessionService.archiveSession(
             sessionId: "s1",
             deleteWorktree: any(named: "deleteWorktree"),
-            deleteBranch: any(named: "deleteBranch"),
             force: any(named: "force"),
           ),
         ).thenThrow(
@@ -550,7 +545,6 @@ void main() {
         final result = await cubit.archiveSession(
           sessionId: "s1",
           deleteWorktree: true,
-          deleteBranch: true,
           force: false,
         );
         expect(result, isFalse);
@@ -580,7 +574,6 @@ void main() {
           () => mockSessionService.deleteSession(
             sessionId: "s1",
             deleteWorktree: any(named: "deleteWorktree"),
-            deleteBranch: any(named: "deleteBranch"),
             force: any(named: "force"),
           ),
         ).thenAnswer((_) async => ApiResponse<void>.success(null));
@@ -591,7 +584,6 @@ void main() {
         final result = await cubit.deleteSession(
           sessionId: "s1",
           deleteWorktree: false,
-          deleteBranch: false,
           force: false,
         );
         expect(result, isTrue);
@@ -619,7 +611,6 @@ void main() {
           () => mockSessionService.deleteSession(
             sessionId: "s1",
             deleteWorktree: any(named: "deleteWorktree"),
-            deleteBranch: any(named: "deleteBranch"),
             force: any(named: "force"),
           ),
         ).thenThrow(
@@ -636,7 +627,6 @@ void main() {
         final result = await cubit.deleteSession(
           sessionId: "s1",
           deleteWorktree: true,
-          deleteBranch: true,
           force: false,
         );
         expect(result, isFalse);
@@ -966,21 +956,17 @@ void main() {
           data: SesoriSseEvent.sessionUpdated(info: withoutPullRequest),
         ),
       );
-      final afterSessionUpdate =
-          await cubit.stream.firstWhere(
-                (state) => state is SessionListLoaded && state.sessions.single.title == "Updated",
-              )
-              as SessionListLoaded;
+      final afterSessionUpdate = await cubit.stream.firstWhere(
+        (state) => state is SessionListLoaded && state.sessions.single.title == "Updated",
+      ) as SessionListLoaded;
       expect(afterSessionUpdate.sessions.single.pullRequest, mergedPullRequest);
 
       eventController.add(
         SseEvent(data: const SesoriSessionsUpdated(projectID: projectId)),
       );
-      final afterAuthoritativeRefresh =
-          await cubit.stream.firstWhere(
-                (state) => state is SessionListLoaded && state.sessions.single.pullRequest == null,
-              )
-              as SessionListLoaded;
+      final afterAuthoritativeRefresh = await cubit.stream.firstWhere(
+        (state) => state is SessionListLoaded && state.sessions.single.pullRequest == null,
+      ) as SessionListLoaded;
       expect(afterAuthoritativeRefresh.sessions.single.pullRequest, isNull);
     });
 

--- a/docs/regression/session-archiving-and-deletion.md
+++ b/docs/regression/session-archiving-and-deletion.md
@@ -36,8 +36,9 @@ entirely along with its transcript and, optionally, its worktree.
   deleted only after cleanup succeeds, and both flows serialize against
   concurrent mutations of the same session family.
 - Published requests retain the retired `deleteBranch` field for mixed-version
-  compatibility. New clients always send `false`, and new bridges ignore either
-  value so old clients cannot cause branch deletion.
+  compatibility. New clients always send `false`, and new bridges explicitly
+  reject `true` before mutation so old clients cannot mistake unperformed branch
+  cleanup for success.
 - Clients present archiving as permanent, hide mutation affordances there, and
   list archived sessions.
 

--- a/docs/regression/session-archiving-and-deletion.md
+++ b/docs/regression/session-archiving-and-deletion.md
@@ -3,7 +3,7 @@
 ## Capability
 
 A session can be retired permanently as a read-only audit record, or removed
-entirely along with its transcript and, optionally, its worktree and branch.
+entirely along with its transcript and, optionally, its worktree.
 
 ## Required Behavior
 
@@ -19,9 +19,9 @@ entirely along with its transcript and, optionally, its worktree and branch.
 - Deletion removes the session record immediately and is destructive and not
   recoverable. History, spilled content, and the archive record are purged
   best-effort after row deletion; a logged failure leaves residue for startup
-  reconciliation. Worktree and branch cleanup happens only when requested;
-  unsafe cleanup (unstaged changes, branch mismatch, shared worktree) is refused
-  with its issues and proceeds only on a forced retry.
+  reconciliation. Worktree cleanup happens only when requested; unsafe cleanup
+  (unstaged changes or a shared worktree) is refused with its issues and proceeds
+  only on a forced retry. Session retirement never deletes a Git branch.
 - For a backend that advertises session close, deleting an active session first
   cancels its turn and pending input, waits within a bounded deadline for that
   session to settle, then closes it before local plugin state is removed. A
@@ -31,14 +31,13 @@ entirely along with its transcript and, optionally, its worktree and branch.
   A bounded but truncated scan uses OMP's global-ID resume fallback; only an
   exhausted scan is treated as idempotent not-found.
 - Cleanup safety rejection happens before mutation. Once cleanup starts, a later
-  visible failure can leave an earlier requested step complete, such as a removed
-  worktree with its branch still present; retry can finish the residue. The session
-  is deleted only after cleanup succeeds, and both flows serialize against
+  visible failure can leave the worktree already removed; an identical retry
+  accepts that missing worktree and completes session retirement. The session is
+  deleted only after cleanup succeeds, and both flows serialize against
   concurrent mutations of the same session family.
-- Selecting both worktree and branch cleanup authorizes removal of the
-  session-owned branch after worktree safety checks pass, including when that
-  branch has unmerged commits. Branch-only cleanup remains non-forcing unless the
-  user explicitly confirms a forced retry.
+- Published requests retain the retired `deleteBranch` field for mixed-version
+  compatibility. New clients always send `false`, and new bridges ignore either
+  value so old clients cannot cause branch deletion.
 - Clients present archiving as permanent, hide mutation affordances there, and
   list archived sessions.
 
@@ -48,7 +47,7 @@ entirely along with its transcript and, optionally, its worktree and branch.
 |---|---|
 | L1 Smoke | Headless bridge, one representative plugin: a session archives, stays readable, and refuses a later non-deletion mutation. |
 | L2 Routine | Headless bridge, representative: deletion removes the session immediately and purges its history and archive record, with a simulated purge failure logged and recovered by startup reconciliation; export and purge observed as a pair with honest completeness; cleanup rejection issues reported without deleting anything; a close-capable ACP session orders cancel, settlement, and close, while timeout preserves retryable state. |
-| L3 Release | Client end to end on the release-target client platform, every supporting production plugin: archive from the session list, read-only detail and archived listing, delete with and without worktree/branch cleanup, refusals presented to the user. |
+| L3 Release | Client end to end on the release-target client platform, every supporting production plugin: archive from the session list, read-only detail and archived listing, delete with and without worktree cleanup, refusals presented to the user, branch retained. |
 | L4 Extended | Relay integration, every supporting production plugin: archive or delete with a live turn, pending requests, or a stopped plugin; competing archive/delete/mutation on one family; a second client observing retirement; shared worktree and forced retry; bridge restart between export and flip. |
 | L5 Full | Headless bridge for unreadable or version-mismatched audit records, failed export, startup reconciliation, missing worktrees, and dirty or diverged repositories; packaged or external for released-client unarchive intent. Every supporting production plugin where backend export participates. |
 
@@ -57,9 +56,9 @@ entirely along with its transcript and, optionally, its worktree and branch.
 Vary session shape: plain, with a dedicated worktree and branch, sharing a
 worktree with another active session, and a family with children. Vary state at
 retirement: idle, mid-turn, awaiting a request, or with its plugin stopped. Vary
-the entry surface and cleanup choices, and alternate archive-then-delete with
-direct deletion. Delete disposable sessions and remove any test worktrees and
-branches that remain after the asserted cleanup behavior.
+the entry surface and worktree-cleanup choice, and alternate archive-then-delete
+with direct deletion. Delete disposable sessions and remove any test worktrees
+and branches that remain after the asserted cleanup behavior.
 
 ## Failure Signals
 
@@ -72,8 +71,9 @@ branches that remain after the asserted cleanup behavior.
 - A close-capable backend is closed while its prompt is still settling, emits
   late events after local removal, or reports timeout/close failure as success.
 - Unsafe cleanup proceeds without a forced retry, a refusal omits the blocking
-  issues, partial cleanup is reported as success or deletes the session, a
-  concurrent mutation interleaves, or a client presents archiving as reversible.
+  issues, session retirement deletes a branch, partial cleanup is reported as
+  success or deletes the session, a concurrent mutation interleaves, or a client
+  presents archiving as reversible.
 
 ## Known Limitations
 

--- a/docs/regression/session-archiving-and-deletion.md
+++ b/docs/regression/session-archiving-and-deletion.md
@@ -35,6 +35,10 @@ entirely along with its transcript and, optionally, its worktree and branch.
   worktree with its branch still present; retry can finish the residue. The session
   is deleted only after cleanup succeeds, and both flows serialize against
   concurrent mutations of the same session family.
+- Selecting both worktree and branch cleanup authorizes removal of the
+  session-owned branch after worktree safety checks pass, including when that
+  branch has unmerged commits. Branch-only cleanup remains non-forcing unless the
+  user explicitly confirms a forced retry.
 - Clients present archiving as permanent, hide mutation affordances there, and
   list archived sessions.
 


### PR DESCRIPTION
## Complexity
⚙️ Moderate

## What
- Stop archive and deletion cleanup from deleting Git branches.
- Remove branch-deletion primitives and the mobile branch-cleanup option.
- Keep the published request field for mixed-version compatibility: new clients send `deleteBranch: false`, and new bridges reject `true` from older clients before mutation.
- Preserve idempotent worktree cleanup so a session whose worktree was already removed can still be retired.

## Why
The original failure exposed a partially completed cleanup, but deleting the stored branch to unblock it can remove work the user intended to keep. Session retirement should own the worktree and session records, not branch lifetime.

## Risk and test focus
Moderate implementation scope with low destructive risk. The main focus is mixed-version compatibility and proving that legacy `deleteBranch: true` requests fail explicitly without deleting a branch or partially retiring a session. There is no database impact. The wire shape is intentionally retained for published client/bridge compatibility.

## Expected result
Archiving or deleting a session may remove its worktree when requested, but never deletes a Git branch. Existing partially cleaned sessions can be retried successfully because a missing worktree is accepted.

## Verification
- Bridge focused suite: 88 tests passed across lifecycle, delete/archive handlers, family mutation, and worktree service.
- Core focused suite: 50 tests passed across session API and session-list state.
- Flutter focused suite: 39 tests passed across lifecycle UI, swipe/menu actions, and adaptive navigation.
- Changed-file `dart analyze --fatal-infos`: no issues in bridge app, client core, or Flutter app.
- Architecture implementation review: approved with no findings.
- `git diff --check origin/main...HEAD`.

`dart format` reports no changes for all touched files it can process. Dart 3.13's formatter still crashes on existing valid primary-constructor enum syntax in some bridge files.
