### PR TITLE
⚙️ Fix client code generation on Dart 3.13

### DIFF
--- a/client/app/lib/core/di/injection.config.dart
+++ b/client/app/lib/core/di/injection.config.dart
@@ -110,6 +110,11 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i908.TemporaryDirectoryClient>(
       () => _i908.TemporaryDirectoryClient(),
     );
+    gh.lazySingleton<_i948.OAuthDeviceDescriptorProvider>(
+      () => _i363.FlutterOAuthDeviceDescriptorProvider(
+        gh<_i833.DeviceInfoPlugin>(),
+      ),
+    );
     gh.singleton<_i948.LifecycleSource>(() => _i875.AppLifecycleObserver());
     gh.singleton<_i948.RouteSource>(() => _i597.GoRouterRouteSource());
     gh.lazySingleton<_i948.LocalNotificationClient>(
@@ -125,14 +130,14 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i948.RouteDispatcher>(
       () => _i610.GoRouterRouteDispatcher(),
     );
+    gh.lazySingleton<_i948.SecureStorage>(
+      () => _i816.FlutterSecureStorageAdapter(gh<_i558.FlutterSecureStorage>()),
+    );
     gh.lazySingleton<_i948.DeepLinkSource>(
       () => _i919.AppLinksDeepLinkSource(),
     );
     gh.lazySingleton<_i140.ComposerImagePicker>(
       () => _i140.ComposerImagePicker(picker: gh<_i183.ImagePicker>()),
-    );
-    gh.lazySingleton<_i948.SecureStorage>(
-      () => _i816.FlutterSecureStorageAdapter(gh<_i558.FlutterSecureStorage>()),
     );
     gh.lazySingleton<_i948.UrlLauncher>(() => _i10.FlutterUrlLauncher());
     gh.lazySingleton<_i982.FirebaseApp>(
@@ -162,11 +167,6 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i178.FirebaseMessagingStaticAdapter>(
       () => firebaseRegisterModule.disabledFirebaseMessagingStaticAdapter,
       registerFor: {_firebaseDisabled},
-    );
-    gh.lazySingleton<_i948.OAuthDeviceDescriptorProvider>(
-      () => _i363.FlutterOAuthDeviceDescriptorProvider(
-        gh<_i833.DeviceInfoPlugin>(),
-      ),
     );
     gh.lazySingleton<_i948.ImageSaver>(
       () => registerModule.imageSaver(
@@ -208,6 +208,13 @@ extension GetItInjectableX on _i174.GetIt {
       ),
       registerFor: {_firebaseDisabled},
     );
+    gh.lazySingleton<_i901.DeepLinkService>(
+      () => _i901.DeepLinkService(gh<_i948.DeepLinkSource>()),
+      dispose: (i) => i.dispose(),
+    );
+    gh.lazySingleton<_i553.FailureReporter>(
+      () => _i534.CrashlyticsFailureReporter(gh<_i141.FirebaseCrashlytics>()),
+    );
     gh.lazySingleton<_i1038.VoiceTranscriptionService>(
       () => _i1038.VoiceTranscriptionService(
         voiceApi: gh<_i948.VoiceApi>(),
@@ -217,10 +224,6 @@ extension GetItInjectableX on _i174.GetIt {
         wakeLockService: gh<_i511.WakeLockService>(),
         audioFormat: gh<_i430.AudioFormatConfig>(),
       ),
-      dispose: (i) => i.dispose(),
-    );
-    gh.lazySingleton<_i901.DeepLinkService>(
-      () => _i901.DeepLinkService(gh<_i948.DeepLinkSource>()),
       dispose: (i) => i.dispose(),
     );
     gh.lazySingleton<_i948.PushMessagingSource>(
@@ -234,9 +237,6 @@ extension GetItInjectableX on _i174.GetIt {
         analytics: gh<_i398.FirebaseAnalytics>(),
         capability: gh<_i948.AnalyticsRuntimeCapability>(),
       ),
-    );
-    gh.lazySingleton<_i553.FailureReporter>(
-      () => _i534.CrashlyticsFailureReporter(gh<_i141.FirebaseCrashlytics>()),
     );
     return this;
   }

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -101,9 +101,9 @@ dev_dependencies:
     path: "../../shared/no_slop_linter"
   freezed: 4.0.0-dev.3
   json_serializable: ^6.14.0
-  injectable_generator: ^3.0.2
+  injectable_generator: ^3.1.2
   bloc_test: ^10.0.0
-  build_runner: any
+  build_runner: ^2.16.0
   mocktail: ^1.0.5
   flutter_native_splash: ^2.4.8
 

--- a/client/desktop/lib/core/di/injection.config.dart
+++ b/client/desktop/lib/core/di/injection.config.dart
@@ -42,17 +42,17 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i558.FlutterSecureStorage>(
       () => registerModule.secureStorage,
     );
-    gh.lazySingleton<_i948.SecureStorage>(
-      () => _i757.DesktopSecureStorageAdapter(gh<_i558.FlutterSecureStorage>()),
-    );
-    gh.singleton<_i948.LifecycleSource>(() => _i670.DesktopLifecycleObserver());
-    gh.lazySingleton<_i948.UrlLauncher>(() => _i137.DesktopUrlLauncher());
-    gh.lazySingleton<_i948.AnalyticsClient>(() => _i262.NoOpAnalyticsClient());
     gh.lazySingleton<_i948.OAuthDeviceDescriptorProvider>(
       () => _i20.DesktopOAuthDeviceDescriptorProvider(
         gh<_i833.DeviceInfoPlugin>(),
       ),
     );
+    gh.singleton<_i948.LifecycleSource>(() => _i670.DesktopLifecycleObserver());
+    gh.lazySingleton<_i948.SecureStorage>(
+      () => _i757.DesktopSecureStorageAdapter(gh<_i558.FlutterSecureStorage>()),
+    );
+    gh.lazySingleton<_i948.UrlLauncher>(() => _i137.DesktopUrlLauncher());
+    gh.lazySingleton<_i948.AnalyticsClient>(() => _i262.NoOpAnalyticsClient());
     return this;
   }
 }

--- a/client/desktop/pubspec.yaml
+++ b/client/desktop/pubspec.yaml
@@ -38,10 +38,10 @@ dev_dependencies:
   no_slop_linter:
     path: "../../shared/no_slop_linter"
   bloc_test: ^10.0.0
-  build_runner: any
+  build_runner: ^2.16.0
   flutter_test:
     sdk: flutter
-  injectable_generator: ^3.0.2
+  injectable_generator: ^3.1.2
   mocktail: ^1.0.5
 
 flutter:

--- a/client/module_auth/pubspec.yaml
+++ b/client/module_auth/pubspec.yaml
@@ -20,12 +20,12 @@ dependencies:
     path: ../../shared/sesori_shared
 
 dev_dependencies:
-  build_runner: any
+  build_runner: ^2.16.0
   no_slop_linter:
     path: "../../shared/no_slop_linter"
   fake_async: ^1.3.3
   freezed: 4.0.0-dev.3
-  injectable_generator: ^3.0.2
+  injectable_generator: ^3.1.2
   json_serializable: ^6.14.0
   mocktail: ^1.0.5
   test: ^1.31.0

--- a/client/module_core/lib/src/di/injection.config.dart
+++ b/client/module_core/lib/src/di/injection.config.dart
@@ -166,8 +166,8 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i895.DefaultModelSelector>(
       () => const _i895.DefaultModelSelector(),
     );
-    gh.lazySingleton<_i896.RoomKeyStorage>(
-      () => _i896.RoomKeyStorage(gh<_i442.SecureStorage>()),
+    gh.lazySingleton<_i176.VoiceApi>(
+      () => _i176.VoiceApi(gh<_i442.AuthenticatedHttpApiClient>()),
     );
     gh.lazySingleton<_i384.BridgeApi>(
       () => _i384.BridgeApi(client: gh<_i442.AuthenticatedHttpApiClient>()),
@@ -188,9 +188,6 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i727.AnalyticsApi>(
       () => _i727.AnalyticsApi(client: gh<_i791.AnalyticsClient>()),
-    );
-    gh.lazySingleton<_i176.VoiceApi>(
-      () => _i176.VoiceApi(gh<_i442.AuthenticatedHttpApiClient>()),
     );
     gh.lazySingleton<_i198.ComposerDraftRepository>(
       () => _i198.ComposerDraftRepository(
@@ -234,54 +231,15 @@ extension GetItInjectableX on _i174.GetIt {
         routeSource: gh<_i366.RouteSource>(),
       ),
     );
+    gh.lazySingleton<_i896.RoomKeyStorage>(
+      () => _i896.RoomKeyStorage(gh<_i442.SecureStorage>()),
+    );
     gh.lazySingleton<_i205.BridgeRepository>(
       () => _i205.BridgeRepository(api: gh<_i384.BridgeApi>()),
     );
     gh.lazySingleton<_i217.RegisteredBridgesStore>(
       () => _i217.RegisteredBridgesStore(
         secureStorage: gh<_i442.SecureStorage>(),
-        authSession: gh<_i442.AuthSession>(),
-      ),
-      dispose: (i) => i.dispose(),
-    );
-    gh.lazySingleton<_i369.ConnectionService>(
-      () => _i369.ConnectionService(
-        gh<_i553.RelayCryptoService>(),
-        gh<_i896.RoomKeyStorage>(),
-        gh<_i442.AuthTokenProvider>(),
-        gh<_i442.AuthSession>(),
-        gh<_i903.LifecycleSource>(),
-        gh<_i553.FailureReporter>(),
-        clock: gh<_i369.ClockProvider>(),
-        relayClientFactory: gh<_i369.RelayClientFactory>(),
-      ),
-    );
-    gh.lazySingleton<_i857.RelayHttpApiClient>(
-      () => _i857.RelayHttpApiClient(gh<_i369.ConnectionService>()),
-    );
-    gh.lazySingleton<_i415.BridgeSettingsApi>(
-      () => _i415.BridgeSettingsApi(client: gh<_i857.RelayHttpApiClient>()),
-    );
-    gh.lazySingleton<_i1068.FilesystemApi>(
-      () => _i1068.FilesystemApi(client: gh<_i857.RelayHttpApiClient>()),
-    );
-    gh.lazySingleton<_i231.PermissionApi>(
-      () => _i231.PermissionApi(client: gh<_i857.RelayHttpApiClient>()),
-    );
-    gh.lazySingleton<_i546.PluginApi>(
-      () => _i546.PluginApi(client: gh<_i857.RelayHttpApiClient>()),
-    );
-    gh.lazySingleton<_i733.ProjectApi>(
-      () => _i733.ProjectApi(client: gh<_i857.RelayHttpApiClient>()),
-    );
-    gh.lazySingleton<_i603.SessionApi>(
-      () => _i603.SessionApi(client: gh<_i857.RelayHttpApiClient>()),
-    );
-    gh.lazySingleton<_i699.RegisteredBridgesService>(
-      () => _i699.RegisteredBridgesService(
-        bridgeRepository: gh<_i205.BridgeRepository>(),
-        registeredBridgesStore: gh<_i217.RegisteredBridgesStore>(),
-        connectionService: gh<_i369.ConnectionService>(),
         authSession: gh<_i442.AuthSession>(),
       ),
       dispose: (i) => i.dispose(),
@@ -305,19 +263,6 @@ extension GetItInjectableX on _i174.GetIt {
         api: gh<_i560.ProductAnalyticsPreferenceApi>(),
         storage: gh<_i197.ProductAnalyticsPreferenceStorage>(),
       ),
-    );
-    gh.lazySingleton<_i210.ProjectViewApi>(
-      () => _i210.ProjectViewApi(
-        connectionService: gh<_i369.ConnectionService>(),
-      ),
-    );
-    gh.lazySingleton<_i157.SessionViewApi>(
-      () => _i157.SessionViewApi(
-        connectionService: gh<_i369.ConnectionService>(),
-      ),
-    );
-    gh.lazySingleton<_i7.SessionRepository>(
-      () => _i7.SessionRepository(api: gh<_i603.SessionApi>()),
     );
     gh.lazySingleton<_i555.ProductAnalyticsPreferenceService>(
       () => _i555.ProductAnalyticsPreferenceService(
@@ -362,16 +307,105 @@ extension GetItInjectableX on _i174.GetIt {
       ),
       dispose: (i) => i.dispose(),
     );
+    gh.lazySingleton<_i369.ConnectionService>(
+      () => _i369.ConnectionService(
+        gh<_i553.RelayCryptoService>(),
+        gh<_i896.RoomKeyStorage>(),
+        gh<_i442.AuthTokenProvider>(),
+        gh<_i442.AuthSession>(),
+        gh<_i903.LifecycleSource>(),
+        gh<_i553.FailureReporter>(),
+        clock: gh<_i369.ClockProvider>(),
+        relayClientFactory: gh<_i369.RelayClientFactory>(),
+      ),
+    );
+    gh.lazySingleton<_i204.ProductAnalyticsService>(
+      () => _i204.ProductAnalyticsService(
+        analyticsRepository: gh<_i274.AnalyticsRepository>(),
+        preferenceService: gh<_i555.ProductAnalyticsPreferenceService>(),
+      ),
+      dispose: (i) => i.dispose(),
+    );
+    gh.lazySingleton<_i508.SseEventTracker>(
+      () => _i508.SseEventTracker(
+        gh<_i369.ConnectionService>(),
+        failureReporter: gh<_i553.FailureReporter>(),
+      ),
+    );
+    gh.lazySingleton<_i699.RegisteredBridgesService>(
+      () => _i699.RegisteredBridgesService(
+        bridgeRepository: gh<_i205.BridgeRepository>(),
+        registeredBridgesStore: gh<_i217.RegisteredBridgesStore>(),
+        connectionService: gh<_i369.ConnectionService>(),
+        authSession: gh<_i442.AuthSession>(),
+      ),
+      dispose: (i) => i.dispose(),
+    );
+    gh.lazySingleton<_i888.AnalyticsRouteListener>(
+      () => _i888.AnalyticsRouteListener(
+        routeSource: gh<_i366.RouteSource>(),
+        analyticsService: gh<_i204.ProductAnalyticsService>(),
+      ),
+      dispose: (i) => i.dispose(),
+    );
+    gh.lazySingleton<_i210.ProjectViewApi>(
+      () => _i210.ProjectViewApi(
+        connectionService: gh<_i369.ConnectionService>(),
+      ),
+    );
+    gh.lazySingleton<_i157.SessionViewApi>(
+      () => _i157.SessionViewApi(
+        connectionService: gh<_i369.ConnectionService>(),
+      ),
+    );
     gh.lazySingleton<_i28.SessionUnseenTracker>(
       () => _i28.SessionUnseenTracker(
         gh<_i369.ConnectionService>(),
         failureReporter: gh<_i553.FailureReporter>(),
       ),
     );
-    gh.lazySingleton<_i508.SseEventTracker>(
-      () => _i508.SseEventTracker(
-        gh<_i369.ConnectionService>(),
-        failureReporter: gh<_i553.FailureReporter>(),
+    gh.lazySingleton<_i271.ProjectViewRepository>(
+      () => _i271.ProjectViewRepository(api: gh<_i210.ProjectViewApi>()),
+    );
+    gh.lazySingleton<_i857.RelayHttpApiClient>(
+      () => _i857.RelayHttpApiClient(gh<_i369.ConnectionService>()),
+    );
+    gh.lazySingleton<_i415.BridgeSettingsApi>(
+      () => _i415.BridgeSettingsApi(client: gh<_i857.RelayHttpApiClient>()),
+    );
+    gh.lazySingleton<_i1068.FilesystemApi>(
+      () => _i1068.FilesystemApi(client: gh<_i857.RelayHttpApiClient>()),
+    );
+    gh.lazySingleton<_i231.PermissionApi>(
+      () => _i231.PermissionApi(client: gh<_i857.RelayHttpApiClient>()),
+    );
+    gh.lazySingleton<_i546.PluginApi>(
+      () => _i546.PluginApi(client: gh<_i857.RelayHttpApiClient>()),
+    );
+    gh.lazySingleton<_i733.ProjectApi>(
+      () => _i733.ProjectApi(client: gh<_i857.RelayHttpApiClient>()),
+    );
+    gh.lazySingleton<_i603.SessionApi>(
+      () => _i603.SessionApi(client: gh<_i857.RelayHttpApiClient>()),
+    );
+    gh.lazySingleton<_i150.SessionViewRepository>(
+      () => _i150.SessionViewRepository(api: gh<_i157.SessionViewApi>()),
+    );
+    gh.lazySingleton<_i413.ProjectViewingService>(
+      () => _i413.ProjectViewingService(
+        viewRepository: gh<_i271.ProjectViewRepository>(),
+        lifecycleSource: gh<_i903.LifecycleSource>(),
+        connectionService: gh<_i369.ConnectionService>(),
+        routeSource: gh<_i366.RouteSource>(),
+      ),
+    );
+    gh.lazySingleton<_i7.SessionRepository>(
+      () => _i7.SessionRepository(api: gh<_i603.SessionApi>()),
+    );
+    gh.lazySingleton<_i18.SessionViewingService>(
+      () => _i18.SessionViewingService(
+        viewRepository: gh<_i150.SessionViewRepository>(),
+        lifecycleSource: gh<_i903.LifecycleSource>(),
       ),
     );
     gh.lazySingleton<_i337.PluginRepository>(
@@ -384,9 +418,6 @@ extension GetItInjectableX on _i174.GetIt {
         authSession: gh<_i442.AuthSession>(),
       ),
     );
-    gh.lazySingleton<_i271.ProjectViewRepository>(
-      () => _i271.ProjectViewRepository(api: gh<_i210.ProjectViewApi>()),
-    );
     gh.lazySingleton<_i102.BridgeSettingsRepository>(
       () => _i102.BridgeSettingsRepository(
         bridgeSettingsApi: gh<_i415.BridgeSettingsApi>(),
@@ -398,22 +429,12 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i679.PermissionRepository>(
       () => _i679.PermissionRepository(api: gh<_i231.PermissionApi>()),
     );
-    gh.lazySingleton<_i204.ProductAnalyticsService>(
-      () => _i204.ProductAnalyticsService(
-        analyticsRepository: gh<_i274.AnalyticsRepository>(),
-        preferenceService: gh<_i555.ProductAnalyticsPreferenceService>(),
-      ),
-      dispose: (i) => i.dispose(),
-    );
     gh.lazySingleton<_i80.ProjectRepository>(
       () => _i80.ProjectRepository(
         api: gh<_i733.ProjectApi>(),
         filesystemApi: gh<_i1068.FilesystemApi>(),
         sessionApi: gh<_i603.SessionApi>(),
       ),
-    );
-    gh.lazySingleton<_i150.SessionViewRepository>(
-      () => _i150.SessionViewRepository(api: gh<_i157.SessionViewApi>()),
     );
     gh.lazySingleton<_i177.NewSessionPluginService>(
       () => _i177.NewSessionPluginService(
@@ -439,32 +460,11 @@ extension GetItInjectableX on _i174.GetIt {
         defaultModelSelector: gh<_i895.DefaultModelSelector>(),
       ),
     );
-    gh.lazySingleton<_i888.AnalyticsRouteListener>(
-      () => _i888.AnalyticsRouteListener(
-        routeSource: gh<_i366.RouteSource>(),
-        analyticsService: gh<_i204.ProductAnalyticsService>(),
-      ),
-      dispose: (i) => i.dispose(),
-    );
-    gh.lazySingleton<_i413.ProjectViewingService>(
-      () => _i413.ProjectViewingService(
-        viewRepository: gh<_i271.ProjectViewRepository>(),
-        lifecycleSource: gh<_i903.LifecycleSource>(),
-        connectionService: gh<_i369.ConnectionService>(),
-        routeSource: gh<_i366.RouteSource>(),
-      ),
-    );
     gh.lazySingleton<_i110.PluginManagementService>(
       () => _i110.PluginManagementService(
         pluginRepository: gh<_i337.PluginRepository>(),
         connectionService: gh<_i369.ConnectionService>(),
         productAnalyticsService: gh<_i204.ProductAnalyticsService>(),
-      ),
-    );
-    gh.lazySingleton<_i18.SessionViewingService>(
-      () => _i18.SessionViewingService(
-        viewRepository: gh<_i150.SessionViewRepository>(),
-        lifecycleSource: gh<_i903.LifecycleSource>(),
       ),
     );
     gh.lazySingleton<_i1033.BridgeSettingsService>(

--- a/client/module_core/pubspec.yaml
+++ b/client/module_core/pubspec.yaml
@@ -31,9 +31,9 @@ dev_dependencies:
   no_slop_linter:
     path: "../../shared/no_slop_linter"
   bloc_test: ^10.0.0
-  build_runner: any
+  build_runner: ^2.16.0
   freezed: 4.0.0-dev.3
-  injectable_generator: ^3.0.2
+  injectable_generator: ^3.1.2
   json_serializable: ^6.14.0
   mocktail: ^1.0.5
   test: ^1.31.0

--- a/client/module_desktop_core/pubspec.yaml
+++ b/client/module_desktop_core/pubspec.yaml
@@ -22,8 +22,8 @@ dependencies:
 dev_dependencies:
   no_slop_linter:
     path: "../../shared/no_slop_linter"
-  build_runner: any
+  build_runner: ^2.16.0
   freezed: 4.0.0-dev.3
-  injectable_generator: ^3.0.2
+  injectable_generator: ^3.1.2
   mocktail: ^1.0.5
   test: ^1.31.0

--- a/client/module_prego/pubspec.yaml
+++ b/client/module_prego/pubspec.yaml
@@ -84,7 +84,7 @@ flutter:
 dev_dependencies:
   no_slop_linter:
     path: "../../shared/no_slop_linter"
-  build_runner: any
+  build_runner: ^2.16.0
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.5

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -2,13 +2,13 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages:
   _fe_analyzer_shared:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: _fe_analyzer_shared
-      sha256: cd6add6f846f35fb79f3c315296703c1a24f3cfd7f4739d91a74961c1c7e9f1b
+      sha256: "1b0e6a07425a3e460666e88bf1c949ccc7bb0116ad562ce94a1eca60fe820725"
       url: "https://pub.dev"
     source: hosted
-    version: "100.0.0"
+    version: "103.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -21,18 +21,18 @@ packages:
     dependency: transitive
     description:
       name: analysis_server_plugin
-      sha256: c4021359e7a673ecd9c6db5f11fea12fabb55e0ba96fa08c78920ae81936f1d1
+      sha256: c58b2a05b260a023eefd0848496ff6b113a318c6c95dad4215165a4bd54ae600
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.15"
+    version: "0.3.18"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "6ba98576948803398b69e3a444df24eacdbe12ed699c7014e120ea38552debbf"
+      sha256: "61c04d0c1bfed555c681ea079519933f071a5a026578ff73c4ff0df2d3462e5e"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "13.3.0"
   analyzer_buffer:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer_plugin
-      sha256: "9a81dc36f7f71890d7cf83960a3a7df1e6c9a24035f98eb848e91ad48b1d21c6"
+      sha256: c2a75baf1657171cc7872db96a12b07e385873cf7a73f2b4f7638e9d0701ee53
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.9"
+    version: "0.14.12"
   ansicolor:
     dependency: transitive
     description:
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
+      sha256: b94f5da9ed3d081fd4ecc426c260998b5f4f4eb2f6d89b7e5472edef0b2b2a1b
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.7"
+    version: "4.0.10"
   build_config:
     dependency: transitive
     description:
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: build_runner
-      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
+      sha256: "90363d438bd9f84a4d5bbb83352251f57d2d9d771bc95a44e6a33fe25fa52774"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.1"
+    version: "2.16.0"
   built_collection:
     dependency: transitive
     description:
@@ -1027,10 +1027,10 @@ packages:
     dependency: transitive
     description:
       name: injectable_generator
-      sha256: "424ea884e3adc9585df0af408cb3b0de19fc2faf52b62bed8b73f3fb15a63115"
+      sha256: ec0ecd82056b62648fc93386068f59e37ac238f6dc16d8279dc6ff5035ddc0d0
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   intl:
     dependency: transitive
     description:
@@ -1115,10 +1115,10 @@ packages:
     dependency: transitive
     description:
       name: lean_builder
-      sha256: "123eef9fba96ec12a18b8eb4889850368d78e8c0a6a63eaa45ec4cf3e73fbded"
+      sha256: ca3948377e4aff44b648c4c22daab632896bf8c2e13123217f6fde3d5d50d57d
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   lints:
     dependency: transitive
     description:

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -14,6 +14,9 @@ workspace:
   - desktop
 
 dependency_overrides:
+  # Freezed 4.0.0-dev.3 still caps analyzer below 14, while lean_builder 1.2.1
+  # otherwise selects the analyzer 14 frontend despite having unchanged code.
+  _fe_analyzer_shared: 103.0.0
   record_android:
     git:
       url: https://github.com/sesori-ai/record.git

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -14,8 +14,9 @@ workspace:
   - desktop
 
 dependency_overrides:
-  # Freezed 4.0.0-dev.3 still caps analyzer below 14, while lean_builder 1.2.1
-  # otherwise selects the analyzer 14 frontend despite having unchanged code.
+  # TODO(2026-08-13): Remove this override after Freezed and analyzer_buffer
+  # publish analyzer 14 support; then verify pub-get, codegen, and analyze in CI.
+  # lean_builder 1.2.1 changed only its frontend constraints from 1.2.0.
   _fe_analyzer_shared: 103.0.0
   record_android:
     git:

--- a/shared/no_slop_linter/pubspec.yaml
+++ b/shared/no_slop_linter/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
   sdk: ">=3.13.0-0 <4.0.0"
 
 dependencies:
-  analysis_server_plugin: ">=0.3.15 <0.3.19"
-  _fe_analyzer_shared: ">=100.0.0 <104.0.0"
-  analyzer: ">=13.0.0 <14.0.0"
-  analyzer_plugin: ">=0.14.9 <0.14.13"
+  analysis_server_plugin: ">=0.3.18 <0.3.19"
+  _fe_analyzer_shared: ">=103.0.0 <104.0.0"
+  analyzer: ">=13.3.0 <14.0.0"
+  analyzer_plugin: ">=0.14.12 <0.14.13"
 
 dev_dependencies:
-  analyzer_testing: ^0.2.1
+  analyzer_testing: ^0.3.2
   dartz: ^0.10.1
   lints: ^6.1.0
   path: ^1.9.1


### PR DESCRIPTION
## Complexity

Moderate. This aligns the client code-generation toolchain around the Dart 3.13-capable analyzer family while preserving Freezed's current analyzer 13 compatibility boundary.

## What

- Upgrade client `build_runner` to 2.16.0 and `injectable_generator` to 3.1.2.
- Upgrade the custom linter to analyzer 13.3 and its matching plugin/test packages.
- Pin `_fe_analyzer_shared` 103.0.0 until Freezed publishes analyzer 14 support.
- Regenerate injectable configuration with the upgraded generator.

## Why

`make codegen` used analyzer 13.0.0, whose parser treats Dart 3.13 primary constructors as disabled. Every client builder therefore failed before generation. Analyzer 13.3 enables the shipped syntax, and the newer build runner and injectable generator also carry current performance and correctness improvements.

## Risk and test focus

No user-visible or database impact. Risk is limited to build tooling and generated dependency-registration order. Focus review on the temporary frontend override and generated DI ordering; runtime DI coverage passes in both product shells.

## Expected result

`make codegen` completes for all six client modules without experimental command-line flags and remains a no-op on a second incremental run.

## Verification

- `make pub-get` from `client/`
- `make codegen` from `client/` twice, with the second run writing zero outputs
- `make analyze` from `client/`
- `make test` from `client/`
- `dart analyze --fatal-infos` from `shared/no_slop_linter/`
- `dart test` from `shared/no_slop_linter/` (197 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes client code generation on Dart 3.13 by upgrading the analyzer family and build tools and regenerating DI configs. Previously, `make codegen` failed on `analyzer` 13.0.0 (primary constructors disabled); now it runs on `analyzer` 13.3 with `build_runner` 2.16.0 and `injectable_generator` 3.1.2.

**Review notes and rollout**
- Aligns the workspace to the Dart 3.13 analyzer family: `shared/no_slop_linter` now targets `analyzer` 13.3 with `analysis_server_plugin` 0.3.18 and `analyzer_plugin` 0.14.12; transitively updates `lean_builder` to 1.2.1. Adds a workspace `dependency_overrides` pin for `_fe_analyzer_shared` 103.0.0 with a TODO for removal once `Freezed` and `analyzer_buffer` support analyzer 14.
- Regenerates DI configs in app, desktop, and `module_core`; changes are ordering-only. Review ordering around `OAuthDeviceDescriptorProvider`, `SecureStorage`, `DeepLinkService`, `FailureReporter`, `VoiceApi`, `RoomKeyStorage`, and connection/session/view services. No user-visible behavior is expected; risk is limited to DI initialization order.
- Required actions: from `client/` run make pub-get; make codegen twice; make analyze; make test. From `shared/no_slop_linter/` run dart analyze --fatal-infos and dart test.

<sup>Written for commit ccadac52cc7717bc02d67dbb08230a0685bc20cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

