### PR TITLE
🌿 Show Claude follow-up user messages

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -240,6 +240,10 @@ final class ClaudePlugin({
       operation: "sendPrompt",
     );
     _unstartedSessions.remove(sessionId);
+    _emitVisibleUserMessage(
+      sessionId: sessionId,
+      text: parts.whereType<PluginPromptPartText>().map((part) => part.text).join("\n"),
+    );
   }
 
   @override

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -134,6 +134,38 @@ void main() {
       await subscription.cancel();
     });
 
+    test("publishes an accepted follow-up prompt as a user message", () async {
+      await harness.createSession();
+      final process = harness.processes.single;
+      await waitForFrame(process, "user");
+      process.emit(_result());
+      await pump();
+      final events = <BridgeSseEvent>[];
+      final subscription = harness.plugin.events.listen(events.add);
+
+      await harness.plugin.sendPrompt(
+        sessionId: testSessionId,
+        parts: const [PluginPromptPart.text(text: "follow up")],
+        variant: null,
+        agent: "Default",
+        model: (providerID: "anthropic", modelID: "default"),
+      );
+      await pump();
+
+      final part = events
+          .whereType<BridgeSseMessagePartUpdated>()
+          .where((event) => event.part.text == "follow up")
+          .single
+          .part;
+      final message = events
+          .whereType<BridgeSseMessageUpdated>()
+          .map((event) => shared.Message.fromJson(event.info))
+          .where((message) => message.id == part.messageID)
+          .single;
+      expect(message, isA<shared.MessageUser>());
+      await subscription.cancel();
+    });
+
     test("fails closed when init violates the pre-bound session identity", () async {
       final events = <BridgeSseEvent>[];
       final subscription = harness.plugin.events.listen(events.add);

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -21,7 +21,8 @@ defaults and queued client sends coherent.
   transition back to idle; retry carries attempt, message, and timing, and
   finalized messages enter durable history matching a history read. Internal
   backend command records are not rendered as conversation messages or used as
-  assistant model attribution.
+  assistant model attribution. Claude follow-up prompts appear as user messages
+  when accepted even though its stream transport does not echo submitted input.
 - Pi keeps at most one lazy resident RPC process per active session and allows
   different sessions to run concurrently. Startup replays and hydrates message
   identity before live frames attach or a turn dispatches; same-session prompts


### PR DESCRIPTION
## Complexity

🌿 Straightforward: localized Claude plugin event synthesis with regression coverage.

## What

Publish an accepted Claude follow-up prompt as a user message using its authored text parts. Add plugin regression coverage and document the expected turn behavior.

## Why

Claude stream-json does not echo submitted follow-up input. The plugin synthesized the initial prompt and slash commands, but ordinary later prompts disappeared from the transcript as soon as the client send settled, while assistant output still streamed.

## Risk and test focus

Low risk. The synthetic event is emitted only after backend acceptance and only includes text prompt parts, avoiding host paths or backend-only attachment representations. There is no database impact or wire-contract change. Focus review on live event ordering and avoiding duplicate user entries.

## Expected result

A second and later Claude prompt remains visible in the session transcript before the assistant response streams.

## Verification

- `dart test` in `bridge/sesori_plugin_claude` (214 tests)
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_claude`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows accepted Claude follow-up prompts as user messages using their text parts. Previously, follow-up prompts were not visible in the transcript; now they appear upon backend acceptance before assistant output streams.

- Emits a single synthetic user message after acceptance, using `PluginPromptPartText` joined with newline; no API, storage, or transport changes.
- Validate event ordering and duplicate prevention; tests in `bridge/sesori_plugin_claude` cover this and `docs/regression/session-turns.md` documents the expected turn behavior.

<sup>Written for commit 9df4bfb46cc729d8a1f130937d44297b9da2f0af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

