### PR TITLE
🌿 Restore project and session context clicks

### DIFF
--- a/client/app/lib/features/project_list/widgets/project_tile.dart
+++ b/client/app/lib/features/project_list/widgets/project_tile.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:flutter/gestures.dart" show kSecondaryButton;
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:material_ui/material_ui.dart";
 import "package:path/path.dart" as p;
@@ -143,8 +144,13 @@ class const ProjectTile({
       // ListTile, whereas an InkWell contributes only the actions, not the
       // role, and leaves the row's three lines as three separate nodes to
       // swipe past.
-      child: GestureDetector(
-        onSecondaryTap: openMenu,
+      child: Listener(
+        // Some desktop pointer paths report the full pressed-button mask.
+        // TapGestureRecognizer ignores combined masks, so inspect the
+        // secondary bit directly instead of waiting for onSecondaryTap.
+        onPointerDown: (event) {
+          if ((event.buttons & kSecondaryButton) != 0) openMenu();
+        },
         child: MergeSemantics(
           child: Semantics(
             button: true,

--- a/client/app/lib/features/session_list/session_tile.dart
+++ b/client/app/lib/features/session_list/session_tile.dart
@@ -1,3 +1,4 @@
+import "package:flutter/gestures.dart" show kSecondaryButton;
 import "package:material_ui/material_ui.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
@@ -106,8 +107,13 @@ class const SessionTile({
       // Right-click is the mouse counterpart of long-press. The row announces
       // itself as one button, so its two lines aren't separate nodes to swipe
       // past.
-      child: GestureDetector(
-        onSecondaryTap: openMenu,
+      child: Listener(
+        // Some desktop pointer paths report the full pressed-button mask.
+        // TapGestureRecognizer ignores combined masks, so inspect the
+        // secondary bit directly instead of waiting for onSecondaryTap.
+        onPointerDown: (event) {
+          if ((event.buttons & kSecondaryButton) != 0) openMenu();
+        },
         child: MergeSemantics(
           child: Semantics(
             button: true,

--- a/client/app/test/features/project_list/project_tile_menu_test.dart
+++ b/client/app/test/features/project_list/project_tile_menu_test.dart
@@ -129,8 +129,15 @@ void main() {
   testWidgets("right-clicking a project opens the same anchored menu without navigating", (tester) async {
     await pumpScreen(tester);
 
-    // The mouse counterpart of the long-press, for the desktop app.
-    await tester.tap(find.widgetWithText(ProjectTile, "my-app"), buttons: kSecondaryMouseButton);
+    // Desktop pointer events can carry the full pressed-button mask rather
+    // than only the button that changed. The secondary bit must still open the
+    // menu instead of being rejected as a combined-button tap.
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.widgetWithText(ProjectTile, "my-app")),
+      kind: PointerDeviceKind.mouse,
+      buttons: kPrimaryButton | kSecondaryButton,
+    );
+    await gesture.up();
     await tester.pumpAndSettle();
 
     expect(find.widgetWithText(InkWell, "Rename"), findsOneWidget);

--- a/client/app/test/features/session_list/session_tile_menu_test.dart
+++ b/client/app/test/features/session_list/session_tile_menu_test.dart
@@ -94,8 +94,15 @@ void main() {
 
     await pumpPanel(tester, session: session);
 
-    // The mouse counterpart of the long-press, for the desktop app.
-    await tester.tap(find.widgetWithText(SessionTile, "My Session"), buttons: kSecondaryMouseButton);
+    // Desktop pointer events can carry the full pressed-button mask rather
+    // than only the button that changed. The secondary bit must still open the
+    // menu instead of being rejected as a combined-button tap.
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.widgetWithText(SessionTile, "My Session")),
+      kind: PointerDeviceKind.mouse,
+      buttons: kPrimaryButton | kSecondaryButton,
+    );
+    await gesture.up();
     await tester.pumpAndSettle();
 
     expect(find.widgetWithText(InkWell, "Rename"), findsOneWidget);

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -26,6 +26,9 @@ child sessions with titles, activity, statuses, and unseen state.
 - Opening validates the path and surfaces the git-initialization choice. Hiding
   delists without destroying sessions or history. Import is explicit, per
   plugin, atomic, non-destructive, cancellable, and attributes progress.
+- Project and session rows open their anchored action menu on long press or a
+  secondary mouse/trackpad click, including desktop events that carry a full
+  pressed-button mask. A context click never opens the row itself.
 - A session created in a dedicated worktree receives a system prompt identifying
   that worktree, its initial branch, and base branch. The prompt requires all
   work to remain in that worktree, while permitting use of the initial branch,
@@ -104,6 +107,7 @@ after a marker has been established.
   awaiting-only is promoted, or inactive session/project or child order changes.
 - Unseen never clears, clears without viewing, or an unavailable plugin is idle.
 - Hiding destroys sessions, or a cancelled import destroys the committed catalog.
+- A secondary click navigates into a row or fails to open its action menu.
 - A generated title/branch update fails to reach list/detail, changes unseen,
   moves the worktree, or rewrites the backend's creation-time system context.
 


### PR DESCRIPTION
## Complexity

🌿 Straightforward. The fix changes only project/session row pointer handling and focused regression coverage.

## What

- Open project and session action menus directly from the secondary-button bit on pointer down.
- Cover real mouse input carrying a combined primary/secondary button mask.
- Record context-click behavior in the projects-and-sessions regression contract.

## Why

The Flutter 3.47 desktop pointer refactor can report the full pressed-button state for pointer events. Flutter's `TapGestureRecognizer`, which backs `GestureDetector.onSecondaryTap`, accepts only a single selected primary, secondary, or tertiary button and ignores combined masks. The rows therefore received context-click input without invoking their menu callback.

The prior tests used `WidgetTester.tap` without `PointerDeviceKind.mouse` and supplied only the secondary-button value, so they did not model the regressed desktop event shape.

## Risk and test focus

Low behavioral risk. The listener opens the menu only when the secondary-button bit is present; primary taps, long press, and horizontal swipe handling remain unchanged. Focus review on context clicks not navigating the row and on swipe/long-press coexistence.

No database, transport, bridge, authentication, or analytics impact.

## Expected result

Right-clicking or trackpad context-clicking a project or session opens its anchored action menu, including when the desktop pointer event carries a combined button mask. The row does not navigate.

## Verification

- `flutter test test/features/project_list/project_tile_menu_test.dart test/features/project_list/project_tile_swipe_test.dart test/features/session_list/session_tile_menu_test.dart test/features/session_list/session_tile_swipe_test.dart`
- `dart analyze` in `client/app`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores project and session context clicks on desktop. Previously, combined primary+secondary mouse events were ignored by `GestureDetector.onSecondaryTap`; now the action menu opens when the secondary-button bit is present and the row does not navigate.

- Replace `onSecondaryTap` with `Listener.onPointerDown` and check `event.buttons & kSecondaryButton` on project and session tiles.
- Update mouse tests to use `PointerDeviceKind.mouse` with `kPrimaryButton | kSecondaryButton`, and document the behavior in the regression contract.
- Verify context clicks open anchored menus without navigation; primary tap, long-press, and horizontal swipe remain unchanged.

<sup>Written for commit f181ffb2c94e6d67b915f039d9bbe4c4a7e67df4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

