### PR TITLE
⚙️ [hermes-plugin] feat(hermes): add descriptor, runtime probe, and setup [step 4/9]

### DIFF
--- a/bridge/Makefile
+++ b/bridge/Makefile
@@ -2,7 +2,7 @@ TOOL_VERSIONS := $(shell git rev-parse --show-toplevel)/.tool-versions
 FLUTTER_VERSION := $(shell grep '^flutter' $(TOOL_VERSIONS) | awk '{print $$2}')
 DART := $(HOME)/.asdf/installs/flutter/$(FLUTTER_VERSION)/bin/cache/dart-sdk/bin/dart
 
-MODULES := sesori_plugin_interface sesori_bridge_foundation sesori_plugin_runtime sesori_plugin_opencode sesori_plugin_codex sesori_plugin_acp sesori_plugin_cursor sesori_plugin_omp sesori_plugin_claude sesori_plugin_pi app
+MODULES := sesori_plugin_interface sesori_bridge_foundation sesori_plugin_runtime sesori_plugin_opencode sesori_plugin_codex sesori_plugin_acp sesori_plugin_cursor sesori_plugin_omp sesori_plugin_claude sesori_plugin_pi sesori_plugin_hermes app
 
 .PHONY: codegen opencode-codegen pub-get test analyze
 

--- a/bridge/pubspec.yaml
+++ b/bridge/pubspec.yaml
@@ -16,3 +16,4 @@ workspace:
   - sesori_plugin_omp
   - sesori_plugin_claude
   - sesori_plugin_pi
+  - sesori_plugin_hermes

--- a/bridge/sesori_plugin_hermes/analysis_options.yaml
+++ b/bridge/sesori_plugin_hermes/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../app/analysis_options.yaml

--- a/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
+++ b/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
@@ -6,3 +6,6 @@
 export "src/hermes_binary.dart";
 export "src/hermes_identity.dart";
 export "src/hermes_plugin_impl.dart";
+// Plugin-lifecycle entry point: the const descriptor the bridge registers.
+export "src/runtime/hermes_plugin_descriptor.dart";
+export "src/runtime/hermes_runtime_manifest.dart";

--- a/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
+++ b/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
@@ -1,0 +1,7 @@
+// Hermes Agent backend for the Sesori bridge.
+//
+// Drives `hermes acp` over the generic ACP machinery (acp_plugin). Hermes is
+// a stock ACP v1 server (protocol version 1), so the plugin core is policy
+// only — no harness-specific protocol extensions.
+export "src/hermes_binary.dart";
+export "src/hermes_identity.dart";

--- a/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
+++ b/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
@@ -5,3 +5,4 @@
 // only — no harness-specific protocol extensions.
 export "src/hermes_binary.dart";
 export "src/hermes_identity.dart";
+export "src/hermes_plugin_impl.dart";

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
@@ -1,0 +1,25 @@
+import "package:acp_plugin/acp_plugin.dart";
+
+/// Builds the launch spec for `hermes acp`.
+///
+/// Auth is out of band: the process factory inherits the bridge's
+/// environment, so a Hermes install with a configured provider/model
+/// (via `hermes setup` / `hermes model`) is picked up automatically.
+abstract final class HermesBinary() {
+  /// The Hermes CLI launcher, resolved on PATH by the descriptor's runtime
+  /// probe (and overridable with `--hermes-bin`).
+  static const String defaultBinary = "hermes";
+
+  static AcpLaunchSpec launchSpec({
+    String binary = defaultBinary,
+    String? cwd,
+    Map<String, String> environment = const {},
+  }) {
+    return AcpLaunchSpec(
+      command: binary,
+      args: const ["acp"],
+      cwd: cwd,
+      environment: environment,
+    );
+  }
+}

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
@@ -6,8 +6,7 @@ import "package:acp_plugin/acp_plugin.dart";
 /// environment, so a Hermes install with a configured provider/model
 /// (via `hermes setup` / `hermes model`) is picked up automatically.
 abstract final class HermesBinary() {
-  /// The Hermes CLI launcher, resolved on PATH by the descriptor's runtime
-  /// probe (and overridable with `--hermes-bin`).
+  /// The Hermes CLI launcher, resolved on PATH.
   static const String defaultBinary = "hermes";
 
   static AcpLaunchSpec launchSpec({

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
@@ -1,0 +1,12 @@
+/// Identity constants for the Hermes Agent harness plugin.
+///
+/// The plugin id is the plain string `hermes` (precedent: the pi and omp
+/// plugins are not members of the legacy `Harness` enum either). Client-side
+/// brand mapping for the id can follow later without a wire-format change.
+abstract final class HermesIdentity() {
+  static const String pluginId = "hermes";
+  static const String displayName = "Hermes Agent";
+  static const String providerId = "hermes";
+  static const String clientName = "sesori-bridge";
+  static const String clientVersion = "0.0.0";
+}

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
@@ -2,7 +2,8 @@
 ///
 /// The plugin id is the plain string `hermes` (precedent: the pi and omp
 /// plugins are not members of the legacy `Harness` enum either). Client-side
-/// brand mapping for the id can follow later without a wire-format change.
+/// branding for the id is handled by `PregoBrandLogo` in module_prego (the
+/// Hermes staff mark + "Hermes Agent" display name), keyed by this id.
 abstract final class HermesIdentity() {
   static const String pluginId = "hermes";
   static const String displayName = "Hermes Agent";

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
@@ -1,13 +1,12 @@
 /// Identity constants for the Hermes Agent harness plugin.
 ///
 /// The plugin id is the plain string `hermes` (precedent: the pi and omp
-/// plugins are not members of the legacy `Harness` enum either). Client-side
-/// branding for the id is handled by `PregoBrandLogo` in module_prego (the
-/// Hermes staff mark + "Hermes Agent" display name), keyed by this id.
-abstract final class HermesIdentity() {
+/// plugins are not members of the legacy `Harness` enum either). The client
+/// brands the id through `PregoBrandLogo` in module_prego (Hermes staff mark
+/// + "Hermes Agent" display name).
+abstract final class HermesPluginIdentity() {
   static const String pluginId = "hermes";
   static const String displayName = "Hermes Agent";
-  static const String providerId = "hermes";
   static const String clientName = "sesori-bridge";
   static const String clientVersion = "0.0.0";
 }

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
@@ -1,0 +1,100 @@
+import "dart:io" show Directory;
+
+import "package:acp_plugin/acp_plugin.dart";
+
+import "hermes_binary.dart";
+import "hermes_identity.dart";
+
+/// Hermes Agent backend over ACP.
+///
+/// Hermes is a stock ACP v1 server: `hermes acp` advertises load/list/resume/
+/// fork/prompt capabilities and streams turns via `session/update`
+/// notifications, so the base [AcpPlugin] machinery applies unchanged — this
+/// class only declares the harness's protocol policies. There are no
+/// `hermes/*` extensions, no config-option model picker, and no managed
+/// runtime (Hermes installs itself; the bridge resolves it on PATH).
+class HermesPlugin._({
+  required super.launchSpec,
+  required super.launchDirectory,
+  required super.contentMapper,
+  required super.eventMapper,
+  required super.commandTracker,
+  required super.sessionOptionsService,
+  super.processFactory,
+}) extends AcpPlugin {
+  factory({
+    String binaryPath = HermesBinary.defaultBinary,
+    String? launchDirectory,
+    AcpProcessFactory? processFactory,
+  }) {
+    final cwd = launchDirectory ?? Directory.current.path;
+    final launchSpec = HermesBinary.launchSpec(
+      binary: binaryPath,
+      cwd: cwd,
+    );
+    final commandTracker = AcpCommandTracker();
+    final configurationTracker = AcpSessionConfigurationTracker();
+    const contentMapper = AcpContentMapper();
+    final sessionOptionsService = AcpSessionOptionsService(
+      configurationTracker: configurationTracker,
+      commandTracker: commandTracker,
+      pluginId: HermesIdentity.pluginId,
+      agentDisplayName: HermesIdentity.displayName,
+    );
+    final mapper = AcpEventMapper(
+      launchDirectory: cwd,
+      agentId: HermesIdentity.pluginId,
+      pluginId: HermesIdentity.pluginId,
+      configurationTracker: configurationTracker,
+      contentMapper: contentMapper,
+    );
+    return HermesPlugin._(
+      launchSpec: launchSpec,
+      launchDirectory: cwd,
+      contentMapper: contentMapper,
+      eventMapper: mapper,
+      commandTracker: commandTracker,
+      sessionOptionsService: sessionOptionsService,
+      processFactory: processFactory,
+    );
+  }
+
+  this
+    : super(
+        id: HermesIdentity.pluginId,
+        agentDisplayName: HermesIdentity.displayName,
+      );
+
+  @override
+  String get clientName => HermesIdentity.clientName;
+
+  @override
+  String get clientVersion => HermesIdentity.clientVersion;
+
+  /// Hermes advertises a provider auth method plus a terminal-setup method;
+  /// the first advertised method is the configured provider, which is what we
+  /// want to authenticate against. `null` picks it.
+  @override
+  String? get authMethodId => null;
+
+  @override
+  Map<String, dynamic>? get initializeCapabilityMeta => null;
+
+  /// Hermes has no `elicitation/create` — permissions arrive as
+  /// `session/request_permission`, which the base approval registry handles.
+  @override
+  bool get supportsFormElicitation => false;
+
+  /// Hermes serializes turns per session (one agent loop per session), so
+  /// concurrent sessions may prompt in parallel.
+  @override
+  bool get serializesPromptsProcessWide => false;
+
+  /// No harness-specific turn selection exists (base [applyTurnSelection] is
+  /// a no-op), so a selection can never fail a turn.
+  @override
+  bool get failsTurnOnSelectionError => false;
+
+  @override
+  Duration get sessionCloseSettlementTimeout => const Duration(seconds: 5);
+}

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
@@ -71,9 +71,10 @@ class HermesPlugin._({
   @override
   String get clientVersion => HermesIdentity.clientVersion;
 
-  /// Hermes advertises a provider auth method plus a terminal-setup method;
-  /// the first advertised method is the configured provider, which is what we
-  /// want to authenticate against. `null` picks it.
+  /// Hermes advertises the configured provider as an agent auth method first
+  /// and a terminal-setup method after it (see `build_auth_methods`); `null`
+  /// picks the first advertised method — the provider — which is what we want
+  /// to authenticate against.
   @override
   String? get authMethodId => null;
 

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
@@ -38,13 +38,13 @@ class HermesPlugin._({
     final sessionOptionsService = AcpSessionOptionsService(
       configurationTracker: configurationTracker,
       commandTracker: commandTracker,
-      pluginId: HermesIdentity.pluginId,
-      agentDisplayName: HermesIdentity.displayName,
+      pluginId: HermesPluginIdentity.pluginId,
+      agentDisplayName: HermesPluginIdentity.displayName,
     );
     final mapper = AcpEventMapper(
       launchDirectory: cwd,
-      agentId: HermesIdentity.pluginId,
-      pluginId: HermesIdentity.pluginId,
+      agentId: HermesPluginIdentity.pluginId,
+      pluginId: HermesPluginIdentity.pluginId,
       configurationTracker: configurationTracker,
       contentMapper: contentMapper,
     );
@@ -61,15 +61,15 @@ class HermesPlugin._({
 
   this
     : super(
-        id: HermesIdentity.pluginId,
-        agentDisplayName: HermesIdentity.displayName,
+        id: HermesPluginIdentity.pluginId,
+        agentDisplayName: HermesPluginIdentity.displayName,
       );
 
   @override
-  String get clientName => HermesIdentity.clientName;
+  String get clientName => HermesPluginIdentity.clientName;
 
   @override
-  String get clientVersion => HermesIdentity.clientVersion;
+  String get clientVersion => HermesPluginIdentity.clientVersion;
 
   /// Hermes advertises the configured provider as an agent auth method first
   /// and a terminal-setup method after it (see `build_auth_methods`); `null`

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -114,7 +114,9 @@ class const HermesPluginDescriptor({
         return PluginSetupRuntimeMissing(
           actionHint: explicitBin != null
               ? "Fix the configured Hermes CLI path, then restart the bridge."
-              : "Install Hermes Agent locally, then retry setup detection.",
+              : runtime.preAcpInstall
+                  ? "The installed Hermes does not expose the `acp` subcommand. Update Hermes, then retry setup detection."
+                  : "Install Hermes Agent locally, then retry setup detection.",
         );
       case _HermesRuntimeProbeState.outdated:
         return const PluginSetupUnavailable(
@@ -145,7 +147,19 @@ class const HermesPluginDescriptor({
         environment: environment,
         timeout: _versionProbeTimeout,
       );
-    } on Object {
+    } on TimeoutException catch (error, stackTrace) {
+      Log.w("[hermes] status probe '$executablePath status' did not exit within ${_versionProbeTimeout.inSeconds}s", error, stackTrace);
+      return const PluginSetupUnknown(
+        actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
+      );
+    } on Object catch (error, stackTrace) {
+      Log.w("[hermes] status probe could not launch '$executablePath status'", error, stackTrace);
+      return const PluginSetupUnknown(
+        actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
+      );
+    }
+    if (statusResult.exitCode != 0) {
+      Log.w("[hermes] status probe '$executablePath status' exited with code ${statusResult.exitCode}");
       return const PluginSetupUnknown(
         actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
       );
@@ -164,7 +178,7 @@ class const HermesPluginDescriptor({
     );
   }
 
-  Future<({_HermesRuntimeProbeState state, String? version})> _probeHermesRuntime({
+  Future<({_HermesRuntimeProbeState state, String? version, bool preAcpInstall})> _probeHermesRuntime({
     required String executablePath,
     required HostProcessService processes,
     required Map<String, String> environment,
@@ -189,35 +203,41 @@ class const HermesPluginDescriptor({
         "[hermes] availability probe '$executablePath acp --version' did not exit within "
         "${_versionProbeTimeout.inSeconds}s",
       );
-      return (state: _HermesRuntimeProbeState.unknown, version: null);
-    } on Object catch (error) {
-      // Spawn could not launch — almost always ENOENT: not installed / not on PATH.
-      Log.d("[hermes] availability probe could not launch '$executablePath acp --version': $error");
-      return (state: _HermesRuntimeProbeState.missing, version: null);
+      return (state: _HermesRuntimeProbeState.unknown, version: null, preAcpInstall: false);
+    } on io.ProcessException catch (error) {
+      // The host process seam reports spawn failures as ProcessException;
+      // ENOENT (errorCode 2) means not installed / not on PATH.
+      Log.d("[hermes] availability probe could not launch '$executablePath acp --version' (${error.errorCode})");
+      return (state: _HermesRuntimeProbeState.missing, version: null, preAcpInstall: false);
+    } on Object catch (error, stackTrace) {
+      // Any other spawn failure (host seam error, permission) is not proof of
+      // a missing runtime — report unknown rather than a misleading hint.
+      Log.w("[hermes] availability probe could not launch '$executablePath acp --version'", error, stackTrace);
+      return (state: _HermesRuntimeProbeState.unknown, version: null, preAcpInstall: false);
     }
 
     if (result.exitCode != 0) {
       Log.d("[hermes] availability probe '$executablePath acp --version' exited with code ${result.exitCode}");
       // A pre-ACP install answers `--version` but rejects the `acp` subcommand
-      // with a nonzero exit; treat that as missing, not unknown, so the setup
-      // hint points at updating the install.
+      // with a nonzero exit; surface that as missing with an update hint, not
+      // as an unknown failure.
       if (result.stderr.contains("acp") && (result.stderr.contains("invalid choice") || result.stderr.contains("error"))) {
-        return (state: _HermesRuntimeProbeState.missing, version: null);
+        return (state: _HermesRuntimeProbeState.missing, version: null, preAcpInstall: true);
       }
-      return (state: _HermesRuntimeProbeState.unknown, version: null);
+      return (state: _HermesRuntimeProbeState.unknown, version: null, preAcpInstall: false);
     }
 
     final parsed = HermesRuntimeManifest.tryParseVersion(value: result.stdout.trim());
     if (parsed == null) {
-      return (state: _HermesRuntimeProbeState.unrecognized, version: null);
+      return (state: _HermesRuntimeProbeState.unrecognized, version: null, preAcpInstall: false);
     }
     if (parsed.compareTo(HermesRuntimeManifest.minAcpVersion) < 0) {
       Log.w("[hermes] Hermes ACP adapter ${parsed.toString()} is below the supported minimum ${HermesRuntimeManifest.minAcpVersion.toString()}");
-      return (state: _HermesRuntimeProbeState.outdated, version: parsed.toString());
+      return (state: _HermesRuntimeProbeState.outdated, version: parsed.toString(), preAcpInstall: false);
     }
     final version = parsed.toString();
     Log.d("[hermes] available: '$executablePath acp --version' -> $version");
-    return (state: _HermesRuntimeProbeState.ready, version: version);
+    return (state: _HermesRuntimeProbeState.ready, version: version, preAcpInstall: false);
   }
 
   String _normalizedStatusOutput(CommandResult result) {
@@ -290,8 +310,8 @@ class const HermesPluginDescriptor({
     Future<Never> rollbackAborted() async {
       try {
         await plugin.shutdown(budget: null);
-      } on Object catch (error) {
-        Log.e("[hermes] rollback after aborted start failed: $error");
+      } on Object catch (error, stackTrace) {
+        Log.e("[hermes] rollback after aborted start failed", error, stackTrace);
       }
       throw const PluginStartAbortedException();
     }

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -67,10 +67,10 @@ class const HermesPluginDescriptor({
   ];
 
   @override
-  String get id => HermesIdentity.pluginId;
+  String get id => HermesPluginIdentity.pluginId;
 
   @override
-  String get displayName => HermesIdentity.displayName;
+  String get displayName => HermesPluginIdentity.displayName;
 
   @override
   PluginProjectOwnership get projectOwnership => PluginProjectOwnership.bridgeDerived;

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -160,11 +160,12 @@ class const HermesPluginDescriptor({
     }
     if (statusResult.exitCode != 0) {
       Log.w("[hermes] status probe '$executablePath status' exited with code ${statusResult.exitCode}");
-      return const PluginSetupUnknown(
-        actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
-      );
     }
     final statusOutput = _normalizedStatusOutput(statusResult);
+    // Output is the source of truth: a nonzero exit with a real `Model:` value
+    // still means the model is configured (the ACP handshake is the actual
+    // auth gate at connect time); the exit code only breaks ties when the
+    // output is ambiguous.
     if (_statusIndicatesConfigured(statusOutput)) {
       return const PluginSetupReady();
     }

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -1,0 +1,313 @@
+import "dart:async";
+import "dart:io" as io;
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart"
+    show CommandResult, HostProcessCommandExecutor;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../hermes_binary.dart";
+import "../hermes_identity.dart";
+import "../hermes_plugin_impl.dart";
+import "hermes_runtime_manifest.dart";
+
+const int _setupProbeOutputLimit = 64 * 1024;
+
+/// Builds the live [HermesPlugin] for a resolved binary. The production
+/// default constructs the real plugin wired to the host-backed process
+/// factory; tests inject a fake to avoid spawning the Hermes CLI.
+typedef HermesPluginFactory = HermesPlugin Function({
+  required String binaryPath,
+  required String launchDirectory,
+  required AcpProcessFactory processFactory,
+});
+
+HermesPlugin _defaultBuildPlugin({
+  required String binaryPath,
+  required String launchDirectory,
+  required AcpProcessFactory processFactory,
+}) {
+  return HermesPlugin(
+    binaryPath: binaryPath,
+    launchDirectory: launchDirectory,
+    processFactory: processFactory,
+  );
+}
+
+/// The const Hermes Agent plugin descriptor.
+///
+/// Hermes drives a `hermes acp` stdio subprocess over the generic ACP
+/// machinery, so it needs no managed-runtime supervisor and no managed
+/// install (Hermes installs itself; the bridge resolves it on PATH). It
+/// declares its CLI surface, probes the `hermes` CLI for availability and a
+/// configured model/provider, and on [start] spawns the agent through the
+/// [PluginHost] process seam and returns an [AcpBridgePlugin].
+///
+/// The optional constructor parameters are test seams; the registered instance
+/// is `const HermesPluginDescriptor()`.
+class const HermesPluginDescriptor({
+  final HermesPluginFactory? _buildPlugin,
+  final Duration _connectBudget = const Duration(seconds: 15),
+  final Duration _versionProbeTimeout = const Duration(seconds: 10),
+}) extends BridgePluginDescriptor {
+  /// CLI option naming the Hermes CLI binary (path or PATH name). Declared
+  /// as the bare local name — the bridge's [PluginCliOptionsMapper] namespaces
+  /// it to the public `--hermes-bin` flag.
+  static const String binOption = "bin";
+
+  static const List<PluginOption> cliOptions = [
+    PluginValueOption(
+      name: binOption,
+      help: "Path to the Hermes CLI binary (hermes)",
+      defaultsTo: HermesBinary.defaultBinary,
+      allowedValues: null,
+      valueHelp: "path",
+      validate: null,
+    ),
+  ];
+
+  @override
+  String get id => HermesIdentity.pluginId;
+
+  @override
+  String get displayName => HermesIdentity.displayName;
+
+  @override
+  PluginProjectOwnership get projectOwnership => PluginProjectOwnership.bridgeDerived;
+
+  @override
+  PluginSessionOptionsScope get sessionOptionsScope => PluginSessionOptionsScope.plugin;
+
+  /// Hermes advertises `prompt_capabilities.image` at initialize, so the
+  /// phone attachment flow works against this backend as-is.
+  @override
+  bool get supportsPromptAttachments => true;
+
+  @override
+  List<PluginOption> get options => cliOptions;
+
+  /// The explicit `--hermes-bin` override, or null when unset, empty, or left
+  /// at the bare default (which means "resolve on PATH").
+  String? _explicitBin(PluginConfig config) {
+    final value = config.value(binOption)?.trim();
+    if (value == null || value.isEmpty || value == HermesBinary.defaultBinary) return null;
+    return value;
+  }
+
+  @override
+  Future<PluginSetupStatus> inspectSetup({
+    required PluginConfig config,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+    required String stateDirectory,
+  }) async {
+    final explicitBin = _explicitBin(config);
+    final executablePath = explicitBin ?? HermesBinary.defaultBinary;
+    final runtime = await _probeHermesRuntime(
+      executablePath: executablePath,
+      processes: processes,
+      environment: environment,
+    );
+
+    switch (runtime.state) {
+      case _HermesRuntimeProbeState.missing:
+        return PluginSetupRuntimeMissing(
+          actionHint: explicitBin != null
+              ? "Fix the configured Hermes CLI path, then restart the bridge."
+              : "Install Hermes Agent locally, then retry setup detection.",
+        );
+      case _HermesRuntimeProbeState.outdated:
+        return const PluginSetupUnavailable(
+          actionHint: "The installed Hermes ACP adapter is too old. Update Hermes and restart the bridge.",
+        );
+      case _HermesRuntimeProbeState.unrecognized:
+      case _HermesRuntimeProbeState.unknown:
+        return const PluginSetupUnknown(
+          actionHint: "Hermes setup could not be determined. Verify the local install and retry.",
+        );
+      case _HermesRuntimeProbeState.ready:
+        break;
+    }
+
+    // Auth probe: `hermes status` reports the configured model/provider.
+    // Best-effort — the true gate is the ACP handshake at connect time, which
+    // degrades the plugin without failing the bridge.
+    final executor = HostProcessCommandExecutor(
+      processes: processes,
+      runInShell: io.Platform.isWindows,
+      maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
+    );
+    final CommandResult statusResult;
+    try {
+      statusResult = await executor.run(
+        executablePath,
+        const ["status"],
+        environment: environment,
+        timeout: _versionProbeTimeout,
+      );
+    } on Object {
+      return const PluginSetupUnknown(
+        actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
+      );
+    }
+    final statusOutput = _normalizedStatusOutput(statusResult);
+    if (_statusIndicatesConfigured(statusOutput)) {
+      return const PluginSetupReady();
+    }
+    if (_statusIndicatesUnconfigured(statusOutput)) {
+      return const PluginSetupAuthenticationRequired(
+        actionHint: "Configure a model and provider with `hermes setup` or `hermes model` on this machine, then retry setup detection.",
+      );
+    }
+    return const PluginSetupUnknown(
+      actionHint: "Hermes setup could not be determined. Run `hermes status` locally and retry.",
+    );
+  }
+
+  Future<({_HermesRuntimeProbeState state, String? version})> _probeHermesRuntime({
+    required String executablePath,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+  }) async {
+    final executor = HostProcessCommandExecutor(
+      processes: processes,
+      runInShell: io.Platform.isWindows,
+      maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
+    );
+    final CommandResult result;
+    try {
+      result = await executor.run(
+        executablePath,
+        const ["acp", "--version"],
+        environment: environment,
+        timeout: _versionProbeTimeout,
+      );
+    } on TimeoutException {
+      // The probe launched but never exited (executor force-killed it):
+      // installed but not answering.
+      Log.d(
+        "[hermes] availability probe '$executablePath acp --version' did not exit within "
+        "${_versionProbeTimeout.inSeconds}s",
+      );
+      return (state: _HermesRuntimeProbeState.unknown, version: null);
+    } on Object catch (error) {
+      // Spawn could not launch — almost always ENOENT: not installed / not on PATH.
+      Log.d("[hermes] availability probe could not launch '$executablePath acp --version': $error");
+      return (state: _HermesRuntimeProbeState.missing, version: null);
+    }
+
+    if (result.exitCode != 0) {
+      Log.d("[hermes] availability probe '$executablePath acp --version' exited with code ${result.exitCode}");
+      // A pre-ACP install answers `--version` but rejects the `acp` subcommand
+      // with a nonzero exit; treat that as missing, not unknown, so the setup
+      // hint points at updating the install.
+      if (result.stderr.contains("acp") && (result.stderr.contains("invalid choice") || result.stderr.contains("error"))) {
+        return (state: _HermesRuntimeProbeState.missing, version: null);
+      }
+      return (state: _HermesRuntimeProbeState.unknown, version: null);
+    }
+
+    final parsed = HermesRuntimeManifest.tryParseVersion(value: result.stdout.trim());
+    if (parsed == null) {
+      return (state: _HermesRuntimeProbeState.unrecognized, version: null);
+    }
+    if (parsed.compareTo(HermesRuntimeManifest.minAcpVersion) < 0) {
+      Log.w("[hermes] Hermes ACP adapter ${parsed.toString()} is below the supported minimum ${HermesRuntimeManifest.minAcpVersion.toString()}");
+      return (state: _HermesRuntimeProbeState.outdated, version: parsed.toString());
+    }
+    final version = parsed.toString();
+    Log.d("[hermes] available: '$executablePath acp --version' -> $version");
+    return (state: _HermesRuntimeProbeState.ready, version: version);
+  }
+
+  String _normalizedStatusOutput(CommandResult result) {
+    final combined = "${result.stdout}\n${result.stderr}";
+    return combined.replaceAll(RegExp(r"\x1B\[[0-?]*[ -/]*[@-~]"), "").trim().toLowerCase();
+  }
+
+  /// True when `hermes status` reports an actual model selection (the
+  /// "Environment" block's `Model:` line holds a real value).
+  bool _statusIndicatesConfigured(String output) {
+    for (final rawLine in output.split("\n")) {
+      final line = rawLine.trim();
+      if (!line.startsWith("model:")) continue;
+      final value = line.substring("model:".length).trim();
+      return value.isNotEmpty &&
+          !RegExp(
+            r"^(none|not set|unset|\(none\)|\(not set\)|✗|—|-)$",
+            caseSensitive: false,
+          ).hasMatch(value);
+    }
+    return false;
+  }
+
+  /// True when `hermes status` explicitly reports no model selection.
+  bool _statusIndicatesUnconfigured(String output) {
+    for (final rawLine in output.split("\n")) {
+      final line = rawLine.trim();
+      if (!line.startsWith("model:")) continue;
+      final value = line.substring("model:".length).trim();
+      return RegExp(
+        r"^(none|not set|unset|\(none\)|\(not set\)|✗|—|-)$",
+        caseSensitive: false,
+      ).hasMatch(value);
+    }
+    return false;
+  }
+
+  @override
+  Future<BridgePlugin> start(PluginHost host) async {
+    if (host.startAborted.isAborted) {
+      throw const PluginStartAbortedException();
+    }
+
+    final binaryPath = _explicitBin(host.config) ?? HermesBinary.defaultBinary;
+
+    // Route the agent subprocess through the host process seam rather than
+    // io.Process.start, so the bridge owns identity capture and signalling.
+    final processFactory = hostProcessAcpFactory(
+      processes: host.processes,
+      environment: host.environment,
+    );
+
+    final hermes = (_buildPlugin ?? _defaultBuildPlugin)(
+      binaryPath: binaryPath,
+      // The bridge seeds the launch directory as an always-present project;
+      // the bridge itself owns all project/session persistence for this
+      // derive-style plugin, so the plugin needs no store of its own.
+      launchDirectory: io.Directory.current.path,
+      processFactory: processFactory,
+    );
+
+    final plugin = AcpBridgePlugin(
+      plugin: hermes,
+      clock: host.clock,
+      endpoint: "$binaryPath acp",
+    );
+
+    // Rolls back the spawned agent and surfaces an abort that arrived while
+    // connecting rather than returning a live plugin.
+    Future<Never> rollbackAborted() async {
+      try {
+        await plugin.shutdown(budget: null);
+      } on Object catch (error) {
+        Log.e("[hermes] rollback after aborted start failed: $error");
+      }
+      throw const PluginStartAbortedException();
+    }
+
+    // Eagerly spawn the agent and run the ACP handshake (bounded), so the
+    // first mobile request is fast and the status reflects reality. A
+    // timeout/failure leaves the plugin degraded rather than failing the
+    // bridge.
+    await plugin.connect(budget: _connectBudget, startAborted: host.startAborted);
+
+    if (host.startAborted.isAborted) {
+      await rollbackAborted();
+    }
+
+    return plugin;
+  }
+}
+
+enum _HermesRuntimeProbeState() { ready, missing, outdated, unknown, unrecognized }

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_runtime_manifest.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_runtime_manifest.dart
@@ -1,0 +1,26 @@
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+
+/// Pinned facts about the Hermes ACP adapter the bridge gates on.
+///
+/// Hermes has no Sesori-managed runtime: it installs itself via its own
+/// installer and the bridge resolves it on PATH (or via `--hermes-bin`). This
+/// manifest only pins the minimum adapter version and the version parsing.
+///
+/// Note the version identity: `hermes acp --version` reports the ACP adapter's
+/// own version (e.g. `0.20.0`), not the Hermes release version. The probe
+/// gates on the adapter version, which is the surface the bridge talks to.
+abstract final class HermesRuntimeManifest() {
+  /// Minimum ACP adapter version the bridge uses as-is. Older adapters either
+  /// predate the `hermes acp` surface entirely or lack behavior the base ACP
+  /// machinery relies on.
+  static final SemanticVersion minAcpVersion = SemanticVersion.parse(value: "0.20.0");
+
+  /// Parses the bare version `hermes acp --version` prints (`0.20.0`),
+  /// tolerating an optional leading `v` defensively. Returns null when the
+  /// output is not a recognizable semver.
+  static SemanticVersion? tryParseVersion({required String value}) {
+    final trimmed = value.trim();
+    final withoutPrefix = trimmed.startsWith("v") ? trimmed.substring(1) : trimmed;
+    return SemanticVersion.tryParse(value: withoutPrefix);
+  }
+}

--- a/bridge/sesori_plugin_hermes/pubspec.yaml
+++ b/bridge/sesori_plugin_hermes/pubspec.yaml
@@ -1,0 +1,19 @@
+name: hermes_plugin
+version: 0.1.0
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.13.0-0
+
+dependencies:
+  sesori_plugin_interface:
+    path: ../sesori_plugin_interface
+  sesori_bridge_foundation:
+    path: ../sesori_bridge_foundation
+  acp_plugin:
+    path: ../sesori_plugin_acp
+
+dev_dependencies:
+  test: ^1.31.1
+  lints: ^6.1.0

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
@@ -99,6 +99,52 @@ void main() {
       );
     });
 
+    test("reports unknown when the host process seam fails for a non-spawn reason", () async {
+      final processes = _ProbeProcessService(
+        spawnError: StateError("host process seam unavailable"),
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(
+        result,
+        isA<PluginSetupUnknown>(),
+        reason: "a non-ENOENT spawn failure is not proof of a missing runtime",
+      );
+    });
+
+    test("reports runtime missing with an update hint for a pre-ACP install", () async {
+      final processes = _ProbeProcessService(
+        processSequence: [
+          _ProbeProcess(
+            pid: 1,
+            stdoutBytes: utf8.encode(""),
+            stderrBytes: utf8.encode("Usage: hermes ...\ninvalid choice: 'acp'\n"),
+            exitCode: Future<int>.value(2),
+          ),
+        ],
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, isA<PluginSetupRuntimeMissing>());
+      expect(
+        (result as PluginSetupRuntimeMissing).actionHint,
+        contains("Update Hermes"),
+        reason: "the binary exists but predates the acp subcommand",
+      );
+    });
+
     test("reports unavailable when the ACP adapter is below the floor", () async {
       final processes = _ProbeProcessService(
         processSequence: [
@@ -324,11 +370,12 @@ class _ProbeProcessService({
   );
 }
 
-/// A canned [SpawnedProcess] with a fixed stdout payload and a caller-supplied
-/// [exitCode] future.
+/// A canned [SpawnedProcess] with fixed stdout/stderr payloads and a
+/// caller-supplied [exitCode] future.
 class _ProbeProcess({
   @override required final int pid,
   required final List<int> _stdoutBytes,
+  final List<int> _stderrBytes = const <int>[],
   required final Future<int> _exitCode,
 }) implements SpawnedProcess {
   @override
@@ -338,7 +385,7 @@ class _ProbeProcess({
   Stream<List<int>> get stdout => Stream<List<int>>.value(_stdoutBytes);
 
   @override
-  Stream<List<int>> get stderr => const Stream<List<int>>.empty();
+  Stream<List<int>> get stderr => Stream<List<int>>.value(_stderrBytes);
 
   @override
   IOSink get stdin => throw UnimplementedError();

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
@@ -1,0 +1,348 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:hermes_plugin/hermes_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("HermesRuntimeManifest", () {
+    test("pins the minimum ACP adapter version the bridge supports", () {
+      expect(HermesRuntimeManifest.minAcpVersion.toString(), "0.20.0");
+    });
+
+    test("parses the bare adapter version `hermes acp --version` prints", () {
+      expect(HermesRuntimeManifest.tryParseVersion(value: "0.20.0\n")?.toString(), "0.20.0");
+      expect(HermesRuntimeManifest.tryParseVersion(value: "v0.20.0")?.toString(), "0.20.0");
+    });
+
+    test("rejects unparseable output", () {
+      expect(HermesRuntimeManifest.tryParseVersion(value: "hermes-acp 0.20"), isNull);
+      expect(HermesRuntimeManifest.tryParseVersion(value: ""), isNull);
+    });
+  });
+
+  group("HermesPluginDescriptor", () {
+    const stateDirectory = "/state";
+    const config = PluginConfig(
+      values: {
+        HermesPluginDescriptor.binOption: HermesBinary.defaultBinary,
+      },
+    );
+
+    test("pins the identity and harness facts", () {
+      expect(const HermesPluginDescriptor().id, "hermes");
+      expect(const HermesPluginDescriptor().displayName, "Hermes Agent");
+      expect(const HermesPluginDescriptor().projectOwnership, PluginProjectOwnership.bridgeDerived);
+      expect(const HermesPluginDescriptor().sessionOptionsScope, PluginSessionOptionsScope.plugin);
+      expect(const HermesPluginDescriptor().supportsPromptAttachments, isTrue,
+          reason: "Hermes advertises prompt image support");
+    });
+
+    test("declares only the binary option and no install capability", () {
+      const descriptor = HermesPluginDescriptor();
+      expect(descriptor.options, hasLength(1));
+      expect(descriptor.options.single.name, HermesPluginDescriptor.binOption);
+      expect(
+        descriptor.managementCapabilities(config: config),
+        isNot(contains(PluginControlCapability.install)),
+        reason: "Hermes installs itself; the bridge never manages its runtime",
+      );
+    });
+
+    test("reports ready after version and status probes", () async {
+      final processes = _ProbeProcessService(
+        processSequence: [
+          _ProbeProcess(pid: 1, stdoutBytes: utf8.encode("0.20.0\n"), exitCode: Future<int>.value(0)),
+          _ProbeProcess(
+            pid: 2,
+            stdoutBytes: utf8.encode("Model: deepseek-v4-flash\nProvider: OpenCode Go\n"),
+            exitCode: Future<int>.value(0),
+          ),
+        ],
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, const PluginSetupReady());
+      expect(processes.spawnedExecutables, ["hermes", "hermes"]);
+      expect(processes.spawnedArguments, [
+        const ["acp", "--version"],
+        const ["status"],
+      ]);
+    });
+
+    test("reports runtime missing when the CLI cannot spawn", () async {
+      final processes = _ProbeProcessService(
+        spawnError: const ProcessException("hermes", []),
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, isA<PluginSetupRuntimeMissing>());
+      expect(
+        (result as PluginSetupRuntimeMissing).actionHint,
+        contains("Install Hermes Agent"),
+      );
+    });
+
+    test("reports unavailable when the ACP adapter is below the floor", () async {
+      final processes = _ProbeProcessService(
+        processSequence: [
+          _ProbeProcess(pid: 1, stdoutBytes: utf8.encode("0.19.0\n"), exitCode: Future<int>.value(0)),
+        ],
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, isA<PluginSetupUnavailable>());
+    });
+
+    test("reports unknown when the version output is unrecognized", () async {
+      final processes = _ProbeProcessService(
+        processSequence: [
+          _ProbeProcess(pid: 1, stdoutBytes: utf8.encode("not-a-version\n"), exitCode: Future<int>.value(0)),
+        ],
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, isA<PluginSetupUnknown>());
+    });
+
+    test("reports authentication required when no model is configured", () async {
+      final processes = _ProbeProcessService(
+        processSequence: [
+          _ProbeProcess(pid: 1, stdoutBytes: utf8.encode("0.20.0\n"), exitCode: Future<int>.value(0)),
+          _ProbeProcess(
+            pid: 2,
+            stdoutBytes: utf8.encode("Model: (not set)\nProvider: none\n"),
+            exitCode: Future<int>.value(0),
+          ),
+        ],
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, isA<PluginSetupAuthenticationRequired>());
+    });
+
+    test("uses an explicit --hermes-bin override for every probe", () async {
+      final processes = _ProbeProcessService(
+        processSequence: [
+          _ProbeProcess(pid: 1, stdoutBytes: utf8.encode("0.20.0\n"), exitCode: Future<int>.value(0)),
+          _ProbeProcess(
+            pid: 2,
+            stdoutBytes: utf8.encode("Model: gpt-5.4\nProvider: openai\n"),
+            exitCode: Future<int>.value(0),
+          ),
+        ],
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: const PluginConfig(values: {HermesPluginDescriptor.binOption: "/custom/hermes"}),
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, const PluginSetupReady());
+      expect(processes.spawnedExecutables, ["/custom/hermes", "/custom/hermes"]);
+    });
+
+    test("start spawns exactly one `hermes acp` process and connects", () async {
+      const descriptor = HermesPluginDescriptor(
+        buildPlugin: _buildTestPlugin,
+      );
+      spawnedAcpProcesses.clear();
+      final handledFrameIds = <Object?>{};
+      var responding = true;
+
+      final responsePump = () async {
+        while (responding) {
+          for (final process in spawnedAcpProcesses) {
+            for (final frame in process.written) {
+              final id = frame["id"];
+              if (id == null || !handledFrameIds.add(id)) continue;
+              if (frame["method"] == "initialize") {
+                process.emit({
+                  "jsonrpc": "2.0",
+                  "id": id,
+                  "result": const {
+                    "protocolVersion": 1,
+                    "agentCapabilities": <String, dynamic>{},
+                    "authMethods": <Object?>[],
+                  },
+                });
+              }
+            }
+          }
+          await Future<void>.delayed(Duration.zero);
+        }
+      }();
+
+      final plugin = await descriptor.start(
+        _StartPluginHost(
+          processes: _ProbeProcessService(
+            spawnError: StateError("injected plugin must own the test process"),
+          ),
+        ),
+      );
+      responding = false;
+      await responsePump;
+
+      expect(
+        spawnedAcpProcesses,
+        hasLength(1),
+        reason: "descriptor startup must only initialize the live ACP process",
+      );
+
+      await plugin.shutdown(budget: null);
+      for (final process in spawnedAcpProcesses) {
+        await process.close();
+      }
+    });
+  });
+}
+
+/// Injected test seam: builds a [HermesPlugin] backed by a fake process and
+/// records every spawned fake for the response pump.
+HermesPlugin _buildTestPlugin({
+  required String binaryPath,
+  required String launchDirectory,
+  required AcpProcessFactory processFactory,
+}) {
+  return HermesPlugin(
+    binaryPath: binaryPath,
+    launchDirectory: launchDirectory,
+    processFactory: (_) async {
+      final process = FakeAcpProcess();
+      spawnedAcpProcesses.add(process);
+      return process;
+    },
+  );
+}
+
+// Keep the injected factory's captured processes reachable without plumbing
+// through the typedef (the test seam closure above shares this list).
+final List<FakeAcpProcess> spawnedAcpProcesses = <FakeAcpProcess>[];
+
+class _StartPluginHost({@override required final HostProcessService processes}) implements PluginHost {
+  @override
+  PluginConfig get config => const PluginConfig(
+    values: {
+      HermesPluginDescriptor.binOption: HermesBinary.defaultBinary,
+    },
+  );
+
+  @override
+  Map<String, String> get environment => const {"HOME": "/tmp"};
+
+  @override
+  String? get provisionedRuntimePath => null;
+
+  @override
+  ServerClock get clock => const ServerClock();
+
+  @override
+  StartAbortSignal get startAborted => StartAbortSignal.never;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// A [HostProcessService] that either throws on [spawn] (to simulate ENOENT)
+/// or returns canned [_ProbeProcess]es in order. Records the spawn arguments.
+class _ProbeProcessService({
+  final Object? spawnError,
+  final List<_ProbeProcess>? processSequence,
+}) implements HostProcessService {
+  int _nextProcess = 0;
+  final List<String> spawnedExecutables = <String>[];
+  final List<List<String>> spawnedArguments = <List<String>>[];
+
+  @override
+  Future<SpawnedProcess> spawn({
+    required String executable,
+    required List<String> arguments,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+    required bool runInShell,
+  }) async {
+    spawnedExecutables.add(executable);
+    spawnedArguments.add(List<String>.from(arguments));
+    final error = spawnError;
+    if (error != null) {
+      throw error;
+    }
+    return processSequence![_nextProcess++];
+  }
+
+  @override
+  Future<ProcessIdentity?> inspect({required int pid}) async => null;
+
+  @override
+  Future<SignalResult> signalGraceful({required int pid}) async => _signal(pid);
+
+  @override
+  Future<SignalResult> signalForce({required int pid}) async => _signal(pid);
+
+  SignalResult _signal(int pid) => SignalResult(
+    pid: pid,
+    requestedSignal: ShutdownSignal.force,
+    deliveredSignal: ProcessSignal.sigkill,
+    wasRequested: true,
+    attemptedAt: DateTime.utc(2026, 6, 1),
+  );
+}
+
+/// A canned [SpawnedProcess] with a fixed stdout payload and a caller-supplied
+/// [exitCode] future.
+class _ProbeProcess({
+  @override required final int pid,
+  required final List<int> _stdoutBytes,
+  required final Future<int> _exitCode,
+}) implements SpawnedProcess {
+  @override
+  Future<int> get exitCode => _exitCode;
+
+  @override
+  Stream<List<int>> get stdout => Stream<List<int>>.value(_stdoutBytes);
+
+  @override
+  Stream<List<int>> get stderr => const Stream<List<int>>.empty();
+
+  @override
+  IOSink get stdin => throw UnimplementedError();
+
+  @override
+  ProcessIdentity get identity => throw UnimplementedError();
+}

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
@@ -8,7 +8,9 @@ import "package:test/test.dart";
 /// The `initialize` result Hermes actually advertises (verified 2026-08-13
 /// against `hermes acp` v0.20.0): load/list/resume/fork session capabilities,
 /// image prompt support, and no `closeSession` — the base must therefore
-/// never call `session/close`.
+/// never call `session/close`. Auth mirrors `build_auth_methods()`: the
+/// configured provider as an agent method first, then a terminal-setup
+/// method.
 const Map<String, dynamic> hermesInitializeResult = {
   "protocolVersion": 1,
   "agentCapabilities": {
@@ -22,9 +24,15 @@ const Map<String, dynamic> hermesInitializeResult = {
   },
   "authMethods": [
     {
+      "id": "opencode-go",
+      "name": "opencode-go runtime credentials",
+      "description": "Authenticate Hermes using the currently configured opencode-go runtime credentials.",
+    },
+    {
       "type": "terminal",
       "id": "hermes-setup",
-      "title": "Hermes terminal setup",
+      "name": "Configure Hermes provider",
+      "description": "Open Hermes' interactive model/provider setup in a terminal.",
     },
   ],
 };
@@ -75,9 +83,16 @@ void main() {
     Future<void> connect() async {
       final connecting = plugin.ensureConnected();
       await respond("initialize", hermesInitializeResult);
-      // Hermes advertises a terminal auth method, so the handshake calls
-      // authenticate with it; a configured install answers with an empty body.
-      await respond("authenticate", const <String, dynamic>{});
+      // Hermes advertises the configured provider method first, then a
+      // terminal-setup method; the handshake authenticates against the first
+      // advertised method because authMethodId is null.
+      final authFrame = await waitForFrame("authenticate");
+      expect(
+        (authFrame["params"] as Map).cast<String, dynamic>()["methodId"],
+        "opencode-go",
+        reason: "the plugin must authenticate against the configured provider, not the setup method",
+      );
+      fake.emit({"jsonrpc": "2.0", "id": authFrame["id"], "result": <String, dynamic>{}});
       expect(await connecting, isTrue);
     }
 

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
@@ -1,0 +1,191 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_testing.dart";
+import "package:hermes_plugin/hermes_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+/// The `initialize` result Hermes actually advertises (verified 2026-08-13
+/// against `hermes acp` v0.20.0): load/list/resume/fork session capabilities,
+/// image prompt support, and no `closeSession` — the base must therefore
+/// never call `session/close`.
+const Map<String, dynamic> hermesInitializeResult = {
+  "protocolVersion": 1,
+  "agentCapabilities": {
+    "loadSession": true,
+    "promptCapabilities": {"image": true},
+    "sessionCapabilities": {
+      "fork": <String, dynamic>{},
+      "list": <String, dynamic>{},
+      "resume": <String, dynamic>{},
+    },
+  },
+  "authMethods": [
+    {
+      "type": "terminal",
+      "id": "hermes-setup",
+      "title": "Hermes terminal setup",
+    },
+  ],
+};
+
+void main() {
+  group("HermesPlugin", () {
+    late FakeAcpProcess fake;
+    late HermesPlugin plugin;
+    late Set<Object?> handledFrameIds;
+
+    setUp(() {
+      fake = FakeAcpProcess();
+      handledFrameIds = {};
+      plugin = HermesPlugin(
+        launchDirectory: "/repo",
+        processFactory: (_) async => fake,
+      );
+    });
+
+    tearDown(() async {
+      await plugin.dispose();
+      await fake.close();
+    });
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+    Future<Map<String, dynamic>> waitForFrame(String method) async {
+      for (var i = 0; i < 50; i++) {
+        final matches = fake.written.where(
+          (frame) => frame["method"] == method && !handledFrameIds.contains(frame["id"]),
+        );
+        if (matches.isNotEmpty) {
+          final frame = matches.first;
+          handledFrameIds.add(frame["id"]);
+          return frame;
+        }
+        await pump();
+      }
+      throw StateError("agent never wrote a '$method' frame");
+    }
+
+    Future<void> respond(String method, Map<String, dynamic> result) async {
+      final frame = await waitForFrame(method);
+      fake.emit({"jsonrpc": "2.0", "id": frame["id"], "result": result});
+      await pump();
+    }
+
+    Future<void> connect() async {
+      final connecting = plugin.ensureConnected();
+      await respond("initialize", hermesInitializeResult);
+      // Hermes advertises a terminal auth method, so the handshake calls
+      // authenticate with it; a configured install answers with an empty body.
+      await respond("authenticate", const <String, dynamic>{});
+      expect(await connecting, isTrue);
+    }
+
+    test("id is hermes", () {
+      expect(plugin.id, "hermes");
+    });
+
+    test("the default binary is the Hermes CLI and the launch spec drives `hermes acp`", () {
+      expect(HermesBinary.defaultBinary, "hermes");
+      final spec = HermesBinary.launchSpec(cwd: "/repo");
+      expect(spec.command, "hermes");
+      expect(spec.args, ["acp"]);
+    });
+
+    test("declares the neutral ACP policies for a stock v1 server", () {
+      expect(plugin.clientName, "sesori-bridge");
+      expect(plugin.clientVersion, "0.0.0");
+      expect(plugin.authMethodId, isNull, reason: "use the first advertised method");
+      expect(plugin.initializeCapabilityMeta, isNull);
+      expect(plugin.supportsFormElicitation, isFalse, reason: "no elicitation/create on Hermes");
+      expect(plugin.serializesPromptsProcessWide, isFalse);
+      expect(plugin.failsTurnOnSelectionError, isFalse);
+      expect(plugin.sessionCloseSettlementTimeout, const Duration(seconds: 5));
+    });
+
+    test("handshake succeeds against Hermes's advertised capabilities", () async {
+      await connect();
+    });
+
+    test("a prompt turn streams text chunks into part delta events", () async {
+      await connect();
+      final events = <BridgeSseEvent>[];
+      final subscription = plugin.events.listen(events.add);
+      addTearDown(subscription.cancel);
+
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond("session/new", const {"sessionId": "s1"});
+      final session = await creating;
+      expect(session.id, "s1");
+
+      final prompting = plugin.sendPrompt(
+        sessionId: session.id,
+        parts: const [PluginPromptPart.text(text: "Hello")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final promptFrame = await waitForFrame("session/prompt");
+      final params = (promptFrame["params"] as Map).cast<String, dynamic>();
+      expect(params["sessionId"], "s1");
+      final prompt = params["prompt"] as List;
+      expect(
+        (prompt.single as Map)["text"],
+        "Hello",
+        reason: "the prompt part must reach the agent verbatim",
+      );
+      fake.emit({"jsonrpc": "2.0", "id": promptFrame["id"], "result": <String, dynamic>{}});
+      await prompting;
+
+      // Hermes streams assistant output as session/update agent_message_chunk
+      // notifications (same shape the base mapper expects).
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": "s1",
+          "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "Hello"},
+          },
+        },
+      });
+      await pump();
+
+      expect(events.whereType<BridgeSseMessagePartDelta>().single.delta, "Hello");
+    });
+
+    test("deleteSession never calls session/close when closeSession is not advertised", () async {
+      await connect();
+
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond("session/new", const {"sessionId": "s1"});
+      await creating;
+
+      await plugin.deleteSession("s1");
+      await pump();
+
+      expect(
+        fake.written.where((frame) => frame["method"] == "session/close"),
+        isEmpty,
+        reason: "Hermes does not advertise closeSession, so deletion must be local-only",
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Complexity

⚙️ Moderate — descriptor with runtime probing and setup inspection; no managed runtime machinery.

## What

Adds the Hermes plugin descriptor and runtime gate:

- `bridge/sesori_plugin_hermes/lib/src/runtime/hermes_runtime_manifest.dart` — pins the minimum ACP adapter version (**0.20.0**) and the version parser for `hermes acp --version` output. Hermes has no Sesori-managed runtime, so this is a gate, not an install manifest.
- `bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart` — const `HermesPluginDescriptor`:
  - `--hermes-bin` CLI option (bare name `bin`; namespaced by the bridge to `--hermes-bin`)
  - `inspectSetup`: probes `hermes acp --version` (missing → runtime-missing with install hint; below floor → unavailable; unparseable → unknown), then probes `hermes status` for a configured model/provider (ready / authentication-required), never touching secrets or raw output
  - `start`: spawns `hermes acp` through the host process seam, wraps in `AcpBridgePlugin`, eager bounded connect with abort rollback
  - declares bridge-derived projects, plugin-scoped session options, and prompt attachments (Hermes advertises image capability); no install capability
- `bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart` — 12 tests: manifest parsing/floor, identity facts, no-install capability, all setup states (ready/missing/unavailable/unknown/auth-required), `--hermes-bin` override, and single-process start with the injected build seam.

## Why

The descriptor is the bridge's registration unit: it declares the CLI surface, gates setup honestly (a stock `hermes` install with a configured model = ready; nothing else), and starts the agent under the host lifecycle contract. The direct-CLI probe pattern mirrors Cursor minus the managed-runtime install path.

## Risk and test focus

- Auth detection via `hermes status` is best-effort by design; the authoritative gate is the live ACP handshake, which degrades the plugin rather than failing the bridge. Tests cover all probe outcomes.
- Merge sequence: part of the `hermes-plugin` series (plan PR #895). All PRs target `main` from the fork; each head branch contains the earlier steps, so diffs shrink automatically as the series merges in order.

## Expected result

Setup inspection reports accurate per-machine states, and starting the plugin spawns exactly one `hermes acp` process and completes the handshake. No user-visible or database impact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Hermes ACP plugin and runtime gate so the bridge can detect a local install and start `hermes acp` without a managed runtime. Previously Hermes was unsupported; now the bridge reports setup and eagerly connects a single `hermes acp` process when ready.

- Adds `HermesPluginDescriptor` with `--hermes-bin` (default `hermes`). Probes `hermes acp --version` (min adapter 0.20.0); pre-ACP installs (invalid `acp` subcommand) report runtime-missing with an update hint; timeouts/spawn failures surface as unknown; unparseable versions as unrecognized.
- Checks auth via `hermes status`; output wins over exit code. Reports ready when a model is set, authentication-required when not, and unknown on launch/timeout/parsing failures.
- Starts via the host process seam and connects within a 15s budget; aborts roll back the spawn. Handshake failures degrade the plugin rather than failing the bridge. Policies: no form elicitation, parallel sessions, never fail turns on selection errors, 5s close settlement timeout, and never call `session/close`.
- Declares bridge-derived project ownership, plugin-scoped session options, and prompt-attachment support; no install capability.
- Wires `sesori_plugin_hermes` into the workspace and `Makefile`.

**Rollout**
- Ensure Hermes is installed on PATH with ACP adapter >= 0.20.0, or pass a full path with `--hermes-bin`.
- Configure a model/provider via `hermes setup` or `hermes model` to avoid authentication-required.

<sup>Written for commit 4996b4c27542361558a1d0a0a89bc6a0f28c303b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

