### PR TITLE
⚙️ [hermes-agent-plugin] feat(hermes): add descriptor, runtime probe, and setup [step 4/9]

### DIFF
--- a/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
+++ b/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
@@ -5,3 +5,6 @@
 // only, with no harness-specific protocol extensions.
 export "src/hermes_binary.dart";
 export "src/hermes_plugin_impl.dart";
+// Plugin-lifecycle entry point: the const descriptor the bridge registers.
+export "src/runtime/hermes_plugin_descriptor.dart";
+export "src/runtime/hermes_runtime_manifest.dart";

--- a/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
+++ b/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
@@ -7,4 +7,3 @@ export "src/hermes_binary.dart";
 export "src/hermes_plugin_impl.dart";
 // Plugin-lifecycle entry point: the const descriptor the bridge registers.
 export "src/runtime/hermes_plugin_descriptor.dart";
-export "src/runtime/hermes_runtime_manifest.dart";

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -237,6 +237,9 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
       // with a nonzero exit; surface that as missing with an update hint, not
       // as an unknown failure.
       final stderr = result.stderr.toLowerCase();
+      if (_isShellCommandNotFound(stderr: stderr)) {
+        return _HermesRuntimeProbeState.missing;
+      }
       if (stderr.contains("acp") && stderr.contains("invalid choice")) {
         return _HermesRuntimeProbeState.preAcpInstall;
       }
@@ -257,6 +260,11 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
     Log.d("[hermes] available: '$executablePath acp --version' -> $version");
     return _HermesRuntimeProbeState.ready;
   }
+
+  bool _isShellCommandNotFound({required String stderr}) =>
+      stderr.contains("is not recognized as an internal or external command") ||
+      stderr.contains("is not recognized as the name of a cmdlet") ||
+      stderr.contains("command not found");
 
   String _normalizedStatusOutput({required CommandResult result}) {
     final combined = "${result.stdout}\n${result.stderr}";

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -114,7 +114,9 @@ class const HermesPluginDescriptor({
         return PluginSetupRuntimeMissing(
           actionHint: explicitBin != null
               ? "Fix the configured Hermes CLI path, then restart the bridge."
-              : "Install Hermes Agent locally, then retry setup detection.",
+              : runtime.preAcpInstall
+                  ? "The installed Hermes does not expose the `acp` subcommand. Update Hermes, then retry setup detection."
+                  : "Install Hermes Agent locally, then retry setup detection.",
         );
       case _HermesRuntimeProbeState.outdated:
         return const PluginSetupUnavailable(
@@ -145,7 +147,19 @@ class const HermesPluginDescriptor({
         environment: environment,
         timeout: _versionProbeTimeout,
       );
-    } on Object {
+    } on TimeoutException catch (error, stackTrace) {
+      Log.w("[hermes] status probe '$executablePath status' did not exit within ${_versionProbeTimeout.inSeconds}s", error, stackTrace);
+      return const PluginSetupUnknown(
+        actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
+      );
+    } on Object catch (error, stackTrace) {
+      Log.w("[hermes] status probe could not launch '$executablePath status'", error, stackTrace);
+      return const PluginSetupUnknown(
+        actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
+      );
+    }
+    if (statusResult.exitCode != 0) {
+      Log.w("[hermes] status probe '$executablePath status' exited with code ${statusResult.exitCode}");
       return const PluginSetupUnknown(
         actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
       );
@@ -164,7 +178,7 @@ class const HermesPluginDescriptor({
     );
   }
 
-  Future<({_HermesRuntimeProbeState state, String? version})> _probeHermesRuntime({
+  Future<({_HermesRuntimeProbeState state, String? version, bool preAcpInstall})> _probeHermesRuntime({
     required String executablePath,
     required HostProcessService processes,
     required Map<String, String> environment,
@@ -189,35 +203,41 @@ class const HermesPluginDescriptor({
         "[hermes] availability probe '$executablePath acp --version' did not exit within "
         "${_versionProbeTimeout.inSeconds}s",
       );
-      return (state: _HermesRuntimeProbeState.unknown, version: null);
-    } on Object catch (error) {
-      // Spawn could not launch — almost always ENOENT: not installed / not on PATH.
-      Log.d("[hermes] availability probe could not launch '$executablePath acp --version': $error");
-      return (state: _HermesRuntimeProbeState.missing, version: null);
+      return (state: _HermesRuntimeProbeState.unknown, version: null, preAcpInstall: false);
+    } on io.ProcessException catch (error) {
+      // The host process seam reports spawn failures as ProcessException;
+      // ENOENT (errorCode 2) means not installed / not on PATH.
+      Log.d("[hermes] availability probe could not launch '$executablePath acp --version' (${error.errorCode})");
+      return (state: _HermesRuntimeProbeState.missing, version: null, preAcpInstall: false);
+    } on Object catch (error, stackTrace) {
+      // Any other spawn failure (host seam error, permission) is not proof of
+      // a missing runtime — report unknown rather than a misleading hint.
+      Log.w("[hermes] availability probe could not launch '$executablePath acp --version'", error, stackTrace);
+      return (state: _HermesRuntimeProbeState.unknown, version: null, preAcpInstall: false);
     }
 
     if (result.exitCode != 0) {
       Log.d("[hermes] availability probe '$executablePath acp --version' exited with code ${result.exitCode}");
       // A pre-ACP install answers `--version` but rejects the `acp` subcommand
-      // with a nonzero exit; treat that as missing, not unknown, so the setup
-      // hint points at updating the install.
+      // with a nonzero exit; surface that as missing with an update hint, not
+      // as an unknown failure.
       if (result.stderr.contains("acp") && (result.stderr.contains("invalid choice") || result.stderr.contains("error"))) {
-        return (state: _HermesRuntimeProbeState.missing, version: null);
+        return (state: _HermesRuntimeProbeState.missing, version: null, preAcpInstall: true);
       }
-      return (state: _HermesRuntimeProbeState.unknown, version: null);
+      return (state: _HermesRuntimeProbeState.unknown, version: null, preAcpInstall: false);
     }
 
     final parsed = HermesRuntimeManifest.tryParseVersion(value: result.stdout.trim());
     if (parsed == null) {
-      return (state: _HermesRuntimeProbeState.unrecognized, version: null);
+      return (state: _HermesRuntimeProbeState.unrecognized, version: null, preAcpInstall: false);
     }
     if (parsed.compareTo(HermesRuntimeManifest.minAcpVersion) < 0) {
       Log.w("[hermes] Hermes ACP adapter ${parsed.toString()} is below the supported minimum ${HermesRuntimeManifest.minAcpVersion.toString()}");
-      return (state: _HermesRuntimeProbeState.outdated, version: parsed.toString());
+      return (state: _HermesRuntimeProbeState.outdated, version: parsed.toString(), preAcpInstall: false);
     }
     final version = parsed.toString();
     Log.d("[hermes] available: '$executablePath acp --version' -> $version");
-    return (state: _HermesRuntimeProbeState.ready, version: version);
+    return (state: _HermesRuntimeProbeState.ready, version: version, preAcpInstall: false);
   }
 
   String _normalizedStatusOutput(CommandResult result) {
@@ -290,8 +310,8 @@ class const HermesPluginDescriptor({
     Future<Never> rollbackAborted() async {
       try {
         await plugin.shutdown(budget: null);
-      } on Object catch (error) {
-        Log.e("[hermes] rollback after aborted start failed: $error");
+      } on Object catch (error, stackTrace) {
+        Log.e("[hermes] rollback after aborted start failed", error, stackTrace);
       }
       throw const PluginStartAbortedException();
     }

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -67,10 +67,10 @@ class const HermesPluginDescriptor({
   ];
 
   @override
-  String get id => HermesIdentity.pluginId;
+  String get id => HermesPluginIdentity.pluginId;
 
   @override
-  String get displayName => HermesIdentity.displayName;
+  String get displayName => HermesPluginIdentity.displayName;
 
   @override
   PluginProjectOwnership get projectOwnership => PluginProjectOwnership.bridgeDerived;

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -2,8 +2,7 @@ import "dart:async";
 import "dart:io" as io;
 
 import "package:acp_plugin/acp_plugin.dart";
-import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart"
-    show CommandResult, HostProcessCommandExecutor;
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show CommandResult, HostProcessCommandExecutor;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "../hermes_binary.dart";
@@ -12,27 +11,6 @@ import "../hermes_plugin_impl.dart";
 import "hermes_runtime_manifest.dart";
 
 const int _setupProbeOutputLimit = 64 * 1024;
-
-/// Builds the live [HermesPlugin] for a resolved binary. The production
-/// default constructs the real plugin wired to the host-backed process
-/// factory; tests inject a fake to avoid spawning the Hermes CLI.
-typedef HermesPluginFactory = HermesPlugin Function({
-  required String binaryPath,
-  required String launchDirectory,
-  required AcpProcessFactory processFactory,
-});
-
-HermesPlugin _defaultBuildPlugin({
-  required String binaryPath,
-  required String launchDirectory,
-  required AcpProcessFactory processFactory,
-}) {
-  return HermesPlugin(
-    binaryPath: binaryPath,
-    launchDirectory: launchDirectory,
-    processFactory: processFactory,
-  );
-}
 
 /// The const Hermes Agent plugin descriptor.
 ///
@@ -43,15 +21,12 @@ HermesPlugin _defaultBuildPlugin({
 /// configured model/provider, and on [start] spawns the agent through the
 /// [PluginHost] process seam and returns an [AcpBridgePlugin].
 ///
-/// The optional constructor parameters are test seams; the registered instance
-/// is `const HermesPluginDescriptor()`.
-class const HermesPluginDescriptor({
-  final HermesPluginFactory? _buildPlugin,
-  final Duration _connectBudget = const Duration(seconds: 15),
-  final Duration _versionProbeTimeout = const Duration(seconds: 10),
-}) extends BridgePluginDescriptor {
+class const HermesPluginDescriptor() extends BridgePluginDescriptor {
+  static const Duration _connectBudget = Duration(seconds: 15);
+  static const Duration _versionProbeTimeout = Duration(seconds: 10);
+
   /// CLI option naming the Hermes CLI binary (path or PATH name). Declared
-  /// as the bare local name — the bridge's [PluginCliOptionsMapper] namespaces
+  /// as the bare local name; the bridge's [PluginCliOptionsMapper] namespaces
   /// it to the public `--hermes-bin` flag.
   static const String binOption = "bin";
 
@@ -67,7 +42,7 @@ class const HermesPluginDescriptor({
   ];
 
   @override
-  String get id => HermesPluginIdentity.pluginId;
+  String get id => HermesPluginIdentity.id;
 
   @override
   String get displayName => HermesPluginIdentity.displayName;
@@ -88,10 +63,40 @@ class const HermesPluginDescriptor({
 
   /// The explicit `--hermes-bin` override, or null when unset, empty, or left
   /// at the bare default (which means "resolve on PATH").
-  String? _explicitBin(PluginConfig config) {
+  String? _explicitBin({required PluginConfig config}) {
     final value = config.value(binOption)?.trim();
     if (value == null || value.isEmpty || value == HermesBinary.defaultBinary) return null;
     return value;
+  }
+
+  @override
+  Stream<RuntimeProvisionProgress> ensureRuntime({required PluginHost host}) async* {
+    if (_explicitBin(config: host.config) != null) return;
+    if (host.startAborted.isAborted) throw const PluginStartAbortedException();
+
+    final state = await _probeHermesRuntime(
+      executablePath: HermesBinary.defaultBinary,
+      processes: host.processes,
+      environment: host.environment,
+    );
+    if (host.startAborted.isAborted) throw const PluginStartAbortedException();
+
+    switch (state) {
+      case _HermesRuntimeProbeState.ready:
+        yield const ProvisionReady(binaryPath: HermesBinary.defaultBinary);
+      case _HermesRuntimeProbeState.missing || _HermesRuntimeProbeState.preAcpInstall:
+        yield const ProvisionFailed(
+          message: "Hermes ACP is unavailable. Install or update Hermes, then retry.",
+        );
+      case _HermesRuntimeProbeState.outdated:
+        yield const ProvisionFailed(
+          message: "The Hermes ACP adapter is too old. Update Hermes, then retry.",
+        );
+      case _HermesRuntimeProbeState.unknown || _HermesRuntimeProbeState.unrecognized:
+        yield const ProvisionFailed(
+          message: "The Hermes ACP runtime could not be verified. Check the local install, then retry.",
+        );
+    }
   }
 
   @override
@@ -101,7 +106,7 @@ class const HermesPluginDescriptor({
     required Map<String, String> environment,
     required String stateDirectory,
   }) async {
-    final explicitBin = _explicitBin(config);
+    final explicitBin = _explicitBin(config: config);
     final executablePath = explicitBin ?? HermesBinary.defaultBinary;
     final runtime = await _probeHermesRuntime(
       executablePath: executablePath,
@@ -109,14 +114,17 @@ class const HermesPluginDescriptor({
       environment: environment,
     );
 
-    switch (runtime.state) {
+    switch (runtime) {
       case _HermesRuntimeProbeState.missing:
         return PluginSetupRuntimeMissing(
           actionHint: explicitBin != null
               ? "Fix the configured Hermes CLI path, then restart the bridge."
-              : runtime.preAcpInstall
-                  ? "The installed Hermes does not expose the `acp` subcommand. Update Hermes, then retry setup detection."
-                  : "Install Hermes Agent locally, then retry setup detection.",
+              : "Install Hermes Agent locally, then retry setup detection.",
+        );
+      case _HermesRuntimeProbeState.preAcpInstall:
+        return const PluginSetupRuntimeMissing(
+          actionHint:
+              "The installed Hermes does not expose the `acp` subcommand. Update Hermes, then retry setup detection.",
         );
       case _HermesRuntimeProbeState.outdated:
         return const PluginSetupUnavailable(
@@ -132,7 +140,7 @@ class const HermesPluginDescriptor({
     }
 
     // Auth probe: `hermes status` reports the configured model/provider.
-    // Best-effort — the true gate is the ACP handshake at connect time, which
+    // Best-effort: the true gate is the ACP handshake at connect time, which
     // degrades the plugin without failing the bridge.
     final executor = HostProcessCommandExecutor(
       processes: processes,
@@ -148,7 +156,11 @@ class const HermesPluginDescriptor({
         timeout: _versionProbeTimeout,
       );
     } on TimeoutException catch (error, stackTrace) {
-      Log.w("[hermes] status probe '$executablePath status' did not exit within ${_versionProbeTimeout.inSeconds}s", error, stackTrace);
+      Log.w(
+        "[hermes] status probe '$executablePath status' did not exit within ${_versionProbeTimeout.inSeconds}s",
+        error,
+        stackTrace,
+      );
       return const PluginSetupUnknown(
         actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
       );
@@ -161,15 +173,16 @@ class const HermesPluginDescriptor({
     if (statusResult.exitCode != 0) {
       Log.w("[hermes] status probe '$executablePath status' exited with code ${statusResult.exitCode}");
     }
-    final statusOutput = _normalizedStatusOutput(statusResult);
-    // Output is the source of truth: a nonzero exit with a real `Model:` value
-    // still means the model is configured (the ACP handshake is the actual
-    // auth gate at connect time); the exit code only breaks ties when the
-    // output is ambiguous.
-    if (_statusIndicatesConfigured(statusOutput)) {
+    final statusOutput = _normalizedStatusOutput(result: statusResult);
+    final model = _statusValue(output: statusOutput, field: "model");
+    final provider = _statusValue(output: statusOutput, field: "provider");
+    // Output is authoritative even on a nonzero exit: Hermes can report valid
+    // configuration alongside another status failure, while the ACP handshake
+    // remains the actual authentication gate at connect time.
+    if (_isConfiguredStatusValue(value: model) && _isConfiguredStatusValue(value: provider)) {
       return const PluginSetupReady();
     }
-    if (_statusIndicatesUnconfigured(statusOutput)) {
+    if (model != null || provider != null) {
       return const PluginSetupAuthenticationRequired(
         actionHint: "Configure a model and provider with `hermes setup` or `hermes model` on this machine, then retry setup detection.",
       );
@@ -179,7 +192,7 @@ class const HermesPluginDescriptor({
     );
   }
 
-  Future<({_HermesRuntimeProbeState state, String? version, bool preAcpInstall})> _probeHermesRuntime({
+  Future<_HermesRuntimeProbeState> _probeHermesRuntime({
     required String executablePath,
     required HostProcessService processes,
     required Map<String, String> environment,
@@ -204,17 +217,18 @@ class const HermesPluginDescriptor({
         "[hermes] availability probe '$executablePath acp --version' did not exit within "
         "${_versionProbeTimeout.inSeconds}s",
       );
-      return (state: _HermesRuntimeProbeState.unknown, version: null, preAcpInstall: false);
-    } on io.ProcessException catch (error) {
+      return _HermesRuntimeProbeState.unknown;
+    } on io.ProcessException catch (error, stackTrace) {
       // The host process seam reports spawn failures as ProcessException;
       // ENOENT (errorCode 2) means not installed / not on PATH.
-      Log.d("[hermes] availability probe could not launch '$executablePath acp --version' (${error.errorCode})");
-      return (state: _HermesRuntimeProbeState.missing, version: null, preAcpInstall: false);
+      if (error.errorCode == 2) return _HermesRuntimeProbeState.missing;
+      Log.w("[hermes] availability probe could not launch '$executablePath acp --version'", error, stackTrace);
+      return _HermesRuntimeProbeState.unknown;
     } on Object catch (error, stackTrace) {
       // Any other spawn failure (host seam error, permission) is not proof of
-      // a missing runtime — report unknown rather than a misleading hint.
+      // a missing runtime; report unknown rather than a misleading hint.
       Log.w("[hermes] availability probe could not launch '$executablePath acp --version'", error, stackTrace);
-      return (state: _HermesRuntimeProbeState.unknown, version: null, preAcpInstall: false);
+      return _HermesRuntimeProbeState.unknown;
     }
 
     if (result.exitCode != 0) {
@@ -222,59 +236,49 @@ class const HermesPluginDescriptor({
       // A pre-ACP install answers `--version` but rejects the `acp` subcommand
       // with a nonzero exit; surface that as missing with an update hint, not
       // as an unknown failure.
-      if (result.stderr.contains("acp") && (result.stderr.contains("invalid choice") || result.stderr.contains("error"))) {
-        return (state: _HermesRuntimeProbeState.missing, version: null, preAcpInstall: true);
+      if (result.stderr.contains("acp") &&
+          (result.stderr.contains("invalid choice") || result.stderr.contains("error"))) {
+        return _HermesRuntimeProbeState.preAcpInstall;
       }
-      return (state: _HermesRuntimeProbeState.unknown, version: null, preAcpInstall: false);
+      return _HermesRuntimeProbeState.unknown;
     }
 
     final parsed = HermesRuntimeManifest.tryParseVersion(value: result.stdout.trim());
     if (parsed == null) {
-      return (state: _HermesRuntimeProbeState.unrecognized, version: null, preAcpInstall: false);
+      return _HermesRuntimeProbeState.unrecognized;
     }
     if (parsed.compareTo(HermesRuntimeManifest.minAcpVersion) < 0) {
-      Log.w("[hermes] Hermes ACP adapter ${parsed.toString()} is below the supported minimum ${HermesRuntimeManifest.minAcpVersion.toString()}");
-      return (state: _HermesRuntimeProbeState.outdated, version: parsed.toString(), preAcpInstall: false);
+      Log.w(
+        "[hermes] Hermes ACP adapter ${parsed.toString()} is below the supported minimum ${HermesRuntimeManifest.minAcpVersion.toString()}",
+      );
+      return _HermesRuntimeProbeState.outdated;
     }
     final version = parsed.toString();
     Log.d("[hermes] available: '$executablePath acp --version' -> $version");
-    return (state: _HermesRuntimeProbeState.ready, version: version, preAcpInstall: false);
+    return _HermesRuntimeProbeState.ready;
   }
 
-  String _normalizedStatusOutput(CommandResult result) {
+  String _normalizedStatusOutput({required CommandResult result}) {
     final combined = "${result.stdout}\n${result.stderr}";
     return combined.replaceAll(RegExp(r"\x1B\[[0-?]*[ -/]*[@-~]"), "").trim().toLowerCase();
   }
 
-  /// True when `hermes status` reports an actual model selection (the
-  /// "Environment" block's `Model:` line holds a real value).
-  bool _statusIndicatesConfigured(String output) {
+  String? _statusValue({required String output, required String field}) {
     for (final rawLine in output.split("\n")) {
       final line = rawLine.trim();
-      if (!line.startsWith("model:")) continue;
-      final value = line.substring("model:".length).trim();
-      return value.isNotEmpty &&
-          !RegExp(
-            r"^(none|not set|unset|\(none\)|\(not set\)|✗|—|-)$",
-            caseSensitive: false,
-          ).hasMatch(value);
+      final prefix = "$field:";
+      if (line.startsWith(prefix)) return line.substring(prefix.length).trim();
     }
-    return false;
+    return null;
   }
 
-  /// True when `hermes status` explicitly reports no model selection.
-  bool _statusIndicatesUnconfigured(String output) {
-    for (final rawLine in output.split("\n")) {
-      final line = rawLine.trim();
-      if (!line.startsWith("model:")) continue;
-      final value = line.substring("model:".length).trim();
-      return RegExp(
+  bool _isConfiguredStatusValue({required String? value}) =>
+      value != null &&
+      value.isNotEmpty &&
+      !RegExp(
         r"^(none|not set|unset|\(none\)|\(not set\)|✗|—|-)$",
         caseSensitive: false,
       ).hasMatch(value);
-    }
-    return false;
-  }
 
   @override
   Future<BridgePlugin> start(PluginHost host) async {
@@ -282,7 +286,7 @@ class const HermesPluginDescriptor({
       throw const PluginStartAbortedException();
     }
 
-    final binaryPath = _explicitBin(host.config) ?? HermesBinary.defaultBinary;
+    final binaryPath = _explicitBin(config: host.config) ?? host.provisionedRuntimePath ?? HermesBinary.defaultBinary;
 
     // Route the agent subprocess through the host process seam rather than
     // io.Process.start, so the bridge owns identity capture and signalling.
@@ -291,7 +295,7 @@ class const HermesPluginDescriptor({
       environment: host.environment,
     );
 
-    final hermes = (_buildPlugin ?? _defaultBuildPlugin)(
+    final hermes = HermesPlugin(
       binaryPath: binaryPath,
       // The bridge seeds the launch directory as an always-present project;
       // the bridge itself owns all project/session persistence for this
@@ -331,4 +335,11 @@ class const HermesPluginDescriptor({
   }
 }
 
-enum _HermesRuntimeProbeState() { ready, missing, outdated, unknown, unrecognized }
+enum _HermesRuntimeProbeState() {
+  ready,
+  missing,
+  preAcpInstall,
+  outdated,
+  unknown,
+  unrecognized;
+}

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -160,11 +160,12 @@ class const HermesPluginDescriptor({
     }
     if (statusResult.exitCode != 0) {
       Log.w("[hermes] status probe '$executablePath status' exited with code ${statusResult.exitCode}");
-      return const PluginSetupUnknown(
-        actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
-      );
     }
     final statusOutput = _normalizedStatusOutput(statusResult);
+    // Output is the source of truth: a nonzero exit with a real `Model:` value
+    // still means the model is configured (the ACP handshake is the actual
+    // auth gate at connect time); the exit code only breaks ties when the
+    // output is ambiguous.
     if (_statusIndicatesConfigured(statusOutput)) {
       return const PluginSetupReady();
     }

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -1,0 +1,313 @@
+import "dart:async";
+import "dart:io" as io;
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart"
+    show CommandResult, HostProcessCommandExecutor;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../hermes_binary.dart";
+import "../hermes_identity.dart";
+import "../hermes_plugin_impl.dart";
+import "hermes_runtime_manifest.dart";
+
+const int _setupProbeOutputLimit = 64 * 1024;
+
+/// Builds the live [HermesPlugin] for a resolved binary. The production
+/// default constructs the real plugin wired to the host-backed process
+/// factory; tests inject a fake to avoid spawning the Hermes CLI.
+typedef HermesPluginFactory = HermesPlugin Function({
+  required String binaryPath,
+  required String launchDirectory,
+  required AcpProcessFactory processFactory,
+});
+
+HermesPlugin _defaultBuildPlugin({
+  required String binaryPath,
+  required String launchDirectory,
+  required AcpProcessFactory processFactory,
+}) {
+  return HermesPlugin(
+    binaryPath: binaryPath,
+    launchDirectory: launchDirectory,
+    processFactory: processFactory,
+  );
+}
+
+/// The const Hermes Agent plugin descriptor.
+///
+/// Hermes drives a `hermes acp` stdio subprocess over the generic ACP
+/// machinery, so it needs no managed-runtime supervisor and no managed
+/// install (Hermes installs itself; the bridge resolves it on PATH). It
+/// declares its CLI surface, probes the `hermes` CLI for availability and a
+/// configured model/provider, and on [start] spawns the agent through the
+/// [PluginHost] process seam and returns an [AcpBridgePlugin].
+///
+/// The optional constructor parameters are test seams; the registered instance
+/// is `const HermesPluginDescriptor()`.
+class const HermesPluginDescriptor({
+  final HermesPluginFactory? _buildPlugin,
+  final Duration _connectBudget = const Duration(seconds: 15),
+  final Duration _versionProbeTimeout = const Duration(seconds: 10),
+}) extends BridgePluginDescriptor {
+  /// CLI option naming the Hermes CLI binary (path or PATH name). Declared
+  /// as the bare local name — the bridge's [PluginCliOptionsMapper] namespaces
+  /// it to the public `--hermes-bin` flag.
+  static const String binOption = "bin";
+
+  static const List<PluginOption> cliOptions = [
+    PluginValueOption(
+      name: binOption,
+      help: "Path to the Hermes CLI binary (hermes)",
+      defaultsTo: HermesBinary.defaultBinary,
+      allowedValues: null,
+      valueHelp: "path",
+      validate: null,
+    ),
+  ];
+
+  @override
+  String get id => HermesIdentity.pluginId;
+
+  @override
+  String get displayName => HermesIdentity.displayName;
+
+  @override
+  PluginProjectOwnership get projectOwnership => PluginProjectOwnership.bridgeDerived;
+
+  @override
+  PluginSessionOptionsScope get sessionOptionsScope => PluginSessionOptionsScope.plugin;
+
+  /// Hermes advertises `prompt_capabilities.image` at initialize, so the
+  /// phone attachment flow works against this backend as-is.
+  @override
+  bool get supportsPromptAttachments => true;
+
+  @override
+  List<PluginOption> get options => cliOptions;
+
+  /// The explicit `--hermes-bin` override, or null when unset, empty, or left
+  /// at the bare default (which means "resolve on PATH").
+  String? _explicitBin(PluginConfig config) {
+    final value = config.value(binOption)?.trim();
+    if (value == null || value.isEmpty || value == HermesBinary.defaultBinary) return null;
+    return value;
+  }
+
+  @override
+  Future<PluginSetupStatus> inspectSetup({
+    required PluginConfig config,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+    required String stateDirectory,
+  }) async {
+    final explicitBin = _explicitBin(config);
+    final executablePath = explicitBin ?? HermesBinary.defaultBinary;
+    final runtime = await _probeHermesRuntime(
+      executablePath: executablePath,
+      processes: processes,
+      environment: environment,
+    );
+
+    switch (runtime.state) {
+      case _HermesRuntimeProbeState.missing:
+        return PluginSetupRuntimeMissing(
+          actionHint: explicitBin != null
+              ? "Fix the configured Hermes CLI path, then restart the bridge."
+              : "Install Hermes Agent locally, then retry setup detection.",
+        );
+      case _HermesRuntimeProbeState.outdated:
+        return const PluginSetupUnavailable(
+          actionHint: "The installed Hermes ACP adapter is too old. Update Hermes and restart the bridge.",
+        );
+      case _HermesRuntimeProbeState.unrecognized:
+      case _HermesRuntimeProbeState.unknown:
+        return const PluginSetupUnknown(
+          actionHint: "Hermes setup could not be determined. Verify the local install and retry.",
+        );
+      case _HermesRuntimeProbeState.ready:
+        break;
+    }
+
+    // Auth probe: `hermes status` reports the configured model/provider.
+    // Best-effort — the true gate is the ACP handshake at connect time, which
+    // degrades the plugin without failing the bridge.
+    final executor = HostProcessCommandExecutor(
+      processes: processes,
+      runInShell: io.Platform.isWindows,
+      maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
+    );
+    final CommandResult statusResult;
+    try {
+      statusResult = await executor.run(
+        executablePath,
+        const ["status"],
+        environment: environment,
+        timeout: _versionProbeTimeout,
+      );
+    } on Object {
+      return const PluginSetupUnknown(
+        actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
+      );
+    }
+    final statusOutput = _normalizedStatusOutput(statusResult);
+    if (_statusIndicatesConfigured(statusOutput)) {
+      return const PluginSetupReady();
+    }
+    if (_statusIndicatesUnconfigured(statusOutput)) {
+      return const PluginSetupAuthenticationRequired(
+        actionHint: "Configure a model and provider with `hermes setup` or `hermes model` on this machine, then retry setup detection.",
+      );
+    }
+    return const PluginSetupUnknown(
+      actionHint: "Hermes setup could not be determined. Run `hermes status` locally and retry.",
+    );
+  }
+
+  Future<({_HermesRuntimeProbeState state, String? version})> _probeHermesRuntime({
+    required String executablePath,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+  }) async {
+    final executor = HostProcessCommandExecutor(
+      processes: processes,
+      runInShell: io.Platform.isWindows,
+      maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
+    );
+    final CommandResult result;
+    try {
+      result = await executor.run(
+        executablePath,
+        const ["acp", "--version"],
+        environment: environment,
+        timeout: _versionProbeTimeout,
+      );
+    } on TimeoutException {
+      // The probe launched but never exited (executor force-killed it):
+      // installed but not answering.
+      Log.d(
+        "[hermes] availability probe '$executablePath acp --version' did not exit within "
+        "${_versionProbeTimeout.inSeconds}s",
+      );
+      return (state: _HermesRuntimeProbeState.unknown, version: null);
+    } on Object catch (error) {
+      // Spawn could not launch — almost always ENOENT: not installed / not on PATH.
+      Log.d("[hermes] availability probe could not launch '$executablePath acp --version': $error");
+      return (state: _HermesRuntimeProbeState.missing, version: null);
+    }
+
+    if (result.exitCode != 0) {
+      Log.d("[hermes] availability probe '$executablePath acp --version' exited with code ${result.exitCode}");
+      // A pre-ACP install answers `--version` but rejects the `acp` subcommand
+      // with a nonzero exit; treat that as missing, not unknown, so the setup
+      // hint points at updating the install.
+      if (result.stderr.contains("acp") && (result.stderr.contains("invalid choice") || result.stderr.contains("error"))) {
+        return (state: _HermesRuntimeProbeState.missing, version: null);
+      }
+      return (state: _HermesRuntimeProbeState.unknown, version: null);
+    }
+
+    final parsed = HermesRuntimeManifest.tryParseVersion(value: result.stdout.trim());
+    if (parsed == null) {
+      return (state: _HermesRuntimeProbeState.unrecognized, version: null);
+    }
+    if (parsed.compareTo(HermesRuntimeManifest.minAcpVersion) < 0) {
+      Log.w("[hermes] Hermes ACP adapter ${parsed.toString()} is below the supported minimum ${HermesRuntimeManifest.minAcpVersion.toString()}");
+      return (state: _HermesRuntimeProbeState.outdated, version: parsed.toString());
+    }
+    final version = parsed.toString();
+    Log.d("[hermes] available: '$executablePath acp --version' -> $version");
+    return (state: _HermesRuntimeProbeState.ready, version: version);
+  }
+
+  String _normalizedStatusOutput(CommandResult result) {
+    final combined = "${result.stdout}\n${result.stderr}";
+    return combined.replaceAll(RegExp(r"\x1B\[[0-?]*[ -/]*[@-~]"), "").trim().toLowerCase();
+  }
+
+  /// True when `hermes status` reports an actual model selection (the
+  /// "Environment" block's `Model:` line holds a real value).
+  bool _statusIndicatesConfigured(String output) {
+    for (final rawLine in output.split("\n")) {
+      final line = rawLine.trim();
+      if (!line.startsWith("model:")) continue;
+      final value = line.substring("model:".length).trim();
+      return value.isNotEmpty &&
+          !RegExp(
+            r"^(none|not set|unset|\(none\)|\(not set\)|✗|—|-)$",
+            caseSensitive: false,
+          ).hasMatch(value);
+    }
+    return false;
+  }
+
+  /// True when `hermes status` explicitly reports no model selection.
+  bool _statusIndicatesUnconfigured(String output) {
+    for (final rawLine in output.split("\n")) {
+      final line = rawLine.trim();
+      if (!line.startsWith("model:")) continue;
+      final value = line.substring("model:".length).trim();
+      return RegExp(
+        r"^(none|not set|unset|\(none\)|\(not set\)|✗|—|-)$",
+        caseSensitive: false,
+      ).hasMatch(value);
+    }
+    return false;
+  }
+
+  @override
+  Future<BridgePlugin> start(PluginHost host) async {
+    if (host.startAborted.isAborted) {
+      throw const PluginStartAbortedException();
+    }
+
+    final binaryPath = _explicitBin(host.config) ?? HermesBinary.defaultBinary;
+
+    // Route the agent subprocess through the host process seam rather than
+    // io.Process.start, so the bridge owns identity capture and signalling.
+    final processFactory = hostProcessAcpFactory(
+      processes: host.processes,
+      environment: host.environment,
+    );
+
+    final hermes = (_buildPlugin ?? _defaultBuildPlugin)(
+      binaryPath: binaryPath,
+      // The bridge seeds the launch directory as an always-present project;
+      // the bridge itself owns all project/session persistence for this
+      // derive-style plugin, so the plugin needs no store of its own.
+      launchDirectory: io.Directory.current.path,
+      processFactory: processFactory,
+    );
+
+    final plugin = AcpBridgePlugin(
+      plugin: hermes,
+      clock: host.clock,
+      endpoint: "$binaryPath acp",
+    );
+
+    // Rolls back the spawned agent and surfaces an abort that arrived while
+    // connecting rather than returning a live plugin.
+    Future<Never> rollbackAborted() async {
+      try {
+        await plugin.shutdown(budget: null);
+      } on Object catch (error) {
+        Log.e("[hermes] rollback after aborted start failed: $error");
+      }
+      throw const PluginStartAbortedException();
+    }
+
+    // Eagerly spawn the agent and run the ACP handshake (bounded), so the
+    // first mobile request is fast and the status reflects reality. A
+    // timeout/failure leaves the plugin degraded rather than failing the
+    // bridge.
+    await plugin.connect(budget: _connectBudget, startAborted: host.startAborted);
+
+    if (host.startAborted.isAborted) {
+      await rollbackAborted();
+    }
+
+    return plugin;
+  }
+}
+
+enum _HermesRuntimeProbeState() { ready, missing, outdated, unknown, unrecognized }

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -236,8 +236,8 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
       // A pre-ACP install answers `--version` but rejects the `acp` subcommand
       // with a nonzero exit; surface that as missing with an update hint, not
       // as an unknown failure.
-      if (result.stderr.contains("acp") &&
-          (result.stderr.contains("invalid choice") || result.stderr.contains("error"))) {
+      final stderr = result.stderr.toLowerCase();
+      if (stderr.contains("acp") && stderr.contains("invalid choice")) {
         return _HermesRuntimeProbeState.preAcpInstall;
       }
       return _HermesRuntimeProbeState.unknown;

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_runtime_manifest.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_runtime_manifest.dart
@@ -1,0 +1,26 @@
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+
+/// Pinned facts about the Hermes ACP adapter the bridge gates on.
+///
+/// Hermes has no Sesori-managed runtime: it installs itself via its own
+/// installer and the bridge resolves it on PATH (or via `--hermes-bin`). This
+/// manifest only pins the minimum adapter version and the version parsing.
+///
+/// Note the version identity: `hermes acp --version` reports the ACP adapter's
+/// own version (e.g. `0.20.0`), not the Hermes release version. The probe
+/// gates on the adapter version, which is the surface the bridge talks to.
+abstract final class HermesRuntimeManifest() {
+  /// Minimum ACP adapter version the bridge uses as-is. Older adapters either
+  /// predate the `hermes acp` surface entirely or lack behavior the base ACP
+  /// machinery relies on.
+  static final SemanticVersion minAcpVersion = SemanticVersion.parse(value: "0.20.0");
+
+  /// Parses the bare version `hermes acp --version` prints (`0.20.0`),
+  /// tolerating an optional leading `v` defensively. Returns null when the
+  /// output is not a recognizable semver.
+  static SemanticVersion? tryParseVersion({required String value}) {
+    final trimmed = value.trim();
+    final withoutPrefix = trimmed.startsWith("v") ? trimmed.substring(1) : trimmed;
+    return SemanticVersion.tryParse(value: withoutPrefix);
+  }
+}

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_runtime_manifest.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_runtime_manifest.dart
@@ -15,12 +15,15 @@ abstract final class HermesRuntimeManifest() {
   /// machinery relies on.
   static final SemanticVersion minAcpVersion = SemanticVersion.parse(value: "0.20.0");
 
-  /// Parses the bare version `hermes acp --version` prints (`0.20.0`),
-  /// tolerating an optional leading `v` defensively. Returns null when the
-  /// output is not a recognizable semver.
+  /// Extracts the first whitespace-separated semantic version token from
+  /// `hermes acp --version` output, tolerating an optional `v` prefix.
   static SemanticVersion? tryParseVersion({required String value}) {
-    final trimmed = value.trim();
-    final withoutPrefix = trimmed.startsWith("v") ? trimmed.substring(1) : trimmed;
-    return SemanticVersion.tryParse(value: withoutPrefix);
+    for (final rawToken in value.split(RegExp(r"\s+"))) {
+      final token = rawToken.trim();
+      final candidate = (token.startsWith("v") || token.startsWith("V")) ? token.substring(1) : token;
+      final version = SemanticVersion.tryParse(value: candidate);
+      if (version != null) return version;
+    }
+    return null;
   }
 }

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
@@ -166,6 +166,33 @@ void main() {
       );
     });
 
+    test("reports runtime missing for a Windows shell command-not-found result", () async {
+      final processes = _ProbeProcessService(
+        spawnError: null,
+        processSequence: [
+          _ProbeProcess(
+            pid: 1,
+            stdoutBytes: const [],
+            stderrBytes: utf8.encode(
+              "'hermes' is not recognized as an internal or external command,\r\n"
+              "operable program or batch file.\r\n",
+            ),
+            exitCode: Future<int>.value(1),
+          ),
+        ],
+        servesAcp: false,
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, isA<PluginSetupRuntimeMissing>());
+    });
+
     test("reports unknown when the host process seam fails for a non-spawn reason", () async {
       final processes = _ProbeProcessService(
         spawnError: StateError("host process seam unavailable"),

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
@@ -99,6 +99,52 @@ void main() {
       );
     });
 
+    test("reports unknown when the host process seam fails for a non-spawn reason", () async {
+      final processes = _ProbeProcessService(
+        spawnError: StateError("host process seam unavailable"),
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(
+        result,
+        isA<PluginSetupUnknown>(),
+        reason: "a non-ENOENT spawn failure is not proof of a missing runtime",
+      );
+    });
+
+    test("reports runtime missing with an update hint for a pre-ACP install", () async {
+      final processes = _ProbeProcessService(
+        processSequence: [
+          _ProbeProcess(
+            pid: 1,
+            stdoutBytes: utf8.encode(""),
+            stderrBytes: utf8.encode("Usage: hermes ...\ninvalid choice: 'acp'\n"),
+            exitCode: Future<int>.value(2),
+          ),
+        ],
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, isA<PluginSetupRuntimeMissing>());
+      expect(
+        (result as PluginSetupRuntimeMissing).actionHint,
+        contains("Update Hermes"),
+        reason: "the binary exists but predates the acp subcommand",
+      );
+    });
+
     test("reports unavailable when the ACP adapter is below the floor", () async {
       final processes = _ProbeProcessService(
         processSequence: [
@@ -324,11 +370,12 @@ class _ProbeProcessService({
   );
 }
 
-/// A canned [SpawnedProcess] with a fixed stdout payload and a caller-supplied
-/// [exitCode] future.
+/// A canned [SpawnedProcess] with fixed stdout/stderr payloads and a
+/// caller-supplied [exitCode] future.
 class _ProbeProcess({
   @override required final int pid,
   required final List<int> _stdoutBytes,
+  final List<int> _stderrBytes = const <int>[],
   required final Future<int> _exitCode,
 }) implements SpawnedProcess {
   @override
@@ -338,7 +385,7 @@ class _ProbeProcess({
   Stream<List<int>> get stdout => Stream<List<int>>.value(_stdoutBytes);
 
   @override
-  Stream<List<int>> get stderr => const Stream<List<int>>.empty();
+  Stream<List<int>> get stderr => Stream<List<int>>.value(_stderrBytes);
 
   @override
   IOSink get stdin => throw UnimplementedError();

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
@@ -1,0 +1,348 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:hermes_plugin/hermes_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("HermesRuntimeManifest", () {
+    test("pins the minimum ACP adapter version the bridge supports", () {
+      expect(HermesRuntimeManifest.minAcpVersion.toString(), "0.20.0");
+    });
+
+    test("parses the bare adapter version `hermes acp --version` prints", () {
+      expect(HermesRuntimeManifest.tryParseVersion(value: "0.20.0\n")?.toString(), "0.20.0");
+      expect(HermesRuntimeManifest.tryParseVersion(value: "v0.20.0")?.toString(), "0.20.0");
+    });
+
+    test("rejects unparseable output", () {
+      expect(HermesRuntimeManifest.tryParseVersion(value: "hermes-acp 0.20"), isNull);
+      expect(HermesRuntimeManifest.tryParseVersion(value: ""), isNull);
+    });
+  });
+
+  group("HermesPluginDescriptor", () {
+    const stateDirectory = "/state";
+    const config = PluginConfig(
+      values: {
+        HermesPluginDescriptor.binOption: HermesBinary.defaultBinary,
+      },
+    );
+
+    test("pins the identity and harness facts", () {
+      expect(const HermesPluginDescriptor().id, "hermes");
+      expect(const HermesPluginDescriptor().displayName, "Hermes Agent");
+      expect(const HermesPluginDescriptor().projectOwnership, PluginProjectOwnership.bridgeDerived);
+      expect(const HermesPluginDescriptor().sessionOptionsScope, PluginSessionOptionsScope.plugin);
+      expect(const HermesPluginDescriptor().supportsPromptAttachments, isTrue,
+          reason: "Hermes advertises prompt image support");
+    });
+
+    test("declares only the binary option and no install capability", () {
+      const descriptor = HermesPluginDescriptor();
+      expect(descriptor.options, hasLength(1));
+      expect(descriptor.options.single.name, HermesPluginDescriptor.binOption);
+      expect(
+        descriptor.managementCapabilities(config: config),
+        isNot(contains(PluginControlCapability.install)),
+        reason: "Hermes installs itself; the bridge never manages its runtime",
+      );
+    });
+
+    test("reports ready after version and status probes", () async {
+      final processes = _ProbeProcessService(
+        processSequence: [
+          _ProbeProcess(pid: 1, stdoutBytes: utf8.encode("0.20.0\n"), exitCode: Future<int>.value(0)),
+          _ProbeProcess(
+            pid: 2,
+            stdoutBytes: utf8.encode("Model: deepseek-v4-flash\nProvider: OpenCode Go\n"),
+            exitCode: Future<int>.value(0),
+          ),
+        ],
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, const PluginSetupReady());
+      expect(processes.spawnedExecutables, ["hermes", "hermes"]);
+      expect(processes.spawnedArguments, [
+        const ["acp", "--version"],
+        const ["status"],
+      ]);
+    });
+
+    test("reports runtime missing when the CLI cannot spawn", () async {
+      final processes = _ProbeProcessService(
+        spawnError: const ProcessException("hermes", []),
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, isA<PluginSetupRuntimeMissing>());
+      expect(
+        (result as PluginSetupRuntimeMissing).actionHint,
+        contains("Install Hermes Agent"),
+      );
+    });
+
+    test("reports unavailable when the ACP adapter is below the floor", () async {
+      final processes = _ProbeProcessService(
+        processSequence: [
+          _ProbeProcess(pid: 1, stdoutBytes: utf8.encode("0.19.0\n"), exitCode: Future<int>.value(0)),
+        ],
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, isA<PluginSetupUnavailable>());
+    });
+
+    test("reports unknown when the version output is unrecognized", () async {
+      final processes = _ProbeProcessService(
+        processSequence: [
+          _ProbeProcess(pid: 1, stdoutBytes: utf8.encode("not-a-version\n"), exitCode: Future<int>.value(0)),
+        ],
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, isA<PluginSetupUnknown>());
+    });
+
+    test("reports authentication required when no model is configured", () async {
+      final processes = _ProbeProcessService(
+        processSequence: [
+          _ProbeProcess(pid: 1, stdoutBytes: utf8.encode("0.20.0\n"), exitCode: Future<int>.value(0)),
+          _ProbeProcess(
+            pid: 2,
+            stdoutBytes: utf8.encode("Model: (not set)\nProvider: none\n"),
+            exitCode: Future<int>.value(0),
+          ),
+        ],
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, isA<PluginSetupAuthenticationRequired>());
+    });
+
+    test("uses an explicit --hermes-bin override for every probe", () async {
+      final processes = _ProbeProcessService(
+        processSequence: [
+          _ProbeProcess(pid: 1, stdoutBytes: utf8.encode("0.20.0\n"), exitCode: Future<int>.value(0)),
+          _ProbeProcess(
+            pid: 2,
+            stdoutBytes: utf8.encode("Model: gpt-5.4\nProvider: openai\n"),
+            exitCode: Future<int>.value(0),
+          ),
+        ],
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: const PluginConfig(values: {HermesPluginDescriptor.binOption: "/custom/hermes"}),
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, const PluginSetupReady());
+      expect(processes.spawnedExecutables, ["/custom/hermes", "/custom/hermes"]);
+    });
+
+    test("start spawns exactly one `hermes acp` process and connects", () async {
+      const descriptor = HermesPluginDescriptor(
+        buildPlugin: _buildTestPlugin,
+      );
+      spawnedAcpProcesses.clear();
+      final handledFrameIds = <Object?>{};
+      var responding = true;
+
+      final responsePump = () async {
+        while (responding) {
+          for (final process in spawnedAcpProcesses) {
+            for (final frame in process.written) {
+              final id = frame["id"];
+              if (id == null || !handledFrameIds.add(id)) continue;
+              if (frame["method"] == "initialize") {
+                process.emit({
+                  "jsonrpc": "2.0",
+                  "id": id,
+                  "result": const {
+                    "protocolVersion": 1,
+                    "agentCapabilities": <String, dynamic>{},
+                    "authMethods": <Object?>[],
+                  },
+                });
+              }
+            }
+          }
+          await Future<void>.delayed(Duration.zero);
+        }
+      }();
+
+      final plugin = await descriptor.start(
+        _StartPluginHost(
+          processes: _ProbeProcessService(
+            spawnError: StateError("injected plugin must own the test process"),
+          ),
+        ),
+      );
+      responding = false;
+      await responsePump;
+
+      expect(
+        spawnedAcpProcesses,
+        hasLength(1),
+        reason: "descriptor startup must only initialize the live ACP process",
+      );
+
+      await plugin.shutdown(budget: null);
+      for (final process in spawnedAcpProcesses) {
+        await process.close();
+      }
+    });
+  });
+}
+
+/// Injected test seam: builds a [HermesPlugin] backed by a fake process and
+/// records every spawned fake for the response pump.
+HermesPlugin _buildTestPlugin({
+  required String binaryPath,
+  required String launchDirectory,
+  required AcpProcessFactory processFactory,
+}) {
+  return HermesPlugin(
+    binaryPath: binaryPath,
+    launchDirectory: launchDirectory,
+    processFactory: (_) async {
+      final process = FakeAcpProcess();
+      spawnedAcpProcesses.add(process);
+      return process;
+    },
+  );
+}
+
+// Keep the injected factory's captured processes reachable without plumbing
+// through the typedef (the test seam closure above shares this list).
+final List<FakeAcpProcess> spawnedAcpProcesses = <FakeAcpProcess>[];
+
+class _StartPluginHost({@override required final HostProcessService processes}) implements PluginHost {
+  @override
+  PluginConfig get config => const PluginConfig(
+    values: {
+      HermesPluginDescriptor.binOption: HermesBinary.defaultBinary,
+    },
+  );
+
+  @override
+  Map<String, String> get environment => const {"HOME": "/tmp"};
+
+  @override
+  String? get provisionedRuntimePath => null;
+
+  @override
+  ServerClock get clock => const ServerClock();
+
+  @override
+  StartAbortSignal get startAborted => StartAbortSignal.never;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// A [HostProcessService] that either throws on [spawn] (to simulate ENOENT)
+/// or returns canned [_ProbeProcess]es in order. Records the spawn arguments.
+class _ProbeProcessService({
+  final Object? spawnError,
+  final List<_ProbeProcess>? processSequence,
+}) implements HostProcessService {
+  int _nextProcess = 0;
+  final List<String> spawnedExecutables = <String>[];
+  final List<List<String>> spawnedArguments = <List<String>>[];
+
+  @override
+  Future<SpawnedProcess> spawn({
+    required String executable,
+    required List<String> arguments,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+    required bool runInShell,
+  }) async {
+    spawnedExecutables.add(executable);
+    spawnedArguments.add(List<String>.from(arguments));
+    final error = spawnError;
+    if (error != null) {
+      throw error;
+    }
+    return processSequence![_nextProcess++];
+  }
+
+  @override
+  Future<ProcessIdentity?> inspect({required int pid}) async => null;
+
+  @override
+  Future<SignalResult> signalGraceful({required int pid}) async => _signal(pid);
+
+  @override
+  Future<SignalResult> signalForce({required int pid}) async => _signal(pid);
+
+  SignalResult _signal(int pid) => SignalResult(
+    pid: pid,
+    requestedSignal: ShutdownSignal.force,
+    deliveredSignal: ProcessSignal.sigkill,
+    wasRequested: true,
+    attemptedAt: DateTime.utc(2026, 6, 1),
+  );
+}
+
+/// A canned [SpawnedProcess] with a fixed stdout payload and a caller-supplied
+/// [exitCode] future.
+class _ProbeProcess({
+  @override required final int pid,
+  required final List<int> _stdoutBytes,
+  required final Future<int> _exitCode,
+}) implements SpawnedProcess {
+  @override
+  Future<int> get exitCode => _exitCode;
+
+  @override
+  Stream<List<int>> get stdout => Stream<List<int>>.value(_stdoutBytes);
+
+  @override
+  Stream<List<int>> get stderr => const Stream<List<int>>.empty();
+
+  @override
+  IOSink get stdin => throw UnimplementedError();
+
+  @override
+  ProcessIdentity get identity => throw UnimplementedError();
+}

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
@@ -216,6 +216,30 @@ void main() {
       );
     });
 
+    test("reports unknown for an unrelated ACP command failure", () async {
+      final processes = _ProbeProcessService(
+        spawnError: null,
+        processSequence: [
+          _ProbeProcess(
+            pid: 1,
+            stdoutBytes: const [],
+            stderrBytes: utf8.encode("ACP initialization error: configuration unavailable\n"),
+            exitCode: Future<int>.value(1),
+          ),
+        ],
+        servesAcp: false,
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, isA<PluginSetupUnknown>());
+    });
+
     test("reports unavailable when the ACP adapter is below the floor", () async {
       final processes = _ProbeProcessService(
         spawnError: null,

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
@@ -3,8 +3,8 @@ import "dart:convert";
 import "dart:io";
 
 import "package:acp_plugin/acp_plugin.dart";
-import "package:acp_plugin/acp_testing.dart";
 import "package:hermes_plugin/hermes_plugin.dart";
+import "package:hermes_plugin/src/runtime/hermes_runtime_manifest.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
@@ -17,6 +17,7 @@ void main() {
     test("parses the bare adapter version `hermes acp --version` prints", () {
       expect(HermesRuntimeManifest.tryParseVersion(value: "0.20.0\n")?.toString(), "0.20.0");
       expect(HermesRuntimeManifest.tryParseVersion(value: "v0.20.0")?.toString(), "0.20.0");
+      expect(HermesRuntimeManifest.tryParseVersion(value: "hermes-acp V0.20.0\n")?.toString(), "0.20.0");
     });
 
     test("rejects unparseable output", () {
@@ -38,8 +39,11 @@ void main() {
       expect(const HermesPluginDescriptor().displayName, "Hermes Agent");
       expect(const HermesPluginDescriptor().projectOwnership, PluginProjectOwnership.bridgeDerived);
       expect(const HermesPluginDescriptor().sessionOptionsScope, PluginSessionOptionsScope.plugin);
-      expect(const HermesPluginDescriptor().supportsPromptAttachments, isTrue,
-          reason: "Hermes advertises prompt image support");
+      expect(
+        const HermesPluginDescriptor().supportsPromptAttachments,
+        isTrue,
+        reason: "Hermes advertises prompt image support",
+      );
     });
 
     test("declares only the binary option and no install capability", () {
@@ -53,16 +57,77 @@ void main() {
       );
     });
 
-    test("reports ready after version and status probes", () async {
+    test("ensureRuntime resolves a supported PATH adapter", () async {
       final processes = _ProbeProcessService(
+        spawnError: null,
         processSequence: [
-          _ProbeProcess(pid: 1, stdoutBytes: utf8.encode("0.20.0\n"), exitCode: Future<int>.value(0)),
           _ProbeProcess(
-            pid: 2,
-            stdoutBytes: utf8.encode("Model: deepseek-v4-flash\nProvider: OpenCode Go\n"),
+            pid: 1,
+            stdoutBytes: utf8.encode("hermes-acp v0.20.0\n"),
+            stderrBytes: const [],
             exitCode: Future<int>.value(0),
           ),
         ],
+        servesAcp: false,
+      );
+
+      final events = await const HermesPluginDescriptor()
+          .ensureRuntime(
+            host: _StartPluginHost(
+              processes: processes,
+              config: config,
+              provisionedRuntimePath: null,
+            ),
+          )
+          .toList();
+
+      expect(events, const [ProvisionReady(binaryPath: HermesBinary.defaultBinary)]);
+      expect(processes.spawnedArguments, [
+        const ["acp", "--version"],
+      ]);
+    });
+
+    test("ensureRuntime skips an explicit binary override", () async {
+      final processes = _ProbeProcessService(
+        spawnError: StateError("an explicit binary must not be probed"),
+        processSequence: const [],
+        servesAcp: false,
+      );
+
+      final events = await const HermesPluginDescriptor()
+          .ensureRuntime(
+            host: _StartPluginHost(
+              processes: processes,
+              config: const PluginConfig(
+                values: {HermesPluginDescriptor.binOption: "/custom/hermes"},
+              ),
+              provisionedRuntimePath: null,
+            ),
+          )
+          .toList();
+
+      expect(events, isEmpty);
+      expect(processes.spawnedExecutables, isEmpty);
+    });
+
+    test("reports ready after version and status probes", () async {
+      final processes = _ProbeProcessService(
+        spawnError: null,
+        processSequence: [
+          _ProbeProcess(
+            pid: 1,
+            stdoutBytes: utf8.encode("0.20.0\n"),
+            stderrBytes: const [],
+            exitCode: Future<int>.value(0),
+          ),
+          _ProbeProcess(
+            pid: 2,
+            stdoutBytes: utf8.encode("Model: deepseek-v4-flash\nProvider: OpenCode Go\n"),
+            stderrBytes: const [],
+            exitCode: Future<int>.value(0),
+          ),
+        ],
+        servesAcp: false,
       );
 
       final result = await const HermesPluginDescriptor().inspectSetup(
@@ -82,7 +147,9 @@ void main() {
 
     test("reports runtime missing when the CLI cannot spawn", () async {
       final processes = _ProbeProcessService(
-        spawnError: const ProcessException("hermes", []),
+        spawnError: const ProcessException("hermes", [], "No such file", 2),
+        processSequence: const [],
+        servesAcp: false,
       );
 
       final result = await const HermesPluginDescriptor().inspectSetup(
@@ -102,6 +169,8 @@ void main() {
     test("reports unknown when the host process seam fails for a non-spawn reason", () async {
       final processes = _ProbeProcessService(
         spawnError: StateError("host process seam unavailable"),
+        processSequence: const [],
+        servesAcp: false,
       );
 
       final result = await const HermesPluginDescriptor().inspectSetup(
@@ -120,6 +189,7 @@ void main() {
 
     test("reports runtime missing with an update hint for a pre-ACP install", () async {
       final processes = _ProbeProcessService(
+        spawnError: null,
         processSequence: [
           _ProbeProcess(
             pid: 1,
@@ -128,6 +198,7 @@ void main() {
             exitCode: Future<int>.value(2),
           ),
         ],
+        servesAcp: false,
       );
 
       final result = await const HermesPluginDescriptor().inspectSetup(
@@ -147,9 +218,16 @@ void main() {
 
     test("reports unavailable when the ACP adapter is below the floor", () async {
       final processes = _ProbeProcessService(
+        spawnError: null,
         processSequence: [
-          _ProbeProcess(pid: 1, stdoutBytes: utf8.encode("0.19.0\n"), exitCode: Future<int>.value(0)),
+          _ProbeProcess(
+            pid: 1,
+            stdoutBytes: utf8.encode("0.19.0\n"),
+            stderrBytes: const [],
+            exitCode: Future<int>.value(0),
+          ),
         ],
+        servesAcp: false,
       );
 
       final result = await const HermesPluginDescriptor().inspectSetup(
@@ -164,9 +242,16 @@ void main() {
 
     test("reports unknown when the version output is unrecognized", () async {
       final processes = _ProbeProcessService(
+        spawnError: null,
         processSequence: [
-          _ProbeProcess(pid: 1, stdoutBytes: utf8.encode("not-a-version\n"), exitCode: Future<int>.value(0)),
+          _ProbeProcess(
+            pid: 1,
+            stdoutBytes: utf8.encode("not-a-version\n"),
+            stderrBytes: const [],
+            exitCode: Future<int>.value(0),
+          ),
         ],
+        servesAcp: false,
       );
 
       final result = await const HermesPluginDescriptor().inspectSetup(
@@ -181,14 +266,22 @@ void main() {
 
     test("reports authentication required when no model is configured", () async {
       final processes = _ProbeProcessService(
+        spawnError: null,
         processSequence: [
-          _ProbeProcess(pid: 1, stdoutBytes: utf8.encode("0.20.0\n"), exitCode: Future<int>.value(0)),
+          _ProbeProcess(
+            pid: 1,
+            stdoutBytes: utf8.encode("0.20.0\n"),
+            stderrBytes: const [],
+            exitCode: Future<int>.value(0),
+          ),
           _ProbeProcess(
             pid: 2,
             stdoutBytes: utf8.encode("Model: (not set)\nProvider: none\n"),
+            stderrBytes: const [],
             exitCode: Future<int>.value(0),
           ),
         ],
+        servesAcp: false,
       );
 
       final result = await const HermesPluginDescriptor().inspectSetup(
@@ -201,16 +294,84 @@ void main() {
       expect(result, isA<PluginSetupAuthenticationRequired>());
     });
 
-    test("uses an explicit --hermes-bin override for every probe", () async {
+    test("reports authentication required when a model has no provider", () async {
       final processes = _ProbeProcessService(
+        spawnError: null,
         processSequence: [
-          _ProbeProcess(pid: 1, stdoutBytes: utf8.encode("0.20.0\n"), exitCode: Future<int>.value(0)),
+          _ProbeProcess(
+            pid: 1,
+            stdoutBytes: utf8.encode("0.20.0\n"),
+            stderrBytes: const [],
+            exitCode: Future<int>.value(0),
+          ),
           _ProbeProcess(
             pid: 2,
-            stdoutBytes: utf8.encode("Model: gpt-5.4\nProvider: openai\n"),
+            stdoutBytes: utf8.encode("Model: deepseek-v4-flash\nProvider: none\n"),
+            stderrBytes: const [],
             exitCode: Future<int>.value(0),
           ),
         ],
+        servesAcp: false,
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, isA<PluginSetupAuthenticationRequired>());
+    });
+
+    test("uses configured status output when the status command exits nonzero", () async {
+      final processes = _ProbeProcessService(
+        spawnError: null,
+        processSequence: [
+          _ProbeProcess(
+            pid: 1,
+            stdoutBytes: utf8.encode("0.20.0\n"),
+            stderrBytes: const [],
+            exitCode: Future<int>.value(0),
+          ),
+          _ProbeProcess(
+            pid: 2,
+            stdoutBytes: utf8.encode("Model: deepseek-v4-flash\nProvider: OpenCode Go\n"),
+            stderrBytes: const [],
+            exitCode: Future<int>.value(1),
+          ),
+        ],
+        servesAcp: false,
+      );
+
+      final result = await const HermesPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, const PluginSetupReady());
+    });
+
+    test("uses an explicit --hermes-bin override for every probe", () async {
+      final processes = _ProbeProcessService(
+        spawnError: null,
+        processSequence: [
+          _ProbeProcess(
+            pid: 1,
+            stdoutBytes: utf8.encode("0.20.0\n"),
+            stderrBytes: const [],
+            exitCode: Future<int>.value(0),
+          ),
+          _ProbeProcess(
+            pid: 2,
+            stdoutBytes: utf8.encode("Model: gpt-5.4\nProvider: openai\n"),
+            stderrBytes: const [],
+            exitCode: Future<int>.value(0),
+          ),
+        ],
+        servesAcp: false,
       );
 
       final result = await const HermesPluginDescriptor().inspectSetup(
@@ -225,95 +386,39 @@ void main() {
     });
 
     test("start spawns exactly one `hermes acp` process and connects", () async {
-      const descriptor = HermesPluginDescriptor(
-        buildPlugin: _buildTestPlugin,
+      const descriptor = HermesPluginDescriptor();
+      final processes = _ProbeProcessService(
+        spawnError: null,
+        processSequence: const [],
+        servesAcp: true,
       );
-      spawnedAcpProcesses.clear();
-      final handledFrameIds = <Object?>{};
-      var responding = true;
-
-      final responsePump = () async {
-        while (responding) {
-          for (final process in spawnedAcpProcesses) {
-            for (final frame in process.written) {
-              final id = frame["id"];
-              if (id == null || !handledFrameIds.add(id)) continue;
-              if (frame["method"] == "initialize") {
-                process.emit({
-                  "jsonrpc": "2.0",
-                  "id": id,
-                  "result": const {
-                    "protocolVersion": 1,
-                    "agentCapabilities": <String, dynamic>{},
-                    "authMethods": <Object?>[],
-                  },
-                });
-              }
-            }
-          }
-          await Future<void>.delayed(Duration.zero);
-        }
-      }();
 
       final plugin = await descriptor.start(
         _StartPluginHost(
-          processes: _ProbeProcessService(
-            spawnError: StateError("injected plugin must own the test process"),
-          ),
+          processes: processes,
+          config: config,
+          provisionedRuntimePath: "/resolved/hermes",
         ),
       );
-      responding = false;
-      await responsePump;
 
-      expect(
-        spawnedAcpProcesses,
-        hasLength(1),
-        reason: "descriptor startup must only initialize the live ACP process",
-      );
+      expect(processes.spawnedExecutables, ["/resolved/hermes"]);
+      expect(processes.spawnedArguments, [
+        const ["acp"],
+      ]);
 
       await plugin.shutdown(budget: null);
-      for (final process in spawnedAcpProcesses) {
-        await process.close();
-      }
+      expect(processes.gracefulSignals, [1]);
     });
   });
 }
 
-/// Injected test seam: builds a [HermesPlugin] backed by a fake process and
-/// records every spawned fake for the response pump.
-HermesPlugin _buildTestPlugin({
-  required String binaryPath,
-  required String launchDirectory,
-  required AcpProcessFactory processFactory,
-}) {
-  return HermesPlugin(
-    binaryPath: binaryPath,
-    launchDirectory: launchDirectory,
-    processFactory: (_) async {
-      final process = FakeAcpProcess();
-      spawnedAcpProcesses.add(process);
-      return process;
-    },
-  );
-}
-
-// Keep the injected factory's captured processes reachable without plumbing
-// through the typedef (the test seam closure above shares this list).
-final List<FakeAcpProcess> spawnedAcpProcesses = <FakeAcpProcess>[];
-
-class _StartPluginHost({@override required final HostProcessService processes}) implements PluginHost {
-  @override
-  PluginConfig get config => const PluginConfig(
-    values: {
-      HermesPluginDescriptor.binOption: HermesBinary.defaultBinary,
-    },
-  );
-
+class _StartPluginHost({
+  @override required final HostProcessService processes,
+  @override required final PluginConfig config,
+  @override required final String? provisionedRuntimePath,
+}) implements PluginHost {
   @override
   Map<String, String> get environment => const {"HOME": "/tmp"};
-
-  @override
-  String? get provisionedRuntimePath => null;
 
   @override
   ServerClock get clock => const ServerClock();
@@ -328,12 +433,15 @@ class _StartPluginHost({@override required final HostProcessService processes}) 
 /// A [HostProcessService] that either throws on [spawn] (to simulate ENOENT)
 /// or returns canned [_ProbeProcess]es in order. Records the spawn arguments.
 class _ProbeProcessService({
-  final Object? spawnError,
-  final List<_ProbeProcess>? processSequence,
+  required final Object? spawnError,
+  required final List<_ProbeProcess> processSequence,
+  required final bool servesAcp,
 }) implements HostProcessService {
   int _nextProcess = 0;
+  _AcpProcess? _acpProcess;
   final List<String> spawnedExecutables = <String>[];
   final List<List<String>> spawnedArguments = <List<String>>[];
+  final List<int> gracefulSignals = <int>[];
 
   @override
   Future<SpawnedProcess> spawn({
@@ -349,22 +457,46 @@ class _ProbeProcessService({
     if (error != null) {
       throw error;
     }
-    return processSequence![_nextProcess++];
+    if (servesAcp) {
+      final process = _AcpProcess();
+      _acpProcess = process;
+      return process;
+    }
+    return processSequence[_nextProcess++];
   }
 
   @override
   Future<ProcessIdentity?> inspect({required int pid}) async => null;
 
   @override
-  Future<SignalResult> signalGraceful({required int pid}) async => _signal(pid);
+  Future<SignalResult> signalGraceful({required int pid}) async {
+    gracefulSignals.add(pid);
+    _acpProcess?.exit(-15);
+    return _signal(
+      pid: pid,
+      requestedSignal: ShutdownSignal.graceful,
+      deliveredSignal: ProcessSignal.sigterm,
+    );
+  }
 
   @override
-  Future<SignalResult> signalForce({required int pid}) async => _signal(pid);
+  Future<SignalResult> signalForce({required int pid}) async {
+    _acpProcess?.exit(-9);
+    return _signal(
+      pid: pid,
+      requestedSignal: ShutdownSignal.force,
+      deliveredSignal: ProcessSignal.sigkill,
+    );
+  }
 
-  SignalResult _signal(int pid) => SignalResult(
+  SignalResult _signal({
+    required int pid,
+    required ShutdownSignal requestedSignal,
+    required ProcessSignal deliveredSignal,
+  }) => SignalResult(
     pid: pid,
-    requestedSignal: ShutdownSignal.force,
-    deliveredSignal: ProcessSignal.sigkill,
+    requestedSignal: requestedSignal,
+    deliveredSignal: deliveredSignal,
     wasRequested: true,
     attemptedAt: DateTime.utc(2026, 6, 1),
   );
@@ -375,7 +507,7 @@ class _ProbeProcessService({
 class _ProbeProcess({
   @override required final int pid,
   required final List<int> _stdoutBytes,
-  final List<int> _stderrBytes = const <int>[],
+  required final List<int> _stderrBytes,
   required final Future<int> _exitCode,
 }) implements SpawnedProcess {
   @override
@@ -392,4 +524,73 @@ class _ProbeProcess({
 
   @override
   ProcessIdentity get identity => throw UnimplementedError();
+}
+
+class _AcpProcess() implements SpawnedProcess {
+  this {
+    stdin = IOSink(_InputSink(onLine: _handleLine));
+  }
+
+  final StreamController<List<int>> _stdout = StreamController<List<int>>();
+  final Completer<int> _exit = Completer<int>();
+
+  @override
+  late final IOSink stdin;
+
+  void _handleLine(String line) {
+    final frame = jsonDecode(line) as Map<String, dynamic>;
+    if (frame["method"] != AcpMethods.initialize) return;
+    _stdout.add(
+      utf8.encode(
+        "${jsonEncode({
+          "jsonrpc": "2.0",
+          "id": frame["id"],
+          "result": {
+            "protocolVersion": 1,
+            "agentCapabilities": <String, dynamic>{},
+            "authMethods": <Object?>[],
+          },
+        })}\n",
+      ),
+    );
+  }
+
+  void exit(int code) {
+    if (!_exit.isCompleted) _exit.complete(code);
+    if (!_stdout.isClosed) unawaited(_stdout.close());
+  }
+
+  @override
+  Future<int> get exitCode => _exit.future;
+
+  @override
+  ProcessIdentity get identity => throw UnimplementedError();
+
+  @override
+  int get pid => 1;
+
+  @override
+  Stream<List<int>> get stderr => const Stream.empty();
+
+  @override
+  Stream<List<int>> get stdout => _stdout.stream;
+}
+
+class _InputSink({required final void Function(String line) onLine}) implements StreamConsumer<List<int>> {
+  final StringBuffer _buffer = StringBuffer();
+
+  @override
+  Future<void> addStream(Stream<List<int>> stream) async {
+    await for (final bytes in stream) {
+      _buffer.write(utf8.decode(bytes));
+      final lines = _buffer.toString().split("\n");
+      _buffer
+        ..clear()
+        ..write(lines.removeLast());
+      lines.where((line) => line.isNotEmpty).forEach(onLine);
+    }
+  }
+
+  @override
+  Future<void> close() async {}
 }


### PR DESCRIPTION
Supersedes #898. This maintainer-owned continuation preserves the contributor's step-four commits and completes the descriptor against the merged plugin core.

## Complexity

⚙️ Moderate - this adds setup classification, runtime validation, and process lifecycle wiring, while reusing the existing descriptor and ACP lifecycle contracts.

## What

- Adds `HermesPluginDescriptor` with `--hermes-bin`, bridge-derived project ownership, plugin-scoped session options, and prompt-attachment support.
- Probes `hermes acp --version`, enforces ACP adapter version `0.20.0`, and revalidates the PATH runtime immediately before startup.
- Inspects `hermes status` for both a configured model and provider.
- Starts `hermes acp` through the real `PluginHost` process seam with bounded eager connection and abort rollback.
- Makes version parsing token-tolerant, recognizes verified pre-ACP and shell command-not-found diagnostics, models runtime outcomes as a closed enum, and keeps internal runtime details out of the public API.
- Expands focused descriptor coverage, including direct host-process startup rather than a production test-only factory seam.

## Why

The descriptor is the bridge lifecycle boundary for Hermes. It must report actionable setup states, avoid managed-runtime behavior, route process ownership through the host, and hand a verified runtime to the ACP plugin core.

The replacement lets maintainers deliver the series sequentially while retaining the contributor's implementation and authorship.

## Risk and test focus

Moderate risk around local CLI probing, setup classification, and subprocess startup/rollback. Review should focus on missing/outdated/unknown runtime distinctions, provider-aware readiness, explicit binary handling, abort behavior, and host-owned process signaling.

Configured `Model:` and `Provider:` output intentionally remains authoritative when `hermes status` exits nonzero; the live ACP handshake is the authentication authority. Regression documentation remains assigned to step 7/9.

## Expected result

The bridge can inspect and start a configured Hermes installation through its standard plugin lifecycle once registration lands in step 5. This step has no user-visible behavior yet and no database or persisted-data impact.

## Verification

- `dart format lib test` from `bridge/sesori_plugin_hermes/`
- `dart analyze --fatal-infos` from `bridge/sesori_plugin_hermes/`
- `dart test` from `bridge/sesori_plugin_hermes/` - 26 tests passed
- Architecture implementation review approved with no findings

## Attribution

This PR carries forward all four step-four commits from @eexxio with their original Git authorship intact. Thank you, @eexxio, for implementing the Hermes descriptor, runtime gate, setup probes, and initial lifecycle tests. We greatly appreciate the contribution; the additional maintainer commits complete review feedback and integration with the merged earlier steps.
