### PR TITLE
🌱 [attachment-references] docs: retire lazy transcript attachments [step 11/11]

### DIFF
--- a/.plan/completed/attachment-references/PLAN.md
+++ b/.plan/completed/attachment-references/PLAN.md
@@ -3,10 +3,10 @@
 ## Status
 
 - **Plan slug:** `attachment-references`
-- **Status:** Step 10/11 - viewer and stored-reference activation in progress
+- **Status:** Completed - all 11 steps delivered and verified
 - **Plan date:** 2026-08-10
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
-- **Implementation base:** `origin/main` at `4b3d67f3`
+- **Implementation base:** `origin/main` at `14a4e405`
 - **Delivery:** one plan PR, nine sequential implementation PRs, and one
   plan-retirement PR
 - **Related future work:** prompt-upload decisions are recorded separately in

--- a/.plan/completed/attachment-references/PLAN.md
+++ b/.plan/completed/attachment-references/PLAN.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Plan slug:** `attachment-references`
-- **Status:** Completed - all 11 steps delivered and verified
+- **Status:** Steps 1-10 merged and verified; Step 11 retirement in review
 - **Plan date:** 2026-08-10
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Implementation base:** `origin/main` at `14a4e405`

--- a/.plan/completed/attachment-references/TRACKER.md
+++ b/.plan/completed/attachment-references/TRACKER.md
@@ -3,12 +3,12 @@
 ## Current State
 
 - **Plan slug:** `attachment-references`
-- **Series state:** Steps 1-10 merged; Step 11 retirement in progress
+- **Series state:** Steps 1-10 merged; Step 11 retirement in review
 - **Current step:** 11/11
 - **Implementation base:** synchronized `origin/main` at `14a4e405`
 - **Plan PR:** [#807](https://github.com/sesori-ai/sesori_apps_monorepo/pull/807)
-- **Current PR:** Pending
-- **Next action:** Publish the plan-retirement PR
+- **Current PR:** [#893](https://github.com/sesori-ai/sesori_apps_monorepo/pull/893)
+- **Next action:** Monitor and merge the plan-retirement PR
 
 ## Plan Review
 
@@ -41,7 +41,7 @@
 | [x] | 8/11 | `🚧 [attachment-references] feat(client): cache encrypted image previews [step 8/11]` | 1,250-1,600 | [PR #876](https://github.com/sesori-ai/sesori_apps_monorepo/pull/876) merged |
 | [x] | 9/11 | `⚙️ [attachment-references] feat(client): render square attachment grids [step 9/11]` | 900-1,450 | [PR #889](https://github.com/sesori-ai/sesori_apps_monorepo/pull/889) merged |
 | [x] | 10/11 | `⚙️ [attachment-references] feat(client): load originals in the image viewer [step 10/11]` | 900-1,450 | [PR #891](https://github.com/sesori-ai/sesori_apps_monorepo/pull/891) merged |
-| [x] | 11/11 | `🌱 [attachment-references] docs: retire lazy transcript attachments [step 11/11]` | 50-200 | Retirement PR pending |
+| [ ] | 11/11 | `🌱 [attachment-references] docs: retire lazy transcript attachments [step 11/11]` | 50-200 | [PR #893](https://github.com/sesori-ai/sesori_apps_monorepo/pull/893) in review |
 
 ## Locked Decisions
 
@@ -280,6 +280,12 @@
   the session from cold history. The slot bridge and simulator were shut down
   after the check. Together with the Step 10 automated matrix, this completes
   the required regression evidence for retirement.
+- Step 11 (in review): Against merge base `14a4e405`, `git diff --numstat`
+  reports 27 additions and 11 deletions across four documentation files (38
+  changed lines), below the 50-200 estimate because Git records the active-to-
+  completed plan move as renames rather than deleting and re-adding both files;
+  `git diff --check` passes. Published as
+  [PR #893](https://github.com/sesori-ai/sesori_apps_monorepo/pull/893).
 
 ## Findings And Plan Deltas
 

--- a/.plan/completed/attachment-references/TRACKER.md
+++ b/.plan/completed/attachment-references/TRACKER.md
@@ -281,7 +281,7 @@
   after the check. Together with the Step 10 automated matrix, this completes
   the required regression evidence for retirement.
 - Step 11 (in review): Against merge base `14a4e405`, `git diff --numstat`
-  reports 27 additions and 11 deletions across four documentation files (38
+  reports 33 additions and 11 deletions across four documentation files (44
   changed lines), below the 50-200 estimate because Git records the active-to-
   completed plan move as renames rather than deleting and re-adding both files;
   `git diff --check` passes. Published as

--- a/.plan/completed/attachment-references/TRACKER.md
+++ b/.plan/completed/attachment-references/TRACKER.md
@@ -3,12 +3,12 @@
 ## Current State
 
 - **Plan slug:** `attachment-references`
-- **Series state:** Step 9 merged; Step 10 in review
-- **Current step:** 10/11
-- **Implementation base:** synchronized `origin/main` at `4b3d67f3`
+- **Series state:** Steps 1-10 merged; Step 11 retirement in progress
+- **Current step:** 11/11
+- **Implementation base:** synchronized `origin/main` at `14a4e405`
 - **Plan PR:** [#807](https://github.com/sesori-ai/sesori_apps_monorepo/pull/807)
-- **Current PR:** [#891](https://github.com/sesori-ai/sesori_apps_monorepo/pull/891)
-- **Next action:** Monitor Step 10 CI and review
+- **Current PR:** Pending
+- **Next action:** Publish the plan-retirement PR
 
 ## Plan Review
 
@@ -40,8 +40,8 @@
 | [x] | 7/11 | `🚧 [attachment-references] feat(client): load stored image renditions [step 7/11]` | 1,500-2,000 | [PR #864](https://github.com/sesori-ai/sesori_apps_monorepo/pull/864) merged |
 | [x] | 8/11 | `🚧 [attachment-references] feat(client): cache encrypted image previews [step 8/11]` | 1,250-1,600 | [PR #876](https://github.com/sesori-ai/sesori_apps_monorepo/pull/876) merged |
 | [x] | 9/11 | `⚙️ [attachment-references] feat(client): render square attachment grids [step 9/11]` | 900-1,450 | [PR #889](https://github.com/sesori-ai/sesori_apps_monorepo/pull/889) merged |
-| [ ] | 10/11 | `⚙️ [attachment-references] feat(client): load originals in the image viewer [step 10/11]` | 900-1,450 | [PR #891](https://github.com/sesori-ai/sesori_apps_monorepo/pull/891) in review |
-| [ ] | 11/11 | `🌱 [attachment-references] docs: retire lazy transcript attachments [step 11/11]` | 50-200 | Pending |
+| [x] | 10/11 | `⚙️ [attachment-references] feat(client): load originals in the image viewer [step 10/11]` | 900-1,450 | [PR #891](https://github.com/sesori-ai/sesori_apps_monorepo/pull/891) merged |
+| [x] | 11/11 | `🌱 [attachment-references] docs: retire lazy transcript attachments [step 11/11]` | 50-200 | Retirement PR pending |
 
 ## Locked Decisions
 
@@ -264,6 +264,22 @@
   900-1,450 estimate because Step 7 already supplied the bounded transport,
   repository, and independent preview/original state machines; `git diff
   --check` passes.
+- Step 10 (merged): Review fixes stage Flutter decoding before swapping the
+  original or enabling actions, retain the thumbnail on decode failure, preserve
+  viewer zoom/drag/Hero state, evict the full-resolution provider on close, and
+  keep action Cubit ownership under `BlocProvider(create:)`. Fatal analysis, 37
+  focused widget tests, the full mobile suite, CI 13/13, and Cubic approval
+  passed; [PR #891](https://github.com/sesori-ai/sesori_apps_monorepo/pull/891)
+  squash-merged as `14a4e405` with no unresolved threads.
+- Step 11 retirement gate: On the slot-owned `sesori-dev-1` simulator and
+  authenticated slot-1 source bridge, a fresh Codex session generated a real
+  PNG attachment. The app received a stored reference, rendered its 320 px
+  square thumbnail, opened thumbnail-first, enabled copy/share/save after the
+  original decoded, reopened from the warm thumbnail cache, survived a bridge
+  stop/start and relay reconnect, and rendered again after leaving and reopening
+  the session from cold history. The slot bridge and simulator were shut down
+  after the check. Together with the Step 10 automated matrix, this completes
+  the required regression evidence for retirement.
 
 ## Findings And Plan Deltas
 

--- a/.plan/drafts/prompt-attachment-uploads/CONSIDERATIONS.md
+++ b/.plan/drafts/prompt-attachment-uploads/CONSIDERATIONS.md
@@ -5,7 +5,7 @@
 - **State:** Discussion record only; not an active implementation plan
 - **Date:** 2026-08-10
 - **Depends on:** the attachment fetch/reference contract being implemented and
-  proven by `.plan/active/attachment-references/`
+  proven by `.plan/completed/attachment-references/`
 - **No fixed PR count, titles, branches, estimates, or architecture are approved
   by this document.** Create a fresh active plan from then-current code before
   implementation.

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -70,4 +70,4 @@ multi-byte, and empty output; compare live with a later reload.
   `bridge/sesori_plugin_*/`; `client/app/lib/features/session_detail/widgets/`
 - Tests: `bridge/app/test/bridge/sse/bridge_event_mapper_test.dart`
 - Plans (discovery only): `.plan/completed/output-image-support`,
-  `.plan/active/attachment-references`
+  `.plan/completed/attachment-references`


### PR DESCRIPTION
## Complexity

🌱 Trivial: documentation-only plan retirement after all implementation and regression gates completed.

## What

- Mark Steps 10 and 11 complete and record the final merge and verification evidence.
- Move the attachment-references plan from `.plan/active/` to `.plan/completed/`.
- Update discovery references to the completed plan path.

## Why

All ten preceding plan and implementation PRs are merged, and the required automated and local end-to-end attachment checks now pass.

## Risk and test focus

Low risk. No production code, wire contract, database, persisted data, or user-visible behavior changes. Review should confirm the recorded PR/merge evidence and completed-plan move.

## Expected result

No user-visible or database impact. The completed attachment-reference series remains discoverable under `.plan/completed/` and no longer appears active.

## Verification

- `git diff --check`
- Confirmed PR #891 merged as `14a4e405` with CI 13/13 and zero unresolved threads
- Slot-1 end to end: Codex generated a real PNG stored attachment; cold square thumbnail, original viewer/actions, warm reopen, bridge restart/reconnect, and cold history reopen all passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires the `attachment-references` plan and updates discovery so the series appears under completed work. Finalizes the series after Step 10 merge verification and the retirement gate.

- Moves `PLAN.md` and `TRACKER.md` to `.plan/completed/attachment-references/` with status “Steps 1–10 merged; Step 11 retirement in review”.
- Updates `TRACKER.md` with Step 10 merge evidence, retirement gate E2E results, corrected diff totals for this PR, and implementation base `14a4e405`.
- Updates references in `.plan/drafts/prompt-attachment-uploads/CONSIDERATIONS.md` and `docs/regression/tools-and-file-changes.md` from active to completed path.
- No production code, contracts, database, or user-visible behavior changes.

<sup>Written for commit b0e4b07821309b259b8bdf913988f22964ada737. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

