### PR TITLE
⚙️ Render queued messages inline

### DIFF
--- a/client/app/lib/features/session_detail/widgets/queued_message_bubble.dart
+++ b/client/app/lib/features/session_detail/widgets/queued_message_bubble.dart
@@ -29,7 +29,8 @@ class const QueuedMessageBubble({
     final loc = context.loc;
     final reducedMotion = context.isReducedMotion;
     final duration = reducedMotion ? Duration.zero : const Duration(milliseconds: 240);
-    final isPending = presentation is PendingMessageBubblePresentation;
+    final isPending =
+        presentation is PendingMessageBubblePresentation || presentation is ReadOnlyPendingMessageBubblePresentation;
     final status = switch (presentation) {
       SendingMessageBubblePresentation() => _status(
         prego: prego,

--- a/client/app/lib/features/session_detail/widgets/queued_message_bubble.dart
+++ b/client/app/lib/features/session_detail/widgets/queued_message_bubble.dart
@@ -27,56 +27,53 @@ class const QueuedMessageBubble({
     final reducedMotion = context.isReducedMotion;
     final duration = reducedMotion ? Duration.zero : const Duration(milliseconds: 240);
     final isPending = presentation is PendingMessageBubblePresentation;
-    final status = KeyedSubtree(
-      key: ValueKey(presentation.runtimeType),
-      child: switch (presentation) {
-        SendingMessageBubblePresentation() => _status(
-          prego: prego,
-          icon: ExcludeSemantics(
-            child: SizedBox.square(
-              dimension: 14,
-              child: CircularProgressIndicator(
-                value: reducedMotion ? 0.75 : null,
-                strokeWidth: 1.5,
-                strokeCap: StrokeCap.round,
-                color: prego.colors.textTertiary,
-              ),
+    final status = switch (presentation) {
+      SendingMessageBubblePresentation() => _status(
+        prego: prego,
+        icon: ExcludeSemantics(
+          child: SizedBox.square(
+            dimension: 14,
+            child: CircularProgressIndicator(
+              value: reducedMotion ? 0.75 : null,
+              strokeWidth: 1.5,
+              strokeCap: StrokeCap.round,
+              color: prego.colors.textTertiary,
             ),
           ),
-          label: loc.sessionDetailSendingMessage,
         ),
-        PendingMessageBubblePresentation(:final onCancel) => Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _status(
-              prego: prego,
-              icon: Icon(
-                submission.isCommand ? TablerRegular.terminal : TablerRegular.clock,
-                size: 14,
-                color: prego.colors.textTertiary,
-              ),
-              label: submission.isCommand ? loc.sessionDetailQueuedCommand : loc.sessionDetailQueuedMessage,
+        label: loc.sessionDetailSendingMessage,
+      ),
+      PendingMessageBubblePresentation(:final onCancel) => Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _status(
+            prego: prego,
+            icon: Icon(
+              submission.isCommand ? TablerRegular.terminal : TablerRegular.clock,
+              size: 14,
+              color: prego.colors.textTertiary,
             ),
-            const SizedBox(width: PregoSpacing.xs),
-            TextButton.icon(
-              onPressed: onCancel,
-              icon: const Icon(TablerRegular.x, size: 14),
-              label: Text(loc.sessionDetailCancelQueued),
-              style: TextButton.styleFrom(
-                foregroundColor: prego.colors.textTertiary,
-                minimumSize: const Size(44, 44),
-                padding: const EdgeInsetsDirectional.symmetric(
-                  horizontal: PregoSpacing.md,
-                ),
-                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                textStyle: prego.textTheme.textXs.medium,
-                shape: const StadiumBorder(),
+            label: submission.isCommand ? loc.sessionDetailQueuedCommand : loc.sessionDetailQueuedMessage,
+          ),
+          const SizedBox(width: PregoSpacing.xs),
+          TextButton.icon(
+            onPressed: onCancel,
+            icon: const Icon(TablerRegular.x, size: 14),
+            label: Text(loc.sessionDetailCancelQueued),
+            style: TextButton.styleFrom(
+              foregroundColor: prego.colors.textTertiary,
+              minimumSize: const Size(44, 44),
+              padding: const EdgeInsetsDirectional.symmetric(
+                horizontal: PregoSpacing.md,
               ),
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              textStyle: prego.textTheme.textXs.medium,
+              shape: const StadiumBorder(),
             ),
-          ],
-        ),
-      },
-    );
+          ),
+        ],
+      ),
+    };
 
     return Column(
       crossAxisAlignment: .end,
@@ -93,40 +90,7 @@ class const QueuedMessageBubble({
             end: PregoSpacing.x2l,
             bottom: PregoSpacing.xs,
           ),
-          child: reducedMotion
-              ? status
-              : AnimatedSize(
-                  duration: duration,
-                  curve: Curves.easeInOutCubic,
-                  alignment: AlignmentDirectional.centerEnd,
-                  child: AnimatedSwitcher(
-                    duration: duration,
-                    switchInCurve: Curves.easeOutCubic,
-                    switchOutCurve: Curves.easeInCubic,
-                    transitionBuilder: (child, animation) => FadeTransition(
-                      opacity: animation,
-                      child: SizeTransition(
-                        axis: Axis.horizontal,
-                        alignment: AlignmentDirectional.centerEnd,
-                        sizeFactor: animation,
-                        child: child,
-                      ),
-                    ),
-                    layoutBuilder: (currentChild, previousChildren) => Stack(
-                      alignment: AlignmentDirectional.centerEnd,
-                      children: [
-                        for (final child in previousChildren)
-                          IgnorePointer(
-                            child: ExcludeFocus(
-                              child: ExcludeSemantics(child: child),
-                            ),
-                          ),
-                        ?currentChild,
-                      ],
-                    ),
-                    child: status,
-                  ),
-                ),
+          child: status,
         ),
       ],
     );

--- a/client/app/lib/features/session_detail/widgets/queued_message_bubble.dart
+++ b/client/app/lib/features/session_detail/widgets/queued_message_bubble.dart
@@ -8,12 +8,15 @@ import "user_message_card.dart";
 sealed class const QueuedMessageBubblePresentation() {
   const factory sending() = SendingMessageBubblePresentation;
   const factory pending({required VoidCallback onCancel}) = PendingMessageBubblePresentation;
+  const factory pendingReadOnly() = ReadOnlyPendingMessageBubblePresentation;
 }
 
 final class const SendingMessageBubblePresentation() extends QueuedMessageBubblePresentation;
 
 final class const PendingMessageBubblePresentation({required final VoidCallback onCancel})
     extends QueuedMessageBubblePresentation;
+
+final class const ReadOnlyPendingMessageBubblePresentation() extends QueuedMessageBubblePresentation;
 
 class const QueuedMessageBubble({
   super.key,
@@ -72,6 +75,15 @@ class const QueuedMessageBubble({
             ),
           ),
         ],
+      ),
+      ReadOnlyPendingMessageBubblePresentation() => _status(
+        prego: prego,
+        icon: Icon(
+          submission.isCommand ? TablerRegular.terminal : TablerRegular.clock,
+          size: 14,
+          color: prego.colors.textTertiary,
+        ),
+        label: submission.isCommand ? loc.sessionDetailQueuedCommand : loc.sessionDetailQueuedMessage,
       ),
     };
 

--- a/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
@@ -45,11 +45,10 @@ class SessionDetailLoadedView extends StatefulWidget {
 
 class _SessionDetailLoadedViewState() extends State<SessionDetailLoadedView> {
   /// Measured height of the floating bottom controls overlaying the bottom of
-  /// the chat — the background-tasks bar, queued messages and the composer. Fed
-  /// to the message list so the newest message rests just above them (and the
+  /// the chat — the background-tasks bar and composer. Fed to the message list
+  /// so the newest message rests just above them (and the
   /// "jump to latest" pill clears them) while older content scrolls up behind
-  /// the composer's fade. Read-only variants normally stay at 0, except while
-  /// an already-submitted prompt remains visible at the bottom edge.
+  /// the composer's fade. Read-only variants stay at 0.
   ///
   /// A notifier rather than state: the composer's layout morphs animate its
   /// height frame-by-frame, and each measurement must re-inset only the
@@ -82,8 +81,7 @@ class _SessionDetailLoadedViewState() extends State<SessionDetailLoadedView> {
     final loc = context.loc;
     final state = widget.state;
     final editableSessionId = widget.readOnly ? null : widget.sessionId;
-    final hasBottomControls =
-        editableSessionId != null || state.sendingSubmission != null || state.queuedMessages.isNotEmpty;
+    final hasBottomControls = editableSessionId != null;
     final showEmptyState =
         !state.hasRenderableMessages &&
         state.retryErrorMessage == null &&
@@ -112,6 +110,8 @@ class _SessionDetailLoadedViewState() extends State<SessionDetailLoadedView> {
                         builder: (context, bottomControlsHeight, _) => SessionDetailMessageList(
                           projectId: widget.projectId,
                           messages: state.messages,
+                          sendingSubmission: state.sendingSubmission,
+                          queuedMessages: state.queuedMessages,
                           isLoadingOlderMessages: state.isLoadingOlderMessages,
                           streamingText: state.streamingText,
                           children: state.children,
@@ -121,16 +121,14 @@ class _SessionDetailLoadedViewState() extends State<SessionDetailLoadedView> {
                           onLoadOlderMessages: state.olderMessagesCursor == null
                               ? null
                               : context.read<SessionDetailCubit>().loadOlderMessages,
+                          onCancelQueuedMessage: context.read<SessionDetailCubit>().cancelQueuedMessage,
                           retryErrorMessage: state.retryErrorMessage,
                           // Pad the oldest-message edge clear of the bar it scrolls
                           // behind, and the newest-message edge clear of the floating
-                          // bottom controls overlaid below (background-tasks bar,
-                          // queued messages and composer); content in between scrolls
+                          // bottom controls overlaid below (background-tasks bar and
+                          // composer); content in between scrolls
                           // up behind the bar's fade and the composer's fade.
                           topInset: topInset,
-                          // Read-only sessions normally have no controls, but a
-                          // send already in progress or stranded by archiving
-                          // remains visible and must not cover the transcript.
                           bottomInset: hasBottomControls ? bottomControlsHeight : 0,
                         ),
                       ),
@@ -179,12 +177,8 @@ class _SessionDetailLoadedViewState() extends State<SessionDetailLoadedView> {
             ],
           ),
         ),
-        // Floating bottom controls — the background-tasks bar, queued messages
-        // and the composer, stacked in that order above the composer at the
-        // bottom edge. They sit over the chat (which scrolls behind them) and
-        // are measured as one cluster so the chat insets its newest message
-        // clear of the whole stack — and so the tasks bar/queued stay tappable
-        // above the composer instead of hidden behind it.
+        // Floating bottom controls — the background-tasks bar and composer.
+        // Queued submissions are regular rows in the transcript above them.
         if (hasBottomControls)
           Positioned(
             bottom: 0,
@@ -198,7 +192,7 @@ class _SessionDetailLoadedViewState() extends State<SessionDetailLoadedView> {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  if (editableSessionId != null && state.children.isNotEmpty)
+                  if (state.children.isNotEmpty)
                     ValueListenableBuilder<PregoComposerSurfaceStyle>(
                       valueListenable: _composerSurfaceStyle,
                       builder: (context, surfaceStyle, _) => BackgroundTasksBar(
@@ -208,66 +202,60 @@ class _SessionDetailLoadedViewState() extends State<SessionDetailLoadedView> {
                         childStatuses: state.childStatuses,
                       ),
                     ),
-                  if (state.sendingSubmission != null || state.queuedMessages.isNotEmpty)
-                    SessionDetailQueuedMessagesSection(
-                      sendingSubmission: state.sendingSubmission,
-                      messages: state.queuedMessages,
-                    ),
-                  if (editableSessionId != null)
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16),
-                      child: PromptInput(
-                        draftIdentity: editableSessionId,
-                        initialDraft: context.read<SessionDetailCubit>().composerDraft,
-                        // Queued messages count: the user has already "sent"
-                        // something, so the composer should rest as a follow-up
-                        // field even before the first message lands in the list.
-                        hasMessages:
-                            state.hasRenderableMessages ||
-                            state.sendingSubmission != null ||
-                            state.queuedMessages.isNotEmpty,
-                        attachmentsSupported: state.supportsPromptAttachments,
-                        isBusy: hasActiveWork(
-                          sessionStatus: state.sessionStatus,
-                          childStatuses: state.childStatuses,
-                        ),
-                        onSend: ({required text, required command, required inputMode, required attachments}) =>
-                            context.read<SessionDetailCubit>().sendMessage(
-                              text: text,
-                              command: command,
-                              inputMode: inputMode,
-                              attachments: attachments,
-                            ),
-                        onVoiceTranscriptionCompleted: context
-                            .read<SessionDetailCubit>()
-                            .reportVoiceTranscriptionCompleted,
-                        onDraftChanged: (draft) => context.read<SessionDetailCubit>().saveComposerDraft(
-                          draft: draft,
-                        ),
-                        onDraftCleared: context.read<SessionDetailCubit>().clearComposerDraft,
-                        onAbort: () => context.read<SessionDetailCubit>().abort(),
-                        surfaceStyleController: _composerSurfaceStyle,
-                        header: null,
-                        composerHeader: ValueListenableBuilder<PregoComposerSurfaceStyle>(
-                          valueListenable: _composerSurfaceStyle,
-                          builder: (context, surfaceStyle, _) => AgentModelButtons(
-                            surfaceStyle: surfaceStyle,
-                            agents: state.availableAgents,
-                            selectedAgent: state.selectedAgent,
-                            onAgentSelected: context.read<SessionDetailCubit>().selectAgent,
-                            providers: state.availableProviders,
-                            selectedAgentModel: state.selectedAgentModel,
-                            onModelSelected: context.read<SessionDetailCubit>().selectModel,
-                            availableVariants: state.availableVariants,
-                            onVariantSelected: context.read<SessionDetailCubit>().selectVariant,
-                          ),
-                        ),
-                        availableCommands: state.availableCommands,
-                        stagedCommand: state.stagedCommand,
-                        onCommandSelected: context.read<SessionDetailCubit>().stageCommand,
-                        onCommandCleared: context.read<SessionDetailCubit>().clearStagedCommand,
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: PromptInput(
+                      draftIdentity: editableSessionId,
+                      initialDraft: context.read<SessionDetailCubit>().composerDraft,
+                      // Queued messages count: the user has already "sent"
+                      // something, so the composer should rest as a follow-up
+                      // field even before the first message lands in the list.
+                      hasMessages:
+                          state.hasRenderableMessages ||
+                          state.sendingSubmission != null ||
+                          state.queuedMessages.isNotEmpty,
+                      attachmentsSupported: state.supportsPromptAttachments,
+                      isBusy: hasActiveWork(
+                        sessionStatus: state.sessionStatus,
+                        childStatuses: state.childStatuses,
                       ),
+                      onSend: ({required text, required command, required inputMode, required attachments}) =>
+                          context.read<SessionDetailCubit>().sendMessage(
+                            text: text,
+                            command: command,
+                            inputMode: inputMode,
+                            attachments: attachments,
+                          ),
+                      onVoiceTranscriptionCompleted: context
+                          .read<SessionDetailCubit>()
+                          .reportVoiceTranscriptionCompleted,
+                      onDraftChanged: (draft) => context.read<SessionDetailCubit>().saveComposerDraft(
+                        draft: draft,
+                      ),
+                      onDraftCleared: context.read<SessionDetailCubit>().clearComposerDraft,
+                      onAbort: () => context.read<SessionDetailCubit>().abort(),
+                      surfaceStyleController: _composerSurfaceStyle,
+                      header: null,
+                      composerHeader: ValueListenableBuilder<PregoComposerSurfaceStyle>(
+                        valueListenable: _composerSurfaceStyle,
+                        builder: (context, surfaceStyle, _) => AgentModelButtons(
+                          surfaceStyle: surfaceStyle,
+                          agents: state.availableAgents,
+                          selectedAgent: state.selectedAgent,
+                          onAgentSelected: context.read<SessionDetailCubit>().selectAgent,
+                          providers: state.availableProviders,
+                          selectedAgentModel: state.selectedAgentModel,
+                          onModelSelected: context.read<SessionDetailCubit>().selectModel,
+                          availableVariants: state.availableVariants,
+                          onVariantSelected: context.read<SessionDetailCubit>().selectVariant,
+                        ),
+                      ),
+                      availableCommands: state.availableCommands,
+                      stagedCommand: state.stagedCommand,
+                      onCommandSelected: context.read<SessionDetailCubit>().stageCommand,
+                      onCommandCleared: context.read<SessionDetailCubit>().clearStagedCommand,
                     ),
+                  ),
                 ],
               ),
             ),

--- a/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
@@ -121,7 +121,9 @@ class _SessionDetailLoadedViewState() extends State<SessionDetailLoadedView> {
                           onLoadOlderMessages: state.olderMessagesCursor == null
                               ? null
                               : context.read<SessionDetailCubit>().loadOlderMessages,
-                          onCancelQueuedMessage: context.read<SessionDetailCubit>().cancelQueuedMessage,
+                          onCancelQueuedMessage: widget.readOnly
+                              ? null
+                              : context.read<SessionDetailCubit>().cancelQueuedMessage,
                           retryErrorMessage: state.retryErrorMessage,
                           // Pad the oldest-message edge clear of the bar it scrolls
                           // behind, and the newest-message edge clear of the floating

--- a/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -13,6 +13,7 @@ import "error_message_card.dart";
 import "follow_detach_scrollable.dart";
 import "jump_to_edge_pill.dart";
 import "message_timestamp_reveal.dart";
+import "queued_message_bubble.dart";
 import "retry_error_message_card.dart";
 import "scroll_follow_tracker.dart";
 import "user_message_card.dart";
@@ -25,7 +26,7 @@ import "user_message_card.dart";
 ///
 /// - The [chat_core.ChatController] holds **content-stable index
 ///   entries** only — one `CustomMessage(id, authorId)` per domain
-///   message (plus one synthetic entry for the retry-error row). All
+///   message, plus synthetic retry-error and transient-submission rows. All
 ///   visible content (message parts, streaming text, tool state) is
 ///   resolved from the cubit-provided widget props inside the row
 ///   builders, keyed by message id. Token deltas therefore never
@@ -49,7 +50,8 @@ import "user_message_card.dart";
 ///   false`; the at-bottom variant is a no-op for reversed lists).
 /// - While **detached** (user dragged / trackpad-scrolled / pan-zoomed
 ///   away from the bottom), the full set of rendered inputs
-///   (`messages`, `streamingText`, `children`, `childStatuses`) is
+///   (`messages`, transient submissions, `streamingText`, `children`,
+///   `childStatuses`) is
 ///   snapshotted AND controller syncing is suspended, so nothing below
 ///   (or above) the user's viewport can grow, shrink, or reorder under
 ///   them. Both freezes lift the moment the user reattaches.
@@ -61,6 +63,8 @@ class const SessionDetailMessageList({
   super.key,
   required final String? projectId,
   required final List<MessageWithParts> messages,
+  required final QueuedSessionSubmission? sendingSubmission,
+  required final List<QueuedSessionSubmission> queuedMessages,
   required final Map<String, String> streamingText,
   required final List<Session> children,
   required final Map<String, SessionStatus> childStatuses,
@@ -68,6 +72,7 @@ class const SessionDetailMessageList({
   /// Requests the page of messages before the ones shown, or null when the
   /// start of the transcript is already loaded.
   required final Future<void> Function()? onLoadOlderMessages,
+  required final ValueChanged<int> onCancelQueuedMessage,
   required final bool isLoadingOlderMessages,
   final String? retryErrorMessage,
 
@@ -93,11 +98,15 @@ class const SessionDetailMessageList({
 /// the viewport stays pinned to what the user was reading.
 typedef _DetachedSnapshot = ({
   List<MessageWithParts> messages,
+  QueuedSessionSubmission? sendingSubmission,
+  List<QueuedSessionSubmission> queuedMessages,
   Map<String, String> streamingText,
   List<Session> children,
   Map<String, SessionStatus> childStatuses,
   String? retryErrorMessage,
 });
+
+typedef _TransientSubmission = ({QueuedSessionSubmission submission, bool isSending});
 
 class _SessionDetailMessageListState() extends State<SessionDetailMessageList> with SingleTickerProviderStateMixin {
   static const _kListViewKey = Key("session-detail-message-list-view");
@@ -118,6 +127,7 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
   /// pinned at the newest edge. Domain message ids come from the
   /// assistant backend and cannot collide with this.
   static const _kRetryErrorRowId = "session-detail-retry-error-row";
+  static const _kTransientSubmissionRowPrefix = "session-detail-transient-submission-";
 
   static const _kUserAuthorId = "user";
   static const _kAgentAuthorId = "agent";
@@ -132,6 +142,7 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
   static const _kUserRole = "user";
   static const _kAssistantRole = "assistant";
   static const _kErrorRole = "error";
+  static const _kTransientSubmissionRole = "transient-submission";
 
   late final ScrollFollowTracker _follow;
   late final chat_core.InMemoryChatController _chatController;
@@ -185,6 +196,11 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
   /// flush — recompute only when the underlying [ThemeData] changes.
   (ThemeData, chat_core.ChatTheme)? _chatThemeCache;
 
+  /// The chat controller needs string IDs; object identity keeps one row stable
+  /// as the queue moves the same submission from pending to sending.
+  final Expando<String> _transientSubmissionEntryIds = Expando<String>();
+  int _nextTransientSubmissionEntryId = 0;
+
   @override
   void initState() {
     super.initState();
@@ -198,6 +214,8 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
     _chatController = chat_core.InMemoryChatController(
       messages: _chatEntriesFor(
         messages: widget.messages,
+        sendingSubmission: widget.sendingSubmission,
+        queuedMessages: widget.queuedMessages,
         hasRetryError: widget.retryErrorMessage != null,
       ),
     );
@@ -249,6 +267,8 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
     setState(() {
       _snapshot = (
         messages: List<MessageWithParts>.unmodifiable(merged),
+        sendingSubmission: frozen.sendingSubmission,
+        queuedMessages: frozen.queuedMessages,
         streamingText: frozen.streamingText,
         children: frozen.children,
         childStatuses: frozen.childStatuses,
@@ -265,6 +285,8 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
     // render agree on both the rows and the retry state.
     _syncChatControllerTo(
       messages: merged,
+      sendingSubmission: frozen.sendingSubmission,
+      queuedMessages: frozen.queuedMessages,
       hasRetryError: frozen.retryErrorMessage != null,
     );
   }
@@ -291,6 +313,8 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
       } else {
         _snapshot ??= (
           messages: List<MessageWithParts>.unmodifiable(widget.messages),
+          sendingSubmission: widget.sendingSubmission,
+          queuedMessages: List<QueuedSessionSubmission>.unmodifiable(widget.queuedMessages),
           streamingText: Map<String, String>.unmodifiable(widget.streamingText),
           children: List<Session>.unmodifiable(widget.children),
           childStatuses: Map<String, SessionStatus>.unmodifiable(widget.childStatuses),
@@ -308,15 +332,24 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
   void _syncChatController() {
     _syncChatControllerTo(
       messages: widget.messages,
+      sendingSubmission: widget.sendingSubmission,
+      queuedMessages: widget.queuedMessages,
       hasRetryError: widget.retryErrorMessage != null,
     );
   }
 
   void _syncChatControllerTo({
     required List<MessageWithParts> messages,
+    required QueuedSessionSubmission? sendingSubmission,
+    required List<QueuedSessionSubmission> queuedMessages,
     required bool hasRetryError,
   }) {
-    final target = _chatEntriesFor(messages: messages, hasRetryError: hasRetryError);
+    final target = _chatEntriesFor(
+      messages: messages,
+      sendingSubmission: sendingSubmission,
+      queuedMessages: queuedMessages,
+      hasRetryError: hasRetryError,
+    );
     final current = _chatController.messages;
     if (_entriesMatch(current: current, target: target)) return;
     unawaited(
@@ -345,6 +378,8 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
 
   List<chat_core.Message> _chatEntriesFor({
     required List<MessageWithParts> messages,
+    required QueuedSessionSubmission? sendingSubmission,
+    required List<QueuedSessionSubmission> queuedMessages,
     required bool hasRetryError,
   }) {
     return <chat_core.Message>[
@@ -370,7 +405,27 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
             },
           ),
       if (hasRetryError) const chat_core.Message.custom(id: _kRetryErrorRowId, authorId: _kAgentAuthorId),
+      if (sendingSubmission != null) _chatEntryFor(submission: sendingSubmission),
+      for (final submission in queuedMessages) _chatEntryFor(submission: submission),
     ];
+  }
+
+  chat_core.Message _chatEntryFor({required QueuedSessionSubmission submission}) {
+    return chat_core.Message.custom(
+      id: _entryIdFor(submission: submission),
+      authorId: _kUserAuthorId,
+      metadata: const <String, String>{
+        _kRoleMetadataKey: _kTransientSubmissionRole,
+      },
+    );
+  }
+
+  String _entryIdFor({required QueuedSessionSubmission submission}) {
+    final existing = _transientSubmissionEntryIds[submission];
+    if (existing != null) return existing;
+    final id = "$_kTransientSubmissionRowPrefix${_nextTransientSubmissionEntryId++}";
+    _transientSubmissionEntryIds[submission] = id;
+    return id;
   }
 
   static Future<chat_core.User?> _resolveUser(String id) async => chat_core.User(id: id);
@@ -380,12 +435,20 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
     final loc = context.loc;
     final snap = _snapshot;
     final messages = snap?.messages ?? widget.messages;
+    final sendingSubmission = snap == null ? widget.sendingSubmission : snap.sendingSubmission;
+    final queuedMessages = snap == null ? widget.queuedMessages : snap.queuedMessages;
     final streamingText = snap?.streamingText ?? widget.streamingText;
     final children = snap?.children ?? widget.children;
     final childStatuses = snap?.childStatuses ?? widget.childStatuses;
     final retryErrorMessage = snap?.retryErrorMessage ?? widget.retryErrorMessage;
 
     final indexById = _indexByIdFor(messages: messages);
+    final transientSubmissions = <String, _TransientSubmission>{
+      if (sendingSubmission != null)
+        _entryIdFor(submission: sendingSubmission): (submission: sendingSubmission, isSending: true),
+      for (final submission in queuedMessages)
+        _entryIdFor(submission: submission): (submission: submission, isSending: false),
+    };
 
     // Coalesced post-frame pin-to-edge while following. The scheduler
     // collapses repeated calls within a frame and the jump is skipped
@@ -465,13 +528,14 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
                   entry: message,
                   messages: messages,
                   indexById: indexById,
+                  transientSubmissions: transientSubmissions,
                   streamingText: streamingText,
                   children: children,
                   childStatuses: childStatuses,
                   retryErrorMessage: retryErrorMessage,
                 ),
-            // The prompt input, queued bubbles and tasks bar live outside
-            // this widget; reserve no composer space inside the list.
+            // The prompt input and tasks bar live outside this widget; reserve
+            // no composer space inside the list.
             composerBuilder: (context) => const SizedBox.shrink(),
             // Follow/detach owns the jump affordance via the overlay pill.
             scrollToBottomBuilder: (context, animation, onPressed) => const SizedBox.shrink(),
@@ -506,6 +570,7 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
     required chat_core.CustomMessage entry,
     required List<MessageWithParts> messages,
     required Map<String, int> indexById,
+    required Map<String, _TransientSubmission> transientSubmissions,
     required Map<String, String> streamingText,
     required List<Session> children,
     required Map<String, SessionStatus> childStatuses,
@@ -515,6 +580,22 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
       if (retryErrorMessage == null) return const SizedBox.shrink();
       // Synthetic row: no timestamp, but it still slides with the rest.
       return _revealable(createdAtMs: null, child: RetryErrorMessageCard(message: retryErrorMessage));
+    }
+    final transientSubmission = transientSubmissions[entry.id];
+    if (transientSubmission != null) {
+      final submission = transientSubmission.submission;
+      return _revealable(
+        createdAtMs: null,
+        child: QueuedMessageBubble(
+          key: ObjectKey(submission),
+          submission: submission,
+          presentation: transientSubmission.isSending
+              ? const QueuedMessageBubblePresentation.sending()
+              : QueuedMessageBubblePresentation.pending(
+                  onCancel: () => _cancelQueuedSubmission(submission: submission),
+                ),
+        ),
+      );
     }
     final index = indexById[entry.id];
     if (index == null || index >= messages.length) return const SizedBox.shrink();
@@ -534,6 +615,36 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
       final MessageError messageError => ErrorMessageCard(message: messageError),
     };
     return _revealable(createdAtMs: message.info.time?.created, child: card);
+  }
+
+  void _cancelQueuedSubmission({required QueuedSessionSubmission submission}) {
+    final index = widget.queuedMessages.indexWhere((candidate) => identical(candidate, submission));
+    if (index < 0) return;
+    final frozen = _snapshot;
+    if (frozen != null) {
+      final queuedMessages = [
+        for (final candidate in frozen.queuedMessages)
+          if (!identical(candidate, submission)) candidate,
+      ];
+      setState(() {
+        _snapshot = (
+          messages: frozen.messages,
+          sendingSubmission: frozen.sendingSubmission,
+          queuedMessages: List<QueuedSessionSubmission>.unmodifiable(queuedMessages),
+          streamingText: frozen.streamingText,
+          children: frozen.children,
+          childStatuses: frozen.childStatuses,
+          retryErrorMessage: frozen.retryErrorMessage,
+        );
+      });
+      _syncChatControllerTo(
+        messages: frozen.messages,
+        sendingSubmission: frozen.sendingSubmission,
+        queuedMessages: queuedMessages,
+        hasRetryError: frozen.retryErrorMessage != null,
+      );
+    }
+    widget.onCancelQueuedMessage(index);
   }
 
   /// Wraps a row so the shared horizontal drag reveals its timestamp.

--- a/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -72,7 +72,7 @@ class const SessionDetailMessageList({
   /// Requests the page of messages before the ones shown, or null when the
   /// start of the transcript is already loaded.
   required final Future<void> Function()? onLoadOlderMessages,
-  required final ValueChanged<int> onCancelQueuedMessage,
+  required final ValueChanged<int>? onCancelQueuedMessage,
   required final bool isLoadingOlderMessages,
   final String? retryErrorMessage,
 
@@ -347,7 +347,10 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
       ?oldWidget.sendingSubmission,
       ...oldWidget.queuedMessages,
     };
-    return widget.queuedMessages.any((submission) => !previous.contains(submission));
+    return [
+      ?widget.sendingSubmission,
+      ...widget.queuedMessages,
+    ].any((submission) => !previous.contains(submission));
   }
 
   /// Mirrors the domain transcript into the chat controller. Entries
@@ -610,6 +613,7 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
     final transientSubmission = transientSubmissions[entry.id];
     if (transientSubmission != null) {
       final submission = transientSubmission.submission;
+      final onCancelQueuedMessage = widget.onCancelQueuedMessage;
       return _revealable(
         createdAtMs: null,
         child: QueuedMessageBubble(
@@ -617,6 +621,8 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
           submission: submission,
           presentation: transientSubmission.isSending
               ? const QueuedMessageBubblePresentation.sending()
+              : onCancelQueuedMessage == null
+              ? const QueuedMessageBubblePresentation.pendingReadOnly()
               : QueuedMessageBubblePresentation.pending(
                   onCancel: () => _cancelQueuedSubmission(submission: submission),
                 ),
@@ -644,9 +650,11 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
   }
 
   void _cancelQueuedSubmission({required QueuedSessionSubmission submission}) {
+    final onCancelQueuedMessage = widget.onCancelQueuedMessage;
+    if (onCancelQueuedMessage == null) return;
     final index = widget.queuedMessages.indexWhere((candidate) => identical(candidate, submission));
     if (index < 0) return;
-    widget.onCancelQueuedMessage(index);
+    onCancelQueuedMessage(index);
   }
 
   /// Wraps a row so the shared horizontal drag reveals its timestamp.

--- a/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -98,8 +98,6 @@ class const SessionDetailMessageList({
 /// the viewport stays pinned to what the user was reading.
 typedef _DetachedSnapshot = ({
   List<MessageWithParts> messages,
-  QueuedSessionSubmission? sendingSubmission,
-  List<QueuedSessionSubmission> queuedMessages,
   Map<String, String> streamingText,
   List<Session> children,
   Map<String, SessionStatus> childStatuses,
@@ -252,6 +250,21 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
       return;
     }
     final frozen = _snapshot;
+    final transientSubmissionsChanged = !_transientSubmissionsMatch(oldWidget: oldWidget);
+    if (frozen != null && transientSubmissionsChanged) {
+      _syncChatControllerTo(
+        messages: frozen.messages,
+        sendingSubmission: widget.sendingSubmission,
+        queuedMessages: widget.queuedMessages,
+        hasRetryError: frozen.retryErrorMessage != null,
+      );
+      if (_hasNewTransientSubmission(oldWidget: oldWidget)) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted || _follow.following) return;
+          unawaited(_follow.animateToEdge());
+        });
+      }
+    }
     if (!olderPageRequestCompleted) return;
     _olderPageRequestInFlight = false;
     if (frozen == null) return;
@@ -267,8 +280,6 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
     setState(() {
       _snapshot = (
         messages: List<MessageWithParts>.unmodifiable(merged),
-        sendingSubmission: frozen.sendingSubmission,
-        queuedMessages: frozen.queuedMessages,
         streamingText: frozen.streamingText,
         children: frozen.children,
         childStatuses: frozen.childStatuses,
@@ -285,8 +296,8 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
     // render agree on both the rows and the retry state.
     _syncChatControllerTo(
       messages: merged,
-      sendingSubmission: frozen.sendingSubmission,
-      queuedMessages: frozen.queuedMessages,
+      sendingSubmission: widget.sendingSubmission,
+      queuedMessages: widget.queuedMessages,
       hasRetryError: frozen.retryErrorMessage != null,
     );
   }
@@ -313,8 +324,6 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
       } else {
         _snapshot ??= (
           messages: List<MessageWithParts>.unmodifiable(widget.messages),
-          sendingSubmission: widget.sendingSubmission,
-          queuedMessages: List<QueuedSessionSubmission>.unmodifiable(widget.queuedMessages),
           streamingText: Map<String, String>.unmodifiable(widget.streamingText),
           children: List<Session>.unmodifiable(widget.children),
           childStatuses: Map<String, SessionStatus>.unmodifiable(widget.childStatuses),
@@ -322,6 +331,23 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
         );
       }
     });
+  }
+
+  bool _transientSubmissionsMatch({required SessionDetailMessageList oldWidget}) {
+    if (!identical(oldWidget.sendingSubmission, widget.sendingSubmission)) return false;
+    if (oldWidget.queuedMessages.length != widget.queuedMessages.length) return false;
+    for (var i = 0; i < widget.queuedMessages.length; i++) {
+      if (!identical(oldWidget.queuedMessages[i], widget.queuedMessages[i])) return false;
+    }
+    return true;
+  }
+
+  bool _hasNewTransientSubmission({required SessionDetailMessageList oldWidget}) {
+    final previous = <QueuedSessionSubmission>{
+      ?oldWidget.sendingSubmission,
+      ...oldWidget.queuedMessages,
+    };
+    return widget.queuedMessages.any((submission) => !previous.contains(submission));
   }
 
   /// Mirrors the domain transcript into the chat controller. Entries
@@ -435,8 +461,8 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
     final loc = context.loc;
     final snap = _snapshot;
     final messages = snap?.messages ?? widget.messages;
-    final sendingSubmission = snap == null ? widget.sendingSubmission : snap.sendingSubmission;
-    final queuedMessages = snap == null ? widget.queuedMessages : snap.queuedMessages;
+    final sendingSubmission = widget.sendingSubmission;
+    final queuedMessages = widget.queuedMessages;
     final streamingText = snap?.streamingText ?? widget.streamingText;
     final children = snap?.children ?? widget.children;
     final childStatuses = snap?.childStatuses ?? widget.childStatuses;
@@ -620,30 +646,6 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
   void _cancelQueuedSubmission({required QueuedSessionSubmission submission}) {
     final index = widget.queuedMessages.indexWhere((candidate) => identical(candidate, submission));
     if (index < 0) return;
-    final frozen = _snapshot;
-    if (frozen != null) {
-      final queuedMessages = [
-        for (final candidate in frozen.queuedMessages)
-          if (!identical(candidate, submission)) candidate,
-      ];
-      setState(() {
-        _snapshot = (
-          messages: frozen.messages,
-          sendingSubmission: frozen.sendingSubmission,
-          queuedMessages: List<QueuedSessionSubmission>.unmodifiable(queuedMessages),
-          streamingText: frozen.streamingText,
-          children: frozen.children,
-          childStatuses: frozen.childStatuses,
-          retryErrorMessage: frozen.retryErrorMessage,
-        );
-      });
-      _syncChatControllerTo(
-        messages: frozen.messages,
-        sendingSubmission: frozen.sendingSubmission,
-        queuedMessages: queuedMessages,
-        hasRetryError: frozen.retryErrorMessage != null,
-      );
-    }
     widget.onCancelQueuedMessage(index);
   }
 

--- a/client/app/lib/features/session_detail/widgets/session_detail_scaffold_sections.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_scaffold_sections.dart
@@ -1,12 +1,10 @@
 import "package:flutter/material.dart";
-import "package:flutter_bloc/flutter_bloc.dart";
 import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:theme_prego/module_prego.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/extensions/remote_failure_x.dart";
-import "queued_message_bubble.dart";
 
 /// A floating call-to-action pinned below the top bar when the session has a
 /// pending question or permission. Rendered as a semantic-tinted liquid-glass
@@ -67,37 +65,6 @@ class const SessionDetailArchivedNotice({super.key}) extends StatelessWidget {
           titleStyle: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textSecondary),
         ),
       ),
-    );
-  }
-}
-
-class const SessionDetailQueuedMessagesSection({
-  super.key,
-  required final QueuedSessionSubmission? sendingSubmission,
-  required final List<QueuedSessionSubmission> messages,
-}) extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        // beginSend moves this exact submission instance from pending to active;
-        // identity keeps its bubble element mounted so it can animate the change.
-        if (sendingSubmission case final submission?)
-          QueuedMessageBubble(
-            key: ObjectKey(submission),
-            submission: submission,
-            presentation: const QueuedMessageBubblePresentation.sending(),
-          ),
-        for (var i = 0; i < messages.length; i++)
-          QueuedMessageBubble(
-            key: ObjectKey(messages[i]),
-            submission: messages[i],
-            presentation: QueuedMessageBubblePresentation.pending(
-              onCancel: () => context.read<SessionDetailCubit>().cancelQueuedMessage(i),
-            ),
-          ),
-      ],
     );
   }
 }

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -2557,7 +2557,7 @@ void main() {
     expect(find.text("1 image"), findsOneWidget);
   });
 
-  testWidgets("a queued submission uses the shared outlined Markdown bubble and status rail", (tester) async {
+  testWidgets("a queued submission renders inline with the transcript", (tester) async {
     const submission = QueuedSessionSubmission.text(
       text: "Please **review** `main.dart`",
       inputMode: ComposerInputMode.typed,
@@ -2574,6 +2574,22 @@ void main() {
     await tester.pumpWidget(_buildApp(cubit: cubit));
     await tester.pumpAndSettle();
 
+    expect(
+      find.descendant(
+        of: find.byType(SessionDetailMessageList),
+        matching: find.byType(QueuedMessageBubble),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.ancestor(
+        of: find.byType(QueuedMessageBubble),
+        matching: find.byWidgetPredicate(
+          (widget) => widget is CustomScrollView && widget.reverse,
+        ),
+      ),
+      findsOneWidget,
+    );
     final bubble = tester.widget<UserMessageBubble>(
       find.descendant(of: find.byType(QueuedMessageBubble), matching: find.byType(UserMessageBubble)),
     );
@@ -2587,7 +2603,7 @@ void main() {
     verify(() => cubit.cancelQueuedMessage(0)).called(1);
   });
 
-  testWidgets("the same queued bubble element animates into sending", (tester) async {
+  testWidgets("the same inline queued bubble becomes sending in place", (tester) async {
     const submission = QueuedSessionSubmission.text(
       text: "Cold-start prompt",
       inputMode: ComposerInputMode.typed,
@@ -2615,12 +2631,9 @@ void main() {
 
     final submissionFinder = find.byKey(const ObjectKey(submission));
     final before = tester.element(submissionFinder);
-    final submissionCancel = find.descendant(
-      of: submissionFinder,
-      matching: find.widgetWithText(TextButton, "Cancel"),
-    );
-    final cancelFocus = Focus.of(
-      tester.element(find.descendant(of: submissionCancel, matching: find.text("Cancel"))),
+    expect(
+      find.descendant(of: find.byType(SessionDetailMessageList), matching: submissionFinder),
+      findsOneWidget,
     );
     expect(
       tester
@@ -2630,10 +2643,6 @@ void main() {
           .outlined,
       isTrue,
     );
-    cancelFocus.requestFocus();
-    await tester.pump();
-    expect(cancelFocus.hasFocus, isTrue);
-
     state = state.copyWith(queuedMessages: const [followingSubmission], sendingSubmission: submission);
     states.add(state);
     await tester.idle();
@@ -2648,19 +2657,9 @@ void main() {
           .outlined,
       isFalse,
     );
-    expect(cancelFocus.hasFocus, isFalse);
     expect(find.text("Sending"), findsOneWidget);
-    expect(find.text("Cancel"), findsNWidgets(2));
-
-    final fadingCancel = find.descendant(of: submissionFinder, matching: find.text("Cancel"));
-    await tester.tap(fadingCancel, warnIfMissed: false);
-    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
-    verifyNever(() => cubit.cancelQueuedMessage(any()));
-
-    await tester.pump(const Duration(milliseconds: 241));
-    await tester.pump();
-    expect(fadingCancel, findsNothing);
     expect(find.text("Cancel"), findsOneWidget);
+    expect(find.descendant(of: submissionFinder, matching: find.text("Cancel")), findsNothing);
   });
 
   testWidgets("reduced motion swaps queued feedback immediately", (tester) async {

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -567,10 +567,22 @@ void main() {
 
   testWidgets("an archived session is read-only: no composer, no pending banners", (tester) async {
     // Archiving is permanent, so an archived session is audit-only.
-    final state = _loadedState(
-      pendingQuestions: const [_question],
-      pendingPermissions: const [_permission],
-    ).copyWith(isArchived: true);
+    final state =
+        _loadedState(
+          pendingQuestions: const [_question],
+          pendingPermissions: const [_permission],
+        ).copyWith(
+          isArchived: true,
+          queuedMessages: const [
+            QueuedSessionSubmission.text(
+              text: "Queued before archive",
+              inputMode: ComposerInputMode.typed,
+              attachments: [],
+              agent: "coder",
+              agentModel: null,
+            ),
+          ],
+        );
     when(() => cubit.state).thenReturn(state);
 
     await tester.pumpWidget(_buildApp(cubit: cubit));
@@ -581,6 +593,9 @@ void main() {
     // Pending requests can never be answered on an archived session.
     expect(find.text("1 pending question"), findsNothing);
     expect(find.text("1 permission request pending"), findsNothing);
+    expect(find.text("Queued before archive"), findsOneWidget);
+    expect(find.text("Queued"), findsOneWidget);
+    expect(find.widgetWithText(TextButton, "Cancel"), findsNothing);
   });
 
   testWidgets("closes an open question when it leaves pending state", (tester) async {

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -596,6 +596,10 @@ void main() {
     expect(find.text("Queued before archive"), findsOneWidget);
     expect(find.text("Queued"), findsOneWidget);
     expect(find.widgetWithText(TextButton, "Cancel"), findsNothing);
+    expect(
+      tester.widget<UserMessageBubble>(find.byType(UserMessageBubble)).outlined,
+      isTrue,
+    );
   });
 
   testWidgets("closes an open question when it leaves pending state", (tester) async {

--- a/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -25,6 +25,7 @@ class _SessionDetailMessageListHarnessState() extends State<_SessionDetailMessag
   late List<MessageWithParts> _messages;
   late Map<String, String> _streamingText;
   late List<QueuedSessionSubmission> _queuedMessages;
+  QueuedSessionSubmission? _sendingSubmission;
   late String? _retryErrorMessage;
   bool _isLoadingOlderMessages = false;
   int? lastCancelledQueuedMessageIndex;
@@ -70,6 +71,17 @@ class _SessionDetailMessageListHarnessState() extends State<_SessionDetailMessag
     setState(() => _queuedMessages = [..._queuedMessages]..removeAt(index));
   }
 
+  void enqueueSubmission(QueuedSessionSubmission submission) {
+    setState(() => _queuedMessages = [..._queuedMessages, submission]);
+  }
+
+  void beginSending() {
+    setState(() {
+      _sendingSubmission = _queuedMessages.first;
+      _queuedMessages = _queuedMessages.sublist(1);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -82,7 +94,7 @@ class _SessionDetailMessageListHarnessState() extends State<_SessionDetailMessag
           projectId: null,
           onLoadOlderMessages: widget.onLoadOlderMessages,
           messages: _messages,
-          sendingSubmission: null,
+          sendingSubmission: _sendingSubmission,
           queuedMessages: _queuedMessages,
           isLoadingOlderMessages: _isLoadingOlderMessages,
           streamingText: _streamingText,
@@ -540,6 +552,73 @@ void main() {
 
     expect(harnessKey.currentState!.lastCancelledQueuedMessageIndex, 0);
     expect(find.text("Queued while reading history"), findsNothing);
+    expect(find.widgetWithText(TextButton, "Cancel"), findsNothing);
+    expect(find.byKey(_jumpToLatestKey), findsOneWidget);
+  });
+
+  testWidgets("submitting while detached returns to latest and shows the inline row", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    const submission = QueuedSessionSubmission.text(
+      text: "New prompt from history",
+      inputMode: ComposerInputMode.typed,
+      attachments: [],
+      agent: "coder",
+      agentModel: null,
+    );
+    final harnessKey = GlobalKey<_SessionDetailMessageListHarnessState>();
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        key: harnessKey,
+        initialMessages: _userMessages(count: 12),
+        initialStreamingText: const {},
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _detachViewport(tester);
+
+    harnessKey.currentState!.enqueueSubmission(submission);
+    await tester.pumpAndSettle();
+
+    expect(find.text("New prompt from history"), findsOneWidget);
+    expect(find.byKey(_jumpToLatestKey), findsNothing);
+    expect(_position(tester).pixels, 0);
+  });
+
+  testWidgets("promotion to sending stays live without reattaching a detached reader", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    const submission = QueuedSessionSubmission.text(
+      text: "Queued before reconnect",
+      inputMode: ComposerInputMode.typed,
+      attachments: [],
+      agent: "coder",
+      agentModel: null,
+    );
+    final harnessKey = GlobalKey<_SessionDetailMessageListHarnessState>();
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        key: harnessKey,
+        initialMessages: _userMessages(count: 12),
+        initialStreamingText: const {},
+        initialQueuedMessages: const [submission],
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _sendPointerScroll(
+      tester: tester,
+      target: find.byKey(_listViewKey),
+      delta: const Offset(0, 30),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byKey(_jumpToLatestKey), findsOneWidget);
+
+    harnessKey.currentState!.beginSending();
+    await _pumpListUpdate(tester);
+
+    expect(find.text("Sending"), findsOneWidget);
     expect(find.widgetWithText(TextButton, "Cancel"), findsNothing);
     expect(find.byKey(_jumpToLatestKey), findsOneWidget);
   });

--- a/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -75,6 +75,10 @@ class _SessionDetailMessageListHarnessState() extends State<_SessionDetailMessag
     setState(() => _queuedMessages = [..._queuedMessages, submission]);
   }
 
+  void sendDirectly(QueuedSessionSubmission submission) {
+    setState(() => _sendingSubmission = submission);
+  }
+
   void beginSending() {
     setState(() {
       _sendingSubmission = _queuedMessages.first;
@@ -621,6 +625,39 @@ void main() {
     expect(find.text("Sending"), findsOneWidget);
     expect(find.widgetWithText(TextButton, "Cancel"), findsNothing);
     expect(find.byKey(_jumpToLatestKey), findsOneWidget);
+  });
+
+  testWidgets("a new direct-to-sending submission returns a detached reader to latest", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    const submission = QueuedSessionSubmission.text(
+      text: "Direct sending prompt",
+      inputMode: ComposerInputMode.typed,
+      attachments: [],
+      agent: "coder",
+      agentModel: null,
+    );
+    final harnessKey = GlobalKey<_SessionDetailMessageListHarnessState>();
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        key: harnessKey,
+        initialMessages: _userMessages(count: 12),
+        initialStreamingText: const {},
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _detachViewport(tester);
+
+    harnessKey.currentState!.sendDirectly(submission);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 181));
+    await tester.pump();
+
+    expect(find.text("Direct sending prompt"), findsOneWidget);
+    expect(find.text("Sending"), findsOneWidget);
+    expect(find.byKey(_jumpToLatestKey), findsNothing);
+    expect(_position(tester).pixels, 0);
   });
 
   // --- Regression tests for the old "jump to top" / "view shifts" bugs ---

--- a/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -1,6 +1,7 @@
 import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/features/session_detail/widgets/message_timestamp_reveal.dart";
 import "package:sesori_mobile/features/session_detail/widgets/retry_error_message_card.dart";
 import "package:sesori_mobile/features/session_detail/widgets/session_detail_message_list.dart";
@@ -12,6 +13,7 @@ class const _SessionDetailMessageListHarness({
   super.key,
   required final List<MessageWithParts> initialMessages,
   required final Map<String, String> initialStreamingText,
+  final List<QueuedSessionSubmission> initialQueuedMessages = const [],
   final String? initialRetryErrorMessage,
   final Future<void> Function()? onLoadOlderMessages,
 }) extends StatefulWidget {
@@ -22,14 +24,17 @@ class const _SessionDetailMessageListHarness({
 class _SessionDetailMessageListHarnessState() extends State<_SessionDetailMessageListHarness> {
   late List<MessageWithParts> _messages;
   late Map<String, String> _streamingText;
+  late List<QueuedSessionSubmission> _queuedMessages;
   late String? _retryErrorMessage;
   bool _isLoadingOlderMessages = false;
+  int? lastCancelledQueuedMessageIndex;
 
   @override
   void initState() {
     super.initState();
     _messages = widget.initialMessages;
     _streamingText = widget.initialStreamingText;
+    _queuedMessages = widget.initialQueuedMessages;
     _retryErrorMessage = widget.initialRetryErrorMessage;
   }
 
@@ -60,6 +65,11 @@ class _SessionDetailMessageListHarnessState() extends State<_SessionDetailMessag
     setState(() => _retryErrorMessage = message);
   }
 
+  void cancelQueuedMessage(int index) {
+    lastCancelledQueuedMessageIndex = index;
+    setState(() => _queuedMessages = [..._queuedMessages]..removeAt(index));
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -72,11 +82,14 @@ class _SessionDetailMessageListHarnessState() extends State<_SessionDetailMessag
           projectId: null,
           onLoadOlderMessages: widget.onLoadOlderMessages,
           messages: _messages,
+          sendingSubmission: null,
+          queuedMessages: _queuedMessages,
           isLoadingOlderMessages: _isLoadingOlderMessages,
           streamingText: _streamingText,
           children: const <Session>[],
           childStatuses: const <String, SessionStatus>{},
           retryErrorMessage: _retryErrorMessage,
+          onCancelQueuedMessage: cancelQueuedMessage,
         ),
       ),
     );
@@ -490,6 +503,45 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(_position(tester).pixels, 0);
+  });
+
+  testWidgets("canceling a queued row while detached removes its frozen row", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    const submission = QueuedSessionSubmission.text(
+      text: "Queued while reading history",
+      inputMode: ComposerInputMode.typed,
+      attachments: [],
+      agent: "coder",
+      agentModel: null,
+    );
+    final harnessKey = GlobalKey<_SessionDetailMessageListHarnessState>();
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        key: harnessKey,
+        initialMessages: _userMessages(count: 12),
+        initialStreamingText: const {},
+        initialQueuedMessages: const [submission],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await _sendPointerScroll(
+      tester: tester,
+      target: find.byKey(_listViewKey),
+      delta: const Offset(0, 30),
+    );
+    await tester.pumpAndSettle();
+    expect(find.byKey(_jumpToLatestKey), findsOneWidget);
+    expect(find.widgetWithText(TextButton, "Cancel"), findsOneWidget);
+    await tester.tap(find.widgetWithText(TextButton, "Cancel"));
+    await _pumpListUpdate(tester);
+
+    expect(harnessKey.currentState!.lastCancelledQueuedMessageIndex, 0);
+    expect(find.text("Queued while reading history"), findsNothing);
+    expect(find.widgetWithText(TextButton, "Cancel"), findsNothing);
+    expect(find.byKey(_jumpToLatestKey), findsOneWidget);
   });
 
   // --- Regression tests for the old "jump to top" / "view shifts" bugs ---

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -33,11 +33,12 @@ defaults and queued client sends coherent.
   dropped. Each queued send retains the agent, model, and variant selected when
   it was submitted. A submitted prompt remains visible while the bridge is
   accepting it, including during a cold backend startup, and a failed acceptance
-  returns it to the head of the queue. Queued and sending text uses the same brand
-  bubble and Markdown rendering as settled user text; a compact status rail and
-  subtle queued outline carry the transient state, with queued-to-sending changes
-  animated when reduced motion is not requested. A turn started on one client is
-  visible to every other client of that bridge.
+  returns it to the head of the queue. Queued and sending text render as the
+  newest rows inside the scrollable transcript, never as controls pinned above
+  the composer. It uses the same brand bubble and Markdown rendering as settled
+  user text; a compact status rail and subtle queued outline carry the transient
+  state, with the outline change animated when reduced motion is not requested.
+  A turn started on one client is visible to every other client of that bridge.
 - Live message envelopes render in transcript timestamp order even when events
   arrive out of order; late envelopes append after existing envelopes with the
   same timestamp rather than reordering an established turn. Finalized parts
@@ -75,7 +76,8 @@ queue, turn length, and client count.
   completion notification, or queued sends reorder, vanish, or resend while the
   session-detail cubit remains alive. Submitted text disappears while bridge
   acceptance or backend startup is still pending, or queued feedback uses a
-  visually unrelated surface or renders authored Markdown as literal syntax.
+  visually unrelated or composer-pinned surface, or renders authored Markdown
+  as literal syntax.
 - Recovery or interruption artifacts from an aborted turn appear in the next
   user turn.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Render queued and sending submissions inline as the newest transcript rows instead of a pinned queued section. This keeps scroll behavior coherent, preserves audit visibility, and retains the queued outline; read-only sessions show non-cancelable queued rows.

- `SessionDetailMessageList` now accepts `sendingSubmission`, `queuedMessages`, and `onCancelQueuedMessage`, and synthesizes stable transient rows via `QueuedMessageBubble` (identity preserved across pending→sending and while detached; read-only uses `pendingReadOnly`).
- Detach behavior: submitting while detached jumps to latest to reveal the new row; promotion to sending updates the same row in place without reattaching; cancel while detached removes the frozen row immediately.
- Removed the queued section from bottom controls; bottom inset now accounts only for the background-tasks bar and composer. Deleted `SessionDetailQueuedMessagesSection`. Queued status rail updates no longer animate.

**Migration**
- Remove any use of `SessionDetailQueuedMessagesSection`.
- Pass `sendingSubmission`, `queuedMessages`, and `onCancelQueuedMessage` to `SessionDetailMessageList` (pass null for `onCancelQueuedMessage` in read-only).
- Do not reserve extra space for a queued section; only pad for the tasks bar and composer.

<sup>Written for commit ae48006a93ae3c34337ed0684d2a24dff51833f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

