### PR TITLE
🌿 Parallelize session startup metadata

### DIFF
--- a/bridge/app/lib/src/bridge/services/session_creation_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_creation_service.dart
@@ -19,16 +19,18 @@ class SessionCreationService({
     // plugin/git side effect. The stored path is authoritative; unknown ids
     // must not be treated as directories.
     final projectDirectory = await _sessionRepository.resolveProjectDirectory(projectId: request.projectId);
-    await _sessionRepository.ensurePluginRoutable(
-      pluginId: request.pluginId,
-      operation: SessionOperation.createSession,
-    );
     final normalizedCommand = request.command?.normalize();
     final agentModel = request.model;
     final userTexts = _extractTexts(parts: request.parts);
     final firstText = userTexts.firstOrNull;
     final userVisibleText = userTexts.isEmpty ? null : userTexts.join("\n\n");
-    final metadata = await _generateMetadata(firstText: firstText);
+    final (_, metadata) = await (
+      _sessionRepository.ensurePluginRoutable(
+        pluginId: request.pluginId,
+        operation: SessionOperation.createSession,
+      ),
+      _generateMetadata(firstText: firstText),
+    ).wait;
     final worktreeResult = await _prepareWorktree(request: request, metadata: metadata);
     final worktreeState = await _resolveWorktreeState(
       projectId: request.projectId,

--- a/bridge/app/lib/src/bridge/services/session_creation_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_creation_service.dart
@@ -24,13 +24,13 @@ class SessionCreationService({
     final userTexts = _extractTexts(parts: request.parts);
     final firstText = userTexts.firstOrNull;
     final userVisibleText = userTexts.isEmpty ? null : userTexts.join("\n\n");
-    final (_, metadata) = await (
-      _sessionRepository.ensurePluginRoutable(
-        pluginId: request.pluginId,
-        operation: SessionOperation.createSession,
-      ),
-      _generateMetadata(firstText: firstText),
-    ).wait;
+    final pluginRoutability = _sessionRepository.ensurePluginRoutable(
+      pluginId: request.pluginId,
+      operation: SessionOperation.createSession,
+    );
+    final metadataGeneration = _generateMetadata(firstText: firstText);
+    await pluginRoutability;
+    final metadata = await metadataGeneration;
     final worktreeResult = await _prepareWorktree(request: request, metadata: metadata);
     final worktreeState = await _resolveWorktreeState(
       projectId: request.projectId,

--- a/bridge/app/test/bridge/services/session_creation_service_test.dart
+++ b/bridge/app/test/bridge/services/session_creation_service_test.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:io";
 
 import "package:http/http.dart" as http;
@@ -17,6 +18,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/plugin_runtime_test_support.dart";
 import "../../helpers/test_database.dart";
 
 void main() {
@@ -95,6 +97,60 @@ void main() {
       expect(worktreeService.resolveCalls, isZero);
       expect(plugin.createCalls, isZero);
       expect(await db.sessionDao.getSession(sessionId: "backend-session"), isNull);
+    });
+
+    test("starts plugin and metadata generation concurrently after project validation", () async {
+      final pluginGate = Completer<void>();
+      final metadataGate = Completer<void>();
+      final runtime = createTestPluginRuntime(plugins: [plugin])
+        ..useStarted = Completer<void>()
+        ..useGate = pluginGate.future;
+      metadataService
+        ..generateStarted = Completer<void>()
+        ..generateGate = metadataGate.future;
+      final repository = singlePluginSessionRepository(
+        plugin: plugin,
+        sessionDao: db.sessionDao,
+        projectsDao: db.projectsDao,
+        pullRequestDao: db.pullRequestDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+        runtime: runtime,
+      );
+      final localOperationDispatcher = SessionOperationDispatcher(sessionRepository: repository);
+      final localMutationDispatcher = SessionMutationDispatcher(
+        sessionRepository: repository,
+        sessionOperationDispatcher: localOperationDispatcher,
+      );
+      final localService = SessionCreationService(
+        metadataService: metadataService,
+        worktreeService: worktreeService,
+        sessionRepository: repository,
+        sessionMutationDispatcher: localMutationDispatcher,
+      );
+
+      final creation = localService.createSession(
+        request: const CreateSessionRequest(
+          projectId: "/repo",
+          pluginId: "fake",
+          dedicatedWorktree: false,
+          parts: [PromptPart.text(text: "Build it")],
+          variant: null,
+          agent: null,
+          model: null,
+          command: null,
+        ),
+      );
+
+      await runtime.useStarted!.future;
+      final metadataStartedWhilePluginBlocked = metadataService.generateStarted?.isCompleted;
+      pluginGate.complete();
+      metadataGate.complete();
+      await creation;
+
+      expect(metadataStartedWhilePluginBlocked, isTrue);
+      await localOperationDispatcher.dispose();
+      await localMutationDispatcher.dispose();
+      await runtime.dispose();
     });
 
     test("stores the created root with its explicit plugin and backend binding", () async {
@@ -241,6 +297,8 @@ void main() {
 
 class _FakeMetadataService() extends MetadataService {
   int generateCalls = 0;
+  Completer<void>? generateStarted;
+  Future<void>? generateGate;
 
   this
     : super(
@@ -252,6 +310,8 @@ class _FakeMetadataService() extends MetadataService {
   @override
   Future<bridge_metadata.SessionMetadata?> generate({required String firstMessage}) async {
     generateCalls++;
+    generateStarted?.complete();
+    if (generateGate case final gate?) await gate;
     return null;
   }
 }

--- a/bridge/app/test/bridge/services/session_creation_service_test.dart
+++ b/bridge/app/test/bridge/services/session_creation_service_test.dart
@@ -153,6 +153,57 @@ void main() {
       await runtime.dispose();
     });
 
+    test("surfaces plugin startup failures without waiting for metadata", () async {
+      final metadataGate = Completer<void>();
+      final runtime = createTestPluginRuntime(plugins: const <BridgePluginApi>[]);
+      metadataService
+        ..generateStarted = Completer<void>()
+        ..generateGate = metadataGate.future;
+      final repository = singlePluginSessionRepository(
+        plugin: plugin,
+        sessionDao: db.sessionDao,
+        projectsDao: db.projectsDao,
+        pullRequestDao: db.pullRequestDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+        runtime: runtime,
+      );
+      final localOperationDispatcher = SessionOperationDispatcher(sessionRepository: repository);
+      final localMutationDispatcher = SessionMutationDispatcher(
+        sessionRepository: repository,
+        sessionOperationDispatcher: localOperationDispatcher,
+      );
+      final localService = SessionCreationService(
+        metadataService: metadataService,
+        worktreeService: worktreeService,
+        sessionRepository: repository,
+        sessionMutationDispatcher: localMutationDispatcher,
+      );
+
+      final creation = localService.createSession(
+        request: const CreateSessionRequest(
+          projectId: "/repo",
+          pluginId: "fake",
+          dedicatedWorktree: false,
+          parts: [PromptPart.text(text: "Build it")],
+          variant: null,
+          agent: null,
+          model: null,
+          command: null,
+        ),
+      );
+
+      final failure = expectLater(
+        creation.timeout(const Duration(milliseconds: 100)),
+        throwsA(isA<PluginOperationException>()),
+      );
+      await metadataService.generateStarted!.future;
+      await failure;
+      metadataGate.complete();
+      await localOperationDispatcher.dispose();
+      await localMutationDispatcher.dispose();
+      await runtime.dispose();
+    });
+
     test("stores the created root with its explicit plugin and backend binding", () async {
       worktreeService.prepareResult = WorktreeSuccess(
         path: "/repo/.worktrees/session-one",
@@ -310,7 +361,7 @@ class _FakeMetadataService() extends MetadataService {
   @override
   Future<bridge_metadata.SessionMetadata?> generate({required String firstMessage}) async {
     generateCalls++;
-    generateStarted?.complete();
+    if (generateStarted case final started? when !started.isCompleted) started.complete();
     if (generateGate case final gate?) await gate;
     return null;
   }

--- a/bridge/app/test/helpers/plugin_runtime_test_support.dart
+++ b/bridge/app/test/helpers/plugin_runtime_test_support.dart
@@ -187,7 +187,7 @@ class TestPluginRuntime({
     required Enum operation,
     required Future<T> Function(BridgePluginApi api) body,
   }) async {
-    useStarted?.complete();
+    if (useStarted case final started? when !started.isCompleted) started.complete();
     if (useGate case final gate?) await gate;
     final plugin = _plugins[pluginId];
     if (plugin == null) {

--- a/bridge/app/test/helpers/plugin_runtime_test_support.dart
+++ b/bridge/app/test/helpers/plugin_runtime_test_support.dart
@@ -59,6 +59,8 @@ class TestPluginRuntime({
   /// Plugin ids that are registered but not running, so `useIfActive` reports
   /// them as unavailable while `use` would start them.
   final Set<String> stoppedPluginIds = {};
+  Completer<void>? useStarted;
+  Future<void>? useGate;
   bool generationCurrent = true;
   bool eventGenerationCurrent = true;
   int currentGeneration = 1;
@@ -185,6 +187,8 @@ class TestPluginRuntime({
     required Enum operation,
     required Future<T> Function(BridgePluginApi api) body,
   }) async {
+    useStarted?.complete();
+    if (useGate case final gate?) await gate;
     final plugin = _plugins[pluginId];
     if (plugin == null) {
       throw PluginOperationException(operation.name, statusCode: 503, message: "plugin $pluginId is not running");

--- a/bridge/app/test/helpers/single_plugin_repository_test_support.dart
+++ b/bridge/app/test/helpers/single_plugin_repository_test_support.dart
@@ -101,12 +101,15 @@ SessionRepository singlePluginSessionRepository({
   required PullRequestDao pullRequestDao,
   required SessionUnseenCalculator unseenCalculator,
   Set<String>? eligiblePluginIds,
+  TestPluginRuntime? runtime,
 }) {
   return SessionRepository(
-    runtime: createTestPluginRuntime(
-      plugins: [plugin],
-      eligiblePluginIds: eligiblePluginIds,
-    ),
+    runtime:
+        runtime ??
+        createTestPluginRuntime(
+          plugins: [plugin],
+          eligiblePluginIds: eligiblePluginIds,
+        ),
     bridgeDerivedProjectPluginIds: {
       if (plugin is BridgeDerivedProjectsPluginApi) plugin.id,
     },

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -23,7 +23,8 @@ variant, and worktree mode, and creating the session with its first input.
   backend and no-ops for a superseded generation.
 - Creation resolves and validates the project handle before checking plugin
   routability, so an unknown project causes no plugin, metadata, git, or session
-  persistence effect.
+  persistence effect. After validation, plugin startup and metadata generation
+  run concurrently so a cold backend does not add its full startup time to naming.
 - Dedicated mode creates a branch and worktree from the resolved base branch,
   rejects unsafe names, falls back to the project directory when the repository
   is absent, commitless, or creation fails, and records worktree, branch, base


### PR DESCRIPTION
## Complexity

🌿 Straightforward: parallelizes two existing independent futures and adds focused concurrency coverage.

## What

- Start plugin routability and session metadata generation concurrently after project validation.
- Preserve metadata dependency for dedicated worktree naming and session title updates.
- Add regression coverage proving metadata generation begins while cold plugin startup is blocked.
- Document session creation startup concurrency.

## Why

Cold plugin startup previously completed before metadata generation began, adding both latencies to session creation. Running them together reduces startup delay when plugin is not already running.

## Risk and test focus

Low risk. Project validation still completes before either side effect, and worktree/session creation still waits for both operations. Focus: concurrency ordering, unknown-project side-effect prevention, plugin startup failure, and metadata fallback.

## Expected result

Cold session creation waits roughly for slower of plugin startup or metadata generation instead of sum. No database or wire-contract impact.

## Verification

- `dart test test/bridge/services/session_creation_service_test.dart`
- `dart analyze --fatal-infos`
- Architecture implementation review: approved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs plugin routability and session metadata generation concurrently after project validation to reduce cold-start latency. Previously metadata generation waited for plugin startup; now both begin together, session/worktree creation still waits for both, and plugin startup failures surface immediately instead of waiting on metadata.

- Validates the project before any side effect; unknown projects still cause no plugin, metadata, git, or session effects.
- Keeps metadata dependency for dedicated worktree naming and session title updates.
- Adds regression tests proving metadata starts while plugin startup is gated and that startup failures propagate without waiting for metadata; extends test helpers to gate runtime `use` and metadata generation; updates docs to reflect concurrency.
- No database or API changes.

<sup>Written for commit b52802e5eb462862cf930bc2be44c1c3bb8d8978. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

