### PR TITLE
⚙️ Rename generated session branches after launch

### DIFF
--- a/.plan/active/fast-new-session-launch/PLAN.md
+++ b/.plan/active/fast-new-session-launch/PLAN.md
@@ -6,9 +6,10 @@
 - **Status:** Active - plan ready for review
 - **Plan date:** 2026-08-13
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
-- **Implementation base:** `origin/main` at `14a4e405`
-- **Current branch:** `speed-up-new-session-load`
-- **Delivery:** six PRs; Step 1 raises this plan before production work
+- **Implementation base:** `origin/main` at `f7bcdc63e` after Step 4 merge
+- **Current branch:** `async-generated-session-branch-rename`
+- **Delivery:** six numbered PRs plus one approved standalone follow-up between
+  Steps 4 and 5; Step 1 raised this plan before production work
 
 This plan and `TRACKER.md` are the authority for implementation. The code and
 released product behavior remain authoritative where this document becomes
@@ -118,15 +119,22 @@ second session and worktree.
   before the bridge supports pending attempts.
 - `New session` is an acceptable temporary title; the generated title updates
   quietly later.
-- Metadata does not choose dedicated-worktree names. Branch and worktree use the
-  same locally generated lowercase ASCII `color-animal` slug, for example
-  `blue-otter`.
+- Metadata never gates dedicated-worktree creation. The branch and worktree
+  initially use the same locally generated lowercase ASCII `color-animal` slug,
+  for example `blue-otter`.
+- After the durable create response, successful metadata may rename only that
+  initial branch to the generated `branchName`. The worktree directory remains
+  the original `color-animal` path. Skip the rename when the worktree is no
+  longer on its initial branch or that branch has an upstream.
 - The vocabulary is a small curated code-owned list. Naming is local,
   dependency-free, backend-neutral, and reusable for future workspace names.
 - On collision, sample another pair for a bounded number of attempts. If those
   attempts are exhausted or the final create races, append the existing secure
   short hexadecimal suffix to the last pair rather than losing workspace
   isolation.
+- A late generated branch collision likewise uses a bounded secure suffix. An
+  invalid generated branch or any Git/persistence failure keeps the initial
+  branch and cannot fail the session or generated-title update.
 - Creation failures return automatically to the filled composer. Text/voice
   provenance, slash command, and attachments are restored. The user explicitly
   presses Send again.
@@ -140,9 +148,10 @@ second session and worktree.
   contract; release verification enumerates every plugin registered in the build
   under test. Unregistered packages receive no product claim or plugin-specific
   production code.
-- Generated title runs fully off the response path. A user title must not be
-  overwritten if avoiding that race is a focused conditional write rather than
-  a new lifecycle state machine.
+- Generated title and eligible generated-branch rename run fully off the response
+  path. A user title must not be overwritten, and a user/agent branch switch or
+  published initial branch must not be renamed. These are focused conditional
+  mutations, not a new lifecycle state machine.
 - Detail first-content staging is explicitly out of scope. The real detail
   route keeps its coherent snapshot and uses the same launch presentation while
   loading, avoiding a launch-view-to-spinner regression.
@@ -307,9 +316,14 @@ Algorithm:
    creation failure fallback semantics.
 
 The generated words are lowercase ASCII and inherently valid Git/path slugs, so
-the metadata-oriented preferred-name parameter and runtime unsafe-name validator
-are deleted. Durable branch/worktree/base facts and the worktree system prompt
-remain unchanged.
+the metadata-oriented preferred-name parameter and its old pre-creation runtime
+validator remain deleted. Durable branch/worktree/base facts and the worktree
+system prompt initially describe this local identity.
+
+The approved follow-up does not rename or move the worktree directory after a
+backend starts in it. It refines only the checked-out branch after metadata, so
+the plugin working directory, stored session directory, and system prompt remain
+valid. The prompt deliberately calls its value the initial branch.
 
 ### 4. Early canonical response
 
@@ -345,10 +359,10 @@ batch `enrichSessions` remains for list reads.
 
 `SessionCreationService` continues to await project validation, plugin
 routability, git/worktree preparation, backend creation, first-input acceptance,
-durable commit, and slash-command acceptance. It then tracks late title
+durable commit, and slash-command acceptance. It then tracks late metadata
 completion and returns the canonical committed session immediately.
 
-### 5. Managed late generated title
+### 5. Managed late generated metadata
 
 Metadata starts only after durable creation and first-input/slash-command
 acceptance. Unknown projects and failed creations therefore cause no metadata
@@ -364,34 +378,36 @@ flow while keeping the auth server as one provider boundary:
 - Layer 1 existing `SesoriServerApi` owns the typed metadata POST alongside its
   other auth-server operations, including abort/deadline behavior, a method-aware
   status exception, token acquisition through injected `TokenRefresher`, one
-  typed 401 force-refresh/retry, and the title-only response DTO;
+  typed 401 force-refresh/retry, and the title-plus-branch response DTO;
 - Layer 2 `SessionMetadataRepository` under `bridge/app/lib/src/repositories/`
   owns the 500-character payload normalization and maps the typed API result;
 - Layer 3 `SessionCreationService` consumes the repository and owns the product
-  decision that metadata failure is logged and degraded to no generated title.
+  decision that metadata failure is logged and degraded to no generated title or
+  branch refinement.
 
 This follows the bridge architecture's explicit authenticated-provider boundary:
 `SesoriServerApi` consumes `TokenRefresher` and owns the complete authenticated
 HTTP operation. The repository does not inspect HTTP status or coordinate token
 lifecycle.
 
-The title-only DTO ignores the deployed response's extra `branchName` and
-`worktreeName` keys. The auth server response remains unchanged for released
-bridges. API/repository errors retain status/cause/stack context; only the
-creation service converts them into the best-effort result.
+The DTO consumes the deployed response's `title` and `branchName` and ignores
+`worktreeName`. The auth server response remains unchanged for released bridges.
+API/repository errors retain status/cause/stack context; only the creation
+service converts them into the best-effort result.
 
 Late work is owned by `SessionCreationService`, not by a detached route future.
 Immediately after all synchronous acceptance gates pass, the service starts and
-registers the complete metadata-to-title workflow in the tracked set before it
+registers the complete metadata workflow in the tracked set before it
 can return the canonical session:
 
-- one set tracks accepted title-completion futures;
+- one set tracks accepted metadata-completion futures, including title and any
+  eligible branch refinement;
 - standalone `TokenManager` refresh HTTP gains an injected request deadline, so
   token acquisition always settles; the desktop control-channel implementation
   retains its existing timeout;
 - one shutdown signal aborts in-flight metadata HTTP;
 - `beginShutdown` stops accepting new late work and triggers that request abort;
-- `drain` waits for tracked title work before session operations/listeners and
+- `drain` waits for tracked metadata work before session operations/listeners and
   the shared HTTP client are disposed.
 
 `drain` awaits the actual tracked workflows, never only a race wrapper while a
@@ -409,14 +425,14 @@ The composition root wires lifecycle ownership explicitly:
    injects that same instance into `OrchestratorSession`.
 2. `OrchestratorSession.beginShutdown` first fences
    `RoutedRequestDispatcher`, then calls
-   `SessionCreationService.beginShutdown` to stop late-title admission and abort
+   `SessionCreationService.beginShutdown` to stop late-metadata admission and abort
    metadata HTTP. An already accepted create may still finish its request, but
    if it reaches durable commit after this fence it returns without scheduling a
    generated title; title generation is best-effort during shutdown.
 3. The normalized event subscription and Orchestrator-owned local-mutation
    subscription move out of the broad `_subscriptions` composite. `_teardown`
    keeps both live while draining routed requests and relay completions, so no
-   accepted route can still reach late-title registration.
+   accepted route can still reach late-metadata registration.
 4. `_teardown` awaits `SessionCreationService.drain`, then begins/drains
    `SessionOperationDispatcher` while `OrchestratorSession` still maps typed
    local mutations to `SessionEventDispatcher`.
@@ -430,7 +446,7 @@ The composition root wires lifecycle ownership explicitly:
 7. The shutdown coordinator closes the shared HTTP client/database only after
    the whole `OrchestratorSession` drain phase.
 
-This order gives every tracked title task live mutation/event dependencies,
+This order gives every tracked metadata task live mutation/event dependencies,
 admits no task after the drain snapshot, and requires no global job registry.
 
 Generated title applies through `SessionMutationDispatcher` under the existing
@@ -446,6 +462,31 @@ local output only. `OrchestratorSession` decides and dispatches the correspondin
 backend-neutral event (`session.updated` for title success) before best-effort
 plugin propagation. Clients already consume it, so no new wire model is needed.
 
+The follow-up extends the same ownership rather than adding another job or event
+pipeline:
+
+1. `SessionCreationService` receives the typed title and generated branch in the
+   existing tracked metadata workflow. Title and branch application are
+   independent so either may succeed when the other fails.
+2. Generated branch application enters `SessionMutationDispatcher` under the
+   existing session-family lane. The dispatcher requires a stored root session
+   with a dedicated worktree and delegates Git decisions to `WorktreeService`.
+3. `WorktreeService` asks `GitCliApi` through `WorktreeRepository` to validate the
+   target, confirm the current branch still equals the durable initial branch,
+   confirm it has no upstream, resolve a bounded collision suffix, and rename the
+   explicit old ref. It re-reads the current branch after the rename before
+   claiming a current-branch projection. No process-global or filesystem lock is
+   added for Git actions performed outside the bridge.
+4. After Git succeeds, `SessionRepository` conditionally replaces the durable
+   `branchName` expected by the operation and updates `currentBranchName` only
+   when Git still reports the renamed ref. A persistence failure attempts a
+   best-effort explicit Git rollback and logs both failures if rollback also
+   fails, preserving diagnostic evidence without failing session creation.
+5. A successful persisted rename emits a `branchUpdated(Session)` local mutation.
+   `OrchestratorSession` maps it to the existing `session.updated` event with
+   `titleChanged: false`; normal PR refresh later reconciles any PR cache. No new
+   client wire shape is introduced.
+
 ## Failure Semantics
 
 - **Still synchronous:** invalid project, unroutable backend, git/worktree setup
@@ -453,16 +494,18 @@ plugin propagation. Clients already consume it, so no new wire model is needed.
   initial prompt/attachment rejection, slash-command rejection, and durable
   binding failure.
 - **Best-effort after response:** metadata generation, bridge-owned generated
-  title application, and backend title propagation.
+  title application, eligible generated-branch rename, and backend title
+  propagation.
 - **Client creation failure:** restore the composer with a duplicate-risk
   warning for every creation-originated error; never auto-resend. Timeout,
   response loss, malformed/empty success, generic errors, and even some server
   rejections cannot prove that no durable session was committed.
 - **Background leave:** do not cancel bridge work. Existing list SSE/reconnect
   reconciliation remains authoritative once the binding commits.
-- **Shutdown:** cancel metadata HTTP, drain tracked title completions, then close
-  operation/event/mutation infrastructure. Do not persist prompt or pending title
-  work across process restart; generated title is explicitly best-effort.
+- **Shutdown:** cancel metadata HTTP, drain tracked metadata completions, then
+  close operation/event/mutation infrastructure. Do not persist prompt or
+  pending metadata work across process restart; generated title and branch
+  refinement are explicitly best-effort.
 
 ## Compatibility
 
@@ -474,9 +517,9 @@ plugin propagation. Clients already consume it, so no new wire model is needed.
   `session.updated` events.
 - No database migration is needed.
 - The auth server continues returning `title`, `branchName`, and `worktreeName`
-  because released bridges require all three fields. The new bridge ignores the
-  latter two. Narrowing that external response is deferred until those released
-  bridges are outside support.
+  because released bridges require all three fields. The new bridge intentionally
+  consumes `branchName` and ignores `worktreeName`; only the latter can be removed
+  once released bridges requiring it are outside support.
 - Production behavior remains plugin-neutral through `BridgePluginApi`.
 
 ## Cleanup Assessment
@@ -490,9 +533,9 @@ plugin propagation. Clients already consume it, so no new wire model is needed.
   keeps its independent dependency.
 - Obsolete loading copy or keys after refreshed copy moves to the shared launch
   view; generated localization outputs are regenerated, never hand-edited.
-- `SessionMetadata.branchName` and `SessionMetadata.worktreeName` plus the old
-  generated bridge model output; Step 3 replaces them with the title-only API
-  response DTO and regenerates its output.
+- The old layer-skipping `SessionMetadata` model and its `worktreeName` coupling;
+  the typed API response retains only the title and generated branch needed by
+  the late workflow.
 - `preferredBranchAndWorktreeName`, the metadata preferred-name branch, its
   runtime safe-name validator, and tests/fake fields that exist only for that
   path.
@@ -510,6 +553,8 @@ plugin propagation. Clients already consume it, so no new wire model is needed.
 
 - Generated title, auth/token refresh, first-message truncation, and the metadata
   endpoint activation side effect through the new API/repository layers.
+- Generated metadata `branchName`, `GitCliApi` branch validation/rename/upstream
+  primitives, and the durable creation/current branch fields.
 - Durable `Session` and database title/branch/worktree/base fields.
 - Explicit user rename APIs and every plugin's `renameSession` implementation.
 - `SessionMutationDispatcher` family serialization.
@@ -521,8 +566,9 @@ plugin propagation. Clients already consume it, so no new wire model is needed.
 
 ### Deferred cleanup
 
-- Auth-server response narrowing/removal of generated branch/worktree values,
-  solely because released bridges deserialize them as required fields.
+- Auth-server response narrowing/removal of generated `worktreeName`, solely
+  because released bridges deserialize it as required. Generated `branchName`
+  remains a live field for current bridges.
 - Replacing the metadata endpoint's activation side effect with a dedicated
   activation outcome.
 - Creation idempotency/pending-session persistence and true instant stable URLs.
@@ -536,6 +582,8 @@ plugin propagation. Clients already consume it, so no new wire model is needed.
 - Worktree cleanup redesign after plugin creation failure.
 - Renaming existing persisted worktrees or rewriting arbitrary `session-*` test
   fixtures unrelated to generation.
+- Renaming a worktree directory after plugin creation, renaming an initial branch
+  with an upstream, or following a user/agent branch switch.
 - Changing plugin prompt semantics, session options discovery, relay timeout,
   or session-detail refresh reconciliation.
 
@@ -547,10 +595,10 @@ plugin propagation. Clients already consume it, so no new wire model is needed.
    launch is sending or being restored. It is required to preserve memory-only
    attachments and voice/command intent across the immediate visual transition;
    the still-mounted screen State retains the independent workspace toggle.
-2. **Late-title future set:** one `Set<Future<void>>` owned by
-   `SessionCreationService`, required so post-response title work cannot outlive
-   bridge dependencies.
-3. **Late-title abort controller/signal:** one shutdown signal shared by
+2. **Late-metadata future set:** the existing `Set<Future<void>>` owned by
+   `SessionCreationService`, renamed to describe that title and branch work cannot
+   outlive bridge dependencies; no second set is added.
+3. **Late-metadata abort controller/signal:** one shutdown signal shared by
    metadata requests, required to keep graceful shutdown from waiting for the
    45-second metadata deadline.
 4. **Memoized drain future/accepting flag:** lifecycle state local to the same
@@ -565,30 +613,34 @@ plugin propagation. Clients already consume it, so no new wire model is needed.
   that ephemeral local set is bounded by the existing attempt count.
 - Zero net long-lived stream controllers/subscriptions: the deletion-only
   mutation stream/listener is generalized in place.
+- Zero new branch registries, watchers, locks, or reconciliation jobs. Each late
+  rename carries only its expected/desired names through the existing tracked
+  workflow and family lane.
 - One UI timer, replacing rather than adding to the current rotating-copy timer.
 - No prompt/transcript persistence and no attachment persistence.
 - One transient sealed restore state and one post-frame consumption callback;
   neither retains state after the composer copies the snapshot.
 
-If implementation needs a pending-attempt registry, per-session title map,
-second mutation stream/listener, or partial-detail reconciliation machinery,
-stop and ask before expanding scope.
+If implementation needs a pending-attempt registry, per-session metadata map,
+second mutation stream/listener, Git watcher/lock, or partial-detail
+reconciliation machinery, stop and ask before expanding scope.
 
 ## Delivery Plan
 
 | Step | Exact PR title | Target | Scope |
 |---|---|---:|---|
 | 1/6 | `🌱 [fast-new-session-launch] docs: plan faster new-session launch [step 1/6]` | 750-900 lines | Add this reviewed plan and tracker only. |
-| 2/6 | `🌿 [fast-new-session-launch] feat(bridge): use local workspace names [step 2/6]` | 200-500 lines | Generate color-animal worktree/branch slugs and remove obsolete preferred-name code/tests. Metadata response fields are removed once in Step 3 with the API/repository replacement. |
+| 2/6 | `🌿 [fast-new-session-launch] feat(bridge): use local workspace names [step 2/6]` | 200-500 lines | Generate color-animal worktree/branch slugs and remove obsolete preferred-name code/tests. The old metadata model is replaced once in Step 3. |
 | 3/6 | `🚧 [fast-new-session-launch] feat(bridge): return sessions before generated titles [step 3/6]` | 950-1,450 lines | Add shared typed metadata request plus bridge API/repository layering, return canonical committed sessions, run title generation off the response path with exact shutdown ownership, conditional local title update, local `session.updated`, generated output, and obsolete-path deletion. |
 | 4/6 | `⚙️ [fast-new-session-launch] feat(client): open launching sessions immediately [step 4/6]` | 800-1,400 lines | Add sealed submission restoration, reusable Prego launch status, detail-shaped launch/loading, honest error warning, delete overlay/dependency/tests, regenerate state/localization. |
+| 4A | `⚙️ Rename generated session branches after launch` | 350-700 lines | Standalone approved follow-up: consume generated branch metadata, conditionally rename only the unpublished initial dedicated branch off the response path, persist both branch facts, and publish the existing session update. |
 | 5/6 | `🌱 [fast-new-session-launch] docs: define launch regression coverage [step 5/6]` | 80-180 lines | Reconcile affected regression docs and complete cleanup audit against actual implementation. |
 | 6/6 | `🌿 [fast-new-session-launch] test: verify faster new-session launch [step 6/6]` | 80-250 lines | Run the recorded level/matrix, record automated/manual results and timings, then move this plan from `active` to `completed` only on full required coverage. |
 
 Each implementation PR must stay below the 1,500 changed-line soft cap. If a
 step exceeds its target, prefer removing unnecessary machinery or splitting
-tests by owner without changing the fixed six-step lifecycle. Do not combine the
-bridge and client production steps into one large PR.
+tests by owner. The approved 4A follow-up does not renumber already merged/open
+six-step titles. Do not combine bridge and client production work.
 
 ## Per-Step Verification
 
@@ -652,6 +704,24 @@ bridge and client production steps into one large PR.
   existing-session queue plus analytics retain their released input-mode
   behavior after the richer callback input.
 
+### Follow-up 4A
+
+- `bridge/app`: metadata API/repository, creation service, mutation dispatcher,
+  worktree service/repository, Git API, DAO/repository persistence, local event
+  mapping, and shutdown tests plus `dart analyze --fatal-infos`.
+- Prove the canonical create response settles before metadata and branch rename,
+  and metadata/title failure remains independent from branch failure.
+- Prove only a stored root dedicated session on its original local branch is
+  eligible; in-place/fallback sessions, switched or detached worktrees, and an
+  initial branch with an upstream retain their current branch.
+- Prove valid metadata renames only the branch, leaves the worktree/directory
+  unchanged, uses bounded secure collision fallback, updates durable/current
+  branch facts, and emits the existing `session.updated` with
+  `titleChanged: false`.
+- Prove generated-title behavior is unchanged, persistence failure attempts Git
+  rollback, deletion/family serialization wins predictably, and shutdown drains
+  the complete metadata workflow.
+
 ## Regression Documentation And Final Matrix
 
 Affected feature documents:
@@ -661,15 +731,19 @@ Affected feature documents:
   durable list/title update;
 - `docs/regression/attachments-and-images.md` - memory-only attachment
   restoration after failed creation.
+- `docs/regression/diffs-and-source-control.md` - late refinement of the durable
+  initial branch without moving the worktree;
+- `docs/regression/pull-request-monitoring.md` - generated branch update through
+  the existing current-branch/session update contract.
 
 `session-turns.md` is inspected for consistency but should not change unless the
 implementation alters existing-session sends, which is not planned.
 
 The durable-plan lifecycle intentionally reconciles these documents in the
-penultimate Step 5. Steps 2-4 record doc deltas in `TRACKER.md` as they merge,
-and the series is not release-complete until Step 5 updates the active contracts;
-this follows `docs/regression/README.md` rather than scattering partial feature
-wording across production steps.
+penultimate Step 5. Steps 2-4 and follow-up 4A record doc deltas in `TRACKER.md`
+as they merge, and the series is not release-complete until Step 5 updates the
+active contracts; this follows `docs/regression/README.md` rather than
+scattering partial feature wording across production steps.
 
 ### Highest required level
 
@@ -689,7 +763,11 @@ plugins. Automated tests are not a substitute for that client/plugin boundary.
   metadata slow/failure, title update, and dedicated-worktree naming because
   those behaviors are bridge-owned after the normalized boundary.
 - **Workspace:** in-place and dedicated; dedicated includes normal generated
-  name, collision retry, and suffix fallback through automated tests.
+  initial name, collision retry, and suffix fallback through automated tests.
+  A representative dedicated session additionally proves metadata arrives after
+  response, renames only the unpublished initial branch, leaves the worktree path
+  stable, updates the client branch, and skips after branch switch/upstream or
+  metadata/Git failure.
 - **Failure:** definitive rejection plus timeout/relay-loss simulation restoring
   the composer with honest warning; reconnect/discovery completion must not
   erase that warning before another explicit submission or route exit.
@@ -716,7 +794,7 @@ The acceptance criterion is structural, not a brittle wall-clock SLA:
   response or synchronous attachment/request/relay-envelope encoding; a
   maximum-sized fixture verifies the launch view paints and remains schedulable
   while every large serialization stage proceeds;
-- metadata/title completion cannot extend create response time;
+- metadata/title/branch completion cannot extend create response time;
 - route replacement occurs only after the real session is durable/queryable;
 - no accepted first input or command is moved behind the success response.
 
@@ -730,21 +808,26 @@ The acceptance criterion is structural, not a brittle wall-clock SLA:
   deduplication is deferred.
 - Generated title is best-effort and is not persisted as pending work across a
   bridge restart. A session may keep its backend/generic title if shutdown wins.
+- Generated branch refinement is likewise best-effort. Metadata failure, an
+  agent branch switch, an upstream, invalid output, collision/create races, or a
+  Git failure leaves the safe initial `color-animal` branch in place.
 - The detail snapshot may remain slower than route replacement. It uses the
   same launch view for continuity, but staged transcript rendering and PR-read
   optimization are separate work.
 - Color-animal combinations are finite. Bounded distinct-pair retry plus one
   secure-suffix attempt handles collisions without an unbounded hot path; a real
   final Git creation failure still follows the existing project fallback.
-- Auth-server branch/worktree generation remains wasted work for new bridges
-  until released bridge compatibility allows endpoint narrowing. Bridge-side
-  dead fields and coupling are still removed now.
+- Auth-server branch generation is intentionally live again for current bridges.
+  Worktree-name generation remains wasted until released bridge compatibility
+  allows that field to be removed.
 
 ## Expected Result
 
 Pressing Send immediately presents the session experience. Metadata service
 latency and backend rename latency no longer delay the durable session response.
-Dedicated workspaces receive friendly local names without a network dependency.
+Dedicated workspaces receive friendly initial local names without a network
+dependency, then eligible unpublished branches refine to the generated task name
+after launch without moving the worktree.
 Success still means the backend accepted the initial action and the stable
 Sesori session is queryable. Failure restores the user's exact submission
 without unsafe automatic retry. No database or client-bridge wire migration is

--- a/.plan/active/fast-new-session-launch/PLAN.md
+++ b/.plan/active/fast-new-session-launch/PLAN.md
@@ -125,7 +125,7 @@ second session and worktree.
 - After the durable create response, successful metadata may rename only that
   initial branch to the generated `branchName`. The worktree directory remains
   the original `color-animal` path. Skip the rename when the worktree is no
-  longer on its initial branch or that branch has an upstream.
+  longer on its initial branch or that branch has an upstream or matching remote ref.
 - The vocabulary is a small curated code-owned list. Naming is local,
   dependency-free, backend-neutral, and reusable for future workspace names.
 - On collision, sample another pair for a bounded number of attempts. If those
@@ -473,7 +473,7 @@ pipeline:
    with a dedicated worktree and delegates Git decisions to `WorktreeService`.
 3. `WorktreeService` asks `GitCliApi` through `WorktreeRepository` to validate the
    target, confirm the current branch still equals the durable initial branch,
-   confirm it has no upstream, resolve a bounded collision suffix, and rename the
+   confirm it has no upstream or matching remote ref, resolve a bounded collision suffix, and rename the
    explicit old ref. It re-reads the current branch after the rename before
    claiming a current-branch projection. No process-global or filesystem lock is
    added for Git actions performed outside the bridge.
@@ -583,7 +583,7 @@ pipeline:
 - Renaming existing persisted worktrees or rewriting arbitrary `session-*` test
   fixtures unrelated to generation.
 - Renaming a worktree directory after plugin creation, renaming an initial branch
-  with an upstream, or following a user/agent branch switch.
+  with an upstream or matching remote ref, or following a user/agent branch switch.
 - Changing plugin prompt semantics, session options discovery, relay timeout,
   or session-detail refresh reconciliation.
 

--- a/.plan/active/fast-new-session-launch/TRACKER.md
+++ b/.plan/active/fast-new-session-launch/TRACKER.md
@@ -3,12 +3,12 @@
 ## Current State
 
 - **Plan slug:** `fast-new-session-launch`
-- **Implementation base:** `origin/main` at `7900c2d5e` after Step 3 merge
-- **Current branch:** `fast-new-session-launch-step-4`
-- **Series state:** Steps 1-3/6 merged; Step 4/6 is open in #913 and monitored
-- **Current step:** finalize the immediate-launch PR after its Step 3 handoff
-- **Next action:** merge Step 4, then implement the approved asynchronous
-  generated-branch rename follow-up before Step 5
+- **Implementation base:** `origin/main` at `f7bcdc63e` after Step 4 merge
+- **Current branch:** `async-generated-session-branch-rename`
+- **Series state:** Steps 1-4/6 merged; approved standalone follow-up 4A is ready
+  for review before Step 5
+- **Current step:** deliver asynchronous generated branch refinement
+- **Next action:** open and monitor the standalone follow-up 4A PR
 
 ## Locked Decisions
 
@@ -20,9 +20,11 @@
 - [x] Metadata/title leaves the create-response critical path.
 - [x] Initial prompt, attachment, and slash-command acceptance remain
   synchronous.
-- [x] Dedicated worktrees use local curated `color-animal` names.
+- [x] Dedicated worktrees initially use local curated `color-animal` names.
 - [x] Pair collisions retry another pair; bounded exhaustion uses a secure
   suffix.
+- [x] Late metadata may rename only the still-current unpublished initial branch;
+  the worktree directory remains unchanged.
 - [x] Failure automatically restores the filled composer; no automatic resend.
 - [x] Because current server errors can occur after durable commit, every
   creation-originated error receives the duplicate-risk warning.
@@ -61,9 +63,13 @@
 - [x] Preserve nullable title handoff; never convert missing title to `""`.
 - [x] Extend authenticated `SesoriServerApi` for metadata, including token
   acquisition and one 401 refresh/retry; do not split one provider by use case.
-- [x] One late-title future set; drain actual workflows, abort metadata HTTP on
+- [x] One late-metadata future set; drain actual workflows, abort metadata HTTP on
   shutdown, and deadline-bound standalone token refresh.
-- [x] Keep the normalized event consumer alive through late-title drain, then
+- [x] Reuse that tracked workflow/family lane for branch refinement; add no
+  branch registry, watcher, lock, or second mutation stream.
+- [x] Generated branch failure cannot fail creation/title, and a switched,
+  detached, or upstream branch is never renamed.
+- [x] Keep the normalized event consumer alive through late-metadata drain, then
   fence mutation producers before draining its listener and event tails.
 - [x] Shared encryption returns preallocated typed bytes without boxed integer
   framing; analyze/test shared crypto and bridge relay callers explicitly.
@@ -79,8 +85,9 @@
 | [x] | 1/6 | `🌱 [fast-new-session-launch] docs: plan faster new-session launch [step 1/6]` | Merged in #894 |
 | [x] | 2/6 | `🌿 [fast-new-session-launch] feat(bridge): use local workspace names [step 2/6]` | Merged in #908 |
 | [x] | 3/6 | `🚧 [fast-new-session-launch] feat(bridge): return sessions before generated titles [step 3/6]` | Merged in #909 |
-| [ ] | 4/6 | `⚙️ [fast-new-session-launch] feat(client): open launching sessions immediately [step 4/6]` | Open in #913; based on `main` |
-| [ ] | 5/6 | `🌱 [fast-new-session-launch] docs: define launch regression coverage [step 5/6]` | Blocked on Step 4 merge |
+| [x] | 4/6 | `⚙️ [fast-new-session-launch] feat(client): open launching sessions immediately [step 4/6]` | Merged in #913 |
+| [ ] | 4A | `⚙️ Rename generated session branches after launch` | Ready for review |
+| [ ] | 5/6 | `🌱 [fast-new-session-launch] docs: define launch regression coverage [step 5/6]` | Blocked on follow-up 4A merge |
 | [ ] | 6/6 | `🌿 [fast-new-session-launch] test: verify faster new-session launch [step 6/6]` | Blocked on Step 5 merge |
 
 ## Step 1 Checklist
@@ -139,11 +146,27 @@
 - [x] Regenerate Freezed/localization output and pass focused tests plus strict
   analysis across all touched owning modules and the downstream mobile app.
 
+## Follow-up 4A Checklist
+
+- [x] Restore typed generated `branchName` consumption while continuing to
+  ignore the auth response's obsolete `worktreeName`.
+- [x] Keep local branch/worktree creation and the canonical response independent
+  from metadata latency or failure.
+- [x] Rename only a root dedicated worktree still on its initial branch with no
+  upstream; leave its directory and plugin working path unchanged.
+- [x] Validate the generated ref, apply bounded secure collision fallback, and
+  preserve the initial branch on every ineligible/failure outcome.
+- [x] Persist durable/current branch facts under the session-family lane and emit
+  existing `session.updated` with `titleChanged: false`.
+- [x] Preserve independent title application and tracked shutdown ownership.
+- [ ] Run codegen, focused tests, strict analysis, cleanup/analytics assessment,
+  and architecture reviews; commit, push, open the standalone PR, and monitor it.
+
 ## Cleanup Ledger
 
 | Artifact | Decision | Owning step |
 |---|---|---|
-| Layer-skipping `MetadataService` and AI branch/worktree response fields | Replaced with shared typed request plus title-only API/repository and regenerated | 3 |
+| Layer-skipping `MetadataService` and AI branch/worktree response fields | Replaced with shared typed request plus title/branch API response; obsolete worktree response remains ignored | 3 + 4A |
 | Preferred-name API/validator and tests | Delete | 2 |
 | Current `session-*` random fallback | Replace with color-animal plus bounded suffix fallback | 2 |
 | Synchronous generated-title await | Deleted from response path | 3 |
@@ -153,7 +176,7 @@
 | Direct mobile `cue` dependency | Delete if no consumer remains | 4 |
 | Friendly rotating-copy timer | Keep one instance in exported `module_prego` launch status | 4 |
 | Composer submission bytes/text snapshot | Release on success/restoration or when a background request settles; never persist attachments | 4 |
-| Auth response branch/worktree keys | Defer for released-bridge compatibility | External follow-up |
+| Auth response branch/worktree keys | Keep branch as live 4A input; defer worktree removal for released-bridge compatibility | 4A + external follow-up |
 | Pending session/idempotency/detail staged load | Explicitly out of scope | Separate evidence-backed work |
 
 ## Verification Record
@@ -225,6 +248,23 @@
 - Step 4 post-Step-3-merge handoff passed 177 focused app routing/launch/detail
   tests, 65 bridge relay/orchestrator tests, and strict analysis in `client/app`
   and `bridge/app`.
+- Follow-up 4A codegen completed for `bridge/app`.
+- Follow-up 4A focused verification passed, 179 tests before architecture fixes
+  and 115 directly affected tests after them; the complete `bridge/app` suite
+  passed all 2,635 tests.
+- Follow-up 4A strict analysis: `dart analyze --fatal-infos` from `bridge/app`
+  passed with no issues.
+- Follow-up 4A architecture implementation review found API DTO leakage through
+  the metadata and Git repository boundaries. Both findings were applied; the
+  permitted second review approved the implementation with no remaining
+  architecture findings.
+- Follow-up 4A analytics assessment: no event added because there is no product
+  decision or funnel step tied to background branch refinement, and branch names
+  are explicitly prohibited analytics data.
+- Informational follow-up 4A diff before delivery: `+1079 / -127` (1,206 changed
+  lines), above the 350-700 target. This includes 264 plan/tracker lines, 33
+  generated model lines, and 582 test lines covering Git eligibility, collisions,
+  response timing, conditional persistence, rollback, events, and shutdown.
 
 ### Manual matrix
 
@@ -245,3 +285,7 @@ and complete detail snapshot under matched baseline/final conditions.
   API/repository layers; `module_prego` launch primitive with app-owned copy.
 - **Consistency corrections:** one-shot attachment consumption, initial
   backend-title semantics, and penultimate-doc-step rationale.
+- **Follow-up 4A review:** approved after clarifying that the deployed auth
+  metadata contract requires sanitized `title`, `branchName`, and
+  `worktreeName`; the bridge restores `branchName` consumption while continuing
+  to ignore `worktreeName`.

--- a/.plan/active/fast-new-session-launch/TRACKER.md
+++ b/.plan/active/fast-new-session-launch/TRACKER.md
@@ -261,11 +261,14 @@
 - Follow-up 4A analytics assessment: no event added because there is no product
   decision or funnel step tied to background branch refinement, and branch names
   are explicitly prohibited analytics data.
-- Informational follow-up 4A diff before delivery: `+1079 / -127` (1,206 changed
-  lines), above the 350-700 target. This includes 264 plan/tracker lines, 33
+- Informational follow-up 4A diff before delivery, measured against implementation
+  base `f7bcdc63e`: `+1079 / -127` (1,206 changed lines), above the 350-700
+  target. This includes 264 plan/tracker lines, 33
   generated model lines, and 582 test lines covering Git eligibility, collisions,
   response timing, conditional persistence, rollback, events, and shutdown.
 - Follow-up 4A PR: #923, based on `main` and monitored.
+- Follow-up 4A review fixes passed 144 focused tests, all 2,641 `bridge/app`
+  tests, strict analysis, and `git diff --check`.
 
 ### Manual matrix
 

--- a/.plan/active/fast-new-session-launch/TRACKER.md
+++ b/.plan/active/fast-new-session-launch/TRACKER.md
@@ -5,10 +5,10 @@
 - **Plan slug:** `fast-new-session-launch`
 - **Implementation base:** `origin/main` at `f7bcdc63e` after Step 4 merge
 - **Current branch:** `async-generated-session-branch-rename`
-- **Series state:** Steps 1-4/6 merged; approved standalone follow-up 4A is ready
-  for review before Step 5
-- **Current step:** deliver asynchronous generated branch refinement
-- **Next action:** open and monitor the standalone follow-up 4A PR
+- **Series state:** Steps 1-4/6 merged; standalone follow-up 4A is in review in
+  PR #923 before Step 5
+- **Current step:** monitor asynchronous generated branch refinement
+- **Next action:** merge PR #923, then continue to Step 5
 
 ## Locked Decisions
 
@@ -86,7 +86,7 @@
 | [x] | 2/6 | `🌿 [fast-new-session-launch] feat(bridge): use local workspace names [step 2/6]` | Merged in #908 |
 | [x] | 3/6 | `🚧 [fast-new-session-launch] feat(bridge): return sessions before generated titles [step 3/6]` | Merged in #909 |
 | [x] | 4/6 | `⚙️ [fast-new-session-launch] feat(client): open launching sessions immediately [step 4/6]` | Merged in #913 |
-| [ ] | 4A | `⚙️ Rename generated session branches after launch` | Ready for review |
+| [ ] | 4A | `⚙️ Rename generated session branches after launch` | PR #923 open and monitored |
 | [ ] | 5/6 | `🌱 [fast-new-session-launch] docs: define launch regression coverage [step 5/6]` | Blocked on follow-up 4A merge |
 | [ ] | 6/6 | `🌿 [fast-new-session-launch] test: verify faster new-session launch [step 6/6]` | Blocked on Step 5 merge |
 
@@ -159,7 +159,7 @@
 - [x] Persist durable/current branch facts under the session-family lane and emit
   existing `session.updated` with `titleChanged: false`.
 - [x] Preserve independent title application and tracked shutdown ownership.
-- [ ] Run codegen, focused tests, strict analysis, cleanup/analytics assessment,
+- [x] Run codegen, focused tests, strict analysis, cleanup/analytics assessment,
   and architecture reviews; commit, push, open the standalone PR, and monitor it.
 
 ## Cleanup Ledger
@@ -265,6 +265,7 @@
   lines), above the 350-700 target. This includes 264 plan/tracker lines, 33
   generated model lines, and 582 test lines covering Git eligibility, collisions,
   response timing, conditional persistence, rollback, events, and shutdown.
+- Follow-up 4A PR: #923, based on `main` and monitored.
 
 ### Manual matrix
 

--- a/bridge/app/lib/src/api/database/daos/session_dao.dart
+++ b/bridge/app/lib/src/api/database/daos/session_dao.dart
@@ -83,6 +83,24 @@ class SessionDao(super.attachedDatabase) extends DatabaseAccessor<AppDatabase> w
     return updatedRows == 1;
   }
 
+  Future<bool> replaceGeneratedBranch({
+    required String sessionId,
+    required String expectedBranchName,
+    required String branchName,
+  }) async {
+    final updatedRows =
+        await (update(sessionTable)..where(
+              (table) => table.sessionId.equals(sessionId) & table.branchName.equals(expectedBranchName),
+            ))
+            .write(
+              SessionTableCompanion(
+                branchName: Value(branchName),
+                currentBranchName: Value(branchName),
+              ),
+            );
+    return updatedRows == 1;
+  }
+
   /// Records a delete tombstone for [backendSessionId]. Idempotent — re-deleting an
   /// already-tombstoned session keeps the original timestamp.
   Future<void> insertSessionTombstone({

--- a/bridge/app/lib/src/api/database/daos/session_dao.dart
+++ b/bridge/app/lib/src/api/database/daos/session_dao.dart
@@ -90,7 +90,12 @@ class SessionDao(super.attachedDatabase) extends DatabaseAccessor<AppDatabase> w
   }) async {
     final updatedRows =
         await (update(sessionTable)..where(
-              (table) => table.sessionId.equals(sessionId) & table.branchName.equals(expectedBranchName),
+              (table) =>
+                  table.sessionId.equals(sessionId) &
+                  table.branchName.equals(expectedBranchName) &
+                  (table.currentBranchName.isNull() |
+                      table.currentBranchName.equals(expectedBranchName) |
+                      table.currentBranchName.equals(branchName)),
             ))
             .write(
               SessionTableCompanion(

--- a/bridge/app/lib/src/api/generate_session_metadata_response.dart
+++ b/bridge/app/lib/src/api/generate_session_metadata_response.dart
@@ -5,7 +5,7 @@ part "generate_session_metadata_response.g.dart";
 
 @Freezed(fromJson: true, toJson: false)
 sealed class GenerateSessionMetadataResponse with _$GenerateSessionMetadataResponse {
-  const factory({required String title}) = _GenerateSessionMetadataResponse;
+  const factory({required String title, required String branchName}) = _GenerateSessionMetadataResponse;
 
   factory fromJson(Map<String, dynamic> json) => _$GenerateSessionMetadataResponseFromJson(json);
 }

--- a/bridge/app/lib/src/api/generate_session_metadata_response.freezed.dart
+++ b/bridge/app/lib/src/api/generate_session_metadata_response.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$GenerateSessionMetadataResponse {
 
- String get title;
+ String get title; String get branchName;
 /// Create a copy of GenerateSessionMetadataResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -27,16 +27,16 @@ $GenerateSessionMetadataResponseCopyWith<GenerateSessionMetadataResponse> get co
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is GenerateSessionMetadataResponse&&(identical(other.title, title) || other.title == title));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GenerateSessionMetadataResponse&&(identical(other.title, title) || other.title == title)&&(identical(other.branchName, branchName) || other.branchName == branchName));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,title);
+int get hashCode => Object.hash(runtimeType,title,branchName);
 
 @override
 String toString() {
-  return 'GenerateSessionMetadataResponse(title: $title)';
+  return 'GenerateSessionMetadataResponse(title: $title, branchName: $branchName)';
 }
 
 
@@ -47,7 +47,7 @@ abstract mixin class $GenerateSessionMetadataResponseCopyWith<$Res>  {
   factory $GenerateSessionMetadataResponseCopyWith(GenerateSessionMetadataResponse value, $Res Function(GenerateSessionMetadataResponse) _then) = _$GenerateSessionMetadataResponseCopyWithImpl;
 @useResult
 $Res call({
- String title
+ String title, String branchName
 });
 
 
@@ -64,9 +64,10 @@ class _$GenerateSessionMetadataResponseCopyWithImpl<$Res>
 
 /// Create a copy of GenerateSessionMetadataResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? title = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? title = null,Object? branchName = null,}) {
   return _then(GenerateSessionMetadataResponse(
 title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,branchName: null == branchName ? _self.branchName : branchName // ignore: cast_nullable_to_non_nullable
 as String,
   ));
 }
@@ -79,10 +80,11 @@ as String,
 @JsonSerializable(createToJson: false)
 
 class _GenerateSessionMetadataResponse implements GenerateSessionMetadataResponse {
-  const _GenerateSessionMetadataResponse({required this.title});
+  const _GenerateSessionMetadataResponse({required this.title, required this.branchName});
   factory _GenerateSessionMetadataResponse.fromJson(Map<String, dynamic> json) => _$GenerateSessionMetadataResponseFromJson(json);
 
 @override final  String title;
+@override final  String branchName;
 
 /// Create a copy of GenerateSessionMetadataResponse
 /// with the given fields replaced by the non-null parameter values.
@@ -94,16 +96,16 @@ _$GenerateSessionMetadataResponseCopyWith<_GenerateSessionMetadataResponse> get 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GenerateSessionMetadataResponse&&(identical(other.title, title) || other.title == title));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GenerateSessionMetadataResponse&&(identical(other.title, title) || other.title == title)&&(identical(other.branchName, branchName) || other.branchName == branchName));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,title);
+int get hashCode => Object.hash(runtimeType,title,branchName);
 
 @override
 String toString() {
-  return 'GenerateSessionMetadataResponse(title: $title)';
+  return 'GenerateSessionMetadataResponse(title: $title, branchName: $branchName)';
 }
 
 
@@ -114,7 +116,7 @@ abstract mixin class _$GenerateSessionMetadataResponseCopyWith<$Res> implements 
   factory _$GenerateSessionMetadataResponseCopyWith(_GenerateSessionMetadataResponse value, $Res Function(_GenerateSessionMetadataResponse) _then) = __$GenerateSessionMetadataResponseCopyWithImpl;
 @override @useResult
 $Res call({
- String title
+ String title, String branchName
 });
 
 
@@ -131,9 +133,10 @@ class __$GenerateSessionMetadataResponseCopyWithImpl<$Res>
 
 /// Create a copy of GenerateSessionMetadataResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? title = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? title = null,Object? branchName = null,}) {
   return _then(_GenerateSessionMetadataResponse(
 title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,branchName: null == branchName ? _self.branchName : branchName // ignore: cast_nullable_to_non_nullable
 as String,
   ));
 }

--- a/bridge/app/lib/src/api/generate_session_metadata_response.g.dart
+++ b/bridge/app/lib/src/api/generate_session_metadata_response.g.dart
@@ -8,4 +8,7 @@ part of 'generate_session_metadata_response.dart';
 
 _GenerateSessionMetadataResponse _$GenerateSessionMetadataResponseFromJson(
   Map json,
-) => _GenerateSessionMetadataResponse(title: json['title'] as String);
+) => _GenerateSessionMetadataResponse(
+  title: json['title'] as String,
+  branchName: json['branchName'] as String,
+);

--- a/bridge/app/lib/src/bridge/api/git_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/git_cli_api.dart
@@ -262,6 +262,18 @@ class GitCliApi({
     return result.stdout.toString().trim().isNotEmpty;
   }
 
+  Future<bool> hasRemoteBranch({
+    required String projectPath,
+    required String branchName,
+  }) async {
+    final arguments = ["for-each-ref", "--format=%(refname)", "refs/remotes/*/$branchName"];
+    final result = await runGit(projectPath: projectPath, arguments: arguments);
+    if (result.exitCode != 0) {
+      throw ProcessException("git", arguments, result.stderr.toString(), result.exitCode);
+    }
+    return result.stdout.toString().trim().isNotEmpty;
+  }
+
   Future<void> renameBranch({
     required String projectPath,
     required String oldBranchName,

--- a/bridge/app/lib/src/bridge/api/git_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/git_cli_api.dart
@@ -244,6 +244,38 @@ class GitCliApi({
     return result.stdout.toString().trim().isNotEmpty;
   }
 
+  Future<bool> isValidBranchName({required String branchName}) async {
+    final arguments = ["check-ref-format", "--branch", branchName];
+    final result = await runGit(projectPath: ".", arguments: arguments);
+    if (result.exitCode == 0) return true;
+    if (result.exitCode == 1) return false;
+    throw ProcessException("git", arguments, result.stderr.toString(), result.exitCode);
+  }
+
+  Future<bool> hasUpstream({
+    required String projectPath,
+    required String branchName,
+  }) async {
+    final arguments = ["for-each-ref", "--format=%(upstream)", "refs/heads/$branchName"];
+    final result = await runGit(projectPath: projectPath, arguments: arguments);
+    if (result.exitCode != 0) {
+      throw ProcessException("git", arguments, result.stderr.toString(), result.exitCode);
+    }
+    return result.stdout.toString().trim().isNotEmpty;
+  }
+
+  Future<void> renameBranch({
+    required String projectPath,
+    required String oldBranchName,
+    required String newBranchName,
+  }) async {
+    final arguments = ["branch", "-m", "--", oldBranchName, newBranchName];
+    final result = await runGit(projectPath: projectPath, arguments: arguments);
+    if (result.exitCode != 0) {
+      throw ProcessException("git", arguments, result.stderr.toString(), result.exitCode);
+    }
+  }
+
   Future<bool> createWorktree({
     required String projectPath,
     required String worktreePath,

--- a/bridge/app/lib/src/bridge/api/git_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/git_cli_api.dart
@@ -247,9 +247,7 @@ class GitCliApi({
   Future<bool> isValidBranchName({required String branchName}) async {
     final arguments = ["check-ref-format", "--branch", branchName];
     final result = await runGit(projectPath: ".", arguments: arguments);
-    if (result.exitCode == 0) return true;
-    if (result.exitCode == 1) return false;
-    throw ProcessException("git", arguments, result.stderr.toString(), result.exitCode);
+    return result.exitCode == 0 && result.stdout.toString().trim() == branchName;
   }
 
   Future<bool> hasUpstream({
@@ -284,7 +282,7 @@ class GitCliApi({
   }) async {
     final result = await runGit(
       projectPath: projectPath,
-      arguments: ["worktree", "add", "-b", branchName, "--", worktreePath, startPoint],
+      arguments: ["worktree", "add", "-b", branchName, "--no-track", "--", worktreePath, startPoint],
     );
     return result.exitCode == 0;
   }

--- a/bridge/app/lib/src/bridge/api/git_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/git_cli_api.dart
@@ -266,12 +266,29 @@ class GitCliApi({
     required String projectPath,
     required String branchName,
   }) async {
-    final arguments = ["for-each-ref", "--format=%(refname)", "refs/remotes/*/$branchName"];
-    final result = await runGit(projectPath: projectPath, arguments: arguments);
-    if (result.exitCode != 0) {
-      throw ProcessException("git", arguments, result.stderr.toString(), result.exitCode);
+    const remoteArguments = ["remote"];
+    final remotesResult = await runGit(projectPath: projectPath, arguments: remoteArguments);
+    if (remotesResult.exitCode != 0) {
+      throw ProcessException("git", remoteArguments, remotesResult.stderr.toString(), remotesResult.exitCode);
     }
-    return result.stdout.toString().trim().isNotEmpty;
+    final remoteNames = remotesResult.stdout
+        .toString()
+        .split("\n")
+        .map((remote) => remote.trim())
+        .where((remote) => remote.isNotEmpty);
+    final matchingRefs = {for (final remote in remoteNames) "refs/remotes/$remote/$branchName"};
+    if (matchingRefs.isEmpty) return false;
+
+    const refArguments = ["for-each-ref", "--format=%(refname)", "refs/remotes"];
+    final refsResult = await runGit(projectPath: projectPath, arguments: refArguments);
+    if (refsResult.exitCode != 0) {
+      throw ProcessException("git", refArguments, refsResult.stderr.toString(), refsResult.exitCode);
+    }
+    return refsResult.stdout
+        .toString()
+        .split("\n")
+        .map((ref) => ref.trim())
+        .any(matchingRefs.contains);
   }
 
   Future<void> renameBranch({

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -275,6 +275,7 @@ class Orchestrator({
     final sessionMutationDispatcher = SessionMutationDispatcher(
       sessionRepository: sessionRepository,
       sessionOperationDispatcher: sessionOperationDispatcher,
+      worktreeService: worktreeService,
     );
     final pushTracker = PushSessionStateTracker(now: clock.now);
     final pushRateLimiter = PushRateLimiter(now: clock.now);
@@ -676,6 +677,7 @@ class Orchestrator({
       pluginId: session.pluginId,
       event: switch (mutation) {
         SessionTitleUpdated() => BridgeSseSessionUpdated(info: session.toJson(), titleChanged: true),
+        SessionBranchUpdated() => BridgeSseSessionUpdated(info: session.toJson(), titleChanged: false),
         SessionDeleted() => BridgeSseSessionDeleted(info: session.toJson()),
       },
     );

--- a/bridge/app/lib/src/bridge/repositories/models/session_operation.dart
+++ b/bridge/app/lib/src/bridge/repositories/models/session_operation.dart
@@ -2,6 +2,7 @@ enum SessionOperation() {
   createSession,
   renameSession,
   applyGeneratedTitle,
+  applyGeneratedBranchName,
   getCommands,
   sendCommand,
   sendPrompt,

--- a/bridge/app/lib/src/bridge/repositories/pull_request_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/pull_request_repository.dart
@@ -34,7 +34,8 @@ class PullRequestRepository({
           final current = currentById[captured.id];
           if (current == null ||
               current.projectId != captured.projectId ||
-              current.parentSessionId != captured.parentSessionId) {
+              current.parentSessionId != captured.parentSessionId ||
+              current.branchName != captured.branchName) {
             continue;
           }
           if (current.directory != captured.directory) {

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -390,6 +390,19 @@ class SessionRepository({
     return updated ? await getCatalogSession(sessionId: sessionId) : null;
   }
 
+  Future<Session?> replaceGeneratedSessionBranch({
+    required String sessionId,
+    required String expectedBranchName,
+    required String branchName,
+  }) async {
+    final updated = await _sessionDao.replaceGeneratedBranch(
+      sessionId: sessionId,
+      expectedBranchName: expectedBranchName,
+      branchName: branchName,
+    );
+    return updated ? await getCatalogSession(sessionId: sessionId) : null;
+  }
+
   Future<bool> isSessionTombstoned({required String sessionId}) async {
     if (_deletedSessionIds.contains(sessionId)) return true;
     final binding = await _sessionDao.getSession(sessionId: sessionId);

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -390,17 +390,16 @@ class SessionRepository({
     return updated ? await getCatalogSession(sessionId: sessionId) : null;
   }
 
-  Future<Session?> replaceGeneratedSessionBranch({
+  Future<bool> replaceGeneratedSessionBranch({
     required String sessionId,
     required String expectedBranchName,
     required String branchName,
-  }) async {
-    final updated = await _sessionDao.replaceGeneratedBranch(
+  }) {
+    return _sessionDao.replaceGeneratedBranch(
       sessionId: sessionId,
       expectedBranchName: expectedBranchName,
       branchName: branchName,
     );
-    return updated ? await getCatalogSession(sessionId: sessionId) : null;
   }
 
   Future<bool> isSessionTombstoned({required String sessionId}) async {

--- a/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
@@ -73,6 +73,37 @@ class WorktreeRepository({
     return _gitApi.branchExists(projectPath: projectPath, branchName: branchName);
   }
 
+  Future<String?> getCurrentBranchName({required String worktreePath}) async {
+    final result = await _gitApi.getCurrentBranch(projectPath: worktreePath);
+    return switch (result) {
+      GitCurrentBranchNamed(:final branchName) => branchName,
+      _ => null,
+    };
+  }
+
+  Future<bool> isValidBranchName({required String branchName}) {
+    return _gitApi.isValidBranchName(branchName: branchName);
+  }
+
+  Future<bool> hasUpstream({
+    required String worktreePath,
+    required String branchName,
+  }) {
+    return _gitApi.hasUpstream(projectPath: worktreePath, branchName: branchName);
+  }
+
+  Future<void> renameBranch({
+    required String worktreePath,
+    required String oldBranchName,
+    required String newBranchName,
+  }) {
+    return _gitApi.renameBranch(
+      projectPath: worktreePath,
+      oldBranchName: oldBranchName,
+      newBranchName: newBranchName,
+    );
+  }
+
   Future<bool> createWorktree({
     required String projectPath,
     required String worktreePath,

--- a/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
@@ -92,6 +92,13 @@ class WorktreeRepository({
     return _gitApi.hasUpstream(projectPath: worktreePath, branchName: branchName);
   }
 
+  Future<bool> hasRemoteBranch({
+    required String worktreePath,
+    required String branchName,
+  }) {
+    return _gitApi.hasRemoteBranch(projectPath: worktreePath, branchName: branchName);
+  }
+
   Future<void> renameBranch({
     required String worktreePath,
     required String oldBranchName,

--- a/bridge/app/lib/src/bridge/services/session_creation_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_creation_service.dart
@@ -272,20 +272,20 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
     }
 
     try {
-      await _sessionMutationDispatcher.applyGeneratedBranchName(
-        sessionId: session.id,
-        branchName: metadata.branchName,
-      );
-    } on Object catch (error, stackTrace) {
-      Log.w("Failed to apply generated branch for session ${session.id}", error, stackTrace);
-    }
-    try {
       await _sessionMutationDispatcher.applyGeneratedTitle(
         sessionId: session.id,
         title: metadata.title,
       );
     } on Object catch (error, stackTrace) {
       Log.w("Failed to apply generated title for session ${session.id}", error, stackTrace);
+    }
+    try {
+      await _sessionMutationDispatcher.applyGeneratedBranchName(
+        sessionId: session.id,
+        branchName: metadata.branchName,
+      );
+    } on Object catch (error, stackTrace) {
+      Log.w("Failed to apply generated branch for session ${session.id}", error, stackTrace);
     }
   }
 

--- a/bridge/app/lib/src/bridge/services/session_creation_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_creation_service.dart
@@ -15,8 +15,8 @@ class SessionCreationService({
   required final SessionRepository _sessionRepository,
   required final SessionMutationDispatcher _sessionMutationDispatcher,
 }) {
-  final Set<Future<void>> _lateTitleWork = <Future<void>>{};
-  bool _acceptingLateTitles = true;
+  final Set<Future<void>> _lateMetadataWork = <Future<void>>{};
+  bool _acceptingLateMetadata = true;
   Future<void>? _drainFuture;
 
   Future<Session> createSession({required CreateSessionRequest request}) async {
@@ -78,13 +78,13 @@ class SessionCreationService({
       agent: request.agent,
       model: request.model,
     );
-    _startLateTitle(session: created, firstText: firstText);
+    _startLateMetadata(session: created, firstText: firstText);
     return created;
   }
 
   void beginShutdown() {
-    if (!_acceptingLateTitles) return;
-    _acceptingLateTitles = false;
+    if (!_acceptingLateMetadata) return;
+    _acceptingLateMetadata = false;
     _sessionMetadataRepository.beginShutdown();
   }
 
@@ -236,42 +236,62 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
 ''';
   }
 
-  void _startLateTitle({required Session session, required String? firstText}) {
-    if (!_acceptingLateTitles || firstText == null) return;
+  void _startLateMetadata({required Session session, required String? firstText}) {
+    if (!_acceptingLateMetadata || firstText == null) return;
     late final Future<void> work;
-    work = _generateAndApplyTitle(session: session, firstText: firstText).whenComplete(() {
-      _lateTitleWork.remove(work);
+    work = _generateAndApplyMetadata(session: session, firstText: firstText).whenComplete(() {
+      _lateMetadataWork.remove(work);
     });
-    _lateTitleWork.add(work);
+    _lateMetadataWork.add(work);
   }
 
-  Future<void> _generateAndApplyTitle({required Session session, required String firstText}) async {
+  Future<void> _generateAndApplyMetadata({required Session session, required String firstText}) async {
+    final GeneratedSessionMetadata metadata;
     try {
-      final title = await _sessionMetadataRepository.generateTitle(
+      metadata = await _sessionMetadataRepository.generateMetadata(
         firstMessage: firstText,
       );
-      await _sessionMutationDispatcher.applyGeneratedTitle(sessionId: session.id, title: title);
     } on SessionMetadataRequestAbortedException catch (error) {
-      if (!_acceptingLateTitles) return;
+      if (!_acceptingLateMetadata) return;
       Log.w(
-        "Generated-title request was aborted for session ${session.id}",
+        "Generated-metadata request was aborted for session ${session.id}",
         error.innerError,
         error.innerStackTrace,
       );
+      return;
     } on SessionMetadataInvalidResponseException catch (error) {
       Log.w(
-        "Failed to generate title for session ${session.id}",
+        "Failed to generate metadata for session ${session.id}",
         error.innerError,
         error.innerStackTrace,
       );
+      return;
     } on Object catch (error, stackTrace) {
-      Log.w("Failed to generate title for session ${session.id}", error, stackTrace);
+      Log.w("Failed to generate metadata for session ${session.id}", error, stackTrace);
+      return;
+    }
+
+    try {
+      await _sessionMutationDispatcher.applyGeneratedBranchName(
+        sessionId: session.id,
+        branchName: metadata.branchName,
+      );
+    } on Object catch (error, stackTrace) {
+      Log.w("Failed to apply generated branch for session ${session.id}", error, stackTrace);
+    }
+    try {
+      await _sessionMutationDispatcher.applyGeneratedTitle(
+        sessionId: session.id,
+        title: metadata.title,
+      );
+    } on Object catch (error, stackTrace) {
+      Log.w("Failed to apply generated title for session ${session.id}", error, stackTrace);
     }
   }
 
   Future<void> _drain() async {
     beginShutdown();
-    await Future.wait(_lateTitleWork.toList(growable: false));
+    await Future.wait(_lateMetadataWork.toList(growable: false));
   }
 }
 

--- a/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
@@ -149,9 +149,9 @@ class SessionMutationDispatcher({
     if (rename is GeneratedBranchRenameSkipped) return null;
     final generatedBranchName = (rename as GeneratedBranchRenamed).branchName;
 
-    final Session? updated;
+    final bool persisted;
     try {
-      updated = await _sessionRepository.replaceGeneratedSessionBranch(
+      persisted = await _sessionRepository.replaceGeneratedSessionBranch(
         sessionId: sessionId,
         expectedBranchName: initialBranchName,
         branchName: generatedBranchName,
@@ -173,15 +173,25 @@ class SessionMutationDispatcher({
       Error.throwWithStackTrace(error, stackTrace);
     }
 
-    if (updated == null) {
-      await _worktreeService.rollbackGeneratedBranchRename(
-        worktreePath: worktreePath,
-        generatedBranchName: generatedBranchName,
-        initialBranchName: initialBranchName,
-      );
-      Log.w("Generated branch persistence changed for session $sessionId; restored its initial branch");
+    if (!persisted) {
+      try {
+        await _worktreeService.rollbackGeneratedBranchRename(
+          worktreePath: worktreePath,
+          generatedBranchName: generatedBranchName,
+          initialBranchName: initialBranchName,
+        );
+        Log.w("Generated branch persistence changed for session $sessionId; restored its initial branch");
+      } on Object catch (rollbackError, rollbackStackTrace) {
+        Log.w(
+          "Could not roll back a generated branch after conditional persistence changed for session $sessionId",
+          rollbackError,
+          rollbackStackTrace,
+        );
+      }
       return null;
     }
+    final updated = await _sessionRepository.getCatalogSession(sessionId: sessionId);
+    if (updated == null) return null;
     _mutationsController.add(LocalSessionMutation.branchUpdated(session: updated));
     return updated;
   }

--- a/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
@@ -7,14 +7,19 @@ import "../repositories/models/session_operation.dart";
 import "../repositories/session_repository.dart";
 import "session_cleanup_result.dart";
 import "session_operation_dispatcher.dart";
+import "worktree_service.dart";
 
 sealed class const LocalSessionMutation({required final Session session}) {
   const factory titleUpdated({required Session session}) = SessionTitleUpdated;
+
+  const factory branchUpdated({required Session session}) = SessionBranchUpdated;
 
   const factory deleted({required Session session}) = SessionDeleted;
 }
 
 final class const SessionTitleUpdated({required super.session}) extends LocalSessionMutation;
+
+final class const SessionBranchUpdated({required super.session}) extends LocalSessionMutation;
 
 final class const SessionDeleted({required super.session}) extends LocalSessionMutation;
 
@@ -22,6 +27,7 @@ final class const SessionDeleted({required super.session}) extends LocalSessionM
 class SessionMutationDispatcher({
   required final SessionRepository _sessionRepository,
   required final SessionOperationDispatcher _sessionOperationDispatcher,
+  required final WorktreeService _worktreeService,
 }) {
   final StreamController<LocalSessionMutation> _mutationsController = StreamController<LocalSessionMutation>.broadcast(
     sync: true,
@@ -46,6 +52,21 @@ class SessionMutationDispatcher({
       sessionId: sessionId,
       operation: SessionOperation.applyGeneratedTitle,
       body: () => _applyGeneratedTitleAlreadyReserved(sessionId: sessionId, title: title),
+    );
+  }
+
+  Future<Session?> applyGeneratedBranchName({
+    required String sessionId,
+    required String branchName,
+  }) {
+    if (_disposed) return Future.error(StateError("SessionMutationDispatcher is disposed"));
+    return _sessionOperationDispatcher.dispatch(
+      sessionId: sessionId,
+      operation: SessionOperation.applyGeneratedBranchName,
+      body: () => _applyGeneratedBranchNameAlreadyReserved(
+        sessionId: sessionId,
+        branchName: branchName,
+      ),
     );
   }
 
@@ -102,6 +123,66 @@ class SessionMutationDispatcher({
     if (updated == null) return null;
     _mutationsController.add(LocalSessionMutation.titleUpdated(session: updated));
     await _propagateTitle(sessionId: sessionId, title: title);
+    return updated;
+  }
+
+  Future<Session?> _applyGeneratedBranchNameAlreadyReserved({
+    required String sessionId,
+    required String branchName,
+  }) async {
+    final stored = await _sessionRepository.getStoredSession(sessionId: sessionId);
+    final worktreePath = stored?.worktreePath;
+    final initialBranchName = stored?.branchName;
+    if (stored == null ||
+        stored.parentSessionId != null ||
+        !stored.isDedicated ||
+        worktreePath == null ||
+        initialBranchName == null) {
+      return null;
+    }
+
+    final rename = await _worktreeService.renameGeneratedBranch(
+      worktreePath: worktreePath,
+      initialBranchName: initialBranchName,
+      generatedBranchName: branchName,
+    );
+    if (rename is GeneratedBranchRenameSkipped) return null;
+    final generatedBranchName = (rename as GeneratedBranchRenamed).branchName;
+
+    final Session? updated;
+    try {
+      updated = await _sessionRepository.replaceGeneratedSessionBranch(
+        sessionId: sessionId,
+        expectedBranchName: initialBranchName,
+        branchName: generatedBranchName,
+      );
+    } on Object catch (error, stackTrace) {
+      try {
+        await _worktreeService.rollbackGeneratedBranchRename(
+          worktreePath: worktreePath,
+          generatedBranchName: generatedBranchName,
+          initialBranchName: initialBranchName,
+        );
+      } on Object catch (rollbackError, rollbackStackTrace) {
+        Log.w(
+          "Could not roll back an unpersisted generated branch rename for session $sessionId",
+          rollbackError,
+          rollbackStackTrace,
+        );
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+
+    if (updated == null) {
+      await _worktreeService.rollbackGeneratedBranchRename(
+        worktreePath: worktreePath,
+        generatedBranchName: generatedBranchName,
+        initialBranchName: initialBranchName,
+      );
+      Log.w("Generated branch persistence changed for session $sessionId; restored its initial branch");
+      return null;
+    }
+    _mutationsController.add(LocalSessionMutation.branchUpdated(session: updated));
     return updated;
   }
 

--- a/bridge/app/lib/src/bridge/services/worktree_service.dart
+++ b/bridge/app/lib/src/bridge/services/worktree_service.dart
@@ -329,6 +329,7 @@ class WorktreeService({required final WorktreeRepository _worktreeRepository}) {
       String? availableBranchName;
       for (var attempt = 0; attempt < _maxWorktreeCreationAttempts; attempt++) {
         final candidate = "$generatedBranchName-${_hexSuffix((suffixOffset + attempt) % _suffixSpace)}";
+        if (!await _worktreeRepository.isValidBranchName(branchName: candidate)) continue;
         if (!await _worktreeRepository.branchExists(
           projectPath: worktreePath,
           branchName: candidate,
@@ -348,7 +349,25 @@ class WorktreeService({required final WorktreeRepository _worktreeRepository}) {
       oldBranchName: initialBranchName,
       newBranchName: targetBranchName,
     );
-    final confirmedBranchName = await _worktreeRepository.getCurrentBranchName(worktreePath: worktreePath);
+    final String? confirmedBranchName;
+    try {
+      confirmedBranchName = await _worktreeRepository.getCurrentBranchName(worktreePath: worktreePath);
+    } on Object catch (error, stackTrace) {
+      try {
+        await rollbackGeneratedBranchRename(
+          worktreePath: worktreePath,
+          generatedBranchName: targetBranchName,
+          initialBranchName: initialBranchName,
+        );
+      } on Object catch (rollbackError, rollbackStackTrace) {
+        Log.w(
+          "Could not roll back generated branch after confirmation failed in $worktreePath",
+          rollbackError,
+          rollbackStackTrace,
+        );
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    }
     if (confirmedBranchName == targetBranchName) {
       return GeneratedBranchRenamed(branchName: targetBranchName);
     }

--- a/bridge/app/lib/src/bridge/services/worktree_service.dart
+++ b/bridge/app/lib/src/bridge/services/worktree_service.dart
@@ -325,8 +325,8 @@ class WorktreeService({required final WorktreeRepository _worktreeRepository}) {
     }
 
     var targetBranchName = generatedBranchName;
-    if (await _worktreeRepository.branchExists(
-      projectPath: worktreePath,
+    if (await _branchExistsLocallyOrRemotely(
+      worktreePath: worktreePath,
       branchName: targetBranchName,
     )) {
       final suffixOffset = _random.nextInt(_suffixSpace);
@@ -334,8 +334,8 @@ class WorktreeService({required final WorktreeRepository _worktreeRepository}) {
       for (var attempt = 0; attempt < _maxWorktreeCreationAttempts; attempt++) {
         final candidate = "$generatedBranchName-${_hexSuffix((suffixOffset + attempt) % _suffixSpace)}";
         if (!await _worktreeRepository.isValidBranchName(branchName: candidate)) continue;
-        if (!await _worktreeRepository.branchExists(
-          projectPath: worktreePath,
+        if (!await _branchExistsLocallyOrRemotely(
+          worktreePath: worktreePath,
           branchName: candidate,
         )) {
           availableBranchName = candidate;
@@ -382,6 +382,20 @@ class WorktreeService({required final WorktreeRepository _worktreeRepository}) {
       initialBranchName: initialBranchName,
     );
     return GeneratedBranchRenameSkipped(reason: GeneratedBranchRenameSkipReason.initialBranchChanged);
+  }
+
+  Future<bool> _branchExistsLocallyOrRemotely({
+    required String worktreePath,
+    required String branchName,
+  }) async {
+    return await _worktreeRepository.branchExists(
+          projectPath: worktreePath,
+          branchName: branchName,
+        ) ||
+        await _worktreeRepository.hasRemoteBranch(
+          worktreePath: worktreePath,
+          branchName: branchName,
+        );
   }
 
   Future<void> rollbackGeneratedBranchRename({

--- a/bridge/app/lib/src/bridge/services/worktree_service.dart
+++ b/bridge/app/lib/src/bridge/services/worktree_service.dart
@@ -316,7 +316,11 @@ class WorktreeService({required final WorktreeRepository _worktreeRepository}) {
     if (await _worktreeRepository.hasUpstream(
       worktreePath: worktreePath,
       branchName: initialBranchName,
-    )) {
+    ) ||
+        await _worktreeRepository.hasRemoteBranch(
+          worktreePath: worktreePath,
+          branchName: initialBranchName,
+        )) {
       return GeneratedBranchRenameSkipped(reason: GeneratedBranchRenameSkipReason.initialBranchPublished);
     }
 

--- a/bridge/app/lib/src/bridge/services/worktree_service.dart
+++ b/bridge/app/lib/src/bridge/services/worktree_service.dart
@@ -297,6 +297,82 @@ class WorktreeService({required final WorktreeRepository _worktreeRepository}) {
   static String _workspaceSlug({required int colorIndex, required int animalIndex}) =>
       "${_workspaceColors[colorIndex]}-${_workspaceAnimals[animalIndex]}";
 
+  Future<GeneratedBranchRenameResult> renameGeneratedBranch({
+    required String worktreePath,
+    required String initialBranchName,
+    required String generatedBranchName,
+  }) async {
+    if (generatedBranchName == initialBranchName) {
+      return GeneratedBranchRenameSkipped(reason: GeneratedBranchRenameSkipReason.unchanged);
+    }
+    if (!await _worktreeRepository.isValidBranchName(branchName: generatedBranchName)) {
+      return GeneratedBranchRenameSkipped(reason: GeneratedBranchRenameSkipReason.invalidGeneratedName);
+    }
+
+    final currentBranchName = await _worktreeRepository.getCurrentBranchName(worktreePath: worktreePath);
+    if (currentBranchName != initialBranchName) {
+      return GeneratedBranchRenameSkipped(reason: GeneratedBranchRenameSkipReason.initialBranchChanged);
+    }
+    if (await _worktreeRepository.hasUpstream(
+      worktreePath: worktreePath,
+      branchName: initialBranchName,
+    )) {
+      return GeneratedBranchRenameSkipped(reason: GeneratedBranchRenameSkipReason.initialBranchPublished);
+    }
+
+    var targetBranchName = generatedBranchName;
+    if (await _worktreeRepository.branchExists(
+      projectPath: worktreePath,
+      branchName: targetBranchName,
+    )) {
+      final suffixOffset = _random.nextInt(_suffixSpace);
+      String? availableBranchName;
+      for (var attempt = 0; attempt < _maxWorktreeCreationAttempts; attempt++) {
+        final candidate = "$generatedBranchName-${_hexSuffix((suffixOffset + attempt) % _suffixSpace)}";
+        if (!await _worktreeRepository.branchExists(
+          projectPath: worktreePath,
+          branchName: candidate,
+        )) {
+          availableBranchName = candidate;
+          break;
+        }
+      }
+      if (availableBranchName == null) {
+        return GeneratedBranchRenameSkipped(reason: GeneratedBranchRenameSkipReason.targetCollisions);
+      }
+      targetBranchName = availableBranchName;
+    }
+
+    await _worktreeRepository.renameBranch(
+      worktreePath: worktreePath,
+      oldBranchName: initialBranchName,
+      newBranchName: targetBranchName,
+    );
+    final confirmedBranchName = await _worktreeRepository.getCurrentBranchName(worktreePath: worktreePath);
+    if (confirmedBranchName == targetBranchName) {
+      return GeneratedBranchRenamed(branchName: targetBranchName);
+    }
+
+    await rollbackGeneratedBranchRename(
+      worktreePath: worktreePath,
+      generatedBranchName: targetBranchName,
+      initialBranchName: initialBranchName,
+    );
+    return GeneratedBranchRenameSkipped(reason: GeneratedBranchRenameSkipReason.initialBranchChanged);
+  }
+
+  Future<void> rollbackGeneratedBranchRename({
+    required String worktreePath,
+    required String generatedBranchName,
+    required String initialBranchName,
+  }) {
+    return _worktreeRepository.renameBranch(
+      worktreePath: worktreePath,
+      oldBranchName: generatedBranchName,
+      newBranchName: initialBranchName,
+    );
+  }
+
   Future<String?> resolveHeadCommit({
     required String projectId,
   }) async {

--- a/bridge/app/lib/src/bridge/worktree_types.dart
+++ b/bridge/app/lib/src/bridge/worktree_types.dart
@@ -18,3 +18,18 @@ class WorktreeSuccess({
 }) extends WorktreeResult;
 
 class WorktreeFallback({required final String originalPath, required final String reason}) extends WorktreeResult;
+
+enum GeneratedBranchRenameSkipReason() {
+  invalidGeneratedName,
+  initialBranchChanged,
+  initialBranchPublished,
+  targetCollisions,
+  unchanged,
+}
+
+sealed class GeneratedBranchRenameResult();
+
+class GeneratedBranchRenamed({required final String branchName}) extends GeneratedBranchRenameResult;
+
+class GeneratedBranchRenameSkipped({required final GeneratedBranchRenameSkipReason reason})
+    extends GeneratedBranchRenameResult;

--- a/bridge/app/lib/src/repositories/session_metadata_repository.dart
+++ b/bridge/app/lib/src/repositories/session_metadata_repository.dart
@@ -5,6 +5,8 @@ import "package:sesori_shared/sesori_shared.dart" show GenerateSessionMetadataRe
 
 import "../api/sesori_server_api.dart";
 
+typedef GeneratedSessionMetadata = ({String title, String branchName});
+
 class SessionMetadataRequestAbortedException({
   required final Object innerError,
   required final StackTrace innerStackTrace,
@@ -23,14 +25,14 @@ class SessionMetadataRepository({required final SesoriServerApi _api}) {
 
   void beginShutdown() => _abortSignal.abort();
 
-  Future<String> generateTitle({required String firstMessage}) async {
+  Future<GeneratedSessionMetadata> generateMetadata({required String firstMessage}) async {
     final normalizedFirstMessage = _clipFirstMessage(firstMessage);
     try {
       final response = await _api.generateSessionMetadata(
         request: GenerateSessionMetadataRequest(firstMessage: normalizedFirstMessage),
         abortSignal: _abortSignal,
       );
-      return response.title;
+      return (title: response.title, branchName: response.branchName);
     } on http.RequestAbortedException catch (error, stackTrace) {
       throw SessionMetadataRequestAbortedException(innerError: error, innerStackTrace: stackTrace);
     } on SesoriServerApiResponseException catch (error, stackTrace) {

--- a/bridge/app/test/api/sesori_server_api_test.dart
+++ b/bridge/app/test/api/sesori_server_api_test.dart
@@ -85,7 +85,7 @@ void main() {
   });
 
   group("SesoriServerApi session metadata", () {
-    test("acquires token and posts typed request while decoding title-only response", () async {
+    test("acquires token and posts typed request while decoding title and branch", () async {
       late http.Request request;
       final tokenRefresher = _FakeTokenRefresher(token: "secret-token");
       final api = SesoriServerApi(
@@ -93,7 +93,7 @@ void main() {
         client: MockClient((incoming) async {
           request = incoming;
           return http.Response(
-            '{"title":"Generated title","branchName":"ignored","worktreeName":"ignored"}',
+            '{"title":"Generated title","branchName":"generated-branch","worktreeName":"ignored"}',
             200,
           );
         }),
@@ -107,6 +107,7 @@ void main() {
       );
 
       expect(response.title, equals("Generated title"));
+      expect(response.branchName, equals("generated-branch"));
       expect(tokenRefresher.forceRefreshValues, equals([false]));
       expect(request.method, equals("POST"));
       expect(request.url, equals(Uri.parse("https://auth.example.test/sessions/generate-metadata")));
@@ -124,7 +125,7 @@ void main() {
           requests.add(request);
           return request.headers["Authorization"] == "Bearer stale"
               ? http.Response("unauthorized", 401)
-              : http.Response('{"title":"Retried"}', 200);
+              : http.Response('{"title":"Retried","branchName":"retried-branch"}', 200);
         }),
         requestDeadline: const Duration(seconds: 1),
         tokenRefresher: tokenRefresher,
@@ -136,6 +137,7 @@ void main() {
       );
 
       expect(response.title, equals("Retried"));
+      expect(response.branchName, equals("retried-branch"));
       expect(tokenRefresher.forceRefreshValues, equals([false, true]));
       expect(requests, hasLength(2));
       expect(requests.last.headers["Authorization"], equals("Bearer fresh"));
@@ -292,7 +294,9 @@ void main() {
     });
 
     test("releases shutdown listener after completed response", () async {
-      final client = _ImmediateClient(responseBody: '{"title":"Generated title"}');
+      final client = _ImmediateClient(
+        responseBody: '{"title":"Generated title","branchName":"generated-branch"}',
+      );
       final abortSignal = SesoriServerRequestAbortSignal();
       final api = SesoriServerApi(
         authBackendUrl: "https://auth.example.test",

--- a/bridge/app/test/bridge/api/git_cli_api_test.dart
+++ b/bridge/app/test/bridge/api/git_cli_api_test.dart
@@ -141,6 +141,27 @@ void main() {
     ]);
   });
 
+  test("hasRemoteBranch finds the exact branch name under any remote", () async {
+    final processRunner = _RecordingProcessRunner(
+      stdout: "refs/remotes/origin/HEAD\nrefs/remotes/origin/initial-branch\n",
+    );
+    final api = GitCliApi(
+      processRunner: processRunner,
+      gitPathExists: ({required String gitPath}) => true,
+    );
+
+    expect(
+      await api.hasRemoteBranch(projectPath: "/worktree", branchName: "initial-branch"),
+      isTrue,
+    );
+    expect(processRunner.workingDirectory, "/worktree");
+    expect(processRunner.arguments, [
+      "for-each-ref",
+      "--format=%(refname)",
+      "refs/remotes/*/initial-branch",
+    ]);
+  });
+
   test("renameBranch uses explicit old and new refs and preserves failures", () async {
     final processRunner = _RecordingProcessRunner();
     final api = GitCliApi(

--- a/bridge/app/test/bridge/api/git_cli_api_test.dart
+++ b/bridge/app/test/bridge/api/git_cli_api_test.dart
@@ -105,8 +105,13 @@ void main() {
   });
 
   test("isValidBranchName delegates to git check-ref-format", () async {
-    for (final testCase in [(exitCode: 0, expected: true), (exitCode: 1, expected: false)]) {
-      final processRunner = _RecordingProcessRunner(exitCode: testCase.exitCode);
+    for (final testCase in [
+      (exitCode: 0, stdout: "generated-branch\n", expected: true),
+      (exitCode: 1, stdout: "", expected: false),
+      (exitCode: 128, stdout: "", expected: false),
+      (exitCode: 0, stdout: "previous-branch\n", expected: false),
+    ]) {
+      final processRunner = _RecordingProcessRunner(exitCode: testCase.exitCode, stdout: testCase.stdout);
       final api = GitCliApi(
         processRunner: processRunner,
         gitPathExists: ({required String gitPath}) => true,

--- a/bridge/app/test/bridge/api/git_cli_api_test.dart
+++ b/bridge/app/test/bridge/api/git_cli_api_test.dart
@@ -103,6 +103,74 @@ void main() {
       throwsA(isA<ProcessException>()),
     );
   });
+
+  test("isValidBranchName delegates to git check-ref-format", () async {
+    for (final testCase in [(exitCode: 0, expected: true), (exitCode: 1, expected: false)]) {
+      final processRunner = _RecordingProcessRunner(exitCode: testCase.exitCode);
+      final api = GitCliApi(
+        processRunner: processRunner,
+        gitPathExists: ({required String gitPath}) => true,
+      );
+
+      expect(await api.isValidBranchName(branchName: "generated-branch"), testCase.expected);
+      expect(processRunner.arguments, ["check-ref-format", "--branch", "generated-branch"]);
+    }
+  });
+
+  test("hasUpstream reads the exact local branch ref", () async {
+    final processRunner = _RecordingProcessRunner(stdout: "refs/remotes/origin/initial-branch\n");
+    final api = GitCliApi(
+      processRunner: processRunner,
+      gitPathExists: ({required String gitPath}) => true,
+    );
+
+    expect(
+      await api.hasUpstream(projectPath: "/worktree", branchName: "initial-branch"),
+      isTrue,
+    );
+    expect(processRunner.workingDirectory, "/worktree");
+    expect(processRunner.arguments, [
+      "for-each-ref",
+      "--format=%(upstream)",
+      "refs/heads/initial-branch",
+    ]);
+  });
+
+  test("renameBranch uses explicit old and new refs and preserves failures", () async {
+    final processRunner = _RecordingProcessRunner();
+    final api = GitCliApi(
+      processRunner: processRunner,
+      gitPathExists: ({required String gitPath}) => true,
+    );
+
+    await api.renameBranch(
+      projectPath: "/worktree",
+      oldBranchName: "initial-branch",
+      newBranchName: "generated-branch",
+    );
+
+    expect(processRunner.workingDirectory, "/worktree");
+    expect(processRunner.arguments, [
+      "branch",
+      "-m",
+      "--",
+      "initial-branch",
+      "generated-branch",
+    ]);
+
+    final failingApi = GitCliApi(
+      processRunner: _RecordingProcessRunner(exitCode: 128, stderr: "rename failed"),
+      gitPathExists: ({required String gitPath}) => true,
+    );
+    await expectLater(
+      failingApi.renameBranch(
+        projectPath: "/worktree",
+        oldBranchName: "initial-branch",
+        newBranchName: "generated-branch",
+      ),
+      throwsA(isA<ProcessException>()),
+    );
+  });
 }
 
 class _RecordingProcessRunner({final String stdout = "", final String stderr = "", final int exitCode = 0})

--- a/bridge/app/test/bridge/api/git_cli_api_test.dart
+++ b/bridge/app/test/bridge/api/git_cli_api_test.dart
@@ -143,7 +143,15 @@ void main() {
 
   test("hasRemoteBranch finds the exact branch name under any remote", () async {
     final processRunner = _RecordingProcessRunner(
-      stdout: "refs/remotes/origin/HEAD\nrefs/remotes/origin/initial-branch\n",
+      results: [
+        ProcessResult(1, 0, "origin\nteam/origin\n", ""),
+        ProcessResult(
+          1,
+          0,
+          "refs/remotes/origin/HEAD\nrefs/remotes/team/origin/initial-branch\n",
+          "",
+        ),
+      ],
     );
     final api = GitCliApi(
       processRunner: processRunner,
@@ -155,10 +163,9 @@ void main() {
       isTrue,
     );
     expect(processRunner.workingDirectory, "/worktree");
-    expect(processRunner.arguments, [
-      "for-each-ref",
-      "--format=%(refname)",
-      "refs/remotes/*/initial-branch",
+    expect(processRunner.invocations, [
+      ["remote"],
+      ["for-each-ref", "--format=%(refname)", "refs/remotes"],
     ]);
   });
 
@@ -199,9 +206,15 @@ void main() {
   });
 }
 
-class _RecordingProcessRunner({final String stdout = "", final String stderr = "", final int exitCode = 0})
+class _RecordingProcessRunner({
+  final String stdout = "",
+  final String stderr = "",
+  final int exitCode = 0,
+  final List<ProcessResult>? results,
+})
     implements ProcessRunner {
   List<String>? arguments;
+  final List<List<String>> invocations = [];
   String? workingDirectory;
   Map<String, String>? environment;
 
@@ -215,8 +228,10 @@ class _RecordingProcessRunner({final String stdout = "", final String stderr = "
   }) async {
     expect(executable, "git");
     this.arguments = arguments;
+    invocations.add(arguments);
     this.workingDirectory = workingDirectory;
     this.environment = environment;
+    if (results case final results? when results.isNotEmpty) return results.removeAt(0);
     return ProcessResult(1, exitCode, stdout, stderr);
   }
 

--- a/bridge/app/test/bridge/repositories/pull_request_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/pull_request_repository_test.dart
@@ -230,6 +230,33 @@ void main() {
       expect(changed, {projectId});
     });
 
+    test("does not apply a target captured before the durable branch changed", () async {
+      await _insertRoot(
+        database: db,
+        sessionId: "worktree-root",
+        worktreePath: "/worktree",
+        creationBranch: "blue-otter",
+      );
+      final captured = await _storedSessions(database: db);
+      await db.sessionDao.replaceGeneratedBranch(
+        sessionId: "worktree-root",
+        expectedBranchName: "blue-otter",
+        branchName: "fix-login-flow",
+      );
+
+      final changed = await repository.applyResolvedTargets(
+        sessionsByProject: {projectId: captured},
+        targetsByDirectory: const {
+          "/worktree": PullRequestLocalBranchDirectoryTarget(branchName: "blue-otter"),
+        },
+      );
+
+      final session = await db.sessionDao.getSession(sessionId: "worktree-root");
+      expect(session?.branchName, "fix-login-flow");
+      expect(session?.currentBranchName, "fix-login-flow");
+      expect(changed, isEmpty);
+    });
+
     test("prepares the verified account without fabricating missing projects", () async {
       await _insertRoot(
         database: db,

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -86,6 +86,7 @@ void main() {
       sessionMutationDispatcher = SessionMutationDispatcher(
         sessionRepository: sessionRepository,
         sessionOperationDispatcher: sessionOperationDispatcher,
+        worktreeService: worktreeService,
       );
       sessionCreationService = SessionCreationService(
         sessionMetadataRepository: metadataRepository,
@@ -483,6 +484,7 @@ void main() {
       final localMutationDispatcher = SessionMutationDispatcher(
         sessionRepository: localRepository,
         sessionOperationDispatcher: localOperationDispatcher,
+        worktreeService: worktreeService,
       );
       final localCreationService = SessionCreationService(
         sessionMetadataRepository: metadataRepository,
@@ -1033,6 +1035,7 @@ void main() {
       final orderedMutationDispatcher = SessionMutationDispatcher(
         sessionRepository: orderedRepository,
         sessionOperationDispatcher: orderedOperationDispatcher,
+        worktreeService: worktreeService,
       );
       final orderedCreationService = SessionCreationService(
         sessionMetadataRepository: metadataRepository,
@@ -1230,6 +1233,7 @@ void main() {
       final throwingDispatcher = SessionMutationDispatcher(
         sessionRepository: throwingRepository,
         sessionOperationDispatcher: throwingOperationDispatcher,
+        worktreeService: worktreeService,
       );
       final localCreationService = SessionCreationService(
         sessionMetadataRepository: metadataRepository,
@@ -1278,6 +1282,9 @@ class _FakeWorktreeService({required AppDatabase database}) extends WorktreeServ
     reason: "default",
   );
   String? resolveHeadCommitResult;
+  GeneratedBranchRenameResult renameResult = GeneratedBranchRenameSkipped(
+    reason: GeneratedBranchRenameSkipReason.initialBranchChanged,
+  );
 
   this
     : super(
@@ -1311,6 +1318,13 @@ class _FakeWorktreeService({required AppDatabase database}) extends WorktreeServ
     lastResolveHeadProjectId = projectId;
     return resolveHeadCommitResult;
   }
+
+  @override
+  Future<GeneratedBranchRenameResult> renameGeneratedBranch({
+    required String worktreePath,
+    required String initialBranchName,
+    required String generatedBranchName,
+  }) async => renameResult;
 }
 
 class _NoopProcessRunner() implements ProcessRunner {

--- a/bridge/app/test/bridge/routing/delete_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/delete_session_handler_test.dart
@@ -51,6 +51,7 @@ void main() {
       sessionMutationDispatcher = SessionMutationDispatcher(
         sessionRepository: sessionRepository,
         sessionOperationDispatcher: sessionOperationDispatcher,
+        worktreeService: worktreeService,
       );
       final sessionLifecycleService = SessionLifecycleService(
         worktreeService: worktreeService,

--- a/bridge/app/test/bridge/routing/rename_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/rename_session_handler_test.dart
@@ -7,6 +7,7 @@ import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.
 import "package:sesori_bridge/src/bridge/routing/rename_session_handler.dart";
 import "package:sesori_bridge/src/bridge/services/session_mutation_dispatcher.dart";
 import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
+import "package:sesori_bridge/src/bridge/services/worktree_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -37,6 +38,7 @@ void main() {
       sessionMutationDispatcher = SessionMutationDispatcher(
         sessionRepository: sessionRepository,
         sessionOperationDispatcher: sessionOperationDispatcher,
+        worktreeService: _UnusedWorktreeService(),
       );
       handler = RenameSessionHandler(sessionMutationDispatcher: sessionMutationDispatcher);
       await sessionRepository.insertStoredSession(
@@ -242,4 +244,9 @@ void main() {
       expect(plugin.lastRenameSessionId, isNull);
     });
   });
+}
+
+class _UnusedWorktreeService() implements WorktreeService {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -569,15 +569,19 @@ class FakeSessionDao() {
 /// Hand-written fake [SessionMetadataRepository] for testing.
 class FakeSessionMetadataRepository() implements SessionMetadataRepository {
   String? generateResult = "Generated title";
+  String generatedBranchName = "generated-branch";
   String? lastGenerateMessage;
 
   @override
   void beginShutdown() {}
 
   @override
-  Future<String> generateTitle({required String firstMessage}) async {
+  Future<GeneratedSessionMetadata> generateMetadata({required String firstMessage}) async {
     lastGenerateMessage = firstMessage;
-    return generateResult ?? (throw StateError("metadata unavailable"));
+    return (
+      title: generateResult ?? (throw StateError("metadata unavailable")),
+      branchName: generatedBranchName,
+    );
   }
 }
 
@@ -848,6 +852,13 @@ class _NoopSessionRepository() implements SessionRepository {
 
   @override
   Future<Session?> setGeneratedSessionTitleIfAbsent({required String sessionId, required String title}) async => null;
+
+  @override
+  Future<Session?> replaceGeneratedSessionBranch({
+    required String sessionId,
+    required String expectedBranchName,
+    required String branchName,
+  }) async => null;
 
   @override
   Future<DeletedSessionSubtree> deleteSession({required String sessionId}) async => _deletedSession(sessionId);
@@ -1154,6 +1165,13 @@ class FakeSessionRepository({
       lastUserActivityAt: stored.lastUserMessageAt,
     );
   }
+
+  @override
+  Future<Session?> replaceGeneratedSessionBranch({
+    required String sessionId,
+    required String expectedBranchName,
+    required String branchName,
+  }) async => null;
 
   @override
   Future<DeletedSessionSubtree> deleteSession({required String sessionId}) async => _deletedSession(sessionId);

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -854,11 +854,11 @@ class _NoopSessionRepository() implements SessionRepository {
   Future<Session?> setGeneratedSessionTitleIfAbsent({required String sessionId, required String title}) async => null;
 
   @override
-  Future<Session?> replaceGeneratedSessionBranch({
+  Future<bool> replaceGeneratedSessionBranch({
     required String sessionId,
     required String expectedBranchName,
     required String branchName,
-  }) async => null;
+  }) async => false;
 
   @override
   Future<DeletedSessionSubtree> deleteSession({required String sessionId}) async => _deletedSession(sessionId);
@@ -1167,11 +1167,11 @@ class FakeSessionRepository({
   }
 
   @override
-  Future<Session?> replaceGeneratedSessionBranch({
+  Future<bool> replaceGeneratedSessionBranch({
     required String sessionId,
     required String expectedBranchName,
     required String branchName,
-  }) async => null;
+  }) async => false;
 
   @override
   Future<DeletedSessionSubtree> deleteSession({required String sessionId}) async => _deletedSession(sessionId);

--- a/bridge/app/test/bridge/services/session_creation_service_test.dart
+++ b/bridge/app/test/bridge/services/session_creation_service_test.dart
@@ -390,6 +390,43 @@ void main() {
       expect(stored?.title, "Generated title");
     });
 
+    test("applies the generated title without waiting for branch refinement", () async {
+      final renameStarted = Completer<void>();
+      final renameGate = Completer<void>();
+      worktreeService
+        ..prepareResult = WorktreeSuccess(
+          path: "/repo/.worktrees/blue-otter",
+          branchName: "blue-otter",
+          baseBranch: "main",
+          baseCommit: "abc123",
+        )
+        ..renameStarted = renameStarted
+        ..renameGate = renameGate.future;
+
+      final created = await service.createSession(
+        request: const CreateSessionRequest(
+          projectId: "/repo",
+          pluginId: "fake",
+          dedicatedWorktree: true,
+          parts: [PromptPart.text(text: "Build it")],
+          variant: null,
+          agent: null,
+          model: null,
+          command: null,
+        ),
+      );
+      await renameStarted.future;
+
+      try {
+        final whileBranchBlocked = await db.sessionDao.getSession(sessionId: created.id);
+        expect(whileBranchBlocked?.title, "Generated title");
+        expect(whileBranchBlocked?.branchName, "blue-otter");
+      } finally {
+        renameGate.complete();
+        await service.drain();
+      }
+    });
+
     test("projects every nonblank user text part without bridge-owned context", () async {
       worktreeService.prepareResult = WorktreeSuccess(
         path: "/repo/.worktrees/session-one",
@@ -600,6 +637,8 @@ class _FakeWorktreeService({required super.worktreeRepository}) extends Worktree
   String? renamedWorktreePath;
   String? renamedInitialBranchName;
   String? renamedGeneratedBranchName;
+  Completer<void>? renameStarted;
+  Future<void>? renameGate;
 
   @override
   Future<WorktreeResult> prepareWorktreeForSession({
@@ -629,6 +668,8 @@ class _FakeWorktreeService({required super.worktreeRepository}) extends Worktree
     renamedWorktreePath = worktreePath;
     renamedInitialBranchName = initialBranchName;
     renamedGeneratedBranchName = generatedBranchName;
+    renameStarted?.complete();
+    if (renameGate case final gate?) await gate;
     if (renameError case final error?) throw error;
     return renameResult;
   }

--- a/bridge/app/test/bridge/services/session_creation_service_test.dart
+++ b/bridge/app/test/bridge/services/session_creation_service_test.dart
@@ -55,6 +55,7 @@ void main() {
       mutationDispatcher = SessionMutationDispatcher(
         sessionRepository: repository,
         sessionOperationDispatcher: operationDispatcher,
+        worktreeService: worktreeService,
       );
       service = SessionCreationService(
         sessionMetadataRepository: metadataRepository,
@@ -118,6 +119,7 @@ void main() {
       final localMutationDispatcher = SessionMutationDispatcher(
         sessionRepository: repository,
         sessionOperationDispatcher: localOperationDispatcher,
+        worktreeService: worktreeService,
       );
       final localService = SessionCreationService(
         sessionMetadataRepository: metadataRepository,
@@ -248,6 +250,7 @@ void main() {
       final localMutationDispatcher = SessionMutationDispatcher(
         sessionRepository: repository,
         sessionOperationDispatcher: localOperationDispatcher,
+        worktreeService: worktreeService,
       );
       final localService = SessionCreationService(
         sessionMetadataRepository: metadataRepository,
@@ -315,6 +318,76 @@ void main() {
       expect(plugin.lastCreateUserVisibleText, "Build it");
       expect(plugin.lastCreateParts, hasLength(2));
       expect(plugin.lastCreateParts?.last, const PluginPromptPart.text(text: "Build it"));
+    });
+
+    test("applies dedicated-session metadata after returning the initial branch", () async {
+      final metadataGate = Completer<void>();
+      metadataRepository.generateGate = metadataGate.future;
+      worktreeService
+        ..prepareResult = WorktreeSuccess(
+          path: "/repo/.worktrees/blue-otter",
+          branchName: "blue-otter",
+          baseBranch: "main",
+          baseCommit: "abc123",
+        )
+        ..renameResult = GeneratedBranchRenamed(branchName: "generated-branch");
+
+      final created = await service
+          .createSession(
+            request: const CreateSessionRequest(
+              projectId: "/repo",
+              pluginId: "fake",
+              dedicatedWorktree: true,
+              parts: [PromptPart.text(text: "Build it")],
+              variant: null,
+              agent: null,
+              model: null,
+              command: null,
+            ),
+          )
+          .timeout(const Duration(seconds: 1));
+
+      expect((await db.sessionDao.getSession(sessionId: created.id))?.branchName, "blue-otter");
+      expect(worktreeService.renameCalls, isZero);
+
+      metadataGate.complete();
+      await service.drain();
+
+      final stored = await db.sessionDao.getSession(sessionId: created.id);
+      expect(stored?.branchName, "generated-branch");
+      expect(stored?.currentBranchName, "generated-branch");
+      expect(stored?.title, "Generated title");
+      expect(worktreeService.renamedWorktreePath, "/repo/.worktrees/blue-otter");
+      expect(worktreeService.renamedInitialBranchName, "blue-otter");
+    });
+
+    test("still applies the generated title when branch rename fails", () async {
+      worktreeService
+        ..prepareResult = WorktreeSuccess(
+          path: "/repo/.worktrees/blue-otter",
+          branchName: "blue-otter",
+          baseBranch: "main",
+          baseCommit: "abc123",
+        )
+        ..renameError = StateError("branch rename failed");
+
+      final created = await service.createSession(
+        request: const CreateSessionRequest(
+          projectId: "/repo",
+          pluginId: "fake",
+          dedicatedWorktree: true,
+          parts: [PromptPart.text(text: "Build it")],
+          variant: null,
+          agent: null,
+          model: null,
+          command: null,
+        ),
+      );
+      await service.drain();
+
+      final stored = await db.sessionDao.getSession(sessionId: created.id);
+      expect(stored?.branchName, "blue-otter");
+      expect(stored?.title, "Generated title");
     });
 
     test("projects every nonblank user text part without bridge-owned context", () async {
@@ -465,7 +538,7 @@ class _FakeSessionMetadataRepository() implements SessionMetadataRepository {
   }
 
   @override
-  Future<String> generateTitle({required String firstMessage}) async {
+  Future<GeneratedSessionMetadata> generateMetadata({required String firstMessage}) async {
     generateCalls++;
     if (generateStarted case final started? when !started.isCompleted) started.complete();
     if (abortOnShutdown) {
@@ -478,7 +551,10 @@ class _FakeSessionMetadataRepository() implements SessionMetadataRepository {
     }
     if (generateGate case final gate?) await gate;
     if (failure case final error?) throw error;
-    return "Generated title";
+    return (
+      title: "Generated title",
+      branchName: "generated-branch",
+    );
   }
 }
 
@@ -515,6 +591,15 @@ class _FakeWorktreeService({required super.worktreeRepository}) extends Worktree
   Completer<void>? prepareStarted;
   WorktreeResult prepareResult = WorktreeFallback(originalPath: "/repo", reason: "fallback");
   String? headCommit;
+  GeneratedBranchRenameResult renameResult = GeneratedBranchRenameSkipped(
+    reason: GeneratedBranchRenameSkipReason.initialBranchChanged,
+  );
+  Object? renameError;
+  int renameCalls = 0;
+  int rollbackCalls = 0;
+  String? renamedWorktreePath;
+  String? renamedInitialBranchName;
+  String? renamedGeneratedBranchName;
 
   @override
   Future<WorktreeResult> prepareWorktreeForSession({
@@ -532,6 +617,29 @@ class _FakeWorktreeService({required super.worktreeRepository}) extends Worktree
   }) async {
     resolveCalls++;
     return headCommit;
+  }
+
+  @override
+  Future<GeneratedBranchRenameResult> renameGeneratedBranch({
+    required String worktreePath,
+    required String initialBranchName,
+    required String generatedBranchName,
+  }) async {
+    renameCalls++;
+    renamedWorktreePath = worktreePath;
+    renamedInitialBranchName = initialBranchName;
+    renamedGeneratedBranchName = generatedBranchName;
+    if (renameError case final error?) throw error;
+    return renameResult;
+  }
+
+  @override
+  Future<void> rollbackGeneratedBranchRename({
+    required String worktreePath,
+    required String generatedBranchName,
+    required String initialBranchName,
+  }) async {
+    rollbackCalls++;
   }
 }
 

--- a/bridge/app/test/bridge/services/session_family_mutation_test.dart
+++ b/bridge/app/test/bridge/services/session_family_mutation_test.dart
@@ -264,11 +264,12 @@ class _Fixture() {
   this {
     repository = _FamilyRepository();
     operations = SessionOperationDispatcher(sessionRepository: repository);
+    worktree = _FamilyWorktreeService();
     mutations = SessionMutationDispatcher(
       sessionRepository: repository,
       sessionOperationDispatcher: operations,
+      worktreeService: worktree,
     );
-    worktree = _FamilyWorktreeService();
     lifecycle = SessionLifecycleService(
       worktreeService: worktree,
       sessionRepository: repository,

--- a/bridge/app/test/bridge/services/session_mutation_dispatcher_test.dart
+++ b/bridge/app/test/bridge/services/session_mutation_dispatcher_test.dart
@@ -6,6 +6,7 @@ import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.
 import "package:sesori_bridge/src/bridge/services/session_cleanup_result.dart";
 import "package:sesori_bridge/src/bridge/services/session_mutation_dispatcher.dart";
 import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
+import "package:sesori_bridge/src/bridge/services/worktree_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
@@ -18,6 +19,7 @@ void main() {
     late SessionOperationDispatcher operationDispatcher;
     late SessionMutationDispatcher dispatcher;
     late _FakeDerivedPlugin plugin;
+    late _FakeWorktreeService worktreeService;
 
     setUp(() {
       db = createTestDatabase();
@@ -30,9 +32,11 @@ void main() {
         unseenCalculator: const SessionUnseenCalculator(),
       );
       operationDispatcher = SessionOperationDispatcher(sessionRepository: repository);
+      worktreeService = _FakeWorktreeService();
       dispatcher = SessionMutationDispatcher(
         sessionRepository: repository,
         sessionOperationDispatcher: operationDispatcher,
+        worktreeService: worktreeService,
       );
     });
 
@@ -42,16 +46,20 @@ void main() {
       await db.close();
     });
 
-    Future<void> insertSession() async {
+    Future<void> insertSession({
+      bool isDedicated = false,
+      String? worktreePath,
+      String? branchName,
+    }) async {
       await repository.insertStoredSession(
         sessionId: "s1",
         backendSessionId: "backend-s1",
         pluginId: "codex",
         projectId: "/repo",
-        isDedicated: false,
+        isDedicated: isDedicated,
         createdAt: 1,
-        worktreePath: null,
-        branchName: null,
+        worktreePath: worktreePath,
+        branchName: branchName,
         baseBranch: null,
         baseCommit: null,
         agent: null,
@@ -174,6 +182,80 @@ void main() {
       expect(plugin.renameCalls, 1);
     });
 
+    test("persists a generated branch and emits the updated session", () async {
+      await insertSession(
+        isDedicated: true,
+        worktreePath: "/repo/.worktrees/blue-otter",
+        branchName: "blue-otter",
+      );
+      worktreeService.renameResult = GeneratedBranchRenamed(branchName: "fix-login-flow");
+      final mutations = <LocalSessionMutation>[];
+      final subscription = dispatcher.mutations.listen(mutations.add);
+
+      final updated = await dispatcher.applyGeneratedBranchName(
+        sessionId: "s1",
+        branchName: "fix-login-flow",
+      );
+
+      final stored = await db.sessionDao.getSession(sessionId: "s1");
+      expect(updated?.branchName, "fix-login-flow");
+      expect(stored?.branchName, "fix-login-flow");
+      expect(stored?.currentBranchName, "fix-login-flow");
+      expect(worktreeService.renameCalls, 1);
+      expect(
+        mutations.single,
+        isA<SessionBranchUpdated>().having(
+          (mutation) => mutation.session.branchName,
+          "branchName",
+          "fix-login-flow",
+        ),
+      );
+      await subscription.cancel();
+    });
+
+    test("rolls back Git when conditional branch persistence loses", () async {
+      await insertSession(
+        isDedicated: true,
+        worktreePath: "/repo/.worktrees/blue-otter",
+        branchName: "blue-otter",
+      );
+      worktreeService
+        ..renameResult = GeneratedBranchRenamed(branchName: "fix-login-flow")
+        ..onRename = () async {
+          await db.sessionDao.replaceGeneratedBranch(
+            sessionId: "s1",
+            expectedBranchName: "blue-otter",
+            branchName: "user-branch",
+          );
+        };
+      final mutations = <LocalSessionMutation>[];
+      final subscription = dispatcher.mutations.listen(mutations.add);
+
+      final updated = await dispatcher.applyGeneratedBranchName(
+        sessionId: "s1",
+        branchName: "fix-login-flow",
+      );
+
+      expect(updated, isNull);
+      expect(worktreeService.rollbackCalls, 1);
+      expect((await db.sessionDao.getSession(sessionId: "s1"))?.branchName, "user-branch");
+      expect(mutations, isEmpty);
+      await subscription.cancel();
+    });
+
+    test("does not invoke Git for an in-place session", () async {
+      await insertSession();
+
+      expect(
+        await dispatcher.applyGeneratedBranchName(
+          sessionId: "s1",
+          branchName: "fix-login-flow",
+        ),
+        isNull,
+      );
+      expect(worktreeService.renameCalls, isZero);
+    });
+
     test("owns repository deletion and typed deleted mutations", () async {
       await insertSession();
       final events = expectLater(
@@ -201,6 +283,42 @@ void main() {
       );
     });
   });
+}
+
+class _FakeWorktreeService() implements WorktreeService {
+  GeneratedBranchRenameResult renameResult = GeneratedBranchRenameSkipped(
+    reason: GeneratedBranchRenameSkipReason.initialBranchChanged,
+  );
+  Object? renameError;
+  Object? rollbackError;
+  int renameCalls = 0;
+  int rollbackCalls = 0;
+  Future<void> Function()? onRename;
+
+  @override
+  Future<GeneratedBranchRenameResult> renameGeneratedBranch({
+    required String worktreePath,
+    required String initialBranchName,
+    required String generatedBranchName,
+  }) async {
+    renameCalls++;
+    if (onRename case final callback?) await callback();
+    if (renameError case final error?) throw error;
+    return renameResult;
+  }
+
+  @override
+  Future<void> rollbackGeneratedBranchRename({
+    required String worktreePath,
+    required String generatedBranchName,
+    required String initialBranchName,
+  }) async {
+    rollbackCalls++;
+    if (rollbackError case final error?) throw error;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _FakeDerivedPlugin() implements BridgeDerivedProjectsPluginApi {

--- a/bridge/app/test/bridge/services/session_mutation_dispatcher_test.dart
+++ b/bridge/app/test/bridge/services/session_mutation_dispatcher_test.dart
@@ -243,6 +243,33 @@ void main() {
       await subscription.cancel();
     });
 
+    test("contains rollback failure when conditional branch persistence loses", () async {
+      await insertSession(
+        isDedicated: true,
+        worktreePath: "/repo/.worktrees/blue-otter",
+        branchName: "blue-otter",
+      );
+      worktreeService
+        ..renameResult = GeneratedBranchRenamed(branchName: "fix-login-flow")
+        ..rollbackError = StateError("rollback failed")
+        ..onRename = () async {
+          await db.sessionDao.replaceGeneratedBranch(
+            sessionId: "s1",
+            expectedBranchName: "blue-otter",
+            branchName: "user-branch",
+          );
+        };
+
+      expect(
+        await dispatcher.applyGeneratedBranchName(
+          sessionId: "s1",
+          branchName: "fix-login-flow",
+        ),
+        isNull,
+      );
+      expect(worktreeService.rollbackCalls, 1);
+    });
+
     test("does not invoke Git for an in-place session", () async {
       await insertSession();
 

--- a/bridge/app/test/bridge/worktree_service_git_test.dart
+++ b/bridge/app/test/bridge/worktree_service_git_test.dart
@@ -325,7 +325,16 @@ void main() {
       expect(processRunner.invocations.single.command, equals("git"));
       expect(
         processRunner.invocations.single.arguments,
-        equals(["worktree", "add", "-b", "feature/x", "--", "/repo/.worktrees/feature-x", "main"]),
+        equals([
+          "worktree",
+          "add",
+          "-b",
+          "feature/x",
+          "--no-track",
+          "--",
+          "/repo/.worktrees/feature-x",
+          "main",
+        ]),
       );
       expect(processRunner.invocations.single.workingDirectory, equals("/repo/project"));
     });

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -5,6 +5,7 @@ import "package:sesori_bridge/src/api/database/daos/session_dao.dart";
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/bridge/api/git_cli_api.dart";
 import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
+import "package:sesori_bridge/src/bridge/repositories/worktree_repository.dart";
 import "package:sesori_bridge/src/bridge/services/worktree_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
@@ -944,6 +945,117 @@ void main() {
       expect(result, isFalse);
     });
   });
+
+  group("WorktreeService.renameGeneratedBranch", () {
+    late _GeneratedRenameWorktreeRepository repository;
+    late WorktreeService service;
+
+    setUp(() {
+      repository = _GeneratedRenameWorktreeRepository();
+      service = WorktreeService(worktreeRepository: repository);
+    });
+
+    test("renames the still-current unpublished initial branch", () async {
+      final result = await service.renameGeneratedBranch(
+        worktreePath: "/repo/.worktrees/blue-otter",
+        initialBranchName: "blue-otter",
+        generatedBranchName: "fix-login-flow",
+      );
+
+      expect(result, isA<GeneratedBranchRenamed>());
+      expect((result as GeneratedBranchRenamed).branchName, "fix-login-flow");
+      expect(repository.renameCalls, [
+        (oldBranchName: "blue-otter", newBranchName: "fix-login-flow"),
+      ]);
+      expect(repository.lastWorktreePath, "/repo/.worktrees/blue-otter");
+    });
+
+    test("skips invalid, switched, and published branches", () async {
+      repository.validBranchName = false;
+      expect(
+        await service.renameGeneratedBranch(
+          worktreePath: "/worktree",
+          initialBranchName: "blue-otter",
+          generatedBranchName: "invalid branch",
+        ),
+        isA<GeneratedBranchRenameSkipped>().having(
+          (result) => result.reason,
+          "reason",
+          GeneratedBranchRenameSkipReason.invalidGeneratedName,
+        ),
+      );
+
+      repository
+        ..validBranchName = true
+        ..currentBranchName = "user-branch";
+      expect(
+        await service.renameGeneratedBranch(
+          worktreePath: "/worktree",
+          initialBranchName: "blue-otter",
+          generatedBranchName: "fix-login-flow",
+        ),
+        isA<GeneratedBranchRenameSkipped>().having(
+          (result) => result.reason,
+          "reason",
+          GeneratedBranchRenameSkipReason.initialBranchChanged,
+        ),
+      );
+
+      repository
+        ..currentBranchName = "blue-otter"
+        ..upstream = true;
+      expect(
+        await service.renameGeneratedBranch(
+          worktreePath: "/worktree",
+          initialBranchName: "blue-otter",
+          generatedBranchName: "fix-login-flow",
+        ),
+        isA<GeneratedBranchRenameSkipped>().having(
+          (result) => result.reason,
+          "reason",
+          GeneratedBranchRenameSkipReason.initialBranchPublished,
+        ),
+      );
+      expect(repository.renameCalls, isEmpty);
+    });
+
+    test("adds a secure suffix when the generated target already exists", () async {
+      repository.existingBranches.add("fix-login-flow");
+
+      final result = await service.renameGeneratedBranch(
+        worktreePath: "/worktree",
+        initialBranchName: "blue-otter",
+        generatedBranchName: "fix-login-flow",
+      );
+
+      final renamed = result as GeneratedBranchRenamed;
+      expect(renamed.branchName, matches(RegExp(r"^fix-login-flow-[0-9a-f]{6}$")));
+      expect(repository.renameCalls.single.newBranchName, renamed.branchName);
+    });
+
+    test("restores the initial ref when current branch changes during rename", () async {
+      repository.currentAfterRename = "user-branch";
+
+      final result = await service.renameGeneratedBranch(
+        worktreePath: "/worktree",
+        initialBranchName: "blue-otter",
+        generatedBranchName: "fix-login-flow",
+      );
+
+      expect(
+        result,
+        isA<GeneratedBranchRenameSkipped>().having(
+          (result) => result.reason,
+          "reason",
+          GeneratedBranchRenameSkipReason.initialBranchChanged,
+        ),
+      );
+      expect(repository.renameCalls, [
+        (oldBranchName: "blue-otter", newBranchName: "fix-login-flow"),
+        (oldBranchName: "fix-login-flow", newBranchName: "blue-otter"),
+      ]);
+    });
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -1021,6 +1133,49 @@ class _FakeProcessRunner() implements ProcessRunner {
     }
     throw next;
   }
+}
+
+class _GeneratedRenameWorktreeRepository() implements WorktreeRepository {
+  bool validBranchName = true;
+  bool upstream = false;
+  String? currentBranchName = "blue-otter";
+  String? currentAfterRename;
+  final Set<String> existingBranches = <String>{};
+  final List<({String oldBranchName, String newBranchName})> renameCalls = [];
+  String? lastWorktreePath;
+
+  @override
+  Future<bool> isValidBranchName({required String branchName}) async => validBranchName;
+
+  @override
+  Future<String?> getCurrentBranchName({required String worktreePath}) async {
+    lastWorktreePath = worktreePath;
+    return currentBranchName;
+  }
+
+  @override
+  Future<bool> hasUpstream({required String worktreePath, required String branchName}) async => upstream;
+
+  @override
+  Future<bool> branchExists({required String projectPath, required String branchName}) async {
+    lastWorktreePath = projectPath;
+    return existingBranches.contains(branchName);
+  }
+
+  @override
+  Future<void> renameBranch({
+    required String worktreePath,
+    required String oldBranchName,
+    required String newBranchName,
+  }) async {
+    lastWorktreePath = worktreePath;
+    renameCalls.add((oldBranchName: oldBranchName, newBranchName: newBranchName));
+    currentBranchName = currentAfterRename ?? newBranchName;
+    currentAfterRename = null;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _FakeBridgePluginApi() implements NativeProjectsPluginApi {

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -1016,6 +1016,22 @@ void main() {
           GeneratedBranchRenameSkipReason.initialBranchPublished,
         ),
       );
+
+      repository
+        ..upstream = false
+        ..remoteBranch = true;
+      expect(
+        await service.renameGeneratedBranch(
+          worktreePath: "/worktree",
+          initialBranchName: "blue-otter",
+          generatedBranchName: "fix-login-flow",
+        ),
+        isA<GeneratedBranchRenameSkipped>().having(
+          (result) => result.reason,
+          "reason",
+          GeneratedBranchRenameSkipReason.initialBranchPublished,
+        ),
+      );
       expect(repository.renameCalls, isEmpty);
     });
 
@@ -1178,6 +1194,7 @@ class _GeneratedRenameWorktreeRepository() implements WorktreeRepository {
   bool validBranchName = true;
   bool Function(String branchName)? branchNameValidator;
   bool upstream = false;
+  bool remoteBranch = false;
   String? currentBranchName = "blue-otter";
   String? currentAfterRename;
   Object? currentBranchReadErrorAfterRename;
@@ -1201,6 +1218,9 @@ class _GeneratedRenameWorktreeRepository() implements WorktreeRepository {
 
   @override
   Future<bool> hasUpstream({required String worktreePath, required String branchName}) async => upstream;
+
+  @override
+  Future<bool> hasRemoteBranch({required String worktreePath, required String branchName}) async => remoteBranch;
 
   @override
   Future<bool> branchExists({required String projectPath, required String branchName}) async {

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -1019,7 +1019,7 @@ void main() {
 
       repository
         ..upstream = false
-        ..remoteBranch = true;
+        ..remoteBranches.add("blue-otter");
       expect(
         await service.renameGeneratedBranch(
           worktreePath: "/worktree",
@@ -1037,6 +1037,20 @@ void main() {
 
     test("adds a secure suffix when the generated target already exists", () async {
       repository.existingBranches.add("fix-login-flow");
+
+      final result = await service.renameGeneratedBranch(
+        worktreePath: "/worktree",
+        initialBranchName: "blue-otter",
+        generatedBranchName: "fix-login-flow",
+      );
+
+      final renamed = result as GeneratedBranchRenamed;
+      expect(renamed.branchName, matches(RegExp(r"^fix-login-flow-[0-9a-f]{6}$")));
+      expect(repository.renameCalls.single.newBranchName, renamed.branchName);
+    });
+
+    test("adds a secure suffix when only a matching remote target exists", () async {
+      repository.remoteBranches.add("fix-login-flow");
 
       final result = await service.renameGeneratedBranch(
         worktreePath: "/worktree",
@@ -1194,7 +1208,7 @@ class _GeneratedRenameWorktreeRepository() implements WorktreeRepository {
   bool validBranchName = true;
   bool Function(String branchName)? branchNameValidator;
   bool upstream = false;
-  bool remoteBranch = false;
+  final Set<String> remoteBranches = <String>{};
   String? currentBranchName = "blue-otter";
   String? currentAfterRename;
   Object? currentBranchReadErrorAfterRename;
@@ -1220,7 +1234,9 @@ class _GeneratedRenameWorktreeRepository() implements WorktreeRepository {
   Future<bool> hasUpstream({required String worktreePath, required String branchName}) async => upstream;
 
   @override
-  Future<bool> hasRemoteBranch({required String worktreePath, required String branchName}) async => remoteBranch;
+  Future<bool> hasRemoteBranch({required String worktreePath, required String branchName}) async {
+    return remoteBranches.contains(branchName);
+  }
 
   @override
   Future<bool> branchExists({required String projectPath, required String branchName}) async {

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -1033,6 +1033,28 @@ void main() {
       expect(repository.renameCalls.single.newBranchName, renamed.branchName);
     });
 
+    test("skips when collision suffixes are not valid branch names", () async {
+      repository
+        ..existingBranches.add("fix-login-flow")
+        ..branchNameValidator = (branchName) => branchName == "fix-login-flow";
+
+      final result = await service.renameGeneratedBranch(
+        worktreePath: "/worktree",
+        initialBranchName: "blue-otter",
+        generatedBranchName: "fix-login-flow",
+      );
+
+      expect(
+        result,
+        isA<GeneratedBranchRenameSkipped>().having(
+          (result) => result.reason,
+          "reason",
+          GeneratedBranchRenameSkipReason.targetCollisions,
+        ),
+      );
+      expect(repository.renameCalls, isEmpty);
+    });
+
     test("restores the initial ref when current branch changes during rename", () async {
       repository.currentAfterRename = "user-branch";
 
@@ -1049,6 +1071,23 @@ void main() {
           "reason",
           GeneratedBranchRenameSkipReason.initialBranchChanged,
         ),
+      );
+      expect(repository.renameCalls, [
+        (oldBranchName: "blue-otter", newBranchName: "fix-login-flow"),
+        (oldBranchName: "fix-login-flow", newBranchName: "blue-otter"),
+      ]);
+    });
+
+    test("restores the initial ref when post-rename confirmation fails", () async {
+      repository.currentBranchReadErrorAfterRename = StateError("confirmation failed");
+
+      await expectLater(
+        service.renameGeneratedBranch(
+          worktreePath: "/worktree",
+          initialBranchName: "blue-otter",
+          generatedBranchName: "fix-login-flow",
+        ),
+        throwsA(isA<StateError>()),
       );
       expect(repository.renameCalls, [
         (oldBranchName: "blue-otter", newBranchName: "fix-login-flow"),
@@ -1137,19 +1176,26 @@ class _FakeProcessRunner() implements ProcessRunner {
 
 class _GeneratedRenameWorktreeRepository() implements WorktreeRepository {
   bool validBranchName = true;
+  bool Function(String branchName)? branchNameValidator;
   bool upstream = false;
   String? currentBranchName = "blue-otter";
   String? currentAfterRename;
+  Object? currentBranchReadErrorAfterRename;
   final Set<String> existingBranches = <String>{};
   final List<({String oldBranchName, String newBranchName})> renameCalls = [];
   String? lastWorktreePath;
 
   @override
-  Future<bool> isValidBranchName({required String branchName}) async => validBranchName;
+  Future<bool> isValidBranchName({required String branchName}) async {
+    return branchNameValidator?.call(branchName) ?? validBranchName;
+  }
 
   @override
   Future<String?> getCurrentBranchName({required String worktreePath}) async {
     lastWorktreePath = worktreePath;
+    if (renameCalls.isNotEmpty) {
+      if (currentBranchReadErrorAfterRename case final error?) throw error;
+    }
     return currentBranchName;
   }
 

--- a/bridge/app/test/persistence/session_dao_test.dart
+++ b/bridge/app/test/persistence/session_dao_test.dart
@@ -89,6 +89,44 @@ void main() {
       expect(result.createdAt, equals(createdAt));
     });
 
+    test("replaceGeneratedBranch conditionally updates durable and current branch names", () async {
+      await dao.insertSession(
+        pluginId: "opencode",
+        sessionId: "ses-generated-branch",
+        backendSessionId: "ses-generated-branch",
+        projectId: "proj-1",
+        isDedicated: true,
+        createdAt: 1,
+        worktreePath: "/tmp/worktrees/blue-otter",
+        branchName: "blue-otter",
+        baseBranch: "main",
+        baseCommit: "abc123",
+        lastAgent: null,
+        lastAgentModel: null,
+      );
+
+      expect(
+        await dao.replaceGeneratedBranch(
+          sessionId: "ses-generated-branch",
+          expectedBranchName: "other-branch",
+          branchName: "fix-login-flow",
+        ),
+        isFalse,
+      );
+      expect(
+        await dao.replaceGeneratedBranch(
+          sessionId: "ses-generated-branch",
+          expectedBranchName: "blue-otter",
+          branchName: "fix-login-flow",
+        ),
+        isTrue,
+      );
+
+      final result = await dao.getSession(sessionId: "ses-generated-branch");
+      expect(result?.branchName, "fix-login-flow");
+      expect(result?.currentBranchName, "fix-login-flow");
+    });
+
     test("generated companion insert persists last default selection fields", () async {
       await db
           .into(db.sessionTable)

--- a/bridge/app/test/persistence/session_dao_test.dart
+++ b/bridge/app/test/persistence/session_dao_test.dart
@@ -127,6 +127,44 @@ void main() {
       expect(result?.currentBranchName, "fix-login-flow");
     });
 
+    test("replaceGeneratedBranch preserves a concurrently switched current branch", () async {
+      await dao.insertSession(
+        pluginId: "opencode",
+        sessionId: "ses-switched-branch",
+        backendSessionId: "ses-switched-branch",
+        projectId: "proj-1",
+        isDedicated: true,
+        createdAt: 1,
+        worktreePath: "/tmp/worktrees/blue-otter",
+        branchName: "blue-otter",
+        baseBranch: "main",
+        baseCommit: "abc123",
+        lastAgent: null,
+        lastAgentModel: null,
+      );
+      await dao.updatePullRequestScopes(
+        updates: const [
+          (
+            sessionId: "ses-switched-branch",
+            currentBranchName: "user-branch",
+            currentGithubRepositoryIdentity: null,
+          ),
+        ],
+      );
+
+      expect(
+        await dao.replaceGeneratedBranch(
+          sessionId: "ses-switched-branch",
+          expectedBranchName: "blue-otter",
+          branchName: "fix-login-flow",
+        ),
+        isFalse,
+      );
+      final result = await dao.getSession(sessionId: "ses-switched-branch");
+      expect(result?.branchName, "blue-otter");
+      expect(result?.currentBranchName, "user-branch");
+    });
+
     test("generated companion insert persists last default selection fields", () async {
       await db
           .into(db.sessionTable)

--- a/bridge/app/test/repositories/session_metadata_repository_test.dart
+++ b/bridge/app/test/repositories/session_metadata_repository_test.dart
@@ -13,9 +13,9 @@ void main() {
       final repository = SessionMetadataRepository(api: api);
       final message = "x" * 500;
 
-      final title = await repository.generateTitle(firstMessage: message);
+      final metadata = await repository.generateMetadata(firstMessage: message);
 
-      expect(title, equals("Generated title"));
+      expect(metadata, (title: "Generated title", branchName: "generated-branch"));
       expect(api.requests.single, equals(GenerateSessionMetadataRequest(firstMessage: message)));
       expect(api.abortSignals.single.isAborted, isFalse);
     });
@@ -24,7 +24,7 @@ void main() {
       final api = _FakeSesoriServerApi();
       final repository = SessionMetadataRepository(api: api);
 
-      await repository.generateTitle(firstMessage: "x" * 501);
+      await repository.generateMetadata(firstMessage: "x" * 501);
 
       expect(api.requests.single.firstMessage, equals("x" * 500));
     });
@@ -33,7 +33,7 @@ void main() {
       final api = _FakeSesoriServerApi();
       final repository = SessionMetadataRepository(api: api);
 
-      await repository.generateTitle(firstMessage: "${"x" * 499}😀tail");
+      await repository.generateMetadata(firstMessage: "${"x" * 499}😀tail");
 
       expect(api.requests.single.firstMessage, equals("x" * 499));
     });
@@ -43,7 +43,7 @@ void main() {
       final repository = SessionMetadataRepository(api: _FakeSesoriServerApi(failure: abort));
 
       await expectLater(
-        repository.generateTitle(firstMessage: "message"),
+        repository.generateMetadata(firstMessage: "message"),
         throwsA(
           isA<SessionMetadataRequestAbortedException>().having(
             (error) => error.innerError,
@@ -66,7 +66,7 @@ void main() {
       final repository = SessionMetadataRepository(api: _FakeSesoriServerApi(failure: apiError));
 
       await expectLater(
-        repository.generateTitle(firstMessage: "message"),
+        repository.generateMetadata(firstMessage: "message"),
         throwsA(
           isA<SessionMetadataInvalidResponseException>()
               .having((error) => error.cause, "cause", same(apiError))
@@ -82,7 +82,7 @@ void main() {
       final repository = SessionMetadataRepository(api: _FakeSesoriServerApi(failure: error));
 
       await expectLater(
-        repository.generateTitle(firstMessage: "message"),
+        repository.generateMetadata(firstMessage: "message"),
         throwsA(same(error)),
       );
     });
@@ -91,7 +91,7 @@ void main() {
       final api = _FakeSesoriServerApi();
       final repository = SessionMetadataRepository(api: api);
 
-      await repository.generateTitle(firstMessage: "message");
+      await repository.generateMetadata(firstMessage: "message");
       repository.beginShutdown();
 
       expect(api.abortSignals.single.isAborted, isTrue);
@@ -113,7 +113,7 @@ class _FakeSesoriServerApi({final Object? failure}) implements SesoriServerApi {
     requests.add(request);
     abortSignals.add(abortSignal);
     if (error case final error?) throw error;
-    return const GenerateSessionMetadataResponse(title: "Generated title");
+    return const GenerateSessionMetadataResponse(title: "Generated title", branchName: "generated-branch");
   }
 
   @override

--- a/docs/regression/diffs-and-source-control.md
+++ b/docs/regression/diffs-and-source-control.md
@@ -27,9 +27,13 @@ that baseline, and the branch and worktree facts a session carries.
 - The base branch can be read and set; setting rejects empty input and applies
   to later dedicated baselines, and the stable project identifier resolves to
   the live directory before git runs.
-- A session reports its creation-time branch and dedicated-worktree facts; live
-  current-branch and PR refresh belong to pull request monitoring. A mutating
-  tool emits the diff refresh signal, and diffs stay encrypted from the relay.
+- A session initially reports its creation-time branch and dedicated-worktree
+  facts. Generated metadata may later rename only the still-current unpublished
+  initial dedicated branch without moving the worktree; durable and current
+  branch facts then update together through the existing session update. Other
+  live current-branch and PR refreshes belong to pull request monitoring. A
+  mutating tool emits the diff refresh signal, and diffs stay encrypted from the
+  relay.
 
 ## Regression Levels
 
@@ -37,7 +41,7 @@ that baseline, and the branch and worktree facts a session carries.
 |---|---|
 | L1 Smoke | Not included because a meaningful diff requires a mutating live turn. |
 | L2 Routine | Headless bridge, representative plugin: after a session edits files the diff lists them with before/after content and line counts; dedicated uses its base branch and in-place its creation-time commit. |
-| L3 Release | Client end to end (phone), representative plugin: added, modified, deleted, and untracked files report correct status and counts; a rename renders as deletion plus addition; binary, too-large, and unreadable files return explicit skip reasons; base-branch read and set apply to later baselines; the diff list, per-file view, and refresh on the file-change signal render. |
+| L3 Release | Client end to end (phone), representative plugin: added, modified, deleted, and untracked files report correct status and counts; a rename renders as deletion plus addition; binary, too-large, and unreadable files return explicit skip reasons; base-branch read and set apply to later baselines; eligible generated branch refinement updates source-control facts without moving the worktree; the diff list, per-file view, and refresh on the file-change signal render. |
 | L4 Extended | Relay integration, every supporting production plugin: unreachable base and no-common-ancestor are distinct client-visible failures; archived sessions and removed worktrees return no diffs without erroring; a moved project still resolves git correctly; each plugin's file-change signal triggers a refresh reflecting the real change set. |
 | L5 Full | Headless bridge for large mixed changes, non-git or commitless sessions returning no diffs, and invalid base branches; relay integration to prove diff payload encryption. Representative plugin. |
 

--- a/docs/regression/diffs-and-source-control.md
+++ b/docs/regression/diffs-and-source-control.md
@@ -60,6 +60,9 @@ and in-place sessions, and default versus explicit base branches.
 - Line counts disagree with content, especially untracked or deletion-only.
 - Diffs never refresh after a mutating tool completes, or a moved project makes
   git run in the old directory.
+- Generated refinement renames a branch after it switches or becomes published,
+  moves the worktree directory, leaves durable/current branch facts disagreeing,
+  or leaves Git and persistence on different branch names after failure.
 
 ## Known Limitations
 

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -42,6 +42,13 @@ variant, and worktree mode, and creating the session with its first input.
   conditional bridge-owned update delivered through the existing
   `session.updated` event. User rename or deletion wins, and plugin rename
   failure does not remove the locally committed generated title.
+- Generated metadata may also rename a root dedicated session's still-current
+  initial branch when it has no upstream. The worktree directory and plugin
+  working path remain unchanged. Generated refs are validated, collisions use a
+  bounded secure suffix, durable and current branch facts commit together, and
+  the existing `session.updated` event reports the result without claiming a
+  title change. Switched, detached, published, invalid, and failed refinements
+  retain the usable initial branch; persistence failure attempts Git rollback.
 - Graceful shutdown fences new create routes, aborts and drains accepted metadata
   work, drains session operations and local mutations, then closes normalized
   event delivery and its remaining tails.
@@ -55,9 +62,9 @@ variant, and worktree mode, and creating the session with its first input.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Headless bridge, representative plugin: a session is created with a first prompt and has attribution and a working directory. |
-| L2 Routine | Headless bridge, representative plugin: options return agents, models, commands; explicit refresh forces discovery; cache-only reports unavailable without discovering; dedicated mode produces a local lowercase `color-animal` branch, worktree, and baseline; a gated metadata request does not gate a queryable create response. |
-| L3 Release | Client end to end (phone), every supporting production plugin: each declared option scope is honored and usable; chosen agent, model, and variant apply; slash-command start dispatches without rendering bridge context; generated title arrives through `session.updated`; pickers, plugin chooser, loading, and no-harness states render. |
-| L4 Extended | Live plugin, every supporting production plugin: occupied branch/path pairs are skipped and pair exhaustion uses a suffix; non-git, empty-repository, worktree-failure, metadata-failure, and plugin-title-rename-failure cases retain a usable session; user rename/deletion wins over late title; failure with a retained cache still serves options while failure without one errors; concurrent requests coalesce; automatic refresh does not start a stopped plugin; a moved project invalidates its options. |
+| L2 Routine | Headless bridge, representative plugin: options return agents, models, commands; explicit refresh forces discovery; cache-only reports unavailable without discovering; dedicated mode produces a local lowercase `color-animal` branch, worktree, and baseline; a gated metadata request does not gate a queryable create response; eligible generated branch refinement preserves the worktree path and publishes the updated session. |
+| L3 Release | Client end to end (phone), every supporting production plugin: each declared option scope is honored and usable; chosen agent, model, and variant apply; slash-command start dispatches without rendering bridge context; generated title and eligible branch refinement arrive through `session.updated`; pickers, plugin chooser, loading, and no-harness states render. |
+| L4 Extended | Live plugin, every supporting production plugin: occupied branch/path pairs are skipped and pair exhaustion uses a suffix; non-git, empty-repository, worktree-failure, metadata-failure, plugin-title-rename-failure, switched/detached/upstream branch, invalid generated ref, branch collision exhaustion, persistence failure, and shutdown cases retain a usable session; user rename/deletion wins over late title; failure with a retained cache still serves options while failure without one errors; concurrent requests coalesce; automatic refresh does not start a stopped plugin; a moved project invalidates its options. |
 | L5 Full | Client end to end, every supporting production plugin: cache expiry and an undecodable entry recover without wrong options; creation is refused for a non-routable plugin and an unknown project; attachment creation works only where declared; unattributed payloads resolve to the historical identity. |
 
 ## Exploration Guidance
@@ -66,7 +73,9 @@ Vary plugin choice, warm cache versus fresh discovery, dedicated versus in-place
 mode, prompt versus command start, default versus explicit options, and fresh,
 collision-prone, or non-git projects. Also vary fast, slow, failed, and
 shutdown-aborted metadata, plus user rename/deletion while title generation is
-in flight.
+in flight. For dedicated sessions, vary untouched, switched, detached, upstream,
+colliding, and rollback-failing branches while confirming the directory stays
+fixed and title application does not wait for branch refinement.
 
 ## Failure Signals
 
@@ -81,6 +90,9 @@ in flight.
 - Metadata completion delays the create response, creates an unqueryable session,
   overwrites a user title, resurrects a deletion, or loses the local title when
   backend rename fails.
+- Generated branch refinement moves the worktree directory, renames a switched or
+  upstream branch, overwrites a newer current-branch observation, delays title
+  application, persists facts that disagree with Git, or misses its session update.
 
 ## Known Limitations
 

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -43,8 +43,8 @@ variant, and worktree mode, and creating the session with its first input.
   `session.updated` event. User rename or deletion wins, and plugin rename
   failure does not remove the locally committed generated title.
 - Generated metadata may also rename a root dedicated session's still-current
-  initial branch when it has no upstream. The worktree directory and plugin
-  working path remain unchanged. Generated refs are validated, collisions use a
+  initial branch when it has no upstream or matching remote ref. The worktree
+  directory and plugin working path remain unchanged. Generated refs are validated, collisions use a
   bounded secure suffix, durable and current branch facts commit together, and
   the existing `session.updated` event reports the result without claiming a
   title change. Switched, detached, published, invalid, and failed refinements


### PR DESCRIPTION
## Complexity

⚙️ Moderate. The change coordinates late metadata, Git eligibility and rename operations, conditional persistence, family serialization, rollback, and existing SSE delivery without moving the worktree directory.

## What

- Consume the generated metadata branch name after canonical session creation returns.
- Rename only a root dedicated session that remains on its unpublished initial branch.
- Validate generated refs and use bounded secure suffixes for collisions.
- Persist both durable and current branch facts, then publish the existing `session.updated` event with `titleChanged: false`.
- Keep generated title and branch application independent and tracked through shutdown.

## Why

Dedicated sessions launch quickly with a local `color-animal` branch, but that initial name does not describe the task. This follow-up refines eligible branches asynchronously using generated metadata without restoring metadata latency to session creation.

## Risk and test focus

The main risk is renaming a branch after the user or agent has changed or published it, or leaving Git and persistence inconsistent. Tests cover invalid, switched, detached-equivalent, upstream, unchanged, and colliding targets; explicit old-ref rename commands; conditional persistence; rollback; mutation events; response timing; title independence; and shutdown draining.

There is no database schema change and no client-to-bridge wire-shape change. The user-visible impact is limited to eligible Git branch names changing after launch; worktree paths and plugin working directories remain unchanged.

## Expected result

New dedicated sessions still return immediately on their local branch. When metadata arrives, an eligible untouched unpublished branch is renamed to the generated task name and clients receive the normal session update. Ineligible or failed refinements leave session creation and generated title behavior intact.

## Verification

- `make codegen` from `bridge/`
- `dart analyze --fatal-infos` from `bridge/app`
- Focused bridge tests: 179 passed before architecture fixes; 115 directly affected tests passed after them
- Full `dart test` from `bridge/app`: 2,635 passed
- Architecture implementation review: approved after repository-boundary findings were applied
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames eligible generated session branches after launch to the generated task name and preserves published branches. Previously we only applied generated titles; now we also consume branchName and rename the still-current, unpublished initial branch without moving worktrees.

- Accepts branchName in `GenerateSessionMetadataResponse`; `SessionMetadataRepository` returns title and branch; continues ignoring `worktreeName`.
- Validates and renames via `GitCliApi`/`WorktreeService`: verify ref format, require current equals initial durable branch, require no upstream and no matching remote ref (exact match, including nested remotes), resolve collisions with a bounded secure suffix, rename the explicit old ref, then re-read current; worktree creation uses `--no-track`.
- Persists durable and current branch together via `SessionDao.replaceGeneratedBranch`; on persistence failure, roll back the Git rename and log rollback failure if it also fails.
- Adds `SessionOperation.applyGeneratedBranchName` and a dispatcher path that emits `SessionBranchUpdated`, delivered through the existing `session.updated` SSE with `titleChanged: false`; title and branch application stay independent and accepted metadata work drains on shutdown.
- Skips in-place sessions, non-root family members, switched/detached worktrees, upstream or remote-initial branches, invalid targets, and unrecoverable collisions.
- Hardens PR target application in `PullRequestRepository` by ignoring captures taken before the durable branch changed.
- No database schema or plugin/client wire-shape changes; worktree directories and plugin working paths remain unchanged.
- Docs record generated-branch failure signals.

<sup>Written for commit 734ccd457c1864d18cb206f432f103b518b34ffd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

