### PR TITLE
⚙️ [hermes-plugin] feat(hermes): add the ACP plugin core [step 3/9]

### DIFF
--- a/bridge/Makefile
+++ b/bridge/Makefile
@@ -2,7 +2,7 @@ TOOL_VERSIONS := $(shell git rev-parse --show-toplevel)/.tool-versions
 FLUTTER_VERSION := $(shell grep '^flutter' $(TOOL_VERSIONS) | awk '{print $$2}')
 DART := $(HOME)/.asdf/installs/flutter/$(FLUTTER_VERSION)/bin/cache/dart-sdk/bin/dart
 
-MODULES := sesori_plugin_interface sesori_bridge_foundation sesori_plugin_runtime sesori_plugin_opencode sesori_plugin_codex sesori_plugin_acp sesori_plugin_cursor sesori_plugin_omp sesori_plugin_claude sesori_plugin_pi app
+MODULES := sesori_plugin_interface sesori_bridge_foundation sesori_plugin_runtime sesori_plugin_opencode sesori_plugin_codex sesori_plugin_acp sesori_plugin_cursor sesori_plugin_omp sesori_plugin_claude sesori_plugin_pi sesori_plugin_hermes app
 
 .PHONY: codegen opencode-codegen pub-get test analyze
 

--- a/bridge/pubspec.yaml
+++ b/bridge/pubspec.yaml
@@ -16,3 +16,4 @@ workspace:
   - sesori_plugin_omp
   - sesori_plugin_claude
   - sesori_plugin_pi
+  - sesori_plugin_hermes

--- a/bridge/sesori_plugin_hermes/analysis_options.yaml
+++ b/bridge/sesori_plugin_hermes/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../app/analysis_options.yaml

--- a/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
+++ b/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
@@ -1,0 +1,7 @@
+// Hermes Agent backend for the Sesori bridge.
+//
+// Drives `hermes acp` over the generic ACP machinery (acp_plugin). Hermes is
+// a stock ACP v1 server (protocol version 1), so the plugin core is policy
+// only — no harness-specific protocol extensions.
+export "src/hermes_binary.dart";
+export "src/hermes_identity.dart";

--- a/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
+++ b/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
@@ -5,3 +5,4 @@
 // only — no harness-specific protocol extensions.
 export "src/hermes_binary.dart";
 export "src/hermes_identity.dart";
+export "src/hermes_plugin_impl.dart";

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
@@ -1,0 +1,25 @@
+import "package:acp_plugin/acp_plugin.dart";
+
+/// Builds the launch spec for `hermes acp`.
+///
+/// Auth is out of band: the process factory inherits the bridge's
+/// environment, so a Hermes install with a configured provider/model
+/// (via `hermes setup` / `hermes model`) is picked up automatically.
+abstract final class HermesBinary() {
+  /// The Hermes CLI launcher, resolved on PATH by the descriptor's runtime
+  /// probe (and overridable with `--hermes-bin`).
+  static const String defaultBinary = "hermes";
+
+  static AcpLaunchSpec launchSpec({
+    String binary = defaultBinary,
+    String? cwd,
+    Map<String, String> environment = const {},
+  }) {
+    return AcpLaunchSpec(
+      command: binary,
+      args: const ["acp"],
+      cwd: cwd,
+      environment: environment,
+    );
+  }
+}

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
@@ -6,8 +6,7 @@ import "package:acp_plugin/acp_plugin.dart";
 /// environment, so a Hermes install with a configured provider/model
 /// (via `hermes setup` / `hermes model`) is picked up automatically.
 abstract final class HermesBinary() {
-  /// The Hermes CLI launcher, resolved on PATH by the descriptor's runtime
-  /// probe (and overridable with `--hermes-bin`).
+  /// The Hermes CLI launcher, resolved on PATH.
   static const String defaultBinary = "hermes";
 
   static AcpLaunchSpec launchSpec({

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
@@ -1,0 +1,12 @@
+/// Identity constants for the Hermes Agent harness plugin.
+///
+/// The plugin id is the plain string `hermes` (precedent: the pi and omp
+/// plugins are not members of the legacy `Harness` enum either). Client-side
+/// brand mapping for the id can follow later without a wire-format change.
+abstract final class HermesIdentity() {
+  static const String pluginId = "hermes";
+  static const String displayName = "Hermes Agent";
+  static const String providerId = "hermes";
+  static const String clientName = "sesori-bridge";
+  static const String clientVersion = "0.0.0";
+}

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
@@ -2,7 +2,8 @@
 ///
 /// The plugin id is the plain string `hermes` (precedent: the pi and omp
 /// plugins are not members of the legacy `Harness` enum either). Client-side
-/// brand mapping for the id can follow later without a wire-format change.
+/// branding for the id is handled by `PregoBrandLogo` in module_prego (the
+/// Hermes staff mark + "Hermes Agent" display name), keyed by this id.
 abstract final class HermesIdentity() {
   static const String pluginId = "hermes";
   static const String displayName = "Hermes Agent";

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
@@ -1,13 +1,12 @@
 /// Identity constants for the Hermes Agent harness plugin.
 ///
 /// The plugin id is the plain string `hermes` (precedent: the pi and omp
-/// plugins are not members of the legacy `Harness` enum either). Client-side
-/// branding for the id is handled by `PregoBrandLogo` in module_prego (the
-/// Hermes staff mark + "Hermes Agent" display name), keyed by this id.
-abstract final class HermesIdentity() {
+/// plugins are not members of the legacy `Harness` enum either). The client
+/// brands the id through `PregoBrandLogo` in module_prego (Hermes staff mark
+/// + "Hermes Agent" display name).
+abstract final class HermesPluginIdentity() {
   static const String pluginId = "hermes";
   static const String displayName = "Hermes Agent";
-  static const String providerId = "hermes";
   static const String clientName = "sesori-bridge";
   static const String clientVersion = "0.0.0";
 }

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
@@ -1,0 +1,100 @@
+import "dart:io" show Directory;
+
+import "package:acp_plugin/acp_plugin.dart";
+
+import "hermes_binary.dart";
+import "hermes_identity.dart";
+
+/// Hermes Agent backend over ACP.
+///
+/// Hermes is a stock ACP v1 server: `hermes acp` advertises load/list/resume/
+/// fork/prompt capabilities and streams turns via `session/update`
+/// notifications, so the base [AcpPlugin] machinery applies unchanged — this
+/// class only declares the harness's protocol policies. There are no
+/// `hermes/*` extensions, no config-option model picker, and no managed
+/// runtime (Hermes installs itself; the bridge resolves it on PATH).
+class HermesPlugin._({
+  required super.launchSpec,
+  required super.launchDirectory,
+  required super.contentMapper,
+  required super.eventMapper,
+  required super.commandTracker,
+  required super.sessionOptionsService,
+  super.processFactory,
+}) extends AcpPlugin {
+  factory({
+    String binaryPath = HermesBinary.defaultBinary,
+    String? launchDirectory,
+    AcpProcessFactory? processFactory,
+  }) {
+    final cwd = launchDirectory ?? Directory.current.path;
+    final launchSpec = HermesBinary.launchSpec(
+      binary: binaryPath,
+      cwd: cwd,
+    );
+    final commandTracker = AcpCommandTracker();
+    final configurationTracker = AcpSessionConfigurationTracker();
+    const contentMapper = AcpContentMapper();
+    final sessionOptionsService = AcpSessionOptionsService(
+      configurationTracker: configurationTracker,
+      commandTracker: commandTracker,
+      pluginId: HermesIdentity.pluginId,
+      agentDisplayName: HermesIdentity.displayName,
+    );
+    final mapper = AcpEventMapper(
+      launchDirectory: cwd,
+      agentId: HermesIdentity.pluginId,
+      pluginId: HermesIdentity.pluginId,
+      configurationTracker: configurationTracker,
+      contentMapper: contentMapper,
+    );
+    return HermesPlugin._(
+      launchSpec: launchSpec,
+      launchDirectory: cwd,
+      contentMapper: contentMapper,
+      eventMapper: mapper,
+      commandTracker: commandTracker,
+      sessionOptionsService: sessionOptionsService,
+      processFactory: processFactory,
+    );
+  }
+
+  this
+    : super(
+        id: HermesIdentity.pluginId,
+        agentDisplayName: HermesIdentity.displayName,
+      );
+
+  @override
+  String get clientName => HermesIdentity.clientName;
+
+  @override
+  String get clientVersion => HermesIdentity.clientVersion;
+
+  /// Hermes advertises a provider auth method plus a terminal-setup method;
+  /// the first advertised method is the configured provider, which is what we
+  /// want to authenticate against. `null` picks it.
+  @override
+  String? get authMethodId => null;
+
+  @override
+  Map<String, dynamic>? get initializeCapabilityMeta => null;
+
+  /// Hermes has no `elicitation/create` — permissions arrive as
+  /// `session/request_permission`, which the base approval registry handles.
+  @override
+  bool get supportsFormElicitation => false;
+
+  /// Hermes serializes turns per session (one agent loop per session), so
+  /// concurrent sessions may prompt in parallel.
+  @override
+  bool get serializesPromptsProcessWide => false;
+
+  /// No harness-specific turn selection exists (base [applyTurnSelection] is
+  /// a no-op), so a selection can never fail a turn.
+  @override
+  bool get failsTurnOnSelectionError => false;
+
+  @override
+  Duration get sessionCloseSettlementTimeout => const Duration(seconds: 5);
+}

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
@@ -71,9 +71,10 @@ class HermesPlugin._({
   @override
   String get clientVersion => HermesIdentity.clientVersion;
 
-  /// Hermes advertises a provider auth method plus a terminal-setup method;
-  /// the first advertised method is the configured provider, which is what we
-  /// want to authenticate against. `null` picks it.
+  /// Hermes advertises the configured provider as an agent auth method first
+  /// and a terminal-setup method after it (see `build_auth_methods`); `null`
+  /// picks the first advertised method — the provider — which is what we want
+  /// to authenticate against.
   @override
   String? get authMethodId => null;
 

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
@@ -38,13 +38,13 @@ class HermesPlugin._({
     final sessionOptionsService = AcpSessionOptionsService(
       configurationTracker: configurationTracker,
       commandTracker: commandTracker,
-      pluginId: HermesIdentity.pluginId,
-      agentDisplayName: HermesIdentity.displayName,
+      pluginId: HermesPluginIdentity.pluginId,
+      agentDisplayName: HermesPluginIdentity.displayName,
     );
     final mapper = AcpEventMapper(
       launchDirectory: cwd,
-      agentId: HermesIdentity.pluginId,
-      pluginId: HermesIdentity.pluginId,
+      agentId: HermesPluginIdentity.pluginId,
+      pluginId: HermesPluginIdentity.pluginId,
       configurationTracker: configurationTracker,
       contentMapper: contentMapper,
     );
@@ -61,15 +61,15 @@ class HermesPlugin._({
 
   this
     : super(
-        id: HermesIdentity.pluginId,
-        agentDisplayName: HermesIdentity.displayName,
+        id: HermesPluginIdentity.pluginId,
+        agentDisplayName: HermesPluginIdentity.displayName,
       );
 
   @override
-  String get clientName => HermesIdentity.clientName;
+  String get clientName => HermesPluginIdentity.clientName;
 
   @override
-  String get clientVersion => HermesIdentity.clientVersion;
+  String get clientVersion => HermesPluginIdentity.clientVersion;
 
   /// Hermes advertises the configured provider as an agent auth method first
   /// and a terminal-setup method after it (see `build_auth_methods`); `null`

--- a/bridge/sesori_plugin_hermes/pubspec.yaml
+++ b/bridge/sesori_plugin_hermes/pubspec.yaml
@@ -1,0 +1,19 @@
+name: hermes_plugin
+version: 0.1.0
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.13.0-0
+
+dependencies:
+  sesori_plugin_interface:
+    path: ../sesori_plugin_interface
+  sesori_bridge_foundation:
+    path: ../sesori_bridge_foundation
+  acp_plugin:
+    path: ../sesori_plugin_acp
+
+dev_dependencies:
+  test: ^1.31.1
+  lints: ^6.1.0

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
@@ -8,7 +8,9 @@ import "package:test/test.dart";
 /// The `initialize` result Hermes actually advertises (verified 2026-08-13
 /// against `hermes acp` v0.20.0): load/list/resume/fork session capabilities,
 /// image prompt support, and no `closeSession` — the base must therefore
-/// never call `session/close`.
+/// never call `session/close`. Auth mirrors `build_auth_methods()`: the
+/// configured provider as an agent method first, then a terminal-setup
+/// method.
 const Map<String, dynamic> hermesInitializeResult = {
   "protocolVersion": 1,
   "agentCapabilities": {
@@ -22,9 +24,15 @@ const Map<String, dynamic> hermesInitializeResult = {
   },
   "authMethods": [
     {
+      "id": "opencode-go",
+      "name": "opencode-go runtime credentials",
+      "description": "Authenticate Hermes using the currently configured opencode-go runtime credentials.",
+    },
+    {
       "type": "terminal",
       "id": "hermes-setup",
-      "title": "Hermes terminal setup",
+      "name": "Configure Hermes provider",
+      "description": "Open Hermes' interactive model/provider setup in a terminal.",
     },
   ],
 };
@@ -75,9 +83,16 @@ void main() {
     Future<void> connect() async {
       final connecting = plugin.ensureConnected();
       await respond("initialize", hermesInitializeResult);
-      // Hermes advertises a terminal auth method, so the handshake calls
-      // authenticate with it; a configured install answers with an empty body.
-      await respond("authenticate", const <String, dynamic>{});
+      // Hermes advertises the configured provider method first, then a
+      // terminal-setup method; the handshake authenticates against the first
+      // advertised method because authMethodId is null.
+      final authFrame = await waitForFrame("authenticate");
+      expect(
+        (authFrame["params"] as Map).cast<String, dynamic>()["methodId"],
+        "opencode-go",
+        reason: "the plugin must authenticate against the configured provider, not the setup method",
+      );
+      fake.emit({"jsonrpc": "2.0", "id": authFrame["id"], "result": <String, dynamic>{}});
       expect(await connecting, isTrue);
     }
 

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
@@ -1,0 +1,191 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_testing.dart";
+import "package:hermes_plugin/hermes_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+/// The `initialize` result Hermes actually advertises (verified 2026-08-13
+/// against `hermes acp` v0.20.0): load/list/resume/fork session capabilities,
+/// image prompt support, and no `closeSession` — the base must therefore
+/// never call `session/close`.
+const Map<String, dynamic> hermesInitializeResult = {
+  "protocolVersion": 1,
+  "agentCapabilities": {
+    "loadSession": true,
+    "promptCapabilities": {"image": true},
+    "sessionCapabilities": {
+      "fork": <String, dynamic>{},
+      "list": <String, dynamic>{},
+      "resume": <String, dynamic>{},
+    },
+  },
+  "authMethods": [
+    {
+      "type": "terminal",
+      "id": "hermes-setup",
+      "title": "Hermes terminal setup",
+    },
+  ],
+};
+
+void main() {
+  group("HermesPlugin", () {
+    late FakeAcpProcess fake;
+    late HermesPlugin plugin;
+    late Set<Object?> handledFrameIds;
+
+    setUp(() {
+      fake = FakeAcpProcess();
+      handledFrameIds = {};
+      plugin = HermesPlugin(
+        launchDirectory: "/repo",
+        processFactory: (_) async => fake,
+      );
+    });
+
+    tearDown(() async {
+      await plugin.dispose();
+      await fake.close();
+    });
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+    Future<Map<String, dynamic>> waitForFrame(String method) async {
+      for (var i = 0; i < 50; i++) {
+        final matches = fake.written.where(
+          (frame) => frame["method"] == method && !handledFrameIds.contains(frame["id"]),
+        );
+        if (matches.isNotEmpty) {
+          final frame = matches.first;
+          handledFrameIds.add(frame["id"]);
+          return frame;
+        }
+        await pump();
+      }
+      throw StateError("agent never wrote a '$method' frame");
+    }
+
+    Future<void> respond(String method, Map<String, dynamic> result) async {
+      final frame = await waitForFrame(method);
+      fake.emit({"jsonrpc": "2.0", "id": frame["id"], "result": result});
+      await pump();
+    }
+
+    Future<void> connect() async {
+      final connecting = plugin.ensureConnected();
+      await respond("initialize", hermesInitializeResult);
+      // Hermes advertises a terminal auth method, so the handshake calls
+      // authenticate with it; a configured install answers with an empty body.
+      await respond("authenticate", const <String, dynamic>{});
+      expect(await connecting, isTrue);
+    }
+
+    test("id is hermes", () {
+      expect(plugin.id, "hermes");
+    });
+
+    test("the default binary is the Hermes CLI and the launch spec drives `hermes acp`", () {
+      expect(HermesBinary.defaultBinary, "hermes");
+      final spec = HermesBinary.launchSpec(cwd: "/repo");
+      expect(spec.command, "hermes");
+      expect(spec.args, ["acp"]);
+    });
+
+    test("declares the neutral ACP policies for a stock v1 server", () {
+      expect(plugin.clientName, "sesori-bridge");
+      expect(plugin.clientVersion, "0.0.0");
+      expect(plugin.authMethodId, isNull, reason: "use the first advertised method");
+      expect(plugin.initializeCapabilityMeta, isNull);
+      expect(plugin.supportsFormElicitation, isFalse, reason: "no elicitation/create on Hermes");
+      expect(plugin.serializesPromptsProcessWide, isFalse);
+      expect(plugin.failsTurnOnSelectionError, isFalse);
+      expect(plugin.sessionCloseSettlementTimeout, const Duration(seconds: 5));
+    });
+
+    test("handshake succeeds against Hermes's advertised capabilities", () async {
+      await connect();
+    });
+
+    test("a prompt turn streams text chunks into part delta events", () async {
+      await connect();
+      final events = <BridgeSseEvent>[];
+      final subscription = plugin.events.listen(events.add);
+      addTearDown(subscription.cancel);
+
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond("session/new", const {"sessionId": "s1"});
+      final session = await creating;
+      expect(session.id, "s1");
+
+      final prompting = plugin.sendPrompt(
+        sessionId: session.id,
+        parts: const [PluginPromptPart.text(text: "Hello")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final promptFrame = await waitForFrame("session/prompt");
+      final params = (promptFrame["params"] as Map).cast<String, dynamic>();
+      expect(params["sessionId"], "s1");
+      final prompt = params["prompt"] as List;
+      expect(
+        (prompt.single as Map)["text"],
+        "Hello",
+        reason: "the prompt part must reach the agent verbatim",
+      );
+      fake.emit({"jsonrpc": "2.0", "id": promptFrame["id"], "result": <String, dynamic>{}});
+      await prompting;
+
+      // Hermes streams assistant output as session/update agent_message_chunk
+      // notifications (same shape the base mapper expects).
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": "s1",
+          "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "Hello"},
+          },
+        },
+      });
+      await pump();
+
+      expect(events.whereType<BridgeSseMessagePartDelta>().single.delta, "Hello");
+    });
+
+    test("deleteSession never calls session/close when closeSession is not advertised", () async {
+      await connect();
+
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond("session/new", const {"sessionId": "s1"});
+      await creating;
+
+      await plugin.deleteSession("s1");
+      await pump();
+
+      expect(
+        fake.written.where((frame) => frame["method"] == "session/close"),
+        isEmpty,
+        reason: "Hermes does not advertise closeSession, so deletion must be local-only",
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Complexity

⚙️ Moderate — new plugin core class, but policy-only over the existing ACP base (no new transport or protocol code).

## What

Adds the Hermes plugin core:

- `bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart` — `HermesPlugin extends AcpPlugin` declaring the harness's protocol policies: `clientName` `sesori-bridge`, `authMethodId` null (use the first advertised method — Hermes's configured provider), `supportsFormElicitation` false (no `elicitation/create`), `serializesPromptsProcessWide` false, `failsTurnOnSelectionError` false, 5s `sessionCloseSettlementTimeout`. Everything else (sessions, prompts, permissions, history replay, SSE) comes from the base machinery unchanged.
- `bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart` — 6 tests with `FakeAcpProcess`: identity, launch spec, policy values, handshake against Hermes's real advertised capabilities (load/list/resume/fork + image prompts + terminal auth), prompt streaming via `agent_message_chunk`, and — the Hermes-specific guarantee — `deleteSession` never calls `session/close` because Hermes doesn't advertise `closeSession`.

## Why

Hermes is a stock ACP v1 server, so the whole harness reduces to declaring its protocol policies. This is the same shape as `TestAcpPlugin` (the base's own neutral adapter) plus the Hermes identity and binary.

## Risk and test focus

- Behavior is inherited from the battle-tested `AcpPlugin` base; this class only pins policy. Tests assert the handshake works against the exact capabilities Hermes advertises and that no unsupported methods are attempted.
- Merge sequence: part of the `hermes-plugin` series. Base is `hermes-plugin-step2` (#896); retarget to `main` after it merges.

## Expected result

A live `HermesPlugin` that connects to a real `hermes acp` process. No user-visible or database impact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Hermes ACP plugin core and wires `sesori_plugin_hermes` into the workspace. It runs a stock ACP v1 `hermes acp` server through the base ACP machinery; deleting a session is local‑only because Hermes does not advertise `session/close`.

- Declares neutral ACP policies: clientName `sesori-bridge`, authMethodId null (use first advertised), no form elicitation, no process‑wide prompt serialization, no turn failure on selection error, 5s close‑settlement timeout.
- Provides identity and launch spec: default binary "hermes", args ["acp"], PATH‑resolved, override via binary path; sessions, prompts, permissions, history replay, and SSE come from `acp_plugin`.
- Tests verify handshake, authentication against the first advertised provider method, prompt streaming via `agent_message_chunk`, and the no `session/close` behavior.
- Adds `sesori_plugin_hermes` to the workspace and Makefile; depends on `acp_plugin`.

**Rollout**
- Part of the hermes-plugin series (step 3/9); retarget to main after step 2 lands.
- No migrations or user-visible changes. Hermes CLI must be on PATH for real runs.

<sup>Written for commit c35891375ea0d9523ba56b5fb39a1d52f2562125. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

