### PR TITLE
🌱 Restore standalone Material scaffold ancestry

### DIFF
--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -452,6 +452,7 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
             builder: (context, bannerHeight, _) => buildScaffold(bannerHeight),
           );
 
+    // Remove this wrapper once liquid_glass_widgets migrates from the Flutter SDK Material and Cupertino libraries to material_ui and cupertino_ui.
     return Scaffold(
       backgroundColor: Colors.transparent,
       resizeToAvoidBottomInset: false,

--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -452,10 +452,14 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
             builder: (context, bannerHeight, _) => buildScaffold(bannerHeight),
           );
 
-    return _TopBarInsetScope(
-      baseInset: topPad + PregoTopNavigation.barHeight,
-      bannerHeight: _bannerHeight,
-      child: scaffold,
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      resizeToAvoidBottomInset: false,
+      body: _TopBarInsetScope(
+        baseInset: topPad + PregoTopNavigation.barHeight,
+        bannerHeight: _bannerHeight,
+        child: scaffold,
+      ),
     );
   }
 }

--- a/client/module_prego/test/components/prego_glass_scaffold_status_bar_test.dart
+++ b/client/module_prego/test/components/prego_glass_scaffold_status_bar_test.dart
@@ -27,6 +27,7 @@ void main() {
   // in-app light/dark choice deliberately overrides.
 
   testWidgets("provides standalone Material and Scaffold ancestors", (tester) async {
+    late BuildContext scaffoldContext;
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(extensions: [PregoDesignSystem.light]),
@@ -36,10 +37,10 @@ void main() {
           slivers: [
             SliverToBoxAdapter(
               child: Builder(
-                builder: (context) => TextButton(
-                  onPressed: () => ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text("Notice"))),
-                  child: const TextField(),
-                ),
+                builder: (context) {
+                  scaffoldContext = context;
+                  return const TextField();
+                },
               ),
             ),
           ],
@@ -48,7 +49,7 @@ void main() {
     );
 
     expect(tester.takeException(), isNull);
-    await tester.tap(find.byType(TextButton));
+    ScaffoldMessenger.of(scaffoldContext).showSnackBar(const SnackBar(content: Text("Notice")));
     await tester.pump();
     expect(find.text("Notice"), findsOneWidget);
   });

--- a/client/module_prego/test/components/prego_glass_scaffold_status_bar_test.dart
+++ b/client/module_prego/test/components/prego_glass_scaffold_status_bar_test.dart
@@ -26,6 +26,33 @@ void main() {
   // contrast with that — not with the device's appearance setting, which an
   // in-app light/dark choice deliberately overrides.
 
+  testWidgets("provides standalone Material and Scaffold ancestors", (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(extensions: [PregoDesignSystem.light]),
+        home: PregoGlassScaffold(
+          title: "Title",
+          automaticallyImplyLeading: false,
+          slivers: [
+            SliverToBoxAdapter(
+              child: Builder(
+                builder: (context) => TextButton(
+                  onPressed: () => ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text("Notice"))),
+                  child: const TextField(),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    await tester.tap(find.byType(TextButton));
+    await tester.pump();
+    expect(find.text("Notice"), findsOneWidget);
+  });
+
   testWidgets("a light app keeps dark status-bar icons on a dark device", (tester) async {
     tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
     addTearDown(tester.platformDispatcher.clearPlatformBrightnessTestValue);


### PR DESCRIPTION
## Complexity

🌱 Trivial — one compatibility scaffold and one regression test.

## What

- Wrap `PregoGlassScaffold` in standalone `material_ui` `Scaffold`.
- Verify standalone `TextField` ancestry and `ScaffoldMessenger` registration.

## Why

PR #886 migrated app widgets to standalone Flutter UI packages while `liquid_glass_widgets` still provides SDK Material scaffolding. These types do not share widget identity, causing 135 Mobile CI failures: standalone `TextField` could not find `Material`, and standalone `ScaffoldMessenger` could not find descendant scaffolds.

## Risk and test focus

Low layout risk. Wrapper is transparent and disables its own keyboard resizing; existing `GlassScaffold` retains layout, overlays, floating actions, and keyboard behavior. No database impact.

## Expected result

Mobile CI passes. Standalone Material widgets under `PregoGlassScaffold` find required Material and Scaffold ancestors. User-visible composer fields and notices render again.

## Verification

- `dart pub get` (`client/`)
- `dart analyze` (`client/app`, `client/module_prego`, `client/desktop`)
- `flutter test` (`client/app`: 979 passed)
- `flutter test` (`client/module_prego`)
- `flutter test` (`client/desktop`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `Material`/`Scaffold` ancestry for standalone widgets under `PregoGlassScaffold`, fixing Mobile CI failures where `TextField` and `ScaffoldMessenger` could not find required ancestors. Standalone widgets now resolve required ancestors and `SnackBar`s render.

- Wraps `PregoGlassScaffold` in a transparent top-level `Scaffold` (`resizeToAvoidBottomInset: false`) as a temporary compatibility layer, noted in code for removal after `liquid_glass_widgets` migrates to `material_ui`/`cupertino_ui`; layout, overlays, FABs, and keyboard behavior remain unchanged.
- Adds a deterministic widget test that verifies `Material`/`Scaffold` ancestry and `SnackBar` delivery.
- No migration required; existing `PregoGlassScaffold` usage continues to work.

<sup>Written for commit f2e2f8a75532c4f5424212d0de67d90774d0af10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

