### PR TITLE
🌿 Restore platform navigation transitions

### DIFF
--- a/client/app/lib/core/routing/app_router.dart
+++ b/client/app/lib/core/routing/app_router.dart
@@ -37,9 +37,21 @@ const _settingsNotificationsRouteSegment = "notifications";
 const _settingsHarnessesRouteSegment = "harnesses";
 const _settingsProfileRouteSegment = "profile";
 
+// go_router only detects the legacy SDK MaterialApp, so builder routes under
+// material_ui.MaterialApp otherwise become NoTransitionPages.
+MaterialPage<void> _materialPage({required GoRouterState state, required Widget child}) {
+  return MaterialPage<void>(
+    key: state.pageKey,
+    name: state.name ?? state.path,
+    arguments: <String, String>{...state.pathParameters, ...state.uri.queryParameters},
+    restorationId: state.pageKey.value,
+    child: child,
+  );
+}
+
 extension AppRouteToGoRoute on AppRouteDef {
   /// Returns the [GoRoute] for this route definition with an exhaustive
-  /// builder switch over decoded [AppRoute] values.
+  /// screen switch over decoded [AppRoute] values.
   GoRoute toGoRoute({List<RouteBase> routes = const []}) {
     // The login screen gets a fade-in page instead of the platform slide so
     // the splash → login hand-off reads as one continuous motion — see
@@ -77,7 +89,10 @@ extension AppRouteToGoRoute on AppRouteDef {
     return GoRoute(
       path: path,
       routes: routes,
-      builder: (context, state) => _buildScreen(context: context, state: state),
+      pageBuilder: (context, state) => _materialPage(
+        state: state,
+        child: _buildScreen(context: context, state: state),
+      ),
     );
   }
 
@@ -250,23 +265,26 @@ List<RouteBase> _buildAppRoutes({
       routes: [
         ShellRoute(
           navigatorKey: sessionShellNavigatorKey,
-          builder: (context, state, child) {
+          pageBuilder: (context, state, child) {
             final projectId = state.pathParameters[projectIdPathParam] ?? "";
             final projectName = state.uri.queryParameters[projectNameQueryParam];
             final selectedSessionId = state.pathParameters[sessionIdPathParam];
             final projectViewingService = getIt<ProjectViewingService>();
 
-            return SessionListCubitProvider(
-              key: ValueKey("session-list-cubit-$projectId"),
-              projectId: projectId,
-              child: SessionSplitShell(
-                projectViewingService: projectViewingService,
-                list: _SessionListPane(
-                  projectId: projectId,
-                  projectName: projectName,
-                  selectedSessionId: selectedSessionId,
+            return _materialPage(
+              state: state,
+              child: SessionListCubitProvider(
+                key: ValueKey("session-list-cubit-$projectId"),
+                projectId: projectId,
+                child: SessionSplitShell(
+                  projectViewingService: projectViewingService,
+                  list: _SessionListPane(
+                    projectId: projectId,
+                    projectName: projectName,
+                    selectedSessionId: selectedSessionId,
+                  ),
+                  child: child,
                 ),
-                child: child,
               ),
             );
           },
@@ -377,7 +395,10 @@ List<RouteBase> _buildAppRoutes({
       routes: [
         GoRoute(
           path: _settingsNotificationsRouteSegment,
-          builder: (context, state) => AppRouteDef.settingsNotifications._buildScreen(context: context, state: state),
+          pageBuilder: (context, state) => _materialPage(
+            state: state,
+            child: AppRouteDef.settingsNotifications._buildScreen(context: context, state: state),
+          ),
         ),
         GoRoute(
           path: _settingsHarnessesRouteSegment,
@@ -389,8 +410,8 @@ List<RouteBase> _buildAppRoutes({
           //
           // The modal is a CupertinoPage for the same reason settings itself
           // uses one: only the Cupertino route honours `fullscreenDialog` on
-          // Android too. The pushed page is the MaterialPage go_router would
-          // have built itself, so it keeps the platform's push transition.
+          // Android too. The pushed page is an explicit MaterialPage, so it
+          // keeps the platform's push transition.
           pageBuilder: (context, state) {
             final route = AppRouteSettingsHarnesses.fromParams(queryParams: state.uri.queryParameters);
             final child = route.screen;
@@ -400,13 +421,16 @@ List<RouteBase> _buildAppRoutes({
                 fullscreenDialog: true,
                 child: child,
               ),
-              HarnessSettingsPresentation.pushed => MaterialPage<void>(key: state.pageKey, child: child),
+              HarnessSettingsPresentation.pushed => _materialPage(state: state, child: child),
             };
           },
         ),
         GoRoute(
           path: _settingsProfileRouteSegment,
-          builder: (context, state) => AppRouteDef.settingsProfile._buildScreen(context: context, state: state),
+          pageBuilder: (context, state) => _materialPage(
+            state: state,
+            child: AppRouteDef.settingsProfile._buildScreen(context: context, state: state),
+          ),
         ),
       ],
     ),

--- a/client/app/lib/core/routing/app_router.dart
+++ b/client/app/lib/core/routing/app_router.dart
@@ -37,8 +37,10 @@ const _settingsNotificationsRouteSegment = "notifications";
 const _settingsHarnessesRouteSegment = "harnesses";
 const _settingsProfileRouteSegment = "profile";
 
-// go_router only detects the legacy SDK MaterialApp, so builder routes under
-// material_ui.MaterialApp otherwise become NoTransitionPages.
+// WORKAROUND: go_router only recognizes package:flutter's legacy MaterialApp,
+// so builder routes under material_ui.MaterialApp become NoTransitionPages.
+// Remove this helper and the explicit pageBuilders once
+// https://github.com/flutter/flutter/issues/191132 is fixed.
 MaterialPage<void> _materialPage({required GoRouterState state, required Widget child}) {
   return MaterialPage<void>(
     key: state.pageKey,

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -46,6 +46,9 @@ dependencies:
   collection: ^1.19.1
   rxdart: ^0.28.0
   flutter_bloc: ^9.1.1
+  # Before updating go_router, check its release notes for a fix to
+  # https://github.com/flutter/flutter/issues/191132. Once fixed, remove the
+  # explicit MaterialPage workaround in lib/core/routing/app_router.dart.
   go_router: ^17.3.0
   get_it: ^9.2.1
   injectable: ^3.0.0

--- a/client/app/test/core/routing/app_route_test.dart
+++ b/client/app/test/core/routing/app_route_test.dart
@@ -141,10 +141,11 @@ void main() {
     });
   });
 
-  group("flat route builders", () {
+  group("flat routes", () {
     test("splash route builds SplashScreen", () {
-      final widget = AppRouteDef.splash.toGoRoute().builder!(_FakeBuildContext(), _FakeGoRouterState());
-      expect(widget, isA<SplashScreen>());
+      final page = AppRouteDef.splash.toGoRoute().pageBuilder!(_FakeBuildContext(), _FakeGoRouterState());
+      expect(page, isA<MaterialPage<void>>());
+      expect((page as MaterialPage<void>).child, isA<SplashScreen>());
     });
 
     test("login route builds LoginScreen behind a fade transition page", () {
@@ -158,8 +159,9 @@ void main() {
     });
 
     test("projects route builds ProjectListScreen", () {
-      final widget = AppRouteDef.projects.toGoRoute().builder!(_FakeBuildContext(), _FakeGoRouterState());
-      expect(widget, isA<ProjectListScreen>());
+      final page = AppRouteDef.projects.toGoRoute().pageBuilder!(_FakeBuildContext(), _FakeGoRouterState());
+      expect(page, isA<MaterialPage<void>>());
+      expect((page as MaterialPage<void>).child, isA<ProjectListScreen>());
     });
 
     // A CupertinoPage, so the bottom-up modal slide is the same on Android,
@@ -182,7 +184,11 @@ void main() {
         children.map((route) => route.path),
         equals(["notifications", "harnesses", "profile"]),
       );
-      expect(children[0].builder!(_FakeBuildContext(), _FakeGoRouterState()), isA<NotificationSettingsScreen>());
+      final notificationsPage = children[0].pageBuilder!(
+        _FakeBuildContext(),
+        _FakeGoRouterState(),
+      ) as MaterialPage<void>;
+      expect(notificationsPage.child, isA<NotificationSettingsScreen>());
       // Harnesses rise as a modal from the new-session harness menu and push
       // in from the settings list, so the route builds its own page per
       // presentation instead of taking the default push for both.
@@ -202,7 +208,11 @@ void main() {
         HarnessSettingsPresentation.pushed,
       );
       expect(children[1].routes, isEmpty);
-      expect(children[2].builder!(_FakeBuildContext(), _FakeGoRouterState()), isA<ProfileScreen>());
+      final profilePage = children[2].pageBuilder!(
+        _FakeBuildContext(),
+        _FakeGoRouterState(),
+      ) as MaterialPage<void>;
+      expect(profilePage.child, isA<ProfileScreen>());
       expect(
         _composeRoutePath(parentPath: AppRouteDef.settings.path, path: children[0].path),
         AppRouteDef.settingsNotifications.path,
@@ -218,10 +228,11 @@ void main() {
     });
 
     test("newSession route builds NewSessionScreen", () {
-      final widget = AppRouteDef.newSession.toGoRoute().builder!(
+      final page = AppRouteDef.newSession.toGoRoute().pageBuilder!(
         _FakeBuildContext(),
         _FakeGoRouterState(pathParameters: {"projectId": "proj-42"}, queryParameters: {"name": "Project One"}),
-      );
+      ) as MaterialPage<void>;
+      final widget = page.child;
       expect(widget, isA<NewSessionScreen>());
       expect((widget as NewSessionScreen).projectId, "proj-42");
       expect(widget.projectName, "Project One");
@@ -229,6 +240,33 @@ void main() {
   });
 
   group("buildAppRoutes", () {
+    test("every route provides an explicit standalone page", () {
+      void expectExplicitPages(List<RouteBase> routes) {
+        for (final route in routes) {
+          switch (route) {
+            case GoRoute(:final pageBuilder, :final routes):
+              expect(
+                pageBuilder,
+                isNotNull,
+                reason: "GoRoute ${route.path} must not rely on go_router's legacy MaterialApp detection",
+              );
+              expectExplicitPages(routes);
+            case ShellRoute(:final pageBuilder, :final routes):
+              expect(
+                pageBuilder,
+                isNotNull,
+                reason: "ShellRoute must not rely on go_router's legacy MaterialApp detection",
+              );
+              expectExplicitPages(routes);
+            default:
+              throw StateError("Unsupported route type ${route.runtimeType}");
+          }
+        }
+      }
+
+      expectExplicitPages(buildAppRoutes());
+    });
+
     test("explicit route table covers every AppRouteDef exactly once", () {
       final routes = buildAppRoutes();
       final registeredPaths = _collectAbsoluteRoutePaths(routes: routes);
@@ -284,20 +322,21 @@ void main() {
       expect(childPaths, equals(["new", ":sessionId"]));
     });
 
-    test("session shell builder hoists cubit provider above split shell", () {
+    test("session shell page hoists cubit provider above split shell", () {
       final getIt = GetIt.instance;
       getIt.registerSingleton<ProjectViewingService>(stubbedProjectViewingService());
       addTearDown(() => getIt.unregister<ProjectViewingService>());
 
       final shell = _sessionShellRoute();
-      final widget = shell.builder!(
+      final page = shell.pageBuilder!(
         _FakeBuildContext(),
         _FakeGoRouterState(
           pathParameters: {"projectId": "proj-42", "sessionId": "ses-99"},
           queryParameters: {"name": "My Project"},
         ),
         const SizedBox(),
-      );
+      ) as MaterialPage<void>;
+      final widget = page.child;
 
       expect(widget, isA<SessionListCubitProvider>());
       final provider = widget as SessionListCubitProvider;
@@ -563,6 +602,12 @@ class _FakeGoRouterState({
   @override final Map<String, String> pathParameters = const {},
   Map<String, String> queryParameters = const {},
 }) extends Fake implements GoRouterState {
+  @override
+  final String? name = null;
+
+  @override
+  final String? path = "/";
+
   @override
   final Uri uri = Uri(path: "/", queryParameters: queryParameters.isEmpty ? null : queryParameters);
 

--- a/docs/regression/README.md
+++ b/docs/regression/README.md
@@ -146,6 +146,7 @@ failed, or unexecuted required coverage keeps the plan active.
 - [Bridge installation and updates](bridge-installation-and-updates.md)
 - [Design catalog](design-catalog.md)
 - [Diffs and source control](diffs-and-source-control.md)
+- [Navigation transitions](navigation-transitions.md)
 - [Notifications](notifications.md)
 - [Permission auto-approval](permission-auto-approval.md)
 - [Plugin runtime installation](plugin-runtime-installation.md)

--- a/docs/regression/navigation-transitions.md
+++ b/docs/regression/navigation-transitions.md
@@ -1,0 +1,41 @@
+# Navigation Transitions
+
+## Capability
+
+The Sesori app gives route changes platform-appropriate motion while keeping
+the intentional login, settings-modal, and split-view transitions distinct.
+
+## Required Behavior
+
+- Standard pushes and pops use the Material platform transition: a horizontal
+  Cupertino slide on iOS and macOS, and the configured Material transition on
+  Android.
+- Compact session-list, session-detail, new-session, and diff navigation uses
+  the same platform transition. Split-view pane changes fade instead of sliding.
+- Settings and modal harness settings rise from the bottom on every platform;
+  settings child pages use the standard platform push.
+- Login uses its intentional fade and logo hero motion.
+- Custom login and session transitions honor reduced-motion mode without
+  changing page identity or dropping in-flight screen state.
+
+## Regression Levels
+
+| Level | Additional coverage |
+|---|---|
+| L1 Smoke | Not included. |
+| L2 Routine | Automated route-table coverage proves every route supplies a standalone page instead of relying on legacy `MaterialApp` detection, and preserves each custom page type. |
+| L3 Release | Client end to end on iOS and Android: exercise a standard push/pop, compact session navigation, a settings child, and the settings modal. |
+| L4 Extended | Repeat the transition matrix on macOS and with reduced motion enabled; exercise split-view pane fading where the viewport supports it. |
+| L5 Full | No additional coverage. |
+
+## Failure Signals
+
+- A route appears or disappears instantly when reduced motion is disabled.
+- iOS or macOS uses no transition, or Android loses its configured transition.
+- A settings child rises as a modal, or the settings modal slides horizontally.
+- Compact and split session layouts use each other's transition.
+
+## Sources
+
+- `client/app/lib/core/routing/app_router.dart`
+- `client/app/test/core/routing/app_route_test.dart`

--- a/docs/regression/navigation-transitions.md
+++ b/docs/regression/navigation-transitions.md
@@ -25,7 +25,7 @@ the intentional login, settings-modal, and split-view transitions distinct.
 | L1 Smoke | Not included. |
 | L2 Routine | Automated route-table coverage proves every route supplies a standalone page instead of relying on legacy `MaterialApp` detection, and preserves each custom page type. |
 | L3 Release | Client end to end on iOS and Android: exercise a standard push/pop, compact session navigation, a settings child, and the settings modal. |
-| L4 Extended | Repeat the transition matrix on macOS and with reduced motion enabled; exercise split-view pane fading where the viewport supports it. |
+| L4 Extended | Client end to end on macOS and with reduced motion enabled: repeat the transition matrix and exercise split-view pane fading where the viewport supports it. |
 | L5 Full | No additional coverage. |
 
 ## Failure Signals


### PR DESCRIPTION
## Complexity

Straightforward. The change replaces implicit GoRouter page selection with the standalone Material page type already used by the app and updates focused route coverage.

## What

- Build standard app routes and the session shell with explicit `material_ui.MaterialPage` instances.
- Keep the login fade, split-pane fade, and full-screen Cupertino settings transitions unchanged.
- Preserve route names, arguments, restoration IDs, and page keys.
- Require every production route to provide an explicit page and document the transition regression matrix.

## Why

`go_router` currently recognizes only the SDK `MaterialApp` by exact type. After the app migrated to `material_ui.MaterialApp`, routes using `builder` were classified as `WidgetsApp` routes and wrapped in `NoTransitionPage`, removing their platform transitions.

## Risk and test focus

Risk is limited to client navigation presentation and page lifecycle. Review standard push/pop motion on iOS and macOS, Android's configured Material motion, session-shell entry, and settings child routes. The custom bottom-up settings modal should remain unchanged. There is no database, protocol, authentication, analytics, or persisted-data impact.

## Expected result

Standard pushes and pops again use the configured platform transition, including Cupertino horizontal slides on iOS and macOS, while existing custom modal and fade transitions continue behaving as before.

## Verification

- `dart analyze` in `client/app`
- `flutter test` in `client/app` (992 tests)
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores platform navigation transitions by returning explicit MaterialPage pages from all `GoRoute`s and the session `ShellRoute`. Previously, builder routes under `material_ui.MaterialApp` were wrapped in `NoTransitionPage`, removing motion; intentional transitions (login fade, split-pane fade, full-screen settings modal) are unchanged. Adds tests enforcing explicit `pageBuilder` usage and documents the transition proof boundary; links the doc from the regression index and notes future `go_router` cleanup in `pubspec.yaml` once flutter/flutter#191132 is fixed.

**Review focus**
- Verify push/pop on iOS/macOS and Android, session-shell entry, settings children, and the bottom-up settings modal.
- Reduced-motion behavior should remain honored. No data, protocol, or auth impact.

**Migration**
- New production routes must return an explicit page via `pageBuilder`; do not rely on `go_router`’s legacy `MaterialApp` detection.

<sup>Written for commit 13b1ca3f311d5f4e04cac1f4d3168e1bf7e8701d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

