### PR TITLE
⚙️ [session-user-interaction-order] feat: order active projects and verify activity ordering [step 4/4]

### DIFF
--- a/.plan/completed/session-user-interaction-order/PLAN.md
+++ b/.plan/completed/session-user-interaction-order/PLAN.md
@@ -1,13 +1,13 @@
-# Running Session User-Activity Order
+# Running Session And Project User-Activity Order
 
 ## Status
 
 - **Plan slug:** `session-user-interaction-order`
-- **Status:** Simplified after product and history review
+- **Status:** Completed and retired
 - **Plan date:** 2026-08-13
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
-- **Implementation base:** `main` at `88059e200`
-- **Implementation branch/worktree:** `session-order-ux-review`
+- **Implementation base:** `main` at `6ee94bfe`
+- **Implementation branch/worktree:** `session-user-interaction-order-verification`
 - **Delivery:** four PRs: plan, implementation, regression contract,
   verification/retirement
 
@@ -18,8 +18,9 @@ its current semantics are stated honestly.
 
 ## Goal
 
-Keep running root sessions promoted at the top of a project's session list, but
-order that running prefix by the bridge's latest recorded user-side activity
+Keep running root sessions promoted at the top of a project's session list and
+projects with running roots promoted at the top of the project list, but order
+both running prefixes by the bridge's latest recorded user-side activity
 instead of alphabetically.
 
 The visible policy otherwise remains unchanged:
@@ -28,7 +29,7 @@ The visible policy otherwise remains unchanged:
 - awaiting-input alone does not promote a session;
 - inactive sessions remain ordered by `Session.time.updated` descending;
 - archived filtering remains unchanged; and
-- project and child-task ordering remain unchanged.
+- inactive project ordering and child-task ordering remain unchanged.
 
 "User-side activity" deliberately means the bridge's existing unseen-state
 marker, not perfect human-origin provenance. It advances for normalized user
@@ -54,8 +55,10 @@ The implementation must stay within all of these constraints:
   dedupe collection, timer, lock, registry, or lifecycle owner;
 - one existing persisted scalar projected additively onto existing REST and SSE
   shapes; and
-- one client running-prefix comparator, using existing activity and list-state
-  delivery.
+- two client running-prefix comparators, using existing activity and list-state
+  delivery; and
+- nullable ordering facts added to the existing active-session summary, with no
+  new route, event, cache, timer, or lifecycle owner.
 
 If implementation exceeds this budget, stop and ask before adding machinery.
 
@@ -64,6 +67,9 @@ If implementation exceeds this budget, stop and ask before adding machinery.
 - `SessionListService.visibleSessions` partitions running roots using
   `SessionActivityCalculator.isRunning`, alphabetizes the running prefix, then
   appends inactive sessions by `time.updated` descending.
+- `ProjectListService.orderProjects` uses the same running calculation,
+  alphabetizes the running project prefix, then appends inactive projects by
+  the existing project timestamp/name/ID order.
 - Session rows already persist nullable `last_user_message_at`. The bridge's
   ordered `SessionUnseenService` writes it from normalized user messages and
   manual question/permission replies.
@@ -93,7 +99,7 @@ If implementation exceeds this budget, stop and ask before adding machinery.
 
 ### Reuse the existing marker
 
-Expose the stored row's `lastUserMessageAt` as required nullable
+Expose the stored row's `lastUserMessageAt` as nullable
 `lastUserActivityAt` on shared `Session` and the existing
 `SesoriSseEvent.sessionUnseenChanged` variant.
 
@@ -167,17 +173,46 @@ Do not add optimistic interaction timestamps on send acceptance. The normalized
 event and existing patch are the authority; the list reorders when that event is
 committed, and reconnect/refresh self-heals a missed patch.
 
+### Project ordering follow-up
+
+The project list follows the same policy without adding project-owned marker
+state. Extend each existing `ActiveSession` in `projects.summary` with nullable
+`lastUserActivityAt` and `updatedAt` facts from its durable bridge
+session binding. The bridge does not calculate project order and plugins remain
+unaware of both fields.
+
+`SseEventTracker` carries those two nullable facts alongside the existing root
+activity status. `ProjectListService.orderProjects` keeps its current partition.
+For each running project, compare the maximum effective value among only its
+running roots:
+
+1. the newer committed marker from `SessionUnseenTracker` and the active
+   summary, when either is present;
+2. otherwise that active root's updated time;
+3. otherwise the project's updated time; and
+4. project ID ascending for deterministic ties.
+
+Inactive projects retain the existing `Project.time.updated`, effective name,
+and ID order. Awaiting-input alone still does not promote either a session or a
+project.
+
+`ProjectListCubit` reuses its existing `SessionUnseenTracker` dependency and
+subscribes to the tracker's existing per-session stream so a committed marker
+re-runs project ordering while status remains unchanged. No additional cache or
+business state is introduced.
+
 ## Compatibility
 
 - **New bridge, old app:** extra nullable keys on known REST/SSE shapes are
   ignored; that app retains its current alphabetical running order.
 - **Old bridge, new app:** omitted fields decode to null and running order falls
-  back to `time.updated`.
+  back to session or project `time.updated` as available.
 - **Existing databases:** no migration; every current marker remains intact.
 - **Internal packages:** shared, bridge, and clients update together; no plugin
   contract changes.
 
-No new route, event variant, capability, or compatibility shim is added.
+No new route, event variant, capability, or compatibility shim is added. The
+existing `projects.summary` shape gains only nullable keys that old apps ignore.
 
 ## Accepted Limitations
 
@@ -200,6 +235,9 @@ No new route, event variant, capability, or compatibility shim is added.
   activity a bridge-owned process cannot observe.
 - A new app connected to an old bridge, and a session whose marker is still
   null, falls back to `time.updated`.
+- An old bridge also omits active-root ordering facts, so a running project
+  falls back to its project updated time. This is useful but less precise than
+  current bridge data when inactive activity also advanced that project.
 - A patch missed across disconnect reorders on the next relevant event or list
   refresh; no replay repair or optimistic timestamp is added.
 - Server-paged third-party root requests retain server order. The current app
@@ -210,21 +248,22 @@ justify new persistence, classifier state, or cross-plugin coordination.
 
 ## Cleanup Assessment
 
-- Remove `_compareSessionsByTitleAndId` and replace alphabetical-running tests.
+- Remove `_compareSessionsByTitleAndId` and `_compareProjectsByNameAndId`, and
+  replace alphabetical-running tests.
 - Update `session.unseen_changed` and tracker documentation to describe their
   complete session-list state payload.
 - Keep `last_user_message_at`, its existing write logic, unseen calculations,
   and persistence tests unchanged; they remain required production behavior.
-- Do not restore `ActiveWorkSummaryService`, `userInteractionOrdered`, project
-  reordering, or any prototype plugin event/origin changes.
+- Do not restore `ActiveWorkSummaryService`, `userInteractionOrdered`,
+  bridge-owned project reordering, or any prototype plugin event/origin changes.
 
 No other service, cache, field, setting, job, or transport variant becomes
 obsolete.
 
 ## Delivery Plan
 
-All steps use the existing `session-order-ux-review` branch/worktree. No extra
-branch or worktree is created.
+The final step uses the existing `session-user-interaction-order-verification`
+branch/worktree. Prior step branches are recorded in the tracker.
 
 ### Step 1/4 - Plan
 
@@ -277,8 +316,13 @@ source is expected; no Drift generation occurs.
 ### Step 4/4 - Verify and retire
 
 **Exact PR title:**
-`🌱 [session-user-interaction-order] docs: verify and retire session activity ordering [step 4/4]`
+`⚙️ [session-user-interaction-order] feat: order active projects and verify activity ordering [step 4/4]`
 
+- Carry durable marker and updated-time facts through the existing active-root
+  summary and order running projects by their latest running-root activity.
+- Reuse the existing session list-state stream for live project reordering while
+  preserving awaiting-only and inactive project behavior.
+- Update regression coverage for project and session ordering.
 - Run cumulative L3 coverage below.
 - Record privacy-safe evidence and accepted limitations.
 - Move the plan to `.plan/completed/` only after required coverage passes.
@@ -302,7 +346,9 @@ Automated proof:
   visible comparator without waiting for another status event or refresh, while
   the initial replay remains guarded until `SessionListLoaded`;
 - running comparator, null fallback, deterministic ties, and unchanged inactive,
-  awaiting-only, archived, project, and child ordering; and
+  awaiting-only, archived, inactive-project, and child ordering;
+- running-project comparator, maximum across running roots, old-bridge fallback,
+  and live marker reordering without another status summary; and
 - Git diff proves no schema/migration or production plugin change.
 
 End-to-end proof:
@@ -310,9 +356,18 @@ End-to-end proof:
 - one release-target phone and bridge host;
 - one representative registered plugin, because ordering starts after the
   existing normalized event boundary and no plugin changes;
-- two running roots reorder after user-side activity while an awaiting-only root
-  is not promoted and inactive rows retain updated-time order; and
-- a current app decoding an omitted marker fixture uses the documented fallback.
+- two running roots reorder after user-side activity while inactive rows retain
+  updated-time order;
+- two projects with running roots follow the same activity order while inactive
+  projects retain their prior order; and
+- a current app connected to a pre-feature bridge that omits the marker uses the
+  documented fallback.
+
+The exact awaiting-only state is representable by an ACP idle permission
+request, but normal production root prompts remain running while awaiting input.
+Focused ACP protocol and client ordering tests therefore provide the
+proportionate proof that awaiting-only is not promoted; no synthetic backend
+flow is required for the release matrix.
 
 No every-plugin live matrix is required. Existing plugin event normalization is
 not changed or newly claimed by this work. Focused mapper analysis/tests cover
@@ -335,3 +390,9 @@ operation hooks. A fresh `architecture-plan-review` approved this revision on
 2026-08-13 with no findings. It confirmed bridge repository/service ownership,
 orchestrator SSE projection, existing tracker lifecycle ownership, client
 comparator ownership, and additive shared-wire compatibility.
+
+After the session implementation merged, the user identified on 2026-08-13 that
+the project list's running prefix should follow the same policy. Step 4 therefore
+changed from documentation-only retirement to a moderate additive follow-up.
+It reuses the same durable marker and client tracker rather than introducing a
+project marker or bridge-owned ordering service.

--- a/.plan/completed/session-user-interaction-order/TRACKER.md
+++ b/.plan/completed/session-user-interaction-order/TRACKER.md
@@ -1,16 +1,18 @@
-# Running Session User-Activity Order: Tracker
+# Running Session And Project User-Activity Order: Tracker
 
 ## Current State
 
 - **Plan slug:** `session-user-interaction-order`
-- **Implementation base:** `main` at `2dcaeba5`
-- **Branch/worktree:** `session-user-interaction-order-regression`
+- **Implementation base:** `main` at `6ee94bfe`
+- **Branch/worktree:** `session-user-interaction-order-verification`
 - **Plan PR:** [#865](https://github.com/sesori-ai/sesori_apps_monorepo/pull/865)
 - **Implementation PR:** [#883](https://github.com/sesori-ai/sesori_apps_monorepo/pull/883)
-- **Series state:** Steps 1-2/4 merged; Step 3/4 regression contract in progress
-- **Current step:** 3/4 documentation ready for validation and publication
-- **Next action:** publish and monitor the Step 3 regression-contract PR
-- **Production source changes published:** Step 2 merged in PR #883
+- **Series state:** Steps 1-3/4 merged; Step 4/4 implementation and cumulative
+  L3 verification complete, with the final retirement PR ready to publish
+- **Current step:** 4/4 completed; plan moved to `.plan/completed/`
+- **Next action:** Publish and monitor the final Step 4 PR
+- **Production source changes published:** Step 2 merged in PR #883; Step 4 is
+  complete and ready for review
 
 ## Simplicity Contract
 
@@ -35,6 +37,9 @@
 - [x] Running roots order by existing user-side activity recency, then ID.
 - [x] Null marker falls back to `time.updated`.
 - [x] Inactive roots remain ordered by `time.updated`, then ID.
+- [x] Projects with running roots order by latest running-root activity, then ID.
+- [x] Awaiting-only does not promote a project; inactive project order remains
+  timestamp, effective name, then ID.
 - [x] Archived filtering and project/child ordering remain unchanged.
 - [x] Auto-approved permission replies remain excluded by current orchestrator
   filtering.
@@ -52,8 +57,8 @@
 |---|---|---|---|
 | [x] | 1/4 | `🌱 [session-user-interaction-order] docs: simplify running session activity order [step 1/4]` | [PR #865](https://github.com/sesori-ai/sesori_apps_monorepo/pull/865) merged |
 | [x] | 2/4 | `⚙️ [session-user-interaction-order] feat: order running sessions by user activity [step 2/4]` | [PR #883](https://github.com/sesori-ai/sesori_apps_monorepo/pull/883) merged |
-| [ ] | 3/4 | `🌱 [session-user-interaction-order] docs: define running session activity coverage [step 3/4]` | Ready to publish |
-| [ ] | 4/4 | `🌱 [session-user-interaction-order] docs: verify and retire session activity ordering [step 4/4]` | Pending |
+| [x] | 3/4 | `🌱 [session-user-interaction-order] docs: define running session activity coverage [step 3/4]` | [PR #885](https://github.com/sesori-ai/sesori_apps_monorepo/pull/885) merged |
+| [x] | 4/4 | `⚙️ [session-user-interaction-order] feat: order active projects and verify activity ordering [step 4/4]` | Implementation and L3 complete; ready to publish |
 
 ## Step 1 Checklist
 
@@ -101,11 +106,13 @@
 
 ## Step 4 Checklist
 
-- [ ] Run cumulative L3 automated and phone/bridge coverage.
-- [ ] Record omitted-marker fallback and live reorder evidence.
-- [ ] Keep plan active for partial/blocked/failed coverage unless explicitly
+- [x] Run cumulative automated coverage and simulator/bridge session coverage.
+- [x] Record omitted-marker fallback and live session reorder evidence.
+- [x] Implement and verify matching running-project activity order.
+- [x] Record complete cumulative project/session L3 evidence.
+- [x] Keep plan active for partial/blocked/failed coverage unless explicitly
   accepted by the user.
-- [ ] Move plan to `.plan/completed/` only after required coverage passes.
+- [x] Move plan to `.plan/completed/` only after required coverage passes.
 
 ## Decision Log
 
@@ -134,6 +141,17 @@
   semantics. Allowed required null arguments at ACP/Codex shared `Session`
   constructors while preserving zero plugin behavior/classifier changes, and
   retained the loaded-state guard around live re-filtering.
+- **2026-08-13 project-order follow-up:** carried the same durable marker and
+  root updated time through the existing active summary, then reused the client
+  comparator and tracker stream rather than adding project-owned ordering state.
+- **2026-08-13 awaiting-only verification:** normal production root prompts stay
+  running while awaiting input. The narrower ACP idle-permission state is
+  representable and covered by focused ACP and client ordering tests; no
+  synthetic backend flow or new test-only product machinery was added.
+- **2026-08-13 row count scope:** retained the pre-existing broad active-summary
+  count used by project-row presentation. Step 4 changes promotion and order;
+  changing status wording for a normally unreachable root state would be a
+  separate behavior change.
 
 ## Verification Log
 
@@ -183,3 +201,69 @@
 - Step 3 reconciles the three planned regression contracts and passes
   `git diff --check`. No Dart/Flutter suites are required for this
   documentation-only change.
+- PR #885 merged as `3c1539e3`; Step 4 rebased onto `origin/main` at
+  `0a9d50ef` on `session-user-interaction-order-verification`.
+- Cumulative Step 4 automation passed before the project-order follow-up:
+  `sesori_shared` 395 tests and analysis; `module_core` 1,114 tests and strict
+  analysis; bridge app 2,593 tests and strict analysis; ACP 240 tests and strict
+  analysis; Codex 361 tests and strict analysis.
+- Local L3 evidence used the source bridge on macOS, the current app on an owned
+  iPhone 17 iOS 26.5 simulator, and the registered Cursor plugin. Two Cursor
+  root sessions were simultaneously reported `busy`; the phone promoted both
+  above inactive roots and ordered the newer committed marker first. Bridge
+  REST returned the corresponding non-null `lastUserActivityAt` values, and
+  phone rows rendered running state and unseen badges consistently.
+- While both Cursor roots remained `busy`, a second accepted prompt advanced the
+  lower root's committed marker and moved it first on the phone without another
+  status transition. This proves live marker-driven reordering rather than a
+  refresh or activity-status edge.
+- The current app was then connected to a bridge built from pre-feature commit
+  `317b1ff1`. Its `/sessions` response omitted `lastUserActivityAt`; with both
+  Cursor roots `busy`, the phone ordered updated time `1786629006860` before
+  `1786629006823`, proving the documented old-bridge fallback.
+- A real OpenCode question reached the supported pending-input UI/API path.
+  OpenCode retains `busy` while a root question is unresolved. The ACP protocol
+  can represent an idle permission request with `awaitingInput` true and all
+  running facts false; the ACP activity test plus session/project ordering tests
+  cover that exact non-promotion state.
+- The iPhone simulator is the repository-prescribed local phone surface. The
+  earlier claim that a physical or cloud phone was required was incorrect and
+  has been superseded.
+- User follow-up on 2026-08-13 identified that running projects should use the
+  same activity policy. Step 4 now carries nullable durable marker/updated facts
+  through `projects.summary`, reuses `SessionUnseenTracker` for live updates,
+  and preserves inactive/awaiting-only project behavior.
+- `origin/main` advanced to `c697f29e` with the standalone Material scaffold
+  ancestry fix while Step 4 was under verification. The branch fast-forwarded
+  to that commit; its scaffold test and all 14 focused project-row widget tests
+  pass, and the owned simulator then rendered the project list without errors.
+- `origin/main` later advanced to `6ee94bfe` with an unrelated standalone
+  scaffold snackbar geometry fix. The branch fast-forwarded cleanly; all 14
+  focused project-row widget tests and strict app analysis still pass.
+- Current-wire capture showed a running root in `projects.summary` with
+  `lastUserActivityAt` `1786632158425` and `updatedAt` `1786632158381`. The
+  following auto-approved permission round trip left that marker unchanged,
+  preserving the existing exclusion policy.
+- With two Cursor projects already `Running`, project one initially led on marker
+  `1786631136341` versus project two's `1786631130835`. A prompt accepted for
+  project two advanced its committed marker to `1786631683136` and moved it
+  first without a refresh or another status transition; the inactive project
+  remained third and unseen rendering stayed correct.
+- The current app then connected to the pre-feature bridge source at `317b1ff1`.
+  Its session payloads omitted `lastUserActivityAt` and its active summaries
+  omitted both new root ordering facts. With both projects `Running`, the phone
+  ordered project updated time `1786632256672` before `1786632248500`, while the
+  inactive project remained third, proving the two-project old-bridge fallback.
+- Final cumulative verification passed: `sesori_shared` 396 tests;
+  `module_core` 1,118 tests; bridge app 2,593 tests; ACP 240 tests; Codex 361
+  tests; the 14 focused project-row widget tests; and strict analysis for every
+  touched or downstream package. The three scaffold regression tests also pass.
+- The final diff contains no schema, migration, or production plugin change;
+  both staged and unstaged whitespace checks passed. Architecture plan and
+  implementation reviews approved the project follow-up with no findings.
+- Final correctness review found that an older cached tracker marker could mask
+  a newer marker delivered by the reconnect summary. The comparator now takes
+  the maximum of those two committed views before considering updated-time
+  fallback, and the inverse stale-cache regression passes.
+- Required coverage is complete, so this plan tree moved from `.plan/active/`
+  to `.plan/completed/` in Step 4.

--- a/bridge/app/lib/src/bridge/repositories/mappers/plugin_activity_summary_mapper.dart
+++ b/bridge/app/lib/src/bridge/repositories/mappers/plugin_activity_summary_mapper.dart
@@ -5,6 +5,8 @@ extension PluginActiveSessionMapper on PluginActiveSession {
   ActiveSession toSharedActiveSession({
     required String sessionId,
     required List<String> childSessionIds,
+    required int? lastUserActivityAt,
+    required int updatedAt,
   }) {
     return ActiveSession(
       id: sessionId,
@@ -12,6 +14,8 @@ extension PluginActiveSessionMapper on PluginActiveSession {
       awaitingInput: awaitingInput,
       isRetrying: isRetrying,
       childSessionIds: childSessionIds,
+      lastUserActivityAt: lastUserActivityAt,
+      updatedAt: updatedAt,
     );
   }
 }

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -680,6 +680,8 @@ class SessionRepository({
           for (final backendChildId in active.childSessionIds)
             if (bindings[backendChildId] case final child?) child.sessionId,
         ],
+        lastUserActivityAt: binding.lastUserMessageAt,
+        updatedAt: binding.updatedAt,
       );
     }
 

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -2056,6 +2056,7 @@ void main() {
         unseenCalculator: const SessionUnseenCalculator(),
       );
       await recordWorktreeSession(db, parent: parent, worktree: worktree, sessionId: "w1");
+      await db.sessionDao.setUserMessageAt(sessionId: "w1", userMessageAt: 7);
       // The plugin groups the active worktree session under its own cwd (the
       // worktree) — exactly what the ACP plugin reports — plus a rowless
       // session under its own directory.
@@ -2095,6 +2096,8 @@ void main() {
       expect(byId.keys, isNot(contains(worktree)));
       expect(byId[parent]!.activeSessions.single.id, "w1");
       expect(byId[parent]!.activeSessions.single.mainAgentRunning, isTrue);
+      expect(byId[parent]!.activeSessions.single.updatedAt, 1);
+      expect(byId[parent]!.activeSessions.single.lastUserActivityAt, 7);
     });
 
     test("getProjectActivitySummaries excludes tombstoned backend sessions", () async {

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -70,6 +70,9 @@ class ProjectListCubit(
     _subscriptions.add(
       _sessionUnseenTracker.projectUnseen.listen((_) => _onUnseenUpdated()),
     );
+    _subscriptions.add(
+      _sessionUnseenTracker.sessionUnseen.listen((_) => _onSessionListStateUpdated()),
+    );
 
     // 2. Auto-refresh: throttled project data fetch, active only while the
     //    projects page is visible. switchMap cancels the inner subscription
@@ -289,6 +292,24 @@ class ProjectListCubit(
       final ordered = _projectListService.orderProjects(
         projects: loaded.projects,
         activityByProjectId: activityByProjectId,
+        listStateByProjectId: _sessionUnseenTracker.currentSessionUnseen,
+      );
+      emit(
+        loaded.copyWith(
+          projects: ordered,
+          unseenByProjectId: _unseenByProjectId(ordered),
+        ),
+      );
+    }
+  }
+
+  void _onSessionListStateUpdated() {
+    if (isClosed) return;
+    if (state case final ProjectListLoaded loaded) {
+      final ordered = _projectListService.orderProjects(
+        projects: loaded.projects,
+        activityByProjectId: _sseEventTracker.currentSessionActivity,
+        listStateByProjectId: _sessionUnseenTracker.currentSessionUnseen,
       );
       emit(
         loaded.copyWith(
@@ -312,6 +333,7 @@ class ProjectListCubit(
         final ordered = _projectListService.orderProjects(
           projects: merged.projects,
           activityByProjectId: _sseEventTracker.currentSessionActivity,
+          listStateByProjectId: _sessionUnseenTracker.currentSessionUnseen,
         );
 
         emit(
@@ -594,6 +616,7 @@ class ProjectListCubit(
           projectId: projectId,
         ),
         activityByProjectId: _sseEventTracker.currentSessionActivity,
+        listStateByProjectId: _sessionUnseenTracker.currentSessionUnseen,
       );
       emit(
         loaded.copyWith(
@@ -750,6 +773,7 @@ class ProjectListCubit(
         final sortedProjects = _projectListService.orderProjects(
           projects: mergedProjects,
           activityByProjectId: _sseEventTracker.currentSessionActivity,
+          listStateByProjectId: _sessionUnseenTracker.currentSessionUnseen,
         );
         // The REST aggregate is authoritative at fetch time — seed the tracker
         // so a stale live `true` can't keep a project bold after its last

--- a/client/module_core/lib/src/services/models/session_activity_info.dart
+++ b/client/module_core/lib/src/services/models/session_activity_info.dart
@@ -13,5 +13,7 @@ sealed class SessionActivityInfo with _$SessionActivityInfo {
     @Default(false) bool awaitingInput,
     @Default(0) int backgroundTaskCount,
     @Default(false) bool isRetrying,
+    required int? lastUserActivityAt,
+    required int? updatedAt,
   }) = _SessionActivityInfo;
 }

--- a/client/module_core/lib/src/services/models/session_activity_info.freezed.dart
+++ b/client/module_core/lib/src/services/models/session_activity_info.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$SessionActivityInfo {
 
- bool get mainAgentRunning; bool get awaitingInput; int get backgroundTaskCount; bool get isRetrying;
+ bool get mainAgentRunning; bool get awaitingInput; int get backgroundTaskCount; bool get isRetrying; int? get lastUserActivityAt; int? get updatedAt;
 /// Create a copy of SessionActivityInfo
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $SessionActivityInfoCopyWith<SessionActivityInfo> get copyWith => _$SessionActiv
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionActivityInfo&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&(identical(other.backgroundTaskCount, backgroundTaskCount) || other.backgroundTaskCount == backgroundTaskCount)&&(identical(other.isRetrying, isRetrying) || other.isRetrying == isRetrying));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionActivityInfo&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&(identical(other.backgroundTaskCount, backgroundTaskCount) || other.backgroundTaskCount == backgroundTaskCount)&&(identical(other.isRetrying, isRetrying) || other.isRetrying == isRetrying)&&(identical(other.lastUserActivityAt, lastUserActivityAt) || other.lastUserActivityAt == lastUserActivityAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,mainAgentRunning,awaitingInput,backgroundTaskCount,isRetrying);
+int get hashCode => Object.hash(runtimeType,mainAgentRunning,awaitingInput,backgroundTaskCount,isRetrying,lastUserActivityAt,updatedAt);
 
 @override
 String toString() {
-  return 'SessionActivityInfo(mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, backgroundTaskCount: $backgroundTaskCount, isRetrying: $isRetrying)';
+  return 'SessionActivityInfo(mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, backgroundTaskCount: $backgroundTaskCount, isRetrying: $isRetrying, lastUserActivityAt: $lastUserActivityAt, updatedAt: $updatedAt)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $SessionActivityInfoCopyWith<$Res>  {
   factory $SessionActivityInfoCopyWith(SessionActivityInfo value, $Res Function(SessionActivityInfo) _then) = _$SessionActivityInfoCopyWithImpl;
 @useResult
 $Res call({
- bool mainAgentRunning, bool awaitingInput, int backgroundTaskCount, bool isRetrying
+ bool mainAgentRunning, bool awaitingInput, int backgroundTaskCount, bool isRetrying, int? lastUserActivityAt, int? updatedAt
 });
 
 
@@ -63,13 +63,15 @@ class _$SessionActivityInfoCopyWithImpl<$Res>
 
 /// Create a copy of SessionActivityInfo
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? mainAgentRunning = null,Object? awaitingInput = null,Object? backgroundTaskCount = null,Object? isRetrying = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? mainAgentRunning = null,Object? awaitingInput = null,Object? backgroundTaskCount = null,Object? isRetrying = null,Object? lastUserActivityAt = freezed,Object? updatedAt = freezed,}) {
   return _then(SessionActivityInfo(
 mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
 as bool,awaitingInput: null == awaitingInput ? _self.awaitingInput : awaitingInput // ignore: cast_nullable_to_non_nullable
 as bool,backgroundTaskCount: null == backgroundTaskCount ? _self.backgroundTaskCount : backgroundTaskCount // ignore: cast_nullable_to_non_nullable
 as int,isRetrying: null == isRetrying ? _self.isRetrying : isRetrying // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,lastUserActivityAt: freezed == lastUserActivityAt ? _self.lastUserActivityAt : lastUserActivityAt // ignore: cast_nullable_to_non_nullable
+as int?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 
@@ -81,13 +83,15 @@ as bool,
 
 
 class _SessionActivityInfo implements SessionActivityInfo {
-  const _SessionActivityInfo({this.mainAgentRunning = false, this.awaitingInput = false, this.backgroundTaskCount = 0, this.isRetrying = false});
+  const _SessionActivityInfo({this.mainAgentRunning = false, this.awaitingInput = false, this.backgroundTaskCount = 0, this.isRetrying = false, required this.lastUserActivityAt, required this.updatedAt});
   
 
 @override@JsonKey() final  bool mainAgentRunning;
 @override@JsonKey() final  bool awaitingInput;
 @override@JsonKey() final  int backgroundTaskCount;
 @override@JsonKey() final  bool isRetrying;
+@override final  int? lastUserActivityAt;
+@override final  int? updatedAt;
 
 /// Create a copy of SessionActivityInfo
 /// with the given fields replaced by the non-null parameter values.
@@ -99,16 +103,16 @@ _$SessionActivityInfoCopyWith<_SessionActivityInfo> get copyWith => __$SessionAc
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionActivityInfo&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&(identical(other.backgroundTaskCount, backgroundTaskCount) || other.backgroundTaskCount == backgroundTaskCount)&&(identical(other.isRetrying, isRetrying) || other.isRetrying == isRetrying));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionActivityInfo&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&(identical(other.backgroundTaskCount, backgroundTaskCount) || other.backgroundTaskCount == backgroundTaskCount)&&(identical(other.isRetrying, isRetrying) || other.isRetrying == isRetrying)&&(identical(other.lastUserActivityAt, lastUserActivityAt) || other.lastUserActivityAt == lastUserActivityAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,mainAgentRunning,awaitingInput,backgroundTaskCount,isRetrying);
+int get hashCode => Object.hash(runtimeType,mainAgentRunning,awaitingInput,backgroundTaskCount,isRetrying,lastUserActivityAt,updatedAt);
 
 @override
 String toString() {
-  return 'SessionActivityInfo(mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, backgroundTaskCount: $backgroundTaskCount, isRetrying: $isRetrying)';
+  return 'SessionActivityInfo(mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, backgroundTaskCount: $backgroundTaskCount, isRetrying: $isRetrying, lastUserActivityAt: $lastUserActivityAt, updatedAt: $updatedAt)';
 }
 
 
@@ -119,7 +123,7 @@ abstract mixin class _$SessionActivityInfoCopyWith<$Res> implements $SessionActi
   factory _$SessionActivityInfoCopyWith(_SessionActivityInfo value, $Res Function(_SessionActivityInfo) _then) = __$SessionActivityInfoCopyWithImpl;
 @override @useResult
 $Res call({
- bool mainAgentRunning, bool awaitingInput, int backgroundTaskCount, bool isRetrying
+ bool mainAgentRunning, bool awaitingInput, int backgroundTaskCount, bool isRetrying, int? lastUserActivityAt, int? updatedAt
 });
 
 
@@ -136,13 +140,15 @@ class __$SessionActivityInfoCopyWithImpl<$Res>
 
 /// Create a copy of SessionActivityInfo
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? mainAgentRunning = null,Object? awaitingInput = null,Object? backgroundTaskCount = null,Object? isRetrying = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? mainAgentRunning = null,Object? awaitingInput = null,Object? backgroundTaskCount = null,Object? isRetrying = null,Object? lastUserActivityAt = freezed,Object? updatedAt = freezed,}) {
   return _then(_SessionActivityInfo(
 mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
 as bool,awaitingInput: null == awaitingInput ? _self.awaitingInput : awaitingInput // ignore: cast_nullable_to_non_nullable
 as bool,backgroundTaskCount: null == backgroundTaskCount ? _self.backgroundTaskCount : backgroundTaskCount // ignore: cast_nullable_to_non_nullable
 as int,isRetrying: null == isRetrying ? _self.isRetrying : isRetrying // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,lastUserActivityAt: freezed == lastUserActivityAt ? _self.lastUserActivityAt : lastUserActivityAt // ignore: cast_nullable_to_non_nullable
+as int?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 

--- a/client/module_core/lib/src/services/project_list_service.dart
+++ b/client/module_core/lib/src/services/project_list_service.dart
@@ -4,6 +4,7 @@ import "package:sesori_shared/sesori_shared.dart";
 
 import "../repositories/project_repository.dart";
 import "models/session_activity_info.dart";
+import "models/session_list_item_state.dart";
 import "session_activity_calculator.dart";
 
 @lazySingleton
@@ -45,18 +46,40 @@ class ProjectListService({
   List<Project> orderProjects({
     required Iterable<Project> projects,
     required Map<String, Map<String, SessionActivityInfo>> activityByProjectId,
+    required Map<String, Map<String, SessionListItemState>> listStateByProjectId,
   }) {
     final running = <Project>[];
     final remaining = <Project>[];
+    final runningActivityAtByProjectId = <String, int>{};
     for (final project in projects) {
       final activity = activityByProjectId[project.id];
-      if (activity != null && activity.values.any((session) => _activityCalculator.isRunning(activity: session))) {
+      final runningSessions = activity?.entries
+          .where((entry) => _activityCalculator.isRunning(activity: entry.value))
+          .toList(growable: false);
+      if (runningSessions != null && runningSessions.isNotEmpty) {
         running.add(project);
+        runningActivityAtByProjectId[project.id] = runningSessions
+            .map(
+              (entry) =>
+                  latestUserActivityAt(
+                    first: listStateByProjectId[project.id]?[entry.key]?.lastUserActivityAt,
+                    second: entry.value.lastUserActivityAt,
+                  ) ??
+                  entry.value.updatedAt ??
+                  project.time?.updated ??
+                  0,
+            )
+            .reduce((latest, candidate) => candidate > latest ? candidate : latest);
       } else {
         remaining.add(project);
       }
     }
-    running.sort((a, b) => _compareProjectsByNameAndId(a: a, b: b));
+    running.sort((a, b) {
+      final aActivityAt = runningActivityAtByProjectId[a.id] ?? 0;
+      final bActivityAt = runningActivityAtByProjectId[b.id] ?? 0;
+      final activityCompare = bActivityAt.compareTo(aActivityAt);
+      return activityCompare != 0 ? activityCompare : a.id.compareTo(b.id);
+    });
     return [...running, ..._sortProjects(remaining)];
   }
 
@@ -80,22 +103,6 @@ class ProjectListService({
     if (nameCompare != 0) return nameCompare;
 
     return a.id.compareTo(b.id);
-  }
-
-  int _compareProjectsByNameAndId({required Project a, required Project b}) {
-    final nameCompare = _displayName(a).toLowerCase().compareTo(_displayName(b).toLowerCase());
-    if (nameCompare != 0) return nameCompare;
-
-    return a.id.compareTo(b.id);
-  }
-
-  String _displayName(Project project) {
-    final name = project.name;
-    if (name != null) return name;
-
-    final path = project.path.isEmpty ? project.id : project.path;
-    final segments = path.replaceAll(r"\", "/").split("/").where((segment) => segment.isNotEmpty);
-    return segments.isEmpty ? path : segments.last;
   }
 
   String _effectiveName(Project project) => project.name ?? project.path;

--- a/client/module_core/lib/src/services/sse_event_tracker.dart
+++ b/client/module_core/lib/src/services/sse_event_tracker.dart
@@ -177,6 +177,8 @@ class SseEventTracker(
             awaitingInput: session.awaitingInput,
             backgroundTaskCount: session.childSessionIds.length,
             isRetrying: session.isRetrying,
+            lastUserActivityAt: session.lastUserActivityAt,
+            updatedAt: session.updatedAt,
           );
         }
         sessionMap[summary.id] = infoMap;

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -1463,7 +1463,7 @@ void main() {
     );
 
     blocTest<ProjectListCubit, ProjectListState>(
-      "running activity received after REST creates an alphabetical prefix",
+      "running activity received after REST creates an activity-ordered prefix",
       build: () {
         when(() => mockProjectRepository.listProjects()).thenAnswer(
           (_) async => ApiResponse.success(Projects(data: [projectA, projectB, projectC])),
@@ -1473,8 +1473,8 @@ void main() {
       act: (_) async {
         await Future<void>.delayed(Duration.zero);
         mockSseEventTracker.emitSessionActivity({
-          "A": {"a": const SessionActivityInfo(mainAgentRunning: true)},
-          "C": {"c": const SessionActivityInfo(backgroundTaskCount: 1)},
+          "A": {"a": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: 20, updatedAt: null)},
+          "C": {"c": const SessionActivityInfo(backgroundTaskCount: 1, lastUserActivityAt: 10, updatedAt: null)},
         });
         await Future<void>.delayed(Duration.zero);
       },
@@ -1492,8 +1492,8 @@ void main() {
       "running activity received before REST is applied when projects arrive",
       build: () {
         mockSseEventTracker.emitSessionActivity({
-          "A": {"a": const SessionActivityInfo(mainAgentRunning: true)},
-          "C": {"c": const SessionActivityInfo(backgroundTaskCount: 1)},
+          "A": {"a": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: 20, updatedAt: null)},
+          "C": {"c": const SessionActivityInfo(backgroundTaskCount: 1, lastUserActivityAt: 10, updatedAt: null)},
         });
         when(() => mockProjectRepository.listProjects()).thenAnswer(
           (_) async => ApiResponse.success(Projects(data: [projectA, projectB, projectC])),
@@ -1508,6 +1508,29 @@ void main() {
         ),
       ],
     );
+
+    test("live session marker reorders projects whose roots are already running", () async {
+      when(() => mockProjectRepository.listProjects()).thenAnswer(
+        (_) async => ApiResponse.success(Projects(data: [projectA, projectB])),
+      );
+      mockSseEventTracker.emitSessionActivity({
+        "A": {"a": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: 20, updatedAt: null)},
+        "B": {"b": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: 10, updatedAt: null)},
+      });
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await cubit.stream.firstWhere((state) => state is ProjectListLoaded);
+      expect((cubit.state as ProjectListLoaded).projects.map((project) => project.id), ["A", "B"]);
+
+      fakeSessionUnseenTracker.emitSessionUnseen({
+        "A": {"a": (unseen: false, lastUserActivityAt: 20)},
+        "B": {"b": (unseen: true, lastUserActivityAt: 30)},
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      expect((cubit.state as ProjectListLoaded).projects.map((project) => project.id), ["B", "A"]);
+    });
 
     // -------------------------------------------------------------------------
     // Test 11: activity update ignored when not loaded

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -263,8 +263,8 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         mockSseEventTracker.emitSessionActivity({
           projectId: {
-            "C": const SessionActivityInfo(mainAgentRunning: true),
-            "A": const SessionActivityInfo(isRetrying: true),
+            "C": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
+            "A": const SessionActivityInfo(isRetrying: true, lastUserActivityAt: null, updatedAt: null),
           },
         });
         await Future<void>.delayed(Duration.zero);
@@ -285,8 +285,8 @@ void main() {
         mockRouteSource = MockRouteSource();
         mockSseEventTracker.emitSessionActivity({
           projectId: {
-            "C": const SessionActivityInfo(mainAgentRunning: true),
-            "A": const SessionActivityInfo(isRetrying: true),
+            "C": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
+            "A": const SessionActivityInfo(isRetrying: true, lastUserActivityAt: null, updatedAt: null),
           },
         });
         when(
@@ -1543,8 +1543,8 @@ void main() {
         // Mock the repository to emit activity for this project.
         mockSseEventTracker.emitSessionActivity({
           projectId: {
-            "s1": const SessionActivityInfo(mainAgentRunning: true),
-            "s2": const SessionActivityInfo(mainAgentRunning: true),
+            "s1": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
+            "s2": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
           },
         });
         return buildCubit();
@@ -1554,8 +1554,8 @@ void main() {
           (s) => s.activeSessionIds,
           "activeSessionIds",
           {
-            "s1": const SessionActivityInfo(mainAgentRunning: true),
-            "s2": const SessionActivityInfo(mainAgentRunning: true),
+            "s1": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
+            "s2": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
           },
         ),
       ],
@@ -1591,7 +1591,7 @@ void main() {
         // Emit initial activity
         mockSseEventTracker.emitSessionActivity({
           projectId: {
-            "s1": const SessionActivityInfo(mainAgentRunning: true),
+            "s1": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
           },
         });
         // Wait for the activity update to be processed
@@ -1599,8 +1599,8 @@ void main() {
         // Emit updated activity
         mockSseEventTracker.emitSessionActivity({
           projectId: {
-            "s1": const SessionActivityInfo(mainAgentRunning: true),
-            "s2": const SessionActivityInfo(mainAgentRunning: true),
+            "s1": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
+            "s2": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
           },
         });
       },
@@ -1611,7 +1611,7 @@ void main() {
           (s) => s.activeSessionIds,
           "activeSessionIds after first update",
           {
-            "s1": const SessionActivityInfo(mainAgentRunning: true),
+            "s1": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
           },
         ),
         // Second activity update: both s1 and s2 are active
@@ -1619,8 +1619,8 @@ void main() {
           (s) => s.activeSessionIds,
           "activeSessionIds after second update",
           {
-            "s1": const SessionActivityInfo(mainAgentRunning: true),
-            "s2": const SessionActivityInfo(mainAgentRunning: true),
+            "s1": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
+            "s2": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
           },
         ),
       ],
@@ -1650,11 +1650,11 @@ void main() {
         // Emit activity for this project and another.
         mockSseEventTracker.emitSessionActivity({
           projectId: {
-            "s1": const SessionActivityInfo(mainAgentRunning: true),
+            "s1": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
           },
           "project-2": {
-            "s2": const SessionActivityInfo(mainAgentRunning: true),
-            "s3": const SessionActivityInfo(mainAgentRunning: true),
+            "s2": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
+            "s3": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
           },
         });
         return buildCubit();
@@ -1664,7 +1664,7 @@ void main() {
           (s) => s.activeSessionIds,
           "activeSessionIds for this project only",
           {
-            "s1": const SessionActivityInfo(mainAgentRunning: true),
+            "s1": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
           },
         ),
       ],
@@ -1783,7 +1783,7 @@ void main() {
         // Emit activity for a different project.
         mockSseEventTracker.emitSessionActivity({
           "project-2": {
-            "s2": const SessionActivityInfo(mainAgentRunning: true),
+            "s2": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
           },
         });
         return buildCubit();
@@ -1818,7 +1818,12 @@ void main() {
         );
         mockSseEventTracker.emitSessionActivity({
           projectId: {
-            "s1": const SessionActivityInfo(mainAgentRunning: true, awaitingInput: true),
+            "s1": const SessionActivityInfo(
+              mainAgentRunning: true,
+              awaitingInput: true,
+              lastUserActivityAt: null,
+              updatedAt: null,
+            ),
           },
         });
         return buildCubit();
@@ -1828,7 +1833,12 @@ void main() {
           (s) => s.activeSessionIds,
           "activeSessionIds with awaitingInput",
           {
-            "s1": const SessionActivityInfo(mainAgentRunning: true, awaitingInput: true),
+            "s1": const SessionActivityInfo(
+              mainAgentRunning: true,
+              awaitingInput: true,
+              lastUserActivityAt: null,
+              updatedAt: null,
+            ),
           },
         ),
       ],
@@ -1982,8 +1992,8 @@ void main() {
       );
       mockSseEventTracker.emitSessionActivity({
         projectId: {
-          "newer": const SessionActivityInfo(mainAgentRunning: true),
-          "older": const SessionActivityInfo(mainAgentRunning: true),
+          "newer": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
+          "older": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
         },
       });
 
@@ -2014,8 +2024,8 @@ void main() {
       ).thenAnswer((_) => response.future);
       mockSseEventTracker.emitSessionActivity({
         projectId: {
-          "s1": const SessionActivityInfo(mainAgentRunning: true),
-          "s2": const SessionActivityInfo(mainAgentRunning: true),
+          "s1": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
+          "s2": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
         },
       });
 

--- a/client/module_core/test/services/project_list_service_test.dart
+++ b/client/module_core/test/services/project_list_service_test.dart
@@ -9,7 +9,7 @@ import "package:test/test.dart";
 class _MockProjectRepository() extends Mock implements ProjectRepository;
 
 void main() {
-  test("running projects form an alphabetical prefix while the tail stays timestamp ordered", () {
+  test("running projects use activity while awaiting-only and inactive projects keep timestamp order", () {
     final service = ProjectListService(
       repository: _MockProjectRepository(),
       activityCalculator: const SessionActivityCalculator(),
@@ -23,10 +23,11 @@ void main() {
         _project(id: "running-a", name: "Alpha", updatedAt: 100),
       ],
       activityByProjectId: const {
-        "running-z": {"z": SessionActivityInfo(mainAgentRunning: true)},
-        "waiting-a": {"waiting": SessionActivityInfo(awaitingInput: true)},
-        "running-a": {"a": SessionActivityInfo(backgroundTaskCount: 1)},
+        "running-z": {"z": SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: 10, updatedAt: null)},
+        "waiting-a": {"waiting": SessionActivityInfo(awaitingInput: true, lastUserActivityAt: 30, updatedAt: null)},
+        "running-a": {"a": SessionActivityInfo(backgroundTaskCount: 1, lastUserActivityAt: 20, updatedAt: null)},
       },
+      listStateByProjectId: const {},
     );
 
     expect(
@@ -35,7 +36,7 @@ void main() {
     );
   });
 
-  test("nameless running projects sort by their displayed directory basename", () {
+  test("live markers override summary activity and use the latest running root", () {
     final service = ProjectListService(
       repository: _MockProjectRepository(),
       activityCalculator: const SessionActivityCalculator(),
@@ -43,16 +44,91 @@ void main() {
 
     final result = service.orderProjects(
       projects: [
-        _project(id: "zulu", name: null, path: "/a/Zulu", updatedAt: 2),
-        _project(id: "alpha", name: null, path: r"C:\z\Alpha", updatedAt: 1),
+        _project(id: "project-a", name: "A", updatedAt: 2),
+        _project(id: "project-b", name: "B", updatedAt: 1),
       ],
       activityByProjectId: const {
-        "zulu": {"z": SessionActivityInfo(mainAgentRunning: true)},
-        "alpha": {"a": SessionActivityInfo(mainAgentRunning: true)},
+        "project-a": {
+          "a1": SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: 70, updatedAt: null),
+          "a2": SessionActivityInfo(isRetrying: true, lastUserActivityAt: 20, updatedAt: null),
+        },
+        "project-b": {"b": SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: 80, updatedAt: null)},
+      },
+      listStateByProjectId: const {
+        "project-a": {"a2": (unseen: false, lastUserActivityAt: 90)},
       },
     );
 
-    expect(result.map((project) => project.id), ["alpha", "zulu"]);
+    expect(result.map((project) => project.id), ["project-a", "project-b"]);
+  });
+
+  test("a fresh summary marker overrides a stale cached marker after reconnect", () {
+    final service = ProjectListService(
+      repository: _MockProjectRepository(),
+      activityCalculator: const SessionActivityCalculator(),
+    );
+
+    final result = service.orderProjects(
+      projects: [
+        _project(id: "project-a", name: "A", updatedAt: 2),
+        _project(id: "project-b", name: "B", updatedAt: 1),
+      ],
+      activityByProjectId: const {
+        "project-a": {"a": SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: 100, updatedAt: 1)},
+        "project-b": {"b": SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: 90, updatedAt: 200)},
+      },
+      listStateByProjectId: const {
+        "project-a": {"a": (unseen: false, lastUserActivityAt: 10)},
+      },
+    );
+
+    expect(result.map((project) => project.id), ["project-a", "project-b"]);
+  });
+
+  test("a live marker beats a markerless root's newer updated time", () {
+    final service = ProjectListService(
+      repository: _MockProjectRepository(),
+      activityCalculator: const SessionActivityCalculator(),
+    );
+
+    final result = service.orderProjects(
+      projects: [
+        _project(id: "project-a", name: "A", updatedAt: 2),
+        _project(id: "project-b", name: "B", updatedAt: 1),
+      ],
+      activityByProjectId: const {
+        "project-a": {"a": SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: 100)},
+        "project-b": {"b": SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: 75, updatedAt: 1)},
+      },
+      listStateByProjectId: const {
+        "project-a": {"a": (unseen: false, lastUserActivityAt: 50)},
+      },
+    );
+
+    expect(result.map((project) => project.id), ["project-b", "project-a"]);
+  });
+
+  test("old-bridge running projects fall back to project updated time and stable IDs", () {
+    final service = ProjectListService(
+      repository: _MockProjectRepository(),
+      activityCalculator: const SessionActivityCalculator(),
+    );
+
+    final result = service.orderProjects(
+      projects: [
+        _project(id: "older", name: "Alpha", updatedAt: 1),
+        _project(id: "newer-b", name: "Zulu", updatedAt: 2),
+        _project(id: "newer-a", name: "Beta", updatedAt: 2),
+      ],
+      activityByProjectId: const {
+        "older": {"older-root": SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null)},
+        "newer-b": {"newer-b-root": SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null)},
+        "newer-a": {"newer-a-root": SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null)},
+      },
+      listStateByProjectId: const {},
+    );
+
+    expect(result.map((project) => project.id), ["newer-a", "newer-b", "older"]);
   });
 }
 

--- a/client/module_core/test/services/session_list_service_test.dart
+++ b/client/module_core/test/services/session_list_service_test.dart
@@ -24,9 +24,9 @@ void main() {
       ],
       showArchived: true,
       activityBySessionId: const {
-        "running-new-update": SessionActivityInfo(isRetrying: true),
-        "waiting": SessionActivityInfo(awaitingInput: true),
-        "running-new-activity": SessionActivityInfo(mainAgentRunning: true),
+        "running-new-update": SessionActivityInfo(isRetrying: true, lastUserActivityAt: null, updatedAt: null),
+        "waiting": SessionActivityInfo(awaitingInput: true, lastUserActivityAt: null, updatedAt: null),
+        "running-new-activity": SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
       },
       listStateBySessionId: const {
         "running-new-update": (unseen: false, lastUserActivityAt: 10),
@@ -53,8 +53,8 @@ void main() {
       ],
       showArchived: true,
       activityBySessionId: const {
-        "new-update": SessionActivityInfo(mainAgentRunning: true),
-        "new-activity": SessionActivityInfo(mainAgentRunning: true),
+        "new-update": SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
+        "new-activity": SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
       },
       listStateBySessionId: const {},
     );
@@ -77,8 +77,8 @@ void main() {
       ],
       showArchived: true,
       activityBySessionId: const {
-        "running-a": SessionActivityInfo(backgroundTaskCount: 1),
-        "running-b": SessionActivityInfo(mainAgentRunning: true),
+        "running-a": SessionActivityInfo(backgroundTaskCount: 1, lastUserActivityAt: null, updatedAt: null),
+        "running-b": SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
       },
       listStateBySessionId: const {},
     );

--- a/client/module_core/test/services/sse_event_tracker_test.dart
+++ b/client/module_core/test/services/sse_event_tracker_test.dart
@@ -84,7 +84,13 @@ void main() {
             ProjectActivitySummary(
               id: "/foo",
               activeSessions: [
-                ActiveSession(id: "s1", mainAgentRunning: true, childSessionIds: []),
+                ActiveSession(
+                  id: "s1",
+                  mainAgentRunning: true,
+                  childSessionIds: [],
+                  lastUserActivityAt: 20,
+                  updatedAt: 10,
+                ),
                 ActiveSession(id: "s2", mainAgentRunning: false, childSessionIds: []),
               ],
             ),
@@ -97,7 +103,11 @@ void main() {
       expect(activity.keys, equals({"/foo"}));
       expect(activity["/foo"]!.keys, unorderedEquals({"s1", "s2"}));
       expect(activity["/foo"]!["s1"]!.mainAgentRunning, isTrue);
+      expect(activity["/foo"]!["s1"]!.lastUserActivityAt, 20);
+      expect(activity["/foo"]!["s1"]!.updatedAt, 10);
       expect(activity["/foo"]!["s2"]!.mainAgentRunning, isFalse);
+      expect(activity["/foo"]!["s2"]!.lastUserActivityAt, isNull);
+      expect(activity["/foo"]!["s2"]!.updatedAt, isNull);
 
       await subscription.cancel();
       await tracker.onDispose();

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -35,17 +35,22 @@ child sessions with titles, activity, statuses, and unseen state.
   preserves resolvable parent-session lineage, and never decodes transcript
   messages to derive titles.
 - Running root sessions remain ahead of inactive roots and order by the latest
-  durable user-side activity marker, descending, then session ID. Running means
-  main-agent work, retry, or a background task; awaiting-input alone does not
-  promote a session. A missing marker falls back to the session's updated time.
-  Inactive roots retain updated-time order, then session ID; archived filtering
-  and project and child-session ordering are unchanged.
+  durable user-side activity marker, descending, then session ID. Projects with
+  running roots likewise remain ahead of inactive projects and order by the
+  latest effective activity among their running roots, then project ID. Running
+  means main-agent work, retry, or a background task; awaiting-input alone does
+  not promote a session or project. A missing root marker falls back to that
+  root's updated time; an older bridge omitting active-root ordering facts falls
+  back to the project's updated time. Inactive roots retain updated-time order,
+  then session ID; inactive projects retain updated-time, effective-name, then
+  ID order. Archived filtering and child-session ordering are unchanged.
 - REST seeds the marker and live list-state patches reorder an already-running
-  session without another status event. A current client accepts an older bridge
-  omitting the marker and uses the updated-time fallback; null markers remain
-  omitted on the wire. Activity markers merge monotonically across live session
-  updates and REST refreshes without preventing authoritative unseen or project
-  aggregate replacement.
+  session and its running project without another status event or project
+  summary. A current client accepts an older bridge omitting the marker and
+  active-root ordering facts and uses the documented updated-time fallbacks;
+  null facts remain omitted on the wire. Activity markers merge monotonically
+  across live session updates and REST refreshes without preventing authoritative
+  unseen or project aggregate replacement.
 - Statuses report per-session idle/busy/retry plus unavailable plugins. A
   payload without plugin attribution means the historical OpenCode identity,
   never "the first enabled plugin".
@@ -56,7 +61,7 @@ child sessions with titles, activity, statuses, and unseen state.
 |---|---|
 | L1 Smoke | Headless bridge, representative plugin: project list and one project's session list return committed data with plugin attribution. |
 | L2 Routine | Headless bridge, representative plugin: open, rename, hide; create a session and see it listed; unseen advances and clears; the existing activity marker appears in REST and live list-state projections; statuses report idle/busy. |
-| L3 Release | Client end to end (phone): every supporting production plugin still covers native/derived ownership, import, and child resolution; Pi imports configured/default/known roots with explicit names and resolvable lineage; one representative plugin proves two running roots reorder after committed user-side activity while awaiting-only is not promoted, inactive order is unchanged, a live patch reorders without another status event, and an omitted marker uses updated-time fallback. Lists and unseen badges render. |
+| L3 Release | Client end to end (phone): every supporting production plugin still covers native/derived ownership, import, and child resolution; Pi imports configured/default/known roots with explicit names and resolvable lineage; one representative plugin proves two running roots and two projects with running roots reorder after committed user-side activity, inactive session/project order is unchanged, a live patch reorders without another status event or project summary, and omitted ordering facts use updated-time fallbacks. Focused ACP protocol and client ordering tests prove the exact awaiting-only state is not promoted because normal production root prompts remain running while awaiting input. Lists and unseen badges render. |
 | L4 Extended | Relay integration, every supporting production plugin: bridge and plugin restart preserve identity and overrides; a moved backend-native project keeps them while a moved bridge-derived project is discovered as new without mutating the old catalog; a cancelled or failed import leaves the prior catalog intact; reads during import stay consistent; an unavailable plugin is reported while others keep listing. |
 | L5 Full | Client end to end, every supporting production plugin: multiple clients observe consistent listings and unseen transitions; large catalogs and paged listings behave; unattributed payloads resolve to the historical identity. |
 
@@ -81,9 +86,9 @@ after a marker has been established.
 - Pi import exposes prompt/transcript text, treats it as a title, follows an
   unbounded symlink/parent tree, or loses sessions stored under a configured or
   bridge-known directory.
-- A running root stays alphabetically ordered, a stale marker masks newer
-  committed activity, a null marker fails to use updated time, awaiting-only is
-  promoted, or inactive/project/child order changes.
+- A running root or project stays alphabetically ordered, a stale marker masks
+  newer committed activity, a null marker fails to use updated time,
+  awaiting-only is promoted, or inactive session/project or child order changes.
 - Unseen never clears, clears without viewing, or an unavailable plugin is idle.
 - Hiding destroys sessions, or a cancelled import destroys the committed catalog.
 
@@ -100,6 +105,8 @@ after a marker has been established.
 - Markers use source event clocks. Skew between backends can misorder running
   sessions across clock domains; no second bridge-observation timestamp exists.
 - A missed live patch self-heals on a later relevant event or list refresh.
+- An old bridge cannot provide per-running-root ordering facts in
+  `projects.summary`, so the current app falls back to project updated time.
 
 ## Sources
 

--- a/shared/sesori_shared/lib/src/models/sesori/active_session.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/active_session.dart
@@ -11,12 +11,16 @@ part "active_session.g.dart";
 /// deeper nesting is ignored.
 @Freezed(fromJson: true, toJson: true)
 sealed class ActiveSession with _$ActiveSession {
+  // ignore: no_slop_linter/prefer_required_named_parameters, released bridges omit these nullable ordering facts
   const factory({
     required String id,
     @Default(false) bool mainAgentRunning,
     @Default(false) bool awaitingInput,
     @Default([]) List<String> childSessionIds,
     @Default(false) bool isRetrying,
+    // COMPATIBILITY 2026-08-13 (v1.8.0): Older bridges omit active-root ordering facts. Remove defaults; require both fields.
+    @Default(null) int? lastUserActivityAt,
+    @Default(null) int? updatedAt,
   }) = _ActiveSession;
 
   factory fromJson(Map<String, dynamic> json) => _$ActiveSessionFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/active_session.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/active_session.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ActiveSession {
 
- String get id; bool get mainAgentRunning; bool get awaitingInput; List<String> get childSessionIds; bool get isRetrying;
+ String get id; bool get mainAgentRunning; bool get awaitingInput; List<String> get childSessionIds; bool get isRetrying; int? get lastUserActivityAt; int? get updatedAt;
 /// Create a copy of ActiveSession
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +29,16 @@ $ActiveSessionCopyWith<ActiveSession> get copyWith => _$ActiveSessionCopyWithImp
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&const DeepCollectionEquality().equals(other.childSessionIds, childSessionIds)&&(identical(other.isRetrying, isRetrying) || other.isRetrying == isRetrying));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&const DeepCollectionEquality().equals(other.childSessionIds, childSessionIds)&&(identical(other.isRetrying, isRetrying) || other.isRetrying == isRetrying)&&(identical(other.lastUserActivityAt, lastUserActivityAt) || other.lastUserActivityAt == lastUserActivityAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,awaitingInput,const DeepCollectionEquality().hash(childSessionIds),isRetrying);
+int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,awaitingInput,const DeepCollectionEquality().hash(childSessionIds),isRetrying,lastUserActivityAt,updatedAt);
 
 @override
 String toString() {
-  return 'ActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, childSessionIds: $childSessionIds, isRetrying: $isRetrying)';
+  return 'ActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, childSessionIds: $childSessionIds, isRetrying: $isRetrying, lastUserActivityAt: $lastUserActivityAt, updatedAt: $updatedAt)';
 }
 
 
@@ -49,7 +49,7 @@ abstract mixin class $ActiveSessionCopyWith<$Res>  {
   factory $ActiveSessionCopyWith(ActiveSession value, $Res Function(ActiveSession) _then) = _$ActiveSessionCopyWithImpl;
 @useResult
 $Res call({
- String id, bool mainAgentRunning, bool awaitingInput, List<String> childSessionIds, bool isRetrying
+ String id, bool mainAgentRunning, bool awaitingInput, List<String> childSessionIds, bool isRetrying, int? lastUserActivityAt, int? updatedAt
 });
 
 
@@ -66,14 +66,16 @@ class _$ActiveSessionCopyWithImpl<$Res>
 
 /// Create a copy of ActiveSession
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? mainAgentRunning = null,Object? awaitingInput = null,Object? childSessionIds = null,Object? isRetrying = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? mainAgentRunning = null,Object? awaitingInput = null,Object? childSessionIds = null,Object? isRetrying = null,Object? lastUserActivityAt = freezed,Object? updatedAt = freezed,}) {
   return _then(ActiveSession(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
 as bool,awaitingInput: null == awaitingInput ? _self.awaitingInput : awaitingInput // ignore: cast_nullable_to_non_nullable
 as bool,childSessionIds: null == childSessionIds ? _self.childSessionIds : childSessionIds // ignore: cast_nullable_to_non_nullable
 as List<String>,isRetrying: null == isRetrying ? _self.isRetrying : isRetrying // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,lastUserActivityAt: freezed == lastUserActivityAt ? _self.lastUserActivityAt : lastUserActivityAt // ignore: cast_nullable_to_non_nullable
+as int?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 
@@ -85,7 +87,7 @@ as bool,
 @JsonSerializable()
 
 class _ActiveSession implements ActiveSession {
-  const _ActiveSession({required this.id, this.mainAgentRunning = false, this.awaitingInput = false,  List<String> childSessionIds = const [], this.isRetrying = false}): _childSessionIds = childSessionIds;
+  const _ActiveSession({required this.id, this.mainAgentRunning = false, this.awaitingInput = false,  List<String> childSessionIds = const [], this.isRetrying = false, this.lastUserActivityAt = null, this.updatedAt = null}): _childSessionIds = childSessionIds;
   factory _ActiveSession.fromJson(Map<String, dynamic> json) => _$ActiveSessionFromJson(json);
 
 @override final  String id;
@@ -99,6 +101,8 @@ class _ActiveSession implements ActiveSession {
 }
 
 @override@JsonKey() final  bool isRetrying;
+@override@JsonKey() final  int? lastUserActivityAt;
+@override@JsonKey() final  int? updatedAt;
 
 /// Create a copy of ActiveSession
 /// with the given fields replaced by the non-null parameter values.
@@ -113,16 +117,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&const DeepCollectionEquality().equals(other._childSessionIds, _childSessionIds)&&(identical(other.isRetrying, isRetrying) || other.isRetrying == isRetrying));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&const DeepCollectionEquality().equals(other._childSessionIds, _childSessionIds)&&(identical(other.isRetrying, isRetrying) || other.isRetrying == isRetrying)&&(identical(other.lastUserActivityAt, lastUserActivityAt) || other.lastUserActivityAt == lastUserActivityAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,awaitingInput,const DeepCollectionEquality().hash(_childSessionIds),isRetrying);
+int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,awaitingInput,const DeepCollectionEquality().hash(_childSessionIds),isRetrying,lastUserActivityAt,updatedAt);
 
 @override
 String toString() {
-  return 'ActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, childSessionIds: $childSessionIds, isRetrying: $isRetrying)';
+  return 'ActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, childSessionIds: $childSessionIds, isRetrying: $isRetrying, lastUserActivityAt: $lastUserActivityAt, updatedAt: $updatedAt)';
 }
 
 
@@ -133,7 +137,7 @@ abstract mixin class _$ActiveSessionCopyWith<$Res> implements $ActiveSessionCopy
   factory _$ActiveSessionCopyWith(_ActiveSession value, $Res Function(_ActiveSession) _then) = __$ActiveSessionCopyWithImpl;
 @override @useResult
 $Res call({
- String id, bool mainAgentRunning, bool awaitingInput, List<String> childSessionIds, bool isRetrying
+ String id, bool mainAgentRunning, bool awaitingInput, List<String> childSessionIds, bool isRetrying, int? lastUserActivityAt, int? updatedAt
 });
 
 
@@ -150,14 +154,16 @@ class __$ActiveSessionCopyWithImpl<$Res>
 
 /// Create a copy of ActiveSession
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? mainAgentRunning = null,Object? awaitingInput = null,Object? childSessionIds = null,Object? isRetrying = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? mainAgentRunning = null,Object? awaitingInput = null,Object? childSessionIds = null,Object? isRetrying = null,Object? lastUserActivityAt = freezed,Object? updatedAt = freezed,}) {
   return _then(_ActiveSession(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
 as bool,awaitingInput: null == awaitingInput ? _self.awaitingInput : awaitingInput // ignore: cast_nullable_to_non_nullable
 as bool,childSessionIds: null == childSessionIds ? _self._childSessionIds : childSessionIds // ignore: cast_nullable_to_non_nullable
 as List<String>,isRetrying: null == isRetrying ? _self.isRetrying : isRetrying // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,lastUserActivityAt: freezed == lastUserActivityAt ? _self.lastUserActivityAt : lastUserActivityAt // ignore: cast_nullable_to_non_nullable
+as int?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as int?,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/active_session.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/active_session.g.dart
@@ -16,6 +16,8 @@ _ActiveSession _$ActiveSessionFromJson(Map json) => _ActiveSession(
           .toList() ??
       const [],
   isRetrying: json['isRetrying'] as bool? ?? false,
+  lastUserActivityAt: (json['lastUserActivityAt'] as num?)?.toInt() ?? null,
+  updatedAt: (json['updatedAt'] as num?)?.toInt() ?? null,
 );
 
 Map<String, dynamic> _$ActiveSessionToJson(_ActiveSession instance) =>
@@ -25,4 +27,6 @@ Map<String, dynamic> _$ActiveSessionToJson(_ActiveSession instance) =>
       'awaitingInput': instance.awaitingInput,
       'childSessionIds': instance.childSessionIds,
       'isRetrying': instance.isRetrying,
+      'lastUserActivityAt': ?instance.lastUserActivityAt,
+      'updatedAt': ?instance.updatedAt,
     };

--- a/shared/sesori_shared/test/models/sesori_sse_event_test.dart
+++ b/shared/sesori_shared/test/models/sesori_sse_event_test.dart
@@ -735,6 +735,29 @@ void main() {
       ]);
     });
 
+    test('active root ordering facts are additive and nullable', () {
+      final legacy = ActiveSession.fromJson({
+        'id': 'legacy',
+        'mainAgentRunning': true,
+        'awaitingInput': false,
+        'isRetrying': false,
+        'childSessionIds': <String>[],
+      });
+      expect(legacy.lastUserActivityAt, isNull);
+      expect(legacy.updatedAt, isNull);
+      expect(legacy.toJson(), isNot(contains('lastUserActivityAt')));
+      expect(legacy.toJson(), isNot(contains('updatedAt')));
+
+      const current = ActiveSession(
+        id: 'current',
+        mainAgentRunning: true,
+        lastUserActivityAt: 20,
+        updatedAt: 10,
+      );
+      expect(current.toJson()['lastUserActivityAt'], 20);
+      expect(current.toJson()['updatedAt'], 10);
+    });
+
     test('deserializes from JSON correctly', () {
       final json = <String, dynamic>{
         'id': '/from/json',


### PR DESCRIPTION
## Complexity

⚙️ Moderate. This carries additive ordering facts across the shared wire, bridge repository, and client service/cubit flow, with mixed-version fallback behavior.

## What

- Add nullable `lastUserActivityAt` and `updatedAt` facts to active roots in `projects.summary`.
- Populate those facts from durable bridge session bindings without changing plugin contracts or behavior.
- Order projects with running roots by their latest effective running-root activity, using stable project-ID ties.
- Reuse the existing session list-state stream so committed activity reorders already-running projects without another status summary.
- Preserve awaiting-only behavior, inactive project order, child order, and old-bridge fallback.
- Update regression coverage and retire the completed four-step plan.

## Why

Running sessions already follow committed user-side activity, but projects with running roots still used alphabetical order. Applying the same policy to the project list keeps active work ordered consistently without introducing project-owned marker state or another lifecycle owner.

## Risk and test focus

Risk is moderate and limited primarily to project ordering and additive mixed-version decoding. Focus review on marker precedence across live and summary state, running-root filtering, old-bridge fallback, deterministic ties, and unchanged inactive/awaiting-only behavior.

There is no database schema, migration, backfill, persistence-write, analytics, or production plugin behavior change.

## Expected result

Projects with running roots remain promoted and reorder immediately by the newest committed running-root activity. A current client connected to an older bridge falls back to project updated time. Inactive projects keep their existing timestamp/name/ID order.

User-visible impact is limited to active project order. Database and persisted-data impact: none.

## Verification

- `sesori_shared`: 396 tests and strict analysis passed.
- `module_core`: 1,118 tests and strict analysis passed.
- Bridge app: 2,593 tests and strict analysis passed.
- ACP: 240 tests and strict analysis passed.
- Codex: 361 tests and strict analysis passed.
- Mobile app: all 14 focused project-row widget tests and strict analysis passed after syncing current `main`.
- Three relevant scaffold regression tests passed.
- Current-bridge simulator exercise proved live two-project reordering while both remained running; inactive order and unseen rendering remained correct.
- Pre-feature bridge exercise proved omitted active-root facts fall back to project updated time.
- Focused tests cover stale cached versus fresh summary markers, live-marker precedence over root updated time, awaiting-only non-promotion, and stable old-bridge ties.
- `git diff --check` passed; architecture plan and implementation reviews reported no findings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Orders the project list’s running prefix by latest committed user-side activity from its running roots; previously running projects were alphabetized. This aligns project ordering with session ordering and reorders live without another project summary; inactive and awaiting-only behavior is unchanged.

- Adds nullable `lastUserActivityAt` and `updatedAt` to `ActiveSession` in `projects.summary` (`sesori_shared`, bridge mapper/repository) populated from durable session bindings without changing plugin contracts.
- `SseEventTracker` now includes those facts in `SessionActivityInfo`; `ProjectListService` orders running projects by the max of live tracker vs summary marker across running roots, then root updated time, then project updated time, then project ID. `ProjectListCubit` listens to session-list state to reorder projects live.
- Compatibility: old apps ignore extra keys; a new app on an old bridge falls back to project updated time; no schema/migration or production plugin behavior changes.

<sup>Written for commit a5b9271d5fb49200684f29f5a516e2a8340ab6c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

