### PR TITLE
🌱 Increase navigation edge fade opacity

### DIFF
--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -832,8 +832,8 @@ class _PromptInputState() extends State<PromptInput> {
           begin: Alignment.center,
           end: Alignment.topCenter,
           colors: [
-            prego.colors.bgSurface1.withValues(alpha: 0.9),
-            prego.colors.bgSurface1.withValues(alpha: 0.7),
+            prego.colors.bgSurface1.withValues(alpha: 0.98),
+            prego.colors.bgSurface1.withValues(alpha: 0.88),
             prego.colors.bgSurface1.withValues(alpha: 0),
           ],
           stops: const [0, 0.8, 1.0],

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -271,6 +271,28 @@ void main() {
     expect(find.text("No messages yet"), findsOneWidget);
   });
 
+  testWidgets("composer fade obscures transcript text behind floating controls", (tester) async {
+    final state = _loadedState(pendingQuestions: const [], pendingPermissions: const []);
+    when(() => cubit.state).thenReturn(state);
+    whenListen(cubit, const Stream<SessionDetailState>.empty(), initialState: state);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final decoratedBox = tester.widget<DecoratedBox>(
+      find.descendant(
+        of: find.byType(PromptInput),
+        matching: find.byWidgetPredicate(
+          (widget) => widget is DecoratedBox && (widget.decoration as BoxDecoration?)?.gradient is LinearGradient,
+        ),
+      ).first,
+    );
+    final gradient = (decoratedBox.decoration as BoxDecoration).gradient! as LinearGradient;
+    expect(gradient.colors[0].a, closeTo(0.98, 0.001));
+    expect(gradient.colors[1].a, closeTo(0.88, 0.001));
+    expect(gradient.colors[2].a, 0);
+  });
+
   testWidgets("an empty newest page keeps older transcript paging reachable", (tester) async {
     final state = _loadedState(pendingQuestions: const [], pendingPermissions: const []).copyWith(
       olderMessagesCursor: 42,

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -283,14 +283,18 @@ void main() {
       find.descendant(
         of: find.byType(PromptInput),
         matching: find.byWidgetPredicate(
-          (widget) => widget is DecoratedBox && (widget.decoration as BoxDecoration?)?.gradient is LinearGradient,
+          (widget) =>
+              widget is DecoratedBox &&
+              widget.decoration is BoxDecoration &&
+              (widget.decoration as BoxDecoration).gradient is LinearGradient,
         ),
       ).first,
     );
     final gradient = (decoratedBox.decoration as BoxDecoration).gradient! as LinearGradient;
-    expect(gradient.colors[0].a, closeTo(0.98, 0.001));
-    expect(gradient.colors[1].a, closeTo(0.88, 0.001));
-    expect(gradient.colors[2].a, 0);
+    final surface = PregoDesignSystem.light.colors.bgSurface1;
+    expect(gradient.colors[0], surface.withValues(alpha: 0.98));
+    expect(gradient.colors[1], surface.withValues(alpha: 0.88));
+    expect(gradient.colors[2], surface.withValues(alpha: 0));
   });
 
   testWidgets("an empty newest page keeps older transcript paging reachable", (tester) async {

--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -403,8 +403,8 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
                 decoration: BoxDecoration(
                   gradient: LinearGradient(
                     colors: [
-                      backgroundColor.withMultipliedOpacity(0.9),
-                      backgroundColor.withMultipliedOpacity(0.7),
+                      backgroundColor.withMultipliedOpacity(0.98),
+                      backgroundColor.withMultipliedOpacity(0.88),
                       backgroundColor.withMultipliedOpacity(0),
                     ],
                     stops: const [0, 0.8, 1.0],

--- a/client/module_prego/test/components/prego_glass_scaffold_banner_test.dart
+++ b/client/module_prego/test/components/prego_glass_scaffold_banner_test.dart
@@ -240,6 +240,11 @@ void main() {
 
     await tester.pumpWidget(_harness(banner: _banner()));
     await tester.pumpAndSettle();
+    final gradient =
+        (tester.widget<Container>(gradientFinder).decoration! as BoxDecoration).gradient! as LinearGradient;
+    expect(gradient.colors[0].a, closeTo(0.98, 0.001));
+    expect(gradient.colors[1].a, closeTo(0.88, 0.001));
+    expect(gradient.colors[2].a, 0);
     expect(
       tester.getSize(gradientFinder).height,
       PregoTopNavigation.barHeight + _bannerHeight,

--- a/client/module_prego/test/components/prego_glass_scaffold_banner_test.dart
+++ b/client/module_prego/test/components/prego_glass_scaffold_banner_test.dart
@@ -242,9 +242,10 @@ void main() {
     await tester.pumpAndSettle();
     final gradient =
         (tester.widget<Container>(gradientFinder).decoration! as BoxDecoration).gradient! as LinearGradient;
-    expect(gradient.colors[0].a, closeTo(0.98, 0.001));
-    expect(gradient.colors[1].a, closeTo(0.88, 0.001));
-    expect(gradient.colors[2].a, 0);
+    final surface = PregoDesignSystem.light.colors.bgSurface1;
+    expect(gradient.colors[0], surface.withValues(alpha: surface.a * 0.98));
+    expect(gradient.colors[1], surface.withValues(alpha: surface.a * 0.88));
+    expect(gradient.colors[2], surface.withValues(alpha: 0));
     expect(
       tester.getSize(gradientFinder).height,
       PregoTopNavigation.barHeight + _bannerHeight,

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -43,6 +43,9 @@ defaults and queued client sends coherent.
   same timestamp rather than reordering an established turn. Finalized parts
   that arrive before their envelope are retained and reconciled without showing
   an empty user bubble or switching the composer to follow-up wording.
+- Transcript content scrolling behind the top navigation or floating composer
+  dissolves into a strong surface-colour fade, keeping the title and controls
+  visually separate and screenshot-readable without text collisions.
 
 ## Regression Levels
 
@@ -78,6 +81,8 @@ queue, turn length, and client count.
   visually unrelated surface or renders authored Markdown as literal syntax.
 - Recovery or interruption artifacts from an aborted turn appear in the next
   user turn.
+- Scrolled transcript text remains clearly visible through the fade and collides
+  with the navigation title or floating composer controls.
 
 ## Known Limitations
 


### PR DESCRIPTION
## Complexity

🌱 Trivial: adjusts the existing top-navigation and floating-composer gradient opacity values and adds focused regression assertions.

## What

- Increase the top navigation scroll-edge fade from `0.90 / 0.70` to `0.98 / 0.88` opacity.
- Apply the same stronger fade to the floating Session Chat and New Session composer edge.
- Assert both gradient recipes in widget tests.
- Document screenshot readability as required Session Turns behavior.

## Why

Scrolled transcript text could remain visually prominent directly behind the navigation title and bottom floating controls, producing text collisions in screenshots. The stronger surface-colour fade keeps foreground controls clearly separated without changing the fade extent or layout.

## Risk and test focus

Low visual risk. The shared scaffold top fade affects screens that extend content behind `PregoGlassScaffold`; the composer fade affects Session Chat and New Session. There is no database, transport, analytics, or other behavioral impact.

Focus review on readability where dense text scrolls directly behind the title and floating composer in light and dark themes.

## Expected result

Content still transitions smoothly beneath floating chrome, but text nearest the title and bottom controls is substantially obscured and no longer competes with foreground labels in screenshots.

## Verification

- `flutter test test/components/prego_glass_scaffold_banner_test.dart` (`client/module_prego`)
- `flutter test test/features/session_detail/widgets/session_detail_body_test.dart` (`client/app`)
- `dart analyze` (`client/module_prego`)
- `dart analyze` (`client/app`)
- Built and launched `client/app` on iPhone 17 Pro Max simulator.
- Manually inspected a real, densely populated Session Chat at multiple scroll positions with transcript content behind both edge fades.

## Screenshots

Captured locally during simulator verification:

- `/var/folders/g6/p0sj7nz10dxg2ffb8k8ctd_h0000gn/T/opencode/fade-opacity-session-chat-scrolled.png`
- `/var/folders/g6/p0sj7nz10dxg2ffb8k8ctd_h0000gn/T/opencode/fade-opacity-session-chat-top-and-bottom.png`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens the scroll-edge fades in the top navigation and floating composer so transcript text no longer competes with titles and controls. Opacity increases from 0.90/0.70 to 0.98/0.88; fade extent and layout are unchanged.

- Affects screens that extend content behind `PregoGlassScaffold` and the Session Chat/New Session composer (`PromptInput`).
- Hardens widget tests to assert the updated gradient colors/stops (using surface alpha in light/dark); updates regression docs to require screenshot readability at these edges.
- Review focus: verify that text behind the title and composer is visibly suppressed in light and dark themes, with no unintended dimming elsewhere.
- No migration or config changes.

<sup>Written for commit 34ebbd0066bd983ef94b4810341b260d265440cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

