### PR TITLE
🌿 Add branded bridge startup banner

### DIFF
--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -25,6 +25,7 @@ import 'package:sesori_bridge/src/bridge/runtime/bridge_logout_runner.dart';
 import 'package:sesori_bridge/src/bridge/runtime/bridge_runtime_runner.dart';
 import 'package:sesori_bridge/src/bridge/runtime/plugin_cli_options_mapper.dart';
 import 'package:sesori_bridge/src/bridge/runtime/plugin_registry.dart';
+import 'package:sesori_bridge/src/foundation/bridge_startup_banner_formatter.dart';
 import 'package:sesori_bridge/src/repositories/app_onboarding_state_repository.dart';
 import 'package:sesori_bridge/src/repositories/bridge_settings_repository.dart';
 import 'package:sesori_bridge/src/repositories/default_editor_repository.dart';
@@ -169,6 +170,14 @@ class RunCommand() extends cli.Command<void> {
       }
     }
     Log.level = LogLevel.values.byName(options.logLevelName);
+
+    if (!options.isSupervised) {
+      final banner = BridgeStartupBannerFormatter(
+        out: stdout,
+        environment: Platform.environment,
+      ).format(version: appVersion);
+      if (banner != null) Console.message(banner);
+    }
 
     // Surface deprecated-flag usage to the user directly. The legacy flag still
     // worked; this only nudges the user toward the namespaced form, so it must

--- a/bridge/app/lib/src/foundation/bridge_startup_banner_formatter.dart
+++ b/bridge/app/lib/src/foundation/bridge_startup_banner_formatter.dart
@@ -1,0 +1,65 @@
+import "dart:io";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
+    show TerminalColorValidator, TerminalGlyphValidator;
+
+/// Renders the installer wordmark for interactive standalone bridge starts.
+class BridgeStartupBannerFormatter({
+  required final Stdout _out,
+  required Map<String, String> environment,
+}) {
+  static const String _reset = "\x1B[0m";
+  static const String _banner = "\x1B[0;2m";
+  static const String _brand = "\x1B[38;5;39m";
+  static const String _bold = "\x1B[1m";
+  static const String _dim = "\x1B[2m";
+
+  static const List<String> _unicodeWordmark = [
+    " ███████╗███████╗███████╗ ██████╗ ██████╗ ██╗",
+    " ██╔════╝██╔════╝██╔════╝██╔═══██╗██╔══██╗██║",
+    " ███████╗█████╗  ███████╗██║   ██║██████╔╝██║",
+    " ╚════██║██╔══╝  ╚════██║██║   ██║██╔══██╗██║",
+    " ███████║███████╗███████║╚██████╔╝██║  ██║██║",
+    " ╚══════╝╚══════╝╚══════╝ ╚═════╝ ╚═╝  ╚═╝╚═╝",
+  ];
+  static const List<String> _asciiWordmark = [
+    "  ____  _____ ____   ___  ____  ___ ",
+    r" / ___|| ____/ ___| / _ \|  _ \|_ _|",
+    r" \___ \|  _| \___ \| | | | |_) || | ",
+    "  ___) | |___ ___) | |_| |  _ < | | ",
+    r" |____/|_____|____/ \___/|_| \_\___|",
+  ];
+
+  final bool _color = TerminalColorValidator.isSupported(
+    out: _out,
+    environment: environment,
+  );
+  final bool _unicode = TerminalGlyphValidator.isSupported(environment: environment);
+
+  /// Returns the banner, or `null` when stdout is not an interactive terminal.
+  String? format({required String version}) {
+    if (!_hasTerminal) return null;
+
+    final wordmark = _unicode ? _unicodeWordmark : _asciiWordmark;
+    final buffer = StringBuffer()..writeln();
+    for (final line in wordmark) {
+      buffer.writeln(_paint(code: _banner, text: line));
+    }
+    buffer
+      ..writeln()
+      ..write("  ${_paint(code: "$_brand$_bold", text: "BRIDGE")} ")
+      ..write(_paint(code: _dim, text: "v$version  |  AI coding sessions on your phone"))
+      ..writeln();
+    return buffer.toString();
+  }
+
+  bool get _hasTerminal {
+    try {
+      return _out.hasTerminal;
+    } on Object {
+      return false;
+    }
+  }
+
+  String _paint({required String code, required String text}) => _color ? "$code$text$_reset" : text;
+}

--- a/bridge/app/lib/src/foundation/bridge_startup_banner_formatter.dart
+++ b/bridge/app/lib/src/foundation/bridge_startup_banner_formatter.dart
@@ -40,15 +40,24 @@ class BridgeStartupBannerFormatter({
   String? format({required String version}) {
     if (!_hasTerminal) return null;
 
-    final wordmark = _unicode ? _unicodeWordmark : _asciiWordmark;
+    final terminalColumns = _terminalColumns;
+    if (terminalColumns == null) return null;
+
+    final compactDetail = " v$version";
+    if (terminalColumns < _maxWidth(_asciiWordmark) || terminalColumns < "  BRIDGE$compactDetail".length) {
+      return null;
+    }
+    final wordmark = _unicode && terminalColumns >= _maxWidth(_unicodeWordmark) ? _unicodeWordmark : _asciiWordmark;
+    final fullDetail = " v$version  |  AI coding sessions on your phone";
+    final detail = terminalColumns >= "  BRIDGE$fullDetail".length ? fullDetail : compactDetail;
     final buffer = StringBuffer()..writeln();
     for (final line in wordmark) {
       buffer.writeln(_paint(code: _banner, text: line));
     }
     buffer
       ..writeln()
-      ..write("  ${_paint(code: "$_brand$_bold", text: "BRIDGE")} ")
-      ..write(_paint(code: _dim, text: "v$version  |  AI coding sessions on your phone"))
+      ..write("  ${_paint(code: "$_brand$_bold", text: "BRIDGE")}")
+      ..write(_paint(code: _dim, text: detail))
       ..writeln();
     return buffer.toString();
   }
@@ -60,6 +69,16 @@ class BridgeStartupBannerFormatter({
       return false;
     }
   }
+
+  int? get _terminalColumns {
+    try {
+      return _out.terminalColumns;
+    } on Object {
+      return null;
+    }
+  }
+
+  static int _maxWidth(List<String> lines) => lines.fold(0, (width, line) => line.length > width ? line.length : width);
 
   String _paint({required String code, required String text}) => _color ? "$code$text$_reset" : text;
 }

--- a/bridge/app/test/foundation/bridge_startup_banner_formatter_test.dart
+++ b/bridge/app/test/foundation/bridge_startup_banner_formatter_test.dart
@@ -1,0 +1,57 @@
+import "dart:io";
+
+import "package:sesori_bridge/src/foundation/bridge_startup_banner_formatter.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("BridgeStartupBannerFormatter", () {
+    test("renders the installer wordmark and version for a capable terminal", () {
+      final output = BridgeStartupBannerFormatter(
+        out: _FakeStdout(hasTerminal: true, supportsAnsiEscapes: true),
+        environment: const {"LANG": "en_US.UTF-8"},
+      ).format(version: "1.8.0");
+
+      expect(output, contains("███████╗███████╗███████╗"));
+      expect(output, contains("\x1B[0;2m"));
+      expect(output, contains("\x1B[38;5;39m\x1B[1mBRIDGE\x1B[0m"));
+      expect(output, contains("v1.8.0  |  AI coding sessions on your phone"));
+    });
+
+    test("uses the ASCII wordmark when the locale is not UTF-8", () {
+      final output = BridgeStartupBannerFormatter(
+        out: _FakeStdout(hasTerminal: true, supportsAnsiEscapes: true),
+        environment: const {"LANG": "C"},
+      ).format(version: "1.8.0");
+
+      expect(output, contains(" ____  _____ ____   ___  ____  ___"));
+      expect(output, isNot(contains("███████╗")));
+    });
+
+    test("keeps the wordmark but omits ANSI when color is disabled", () {
+      final output = BridgeStartupBannerFormatter(
+        out: _FakeStdout(hasTerminal: true, supportsAnsiEscapes: true),
+        environment: const {"LANG": "en_US.UTF-8", "NO_COLOR": ""},
+      ).format(version: "1.8.0");
+
+      expect(output, contains("███████╗███████╗███████╗"));
+      expect(output, isNot(contains("\x1B[")));
+    });
+
+    test("does not render into redirected output", () {
+      final output = BridgeStartupBannerFormatter(
+        out: _FakeStdout(hasTerminal: false, supportsAnsiEscapes: false),
+        environment: const {"LANG": "en_US.UTF-8"},
+      ).format(version: "1.8.0");
+
+      expect(output, isNull);
+    });
+  });
+}
+
+class _FakeStdout({
+  @override required final bool hasTerminal,
+  @override required final bool supportsAnsiEscapes,
+}) implements Stdout {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/foundation/bridge_startup_banner_formatter_test.dart
+++ b/bridge/app/test/foundation/bridge_startup_banner_formatter_test.dart
@@ -7,7 +7,7 @@ void main() {
   group("BridgeStartupBannerFormatter", () {
     test("renders the installer wordmark and version for a capable terminal", () {
       final output = BridgeStartupBannerFormatter(
-        out: _FakeStdout(hasTerminal: true, supportsAnsiEscapes: true),
+        out: _FakeStdout(hasTerminal: true, supportsAnsiEscapes: true, terminalColumns: 80),
         environment: const {"LANG": "en_US.UTF-8"},
       ).format(version: "1.8.0");
 
@@ -19,7 +19,7 @@ void main() {
 
     test("uses the ASCII wordmark when the locale is not UTF-8", () {
       final output = BridgeStartupBannerFormatter(
-        out: _FakeStdout(hasTerminal: true, supportsAnsiEscapes: true),
+        out: _FakeStdout(hasTerminal: true, supportsAnsiEscapes: true, terminalColumns: 80),
         environment: const {"LANG": "C"},
       ).format(version: "1.8.0");
 
@@ -29,7 +29,7 @@ void main() {
 
     test("keeps the wordmark but omits ANSI when color is disabled", () {
       final output = BridgeStartupBannerFormatter(
-        out: _FakeStdout(hasTerminal: true, supportsAnsiEscapes: true),
+        out: _FakeStdout(hasTerminal: true, supportsAnsiEscapes: true, terminalColumns: 80),
         environment: const {"LANG": "en_US.UTF-8", "NO_COLOR": ""},
       ).format(version: "1.8.0");
 
@@ -37,9 +37,22 @@ void main() {
       expect(output, isNot(contains("\x1B[")));
     });
 
+    test("uses compact ASCII output when the Unicode banner would wrap", () {
+      final output = BridgeStartupBannerFormatter(
+        out: _FakeStdout(hasTerminal: true, supportsAnsiEscapes: false, terminalColumns: 40),
+        environment: const {"LANG": "en_US.UTF-8"},
+      ).format(version: "1.8.0");
+
+      expect(output, contains(" ____  _____ ____   ___  ____  ___"));
+      expect(output, isNot(contains("███████╗")));
+      expect(output, contains("BRIDGE v1.8.0"));
+      expect(output, isNot(contains("AI coding sessions on your phone")));
+      expect(output!.split("\n").every((line) => line.length <= 40), isTrue);
+    });
+
     test("does not render into redirected output", () {
       final output = BridgeStartupBannerFormatter(
-        out: _FakeStdout(hasTerminal: false, supportsAnsiEscapes: false),
+        out: _FakeStdout(hasTerminal: false, supportsAnsiEscapes: false, terminalColumns: 80),
         environment: const {"LANG": "en_US.UTF-8"},
       ).format(version: "1.8.0");
 
@@ -51,6 +64,7 @@ void main() {
 class _FakeStdout({
   @override required final bool hasTerminal,
   @override required final bool supportsAnsiEscapes,
+  @override required final int terminalColumns,
 }) implements Stdout {
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/docs/regression/bridge-installation-and-updates.md
+++ b/docs/regression/bridge-installation-and-updates.md
@@ -12,9 +12,10 @@ reconciliation, periodic check, in-place apply, and explicit update command.
   `sesori-bridge` launcher, and report the version; installers take the newest
   non-prerelease release carrying the platform archive and its basename-keyed checksum
   manifest, and verify artifacts before installing them.
-- An interactive standalone `run` identifies the bridge with the installer wordmark and
-  current version. It uses the shared color and Unicode capability rules, while supervised
-  starts, redirected output, `--version`, and non-run subcommands stay banner-free.
+- An interactive standalone `run` on a sufficiently wide terminal identifies the bridge
+  with the installer wordmark and current version. It uses the shared color and Unicode
+  capability rules plus a compact ASCII fallback, while supervised starts, redirected
+  output, `--version`, and non-run subcommands stay banner-free.
 - The npm package is bootstrap-only: it installs or refreshes the managed runtime and
   points at the managed launcher. Direct execution from an npm payload is unsupported,
   its removal leaves the managed install, and full uninstall is manual.

--- a/docs/regression/bridge-installation-and-updates.md
+++ b/docs/regression/bridge-installation-and-updates.md
@@ -12,6 +12,9 @@ reconciliation, periodic check, in-place apply, and explicit update command.
   `sesori-bridge` launcher, and report the version; installers take the newest
   non-prerelease release carrying the platform archive and its basename-keyed checksum
   manifest, and verify artifacts before installing them.
+- An interactive standalone `run` identifies the bridge with the installer wordmark and
+  current version. It uses the shared color and Unicode capability rules, while supervised
+  starts, redirected output, `--version`, and non-run subcommands stay banner-free.
 - The npm package is bootstrap-only: it installs or refreshes the managed runtime and
   points at the managed launcher. Direct execution from an npm payload is unsupported,
   its removal leaves the managed install, and full uninstall is manual.
@@ -69,6 +72,7 @@ after apply. Use a throwaway machine when mutating an install root.
 ## Sources
 
 - `bridge/RELEASING.md`, `bridge/INSTALL.md`, `install.sh`, `install.ps1`, `app/npm/`
+- `bridge/app/lib/src/foundation/bridge_startup_banner_formatter.dart`
 - `bridge/app/lib/src/updater/` policy, track, lock, repositories, services;
   `bridge/app/bin/bridge.dart` (`update`, `config track`)
 - Tests: `bridge/app/test/updater/`, notably policy and release-contract suites


### PR DESCRIPTION
## Complexity

Straightforward. This adds one pure terminal formatter and wires it into the existing standalone `run` entry point.

## What

- Show the installer-style SESORI wordmark and current bridge version on interactive standalone starts.
- Reuse the shared color and Unicode capability checks, including an ASCII fallback and `NO_COLOR` behavior.
- Keep supervised desktop starts, redirected/headless output, `--version`, and non-run subcommands banner-free.
- Add focused formatter tests and update the bridge installation/update regression contract.

## Why

The first-install flow already has a polished branded terminal experience, but later bridge starts drop back to plain logs. Reusing that visual language makes the CLI feel intentional and immediately identifies the running bridge version.

## Risk and test focus

This is a user-visible CLI presentation change only. There is no database, wire-contract, authentication, plugin, or runtime-lifecycle impact. The main risk is emitting ANSI or Unicode into unsupported output, covered by terminal capability, ASCII, `NO_COLOR`, and redirected-output tests.

## Expected result

Running `sesori-bridge` in an interactive terminal shows the SESORI wordmark followed by `BRIDGE`, the installed version, and a short product line before normal startup output. Automation, services, and desktop-supervised runs retain clean output.

## Verification

- `dart test test/foundation/bridge_startup_banner_formatter_test.dart`
- `dart analyze lib/src/foundation/bridge_startup_banner_formatter.dart test/foundation/bridge_startup_banner_formatter_test.dart --fatal-infos`
- `dart analyze bin/bridge.dart lib/src/foundation/bridge_startup_banner_formatter.dart`
- Scoped architecture implementation review: approved with no findings
- Did not launch the bridge, so the existing resident bridge was not touched

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a branded startup banner to interactive standalone `sesori-bridge run`, choosing Unicode/ASCII and color based on terminal capabilities and keeping the output within the terminal width. Previously starts printed plain logs; now a banner appears only on capable terminals and is omitted if the terminal is too narrow.

- Hooks into `RunCommand` to render only when stdout has a terminal and the run is not supervised.
- Uses `TerminalColorValidator` and `TerminalGlyphValidator` from `sesori_plugin_interface`; honors `NO_COLOR`.
- Chooses Unicode vs ASCII wordmark and compact vs full detail to avoid wrapping; hides the banner if even the compact ASCII line wouldn’t fit.
- Suppressed for supervised desktop starts, redirected/headless output, `--version`, and non-run subcommands.
- Adds focused formatter tests and updates the regression doc to capture width and capability behavior.

<sup>Written for commit 5c7473c54b80b5e2daacd7551b7a4424c7432435. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

