### PR TITLE
🌿 Keep macOS bridge names stable

### DIFF
--- a/bridge/app/lib/src/auth/bridge_registration_service.dart
+++ b/bridge/app/lib/src/auth/bridge_registration_service.dart
@@ -26,6 +26,8 @@ class BridgeRegistrationService({
   required String hostName,
   required final String _platform,
 }) implements BridgeIdProvider {
+  static const fallbackName = "sesori-bridge";
+
   final String _hostName = sanitizeBridgeName(hostName);
   bool _registered = false;
   String? _bridgeId;
@@ -43,7 +45,7 @@ class BridgeRegistrationService({
   /// exotic hostname can never fail registration with a 400.
   static String sanitizeBridgeName(String name) {
     final trimmed = name.trim();
-    if (trimmed.isEmpty) return "sesori-bridge";
+    if (trimmed.isEmpty) return fallbackName;
     return trimmed.length <= 120 ? trimmed : trimmed.substring(0, 120);
   }
 

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -1417,8 +1417,10 @@ class const BridgeRuntimeRunner._() {
       );
       final stableName = result.stdout.toString().trim();
       if (result.exitCode == 0 && stableName.isNotEmpty) return stableName;
+      final stderr = result.stderr.toString().trim();
       Log.w(
         "Failed to read macOS LocalHostName (exit code ${result.exitCode}); using fallback hostname",
+        stderr.isEmpty ? null : stderr,
       );
     } on Object catch (error, stackTrace) {
       Log.w(
@@ -1431,7 +1433,7 @@ class const BridgeRuntimeRunner._() {
     final fallback = localHostname.trim();
     if (io.InternetAddress.tryParse(fallback) == null) return fallback;
     Log.w("Replacing numeric macOS fallback hostname with the generic bridge name");
-    return "sesori-bridge";
+    return BridgeRegistrationService.fallbackName;
   }
 
   /// Reads `/etc/os-release` (Linux only) so [OsVersionFormatter] can derive the

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -1430,8 +1430,8 @@ class const BridgeRuntimeRunner._() {
 
     final fallback = localHostname.trim();
     if (io.InternetAddress.tryParse(fallback) == null) return fallback;
-    Log.w("Ignoring numeric macOS fallback hostname");
-    return "";
+    Log.w("Replacing numeric macOS fallback hostname with the generic bridge name");
+    return "sesori-bridge";
   }
 
   /// Reads `/etc/os-release` (Linux only) so [OsVersionFormatter] can derive the

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -323,6 +323,11 @@ class const BridgeRuntimeRunner._() {
     );
     shutdownCoordinator.add(disposable: httpClient.close);
 
+    final machineName = await resolveLocalMachineName(
+      isMacOS: io.Platform.isMacOS,
+      processRunner: processRunner,
+      localHostname: _localHostname(),
+    );
     final bridgeClientType = _bridgeClientType();
     final runtimeAuthService = BridgeRuntimeAuthService(
       loginEmailRepository: LoginEmailRepository(
@@ -334,7 +339,10 @@ class const BridgeRuntimeRunner._() {
           authBackendUrl: options.authBackendUrl,
           client: httpClient,
           clientType: bridgeClientType,
-          device: _bridgeDeviceInfo(clientType: bridgeClientType),
+          device: _bridgeDeviceInfo(
+            clientType: bridgeClientType,
+            machineName: machineName,
+          ),
         ),
         browserLauncher: openOAuthBrowser,
         browserOpenability: detectBrowserOpenability,
@@ -414,6 +422,7 @@ class const BridgeRuntimeRunner._() {
           authBackendUrl: options.authBackendUrl,
           tokenRefresher: controlChannelTokenService,
           bridgeIdStorage: bridgeIdStorage,
+          machineName: machineName,
         );
         shutdownCoordinator.add(disposable: supervisedRegistrationService.dispose);
         // Handles the GUI's `unregister_and_exit` logout command: unregister the
@@ -590,6 +599,7 @@ class const BridgeRuntimeRunner._() {
           authBackendUrl: options.authBackendUrl,
           tokenRefresher: tokenRefresher,
           bridgeIdStorage: bridgeIdStorage,
+          machineName: machineName,
         );
         shutdownCoordinator.add(disposable: bridgeRegistrationService.dispose);
       }
@@ -1122,6 +1132,7 @@ class const BridgeRuntimeRunner._() {
     required String authBackendUrl,
     required TokenRefresher tokenRefresher,
     required BridgeIdStorage bridgeIdStorage,
+    required String machineName,
   }) {
     return BridgeRegistrationService(
       repository: BridgeRegistrationRepository(
@@ -1132,11 +1143,7 @@ class const BridgeRuntimeRunner._() {
       ),
       tokenRefresher: tokenRefresher,
       bridgeIdStorage: bridgeIdStorage,
-      // Safe helper (not io.Platform.localHostname directly): hostname
-      // resolution can throw a SocketException in restricted/containerized
-      // environments; degrade to "" (which BridgeRegistrationService clamps to
-      // "sesori-bridge") instead of crashing startup.
-      hostName: _localHostname(),
+      hostName: machineName,
       platform: BridgeRegistrationService.currentPlatformName(),
     );
   }
@@ -1359,10 +1366,13 @@ class const BridgeRuntimeRunner._() {
         PlatformOs.linux => AuthClientType.bridgeLinux,
       };
 
-  static DeviceInfo _bridgeDeviceInfo({required AuthClientType clientType}) {
+  static DeviceInfo _bridgeDeviceInfo({
+    required AuthClientType clientType,
+    required String machineName,
+  }) {
     return const AuthDeviceInfoBuilder().build(
       clientType: clientType,
-      detectedName: _localHostname(),
+      detectedName: machineName,
       osVersion: const OsVersionFormatter().format(
         operatingSystem: io.Platform.operatingSystem,
         operatingSystemVersion: io.Platform.operatingSystemVersion,
@@ -1373,8 +1383,9 @@ class const BridgeRuntimeRunner._() {
   }
 
   /// `Platform.localHostname` can throw (e.g. `SocketException` when hostname
-  /// resolution fails in restricted/containerized environments). The descriptor
-  /// is best-effort, so degrade to an empty name and let the caller fall back.
+  /// resolution fails in restricted/containerized environments). Machine
+  /// identity is best-effort, so degrade to an empty name and let callers fall
+  /// back.
   static String _localHostname() {
     try {
       return io.Platform.localHostname;
@@ -1382,6 +1393,45 @@ class const BridgeRuntimeRunner._() {
       Log.w("Failed to read localHostname for the device descriptor", error);
       return "";
     }
+  }
+
+  /// Resolves the stable machine name used for OAuth and bridge registration.
+  ///
+  /// macOS can temporarily make `gethostname()` equal a DHCP-assigned IP when
+  /// its explicit `HostName` is unset. `LocalHostName` is the stable Bonjour
+  /// machine identity and does not change with the active network. Other
+  /// platforms retain Dart's `gethostname()` value.
+  @visibleForTesting
+  static Future<String> resolveLocalMachineName({
+    required bool isMacOS,
+    required ProcessRunner processRunner,
+    required String localHostname,
+  }) async {
+    if (!isMacOS) return localHostname;
+
+    try {
+      final result = await processRunner.run(
+        "/usr/sbin/scutil",
+        const ["--get", "LocalHostName"],
+        timeout: const Duration(seconds: 2),
+      );
+      final stableName = result.stdout.toString().trim();
+      if (result.exitCode == 0 && stableName.isNotEmpty) return stableName;
+      Log.w(
+        "Failed to read macOS LocalHostName (exit code ${result.exitCode}); using fallback hostname",
+      );
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        "Failed to read macOS LocalHostName; using fallback hostname",
+        error,
+        stackTrace,
+      );
+    }
+
+    final fallback = localHostname.trim();
+    if (io.InternetAddress.tryParse(fallback) == null) return fallback;
+    Log.w("Ignoring numeric macOS fallback hostname");
+    return "";
   }
 
   /// Reads `/etc/os-release` (Linux only) so [OsVersionFormatter] can derive the

--- a/bridge/app/test/bridge/runtime/bridge_runtime_runner_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_runner_test.dart
@@ -83,7 +83,7 @@ void main() {
       expect(name, "dev-laptop.local");
     });
 
-    test("rejects a numeric macOS fallback hostname", () async {
+    test("replaces a numeric macOS fallback hostname with one canonical name", () async {
       final name = await BridgeRuntimeRunner.resolveLocalMachineName(
         isMacOS: true,
         processRunner: _RecordingProcessRunner(
@@ -92,7 +92,7 @@ void main() {
         localHostname: "192.168.1.170",
       );
 
-      expect(name, isEmpty);
+      expect(name, "sesori-bridge");
     });
 
     test("keeps the platform hostname without invoking scutil elsewhere", () async {

--- a/bridge/app/test/bridge/runtime/bridge_runtime_runner_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_runner_test.dart
@@ -1,3 +1,6 @@
+import "dart:io";
+
+import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
 import "package:sesori_bridge/src/bridge/runtime/bridge_runtime_runner.dart";
 import "package:test/test.dart";
 
@@ -50,4 +53,88 @@ void main() {
       );
     });
   });
+
+  group("BridgeRuntimeRunner.resolveLocalMachineName", () {
+    test("uses the stable macOS LocalHostName instead of a numeric hostname", () async {
+      final runner = _RecordingProcessRunner(
+        result: ProcessResult(1, 0, "Alexs-MB-2025\n", ""),
+      );
+
+      final name = await BridgeRuntimeRunner.resolveLocalMachineName(
+        isMacOS: true,
+        processRunner: runner,
+        localHostname: "192.168.1.170",
+      );
+
+      expect(name, "Alexs-MB-2025");
+      expect(runner.executable, "/usr/sbin/scutil");
+      expect(runner.arguments, ["--get", "LocalHostName"]);
+    });
+
+    test("uses a non-numeric macOS hostname when LocalHostName is unavailable", () async {
+      final name = await BridgeRuntimeRunner.resolveLocalMachineName(
+        isMacOS: true,
+        processRunner: _RecordingProcessRunner(
+          result: ProcessResult(1, 1, "", "No such key"),
+        ),
+        localHostname: "dev-laptop.local",
+      );
+
+      expect(name, "dev-laptop.local");
+    });
+
+    test("rejects a numeric macOS fallback hostname", () async {
+      final name = await BridgeRuntimeRunner.resolveLocalMachineName(
+        isMacOS: true,
+        processRunner: _RecordingProcessRunner(
+          result: ProcessResult(1, 1, "", "No such key"),
+        ),
+        localHostname: "192.168.1.170",
+      );
+
+      expect(name, isEmpty);
+    });
+
+    test("keeps the platform hostname without invoking scutil elsewhere", () async {
+      final runner = _RecordingProcessRunner(
+        result: ProcessResult(1, 0, "unused", ""),
+      );
+
+      final name = await BridgeRuntimeRunner.resolveLocalMachineName(
+        isMacOS: false,
+        processRunner: runner,
+        localHostname: "linux-workstation",
+      );
+
+      expect(name, "linux-workstation");
+      expect(runner.executable, isNull);
+    });
+  });
+}
+
+class _RecordingProcessRunner({required final ProcessResult result}) implements ProcessRunner {
+  String? executable;
+  List<String>? arguments;
+
+  @override
+  Future<ProcessResult> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    Duration timeout = const Duration(seconds: 15),
+  }) async {
+    this.executable = executable;
+    this.arguments = arguments;
+    return result;
+  }
+
+  @override
+  Future<int> startDetached({
+    required String executable,
+    required List<String> arguments,
+    Map<String, String>? environment,
+  }) {
+    throw UnimplementedError();
+  }
 }

--- a/docs/regression/bridge-connectivity.md
+++ b/docs/regression/bridge-connectivity.md
@@ -21,6 +21,8 @@ explicit restart, and the connection states the app presents.
   once and can never later authenticate.
 - One live bridge per account holds the slot; a second start resolves ownership
   explicitly, and an explicit restart hands off to its successor cleanly.
+- Bridge registration uses a stable machine name. On macOS, transient
+  network-derived numeric hostnames must not replace the machine's LocalHostName.
 - The client distinguishes connected, reconnecting, connection lost, bridge offline, and
   disconnected, and returns to connected when the bridge is back.
 - The configured sleep policy applies at standalone startup and releases its wake lock on

--- a/docs/regression/bridge-connectivity.md
+++ b/docs/regression/bridge-connectivity.md
@@ -36,7 +36,7 @@ explicit restart, and the connection states the app presents.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | A started bridge reaches readiness and answers a health request; a connected client reports connected. Headless bridge plus relay integration for the client-visible state; no plugin. |
-| L2 Routine | Relay integration for key exchange, a normal drop and reconnect, and clean shutdown; automated and headless bridge for sleep-policy enable, disable, warning, and wake-lock release. No plugin. |
+| L2 Routine | Relay integration for key exchange, a normal drop and reconnect, and clean shutdown; automated and headless bridge for stable machine-name registration plus sleep-policy enable, disable, warning, and wake-lock release. No plugin. |
 | L3 Release | The full connection state machine as presented, explicit restart with successor handoff, second-start ownership resolution, and a slow in-flight request not blocking key exchange or further requests. Client end to end plus headless bridge; a representative harness supplies the slow operation. |
 | L4 Extended | Relay integration or client end to end for takeover, revocation, live token re-authentication, handshake shutdown, app/network recovery, several clients, and alternate client platforms; headless supervised harness for control authentication, token rotation, prompts, status, provisioning progress, unregister, restart sentinels, owner loss, and orphan cleanup. |
 | L5 Full | Store-distributed app against a released bridge over production relay, older app against newer bridge and the reverse for the client/bridge wire contract, and a long-lived headless VM run over repeated reconnects. Packaged or external. |
@@ -56,6 +56,7 @@ the bridge starts, how many clients are present, and whether restart is explicit
   route freezes all traffic.
 - Reconnect tight-looping, an exhausted iterator reused, or two bridges displacing each
   other without backoff.
+- A bridge registering a network-derived numeric hostname as its machine name.
 - A clean shutdown producing reconnects, a cancelled handshake later sending auth, or an
   app stuck reconnecting after the bridge returns.
 


### PR DESCRIPTION
## Complexity

Straightforward. The change is localized to bridge startup name resolution and reuses the existing process runner.

## What

- Resolve macOS bridge identity from the stable `LocalHostName` via `scutil`.
- Reuse one resolved machine name for OAuth device information and bridge registration.
- Reject numeric macOS `gethostname()` fallbacks while preserving existing behavior on Linux and Windows.
- Add focused regression coverage and document the connectivity invariant.

## Why

When macOS has no explicit `HostName`, `gethostname()` can temporarily return a DHCP-derived local IP address. The bridge captured that value at startup and registered it as the machine name, causing Projects to show an address such as `192.168.1.170` instead of the stable hostname.

## Risk and test focus

The main risk is name discovery failure on macOS. A failed `scutil` call remains observable and falls back to a non-numeric `gethostname()` value; numeric fallbacks degrade to the existing generic bridge name. Other platforms skip `scutil` entirely.

There is no wire-contract or database-schema impact. The user-visible bridge name is corrected on the next bridge registration.

## Expected result

Projects consistently shows the Mac's stable local hostname rather than a transient private IP address.

## Verification

- `dart test test/bridge/runtime/bridge_runtime_runner_test.dart test/auth/bridge_registration_service_test.dart`
- `dart analyze --fatal-infos`
- `git diff --check`

`dart format` formatted the test file but hit a Dart 3.13 `dart_style` crash while parsing the existing runtime file; analyzer and tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps macOS bridge names stable by resolving the Bonjour LocalHostName via scutil and reusing it for both OAuth device info and bridge registration. This avoids registering DHCP-derived numeric IPs and makes the displayed machine name consistent.

- macOS: run /usr/sbin/scutil --get LocalHostName (2s timeout); if it fails, use a non-numeric Platform.localHostname; if numeric, fall back to the canonical "sesori-bridge".
- Non‑macOS: keep Platform.localHostname.
- Resolve once at startup and pass the result as AuthDeviceInfo.detectedName and BridgeRegistrationService.hostName.
- Preserve diagnostics: log scutil failures (exit code/stderr) and when replacing a numeric fallback name.
- Align fallback handling: centralize the default name as BridgeRegistrationService.fallbackName and have sanitizeBridgeName use it.
- No API or schema changes. Names update on the next registration. Added focused tests and updated the connectivity invariant in docs.

<sup>Written for commit ca849cd00c010f17f823896fa7115a063c2e6362. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

