### PR TITLE
🌱 [hermes-agent-plugin] feat(hermes): scaffold the ACP plugin package [step 2/9]

### DIFF
--- a/bridge/Makefile
+++ b/bridge/Makefile
@@ -2,7 +2,7 @@ TOOL_VERSIONS := $(shell git rev-parse --show-toplevel)/.tool-versions
 FLUTTER_VERSION := $(shell grep '^flutter' $(TOOL_VERSIONS) | awk '{print $$2}')
 DART := $(HOME)/.asdf/installs/flutter/$(FLUTTER_VERSION)/bin/cache/dart-sdk/bin/dart
 
-MODULES := sesori_plugin_interface sesori_bridge_foundation sesori_plugin_runtime sesori_plugin_opencode sesori_plugin_codex sesori_plugin_acp sesori_plugin_cursor sesori_plugin_omp sesori_plugin_claude sesori_plugin_pi app
+MODULES := sesori_plugin_interface sesori_bridge_foundation sesori_plugin_runtime sesori_plugin_opencode sesori_plugin_codex sesori_plugin_acp sesori_plugin_cursor sesori_plugin_omp sesori_plugin_claude sesori_plugin_pi sesori_plugin_hermes app
 
 .PHONY: codegen opencode-codegen pub-get test analyze
 

--- a/bridge/pubspec.yaml
+++ b/bridge/pubspec.yaml
@@ -16,3 +16,4 @@ workspace:
   - sesori_plugin_omp
   - sesori_plugin_claude
   - sesori_plugin_pi
+  - sesori_plugin_hermes

--- a/bridge/sesori_plugin_hermes/analysis_options.yaml
+++ b/bridge/sesori_plugin_hermes/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../app/analysis_options.yaml

--- a/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
+++ b/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
@@ -1,0 +1,7 @@
+// Hermes Agent backend for the Sesori bridge.
+//
+// Drives `hermes acp` over the generic ACP machinery (acp_plugin). Hermes is
+// a stock ACP v1 server (protocol version 1), so the plugin core is policy
+// only — no harness-specific protocol extensions.
+export "src/hermes_binary.dart";
+export "src/hermes_identity.dart";

--- a/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
+++ b/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
@@ -2,6 +2,5 @@
 //
 // Drives `hermes acp` over the generic ACP machinery (acp_plugin). Hermes is
 // a stock ACP v1 server (protocol version 1), so the plugin core is policy
-// only — no harness-specific protocol extensions.
+// only, with no harness-specific protocol extensions.
 export "src/hermes_binary.dart";
-export "src/hermes_identity.dart";

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
@@ -1,0 +1,25 @@
+import "package:acp_plugin/acp_plugin.dart";
+
+/// Builds the launch spec for `hermes acp`.
+///
+/// Auth is out of band: the process factory inherits the bridge's
+/// environment, so a Hermes install with a configured provider/model
+/// (via `hermes setup` / `hermes model`) is picked up automatically.
+abstract final class HermesBinary() {
+  /// The Hermes CLI launcher, resolved on PATH by the descriptor's runtime
+  /// probe (and overridable with `--hermes-bin`).
+  static const String defaultBinary = "hermes";
+
+  static AcpLaunchSpec launchSpec({
+    String binary = defaultBinary,
+    String? cwd,
+    Map<String, String> environment = const {},
+  }) {
+    return AcpLaunchSpec(
+      command: binary,
+      args: const ["acp"],
+      cwd: cwd,
+      environment: environment,
+    );
+  }
+}

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
@@ -6,8 +6,7 @@ import "package:acp_plugin/acp_plugin.dart";
 /// environment, so a Hermes install with a configured provider/model
 /// (via `hermes setup` / `hermes model`) is picked up automatically.
 abstract final class HermesBinary() {
-  /// The Hermes CLI launcher, resolved on PATH by the descriptor's runtime
-  /// probe (and overridable with `--hermes-bin`).
+  /// The Hermes CLI launcher, resolved on PATH.
   static const String defaultBinary = "hermes";
 
   static AcpLaunchSpec launchSpec({

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_binary.dart
@@ -10,9 +10,9 @@ abstract final class HermesBinary() {
   static const String defaultBinary = "hermes";
 
   static AcpLaunchSpec launchSpec({
-    String binary = defaultBinary,
-    String? cwd,
-    Map<String, String> environment = const {},
+    required String binary,
+    required String? cwd,
+    required Map<String, String> environment,
   }) {
     return AcpLaunchSpec(
       command: binary,

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
@@ -1,12 +1,9 @@
 /// Identity constants for the Hermes Agent harness plugin.
 ///
 /// The plugin id is the plain string `hermes` (precedent: the pi and omp
-/// plugins are not members of the legacy `Harness` enum either). The client
-/// brands the id through `PregoBrandLogo` in module_prego (Hermes staff mark
-/// + "Hermes Agent" display name).
+/// plugins are not members of the legacy `Harness` enum either). Client-side
+/// brand mapping for the id can follow without a wire-format change.
 abstract final class HermesPluginIdentity() {
-  static const String pluginId = "hermes";
+  static const String id = "hermes";
   static const String displayName = "Hermes Agent";
-  static const String clientName = "sesori-bridge";
-  static const String clientVersion = "0.0.0";
 }

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
@@ -1,0 +1,12 @@
+/// Identity constants for the Hermes Agent harness plugin.
+///
+/// The plugin id is the plain string `hermes` (precedent: the pi and omp
+/// plugins are not members of the legacy `Harness` enum either). Client-side
+/// brand mapping for the id can follow later without a wire-format change.
+abstract final class HermesIdentity() {
+  static const String pluginId = "hermes";
+  static const String displayName = "Hermes Agent";
+  static const String providerId = "hermes";
+  static const String clientName = "sesori-bridge";
+  static const String clientVersion = "0.0.0";
+}

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
@@ -2,7 +2,8 @@
 ///
 /// The plugin id is the plain string `hermes` (precedent: the pi and omp
 /// plugins are not members of the legacy `Harness` enum either). Client-side
-/// brand mapping for the id can follow later without a wire-format change.
+/// branding for the id is handled by `PregoBrandLogo` in module_prego (the
+/// Hermes staff mark + "Hermes Agent" display name), keyed by this id.
 abstract final class HermesIdentity() {
   static const String pluginId = "hermes";
   static const String displayName = "Hermes Agent";

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_identity.dart
@@ -1,13 +1,12 @@
 /// Identity constants for the Hermes Agent harness plugin.
 ///
 /// The plugin id is the plain string `hermes` (precedent: the pi and omp
-/// plugins are not members of the legacy `Harness` enum either). Client-side
-/// branding for the id is handled by `PregoBrandLogo` in module_prego (the
-/// Hermes staff mark + "Hermes Agent" display name), keyed by this id.
-abstract final class HermesIdentity() {
+/// plugins are not members of the legacy `Harness` enum either). The client
+/// brands the id through `PregoBrandLogo` in module_prego (Hermes staff mark
+/// + "Hermes Agent" display name).
+abstract final class HermesPluginIdentity() {
   static const String pluginId = "hermes";
   static const String displayName = "Hermes Agent";
-  static const String providerId = "hermes";
   static const String clientName = "sesori-bridge";
   static const String clientVersion = "0.0.0";
 }

--- a/bridge/sesori_plugin_hermes/pubspec.yaml
+++ b/bridge/sesori_plugin_hermes/pubspec.yaml
@@ -1,0 +1,19 @@
+name: hermes_plugin
+version: 0.1.0
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.13.0-0
+
+dependencies:
+  sesori_plugin_interface:
+    path: ../sesori_plugin_interface
+  sesori_bridge_foundation:
+    path: ../sesori_bridge_foundation
+  acp_plugin:
+    path: ../sesori_plugin_acp
+
+dev_dependencies:
+  test: ^1.31.1
+  lints: ^6.1.0


### PR DESCRIPTION
Supersedes #896. This maintainer-owned continuation preserves the original contributor's commits while incorporating the remaining review feedback.

## Complexity

🌱 Trivial - this is an additive package scaffold and workspace wiring with no registered runtime behavior yet.

## What

- Adds the `bridge/sesori_plugin_hermes` package for the Hermes ACP integration.
- Exposes the `hermes acp` launch-spec builder and keeps plugin identity internal to the package.
- Wires the package into the bridge workspace and normal Makefile module flow.
- Requires launch arguments explicitly and aligns the stable identity constant with sibling plugin conventions.

## Why

Hermes Agent exposes a standard ACP v1 server, so Sesori can implement it as a thin package over `sesori_plugin_acp`. This step establishes the package boundary needed by the later plugin-core and descriptor steps.

The replacement lets maintainers finish and merge the series one step at a time while retaining the contributor's work.

## Risk and test focus

Low risk. The package is additive and is not registered with the bridge in this step. Review should focus on workspace resolution, the public package boundary, and the launch-spec shape.

## Expected result

The Hermes plugin scaffold compiles and participates in bridge workspace tooling. There is no user-visible behavior and no database or persisted-data impact.

## Verification

- `dart pub get` from `bridge/`
- `dart format --output=none --set-exit-if-changed lib` from `bridge/sesori_plugin_hermes/`
- `dart analyze --fatal-infos` from `bridge/sesori_plugin_hermes/`
- Architecture implementation review completed; both package-boundary findings were addressed

## Attribution

This PR carries forward all three commits from @eexxio with their original Git authorship intact. Thank you, @eexxio, for contributing the Hermes plan and implementation series; that work provided the foundation for this step, and we greatly appreciate the contribution. The additional maintainer commit is limited to completing review feedback and tightening the package boundary.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scaffolds the `sesori_plugin_hermes` ACP plugin package and wires it into the bridge workspace so Hermes Agent integration can proceed. No runtime registration or user-visible behavior changes.

- Adds `sesori_plugin_hermes` exposing `HermesBinary.launchSpec` for `hermes acp` on PATH, with explicit `binary`, `cwd`, and `environment` inputs; auth/config are picked up from the bridge environment.
- Defines plugin identity constants (`id: "hermes"`, `displayName: "Hermes Agent"`) and keeps identity internal to the package.
- Updates `bridge/Makefile` and `bridge/pubspec.yaml` to include the package; compile-time only.
- Not registered with the bridge; no runtime, database, or migration impact.

<sup>Written for commit 2ad60532c3c204ad4c51a3262bac571a44e8d645. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

