### PR TITLE
🚧 [pi-harness] feat(pi): manage session residency and turns [step 14/21]

### DIFF
--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -445,7 +445,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   exact slash-command dispatch with privacy-safe presentation, ambiguous-timeout
   teardown with old-dialog retirement, and disposal waiting for active idle-reap
   teardown.
-- Full package tests pass (210 tests); fatal analysis and diff checks pass. The
+- Full package tests pass (211 tests); fatal analysis and diff checks pass. The
   pinned formatter still crashes on the pre-existing Dart 3.13
   primary-constructor enum in `pi_session_storage_api.dart`; every other changed
   Dart file formats cleanly.
@@ -456,7 +456,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   so cold replay conservatively displays only the slash-command token for both
   API commands and manually typed slash prompts, never hidden raw arguments;
   live API-command presentation retains exact `userVisibleArguments`.
-- Diff: +3,152/-101 = 3,253 changed lines; generated lines: 0; tests run: 210.
+- Diff: +3,202/-102 = 3,304 changed lines; generated lines: 0; tests run: 211.
   Review-fix working-tree delta excluding this tracker evidence: +586/-85 =
   671 changed lines. Recorded overage:
   persistence, residency, replay hydration, turn settlement, attachment

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -445,7 +445,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   exact slash-command dispatch with privacy-safe presentation, ambiguous-timeout
   teardown with old-dialog retirement, and disposal waiting for active idle-reap
   teardown.
-- Full package tests pass (208 tests); fatal analysis and diff checks pass. The
+- Full package tests pass (209 tests); fatal analysis and diff checks pass. The
   pinned formatter still crashes on the pre-existing Dart 3.13
   primary-constructor enum in `pi_session_storage_api.dart`; every other changed
   Dart file formats cleanly.
@@ -456,7 +456,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   so cold replay conservatively displays only the slash-command token for both
   API commands and manually typed slash prompts, never hidden raw arguments;
   live API-command presentation retains exact `userVisibleArguments`.
-- Diff: +3,074/-101 = 3,175 changed lines; generated lines: 0; tests run: 208.
+- Diff: +3,114/-101 = 3,215 changed lines; generated lines: 0; tests run: 209.
   Review-fix working-tree delta excluding this tracker evidence: +586/-85 =
   671 changed lines. Recorded overage:
   persistence, residency, replay hydration, turn settlement, attachment

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -439,17 +439,30 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 - Added strict bounded inline image validation and visible privacy-safe rejection
   of paths, URLs, non-image data, malformed base64, and oversized collections.
 - Architecture implementation review approved direct resident-repository
-  response ownership. Full package tests pass (194 tests); fatal analysis and
-  diff checks pass. The pinned formatter still crashes on the pre-existing Dart
-  3.13 primary-constructor enum in `pi_session_storage_api.dart`.
+  response ownership. Validated PR review fixes then added CR/LF-safe pending
+  markers, pre-start best-effort stale-marker cleanup, connecting-client and
+  globally monotonic generation fencing, generation-safe extension dialogs,
+  exact slash-command dispatch with privacy-safe presentation, ambiguous-timeout
+  teardown with old-dialog retirement, and disposal waiting for active idle-reap
+  teardown.
+- Full package tests pass (203 tests); fatal analysis and diff checks pass. The
+  pinned formatter still crashes on the pre-existing Dart 3.13
+  primary-constructor enum in `pi_session_storage_api.dart`; every other changed
+  Dart file formats cleanly.
 - No generated files, database schema, client/bridge wire contract, analytics,
   or registered plugin change. Pi composition/catalog exposure remain Steps
-  15-16; Pi remains app-invisible until Step 18.
-- Diff: +2,285/-81 = 2,366 changed lines; generated lines: 0; tests run: 194.
-  Recorded overage: persistence, residency, replay hydration, turn settlement,
-  attachment validation, and focused concurrency/lifecycle tests form one
-  required Step 14 seam; splitting would leave resident processes without their
-  owning lane or required fencing evidence.
+  15-16; Pi remains app-invisible until Step 18. Cold replay cannot recover
+  `userVisibleArguments` from Pi's persisted raw command without new persistence,
+  so cold replay conservatively displays only the slash-command token for both
+  API commands and manually typed slash prompts, never hidden raw arguments;
+  live API-command presentation retains exact `userVisibleArguments`.
+- Diff: +2,855/-101 = 2,956 changed lines; generated lines: 0; tests run: 203.
+  Review-fix working-tree delta excluding this tracker evidence: +586/-85 =
+  671 changed lines. Recorded overage:
+  persistence, residency, replay hydration, turn settlement, attachment
+  validation, and focused concurrency/lifecycle tests form one required Step 14
+  seam; splitting would leave resident processes without their owning lane or
+  required fencing evidence.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -445,7 +445,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   exact slash-command dispatch with privacy-safe presentation, ambiguous-timeout
   teardown with old-dialog retirement, and disposal waiting for active idle-reap
   teardown.
-- Full package tests pass (206 tests); fatal analysis and diff checks pass. The
+- Full package tests pass (208 tests); fatal analysis and diff checks pass. The
   pinned formatter still crashes on the pre-existing Dart 3.13
   primary-constructor enum in `pi_session_storage_api.dart`; every other changed
   Dart file formats cleanly.
@@ -456,7 +456,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   so cold replay conservatively displays only the slash-command token for both
   API commands and manually typed slash prompts, never hidden raw arguments;
   live API-command presentation retains exact `userVisibleArguments`.
-- Diff: +3,000/-101 = 3,101 changed lines; generated lines: 0; tests run: 206.
+- Diff: +3,075/-101 = 3,176 changed lines; generated lines: 0; tests run: 208.
   Review-fix working-tree delta excluding this tracker evidence: +586/-85 =
   671 changed lines. Recorded overage:
   persistence, residency, replay hydration, turn settlement, attachment

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -3,9 +3,9 @@
 ## Current State
 
 - **Plan slug:** `pi-harness`
-- **Implementation base:** current `origin/main` with Step 12 merged
-- **Series state:** Step 12/21 merged; Step 13/21 in PR
-- **Current step:** 13/21, Pi extension dialogs
+- **Implementation base:** current `origin/main` with Step 13 merged
+- **Series state:** Step 13/21 merged; Step 14/21 ready for PR
+- **Current step:** 14/21, Pi session residency and turns
 - **Plan PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/811
 - **Step 2 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/819
 - **Step 3 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/820
@@ -20,7 +20,7 @@
 - **Step 11 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/892
 - **Step 12 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/905
 - **Step 13 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/910
-- **Next action:** monitor the Step 13 PR while starting Step 14 locally
+- **Next action:** open and monitor the Step 14 PR, then start Step 15 locally
 
 ## Locked Decisions
 
@@ -59,8 +59,8 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 | [x] | 10/21 | `🚧 [pi-harness] feat(pi): enumerate persisted sessions [step 10/21]` | 1,000-1,400 (recorded overage) | Merged as PR #884 |
 | [x] | 11/21 | `⚙️ [pi-harness] feat(pi): replay Pi session history [step 11/21]` | 1,100-1,500 (recorded overage) | Merged as PR #892 |
 | [x] | 12/21 | `🚧 [pi-harness] feat(pi): map live messages and tools [step 12/21]` | 1,200-1,500 (recorded overage) | Merged as PR #905 |
-| [ ] | 13/21 | `⚙️ [pi-harness] feat(pi): bridge extension dialogs [step 13/21]` | 900-1,300 | PR #910 open |
-| [ ] | 14/21 | `🚧 [pi-harness] feat(pi): manage session residency and turns [step 14/21]` | 1,200-1,500 | Not started |
+| [x] | 13/21 | `⚙️ [pi-harness] feat(pi): bridge extension dialogs [step 13/21]` | 900-1,300 | Merged as PR #910 |
+| [ ] | 14/21 | `🚧 [pi-harness] feat(pi): manage session residency and turns [step 14/21]` | 1,200-1,500 (recorded overage) | Ready for PR |
 | [ ] | 15/21 | `⚙️ [pi-harness] feat(pi): expose models and commands [step 15/21]` | 900-1,300 | Not started |
 | [ ] | 16/21 | `🚧 [pi-harness] feat(pi): implement the plugin API [step 16/21]` | 1,100-1,500 | Not started |
 | [ ] | 17/21 | `🚧 [pi-harness] feat(pi): add managed runtime and lifecycle [step 17/21]` | 1,100-1,500 | Not started; runtime dependency merged |
@@ -424,7 +424,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   plugin impact; Pi remains app-invisible until Step 18.
 - Diff: +1,003/-7 = 1,010 changed lines; generated lines: 0; tests run: 170.
 
-### Step 14/21 (local evidence; Step 13 remains in PR)
+### Step 14/21
 
 - Added persistent pending-new markers, secure caller-owned IDs, one
   generation-fenced resident RPC client per active session, replay hydration
@@ -444,7 +444,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 - No generated files, database schema, client/bridge wire contract, analytics,
   or registered plugin change. Pi composition/catalog exposure remain Steps
   15-16; Pi remains app-invisible until Step 18.
-- Diff: +2,278/-75 = 2,353 changed lines; generated lines: 0; tests run: 194.
+- Diff: +2,284/-81 = 2,365 changed lines; generated lines: 0; tests run: 194.
   Recorded overage: persistence, residency, replay hydration, turn settlement,
   attachment validation, and focused concurrency/lifecycle tests form one
   required Step 14 seam; splitting would leave resident processes without their

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -4,7 +4,7 @@
 
 - **Plan slug:** `pi-harness`
 - **Implementation base:** current `origin/main` with Step 13 merged
-- **Series state:** Step 13/21 merged; Step 14/21 ready for PR
+- **Series state:** Step 13/21 merged; Step 14/21 in PR
 - **Current step:** 14/21, Pi session residency and turns
 - **Plan PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/811
 - **Step 2 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/819
@@ -20,7 +20,8 @@
 - **Step 11 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/892
 - **Step 12 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/905
 - **Step 13 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/910
-- **Next action:** open and monitor the Step 14 PR, then start Step 15 locally
+- **Step 14 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/914
+- **Next action:** monitor the Step 14 PR while starting Step 15 locally
 
 ## Locked Decisions
 
@@ -60,7 +61,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 | [x] | 11/21 | `⚙️ [pi-harness] feat(pi): replay Pi session history [step 11/21]` | 1,100-1,500 (recorded overage) | Merged as PR #892 |
 | [x] | 12/21 | `🚧 [pi-harness] feat(pi): map live messages and tools [step 12/21]` | 1,200-1,500 (recorded overage) | Merged as PR #905 |
 | [x] | 13/21 | `⚙️ [pi-harness] feat(pi): bridge extension dialogs [step 13/21]` | 900-1,300 | Merged as PR #910 |
-| [ ] | 14/21 | `🚧 [pi-harness] feat(pi): manage session residency and turns [step 14/21]` | 1,200-1,500 (recorded overage) | Ready for PR |
+| [ ] | 14/21 | `🚧 [pi-harness] feat(pi): manage session residency and turns [step 14/21]` | 1,200-1,500 (recorded overage) | PR #914 open |
 | [ ] | 15/21 | `⚙️ [pi-harness] feat(pi): expose models and commands [step 15/21]` | 900-1,300 | Not started |
 | [ ] | 16/21 | `🚧 [pi-harness] feat(pi): implement the plugin API [step 16/21]` | 1,100-1,500 | Not started |
 | [ ] | 17/21 | `🚧 [pi-harness] feat(pi): add managed runtime and lifecycle [step 17/21]` | 1,100-1,500 | Not started; runtime dependency merged |
@@ -444,7 +445,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 - No generated files, database schema, client/bridge wire contract, analytics,
   or registered plugin change. Pi composition/catalog exposure remain Steps
   15-16; Pi remains app-invisible until Step 18.
-- Diff: +2,284/-81 = 2,365 changed lines; generated lines: 0; tests run: 194.
+- Diff: +2,285/-81 = 2,366 changed lines; generated lines: 0; tests run: 194.
   Recorded overage: persistence, residency, replay hydration, turn settlement,
   attachment validation, and focused concurrency/lifecycle tests form one
   required Step 14 seam; splitting would leave resident processes without their

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -456,7 +456,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   so cold replay conservatively displays only the slash-command token for both
   API commands and manually typed slash prompts, never hidden raw arguments;
   live API-command presentation retains exact `userVisibleArguments`.
-- Diff: +3,152/-109 = 3,261 changed lines; generated lines: 0; tests run: 210.
+- Diff: +3,152/-101 = 3,253 changed lines; generated lines: 0; tests run: 210.
   Review-fix working-tree delta excluding this tracker evidence: +586/-85 =
   671 changed lines. Recorded overage:
   persistence, residency, replay hydration, turn settlement, attachment

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -456,7 +456,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   so cold replay conservatively displays only the slash-command token for both
   API commands and manually typed slash prompts, never hidden raw arguments;
   live API-command presentation retains exact `userVisibleArguments`.
-- Diff: +3,202/-102 = 3,304 changed lines; generated lines: 0; tests run: 211.
+- Diff: +3,202/-101 = 3,303 changed lines; generated lines: 0; tests run: 211.
   Review-fix working-tree delta excluding this tracker evidence: +586/-85 =
   671 changed lines. Recorded overage:
   persistence, residency, replay hydration, turn settlement, attachment

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -445,7 +445,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   exact slash-command dispatch with privacy-safe presentation, ambiguous-timeout
   teardown with old-dialog retirement, and disposal waiting for active idle-reap
   teardown.
-- Full package tests pass (203 tests); fatal analysis and diff checks pass. The
+- Full package tests pass (206 tests); fatal analysis and diff checks pass. The
   pinned formatter still crashes on the pre-existing Dart 3.13
   primary-constructor enum in `pi_session_storage_api.dart`; every other changed
   Dart file formats cleanly.
@@ -456,7 +456,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   so cold replay conservatively displays only the slash-command token for both
   API commands and manually typed slash prompts, never hidden raw arguments;
   live API-command presentation retains exact `userVisibleArguments`.
-- Diff: +2,855/-101 = 2,956 changed lines; generated lines: 0; tests run: 203.
+- Diff: +3,000/-101 = 3,101 changed lines; generated lines: 0; tests run: 206.
   Review-fix working-tree delta excluding this tracker evidence: +586/-85 =
   671 changed lines. Recorded overage:
   persistence, residency, replay hydration, turn settlement, attachment

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -424,6 +424,32 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   plugin impact; Pi remains app-invisible until Step 18.
 - Diff: +1,003/-7 = 1,010 changed lines; generated lines: 0; tests run: 170.
 
+### Step 14/21 (local evidence; Step 13 remains in PR)
+
+- Added persistent pending-new markers, secure caller-owned IDs, one
+  generation-fenced resident RPC client per active session, replay hydration
+  before frame attachment, merged tagged frame/exit streams, and resident or
+  transient history/rename leases.
+- Added per-session prompt lanes with immediate admission, selection-before-
+  prompt ordering, same-session FIFO and cross-session concurrency, dialog-first
+  command acceptance, correlated response/event settlement, no-run state
+  barriers, failed-response/exit settlement, abort teardown, idle reap, and
+  idempotent disposal.
+- Added strict bounded inline image validation and visible privacy-safe rejection
+  of paths, URLs, non-image data, malformed base64, and oversized collections.
+- Architecture implementation review approved direct resident-repository
+  response ownership. Full package tests pass (194 tests); fatal analysis and
+  diff checks pass. The pinned formatter still crashes on the pre-existing Dart
+  3.13 primary-constructor enum in `pi_session_storage_api.dart`.
+- No generated files, database schema, client/bridge wire contract, analytics,
+  or registered plugin change. Pi composition/catalog exposure remain Steps
+  15-16; Pi remains app-invisible until Step 18.
+- Diff: +2,278/-75 = 2,353 changed lines; generated lines: 0; tests run: 194.
+  Recorded overage: persistence, residency, replay hydration, turn settlement,
+  attachment validation, and focused concurrency/lifecycle tests form one
+  required Step 14 seam; splitting would leave resident processes without their
+  owning lane or required fencing evidence.
+
 ## Findings And Plan Deltas
 
 - Earlier reviews corrected Pi architecture/lifecycle and added rendered toasts,

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -456,7 +456,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   so cold replay conservatively displays only the slash-command token for both
   API commands and manually typed slash prompts, never hidden raw arguments;
   live API-command presentation retains exact `userVisibleArguments`.
-- Diff: +3,075/-101 = 3,176 changed lines; generated lines: 0; tests run: 208.
+- Diff: +3,074/-101 = 3,175 changed lines; generated lines: 0; tests run: 208.
   Review-fix working-tree delta excluding this tracker evidence: +586/-85 =
   671 changed lines. Recorded overage:
   persistence, residency, replay hydration, turn settlement, attachment

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -445,7 +445,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   exact slash-command dispatch with privacy-safe presentation, ambiguous-timeout
   teardown with old-dialog retirement, and disposal waiting for active idle-reap
   teardown.
-- Full package tests pass (209 tests); fatal analysis and diff checks pass. The
+- Full package tests pass (210 tests); fatal analysis and diff checks pass. The
   pinned formatter still crashes on the pre-existing Dart 3.13
   primary-constructor enum in `pi_session_storage_api.dart`; every other changed
   Dart file formats cleanly.
@@ -456,7 +456,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   so cold replay conservatively displays only the slash-command token for both
   API commands and manually typed slash prompts, never hidden raw arguments;
   live API-command presentation retains exact `userVisibleArguments`.
-- Diff: +3,114/-101 = 3,215 changed lines; generated lines: 0; tests run: 209.
+- Diff: +3,152/-109 = 3,261 changed lines; generated lines: 0; tests run: 210.
   Review-fix working-tree delta excluding this tracker evidence: +586/-85 =
   671 changed lines. Recorded overage:
   persistence, residency, replay hydration, turn settlement, attachment

--- a/bridge/sesori_plugin_pi/lib/src/api/pi_launch_spec.dart
+++ b/bridge/sesori_plugin_pi/lib/src/api/pi_launch_spec.dart
@@ -6,7 +6,7 @@ sealed class const PiSessionLaunch();
 /// Starts a new session under a bridge-generated ID.
 final class PiNewSession({required final String sessionId}) extends PiSessionLaunch {
   this {
-    if (!_sessionIdPattern.hasMatch(sessionId)) {
+    if (!isValidPiSessionId(sessionId: sessionId)) {
       throw ArgumentError.value(sessionId, "sessionId", "must be a valid Pi session ID");
     }
   }
@@ -22,6 +22,8 @@ final class PiResumedSession({required final String sessionPath}) extends PiSess
 }
 
 final RegExp _sessionIdPattern = RegExp(r"^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$");
+
+bool isValidPiSessionId({required String sessionId}) => _sessionIdPattern.hasMatch(sessionId);
 
 /// The verified command line for one Pi JSONL RPC process.
 ///

--- a/bridge/sesori_plugin_pi/lib/src/api/pi_session_storage_api.dart
+++ b/bridge/sesori_plugin_pi/lib/src/api/pi_session_storage_api.dart
@@ -101,6 +101,9 @@ class PiSessionStorageApi({required Map<String, String> environment}) {
     if (!isValidPiSessionId(sessionId: sessionId)) {
       throw ArgumentError.value(sessionId, "sessionId", "must be a valid Pi session ID");
     }
+    if (cwd.contains("\n") || cwd.contains("\r")) {
+      throw ArgumentError.value(cwd, "cwd", "must not contain CR or LF");
+    }
     final normalizedCwd = _absolute(cwd);
     final markerPath = _pendingMarkerPath(environment: _environment, sessionId: sessionId, cwd: normalizedCwd);
     await Isolate.run(() => _writePendingMarker(path: markerPath, cwd: normalizedCwd));

--- a/bridge/sesori_plugin_pi/lib/src/api/pi_session_storage_api.dart
+++ b/bridge/sesori_plugin_pi/lib/src/api/pi_session_storage_api.dart
@@ -126,7 +126,8 @@ class PiSessionStorageApi({required Map<String, String> environment}) {
         return null;
       case _PiPendingMarkerFound(:final cwd):
         return PiPendingNewSession(id: sessionId, cwd: cwd);
-      case _PiPendingMarkerInvalid(:final error, :final stackTrace):
+      case _PiPendingMarkerInvalid(:final path, :final error, :final stackTrace):
+        Log.w("[pi] invalid pending session marker session_id=$sessionId path=$path", error, stackTrace);
         Error.throwWithStackTrace(
           PiInvalidPendingNewSessionException(sessionId: sessionId, cause: error),
           stackTrace,
@@ -302,7 +303,7 @@ void _writePendingMarker({required String path, required String cwd}) {
       found = normalized;
     } on Object catch (error, stackTrace) {
       return (
-        marker: _PiPendingMarkerInvalid(error: error, stackTrace: stackTrace),
+        marker: _PiPendingMarkerInvalid(path: markerPath, error: error, stackTrace: stackTrace),
         diagnostics: markers.diagnostics,
       );
     }
@@ -1010,7 +1011,11 @@ final class const _PiPendingMarkerAbsent() extends _PiPendingMarkerResult;
 
 final class const _PiPendingMarkerFound({required final String cwd}) extends _PiPendingMarkerResult;
 
-final class const _PiPendingMarkerInvalid({required final Object error, required final StackTrace stackTrace})
+final class const _PiPendingMarkerInvalid({
+  required final String path,
+  required final Object error,
+  required final StackTrace stackTrace,
+})
     extends _PiPendingMarkerResult;
 
 final class const _PiSettingsAbsent() extends _PiSettingsValue;

--- a/bridge/sesori_plugin_pi/lib/src/api/pi_session_storage_api.dart
+++ b/bridge/sesori_plugin_pi/lib/src/api/pi_session_storage_api.dart
@@ -105,8 +105,9 @@ class PiSessionStorageApi({required Map<String, String> environment}) {
       throw ArgumentError.value(cwd, "cwd", "must not contain CR or LF");
     }
     final normalizedCwd = _absolute(cwd);
-    final markerPath = _pendingMarkerPath(environment: _environment, sessionId: sessionId, cwd: normalizedCwd);
-    await Isolate.run(() => _writePendingMarker(path: markerPath, cwd: normalizedCwd));
+    final marker = _pendingMarkerPath(environment: _environment, sessionId: sessionId, cwd: normalizedCwd);
+    _logDiagnostics(marker.diagnostics);
+    await Isolate.run(() => _writePendingMarker(path: marker.path, cwd: normalizedCwd));
   }
 
   Future<PiPendingNewSession?> readPendingNewSession({
@@ -119,7 +120,8 @@ class PiSessionStorageApi({required Map<String, String> environment}) {
     final result = await Isolate.run(
       () => _readPendingMarker(environment: environment, sessionId: sessionId, knownDirectories: directories),
     );
-    switch (result) {
+    result.diagnostics.forEach(_logDiagnostics);
+    switch (result.marker) {
       case _PiPendingMarkerAbsent():
         return null;
       case _PiPendingMarkerFound(:final cwd):
@@ -136,9 +138,10 @@ class PiSessionStorageApi({required Map<String, String> environment}) {
     if (!isValidPiSessionId(sessionId: sessionId)) return;
     final environment = _environment;
     final directories = Set<String>.of(knownDirectories);
-    await Isolate.run(
+    final diagnostics = await Isolate.run(
       () => _clearPendingMarkers(environment: environment, sessionId: sessionId, knownDirectories: directories),
     );
+    diagnostics.forEach(_logDiagnostics);
   }
 
   Future<PiSessionFileHistoryDto> _readSessionHistory({required String path}) async {
@@ -243,7 +246,7 @@ class PiSessionHistoryStorageApi({required final PiSessionStorageApi storageApi}
       storageApi._readSessionHistory(path: path);
 }
 
-String _pendingMarkerPath({
+({String path, _PiScanDiagnostics diagnostics}) _pendingMarkerPath({
   required Map<String, String> environment,
   required String sessionId,
   required String cwd,
@@ -251,7 +254,7 @@ String _pendingMarkerPath({
   final result = _resolveEffectiveSessionDirectory(environment: environment, directory: cwd);
   final root = result.path;
   if (root == null) throw StateError("Pi session directory could not be resolved");
-  return p.join(root, ".sesori-pending", "$sessionId.pending");
+  return (path: p.join(root, ".sesori-pending", "$sessionId.pending"), diagnostics: result.diagnostics);
 }
 
 void _writePendingMarker({required String path, required String cwd}) {
@@ -266,17 +269,18 @@ void _writePendingMarker({required String path, required String cwd}) {
   }
 }
 
-_PiPendingMarkerResult _readPendingMarker({
+({_PiPendingMarkerResult marker, List<_PiScanDiagnostics> diagnostics}) _readPendingMarker({
   required Map<String, String> environment,
   required String sessionId,
   required Set<String> knownDirectories,
 }) {
   String? found;
-  for (final markerPath in _pendingMarkerPaths(
+  final markers = _pendingMarkerPaths(
     environment: environment,
     sessionId: sessionId,
     knownDirectories: knownDirectories,
-  )) {
+  );
+  for (final markerPath in markers.paths) {
     final file = File(markerPath);
     if (!file.existsSync()) continue;
     try {
@@ -297,35 +301,49 @@ _PiPendingMarkerResult _readPendingMarker({
       if (found != null && found != normalized) throw const FormatException("Conflicting pending markers");
       found = normalized;
     } on Object catch (error, stackTrace) {
-      return _PiPendingMarkerInvalid(error: error, stackTrace: stackTrace);
+      return (
+        marker: _PiPendingMarkerInvalid(error: error, stackTrace: stackTrace),
+        diagnostics: markers.diagnostics,
+      );
     }
   }
-  return found == null ? const _PiPendingMarkerAbsent() : _PiPendingMarkerFound(cwd: found);
+  return (
+    marker: found == null ? const _PiPendingMarkerAbsent() : _PiPendingMarkerFound(cwd: found),
+    diagnostics: markers.diagnostics,
+  );
 }
 
-void _clearPendingMarkers({
+List<_PiScanDiagnostics> _clearPendingMarkers({
   required Map<String, String> environment,
   required String sessionId,
   required Set<String> knownDirectories,
 }) {
-  for (final markerPath in _pendingMarkerPaths(
+  final markers = _pendingMarkerPaths(
     environment: environment,
     sessionId: sessionId,
     knownDirectories: knownDirectories,
-  )) {
+  );
+  for (final markerPath in markers.paths) {
     final file = File(markerPath);
     if (file.existsSync()) file.deleteSync();
   }
+  return markers.diagnostics;
 }
 
-Set<String> _pendingMarkerPaths({
+({Set<String> paths, List<_PiScanDiagnostics> diagnostics}) _pendingMarkerPaths({
   required Map<String, String> environment,
   required String sessionId,
   required Set<String> knownDirectories,
-}) => {
-  for (final directory in knownDirectories)
-    _pendingMarkerPath(environment: environment, sessionId: sessionId, cwd: directory),
-};
+}) {
+  final paths = <String>{};
+  final diagnostics = <_PiScanDiagnostics>[];
+  for (final directory in knownDirectories) {
+    final marker = _pendingMarkerPath(environment: environment, sessionId: sessionId, cwd: directory);
+    paths.add(marker.path);
+    diagnostics.add(marker.diagnostics);
+  }
+  return (paths: paths, diagnostics: diagnostics);
+}
 
 _PiHistoryReadResult _readPiSessionHistory({required String path}) {
   var resolvedPath = _absolute(path);

--- a/bridge/sesori_plugin_pi/lib/src/api/pi_session_storage_api.dart
+++ b/bridge/sesori_plugin_pi/lib/src/api/pi_session_storage_api.dart
@@ -10,6 +10,7 @@ import "package:sesori_shared/sesori_shared.dart" show jsonDecodeMap;
 
 import "models/pi_session_history_dto.dart";
 import "models/pi_session_metadata_dto.dart";
+import "pi_launch_spec.dart";
 
 final class const PiSessionMetadata({
   required final String id,
@@ -24,6 +25,19 @@ final class const PiResolvedSession({
   required final PiSessionMetadata metadata,
   required final String path,
 });
+
+final class const PiPendingNewSession({
+  required final String id,
+  required final String cwd,
+});
+
+final class const PiInvalidPendingNewSessionException({
+  required final String sessionId,
+  required final Object cause,
+}) implements Exception {
+  @override
+  String toString() => "Invalid pending Pi session marker";
+}
 
 final class const PiInvalidSessionHistoryException({
   required final String path,
@@ -81,6 +95,47 @@ class PiSessionStorageApi({required Map<String, String> environment}) {
     );
     _logDiagnostics(result.diagnostics);
     return result.path;
+  }
+
+  Future<void> writePendingNewSession({required String sessionId, required String cwd}) async {
+    if (!isValidPiSessionId(sessionId: sessionId)) {
+      throw ArgumentError.value(sessionId, "sessionId", "must be a valid Pi session ID");
+    }
+    final normalizedCwd = _absolute(cwd);
+    final markerPath = _pendingMarkerPath(environment: _environment, sessionId: sessionId, cwd: normalizedCwd);
+    await Isolate.run(() => _writePendingMarker(path: markerPath, cwd: normalizedCwd));
+  }
+
+  Future<PiPendingNewSession?> readPendingNewSession({
+    required String sessionId,
+    required Set<String> knownDirectories,
+  }) async {
+    if (!isValidPiSessionId(sessionId: sessionId)) return null;
+    final environment = _environment;
+    final directories = Set<String>.of(knownDirectories);
+    final result = await Isolate.run(
+      () => _readPendingMarker(environment: environment, sessionId: sessionId, knownDirectories: directories),
+    );
+    switch (result) {
+      case _PiPendingMarkerAbsent():
+        return null;
+      case _PiPendingMarkerFound(:final cwd):
+        return PiPendingNewSession(id: sessionId, cwd: cwd);
+      case _PiPendingMarkerInvalid(:final error, :final stackTrace):
+        Error.throwWithStackTrace(
+          PiInvalidPendingNewSessionException(sessionId: sessionId, cause: error),
+          stackTrace,
+        );
+    }
+  }
+
+  Future<void> clearPendingNewSession({required String sessionId, required Set<String> knownDirectories}) async {
+    if (!isValidPiSessionId(sessionId: sessionId)) return;
+    final environment = _environment;
+    final directories = Set<String>.of(knownDirectories);
+    await Isolate.run(
+      () => _clearPendingMarkers(environment: environment, sessionId: sessionId, knownDirectories: directories),
+    );
   }
 
   Future<PiSessionFileHistoryDto> _readSessionHistory({required String path}) async {
@@ -184,6 +239,90 @@ class PiSessionHistoryStorageApi({required final PiSessionStorageApi storageApi}
   Future<PiSessionFileHistoryDto> readSessionHistory({required String path}) =>
       storageApi._readSessionHistory(path: path);
 }
+
+String _pendingMarkerPath({
+  required Map<String, String> environment,
+  required String sessionId,
+  required String cwd,
+}) {
+  final result = _resolveEffectiveSessionDirectory(environment: environment, directory: cwd);
+  final root = result.path;
+  if (root == null) throw StateError("Pi session directory could not be resolved");
+  return p.join(root, ".sesori-pending", "$sessionId.pending");
+}
+
+void _writePendingMarker({required String path, required String cwd}) {
+  final directory = Directory(p.dirname(path));
+  directory.createSync(recursive: true);
+  final temporary = File("$path.tmp");
+  try {
+    temporary.writeAsStringSync("$cwd\n", flush: true);
+    temporary.renameSync(path);
+  } finally {
+    if (temporary.existsSync()) temporary.deleteSync();
+  }
+}
+
+_PiPendingMarkerResult _readPendingMarker({
+  required Map<String, String> environment,
+  required String sessionId,
+  required Set<String> knownDirectories,
+}) {
+  String? found;
+  for (final markerPath in _pendingMarkerPaths(
+    environment: environment,
+    sessionId: sessionId,
+    knownDirectories: knownDirectories,
+  )) {
+    final file = File(markerPath);
+    if (!file.existsSync()) continue;
+    try {
+      final bytes = file.openSync(mode: FileMode.read)..setPositionSync(0);
+      late final List<int> content;
+      try {
+        content = bytes.readSync(16 * 1024 + 1);
+      } finally {
+        bytes.closeSync();
+      }
+      if (content.length > 16 * 1024) throw const FormatException("Pending marker exceeds byte limit");
+      final text = utf8.decode(content, allowMalformed: false);
+      final cwd = text.endsWith("\n") ? text.substring(0, text.length - 1) : text;
+      if (cwd.isEmpty || cwd.contains("\n") || cwd.contains("\r") || !p.isAbsolute(cwd)) {
+        throw const FormatException("Pending marker cwd is invalid");
+      }
+      final normalized = _absolute(cwd);
+      if (found != null && found != normalized) throw const FormatException("Conflicting pending markers");
+      found = normalized;
+    } on Object catch (error, stackTrace) {
+      return _PiPendingMarkerInvalid(error: error, stackTrace: stackTrace);
+    }
+  }
+  return found == null ? const _PiPendingMarkerAbsent() : _PiPendingMarkerFound(cwd: found);
+}
+
+void _clearPendingMarkers({
+  required Map<String, String> environment,
+  required String sessionId,
+  required Set<String> knownDirectories,
+}) {
+  for (final markerPath in _pendingMarkerPaths(
+    environment: environment,
+    sessionId: sessionId,
+    knownDirectories: knownDirectories,
+  )) {
+    final file = File(markerPath);
+    if (file.existsSync()) file.deleteSync();
+  }
+}
+
+Set<String> _pendingMarkerPaths({
+  required Map<String, String> environment,
+  required String sessionId,
+  required Set<String> knownDirectories,
+}) => {
+  for (final directory in knownDirectories)
+    _pendingMarkerPath(environment: environment, sessionId: sessionId, cwd: directory),
+};
 
 _PiHistoryReadResult _readPiSessionHistory({required String path}) {
   var resolvedPath = _absolute(path);
@@ -843,6 +982,15 @@ final class const _PiStorageLayout({required final List<_PiScanRoot> roots});
 final class const _PiAgentScope({required final String agentDirectory, required final String? baseDirectory});
 
 sealed class const _PiSettingsValue();
+
+sealed class const _PiPendingMarkerResult();
+
+final class const _PiPendingMarkerAbsent() extends _PiPendingMarkerResult;
+
+final class const _PiPendingMarkerFound({required final String cwd}) extends _PiPendingMarkerResult;
+
+final class const _PiPendingMarkerInvalid({required final Object error, required final StackTrace stackTrace})
+    extends _PiPendingMarkerResult;
 
 final class const _PiSettingsAbsent() extends _PiSettingsValue;
 

--- a/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_history_mapper.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_history_mapper.dart
@@ -94,10 +94,12 @@ final class PiHistoryMapper({
     required String sessionId,
     required String messageId,
     required PiUserMessageDto message,
+    required String? exactText,
   }) => _mapUserMessage(
     sessionId: sessionId,
     messageId: messageId,
     message: message,
+    exactText: exactText,
     warnings: <_PiHistoryWarning>{},
   );
 
@@ -105,10 +107,12 @@ final class PiHistoryMapper({
     required String sessionId,
     required String messageId,
     required PiUserMessageDto message,
+    required String? exactText,
     required Set<_PiHistoryWarning> warnings,
   }) {
     final parts = _mapUserContent(
       content: message.content,
+      exactText: exactText,
       sessionId: sessionId,
       messageId: messageId,
       warnings: warnings,
@@ -320,6 +324,7 @@ final class PiHistoryMapper({
                 sessionId: sessionId,
                 messageId: messageId,
                 message: message,
+                exactText: null,
                 warnings: warnings,
               );
               if (mapped != null) messages.add(_MessageDraft(info: mapped.info, parts: mapped.parts.toList()));
@@ -471,6 +476,7 @@ final class PiHistoryMapper({
 
   List<PluginMessagePart> _mapUserContent({
     required List<PiContentDto> content,
+    required String? exactText,
     required String sessionId,
     required String messageId,
     required Set<_PiHistoryWarning> warnings,
@@ -481,7 +487,7 @@ final class PiHistoryMapper({
       final block = content[index];
       switch (block) {
         case PiTextContentDto(:final text):
-          final visibleText = _persistedUserTextCodec.decodeVisibleText(persistedText: text);
+          final visibleText = exactText ?? _persistedUserTextCodec.decodeVisibleText(persistedText: text);
           if (visibleText.isEmpty) continue;
           parts.add(
             _part(

--- a/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_persisted_user_text_codec.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_persisted_user_text_codec.dart
@@ -16,7 +16,13 @@ final class const PiPersistedUserTextCodec() {
   }
 
   String decodeVisibleText({required String persistedText}) {
-    if (!persistedText.startsWith(marker)) return persistedText;
+    if (!persistedText.startsWith(marker)) {
+      if (persistedText.startsWith("/")) {
+        final separator = persistedText.indexOf(RegExp(r"\s"));
+        return separator < 0 ? persistedText : persistedText.substring(0, separator);
+      }
+      return persistedText;
+    }
     final hiddenSeparator = persistedText.indexOf(":", marker.length);
     if (hiddenSeparator < 0) return persistedText;
     final visibleSeparator = persistedText.indexOf(":", hiddenSeparator + 1);

--- a/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
@@ -130,6 +130,8 @@ final class PiSessionProcessRepository({
     required String sessionId,
     required Set<String> knownDirectories,
   }) async {
+    final resident = _residents[sessionId];
+    if (resident == null || !resident.pendingPersistence) return false;
     final resolved = await _storageApi.resolveSession(
       sessionId: sessionId,
       knownDirectories: knownDirectories,
@@ -139,6 +141,7 @@ final class PiSessionProcessRepository({
       sessionId: sessionId,
       knownDirectories: {...knownDirectories, resolved.metadata.cwd},
     );
+    if (identical(_residents[sessionId], resident)) resident.pendingPersistence = false;
     return true;
   }
 
@@ -236,7 +239,11 @@ final class PiSessionProcessRepository({
         await client.dispose();
         throw StateError("Pi session connection was invalidated during startup");
       }
-      final resident = _ResidentClient(client: client, generation: generation);
+      final resident = _ResidentClient(
+        client: client,
+        generation: generation,
+        initialPendingPersistence: pending != null,
+      );
       _residents[sessionId] = resident;
       resident.frameSubscription = client.frames.listen((frame) {
         if (identical(_residents[sessionId], resident) && !_frames.isClosed) {
@@ -878,11 +885,15 @@ final class PiSessionProcessRepository({
 
 final class const _ConnectingClient({required final PiRpcClient client, required final int generation});
 
-final class _ResidentClient({required final PiRpcClient client, required final int generation}) {
+final class _ResidentClient({
+  required final PiRpcClient client,
+  required final int generation,
+  required bool initialPendingPersistence,
+}) {
   StreamSubscription<PiRpcFrame>? frameSubscription;
   ({String providerID, String modelID})? model;
   String? variant;
-
+  bool pendingPersistence = initialPendingPersistence;
   Future<void> cancelFrames() async {
     await frameSubscription?.cancel();
     frameSubscription = null;

--- a/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
@@ -601,12 +601,13 @@ final class PiSessionProcessRepository({
     required Set<String> knownDirectories,
   }) async {
     if (_disposed) throw const PiRpcDisposedException();
+    final hydration = _identityTracker.beginHydration(sessionId: sessionId);
     final PiResolvedSession? resolved;
     try {
       final resident = _residents[sessionId];
       if (resident != null) {
         final history = await _getEntries(client: resident.client);
-        return _hydrateHistory(sessionId: sessionId, history: history);
+        return _hydrateHistory(sessionId: sessionId, history: history, hydration: hydration);
       }
       resolved = await _storageApi.resolveSession(sessionId: sessionId, knownDirectories: knownDirectories);
     } on Object catch (error, stack) {
@@ -628,6 +629,7 @@ final class PiSessionProcessRepository({
       return _hydrateHistory(
         sessionId: sessionId,
         history: await _readHistory(resolved: resolved),
+        hydration: hydration,
       );
     } on Object catch (error, stack) {
       _throwLoadFailure(path: resolved.path, error: error, stack: stack);
@@ -652,17 +654,18 @@ final class PiSessionProcessRepository({
     }
   }
 
-  List<PluginMessageWithParts> _hydrateHistory({required String sessionId, required PiSessionEntriesDto history}) =>
-      _identityTracker
-          .beginHydration(sessionId: sessionId)
-          .complete(
-            map: (identities) => _historyMapper.map(
-              sessionId: sessionId,
-              entries: history.entries,
-              leafId: history.leafId,
-              identities: identities,
-            ),
-          );
+  List<PluginMessageWithParts> _hydrateHistory({
+    required String sessionId,
+    required PiSessionEntriesDto history,
+    required PiMessageIdentityHydration hydration,
+  }) => hydration.complete(
+    map: (identities) => _historyMapper.map(
+      sessionId: sessionId,
+      entries: history.entries,
+      leafId: history.leafId,
+      identities: identities,
+    ),
+  );
 
   Future<PiSessionEntriesDto> _readHistory({required PiResolvedSession resolved}) async {
     try {

--- a/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
@@ -126,6 +126,22 @@ final class PiSessionProcessRepository({
   Future<void> markPendingNew({required String sessionId, required String directory}) =>
       _storageApi.writePendingNewSession(sessionId: sessionId, cwd: directory);
 
+  Future<bool> clearPendingWhenPersisted({
+    required String sessionId,
+    required Set<String> knownDirectories,
+  }) async {
+    final resolved = await _storageApi.resolveSession(
+      sessionId: sessionId,
+      knownDirectories: knownDirectories,
+    );
+    if (resolved == null) return false;
+    await _storageApi.clearPendingNewSession(
+      sessionId: sessionId,
+      knownDirectories: {...knownDirectories, resolved.metadata.cwd},
+    );
+    return true;
+  }
+
   Future<PiSessionConnection> ensureResident({
     required String sessionId,
     required Set<String> knownDirectories,
@@ -348,7 +364,9 @@ final class PiSessionProcessRepository({
 
   PiPromptPayload mapPrompt({required List<PluginPromptPart> parts, required String? userVisibleText}) {
     final executionText = parts.whereType<PluginPromptPartText>().map((part) => part.text).join();
-    final message = executionText == userVisibleText
+    final message = executionText.isEmpty && (userVisibleText == null || userVisibleText.isEmpty)
+        ? ""
+        : executionText == userVisibleText
         ? executionText
         : const PiPersistedUserTextCodec().encode(
             executionText: executionText,

--- a/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
@@ -512,7 +512,7 @@ final class PiSessionProcessRepository({
   }
 
   Future<void> teardown({required String sessionId}) async {
-    _generations[sessionId] = ++_nextConnectionGeneration;
+    _generations.remove(sessionId);
     final connecting = _connectingClients.remove(sessionId);
     if (connecting != null) {
       final wasRunning = connecting.client.isRunning;

--- a/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
@@ -101,10 +101,12 @@ final class PiSessionProcessRepository({
   final Map<String, String> _environment = Map.unmodifiable(environment);
   final Map<String, _ResidentClient> _residents = {};
   final Map<String, Future<PiSessionConnection>> _connecting = {};
+  final Map<String, _ConnectingClient> _connectingClients = {};
   final Map<String, Future<void>> _sessionOperationTails = {};
   final Map<String, int> _generations = {};
   final StreamController<PiSessionProcessFrame> _frames = StreamController.broadcast();
   final StreamController<PiSessionProcessExit> _exits = StreamController.broadcast();
+  var _nextConnectionGeneration = 0;
   bool _disposed = false;
 
   Stream<PiSessionProcessFrame> get frames => _frames.stream;
@@ -156,7 +158,7 @@ final class PiSessionProcessRepository({
     required String sessionId,
     required Set<String> knownDirectories,
   }) async {
-    final generation = (_generations[sessionId] ?? 0) + 1;
+    final generation = ++_nextConnectionGeneration;
     _generations[sessionId] = generation;
     final resolved = await _storageApi.resolveSession(
       sessionId: sessionId,
@@ -175,6 +177,16 @@ final class PiSessionProcessRepository({
         cause: PiSessionHistoryNotFoundException(sessionId: sessionId),
       );
     }
+    if (resolved != null) {
+      try {
+        await _storageApi.clearPendingNewSession(
+          sessionId: sessionId,
+          knownDirectories: {...knownDirectories, resolved.metadata.cwd},
+        );
+      } on Object catch (error, stack) {
+        Log.w("[pi] failed to clear stale pending marker for resolved session id=$sessionId; continuing", error, stack);
+      }
+    }
     final launch = resolved == null ? PiNewSession(sessionId: sessionId) : PiResumedSession(sessionPath: resolved.path);
     final cwd = resolved?.metadata.cwd ?? pending!.cwd;
     final client = PiRpcClient(
@@ -186,6 +198,8 @@ final class PiSessionProcessRepository({
       ),
       processFactory: _processFactory,
     );
+    final connecting = _ConnectingClient(client: client, generation: generation);
+    _connectingClients[sessionId] = connecting;
     try {
       await client.start();
       if (_disposed || _generations[sessionId] != generation) {
@@ -230,9 +244,6 @@ final class PiSessionProcessRepository({
           }
         }),
       );
-      if (resolved != null) {
-        await _storageApi.clearPendingNewSession(sessionId: sessionId, knownDirectories: knownDirectories);
-      }
       return PiSessionConnection(sessionId: sessionId, generation: generation);
     } on Object catch (error, stack) {
       final authUnavailable = client.stderrDiagnostics.contains(PiRpcClient.noModelsDiagnosticPrefix);
@@ -241,6 +252,10 @@ final class PiSessionProcessRepository({
         Error.throwWithStackTrace(PiSessionAuthenticationException(innerError: error), stack);
       }
       rethrow;
+    } finally {
+      if (identical(_connectingClients[sessionId], connecting)) {
+        _connectingClients.remove(sessionId);
+      }
     }
   }
 
@@ -321,9 +336,15 @@ final class PiSessionProcessRepository({
 
   bool sendExtensionUiResponse({
     required String ownerSessionId,
+    required int generation,
     required String requestId,
     required PiExtensionUiReply reply,
-  }) => _residents[ownerSessionId]?.client.sendExtensionUiResponse(id: requestId, reply: reply) ?? false;
+  }) {
+    final resident = _residents[ownerSessionId];
+    return resident != null && resident.generation == generation
+        ? resident.client.sendExtensionUiResponse(id: requestId, reply: reply)
+        : false;
+  }
 
   PiPromptPayload mapPrompt({required List<PluginPromptPart> parts, required String? userVisibleText}) {
     final executionText = parts.whereType<PluginPromptPartText>().map((part) => part.text).join();
@@ -491,26 +512,37 @@ final class PiSessionProcessRepository({
   }
 
   Future<void> teardown({required String sessionId}) async {
-    _generations[sessionId] = (_generations[sessionId] ?? 0) + 1;
+    _generations[sessionId] = ++_nextConnectionGeneration;
+    final connecting = _connectingClients.remove(sessionId);
+    if (connecting != null) {
+      final wasRunning = connecting.client.isRunning;
+      final disposal = connecting.client.dispose();
+      if (wasRunning) {
+        await disposal;
+      } else {
+        unawaited(
+          disposal.catchError((Object error, StackTrace stack) {
+            Log.w("[pi] connecting client teardown failed for session id=$sessionId", error, stack);
+          }),
+        );
+      }
+    }
     final resident = _residents.remove(sessionId);
     if (resident == null) return;
     await resident.cancelFrames();
     await resident.client.dispose();
   }
 
-  Future<bool> clearPendingWhenPersisted({
-    required String sessionId,
-    required Set<String> knownDirectories,
-  }) async {
-    final resolved = await _storageApi.resolveSession(sessionId: sessionId, knownDirectories: knownDirectories);
-    if (resolved == null) return false;
-    await _storageApi.clearPendingNewSession(sessionId: sessionId, knownDirectories: knownDirectories);
-    return true;
+  Future<void> teardownConnection({required PiSessionConnection connection}) async {
+    final resident = _residents[connection.sessionId];
+    if (resident == null || resident.generation != connection.generation) return;
+    await teardown(sessionId: connection.sessionId);
   }
 
   Future<void> forgetSession({required String sessionId, required Set<String> knownDirectories}) async {
     await teardown(sessionId: sessionId);
     await _storageApi.clearPendingNewSession(sessionId: sessionId, knownDirectories: knownDirectories);
+    _generations.remove(sessionId);
     _identityTracker.forgetSession(sessionId: sessionId);
   }
 
@@ -518,9 +550,11 @@ final class PiSessionProcessRepository({
     if (_disposed) return;
     _disposed = true;
     for (final sessionId in {..._residents.keys, ..._connecting.keys}) {
-      _generations[sessionId] = (_generations[sessionId] ?? 0) + 1;
+      _generations[sessionId] = ++_nextConnectionGeneration;
     }
-    await Future.wait([for (final sessionId in _residents.keys.toList()) teardown(sessionId: sessionId)]);
+    await Future.wait([
+      for (final sessionId in {..._residents.keys, ..._connectingClients.keys}) teardown(sessionId: sessionId),
+    ]);
     await Future.wait(
       _connecting.values.map((future) => future.then<void>((_) {}, onError: (Object _, StackTrace _) {})),
     );
@@ -823,6 +857,8 @@ final class PiSessionProcessRepository({
     );
   }
 }
+
+final class const _ConnectingClient({required final PiRpcClient client, required final int generation});
 
 final class _ResidentClient({required final PiRpcClient client, required final int generation}) {
   StreamSubscription<PiRpcFrame>? frameSubscription;

--- a/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
@@ -601,11 +601,11 @@ final class PiSessionProcessRepository({
     required Set<String> knownDirectories,
   }) async {
     if (_disposed) throw const PiRpcDisposedException();
-    final hydration = _identityTracker.beginHydration(sessionId: sessionId);
     final PiResolvedSession? resolved;
     try {
       final resident = _residents[sessionId];
       if (resident != null) {
+        final hydration = _identityTracker.beginHydration(sessionId: sessionId);
         final history = await _getEntries(client: resident.client);
         return _hydrateHistory(sessionId: sessionId, history: history, hydration: hydration);
       }
@@ -626,10 +626,11 @@ final class PiSessionProcessRepository({
     }
 
     try {
+      final history = await _readHistory(resolved: resolved);
       return _hydrateHistory(
         sessionId: sessionId,
-        history: await _readHistory(resolved: resolved),
-        hydration: hydration,
+        history: history,
+        hydration: _identityTracker.beginHydration(sessionId: sessionId),
       );
     } on Object catch (error, stack) {
       _throwLoadFailure(path: resolved.path, error: error, stack: stack);

--- a/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
@@ -1,8 +1,12 @@
-import "dart:async" show TimeoutException;
+import "dart:async";
+import "dart:convert";
+import "dart:math";
 
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
-    show Log, PluginMessageWithParts, PluginOperationException;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart"
+    show decodedBase64Length, isInlineMessageAttachmentWithinSizeLimit, maxInlineMessageAttachmentBytes;
 
+import "../api/models/pi_rpc_frame.dart";
 import "../api/models/pi_session_history_dto.dart";
 import "../api/pi_launch_spec.dart";
 import "../api/pi_process_factory.dart";
@@ -11,6 +15,7 @@ import "../api/pi_session_storage_api.dart";
 import "../models/pi_rpc_command.dart";
 import "../trackers/pi_message_identity_tracker.dart";
 import "mappers/pi_history_mapper.dart";
+import "mappers/pi_persisted_user_text_codec.dart";
 
 final class const PiSessionHistoryNotFoundException({required final String sessionId}) implements Exception {
   @override
@@ -37,6 +42,51 @@ final class const PiSessionHistoryCommandDiagnostic({required final String detai
   String toString() => "Pi session history command failed: $detail";
 }
 
+final class const PiSessionProcessFrame({
+  required final String sessionId,
+  required final int generation,
+  required final PiRpcFrame frame,
+});
+
+final class const PiSessionProcessExit({
+  required final String sessionId,
+  required final int generation,
+  required final int exitCode,
+  required final bool authUnavailable,
+});
+
+final class const PiSessionConnection({
+  required final String sessionId,
+  required final int generation,
+});
+
+final class const PiPromptPayload({required final String message, required final List<Map<String, Object?>> images});
+
+final class const PiAgentState({required final bool streaming, required final int pendingMessageCount});
+
+final class const PiUnsupportedPromptAttachmentException({required final String variant}) implements Exception {
+  @override
+  String toString() => "Unsupported Pi prompt attachment variant: $variant";
+}
+
+final class const PiInvalidPromptImageException({required final String reason}) implements Exception {
+  @override
+  String toString() => "Invalid Pi prompt image: $reason";
+}
+
+final class const PiSessionAuthenticationException({required final Object innerError}) implements Exception {
+  @override
+  String toString() => "Pi session authentication is unavailable";
+}
+
+final class const PiSessionCommandDiagnostic({
+  required final PiRpcCommand command,
+  required final String detail,
+}) implements Exception {
+  @override
+  String toString() => "Pi session command ${command.wireValue} failed: $detail";
+}
+
 final class PiSessionProcessRepository({
   required final PiSessionStorageApi _storageApi,
   required final PiSessionHistoryStorageApi _historyStorageApi,
@@ -49,13 +99,456 @@ final class PiSessionProcessRepository({
   required final Duration _historyRpcTimeout,
 }) {
   final Map<String, String> _environment = Map.unmodifiable(environment);
+  final Map<String, _ResidentClient> _residents = {};
+  final Map<String, Future<PiSessionConnection>> _connecting = {};
+  final Map<String, Future<void>> _sessionOperationTails = {};
+  final Map<String, int> _generations = {};
+  final StreamController<PiSessionProcessFrame> _frames = StreamController.broadcast();
+  final StreamController<PiSessionProcessExit> _exits = StreamController.broadcast();
+  bool _disposed = false;
+
+  Stream<PiSessionProcessFrame> get frames => _frames.stream;
+  Stream<PiSessionProcessExit> get exits => _exits.stream;
+  Set<String> get residentSessionIds => Set.unmodifiable(_residents.keys);
+
+  String generateSessionId() {
+    final random = Random.secure();
+    final bytes = List<int>.generate(16, (_) => random.nextInt(256));
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    final hex = bytes.map((byte) => byte.toRadixString(16).padLeft(2, "0")).join();
+    return "${hex.substring(0, 8)}-${hex.substring(8, 12)}-${hex.substring(12, 16)}-"
+        "${hex.substring(16, 20)}-${hex.substring(20)}";
+  }
+
+  Future<void> markPendingNew({required String sessionId, required String directory}) =>
+      _storageApi.writePendingNewSession(sessionId: sessionId, cwd: directory);
+
+  Future<PiSessionConnection> ensureResident({
+    required String sessionId,
+    required Set<String> knownDirectories,
+  }) => _withSessionOperation(
+    sessionId: sessionId,
+    operation: () => _ensureResident(sessionId: sessionId, knownDirectories: knownDirectories),
+  );
+
+  Future<PiSessionConnection> _ensureResident({
+    required String sessionId,
+    required Set<String> knownDirectories,
+  }) async {
+    if (_disposed) throw const PiRpcDisposedException();
+    final resident = _residents[sessionId];
+    if (resident != null) {
+      return PiSessionConnection(sessionId: sessionId, generation: resident.generation);
+    }
+    final connecting = _connecting[sessionId];
+    if (connecting != null) return await connecting;
+    final future = _connect(sessionId: sessionId, knownDirectories: knownDirectories);
+    _connecting[sessionId] = future;
+    try {
+      return await future;
+    } finally {
+      if (identical(_connecting[sessionId], future)) unawaited(_connecting.remove(sessionId));
+    }
+  }
+
+  Future<PiSessionConnection> _connect({
+    required String sessionId,
+    required Set<String> knownDirectories,
+  }) async {
+    final generation = (_generations[sessionId] ?? 0) + 1;
+    _generations[sessionId] = generation;
+    final resolved = await _storageApi.resolveSession(
+      sessionId: sessionId,
+      knownDirectories: knownDirectories,
+    );
+    final pending = resolved == null
+        ? await _storageApi.readPendingNewSession(
+            sessionId: sessionId,
+            knownDirectories: knownDirectories,
+          )
+        : null;
+    if (resolved == null && pending == null) {
+      throw PluginOperationException.notFound(
+        "connect Pi session",
+        message: "Pi session was not found.",
+        cause: PiSessionHistoryNotFoundException(sessionId: sessionId),
+      );
+    }
+    final launch = resolved == null ? PiNewSession(sessionId: sessionId) : PiResumedSession(sessionPath: resolved.path);
+    final cwd = resolved?.metadata.cwd ?? pending!.cwd;
+    final client = PiRpcClient(
+      launchSpec: PiLaunchSpec(
+        binaryPath: _binaryPath,
+        workingDirectory: cwd,
+        launch: launch,
+        environment: _environment,
+      ),
+      processFactory: _processFactory,
+    );
+    try {
+      await client.start();
+      if (_disposed || _generations[sessionId] != generation) {
+        await client.dispose();
+        throw StateError("Pi session connection was invalidated during startup");
+      }
+      final history = await _getEntries(client: client);
+      final hydration = _identityTracker.beginHydration(sessionId: sessionId);
+      hydration.complete(
+        map: (identities) => _historyMapper.map(
+          sessionId: sessionId,
+          entries: history.entries,
+          leafId: history.leafId,
+          identities: identities,
+        ),
+      );
+      if (_disposed || _generations[sessionId] != generation) {
+        await client.dispose();
+        throw StateError("Pi session connection was invalidated during startup");
+      }
+      final resident = _ResidentClient(client: client, generation: generation);
+      _residents[sessionId] = resident;
+      resident.frameSubscription = client.frames.listen((frame) {
+        if (identical(_residents[sessionId], resident) && !_frames.isClosed) {
+          _frames.add(PiSessionProcessFrame(sessionId: sessionId, generation: generation, frame: frame));
+        }
+      });
+      unawaited(
+        client.processExit.then((exitCode) {
+          if (!identical(_residents[sessionId], resident)) return;
+          _residents.remove(sessionId);
+          unawaited(resident.cancelFrames());
+          if (!_exits.isClosed) {
+            _exits.add(
+              PiSessionProcessExit(
+                sessionId: sessionId,
+                generation: generation,
+                exitCode: exitCode,
+                authUnavailable: client.stderrDiagnostics.contains(PiRpcClient.noModelsDiagnosticPrefix),
+              ),
+            );
+          }
+        }),
+      );
+      if (resolved != null) {
+        await _storageApi.clearPendingNewSession(sessionId: sessionId, knownDirectories: knownDirectories);
+      }
+      return PiSessionConnection(sessionId: sessionId, generation: generation);
+    } on Object catch (error, stack) {
+      final authUnavailable = client.stderrDiagnostics.contains(PiRpcClient.noModelsDiagnosticPrefix);
+      if (!_residents.containsKey(sessionId)) await client.dispose();
+      if (authUnavailable) {
+        Error.throwWithStackTrace(PiSessionAuthenticationException(innerError: error), stack);
+      }
+      rethrow;
+    }
+  }
+
+  Future<PiSessionEntriesDto> _getEntries({required PiRpcClient client}) async {
+    final response = await client.send(
+      command: PiRpcCommand.getEntries,
+      arguments: const {},
+      timeout: _historyRpcTimeout,
+    );
+    try {
+      return PiSessionEntriesDto.fromJson(response.data.cast<String, dynamic>());
+    } on Object catch (error, stack) {
+      Error.throwWithStackTrace(PiSessionHistoryParseException(innerError: error), stack);
+    }
+  }
+
+  Future<void> applySelection({
+    required String sessionId,
+    required PiSessionConnection connection,
+    required ({String providerID, String modelID})? model,
+    required PluginSessionVariant? variant,
+  }) async {
+    final resident = _requiredResident(connection);
+    if (model != null && resident.model != model) {
+      await resident.client.send(
+        command: PiRpcCommand.setModel,
+        arguments: {"provider": model.providerID, "modelId": model.modelID},
+        timeout: _historyRpcTimeout,
+      );
+      resident.model = model;
+      resident.variant = null;
+    }
+    final variantId = variant?.id;
+    if (variantId != null && resident.variant != variantId) {
+      await resident.client.send(
+        command: PiRpcCommand.setThinkingLevel,
+        arguments: {"level": variantId},
+        timeout: _historyRpcTimeout,
+      );
+      resident.variant = variantId;
+    }
+  }
+
+  Future<void> dispatchPrompt({
+    required PiSessionConnection connection,
+    required PiPromptPayload payload,
+  }) async {
+    final resident = _requiredResident(connection);
+    await resident.client.send(
+      command: PiRpcCommand.prompt,
+      arguments: {"message": payload.message, "images": payload.images},
+      timeout: _historyRpcTimeout,
+    );
+  }
+
+  Future<PiAgentState> getState({required PiSessionConnection connection}) async {
+    final data = (await _requiredResident(connection).client.send(
+      command: PiRpcCommand.getState,
+      arguments: const {},
+      timeout: _historyRpcTimeout,
+    )).data;
+    return PiAgentState(
+      streaming: data["isStreaming"] == true,
+      pendingMessageCount: switch (data["pendingMessageCount"]) {
+        final int value when value >= 0 => value,
+        _ => 0,
+      },
+    );
+  }
+
+  Future<void> abort({required PiSessionConnection connection}) async {
+    await _requiredResident(connection).client.send(
+      command: PiRpcCommand.abort,
+      arguments: const {},
+      timeout: _historyRpcTimeout,
+    );
+  }
+
+  bool sendExtensionUiResponse({
+    required String ownerSessionId,
+    required String requestId,
+    required PiExtensionUiReply reply,
+  }) => _residents[ownerSessionId]?.client.sendExtensionUiResponse(id: requestId, reply: reply) ?? false;
+
+  PiPromptPayload mapPrompt({required List<PluginPromptPart> parts, required String? userVisibleText}) {
+    final executionText = parts.whereType<PluginPromptPartText>().map((part) => part.text).join();
+    final message = executionText == userVisibleText
+        ? executionText
+        : const PiPersistedUserTextCodec().encode(
+            executionText: executionText,
+            userVisibleText: userVisibleText,
+          );
+    var totalImageBytes = 0;
+    final images = <Map<String, Object?>>[];
+    for (final part in parts) {
+      switch (part) {
+        case PluginPromptPartText():
+          break;
+        case PluginPromptPartFileData(:final mime, base64: final raw):
+          if (!const {"image/gif", "image/jpeg", "image/png", "image/webp"}.contains(mime.toLowerCase())) {
+            _throwAttachmentFailure(
+              cause: const PiUnsupportedPromptAttachmentException(variant: "inline non-image data"),
+            );
+          }
+          if (raw.isEmpty || !isInlineMessageAttachmentWithinSizeLimit(base64Length: raw.length)) {
+            _throwAttachmentFailure(cause: const PiInvalidPromptImageException(reason: "image exceeds size limit"));
+          }
+          final String normalized;
+          try {
+            normalized = base64.normalize(raw);
+          } on FormatException catch (error, stack) {
+            Error.throwWithStackTrace(
+              PluginOperationException(
+                "send Pi prompt",
+                statusCode: 400,
+                message: "Pi supports valid inline image data only.",
+                cause: PiInvalidPromptImageException(reason: error.message),
+              ),
+              stack,
+            );
+          }
+          try {
+            base64.decode(normalized);
+          } on FormatException catch (error, stack) {
+            Error.throwWithStackTrace(
+              PluginOperationException(
+                "send Pi prompt",
+                statusCode: 400,
+                message: "Pi supports valid inline image data only.",
+                cause: PiInvalidPromptImageException(reason: error.message),
+              ),
+              stack,
+            );
+          }
+          final decodedBytes = decodedBase64Length(base64Data: normalized);
+          totalImageBytes += decodedBytes;
+          if (decodedBytes == 0 ||
+              decodedBytes > maxInlineMessageAttachmentBytes ||
+              totalImageBytes > maxInlineMessageAttachmentBytes) {
+            _throwAttachmentFailure(cause: const PiInvalidPromptImageException(reason: "image exceeds size limit"));
+          }
+          images.add({"type": "image", "data": normalized, "mimeType": mime.toLowerCase()});
+        case PluginPromptPartFilePath():
+          _throwAttachmentFailure(cause: const PiUnsupportedPromptAttachmentException(variant: "file path"));
+        case PluginPromptPartFileUrl():
+          _throwAttachmentFailure(cause: const PiUnsupportedPromptAttachmentException(variant: "file URL"));
+      }
+    }
+    return PiPromptPayload(message: message, images: List.unmodifiable(images));
+  }
+
+  Never _throwAttachmentFailure({required Object cause}) => throw PluginOperationException(
+    "send Pi prompt",
+    statusCode: 400,
+    message: "Pi supports inline image data only.",
+    cause: cause,
+  );
+
+  PluginOperationException presentTurnFailure({required String sessionId, required Object error}) {
+    final resident = _residents[sessionId];
+    final authUnavailable =
+        error is PiSessionAuthenticationException ||
+        (resident?.client.stderrDiagnostics.contains(PiRpcClient.noModelsDiagnosticPrefix) ?? false);
+    return PluginOperationException(
+      "run Pi session turn",
+      message: authUnavailable
+          ? "Pi has no model available. Run Pi locally and use /login, then try again."
+          : "Pi could not run this turn.",
+      cause: authUnavailable
+          ? PiSessionAuthenticationException(innerError: error)
+          : switch (error) {
+              PiRpcCommandFailureException(:final command, :final error) => PiSessionCommandDiagnostic(
+                command: command,
+                detail: error,
+              ),
+              _ => error,
+            },
+    );
+  }
+
+  _ResidentClient _requiredResident(PiSessionConnection connection) {
+    final resident = _residents[connection.sessionId];
+    if (resident == null || resident.generation != connection.generation) {
+      throw const PiRpcDisposedException();
+    }
+    return resident;
+  }
+
+  Future<void> renameSession({
+    required String sessionId,
+    required String title,
+    required Set<String> knownDirectories,
+  }) => _withSessionOperation(
+    sessionId: sessionId,
+    operation: () => _renameSession(sessionId: sessionId, title: title, knownDirectories: knownDirectories),
+  );
+
+  Future<void> _renameSession({
+    required String sessionId,
+    required String title,
+    required Set<String> knownDirectories,
+  }) async {
+    if (_disposed) throw const PiRpcDisposedException();
+    final resident = _residents[sessionId];
+    if (resident != null) {
+      await resident.client.send(
+        command: PiRpcCommand.setSessionName,
+        arguments: {"name": title},
+        timeout: _historyRpcTimeout,
+      );
+      return;
+    }
+    final lease = await _openTransient(sessionId: sessionId, knownDirectories: knownDirectories);
+    try {
+      await lease.client.send(
+        command: PiRpcCommand.setSessionName,
+        arguments: {"name": title},
+        timeout: _historyRpcTimeout,
+      );
+    } finally {
+      await lease.client.dispose();
+    }
+  }
+
+  Future<_TransientClient> _openTransient({
+    required String sessionId,
+    required Set<String> knownDirectories,
+  }) async {
+    final resolved = await _storageApi.resolveSession(sessionId: sessionId, knownDirectories: knownDirectories);
+    if (resolved == null) {
+      throw PluginOperationException.notFound(
+        "open Pi session",
+        message: "Pi session was not found.",
+        cause: PiSessionHistoryNotFoundException(sessionId: sessionId),
+      );
+    }
+    final client = PiRpcClient(
+      launchSpec: PiLaunchSpec(
+        binaryPath: _binaryPath,
+        workingDirectory: resolved.metadata.cwd,
+        launch: PiResumedSession(sessionPath: resolved.path),
+        environment: _environment,
+      ),
+      processFactory: _processFactory,
+    );
+    await client.start();
+    return _TransientClient(client: client, resolved: resolved);
+  }
+
+  Future<void> teardown({required String sessionId}) async {
+    _generations[sessionId] = (_generations[sessionId] ?? 0) + 1;
+    final resident = _residents.remove(sessionId);
+    if (resident == null) return;
+    await resident.cancelFrames();
+    await resident.client.dispose();
+  }
+
+  Future<bool> clearPendingWhenPersisted({
+    required String sessionId,
+    required Set<String> knownDirectories,
+  }) async {
+    final resolved = await _storageApi.resolveSession(sessionId: sessionId, knownDirectories: knownDirectories);
+    if (resolved == null) return false;
+    await _storageApi.clearPendingNewSession(sessionId: sessionId, knownDirectories: knownDirectories);
+    return true;
+  }
+
+  Future<void> forgetSession({required String sessionId, required Set<String> knownDirectories}) async {
+    await teardown(sessionId: sessionId);
+    await _storageApi.clearPendingNewSession(sessionId: sessionId, knownDirectories: knownDirectories);
+    _identityTracker.forgetSession(sessionId: sessionId);
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    for (final sessionId in {..._residents.keys, ..._connecting.keys}) {
+      _generations[sessionId] = (_generations[sessionId] ?? 0) + 1;
+    }
+    await Future.wait([for (final sessionId in _residents.keys.toList()) teardown(sessionId: sessionId)]);
+    await Future.wait(
+      _connecting.values.map((future) => future.then<void>((_) {}, onError: (Object _, StackTrace _) {})),
+    );
+    await Future.wait(_sessionOperationTails.values.toList());
+    await _frames.close();
+    await _exits.close();
+  }
 
   Future<List<PluginMessageWithParts>> loadHistory({
     required String sessionId,
     required Set<String> knownDirectories,
+  }) => _withSessionOperation(
+    sessionId: sessionId,
+    operation: () => _loadHistory(sessionId: sessionId, knownDirectories: knownDirectories),
+  );
+
+  Future<List<PluginMessageWithParts>> _loadHistory({
+    required String sessionId,
+    required Set<String> knownDirectories,
   }) async {
+    if (_disposed) throw const PiRpcDisposedException();
     final PiResolvedSession? resolved;
     try {
+      final resident = _residents[sessionId];
+      if (resident != null) {
+        final history = await _getEntries(client: resident.client);
+        return _hydrateHistory(sessionId: sessionId, history: history);
+      }
       resolved = await _storageApi.resolveSession(sessionId: sessionId, knownDirectories: knownDirectories);
     } on Object catch (error, stack) {
       _throwLoadFailure(path: "session storage", error: error, stack: stack);
@@ -72,26 +565,52 @@ final class PiSessionProcessRepository({
       );
     }
 
-    final identityHydration = _identityTracker.beginHydration(sessionId: sessionId);
     try {
-      final history = await _readHistory(resolved: resolved);
-      final mapped = identityHydration.complete(
-        map: (identities) => _historyMapper.map(
-          sessionId: sessionId,
-          entries: history.entries,
-          leafId: history.leafId,
-          identities: identities,
-        ),
+      return _hydrateHistory(
+        sessionId: sessionId,
+        history: await _readHistory(resolved: resolved),
       );
-      return mapped;
     } on Object catch (error, stack) {
       _throwLoadFailure(path: resolved.path, error: error, stack: stack);
     }
   }
 
+  Future<T> _withSessionOperation<T>({
+    required String sessionId,
+    required Future<T> Function() operation,
+  }) async {
+    final previous = _sessionOperationTails[sessionId] ?? Future.value();
+    final completed = Completer<void>();
+    _sessionOperationTails[sessionId] = completed.future;
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      completed.complete();
+      if (identical(_sessionOperationTails[sessionId], completed.future)) {
+        unawaited(_sessionOperationTails.remove(sessionId));
+      }
+    }
+  }
+
+  List<PluginMessageWithParts> _hydrateHistory({required String sessionId, required PiSessionEntriesDto history}) =>
+      _identityTracker
+          .beginHydration(sessionId: sessionId)
+          .complete(
+            map: (identities) => _historyMapper.map(
+              sessionId: sessionId,
+              entries: history.entries,
+              leafId: history.leafId,
+              identities: identities,
+            ),
+          );
+
   Future<PiSessionEntriesDto> _readHistory({required PiResolvedSession resolved}) async {
     try {
-      return await _readHistoryFromRpc(resolved: resolved);
+      final resident = _residents[resolved.metadata.id];
+      return resident == null
+          ? await _readHistoryFromRpc(resolved: resolved)
+          : await _getEntries(client: resident.client);
     } on PiHistoryRpcStartupUnavailableException catch (error, stack) {
       Log.w(
         "[pi] history RPC startup unavailable at '${resolved.path}'; reading persisted session history",
@@ -304,3 +823,16 @@ final class PiSessionProcessRepository({
     );
   }
 }
+
+final class _ResidentClient({required final PiRpcClient client, required final int generation}) {
+  StreamSubscription<PiRpcFrame>? frameSubscription;
+  ({String providerID, String modelID})? model;
+  String? variant;
+
+  Future<void> cancelFrames() async {
+    await frameSubscription?.cancel();
+    frameSubscription = null;
+  }
+}
+
+final class const _TransientClient({required final PiRpcClient client, required final PiResolvedSession resolved});

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
@@ -305,9 +305,9 @@ final class PiEventDispatcher({
     final message = _historyMapper.decodeUserMessage(raw: raw);
     if (message == null) return const [];
     final state = _session(sessionId);
-    final content = message.content.singleOrNull;
+    final textContent = message.content.whereType<PiTextContentDto>().singleOrNull;
     final visibleText = state.userVisibleText;
-    final exactText = content is PiTextContentDto && content.text == state.executionText ? visibleText : null;
+    final exactText = textContent?.text == state.executionText ? visibleText : null;
     final messageId = state.identities.next(role: PiMessageIdentityRole.user, timestamp: message.timestamp);
     final mapped = _historyMapper.mapUserMessage(
       sessionId: sessionId,

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
@@ -19,8 +19,12 @@ final class PiEventDispatcher({
   final PiToolTracker _tools = toolTracker;
   final Map<String, _SessionState> _sessions = {};
 
-  void beginTurn({required String sessionId}) {
-    _session(sessionId).clearMessage();
+  void beginTurn({required String sessionId, required String? executionText, required String? userVisibleText}) {
+    final state = _session(sessionId);
+    state
+      ..clearMessage()
+      ..executionText = executionText
+      ..userVisibleText = userVisibleText;
     _tools.beginTurn(sessionId: sessionId);
   }
 
@@ -301,8 +305,16 @@ final class PiEventDispatcher({
     final message = _historyMapper.decodeUserMessage(raw: raw);
     if (message == null) return const [];
     final state = _session(sessionId);
+    final content = message.content.singleOrNull;
+    final visibleText = state.userVisibleText;
+    final exactText = content is PiTextContentDto && content.text == state.executionText ? visibleText : null;
     final messageId = state.identities.next(role: PiMessageIdentityRole.user, timestamp: message.timestamp);
-    final mapped = _historyMapper.mapUserMessage(sessionId: sessionId, messageId: messageId, message: message);
+    final mapped = _historyMapper.mapUserMessage(
+      sessionId: sessionId,
+      messageId: messageId,
+      message: message,
+      exactText: exactText,
+    );
     if (mapped == null) return const [];
     return [
       BridgeSseMessageUpdated(info: mapped.info.toJson()),
@@ -591,6 +603,8 @@ final class PiEventDispatcher({
 final class _SessionState({required final PiMessageIdentityBuilder identities}) {
   String? messageId;
   PiAssistantMessageDto? message;
+  String? executionText;
+  String? userVisibleText;
   bool announced = false;
   final Set<({int contentIndex, PluginMessagePartType type})> startedParts = {};
   final Set<String> emittedPartIds = {};

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_extension_ui_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_extension_ui_service.dart
@@ -48,11 +48,16 @@ final class PiExtensionUiService({
   final StreamController<PiExtensionUiEvent> _events = StreamController.broadcast(sync: true);
   final Map<String, Timer> _timers = {};
   final Map<String, int> _ownerGenerations = {};
+  final Map<String, int> _cancelledProcessGenerations = {};
   var _disposed = false;
 
   Stream<PiExtensionUiEvent> get events => _events.stream;
 
-  Future<void> handleRequest({required String ownerSessionId, required PiExtensionUiRequest request}) async {
+  Future<void> handleRequest({
+    required String ownerSessionId,
+    required int processGeneration,
+    required PiExtensionUiRequest request,
+  }) async {
     if (_disposed) return;
     switch (request) {
       case PiNotifyRequest(:final message, :final notifyType):
@@ -74,30 +79,56 @@ final class PiExtensionUiService({
         try {
           scope = await _catalogRepository.resolveDisplayScope(sessionId: ownerSessionId);
         } on Object {
-          _cancel(ownerSessionId: ownerSessionId, requestId: dialog.id);
+          _cancel(
+            ownerSessionId: ownerSessionId,
+            processGeneration: processGeneration,
+            requestId: dialog.id,
+          );
           rethrow;
         }
         if (_disposed) {
-          _cancel(ownerSessionId: ownerSessionId, requestId: dialog.id);
+          _cancel(
+            ownerSessionId: ownerSessionId,
+            processGeneration: processGeneration,
+            requestId: dialog.id,
+          );
           return;
         }
-        if ((_ownerGenerations[ownerSessionId] ?? 0) != generation) {
-          _cancel(ownerSessionId: ownerSessionId, requestId: dialog.id);
+        if ((_ownerGenerations[ownerSessionId] ?? 0) != generation ||
+            processGeneration <= (_cancelledProcessGenerations[ownerSessionId] ?? -1)) {
+          _cancel(
+            ownerSessionId: ownerSessionId,
+            processGeneration: processGeneration,
+            requestId: dialog.id,
+          );
           return;
         }
         if (scope == null) {
-          _cancel(ownerSessionId: ownerSessionId, requestId: dialog.id);
+          _cancel(
+            ownerSessionId: ownerSessionId,
+            processGeneration: processGeneration,
+            requestId: dialog.id,
+          );
           return;
         }
         final timeout = _timeoutFor(dialog);
         final remaining = timeout == null ? null : timeout - elapsed.elapsed;
         if (remaining != null && remaining <= Duration.zero) {
           if (dialog is PiEditorDialogRequest) {
-            _cancel(ownerSessionId: ownerSessionId, requestId: dialog.id);
+            _cancel(
+              ownerSessionId: ownerSessionId,
+              processGeneration: processGeneration,
+              requestId: dialog.id,
+            );
           }
           return;
         }
-        final tracked = _tracked(dialog: dialog, ownerSessionId: ownerSessionId, scope: scope);
+        final tracked = _tracked(
+          dialog: dialog,
+          ownerSessionId: ownerSessionId,
+          processGeneration: processGeneration,
+          scope: scope,
+        );
         _tracker.add(dialog: tracked);
         _scheduleTimeout(tracked: tracked, timeout: remaining);
         _events.add(PiExtensionUiQuestionAsked(question: _tracker.pending(dialog: tracked)));
@@ -126,6 +157,7 @@ final class PiExtensionUiService({
     }
     if (!_processRepository.sendExtensionUiResponse(
       ownerSessionId: dialog.ownerSessionId,
+      generation: dialog.processGeneration,
       requestId: dialog.requestId,
       reply: reply,
     )) {
@@ -145,6 +177,7 @@ final class PiExtensionUiService({
     final dialog = _required(questionId: questionId, sessionId: sessionId);
     if (!_processRepository.sendExtensionUiResponse(
       ownerSessionId: dialog.ownerSessionId,
+      generation: dialog.processGeneration,
       requestId: dialog.requestId,
       reply: const PiExtensionUiCancelledReply(),
     )) {
@@ -154,12 +187,20 @@ final class PiExtensionUiService({
     _rejected(dialog);
   }
 
-  void cancelForOwner({required String sessionId}) {
-    _ownerGenerations[sessionId] = (_ownerGenerations[sessionId] ?? 0) + 1;
-    for (final dialog in _tracker.takeForOwner(sessionId: sessionId)) {
+  void cancelForOwner({required String sessionId, required int? processGeneration}) {
+    if (processGeneration == null) {
+      _ownerGenerations[sessionId] = (_ownerGenerations[sessionId] ?? 0) + 1;
+    } else {
+      _cancelledProcessGenerations[sessionId] = processGeneration;
+    }
+    for (final dialog in _tracker.takeForOwner(
+      sessionId: sessionId,
+      processGeneration: processGeneration,
+    )) {
       _cancelTimer(questionId: dialog.questionId);
       _processRepository.sendExtensionUiResponse(
         ownerSessionId: dialog.ownerSessionId,
+        generation: dialog.processGeneration,
         requestId: dialog.requestId,
         reply: const PiExtensionUiCancelledReply(),
       );
@@ -174,18 +215,21 @@ final class PiExtensionUiService({
       _cancelTimer(questionId: dialog.questionId);
       _processRepository.sendExtensionUiResponse(
         ownerSessionId: dialog.ownerSessionId,
+        generation: dialog.processGeneration,
         requestId: dialog.requestId,
         reply: const PiExtensionUiCancelledReply(),
       );
       _rejected(dialog);
     }
     _ownerGenerations.clear();
+    _cancelledProcessGenerations.clear();
     await _events.close();
   }
 
   PiTrackedExtensionDialog _tracked({
     required PiExtensionDialogRequest dialog,
     required String ownerSessionId,
+    required int processGeneration,
     required ({String displaySessionId, String projectId}) scope,
   }) {
     final questionId = _tracker.nextQuestionId();
@@ -193,6 +237,7 @@ final class PiExtensionUiService({
       questionId: questionId,
       requestId: dialog.id,
       ownerSessionId: ownerSessionId,
+      processGeneration: processGeneration,
       displaySessionId: scope.displaySessionId,
       projectId: scope.projectId,
     );
@@ -201,6 +246,7 @@ final class PiExtensionUiService({
         questionId: shared.questionId,
         requestId: shared.requestId,
         ownerSessionId: shared.ownerSessionId,
+        processGeneration: shared.processGeneration,
         displaySessionId: shared.displaySessionId,
         projectId: shared.projectId,
         question: PluginQuestionInfo(
@@ -216,6 +262,7 @@ final class PiExtensionUiService({
         questionId: shared.questionId,
         requestId: shared.requestId,
         ownerSessionId: shared.ownerSessionId,
+        processGeneration: shared.processGeneration,
         displaySessionId: shared.displaySessionId,
         projectId: shared.projectId,
         question: PluginQuestionInfo(
@@ -233,6 +280,7 @@ final class PiExtensionUiService({
         questionId: shared.questionId,
         requestId: shared.requestId,
         ownerSessionId: shared.ownerSessionId,
+        processGeneration: shared.processGeneration,
         displaySessionId: shared.displaySessionId,
         projectId: shared.projectId,
         question: PluginQuestionInfo(
@@ -247,6 +295,7 @@ final class PiExtensionUiService({
         questionId: shared.questionId,
         requestId: shared.requestId,
         ownerSessionId: shared.ownerSessionId,
+        processGeneration: shared.processGeneration,
         displaySessionId: shared.displaySessionId,
         projectId: shared.projectId,
         question: PluginQuestionInfo(
@@ -279,6 +328,7 @@ final class PiExtensionUiService({
       if (tracked is PiTrackedEditorDialog) {
         _processRepository.sendExtensionUiResponse(
           ownerSessionId: tracked.ownerSessionId,
+          generation: tracked.processGeneration,
           requestId: tracked.requestId,
           reply: const PiExtensionUiCancelledReply(),
         );
@@ -306,9 +356,14 @@ final class PiExtensionUiService({
 
   void _cancelTimer({required String questionId}) => _timers.remove(questionId)?.cancel();
 
-  void _cancel({required String ownerSessionId, required String requestId}) {
+  void _cancel({
+    required String ownerSessionId,
+    required int processGeneration,
+    required String requestId,
+  }) {
     _processRepository.sendExtensionUiResponse(
       ownerSessionId: ownerSessionId,
+      generation: processGeneration,
       requestId: requestId,
       reply: const PiExtensionUiCancelledReply(),
     );

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_extension_ui_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_extension_ui_service.dart
@@ -6,13 +6,8 @@ import "../api/models/pi_extension_ui_request.dart";
 import "../api/pi_rpc_client.dart";
 import "../models/pi_notification_type.dart";
 import "../repositories/pi_session_catalog_repository.dart";
+import "../repositories/pi_session_process_repository.dart";
 import "../trackers/pi_extension_ui_tracker.dart";
-
-typedef PiExtensionUiResponseSender = bool Function({
-  required String ownerSessionId,
-  required String requestId,
-  required PiExtensionUiReply reply,
-});
 
 sealed class const PiExtensionUiEvent();
 
@@ -39,16 +34,16 @@ final class const PiExtensionUiToast({
 
 final class PiExtensionUiService({
   required final PiSessionCatalogRepository catalogRepository,
+  required final PiSessionProcessRepository processRepository,
   required final PiExtensionUiTracker tracker,
-  required final PiExtensionUiResponseSender responseSender,
   required final Duration editorTimeout,
 }) {
   static const maxTextLength = 500;
   static const defaultEditorTimeout = Duration(minutes: 30);
 
   final PiSessionCatalogRepository _catalogRepository = catalogRepository;
+  final PiSessionProcessRepository _processRepository = processRepository;
   final PiExtensionUiTracker _tracker = tracker;
-  final PiExtensionUiResponseSender _responseSender = responseSender;
   final Duration _editorTimeout = editorTimeout;
   final StreamController<PiExtensionUiEvent> _events = StreamController.broadcast(sync: true);
   final Map<String, Timer> _timers = {};
@@ -129,7 +124,11 @@ final class PiExtensionUiService({
         message: "The question response is invalid.",
       );
     }
-    if (!_responseSender(ownerSessionId: dialog.ownerSessionId, requestId: dialog.requestId, reply: reply)) {
+    if (!_processRepository.sendExtensionUiResponse(
+      ownerSessionId: dialog.ownerSessionId,
+      requestId: dialog.requestId,
+      reply: reply,
+    )) {
       _retireUnavailable(dialog: dialog, operation: "reply to Pi extension question");
     }
     _take(questionId: questionId);
@@ -144,7 +143,7 @@ final class PiExtensionUiService({
 
   void rejectQuestion({required String questionId, required String? sessionId}) {
     final dialog = _required(questionId: questionId, sessionId: sessionId);
-    if (!_responseSender(
+    if (!_processRepository.sendExtensionUiResponse(
       ownerSessionId: dialog.ownerSessionId,
       requestId: dialog.requestId,
       reply: const PiExtensionUiCancelledReply(),
@@ -159,7 +158,7 @@ final class PiExtensionUiService({
     _ownerGenerations[sessionId] = (_ownerGenerations[sessionId] ?? 0) + 1;
     for (final dialog in _tracker.takeForOwner(sessionId: sessionId)) {
       _cancelTimer(questionId: dialog.questionId);
-      _responseSender(
+      _processRepository.sendExtensionUiResponse(
         ownerSessionId: dialog.ownerSessionId,
         requestId: dialog.requestId,
         reply: const PiExtensionUiCancelledReply(),
@@ -173,7 +172,7 @@ final class PiExtensionUiService({
     _disposed = true;
     for (final dialog in _tracker.takeAll()) {
       _cancelTimer(questionId: dialog.questionId);
-      _responseSender(
+      _processRepository.sendExtensionUiResponse(
         ownerSessionId: dialog.ownerSessionId,
         requestId: dialog.requestId,
         reply: const PiExtensionUiCancelledReply(),
@@ -278,7 +277,7 @@ final class PiExtensionUiService({
       _tracker.take(questionId: tracked.questionId);
       _timers.remove(tracked.questionId);
       if (tracked is PiTrackedEditorDialog) {
-        _responseSender(
+        _processRepository.sendExtensionUiResponse(
           ownerSessionId: tracked.ownerSessionId,
           requestId: tracked.requestId,
           reply: const PiExtensionUiCancelledReply(),
@@ -308,7 +307,7 @@ final class PiExtensionUiService({
   void _cancelTimer({required String questionId}) => _timers.remove(questionId)?.cancel();
 
   void _cancel({required String ownerSessionId, required String requestId}) {
-    _responseSender(
+    _processRepository.sendExtensionUiResponse(
       ownerSessionId: ownerSessionId,
       requestId: requestId,
       reply: const PiExtensionUiCancelledReply(),

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_extension_ui_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_extension_ui_service.dart
@@ -191,7 +191,10 @@ final class PiExtensionUiService({
     if (processGeneration == null) {
       _ownerGenerations[sessionId] = (_ownerGenerations[sessionId] ?? 0) + 1;
     } else {
-      _cancelledProcessGenerations[sessionId] = processGeneration;
+      final cancelledGeneration = _cancelledProcessGenerations[sessionId];
+      if (cancelledGeneration == null || processGeneration > cancelledGeneration) {
+        _cancelledProcessGenerations[sessionId] = processGeneration;
+      }
     }
     for (final dialog in _tracker.takeForOwner(
       sessionId: sessionId,

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -410,6 +410,8 @@ final class PiSessionService({
     _extensionUi.cancelForOwner(sessionId: sessionId, processGeneration: null);
     final connection = cancelled.firstOrNull?.connection;
     try {
+      final idleReap = state.idleReap;
+      if (idleReap != null) await idleReap;
       if (connection != null) await _processes.abort(connection: connection);
     } on Object catch (error, stack) {
       Log.w("[pi] abort command failed for session id=$sessionId", error, stack);

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -25,6 +25,7 @@ final class _PiSessionTurnState({required final String initialDirectory}) {
   String directory = initialDirectory;
   final List<_PiTurn> queue = [];
   _PiTurn? active;
+  Future<void>? idleReap;
   int generation = 0;
   int idleGeneration = 0;
 }
@@ -180,6 +181,11 @@ final class PiSessionService({
     required int generation,
   }) async {
     try {
+      final idleReap = state.idleReap;
+      if (idleReap != null) await idleReap;
+      if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) {
+        throw PiTurnCancelledException(sessionId: sessionId);
+      }
       final connection = await _processes.ensureResident(
         sessionId: sessionId,
         knownDirectories: {state.directory},
@@ -354,6 +360,7 @@ final class PiSessionService({
     if (!identical(_sessions[sessionId], state) || !identical(state.active, turn)) return;
     state.active = null;
     if (failed) _emit(BridgeSseSessionError(sessionID: sessionId));
+    unawaited(_clearPendingWhenPersisted(sessionId: sessionId, directory: state.directory));
     if (state.queue.isNotEmpty) {
       _startNext(sessionId: sessionId, state: state);
       return;
@@ -368,6 +375,19 @@ final class PiSessionService({
     _emit(const BridgeSseProjectUpdated());
     _syncWorkState();
     _scheduleIdleReap(sessionId: sessionId, state: state);
+  }
+
+  Future<void> _clearPendingWhenPersisted({required String sessionId, required String directory}) async {
+    try {
+      if (await _processes.clearPendingWhenPersisted(
+        sessionId: sessionId,
+        knownDirectories: {directory},
+      )) {
+        _pendingNewDirectories.remove(sessionId);
+      }
+    } on Object catch (error, stack) {
+      Log.w("[pi] failed to clear persisted pending marker for session id=$sessionId", error, stack);
+    }
   }
 
   Future<void> abort({required String sessionId}) async {
@@ -437,10 +457,12 @@ final class PiSessionService({
       }
       _extensionUi.cancelForOwner(sessionId: sessionId, processGeneration: null);
       final teardown = _processes.teardown(sessionId: sessionId);
+      state.idleReap = teardown;
       _activeIdleReaps.add(teardown);
       try {
         await teardown;
       } finally {
+        if (identical(state.idleReap, teardown)) state.idleReap = null;
         _activeIdleReaps.remove(teardown);
       }
       if (identical(_sessions[sessionId], state) && state.idleGeneration == generation) {

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -33,6 +33,7 @@ final class _PiTurn({
   required final PiPromptPayload payload,
   required final ({String providerID, String modelID})? model,
   required final PluginSessionVariant? variant,
+  required final String? userVisibleText,
   required final Completer<void>? commandAcceptance,
 }) {
   PiSessionConnection? connection;
@@ -62,6 +63,7 @@ final class PiSessionService({
   final Duration _idleTimeout = idleTimeout;
   final Map<String, _PiSessionTurnState> _sessions = {};
   final Map<String, String> _pendingNewDirectories = {};
+  final Set<Future<void>> _activeIdleReaps = {};
   final StreamController<BridgeSseEvent> _events = StreamController.broadcast();
   final PluginWorkStateController _workState = PluginWorkStateController(initial: PluginWorkState.idle);
   late final StreamSubscription<PiSessionProcessFrame> _frameSubscription;
@@ -105,6 +107,7 @@ final class PiSessionService({
         payload: payload,
         model: model,
         variant: variant,
+        userVisibleText: userVisibleText,
         commandAcceptance: null,
       ),
     );
@@ -126,11 +129,10 @@ final class PiSessionService({
       return Future.error(PiSessionBusyException(sessionId: sessionId));
     }
     final execution = arguments.isEmpty ? "/$command" : "/$command $arguments";
+    final visibleArguments = userVisibleArguments;
+    final visible = visibleArguments == null || visibleArguments.isEmpty ? "/$command" : "/$command $visibleArguments";
     final acceptance = Completer<void>();
-    final payload = _processes.mapPrompt(
-      parts: [PluginPromptPart.text(text: execution)],
-      userVisibleText: userVisibleArguments,
-    );
+    final payload = PiPromptPayload(message: execution, images: const []);
     _admit(
       sessionId: sessionId,
       directory: directory,
@@ -138,6 +140,7 @@ final class PiSessionService({
         payload: payload,
         model: model,
         variant: variant,
+        userVisibleText: visible,
         commandAcceptance: acceptance,
       ),
     );
@@ -194,7 +197,11 @@ final class PiSessionService({
       if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) {
         throw PiTurnCancelledException(sessionId: sessionId);
       }
-      _dispatcher.beginTurn(sessionId: sessionId);
+      _dispatcher.beginTurn(
+        sessionId: sessionId,
+        executionText: turn.payload.message,
+        userVisibleText: turn.userVisibleText,
+      );
       turn.promptDispatched = true;
       final response = _processes.dispatchPrompt(connection: connection, payload: turn.payload);
       await response;
@@ -221,6 +228,17 @@ final class PiSessionService({
       if (error is PiRpcProcessExitException) {
         await Future<void>.delayed(Duration.zero);
         if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
+      }
+      if (error is TimeoutException && turn.promptDispatched) {
+        final connection = turn.connection;
+        if (connection != null) {
+          _extensionUi.cancelForOwner(
+            sessionId: sessionId,
+            processGeneration: connection.generation,
+          );
+          await _processes.teardownConnection(connection: connection);
+          if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
+        }
       }
       final acceptance = turn.commandAcceptance;
       if (acceptance != null && !acceptance.isCompleted) acceptance.completeError(error, stack);
@@ -280,11 +298,17 @@ final class PiSessionService({
           acceptance.complete();
         }
         unawaited(
-          _extensionUi.handleRequest(ownerSessionId: processFrame.sessionId, request: request).catchError(
-            (Object error, StackTrace stack) {
-              Log.w("[pi] extension UI routing failed for session id=${processFrame.sessionId}", error, stack);
-            },
-          ),
+          _extensionUi
+              .handleRequest(
+                ownerSessionId: processFrame.sessionId,
+                processGeneration: processFrame.generation,
+                request: request,
+              )
+              .catchError(
+                (Object error, StackTrace stack) {
+                  Log.w("[pi] extension UI routing failed for session id=${processFrame.sessionId}", error, stack);
+                },
+              ),
         );
       case PiResponseFrame() || PiUnknownFrame():
         break;
@@ -292,7 +316,7 @@ final class PiSessionService({
   }
 
   void _handleExit(PiSessionProcessExit exit) {
-    _extensionUi.cancelForOwner(sessionId: exit.sessionId);
+    _extensionUi.cancelForOwner(sessionId: exit.sessionId, processGeneration: exit.generation);
     final state = _sessions[exit.sessionId];
     final turn = state?.active;
     if (state == null || turn == null || turn.connection?.generation != exit.generation) return;
@@ -330,7 +354,6 @@ final class PiSessionService({
     if (!identical(_sessions[sessionId], state) || !identical(state.active, turn)) return;
     state.active = null;
     if (failed) _emit(BridgeSseSessionError(sessionID: sessionId));
-    unawaited(_clearPendingWhenPersisted(sessionId: sessionId, directory: state.directory));
     if (state.queue.isNotEmpty) {
       _startNext(sessionId: sessionId, state: state);
       return;
@@ -345,19 +368,6 @@ final class PiSessionService({
     _emit(const BridgeSseProjectUpdated());
     _syncWorkState();
     _scheduleIdleReap(sessionId: sessionId, state: state);
-  }
-
-  Future<void> _clearPendingWhenPersisted({required String sessionId, required String directory}) async {
-    try {
-      if (await _processes.clearPendingWhenPersisted(
-        sessionId: sessionId,
-        knownDirectories: {directory},
-      )) {
-        _pendingNewDirectories.remove(sessionId);
-      }
-    } on Object catch (error, stack) {
-      Log.w("[pi] failed to clear persisted pending marker for session id=$sessionId", error, stack);
-    }
   }
 
   Future<void> abort({required String sessionId}) async {
@@ -377,7 +387,7 @@ final class PiSessionService({
         acceptance.completeError(PiTurnCancelledException(sessionId: sessionId), StackTrace.current);
       }
     }
-    _extensionUi.cancelForOwner(sessionId: sessionId);
+    _extensionUi.cancelForOwner(sessionId: sessionId, processGeneration: null);
     final connection = cancelled.firstOrNull?.connection;
     try {
       if (connection != null) await _processes.abort(connection: connection);
@@ -404,7 +414,7 @@ final class PiSessionService({
       state.generation++;
       state.idleGeneration++;
     }
-    _extensionUi.cancelForOwner(sessionId: sessionId);
+    _extensionUi.cancelForOwner(sessionId: sessionId, processGeneration: null);
     final pendingDirectory = _pendingNewDirectories.remove(sessionId);
     await _processes.forgetSession(
       sessionId: sessionId,
@@ -425,8 +435,14 @@ final class PiSessionService({
           state.idleGeneration != generation) {
         return;
       }
-      _extensionUi.cancelForOwner(sessionId: sessionId);
-      await _processes.teardown(sessionId: sessionId);
+      _extensionUi.cancelForOwner(sessionId: sessionId, processGeneration: null);
+      final teardown = _processes.teardown(sessionId: sessionId);
+      _activeIdleReaps.add(teardown);
+      try {
+        await teardown;
+      } finally {
+        _activeIdleReaps.remove(teardown);
+      }
       if (identical(_sessions[sessionId], state) && state.idleGeneration == generation) {
         _sessions.remove(sessionId);
       }
@@ -471,6 +487,7 @@ final class PiSessionService({
     await _frameSubscription.cancel();
     await _exitSubscription.cancel();
     await _extensionUi.dispose();
+    await Future.wait(_activeIdleReaps.toList());
     await _processes.dispose();
     _sessions.clear();
     _pendingNewDirectories.clear();

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -1,0 +1,480 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" as shared;
+
+import "../api/models/pi_event.dart";
+import "../api/models/pi_extension_ui_request.dart";
+import "../api/models/pi_rpc_frame.dart";
+import "../api/pi_rpc_client.dart";
+import "../repositories/pi_session_process_repository.dart";
+import "pi_event_dispatcher.dart";
+import "pi_extension_ui_service.dart";
+
+final class const PiSessionBusyException({required final String sessionId}) implements Exception {
+  @override
+  String toString() => "Pi session is busy";
+}
+
+final class const PiTurnCancelledException({required final String sessionId}) implements Exception {
+  @override
+  String toString() => "Pi turn was cancelled";
+}
+
+final class _PiSessionTurnState({required final String initialDirectory}) {
+  String directory = initialDirectory;
+  final List<_PiTurn> queue = [];
+  _PiTurn? active;
+  int generation = 0;
+  int idleGeneration = 0;
+}
+
+final class _PiTurn({
+  required final PiPromptPayload payload,
+  required final ({String providerID, String modelID})? model,
+  required final PluginSessionVariant? variant,
+  required final Completer<void>? commandAcceptance,
+}) {
+  PiSessionConnection? connection;
+  bool promptDispatched = false;
+  bool responseSucceeded = false;
+  bool agentStarted = false;
+  bool agentSettled = false;
+  bool settled = false;
+}
+
+final class PiSessionService({
+  required final PiSessionProcessRepository processRepository,
+  required final PiEventDispatcher eventDispatcher,
+  required final PiExtensionUiService extensionUiService,
+  required final ServerClock clock,
+  required final Duration idleTimeout,
+}) {
+  this {
+    _frameSubscription = _processes.frames.listen(_handleFrame);
+    _exitSubscription = _processes.exits.listen(_handleExit);
+  }
+
+  final PiSessionProcessRepository _processes = processRepository;
+  final PiEventDispatcher _dispatcher = eventDispatcher;
+  final PiExtensionUiService _extensionUi = extensionUiService;
+  final ServerClock _clock = clock;
+  final Duration _idleTimeout = idleTimeout;
+  final Map<String, _PiSessionTurnState> _sessions = {};
+  final Map<String, String> _pendingNewDirectories = {};
+  final StreamController<BridgeSseEvent> _events = StreamController.broadcast();
+  final PluginWorkStateController _workState = PluginWorkStateController(initial: PluginWorkState.idle);
+  late final StreamSubscription<PiSessionProcessFrame> _frameSubscription;
+  late final StreamSubscription<PiSessionProcessExit> _exitSubscription;
+  Future<void>? _disposeFuture;
+  bool _disposed = false;
+
+  Stream<BridgeSseEvent> get events => _events.stream;
+  Stream<PluginWorkState> get workState => _workState.stream;
+  PluginWorkState get currentWorkState => _workState.current;
+
+  Future<String> prepareNewSession({required String directory}) async {
+    if (_disposed) throw const PiRpcDisposedException();
+    final sessionId = _processes.generateSessionId();
+    await _processes.markPendingNew(sessionId: sessionId, directory: directory);
+    _pendingNewDirectories[sessionId] = directory;
+    return sessionId;
+  }
+
+  Map<String, PluginSessionStatus> get sessionStatuses => Map.unmodifiable({
+    for (final entry in _sessions.entries)
+      entry.key: entry.value.active != null || entry.value.queue.isNotEmpty
+          ? const PluginSessionStatus.busy()
+          : const PluginSessionStatus.idle(),
+  });
+
+  Future<void> sendPrompt({
+    required String sessionId,
+    required String directory,
+    required List<PluginPromptPart> parts,
+    required String? userVisibleText,
+    required PluginSessionVariant? variant,
+    required ({String providerID, String modelID})? model,
+  }) {
+    if (_disposed) return Future.error(const PiRpcDisposedException());
+    final payload = _processes.mapPrompt(parts: parts, userVisibleText: userVisibleText);
+    _admit(
+      sessionId: sessionId,
+      directory: directory,
+      turn: _PiTurn(
+        payload: payload,
+        model: model,
+        variant: variant,
+        commandAcceptance: null,
+      ),
+    );
+    return Future.value();
+  }
+
+  Future<void> sendCommand({
+    required String sessionId,
+    required String directory,
+    required String command,
+    required String arguments,
+    required String? userVisibleArguments,
+    required PluginSessionVariant? variant,
+    required ({String providerID, String modelID})? model,
+  }) {
+    if (_disposed) return Future.error(const PiRpcDisposedException());
+    final state = _sessions[sessionId];
+    if (state?.active != null || (state?.queue.isNotEmpty ?? false)) {
+      return Future.error(PiSessionBusyException(sessionId: sessionId));
+    }
+    final execution = arguments.isEmpty ? "/$command" : "/$command $arguments";
+    final acceptance = Completer<void>();
+    final payload = _processes.mapPrompt(
+      parts: [PluginPromptPart.text(text: execution)],
+      userVisibleText: userVisibleArguments,
+    );
+    _admit(
+      sessionId: sessionId,
+      directory: directory,
+      turn: _PiTurn(
+        payload: payload,
+        model: model,
+        variant: variant,
+        commandAcceptance: acceptance,
+      ),
+    );
+    return acceptance.future;
+  }
+
+  void _admit({required String sessionId, required String directory, required _PiTurn turn}) {
+    final state = _sessions.putIfAbsent(sessionId, () => _PiSessionTurnState(initialDirectory: directory));
+    state.directory = directory;
+    state.idleGeneration++;
+    state.queue.add(turn);
+    if (state.active == null && state.queue.length == 1) {
+      _emit(
+        BridgeSseSessionStatus(
+          sessionID: sessionId,
+          status: const shared.SessionStatus.busy().toJson(),
+        ),
+      );
+      _emit(const BridgeSseProjectUpdated());
+    }
+    _syncWorkState();
+    _startNext(sessionId: sessionId, state: state);
+  }
+
+  void _startNext({required String sessionId, required _PiSessionTurnState state}) {
+    if (_disposed || state.active != null || state.queue.isEmpty || !identical(_sessions[sessionId], state)) return;
+    final turn = state.queue.removeAt(0);
+    state.active = turn;
+    final generation = state.generation;
+    unawaited(_runTurn(sessionId: sessionId, state: state, turn: turn, generation: generation));
+  }
+
+  Future<void> _runTurn({
+    required String sessionId,
+    required _PiSessionTurnState state,
+    required _PiTurn turn,
+    required int generation,
+  }) async {
+    try {
+      final connection = await _processes.ensureResident(
+        sessionId: sessionId,
+        knownDirectories: {state.directory},
+      );
+      if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) {
+        throw PiTurnCancelledException(sessionId: sessionId);
+      }
+      turn.connection = connection;
+      await _processes.applySelection(
+        sessionId: sessionId,
+        connection: connection,
+        model: turn.model,
+        variant: turn.variant,
+      );
+      if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) {
+        throw PiTurnCancelledException(sessionId: sessionId);
+      }
+      _dispatcher.beginTurn(sessionId: sessionId);
+      turn.promptDispatched = true;
+      final response = _processes.dispatchPrompt(connection: connection, payload: turn.payload);
+      await response;
+      if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
+      turn.responseSucceeded = true;
+      final acceptance = turn.commandAcceptance;
+      if (acceptance != null && !acceptance.isCompleted) acceptance.complete();
+      await Future<void>.delayed(Duration.zero);
+      if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
+      if (turn.agentSettled) {
+        _finish(sessionId: sessionId, state: state, turn: turn, failed: false, failure: null);
+      } else if (!turn.agentStarted) {
+        final agentState = await _processes.getState(connection: connection);
+        await Future<void>.delayed(Duration.zero);
+        if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
+        if (!turn.agentStarted && !agentState.streaming && agentState.pendingMessageCount == 0) {
+          _finish(sessionId: sessionId, state: state, turn: turn, failed: false, failure: null);
+        }
+      }
+    } on PiTurnCancelledException catch (error, stack) {
+      final acceptance = turn.commandAcceptance;
+      if (acceptance != null && !acceptance.isCompleted) acceptance.completeError(error, stack);
+    } on Object catch (error, stack) {
+      if (error is PiRpcProcessExitException) {
+        await Future<void>.delayed(Duration.zero);
+        if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
+      }
+      final acceptance = turn.commandAcceptance;
+      if (acceptance != null && !acceptance.isCompleted) acceptance.completeError(error, stack);
+      if (_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) {
+        final presented = _processes.presentTurnFailure(sessionId: sessionId, error: error);
+        Log.w("[pi] admitted turn failed for session id=$sessionId", presented.cause, stack);
+        if (presented.message?.contains("/login") ?? false) {
+          _emit(
+            BridgeSseTuiToastShow(
+              title: "Pi login required",
+              message: presented.message,
+              variant: "warning",
+            ),
+          );
+        }
+        _finish(sessionId: sessionId, state: state, turn: turn, failed: true, failure: error);
+      }
+    }
+  }
+
+  void _handleFrame(PiSessionProcessFrame processFrame) {
+    final state = _sessions[processFrame.sessionId];
+    final turn = state?.active;
+    if (state == null || turn == null) return;
+    turn.connection ??= PiSessionConnection(
+      sessionId: processFrame.sessionId,
+      generation: processFrame.generation,
+    );
+    if (turn.connection?.generation != processFrame.generation) return;
+    switch (processFrame.frame) {
+      case PiEventFrame(:final event):
+        if (turn.promptDispatched && event is PiAgentStartEvent) turn.agentStarted = true;
+        for (final mapped in _dispatcher.map(sessionId: processFrame.sessionId, event: event)) {
+          final serviceOwnsLifecycle =
+              (event is PiAgentStartEvent || event is PiAgentSettledEvent) &&
+              (mapped is BridgeSseSessionStatus || mapped is BridgeSseSessionIdle);
+          if (!serviceOwnsLifecycle) _emit(mapped);
+        }
+        if (turn.promptDispatched && event is PiAgentSettledEvent) {
+          turn.agentSettled = true;
+          if (turn.responseSucceeded) {
+            _finish(
+              sessionId: processFrame.sessionId,
+              state: state,
+              turn: turn,
+              failed: false,
+              failure: null,
+            );
+          }
+        }
+      case PiExtensionUiFrame(:final request):
+        final acceptance = turn.commandAcceptance;
+        if (turn.promptDispatched &&
+            request is PiExtensionDialogRequest &&
+            acceptance != null &&
+            !acceptance.isCompleted) {
+          acceptance.complete();
+        }
+        unawaited(
+          _extensionUi.handleRequest(ownerSessionId: processFrame.sessionId, request: request).catchError(
+            (Object error, StackTrace stack) {
+              Log.w("[pi] extension UI routing failed for session id=${processFrame.sessionId}", error, stack);
+            },
+          ),
+        );
+      case PiResponseFrame() || PiUnknownFrame():
+        break;
+    }
+  }
+
+  void _handleExit(PiSessionProcessExit exit) {
+    _extensionUi.cancelForOwner(sessionId: exit.sessionId);
+    final state = _sessions[exit.sessionId];
+    final turn = state?.active;
+    if (state == null || turn == null || turn.connection?.generation != exit.generation) return;
+    if (exit.authUnavailable) {
+      _emit(
+        const BridgeSseTuiToastShow(
+          title: "Pi login required",
+          message: "Pi has no model available. Run Pi locally and use /login, then try again.",
+          variant: "warning",
+        ),
+      );
+    }
+    _finish(
+      sessionId: exit.sessionId,
+      state: state,
+      turn: turn,
+      failed: true,
+      failure: PiRpcProcessExitException(exitCode: exit.exitCode),
+    );
+  }
+
+  void _finish({
+    required String sessionId,
+    required _PiSessionTurnState state,
+    required _PiTurn turn,
+    required bool failed,
+    required Object? failure,
+  }) {
+    if (turn.settled) return;
+    turn.settled = true;
+    final acceptance = turn.commandAcceptance;
+    if (acceptance != null && !acceptance.isCompleted && failed) {
+      acceptance.completeError(failure ?? StateError("Pi command failed before acceptance"), StackTrace.current);
+    }
+    if (!identical(_sessions[sessionId], state) || !identical(state.active, turn)) return;
+    state.active = null;
+    if (failed) _emit(BridgeSseSessionError(sessionID: sessionId));
+    unawaited(_clearPendingWhenPersisted(sessionId: sessionId, directory: state.directory));
+    if (state.queue.isNotEmpty) {
+      _startNext(sessionId: sessionId, state: state);
+      return;
+    }
+    _emit(
+      BridgeSseSessionStatus(
+        sessionID: sessionId,
+        status: const shared.SessionStatus.idle().toJson(),
+      ),
+    );
+    _emit(BridgeSseSessionIdle(sessionID: sessionId));
+    _emit(const BridgeSseProjectUpdated());
+    _syncWorkState();
+    _scheduleIdleReap(sessionId: sessionId, state: state);
+  }
+
+  Future<void> _clearPendingWhenPersisted({required String sessionId, required String directory}) async {
+    try {
+      if (await _processes.clearPendingWhenPersisted(
+        sessionId: sessionId,
+        knownDirectories: {directory},
+      )) {
+        _pendingNewDirectories.remove(sessionId);
+      }
+    } on Object catch (error, stack) {
+      Log.w("[pi] failed to clear persisted pending marker for session id=$sessionId", error, stack);
+    }
+  }
+
+  Future<void> abort({required String sessionId}) async {
+    final state = _sessions[sessionId];
+    if (state == null) {
+      await _processes.teardown(sessionId: sessionId);
+      return;
+    }
+    state.generation++;
+    state.idleGeneration++;
+    final cancelled = [?state.active, ...state.queue];
+    state.active = null;
+    state.queue.clear();
+    for (final turn in cancelled) {
+      final acceptance = turn.commandAcceptance;
+      if (acceptance != null && !acceptance.isCompleted) {
+        acceptance.completeError(PiTurnCancelledException(sessionId: sessionId), StackTrace.current);
+      }
+    }
+    _extensionUi.cancelForOwner(sessionId: sessionId);
+    final connection = cancelled.firstOrNull?.connection;
+    try {
+      if (connection != null) await _processes.abort(connection: connection);
+    } on Object catch (error, stack) {
+      Log.w("[pi] abort command failed for session id=$sessionId", error, stack);
+    } finally {
+      await _processes.teardown(sessionId: sessionId);
+    }
+    _emit(
+      BridgeSseSessionStatus(
+        sessionID: sessionId,
+        status: const shared.SessionStatus.idle().toJson(),
+      ),
+    );
+    _emit(BridgeSseSessionIdle(sessionID: sessionId));
+    _emit(const BridgeSseProjectUpdated());
+    _syncWorkState();
+    _scheduleIdleReap(sessionId: sessionId, state: state);
+  }
+
+  Future<void> forgetSession({required String sessionId}) async {
+    final state = _sessions.remove(sessionId);
+    if (state != null) {
+      state.generation++;
+      state.idleGeneration++;
+    }
+    _extensionUi.cancelForOwner(sessionId: sessionId);
+    final pendingDirectory = _pendingNewDirectories.remove(sessionId);
+    await _processes.forgetSession(
+      sessionId: sessionId,
+      knownDirectories: {?state?.directory, ?pendingDirectory},
+    );
+    _dispatcher.forgetSession(sessionId: sessionId);
+    _syncWorkState();
+  }
+
+  void _scheduleIdleReap({required String sessionId, required _PiSessionTurnState state}) {
+    final generation = ++state.idleGeneration;
+    unawaited(() async {
+      await _clock.delay(duration: _idleTimeout);
+      if (_disposed ||
+          !identical(_sessions[sessionId], state) ||
+          state.active != null ||
+          state.queue.isNotEmpty ||
+          state.idleGeneration != generation) {
+        return;
+      }
+      _extensionUi.cancelForOwner(sessionId: sessionId);
+      await _processes.teardown(sessionId: sessionId);
+      if (identical(_sessions[sessionId], state) && state.idleGeneration == generation) {
+        _sessions.remove(sessionId);
+      }
+    }());
+  }
+
+  bool _isCurrent({
+    required String sessionId,
+    required _PiSessionTurnState state,
+    required _PiTurn turn,
+    required int generation,
+  }) =>
+      !_disposed &&
+      identical(_sessions[sessionId], state) &&
+      identical(state.active, turn) &&
+      state.generation == generation;
+
+  void _syncWorkState() => _workState.set(
+    _sessions.values.any((state) => state.active != null || state.queue.isNotEmpty)
+        ? PluginWorkState.busy
+        : PluginWorkState.idle,
+  );
+
+  void _emit(BridgeSseEvent event) {
+    if (!_events.isClosed) _events.add(event);
+  }
+
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
+    _disposed = true;
+    for (final state in _sessions.values) {
+      state.generation++;
+      state.idleGeneration++;
+      for (final turn in [?state.active, ...state.queue]) {
+        final acceptance = turn.commandAcceptance;
+        if (acceptance != null && !acceptance.isCompleted) {
+          acceptance.completeError(const PiRpcDisposedException(), StackTrace.current);
+        }
+      }
+    }
+    await _frameSubscription.cancel();
+    await _exitSubscription.cancel();
+    await _extensionUi.dispose();
+    await _processes.dispose();
+    _sessions.clear();
+    _pendingNewDirectories.clear();
+    await _events.close();
+    await _workState.close();
+  }
+}

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -335,12 +335,14 @@ final class PiSessionService({
         ),
       );
     }
+    final failure = PiRpcProcessExitException(exitCode: exit.exitCode);
+    Log.w("[pi] resident process exited during active turn for session id=${exit.sessionId}", failure);
     _finish(
       sessionId: exit.sessionId,
       state: state,
       turn: turn,
       failed: true,
-      failure: PiRpcProcessExitException(exitCode: exit.exitCode),
+      failure: failure,
     );
   }
 

--- a/bridge/sesori_plugin_pi/lib/src/trackers/pi_extension_ui_tracker.dart
+++ b/bridge/sesori_plugin_pi/lib/src/trackers/pi_extension_ui_tracker.dart
@@ -4,6 +4,7 @@ sealed class const PiTrackedExtensionDialog({
   required final String questionId,
   required final String requestId,
   required final String ownerSessionId,
+  required final int processGeneration,
   required final String displaySessionId,
   required final String projectId,
   required final PluginQuestionInfo question,
@@ -13,6 +14,7 @@ final class const PiTrackedSelectDialog({
   required super.questionId,
   required super.requestId,
   required super.ownerSessionId,
+  required super.processGeneration,
   required super.displaySessionId,
   required super.projectId,
   required super.question,
@@ -23,6 +25,7 @@ final class const PiTrackedConfirmDialog({
   required super.questionId,
   required super.requestId,
   required super.ownerSessionId,
+  required super.processGeneration,
   required super.displaySessionId,
   required super.projectId,
   required super.question,
@@ -32,6 +35,7 @@ final class const PiTrackedInputDialog({
   required super.questionId,
   required super.requestId,
   required super.ownerSessionId,
+  required super.processGeneration,
   required super.displaySessionId,
   required super.projectId,
   required super.question,
@@ -41,6 +45,7 @@ final class const PiTrackedEditorDialog({
   required super.questionId,
   required super.requestId,
   required super.ownerSessionId,
+  required super.processGeneration,
   required super.displaySessionId,
   required super.projectId,
   required super.question,
@@ -83,7 +88,17 @@ final class PiExtensionUiTracker() {
   List<PluginPendingQuestion> pendingForProject({required String projectId}) =>
       _forQuestionId(_byProject[projectId] ?? const {}).map(_pending).toList(growable: false);
 
-  List<PiTrackedExtensionDialog> takeForOwner({required String sessionId}) => _takeMany(_byOwner[sessionId]);
+  List<PiTrackedExtensionDialog> takeForOwner({
+    required String sessionId,
+    required int? processGeneration,
+  }) => _takeMany(
+    processGeneration == null
+        ? _byOwner[sessionId]
+        : {
+            for (final id in _byOwner[sessionId] ?? const <String>{})
+              if (_byQuestionId[id]?.processGeneration == processGeneration) id,
+          },
+  );
 
   List<PiTrackedExtensionDialog> takeAll() => _takeMany(_byQuestionId.keys.toSet());
 

--- a/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
@@ -316,6 +316,30 @@ void main() {
     await delayed.dispose();
   });
 
+  test("older process exit cannot lower the cancelled generation fence", () async {
+    final oldGeneration = processes.generation;
+    await processes.reconnect();
+    final currentGeneration = processes.generation;
+    service.cancelForOwner(sessionId: "child", processGeneration: currentGeneration);
+    service.cancelForOwner(sessionId: "child", processGeneration: oldGeneration);
+
+    await service.handleRequest(
+      ownerSessionId: "child",
+      processGeneration: currentGeneration,
+      request: const PiInputDialogRequest(
+        id: "cancelled-current-dialog",
+        title: null,
+        placeholder: null,
+        timeoutMs: null,
+        raw: {},
+      ),
+    );
+
+    expect(service.getPendingQuestions(sessionId: "child"), isEmpty);
+    expect(processes.replies.single.requestId, "cancelled-current-dialog");
+    expect(processes.replies.single.reply, isA<PiExtensionUiCancelledReply>());
+  });
+
   test("catalog failures cancel the unresolved Pi dialog", () async {
     final failing = PiExtensionUiService(
       catalogRepository: PiSessionCatalogRepository(

--- a/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
@@ -46,6 +46,7 @@ void main() {
   test("maps dialogs, indexes imported scope, and sends exact reply variants", () async {
     await service.handleRequest(
       ownerSessionId: "child",
+      processGeneration: processes.generation,
       request: const PiSelectDialogRequest(
         id: "select-wire",
         title: "Choose",
@@ -73,6 +74,7 @@ void main() {
 
     await service.handleRequest(
       ownerSessionId: "child",
+      processGeneration: processes.generation,
       request: const PiConfirmDialogRequest(
         id: "confirm-wire",
         title: null,
@@ -93,6 +95,7 @@ void main() {
 
     await service.handleRequest(
       ownerSessionId: "child",
+      processGeneration: processes.generation,
       request: const PiInputDialogRequest(
         id: "input-wire",
         title: null,
@@ -115,6 +118,7 @@ void main() {
   test("editor exposes bounded prefill and sends complete replacement", () async {
     await service.handleRequest(
       ownerSessionId: "child",
+      processGeneration: processes.generation,
       request: PiEditorDialogRequest(
         id: "editor-wire",
         title: "Edit",
@@ -142,6 +146,7 @@ void main() {
   test("invalid and late replies do not consume pending state", () async {
     await service.handleRequest(
       ownerSessionId: "child",
+      processGeneration: processes.generation,
       request: const PiSelectDialogRequest(
         id: "select-wire",
         title: null,
@@ -185,6 +190,7 @@ void main() {
   test("mirrors upstream timeout, owns editor expiry, and bounds notifications", () async {
     await service.handleRequest(
       ownerSessionId: "child",
+      processGeneration: processes.generation,
       request: const PiInputDialogRequest(
         id: "upstream-timeout",
         title: null,
@@ -195,10 +201,12 @@ void main() {
     );
     await service.handleRequest(
       ownerSessionId: "child",
+      processGeneration: processes.generation,
       request: const PiEditorDialogRequest(id: "editor-timeout", title: null, prefill: null, raw: {}),
     );
     await service.handleRequest(
       ownerSessionId: "child",
+      processGeneration: processes.generation,
       request: PiNotifyRequest(
         id: "notify",
         message: _repeat("n", 600),
@@ -208,6 +216,7 @@ void main() {
     );
     await service.handleRequest(
       ownerSessionId: "child",
+      processGeneration: processes.generation,
       request: const PiSetStatusRequest(id: "status", statusKey: "key", statusText: "secret", raw: {}),
     );
 
@@ -225,6 +234,7 @@ void main() {
   test("unknown owners are cancelled and owner cleanup rejects every card", () async {
     await service.handleRequest(
       ownerSessionId: "missing",
+      processGeneration: processes.generation,
       request: const PiInputDialogRequest(id: "missing", title: null, placeholder: null, timeoutMs: null, raw: {}),
     );
     expect(processes.replies, isEmpty);
@@ -233,10 +243,11 @@ void main() {
     for (final id in ["one", "two"]) {
       await service.handleRequest(
         ownerSessionId: "child",
+        processGeneration: processes.generation,
         request: PiInputDialogRequest(id: id, title: null, placeholder: null, timeoutMs: null, raw: const {}),
       );
     }
-    service.cancelForOwner(sessionId: "child");
+    service.cancelForOwner(sessionId: "child", processGeneration: null);
 
     expect(service.getPendingQuestions(sessionId: "root"), isEmpty);
     expect(processes.replies.map((reply) => reply.requestId), ["one", "two"]);
@@ -258,17 +269,50 @@ void main() {
     );
     final handling = delayed.handleRequest(
       ownerSessionId: "child",
+      processGeneration: processes.generation,
       request: const PiInputDialogRequest(id: "late", title: null, placeholder: null, timeoutMs: null, raw: {}),
     );
     await Future<void>.delayed(Duration.zero);
 
-    delayed.cancelForOwner(sessionId: "child");
+    delayed.cancelForOwner(sessionId: "child", processGeneration: null);
     gate.complete();
     await handling;
 
     expect(delayed.getPendingQuestions(sessionId: "child"), isEmpty);
     expect(processes.replies.single.requestId, "late");
     expect(processes.replies.single.reply, isA<PiExtensionUiCancelledReply>());
+    await delayed.dispose();
+  });
+
+  test("delayed old lookup cannot cancel through replacement process generation", () async {
+    final gate = Completer<void>();
+    final delayed = PiExtensionUiService(
+      catalogRepository: PiSessionCatalogRepository(
+        storageApi: _FakeStorageApi(
+          sessions: [_metadata(id: "child", cwd: "/repo", updated: 1)],
+          gate: gate,
+        ),
+      ),
+      processRepository: processes.repository,
+      tracker: PiExtensionUiTracker(),
+      editorTimeout: const Duration(minutes: 30),
+    );
+    final oldGeneration = processes.generation;
+    final handling = delayed.handleRequest(
+      ownerSessionId: "child",
+      processGeneration: oldGeneration,
+      request: const PiInputDialogRequest(id: "old-dialog", title: null, placeholder: null, timeoutMs: null, raw: {}),
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    await processes.reconnect();
+    delayed.cancelForOwner(sessionId: "child", processGeneration: oldGeneration);
+    gate.complete();
+    await handling;
+
+    expect(processes.processes.first.written.where((frame) => frame["type"] == "extension_ui_response"), isEmpty);
+    expect(processes.processes.last.written.where((frame) => frame["type"] == "extension_ui_response"), isEmpty);
+    expect(delayed.getPendingQuestions(sessionId: "child"), isEmpty);
     await delayed.dispose();
   });
 
@@ -285,6 +329,7 @@ void main() {
     await expectLater(
       failing.handleRequest(
         ownerSessionId: "child",
+        processGeneration: processes.generation,
         request: const PiInputDialogRequest(
           id: "catalog-failure",
           title: null,
@@ -316,6 +361,7 @@ void main() {
     );
     final handling = delayed.handleRequest(
       ownerSessionId: "child",
+      processGeneration: processes.generation,
       request: const PiInputDialogRequest(
         id: "elapsed-timeout",
         title: null,
@@ -349,6 +395,7 @@ void main() {
     unavailable.events.listen(unavailableEvents.add);
     await unavailable.handleRequest(
       ownerSessionId: "child",
+      processGeneration: processes.generation,
       request: const PiInputDialogRequest(
         id: "unavailable",
         title: null,
@@ -382,13 +429,14 @@ final class const _SentReply({
 });
 
 final class _ProcessFixture({required final _FakeStorageApi storage}) {
-  final FakePiProcess process = FakePiProcess();
+  final List<FakePiProcess> processes = [FakePiProcess()];
+  late int generation;
   late final PiSessionProcessRepository repository = PiSessionProcessRepository(
     storageApi: storage,
     historyStorageApi: _FakeHistoryStorage(storageApi: storage),
     binaryPath: "/runtime/pi",
     environment: const {},
-    processFactory: ({required spec}) async => process,
+    processFactory: ({required spec}) async => processes.last,
     historyMapper: PiHistoryMapper(pluginId: "pi"),
     identityTracker: PiMessageIdentityTracker(pluginId: "pi"),
     startupExitTimeout: const Duration(milliseconds: 50),
@@ -396,31 +444,42 @@ final class _ProcessFixture({required final _FakeStorageApi storage}) {
   );
 
   List<_SentReply> get replies => [
-    for (final frame in process.written)
-      if (frame["type"] == "extension_ui_response")
-        _SentReply(
-          ownerSessionId: "child",
-          requestId: frame["id"]! as String,
-          reply: switch (frame) {
-            {"value": final String value} => PiExtensionUiValueReply(value: value),
-            {"confirmed": final bool confirmed} => PiExtensionUiConfirmationReply(confirmed: confirmed),
-            _ => const PiExtensionUiCancelledReply(),
-          },
-        ),
+    for (final process in processes)
+      for (final frame in process.written)
+        if (frame["type"] == "extension_ui_response")
+          _SentReply(
+            ownerSessionId: "child",
+            requestId: frame["id"]! as String,
+            reply: switch (frame) {
+              {"value": final String value} => PiExtensionUiValueReply(value: value),
+              {"confirmed": final bool confirmed} => PiExtensionUiConfirmationReply(confirmed: confirmed),
+              _ => const PiExtensionUiCancelledReply(),
+            },
+          ),
   ];
 
   Future<void> start({required String sessionId, required String directory}) async {
+    final process = processes.last;
     final connecting = repository.ensureResident(sessionId: sessionId, knownDirectories: {directory});
-    final command = await _waitForCommand(type: "get_entries");
+    final command = await _waitForCommand(process: process, type: "get_entries");
     process.emitResponse(
       id: command["id"]! as String,
       command: "get_entries",
       data: const {"entries": <Object?>[], "leafId": null},
     );
-    await connecting;
+    generation = (await connecting).generation;
   }
 
-  Future<Map<String, Object?>> _waitForCommand({required String type}) async {
+  Future<void> reconnect() async {
+    await repository.teardown(sessionId: "child");
+    processes.add(FakePiProcess());
+    await start(sessionId: "child", directory: "/repo/worktree");
+  }
+
+  Future<Map<String, Object?>> _waitForCommand({
+    required FakePiProcess process,
+    required String type,
+  }) async {
     for (var attempt = 0; attempt < 50; attempt++) {
       for (final frame in process.written) {
         if (frame["type"] == type) return frame;

--- a/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
@@ -1,42 +1,47 @@
 import "dart:async";
 
 import "package:pi_plugin/pi_plugin.dart";
+import "package:pi_plugin/pi_testing.dart";
+import "package:pi_plugin/src/api/models/pi_session_history_dto.dart";
+import "package:pi_plugin/src/repositories/mappers/pi_history_mapper.dart";
+import "package:pi_plugin/src/repositories/pi_session_process_repository.dart";
 import "package:pi_plugin/src/services/pi_extension_ui_service.dart";
 import "package:pi_plugin/src/trackers/pi_extension_ui_tracker.dart";
+import "package:pi_plugin/src/trackers/pi_message_identity_tracker.dart";
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show normalizeProjectDirectory;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
 void main() {
   late List<PiExtensionUiEvent> events;
-  late List<_SentReply> replies;
   late PiExtensionUiService service;
+  late _ProcessFixture processes;
   late String projectId;
 
-  setUp(() {
+  setUp(() async {
     events = [];
-    replies = [];
     projectId = normalizeProjectDirectory(directory: "/repo/worktree");
+    final storage = _FakeStorageApi(
+      sessions: [
+        _metadata(id: "root", cwd: "/repo", updated: 3),
+        _metadata(id: "child", cwd: "/repo/worktree", updated: 2, parentId: "root"),
+      ],
+    );
+    processes = _ProcessFixture(storage: storage);
+    await processes.start(sessionId: "child", directory: "/repo/worktree");
     service = PiExtensionUiService(
-      catalogRepository: PiSessionCatalogRepository(
-        storageApi: _FakeStorageApi(
-          sessions: [
-            _metadata(id: "root", cwd: "/repo", updated: 3),
-            _metadata(id: "child", cwd: "/repo/worktree", updated: 2, parentId: "root"),
-          ],
-        ),
-      ),
+      catalogRepository: PiSessionCatalogRepository(storageApi: storage),
+      processRepository: processes.repository,
       tracker: PiExtensionUiTracker(),
-      responseSender: ({required ownerSessionId, required requestId, required reply}) {
-        replies.add(_SentReply(ownerSessionId: ownerSessionId, requestId: requestId, reply: reply));
-        return true;
-      },
       editorTimeout: const Duration(milliseconds: 20),
     );
     service.events.listen(events.add);
   });
 
-  tearDown(() => service.dispose());
+  tearDown(() async {
+    await service.dispose();
+    await processes.dispose();
+  });
 
   test("maps dialogs, indexes imported scope, and sends exact reply variants", () async {
     await service.handleRequest(
@@ -62,8 +67,8 @@ void main() {
         ["two"],
       ],
     );
-    expect(replies.single.requestId, "select-wire");
-    expect((replies.single.reply as PiExtensionUiValueReply).value, "two");
+    expect(processes.replies.single.requestId, "select-wire");
+    expect((processes.replies.single.reply as PiExtensionUiValueReply).value, "two");
     expect(events.whereType<PiExtensionUiQuestionReplied>().single.requestId, select.id);
 
     await service.handleRequest(
@@ -84,7 +89,7 @@ void main() {
         ["No"],
       ],
     );
-    expect((replies.last.reply as PiExtensionUiConfirmationReply).confirmed, isFalse);
+    expect((processes.replies.last.reply as PiExtensionUiConfirmationReply).confirmed, isFalse);
 
     await service.handleRequest(
       ownerSessionId: "child",
@@ -104,7 +109,7 @@ void main() {
         ["line 1\nline 2"],
       ],
     );
-    expect((replies.last.reply as PiExtensionUiValueReply).value, "line 1\nline 2");
+    expect((processes.replies.last.reply as PiExtensionUiValueReply).value, "line 1\nline 2");
   });
 
   test("editor exposes bounded prefill and sends complete replacement", () async {
@@ -131,7 +136,7 @@ void main() {
       ],
     );
 
-    expect((replies.single.reply as PiExtensionUiValueReply).value, "replacement\n");
+    expect((processes.replies.single.reply as PiExtensionUiValueReply).value, "replacement\n");
   });
 
   test("invalid and late replies do not consume pending state", () async {
@@ -170,7 +175,7 @@ void main() {
     expect(service.getPendingQuestions(sessionId: "child"), hasLength(1));
 
     service.rejectQuestion(questionId: question.id, sessionId: "child");
-    expect(replies.single.reply, isA<PiExtensionUiCancelledReply>());
+    expect(processes.replies.single.reply, isA<PiExtensionUiCancelledReply>());
     expect(
       () => service.rejectQuestion(questionId: question.id, sessionId: "child"),
       throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "status", 404)),
@@ -209,8 +214,8 @@ void main() {
     await Future<void>.delayed(const Duration(milliseconds: 35));
 
     expect(service.getPendingQuestions(sessionId: "child"), isEmpty);
-    expect(replies.map((reply) => reply.requestId), ["editor-timeout"]);
-    expect(replies.single.reply, isA<PiExtensionUiCancelledReply>());
+    expect(processes.replies.map((reply) => reply.requestId), ["editor-timeout"]);
+    expect(processes.replies.single.reply, isA<PiExtensionUiCancelledReply>());
     expect(events.whereType<PiExtensionUiQuestionRejected>(), hasLength(2));
     final toast = events.whereType<PiExtensionUiToast>().single;
     expect(toast.message.runes.length, PiExtensionUiService.maxTextLength);
@@ -222,7 +227,7 @@ void main() {
       ownerSessionId: "missing",
       request: const PiInputDialogRequest(id: "missing", title: null, placeholder: null, timeoutMs: null, raw: {}),
     );
-    expect(replies.single.requestId, "missing");
+    expect(processes.replies, isEmpty);
     expect(service.getPendingQuestions(sessionId: "missing"), isEmpty);
 
     for (final id in ["one", "two"]) {
@@ -234,7 +239,7 @@ void main() {
     service.cancelForOwner(sessionId: "child");
 
     expect(service.getPendingQuestions(sessionId: "root"), isEmpty);
-    expect(replies.skip(1).map((reply) => reply.requestId), ["one", "two"]);
+    expect(processes.replies.map((reply) => reply.requestId), ["one", "two"]);
     expect(events.whereType<PiExtensionUiQuestionRejected>(), hasLength(2));
   });
 
@@ -247,11 +252,8 @@ void main() {
           gate: gate,
         ),
       ),
+      processRepository: processes.repository,
       tracker: PiExtensionUiTracker(),
-      responseSender: ({required ownerSessionId, required requestId, required reply}) {
-        replies.add(_SentReply(ownerSessionId: ownerSessionId, requestId: requestId, reply: reply));
-        return true;
-      },
       editorTimeout: const Duration(minutes: 30),
     );
     final handling = delayed.handleRequest(
@@ -265,8 +267,8 @@ void main() {
     await handling;
 
     expect(delayed.getPendingQuestions(sessionId: "child"), isEmpty);
-    expect(replies.single.requestId, "late");
-    expect(replies.single.reply, isA<PiExtensionUiCancelledReply>());
+    expect(processes.replies.single.requestId, "late");
+    expect(processes.replies.single.reply, isA<PiExtensionUiCancelledReply>());
     await delayed.dispose();
   });
 
@@ -275,11 +277,8 @@ void main() {
       catalogRepository: PiSessionCatalogRepository(
         storageApi: _FakeStorageApi(sessions: const [], error: StateError("catalog unavailable")),
       ),
+      processRepository: processes.repository,
       tracker: PiExtensionUiTracker(),
-      responseSender: ({required ownerSessionId, required requestId, required reply}) {
-        replies.add(_SentReply(ownerSessionId: ownerSessionId, requestId: requestId, reply: reply));
-        return true;
-      },
       editorTimeout: const Duration(minutes: 30),
     );
 
@@ -297,8 +296,8 @@ void main() {
       throwsStateError,
     );
 
-    expect(replies.single.requestId, "catalog-failure");
-    expect(replies.single.reply, isA<PiExtensionUiCancelledReply>());
+    expect(processes.replies.single.requestId, "catalog-failure");
+    expect(processes.replies.single.reply, isA<PiExtensionUiCancelledReply>());
     await failing.dispose();
   });
 
@@ -311,11 +310,8 @@ void main() {
           gate: gate,
         ),
       ),
+      processRepository: processes.repository,
       tracker: PiExtensionUiTracker(),
-      responseSender: ({required ownerSessionId, required requestId, required reply}) {
-        replies.add(_SentReply(ownerSessionId: ownerSessionId, requestId: requestId, reply: reply));
-        return true;
-      },
       editorTimeout: const Duration(minutes: 30),
     );
     final handling = delayed.handleRequest(
@@ -333,19 +329,20 @@ void main() {
     await handling;
 
     expect(delayed.getPendingQuestions(sessionId: "child"), isEmpty);
-    expect(replies, isEmpty);
+    expect(processes.replies, isEmpty);
     await delayed.dispose();
   });
 
   test("failed response writes retire pending questions", () async {
+    await processes.repository.teardown(sessionId: "child");
     final unavailable = PiExtensionUiService(
       catalogRepository: PiSessionCatalogRepository(
         storageApi: _FakeStorageApi(
           sessions: [_metadata(id: "child", cwd: "/repo", updated: 1)],
         ),
       ),
+      processRepository: processes.repository,
       tracker: PiExtensionUiTracker(),
-      responseSender: ({required ownerSessionId, required requestId, required reply}) => false,
       editorTimeout: const Duration(minutes: 30),
     );
     final unavailableEvents = <PiExtensionUiEvent>[];
@@ -384,6 +381,64 @@ final class const _SentReply({
   required final PiExtensionUiReply reply,
 });
 
+final class _ProcessFixture({required final _FakeStorageApi storage}) {
+  final FakePiProcess process = FakePiProcess();
+  late final PiSessionProcessRepository repository = PiSessionProcessRepository(
+    storageApi: storage,
+    historyStorageApi: _FakeHistoryStorage(storageApi: storage),
+    binaryPath: "/runtime/pi",
+    environment: const {},
+    processFactory: ({required spec}) async => process,
+    historyMapper: PiHistoryMapper(pluginId: "pi"),
+    identityTracker: PiMessageIdentityTracker(pluginId: "pi"),
+    startupExitTimeout: const Duration(milliseconds: 50),
+    historyRpcTimeout: const Duration(seconds: 2),
+  );
+
+  List<_SentReply> get replies => [
+    for (final frame in process.written)
+      if (frame["type"] == "extension_ui_response")
+        _SentReply(
+          ownerSessionId: "child",
+          requestId: frame["id"]! as String,
+          reply: switch (frame) {
+            {"value": final String value} => PiExtensionUiValueReply(value: value),
+            {"confirmed": final bool confirmed} => PiExtensionUiConfirmationReply(confirmed: confirmed),
+            _ => const PiExtensionUiCancelledReply(),
+          },
+        ),
+  ];
+
+  Future<void> start({required String sessionId, required String directory}) async {
+    final connecting = repository.ensureResident(sessionId: sessionId, knownDirectories: {directory});
+    final command = await _waitForCommand(type: "get_entries");
+    process.emitResponse(
+      id: command["id"]! as String,
+      command: "get_entries",
+      data: const {"entries": <Object?>[], "leafId": null},
+    );
+    await connecting;
+  }
+
+  Future<Map<String, Object?>> _waitForCommand({required String type}) async {
+    for (var attempt = 0; attempt < 50; attempt++) {
+      for (final frame in process.written) {
+        if (frame["type"] == type) return frame;
+      }
+      await Future<void>.delayed(Duration.zero);
+    }
+    throw StateError("missing $type command");
+  }
+
+  Future<void> dispose() => repository.dispose();
+}
+
+final class _FakeHistoryStorage({required super.storageApi}) extends PiSessionHistoryStorageApi {
+  @override
+  Future<PiSessionFileHistoryDto> readSessionHistory({required String path}) =>
+      Future.error(StateError("file fallback not expected"));
+}
+
 PiSessionMetadata _metadata({required String id, required String cwd, required int updated, String? parentId}) =>
     PiSessionMetadata(
       id: id,
@@ -410,11 +465,30 @@ final class _FakeStorageApi({
   Future<String?> resolveEffectiveSessionDirectory({required String directory}) async => null;
 
   @override
-  Future<PiResolvedSession?> resolveSession({required String sessionId, required Set<String> knownDirectories}) async =>
-      null;
+  Future<void> clearPendingNewSession({required String sessionId, required Set<String> knownDirectories}) async {}
+
+  @override
+  Future<PiPendingNewSession?> readPendingNewSession({
+    required String sessionId,
+    required Set<String> knownDirectories,
+  }) async => null;
+
+  @override
+  Future<void> writePendingNewSession({required String sessionId, required String cwd}) async {}
+
+  @override
+  Future<PiResolvedSession?> resolveSession({required String sessionId, required Set<String> knownDirectories}) async {
+    for (final metadata in sessions) {
+      if (metadata.id == sessionId) return PiResolvedSession(metadata: metadata, path: "/sessions/$sessionId.jsonl");
+    }
+    return null;
+  }
 
   @override
   Future<String?> resolveSessionPath({required String sessionId, required Set<String> knownDirectories}) async => null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 String _repeat(String value, int count) => List.filled(count, value).join();

--- a/bridge/sesori_plugin_pi/test/pi_session_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_catalog_repository_test.dart
@@ -144,4 +144,7 @@ final class _FakeStorageApi({required List<PiSessionMetadata> sessions, final Ob
 
   @override
   Future<String?> resolveSessionPath({required String sessionId, required Set<String> knownDirectories}) async => null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/bridge/sesori_plugin_pi/test/pi_session_process_repository_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_process_repository_test.dart
@@ -6,6 +6,7 @@ import "package:pi_plugin/pi_plugin.dart";
 import "package:pi_plugin/pi_testing.dart";
 import "package:pi_plugin/src/api/models/pi_session_history_dto.dart";
 import "package:pi_plugin/src/repositories/mappers/pi_history_mapper.dart";
+import "package:pi_plugin/src/repositories/mappers/pi_message_identity_builder.dart";
 import "package:pi_plugin/src/repositories/mappers/pi_persisted_user_text_codec.dart";
 import "package:pi_plugin/src/repositories/pi_session_process_repository.dart";
 import "package:pi_plugin/src/trackers/pi_message_identity_tracker.dart";
@@ -46,6 +47,34 @@ void main() {
       expect(messages.single.parts.single.text, "from rpc");
       expect(process.stdinClosed, isTrue);
       expect(process.killed, isTrue);
+    });
+
+    test("resident history preserves identities allocated while replay is pending", () async {
+      final process = FakePiProcess();
+      final identities = PiMessageIdentityTracker(pluginId: "pi");
+      final repository = _repository(
+        processFactory: ({required spec}) async => process,
+        identityTracker: identities,
+      );
+      addTearDown(repository.dispose);
+      final connecting = repository.ensureResident(sessionId: "session", knownDirectories: const {});
+      final initial = await waitForCommand(process: process, type: "get_entries");
+      process.emitResponse(id: initial["id"]! as String, command: "get_entries", data: _historyJson(text: "first"));
+      await connecting;
+
+      final pending = repository.loadHistory(sessionId: "session", knownDirectories: const {});
+      final replay = await _waitForNthCommand(process: process, type: "get_entries", count: 2);
+      expect(
+        identities.forSession(sessionId: "session").next(role: PiMessageIdentityRole.user, timestamp: 1),
+        "pi:session:user:1:2",
+      );
+      process.emitResponse(id: replay["id"]! as String, command: "get_entries", data: _historyJson(text: "first"));
+      await pending;
+
+      expect(
+        identities.forSession(sessionId: "session").next(role: PiMessageIdentityRole.user, timestamp: 1),
+        "pi:session:user:1:3",
+      );
     });
 
     test("uses the injected replay timeout for get_entries", () async {
@@ -384,6 +413,7 @@ void main() {
 PiSessionProcessRepository _repository({
   PiSessionStorageApi? storageApi,
   required PiProcessFactory processFactory,
+  PiMessageIdentityTracker? identityTracker,
   Duration startupExitTimeout = const Duration(seconds: 5),
   Duration historyRpcTimeout = const Duration(minutes: 2),
 }) {
@@ -395,10 +425,23 @@ PiSessionProcessRepository _repository({
     environment: const {"EXTRA": "value"},
     processFactory: processFactory,
     historyMapper: PiHistoryMapper(pluginId: "pi"),
-    identityTracker: PiMessageIdentityTracker(pluginId: "pi"),
+    identityTracker: identityTracker ?? PiMessageIdentityTracker(pluginId: "pi"),
     startupExitTimeout: startupExitTimeout,
     historyRpcTimeout: historyRpcTimeout,
   );
+}
+
+Future<Map<String, Object?>> _waitForNthCommand({
+  required FakePiProcess process,
+  required String type,
+  required int count,
+}) async {
+  for (var attempt = 0; attempt < 50; attempt++) {
+    final commands = process.written.where((frame) => frame["type"] == type);
+    if (commands.length >= count) return commands.elementAt(count - 1);
+    await pump();
+  }
+  throw StateError("no command '$type' number $count");
 }
 
 Map<String, Object?> _historyJson({required String text}) => {
@@ -453,6 +496,9 @@ final class _FakeStorageApi({
   final PiSessionFileHistoryDto? history,
 }) implements PiSessionStorageApi {
   final bool _missing = missing;
+
+  @override
+  Future<void> clearPendingNewSession({required String sessionId, required Set<String> knownDirectories}) async {}
 
   @override
   Future<PiResolvedSession?> resolveSession({required String sessionId, required Set<String> knownDirectories}) async {

--- a/bridge/sesori_plugin_pi/test/pi_session_process_repository_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_process_repository_test.dart
@@ -339,6 +339,23 @@ void main() {
       expect(messages.single.parts.single.text, "hook content");
     });
 
+    test("cold replay keeps slash command visible without exposing persisted arguments", () async {
+      final process = FakePiProcess();
+      final repository = _repository(processFactory: ({required spec}) async => process);
+
+      final pending = repository.loadHistory(sessionId: "session", knownDirectories: const {});
+      final command = await waitForCommand(process: process, type: "get_entries");
+      process.emitResponse(
+        id: command["id"]! as String,
+        command: "get_entries",
+        data: _historyJson(text: "/deploy --token private"),
+      );
+
+      final messages = await pending;
+      expect(messages.single.parts.single.text, "/deploy");
+      expect(messages.single.parts.single.text, isNot(contains("private")));
+    });
+
     test("decodes exact persisted user-visible text marker", () async {
       final process = FakePiProcess();
       final repository = _repository(processFactory: ({required spec}) async => process);

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -49,6 +49,31 @@ void main() {
     expect(storage.clearedDirectories, contains("/project"));
   });
 
+  test("persisted turns do not rescan pending marker storage", () async {
+    final process = FakePiProcess();
+    final storage = _Storage(initialResolved: _resolved());
+    final fixture = _Fixture(processes: [process], storageOverride: storage);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "persisted")],
+      userVisibleText: "persisted",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    final prompt = await waitForCommand(process: process, type: "prompt");
+    process.emitResponse(id: prompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: "session");
+    await pump();
+
+    expect(storage.resolveCalls, 1);
+  });
+
   test("connect hydrates before exposing startup frames and shares one spawn", () async {
     final process = FakePiProcess();
     final fixture = _Fixture(processes: [process]);
@@ -159,6 +184,7 @@ void main() {
 
     expect(storage.pending, isNull);
     expect(storage.clearedDirectories, contains("/project"));
+    expect(storage.resolveCalls, 2);
   });
 
   test("teardown promptly disposes a connecting process waiting on history", () async {
@@ -989,6 +1015,39 @@ void main() {
     await _waitForIdle(service: service, sessionId: "session");
   });
 
+  test("abort waits for active idle-reap teardown", () async {
+    final process = FakePiProcess(stdinCloseCompletes: false);
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final clock = _ManualClock();
+    final service = fixture.service(clock: clock);
+
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "prompt")],
+      userVisibleText: "prompt",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    final prompt = await waitForCommand(process: process, type: "prompt");
+    process.emitResponse(id: prompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: "session");
+    clock.elapse();
+    await pump();
+
+    var completed = false;
+    final abort = service.abort(sessionId: "session").then((_) => completed = true);
+    await pump();
+    expect(completed, isFalse);
+
+    process.completeStdinClose();
+    await abort;
+    expect(process.killed, isTrue);
+  });
+
   test("idle reap preserves pending marker location for later deletion", () async {
     final process = FakePiProcess();
     final storage = _Storage(initialResolved: null);
@@ -1219,8 +1278,10 @@ final class _Storage({
   PiResolvedSession? resolved = initialResolved;
   PiPendingNewSession? pending = initialPending;
   Set<String>? clearedDirectories;
+  int resolveCalls = 0;
   @override
   Future<PiResolvedSession?> resolveSession({required String sessionId, required Set<String> knownDirectories}) async {
+    resolveCalls++;
     await resolveGate?.future;
     return resolved == null || resolved?.metadata.id == sessionId ? resolved : _resolved(id: sessionId);
   }

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -566,7 +566,7 @@ void main() {
     await expectLater(noArguments, throwsA(isA<PiRpcCommandFailureException>()));
   });
 
-  test("manually typed slash prompt keeps exact live presentation", () async {
+  test("manually typed slash prompt with an image keeps exact live presentation", () async {
     final process = FakePiProcess();
     final fixture = _Fixture(processes: [process]);
     addTearDown(fixture.dispose);
@@ -577,7 +577,10 @@ void main() {
     await service.sendPrompt(
       sessionId: "session",
       directory: "/project",
-      parts: [const PluginPromptPart.text(text: "/review src")],
+      parts: [
+        const PluginPromptPart.text(text: "/review src"),
+        const PluginPromptPart.fileData(mime: "image/png", base64: "cG5n", filename: null),
+      ],
       userVisibleText: "/review src",
       variant: null,
       model: null,
@@ -591,6 +594,7 @@ void main() {
           "role": "user",
           "content": [
             {"type": "text", "text": "/review src"},
+            {"type": "image", "data": "cG5n", "mimeType": "image/png"},
           ],
           "timestamp": 1,
         },
@@ -599,7 +603,10 @@ void main() {
     process.emitFailure(id: prompt["id"]! as String, command: "prompt", error: "done");
     await _waitForIdle(service: service, sessionId: "session");
 
-    expect(events.whereType<BridgeSseMessagePartUpdated>().single.part.text, "/review src");
+    expect(
+      events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part.text),
+      contains("/review src"),
+    );
   });
 
   test("command rejects busy, accepts dialog-first, and uses no-run state barrier", () async {

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -133,6 +133,34 @@ void main() {
     expect(fixture.spawned.last.launch, isA<PiNewSession>());
   });
 
+  test("new session clears its pending marker once persistence becomes observable", () async {
+    final process = FakePiProcess();
+    final storage = _Storage(initialResolved: null);
+    final fixture = _Fixture(processes: [process], storageOverride: storage);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+    final sessionId = await service.prepareNewSession(directory: "/project");
+
+    await service.sendPrompt(
+      sessionId: sessionId,
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "persist")],
+      userVisibleText: "persist",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    final prompt = await waitForCommand(process: process, type: "prompt");
+    storage.resolved = _resolved(id: sessionId);
+    process.emitResponse(id: prompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: sessionId);
+    await pump();
+
+    expect(storage.pending, isNull);
+    expect(storage.clearedDirectories, contains("/project"));
+  });
+
   test("teardown promptly disposes a connecting process waiting on history", () async {
     final process = FakePiProcess();
     final fixture = _Fixture(processes: [process]);
@@ -918,6 +946,49 @@ void main() {
     await fixture.dispose();
   });
 
+  test("new turn waits for active idle-reap teardown before reconnecting", () async {
+    final oldProcess = FakePiProcess(stdinCloseCompletes: false);
+    final replacement = FakePiProcess();
+    final fixture = _Fixture(processes: [oldProcess, replacement]);
+    addTearDown(fixture.dispose);
+    final clock = _ManualClock();
+    final service = fixture.service(clock: clock);
+
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "first")],
+      userVisibleText: "first",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(oldProcess);
+    final firstPrompt = await waitForCommand(process: oldProcess, type: "prompt");
+    oldProcess.emitResponse(id: firstPrompt["id"]! as String, command: "prompt");
+    oldProcess.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: "session");
+    clock.elapse();
+    await pump();
+
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "second")],
+      userVisibleText: "second",
+      variant: null,
+      model: null,
+    );
+    await pump();
+    expect(fixture.spawned, hasLength(1));
+
+    oldProcess.completeStdinClose();
+    await _answerEntries(replacement);
+    final secondPrompt = await waitForCommand(process: replacement, type: "prompt");
+    expect(secondPrompt["message"], "second");
+    replacement.emitFailure(id: secondPrompt["id"]! as String, command: "prompt", error: "done");
+    await _waitForIdle(service: service, sessionId: "session");
+  });
+
   test("idle reap preserves pending marker location for later deletion", () async {
     final process = FakePiProcess();
     final storage = _Storage(initialResolved: null);
@@ -968,6 +1039,13 @@ void main() {
       userVisibleText: "visible",
     );
     expect(context.message, startsWith(PiPersistedUserTextCodec.marker));
+    final imageOnly = fixture.repository.mapPrompt(
+      parts: [
+        PluginPromptPart.fileData(mime: "image/png", base64: base64Encode([1]), filename: "a.png"),
+      ],
+      userVisibleText: null,
+    );
+    expect(imageOnly.message, isEmpty);
     for (final attachment in <PluginPromptPart>[
       const PluginPromptPart.filePath(mime: "image/png", path: "/private/a.png", filename: null),
       const PluginPromptPart.fileUrl(mime: "image/png", url: "https://private.invalid/a.png", filename: null),

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -1,0 +1,899 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:pi_plugin/pi_plugin.dart";
+import "package:pi_plugin/pi_testing.dart";
+import "package:pi_plugin/src/api/models/pi_session_history_dto.dart";
+import "package:pi_plugin/src/repositories/mappers/pi_history_mapper.dart";
+import "package:pi_plugin/src/repositories/mappers/pi_persisted_user_text_codec.dart";
+import "package:pi_plugin/src/repositories/pi_session_process_repository.dart";
+import "package:pi_plugin/src/services/pi_event_dispatcher.dart";
+import "package:pi_plugin/src/services/pi_extension_ui_service.dart";
+import "package:pi_plugin/src/services/pi_session_service.dart";
+import "package:pi_plugin/src/trackers/pi_extension_ui_tracker.dart";
+import "package:pi_plugin/src/trackers/pi_message_identity_tracker.dart";
+import "package:pi_plugin/src/trackers/pi_tool_tracker.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+import "support/pi_rpc_client_test_factory.dart";
+
+void main() {
+  test("new session preparation generates a valid secure id and persists its marker", () async {
+    final storage = _Storage(initialResolved: null);
+    final fixture = _Fixture(processes: const [], storageOverride: storage);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+
+    final sessionId = await service.prepareNewSession(directory: "/project");
+    final secondSessionId = await service.prepareNewSession(directory: "/project");
+
+    expect(PiNewSession(sessionId: sessionId).sessionId, sessionId);
+    expect(sessionId, matches(RegExp(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")));
+    expect(secondSessionId, isNot(sessionId));
+    expect(storage.pending?.id, secondSessionId);
+    expect(storage.pending?.cwd, "/project");
+  });
+
+  test("prepared sessions retain their marker directory until deletion", () async {
+    final storage = _Storage(initialResolved: null);
+    final fixture = _Fixture(processes: const [], storageOverride: storage);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+    final sessionId = await service.prepareNewSession(directory: "/project");
+
+    await service.forgetSession(sessionId: sessionId);
+
+    expect(storage.pending, isNull);
+    expect(storage.clearedDirectories, contains("/project"));
+  });
+
+  test("connect hydrates before exposing startup frames and shares one spawn", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final frames = <PiSessionProcessFrame>[];
+    fixture.repository.frames.listen(frames.add);
+
+    final first = fixture.repository.ensureResident(sessionId: "session", knownDirectories: const {"/project"});
+    final second = fixture.repository.ensureResident(sessionId: "session", knownDirectories: const {"/project"});
+    process.emit(frame: {"type": "agent_start"});
+    await pump();
+    expect(frames, isEmpty);
+
+    await _answerEntries(process);
+    expect((await first).generation, (await second).generation);
+    await pump();
+    expect(frames.where((frame) => frame.frame is PiEventFrame), hasLength(1));
+    expect(fixture.spawned, hasLength(1));
+  });
+
+  test("persisted file wins over pending marker and marker resumes new when file is absent", () async {
+    final resumed = FakePiProcess();
+    final created = FakePiProcess();
+    final storage = _Storage(
+      initialResolved: _resolved(),
+      initialPending: const PiPendingNewSession(id: "session", cwd: "/pending"),
+    );
+    final fixture = _Fixture(processes: [resumed, created], storageOverride: storage);
+    addTearDown(fixture.dispose);
+
+    final resident = fixture.repository.ensureResident(sessionId: "session", knownDirectories: const {"/project"});
+    await _answerEntries(resumed);
+    await resident;
+    expect(fixture.spawned.single.launch, isA<PiResumedSession>());
+    await fixture.repository.teardown(sessionId: "session");
+
+    storage
+      ..resolved = null
+      ..pending = const PiPendingNewSession(id: "session", cwd: "/pending");
+    final pending = fixture.repository.ensureResident(sessionId: "session", knownDirectories: const {"/pending"});
+    await _answerEntries(created);
+    await pending;
+    expect(fixture.spawned.last.launch, isA<PiNewSession>());
+  });
+
+  test("teardown fences and reaps a process whose spawn completes late", () async {
+    final process = FakePiProcess();
+    final spawn = Completer<PiProcessHandle>();
+    final storage = _Storage(initialResolved: _resolved());
+    final identities = PiMessageIdentityTracker(pluginId: "pi");
+    final repository = PiSessionProcessRepository(
+      storageApi: storage,
+      historyStorageApi: _HistoryStorage(storageApi: storage),
+      binaryPath: "/runtime/pi",
+      environment: const {},
+      processFactory: ({required spec}) => spawn.future,
+      historyMapper: PiHistoryMapper(pluginId: "pi"),
+      identityTracker: identities,
+      startupExitTimeout: const Duration(milliseconds: 50),
+      historyRpcTimeout: const Duration(seconds: 2),
+    );
+    addTearDown(repository.dispose);
+
+    final connecting = repository.ensureResident(sessionId: "session", knownDirectories: const {"/project"});
+    await pump();
+    await repository.teardown(sessionId: "session");
+    spawn.complete(process);
+
+    await expectLater(connecting, throwsStateError);
+    expect(process.killed, isTrue);
+    expect(repository.residentSessionIds, isEmpty);
+  });
+
+  test("resident history and rename reuse process while transient rename disposes its lease", () async {
+    final resident = FakePiProcess();
+    final transient = FakePiProcess();
+    final fixture = _Fixture(processes: [resident, transient]);
+    addTearDown(fixture.dispose);
+
+    final connecting = fixture.repository.ensureResident(sessionId: "session", knownDirectories: const {"/project"});
+    final history = fixture.repository.loadHistory(sessionId: "session", knownDirectories: const {"/project"});
+    final rename = fixture.repository.renameSession(
+      sessionId: "session",
+      title: "Resident",
+      knownDirectories: const {"/project"},
+    );
+    await pump();
+    expect(fixture.spawned, hasLength(1));
+    await _answerEntries(resident);
+    await connecting;
+    await _answerNthEntries(resident, count: 2);
+    final residentRename = await waitForCommand(process: resident, type: "set_session_name");
+    resident.emitResponse(id: residentRename["id"]! as String, command: "set_session_name");
+    await history;
+    await rename;
+    expect(fixture.spawned, hasLength(1));
+
+    await fixture.repository.teardown(sessionId: "session");
+    final transientRename = fixture.repository.renameSession(
+      sessionId: "session",
+      title: "Transient",
+      knownDirectories: const {"/project"},
+    );
+    final transientCommand = await waitForCommand(process: transient, type: "set_session_name");
+    transient.emitResponse(id: transientCommand["id"]! as String, command: "set_session_name");
+    await transientRename;
+    expect(transient.killed, isTrue);
+  });
+
+  for (final operation in ["history", "rename"]) {
+    test("$operation starting before residency never overlaps another process", () async {
+      final transient = FakePiProcess();
+      final resident = FakePiProcess();
+      final gate = Completer<void>();
+      final storage = _Storage(initialResolved: _resolved(), resolveGate: gate);
+      final fixture = _Fixture(processes: [transient, resident], storageOverride: storage);
+      addTearDown(fixture.dispose);
+
+      final Future<void> firstOperation;
+      if (operation == "history") {
+        firstOperation = fixture.repository
+            .loadHistory(sessionId: "session", knownDirectories: const {"/project"})
+            .then<void>((_) {});
+      } else {
+        firstOperation = fixture.repository.renameSession(
+          sessionId: "session",
+          title: "Transient",
+          knownDirectories: const {"/project"},
+        );
+      }
+      await pump();
+      final connecting = fixture.repository.ensureResident(
+        sessionId: "session",
+        knownDirectories: const {"/project"},
+      );
+      gate.complete();
+
+      if (operation == "history") {
+        await _answerEntries(transient);
+      } else {
+        final rename = await waitForCommand(process: transient, type: "set_session_name");
+        transient.emitResponse(id: rename["id"]! as String, command: "set_session_name");
+      }
+      await firstOperation;
+      expect(transient.killed, isTrue);
+      expect(fixture.spawned, hasLength(1));
+
+      await _answerEntries(resident);
+      await connecting;
+      expect(fixture.spawned, hasLength(2));
+    });
+  }
+
+  test("selection completes before prompt dispatch", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "selected")],
+      userVisibleText: "selected",
+      variant: const PluginSessionVariant(id: "high"),
+      model: (providerID: "provider", modelID: "model"),
+    );
+    await _answerEntries(process);
+    final model = await waitForCommand(process: process, type: "set_model");
+    expect(process.written.where((frame) => frame["type"] == "prompt"), isEmpty);
+    process.emitResponse(id: model["id"]! as String, command: "set_model");
+    final thinking = await waitForCommand(process: process, type: "set_thinking_level");
+    expect(process.written.where((frame) => frame["type"] == "prompt"), isEmpty);
+    process.emitResponse(id: thinking["id"]! as String, command: "set_thinking_level");
+    final prompt = await waitForCommand(process: process, type: "prompt");
+    expect(prompt["message"], "selected");
+  });
+
+  test("selection failure prevents prompt dispatch and settles the lane", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+    final events = <BridgeSseEvent>[];
+    service.events.listen(events.add);
+
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "selected")],
+      userVisibleText: "selected",
+      variant: null,
+      model: (providerID: "provider", modelID: "model"),
+    );
+    await _answerEntries(process);
+    final model = await waitForCommand(process: process, type: "set_model");
+    process.emitFailure(id: model["id"]! as String, command: "set_model", error: "unavailable");
+    await _waitForIdle(service: service, sessionId: "session");
+
+    expect(process.written.where((frame) => frame["type"] == "prompt"), isEmpty);
+    expect(events.whereType<BridgeSseSessionError>(), hasLength(1));
+  });
+
+  test("prompt emits busy before live frames and idle status before idle event", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+    final events = <BridgeSseEvent>[];
+    service.events.listen(events.add);
+
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "ordered")],
+      userVisibleText: "ordered",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    final prompt = await waitForCommand(process: process, type: "prompt");
+    process.emitResponse(id: prompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_start"});
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForEvent<BridgeSseSessionIdle>(events: events);
+
+    final statuses = events.whereType<BridgeSseSessionStatus>().toList();
+    final idleIndex = events.indexWhere((event) => event is BridgeSseSessionIdle);
+    expect(statuses.first.status["type"], "busy");
+    expect(statuses.last.status["type"], "idle");
+    expect(events.indexOf(statuses.last), lessThan(idleIndex));
+  });
+
+  test("agent settlement waits for the correlated prompt response", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+
+    final accepted = service.sendCommand(
+      sessionId: "session",
+      directory: "/project",
+      command: "name",
+      arguments: "first",
+      userVisibleArguments: "first",
+      variant: null,
+      model: null,
+    );
+    var completed = false;
+    unawaited(accepted.then((_) => completed = true));
+    await _answerEntries(process);
+    final firstPrompt = await waitForCommand(process: process, type: "prompt");
+    process.emit(frame: {"type": "agent_start"});
+    process.emit(frame: {"type": "agent_settled"});
+    await pump();
+    expect(completed, isFalse);
+    process.emitResponse(id: firstPrompt["id"]! as String, command: "prompt");
+    await accepted;
+    await _waitForIdle(service: service, sessionId: "session");
+
+    final failed = service.sendCommand(
+      sessionId: "session",
+      directory: "/project",
+      command: "name",
+      arguments: "second",
+      userVisibleArguments: "second",
+      variant: null,
+      model: null,
+    );
+    final secondPrompt = await _waitForNthCommand(process: process, type: "prompt", count: 2);
+    process.emit(frame: {"type": "agent_start"});
+    process.emit(frame: {"type": "agent_settled"});
+    process.emitFailure(id: secondPrompt["id"]! as String, command: "prompt", error: "rejected");
+
+    await expectLater(failed, throwsA(isA<PiRpcCommandFailureException>()));
+    await _waitForIdle(service: service, sessionId: "session");
+  });
+
+  test("prompt admission is immediate, same-session FIFO, and sessions run concurrently", () async {
+    final first = FakePiProcess();
+    final other = FakePiProcess();
+    final fixture = _Fixture(processes: [first, other]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+
+    await service.sendPrompt(
+      sessionId: "one",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "first")],
+      userVisibleText: "first",
+      variant: null,
+      model: null,
+    );
+    await service.sendPrompt(
+      sessionId: "one",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "second")],
+      userVisibleText: "second",
+      variant: null,
+      model: null,
+    );
+    await service.sendPrompt(
+      sessionId: "two",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "other")],
+      userVisibleText: "other",
+      variant: null,
+      model: null,
+    );
+
+    await Future.wait([_answerEntries(first), _answerEntries(other)]);
+    final firstPrompt = await waitForCommand(process: first, type: "prompt");
+    final otherPrompt = await waitForCommand(process: other, type: "prompt");
+    expect(firstPrompt["message"], "first");
+    expect(otherPrompt["message"], "other");
+    expect(first.written.where((frame) => frame["type"] == "prompt"), hasLength(1));
+
+    first.emitResponse(id: firstPrompt["id"]! as String, command: "prompt");
+    first.emit(frame: {"type": "agent_settled"});
+    final secondPrompt = await _waitForNthCommand(process: first, type: "prompt", count: 2);
+    expect(secondPrompt["message"], "second");
+  });
+
+  test("command rejects busy, accepts dialog-first, and uses no-run state barrier", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "busy")],
+      userVisibleText: "busy",
+      variant: null,
+      model: null,
+    );
+    await expectLater(
+      service.sendCommand(
+        sessionId: "session",
+        directory: "/project",
+        command: "name",
+        arguments: "x",
+        userVisibleArguments: "x",
+        variant: null,
+        model: null,
+      ),
+      throwsA(isA<PiSessionBusyException>()),
+    );
+    await _answerEntries(process);
+    final busyPrompt = await waitForCommand(process: process, type: "prompt");
+    process.emitResponse(id: busyPrompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_start"});
+    process.emit(frame: {"type": "agent_settled"});
+    await pump();
+
+    final accepted = service.sendCommand(
+      sessionId: "session",
+      directory: "/project",
+      command: "name",
+      arguments: "private visible",
+      userVisibleArguments: "visible",
+      variant: null,
+      model: null,
+    );
+    final commandPrompt = await _waitForNthCommand(process: process, type: "prompt", count: 2);
+    var commandAccepted = false;
+    unawaited(accepted.then((_) => commandAccepted = true));
+    process.emit(
+      frame: {
+        "type": "extension_ui_request",
+        "id": "notify",
+        "method": "notify",
+        "message": "still running",
+      },
+    );
+    await pump();
+    expect(commandAccepted, isFalse);
+    process.emit(
+      frame: {
+        "type": "extension_ui_request",
+        "id": "dialog",
+        "method": "input",
+        "title": "Input",
+      },
+    );
+    await accepted;
+    process.emitResponse(id: commandPrompt["id"]! as String, command: "prompt");
+    final idle = service.events.firstWhere((event) => event is BridgeSseSessionIdle);
+    final state = await waitForCommand(process: process, type: "get_state");
+    process.emitResponse(
+      id: state["id"]! as String,
+      command: "get_state",
+      data: {"isStreaming": false, "pendingMessageCount": 0},
+    );
+    await idle;
+    await _waitForIdle(service: service, sessionId: "session");
+    expect(service.sessionStatuses["session"], const PluginSessionStatus.idle());
+  });
+
+  test("startup no-model failure emits privacy-safe login guidance", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+    final events = <BridgeSseEvent>[];
+    service.events.listen(events.add);
+
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "prompt")],
+      userVisibleText: "prompt",
+      variant: null,
+      model: null,
+    );
+    await waitForCommand(process: process, type: "get_entries");
+    process.emitStderrRaw(
+      bytes: utf8.encode("${PiRpcClient.noModelsDiagnosticPrefix} /private/model/path\n"),
+    );
+    process.exit(code: 78);
+    await _waitForEvent<BridgeSseTuiToastShow>(events: events);
+
+    final toast = events.whereType<BridgeSseTuiToastShow>().single;
+    expect(toast.message, contains("/login"));
+    expect(toast.message, isNot(contains("/private")));
+    expect(events.whereType<BridgeSseSessionError>(), hasLength(1));
+  });
+
+  test("command exit before response or dialog fails acceptance", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+
+    final accepted = service.sendCommand(
+      sessionId: "session",
+      directory: "/project",
+      command: "name",
+      arguments: "value",
+      userVisibleArguments: "value",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    await waitForCommand(process: process, type: "prompt");
+    process.exit(code: 9);
+
+    await expectLater(accepted, throwsA(isA<PiRpcProcessExitException>()));
+    await _waitForIdle(service: service, sessionId: "session");
+  });
+
+  test("post-acceptance process exit fails the active turn", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+    final events = <BridgeSseEvent>[];
+    service.events.listen(events.add);
+
+    final accepted = service.sendCommand(
+      sessionId: "session",
+      directory: "/project",
+      command: "name",
+      arguments: "value",
+      userVisibleArguments: "value",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    await waitForCommand(process: process, type: "prompt");
+    process.emit(
+      frame: {
+        "type": "extension_ui_request",
+        "id": "dialog",
+        "method": "input",
+        "title": "Input",
+      },
+    );
+    await accepted;
+    process.exit(code: 9);
+
+    await _waitForIdle(service: service, sessionId: "session");
+    expect(events.whereType<BridgeSseSessionError>(), hasLength(1));
+  });
+
+  test("failed prompt response and process exit settle queued work", () async {
+    final failed = FakePiProcess();
+    final replacement = FakePiProcess();
+    final fixture = _Fixture(processes: [failed, replacement]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+    final events = <BridgeSseEvent>[];
+    service.events.listen(events.add);
+
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "first")],
+      userVisibleText: "first",
+      variant: null,
+      model: null,
+    );
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "second")],
+      userVisibleText: "second",
+      variant: null,
+      model: null,
+    );
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "third")],
+      userVisibleText: "third",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(failed);
+    final prompt = await waitForCommand(process: failed, type: "prompt");
+    failed.emitFailure(id: prompt["id"]! as String, command: "prompt", error: "private failure");
+    final second = await _waitForNthCommand(process: failed, type: "prompt", count: 2);
+    failed.emitStderrRaw(bytes: utf8.encode("${PiRpcClient.noModelsDiagnosticPrefix}\n"));
+    failed.exit(code: 9);
+    await _answerEntries(replacement);
+    final queued = await waitForCommand(process: replacement, type: "prompt");
+    replacement.emitFailure(id: queued["id"]! as String, command: "prompt", error: "failed");
+    await _waitForEvent<BridgeSseTuiToastShow>(events: events);
+    await _waitForEventCount<BridgeSseSessionError>(events: events, count: 3);
+
+    expect(second["message"], "second");
+    expect(queued["message"], "third");
+    expect(events.whereType<BridgeSseSessionError>(), hasLength(3));
+    expect(
+      events.whereType<BridgeSseTuiToastShow>(),
+      contains(isA<BridgeSseTuiToastShow>().having((event) => event.message, "message", contains("/login"))),
+    );
+    expect(service.sessionStatuses["session"], const PluginSessionStatus.idle());
+  });
+
+  test("abort invalidates queue, sends abort, and tears down process", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "first")],
+      userVisibleText: "first",
+      variant: null,
+      model: null,
+    );
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "queued")],
+      userVisibleText: "queued",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    final prompt = await waitForCommand(process: process, type: "prompt");
+    process.emitResponse(id: prompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_start"});
+    final abort = service.abort(sessionId: "session");
+    final abortCommand = await waitForCommand(process: process, type: "abort");
+    process.emitResponse(id: abortCommand["id"]! as String, command: "abort");
+    await abort;
+
+    expect(process.killed, isTrue);
+    expect(process.written.where((frame) => frame["type"] == "prompt"), hasLength(1));
+    expect(fixture.repository.residentSessionIds, isEmpty);
+  });
+
+  test("idle reap and disposal terminate residents", () async {
+    final first = FakePiProcess();
+    final second = FakePiProcess();
+    final fixture = _Fixture(processes: [first, second]);
+    final clock = _ManualClock();
+    final service = fixture.service(clock: clock);
+
+    await service.sendPrompt(
+      sessionId: "one",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "one")],
+      userVisibleText: "one",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(first);
+    final prompt = await waitForCommand(process: first, type: "prompt");
+    first.emitResponse(id: prompt["id"]! as String, command: "prompt");
+    first.emit(frame: {"type": "agent_settled"});
+    await pump();
+    clock.elapse();
+    await pump();
+    expect(first.killed, isTrue);
+
+    final resident = fixture.repository.ensureResident(sessionId: "two", knownDirectories: const {"/project"});
+    await _answerEntries(second);
+    await resident;
+    await service.dispose();
+    expect(second.killed, isTrue);
+  });
+
+  test("idle reap preserves pending marker location for later deletion", () async {
+    final process = FakePiProcess();
+    final storage = _Storage(initialResolved: null);
+    final fixture = _Fixture(processes: [process], storageOverride: storage);
+    final clock = _ManualClock();
+    final service = fixture.service(clock: clock);
+    final sessionId = await service.prepareNewSession(directory: "/project");
+    await service.sendPrompt(
+      sessionId: sessionId,
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "prompt")],
+      userVisibleText: "prompt",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    final prompt = await waitForCommand(process: process, type: "prompt");
+    process.emitResponse(id: prompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: sessionId);
+    clock.elapse();
+    await pump();
+
+    await service.forgetSession(sessionId: sessionId);
+
+    expect(storage.pending, isNull);
+    expect(storage.clearedDirectories, contains("/project"));
+    await fixture.dispose();
+  });
+
+  test("prompt mapper validates inline images and rejects every unsupported attachment", () {
+    final fixture = _Fixture(processes: const []);
+    addTearDown(fixture.dispose);
+
+    final payload = fixture.repository.mapPrompt(
+      parts: [
+        const PluginPromptPart.text(text: "image"),
+        PluginPromptPart.fileData(mime: "image/png", base64: base64Encode([1, 2, 3]), filename: "a.png"),
+      ],
+      userVisibleText: "image",
+    );
+    expect(payload.images.single["data"], "AQID");
+    final context = fixture.repository.mapPrompt(
+      parts: const [
+        PluginPromptPart.text(text: "private context\n"),
+        PluginPromptPart.text(text: "visible"),
+      ],
+      userVisibleText: "visible",
+    );
+    expect(context.message, startsWith(PiPersistedUserTextCodec.marker));
+    for (final attachment in <PluginPromptPart>[
+      const PluginPromptPart.filePath(mime: "image/png", path: "/private/a.png", filename: null),
+      const PluginPromptPart.fileUrl(mime: "image/png", url: "https://private.invalid/a.png", filename: null),
+      const PluginPromptPart.fileData(mime: "text/plain", base64: "YQ==", filename: null),
+      const PluginPromptPart.fileData(mime: "image/png", base64: "not-base64", filename: null),
+    ]) {
+      expect(
+        () => fixture.repository.mapPrompt(parts: [attachment], userVisibleText: null),
+        throwsA(
+          isA<PluginOperationException>()
+              .having((error) => error.statusCode, "status", 400)
+              .having((error) => error.toString(), "privacy", isNot(contains("private.invalid"))),
+        ),
+      );
+    }
+  });
+}
+
+Future<void> _answerEntries(FakePiProcess process) => _answerNthEntries(process, count: 1);
+
+Future<void> _answerNthEntries(FakePiProcess process, {required int count}) async {
+  final command = await _waitForNthCommand(process: process, type: "get_entries", count: count);
+  process.emitResponse(
+    id: command["id"]! as String,
+    command: "get_entries",
+    data: const {"entries": <Object?>[], "leafId": null},
+  );
+}
+
+Future<void> _waitForEventCount<T>({required List<BridgeSseEvent> events, required int count}) async {
+  for (var attempt = 0; attempt < 100; attempt++) {
+    if (events.whereType<T>().length >= count) return;
+    await pump();
+  }
+  throw StateError("event $T count=$count did not arrive");
+}
+
+Future<void> _waitForEvent<T>({required List<BridgeSseEvent> events}) async {
+  for (var attempt = 0; attempt < 100; attempt++) {
+    if (events.whereType<T>().isNotEmpty) return;
+    await pump();
+  }
+  throw StateError("event $T did not arrive");
+}
+
+Future<void> _waitForIdle({required PiSessionService service, required String sessionId}) async {
+  for (var attempt = 0; attempt < 100; attempt++) {
+    if (service.sessionStatuses[sessionId] == const PluginSessionStatus.idle()) return;
+    await pump();
+  }
+  throw StateError("session did not become idle");
+}
+
+Future<Map<String, Object?>> _waitForNthCommand({
+  required FakePiProcess process,
+  required String type,
+  required int count,
+}) async {
+  for (var attempt = 0; attempt < 100; attempt++) {
+    final matches = process.written.where((frame) => frame["type"] == type).toList();
+    if (matches.length >= count) return matches[count - 1];
+    await pump();
+  }
+  throw StateError("no command type=$type count=$count");
+}
+
+PiResolvedSession _resolved({String id = "session"}) => PiResolvedSession(
+  metadata: PiSessionMetadata(
+    id: id,
+    cwd: "/project",
+    parentId: null,
+    title: null,
+    createdAt: null,
+    updatedAt: DateTime.fromMillisecondsSinceEpoch(0),
+  ),
+  path: "/sessions/$id.jsonl",
+);
+
+final class _Fixture({required List<FakePiProcess> processes, final _Storage? storageOverride}) {
+  final List<FakePiProcess> _processes = List.of(processes);
+  late final _Storage storage = storageOverride ?? _Storage(initialResolved: _resolved());
+  final List<PiLaunchSpec> spawned = [];
+  late final PiMessageIdentityTracker identities = PiMessageIdentityTracker(pluginId: "pi");
+  late final PiHistoryMapper historyMapper = PiHistoryMapper(pluginId: "pi");
+  final List<PiSessionService> _services = [];
+  late final PiSessionProcessRepository repository = PiSessionProcessRepository(
+    storageApi: storage,
+    historyStorageApi: _HistoryStorage(storageApi: storage),
+    binaryPath: "/runtime/pi",
+    environment: const {},
+    processFactory: ({required spec}) async {
+      spawned.add(spec);
+      return _processes.removeAt(0);
+    },
+    historyMapper: historyMapper,
+    identityTracker: identities,
+    startupExitTimeout: const Duration(milliseconds: 50),
+    historyRpcTimeout: const Duration(seconds: 2),
+  );
+
+  PiSessionService service({ServerClock clock = const ServerClock()}) {
+    late final PiExtensionUiService extension;
+    extension = PiExtensionUiService(
+      catalogRepository: PiSessionCatalogRepository(storageApi: storage),
+      processRepository: repository,
+      tracker: PiExtensionUiTracker(),
+      editorTimeout: const Duration(minutes: 1),
+    );
+    final service = PiSessionService(
+      processRepository: repository,
+      eventDispatcher: PiEventDispatcher(
+        historyMapper: historyMapper,
+        identityTracker: identities,
+        toolTracker: PiToolTracker(),
+      ),
+      extensionUiService: extension,
+      clock: clock,
+      idleTimeout: const Duration(minutes: 5),
+    );
+    _services.add(service);
+    return service;
+  }
+
+  Future<void> dispose() async {
+    for (final service in _services) {
+      await service.dispose();
+    }
+    await repository.dispose();
+    for (final process in _processes) {
+      await process.close();
+    }
+  }
+}
+
+final class _Storage({
+  required final PiResolvedSession? initialResolved,
+  final PiPendingNewSession? initialPending,
+  final Completer<void>? resolveGate,
+}) implements PiSessionStorageApi {
+  PiResolvedSession? resolved = initialResolved;
+  PiPendingNewSession? pending = initialPending;
+  Set<String>? clearedDirectories;
+  @override
+  Future<PiResolvedSession?> resolveSession({required String sessionId, required Set<String> knownDirectories}) async {
+    await resolveGate?.future;
+    return resolved == null || resolved?.metadata.id == sessionId ? resolved : _resolved(id: sessionId);
+  }
+
+  @override
+  Future<PiPendingNewSession?> readPendingNewSession({
+    required String sessionId,
+    required Set<String> knownDirectories,
+  }) async => pending;
+
+  @override
+  Future<void> clearPendingNewSession({required String sessionId, required Set<String> knownDirectories}) async {
+    clearedDirectories = Set.of(knownDirectories);
+    pending = null;
+  }
+
+  @override
+  Future<void> writePendingNewSession({required String sessionId, required String cwd}) async {
+    pending = PiPendingNewSession(id: sessionId, cwd: cwd);
+  }
+
+  @override
+  Future<List<PiSessionMetadata>> listSessionMetadata({required Set<String> knownDirectories}) async => [
+    if (resolved case PiResolvedSession(:final metadata)) metadata,
+  ];
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+final class _HistoryStorage({required super.storageApi}) extends PiSessionHistoryStorageApi {
+  @override
+  Future<PiSessionFileHistoryDto> readSessionHistory({required String path}) =>
+      Future.error(StateError("file fallback not expected"));
+}
+
+final class _ManualClock() implements ServerClock {
+  Completer<void>? _delay;
+
+  @override
+  Future<void> delay({required Duration duration}) => (_delay = Completer<void>()).future;
+
+  void elapse() => _delay?.complete();
+
+  @override
+  DateTime now() => DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
+}

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 import "dart:convert";
+import "dart:io";
 
 import "package:pi_plugin/pi_plugin.dart";
 import "package:pi_plugin/pi_testing.dart";
@@ -68,6 +69,45 @@ void main() {
     expect(fixture.spawned, hasLength(1));
   });
 
+  test("resolved session clears stale marker before startup and cleanup failure remains best-effort", () async {
+    final process = FakePiProcess();
+    final storage = _Storage(
+      initialResolved: _resolved(),
+      initialPending: const PiPendingNewSession(id: "session", cwd: "/pending"),
+    );
+    final fixture = _Fixture(processes: [process], storageOverride: storage);
+    addTearDown(fixture.dispose);
+
+    final resident = fixture.repository.ensureResident(sessionId: "session", knownDirectories: const {"/project"});
+    await waitForCommand(process: process, type: "get_entries");
+    expect(storage.pending, isNull);
+    expect(storage.clearedDirectories, containsAll({"/project"}));
+    await _answerEntries(process);
+    await resident;
+
+    final failedCleanupProcess = FakePiProcess();
+    final failedCleanupStorage = _Storage(
+      initialResolved: _resolved(id: "other"),
+      clearError: StateError("marker cleanup failed"),
+    );
+    final failedCleanupFixture = _Fixture(
+      processes: [failedCleanupProcess],
+      storageOverride: failedCleanupStorage,
+    );
+    addTearDown(failedCleanupFixture.dispose);
+    final warnings = await _captureWarnings(() async {
+      final connection = failedCleanupFixture.repository.ensureResident(
+        sessionId: "other",
+        knownDirectories: const {"/project"},
+      );
+      await _answerEntries(failedCleanupProcess);
+      await connection;
+    });
+    expect(warnings, contains("failed to clear stale pending marker"));
+    expect(warnings, contains("marker cleanup failed"));
+    expect(warnings, contains("pi_session_service_test.dart"));
+  });
+
   test("persisted file wins over pending marker and marker resumes new when file is absent", () async {
     final resumed = FakePiProcess();
     final created = FakePiProcess();
@@ -91,6 +131,23 @@ void main() {
     await _answerEntries(created);
     await pending;
     expect(fixture.spawned.last.launch, isA<PiNewSession>());
+  });
+
+  test("teardown promptly disposes a connecting process waiting on history", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+
+    final connecting = fixture.repository.ensureResident(
+      sessionId: "session",
+      knownDirectories: const {"/project"},
+    );
+    await waitForCommand(process: process, type: "get_entries");
+
+    await fixture.repository.teardown(sessionId: "session");
+
+    expect(process.killed, isTrue);
+    await expectLater(connecting, throwsA(isA<PiRpcDisposedException>()));
   });
 
   test("teardown fences and reaps a process whose spawn completes late", () async {
@@ -119,6 +176,28 @@ void main() {
     await expectLater(connecting, throwsStateError);
     expect(process.killed, isTrue);
     expect(repository.residentSessionIds, isEmpty);
+  });
+
+  test("forget removes per-session state without reusing a connection generation", () async {
+    final first = FakePiProcess();
+    final second = FakePiProcess();
+    final fixture = _Fixture(processes: [first, second]);
+    addTearDown(fixture.dispose);
+
+    final firstConnection = fixture.repository.ensureResident(
+      sessionId: "session",
+      knownDirectories: const {"/project"},
+    );
+    await _answerEntries(first);
+    final firstGeneration = (await firstConnection).generation;
+    await fixture.repository.forgetSession(sessionId: "session", knownDirectories: const {"/project"});
+
+    final secondConnection = fixture.repository.ensureResident(
+      sessionId: "session",
+      knownDirectories: const {"/project"},
+    );
+    await _answerEntries(second);
+    expect((await secondConnection).generation, greaterThan(firstGeneration));
   });
 
   test("resident history and rename reuse process while transient rename disposes its lease", () async {
@@ -371,6 +450,104 @@ void main() {
     expect(secondPrompt["message"], "second");
   });
 
+  test("slash command keeps exact backend text and privacy-safe live presentation", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+    final events = <BridgeSseEvent>[];
+    service.events.listen(events.add);
+
+    final accepted = service.sendCommand(
+      sessionId: "session",
+      directory: "/project",
+      command: "deploy",
+      arguments: "--token hidden public",
+      userVisibleArguments: "public",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    final prompt = await waitForCommand(process: process, type: "prompt");
+    expect(prompt["message"], "/deploy --token hidden public");
+    expect(prompt["message"], isNot(startsWith(PiPersistedUserTextCodec.marker)));
+    process.emit(
+      frame: {
+        "type": "message_end",
+        "message": {
+          "role": "user",
+          "content": [
+            {"type": "text", "text": "/deploy --token hidden public"},
+          ],
+          "timestamp": 1,
+        },
+      },
+    );
+    process.emitResponse(id: prompt["id"]! as String, command: "prompt");
+    final state = await waitForCommand(process: process, type: "get_state");
+    process.emitResponse(
+      id: state["id"]! as String,
+      command: "get_state",
+      data: {"isStreaming": false, "pendingMessageCount": 0},
+    );
+    await accepted;
+    await _waitForIdle(service: service, sessionId: "session");
+    expect(
+      events.whereType<BridgeSseMessagePartUpdated>().single.part.text,
+      "/deploy public",
+    );
+
+    final noArguments = service.sendCommand(
+      sessionId: "session",
+      directory: "/project",
+      command: "status",
+      arguments: "",
+      userVisibleArguments: null,
+      variant: null,
+      model: null,
+    );
+    final noArgumentsPrompt = await _waitForNthCommand(process: process, type: "prompt", count: 2);
+    expect(noArgumentsPrompt["message"], "/status");
+    process.emitFailure(id: noArgumentsPrompt["id"]! as String, command: "prompt", error: "done");
+    await expectLater(noArguments, throwsA(isA<PiRpcCommandFailureException>()));
+  });
+
+  test("manually typed slash prompt keeps exact live presentation", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+    final events = <BridgeSseEvent>[];
+    service.events.listen(events.add);
+
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "/review src")],
+      userVisibleText: "/review src",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    final prompt = await waitForCommand(process: process, type: "prompt");
+    process.emit(
+      frame: {
+        "type": "message_end",
+        "message": {
+          "role": "user",
+          "content": [
+            {"type": "text", "text": "/review src"},
+          ],
+          "timestamp": 1,
+        },
+      },
+    );
+    process.emitFailure(id: prompt["id"]! as String, command: "prompt", error: "done");
+    await _waitForIdle(service: service, sessionId: "session");
+
+    expect(events.whereType<BridgeSseMessagePartUpdated>().single.part.text, "/review src");
+  });
+
   test("command rejects busy, accepts dialog-first, and uses no-run state barrier", () async {
     final process = FakePiProcess();
     final fixture = _Fixture(processes: [process]);
@@ -534,6 +711,59 @@ void main() {
     expect(events.whereType<BridgeSseSessionError>(), hasLength(1));
   });
 
+  test("ambiguous prompt timeout tears down generation before queued work reconnects", () async {
+    final timedOut = FakePiProcess();
+    final replacement = FakePiProcess();
+    final fixture = _Fixture(
+      processes: [timedOut, replacement],
+      historyRpcTimeout: const Duration(milliseconds: 20),
+    );
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "first")],
+      userVisibleText: "first",
+      variant: null,
+      model: null,
+    );
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "queued")],
+      userVisibleText: "queued",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(timedOut);
+    final oldPrompt = await waitForCommand(process: timedOut, type: "prompt");
+    timedOut.emit(
+      frame: {
+        "type": "extension_ui_request",
+        "id": "old-dialog",
+        "method": "input",
+        "title": "Input",
+      },
+    );
+    await pump();
+    expect(fixture.extensions.single.getPendingQuestions(sessionId: "session"), hasLength(1));
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+    await _answerEntries(replacement);
+    final queued = await waitForCommand(process: replacement, type: "prompt");
+
+    expect(timedOut.killed, isTrue);
+    expect(fixture.extensions.single.getPendingQuestions(sessionId: "session"), isEmpty);
+    expect(queued["message"], "queued");
+    timedOut.emitResponse(id: oldPrompt["id"]! as String, command: "prompt");
+    timedOut.emit(frame: {"type": "agent_settled"});
+    await pump();
+    expect(service.sessionStatuses["session"], const PluginSessionStatus.busy());
+    replacement.emitFailure(id: queued["id"]! as String, command: "prompt", error: "terminal");
+    await _waitForIdle(service: service, sessionId: "session");
+  });
+
   test("failed prompt response and process exit settle queued work", () async {
     final failed = FakePiProcess();
     final replacement = FakePiProcess();
@@ -656,6 +886,38 @@ void main() {
     expect(second.killed, isTrue);
   });
 
+  test("dispose awaits an active idle-reap teardown", () async {
+    final process = FakePiProcess(stdinCloseCompletes: false);
+    final fixture = _Fixture(processes: [process]);
+    final clock = _ManualClock();
+    final service = fixture.service(clock: clock);
+
+    await service.sendPrompt(
+      sessionId: "session",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "prompt")],
+      userVisibleText: "prompt",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    final prompt = await waitForCommand(process: process, type: "prompt");
+    process.emitResponse(id: prompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: "session");
+    clock.elapse();
+    await pump();
+
+    var disposed = false;
+    final disposal = service.dispose().then((_) => disposed = true);
+    await pump();
+    expect(disposed, isFalse);
+    process.completeStdinClose();
+    await disposal;
+    expect(process.killed, isTrue);
+    await fixture.dispose();
+  });
+
   test("idle reap preserves pending marker location for later deletion", () async {
     final process = FakePiProcess();
     final storage = _Storage(initialResolved: null);
@@ -724,6 +986,30 @@ void main() {
   });
 }
 
+Future<String> _captureWarnings(Future<void> Function() action) async {
+  final previousLevel = Log.level;
+  final stderr = _BufferingStdout();
+  try {
+    Log.level = LogLevel.warning;
+    await IOOverrides.runZoned(action, stderr: () => stderr);
+  } finally {
+    Log.level = previousLevel;
+  }
+  return stderr.text;
+}
+
+final class _BufferingStdout() implements Stdout {
+  final StringBuffer _buffer = StringBuffer();
+
+  String get text => _buffer.toString();
+
+  @override
+  void writeln([Object? object = ""]) => _buffer.writeln(object);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
 Future<void> _answerEntries(FakePiProcess process) => _answerNthEntries(process, count: 1);
 
 Future<void> _answerNthEntries(FakePiProcess process, {required int count}) async {
@@ -784,13 +1070,18 @@ PiResolvedSession _resolved({String id = "session"}) => PiResolvedSession(
   path: "/sessions/$id.jsonl",
 );
 
-final class _Fixture({required List<FakePiProcess> processes, final _Storage? storageOverride}) {
+final class _Fixture({
+  required List<FakePiProcess> processes,
+  final _Storage? storageOverride,
+  final Duration historyRpcTimeout = const Duration(seconds: 2),
+}) {
   final List<FakePiProcess> _processes = List.of(processes);
   late final _Storage storage = storageOverride ?? _Storage(initialResolved: _resolved());
   final List<PiLaunchSpec> spawned = [];
   late final PiMessageIdentityTracker identities = PiMessageIdentityTracker(pluginId: "pi");
   late final PiHistoryMapper historyMapper = PiHistoryMapper(pluginId: "pi");
   final List<PiSessionService> _services = [];
+  final List<PiExtensionUiService> extensions = [];
   late final PiSessionProcessRepository repository = PiSessionProcessRepository(
     storageApi: storage,
     historyStorageApi: _HistoryStorage(storageApi: storage),
@@ -803,7 +1094,7 @@ final class _Fixture({required List<FakePiProcess> processes, final _Storage? st
     historyMapper: historyMapper,
     identityTracker: identities,
     startupExitTimeout: const Duration(milliseconds: 50),
-    historyRpcTimeout: const Duration(seconds: 2),
+    historyRpcTimeout: historyRpcTimeout,
   );
 
   PiSessionService service({ServerClock clock = const ServerClock()}) {
@@ -825,6 +1116,7 @@ final class _Fixture({required List<FakePiProcess> processes, final _Storage? st
       clock: clock,
       idleTimeout: const Duration(minutes: 5),
     );
+    extensions.add(extension);
     _services.add(service);
     return service;
   }
@@ -844,6 +1136,7 @@ final class _Storage({
   required final PiResolvedSession? initialResolved,
   final PiPendingNewSession? initialPending,
   final Completer<void>? resolveGate,
+  final Object? clearError,
 }) implements PiSessionStorageApi {
   PiResolvedSession? resolved = initialResolved;
   PiPendingNewSession? pending = initialPending;
@@ -862,6 +1155,7 @@ final class _Storage({
 
   @override
   Future<void> clearPendingNewSession({required String sessionId, required Set<String> knownDirectories}) async {
+    if (clearError case final error?) throw error;
     clearedDirectories = Set.of(knownDirectories);
     pending = null;
   }

--- a/bridge/sesori_plugin_pi/test/pi_session_storage_api_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_storage_api_test.dart
@@ -896,6 +896,26 @@ void main() {
       expect(await api.readPendingNewSession(sessionId: "secure-id", knownDirectories: {cwd}), isNull);
     });
 
+    test("marker resolution reports malformed settings without their content", () async {
+      final fixture = _StorageFixture();
+      addTearDown(fixture.dispose);
+      final project = fixture.directory("pending-project");
+      fixture.directory(p.join("pending-project", ".pi"));
+      final settingsPath = p.join(project, ".pi", "settings.json");
+      File(settingsPath).writeAsStringSync('{"private-setting":');
+      final api = fixture.api();
+
+      final warnings = await _captureWarnings(() async {
+        await api.writePendingNewSession(sessionId: "secure-id", cwd: project);
+        await api.readPendingNewSession(sessionId: "secure-id", knownDirectories: {project});
+        await api.clearPendingNewSession(sessionId: "secure-id", knownDirectories: {project});
+      });
+
+      expect(warnings, contains("malformed session settings"));
+      expect(warnings, contains(settingsPath));
+      expect(warnings, isNot(contains("private-setting")));
+    });
+
     test("rejects unsafe marker ids and line-breaking cwd values", () async {
       final fixture = _StorageFixture();
       addTearDown(fixture.dispose);

--- a/bridge/sesori_plugin_pi/test/pi_session_storage_api_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_storage_api_test.dart
@@ -879,6 +879,34 @@ void main() {
     });
   });
 
+  group("pending new sessions", () {
+    test("persists and clears caller-owned session markers", () async {
+      final fixture = _StorageFixture();
+      addTearDown(fixture.dispose);
+      final cwd = fixture.directory("pending-project");
+      final api = fixture.api();
+
+      await api.writePendingNewSession(sessionId: "secure-id", cwd: cwd);
+
+      expect(
+        await api.readPendingNewSession(sessionId: "secure-id", knownDirectories: {cwd}),
+        isA<PiPendingNewSession>().having((marker) => marker.cwd, "cwd", p.normalize(p.absolute(cwd))),
+      );
+      await api.clearPendingNewSession(sessionId: "secure-id", knownDirectories: {cwd});
+      expect(await api.readPendingNewSession(sessionId: "secure-id", knownDirectories: {cwd}), isNull);
+    });
+
+    test("rejects unsafe marker ids", () async {
+      final fixture = _StorageFixture();
+      addTearDown(fixture.dispose);
+
+      await expectLater(
+        fixture.api().writePendingNewSession(sessionId: "../escape", cwd: fixture.root.path),
+        throwsArgumentError,
+      );
+    });
+  });
+
   test("real Pi root scan retains metadata-only structural invariants when available", () async {
     final sessions = await PiSessionStorageApi(
       environment: Platform.environment,

--- a/bridge/sesori_plugin_pi/test/pi_session_storage_api_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_storage_api_test.dart
@@ -916,6 +916,32 @@ void main() {
       expect(warnings, isNot(contains("private-setting")));
     });
 
+    test("invalid marker logs its path and original failure", () async {
+      final fixture = _StorageFixture();
+      addTearDown(fixture.dispose);
+      final project = fixture.directory("pending-project");
+      final markerPath = p.join(
+        _defaultSessionDirectory(agentDirectory: fixture.agentDirectory, cwd: project),
+        ".sesori-pending",
+        "secure-id.pending",
+      );
+      final api = fixture.api();
+      await api.writePendingNewSession(sessionId: "secure-id", cwd: project);
+      File(markerPath).writeAsStringSync("relative-private-value");
+
+      final warnings = await _captureWarnings(() async {
+        await expectLater(
+          api.readPendingNewSession(sessionId: "secure-id", knownDirectories: {project}),
+          throwsA(isA<PiInvalidPendingNewSessionException>()),
+        );
+      });
+
+      expect(warnings, contains("invalid pending session marker session_id=secure-id"));
+      expect(warnings, contains(markerPath));
+      expect(warnings, contains("Pending marker cwd is invalid"));
+      expect(warnings, isNot(contains("relative-private-value")));
+    });
+
     test("rejects unsafe marker ids and line-breaking cwd values", () async {
       final fixture = _StorageFixture();
       addTearDown(fixture.dispose);

--- a/bridge/sesori_plugin_pi/test/pi_session_storage_api_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_storage_api_test.dart
@@ -896,13 +896,24 @@ void main() {
       expect(await api.readPendingNewSession(sessionId: "secure-id", knownDirectories: {cwd}), isNull);
     });
 
-    test("rejects unsafe marker ids", () async {
+    test("rejects unsafe marker ids and line-breaking cwd values", () async {
       final fixture = _StorageFixture();
       addTearDown(fixture.dispose);
+      final api = fixture.api();
 
       await expectLater(
-        fixture.api().writePendingNewSession(sessionId: "../escape", cwd: fixture.root.path),
+        api.writePendingNewSession(sessionId: "../escape", cwd: fixture.root.path),
         throwsArgumentError,
+      );
+      for (final cwd in ["${fixture.root.path}\nother", "${fixture.root.path}\rother"]) {
+        await expectLater(
+          api.writePendingNewSession(sessionId: "secure-id", cwd: cwd),
+          throwsArgumentError,
+        );
+      }
+      expect(
+        await api.readPendingNewSession(sessionId: "secure-id", knownDirectories: {fixture.root.path}),
+        isNull,
       );
     });
   });

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -22,6 +22,18 @@ defaults and queued client sends coherent.
   finalized messages enter durable history matching a history read. Internal
   backend command records are not rendered as conversation messages or used as
   assistant model attribution.
+- Pi keeps at most one lazy resident RPC process per active session and allows
+  different sessions to run concurrently. Startup replays and hydrates message
+  identity before live frames attach or a turn dispatches; same-session prompts
+  remain FIFO. Process exit settles current work before queued work reconnects.
+- Pi slash commands are accepted by their correlated response or a matching
+  extension dialog. Commands reject while that session is busy, and a successful
+  command with no agent run crosses `get_state` before returning the lane idle.
+  Abort rejects queued work and replaces the process so hidden steering or
+  follow-up input cannot leak into the next turn.
+- Pi accepts only bounded, valid inline GIF, JPEG, PNG, and WebP data. Paths,
+  URLs, non-image data, malformed base64, and oversized images fail visibly
+  before admission and are never fetched, stringified, or silently omitted.
 - Normalized user-message events feed the durable user-side activity marker used
   to order running roots. Known event times are applied monotonically. Backend
   input represented as a user message, including automatic compaction or other

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -114,6 +114,10 @@ queue, turn length, and client count.
   churn is recorded as evidence rather than judged pass or fail.
 - The prompt queue is in memory and owned by session detail; leaving that surface
   disposes queued submissions rather than restoring them on reopen.
+- Pi persists API commands and manually typed slash prompts in the same raw
+  shape. Cold replay therefore shows only the slash-command token to avoid
+  exposing bridge-owned arguments; live API-command presentation retains only
+  the exact user-authored arguments.
 
 ## Sources
 


### PR DESCRIPTION
## Complexity

🚧 Complex. This step owns persisted creation markers, resident child-process lifecycle, per-session concurrency, event/response ordering, attachment validation, and failure recovery.

## What

- Add one generation-fenced resident Pi RPC client per active session, with replay identity hydration before live frame exposure.
- Add secure caller-owned session IDs and pending-new markers that survive lazy Pi JSONL creation.
- Add per-session prompt lanes, selection-before-prompt dispatch, exact command acceptance, no-run barriers, queued work, abort teardown, idle reap, and shutdown cleanup.
- Reuse resident processes for history and rename, while serializing bounded transient leases so a session never has overlapping Pi writers.
- Route extension dialog replies through the resident repository and validate inline image prompt parts without fetching or silently dropping unsupported attachments.
- Add focused storage, process, turn, concurrency, ordering, failure, and cleanup coverage.

## Why

Pi RPC controls exactly one loaded session per process. Sesori therefore needs explicit per-session residency and turn ownership before the plugin API can safely expose prompts, commands, questions, history, and lifecycle operations.

## Risk and test focus

Risk is concentrated in process-generation fencing, replay-before-live ordering, response/event races, same-session serialization, cross-session concurrency, marker cleanup, abort/exit behavior, and privacy-safe attachment rejection.

Review should focus on startup/teardown races, events arriving before prompt responses, dialog-first command acceptance, history or rename racing residency, failed selections and process exits, and pending-marker behavior before Pi creates its JSONL file.

## Expected result

Pi sessions can remain resident independently, accept serialized turns without blocking other sessions, recover from process exits, and resume bridge-created sessions that have not yet materialized a JSONL file.

There is no current user-visible, database, analytics, registered-plugin, or client-wire impact. Pending-new marker files are the only new persisted state; they are scoped to Pi session storage and removed after persistence or deletion. Pi remains app-invisible until Step 18.

## Verification

- `dart test` (194 tests)
- `dart analyze --fatal-infos`
- `git diff --check origin/main...HEAD`
- Architecture implementation review approved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Per-session Pi process residency with generation fences and FIFO turns replaces overlapping writers and unrouted replies. Cold replays hydrate message identity inside a scoped fence and map exact slash commands to visible text before any live frames attach.

- Lifecycle and fences: scoped replay-before-live hydration; fences release on exit/abort; process exit settles active work; reconnects preserve diagnostics, prompt context, and caller-owned pending-new markers.
- Ordering and mapping: per-session FIFO; turn begin records execution and user-visible text; history maps exact command text to visible slash content; identity hydrates before live frames attach.
- Dialog routing: extension replies carry and must match the resident process generation.
- Safety: same-session busy rejection (PiSessionBusyException); abort clears queued work and replaces the process; bounded inline image attachment type/size validation.
- Storage: write/read/clear pending-new session markers; malformed markers raise PiInvalidPendingNewSessionException without exposing content.
- Validation: isValidPiSessionId centralizes session ID checks.

**Migration**
- Construct PiExtensionUiService with a PiSessionProcessRepository; remove the response-sender callback.
- Handle PiSessionBusyException for same-session commands.

<sup>Written for commit 2b088003bed00769d949f412e1dc46d49057c401. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

