### PR TITLE
⚙️ [attachment-references] feat(client): load originals in the image viewer [step 10/11]

### DIFF
--- a/.plan/active/attachment-references/PLAN.md
+++ b/.plan/active/attachment-references/PLAN.md
@@ -3,10 +3,10 @@
 ## Status
 
 - **Plan slug:** `attachment-references`
-- **Status:** Step 8/11 - client thumbnail cache ready for review
+- **Status:** Step 10/11 - viewer and stored-reference activation in progress
 - **Plan date:** 2026-08-10
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
-- **Implementation base:** `origin/main` at `57e1d0ea`
+- **Implementation base:** `origin/main` at `4b3d67f3`
 - **Delivery:** one plan PR, nine sequential implementation PRs, and one
   plan-retirement PR
 - **Related future work:** prompt-upload decisions are recorded separately in

--- a/.plan/active/attachment-references/TRACKER.md
+++ b/.plan/active/attachment-references/TRACKER.md
@@ -259,10 +259,11 @@
   behavior could not be exercised meaningfully without creating external test
   session data; the automated cache, history, SSE, and viewer coverage remains
   the evidence for those paths. Against `origin/main` at `4b3d67f3`, the local
-  diff has 578 additions and 62 deletions across 15 files (640 changed lines),
-  below the 900-1,450 estimate because Step 7 already supplied the bounded
-  transport, repository, and independent preview/original state machines;
-  `git diff --check` passes.
+  implementation diff excluding this tracker bookkeeping has 876 additions and
+  152 deletions across the other 14 files (1,028 changed lines), within the
+  900-1,450 estimate because Step 7 already supplied the bounded transport,
+  repository, and independent preview/original state machines; `git diff
+  --check` passes.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/attachment-references/TRACKER.md
+++ b/.plan/active/attachment-references/TRACKER.md
@@ -3,12 +3,12 @@
 ## Current State
 
 - **Plan slug:** `attachment-references`
-- **Series state:** Step 8 merged; Step 9 in review
-- **Current step:** 9/11
-- **Implementation base:** synchronized `origin/main` at `6ee94bfe`
+- **Series state:** Step 9 merged; Step 10 in progress
+- **Current step:** 10/11
+- **Implementation base:** synchronized `origin/main` at `4b3d67f3`
 - **Plan PR:** [#807](https://github.com/sesori-ai/sesori_apps_monorepo/pull/807)
-- **Current PR:** [#889](https://github.com/sesori-ai/sesori_apps_monorepo/pull/889)
-- **Next action:** Monitor Step 9 CI and review
+- **Current PR:** Pending
+- **Next action:** Verify Step 10 viewer activation and stored-reference delivery
 
 ## Plan Review
 
@@ -39,8 +39,8 @@
 | [x] | 6/11 | `⚙️ [attachment-references] feat(bridge): retain larger transcript images [step 6/11]` | 900-1,450 | [PR #854](https://github.com/sesori-ai/sesori_apps_monorepo/pull/854) merged |
 | [x] | 7/11 | `🚧 [attachment-references] feat(client): load stored image renditions [step 7/11]` | 1,500-2,000 | [PR #864](https://github.com/sesori-ai/sesori_apps_monorepo/pull/864) merged |
 | [x] | 8/11 | `🚧 [attachment-references] feat(client): cache encrypted image previews [step 8/11]` | 1,250-1,600 | [PR #876](https://github.com/sesori-ai/sesori_apps_monorepo/pull/876) merged |
-| [ ] | 9/11 | `⚙️ [attachment-references] feat(client): render square attachment grids [step 9/11]` | 900-1,450 | [PR #889](https://github.com/sesori-ai/sesori_apps_monorepo/pull/889) in review |
-| [ ] | 10/11 | `⚙️ [attachment-references] feat(client): load originals in the image viewer [step 10/11]` | 900-1,450 | Pending |
+| [x] | 9/11 | `⚙️ [attachment-references] feat(client): render square attachment grids [step 9/11]` | 900-1,450 | [PR #889](https://github.com/sesori-ai/sesori_apps_monorepo/pull/889) merged |
+| [ ] | 10/11 | `⚙️ [attachment-references] feat(client): load originals in the image viewer [step 10/11]` | 900-1,450 | In progress |
 | [ ] | 11/11 | `🌱 [attachment-references] docs: retire lazy transcript attachments [step 11/11]` | 50-200 | Pending |
 
 ## Locked Decisions
@@ -233,6 +233,36 @@
   state infrastructure. No analytics event was added: passive tile rendering or
   taps have no defined product decision or authoritative outcome to measure.
   Published as [PR #889](https://github.com/sesori-ai/sesori_apps_monorepo/pull/889).
+  Review fixes preserved hidden assistant run boundaries, filtered unsupported
+  attachments before layout, stabilized tile identity, corrected semantics and
+  theme contrast, retained metadata under extreme scaling, kept overlays from
+  intercepting retry, and made immutable inline rejection terminal while
+  preserving retry for remote failures. Fatal analysis, 34 focused widget
+  tests, the full mobile suite, and CI passed; the PR squash-merged as
+  `4b3d67f3`.
+- Step 10 (local): The existing tile-owned `MessageImageCubit` now releases
+  original state on viewer close. Stored-image viewers open on the thumbnail,
+  start the original request only after opening, replace the in-memory provider
+  in place after validation, gate copy/share/save until then, and retain the
+  thumbnail with retry when the original is unavailable. History and SSE
+  requests now opt into `storedReference`; shared compatibility defaults remain
+  unchanged. Module-core fatal analysis and all 1,122 tests pass; mobile fatal
+  analysis and the full suite pass, including 36 focused file/assistant widget
+  tests; desktop fatal analysis and five focused bridge history/archive parity
+  tests pass. Module-core code generation succeeds with its expected external
+  registration warnings, and localization generation reproduces the intended
+  API. Architecture implementation review approved the transport activation,
+  cubit lifecycle, and app-shell presentation seams with no findings. An
+  isolated slot-1 source bridge authenticated, registered, exposed debug port
+  9971, connected to the relay, and shut down cleanly. That fresh slot imported
+  no backend projects or sessions, so cold/warm transcript and reconnect media
+  behavior could not be exercised meaningfully without creating external test
+  session data; the automated cache, history, SSE, and viewer coverage remains
+  the evidence for those paths. Against `origin/main` at `4b3d67f3`, the local
+  diff has 578 additions and 62 deletions across 15 files (640 changed lines),
+  below the 900-1,450 estimate because Step 7 already supplied the bounded
+  transport, repository, and independent preview/original state machines;
+  `git diff --check` passes.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/attachment-references/TRACKER.md
+++ b/.plan/active/attachment-references/TRACKER.md
@@ -3,12 +3,12 @@
 ## Current State
 
 - **Plan slug:** `attachment-references`
-- **Series state:** Step 9 merged; Step 10 in progress
+- **Series state:** Step 9 merged; Step 10 in review
 - **Current step:** 10/11
 - **Implementation base:** synchronized `origin/main` at `4b3d67f3`
 - **Plan PR:** [#807](https://github.com/sesori-ai/sesori_apps_monorepo/pull/807)
-- **Current PR:** Pending
-- **Next action:** Verify Step 10 viewer activation and stored-reference delivery
+- **Current PR:** [#891](https://github.com/sesori-ai/sesori_apps_monorepo/pull/891)
+- **Next action:** Monitor Step 10 CI and review
 
 ## Plan Review
 
@@ -40,7 +40,7 @@
 | [x] | 7/11 | `🚧 [attachment-references] feat(client): load stored image renditions [step 7/11]` | 1,500-2,000 | [PR #864](https://github.com/sesori-ai/sesori_apps_monorepo/pull/864) merged |
 | [x] | 8/11 | `🚧 [attachment-references] feat(client): cache encrypted image previews [step 8/11]` | 1,250-1,600 | [PR #876](https://github.com/sesori-ai/sesori_apps_monorepo/pull/876) merged |
 | [x] | 9/11 | `⚙️ [attachment-references] feat(client): render square attachment grids [step 9/11]` | 900-1,450 | [PR #889](https://github.com/sesori-ai/sesori_apps_monorepo/pull/889) merged |
-| [ ] | 10/11 | `⚙️ [attachment-references] feat(client): load originals in the image viewer [step 10/11]` | 900-1,450 | In progress |
+| [ ] | 10/11 | `⚙️ [attachment-references] feat(client): load originals in the image viewer [step 10/11]` | 900-1,450 | [PR #891](https://github.com/sesori-ai/sesori_apps_monorepo/pull/891) in review |
 | [ ] | 11/11 | `🌱 [attachment-references] docs: retire lazy transcript attachments [step 11/11]` | 50-200 | Pending |
 
 ## Locked Decisions

--- a/client/app/lib/features/session_detail/widgets/file_part_widget.dart
+++ b/client/app/lib/features/session_detail/widgets/file_part_widget.dart
@@ -399,6 +399,13 @@ class _LoadedImageAttachmentState() extends State<_LoadedImageAttachment> {
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
+    final cubit = context.read<MessageImageCubit>();
+    final viewerImage = cubit.state.original is MessageImageOriginalUnavailable
+        ? _image
+        : StoredMessageImage(
+            thumbnail: ViewOnlyMessageImage(provider: _image.provider, originalUri: _image.originalUri),
+            cubit: cubit,
+          );
     return Semantics(
       button: _isDecoded,
       label: context.loc.sessionDetailImageOpen,
@@ -410,7 +417,7 @@ class _LoadedImageAttachmentState() extends State<_LoadedImageAttachment> {
             : () => unawaited(
                 showImageAttachmentViewer(
                   context: context,
-                  image: _image,
+                  image: viewerImage,
                   filename: widget.filename,
                   heroTag: _heroTag,
                 ),

--- a/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
+++ b/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
@@ -61,21 +61,18 @@ Future<void> showImageAttachmentViewer({
     reverseTransitionDuration: const Duration(milliseconds: 220),
     pageBuilder: (_, _, _) => ScaffoldMessenger(
       child: switch (image) {
-        LoadedMessageImage() => BlocProvider(
-          create: (_) => _createActionsCubit(image: image),
-          child: ImageAttachmentViewer(
-            image: image,
-            filename: filename,
-            heroTag: heroTag,
-            originalState: null,
-            onRetryOriginal: null,
-          ),
+        LoadedMessageImage() => ImageAttachmentViewer(
+          image: image,
+          filename: filename,
+          heroTag: heroTag,
+          originalPresentation: ImageAttachmentOriginalPresentation.idle,
+          onRetryOriginal: null,
         ),
         ViewOnlyMessageImage() => ImageAttachmentViewer(
           image: image,
           filename: filename,
           heroTag: heroTag,
-          originalState: null,
+          originalPresentation: ImageAttachmentOriginalPresentation.idle,
           onRetryOriginal: null,
         ),
         StoredMessageImage() => _StoredImageAttachmentViewer(
@@ -102,7 +99,6 @@ Future<void> showImageAttachmentViewer({
   return result.whenComplete(() {
     shouldDismissViewerWithHistory = false;
     historyEntry.remove();
-    if (image case StoredMessageImage(:final cubit)) cubit.releaseOriginal();
   });
 }
 
@@ -132,50 +128,157 @@ class _StoredImageAttachmentViewerState() extends State<_StoredImageAttachmentVi
   }
 
   @override
-  Widget build(BuildContext context) => BlocProvider.value(
-    value: widget.image.cubit,
-    child: _StoredImageAttachmentViewerContent(
-      thumbnail: widget.image.thumbnail,
-      filename: widget.filename,
-      heroTag: widget.heroTag,
-    ),
+  void dispose() {
+    widget.image.cubit.releaseOriginal();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => _StoredImageAttachmentViewerContent(
+    thumbnail: widget.image.thumbnail,
+    cubit: widget.image.cubit,
+    filename: widget.filename,
+    heroTag: widget.heroTag,
   );
+}
+
+enum ImageAttachmentOriginalPresentation() {
+  idle,
+  loading,
+  failed;
 }
 
 class const _StoredImageAttachmentViewerContent({
   required final ViewOnlyMessageImage thumbnail,
+  required final MessageImageCubit cubit,
   required final String? filename,
   required final Key heroTag,
-}) extends StatelessWidget {
+}) extends StatefulWidget {
+  @override
+  State<_StoredImageAttachmentViewerContent> createState() => _StoredImageAttachmentViewerContentState();
+}
+
+class _StoredImageAttachmentViewerContentState() extends State<_StoredImageAttachmentViewerContent> {
+  late final StreamSubscription<MessageImageState> _stateSubscription;
+  late MessageImageOriginalState _original;
+  MemoryImage? _originalProvider;
+  ImageStream? _decodeStream;
+  ImageStreamListener? _decodeListener;
+  LoadedMessageImage? _decodedOriginal;
+  bool _decodeFailed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _original = widget.cubit.state.original;
+    _stateSubscription = widget.cubit.stream.listen((state) {
+      if (!mounted) return;
+      setState(() => _original = state.original);
+      _processOriginal();
+    });
+    _processOriginal();
+  }
+
+  @override
+  void dispose() {
+    unawaited(_stateSubscription.cancel());
+    _clearOriginal();
+    super.dispose();
+  }
+
+  void _processOriginal() {
+    if (_original case MessageImageOriginalLoaded(:final bytes, :final mime, :final actionFilename)) {
+      if (_originalProvider == null && _decodedOriginal == null) {
+        _startDecode(bytes: bytes, mime: mime, actionFilename: actionFilename);
+      }
+    } else {
+      _clearOriginal();
+      _decodeFailed = false;
+    }
+  }
+
+  void _startDecode({required Uint8List bytes, required String mime, required String actionFilename}) {
+    _clearOriginal();
+    _decodeFailed = false;
+    final provider = MemoryImage(bytes);
+    final stream = provider.resolve(createLocalImageConfiguration(context));
+    late final ImageStreamListener listener;
+    listener = ImageStreamListener(
+      (image, synchronousCall) {
+        if (!identical(_originalProvider, provider)) return;
+        void acceptOriginal() {
+          if (!mounted || !identical(_originalProvider, provider)) return;
+          _removeDecodeListener();
+          final loaded = LoadedMessageImage(
+            bytes: bytes,
+            provider: provider,
+            mime: mime,
+            actionFilename: actionFilename,
+            originalUri: null,
+          );
+          setState(() => _decodedOriginal = loaded);
+        }
+
+        if (synchronousCall) {
+          scheduleMicrotask(acceptOriginal);
+        } else {
+          acceptOriginal();
+        }
+      },
+      onError: (error, stackTrace) {
+        if (!identical(_originalProvider, provider)) return;
+        logw("Failed to decode a stored message image original", error, stackTrace);
+        _removeDecodeListener();
+        unawaited(provider.evict());
+        if (!mounted) return;
+        setState(() => _decodeFailed = true);
+      },
+    );
+    _originalProvider = provider;
+    _decodeStream = stream;
+    _decodeListener = listener;
+    stream.addListener(listener);
+  }
+
+  void _removeDecodeListener() {
+    final stream = _decodeStream;
+    final listener = _decodeListener;
+    if (stream != null && listener != null) stream.removeListener(listener);
+    _decodeStream = null;
+    _decodeListener = null;
+  }
+
+  void _clearOriginal() {
+    _removeDecodeListener();
+    _decodedOriginal = null;
+    final provider = _originalProvider;
+    _originalProvider = null;
+    if (provider != null) unawaited(provider.evict());
+  }
+
+  void _retryOriginal() {
+    widget.cubit.releaseOriginal();
+    unawaited(widget.cubit.retryOriginal());
+  }
+
   @override
   Widget build(BuildContext context) {
-    final original = context.watch<MessageImageCubit>().state.original;
-    final loaded = switch (original) {
-      MessageImageOriginalLoaded(:final bytes, :final mime, :final actionFilename) => LoadedMessageImage(
-        bytes: bytes,
-        provider: MemoryImage(bytes),
-        mime: mime,
-        actionFilename: actionFilename,
-        originalUri: null,
-      ),
-      MessageImageOriginalAvailable() ||
-      MessageImageOriginalUnavailable() ||
-      MessageImageOriginalLoading() ||
+    final presentation = switch (_original) {
+      MessageImageOriginalLoading() => ImageAttachmentOriginalPresentation.loading,
+      MessageImageOriginalLoaded() when _decodedOriginal == null && !_decodeFailed =>
+        ImageAttachmentOriginalPresentation.loading,
+      MessageImageOriginalLoaded() when _decodeFailed => ImageAttachmentOriginalPresentation.failed,
       MessageImageOriginalRejected() ||
-      MessageImageOriginalFailed() => null,
+      MessageImageOriginalFailed() ||
+      MessageImageOriginalUnavailable() => ImageAttachmentOriginalPresentation.failed,
+      MessageImageOriginalAvailable() || MessageImageOriginalLoaded() => ImageAttachmentOriginalPresentation.idle,
     };
-    final viewer = ImageAttachmentViewer(
-      image: loaded ?? thumbnail,
-      filename: filename,
-      heroTag: heroTag,
-      originalState: original,
-      onRetryOriginal: () => unawaited(context.read<MessageImageCubit>().retryOriginal()),
-    );
-    if (loaded == null) return viewer;
-    return BlocProvider(
-      key: ValueKey(loaded.bytes),
-      create: (_) => _createActionsCubit(image: loaded),
-      child: viewer,
+    return ImageAttachmentViewer(
+      image: _decodedOriginal ?? widget.thumbnail,
+      filename: widget.filename,
+      heroTag: widget.heroTag,
+      originalPresentation: presentation,
+      onRetryOriginal: _retryOriginal,
     );
   }
 }
@@ -185,7 +288,7 @@ class const ImageAttachmentViewer({
   required final MessageImageViewerImage image,
   required final String? filename,
   required final Key heroTag,
-  required final MessageImageOriginalState? originalState,
+  required final ImageAttachmentOriginalPresentation originalPresentation,
   required final VoidCallback? onRetryOriginal,
 }) extends StatefulWidget {
   static const imageKey = ValueKey("imageAttachmentViewer.image");
@@ -359,8 +462,7 @@ class _ImageAttachmentViewerState() extends State<ImageAttachmentViewer> with Ti
     );
   }
 
-  // ignore: no_slop_linter/prefer_required_named_parameters, callback signature is defined by BlocListener
-  void _handleActionState(BuildContext context, ImageAttachmentActionsState state) {
+  void _handleActionState({required BuildContext context, required ImageAttachmentActionsState state}) {
     final message = switch (state) {
       ImageAttachmentSaved() => context.loc.sessionDetailImageSaved,
       ImageAttachmentCopied() => context.loc.sessionDetailImageCopied,
@@ -375,15 +477,97 @@ class _ImageAttachmentViewerState() extends State<ImageAttachmentViewer> with Ti
     context.read<ImageAttachmentActionsCubit>().outcomeHandled();
   }
 
+  Widget _buildToolbar({
+    required BuildContext context,
+    required ImageAttachmentActionsCubit? actionsCubit,
+    required bool isRunningAction,
+    required double opacity,
+  }) {
+    final prego = context.prego;
+    final originalUri = widget.image.originalUri;
+    final displayFilename = widget.filename;
+    return IgnorePointer(
+      ignoring: _isDismissDrag,
+      child: Opacity(
+        opacity: opacity,
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: prego.spacing.sm),
+          child: Row(
+            children: [
+              IconButton(
+                tooltip: context.loc.sessionDetailImageClose,
+                onPressed: _dismiss,
+                icon: Icon(Icons.close, color: prego.colors.textPrimary),
+              ),
+              SizedBox(width: prego.spacing.xs),
+              Expanded(
+                child: displayFilename == null
+                    ? const SizedBox.shrink()
+                    : Text(
+                        displayFilename,
+                        style: prego.textTheme.textSm.bold,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+              ),
+              if (isRunningAction)
+                Padding(
+                  padding: EdgeInsets.all(prego.spacing.md),
+                  child: SizedBox.square(
+                    dimension: prego.spacing.x2l,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: prego.colors.fgBrandPrimary,
+                    ),
+                  ),
+                )
+              else ...[
+                if (originalUri != null)
+                  IconButton(
+                    tooltip: context.loc.sessionDetailImageOpenOriginal,
+                    onPressed: () => unawaited(
+                      openExternalLink(
+                        url: originalUri,
+                        mode: UrlLaunchMode.externalApp,
+                      ).then<void>((_) {}),
+                    ),
+                    icon: Icon(Icons.open_in_new, color: prego.colors.textPrimary),
+                  ),
+                if (actionsCubit != null) ...[
+                  IconButton(
+                    tooltip: context.loc.sessionDetailImageCopy,
+                    onPressed: () => unawaited(actionsCubit.copy()),
+                    icon: Icon(Icons.content_copy, color: prego.colors.textPrimary),
+                  ),
+                  Builder(
+                    builder: (buttonContext) => IconButton(
+                      tooltip: context.loc.sessionDetailImageShare,
+                      onPressed: () => unawaited(
+                        actionsCubit.share(
+                          origin: _shareOrigin(originContext: buttonContext),
+                        ),
+                      ),
+                      icon: Icon(Icons.share_outlined, color: prego.colors.textPrimary),
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: context.loc.sessionDetailImageSave,
+                    onPressed: () => unawaited(actionsCubit.save()),
+                    icon: Icon(Icons.download_outlined, color: prego.colors.textPrimary),
+                  ),
+                ],
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
     final image = widget.image;
-    final originalUri = widget.image.originalUri;
-    final displayFilename = widget.filename;
-    final hasAttachmentActions = image is LoadedMessageImage;
-    final isRunningAction =
-        hasAttachmentActions && context.watch<ImageAttachmentActionsCubit>().state is ImageAttachmentActionRunning;
     final dismissRange = (MediaQuery.sizeOf(context).height * 0.45).clamp(1.0, double.infinity);
     final dismissProgress = (_dragOffset.distance / dismissRange).clamp(0.0, 1.0);
     final chromeOpacity = 1 - dismissProgress;
@@ -393,82 +577,33 @@ class _ImageAttachmentViewerState() extends State<ImageAttachmentViewer> with Ti
       body: SafeArea(
         child: Column(
           children: [
-            IgnorePointer(
-              ignoring: _isDismissDrag,
-              child: Opacity(
-                opacity: chromeOpacity,
-                child: Padding(
-                  padding: EdgeInsets.symmetric(horizontal: prego.spacing.sm),
-                  child: Row(
-                    children: [
-                      IconButton(
-                        tooltip: context.loc.sessionDetailImageClose,
-                        onPressed: _dismiss,
-                        icon: Icon(Icons.close, color: prego.colors.textPrimary),
-                      ),
-                      SizedBox(width: prego.spacing.xs),
-                      Expanded(
-                        child: displayFilename == null
-                            ? const SizedBox.shrink()
-                            : Text(
-                                displayFilename,
-                                style: prego.textTheme.textSm.bold,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                      ),
-                      if (isRunningAction)
-                        Padding(
-                          padding: EdgeInsets.all(prego.spacing.md),
-                          child: SizedBox.square(
-                            dimension: prego.spacing.x2l,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              color: prego.colors.fgBrandPrimary,
-                            ),
-                          ),
-                        )
-                      else ...[
-                        if (originalUri != null)
-                          IconButton(
-                            tooltip: context.loc.sessionDetailImageOpenOriginal,
-                            onPressed: () => unawaited(
-                              openExternalLink(
-                                url: originalUri,
-                                mode: UrlLaunchMode.externalApp,
-                              ).then<void>((_) {}),
-                            ),
-                            icon: Icon(Icons.open_in_new, color: prego.colors.textPrimary),
-                          ),
-                        if (hasAttachmentActions) ...[
-                          IconButton(
-                            tooltip: context.loc.sessionDetailImageCopy,
-                            onPressed: () => unawaited(context.read<ImageAttachmentActionsCubit>().copy()),
-                            icon: Icon(Icons.content_copy, color: prego.colors.textPrimary),
-                          ),
-                          Builder(
-                            builder: (buttonContext) => IconButton(
-                              tooltip: context.loc.sessionDetailImageShare,
-                              onPressed: () => unawaited(
-                                context.read<ImageAttachmentActionsCubit>().share(
-                                  origin: _shareOrigin(originContext: buttonContext),
-                                ),
-                              ),
-                              icon: Icon(Icons.share_outlined, color: prego.colors.textPrimary),
-                            ),
-                          ),
-                          IconButton(
-                            tooltip: context.loc.sessionDetailImageSave,
-                            onPressed: () => unawaited(context.read<ImageAttachmentActionsCubit>().save()),
-                            icon: Icon(Icons.download_outlined, color: prego.colors.textPrimary),
-                          ),
-                        ],
-                      ],
-                    ],
+            switch (image) {
+              final LoadedMessageImage image => BlocProvider(
+                key: ObjectKey(image),
+                create: (_) => _createActionsCubit(image: image),
+                child: BlocListener<ImageAttachmentActionsCubit, ImageAttachmentActionsState>(
+                  listener: (context, state) => _handleActionState(context: context, state: state),
+                  child: Builder(
+                    builder: (context) {
+                      final actionsCubit = context.read<ImageAttachmentActionsCubit>();
+                      return _buildToolbar(
+                        context: context,
+                        actionsCubit: actionsCubit,
+                        isRunningAction:
+                            context.watch<ImageAttachmentActionsCubit>().state is ImageAttachmentActionRunning,
+                        opacity: chromeOpacity,
+                      );
+                    },
                   ),
                 ),
               ),
-            ),
+              ViewOnlyMessageImage() || StoredMessageImage() => _buildToolbar(
+                context: context,
+                actionsCubit: null,
+                isRunningAction: false,
+                opacity: chromeOpacity,
+              ),
+            },
             Expanded(
               child: Stack(
                 children: [
@@ -504,7 +639,7 @@ class _ImageAttachmentViewerState() extends State<ImageAttachmentViewer> with Ti
                       ),
                     ),
                   ),
-                  if (widget.originalState is MessageImageOriginalLoading)
+                  if (widget.originalPresentation == ImageAttachmentOriginalPresentation.loading)
                     PositionedDirectional(
                       bottom: prego.spacing.lg,
                       end: prego.spacing.lg,
@@ -513,9 +648,7 @@ class _ImageAttachmentViewerState() extends State<ImageAttachmentViewer> with Ti
                         color: prego.colors.fgBrandPrimary,
                       ),
                     ),
-                  if (widget.originalState is MessageImageOriginalRejected ||
-                      widget.originalState is MessageImageOriginalFailed ||
-                      widget.originalState is MessageImageOriginalUnavailable)
+                  if (widget.originalPresentation == ImageAttachmentOriginalPresentation.failed)
                     Align(
                       alignment: Alignment.bottomCenter,
                       child: Padding(
@@ -540,7 +673,7 @@ class _ImageAttachmentViewerState() extends State<ImageAttachmentViewer> with Ti
                                 TextButton.icon(
                                   onPressed: widget.onRetryOriginal,
                                   icon: const Icon(Icons.refresh),
-                                  label: Text(context.loc.sessionDetailRetry),
+                                  label: Text(context.loc.sessionDetailRetryOriginal),
                                 ),
                               ],
                             ),
@@ -555,10 +688,6 @@ class _ImageAttachmentViewerState() extends State<ImageAttachmentViewer> with Ti
         ),
       ),
     );
-    if (!hasAttachmentActions) return viewer;
-    return BlocListener<ImageAttachmentActionsCubit, ImageAttachmentActionsState>(
-      listener: _handleActionState,
-      child: viewer,
-    );
+    return viewer;
   }
 }

--- a/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
+++ b/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
@@ -32,6 +32,19 @@ final class const ViewOnlyMessageImage({
   this : super();
 }
 
+final class const StoredMessageImage({
+  required final ViewOnlyMessageImage thumbnail,
+  required final MessageImageCubit cubit,
+}) extends MessageImageViewerImage {
+  this : super();
+
+  @override
+  ImageProvider get provider => thumbnail.provider;
+
+  @override
+  Uri? get originalUri => thumbnail.originalUri;
+}
+
 Future<void> showImageAttachmentViewer({
   required BuildContext context,
   required MessageImageViewerImage image,
@@ -46,29 +59,32 @@ Future<void> showImageAttachmentViewer({
     opaque: false,
     transitionDuration: const Duration(milliseconds: 260),
     reverseTransitionDuration: const Duration(milliseconds: 220),
-    pageBuilder: (_, _, _) {
-      final viewer = ScaffoldMessenger(
-        child: ImageAttachmentViewer(
+    pageBuilder: (_, _, _) => ScaffoldMessenger(
+      child: switch (image) {
+        LoadedMessageImage() => BlocProvider(
+          create: (_) => _createActionsCubit(image: image),
+          child: ImageAttachmentViewer(
+            image: image,
+            filename: filename,
+            heroTag: heroTag,
+            originalState: null,
+            onRetryOriginal: null,
+          ),
+        ),
+        ViewOnlyMessageImage() => ImageAttachmentViewer(
+          image: image,
+          filename: filename,
+          heroTag: heroTag,
+          originalState: null,
+          onRetryOriginal: null,
+        ),
+        StoredMessageImage() => _StoredImageAttachmentViewer(
           image: image,
           filename: filename,
           heroTag: heroTag,
         ),
-      );
-      return switch (image) {
-        LoadedMessageImage() => BlocProvider(
-          create: (_) => ImageAttachmentActionsCubit(
-            imageSaver: getIt<ImageSaver>(),
-            imageClipboard: getIt<ImageClipboard>(),
-            imageSharer: getIt<ImageSharer>(),
-            bytes: image.bytes,
-            mime: image.mime,
-            actionFilename: image.actionFilename,
-          ),
-          child: viewer,
-        ),
-        ViewOnlyMessageImage() => viewer,
-      };
-    },
+      },
+    ),
     transitionsBuilder: (_, animation, _, child) => FadeTransition(opacity: animation, child: child),
   );
   var shouldDismissViewerWithHistory = true;
@@ -86,7 +102,82 @@ Future<void> showImageAttachmentViewer({
   return result.whenComplete(() {
     shouldDismissViewerWithHistory = false;
     historyEntry.remove();
+    if (image case StoredMessageImage(:final cubit)) cubit.releaseOriginal();
   });
+}
+
+ImageAttachmentActionsCubit _createActionsCubit({required LoadedMessageImage image}) => ImageAttachmentActionsCubit(
+  imageSaver: getIt<ImageSaver>(),
+  imageClipboard: getIt<ImageClipboard>(),
+  imageSharer: getIt<ImageSharer>(),
+  bytes: image.bytes,
+  mime: image.mime,
+  actionFilename: image.actionFilename,
+);
+
+class const _StoredImageAttachmentViewer({
+  required final StoredMessageImage image,
+  required final String? filename,
+  required final Key heroTag,
+}) extends StatefulWidget {
+  @override
+  State<_StoredImageAttachmentViewer> createState() => _StoredImageAttachmentViewerState();
+}
+
+class _StoredImageAttachmentViewerState() extends State<_StoredImageAttachmentViewer> {
+  @override
+  void initState() {
+    super.initState();
+    unawaited(widget.image.cubit.loadOriginal());
+  }
+
+  @override
+  Widget build(BuildContext context) => BlocProvider.value(
+    value: widget.image.cubit,
+    child: _StoredImageAttachmentViewerContent(
+      thumbnail: widget.image.thumbnail,
+      filename: widget.filename,
+      heroTag: widget.heroTag,
+    ),
+  );
+}
+
+class const _StoredImageAttachmentViewerContent({
+  required final ViewOnlyMessageImage thumbnail,
+  required final String? filename,
+  required final Key heroTag,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final original = context.watch<MessageImageCubit>().state.original;
+    final loaded = switch (original) {
+      MessageImageOriginalLoaded(:final bytes, :final mime, :final actionFilename) => LoadedMessageImage(
+        bytes: bytes,
+        provider: MemoryImage(bytes),
+        mime: mime,
+        actionFilename: actionFilename,
+        originalUri: null,
+      ),
+      MessageImageOriginalAvailable() ||
+      MessageImageOriginalUnavailable() ||
+      MessageImageOriginalLoading() ||
+      MessageImageOriginalRejected() ||
+      MessageImageOriginalFailed() => null,
+    };
+    final viewer = ImageAttachmentViewer(
+      image: loaded ?? thumbnail,
+      filename: filename,
+      heroTag: heroTag,
+      originalState: original,
+      onRetryOriginal: () => unawaited(context.read<MessageImageCubit>().retryOriginal()),
+    );
+    if (loaded == null) return viewer;
+    return BlocProvider(
+      key: ValueKey(loaded.bytes),
+      create: (_) => _createActionsCubit(image: loaded),
+      child: viewer,
+    );
+  }
 }
 
 class const ImageAttachmentViewer({
@@ -94,6 +185,8 @@ class const ImageAttachmentViewer({
   required final MessageImageViewerImage image,
   required final String? filename,
   required final Key heroTag,
+  required final MessageImageOriginalState? originalState,
+  required final VoidCallback? onRetryOriginal,
 }) extends StatefulWidget {
   static const imageKey = ValueKey("imageAttachmentViewer.image");
 
@@ -377,37 +470,85 @@ class _ImageAttachmentViewerState() extends State<ImageAttachmentViewer> with Ti
               ),
             ),
             Expanded(
-              child: Transform.translate(
-                offset: _dragOffset,
-                child: GestureDetector(
-                  behavior: HitTestBehavior.opaque,
-                  onDoubleTapDown: (details) => _captureDoubleTapPosition(details: details),
-                  onDoubleTap: _toggleZoom,
-                  child: InteractiveViewer(
-                    transformationController: _transformationController,
-                    minScale: 0.8,
-                    maxScale: 5,
-                    onInteractionStart: (details) => _handleInteractionStart(details: details),
-                    onInteractionUpdate: (details) => _handleInteractionUpdate(details: details),
-                    onInteractionEnd: (details) => _handleInteractionEnd(details: details),
-                    child: Hero(
-                      tag: widget.heroTag,
-                      child: SizedBox.expand(
-                        child: Image(
-                          key: ImageAttachmentViewer.imageKey,
-                          image: image.provider,
-                          fit: BoxFit.contain,
-                          semanticLabel: widget.filename,
-                          errorBuilder: (_, _, _) => Icon(
-                            Icons.broken_image,
-                            size: prego.spacing.x6l,
-                            color: prego.colors.textTertiary,
+              child: Stack(
+                children: [
+                  Transform.translate(
+                    offset: _dragOffset,
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onDoubleTapDown: (details) => _captureDoubleTapPosition(details: details),
+                      onDoubleTap: _toggleZoom,
+                      child: InteractiveViewer(
+                        transformationController: _transformationController,
+                        minScale: 0.8,
+                        maxScale: 5,
+                        onInteractionStart: (details) => _handleInteractionStart(details: details),
+                        onInteractionUpdate: (details) => _handleInteractionUpdate(details: details),
+                        onInteractionEnd: (details) => _handleInteractionEnd(details: details),
+                        child: Hero(
+                          tag: widget.heroTag,
+                          child: SizedBox.expand(
+                            child: Image(
+                              key: ImageAttachmentViewer.imageKey,
+                              image: image.provider,
+                              fit: BoxFit.contain,
+                              semanticLabel: widget.filename,
+                              errorBuilder: (_, _, _) => Icon(
+                                Icons.broken_image,
+                                size: prego.spacing.x6l,
+                                color: prego.colors.textTertiary,
+                              ),
+                            ),
                           ),
                         ),
                       ),
                     ),
                   ),
-                ),
+                  if (widget.originalState is MessageImageOriginalLoading)
+                    PositionedDirectional(
+                      bottom: prego.spacing.lg,
+                      end: prego.spacing.lg,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: prego.colors.fgBrandPrimary,
+                      ),
+                    ),
+                  if (widget.originalState is MessageImageOriginalRejected ||
+                      widget.originalState is MessageImageOriginalFailed ||
+                      widget.originalState is MessageImageOriginalUnavailable)
+                    Align(
+                      alignment: Alignment.bottomCenter,
+                      child: Padding(
+                        padding: EdgeInsets.all(prego.spacing.lg),
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            color: prego.colors.bgSurface2,
+                            borderRadius: BorderRadius.circular(prego.radius.lg),
+                          ),
+                          child: Padding(
+                            padding: EdgeInsets.all(prego.spacing.md),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Flexible(
+                                  child: Text(
+                                    context.loc.sessionDetailImageOriginalLoadFailed,
+                                    style: prego.textTheme.textSm.regular,
+                                  ),
+                                ),
+                                SizedBox(width: prego.spacing.md),
+                                TextButton.icon(
+                                  onPressed: widget.onRetryOriginal,
+                                  icon: const Icon(Icons.refresh),
+                                  label: Text(context.loc.sessionDetailRetry),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
               ),
             ),
           ],

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -532,7 +532,11 @@
   "sessionDetailImageOpenOriginal": "Open original",
   "sessionDetailImageOriginalLoadFailed": "Couldn’t load the original image.",
   "@sessionDetailImageOriginalLoadFailed": {
-    "description": "Message shown over a stored image thumbnail when loading its full-resolution original fails or is rejected."
+    "description": "Message shown over a stored image thumbnail when loading or decoding its full-resolution original fails or is rejected."
+  },
+  "sessionDetailRetryOriginal": "Retry original",
+  "@sessionDetailRetryOriginal": {
+    "description": "Accessible button label that retries loading and decoding the full-resolution stored image."
   },
   "sessionDetailImageSaved": "Image saved",
   "sessionDetailImageSaveFailed": "Couldn’t save image",

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -530,6 +530,10 @@
   "sessionDetailImageCopy": "Copy image",
   "sessionDetailImageSave": "Save image",
   "sessionDetailImageOpenOriginal": "Open original",
+  "sessionDetailImageOriginalLoadFailed": "Couldn’t load the original image.",
+  "@sessionDetailImageOriginalLoadFailed": {
+    "description": "Message shown over a stored image thumbnail when loading its full-resolution original fails or is rejected."
+  },
   "sessionDetailImageSaved": "Image saved",
   "sessionDetailImageSaveFailed": "Couldn’t save image",
   "sessionDetailImageShareFailed": "Couldn’t share image",

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -1735,11 +1735,17 @@ abstract class AppLocalizations {
   /// **'Open original'**
   String get sessionDetailImageOpenOriginal;
 
-  /// Message shown over a stored image thumbnail when loading its full-resolution original fails or is rejected.
+  /// Message shown over a stored image thumbnail when loading or decoding its full-resolution original fails or is rejected.
   ///
   /// In en, this message translates to:
   /// **'Couldn’t load the original image.'**
   String get sessionDetailImageOriginalLoadFailed;
+
+  /// Accessible button label that retries loading and decoding the full-resolution stored image.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry original'**
+  String get sessionDetailRetryOriginal;
 
   /// No description provided for @sessionDetailImageSaved.
   ///

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -1735,6 +1735,12 @@ abstract class AppLocalizations {
   /// **'Open original'**
   String get sessionDetailImageOpenOriginal;
 
+  /// Message shown over a stored image thumbnail when loading its full-resolution original fails or is rejected.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn’t load the original image.'**
+  String get sessionDetailImageOriginalLoadFailed;
+
   /// No description provided for @sessionDetailImageSaved.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -894,6 +894,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionDetailImageOpenOriginal => 'Open original';
 
   @override
+  String get sessionDetailImageOriginalLoadFailed => 'Couldn’t load the original image.';
+
+  @override
   String get sessionDetailImageSaved => 'Image saved';
 
   @override

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -897,6 +897,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionDetailImageOriginalLoadFailed => 'Couldn’t load the original image.';
 
   @override
+  String get sessionDetailRetryOriginal => 'Retry original';
+
+  @override
   String get sessionDetailImageSaved => 'Image saved';
 
   @override

--- a/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
+++ b/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
@@ -29,12 +29,15 @@ class _MockAuthSession() extends Mock implements AuthSession;
 
 class _MockAttachmentThumbnailStorage() extends Mock implements AttachmentThumbnailStorage;
 
+class _MockMessageImageRepository() extends Mock implements MessageImageRepository;
+
 const _authUser = AuthUser(
   id: "account-a",
   provider: AuthProvider.github,
   providerUserId: "provider-a",
   providerUsername: "alice",
 );
+const _pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==";
 
 class _FakeImageSaver() implements ImageSaver {
   Uint8List? savedBytes;
@@ -124,6 +127,8 @@ void main() {
   setUpAll(() {
     registerFallbackValue(Uri());
     registerFallbackValue(UrlLaunchMode.externalApp);
+    registerFallbackValue(const MessageAttachment.unknown());
+    registerFallbackValue(SessionAttachmentRendition.thumbnail);
   });
 
   setUp(() async {
@@ -454,6 +459,158 @@ void main() {
     semantics.dispose();
   });
 
+  testWidgets("stored viewer loads original after opening, gates actions, swaps bytes, and releases on close", (
+    tester,
+  ) async {
+    final repository = _MockMessageImageRepository();
+    final original = Completer<MessageImageLoadResult>();
+    var originalRequests = 0;
+    const attachment = MessageAttachment.storedImage(
+      attachmentId: "attachment-1",
+      bridgeId: "bridge-1",
+      mime: "image/png",
+      filename: "stored.png",
+      byteLength: 68,
+    );
+    when(() => repository.canLoad(attachment: attachment)).thenReturn(true);
+    when(() => repository.canLoadOriginal(attachment: attachment)).thenReturn(true);
+    when(
+      () => repository.load(
+        sessionId: "session-1",
+        attachment: attachment,
+        rendition: SessionAttachmentRendition.thumbnail,
+      ),
+    ).thenAnswer(
+      (_) async => MessageImageLoadSuccess(
+        bytes: Uint8List.fromList(base64Decode(_pngBase64)),
+        mime: "image/png",
+        actionFilename: "stored.png",
+        originalUri: null,
+      ),
+    );
+    when(
+      () => repository.load(
+        sessionId: "session-1",
+        attachment: attachment,
+        rendition: SessionAttachmentRendition.original,
+      ),
+    ).thenAnswer((_) {
+      originalRequests++;
+      return original.future;
+    });
+    await GetIt.instance.unregister<MessageImageRepository>();
+    GetIt.instance.registerSingleton<MessageImageRepository>(repository);
+
+    await tester.pumpWidget(
+      _app(
+        child: const FilePartWidget(sessionId: "session-1", attachment: attachment),
+      ),
+    );
+    await _finishAsyncDecode(tester: tester);
+    expect(originalRequests, 0);
+
+    final preview = tester.widget<Image>(find.byKey(FilePartWidget.previewImageKey));
+    await tester.runAsync(
+      () => precacheImage(
+        preview.image,
+        tester.element(find.byKey(FilePartWidget.previewImageKey)),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(FilePartWidget.previewTapTargetKey));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump();
+
+    expect(originalRequests, 1);
+    final thumbnailImage = tester.widget<Image>(find.byKey(ImageAttachmentViewer.imageKey));
+    expect(find.byIcon(Icons.content_copy), findsNothing);
+    expect(find.byIcon(Icons.share_outlined), findsNothing);
+    expect(find.byIcon(Icons.download_outlined), findsNothing);
+
+    final originalBytes = Uint8List.fromList(base64Decode(_pngBase64));
+    original.complete(
+      MessageImageLoadSuccess(
+        bytes: originalBytes,
+        mime: "image/png",
+        actionFilename: "stored.png",
+        originalUri: null,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final originalImage = tester.widget<Image>(find.byKey(ImageAttachmentViewer.imageKey));
+    expect(identical(originalImage.image, thumbnailImage.image), isFalse);
+    expect((originalImage.image as MemoryImage).bytes, same(originalBytes));
+    expect(find.byIcon(Icons.content_copy), findsOneWidget);
+    expect(find.byIcon(Icons.share_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.download_outlined), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pumpAndSettle();
+
+    final cubit = tester.element(find.byKey(FilePartWidget.previewTapTargetKey)).read<MessageImageCubit>();
+    expect(cubit.state.original, isA<MessageImageOriginalAvailable>());
+  });
+
+  testWidgets("stored viewer retains thumbnail and retries original after failure", (tester) async {
+    final repository = _MockMessageImageRepository();
+    var originalRequests = 0;
+    const attachment = MessageAttachment.storedImage(
+      attachmentId: "attachment-1",
+      bridgeId: "bridge-1",
+      mime: "image/png",
+      filename: "stored.png",
+      byteLength: 68,
+    );
+    when(() => repository.canLoad(attachment: attachment)).thenReturn(true);
+    when(() => repository.canLoadOriginal(attachment: attachment)).thenReturn(true);
+    when(
+      () => repository.load(
+        sessionId: "session-1",
+        attachment: attachment,
+        rendition: SessionAttachmentRendition.thumbnail,
+      ),
+    ).thenAnswer(
+      (_) async => MessageImageLoadSuccess(
+        bytes: Uint8List.fromList(base64Decode(_pngBase64)),
+        mime: "image/png",
+        actionFilename: "stored.png",
+        originalUri: null,
+      ),
+    );
+    when(
+      () => repository.load(
+        sessionId: "session-1",
+        attachment: attachment,
+        rendition: SessionAttachmentRendition.original,
+      ),
+    ).thenAnswer((_) async {
+      originalRequests++;
+      return const MessageImageLoadRejected();
+    });
+    await GetIt.instance.unregister<MessageImageRepository>();
+    GetIt.instance.registerSingleton<MessageImageRepository>(repository);
+
+    await tester.pumpWidget(
+      _app(
+        child: const FilePartWidget(sessionId: "session-1", attachment: attachment),
+      ),
+    );
+    await _openImageViewer(tester: tester);
+
+    final thumbnailProvider = tester.widget<Image>(find.byKey(ImageAttachmentViewer.imageKey)).image;
+    expect(find.text("Couldn’t load the original image."), findsOneWidget);
+    expect(find.byIcon(Icons.content_copy), findsNothing);
+    expect(originalRequests, 1);
+
+    await tester.tap(find.widgetWithText(TextButton, "Retry"));
+    await tester.pumpAndSettle();
+
+    expect(originalRequests, 2);
+    expect(tester.widget<Image>(find.byKey(ImageAttachmentViewer.imageKey)).image, same(thumbnailProvider));
+  });
+
   testWidgets("opens inline images in a zoomable Hero viewer using the same provider", (tester) async {
     const attachment = MessageAttachment.inlineImage(
       mime: "image/png",
@@ -750,6 +907,8 @@ void main() {
             image: image,
             filename: "../../unsafe.exe",
             heroTag: UniqueKey(),
+            originalState: null,
+            onRetryOriginal: null,
           ),
         ),
       ),

--- a/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
+++ b/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
@@ -459,9 +459,7 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets("stored viewer loads original after opening, gates actions, swaps bytes, and releases on close", (
-    tester,
-  ) async {
+  testWidgets("stored viewer decodes before swapping or enabling actions and evicts on close", (tester) async {
     final repository = _MockMessageImageRepository();
     final original = Completer<MessageImageLoadResult>();
     var originalRequests = 0;
@@ -524,6 +522,10 @@ void main() {
 
     expect(originalRequests, 1);
     final thumbnailImage = tester.widget<Image>(find.byKey(ImageAttachmentViewer.imageKey));
+    final transformationController = tester
+        .widget<InteractiveViewer>(find.byType(InteractiveViewer))
+        .transformationController!;
+    transformationController.value = Matrix4.diagonal3Values(2, 2, 1);
     expect(find.byIcon(Icons.content_copy), findsNothing);
     expect(find.byIcon(Icons.share_outlined), findsNothing);
     expect(find.byIcon(Icons.download_outlined), findsNothing);
@@ -537,23 +539,40 @@ void main() {
         originalUri: null,
       ),
     );
-    await tester.pumpAndSettle();
+    await tester.pump();
+
+    expect(tester.widget<Image>(find.byKey(ImageAttachmentViewer.imageKey)).image, same(thumbnailImage.image));
+    expect(find.byIcon(Icons.content_copy), findsNothing);
+    expect(find.byIcon(Icons.share_outlined), findsNothing);
+    expect(find.byIcon(Icons.download_outlined), findsNothing);
+
+    await _finishAsyncDecode(tester: tester);
 
     final originalImage = tester.widget<Image>(find.byKey(ImageAttachmentViewer.imageKey));
-    expect(identical(originalImage.image, thumbnailImage.image), isFalse);
-    expect((originalImage.image as MemoryImage).bytes, same(originalBytes));
+    final originalProvider = originalImage.image as MemoryImage;
+    expect(originalProvider.bytes, same(originalBytes));
+    expect(transformationController.value.getMaxScaleOnAxis(), 2);
+    expect(
+      tester.widget<InteractiveViewer>(find.byType(InteractiveViewer)).transformationController,
+      same(transformationController),
+    );
     expect(find.byIcon(Icons.content_copy), findsOneWidget);
     expect(find.byIcon(Icons.share_outlined), findsOneWidget);
     expect(find.byIcon(Icons.download_outlined), findsOneWidget);
+    expect(await originalProvider.obtainCacheStatus(configuration: ImageConfiguration.empty), isNotNull);
 
     await tester.tap(find.byIcon(Icons.close));
     await tester.pumpAndSettle();
 
     final cubit = tester.element(find.byKey(FilePartWidget.previewTapTargetKey)).read<MessageImageCubit>();
     expect(cubit.state.original, isA<MessageImageOriginalAvailable>());
+    final evictedStatus = await originalProvider.obtainCacheStatus(configuration: ImageConfiguration.empty);
+    expect(evictedStatus?.pending, isFalse);
+    expect(evictedStatus?.keepAlive, isFalse);
+    expect(evictedStatus?.live, isFalse);
   });
 
-  testWidgets("stored viewer retains thumbnail and retries original after failure", (tester) async {
+  testWidgets("stored viewer retains thumbnail and exposes accessible retry after request failure", (tester) async {
     final repository = _MockMessageImageRepository();
     var originalRequests = 0;
     const attachment = MessageAttachment.storedImage(
@@ -592,6 +611,7 @@ void main() {
     await GetIt.instance.unregister<MessageImageRepository>();
     GetIt.instance.registerSingleton<MessageImageRepository>(repository);
 
+    final semantics = tester.ensureSemantics();
     await tester.pumpWidget(
       _app(
         child: const FilePartWidget(sessionId: "session-1", attachment: attachment),
@@ -603,12 +623,91 @@ void main() {
     expect(find.text("Couldn’t load the original image."), findsOneWidget);
     expect(find.byIcon(Icons.content_copy), findsNothing);
     expect(originalRequests, 1);
+    expect(
+      tester.getSemantics(find.text("Retry original")).getSemanticsData().hasAction(SemanticsAction.tap),
+      isTrue,
+    );
 
-    await tester.tap(find.widgetWithText(TextButton, "Retry"));
+    await tester.tap(find.widgetWithText(TextButton, "Retry original"));
     await tester.pumpAndSettle();
 
     expect(originalRequests, 2);
     expect(tester.widget<Image>(find.byKey(ImageAttachmentViewer.imageKey)).image, same(thumbnailProvider));
+    semantics.dispose();
+  });
+
+  testWidgets("stored viewer retains thumbnail and disables actions when original decode fails", (tester) async {
+    final repository = _MockMessageImageRepository();
+    var originalRequests = 0;
+    const attachment = MessageAttachment.storedImage(
+      attachmentId: "attachment-1",
+      bridgeId: "bridge-1",
+      mime: "image/png",
+      filename: "stored.png",
+      byteLength: 68,
+    );
+    when(() => repository.canLoad(attachment: attachment)).thenReturn(true);
+    when(() => repository.canLoadOriginal(attachment: attachment)).thenReturn(true);
+    when(
+      () => repository.load(
+        sessionId: "session-1",
+        attachment: attachment,
+        rendition: SessionAttachmentRendition.thumbnail,
+      ),
+    ).thenAnswer(
+      (_) async => MessageImageLoadSuccess(
+        bytes: Uint8List.fromList(base64Decode(_pngBase64)),
+        mime: "image/png",
+        actionFilename: "stored.png",
+        originalUri: null,
+      ),
+    );
+    when(
+      () => repository.load(
+        sessionId: "session-1",
+        attachment: attachment,
+        rendition: SessionAttachmentRendition.original,
+      ),
+    ).thenAnswer((_) async {
+      originalRequests++;
+      return MessageImageLoadSuccess(
+        bytes: Uint8List.fromList(const [0x89, 0x50, 0x4E, 0x47]),
+        mime: "image/png",
+        actionFilename: "stored.png",
+        originalUri: null,
+      );
+    });
+    await GetIt.instance.unregister<MessageImageRepository>();
+    GetIt.instance.registerSingleton<MessageImageRepository>(repository);
+    final semantics = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      _app(
+        child: const FilePartWidget(sessionId: "session-1", attachment: attachment),
+      ),
+    );
+    await _openImageViewer(tester: tester);
+
+    final thumbnailProvider = tester.widget<Image>(find.byKey(ImageAttachmentViewer.imageKey)).image;
+    expect(originalRequests, 1);
+    expect(find.text("Couldn’t load the original image."), findsOneWidget);
+    expect(find.text("Retry original"), findsOneWidget);
+    expect(find.byIcon(Icons.content_copy), findsNothing);
+    expect(find.byIcon(Icons.share_outlined), findsNothing);
+    expect(find.byIcon(Icons.download_outlined), findsNothing);
+    expect(tester.widget<Image>(find.byKey(ImageAttachmentViewer.imageKey)).image, same(thumbnailProvider));
+    expect(
+      tester.getSemantics(find.text("Retry original")).getSemanticsData().hasAction(SemanticsAction.tap),
+      isTrue,
+    );
+
+    await tester.tap(find.widgetWithText(TextButton, "Retry original"));
+    await _finishAsyncDecode(tester: tester);
+
+    expect(originalRequests, 2);
+    expect(find.text("Couldn’t load the original image."), findsOneWidget);
+    expect(tester.widget<Image>(find.byKey(ImageAttachmentViewer.imageKey)).image, same(thumbnailProvider));
+    semantics.dispose();
   });
 
   testWidgets("opens inline images in a zoomable Hero viewer using the same provider", (tester) async {
@@ -894,22 +993,12 @@ void main() {
 
     await tester.pumpWidget(
       _app(
-        child: BlocProvider(
-          create: (_) => ImageAttachmentActionsCubit(
-            imageSaver: imageSaver,
-            imageClipboard: imageClipboard,
-            imageSharer: imageSharer,
-            bytes: bytes,
-            mime: "image/png",
-            actionFilename: "unsafe.png",
-          ),
-          child: ImageAttachmentViewer(
-            image: image,
-            filename: "../../unsafe.exe",
-            heroTag: UniqueKey(),
-            originalState: null,
-            onRetryOriginal: null,
-          ),
+        child: ImageAttachmentViewer(
+          image: image,
+          filename: "../../unsafe.exe",
+          heroTag: UniqueKey(),
+          originalPresentation: ImageAttachmentOriginalPresentation.idle,
+          onRetryOriginal: null,
         ),
       ),
     );

--- a/client/module_core/lib/src/api/session_api.dart
+++ b/client/module_core/lib/src/api/session_api.dart
@@ -255,7 +255,7 @@ class SessionApi({required final RelayHttpApiClient _client}) {
         sessionId: sessionId,
         limit: limit,
         before: before,
-        attachmentDelivery: MessageAttachmentDelivery.inline,
+        attachmentDelivery: MessageAttachmentDelivery.storedReference,
       ),
     );
   }

--- a/client/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/client/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -410,7 +410,7 @@ class RelayClient._({
     _sseController = controller;
     unawaited(
       _sendEncryptedMessage(
-        RelayMessage.sseSubscribe(path: path, attachmentDelivery: MessageAttachmentDelivery.inline),
+        RelayMessage.sseSubscribe(path: path, attachmentDelivery: MessageAttachmentDelivery.storedReference),
       ),
     );
     return controller.stream;

--- a/client/module_core/lib/src/cubits/message_image/message_image_cubit.dart
+++ b/client/module_core/lib/src/cubits/message_image/message_image_cubit.dart
@@ -76,6 +76,19 @@ class MessageImageCubit({
 
   Future<void> retryOriginal() => loadOriginal();
 
+  void releaseOriginal() {
+    if (isClosed) return;
+    _originalGeneration++;
+    emit(
+      MessageImageState(
+        preview: state.preview,
+        original: _repository.canLoadOriginal(attachment: _attachment)
+            ? const MessageImageOriginalAvailable()
+            : const MessageImageOriginalUnavailable(),
+      ),
+    );
+  }
+
   Future<void> _loadPreview() async {
     final generation = ++_previewGeneration;
     final result = await _repository.load(

--- a/client/module_core/test/api/session_api_test.dart
+++ b/client/module_core/test/api/session_api_test.dart
@@ -324,6 +324,31 @@ void main() {
       ).called(1);
     });
 
+    test("getMessages requests stored attachment references", () async {
+      when(
+        () => client.post<MessageWithPartsResponse>(
+          any(),
+          fromJson: any(named: "fromJson"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer(
+        (_) async =>
+            ApiResponse.success(const MessageWithPartsResponse(messages: <MessageWithParts>[], nextCursor: null)),
+      );
+
+      await api.getMessages(sessionId: "session-1", limit: 50, before: 100);
+
+      final verification = verify(
+        () => client.post<MessageWithPartsResponse>(
+          "/session/messages",
+          fromJson: any(named: "fromJson"),
+          body: captureAny(named: "body"),
+        ),
+      )..called(1);
+      final request = verification.captured.single as SessionMessagesRequest;
+      expect(request.toJson()["attachmentDelivery"], "storedReference");
+    });
+
     test("getSessionDiffs posts the session id request", () async {
       when(
         () => client.post<SessionDiffsResponse>(

--- a/client/module_core/test/capabilities/relay/relay_client_handshake_replay_test.dart
+++ b/client/module_core/test/capabilities/relay/relay_client_handshake_replay_test.dart
@@ -57,6 +57,45 @@ void main() {
     expect(client.didResume, isTrue);
     verifyNever(roomKeyStorage.clearRoomKey);
   });
+
+  test("SSE subscription requests stored attachment references", () async {
+    final roomKey = Uint8List.fromList(List<int>.generate(32, (index) => index));
+    final roomKeyStorage = _MockRoomKeyStorage();
+    when(roomKeyStorage.getRoomKey).thenAnswer((_) async => roomKey);
+    final socket = _FakeWebSocket();
+    final client = RelayClient.withChannelConnector(
+      relayHost: "relay.example.com",
+      cryptoService: RelayCryptoService(),
+      roomKeyStorage: roomKeyStorage,
+      authToken: null,
+      channelConnector: (_) => socket.channel,
+    );
+    final outgoing = StreamIterator<Object?>(socket.outgoing);
+    addTearDown(() async {
+      await client.disconnect();
+      await outgoing.cancel();
+      await socket.close();
+    });
+
+    final resumeReady = outgoing.moveNext();
+    final connectFuture = client.connect();
+    expect(await resumeReady.timeout(const Duration(seconds: 1)), isTrue);
+    final encryptor = RelayCryptoService().createSessionEncryptor(SecretKey(roomKey));
+    socket.serverSink.add(
+      await frame(utf8.encode(jsonEncode(const RelayMessage.resumeAck().toJson())), encryptor: encryptor),
+    );
+    await connectFuture.timeout(const Duration(seconds: 1));
+
+    client.subscribeSse("/event");
+    expect(await outgoing.moveNext().timeout(const Duration(seconds: 1)), isTrue);
+    final payload = await unframe(Uint8List.fromList(outgoing.current! as List<int>), encryptor: encryptor);
+    final message = RelayMessage.fromJson(jsonDecode(utf8.decode(payload)) as Map<String, dynamic>);
+
+    expect(
+      message,
+      const RelayMessage.sseSubscribe(path: "/event", attachmentDelivery: MessageAttachmentDelivery.storedReference),
+    );
+  });
 }
 
 class _FakeWebSocket() {

--- a/client/module_core/test/cubits/message_image/message_image_cubit_test.dart
+++ b/client/module_core/test/cubits/message_image/message_image_cubit_test.dart
@@ -155,6 +155,91 @@ void main() {
     expect(cubit.state.original, isA<MessageImageOriginalLoaded>());
   });
 
+  test("release drops loaded original bytes and ignores an in-flight result", () async {
+    final original = Completer<MessageImageLoadResult>();
+    when(
+      () => repository.load(
+        sessionId: "session-1",
+        attachment: _stored,
+        rendition: SessionAttachmentRendition.thumbnail,
+      ),
+    ).thenAnswer(
+      (_) async => MessageImageLoadSuccess(
+        bytes: Uint8List.fromList(const [1]),
+        mime: "image/png",
+        actionFilename: "image.png",
+        originalUri: null,
+      ),
+    );
+    when(
+      () => repository.load(
+        sessionId: "session-1",
+        attachment: _stored,
+        rendition: SessionAttachmentRendition.original,
+      ),
+    ).thenAnswer((_) => original.future);
+    final cubit = MessageImageCubit(repository: repository, sessionId: "session-1", attachment: _stored);
+    addTearDown(cubit.close);
+    await cubit.stream.firstWhere((state) => state.preview is MessageImagePreviewLoaded);
+
+    final load = cubit.loadOriginal();
+    cubit.releaseOriginal();
+    expect(cubit.state.original, isA<MessageImageOriginalAvailable>());
+    original.complete(
+      MessageImageLoadSuccess(
+        bytes: Uint8List.fromList(const [2]),
+        mime: "image/png",
+        actionFilename: "image.png",
+        originalUri: null,
+      ),
+    );
+    await load;
+
+    expect(cubit.state.original, isA<MessageImageOriginalAvailable>());
+    expect(cubit.state.preview, isA<MessageImagePreviewLoaded>());
+  });
+
+  test("release drops a completed original while preserving the preview", () async {
+    when(
+      () => repository.load(
+        sessionId: "session-1",
+        attachment: _stored,
+        rendition: SessionAttachmentRendition.thumbnail,
+      ),
+    ).thenAnswer(
+      (_) async => MessageImageLoadSuccess(
+        bytes: Uint8List.fromList(const [1]),
+        mime: "image/png",
+        actionFilename: "image.png",
+        originalUri: null,
+      ),
+    );
+    when(
+      () => repository.load(
+        sessionId: "session-1",
+        attachment: _stored,
+        rendition: SessionAttachmentRendition.original,
+      ),
+    ).thenAnswer(
+      (_) async => MessageImageLoadSuccess(
+        bytes: Uint8List.fromList(const [2]),
+        mime: "image/png",
+        actionFilename: "image.png",
+        originalUri: null,
+      ),
+    );
+    final cubit = MessageImageCubit(repository: repository, sessionId: "session-1", attachment: _stored);
+    addTearDown(cubit.close);
+    await cubit.stream.firstWhere((state) => state.preview is MessageImagePreviewLoaded);
+    final preview = cubit.state.preview;
+    await cubit.loadOriginal();
+
+    cubit.releaseOriginal();
+
+    expect(cubit.state.preview, same(preview));
+    expect(cubit.state.original, isA<MessageImageOriginalAvailable>());
+  });
+
   test("retry intents reload independent state machines", () async {
     var previewRequests = 0;
     var originalRequests = 0;

--- a/docs/regression/attachments-and-images.md
+++ b/docs/regression/attachments-and-images.md
@@ -40,10 +40,12 @@ content the transcript renders live and after reload.
   copy, share, and save on the original, and an unknown shape degrades safely.
 - Capable clients request stored references for normal history pages and live
   subscriptions. Opening a stored image keeps its thumbnail visible while the
-  original loads, replaces it in place after validation, and enables copy,
-  share, and save only for the original. Failure retains the thumbnail with an
-  explicit retry; closing the viewer releases completed or in-flight original
-  state, and scrolling never starts an original request.
+  original loads and decodes, replaces it in place without resetting viewer
+  state, and enables copy, share, and save only after that decode succeeds.
+  Failure retains the thumbnail with an explicit accessible original retry;
+  closing the viewer releases Cubit bytes and evicts the full-resolution image
+  provider from Flutter's image cache, and scrolling never starts an original
+  request.
 - User, tool, and each maximal contiguous run of assistant file attachments use
   the same left-aligned square collection, capped at 320 px and constrained by
   the available parent width. One attachment spans the collection, two split a
@@ -74,7 +76,7 @@ content the transcript renders live and after reload.
 
 | Level | Additional coverage |
 |---|---|
-| L1 Smoke | Automated, no plugin: the attachment contract's decode, size-bound, unknown-variant, typed stored-rendition request, scoped coalescing, timeout, sensitive-response redaction, persistent thumbnail cache, corruption recovery, bounded pruning, and auth cleanup behavior holds in its owning suites; capable-client history and SSE requests opt into stored references while shared defaults preserve old clients; attachment collections retain square layouts and chronology; stored viewers remain thumbnail-first, gate original actions, retry failures, and release original state on close. |
+| L1 Smoke | Automated, no plugin: the attachment contract's decode, size-bound, unknown-variant, typed stored-rendition request, scoped coalescing, timeout, sensitive-response redaction, persistent thumbnail cache, corruption recovery, bounded pruning, and auth cleanup behavior holds in its owning suites; capable-client history and SSE requests opt into stored references while shared defaults preserve old clients; attachment collections retain square layouts and chronology; stored viewers remain thumbnail-first through original decode, preserve viewer state, gate original actions, retry decode/load failures, and evict/release originals on close. |
 | L2 Routine | Live plugin, one representative plugin: a backend-produced image survives the plugin boundary as a bounded client-safe attachment, live and after a cold history read. |
 | L3 Release | Client end to end on the release-target client platform, every supporting production plugin: staged composer images sent and echoed per attachment-capable plugin, generated and tool-output images displayed, text/image/text order preserved live and after reload, viewer copy/share/save. |
 | L4 Extended | Live plugin for budget-exceeding or mixed collections, malformed types, attachment remote-URL rejection, abort, and plugin restart; relay integration for a second client loading the same transcript. Every supporting production plugin. |
@@ -108,8 +110,9 @@ live, after paging back, or after a reopen, and vary the plugin.
   geometry between states, reorders assistant content, or offers a failed image
   without an accessible retry action.
 - A stored viewer fetches an original before opening, blanks the cached
-  thumbnail while loading or after failure, enables actions against thumbnail
-  bytes, or retains original bytes after closing.
+  thumbnail while loading or after load/decode failure, resets zoom or drag when
+  the original appears, enables actions before original decode succeeds, or
+  retains original bytes/provider cache entries after closing.
 - The composer offers or sends attachments to an unsupporting backend, retains
   staged images after switching to one, or the viewer acts on the wrong image.
 

--- a/docs/regression/attachments-and-images.md
+++ b/docs/regression/attachments-and-images.md
@@ -38,6 +38,12 @@ content the transcript renders live and after reload.
 - Live streaming and history replay converge: same image, same message and part
   identity, same position relative to text and tool output. The viewer offers
   copy, share, and save on the original, and an unknown shape degrades safely.
+- Capable clients request stored references for normal history pages and live
+  subscriptions. Opening a stored image keeps its thumbnail visible while the
+  original loads, replaces it in place after validation, and enables copy,
+  share, and save only for the original. Failure retains the thumbnail with an
+  explicit retry; closing the viewer releases completed or in-flight original
+  state, and scrolling never starts an original request.
 - User, tool, and each maximal contiguous run of assistant file attachments use
   the same left-aligned square collection, capped at 320 px and constrained by
   the available parent width. One attachment spans the collection, two split a
@@ -68,7 +74,7 @@ content the transcript renders live and after reload.
 
 | Level | Additional coverage |
 |---|---|
-| L1 Smoke | Automated, no plugin: the attachment contract's decode, size-bound, unknown-variant, typed stored-rendition request, scoped coalescing, timeout, sensitive-response redaction, persistent thumbnail cache, corruption recovery, bounded pruning, and auth cleanup behavior holds in its owning suites; history projection and live event shaping preserve inline defaults and return stored references only when requested; attachment collections retain square one/two/three/four layouts, width caps, assistant chronology, bounded metadata, reduced-motion loading, and accessible retry. |
+| L1 Smoke | Automated, no plugin: the attachment contract's decode, size-bound, unknown-variant, typed stored-rendition request, scoped coalescing, timeout, sensitive-response redaction, persistent thumbnail cache, corruption recovery, bounded pruning, and auth cleanup behavior holds in its owning suites; capable-client history and SSE requests opt into stored references while shared defaults preserve old clients; attachment collections retain square layouts and chronology; stored viewers remain thumbnail-first, gate original actions, retry failures, and release original state on close. |
 | L2 Routine | Live plugin, one representative plugin: a backend-produced image survives the plugin boundary as a bounded client-safe attachment, live and after a cold history read. |
 | L3 Release | Client end to end on the release-target client platform, every supporting production plugin: staged composer images sent and echoed per attachment-capable plugin, generated and tool-output images displayed, text/image/text order preserved live and after reload, viewer copy/share/save. |
 | L4 Extended | Live plugin for budget-exceeding or mixed collections, malformed types, attachment remote-URL rejection, abort, and plugin restart; relay integration for a second client loading the same transcript. Every supporting production plugin. |
@@ -101,6 +107,9 @@ live, after paging back, or after a reopen, and vary the plugin.
 - An attachment collection exceeds its parent or 320 px cap, loses square tile
   geometry between states, reorders assistant content, or offers a failed image
   without an accessible retry action.
+- A stored viewer fetches an original before opening, blanks the cached
+  thumbnail while loading or after failure, enables actions against thumbnail
+  bytes, or retains original bytes after closing.
 - The composer offers or sends attachments to an unsupporting backend, retains
   staged images after switching to one, or the viewer acts on the wrong image.
 
@@ -115,11 +124,10 @@ live, after paging back, or after a reopen, and vary the plugin.
   covered by the remote-attachment guarantee.
 - Cursor path-only generated images are read locally inside its plugin and
   delivered as bounded attachments; the host path still never crosses the wire.
-- Stored-image fetching and persistent thumbnail caching exist in the client
-  data layer, but normal history and live subscriptions still request inline
-  delivery. Square-grid presentation is active for existing inline, remote, and
-  metadata attachments; viewer original loading and reference activation follow
-  in a later step.
+- Older apps continue to request inline delivery by default, and newer apps
+  continue to render inline images returned by older bridges. The current
+  viewer remains single-image; galleries and persistent original caching are
+  intentionally excluded.
 
 ## Sources
 


### PR DESCRIPTION
## Complexity

⚙️ Moderate: activates existing cross-layer attachment delivery and coordinates thumbnail/original viewer state and lifecycle without changing the wire contract.

## What

- Request stored references for normal history pages and live SSE subscriptions.
- Open stored images thumbnail-first, load and swap in validated originals, gate copy/share/save until ready, retain thumbnail on failure, and release original state on close.
- Add transport, cubit, viewer, failure/retry, action-gating, and regression coverage.

## Why

This completes the capable-client path so transcript pages and live events stop carrying bridge-owned original image bytes while preserving the existing viewer experience and old-peer compatibility.

## Risk and test focus

Moderate risk around history/SSE capability activation, image action byte ownership, viewer close lifecycle, retries, and old app/bridge interoperability. There is no database migration or trust-posture change; thumbnails remain the only persisted client image bytes.

## Expected result

New app/new bridge pairs receive stored references, render cached square thumbnails, and fetch originals only after opening the viewer. Old apps continue to default to inline delivery, and new apps continue to render inline data from old bridges. No database change.

## Verification

- `dart analyze --fatal-infos` in module_core, mobile app, and desktop
- All 1,122 module_core tests
- Full mobile Flutter suite and 36 focused file/assistant widget tests
- Five focused bridge history/archive attachment-delivery tests
- Module-core code generation and Flutter localization generation
- Architecture implementation review: approved with no findings
- Isolated slot-1 source bridge authenticated, registered, exposed debug port 9971, connected to relay, and shut down cleanly

The fresh integration slot contained no backend projects/sessions, so cold/warm transcript and reconnect media behavior could not be exercised without creating external test session data; automated cache, history, SSE, and viewer coverage validates those paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Loads originals for stored image attachments in the viewer and opts the client into `storedReference` delivery for history and SSE. Previously we requested inline bytes and opened the viewer on them; now the viewer opens on the cached thumbnail, fetches and decodes the original only after opening, gates copy/share/save until decoded, shows loading/failure UI with accessible retry, and releases original state and evicts the decoded provider on close.

- Review notes
  - `SessionApi` and `RelayClient` switch `attachmentDelivery` to `storedReference`; no wire-format changes.
  - `ImageAttachmentViewer` supports `StoredMessageImage`, keeps the thumbnail visible, adds loading spinner and failure+“Retry original” overlay, preserves zoom/drag across swap, and creates the actions cubit only for a decoded original.
  - `MessageImageCubit` adds `releaseOriginal()`, starts `loadOriginal()` on open, and wires `retryOriginal()` from the viewer.
  - `FilePartWidget` opens stored images as `StoredMessageImage` when originals are supported; Hero/semantics unchanged.
  - Localization adds: “Couldn’t load the original image.” and “Retry original”.

- Rollout and compatibility
  - New app + new bridge: stored references with cached thumbnails; originals fetch only after opening.
  - Old apps still default to inline; new apps render inline data from old bridges.
  - No schema changes; thumbnails remain the only persisted client image bytes.

<sup>Written for commit d54caf51647bdfd39119f6f36fa40a89e48a9a6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

