### PR TITLE
🌱 [hermes-plugin] feat(hermes): scaffold the ACP plugin package [step 2/9]

### DIFF
--- a/bridge/Makefile
+++ b/bridge/Makefile
@@ -2,7 +2,7 @@ TOOL_VERSIONS := $(shell git rev-parse --show-toplevel)/.tool-versions
 FLUTTER_VERSION := $(shell grep '^flutter' $(TOOL_VERSIONS) | awk '{print $$2}')
 DART := $(HOME)/.asdf/installs/flutter/$(FLUTTER_VERSION)/bin/cache/dart-sdk/bin/dart
 
-MODULES := sesori_plugin_interface sesori_bridge_foundation sesori_plugin_runtime sesori_plugin_opencode sesori_plugin_codex sesori_plugin_acp sesori_plugin_cursor sesori_plugin_omp sesori_plugin_claude sesori_plugin_pi app
+MODULES := sesori_plugin_interface sesori_bridge_foundation sesori_plugin_runtime sesori_plugin_opencode sesori_plugin_codex sesori_plugin_acp sesori_plugin_cursor sesori_plugin_omp sesori_plugin_claude sesori_plugin_pi sesori_plugin_hermes app
 
 .PHONY: codegen opencode-codegen pub-get test analyze
 

--- a/bridge/pubspec.yaml
+++ b/bridge/pubspec.yaml
@@ -16,3 +16,4 @@ workspace:
   - sesori_plugin_omp
   - sesori_plugin_claude
   - sesori_plugin_pi
+  - sesori_plugin_hermes

--- a/bridge/sesori_plugin_hermes/analysis_options.yaml
+++ b/bridge/sesori_plugin_hermes/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../app/analysis_options.yaml

--- a/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
+++ b/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
@@ -1,0 +1,7 @@
+// Hermes Agent backend for the Sesori bridge.
+//
+// Drives `hermes acp` over the generic ACP machinery (acp_plugin). Hermes is
+// a stock ACP v1 server (protocol version 1), so the plugin core is policy
+// only — no harness-specific protocol extensions.
+export "src/hermes_binary.dart";
+export "src/hermes_identity.dart";

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
@@ -1,0 +1,25 @@
+import "package:acp_plugin/acp_plugin.dart";
+
+/// Builds the launch spec for `hermes acp`.
+///
+/// Auth is out of band: the process factory inherits the bridge's
+/// environment, so a Hermes install with a configured provider/model
+/// (via `hermes setup` / `hermes model`) is picked up automatically.
+abstract final class HermesBinary() {
+  /// The Hermes CLI launcher, resolved on PATH by the descriptor's runtime
+  /// probe (and overridable with `--hermes-bin`).
+  static const String defaultBinary = "hermes";
+
+  static AcpLaunchSpec launchSpec({
+    String binary = defaultBinary,
+    String? cwd,
+    Map<String, String> environment = const {},
+  }) {
+    return AcpLaunchSpec(
+      command: binary,
+      args: const ["acp"],
+      cwd: cwd,
+      environment: environment,
+    );
+  }
+}

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
@@ -6,8 +6,7 @@ import "package:acp_plugin/acp_plugin.dart";
 /// environment, so a Hermes install with a configured provider/model
 /// (via `hermes setup` / `hermes model`) is picked up automatically.
 abstract final class HermesBinary() {
-  /// The Hermes CLI launcher, resolved on PATH by the descriptor's runtime
-  /// probe (and overridable with `--hermes-bin`).
+  /// The Hermes CLI launcher, resolved on PATH.
   static const String defaultBinary = "hermes";
 
   static AcpLaunchSpec launchSpec({

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
@@ -1,0 +1,12 @@
+/// Identity constants for the Hermes Agent harness plugin.
+///
+/// The plugin id is the plain string `hermes` (precedent: the pi and omp
+/// plugins are not members of the legacy `Harness` enum either). Client-side
+/// brand mapping for the id can follow later without a wire-format change.
+abstract final class HermesIdentity() {
+  static const String pluginId = "hermes";
+  static const String displayName = "Hermes Agent";
+  static const String providerId = "hermes";
+  static const String clientName = "sesori-bridge";
+  static const String clientVersion = "0.0.0";
+}

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
@@ -2,7 +2,8 @@
 ///
 /// The plugin id is the plain string `hermes` (precedent: the pi and omp
 /// plugins are not members of the legacy `Harness` enum either). Client-side
-/// brand mapping for the id can follow later without a wire-format change.
+/// branding for the id is handled by `PregoBrandLogo` in module_prego (the
+/// Hermes staff mark + "Hermes Agent" display name), keyed by this id.
 abstract final class HermesIdentity() {
   static const String pluginId = "hermes";
   static const String displayName = "Hermes Agent";

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
@@ -1,13 +1,12 @@
 /// Identity constants for the Hermes Agent harness plugin.
 ///
 /// The plugin id is the plain string `hermes` (precedent: the pi and omp
-/// plugins are not members of the legacy `Harness` enum either). Client-side
-/// branding for the id is handled by `PregoBrandLogo` in module_prego (the
-/// Hermes staff mark + "Hermes Agent" display name), keyed by this id.
-abstract final class HermesIdentity() {
+/// plugins are not members of the legacy `Harness` enum either). The client
+/// brands the id through `PregoBrandLogo` in module_prego (Hermes staff mark
+/// + "Hermes Agent" display name).
+abstract final class HermesPluginIdentity() {
   static const String pluginId = "hermes";
   static const String displayName = "Hermes Agent";
-  static const String providerId = "hermes";
   static const String clientName = "sesori-bridge";
   static const String clientVersion = "0.0.0";
 }

--- a/bridge/sesori_plugin_hermes/pubspec.yaml
+++ b/bridge/sesori_plugin_hermes/pubspec.yaml
@@ -1,0 +1,19 @@
+name: hermes_plugin
+version: 0.1.0
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.13.0-0
+
+dependencies:
+  sesori_plugin_interface:
+    path: ../sesori_plugin_interface
+  sesori_bridge_foundation:
+    path: ../sesori_bridge_foundation
+  acp_plugin:
+    path: ../sesori_plugin_acp
+
+dev_dependencies:
+  test: ^1.31.1
+  lints: ^6.1.0


### PR DESCRIPTION
## Complexity

🌱 Trivial — a new package skeleton plus workspace wiring. No behavior yet.

## What

Scaffolds the Hermes Agent ACP plugin package and wires it into the bridge workspace:

- `bridge/sesori_plugin_hermes/` — new package `hermes_plugin`:
  - `pubspec.yaml` (deps: `sesori_plugin_interface`, `sesori_bridge_foundation`, `acp_plugin`; no generated code, no `build_runner`)
  - `analysis_options.yaml` (inherits `app/` lints)
  - `lib/hermes_plugin.dart` — package export surface
  - `lib/src/hermes_identity.dart` — pluginId `hermes`, display name `Hermes Agent`
  - `lib/src/hermes_binary.dart` — `AcpLaunchSpec` for `hermes acp` (auth out of band, inherited environment)
- `bridge/pubspec.yaml` — workspace member
- `bridge/Makefile` — `MODULES` entry

## Why

Hermes Agent ships a standard ACP v1 server (`hermes acp`), so the harness is a thin plugin over the existing `sesori_plugin_acp` base (same pattern as Cursor). This PR lays the package down; the plugin core, descriptor, and registration land in steps 3–5/9. The workspace + Makefile entries are added now (pi/omp precedent) so `dart pub get` resolves the package from step 2 onward.

## Risk and test focus

- Pure additive: no existing behavior changes. Verified `dart analyze` clean on the package `lib/` and full workspace `dart pub get` resolves.
- Merge sequence: part of the `hermes-plugin` series (plan PR #895). Base is `main`; the next PRs chain off this branch and should be retargeted to `main` as each merges.

## Expected result

A compiling, empty-but-wired Hermes plugin package. No user-visible or database impact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scaffolds the Hermes ACP plugin as `hermes_plugin` and wires it into the bridge workspace. No runtime behavior changes; prepares a thin plugin over `acp_plugin` and aligns identity naming with repo precedent.

- Adds workspace member `sesori_plugin_hermes` (deps: `sesori_plugin_interface`, `sesori_bridge_foundation`, `acp_plugin`); no codegen.
- Exposes `HermesBinary.launchSpec` (default binary "hermes", args ["acp"]; inherits environment for auth).
- Exposes `HermesPluginIdentity` (pluginId "hermes", displayName "Hermes Agent", clientName "sesori-bridge", clientVersion "0.0.0").
- Updates `bridge/pubspec.yaml` and `Makefile` MODULES to include `sesori_plugin_hermes`.

<sup>Written for commit f3cb32b13e416f5a92820762c766a58f03376465. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

