### PR TITLE
🌿 Smooth macOS mouse-wheel chat scrolling

### DIFF
--- a/client/app/lib/features/session_detail/widgets/scroll_follow_tracker.dart
+++ b/client/app/lib/features/session_detail/widgets/scroll_follow_tracker.dart
@@ -1,3 +1,6 @@
+import "dart:async";
+
+import "package:flutter/foundation.dart" show TargetPlatform, defaultTargetPlatform, kIsWeb;
 import "package:flutter/gestures.dart";
 import "package:flutter/rendering.dart";
 import "package:flutter/widgets.dart";
@@ -39,7 +42,7 @@ class ScrollFollowTracker({
     required final ScrollFollowEdge edge,
     final double _edgeTolerance = 20.0,
   }) extends ChangeNotifier {
-  this : scrollController = ScrollController();
+  this : scrollController = _createScrollController();
 
   final ScrollController scrollController;
 
@@ -200,5 +203,77 @@ class ScrollFollowTracker({
       ScrollFollowEdge.min => metrics.minScrollExtent,
       ScrollFollowEdge.max => metrics.maxScrollExtent,
     };
+  }
+}
+
+ScrollController _createScrollController() {
+  if (!kIsWeb && defaultTargetPlatform == TargetPlatform.macOS) {
+    return _SmoothPointerScrollController();
+  }
+  return ScrollController();
+}
+
+/// Smooths macOS's discrete physical mouse-wheel deltas without touching its
+/// trackpad path, which Flutter delivers as native pan/zoom gestures.
+class _SmoothPointerScrollController() extends ScrollController {
+  @override
+  ScrollPosition createScrollPosition(
+    ScrollPhysics physics,
+    ScrollContext context,
+    ScrollPosition? oldPosition,
+  ) {
+    return _SmoothPointerScrollPosition(
+      physics: physics,
+      context: context,
+      initialPixels: initialScrollOffset,
+      keepScrollOffset: keepScrollOffset,
+      oldPosition: oldPosition,
+      debugLabel: debugLabel,
+    );
+  }
+}
+
+class _SmoothPointerScrollPosition({
+  required super.physics,
+  required super.context,
+  required super.initialPixels,
+  required super.keepScrollOffset,
+  required super.oldPosition,
+  required super.debugLabel,
+}) extends ScrollPositionWithSingleContext {
+  static const _animationDuration = Duration(milliseconds: 120);
+
+  double? _pointerScrollTarget;
+  bool _startingPointerScroll = false;
+
+  @override
+  void pointerScroll(double delta) {
+    if (delta == 0) {
+      _pointerScrollTarget = null;
+      super.pointerScroll(delta);
+      return;
+    }
+
+    // Add rapid wheel ticks to the destination rather than to the partially
+    // animated current offset. Otherwise each new tick discards the remaining
+    // distance from the previous one and makes fast wheel scrolling feel slow.
+    final target = ((_pointerScrollTarget ?? pixels) + delta).clamp(minScrollExtent, maxScrollExtent).toDouble();
+    _pointerScrollTarget = target;
+    updateUserScrollDirection(delta < 0 ? ScrollDirection.forward : ScrollDirection.reverse);
+
+    _startingPointerScroll = true;
+    try {
+      unawaited(animateTo(target, duration: _animationDuration, curve: Curves.easeOutCubic));
+    } finally {
+      _startingPointerScroll = false;
+    }
+  }
+
+  @override
+  void beginActivity(ScrollActivity? newActivity) {
+    // A drag, trackpad gesture, programmatic scroll, or completed wheel
+    // animation invalidates the accumulated wheel destination.
+    if (!_startingPointerScroll) _pointerScrollTarget = null;
+    super.beginActivity(newActivity);
   }
 }

--- a/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -1,3 +1,4 @@
+import "package:flutter/foundation.dart";
 import "package:flutter/gestures.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:material_ui/material_ui.dart";
@@ -495,6 +496,49 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byKey(_jumpToLatestKey), findsOneWidget);
+  });
+
+  testWidgets("macOS mouse-wheel scrolling animates and accumulates rapid ticks", (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    try {
+      await tester.binding.setSurfaceSize(const Size(900, 700));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        _SessionDetailMessageListHarness(
+          initialMessages: _userMessages(count: 12),
+          initialStreamingText: const {},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await _sendPointerScroll(
+        tester: tester,
+        target: find.byKey(_listViewKey),
+        delta: const Offset(0, -120),
+      );
+
+      expect(_position(tester).pixels, 0, reason: "a wheel tick should not jump the transcript in one frame");
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 40));
+      expect(_position(tester).pixels, allOf(greaterThan(0), lessThan(120)));
+
+      await _sendPointerScroll(
+        tester: tester,
+        target: find.byKey(_listViewKey),
+        delta: const Offset(0, -120),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        _position(tester).pixels,
+        closeTo(240, 0.5),
+        reason: "a second tick must extend the destination instead of replacing unfinished travel",
+      );
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
   });
 
   testWidgets("programmatic scroll changes do not detach follow mode", (tester) async {

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -82,6 +82,9 @@ defaults and queued client sends coherent.
 - Transcript content scrolling behind the top navigation or floating composer
   dissolves into a strong surface-colour fade, keeping the title and controls
   visually separate and screenshot-readable without text collisions.
+- On macOS, discrete physical mouse-wheel ticks scroll the session transcript
+  smoothly and accumulate while an earlier tick is still animating. Trackpad
+  scrolling keeps Flutter's native direct-manipulation and momentum behavior.
 
 ## Regression Levels
 
@@ -125,6 +128,8 @@ has started.
   running session as if they were user activity.
 - Scrolled transcript text remains clearly visible through the fade and collides
   with the navigation title or floating composer controls.
+- On macOS, a physical mouse wheel moves the transcript in abrupt steps, loses
+  distance across rapid ticks, or changes the smooth native trackpad behavior.
 
 ## Known Limitations
 


### PR DESCRIPTION
## Complexity

Straightforward. The change customizes the session transcript's existing scroll position on native macOS only.

## What

- Animate discrete macOS mouse-wheel deltas over a short ease-out transition.
- Accumulate rapid wheel ticks against the pending destination so no distance is lost mid-animation.
- Preserve Flutter's native trackpad pan, momentum, and all non-macOS behavior.
- Add widget regression coverage and document the expected interaction.

## Why

Flutter applies physical mouse-wheel deltas as immediate offset jumps. On a Logitech MX Master this makes the session transcript feel slow and glitchy compared with the MacBook trackpad.

## Risk and test focus

Risk is limited to native macOS physical mouse-wheel scrolling in session-detail followable lists. Focus on wheel responsiveness, rapid direction changes, follow/detach behavior, jump-to-latest, and unchanged trackpad momentum. There is no database or wire-contract impact.

## Expected result

The macOS session transcript moves smoothly and preserves the full distance from rapid mouse-wheel ticks, while trackpad scrolling remains unchanged.

## Verification

- `flutter test test/features/session_detail/widgets/session_detail_message_list_test.dart test/features/session_detail/widgets/scroll_follow_tracker_test.dart test/features/session_detail/widgets/reasoning_modal_test.dart`
- `dart analyze` in `client/app`
- Architecture implementation review: approved with no findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smooths native macOS physical mouse‑wheel scrolling in the session transcript to remove abrupt jumps and lost distance during fast ticks. Previously each tick applied immediately; now each tick animates over 120 ms with accumulation, while `flutter` trackpad behavior stays unchanged.

**Review focus**
- Applies only on native macOS (not web) and only to session‑detail followable lists; all other platforms and `flutter` trackpad pan/momentum are unchanged.
- Verify wheel responsiveness, rapid direction changes, follow/detach, jump‑to‑latest, and preserved trackpad momentum.
- Adds a macOS wheel‑accumulation widget test; updates regression docs.

<sup>Written for commit fcab32bf55e52fcce44b3de96f3044b2f88c0f51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

