### PR TITLE
🌱 [session-user-interaction-order] docs: define running session activity coverage [step 3/4]

### DIFF
--- a/.plan/active/session-user-interaction-order/TRACKER.md
+++ b/.plan/active/session-user-interaction-order/TRACKER.md
@@ -3,14 +3,14 @@
 ## Current State
 
 - **Plan slug:** `session-user-interaction-order`
-- **Implementation base:** `main` at `ae7bd8f7`
-- **Branch/worktree:** `session-user-interaction-order-implementation`
+- **Implementation base:** `main` at `2dcaeba5`
+- **Branch/worktree:** `session-user-interaction-order-regression`
 - **Plan PR:** [#865](https://github.com/sesori-ai/sesori_apps_monorepo/pull/865)
-- **Series state:** Step 1/4 merged; Step 2/4 implementation verified locally
-- **Current step:** 2/4 ready for publication
-- **Next action:** publish and monitor the Step 2 implementation PR
-- **Production source changes published:** none; Step 2 remains local until its
-  PR is opened
+- **Implementation PR:** [#883](https://github.com/sesori-ai/sesori_apps_monorepo/pull/883)
+- **Series state:** Steps 1-2/4 merged; Step 3/4 regression contract in progress
+- **Current step:** 3/4 documentation ready for validation and publication
+- **Next action:** publish and monitor the Step 3 regression-contract PR
+- **Production source changes published:** Step 2 merged in PR #883
 
 ## Simplicity Contract
 
@@ -51,8 +51,8 @@
 | Done | Step | Exact PR title | State |
 |---|---|---|---|
 | [x] | 1/4 | `🌱 [session-user-interaction-order] docs: simplify running session activity order [step 1/4]` | [PR #865](https://github.com/sesori-ai/sesori_apps_monorepo/pull/865) merged |
-| [ ] | 2/4 | `⚙️ [session-user-interaction-order] feat: order running sessions by user activity [step 2/4]` | Verified locally; ready to publish |
-| [ ] | 3/4 | `🌱 [session-user-interaction-order] docs: define running session activity coverage [step 3/4]` | Pending |
+| [x] | 2/4 | `⚙️ [session-user-interaction-order] feat: order running sessions by user activity [step 2/4]` | [PR #883](https://github.com/sesori-ai/sesori_apps_monorepo/pull/883) merged |
+| [ ] | 3/4 | `🌱 [session-user-interaction-order] docs: define running session activity coverage [step 3/4]` | Ready to publish |
 | [ ] | 4/4 | `🌱 [session-user-interaction-order] docs: verify and retire session activity ordering [step 4/4]` | Pending |
 
 ## Step 1 Checklist
@@ -93,11 +93,11 @@
 
 ## Step 3 Checklist
 
-- [ ] Update projects/sessions regression behavior and L3 exercise.
-- [ ] Reconcile turns and questions/permissions with existing marker inputs and
+- [x] Update projects/sessions regression behavior and L3 exercise.
+- [x] Reconcile turns and questions/permissions with existing marker inputs and
   auto-approval exclusion without claiming perfect human provenance.
-- [ ] Record representative-plugin scope and generated-input limitation.
-- [ ] Validate documentation consistency and whitespace.
+- [x] Record representative-plugin scope and generated-input limitation.
+- [x] Validate documentation consistency and whitespace.
 
 ## Step 4 Checklist
 
@@ -176,3 +176,10 @@
   client Layer-3 state/comparator ownership.
 - No analytics event is added: this changes a derived list order rather than
   creating a distinct user action or authoritative product outcome.
+- PR #883 merged as `2dcaeba5` with 16/16 checks passing. Review fixes kept
+  activity merging inside `SessionUnseenTracker`, preserved authoritative REST
+  unseen/project seeds, and received two architecture implementation approvals
+  with no findings.
+- Step 3 reconciles the three planned regression contracts and passes
+  `git diff --check`. No Dart/Flutter suites are required for this
+  documentation-only change.

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -28,6 +28,18 @@ child sessions with titles, activity, statuses, and unseen state.
 - Session listings are project-scoped and pageable and carry plugin attribution,
   times, worktree and branch facts, prompt defaults, and unseen state that
   advances on activity and clears on view or mark-as-read.
+- Running root sessions remain ahead of inactive roots and order by the latest
+  durable user-side activity marker, descending, then session ID. Running means
+  main-agent work, retry, or a background task; awaiting-input alone does not
+  promote a session. A missing marker falls back to the session's updated time.
+  Inactive roots retain updated-time order, then session ID; archived filtering
+  and project and child-session ordering are unchanged.
+- REST seeds the marker and live list-state patches reorder an already-running
+  session without another status event. A current client accepts an older bridge
+  omitting the marker and uses the updated-time fallback; null markers remain
+  omitted on the wire. Activity markers merge monotonically across live session
+  updates and REST refreshes without preventing authoritative unseen or project
+  aggregate replacement.
 - Statuses report per-session idle/busy/retry plus unavailable plugins. A
   payload without plugin attribution means the historical OpenCode identity,
   never "the first enabled plugin".
@@ -37,8 +49,8 @@ child sessions with titles, activity, statuses, and unseen state.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Headless bridge, representative plugin: project list and one project's session list return committed data with plugin attribution. |
-| L2 Routine | Headless bridge, representative plugin: open, rename, hide; create a session and see it listed; unseen advances and clears; statuses report idle/busy. |
-| L3 Release | Client end to end (phone), every supporting production plugin: native and derived project ownership both list correctly; explicit import commits atomically with attributed progress; child sessions resolve under their root; lists, ordering, and unseen badges render. |
+| L2 Routine | Headless bridge, representative plugin: open, rename, hide; create a session and see it listed; unseen advances and clears; the existing activity marker appears in REST and live list-state projections; statuses report idle/busy. |
+| L3 Release | Client end to end (phone): every supporting production plugin still covers native/derived ownership, import, and child resolution; one representative plugin proves two running roots reorder after committed user-side activity while awaiting-only is not promoted, inactive order is unchanged, a live patch reorders without another status event, and an omitted marker uses updated-time fallback. Lists and unseen badges render. |
 | L4 Extended | Relay integration, every supporting production plugin: bridge and plugin restart preserve identity and overrides; a moved backend-native project keeps them while a moved bridge-derived project is discovered as new without mutating the old catalog; a cancelled or failed import leaves the prior catalog intact; reads during import stay consistent; an unavailable plugin is reported while others keep listing. |
 | L5 Full | Client end to end, every supporting production plugin: multiple clients observe consistent listings and unseen transitions; large catalogs and paged listings behave; unattributed payloads resolve to the historical identity. |
 
@@ -48,6 +60,9 @@ Vary the owning plugin, manual open versus import discovery, git and non-git
 folders, and whether the directory moved between runs. Alternate empty,
 child-only, and large projects, and reorder import, listing, creation. Remove
 disposable sessions and projects and restore hidden-state changes afterwards.
+For activity order, vary REST versus live delivery, null versus populated
+markers, ties, awaiting-only versus running state, and assistant/tool updates
+after a marker has been established.
 
 ## Failure Signals
 
@@ -57,6 +72,9 @@ disposable sessions and projects and restore hidden-state changes afterwards.
   identity instead of being discovered as new.
 - Sessions lose attribution, land under the wrong project, or a child lists as a
   root.
+- A running root stays alphabetically ordered, a stale marker masks newer
+  committed activity, a null marker fails to use updated time, awaiting-only is
+  promoted, or inactive/project/child order changes.
 - Unseen never clears, clears without viewing, or an unavailable plugin is idle.
 - Hiding destroys sessions, or a cancelled import destroys the committed catalog.
 
@@ -67,6 +85,12 @@ disposable sessions and projects and restore hidden-state changes afterwards.
 - Derived lists are bounded by backend enumeration; a directory-scoped backend
   only rediscovers sessions in directories the bridge already knows.
 - Only plugins registered in the build under test count.
+- User-side activity is an ordering heuristic, not proof of human intent.
+  Generated backend input normalized as a user message and lifecycle-generated
+  replies or rejections that clear pending input can advance it.
+- Markers use source event clocks. Skew between backends can misorder running
+  sessions across clock domains; no second bridge-observation timestamp exists.
+- A missed live patch self-heals on a later relevant event or list refresh.
 
 ## Sources
 
@@ -75,6 +99,10 @@ disposable sessions and projects and restore hidden-state changes afterwards.
   catalog and session handlers in `bridge/routing/`
 - Contract: `bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart`
 - Tests: `bridge/app/test/bridge/routing/catalog_read_handlers_test.dart`,
-  `test/bridge/repositories/project_repository_test.dart`
+  `test/bridge/repositories/project_repository_test.dart`;
+  `client/module_core/test/services/session_list_service_test.dart`,
+  `test/services/session_unseen_tracker_test.dart`,
+  `test/cubits/session_list/session_list_cubit_test.dart`
 - Plans (discovery only): `.plan/completed/multi-plugin-release-prep`,
-  `setup-aware-plugin-management`, `relay-request-concurrency`
+  `setup-aware-plugin-management`, `relay-request-concurrency`;
+  `.plan/active/session-user-interaction-order`

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -99,10 +99,10 @@ after a marker has been established.
   catalog and session handlers in `bridge/routing/`
 - Contract: `bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart`
 - Tests: `bridge/app/test/bridge/routing/catalog_read_handlers_test.dart`,
-  `test/bridge/repositories/project_repository_test.dart`;
+  `bridge/app/test/bridge/repositories/project_repository_test.dart`;
   `client/module_core/test/services/session_list_service_test.dart`,
-  `test/services/session_unseen_tracker_test.dart`,
-  `test/cubits/session_list/session_list_cubit_test.dart`
+  `client/module_core/test/services/session_unseen_tracker_test.dart`,
+  `client/module_core/test/cubits/session_list/session_list_cubit_test.dart`
 - Plans (discovery only): `.plan/completed/multi-plugin-release-prep`,
   `setup-aware-plugin-management`, `relay-request-concurrency`;
   `.plan/active/session-user-interaction-order`

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -25,6 +25,11 @@ reaches the backend so the turn continues.
   process-wide so another session cannot become the attribution target.
 - Resolving a request retires it in the pending list, on every open surface, and
   in completion-notification suppression.
+- Normalized question and permission replies or rejections feed the existing
+  durable user-side activity marker. Lifecycle cleanup that emits those events
+  to retire pending UI on abort, thread close, process exit, or disposal can
+  therefore advance the marker. Permission replies consumed by bridge
+  auto-approval before normal event routing do not advance it.
 - Child or sub-agent requests surface under their display root.
 - Per-session pending lists are empty while a plugin is stopped or terminally
   failed and never start it. A project-wide question list reports unavailable
@@ -60,6 +65,8 @@ different combination than the previous recorded run.
   backend value, reaches the wrong session, or remains pending after abort.
 - A resolved request stays visible, keeps suppressing notifications, or returns
   after reconnect.
+- A manually routed reply/rejection fails to advance the existing activity
+  marker, or an auto-approved permission reply advances it.
 - Reading pending state starts an intentionally stopped backend.
 - An archived session accepts a reply.
 

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -22,6 +22,11 @@ defaults and queued client sends coherent.
   finalized messages enter durable history matching a history read. Internal
   backend command records are not rendered as conversation messages or used as
   assistant model attribution.
+- Normalized user-message events feed the durable user-side activity marker used
+  to order running roots. Known event times are applied monotonically. Backend
+  input represented as a user message, including automatic compaction or other
+  generated input, can therefore count; the marker does not claim perfect human
+  provenance.
 - Prompt defaults update after a successful send and are published so other
   surfaces converge. Backend-originated mode changes such as an approved plan
   exit also persist and publish their effective defaults. A defaults-write
@@ -83,6 +88,9 @@ queue, turn length, and client count.
   as literal syntax.
 - Recovery or interruption artifacts from an aborted turn appear in the next
   user turn.
+- A normalized user message fails to advance the existing activity marker, or
+  assistant/tool/title-only updates replace an established marker and move the
+  running session as if they were user activity.
 - Scrolled transcript text remains clearly visible through the fade and collides
   with the navigation title or floating composer controls.
 


### PR DESCRIPTION
## Complexity

🌱 Trivial. This documentation-only step records the shipped activity-ordering contract and its release coverage without changing production code.

## What

- Define running-root activity ordering, fallback, tie-breaking, and live reordering in the projects/sessions regression contract.
- Record representative-plugin coverage for the backend-neutral ordering path while retaining existing every-supporting-plugin catalog coverage.
- Identify the existing normalized user-message, question, and permission events that feed the marker.
- Document auto-approval exclusion and accepted generated-input, lifecycle-cleanup, missed-patch, and clock-skew limitations.
- Advance the active plan tracker after Step 2 merged.

## Why

The implementation in #883 materially changed session-list behavior. Durable regression guidance now needs exact acceptance criteria and an honest test matrix before final release verification and plan retirement.

## Risk and test focus

Low risk. Review for consistency with the shipped comparator and marker semantics, especially awaiting-only behavior, inactive/project/child ordering, mixed-version fallback, representative-plugin scope, and the distinction between user-side activity and proven human intent.

## Expected result

No user-visible change and no database or persisted-data impact. Regression runners have a precise contract for automated and phone/bridge verification in Step 4.

## Verification

- Reviewed the three regression contracts together for consistency
- `git diff --check`
- Confirmed the obsolete pre-simplification prototype stash remains untouched
- No Dart/Flutter suites required for documentation-only changes

## Series

Step 3 of 4 for `.plan/active/session-user-interaction-order/`.

Previous: #883

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the shipped running-session ordering contract and its release coverage without changing production behavior. It codifies that running roots sort by a durable user-side activity marker with updated-time fallback and tie-break by session ID.

- Defines ordering: running roots use latest user-side activity; awaiting-input alone does not promote; missing marker falls back to updated time; inactive roots keep updated-time order; project and child ordering unchanged.
- Describes delivery: REST seeds the marker; live list-state patches can reorder a running session; null markers are omitted and older bridges use updated-time fallback; markers merge monotonically without blocking authoritative unseen/project replacements.
- Identifies marker sources and exclusions: normalized user messages; normalized question/permission replies or rejections (including lifecycle cleanup) advance; auto-approved permissions do not; backend-generated input normalized as a user message can count.
- Updates coverage: L2 shows the marker in REST and live projections; L3 proves reorder with a representative plugin (awaiting-only not promoted, inactive order unchanged, live patch reorders, fallback when marker omitted); every-plugin coverage remains for ownership/import/child resolution.
- Notes limits and recovery: source-clock skew can misorder across backends; missed live patches self-heal on later events or refresh.
- Advances the plan tracker to Step 3 and fixes regression source paths, adding explicit test references.

<sup>Written for commit 7285a52e25f51ae0e844fbaf0ca87fc4811ade5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

