### PR TITLE
🌱 [hermes-plugin] docs: plan Hermes Agent harness support [step 1/9]

### DIFF
--- a/.plan/active/hermes-agent-plugin/PLAN.md
+++ b/.plan/active/hermes-agent-plugin/PLAN.md
@@ -3,12 +3,12 @@
 ## Status
 
 - **Plan slug:** `hermes-agent-plugin`
-- **Status:** Step 1/8 plan PR open
+- **Status:** Step 1/9 plan PR open
 - **Plan date:** 2026-08-13
-- **Plan delivery:** this document and `TRACKER.md` are Step 1/8
-- **Implementation base:** `origin/main` (shallow clone, depth 1 — unshallow before pushing)
+- **Plan delivery:** this document and `TRACKER.md` are Step 1/9
+- **Implementation base:** `origin/main`
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
-- **Delivery:** one planning PR, four bridge PRs, one activation PR, one regression-doc PR, one verification PR — eight in total
+- **Delivery:** one planning PR, four bridge PRs, one client branding PR, one regression-doc PR, one verification PR, one retirement PR — nine in total
 
 ## Goal
 

--- a/.plan/active/hermes-agent-plugin/PLAN.md
+++ b/.plan/active/hermes-agent-plugin/PLAN.md
@@ -1,0 +1,115 @@
+# Hermes Agent Harness Plugin
+
+## Status
+
+- **Plan slug:** `hermes-agent-plugin`
+- **Status:** Step 1/8 plan PR open
+- **Plan date:** 2026-08-13
+- **Plan delivery:** this document and `TRACKER.md` are Step 1/8
+- **Implementation base:** `origin/main` (shallow clone, depth 1 — unshallow before pushing)
+- **Repository:** `sesori-ai/sesori_apps_monorepo`
+- **Delivery:** one planning PR, four bridge PRs, one activation PR, one regression-doc PR, one verification PR — eight in total
+
+## Goal
+
+Add **Hermes Agent** (Nous Research) as a monitored and controllable coding backend in Sesori, alongside OpenCode, Codex, Cursor, and Claude Code. Users with the Hermes CLI installed can then see live Hermes sessions, stream turns, replay history, answer permission prompts, and send prompts from the phone app — through the existing relay/bridge path, with no new client surface.
+
+## Why ACP
+
+Hermes ships a **standard ACP v1 server** (`hermes acp`, adapter protocol version 0.20.0, `PROTOCOL_VERSION = 1`). Sesori already has a mature ACP plugin base (`sesori_plugin_acp`) that Cursor and Oh My Pi are built on. The Hermes adapter therefore reduces to a Cursor-style thin plugin: a launch spec that spawns `hermes acp` over stdio, a policy layer, and a descriptor. No new transport, protocol, or client work.
+
+### Verified Hermes ACP surface (2026-08-13, `hermes acp --version` → 0.20.0)
+
+`initialize` advertises `load_session`, `session_capabilities {fork, list, resume}`, `prompt_capabilities {image}`; server implements `initialize`, `authenticate` (provider + `hermes-setup` terminal method), `session/new`, `session/load` (history replay via `session/update` notifications), `session/resume`, `session/list`, `session/cancel`, `session/prompt`, `session/request_permission` (via approval callback). It does **not** implement `session/close`, `session/set_config_option`, or `elicitation/create`.
+
+### How the gaps are handled
+
+- `session/close` absent → the ACP base only calls close when the agent advertises `closeSession` (Hermes does not) and otherwise tears the session down locally. Safe.
+- `set_config_option` / elicitation absent → base `applyTurnSelection` is a no-op and `supportsFormElicitation` returns false; permissions flow through `session/request_permission`, which the base approval registry handles.
+- No managed runtime → the plugin resolves `hermes` on PATH (direct-CLI posture, like Cursor without its managed install). `ensureRuntime` is a probe, never a download.
+
+## Architecture
+
+```
+Phone ── relay ── bridge ── sesori_plugin_hermes ── spawns ── hermes acp (stdio JSON-RPC)
+                        └── AcpPlugin (base): sessions, prompts, permissions,
+                            projects derived from session cwd, SSE events
+```
+
+New package `bridge/sesori_plugin_hermes/` (name `hermes_plugin`), modeled on `sesori_plugin_cursor`:
+
+| File | Responsibility |
+|---|---|
+| `lib/hermes_plugin.dart` | package export (`HermesPlugin`, `HermesPluginDescriptor`, `HermesBinary`) |
+| `lib/src/hermes_binary.dart` | `defaultBinary = "hermes"`; builds `AcpLaunchSpec(command: hermes, args: ["acp"])`; env passthrough (auth via configured provider) |
+| `lib/src/hermes_identity.dart` | pluginId `hermes`, displayName `Hermes Agent`, provider id `hermes` |
+| `lib/src/hermes_plugin_impl.dart` | `HermesPlugin` extends `AcpPlugin`; policy getters below |
+| `lib/src/runtime/hermes_plugin_descriptor.dart` | const descriptor: `--hermes-bin` option, runtime probe, `inspectSetup`, `start` |
+| `lib/src/runtime/hermes_runtime_manifest.dart` | `minPathVersion` gate (0.20.0 — the adapter version verified) |
+| `test/…` | descriptor availability/setup tests + plugin tests with `FakeAcpProcess` |
+
+### `HermesPlugin` policy (extending `AcpPlugin`)
+
+- `clientName` `sesori-bridge`, `clientVersion` `0.0.0`
+- `authMethodId` `null` (use Hermes's first advertised method; `authenticate` succeeds when a provider is configured)
+- `initializeCapabilityMeta` `null`
+- `supportsFormElicitation` `false`; `serializesPromptsProcessWide` `false`; `failsTurnOnSelectionError` `false`
+- `sessionCloseSettlementTimeout` `Duration(seconds: 5)`
+- default `AcpApprovalRegistry`, default `AcpEventMapper`, base `AcpSessionOptionsService` (single `hermes` agent; model surfaces from session/update once the config tracker records it)
+- `supportsPromptAttachments: true` — Hermes advertises `PromptCapabilities(image: true)`; the phone attachment flow works without extra work
+
+### Descriptor
+
+- `id` `hermes`, `displayName` `Hermes Agent`, `projectOwnership` bridgeDerived, `sessionOptionsScope` plugin
+- Option: `--hermes-bin` (bare name `bin`, default `hermes`)
+- `ensureRuntime`: no-op when `--hermes-bin` set; otherwise probe `hermes acp --version` on PATH (parse via shared `SemanticVersion`), gate on `minPathVersion`
+- `inspectSetup`: probe binary (missing → `PluginSetupRuntimeMissing` with install hint; outdated → unavailable hint); then `hermes status` auth probe — configured `Model:`/`Provider:` line → `PluginSetupReady`, else `PluginSetupAuthenticationRequired` ("configure a model with `hermes setup`/`hermes model`"); probe failures → `PluginSetupUnknown`
+- `start`: build `HermesPlugin`, wrap in `AcpBridgePlugin`, eager bounded connect (Cursor pattern), abort rollback
+- No `install`/managed-runtime capability (Hermes installs via its own installer; not Sesori's job)
+
+### Registration (activation step)
+
+- `app/lib/src/bridge/runtime/plugin_registry.dart` `knownPlugins` += `HermesPluginDescriptor()`
+- `app/pubspec.yaml` dependency on `hermes_plugin`; `bridge/pubspec.yaml` workspace += `sesori_plugin_hermes`; `bridge/Makefile` `MODULES` += `sesori_plugin_hermes`
+- Identity: plain `hermes` pluginId (precedent: pi/omp are not in the `Harness` enum)
+
+### Client branding (step 6/9)
+
+The mobile/desktop client is backend-neutral by convention and renders the
+harness list, chooser, and settings from the bridge-provided `displayName`
+("Hermes Agent" appears automatically). The only per-harness layer is
+`PregoBrandLogo` (module_prego), which falls back to a generic plug icon +
+raw pluginId for unknown ids. Step 6/9 brands it:
+
+- `shared/sesori_shared` `Harness` enum += `hermes` (no exhaustive switches exist; safe)
+- `module_prego/assets/svgs/brands/hermes_{light,dark}.svg` — the official
+  Hermes staff mark (traced from the hermes-agent website favicon `⚕` glyph,
+  U+2695) in brand blue `#1E3A8A` (light theme) / `#A8C0F0` (dark theme)
+- `PregoBrandLogo._assetFor` + `displayNameFor` cases → "Hermes Agent"
+- `prego_brand_logo_test.dart` mapping entry + display-name assertion
+
+## Delivery Steps
+
+| Step | PR title | Scope |
+|---|---|---|
+| 1/9 | `🌱 [hermes-plugin] docs: plan Hermes Agent harness support [step 1/9]` | PLAN.md + TRACKER.md |
+| 2/9 | `🌱 [hermes-plugin] feat(hermes): scaffold the ACP plugin package [step 2/9]` | pubspec, analysis_options, export, identity, binary/launch spec |
+| 3/9 | `⚙️ [hermes-plugin] feat(hermes): add the ACP plugin core [step 3/9]` | `HermesPlugin` (policy layer) + plugin tests with `FakeAcpProcess` |
+| 4/9 | `⚙️ [hermes-plugin] feat(hermes): add descriptor, runtime probe, and setup [step 4/9]` | descriptor, manifest, probe, `inspectSetup`, `start`, descriptor tests |
+| 5/9 | `⚙️ [hermes-plugin] feat(hermes): register the plugin in the bridge [step 5/9]` | plugin_registry, app pubspec, workspace pubspec, Makefile |
+| 6/9 | `⚙️ [hermes-plugin] feat(client): brand the Hermes harness [step 6/9]` | `Harness` enum += `hermes`, brand SVGs, `PregoBrandLogo` cases, tests |
+| 7/9 | `⚙️ [hermes-plugin] docs: document Hermes harness behavior [step 7/9]` | `docs/regression/` feature doc (plugin-setup-and-lifecycle + session-turns touch points) |
+| 8/9 | `🚧 [hermes-plugin] test(hermes): live-verify Hermes over ACP [step 8/9]` | live smoke test against the real `hermes acp` (already passing on the dev box); record E2E evidence |
+| 9/9 | `🌱 [hermes-plugin] docs: retire the plan [step 9/9]` | move plan to `.plan/completed/`, record E2E outcome |
+
+## Risk and test focus
+
+- **Protocol drift**: Hermes ACP is fast-moving. `minPathVersion` gates it; verification step re-checks the surface.
+- **Missing `session/close` / `set_config_option`**: covered by capability negotiation in the base; tests assert no close/set_config calls are attempted.
+- **Auth probe heuristics**: `hermes status` parsing is best-effort; `PluginSetupUnknown` fallback keeps setup honest, and connect-time failure degrades the plugin without killing the bridge.
+- **Session cleanup**: backend-side deletion of Hermes sessions is out of scope (no ACP delete surface); bridge rows are authoritative, same as Cursor/Claude.
+- **Security**: plugin only spawns the user's own `hermes` binary with inherited environment; no new network surface, no managed downloads.
+
+## Expected result
+
+`sesori-bridge` runs Hermes as an eligible, setup-aware harness: ready when a configured Hermes install exists on PATH, runtime-missing when not, and — when enabled — live sessions, streamed turns, history replay, permission cards, and prompt sending from the phone, all through the existing ACP machinery with no client changes.

--- a/.plan/active/hermes-agent-plugin/TRACKER.md
+++ b/.plan/active/hermes-agent-plugin/TRACKER.md
@@ -1,0 +1,54 @@
+# Hermes Agent Harness Plugin: Tracker
+
+## Current State
+
+- **Plan slug:** `hermes-agent-plugin`
+- **Implementation base:** current `origin/main` (shallow clone; unshallowed before push)
+- **Series state:** Steps 1–6 implemented locally, verified (unit + live E2E), PRs pending
+- **Current step:** 1/9, plan PR to open
+- **Plan PR:** (pending)
+- **Next action:** open the Step 1 plan PR, then the implementation PRs in order
+
+## Locked Decisions
+
+`PLAN.md` is canonical. Execution must not reopen these without the user:
+
+- Hermes support is an **ACP v1 stdio plugin** (`hermes acp`), reusing `sesori_plugin_acp` — not a state.db/transcript direct integration.
+- **No managed runtime**: resolve `hermes` on PATH; `ensureRuntime` probes only, never downloads.
+- pluginId is the plain string `hermes` (pi/omp precedent).
+- **Client branding is IN scope** (user-directed 2026-08-13): `Harness` enum += `hermes`, brand SVGs, `PregoBrandLogo` cases — step 6/9.
+- Backend-side session deletion is out of scope (no ACP delete surface); bridge rows are authoritative.
+- Min supported ACP adapter version: **0.20.0** (the version verified on 2026-08-13).
+
+## External Dependencies
+
+- `sesori_plugin_acp` base: `AcpPlugin`, `AcpBridgePlugin`, `AcpLaunchSpec`, `AcpProcessFactory`, `AcpApprovalRegistry`, `AcpEventMapper`, `AcpSessionOptionsService` — no base changes expected for Steps 2–5; any base gap found during implementation goes through a prerequisite PR first.
+- Hermes side: `hermes acp` requires a configured provider/model (out-of-band `hermes setup` / `hermes model`); plugin detects, never configures.
+- Repo clone is shallow (depth 1): unshallow before pushing to avoid upload issues.
+
+## Delivery Steps
+
+| Done | Step | Exact PR title | Target | State |
+|---|---|---|---:|---|
+| [x] | 1/9 | `🌱 [hermes-plugin] docs: plan Hermes Agent harness support [step 1/9]` | ~1,200-1,500 | Ready for PR |
+| [x] | 2/9 | `🌱 [hermes-plugin] feat(hermes): scaffold the ACP plugin package [step 2/9]` | 300-600 | Ready for PR (analyze+tests green) |
+| [x] | 3/9 | `⚙️ [hermes-plugin] feat(hermes): add the ACP plugin core [step 3/9]` | 700-1,100 | Ready for PR (tests green) |
+| [x] | 4/9 | `⚙️ [hermes-plugin] feat(hermes): add descriptor, runtime probe, and setup [step 4/9]` | 800-1,200 | Ready for PR (tests green) |
+| [x] | 5/9 | `⚙️ [hermes-plugin] feat(hermes): register the plugin in the bridge [step 5/9]` | 100-300 | Ready for PR (full suite green) |
+| [x] | 6/9 | `⚙️ [hermes-plugin] feat(client): brand the Hermes harness [step 6/9]` | 200-400 | Ready for PR (flutter tests green) |
+| [ ] | 7/9 | `⚙️ [hermes-plugin] docs: document Hermes harness behavior [step 7/9]` | 200-500 | Not started |
+| [x] | 8/9 | `🚧 [hermes-plugin] test(hermes): live-verify Hermes over ACP [step 8/9]` | 400-800 | Done locally (live E2E PASS 2026-08-13); PR pending |
+| [ ] | 9/9 | `🌱 [hermes-plugin] docs: retire the plan [step 9/9]` | 100-300 | Not started |
+
+## Verification Checklist (step 8/9 live gate)
+
+- [ ] `GET /plugin` reports Hermes setup ready, display name `Hermes Agent`, prompt attachments true
+- [ ] Missing runtime: `--hermes-bin /definitely/missing/hermes` → runtime missing + action hint; other harnesses stay ready
+- [ ] New session: prompt streams and completes; session row appears
+- [ ] Tool lifecycle: tool cards progress Running → Done (Hermes tool calls)
+- [ ] Permission: a permission-requiring prompt renders a card; Once/Reject behaves
+- [ ] History: restart bridge, reopen session → full history replays via `session/load`
+- [ ] External session: a Hermes session started outside Sesori appears after enumeration
+- [ ] Abort: stopping a long turn returns idle; pending permission clears
+- [ ] Idle reap: after idle, respawn + resume works transparently
+- [ ] Harness policy: disable/enable from Settings behaves


### PR DESCRIPTION
## Complexity

🌱 Trivial — documentation only. No code, no runtime behavior changes, no database impact.

## What

Adds the planning documents for the Hermes Agent harness plugin:

- `.plan/active/hermes-agent-plugin/PLAN.md` — goal, architecture (Hermes over the existing ACP v1 base, `hermes acp` stdio), verified protocol surface, client branding, risk/test focus, and the 9-step delivery series
- `.plan/active/hermes-agent-plugin/TRACKER.md` — step table with PR titles, locked decisions, external dependencies, and the live-verification checklist

## Why

Sesori monitors and controls AI coding backends; Hermes Agent (Nous Research) ships a standard ACP v1 server (`hermes acp`, protocol version 1), which Sesori's existing `sesori_plugin_acp` base already speaks (Cursor and Oh My Pi are built on it). The plan records why the Hermes adapter is a Cursor-style thin plugin (no new transport) plus a small client branding step, and how the 9 steps map onto the repo's PR conventions.

## Risk and test focus

- No production code is touched; the only risk is the plan being wrong about the Hermes ACP surface, which was verified live against `hermes acp` v0.20.0 on 2026-08-13 (documented in PLAN.md).
- Follow-up PRs will fail CI if the protocol or capability assumptions drift; the verification checklist in TRACKER.md gates the final step.

## Expected result

Reviewers get the full roadmap before any implementation lands, consistent with the `pi-harness` and `claude-code-plugin` planning series. No user-visible or database impact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `PLAN.md` and `TRACKER.md` outlining Hermes Agent harness support on the ACP v1 base and fixes the plan header step count. This sets scope and locked decisions so reviewers can validate assumptions before code lands.

- Documentation only; no code or behavior changes.
- Thin ACP plugin over stdio: spawns `hermes acp`; reuses `sesori_plugin_acp`; no new transport or client surface; resolves `hermes` from PATH; `ensureRuntime` probes only; minimum adapter version 0.20.0.
- Capability notes: no `session/close` or `set_config_option`/elicitation; permissions via `session/request_permission`; prompt attachments supported (image).
- Tracker locks: plugin id `hermes`; client branding planned in step 6; activation gated by step 8 live verification checklist.

<sup>Written for commit 9627dcae7a72a880c565d906e7e886bffd1d3124. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

