### PR TITLE
⚙️ [hermes-agent-plugin] feat(hermes): add the ACP plugin core [step 3/9]

### DIFF
--- a/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
+++ b/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
@@ -4,3 +4,4 @@
 // a stock ACP v1 server (protocol version 1), so the plugin core is policy
 // only, with no harness-specific protocol extensions.
 export "src/hermes_binary.dart";
+export "src/hermes_plugin_impl.dart";

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
@@ -1,0 +1,100 @@
+import "dart:io" show Directory;
+
+import "package:acp_plugin/acp_plugin.dart";
+
+import "hermes_binary.dart";
+import "hermes_identity.dart";
+
+/// Hermes Agent backend over ACP.
+///
+/// Hermes is a stock ACP v1 server: `hermes acp` advertises load/list/resume/
+/// fork/prompt capabilities and streams turns via `session/update`
+/// notifications, so the base [AcpPlugin] machinery applies unchanged — this
+/// class only declares the harness's protocol policies. There are no
+/// `hermes/*` extensions, no config-option model picker, and no managed
+/// runtime (Hermes installs itself; the bridge resolves it on PATH).
+class HermesPlugin._({
+  required super.launchSpec,
+  required super.launchDirectory,
+  required super.contentMapper,
+  required super.eventMapper,
+  required super.commandTracker,
+  required super.sessionOptionsService,
+  super.processFactory,
+}) extends AcpPlugin {
+  factory({
+    String binaryPath = HermesBinary.defaultBinary,
+    String? launchDirectory,
+    AcpProcessFactory? processFactory,
+  }) {
+    final cwd = launchDirectory ?? Directory.current.path;
+    final launchSpec = HermesBinary.launchSpec(
+      binary: binaryPath,
+      cwd: cwd,
+    );
+    final commandTracker = AcpCommandTracker();
+    final configurationTracker = AcpSessionConfigurationTracker();
+    const contentMapper = AcpContentMapper();
+    final sessionOptionsService = AcpSessionOptionsService(
+      configurationTracker: configurationTracker,
+      commandTracker: commandTracker,
+      pluginId: HermesIdentity.pluginId,
+      agentDisplayName: HermesIdentity.displayName,
+    );
+    final mapper = AcpEventMapper(
+      launchDirectory: cwd,
+      agentId: HermesIdentity.pluginId,
+      pluginId: HermesIdentity.pluginId,
+      configurationTracker: configurationTracker,
+      contentMapper: contentMapper,
+    );
+    return HermesPlugin._(
+      launchSpec: launchSpec,
+      launchDirectory: cwd,
+      contentMapper: contentMapper,
+      eventMapper: mapper,
+      commandTracker: commandTracker,
+      sessionOptionsService: sessionOptionsService,
+      processFactory: processFactory,
+    );
+  }
+
+  this
+    : super(
+        id: HermesIdentity.pluginId,
+        agentDisplayName: HermesIdentity.displayName,
+      );
+
+  @override
+  String get clientName => HermesIdentity.clientName;
+
+  @override
+  String get clientVersion => HermesIdentity.clientVersion;
+
+  /// Hermes advertises a provider auth method plus a terminal-setup method;
+  /// the first advertised method is the configured provider, which is what we
+  /// want to authenticate against. `null` picks it.
+  @override
+  String? get authMethodId => null;
+
+  @override
+  Map<String, dynamic>? get initializeCapabilityMeta => null;
+
+  /// Hermes has no `elicitation/create` — permissions arrive as
+  /// `session/request_permission`, which the base approval registry handles.
+  @override
+  bool get supportsFormElicitation => false;
+
+  /// Hermes serializes turns per session (one agent loop per session), so
+  /// concurrent sessions may prompt in parallel.
+  @override
+  bool get serializesPromptsProcessWide => false;
+
+  /// No harness-specific turn selection exists (base [applyTurnSelection] is
+  /// a no-op), so a selection can never fail a turn.
+  @override
+  bool get failsTurnOnSelectionError => false;
+
+  @override
+  Duration get sessionCloseSettlementTimeout => const Duration(seconds: 5);
+}

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
@@ -9,7 +9,7 @@ import "hermes_identity.dart";
 ///
 /// Hermes is a stock ACP v1 server: `hermes acp` advertises load/list/resume/
 /// fork/prompt capabilities and streams turns via `session/update`
-/// notifications, so the base [AcpPlugin] machinery applies unchanged — this
+/// notifications, so the base [AcpPlugin] machinery applies unchanged. This
 /// class only declares the harness's protocol policies. There are no
 /// `hermes/*` extensions, no config-option model picker, and no managed
 /// runtime (Hermes installs itself; the bridge resolves it on PATH).
@@ -20,17 +20,18 @@ class HermesPlugin._({
   required super.eventMapper,
   required super.commandTracker,
   required super.sessionOptionsService,
-  super.processFactory,
+  required super.processFactory,
 }) extends AcpPlugin {
   factory({
-    String binaryPath = HermesBinary.defaultBinary,
-    String? launchDirectory,
-    AcpProcessFactory? processFactory,
+    required String binaryPath,
+    required String? launchDirectory,
+    required AcpProcessFactory processFactory,
   }) {
     final cwd = launchDirectory ?? Directory.current.path;
     final launchSpec = HermesBinary.launchSpec(
       binary: binaryPath,
       cwd: cwd,
+      environment: const {},
     );
     final commandTracker = AcpCommandTracker();
     final configurationTracker = AcpSessionConfigurationTracker();
@@ -38,13 +39,13 @@ class HermesPlugin._({
     final sessionOptionsService = AcpSessionOptionsService(
       configurationTracker: configurationTracker,
       commandTracker: commandTracker,
-      pluginId: HermesPluginIdentity.pluginId,
+      pluginId: HermesPluginIdentity.id,
       agentDisplayName: HermesPluginIdentity.displayName,
     );
     final mapper = AcpEventMapper(
       launchDirectory: cwd,
-      agentId: HermesPluginIdentity.pluginId,
-      pluginId: HermesPluginIdentity.pluginId,
+      agentId: HermesPluginIdentity.id,
+      pluginId: HermesPluginIdentity.id,
       configurationTracker: configurationTracker,
       contentMapper: contentMapper,
     );
@@ -61,27 +62,26 @@ class HermesPlugin._({
 
   this
     : super(
-        id: HermesPluginIdentity.pluginId,
+        id: HermesPluginIdentity.id,
         agentDisplayName: HermesPluginIdentity.displayName,
       );
 
   @override
-  String get clientName => HermesPluginIdentity.clientName;
+  String get clientName => "sesori-bridge";
 
   @override
-  String get clientVersion => HermesPluginIdentity.clientVersion;
+  String get clientVersion => "0.0.0";
 
-  /// Hermes advertises the configured provider as an agent auth method first
-  /// and a terminal-setup method after it (see `build_auth_methods`); `null`
-  /// picks the first advertised method — the provider — which is what we want
-  /// to authenticate against.
+  /// Hermes provider method ids are dynamic, so there is no fixed preferred
+  /// id. Hermes advertises the configured provider first and its terminal
+  /// setup method second; the ACP base uses the first method when this is null.
   @override
   String? get authMethodId => null;
 
   @override
   Map<String, dynamic>? get initializeCapabilityMeta => null;
 
-  /// Hermes has no `elicitation/create` — permissions arrive as
+  /// Hermes has no `elicitation/create`; permissions arrive as
   /// `session/request_permission`, which the base approval registry handles.
   @override
   bool get supportsFormElicitation => false;

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
@@ -71,9 +71,10 @@ class HermesPlugin._({
   @override
   String get clientVersion => HermesIdentity.clientVersion;
 
-  /// Hermes advertises a provider auth method plus a terminal-setup method;
-  /// the first advertised method is the configured provider, which is what we
-  /// want to authenticate against. `null` picks it.
+  /// Hermes advertises the configured provider as an agent auth method first
+  /// and a terminal-setup method after it (see `build_auth_methods`); `null`
+  /// picks the first advertised method — the provider — which is what we want
+  /// to authenticate against.
   @override
   String? get authMethodId => null;
 

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
@@ -38,13 +38,13 @@ class HermesPlugin._({
     final sessionOptionsService = AcpSessionOptionsService(
       configurationTracker: configurationTracker,
       commandTracker: commandTracker,
-      pluginId: HermesIdentity.pluginId,
-      agentDisplayName: HermesIdentity.displayName,
+      pluginId: HermesPluginIdentity.pluginId,
+      agentDisplayName: HermesPluginIdentity.displayName,
     );
     final mapper = AcpEventMapper(
       launchDirectory: cwd,
-      agentId: HermesIdentity.pluginId,
-      pluginId: HermesIdentity.pluginId,
+      agentId: HermesPluginIdentity.pluginId,
+      pluginId: HermesPluginIdentity.pluginId,
       configurationTracker: configurationTracker,
       contentMapper: contentMapper,
     );
@@ -61,15 +61,15 @@ class HermesPlugin._({
 
   this
     : super(
-        id: HermesIdentity.pluginId,
-        agentDisplayName: HermesIdentity.displayName,
+        id: HermesPluginIdentity.pluginId,
+        agentDisplayName: HermesPluginIdentity.displayName,
       );
 
   @override
-  String get clientName => HermesIdentity.clientName;
+  String get clientName => HermesPluginIdentity.clientName;
 
   @override
-  String get clientVersion => HermesIdentity.clientVersion;
+  String get clientVersion => HermesPluginIdentity.clientVersion;
 
   /// Hermes advertises the configured provider as an agent auth method first
   /// and a terminal-setup method after it (see `build_auth_methods`); `null`

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
@@ -8,7 +8,9 @@ import "package:test/test.dart";
 /// The `initialize` result Hermes actually advertises (verified 2026-08-13
 /// against `hermes acp` v0.20.0): load/list/resume/fork session capabilities,
 /// image prompt support, and no `closeSession` — the base must therefore
-/// never call `session/close`.
+/// never call `session/close`. Auth mirrors `build_auth_methods()`: the
+/// configured provider as an agent method first, then a terminal-setup
+/// method.
 const Map<String, dynamic> hermesInitializeResult = {
   "protocolVersion": 1,
   "agentCapabilities": {
@@ -22,9 +24,15 @@ const Map<String, dynamic> hermesInitializeResult = {
   },
   "authMethods": [
     {
+      "id": "opencode-go",
+      "name": "opencode-go runtime credentials",
+      "description": "Authenticate Hermes using the currently configured opencode-go runtime credentials.",
+    },
+    {
       "type": "terminal",
       "id": "hermes-setup",
-      "title": "Hermes terminal setup",
+      "name": "Configure Hermes provider",
+      "description": "Open Hermes' interactive model/provider setup in a terminal.",
     },
   ],
 };
@@ -75,9 +83,16 @@ void main() {
     Future<void> connect() async {
       final connecting = plugin.ensureConnected();
       await respond("initialize", hermesInitializeResult);
-      // Hermes advertises a terminal auth method, so the handshake calls
-      // authenticate with it; a configured install answers with an empty body.
-      await respond("authenticate", const <String, dynamic>{});
+      // Hermes advertises the configured provider method first, then a
+      // terminal-setup method; the handshake authenticates against the first
+      // advertised method because authMethodId is null.
+      final authFrame = await waitForFrame("authenticate");
+      expect(
+        (authFrame["params"] as Map).cast<String, dynamic>()["methodId"],
+        "opencode-go",
+        reason: "the plugin must authenticate against the configured provider, not the setup method",
+      );
+      fake.emit({"jsonrpc": "2.0", "id": authFrame["id"], "result": <String, dynamic>{}});
       expect(await connecting, isTrue);
     }
 

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
@@ -1,0 +1,191 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_testing.dart";
+import "package:hermes_plugin/hermes_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+/// The `initialize` result Hermes actually advertises (verified 2026-08-13
+/// against `hermes acp` v0.20.0): load/list/resume/fork session capabilities,
+/// image prompt support, and no `closeSession` — the base must therefore
+/// never call `session/close`.
+const Map<String, dynamic> hermesInitializeResult = {
+  "protocolVersion": 1,
+  "agentCapabilities": {
+    "loadSession": true,
+    "promptCapabilities": {"image": true},
+    "sessionCapabilities": {
+      "fork": <String, dynamic>{},
+      "list": <String, dynamic>{},
+      "resume": <String, dynamic>{},
+    },
+  },
+  "authMethods": [
+    {
+      "type": "terminal",
+      "id": "hermes-setup",
+      "title": "Hermes terminal setup",
+    },
+  ],
+};
+
+void main() {
+  group("HermesPlugin", () {
+    late FakeAcpProcess fake;
+    late HermesPlugin plugin;
+    late Set<Object?> handledFrameIds;
+
+    setUp(() {
+      fake = FakeAcpProcess();
+      handledFrameIds = {};
+      plugin = HermesPlugin(
+        launchDirectory: "/repo",
+        processFactory: (_) async => fake,
+      );
+    });
+
+    tearDown(() async {
+      await plugin.dispose();
+      await fake.close();
+    });
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+    Future<Map<String, dynamic>> waitForFrame(String method) async {
+      for (var i = 0; i < 50; i++) {
+        final matches = fake.written.where(
+          (frame) => frame["method"] == method && !handledFrameIds.contains(frame["id"]),
+        );
+        if (matches.isNotEmpty) {
+          final frame = matches.first;
+          handledFrameIds.add(frame["id"]);
+          return frame;
+        }
+        await pump();
+      }
+      throw StateError("agent never wrote a '$method' frame");
+    }
+
+    Future<void> respond(String method, Map<String, dynamic> result) async {
+      final frame = await waitForFrame(method);
+      fake.emit({"jsonrpc": "2.0", "id": frame["id"], "result": result});
+      await pump();
+    }
+
+    Future<void> connect() async {
+      final connecting = plugin.ensureConnected();
+      await respond("initialize", hermesInitializeResult);
+      // Hermes advertises a terminal auth method, so the handshake calls
+      // authenticate with it; a configured install answers with an empty body.
+      await respond("authenticate", const <String, dynamic>{});
+      expect(await connecting, isTrue);
+    }
+
+    test("id is hermes", () {
+      expect(plugin.id, "hermes");
+    });
+
+    test("the default binary is the Hermes CLI and the launch spec drives `hermes acp`", () {
+      expect(HermesBinary.defaultBinary, "hermes");
+      final spec = HermesBinary.launchSpec(cwd: "/repo");
+      expect(spec.command, "hermes");
+      expect(spec.args, ["acp"]);
+    });
+
+    test("declares the neutral ACP policies for a stock v1 server", () {
+      expect(plugin.clientName, "sesori-bridge");
+      expect(plugin.clientVersion, "0.0.0");
+      expect(plugin.authMethodId, isNull, reason: "use the first advertised method");
+      expect(plugin.initializeCapabilityMeta, isNull);
+      expect(plugin.supportsFormElicitation, isFalse, reason: "no elicitation/create on Hermes");
+      expect(plugin.serializesPromptsProcessWide, isFalse);
+      expect(plugin.failsTurnOnSelectionError, isFalse);
+      expect(plugin.sessionCloseSettlementTimeout, const Duration(seconds: 5));
+    });
+
+    test("handshake succeeds against Hermes's advertised capabilities", () async {
+      await connect();
+    });
+
+    test("a prompt turn streams text chunks into part delta events", () async {
+      await connect();
+      final events = <BridgeSseEvent>[];
+      final subscription = plugin.events.listen(events.add);
+      addTearDown(subscription.cancel);
+
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond("session/new", const {"sessionId": "s1"});
+      final session = await creating;
+      expect(session.id, "s1");
+
+      final prompting = plugin.sendPrompt(
+        sessionId: session.id,
+        parts: const [PluginPromptPart.text(text: "Hello")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final promptFrame = await waitForFrame("session/prompt");
+      final params = (promptFrame["params"] as Map).cast<String, dynamic>();
+      expect(params["sessionId"], "s1");
+      final prompt = params["prompt"] as List;
+      expect(
+        (prompt.single as Map)["text"],
+        "Hello",
+        reason: "the prompt part must reach the agent verbatim",
+      );
+      fake.emit({"jsonrpc": "2.0", "id": promptFrame["id"], "result": <String, dynamic>{}});
+      await prompting;
+
+      // Hermes streams assistant output as session/update agent_message_chunk
+      // notifications (same shape the base mapper expects).
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": "s1",
+          "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "Hello"},
+          },
+        },
+      });
+      await pump();
+
+      expect(events.whereType<BridgeSseMessagePartDelta>().single.delta, "Hello");
+    });
+
+    test("deleteSession never calls session/close when closeSession is not advertised", () async {
+      await connect();
+
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond("session/new", const {"sessionId": "s1"});
+      await creating;
+
+      await plugin.deleteSession("s1");
+      await pump();
+
+      expect(
+        fake.written.where((frame) => frame["method"] == "session/close"),
+        isEmpty,
+        reason: "Hermes does not advertise closeSession, so deletion must be local-only",
+      );
+    });
+  });
+}

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
@@ -7,7 +7,7 @@ import "package:test/test.dart";
 
 /// The `initialize` result Hermes actually advertises (verified 2026-08-13
 /// against `hermes acp` v0.20.0): load/list/resume/fork session capabilities,
-/// image prompt support, and no `closeSession` — the base must therefore
+/// image prompt support, and no `closeSession`. The base must therefore
 /// never call `session/close`. Auth mirrors `build_auth_methods()`: the
 /// configured provider as an agent method first, then a terminal-setup
 /// method.
@@ -47,6 +47,7 @@ void main() {
       fake = FakeAcpProcess();
       handledFrameIds = {};
       plugin = HermesPlugin(
+        binaryPath: HermesBinary.defaultBinary,
         launchDirectory: "/repo",
         processFactory: (_) async => fake,
       );
@@ -59,7 +60,7 @@ void main() {
 
     Future<void> pump() => Future<void>.delayed(Duration.zero);
 
-    Future<Map<String, dynamic>> waitForFrame(String method) async {
+    Future<Map<String, dynamic>> waitForFrame({required String method}) async {
       for (var i = 0; i < 50; i++) {
         final matches = fake.written.where(
           (frame) => frame["method"] == method && !handledFrameIds.contains(frame["id"]),
@@ -74,19 +75,22 @@ void main() {
       throw StateError("agent never wrote a '$method' frame");
     }
 
-    Future<void> respond(String method, Map<String, dynamic> result) async {
-      final frame = await waitForFrame(method);
+    Future<void> respond({
+      required String method,
+      required Map<String, dynamic> result,
+    }) async {
+      final frame = await waitForFrame(method: method);
       fake.emit({"jsonrpc": "2.0", "id": frame["id"], "result": result});
       await pump();
     }
 
     Future<void> connect() async {
       final connecting = plugin.ensureConnected();
-      await respond("initialize", hermesInitializeResult);
+      await respond(method: "initialize", result: hermesInitializeResult);
       // Hermes advertises the configured provider method first, then a
       // terminal-setup method; the handshake authenticates against the first
       // advertised method because authMethodId is null.
-      final authFrame = await waitForFrame("authenticate");
+      final authFrame = await waitForFrame(method: "authenticate");
       expect(
         (authFrame["params"] as Map).cast<String, dynamic>()["methodId"],
         "opencode-go",
@@ -102,7 +106,11 @@ void main() {
 
     test("the default binary is the Hermes CLI and the launch spec drives `hermes acp`", () {
       expect(HermesBinary.defaultBinary, "hermes");
-      final spec = HermesBinary.launchSpec(cwd: "/repo");
+      final spec = HermesBinary.launchSpec(
+        binary: HermesBinary.defaultBinary,
+        cwd: "/repo",
+        environment: const {},
+      );
       expect(spec.command, "hermes");
       expect(spec.args, ["acp"]);
     });
@@ -137,7 +145,7 @@ void main() {
         agent: null,
         model: null,
       );
-      await respond("session/new", const {"sessionId": "s1"});
+      await respond(method: "session/new", result: const {"sessionId": "s1"});
       final session = await creating;
       expect(session.id, "s1");
 
@@ -148,7 +156,7 @@ void main() {
         agent: null,
         model: null,
       );
-      final promptFrame = await waitForFrame("session/prompt");
+      final promptFrame = await waitForFrame(method: "session/prompt");
       final params = (promptFrame["params"] as Map).cast<String, dynamic>();
       expect(params["sessionId"], "s1");
       final prompt = params["prompt"] as List;
@@ -190,7 +198,7 @@ void main() {
         agent: null,
         model: null,
       );
-      await respond("session/new", const {"sessionId": "s1"});
+      await respond(method: "session/new", result: const {"sessionId": "s1"});
       await creating;
 
       await plugin.deleteSession("s1");


### PR DESCRIPTION
Supersedes #897. This maintainer-owned continuation preserves the contributor's step-three commits and completes their integration with the merged scaffold.

## Complexity

⚙️ Moderate - this adds a concrete backend plugin with handshake and session behavior, while reusing the existing ACP transport and lifecycle implementation.

## What

- Adds `HermesPlugin` as a policy-only `AcpPlugin` implementation.
- Wires stable Hermes identity, launch configuration, event mapping, command tracking, and session options through the generic ACP machinery.
- Requires the binary path, launch directory choice, and process factory explicitly.
- Adds focused fake-process tests for identity, launch shape, Hermes authentication ordering, prompt streaming, and the absence of unsupported `session/close` calls.

## Why

Hermes Agent exposes a standard ACP v1 server. A thin plugin policy layer keeps Hermes-specific identity and capabilities in its own package without duplicating transport, session, permission, history, or SSE behavior.

The replacement lets maintainers merge the series sequentially while retaining the contributor's implementation and authorship.

## Risk and test focus

Moderate internal risk around ACP handshake policy and session lifecycle assumptions. The plugin is not registered with the bridge in this step, so there is no user-visible runtime path yet. The most valuable checks are provider-method authentication, prompt event mapping, injected process isolation, and local-only deletion when Hermes omits `closeSession`.

Regression documentation remains assigned to step 7/9, before the series is retired.

## Expected result

The Hermes package contains a tested ACP plugin core ready for descriptor and setup wiring in step 4. There is no user-visible behavior and no database or persisted-data impact in this step.

## Verification

- `dart format lib test` from `bridge/sesori_plugin_hermes/`
- `dart analyze --fatal-infos` from `bridge/sesori_plugin_hermes/`
- `dart test` from `bridge/sesori_plugin_hermes/` - 6 tests passed
- Architecture implementation review approved with no findings

## Attribution

This PR carries forward all three step-three commits from @eexxio with their original Git authorship intact. Thank you, @eexxio, for implementing the Hermes ACP core and its initial test coverage. We greatly appreciate the contribution; the additional maintainer commit is limited to review feedback and integration with the merged step-two API.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `HermesPlugin` as a policy-only `AcpPlugin` for Hermes ACP v1, wiring identity, launch, event mapping, command tracking, and session options through existing ACP machinery. No user-visible behavior yet; the plugin is not registered with the bridge in this step.

- Factory: requires `binaryPath`, optional `launchDirectory`, and an `AcpProcessFactory`; constructs `HermesBinary.launchSpec` with `["acp"]`.
- Handshake: `authMethodId` is null so authentication uses the first advertised method (configured provider), verified against a captured `initialize` result.
- Session behavior: never calls `session/close` when Hermes does not advertise it; streams assistant output via `session/update` agent_message_chunk into part deltas; allows concurrent sessions; does not fail turns on selection errors.
- Policy constants: `clientName` "sesori-bridge", `clientVersion` "0.0.0"; no form elicitation; 5s session-close settlement timeout.
- Tests: `acp_plugin` fakes validate identity, launch shape, auth ordering, prompt streaming, and local-only deletion. No database or persisted-data impact.

<sup>Written for commit 59641a537a55c635d6a672bc1070e0b3511def76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

