### PR TITLE
🌿 Soften navigation and composer edge fades

### DIFF
--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -850,7 +850,7 @@ class _PromptInputState() extends State<PromptInput> {
       // controls keep their own surfaces.
       decoration: BoxDecoration(
         gradient: LinearGradient(
-          begin: Alignment.center,
+          begin: Alignment.bottomCenter,
           end: Alignment.topCenter,
           colors: [
             prego.colors.bgSurface1.withValues(alpha: 0.98),

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -424,6 +424,8 @@ void main() {
     expect(gradient.colors[0], surface.withValues(alpha: 0.98));
     expect(gradient.colors[1], surface.withValues(alpha: 0.88));
     expect(gradient.colors[2], surface.withValues(alpha: 0));
+    expect(gradient.begin, Alignment.bottomCenter);
+    expect(gradient.end, Alignment.topCenter);
   });
 
   testWidgets("an empty newest page keeps older transcript paging reachable", (tester) async {

--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -272,6 +272,9 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
       onBack: widget.onBack,
       automaticallyImplyLeading: widget.automaticallyImplyLeading,
     );
+    final barInset = topPad + topNav.preferredSize.height;
+    double scrollEdgeInset(double bannerHeight) =>
+        barInset + bannerHeight + PregoGlassScaffold._scrollEdgeFadeExtent;
 
     // The top-navigation area handed to GlassScaffold: status-bar inset, then
     // the animated banner slot, then the bar row. GlassScaffold positions it
@@ -345,11 +348,7 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
                 builder: (context, bannerHeight, indicator) => Transform.translate(
                   offset: Offset(
                     0,
-                    topPad +
-                        topNav.preferredSize.height +
-                        bannerHeight +
-                        PregoGlassScaffold._scrollEdgeFadeExtent +
-                        (collapsing ? _largeTitleHeight : 0),
+                    scrollEdgeInset(bannerHeight) + (collapsing ? _largeTitleHeight : 0),
                   ),
                   child: indicator,
                 ),
@@ -365,10 +364,7 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
           SliverToBoxAdapter(
             child: ValueListenableBuilder<double>(
               valueListenable: _bannerHeight,
-              builder: (context, bannerHeight, _) => SizedBox(
-                height:
-                    topPad + topNav.preferredSize.height + bannerHeight + PregoGlassScaffold._scrollEdgeFadeExtent,
-              ),
+              builder: (context, bannerHeight, _) => SizedBox(height: scrollEdgeInset(bannerHeight)),
             ),
           ),
         // The fixed-title modes (inline, back-leading) show their title in the
@@ -421,11 +417,7 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
                     end: Alignment.bottomCenter,
                   ),
                 ),
-                height:
-                    topPad +
-                    topNav.preferredSize.height +
-                    bannerHeight +
-                    PregoGlassScaffold._scrollEdgeFadeExtent,
+                height: scrollEdgeInset(bannerHeight),
               ),
             ),
           ),
@@ -469,10 +461,7 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
       backgroundColor: Colors.transparent,
       floatingActionButton: _floatingActionButton,
       body: top_bar.PregoTopBarInsetScope(
-        baseInset:
-            topPad +
-            PregoTopNavigation.barHeight +
-            (extendBehind ? PregoGlassScaffold._scrollEdgeFadeExtent : 0),
+        baseInset: extendBehind ? scrollEdgeInset(0) : barInset,
         bannerHeight: _bannerHeight,
         child: scaffold,
       ),

--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -166,9 +166,9 @@ class const PregoGlassScaffold({
   @override
   State<PregoGlassScaffold> createState() => _PregoGlassScaffoldState();
 
-  /// Extra space below the navigation bar over which scrolling content fades
-  /// back to full opacity.
-  static const double _scrollEdgeFadeExtent = PregoSpacing.xl;
+  /// Extra paint below the navigation bar over which scrolling content fades
+  /// back to full opacity. This does not increase the bar's layout inset.
+  static const double _scrollEdgeFadePaintExtent = PregoSpacing.xl;
 }
 
 class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
@@ -273,8 +273,9 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
       automaticallyImplyLeading: widget.automaticallyImplyLeading,
     );
     final barInset = topPad + topNav.preferredSize.height;
-    double scrollEdgeInset(double bannerHeight) =>
-        barInset + bannerHeight + PregoGlassScaffold._scrollEdgeFadeExtent;
+    double topBarInset(double bannerHeight) => barInset + bannerHeight;
+    double scrollEdgePaintExtent(double bannerHeight) =>
+        topBarInset(bannerHeight) + PregoGlassScaffold._scrollEdgeFadePaintExtent;
 
     // The top-navigation area handed to GlassScaffold: status-bar inset, then
     // the animated banner slot, then the bar row. GlassScaffold positions it
@@ -348,7 +349,7 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
                 builder: (context, bannerHeight, indicator) => Transform.translate(
                   offset: Offset(
                     0,
-                    scrollEdgeInset(bannerHeight) + (collapsing ? _largeTitleHeight : 0),
+                    topBarInset(bannerHeight) + (collapsing ? _largeTitleHeight : 0),
                   ),
                   child: indicator,
                 ),
@@ -364,7 +365,7 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
           SliverToBoxAdapter(
             child: ValueListenableBuilder<double>(
               valueListenable: _bannerHeight,
-              builder: (context, bannerHeight, _) => SizedBox(height: scrollEdgeInset(bannerHeight)),
+              builder: (context, bannerHeight, _) => SizedBox(height: topBarInset(bannerHeight)),
             ),
           ),
         // The fixed-title modes (inline, back-leading) show their title in the
@@ -417,7 +418,7 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
                     end: Alignment.bottomCenter,
                   ),
                 ),
-                height: scrollEdgeInset(bannerHeight),
+                height: scrollEdgePaintExtent(bannerHeight),
               ),
             ),
           ),
@@ -461,7 +462,7 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
       backgroundColor: Colors.transparent,
       floatingActionButton: _floatingActionButton,
       body: top_bar.PregoTopBarInsetScope(
-        baseInset: extendBehind ? scrollEdgeInset(0) : barInset,
+        baseInset: barInset,
         bannerHeight: _bannerHeight,
         child: scaffold,
       ),

--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -165,6 +165,10 @@ class const PregoGlassScaffold({
 
   @override
   State<PregoGlassScaffold> createState() => _PregoGlassScaffoldState();
+
+  /// Extra space below the navigation bar over which scrolling content fades
+  /// back to full opacity.
+  static const double _scrollEdgeFadeExtent = PregoSpacing.xl;
 }
 
 class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
@@ -341,7 +345,11 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
                 builder: (context, bannerHeight, indicator) => Transform.translate(
                   offset: Offset(
                     0,
-                    topPad + topNav.preferredSize.height + bannerHeight + (collapsing ? _largeTitleHeight : 0),
+                    topPad +
+                        topNav.preferredSize.height +
+                        bannerHeight +
+                        PregoGlassScaffold._scrollEdgeFadeExtent +
+                        (collapsing ? _largeTitleHeight : 0),
                   ),
                   child: indicator,
                 ),
@@ -357,8 +365,10 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
           SliverToBoxAdapter(
             child: ValueListenableBuilder<double>(
               valueListenable: _bannerHeight,
-              builder: (context, bannerHeight, _) =>
-                  SizedBox(height: topPad + topNav.preferredSize.height + bannerHeight),
+              builder: (context, bannerHeight, _) => SizedBox(
+                height:
+                    topPad + topNav.preferredSize.height + bannerHeight + PregoGlassScaffold._scrollEdgeFadeExtent,
+              ),
             ),
           ),
         // The fixed-title modes (inline, back-leading) show their title in the
@@ -388,8 +398,8 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
       // there is nothing behind it to fade. Wrapped in [IgnorePointer] so the
       // decorative gradient never swallows taps or scroll drags starting in the
       // top region — content beneath it stays fully interactive. The fade spans
-      // the whole top area, banner included, so content dissolves before it
-      // slides under the (opaque) banner exactly as it does under the bar.
+      // the whole top area, banner included, and extends slightly below the bar
+      // so content dissolves before sliding under the navigation controls.
       if (extendBehind)
         Positioned(
           top: 0,
@@ -411,7 +421,11 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
                     end: Alignment.bottomCenter,
                   ),
                 ),
-                height: topPad + topNav.preferredSize.height + bannerHeight,
+                height:
+                    topPad +
+                    topNav.preferredSize.height +
+                    bannerHeight +
+                    PregoGlassScaffold._scrollEdgeFadeExtent,
               ),
             ),
           ),
@@ -455,7 +469,10 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
       backgroundColor: Colors.transparent,
       floatingActionButton: _floatingActionButton,
       body: top_bar.PregoTopBarInsetScope(
-        baseInset: topPad + PregoTopNavigation.barHeight,
+        baseInset:
+            topPad +
+            PregoTopNavigation.barHeight +
+            (extendBehind ? PregoGlassScaffold._scrollEdgeFadeExtent : 0),
         bannerHeight: _bannerHeight,
         child: scaffold,
       ),

--- a/client/module_prego/test/components/prego_glass_scaffold_banner_test.dart
+++ b/client/module_prego/test/components/prego_glass_scaffold_banner_test.dart
@@ -47,18 +47,15 @@ Widget _harness({
 
 void main() {
   // The test viewport has no status-bar inset, so the top-bar geometry is:
-  // bar row top == banner height, first content top == banner height + the bar
-  // and its scroll-edge fade extent.
+  // bar row top == banner height, first content top == banner height + 54. The
+  // decorative scroll-edge fade paints below that layout boundary.
 
   testWidgets("without a banner the bar sits at the top and content clears it", (tester) async {
     await tester.pumpWidget(_harness(banner: null));
     await tester.pump();
 
     expect(tester.getTopLeft(find.byType(GlassAppBar)).dy, 0);
-    expect(
-      tester.getTopLeft(find.byKey(_contentKey)).dy,
-      PregoTopNavigation.barHeight + PregoSpacing.xl,
-    );
+    expect(tester.getTopLeft(find.byKey(_contentKey)).dy, PregoTopNavigation.barHeight);
   });
 
   testWidgets("a banner mounted with the scaffold shifts the bar and content down by its height", (tester) async {
@@ -72,7 +69,7 @@ void main() {
     expect(tester.getTopLeft(find.byType(GlassAppBar)).dy, _bannerHeight);
     expect(
       tester.getTopLeft(find.byKey(_contentKey)).dy,
-      _bannerHeight + PregoTopNavigation.barHeight + PregoSpacing.xl,
+      _bannerHeight + PregoTopNavigation.barHeight,
     );
   });
 
@@ -89,13 +86,13 @@ void main() {
     expect(midBarTop, lessThan(_bannerHeight));
     // The measured inset trails the animation by one frame (measure → notify →
     // rebuild). After a zero-duration frame the animation hasn't advanced, so
-    // the content must sit one bar and fade extent below the mid-animation bar.
+    // the content must sit exactly one bar height below the mid-animation bar.
     await tester.pump(Duration.zero);
     final midContentTop = tester.getTopLeft(find.byKey(_contentKey)).dy;
     expect(
       midContentTop,
       moreOrLessEquals(
-        midBarTop + PregoTopNavigation.barHeight + PregoSpacing.xl,
+        midBarTop + PregoTopNavigation.barHeight,
       ),
     );
 
@@ -103,7 +100,7 @@ void main() {
     expect(tester.getTopLeft(find.byType(GlassAppBar)).dy, _bannerHeight);
     expect(
       tester.getTopLeft(find.byKey(_contentKey)).dy,
-      _bannerHeight + PregoTopNavigation.barHeight + PregoSpacing.xl,
+      _bannerHeight + PregoTopNavigation.barHeight,
     );
   });
 
@@ -125,10 +122,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text("banner-content"), findsNothing);
     expect(tester.getTopLeft(find.byType(GlassAppBar)).dy, 0);
-    expect(
-      tester.getTopLeft(find.byKey(_contentKey)).dy,
-      PregoTopNavigation.barHeight + PregoSpacing.xl,
-    );
+    expect(tester.getTopLeft(find.byKey(_contentKey)).dy, PregoTopNavigation.barHeight);
   });
 
   testWidgets("PregoTopBarInsetBuilder tracks the banner height inside the scaffold", (tester) async {
@@ -146,15 +140,12 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       capturedInsets.last,
-      PregoTopNavigation.barHeight + _bannerHeight + PregoSpacing.xl,
+      PregoTopNavigation.barHeight + _bannerHeight,
     );
 
     await tester.pumpWidget(_harness(banner: null, extraSlivers: [probe]));
     await tester.pumpAndSettle();
-    expect(
-      capturedInsets.last,
-      PregoTopNavigation.barHeight + PregoSpacing.xl,
-    );
+    expect(capturedInsets.last, PregoTopNavigation.barHeight);
   });
 
   testWidgets("PregoTopBarInsetBuilder falls back to the static bar inset without a scaffold", (tester) async {
@@ -205,7 +196,7 @@ void main() {
     expect(tester.getSize(find.byType(GlassAppBar)).height, PregoTopNavigation.barHeight);
     expect(
       tester.getTopLeft(find.byKey(_contentKey)).dy,
-      topPad + _bannerHeight + PregoTopNavigation.barHeight + PregoSpacing.xl,
+      topPad + _bannerHeight + PregoTopNavigation.barHeight,
     );
   });
 

--- a/client/module_prego/test/components/prego_glass_scaffold_banner_test.dart
+++ b/client/module_prego/test/components/prego_glass_scaffold_banner_test.dart
@@ -246,6 +246,8 @@ void main() {
     expect(gradient.colors[0], surface.withValues(alpha: surface.a * 0.98));
     expect(gradient.colors[1], surface.withValues(alpha: surface.a * 0.88));
     expect(gradient.colors[2], surface.withValues(alpha: 0));
+    expect(gradient.begin, Alignment.topCenter);
+    expect(gradient.end, Alignment.bottomCenter);
     expect(
       tester.getSize(gradientFinder).height,
       PregoTopNavigation.barHeight + _bannerHeight,

--- a/client/module_prego/test/components/prego_glass_scaffold_banner_test.dart
+++ b/client/module_prego/test/components/prego_glass_scaffold_banner_test.dart
@@ -47,14 +47,18 @@ Widget _harness({
 
 void main() {
   // The test viewport has no status-bar inset, so the top-bar geometry is:
-  // bar row top == banner height, first content top == banner height + 54.
+  // bar row top == banner height, first content top == banner height + the bar
+  // and its scroll-edge fade extent.
 
   testWidgets("without a banner the bar sits at the top and content clears it", (tester) async {
     await tester.pumpWidget(_harness(banner: null));
     await tester.pump();
 
     expect(tester.getTopLeft(find.byType(GlassAppBar)).dy, 0);
-    expect(tester.getTopLeft(find.byKey(_contentKey)).dy, PregoTopNavigation.barHeight);
+    expect(
+      tester.getTopLeft(find.byKey(_contentKey)).dy,
+      PregoTopNavigation.barHeight + PregoSpacing.xl,
+    );
   });
 
   testWidgets("a banner mounted with the scaffold shifts the bar and content down by its height", (tester) async {
@@ -68,7 +72,7 @@ void main() {
     expect(tester.getTopLeft(find.byType(GlassAppBar)).dy, _bannerHeight);
     expect(
       tester.getTopLeft(find.byKey(_contentKey)).dy,
-      _bannerHeight + PregoTopNavigation.barHeight,
+      _bannerHeight + PregoTopNavigation.barHeight + PregoSpacing.xl,
     );
   });
 
@@ -85,16 +89,21 @@ void main() {
     expect(midBarTop, lessThan(_bannerHeight));
     // The measured inset trails the animation by one frame (measure → notify →
     // rebuild). After a zero-duration frame the animation hasn't advanced, so
-    // the content must sit exactly one bar height below the mid-animation bar.
+    // the content must sit one bar and fade extent below the mid-animation bar.
     await tester.pump(Duration.zero);
     final midContentTop = tester.getTopLeft(find.byKey(_contentKey)).dy;
-    expect(midContentTop, moreOrLessEquals(midBarTop + PregoTopNavigation.barHeight));
+    expect(
+      midContentTop,
+      moreOrLessEquals(
+        midBarTop + PregoTopNavigation.barHeight + PregoSpacing.xl,
+      ),
+    );
 
     await tester.pumpAndSettle();
     expect(tester.getTopLeft(find.byType(GlassAppBar)).dy, _bannerHeight);
     expect(
       tester.getTopLeft(find.byKey(_contentKey)).dy,
-      _bannerHeight + PregoTopNavigation.barHeight,
+      _bannerHeight + PregoTopNavigation.barHeight + PregoSpacing.xl,
     );
   });
 
@@ -116,7 +125,10 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text("banner-content"), findsNothing);
     expect(tester.getTopLeft(find.byType(GlassAppBar)).dy, 0);
-    expect(tester.getTopLeft(find.byKey(_contentKey)).dy, PregoTopNavigation.barHeight);
+    expect(
+      tester.getTopLeft(find.byKey(_contentKey)).dy,
+      PregoTopNavigation.barHeight + PregoSpacing.xl,
+    );
   });
 
   testWidgets("PregoTopBarInsetBuilder tracks the banner height inside the scaffold", (tester) async {
@@ -132,11 +144,17 @@ void main() {
 
     await tester.pumpWidget(_harness(banner: _banner(), extraSlivers: [probe]));
     await tester.pumpAndSettle();
-    expect(capturedInsets.last, PregoTopNavigation.barHeight + _bannerHeight);
+    expect(
+      capturedInsets.last,
+      PregoTopNavigation.barHeight + _bannerHeight + PregoSpacing.xl,
+    );
 
     await tester.pumpWidget(_harness(banner: null, extraSlivers: [probe]));
     await tester.pumpAndSettle();
-    expect(capturedInsets.last, PregoTopNavigation.barHeight);
+    expect(
+      capturedInsets.last,
+      PregoTopNavigation.barHeight + PregoSpacing.xl,
+    );
   });
 
   testWidgets("PregoTopBarInsetBuilder falls back to the static bar inset without a scaffold", (tester) async {
@@ -187,7 +205,7 @@ void main() {
     expect(tester.getSize(find.byType(GlassAppBar)).height, PregoTopNavigation.barHeight);
     expect(
       tester.getTopLeft(find.byKey(_contentKey)).dy,
-      topPad + _bannerHeight + PregoTopNavigation.barHeight,
+      topPad + _bannerHeight + PregoTopNavigation.barHeight + PregoSpacing.xl,
     );
   });
 
@@ -230,7 +248,7 @@ void main() {
     expect(parent?.widget, isA<Builder>());
   });
 
-  testWidgets("the scroll-edge gradient spans the banner and the bar", (tester) async {
+  testWidgets("the scroll-edge gradient extends below the banner and bar", (tester) async {
     final gradientFinder = find.byWidgetPredicate(
       (widget) =>
           widget is Container &&
@@ -250,12 +268,15 @@ void main() {
     expect(gradient.end, Alignment.bottomCenter);
     expect(
       tester.getSize(gradientFinder).height,
-      PregoTopNavigation.barHeight + _bannerHeight,
+      PregoTopNavigation.barHeight + _bannerHeight + PregoSpacing.xl,
     );
 
     await tester.pumpWidget(_harness(banner: null));
     await tester.pumpAndSettle();
-    expect(tester.getSize(gradientFinder).height, PregoTopNavigation.barHeight);
+    expect(
+      tester.getSize(gradientFinder).height,
+      PregoTopNavigation.barHeight + PregoSpacing.xl,
+    );
   });
 
   testWidgets("pull-to-refresh opens below the bar and moves content down", (tester) async {

--- a/client/module_prego/test/components/prego_popup_alerts_notifications_test.dart
+++ b/client/module_prego/test/components/prego_popup_alerts_notifications_test.dart
@@ -298,7 +298,7 @@ void main() {
 
     expect(
       tester.getTopLeft(find.byType(PregoPopupAlertsNotifications)).dy,
-      PregoTopNavigation.barHeight + 30 + 2 * PregoSpacing.xl,
+      PregoTopNavigation.barHeight + 30 + PregoSpacing.xl,
     );
   });
 }

--- a/client/module_prego/test/components/prego_popup_alerts_notifications_test.dart
+++ b/client/module_prego/test/components/prego_popup_alerts_notifications_test.dart
@@ -298,7 +298,7 @@ void main() {
 
     expect(
       tester.getTopLeft(find.byType(PregoPopupAlertsNotifications)).dy,
-      PregoTopNavigation.barHeight + 30 + PregoSpacing.xl,
+      PregoTopNavigation.barHeight + 30 + 2 * PregoSpacing.xl,
     );
   });
 }


### PR DESCRIPTION
## Complexity

Straightforward. This adjusts existing gradient geometry and keeps the related scroll insets synchronized.

## What

- Correct the session composer fade direction so transcript content dissolves toward the floating controls.
- Extend the shared top-navigation scroll-edge fade 16pt below the bar.
- Keep resting content, nested-scroll, and refresh-indicator geometry at the true bar boundary while the decorative gradient paints beyond it.
- Update widget tests for the revised gradient directions and dimensions.

## Why

The fades previously ended at the navigation boundary or ran along the wrong axis, making scrolling content meet floating controls too abruptly. Extending the fade slightly below the top bar creates the softer iOS-style scroll edge while keeping resting content fully legible.

## Risk and test focus

Low visual risk. Focus review on pages with extended glass navigation, animated connection banners, nested transcript scrolling, pull-to-refresh, and non-extended bodies. There is no database, wire-contract, authentication, or analytics impact.

## Expected result

Content scrolling toward top navigation or the session composer dissolves smoothly before passing behind controls. The top gradient paints 16pt beyond the bar without increasing page layout insets, while non-extended pages retain their existing layout.

## Verification

- `dart analyze` in `client/module_prego`
- `dart analyze` in `client/app`
- `flutter test test/components/prego_glass_scaffold_banner_test.dart` in `client/module_prego`
- `flutter test test/features/project_list/project_list_nav_bar_test.dart` in `client/app`
- `flutter test test/features/session_detail/widgets/session_detail_body_test.dart` in `client/app`
- `git diff --check`
