### PR TITLE
⚙️ [hermes-agent-plugin] feat(hermes): register the plugin in the bridge [step 5/9]

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -90,6 +90,10 @@ jobs:
         run: dart analyze --fatal-infos
         working-directory: bridge/sesori_plugin_pi
 
+      - name: Analyze sesori_plugin_hermes
+        run: dart analyze --fatal-infos
+        working-directory: bridge/sesori_plugin_hermes
+
       - name: Run tests for bridge/app
         run: dart test
         working-directory: bridge/app
@@ -133,6 +137,10 @@ jobs:
       - name: Run tests for sesori_plugin_pi
         run: dart test
         working-directory: bridge/sesori_plugin_pi
+
+      - name: Run tests for sesori_plugin_hermes
+        run: dart test
+        working-directory: bridge/sesori_plugin_hermes
 
   build-smoke:
     needs: toolchain

--- a/bridge/app/lib/src/bridge/runtime/plugin_registry.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_registry.dart
@@ -1,6 +1,7 @@
 import "package:claude_plugin/claude_plugin.dart" show ClaudePluginDescriptor;
 import "package:codex_plugin/codex_plugin.dart" show CodexPluginDescriptor;
 import "package:cursor_plugin/cursor_plugin.dart" show CursorPluginDescriptor;
+import "package:hermes_plugin/hermes_plugin.dart" show HermesPluginDescriptor;
 import "package:opencode_plugin/opencode_plugin.dart" show OpenCodePluginDescriptor;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginDescriptor;
 
@@ -13,6 +14,7 @@ const List<BridgePluginDescriptor> knownPlugins = [
   CodexPluginDescriptor(),
   CursorPluginDescriptor(),
   ClaudePluginDescriptor(),
+  HermesPluginDescriptor(),
 ];
 
 /// Product-preferred default when OpenCode is selectable. Lifecycle policy

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -36,6 +36,8 @@ dependencies:
     path: ../sesori_plugin_cursor
   claude_plugin:
     path: ../sesori_plugin_claude
+  hermes_plugin:
+    path: ../sesori_plugin_hermes
   meta: ^1.19.0
   # Keep runtime and codegen on the same patch; skew breaks the Drift schema verifier.
   drift: 2.34.3

--- a/bridge/app/test/bridge/runtime/plugin_registry_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_registry_test.dart
@@ -5,7 +5,7 @@ void main() {
   test("registry contains every bundled plugin exactly once", () {
     final ids = knownPlugins.map((plugin) => plugin.id).toList();
 
-    expect(ids, containsAll(["opencode", "codex", "cursor", "claude"]));
+    expect(ids, containsAll(["opencode", "codex", "cursor", "claude", "hermes"]));
     expect(ids.toSet(), hasLength(ids.length));
   });
 

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -15,6 +15,9 @@ idle suspension, the management snapshot, and lifecycle commands.
 - Runtime resolution before start may resolve a suitable existing or managed binary but
   never downloads or mutates files, and failure there is non-fatal. The persisted disable
   list is the only durable eligibility policy, with setup deciding blocked versus routable.
+- Hermes is a direct-CLI harness with no managed install. Setup distinguishes a missing or
+  pre-ACP binary, an adapter below `0.20.0`, and missing model/provider configuration;
+  startup revalidates the PATH adapter while an explicit `--hermes-bin` remains authoritative.
 - Listings order by display name case-insensitively with the identifier as tie-breaker,
   and the default is the preferred harness when selectable, else the first selectable.
 - Harnesses start on demand unless eager; a transient one may suspend after a confirmed
@@ -93,7 +96,7 @@ directories. Restore eligibility, timeouts, and sessions afterwards.
 ## Sources
 
 - `bridge/sesori_plugin_interface/lib/src/lifecycle/`; registered OpenCode, Codex,
-  Cursor, and Claude Code descriptors; plugin routing handlers
+  Cursor, Claude Code, and Hermes Agent descriptors; plugin routing handlers
 - `bridge/app/lib/src/services/plugin_lifecycle_service.dart`,
   `bridge/app/lib/src/bridge/runtime/plugin_registry.dart`
 - `client/module_core/.../plugin_management_service.dart` and the harness settings screen


### PR DESCRIPTION
Supersedes #899. This maintainer-owned continuation preserves the contributor's registration and CI commits on top of the merged Hermes descriptor.

## Complexity

⚙️ Moderate - the code changes are small, but they activate Hermes in the running bridge's plugin composition and verification matrix.

## What

- Adds `hermes_plugin` as a bridge app dependency.
- Registers `HermesPluginDescriptor()` at the supported `plugin_registry.dart` composition point.
- Extends the bundled-plugin registry test with the stable `hermes` id.
- Adds explicit strict-analysis and test steps for `sesori_plugin_hermes` to Bridge CI.
- Records Hermes's direct-CLI setup contract in the plugin setup/lifecycle regression document.

## Why

The earlier steps established and verified the package, plugin core, and lifecycle descriptor. Registration makes that descriptor discoverable by the headless bridge while keeping all Hermes-specific behavior inside its plugin package.

The replacement lets maintainers merge the series sequentially while retaining the contributor's implementation and authorship.

## Risk and test focus

Moderate activation risk. Hermes becomes an eligible bundled plugin, while setup readiness still independently gates routing and startup. Review should focus on the single composition point, unique plugin identity, package dependency direction, and CI coverage.

Step 7/9 will complete the broader Hermes session regression documentation.

## Expected result

Hermes Agent appears in the bridge plugin listing and reports setup state based on the local Hermes installation. There is no database migration or persisted-data change; existing plugin eligibility and setup policies remain unchanged.

## Verification

- `dart pub get` from `bridge/`
- `dart analyze --fatal-infos` from `bridge/app/`
- `dart test test/bridge/runtime/plugin_registry_test.dart` from `bridge/app/` - 2 tests passed
- Regression document diff validated with `git diff --check`
- Architecture implementation review approved with no findings

## Attribution

This PR carries forward both step-five commits from @eexxio with their original Git authorship intact. Thank you, @eexxio, for wiring Hermes into the bridge composition and CI matrix. We greatly appreciate the contribution and the care taken to cover activation with a registry assertion; the maintainer follow-up only records the activated setup regression contract.
