### PR TITLE
🌿 Bound project Git worktree inspections

### DIFF
--- a/bridge/app/lib/src/bridge/repositories/project_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/project_repository.dart
@@ -29,15 +29,23 @@ class ProjectRepository({
 }) {
   static const GitRemoteIdentityParser _remoteIdentityParser = GitRemoteIdentityParser();
   static const ProjectCatalogMapper _projectCatalogMapper = ProjectCatalogMapper();
+  static const int _maxConcurrentWorktreeInspections = 8;
 
   Future<List<Project>> getProjects() async {
     final rows = await _projectsDao.getCatalogProjects();
     final unseenById = await unseenByProjectId(
       projectIds: [for (final row in rows) row.projectId],
     );
-    final worktreeCapabilities = await Future.wait([
-      for (final row in rows) _supportsDedicatedWorktrees(path: row.path),
-    ]);
+    final worktreeCapabilities = <bool>[];
+    for (var start = 0; start < rows.length; start += _maxConcurrentWorktreeInspections) {
+      final end = start + _maxConcurrentWorktreeInspections;
+      worktreeCapabilities.addAll(
+        await Future.wait([
+          for (final row in rows.sublist(start, end < rows.length ? end : rows.length))
+            _supportsDedicatedWorktrees(path: row.path),
+        ]),
+      );
+    }
     return [
       for (final (index, row) in rows.indexed)
         _projectCatalogMapper.map(

--- a/bridge/app/lib/src/bridge/repositories/project_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/project_repository.dart
@@ -1,10 +1,8 @@
-import "dart:async" show Completer;
-import "dart:collection" show Queue;
 import "dart:io" show FileSystemException;
 import "dart:math" show max;
 
 import "package:path/path.dart" as p;
-import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show normalizeProjectDirectory;
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show ParallelLock, normalizeProjectDirectory;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart" show Project, ProjectTime;
 
@@ -32,8 +30,9 @@ class ProjectRepository({
   static const GitRemoteIdentityParser _remoteIdentityParser = GitRemoteIdentityParser();
   static const ProjectCatalogMapper _projectCatalogMapper = ProjectCatalogMapper();
   static const int _maxConcurrentWorktreeInspections = 8;
-  final Queue<Completer<void>> _worktreeInspectionWaiters = Queue<Completer<void>>();
-  int _activeWorktreeInspections = 0;
+  final ParallelLock _worktreeInspectionLock = ParallelLock(
+    maxParallelOperations: _maxConcurrentWorktreeInspections,
+  );
 
   Future<List<Project>> getProjects() async {
     final rows = await _projectsDao.getCatalogProjects();
@@ -263,18 +262,17 @@ class ProjectRepository({
     }
   }
 
-  Future<bool> _supportsDedicatedWorktrees({required String path}) async {
-    await _acquireWorktreeInspectionSlot();
-    try {
-      if (!await _gitCliApi.isGitInitialized(projectPath: path)) return false;
-      return await _gitCliApi.hasAtLeastOneCommit(projectPath: path);
-    } on Object catch (error, stackTrace) {
-      Log.w("ProjectRepository: failed to inspect Git worktree support for $path", error, stackTrace);
-      return false;
-    } finally {
-      _releaseWorktreeInspectionSlot();
-    }
-  }
+  Future<bool> _supportsDedicatedWorktrees({required String path}) => _worktreeInspectionLock.use(
+    operation: () async {
+      try {
+        if (!await _gitCliApi.isGitInitialized(projectPath: path)) return false;
+        return await _gitCliApi.hasAtLeastOneCommit(projectPath: path);
+      } on Object catch (error, stackTrace) {
+        Log.w("ProjectRepository: failed to inspect Git worktree support for $path", error, stackTrace);
+        return false;
+      }
+    },
+  );
 
   Future<List<bool>> _inspectWorktreeCapabilities({required List<ProjectDto> rows}) async {
     final capabilities = List<bool>.filled(rows.length, false);
@@ -291,24 +289,6 @@ class ProjectRepository({
       for (var worker = 0; worker < _maxConcurrentWorktreeInspections && worker < rows.length; worker++) inspectNext(),
     ]);
     return capabilities;
-  }
-
-  Future<void> _acquireWorktreeInspectionSlot() async {
-    if (_activeWorktreeInspections < _maxConcurrentWorktreeInspections) {
-      _activeWorktreeInspections++;
-      return;
-    }
-    final waiter = Completer<void>();
-    _worktreeInspectionWaiters.addLast(waiter);
-    await waiter.future;
-  }
-
-  void _releaseWorktreeInspectionSlot() {
-    if (_worktreeInspectionWaiters.isNotEmpty) {
-      _worktreeInspectionWaiters.removeFirst().complete();
-    } else {
-      _activeWorktreeInspections--;
-    }
   }
 
   static ProjectTime _activityToTime(ProjectActivity activity) {

--- a/bridge/app/lib/src/bridge/repositories/project_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/project_repository.dart
@@ -40,9 +40,7 @@ class ProjectRepository({
     final unseenById = await unseenByProjectId(
       projectIds: [for (final row in rows) row.projectId],
     );
-    final worktreeCapabilities = await Future.wait([
-      for (final row in rows) _supportsDedicatedWorktrees(path: row.path),
-    ]);
+    final worktreeCapabilities = await _inspectWorktreeCapabilities(rows: rows);
     return [
       for (final (index, row) in rows.indexed)
         _projectCatalogMapper.map(
@@ -276,6 +274,23 @@ class ProjectRepository({
     } finally {
       _releaseWorktreeInspectionSlot();
     }
+  }
+
+  Future<List<bool>> _inspectWorktreeCapabilities({required List<ProjectDto> rows}) async {
+    final capabilities = List<bool>.filled(rows.length, false);
+    var nextIndex = 0;
+
+    Future<void> inspectNext() async {
+      while (nextIndex < rows.length) {
+        final index = nextIndex++;
+        capabilities[index] = await _supportsDedicatedWorktrees(path: rows[index].path);
+      }
+    }
+
+    await Future.wait([
+      for (var worker = 0; worker < _maxConcurrentWorktreeInspections && worker < rows.length; worker++) inspectNext(),
+    ]);
+    return capabilities;
   }
 
   Future<void> _acquireWorktreeInspectionSlot() async {

--- a/bridge/app/lib/src/bridge/repositories/project_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/project_repository.dart
@@ -1,3 +1,5 @@
+import "dart:async" show Completer;
+import "dart:collection" show Queue;
 import "dart:io" show FileSystemException;
 import "dart:math" show max;
 
@@ -30,22 +32,17 @@ class ProjectRepository({
   static const GitRemoteIdentityParser _remoteIdentityParser = GitRemoteIdentityParser();
   static const ProjectCatalogMapper _projectCatalogMapper = ProjectCatalogMapper();
   static const int _maxConcurrentWorktreeInspections = 8;
+  final Queue<Completer<void>> _worktreeInspectionWaiters = Queue<Completer<void>>();
+  int _activeWorktreeInspections = 0;
 
   Future<List<Project>> getProjects() async {
     final rows = await _projectsDao.getCatalogProjects();
     final unseenById = await unseenByProjectId(
       projectIds: [for (final row in rows) row.projectId],
     );
-    final worktreeCapabilities = <bool>[];
-    for (var start = 0; start < rows.length; start += _maxConcurrentWorktreeInspections) {
-      final end = start + _maxConcurrentWorktreeInspections;
-      worktreeCapabilities.addAll(
-        await Future.wait([
-          for (final row in rows.sublist(start, end < rows.length ? end : rows.length))
-            _supportsDedicatedWorktrees(path: row.path),
-        ]),
-      );
-    }
+    final worktreeCapabilities = await Future.wait([
+      for (final row in rows) _supportsDedicatedWorktrees(path: row.path),
+    ]);
     return [
       for (final (index, row) in rows.indexed)
         _projectCatalogMapper.map(
@@ -269,12 +266,33 @@ class ProjectRepository({
   }
 
   Future<bool> _supportsDedicatedWorktrees({required String path}) async {
+    await _acquireWorktreeInspectionSlot();
     try {
       if (!await _gitCliApi.isGitInitialized(projectPath: path)) return false;
       return await _gitCliApi.hasAtLeastOneCommit(projectPath: path);
     } on Object catch (error, stackTrace) {
       Log.w("ProjectRepository: failed to inspect Git worktree support for $path", error, stackTrace);
       return false;
+    } finally {
+      _releaseWorktreeInspectionSlot();
+    }
+  }
+
+  Future<void> _acquireWorktreeInspectionSlot() async {
+    if (_activeWorktreeInspections < _maxConcurrentWorktreeInspections) {
+      _activeWorktreeInspections++;
+      return;
+    }
+    final waiter = Completer<void>();
+    _worktreeInspectionWaiters.addLast(waiter);
+    await waiter.future;
+  }
+
+  void _releaseWorktreeInspectionSlot() {
+    if (_worktreeInspectionWaiters.isNotEmpty) {
+      _worktreeInspectionWaiters.removeFirst().complete();
+    } else {
+      _activeWorktreeInspections--;
     }
   }
 

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -406,6 +406,45 @@ void main() {
       expect(result.single.time, const ProjectTime(created: 10, updated: 20));
     });
 
+    test("getProjects bounds concurrent Git worktree inspections", () async {
+      final paths = [
+        for (var index = 0; index < 9; index++) "/project-${index.toString().padLeft(2, "0")}",
+      ];
+      for (final (index, path) in paths.indexed) {
+        await db.projectsDao.setActivity(
+          projectId: path,
+          createdAt: 1,
+          updatedAt: paths.length - index,
+        );
+      }
+      final gitCliApi = _CompletingGitCliApi(paths: paths);
+      final boundedRepo = singlePluginProjectRepository(
+        gitCliApi: gitCliApi,
+        projectsDao: db.projectsDao,
+        sessionDao: db.sessionDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(),
+      );
+
+      final listing = boundedRepo.getProjects();
+      await gitCliApi.inspectionLimitReached.future;
+
+      expect(gitCliApi.inspectedPaths, paths.take(8));
+      expect(gitCliApi.nextInspectionStarted.isCompleted, isFalse);
+      for (final path in paths.take(8)) {
+        gitCliApi.results[path]!.complete(true);
+      }
+
+      await gitCliApi.nextInspectionStarted.future;
+      expect(gitCliApi.inspectedPaths, paths);
+      gitCliApi.results[paths.last]!.complete(false);
+
+      final projects = await listing;
+      expect(projects.map((project) => project.path), paths);
+      expect(projects.take(8).every((project) => project.supportsDedicatedWorktrees), isTrue);
+      expect(projects.last.supportsDedicatedWorktrees, isFalse);
+    });
+
     test("getProjects breaks equal timestamps by project id descending", () async {
       plugin.projectsResult = const [
         PluginProject(id: "z", directory: "z", name: "Beta"),
@@ -1448,5 +1487,25 @@ class _BlockingSnapshotProjectsDao({required AppDatabase database}) extends Proj
       await releaseSnapshot.future;
     }
     return projects;
+  }
+}
+
+class _CompletingGitCliApi({required List<String> paths}) extends FakeGitCliApi {
+  final Map<String, Completer<bool>> results = {
+    for (final path in paths) path: Completer<bool>(),
+  };
+  final List<String> inspectedPaths = [];
+  final Completer<void> inspectionLimitReached = Completer<void>();
+  final Completer<void> nextInspectionStarted = Completer<void>();
+
+  @override
+  Future<bool> isGitInitialized({required String projectPath}) async => true;
+
+  @override
+  Future<bool> hasAtLeastOneCommit({required String projectPath}) {
+    inspectedPaths.add(projectPath);
+    if (inspectedPaths.length == 8) inspectionLimitReached.complete();
+    if (inspectedPaths.length == 9) nextInspectionStarted.complete();
+    return results[projectPath]!.future;
   }
 }

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -406,7 +406,7 @@ void main() {
       expect(result.single.time, const ProjectTime(created: 10, updated: 20));
     });
 
-    test("getProjects bounds concurrent Git worktree inspections", () async {
+    test("getProjects reuses an available Git worktree inspection slot", () async {
       final paths = [
         for (var index = 0; index < 9; index++) "/project-${index.toString().padLeft(2, "0")}",
       ];
@@ -417,7 +417,7 @@ void main() {
           updatedAt: paths.length - index,
         );
       }
-      final gitCliApi = _CompletingGitCliApi(paths: paths);
+      final gitCliApi = _BlockingGitCliApi();
       final boundedRepo = singlePluginProjectRepository(
         gitCliApi: gitCliApi,
         projectsDao: db.projectsDao,
@@ -431,18 +431,51 @@ void main() {
 
       expect(gitCliApi.inspectedPaths, paths.take(8));
       expect(gitCliApi.nextInspectionStarted.isCompleted, isFalse);
-      for (final path in paths.take(8)) {
-        gitCliApi.results[path]!.complete(true);
-      }
+      gitCliApi.completeFirst(result: true);
 
       await gitCliApi.nextInspectionStarted.future.timeout(const Duration(seconds: 1));
       expect(gitCliApi.inspectedPaths, paths);
-      gitCliApi.results[paths.last]!.complete(false);
+      expect(gitCliApi.activeInspections, 8);
+      gitCliApi.releaseAll(result: true);
 
       final projects = await listing;
       expect(projects.map((project) => project.path), paths);
-      expect(projects.take(8).every((project) => project.supportsDedicatedWorktrees), isTrue);
-      expect(projects.last.supportsDedicatedWorktrees, isFalse);
+      expect(projects.every((project) => project.supportsDedicatedWorktrees), isTrue);
+      expect(gitCliApi.maximumActiveInspections, 8);
+    });
+
+    test("concurrent project listings share the Git worktree inspection limit", () async {
+      final paths = [
+        for (var index = 0; index < 9; index++) "/project-${index.toString().padLeft(2, "0")}",
+      ];
+      for (final (index, path) in paths.indexed) {
+        await db.projectsDao.setActivity(
+          projectId: path,
+          createdAt: 1,
+          updatedAt: paths.length - index,
+        );
+      }
+      final gitCliApi = _BlockingGitCliApi();
+      final boundedRepo = singlePluginProjectRepository(
+        gitCliApi: gitCliApi,
+        projectsDao: db.projectsDao,
+        sessionDao: db.sessionDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(),
+      );
+
+      final listings = Future.wait([boundedRepo.getProjects(), boundedRepo.getProjects()]);
+      await gitCliApi.inspectionLimitReached.future.timeout(const Duration(seconds: 1));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(gitCliApi.activeInspections, 8);
+      expect(gitCliApi.maximumActiveInspections, 8);
+      gitCliApi.releaseAll(result: true);
+
+      final results = await listings;
+      expect(results, everyElement(hasLength(paths.length)));
+      expect(gitCliApi.inspectedPaths, hasLength(paths.length * 2));
+      expect(gitCliApi.maximumActiveInspections, 8);
     });
 
     test("getProjects breaks equal timestamps by project id descending", () async {
@@ -1490,22 +1523,49 @@ class _BlockingSnapshotProjectsDao({required AppDatabase database}) extends Proj
   }
 }
 
-class _CompletingGitCliApi({required List<String> paths}) extends FakeGitCliApi {
-  final Map<String, Completer<bool>> results = {
-    for (final path in paths) path: Completer<bool>(),
-  };
+class _BlockingGitCliApi() extends FakeGitCliApi {
   final List<String> inspectedPaths = [];
   final Completer<void> inspectionLimitReached = Completer<void>();
   final Completer<void> nextInspectionStarted = Completer<void>();
+  final List<Completer<bool>> _pending = [];
+  bool _released = false;
+  int activeInspections = 0;
+  int maximumActiveInspections = 0;
 
   @override
   Future<bool> isGitInitialized({required String projectPath}) async => true;
 
   @override
-  Future<bool> hasAtLeastOneCommit({required String projectPath}) {
+  Future<bool> hasAtLeastOneCommit({required String projectPath}) async {
     inspectedPaths.add(projectPath);
+    activeInspections++;
+    if (activeInspections > maximumActiveInspections) {
+      maximumActiveInspections = activeInspections;
+    }
     if (inspectedPaths.length == 8) inspectionLimitReached.complete();
     if (inspectedPaths.length == 9) nextInspectionStarted.complete();
-    return results[projectPath]!.future;
+    if (_released) {
+      activeInspections--;
+      return true;
+    }
+    final completer = Completer<bool>();
+    _pending.add(completer);
+    try {
+      return await completer.future;
+    } finally {
+      activeInspections--;
+    }
+  }
+
+  void completeFirst({required bool result}) {
+    _pending.removeAt(0).complete(result);
+  }
+
+  void releaseAll({required bool result}) {
+    _released = true;
+    for (final completer in _pending) {
+      completer.complete(result);
+    }
+    _pending.clear();
   }
 }

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -427,7 +427,7 @@ void main() {
       );
 
       final listing = boundedRepo.getProjects();
-      await gitCliApi.inspectionLimitReached.future;
+      await gitCliApi.inspectionLimitReached.future.timeout(const Duration(seconds: 1));
 
       expect(gitCliApi.inspectedPaths, paths.take(8));
       expect(gitCliApi.nextInspectionStarted.isCompleted, isFalse);
@@ -435,7 +435,7 @@ void main() {
         gitCliApi.results[path]!.complete(true);
       }
 
-      await gitCliApi.nextInspectionStarted.future;
+      await gitCliApi.nextInspectionStarted.future.timeout(const Duration(seconds: 1));
       expect(gitCliApi.inspectedPaths, paths);
       gitCliApi.results[paths.last]!.complete(false);
 

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -478,6 +478,44 @@ void main() {
       expect(gitCliApi.maximumActiveInspections, 8);
     });
 
+    test("a single-project probe gets the next slot during a large listing", () async {
+      final paths = [
+        for (var index = 0; index < 17; index++) "/project-${index.toString().padLeft(2, "0")}",
+      ];
+      for (final (index, path) in paths.indexed) {
+        await db.projectsDao.setActivity(
+          projectId: path,
+          createdAt: 1,
+          updatedAt: paths.length - index,
+        );
+      }
+      final gitCliApi = _BlockingGitCliApi();
+      final projectsDao = _SignalingProjectsDao(database: db);
+      final boundedRepo = singlePluginProjectRepository(
+        gitCliApi: gitCliApi,
+        projectsDao: projectsDao,
+        sessionDao: db.sessionDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(),
+      );
+
+      final listing = boundedRepo.getProjects();
+      await gitCliApi.inspectionLimitReached.future.timeout(const Duration(seconds: 1));
+      final detail = boundedRepo.resolveProjectOpenTarget(path: "/priority-project");
+      await projectsDao.allProjectsRead.future.timeout(const Duration(seconds: 1));
+      await Future<void>.delayed(Duration.zero);
+      gitCliApi.completeFirst(result: true);
+      await gitCliApi.nextInspectionStarted.future.timeout(const Duration(seconds: 1));
+
+      expect(gitCliApi.inspectedPaths[8], "/priority-project");
+      expect(gitCliApi.maximumActiveInspections, 8);
+      gitCliApi.releaseAll(result: true);
+
+      expect((await detail).supportsDedicatedWorktrees, isTrue);
+      expect(await listing, hasLength(paths.length));
+      expect(gitCliApi.maximumActiveInspections, 8);
+    });
+
     test("getProjects breaks equal timestamps by project id descending", () async {
       plugin.projectsResult = const [
         PluginProject(id: "z", directory: "z", name: "Beta"),
@@ -1503,6 +1541,19 @@ class _CountingProjectsDao({required AppDatabase database}) extends ProjectsDao 
   Future<ProjectDto?> getProject({required String projectId}) {
     getProjectCallCount++;
     return super.getProject(projectId: projectId);
+  }
+}
+
+class _SignalingProjectsDao({required AppDatabase database}) extends ProjectsDao {
+  this : super(database);
+
+  final Completer<void> allProjectsRead = Completer<void>();
+
+  @override
+  Future<List<ProjectDto>> getAllProjects() async {
+    final projects = await super.getAllProjects();
+    allProjectsRead.complete();
+    return projects;
   }
 }
 

--- a/bridge/sesori_bridge_foundation/lib/sesori_bridge_foundation.dart
+++ b/bridge/sesori_bridge_foundation/lib/sesori_bridge_foundation.dart
@@ -9,6 +9,7 @@ export "src/checksum_validator.dart";
 export "src/command_executor.dart";
 export "src/host_process_command_executor.dart";
 export "src/os_version_formatter.dart";
+export "src/parallel_lock.dart";
 export "src/platform_target.dart";
 export "src/project_directory.dart";
 export "src/semantic_version.dart";

--- a/bridge/sesori_bridge_foundation/lib/src/parallel_lock.dart
+++ b/bridge/sesori_bridge_foundation/lib/src/parallel_lock.dart
@@ -1,0 +1,43 @@
+import "dart:async" show Completer, FutureOr;
+import "dart:collection" show Queue;
+
+/// Runs at most [maxParallelOperations] callbacks at once in FIFO order.
+final class ParallelLock({required int maxParallelOperations}) {
+  final Queue<Completer<void>> _waiters = Queue<Completer<void>>();
+  int _availablePermits = _validateMaxParallelOperations(maxParallelOperations);
+
+  static int _validateMaxParallelOperations(int maxParallelOperations) {
+    if (maxParallelOperations < 1) {
+      throw ArgumentError.value(maxParallelOperations, "maxParallelOperations", "must be positive");
+    }
+    return maxParallelOperations;
+  }
+
+  Future<T> use<T>({required FutureOr<T> Function() operation}) async {
+    await _acquire();
+    try {
+      return await operation();
+    } finally {
+      _release();
+    }
+  }
+
+  Future<void> _acquire() async {
+    if (_availablePermits > 0) {
+      _availablePermits--;
+      return;
+    }
+
+    final waiter = Completer<void>();
+    _waiters.addLast(waiter);
+    await waiter.future;
+  }
+
+  void _release() {
+    if (_waiters.isNotEmpty) {
+      _waiters.removeFirst().complete();
+      return;
+    }
+    _availablePermits++;
+  }
+}

--- a/bridge/sesori_bridge_foundation/test/parallel_lock_test.dart
+++ b/bridge/sesori_bridge_foundation/test/parallel_lock_test.dart
@@ -1,0 +1,55 @@
+import "dart:async" show Completer;
+
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show ParallelLock;
+import "package:test/test.dart";
+
+void main() {
+  test("rejects a non-positive parallel operation limit", () {
+    expect(
+      () => ParallelLock(maxParallelOperations: 0),
+      throwsArgumentError,
+    );
+  });
+
+  test("runs callbacks up to the limit and admits waiters in FIFO order", () async {
+    final lock = ParallelLock(maxParallelOperations: 2);
+    final releases = [for (var index = 0; index < 4; index++) Completer<void>()];
+    final started = <int>[];
+
+    final operations = [
+      for (var index = 0; index < releases.length; index++)
+        lock.use(
+          operation: () async {
+            started.add(index);
+            await releases[index].future;
+            return index;
+          },
+        ),
+    ];
+    await Future<void>.delayed(Duration.zero);
+    expect(started, [0, 1]);
+
+    releases[1].complete();
+    await Future<void>.delayed(Duration.zero);
+    expect(started, [0, 1, 2]);
+
+    releases[0].complete();
+    await Future<void>.delayed(Duration.zero);
+    expect(started, [0, 1, 2, 3]);
+
+    releases[2].complete();
+    releases[3].complete();
+    expect(await Future.wait(operations), [0, 1, 2, 3]);
+  });
+
+  test("releases a permit when the callback throws", () async {
+    final lock = ParallelLock(maxParallelOperations: 1);
+
+    await expectLater(
+      lock.use<void>(operation: () => throw StateError("failed")),
+      throwsA(isA<StateError>()),
+    );
+
+    expect(await lock.use(operation: () => 42), 42);
+  });
+}

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -9,7 +9,9 @@ child sessions with titles, activity, statuses, and unseen state.
 ## Required Behavior
 
 - Catalog reads come from the bridge database: no backend start, no blocking on
-  an in-progress import, always the last committed snapshot.
+  an in-progress import, always the last committed snapshot. Worktree capability
+  inspection is concurrency-bounded so large catalogs cannot exhaust host file
+  descriptors while Git metadata is read.
 - Backends that own projects supply the list; the bridge derives it for backends
   without a project concept. Both appear as ordinary projects.
 - A backend-native project identifier is stable and independent of its directory,


### PR DESCRIPTION
## Complexity

🌿 Straightforward: bounds an existing per-project Git probe with a small shared callback-scoped concurrency primitive and focused deterministic coverage.

## What

- Add a reusable FIFO `ParallelLock` to `sesori_bridge_foundation`, configured with a maximum number of parallel operations.
- Run protected operations through `use(operation: ...)`, which waits for a permit and releases it automatically after success or failure.
- Limit project Git worktree capability inspections to eight shared concurrent operations.
- Schedule catalog probes lazily so released slots remain work-conserving and later point reads can compete fairly.
- Add focused lock and repository concurrency tests.

## Why

Large or overlapping catalogs could start enough Git processes to exhaust the bridge process file-descriptor limit and surface `ProcessException: Too many open files`. Callback-scoped permit ownership also removes error-prone manual acquire/release bookkeeping and avoids a last-waiter handoff race in the original limiter.

## Risk and test focus

The main risk is concurrency accounting: never exceeding eight active probes, preserving FIFO admission, releasing permits after errors, sharing the cap across listings, and admitting new work as soon as a slot frees. There is no user-visible, database, or wire-contract impact beyond preventing resource-exhaustion failures.

## Expected result

Project Git capability checks remain bounded and work-conserving across concurrent repository operations, without manual lock lifecycle at call sites or permit handoff races.

## Verification

- Full `sesori_bridge_foundation` test suite
- `sesori_bridge_foundation` `dart analyze --fatal-infos`
- `dart test test/bridge/repositories/project_repository_test.dart`
- Bridge app `dart analyze --fatal-infos`
- `git diff --check`
