### PR TITLE
⚙️ Render Claude user prompts from replayed stdin echoes

### DIFF
--- a/.plan/completed/claude-code-plugin/PROTOCOL.md
+++ b/.plan/completed/claude-code-plugin/PROTOCOL.md
@@ -27,6 +27,7 @@ And Plan Deltas.
 ```
 claude -p --input-format stream-json --output-format stream-json \
        --verbose --include-partial-messages \
+       --replay-user-messages \
        --permission-prompt-tool stdio \
        [--permission-mode <mode>] [--model <id>] [--effort <level>] \
        [--session-id <uuid> | --resume <uuid>]
@@ -74,7 +75,7 @@ supervised child. Not yet probed; resolve before the descriptor lands.
 | `--agent <agent>` | verified present | Selects a first-party agent. See section 6. |
 | `--permission-mode <mode>` | verified | Choices differ from the control API — see section 6. |
 | `--forward-subagent-text` | verified present | Opt-in; forwards subagent text/thinking with `parent_tool_use_id` set. Not used in v1. |
-| `--replay-user-messages` | verified present | Re-emits stdin user messages on stdout for acknowledgment. Candidate for `sendPrompt` acceptance. |
+| `--replay-user-messages` | verified, used | Re-emits every stdin user turn on stdout under its transcript uuid (`isReplay: true`), before the turn's assistant output, on both `--session-id` and `--resume`. The replay is the live transcript's only user-message source; a slash command's replay is the internal `<command-message>` envelope and is dropped by mapping. |
 | `--include-hook-events` | verified present | Not used. |
 | `--no-session-persistence` | verified present | Must **not** be used — it disables the transcripts the catalog enumerates. |
 

--- a/bridge/sesori_plugin_claude/lib/src/api/claude_launch_spec.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/claude_launch_spec.dart
@@ -109,6 +109,11 @@ class ClaudeLaunchSpec({
     "--verbose",
     // Enables the token-level `stream_event` deltas the client renders.
     "--include-partial-messages",
+    // Re-emits every stdin user turn on stdout under its transcript uuid, so
+    // the live user message and the transcript backfill row share one id and
+    // can never duplicate. Verified live: the replay arrives before the turn's
+    // assistant output on both --session-id and --resume launches.
+    "--replay-user-messages",
     ...permissionPromptToolArguments,
     // Pattern-bound rather than null-checked so a later edit cannot separate the
     // check from the dereference.

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -226,7 +226,7 @@ final class ClaudeEventDispatcher({
     _messageIds[sessionId] = messageId;
     if (_realModel(model: message.model) case final model?) _models[sessionId] = model;
     final mapped = _content.map(content: message.message["content"]);
-    if (_containsInternalCommandOutput(blocks: mapped)) return const [];
+    if (_content.containsInternalCommandOutput(blocks: mapped)) return const [];
     final parts = _content.mapParts(content: message.message["content"], sessionId: sessionId, messageId: messageId);
     if (!parts.any((part) => part.type.isVisible)) return const [];
     _announcedMessageIds[sessionId] = messageId;
@@ -268,7 +268,7 @@ final class ClaudeEventDispatcher({
     required ClaudeUserMessage message,
   }) {
     final mapped = _content.map(content: message.message["content"]);
-    if (_containsInternalCommandOutput(blocks: mapped)) return const [];
+    if (_content.containsInternalCommandOutput(blocks: mapped)) return const [];
     final results = mapped.whereType<ClaudeMappedToolResultContentBlock>().toList();
     if (results.isNotEmpty) {
       final events = <BridgeSseEvent>[];
@@ -294,7 +294,14 @@ final class ClaudeEventDispatcher({
 
     final messageId = _nonEmptyString(message.uuid);
     if (messageId == null) return const [];
-    final parts = _content.mapParts(content: message.message["content"], sessionId: sessionId, messageId: messageId);
+    // Replayed stdin turns echo the exact execution payload, so the
+    // bridge-owned worktree context is stripped the same way the transcript
+    // history path strips it.
+    final parts = _content.mapParts(
+      content: _content.visibleUserContent(content: message.message["content"]),
+      sessionId: sessionId,
+      messageId: messageId,
+    );
     if (!parts.any((part) => part.type.isVisible)) return const [];
     return [
       BridgeSseMessageUpdated(
@@ -427,14 +434,6 @@ String? _realModel({required String? model}) {
   final normalized = _nonEmptyString(model);
   return normalized == "<synthetic>" ? null : normalized;
 }
-
-bool _containsInternalCommandOutput({required List<ClaudeMappedContentBlock> blocks}) => blocks.any(
-  (block) =>
-      block is ClaudeMappedTextContentBlock &&
-      (block.text.contains("<local-command-stdout>") ||
-          block.text.contains("<local-command-caveat>") ||
-          block.text.contains("<command-name>")),
-);
 
 PluginMessageTime? _messageTime(DateTime? timestamp) =>
     timestamp == null ? null : PluginMessageTime(created: timestamp.millisecondsSinceEpoch, completed: null);

--- a/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
@@ -21,7 +21,7 @@ final class const ClaudeHistoryMapper({
         case ClaudeTranscriptAssistantRecord():
           if (_skipRecord(record: record, sessionId: sessionId)) continue;
           final blocks = _content.map(content: record.content);
-          if (_containsInternalCommandOutput(blocks: blocks)) continue;
+          if (_content.containsInternalCommandOutput(blocks: blocks)) continue;
           final assistant = assistantsByMessageId.putIfAbsent(record.id, () {
             final created = _AssistantHistoryMessage(
               id: record.id,
@@ -43,7 +43,7 @@ final class const ClaudeHistoryMapper({
             continue;
           }
           final blocks = _content.map(content: record.content);
-          if (_containsInternalCommandOutput(blocks: blocks)) continue;
+          if (_content.containsInternalCommandOutput(blocks: blocks)) continue;
           final results = [
             for (final block in blocks)
               if (block is ClaudeMappedToolResultContentBlock) block,
@@ -57,7 +57,7 @@ final class const ClaudeHistoryMapper({
           }
 
           final parts = _content.mapParts(
-            content: _visibleUserContent(record.content),
+            content: _content.visibleUserContent(content: record.content),
             sessionId: sessionId,
             messageId: record.id,
           );
@@ -155,38 +155,3 @@ final class _AssistantHistoryMessage({
 
 PluginMessageTime? _messageTime(DateTime? timestamp) =>
     timestamp == null ? null : PluginMessageTime(created: timestamp.millisecondsSinceEpoch, completed: null);
-
-Object? _visibleUserContent(Object? content) {
-  if (content is! List) return content;
-  final visible = <Object?>[];
-  for (final block in content) {
-    if (block is Map && block["type"] == "text" && block["text"] is String) {
-      final text = _stripBridgeContext(block["text"]! as String);
-      if (text != null && text.isNotEmpty) visible.add({...block.cast<String, Object?>(), "text": text});
-    } else {
-      visible.add(block);
-    }
-  }
-  return visible;
-}
-
-String? _stripBridgeContext(String text) {
-  const marker = "[SYSTEM CONTEXT \u2014 IMPORTANT]";
-  final markerIndex = text.indexOf(marker);
-  if (markerIndex < 0) return text;
-  final envelopeEnd = text.indexOf("\n---", markerIndex);
-  if (envelopeEnd < 0) return text;
-  final trailing = text.substring(envelopeEnd + "\n---".length).trim();
-  if (markerIndex == 0) return trailing.isEmpty ? null : trailing;
-  final prefix = text.substring(0, markerIndex).trimRight();
-  if (!prefix.startsWith("/")) return text;
-  return trailing.isEmpty ? prefix : "$prefix $trailing";
-}
-
-bool _containsInternalCommandOutput({required List<ClaudeMappedContentBlock> blocks}) => blocks.any(
-  (block) =>
-      block is ClaudeMappedTextContentBlock &&
-      (block.text.contains("<local-command-stdout>") ||
-          block.text.contains("<local-command-caveat>") ||
-          block.text.contains("<command-name>")),
-);

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -148,7 +148,6 @@ final class ClaudePlugin({
         rethrow;
       }
     }
-    _emitVisibleUserMessage(sessionId: sessionId, text: userVisibleText);
     return session;
   }
 
@@ -507,6 +506,12 @@ final class ClaudePlugin({
     }
   }
 
+  /// Synthesizes the visible user bubble for a slash command.
+  ///
+  /// Plain prompts never need this: `--replay-user-messages` echoes them under
+  /// their transcript uuid. A command's echo (and its transcript row) is the
+  /// CLI's `<command-name>` envelope, which both mapping paths drop, so this
+  /// synthetic message stays the turn's only user row and cannot duplicate.
   void _emitVisibleUserMessage({required String sessionId, required String? text}) {
     final visible = text?.trim();
     if (visible == null || visible.isEmpty) return;

--- a/bridge/sesori_plugin_claude/lib/src/repositories/mappers/claude_content_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/mappers/claude_content_mapper.dart
@@ -56,6 +56,50 @@ final class const ClaudeContentMapper() {
     return _mapValue(content: content, state: state).toList(growable: false);
   }
 
+  /// Whether [blocks] carry the CLI's internal slash-command envelope or local
+  /// command output, which is never rendered as a user message.
+  bool containsInternalCommandOutput({required List<ClaudeMappedContentBlock> blocks}) => blocks.any(
+    (block) =>
+        block is ClaudeMappedTextContentBlock &&
+        (block.text.contains("<local-command-stdout>") ||
+            block.text.contains("<local-command-caveat>") ||
+            block.text.contains("<command-name>")),
+  );
+
+  /// Strips the bridge-owned worktree context envelope from user [content], so
+  /// both the live replay echo and the persisted transcript render only the
+  /// user-authored text.
+  Object? visibleUserContent({required Object? content}) {
+    if (content is String) {
+      final text = _stripBridgeContext(content);
+      return text == null || text.isEmpty ? const <Object?>[] : [{"type": "text", "text": text}];
+    }
+    if (content is! List) return content;
+    final visible = <Object?>[];
+    for (final block in content) {
+      if (block is Map && block["type"] == "text" && block["text"] is String) {
+        final text = _stripBridgeContext(block["text"]! as String);
+        if (text != null && text.isNotEmpty) visible.add({...block.cast<String, Object?>(), "text": text});
+      } else {
+        visible.add(block);
+      }
+    }
+    return visible;
+  }
+
+  String? _stripBridgeContext(String text) {
+    const marker = "[SYSTEM CONTEXT \u2014 IMPORTANT]";
+    final markerIndex = text.indexOf(marker);
+    if (markerIndex < 0) return text;
+    final envelopeEnd = text.indexOf("\n---", markerIndex);
+    if (envelopeEnd < 0) return text;
+    final trailing = text.substring(envelopeEnd + "\n---".length).trim();
+    if (markerIndex == 0) return trailing.isEmpty ? null : trailing;
+    final prefix = text.substring(0, markerIndex).trimRight();
+    if (!prefix.startsWith("/")) return text;
+    return trailing.isEmpty ? prefix : "$prefix $trailing";
+  }
+
   List<PluginMessagePart> mapParts({
     required Object? content,
     required String sessionId,

--- a/bridge/sesori_plugin_claude/lib/src/repositories/mappers/claude_content_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/mappers/claude_content_mapper.dart
@@ -56,14 +56,24 @@ final class const ClaudeContentMapper() {
     return _mapValue(content: content, state: state).toList(growable: false);
   }
 
+  static const List<String> _internalCommandMarkers = [
+    "<local-command-stdout>",
+    "<local-command-caveat>",
+    "<command-name>",
+    "<command-message>",
+  ];
+
   /// Whether [blocks] carry the CLI's internal slash-command envelope or local
   /// command output, which is never rendered as a user message.
+  ///
+  /// The envelope always leads with its tag, so only a block that *starts*
+  /// with a marker is internal. A prompt that merely mentions a marker mid-text
+  /// stays visible — with replay as the only echo source, a substring match
+  /// would silently hide that prompt everywhere.
   bool containsInternalCommandOutput({required List<ClaudeMappedContentBlock> blocks}) => blocks.any(
     (block) =>
         block is ClaudeMappedTextContentBlock &&
-        (block.text.contains("<local-command-stdout>") ||
-            block.text.contains("<local-command-caveat>") ||
-            block.text.contains("<command-name>")),
+        _internalCommandMarkers.any((marker) => block.text.trimLeft().startsWith(marker)),
   );
 
   /// Strips the bridge-owned worktree context envelope from user [content], so
@@ -94,8 +104,8 @@ final class const ClaudeContentMapper() {
     final envelopeEnd = text.indexOf("\n---", markerIndex);
     if (envelopeEnd < 0) return text;
     final trailing = text.substring(envelopeEnd + "\n---".length).trim();
-    if (markerIndex == 0) return trailing.isEmpty ? null : trailing;
-    final prefix = text.substring(0, markerIndex).trimRight();
+    final prefix = text.substring(0, markerIndex).trim();
+    if (prefix.isEmpty) return trailing.isEmpty ? null : trailing;
     if (!prefix.startsWith("/")) return text;
     return trailing.isEmpty ? prefix : "$prefix $trailing";
   }

--- a/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
@@ -368,6 +368,33 @@ void main() {
       expect(unmatchedResult, isEmpty);
     });
 
+    test("strips the bridge worktree envelope from a replayed user frame", () {
+      const envelope =
+          "[SYSTEM CONTEXT \u2014 IMPORTANT]\nWorktree path: /private/worktree\n---\n";
+      final replayed = _map(
+        mapper,
+        _user(
+          uuid: "replay-frame",
+          content: [
+            {"type": "text", "text": "${envelope}authored follow-up"},
+          ],
+        ),
+      );
+      final contextOnly = _map(
+        mapper,
+        _user(
+          uuid: "context-frame",
+          content: [
+            {"type": "text", "text": envelope},
+          ],
+        ),
+      );
+
+      expect((replayed.first as BridgeSseMessageUpdated).info["id"], "replay-frame");
+      expect((replayed.last as BridgeSseMessagePartUpdated).part.text, "authored follow-up");
+      expect(contextOnly, isEmpty);
+    });
+
     test("maps retry and terminal errors with parseable privacy-safe payloads", () {
       final before = DateTime.now().millisecondsSinceEpoch;
       final retry =

--- a/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
@@ -195,6 +195,24 @@ void main() {
       expect((shared.Message.fromJson(error.info) as shared.MessageError).modelID, "claude-opus-5");
     });
 
+    test("keeps a prompt that merely mentions internal command markers", () {
+      final mentioned = _map(
+        mapper,
+        _user(
+          uuid: "user-mention",
+          content: const [
+            {"type": "text", "text": "What does <command-name> mean in <local-command-stdout> output?"},
+          ],
+        ),
+      );
+
+      expect((mentioned.first as BridgeSseMessageUpdated).info["id"], "user-mention");
+      expect(
+        (mentioned.last as BridgeSseMessagePartUpdated).part.text,
+        "What does <command-name> mean in <local-command-stdout> output?",
+      );
+    });
+
     test("maps tool input and completion with one diff signal", () {
       _startMessage(mapper, messageId: "msg-tool");
       final started = _map(

--- a/bridge/sesori_plugin_claude/test/claude_launch_spec_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_launch_spec_test.dart
@@ -33,6 +33,9 @@ void main() {
       expect(arguments, containsAllInOrder(["--output-format", "stream-json"]));
       expect(arguments, contains("--verbose"));
       expect(arguments, contains("--include-partial-messages"));
+      // The replay echo is the only user-message event source; without it every
+      // stdin turn would be invisible in the live transcript.
+      expect(arguments, contains("--replay-user-messages"));
     });
 
     test("always routes permission asks over stdio", () {

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -107,7 +107,7 @@ void main() {
       await subscription.cancel();
     });
 
-    test("shows only userVisibleText while sending full execution context", () async {
+    test("shows only the user-authored text from a replayed execution context", () async {
       final events = <BridgeSseEvent>[];
       final subscription = harness.plugin.events.listen(events.add);
 
@@ -123,14 +123,22 @@ void main() {
         agent: "Default",
         model: (providerID: "anthropic", modelID: "default"),
       );
+      final process = harness.processes.single;
+      final written = await waitForFrame(process, "user");
+      final executionText = _userTexts(process).join("\n");
+      expect(executionText, contains("private-branch"));
+      process.emit(_replayOf(written, uuid: "replay-user-1"));
       await pump();
 
       final visibleParts = events.whereType<BridgeSseMessagePartUpdated>().where(
         (event) => event.part.type == PluginMessagePartType.text,
       );
       expect(visibleParts.single.part.text, "visible prompt");
-      final executionText = _userTexts(harness.processes.single).join("\n");
-      expect(executionText, contains("private-branch"));
+      expect(visibleParts.single.part.messageID, "replay-user-1");
+      final user = events.whereType<BridgeSseMessageUpdated>().where(
+        (event) => event.info["role"] == "user",
+      );
+      expect(user.single.info["id"], "replay-user-1");
       await subscription.cancel();
     });
 
@@ -210,6 +218,38 @@ void main() {
               .having((error) => error.cause, "cause", isNotNull),
         ),
       );
+    });
+
+    test("renders a follow-up prompt from its replayed user frame", () async {
+      await harness.createSession();
+      final first = harness.processes.single;
+      await waitForFrame(first, "user");
+      first.emit(_result());
+      await pump();
+      final events = <BridgeSseEvent>[];
+      final subscription = harness.plugin.events.listen(events.add);
+
+      await harness.plugin.sendPrompt(
+        sessionId: testSessionId,
+        parts: const [PluginPromptPart.text(text: "follow-up")],
+        variant: null,
+        agent: "Default",
+        model: (providerID: "anthropic", modelID: "default"),
+      );
+      await _waitForUserText(first, "follow-up");
+      final written = first.written.lastWhere((frame) => frame["type"] == "user");
+      first.emit(_replayOf(written, uuid: "replay-user-2"));
+      await pump();
+
+      final visible = events.whereType<BridgeSseMessagePartUpdated>().where(
+        (event) => event.part.text == "follow-up",
+      );
+      expect(visible.single.part.messageID, "replay-user-2");
+      final message = events.whereType<BridgeSseMessageUpdated>().where(
+        (event) => event.info["id"] == "replay-user-2" && event.info["role"] == "user",
+      );
+      expect(message, hasLength(1));
+      await subscription.cancel();
     });
 
     test("respawns between turns when launch-only effort changes", () async {
@@ -607,6 +647,15 @@ Map<String, Object?> _result() => {
   "subtype": "success",
   "session_id": testSessionId,
   "is_error": false,
+};
+
+/// The CLI's `--replay-user-messages` echo of a stdin user frame [written],
+/// stamped with its transcript [uuid].
+Map<String, Object?> _replayOf(Map<String, Object?> written, {required String uuid}) => {
+  ...written,
+  "uuid": uuid,
+  "isReplay": true,
+  "timestamp": "2026-08-11T12:00:00.000Z",
 };
 
 final class _ThrowingDeleteTranscriptApi() extends ClaudeTranscriptApi {

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -22,6 +22,12 @@ defaults and queued client sends coherent.
   finalized messages enter durable history matching a history read. Internal
   backend command records are not rendered as conversation messages or used as
   assistant model attribution.
+- Claude user prompts appear in the live transcript from the CLI's replayed
+  stdin echo under their transcript uuid, so a follow-up prompt stays visible
+  and a later transcript backfill converges on the same message instead of
+  duplicating it. The bridge worktree context envelope is stripped from the
+  echo, and a slash command renders one synthetic user message because its
+  echo is the CLI's internal command envelope.
 - Pi keeps at most one lazy resident RPC process per active session and allows
   different sessions to run concurrently. Startup replays and hydrates message
   identity before live frames attach or a turn dispatches; same-session prompts


### PR DESCRIPTION
## Complexity

⚙️ Moderate: replaces the Claude plugin's synthetic user-echo mechanism with the CLI's own replay stream and reworks the affected mapping paths and tests.

## What

- Launch the Claude CLI with `--replay-user-messages`, so every stdin user turn is re-emitted on stdout under its transcript uuid.
- Render live user messages from those replay frames in `ClaudeEventDispatcher`, stripping the bridge worktree context envelope with the same logic the transcript history path already uses (now shared on `ClaudeContentMapper`).
- Delete the synthetic user echoes from `createSession` and `sendPrompt`. The synthetic echo remains only for slash commands, whose replay is the CLI's internal `<command-name>` envelope and is deliberately dropped by both mapping paths, so the command's synthetic message stays the turn's only user row.

## Why

Claude's stream transport did not echo submitted input back, and only the first prompt and slash commands were synthesized. A follow-up prompt therefore vanished from the phone as soon as the send settled (the optimistic bubble cleared and no user message ever arrived), while assistant output still streamed.

The previously attempted fix — synthesizing an echo for follow-ups too (#935 and an earlier draft of this branch) — leaves a second defect in place: synthetic ids (`sesori-user-N`) never match the transcript uuid, so any full backfill (e.g. bridge restart) duplicates every synthesized prompt. Verified live before this change: the first prompt appeared twice after a backfill. Replay frames carry the real transcript uuid, so the live row and the backfill row converge by construction.

## Risk and test focus

- The replay flag is documented present and verified live at CLI 2.1.221–2.1.233; the pinned `minVersion` is 2.1.221, so no version bump.
- Replay echoes the full execution payload, including the bridge worktree context; focus review on the envelope strip in the dispatcher (`visibleUserContent`) and on slash commands keeping exactly one visible user row.
- No database impact. No wire-contract change: the same SSE event shapes are emitted, only their source and ids change.

## Expected result

Follow-up Claude prompts stay visible on the phone, and restarting the bridge (transcript backfill) no longer duplicates user messages.

## Verification

- `dart analyze --fatal-infos` and `dart test` (215) in `bridge/sesori_plugin_claude`
- Live CLI probes: replay present on `--session-id` and `--resume`; replay uuid == transcript uuid; slash-command replay is the internal envelope; `/compact` emits no replay
- E2E against a real bridge + relay + phone simulator (slot 1):
  - fresh session → exactly one user row under the transcript uuid
  - follow-up prompt → visible, correct uuid, survives the post-completion refresh
  - bridge restart → backfill converges on the same 4 rows, no duplicates
  - dedicated-worktree session → context envelope stripped from the live echo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders Claude user prompts from the CLI’s `--replay-user-messages` echo instead of synthesizing them, so follow-up prompts stay visible and transcript backfills converge on the same message via the transcript uuid. Internal command frames are ignored; slash commands still synthesize one user bubble.

- Launch adds `--replay-user-messages`; the dispatcher renders replay frames while `ClaudeContentMapper.visibleUserContent` strips the bridge worktree context for both live and history paths.
- `ClaudeContentMapper.containsInternalCommandOutput` drops command envelopes/output and now matches markers only at the start of a text block, so prompts that merely mention markers remain visible.
- No database or SSE shape changes; minimum CLI stays 2.1.221. Tests assert replay ids, follow-ups from replay, and marker handling. PROTOCOL marks the flag as canonical.

<sup>Written for commit 36680faf697bdce7cc07e4595e9b3a5a687a9bf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

