### PR TITLE
🌱 Fix standalone scaffold snackbar geometry

### DIFF
--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -127,7 +127,7 @@ class const PregoGlassScaffold({
     /// Whether the bar may infer a back button from the navigator when neither
   /// [leading] nor [onBack] is supplied.
   final bool automaticallyImplyLeading = true,
-    /// Optional floating action button, forwarded to the inner [GlassScaffold].
+    /// Optional floating action button, hosted by the standalone [Scaffold].
   final Widget? floatingActionButton,
     /// Where [floatingActionButton] sits horizontally. Defaults to the trailing
   /// edge.
@@ -195,12 +195,11 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
     super.dispose();
   }
 
-  /// The floating action handed to [GlassScaffold], positioned per
+  /// The floating action handed to the standalone [Scaffold], positioned per
   /// [PregoGlassScaffold.floatingActionAlignment].
   ///
-  /// [GlassScaffold] gives its inner [Scaffold] no
-  /// [FloatingActionButtonLocation], so the action always lands on
-  /// [FloatingActionButtonLocation.endFloat]. Rather than reimplement that
+  /// The [Scaffold] has no [FloatingActionButtonLocation], so the action always
+  /// lands on [FloatingActionButtonLocation.endFloat]. Rather than reimplement that
   /// slot's vertical placement — which already clears the keyboard, the home
   /// indicator and any snack bar — the centred variant widens the action to
   /// the full content width and centres the caller's widget inside it.
@@ -435,7 +434,6 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
       extendBody: extendBehind,
       topEdgeFade: false, // Disable the top edge fade -- we use our own custom gradient
       bottomEdgeFade: false, // Disable the bottom edge fade -- we use our own custom gradient
-      floatingActionButton: _floatingActionButton,
       bodyOverlays: bodyOverlays.isEmpty ? null : bodyOverlays,
       appBar: topBar,
       // The top bar is a Column (not a PreferredSizeWidget), so GlassScaffold
@@ -455,7 +453,7 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
     // Remove this wrapper once liquid_glass_widgets migrates from the Flutter SDK Material and Cupertino libraries to material_ui and cupertino_ui.
     return Scaffold(
       backgroundColor: Colors.transparent,
-      resizeToAvoidBottomInset: false,
+      floatingActionButton: _floatingActionButton,
       body: _TopBarInsetScope(
         baseInset: topPad + PregoTopNavigation.barHeight,
         bannerHeight: _bannerHeight,

--- a/client/module_prego/test/components/prego_glass_scaffold_fab_test.dart
+++ b/client/module_prego/test/components/prego_glass_scaffold_fab_test.dart
@@ -23,7 +23,11 @@ Widget _harness({
   );
   return MaterialApp(
     theme: ThemeData(extensions: [PregoDesignSystem.light]),
-    home: paneWidth == null ? scaffold : Center(child: SizedBox(width: paneWidth, child: scaffold)),
+    home: paneWidth == null
+        ? scaffold
+        : Center(
+            child: SizedBox(width: paneWidth, child: scaffold),
+          ),
   );
 }
 
@@ -91,5 +95,64 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(scrollable.controller!.offset, greaterThan(0));
+  });
+
+  testWidgets("a snackbar clears the floating action", (tester) async {
+    late BuildContext bodyContext;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(extensions: [PregoDesignSystem.light]),
+        home: PregoGlassScaffold(
+          title: "Title",
+          automaticallyImplyLeading: false,
+          floatingActionButton: const SizedBox(key: _fabKey, width: 120, height: 52),
+          slivers: [
+            SliverToBoxAdapter(
+              child: Builder(
+                builder: (context) {
+                  bodyContext = context;
+                  return const SizedBox(height: 10);
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    ScaffoldMessenger.of(bodyContext).showSnackBar(const SnackBar(content: Text("Notice")));
+    await tester.pumpAndSettle();
+
+    expect(tester.getRect(find.byKey(_fabKey)).bottom, lessThanOrEqualTo(tester.getRect(find.byType(SnackBar)).top));
+  });
+
+  testWidgets("a snackbar clears the keyboard", (tester) async {
+    late BuildContext bodyContext;
+    addTearDown(tester.view.resetViewInsets);
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(extensions: [PregoDesignSystem.light]),
+        home: PregoGlassScaffold(
+          title: "Title",
+          automaticallyImplyLeading: false,
+          slivers: [
+            SliverToBoxAdapter(
+              child: Builder(
+                builder: (context) {
+                  bodyContext = context;
+                  return const TextField();
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    tester.view.viewInsets = const FakeViewPadding(bottom: 180);
+    ScaffoldMessenger.of(bodyContext).showSnackBar(const SnackBar(content: Text("Notice")));
+    await tester.pumpAndSettle();
+
+    expect(tester.getRect(find.byType(SnackBar)).bottom, lessThanOrEqualTo(tester.view.physicalSize.height - 180));
   });
 }

--- a/client/module_prego/test/components/prego_glass_scaffold_fab_test.dart
+++ b/client/module_prego/test/components/prego_glass_scaffold_fab_test.dart
@@ -128,6 +128,8 @@ void main() {
 
   testWidgets("a snackbar clears the keyboard", (tester) async {
     late BuildContext bodyContext;
+    const keyboardInset = 180.0;
+    final devicePixelRatio = tester.view.devicePixelRatio;
     addTearDown(tester.view.resetViewInsets);
     await tester.pumpWidget(
       MaterialApp(
@@ -149,10 +151,11 @@ void main() {
       ),
     );
 
-    tester.view.viewInsets = const FakeViewPadding(bottom: 180);
+    tester.view.viewInsets = FakeViewPadding(bottom: keyboardInset * devicePixelRatio);
     ScaffoldMessenger.of(bodyContext).showSnackBar(const SnackBar(content: Text("Notice")));
     await tester.pumpAndSettle();
 
-    expect(tester.getRect(find.byType(SnackBar)).bottom, lessThanOrEqualTo(tester.view.physicalSize.height - 180));
+    final logicalHeight = tester.view.physicalSize.height / devicePixelRatio;
+    expect(tester.getRect(find.byType(SnackBar)).bottom, lessThanOrEqualTo(logicalHeight - keyboardInset));
   });
 }


### PR DESCRIPTION
## Complexity

🌱 Trivial — correct ownership of existing scaffold slots plus two geometry regressions.

## What

- Move `PregoGlassScaffold` floating actions from legacy `GlassScaffold` to standalone `material_ui` `Scaffold`.
- Let standalone scaffold own keyboard resizing.
- Verify snackbars clear both visible floating actions and keyboard insets.

## Why

Post-merge review of #887 identified two real mixed-scaffold geometry gaps. Standalone snackbars were laid out by the new outer scaffold, while floating actions and keyboard resizing remained owned by the legacy inner scaffold. That prevented snackbar layout from accounting for either obstruction.

## Risk and test focus

Low layout risk. Floating actions keep the same `endFloat` placement and existing alignment wrapper. Existing FAB position, hit-testing, mobile, shared UI, and desktop suites pass. No database impact.

## Expected result

Standalone snackbars remain visible above an open keyboard and never overlap `PregoGlassScaffold` floating actions. No other user-visible behavior changes.

## Verification

- `flutter test && dart analyze` (`client/module_prego`)
- `flutter test && dart analyze` (`client/app`: 979 passed)
- `flutter test && dart analyze` (`client/desktop`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes snackbar geometry in the standalone `material_ui` scaffold so snackbars no longer overlap the `PregoGlassScaffold` floating action button or the keyboard. Previously, snackbars were laid out by the outer scaffold while the inner `GlassScaffold` controlled the FAB and keyboard insets; now the standalone scaffold hosts the FAB and owns keyboard resizing.

**Review notes**
- Moves `floatingActionButton` from the inner `GlassScaffold` to the standalone `Scaffold`; keeps `FloatingActionButtonLocation.endFloat` and the existing alignment wrapper.
- Removes the inner action slot; the outer scaffold now resizes to avoid bottom insets so snackbars clear both the FAB and the keyboard.
- Adds widget tests for snackbar clearance of the FAB and keyboard; fixes test pixel units by using `viewInsets` in physical pixels with `devicePixelRatio`-aware assertions.

<sup>Written for commit 40eae7cf03cdbb2a8d6802e154522ea4d9307b8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

