### PR TITLE
⚙️ Show selected harness runtime versions

### DIFF
--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -1065,6 +1065,7 @@ class PluginLifecycleService({
         PluginSetupUnavailable() => PluginSetupState.unavailable,
         PluginSetupUnknown() => PluginSetupState.unknown,
       },
+      runtimeVersion: setup.runtimeVersion,
       actionHint: setup.actionHint,
     );
   }

--- a/bridge/app/test/bridge/routing/get_plugin_management_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_plugin_management_handler_test.dart
@@ -43,6 +43,7 @@ const _response = PluginManagementResponse(
         id: "one",
         displayName: "One",
         state: PluginSetupState.ready,
+        runtimeVersion: "1.2.3",
         actionHint: null,
       ),
       runtimeState: PluginRuntimeState.dormant,

--- a/bridge/app/test/bridge/routing/patch_plugin_idle_timeout_handler_test.dart
+++ b/bridge/app/test/bridge/routing/patch_plugin_idle_timeout_handler_test.dart
@@ -133,6 +133,7 @@ const _unsupportedPlugin = PluginManagementMetadata(
     id: "one",
     displayName: "One",
     state: PluginSetupState.ready,
+    runtimeVersion: null,
     actionHint: null,
   ),
   runtimeState: PluginRuntimeState.dormant,

--- a/bridge/app/test/bridge/routing/plugin_authentication_handlers_test.dart
+++ b/bridge/app/test/bridge/routing/plugin_authentication_handlers_test.dart
@@ -88,6 +88,7 @@ const _metadata = PluginManagementMetadata(
     id: "codex",
     displayName: "Codex",
     state: PluginSetupState.authenticationRequired,
+    runtimeVersion: "0.42.0",
     actionHint: "Sign in.",
   ),
   runtimeState: PluginRuntimeState.blocked,

--- a/bridge/app/test/bridge/routing/post_plugin_lifecycle_command_handler_test.dart
+++ b/bridge/app/test/bridge/routing/post_plugin_lifecycle_command_handler_test.dart
@@ -88,6 +88,7 @@ const _plugin = PluginManagementMetadata(
     id: "one",
     displayName: "One",
     state: PluginSetupState.ready,
+    runtimeVersion: "1.2.3",
     actionHint: null,
   ),
   runtimeState: PluginRuntimeState.dormant,

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -513,7 +513,10 @@ void main() {
       disabledPluginIds: const {"cursor"},
       setupById: const {
         "cursor": PluginSetupNotInspected(),
-        "opencode": PluginSetupAuthenticationRequired(actionHint: "Run opencode auth login."),
+        "opencode": PluginSetupAuthenticationRequired.versioned(
+          actionHint: "Run opencode auth login.",
+          runtimeVersion: "1.18.11",
+        ),
       },
     );
 
@@ -524,12 +527,14 @@ void main() {
           id: "cursor",
           displayName: "Cursor",
           state: PluginSetupState.notInspected,
+          runtimeVersion: null,
           actionHint: null,
         ),
         const PluginSetupMetadata(
           id: "opencode",
           displayName: "OpenCode",
           state: PluginSetupState.authenticationRequired,
+          runtimeVersion: "1.18.11",
           actionHint: "Run opencode auth login.",
         ),
       ],

--- a/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
@@ -134,6 +134,7 @@ final class const ClaudePluginDescriptor({
         actionHint: "Update Claude Code to a supported version, then retry setup detection.",
       );
     }
+    final runtimeVersion = version.toString();
 
     final CommandResult authResult;
     try {
@@ -144,24 +145,28 @@ final class const ClaudePluginDescriptor({
         timeout: _probeTimeout,
       );
     } on Object {
-      return const PluginSetupUnknown(
+      return PluginSetupUnknown.versioned(
         actionHint: "Claude Code authentication could not be determined. Run `claude auth status` locally and retry.",
+        runtimeVersion: runtimeVersion,
       );
     }
     try {
       final status = ClaudeAuthStatusDto.fromJson(jsonDecodeMap(authResult.stdout));
       return switch (status.loggedIn) {
-        true => const PluginSetupReady(),
-        false => const PluginSetupAuthenticationRequired(
+        true => PluginSetupReady.versioned(runtimeVersion: runtimeVersion),
+        false => PluginSetupAuthenticationRequired.versioned(
           actionHint: "Run `claude auth login` on this machine, then retry setup detection.",
+          runtimeVersion: runtimeVersion,
         ),
-        null => const PluginSetupUnknown(
+        null => PluginSetupUnknown.versioned(
           actionHint: "Claude Code authentication could not be determined. Run `claude auth status` locally and retry.",
+          runtimeVersion: runtimeVersion,
         ),
       };
     } on Object {
-      return const PluginSetupUnknown(
+      return PluginSetupUnknown.versioned(
         actionHint: "Claude Code authentication could not be determined. Run `claude auth status` locally and retry.",
+        runtimeVersion: runtimeVersion,
       );
     }
   }

--- a/bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart
@@ -42,7 +42,7 @@ void main() {
         stateDirectory: "/state",
       );
 
-      expect(status, const PluginSetupReady());
+      expect(status, const PluginSetupReady.versioned(runtimeVersion: "2.1.226"));
       expect(processes.arguments, [
         const ["--version"],
         const ["auth", "status"],
@@ -101,6 +101,7 @@ void main() {
       );
 
       _expectNonReady<PluginSetupAuthenticationRequired>(status);
+      expect(status.runtimeVersion, "2.1.221");
       expect(status.actionHint, isNot(contains("private@example.com")));
     });
 
@@ -118,6 +119,7 @@ void main() {
       );
 
       _expectNonReady<PluginSetupUnknown>(status);
+      expect(status.runtimeVersion, "2.1.221");
       expect(status.actionHint, isNot(contains("private-account-output")));
     });
 

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
@@ -316,7 +316,9 @@ class const CodexPluginDescriptor({
                 ),
       };
     }
-    final executable = (selection as CodexRuntimeSelected).binaryPath;
+    final selectedRuntime = selection as CodexRuntimeSelected;
+    final executable = selectedRuntime.binaryPath;
+    final runtimeVersion = selectedRuntime.version.raw;
     final executor = HostProcessCommandExecutor(
       processes: processes,
       runInShell: io.Platform.isWindows,
@@ -332,21 +334,24 @@ class const CodexPluginDescriptor({
         timeout: _versionProbeTimeout,
       );
     } on Object {
-      return const PluginSetupUnknown(
+      return PluginSetupUnknown.versioned(
         actionHint: "Codex authentication could not be determined. Run `codex login status` locally and retry.",
+        runtimeVersion: runtimeVersion,
       );
     }
     final statusOutput = _normalizedStatusOutput(loginResult);
     if (statusOutput.contains("not logged in") || statusOutput.contains("logged out")) {
-      return const PluginSetupAuthenticationRequired(
+      return PluginSetupAuthenticationRequired.versioned(
         actionHint: "Sign in to Codex, then retry setup detection.",
+        runtimeVersion: runtimeVersion,
       );
     }
     if (loginResult.exitCode == 0 && statusOutput.contains("logged in")) {
-      return const PluginSetupReady();
+      return PluginSetupReady.versioned(runtimeVersion: runtimeVersion);
     }
-    return const PluginSetupUnknown(
+    return PluginSetupUnknown.versioned(
       actionHint: "Codex authentication could not be determined. Run `codex login status` locally and retry.",
+      runtimeVersion: runtimeVersion,
     );
   }
 

--- a/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
@@ -75,7 +75,7 @@ void main() {
         stateDirectory: stateDirectory,
       );
 
-      expect(result, const PluginSetupReady());
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "0.146.0"));
       expect(processes.spawnedExecutables, ["codex", "codex"]);
       expect(processes.spawnedArguments, [
         const ["--version"],
@@ -124,7 +124,10 @@ void main() {
         stateDirectory: stateDirectory,
       );
 
-      expect(result, const PluginSetupReady());
+      expect(
+        result,
+        PluginSetupReady.versioned(runtimeVersion: manifest.bundledVersion.raw),
+      );
       expect(processes.spawnedExecutables, ["codex", managedBinaryPath, managedBinaryPath]);
     });
 
@@ -156,7 +159,7 @@ void main() {
             stateDirectory: stateDirectory,
           );
 
-      expect(result, const PluginSetupReady());
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "0.146.0"));
       expect(processes.spawnedExecutables, ["codex", appCli, appCli]);
     });
 
@@ -195,7 +198,10 @@ void main() {
             stateDirectory: stateDirectory,
           );
 
-      expect(result, const PluginSetupReady());
+      expect(
+        result,
+        PluginSetupReady.versioned(runtimeVersion: manifest.bundledVersion.raw),
+      );
       expect(processes.spawnedExecutables, ["codex", appCli, managedBinaryPath, managedBinaryPath]);
     });
 
@@ -295,8 +301,9 @@ void main() {
 
       expect(
         result,
-        const PluginSetupAuthenticationRequired(
+        const PluginSetupAuthenticationRequired.versioned(
           actionHint: "Sign in to Codex, then retry setup detection.",
+          runtimeVersion: "0.146.0",
         ),
       );
       expect(processes.spawnedArguments, [
@@ -330,6 +337,7 @@ void main() {
       );
 
       expect(result, isA<PluginSetupUnknown>());
+      expect(result.runtimeVersion, "0.146.0");
       expect(result.actionHint, isNot(contains("account-secret-output")));
     });
 
@@ -358,6 +366,7 @@ void main() {
       );
 
       expect(result, isA<PluginSetupUnknown>());
+      expect(result.runtimeVersion, "0.146.0");
     });
   });
 }

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
@@ -248,11 +248,9 @@ class const CursorPluginDescriptor({
       processes: processes,
       environment: environment,
     );
-    var runtimeVersion = runtime.version;
-
-    /// Whether the pinned managed runtime is already installed and runnable.
-    /// Only consulted without an explicit `--cursor-bin`, which is
-    /// authoritative when set.
+    /// The pinned managed runtime's version when it is already installed and
+    /// runnable, or null. Only consulted without an explicit `--cursor-bin`,
+    /// which is authoritative when set.
     Future<String?> managedRuntimeVersion() async {
       if (explicitBin != null) return null;
       const manifest = CursorRuntimeManifest();
@@ -262,7 +260,7 @@ class const CursorPluginDescriptor({
         processes: processes,
         environment: environment,
       );
-      if (managed.state != _CursorRuntimeProbeState.ready) return null;
+      if (managed is! _CursorRuntimeReady) return null;
       // The auth probe below must run against the binary that actually
       // resolved, not the PATH name that failed.
       executablePath = managedPath;
@@ -281,37 +279,44 @@ class const CursorPluginDescriptor({
           : "Install the Cursor CLI from Sesori, or install it locally and retry setup detection.";
     }
 
-    if (runtime.state != _CursorRuntimeProbeState.ready) {
-      runtimeVersion = await managedRuntimeVersion();
-      if (runtimeVersion == null) {
-        switch (runtime.state) {
-          case _CursorRuntimeProbeState.missing:
-            return PluginSetupRuntimeMissing(
-              actionHint: explicitBin != null
-                  ? "Fix the configured Cursor CLI path, then restart the bridge."
-                  : missingRuntimeHint(),
-            );
-          case _CursorRuntimeProbeState.outdated:
-            // Without an explicit binary a managed install fixes this, so it is
-            // reported as a missing runtime (installable) rather than
-            // unavailable — matching OpenCode and Codex.
-            if (explicitBin == null) return PluginSetupRuntimeMissing(actionHint: missingRuntimeHint());
-            return const PluginSetupUnavailable(
-              actionHint: "The configured Cursor CLI is too old. Update it and restart the bridge.",
-            );
-          case _CursorRuntimeProbeState.unknown:
-          case _CursorRuntimeProbeState.unrecognized:
-            return const PluginSetupUnknown(
-              actionHint: "Cursor setup could not be determined. Verify the local CLI and retry.",
-            );
-          case _CursorRuntimeProbeState.ready:
-            throw StateError("A ready Cursor runtime must carry a version");
+    final String runtimeVersion;
+    switch (runtime) {
+      case _CursorRuntimeReady(:final version):
+        runtimeVersion = version;
+      case _CursorRuntimeMissing():
+        final managedVersion = await managedRuntimeVersion();
+        if (managedVersion == null) {
+          return PluginSetupRuntimeMissing(
+            actionHint: explicitBin != null
+                ? "Fix the configured Cursor CLI path, then restart the bridge."
+                : missingRuntimeHint(),
+          );
         }
-      }
+        runtimeVersion = managedVersion;
+      case _CursorRuntimeOutdated():
+        final managedVersion = await managedRuntimeVersion();
+        if (managedVersion == null) {
+          // Without an explicit binary a managed install fixes this, so it is
+          // reported as a missing runtime (installable) rather than
+          // unavailable — matching OpenCode and Codex.
+          if (explicitBin == null) return PluginSetupRuntimeMissing(actionHint: missingRuntimeHint());
+          return const PluginSetupUnavailable(
+            actionHint: "The configured Cursor CLI is too old. Update it and restart the bridge.",
+          );
+        }
+        runtimeVersion = managedVersion;
+      case _CursorRuntimeUnknown() || _CursorRuntimeUnrecognized():
+        final managedVersion = await managedRuntimeVersion();
+        if (managedVersion == null) {
+          return const PluginSetupUnknown(
+            actionHint: "Cursor setup could not be determined. Verify the local CLI and retry.",
+          );
+        }
+        runtimeVersion = managedVersion;
     }
 
     if (environment["CURSOR_API_KEY"]?.trim().isNotEmpty ?? false) {
-      return PluginSetupReady.versioned(runtimeVersion: runtimeVersion!);
+      return PluginSetupReady.versioned(runtimeVersion: runtimeVersion);
     }
     final executor = HostProcessCommandExecutor(
       processes: processes,
@@ -330,7 +335,7 @@ class const CursorPluginDescriptor({
       return PluginSetupUnknown.versioned(
         actionHint:
             "Cursor authentication could not be determined. Run the Cursor CLI status command locally and retry.",
-        runtimeVersion: runtimeVersion!,
+        runtimeVersion: runtimeVersion,
       );
     }
     final statusOutput = _normalizedStatusOutput(statusResult);
@@ -340,19 +345,19 @@ class const CursorPluginDescriptor({
         statusOutput.contains("logged out")) {
       return PluginSetupAuthenticationRequired.versioned(
         actionHint: "Log in with the Cursor CLI on this machine, then retry setup detection.",
-        runtimeVersion: runtimeVersion!,
+        runtimeVersion: runtimeVersion,
       );
     }
     if (statusResult.exitCode == 0 && (statusOutput.contains("authenticated") || statusOutput.contains("logged in"))) {
-      return PluginSetupReady.versioned(runtimeVersion: runtimeVersion!);
+      return PluginSetupReady.versioned(runtimeVersion: runtimeVersion);
     }
     return PluginSetupUnknown.versioned(
       actionHint: "Cursor authentication could not be determined. Run the Cursor CLI status command locally and retry.",
-      runtimeVersion: runtimeVersion!,
+      runtimeVersion: runtimeVersion,
     );
   }
 
-  Future<({_CursorRuntimeProbeState state, String? version})> _probeCursorRuntime({
+  Future<_CursorRuntimeProbe> _probeCursorRuntime({
     required String executablePath,
     required HostProcessService processes,
     required Map<String, String> environment,
@@ -377,30 +382,30 @@ class const CursorPluginDescriptor({
         "[cursor] availability probe '$executablePath --version' did not exit within "
         "${_versionProbeTimeout.inSeconds}s",
       );
-      return (state: _CursorRuntimeProbeState.unknown, version: null);
+      return const _CursorRuntimeUnknown();
     } on Object catch (error) {
       // Spawn could not launch — almost always ENOENT: not installed / not on PATH.
       Log.d("[cursor] availability probe could not launch '$executablePath --version': $error");
-      return (state: _CursorRuntimeProbeState.missing, version: null);
+      return const _CursorRuntimeMissing();
     }
 
     if (result.exitCode != 0) {
       Log.d("[cursor] availability probe '$executablePath --version' exited with code ${result.exitCode}");
-      return (state: _CursorRuntimeProbeState.unknown, version: null);
+      return const _CursorRuntimeUnknown();
     }
 
     const manifest = CursorRuntimeManifest();
     final parsed = manifest.parseVersion(value: result.stdout.trim().split(RegExp(r"\s+")).first);
     if (parsed == null) {
-      return (state: _CursorRuntimeProbeState.unrecognized, version: null);
+      return const _CursorRuntimeUnrecognized();
     }
     if (parsed.compareTo(manifest.minPathVersion) < 0) {
       Log.w("[cursor] Cursor CLI ${parsed.raw} is below the supported minimum ${manifest.minPathVersion.raw}");
-      return (state: _CursorRuntimeProbeState.outdated, version: parsed.raw);
+      return const _CursorRuntimeOutdated();
     }
     final version = parsed.raw;
     Log.d("[cursor] available: '$executablePath --version' -> $version");
-    return (state: _CursorRuntimeProbeState.ready, version: version);
+    return _CursorRuntimeReady(version: version);
   }
 
   String _normalizedStatusOutput(CommandResult result) {
@@ -476,4 +481,17 @@ class const CursorPluginDescriptor({
   }
 }
 
-enum _CursorRuntimeProbeState() { ready, missing, outdated, unknown, unrecognized }
+/// Outcome of the Cursor availability probe. Only [_CursorRuntimeReady]
+/// carries the selected runtime version, so a version can never accompany a
+/// rejected or unresolved runtime.
+sealed class const _CursorRuntimeProbe();
+
+final class const _CursorRuntimeReady({required final String version}) extends _CursorRuntimeProbe;
+
+final class const _CursorRuntimeMissing() extends _CursorRuntimeProbe;
+
+final class const _CursorRuntimeOutdated() extends _CursorRuntimeProbe;
+
+final class const _CursorRuntimeUnknown() extends _CursorRuntimeProbe;
+
+final class const _CursorRuntimeUnrecognized() extends _CursorRuntimeProbe;

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
@@ -248,12 +248,13 @@ class const CursorPluginDescriptor({
       processes: processes,
       environment: environment,
     );
+    var runtimeVersion = runtime.version;
 
     /// Whether the pinned managed runtime is already installed and runnable.
     /// Only consulted without an explicit `--cursor-bin`, which is
     /// authoritative when set.
-    Future<bool> managedRuntimeIsReady() async {
-      if (explicitBin != null) return false;
+    Future<String?> managedRuntimeVersion() async {
+      if (explicitBin != null) return null;
       const manifest = CursorRuntimeManifest();
       final managedPath = manifest.managedBinaryPath(stateDirectory: stateDirectory);
       final managed = await _probeCursorRuntime(
@@ -261,11 +262,11 @@ class const CursorPluginDescriptor({
         processes: processes,
         environment: environment,
       );
-      if (managed.state != _CursorRuntimeProbeState.ready) return false;
+      if (managed.state != _CursorRuntimeProbeState.ready) return null;
       // The auth probe below must run against the binary that actually
       // resolved, not the PATH name that failed.
       executablePath = managedPath;
-      return true;
+      return managed.version;
     }
 
     /// What to tell the user when nothing usable was found and Sesori can
@@ -280,38 +281,37 @@ class const CursorPluginDescriptor({
           : "Install the Cursor CLI from Sesori, or install it locally and retry setup detection.";
     }
 
-    switch (runtime.state) {
-      case _CursorRuntimeProbeState.missing:
-        if (!await managedRuntimeIsReady()) {
-          return PluginSetupRuntimeMissing(
-            actionHint: explicitBin != null
-                ? "Fix the configured Cursor CLI path, then restart the bridge."
-                : missingRuntimeHint(),
-          );
+    if (runtime.state != _CursorRuntimeProbeState.ready) {
+      runtimeVersion = await managedRuntimeVersion();
+      if (runtimeVersion == null) {
+        switch (runtime.state) {
+          case _CursorRuntimeProbeState.missing:
+            return PluginSetupRuntimeMissing(
+              actionHint: explicitBin != null
+                  ? "Fix the configured Cursor CLI path, then restart the bridge."
+                  : missingRuntimeHint(),
+            );
+          case _CursorRuntimeProbeState.outdated:
+            // Without an explicit binary a managed install fixes this, so it is
+            // reported as a missing runtime (installable) rather than
+            // unavailable — matching OpenCode and Codex.
+            if (explicitBin == null) return PluginSetupRuntimeMissing(actionHint: missingRuntimeHint());
+            return const PluginSetupUnavailable(
+              actionHint: "The configured Cursor CLI is too old. Update it and restart the bridge.",
+            );
+          case _CursorRuntimeProbeState.unknown:
+          case _CursorRuntimeProbeState.unrecognized:
+            return const PluginSetupUnknown(
+              actionHint: "Cursor setup could not be determined. Verify the local CLI and retry.",
+            );
+          case _CursorRuntimeProbeState.ready:
+            throw StateError("A ready Cursor runtime must carry a version");
         }
-      case _CursorRuntimeProbeState.outdated:
-        if (!await managedRuntimeIsReady()) {
-          // Without an explicit binary a managed install fixes this, so it is
-          // reported as a missing runtime (installable) rather than
-          // unavailable — matching OpenCode and Codex.
-          if (explicitBin == null) return PluginSetupRuntimeMissing(actionHint: missingRuntimeHint());
-          return const PluginSetupUnavailable(
-            actionHint: "The configured Cursor CLI is too old. Update it and restart the bridge.",
-          );
-        }
-      case _CursorRuntimeProbeState.unknown:
-      case _CursorRuntimeProbeState.unrecognized:
-        if (!await managedRuntimeIsReady()) {
-          return const PluginSetupUnknown(
-            actionHint: "Cursor setup could not be determined. Verify the local CLI and retry.",
-          );
-        }
-      case _CursorRuntimeProbeState.ready:
-        break;
+      }
     }
 
     if (environment["CURSOR_API_KEY"]?.trim().isNotEmpty ?? false) {
-      return const PluginSetupReady();
+      return PluginSetupReady.versioned(runtimeVersion: runtimeVersion!);
     }
     final executor = HostProcessCommandExecutor(
       processes: processes,
@@ -327,9 +327,10 @@ class const CursorPluginDescriptor({
         timeout: _versionProbeTimeout,
       );
     } on Object {
-      return const PluginSetupUnknown(
+      return PluginSetupUnknown.versioned(
         actionHint:
             "Cursor authentication could not be determined. Run the Cursor CLI status command locally and retry.",
+        runtimeVersion: runtimeVersion!,
       );
     }
     final statusOutput = _normalizedStatusOutput(statusResult);
@@ -337,15 +338,17 @@ class const CursorPluginDescriptor({
         statusOutput.contains("unauthenticated") ||
         statusOutput.contains("not logged in") ||
         statusOutput.contains("logged out")) {
-      return const PluginSetupAuthenticationRequired(
+      return PluginSetupAuthenticationRequired.versioned(
         actionHint: "Log in with the Cursor CLI on this machine, then retry setup detection.",
+        runtimeVersion: runtimeVersion!,
       );
     }
     if (statusResult.exitCode == 0 && (statusOutput.contains("authenticated") || statusOutput.contains("logged in"))) {
-      return const PluginSetupReady();
+      return PluginSetupReady.versioned(runtimeVersion: runtimeVersion!);
     }
-    return const PluginSetupUnknown(
+    return PluginSetupUnknown.versioned(
       actionHint: "Cursor authentication could not be determined. Run the Cursor CLI status command locally and retry.",
+      runtimeVersion: runtimeVersion!,
     );
   }
 

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
@@ -72,7 +72,7 @@ void main() {
         stateDirectory: stateDirectory,
       );
 
-      expect(result, const PluginSetupReady());
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "2026.07.23-e383d2b"));
       expect(processes.spawnedExecutables, ["cursor-agent", "cursor-agent"]);
       expect(processes.spawnedArguments, [
         const ["--version"],
@@ -109,7 +109,7 @@ void main() {
                 environment: const <String, String>{},
                 stateDirectory: stateDirectory,
               ),
-              const PluginSetupReady(),
+              const PluginSetupReady.versioned(runtimeVersion: "2026.07.23-e383d2b"),
             );
           },
           stderr: () => _CapturingStdout(stderrLines),
@@ -141,6 +141,39 @@ void main() {
       );
 
       expect(result, isA<PluginSetupRuntimeMissing>());
+    });
+
+    test("reports the managed runtime version selected after PATH is missing", () async {
+      const manifest = CursorRuntimeManifest();
+      final managedBinaryPath = manifest.managedBinaryPath(stateDirectory: stateDirectory);
+      final processes = _ProbeProcessService(
+        spawnOutcomes: [
+          const ProcessException("cursor-agent", ["--version"], "missing", 2),
+          _ProbeProcess(
+            pid: 7,
+            stdoutBytes: utf8.encode("${manifest.bundledVersion}\n"),
+            exitCode: Future<int>.value(0),
+          ),
+          _ProbeProcess(
+            pid: 8,
+            stdoutBytes: utf8.encode("Authenticated\n"),
+            exitCode: Future<int>.value(0),
+          ),
+        ],
+      );
+
+      final result = await const CursorPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(
+        result,
+        PluginSetupReady.versioned(runtimeVersion: manifest.bundledVersion.raw),
+      );
+      expect(processes.spawnedExecutables, ["cursor-agent", managedBinaryPath, managedBinaryPath]);
     });
 
     test("an outdated PATH CLI is installable and never leaks version probe text", () async {
@@ -270,6 +303,7 @@ void main() {
       );
 
       expect(result, isA<PluginSetupAuthenticationRequired>());
+      expect(result.runtimeVersion, "2026.07.16");
       expect(processes.spawnedArguments, [
         const ["--version"],
         const ["status"],
@@ -301,6 +335,7 @@ void main() {
       );
 
       expect(result, isA<PluginSetupUnknown>());
+      expect(result.runtimeVersion, "2026.07.16");
       expect(result.actionHint, isNot(contains("account-secret-output")));
     });
   });

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -82,18 +82,18 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
     );
     if (host.startAborted.isAborted) throw const PluginStartAbortedException();
 
-    switch (runtime.state) {
-      case _HermesRuntimeProbeState.ready:
+    switch (runtime) {
+      case _HermesRuntimeReady():
         yield ProvisionReady(binaryPath: executablePath);
-      case _HermesRuntimeProbeState.missing || _HermesRuntimeProbeState.preAcpInstall:
+      case _HermesRuntimeMissing() || _HermesRuntimePreAcpInstall():
         yield const ProvisionFailed(
           message: "Hermes ACP is unavailable. Install or update Hermes, then retry.",
         );
-      case _HermesRuntimeProbeState.outdated:
+      case _HermesRuntimeOutdated():
         yield const ProvisionFailed(
           message: "The Hermes Agent version is too old. Update Hermes, then retry.",
         );
-      case _HermesRuntimeProbeState.unknown || _HermesRuntimeProbeState.unrecognized:
+      case _HermesRuntimeUnknown() || _HermesRuntimeUnrecognized():
         yield const ProvisionFailed(
           message: "The Hermes ACP runtime could not be verified. Check the local install, then retry.",
         );
@@ -115,31 +115,31 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
       environment: environment,
     );
 
-    switch (runtime.state) {
-      case _HermesRuntimeProbeState.missing:
+    final String runtimeVersion;
+    switch (runtime) {
+      case _HermesRuntimeMissing():
         return PluginSetupRuntimeMissing(
           actionHint: explicitBin != null
               ? "Fix the configured Hermes CLI path, then restart the bridge."
               : "Install Hermes Agent locally, then retry setup detection.",
         );
-      case _HermesRuntimeProbeState.preAcpInstall:
+      case _HermesRuntimePreAcpInstall():
         return const PluginSetupRuntimeMissing(
           actionHint:
               "The installed Hermes does not expose the `acp` subcommand. Update Hermes, then retry setup detection.",
         );
-      case _HermesRuntimeProbeState.outdated:
+      case _HermesRuntimeOutdated():
         return PluginSetupUnavailable(
           actionHint: explicitBin != null
               ? "The configured Hermes CLI path points to an unsupported version. Update that install or fix `--hermes-bin`."
               : "The installed Hermes Agent version is too old. Update Hermes and restart the bridge.",
         );
-      case _HermesRuntimeProbeState.unrecognized:
-      case _HermesRuntimeProbeState.unknown:
+      case _HermesRuntimeUnrecognized() || _HermesRuntimeUnknown():
         return const PluginSetupUnknown(
           actionHint: "Hermes setup could not be determined. Verify the local install and retry.",
         );
-      case _HermesRuntimeProbeState.ready:
-        break;
+      case _HermesRuntimeReady(:final version):
+        runtimeVersion = version;
     }
 
     // Auth probe: `hermes status` reports the configured model/provider.
@@ -166,41 +166,41 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
       );
       return PluginSetupUnknown.versioned(
         actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
-        runtimeVersion: runtime.version!,
+        runtimeVersion: runtimeVersion,
       );
     } on Object catch (error, stackTrace) {
       Log.w("[hermes] status probe could not launch '$executablePath status'", error, stackTrace);
       return PluginSetupUnknown.versioned(
         actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
-        runtimeVersion: runtime.version!,
+        runtimeVersion: runtimeVersion,
       );
     }
     if (statusResult.exitCode != 0) {
       Log.w("[hermes] status probe '$executablePath status' exited with code ${statusResult.exitCode}");
       return PluginSetupUnknown.versioned(
         actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
-        runtimeVersion: runtime.version!,
+        runtimeVersion: runtimeVersion,
       );
     }
     final statusOutput = _normalizedStatusOutput(result: statusResult);
     final model = _statusValue(output: statusOutput, field: "model");
     final provider = _statusValue(output: statusOutput, field: "provider");
     if (_isConfiguredStatusValue(value: model) && _isConfiguredStatusValue(value: provider)) {
-      return PluginSetupReady.versioned(runtimeVersion: runtime.version!);
+      return PluginSetupReady.versioned(runtimeVersion: runtimeVersion);
     }
     if (model != null || provider != null) {
       return PluginSetupAuthenticationRequired.versioned(
         actionHint: "Configure a model and provider with `hermes setup` or `hermes model` on this machine, then retry setup detection.",
-        runtimeVersion: runtime.version!,
+        runtimeVersion: runtimeVersion,
       );
     }
     return PluginSetupUnknown.versioned(
       actionHint: "Hermes setup could not be determined. Run `hermes status` locally and retry.",
-      runtimeVersion: runtime.version!,
+      runtimeVersion: runtimeVersion,
     );
   }
 
-  Future<({String? version, _HermesRuntimeProbeState state})> _probeHermesRuntime({
+  Future<_HermesRuntimeProbe> _probeHermesRuntime({
     required String executablePath,
     required HostProcessService processes,
     required Map<String, String> environment,
@@ -225,18 +225,18 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
         "[hermes] availability probe '$executablePath acp --version' did not exit within "
         "${_versionProbeTimeout.inSeconds}s",
       );
-      return (state: _HermesRuntimeProbeState.unknown, version: null);
+      return const _HermesRuntimeUnknown();
     } on io.ProcessException catch (error, stackTrace) {
       // The host process seam reports spawn failures as ProcessException;
       // ENOENT (errorCode 2) means not installed / not on PATH.
-      if (error.errorCode == 2) return (state: _HermesRuntimeProbeState.missing, version: null);
+      if (error.errorCode == 2) return const _HermesRuntimeMissing();
       Log.w("[hermes] availability probe could not launch '$executablePath acp --version'", error, stackTrace);
-      return (state: _HermesRuntimeProbeState.unknown, version: null);
+      return const _HermesRuntimeUnknown();
     } on Object catch (error, stackTrace) {
       // Any other spawn failure (host seam error, permission) is not proof of
       // a missing runtime; report unknown rather than a misleading hint.
       Log.w("[hermes] availability probe could not launch '$executablePath acp --version'", error, stackTrace);
-      return (state: _HermesRuntimeProbeState.unknown, version: null);
+      return const _HermesRuntimeUnknown();
     }
 
     if (result.exitCode != 0) {
@@ -246,27 +246,27 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
       // as an unknown failure.
       final stderr = result.stderr.toLowerCase();
       if (_isShellCommandNotFound(stderr: stderr)) {
-        return (state: _HermesRuntimeProbeState.missing, version: null);
+        return const _HermesRuntimeMissing();
       }
       if (stderr.contains("acp") && stderr.contains("invalid choice")) {
-        return (state: _HermesRuntimeProbeState.preAcpInstall, version: null);
+        return const _HermesRuntimePreAcpInstall();
       }
-      return (state: _HermesRuntimeProbeState.unknown, version: null);
+      return const _HermesRuntimeUnknown();
     }
 
     final parsed = _tryParseVersion(value: result.stdout.trim());
     if (parsed == null) {
-      return (state: _HermesRuntimeProbeState.unrecognized, version: null);
+      return const _HermesRuntimeUnrecognized();
     }
     if (parsed.compareTo(_minHermesVersion) < 0) {
       Log.w(
         "[hermes] Hermes Agent ${parsed.toString()} is below the supported minimum ${_minHermesVersion.toString()}",
       );
-      return (state: _HermesRuntimeProbeState.outdated, version: null);
+      return const _HermesRuntimeOutdated();
     }
     final version = parsed.toString();
     Log.d("[hermes] available: '$executablePath acp --version' -> $version");
-    return (state: _HermesRuntimeProbeState.ready, version: version);
+    return _HermesRuntimeReady(version: version);
   }
 
   bool _isShellCommandNotFound({required String stderr}) =>
@@ -361,11 +361,19 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
   }
 }
 
-enum _HermesRuntimeProbeState() {
-  ready,
-  missing,
-  preAcpInstall,
-  outdated,
-  unknown,
-  unrecognized;
-}
+/// Outcome of the Hermes availability probe. Only [_HermesRuntimeReady]
+/// carries the selected runtime version, so a version can never accompany a
+/// rejected or unresolved runtime.
+sealed class const _HermesRuntimeProbe();
+
+final class const _HermesRuntimeReady({required final String version}) extends _HermesRuntimeProbe;
+
+final class const _HermesRuntimeMissing() extends _HermesRuntimeProbe;
+
+final class const _HermesRuntimePreAcpInstall() extends _HermesRuntimeProbe;
+
+final class const _HermesRuntimeOutdated() extends _HermesRuntimeProbe;
+
+final class const _HermesRuntimeUnknown() extends _HermesRuntimeProbe;
+
+final class const _HermesRuntimeUnrecognized() extends _HermesRuntimeProbe;

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -75,14 +75,14 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
     if (host.startAborted.isAborted) throw const PluginStartAbortedException();
 
     final executablePath = _explicitBin(config: host.config) ?? HermesBinary.defaultBinary;
-    final state = await _probeHermesRuntime(
+    final runtime = await _probeHermesRuntime(
       executablePath: executablePath,
       processes: host.processes,
       environment: host.environment,
     );
     if (host.startAborted.isAborted) throw const PluginStartAbortedException();
 
-    switch (state) {
+    switch (runtime.state) {
       case _HermesRuntimeProbeState.ready:
         yield ProvisionReady(binaryPath: executablePath);
       case _HermesRuntimeProbeState.missing || _HermesRuntimeProbeState.preAcpInstall:
@@ -115,7 +115,7 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
       environment: environment,
     );
 
-    switch (runtime) {
+    switch (runtime.state) {
       case _HermesRuntimeProbeState.missing:
         return PluginSetupRuntimeMissing(
           actionHint: explicitBin != null
@@ -164,38 +164,43 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
         error,
         stackTrace,
       );
-      return const PluginSetupUnknown(
+      return PluginSetupUnknown.versioned(
         actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
+        runtimeVersion: runtime.version!,
       );
     } on Object catch (error, stackTrace) {
       Log.w("[hermes] status probe could not launch '$executablePath status'", error, stackTrace);
-      return const PluginSetupUnknown(
+      return PluginSetupUnknown.versioned(
         actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
+        runtimeVersion: runtime.version!,
       );
     }
     if (statusResult.exitCode != 0) {
       Log.w("[hermes] status probe '$executablePath status' exited with code ${statusResult.exitCode}");
-      return const PluginSetupUnknown(
+      return PluginSetupUnknown.versioned(
         actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
+        runtimeVersion: runtime.version!,
       );
     }
     final statusOutput = _normalizedStatusOutput(result: statusResult);
     final model = _statusValue(output: statusOutput, field: "model");
     final provider = _statusValue(output: statusOutput, field: "provider");
     if (_isConfiguredStatusValue(value: model) && _isConfiguredStatusValue(value: provider)) {
-      return const PluginSetupReady();
+      return PluginSetupReady.versioned(runtimeVersion: runtime.version!);
     }
     if (model != null || provider != null) {
-      return const PluginSetupAuthenticationRequired(
+      return PluginSetupAuthenticationRequired.versioned(
         actionHint: "Configure a model and provider with `hermes setup` or `hermes model` on this machine, then retry setup detection.",
+        runtimeVersion: runtime.version!,
       );
     }
-    return const PluginSetupUnknown(
+    return PluginSetupUnknown.versioned(
       actionHint: "Hermes setup could not be determined. Run `hermes status` locally and retry.",
+      runtimeVersion: runtime.version!,
     );
   }
 
-  Future<_HermesRuntimeProbeState> _probeHermesRuntime({
+  Future<({String? version, _HermesRuntimeProbeState state})> _probeHermesRuntime({
     required String executablePath,
     required HostProcessService processes,
     required Map<String, String> environment,
@@ -220,18 +225,18 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
         "[hermes] availability probe '$executablePath acp --version' did not exit within "
         "${_versionProbeTimeout.inSeconds}s",
       );
-      return _HermesRuntimeProbeState.unknown;
+      return (state: _HermesRuntimeProbeState.unknown, version: null);
     } on io.ProcessException catch (error, stackTrace) {
       // The host process seam reports spawn failures as ProcessException;
       // ENOENT (errorCode 2) means not installed / not on PATH.
-      if (error.errorCode == 2) return _HermesRuntimeProbeState.missing;
+      if (error.errorCode == 2) return (state: _HermesRuntimeProbeState.missing, version: null);
       Log.w("[hermes] availability probe could not launch '$executablePath acp --version'", error, stackTrace);
-      return _HermesRuntimeProbeState.unknown;
+      return (state: _HermesRuntimeProbeState.unknown, version: null);
     } on Object catch (error, stackTrace) {
       // Any other spawn failure (host seam error, permission) is not proof of
       // a missing runtime; report unknown rather than a misleading hint.
       Log.w("[hermes] availability probe could not launch '$executablePath acp --version'", error, stackTrace);
-      return _HermesRuntimeProbeState.unknown;
+      return (state: _HermesRuntimeProbeState.unknown, version: null);
     }
 
     if (result.exitCode != 0) {
@@ -241,27 +246,27 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
       // as an unknown failure.
       final stderr = result.stderr.toLowerCase();
       if (_isShellCommandNotFound(stderr: stderr)) {
-        return _HermesRuntimeProbeState.missing;
+        return (state: _HermesRuntimeProbeState.missing, version: null);
       }
       if (stderr.contains("acp") && stderr.contains("invalid choice")) {
-        return _HermesRuntimeProbeState.preAcpInstall;
+        return (state: _HermesRuntimeProbeState.preAcpInstall, version: null);
       }
-      return _HermesRuntimeProbeState.unknown;
+      return (state: _HermesRuntimeProbeState.unknown, version: null);
     }
 
     final parsed = _tryParseVersion(value: result.stdout.trim());
     if (parsed == null) {
-      return _HermesRuntimeProbeState.unrecognized;
+      return (state: _HermesRuntimeProbeState.unrecognized, version: null);
     }
     if (parsed.compareTo(_minHermesVersion) < 0) {
       Log.w(
         "[hermes] Hermes Agent ${parsed.toString()} is below the supported minimum ${_minHermesVersion.toString()}",
       );
-      return _HermesRuntimeProbeState.outdated;
+      return (state: _HermesRuntimeProbeState.outdated, version: null);
     }
     final version = parsed.toString();
     Log.d("[hermes] available: '$executablePath acp --version' -> $version");
-    return _HermesRuntimeProbeState.ready;
+    return (state: _HermesRuntimeProbeState.ready, version: version);
   }
 
   bool _isShellCommandNotFound({required String stderr}) =>

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
@@ -135,7 +135,7 @@ void main() {
         stateDirectory: stateDirectory,
       );
 
-      expect(result, const PluginSetupReady());
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "0.20.0"));
       expect(processes.spawnedExecutables, ["hermes", "hermes"]);
       expect(processes.spawnedArguments, [
         const ["acp", "--version"],
@@ -366,6 +366,7 @@ void main() {
       );
 
       expect(result, isA<PluginSetupAuthenticationRequired>());
+      expect(result.runtimeVersion, "0.20.0");
     });
 
     test("reports authentication required when a model has no provider", () async {
@@ -396,6 +397,7 @@ void main() {
       );
 
       expect(result, isA<PluginSetupAuthenticationRequired>());
+      expect(result.runtimeVersion, "0.20.0");
     });
 
     test("reports unknown when the status command exits nonzero", () async {
@@ -426,6 +428,7 @@ void main() {
       );
 
       expect(result, isA<PluginSetupUnknown>());
+      expect(result.runtimeVersion, "0.20.0");
     });
 
     test("uses an explicit --hermes-bin override for every probe", () async {
@@ -455,7 +458,7 @@ void main() {
         stateDirectory: stateDirectory,
       );
 
-      expect(result, const PluginSetupReady());
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "0.20.0"));
       expect(processes.spawnedExecutables, ["/custom/hermes", "/custom/hermes"]);
     });
 

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_setup_status.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_setup_status.dart
@@ -8,12 +8,21 @@ import "package:meta/meta.dart";
 sealed class const PluginSetupStatus() {
   /// Generic, user-facing guidance authored by the plugin.
   String? get actionHint;
+
+  /// Display-ready version of the usable runtime selected by inspection.
+  ///
+  /// Null means inspection did not select a versioned local runtime. Raw
+  /// command output must never be exposed through this field.
+  String? get runtimeVersion;
 }
 
 /// Setup was deliberately not inspected because the plugin is disabled.
 final class const PluginSetupNotInspected() extends PluginSetupStatus {
   @override
   String? get actionHint => null;
+
+  @override
+  String? get runtimeVersion => null;
 
   @override
   bool operator ==(Object other) => other is PluginSetupNotInspected;
@@ -26,23 +35,36 @@ final class const PluginSetupNotInspected() extends PluginSetupStatus {
 }
 
 /// The required runtime and authentication are already available.
-final class const PluginSetupReady() extends PluginSetupStatus {
+base class const PluginSetupReady() extends PluginSetupStatus {
+  const factory versioned({required String runtimeVersion}) = _VersionedPluginSetupReady;
+
   @override
   String? get actionHint => null;
 
   @override
-  bool operator ==(Object other) => other is PluginSetupReady;
+  String? get runtimeVersion => null;
 
   @override
-  int get hashCode => runtimeType.hashCode;
+  bool operator ==(Object other) => other is PluginSetupReady && other.runtimeVersion == runtimeVersion;
 
   @override
-  String toString() => "PluginSetupReady";
+  int get hashCode => runtimeVersion.hashCode;
+
+  @override
+  String toString() => "PluginSetupReady(runtimeVersion: $runtimeVersion)";
+}
+
+final class const _VersionedPluginSetupReady({@override required final String runtimeVersion})
+    extends PluginSetupReady {
+  this : assert(runtimeVersion != "", "PluginSetupReady.runtimeVersion must not be empty"), super();
 }
 
 /// No usable backend runtime was found.
 final class const PluginSetupRuntimeMissing({@override required final String? actionHint}) extends PluginSetupStatus {
   this : assert(actionHint != "", "PluginSetupRuntimeMissing.actionHint must not be empty");
+
+  @override
+  String? get runtimeVersion => null;
 
   @override
   bool operator ==(Object other) => other is PluginSetupRuntimeMissing && other.actionHint == actionHint;
@@ -55,23 +77,44 @@ final class const PluginSetupRuntimeMissing({@override required final String? ac
 }
 
 /// The runtime exists, but the backend requires authentication.
-final class const PluginSetupAuthenticationRequired({@override required final String? actionHint})
+base class const PluginSetupAuthenticationRequired({@override required final String? actionHint})
     extends PluginSetupStatus {
   this : assert(actionHint != "", "PluginSetupAuthenticationRequired.actionHint must not be empty");
 
-  @override
-  bool operator ==(Object other) => other is PluginSetupAuthenticationRequired && other.actionHint == actionHint;
+  const factory versioned({
+    required String? actionHint,
+    required String runtimeVersion,
+  }) = _VersionedPluginSetupAuthenticationRequired;
 
   @override
-  int get hashCode => actionHint.hashCode;
+  String? get runtimeVersion => null;
 
   @override
-  String toString() => "PluginSetupAuthenticationRequired(actionHint: $actionHint)";
+  bool operator ==(Object other) =>
+      other is PluginSetupAuthenticationRequired &&
+      other.actionHint == actionHint &&
+      other.runtimeVersion == runtimeVersion;
+
+  @override
+  int get hashCode => Object.hash(actionHint, runtimeVersion);
+
+  @override
+  String toString() => "PluginSetupAuthenticationRequired(actionHint: $actionHint, runtimeVersion: $runtimeVersion)";
+}
+
+final class const _VersionedPluginSetupAuthenticationRequired({
+  required super.actionHint,
+  @override required final String runtimeVersion,
+}) extends PluginSetupAuthenticationRequired {
+  this : assert(runtimeVersion != "", "PluginSetupAuthenticationRequired.runtimeVersion must not be empty"), super();
 }
 
 /// The backend is present but unsupported or otherwise unusable.
 final class const PluginSetupUnavailable({@override required final String? actionHint}) extends PluginSetupStatus {
   this : assert(actionHint != "", "PluginSetupUnavailable.actionHint must not be empty");
+
+  @override
+  String? get runtimeVersion => null;
 
   @override
   bool operator ==(Object other) => other is PluginSetupUnavailable && other.actionHint == actionHint;
@@ -84,15 +127,28 @@ final class const PluginSetupUnavailable({@override required final String? actio
 }
 
 /// Setup could not be determined safely after a transient or ambiguous probe.
-final class const PluginSetupUnknown({@override required final String? actionHint}) extends PluginSetupStatus {
+base class const PluginSetupUnknown({@override required final String? actionHint}) extends PluginSetupStatus {
   this : assert(actionHint != "", "PluginSetupUnknown.actionHint must not be empty");
 
-  @override
-  bool operator ==(Object other) => other is PluginSetupUnknown && other.actionHint == actionHint;
+  const factory versioned({required String? actionHint, required String runtimeVersion}) = _VersionedPluginSetupUnknown;
 
   @override
-  int get hashCode => actionHint.hashCode;
+  String? get runtimeVersion => null;
 
   @override
-  String toString() => "PluginSetupUnknown(actionHint: $actionHint)";
+  bool operator ==(Object other) =>
+      other is PluginSetupUnknown && other.actionHint == actionHint && other.runtimeVersion == runtimeVersion;
+
+  @override
+  int get hashCode => Object.hash(actionHint, runtimeVersion);
+
+  @override
+  String toString() => "PluginSetupUnknown(actionHint: $actionHint, runtimeVersion: $runtimeVersion)";
+}
+
+final class const _VersionedPluginSetupUnknown({
+  required super.actionHint,
+  @override required final String runtimeVersion,
+}) extends PluginSetupUnknown {
+  this : assert(runtimeVersion != "", "PluginSetupUnknown.runtimeVersion must not be empty"), super();
 }

--- a/bridge/sesori_plugin_interface/test/lifecycle/bridge_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_interface/test/lifecycle/bridge_plugin_descriptor_test.dart
@@ -88,6 +88,26 @@ void main() {
 
       expect(setup, const PluginSetupReady());
     });
+
+    test('versioned setup states retain only the selected runtime version', () {
+      expect(const PluginSetupReady.versioned(runtimeVersion: "1.2.3").runtimeVersion, "1.2.3");
+      expect(
+        const PluginSetupAuthenticationRequired.versioned(
+          actionHint: "Sign in.",
+          runtimeVersion: "2.3.4",
+        ).runtimeVersion,
+        "2.3.4",
+      );
+      expect(
+        const PluginSetupUnknown.versioned(
+          actionHint: "Authentication could not be determined.",
+          runtimeVersion: "3.4.5",
+        ).runtimeVersion,
+        "3.4.5",
+      );
+      expect(const PluginSetupReady().runtimeVersion, isNull);
+      expect(const PluginSetupRuntimeMissing(actionHint: null).runtimeVersion, isNull);
+    });
   });
 
   group('PluginOption', () {

--- a/bridge/sesori_plugin_omp/lib/src/runtime/omp_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_omp/lib/src/runtime/omp_plugin_descriptor.dart
@@ -185,9 +185,11 @@ final class const OmpPluginDescriptor({
       expectedVersion: manifest.minPathVersion,
       exactVersion: false,
     );
-    if (pathProbe == _OmpRuntimeProbe.ready) return const PluginSetupReady();
+    if (pathProbe.state == _OmpRuntimeProbe.ready) {
+      return PluginSetupReady.versioned(runtimeVersion: pathProbe.version!);
+    }
     if (explicitBin != null) {
-      return switch (pathProbe) {
+      return switch (pathProbe.state) {
         _OmpRuntimeProbe.missing => const PluginSetupRuntimeMissing(
           actionHint: "Fix the configured Oh My Pi CLI path, then restart the bridge.",
         ),
@@ -197,7 +199,7 @@ final class const OmpPluginDescriptor({
         _OmpRuntimeProbe.unknown => const PluginSetupUnknown(
           actionHint: "Oh My Pi setup could not be determined. Verify the configured CLI and retry.",
         ),
-        _OmpRuntimeProbe.ready => const PluginSetupReady(),
+        _OmpRuntimeProbe.ready => PluginSetupReady.versioned(runtimeVersion: pathProbe.version!),
       };
     }
     final managedProbe = await _probeRuntime(
@@ -207,8 +209,10 @@ final class const OmpPluginDescriptor({
       expectedVersion: manifest.bundledVersion,
       exactVersion: true,
     );
-    if (managedProbe == _OmpRuntimeProbe.ready) return const PluginSetupReady();
-    if (pathProbe == _OmpRuntimeProbe.unknown || managedProbe == _OmpRuntimeProbe.unknown) {
+    if (managedProbe.state == _OmpRuntimeProbe.ready) {
+      return PluginSetupReady.versioned(runtimeVersion: managedProbe.version!);
+    }
+    if (pathProbe.state == _OmpRuntimeProbe.unknown || managedProbe.state == _OmpRuntimeProbe.unknown) {
       return const PluginSetupUnknown(
         actionHint: "Oh My Pi setup could not be determined. Verify the local CLI and retry.",
       );
@@ -229,7 +233,7 @@ final class const OmpPluginDescriptor({
     }
   }
 
-  Future<_OmpRuntimeProbe> _probeRuntime({
+  Future<({String? version, _OmpRuntimeProbe state})> _probeRuntime({
     required String executable,
     required HostProcessService processes,
     required Map<String, String> environment,
@@ -250,18 +254,21 @@ final class const OmpPluginDescriptor({
         timeout: _versionProbeTimeout,
       );
     } on TimeoutException {
-      return _OmpRuntimeProbe.unknown;
+      return (state: _OmpRuntimeProbe.unknown, version: null);
     } on io.ProcessException {
-      return _OmpRuntimeProbe.missing;
+      return (state: _OmpRuntimeProbe.missing, version: null);
     } on Object catch (error, stackTrace) {
       Log.w("[omp] runtime version probe failed", error, stackTrace);
-      return _OmpRuntimeProbe.unknown;
+      return (state: _OmpRuntimeProbe.unknown, version: null);
     }
-    if (result.exitCode != 0) return _OmpRuntimeProbe.unknown;
+    if (result.exitCode != 0) return (state: _OmpRuntimeProbe.unknown, version: null);
     final version = _versionValidator(processes: processes).parseVersionOutput(output: result.stdout);
-    if (version == null) return _OmpRuntimeProbe.unknown;
+    if (version == null) return (state: _OmpRuntimeProbe.unknown, version: null);
     final comparison = version.compareTo(expectedVersion);
-    return (exactVersion ? comparison == 0 : comparison >= 0) ? _OmpRuntimeProbe.ready : _OmpRuntimeProbe.outdated;
+    final state = (exactVersion ? comparison == 0 : comparison >= 0)
+        ? _OmpRuntimeProbe.ready
+        : _OmpRuntimeProbe.outdated;
+    return (state: state, version: state == _OmpRuntimeProbe.ready ? version.raw : null);
   }
 
   RuntimeVersionValidator _versionValidator({required HostProcessService processes}) => RuntimeVersionValidator(

--- a/bridge/sesori_plugin_omp/lib/src/runtime/omp_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_omp/lib/src/runtime/omp_plugin_descriptor.dart
@@ -185,21 +185,21 @@ final class const OmpPluginDescriptor({
       expectedVersion: manifest.minPathVersion,
       exactVersion: false,
     );
-    if (pathProbe.state == _OmpRuntimeProbe.ready) {
-      return PluginSetupReady.versioned(runtimeVersion: pathProbe.version!);
+    if (pathProbe case _OmpRuntimeReady(:final version)) {
+      return PluginSetupReady.versioned(runtimeVersion: version);
     }
     if (explicitBin != null) {
-      return switch (pathProbe.state) {
-        _OmpRuntimeProbe.missing => const PluginSetupRuntimeMissing(
+      return switch (pathProbe) {
+        _OmpRuntimeReady(:final version) => PluginSetupReady.versioned(runtimeVersion: version),
+        _OmpRuntimeMissing() => const PluginSetupRuntimeMissing(
           actionHint: "Fix the configured Oh My Pi CLI path, then restart the bridge.",
         ),
-        _OmpRuntimeProbe.outdated => const PluginSetupUnavailable(
+        _OmpRuntimeOutdated() => const PluginSetupUnavailable(
           actionHint: "Update the configured Oh My Pi CLI, then restart the bridge.",
         ),
-        _OmpRuntimeProbe.unknown => const PluginSetupUnknown(
+        _OmpRuntimeUnknown() => const PluginSetupUnknown(
           actionHint: "Oh My Pi setup could not be determined. Verify the configured CLI and retry.",
         ),
-        _OmpRuntimeProbe.ready => PluginSetupReady.versioned(runtimeVersion: pathProbe.version!),
       };
     }
     final managedProbe = await _probeRuntime(
@@ -209,10 +209,10 @@ final class const OmpPluginDescriptor({
       expectedVersion: manifest.bundledVersion,
       exactVersion: true,
     );
-    if (managedProbe.state == _OmpRuntimeProbe.ready) {
-      return PluginSetupReady.versioned(runtimeVersion: managedProbe.version!);
+    if (managedProbe case _OmpRuntimeReady(:final version)) {
+      return PluginSetupReady.versioned(runtimeVersion: version);
     }
-    if (pathProbe.state == _OmpRuntimeProbe.unknown || managedProbe.state == _OmpRuntimeProbe.unknown) {
+    if (pathProbe is _OmpRuntimeUnknown || managedProbe is _OmpRuntimeUnknown) {
       return const PluginSetupUnknown(
         actionHint: "Oh My Pi setup could not be determined. Verify the local CLI and retry.",
       );
@@ -233,7 +233,7 @@ final class const OmpPluginDescriptor({
     }
   }
 
-  Future<({String? version, _OmpRuntimeProbe state})> _probeRuntime({
+  Future<_OmpRuntimeProbe> _probeRuntime({
     required String executable,
     required HostProcessService processes,
     required Map<String, String> environment,
@@ -254,21 +254,21 @@ final class const OmpPluginDescriptor({
         timeout: _versionProbeTimeout,
       );
     } on TimeoutException {
-      return (state: _OmpRuntimeProbe.unknown, version: null);
+      return const _OmpRuntimeUnknown();
     } on io.ProcessException {
-      return (state: _OmpRuntimeProbe.missing, version: null);
+      return const _OmpRuntimeMissing();
     } on Object catch (error, stackTrace) {
       Log.w("[omp] runtime version probe failed", error, stackTrace);
-      return (state: _OmpRuntimeProbe.unknown, version: null);
+      return const _OmpRuntimeUnknown();
     }
-    if (result.exitCode != 0) return (state: _OmpRuntimeProbe.unknown, version: null);
+    if (result.exitCode != 0) return const _OmpRuntimeUnknown();
     final version = _versionValidator(processes: processes).parseVersionOutput(output: result.stdout);
-    if (version == null) return (state: _OmpRuntimeProbe.unknown, version: null);
+    if (version == null) return const _OmpRuntimeUnknown();
     final comparison = version.compareTo(expectedVersion);
-    final state = (exactVersion ? comparison == 0 : comparison >= 0)
-        ? _OmpRuntimeProbe.ready
-        : _OmpRuntimeProbe.outdated;
-    return (state: state, version: state == _OmpRuntimeProbe.ready ? version.raw : null);
+    if (exactVersion ? comparison == 0 : comparison >= 0) {
+      return _OmpRuntimeReady(version: version.raw);
+    }
+    return const _OmpRuntimeOutdated();
   }
 
   RuntimeVersionValidator _versionValidator({required HostProcessService processes}) => RuntimeVersionValidator(
@@ -303,4 +303,15 @@ final class const OmpPluginDescriptor({
   }
 }
 
-enum _OmpRuntimeProbe() { ready, missing, outdated, unknown }
+/// Outcome of an Oh My Pi runtime probe. Only [_OmpRuntimeReady] carries the
+/// selected runtime version, so a version can never accompany a rejected or
+/// unresolved runtime.
+sealed class const _OmpRuntimeProbe();
+
+final class const _OmpRuntimeReady({required final String version}) extends _OmpRuntimeProbe;
+
+final class const _OmpRuntimeMissing() extends _OmpRuntimeProbe;
+
+final class const _OmpRuntimeOutdated() extends _OmpRuntimeProbe;
+
+final class const _OmpRuntimeUnknown() extends _OmpRuntimeProbe;

--- a/bridge/sesori_plugin_omp/test/omp_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_plugin_descriptor_test.dart
@@ -79,7 +79,7 @@ void main() {
         stateDirectory: "/state",
       );
 
-      expect(result, const PluginSetupReady());
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "17.2.13"));
       expect(processes.arguments, [
         const ["--version"],
       ]);
@@ -96,7 +96,7 @@ void main() {
         stateDirectory: "/state",
       );
 
-      expect(result, const PluginSetupReady());
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "17.2.13"));
     });
 
     test("reports an installable missing runtime after PATH and managed probes", () async {

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
@@ -352,6 +352,7 @@ class const OpenCodePluginDescriptor({
       manifest: manifest,
       probeTimeout: _versionProbeTimeout,
     );
+    String? runtimeVersion;
 
     Future<bool> managedRuntimeIsReady() async {
       if (hasExplicitBin) return false;
@@ -359,7 +360,9 @@ class const OpenCodePluginDescriptor({
         executable: manifest.managedBinaryPath(stateDirectory: stateDirectory),
         environment: environment,
       );
-      return managedVersion != null && managedVersion.compareTo(manifest.bundledVersion) == 0;
+      final isReady = managedVersion != null && managedVersion.compareTo(manifest.bundledVersion) == 0;
+      if (isReady) runtimeVersion = managedVersion.raw;
+      return isReady;
     }
 
     /// What to tell the user when no usable runtime was found and Sesori can
@@ -433,10 +436,12 @@ class const OpenCodePluginDescriptor({
               actionHint: "The configured OpenCode binary is too old. Update it and restart the bridge.",
             );
           }
+        } else {
+          runtimeVersion = version.raw;
         }
       }
     }
-    return const PluginSetupReady();
+    return PluginSetupReady.versioned(runtimeVersion: runtimeVersion!);
   }
 
   /// Resolves an existing OpenCode runtime (a recent-enough PATH install or the

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
@@ -352,17 +352,17 @@ class const OpenCodePluginDescriptor({
       manifest: manifest,
       probeTimeout: _versionProbeTimeout,
     );
-    String? runtimeVersion;
-
-    Future<bool> managedRuntimeIsReady() async {
-      if (hasExplicitBin) return false;
+    /// The pinned managed runtime's version when it is already installed and
+    /// matches the bundled pin, or null. Only consulted without an explicit
+    /// binary, which is authoritative when set.
+    Future<String?> managedRuntimeVersion() async {
+      if (hasExplicitBin) return null;
       final managedVersion = await versionValidator.detectVersion(
         executable: manifest.managedBinaryPath(stateDirectory: stateDirectory),
         environment: environment,
       );
-      final isReady = managedVersion != null && managedVersion.compareTo(manifest.bundledVersion) == 0;
-      if (isReady) runtimeVersion = managedVersion.raw;
-      return isReady;
+      if (managedVersion == null || managedVersion.compareTo(manifest.bundledVersion) != 0) return null;
+      return managedVersion.raw;
     }
 
     /// What to tell the user when no usable runtime was found and Sesori can
@@ -375,8 +375,7 @@ class const OpenCodePluginDescriptor({
           : "Install OpenCode from Sesori, or install it locally and retry setup detection.";
     }
 
-    CommandResult? result;
-    var runtimeResolved = false;
+    final CommandResult result;
     try {
       result = await executor.run(
         executable,
@@ -385,63 +384,68 @@ class const OpenCodePluginDescriptor({
         timeout: _versionProbeTimeout,
       );
     } on io.ProcessException {
-      runtimeResolved = await managedRuntimeIsReady();
-      if (!runtimeResolved) {
+      final managedVersion = await managedRuntimeVersion();
+      if (managedVersion == null) {
         return PluginSetupRuntimeMissing(
           actionHint: hasExplicitBin
               ? "Fix the configured OpenCode binary path, then restart the bridge."
               : missingRuntimeHint(),
         );
       }
+      return PluginSetupReady.versioned(runtimeVersion: managedVersion);
     } on TimeoutException {
-      runtimeResolved = await managedRuntimeIsReady();
-      if (!runtimeResolved) {
+      final managedVersion = await managedRuntimeVersion();
+      if (managedVersion == null) {
         return const PluginSetupUnknown(
           actionHint: "OpenCode did not answer its setup check. Verify the local installation and retry.",
         );
       }
+      return PluginSetupReady.versioned(runtimeVersion: managedVersion);
     } on Object {
-      runtimeResolved = await managedRuntimeIsReady();
-      if (!runtimeResolved) {
+      final managedVersion = await managedRuntimeVersion();
+      if (managedVersion == null) {
         return const PluginSetupUnknown(
           actionHint: "OpenCode setup could not be determined. Verify the local installation and retry.",
         );
       }
+      return PluginSetupReady.versioned(runtimeVersion: managedVersion);
     }
 
-    if (!runtimeResolved) {
-      if (result!.exitCode != 0) {
-        if (!await managedRuntimeIsReady()) {
-          if (!hasExplicitBin) {
-            return PluginSetupRuntimeMissing(actionHint: missingRuntimeHint());
-          }
-          return const PluginSetupUnknown(
-            actionHint: "OpenCode did not answer its setup check. Verify the local installation and retry.",
-          );
+    if (result.exitCode != 0) {
+      final managedVersion = await managedRuntimeVersion();
+      if (managedVersion == null) {
+        if (!hasExplicitBin) {
+          return PluginSetupRuntimeMissing(actionHint: missingRuntimeHint());
         }
-      } else {
-        final version = versionValidator.parseVersionOutput(output: result.stdout);
-        if (version == null) {
-          if (!await managedRuntimeIsReady()) {
-            return const PluginSetupUnknown(
-              actionHint: "OpenCode returned an unrecognized version. Update OpenCode and retry.",
-            );
-          }
-        } else if (version.compareTo(manifest.minPathVersion) < 0) {
-          if (!await managedRuntimeIsReady()) {
-            if (!hasExplicitBin) {
-              return PluginSetupRuntimeMissing(actionHint: missingRuntimeHint());
-            }
-            return const PluginSetupUnavailable(
-              actionHint: "The configured OpenCode binary is too old. Update it and restart the bridge.",
-            );
-          }
-        } else {
-          runtimeVersion = version.raw;
-        }
+        return const PluginSetupUnknown(
+          actionHint: "OpenCode did not answer its setup check. Verify the local installation and retry.",
+        );
       }
+      return PluginSetupReady.versioned(runtimeVersion: managedVersion);
     }
-    return PluginSetupReady.versioned(runtimeVersion: runtimeVersion!);
+    final version = versionValidator.parseVersionOutput(output: result.stdout);
+    if (version == null) {
+      final managedVersion = await managedRuntimeVersion();
+      if (managedVersion == null) {
+        return const PluginSetupUnknown(
+          actionHint: "OpenCode returned an unrecognized version. Update OpenCode and retry.",
+        );
+      }
+      return PluginSetupReady.versioned(runtimeVersion: managedVersion);
+    }
+    if (version.compareTo(manifest.minPathVersion) < 0) {
+      final managedVersion = await managedRuntimeVersion();
+      if (managedVersion == null) {
+        if (!hasExplicitBin) {
+          return PluginSetupRuntimeMissing(actionHint: missingRuntimeHint());
+        }
+        return const PluginSetupUnavailable(
+          actionHint: "The configured OpenCode binary is too old. Update it and restart the bridge.",
+        );
+      }
+      return PluginSetupReady.versioned(runtimeVersion: managedVersion);
+    }
+    return PluginSetupReady.versioned(runtimeVersion: version.raw);
   }
 
   /// Resolves an existing OpenCode runtime (a recent-enough PATH install or the

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_availability_test.dart
@@ -37,7 +37,7 @@ void main() {
         stateDirectory: stateDirectory,
       );
 
-      expect(result, const PluginSetupReady());
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "1.18.11"));
       expect(processes.spawnedExecutables, ["opencode"]);
       expect(processes.spawnedArguments, [
         const ["--version"],
@@ -103,7 +103,10 @@ void main() {
         stateDirectory: stateDirectory,
       );
 
-      expect(result, const PluginSetupReady());
+      expect(
+        result,
+        PluginSetupReady.versioned(runtimeVersion: manifest.bundledVersion.raw),
+      );
       expect(processes.spawnedExecutables, ["opencode", managedBinaryPath]);
     });
 

--- a/client/app/lib/features/settings/harnesses_settings_screen.dart
+++ b/client/app/lib/features/settings/harnesses_settings_screen.dart
@@ -399,6 +399,7 @@ class const _HarnessControlCard({
     final supportsIdleTimeout = capabilities.contains(PluginManagementCapability.idleTimeout);
     final showExternal = !supportsLifecycle && !capabilities.contains(PluginManagementCapability.unknown);
     final setupReady = plugin.setup.state == PluginSetupState.ready;
+    final showVersion = plugin.setup.runtimeVersion != null;
     final runtimeKnown = plugin.runtimeState != PluginRuntimeState.unknown;
     final enabled = plugin.runtimeState.isEnabled;
     final showOperational = setupReady && enabled;
@@ -473,7 +474,8 @@ class const _HarnessControlCard({
             title: loc.harnessesSetupStatus,
             value: _setupStatus(context: context, state: plugin.setup.state),
             isLast:
-                !(showRuntime ||
+                !(showVersion ||
+                    showRuntime ||
                     showWork ||
                     showExternal ||
                     showInstall ||
@@ -484,6 +486,22 @@ class const _HarnessControlCard({
                     showTimeout ||
                     showClearTimeout),
           ),
+          if (showVersion)
+            _FactRow(
+              title: loc.harnessesRuntimeVersion,
+              value: plugin.setup.runtimeVersion!,
+              isLast:
+                  !(showRuntime ||
+                      showWork ||
+                      showExternal ||
+                      showInstall ||
+                      showAuthentication ||
+                      showLifecycle ||
+                      showSetupRefresh ||
+                      showRestart ||
+                      showTimeout ||
+                      showClearTimeout),
+            ),
           if (showAuthentication)
             PregoGroupedRow(
               key: Key("harness_authentication_$pluginId"),

--- a/client/app/lib/features/settings/harnesses_settings_screen.dart
+++ b/client/app/lib/features/settings/harnesses_settings_screen.dart
@@ -399,7 +399,7 @@ class const _HarnessControlCard({
     final supportsIdleTimeout = capabilities.contains(PluginManagementCapability.idleTimeout);
     final showExternal = !supportsLifecycle && !capabilities.contains(PluginManagementCapability.unknown);
     final setupReady = plugin.setup.state == PluginSetupState.ready;
-    final showVersion = plugin.setup.runtimeVersion != null;
+    final runtimeVersion = plugin.setup.runtimeVersion;
     final runtimeKnown = plugin.runtimeState != PluginRuntimeState.unknown;
     final enabled = plugin.runtimeState.isEnabled;
     final showOperational = setupReady && enabled;
@@ -474,7 +474,7 @@ class const _HarnessControlCard({
             title: loc.harnessesSetupStatus,
             value: _setupStatus(context: context, state: plugin.setup.state),
             isLast:
-                !(showVersion ||
+                !(runtimeVersion != null ||
                     showRuntime ||
                     showWork ||
                     showExternal ||
@@ -486,10 +486,10 @@ class const _HarnessControlCard({
                     showTimeout ||
                     showClearTimeout),
           ),
-          if (showVersion)
+          if (runtimeVersion != null)
             _FactRow(
               title: loc.harnessesRuntimeVersion,
-              value: plugin.setup.runtimeVersion!,
+              value: runtimeVersion,
               isLast:
                   !(showRuntime ||
                       showWork ||

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -292,6 +292,7 @@
   "harnessesDismissRefreshError": "Dismiss refresh error",
   "harnessesDefaultBadge": "Default",
   "harnessesSetupStatus": "Setup",
+  "harnessesRuntimeVersion": "Version",
   "harnessesRuntimeStatus": "Runtime",
   "harnessesWorkStatus": "Work",
   "harnessesCustomIdleTimeout": "Custom for this harness",

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -1033,6 +1033,12 @@ abstract class AppLocalizations {
   /// **'Setup'**
   String get harnessesSetupStatus;
 
+  /// No description provided for @harnessesRuntimeVersion.
+  ///
+  /// In en, this message translates to:
+  /// **'Version'**
+  String get harnessesRuntimeVersion;
+
   /// No description provided for @harnessesRuntimeStatus.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -526,6 +526,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get harnessesSetupStatus => 'Setup';
 
   @override
+  String get harnessesRuntimeVersion => 'Version';
+
+  @override
   String get harnessesRuntimeStatus => 'Runtime';
 
   @override

--- a/client/app/test/features/settings/harnesses_settings_screen_test.dart
+++ b/client/app/test/features/settings/harnesses_settings_screen_test.dart
@@ -28,6 +28,7 @@ const _managed = PluginManagementMetadata(
     id: "future-harness",
     displayName: "Future Harness",
     state: PluginSetupState.ready,
+    runtimeVersion: "9.8.7",
     actionHint: null,
   ),
   runtimeState: PluginRuntimeState.active,
@@ -47,6 +48,7 @@ const _externalOpenCode = PluginManagementMetadata(
     id: "opencode",
     displayName: "OpenCode",
     state: PluginSetupState.ready,
+    runtimeVersion: null,
     actionHint: "Run login if requests fail.",
   ),
   runtimeState: PluginRuntimeState.active,
@@ -62,6 +64,7 @@ const _authenticationRequired = PluginManagementMetadata(
     id: "codex",
     displayName: "Codex",
     state: PluginSetupState.authenticationRequired,
+    runtimeVersion: "0.42.0",
     actionHint: "Log in to continue.",
   ),
   runtimeState: PluginRuntimeState.blocked,
@@ -323,6 +326,7 @@ void main() {
 
     expect(find.byKey(const Key("harness_authentication_codex")), findsOneWidget);
     expect(find.text("Log in"), findsOneWidget);
+    expect(find.text("0.42.0"), findsOneWidget);
     expect(find.byKey(const Key("harness_authentication_future-harness")), findsNothing);
 
     snapshots.add(
@@ -777,6 +781,8 @@ void main() {
     expect(find.text("Runtime"), findsNothing);
     expect(find.text("Work"), findsNothing);
     expect(find.text("Idle"), findsNothing);
+    expect(find.text("Version"), findsOneWidget);
+    expect(find.text("9.8.7"), findsOneWidget);
 
     await tester.tap(_switchFor("future-harness"));
     await tester.pump();
@@ -806,6 +812,8 @@ void main() {
     expect(find.byIcon(TablerRegular.plug), findsOneWidget);
     expect(find.text("Default"), findsOneWidget);
     expect(find.text("Run login if requests fail."), findsOneWidget);
+    expect(find.text("Version"), findsOneWidget);
+    expect(find.text("9.8.7"), findsOneWidget);
     expect(find.text("Active"), findsNWidgets(2));
     expect(find.text("Idle"), findsNWidgets(2));
     expect(find.byKey(const Key("harness_management_enabled_future-harness")), findsOneWidget);
@@ -836,6 +844,7 @@ void main() {
     expect(find.byKey(const Key("harness_management_default_timeout")), findsNothing);
     expect(find.text("Active"), findsOneWidget);
     expect(find.text("Idle"), findsOneWidget);
+    expect(find.text("Version"), findsNothing);
 
     snapshots.add(
       PluginManagementLoadResult.supported(

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -799,6 +799,7 @@ PluginLifecycleConflict _conflict(List<PluginLifecycleConflictReason> reasons) {
         id: "one",
         displayName: "One",
         state: PluginSetupState.ready,
+        runtimeVersion: null,
         actionHint: null,
       ),
       runtimeState: PluginRuntimeState.dormant,

--- a/client/module_core/test/repositories/plugin_repository_test.dart
+++ b/client/module_core/test/repositories/plugin_repository_test.dart
@@ -433,6 +433,7 @@ const _managementPlugin = PluginManagementMetadata(
     id: "codex",
     displayName: "Codex",
     state: PluginSetupState.ready,
+    runtimeVersion: "0.42.0",
     actionHint: null,
   ),
   runtimeState: PluginRuntimeState.active,

--- a/client/module_core/test/services/plugin_management_service_test.dart
+++ b/client/module_core/test/services/plugin_management_service_test.dart
@@ -1255,6 +1255,7 @@ PluginLifecycleConflict _conflict(List<PluginLifecycleConflictReason> reasons) {
         id: "one",
         displayName: "One",
         state: PluginSetupState.ready,
+        runtimeVersion: null,
         actionHint: null,
       ),
       runtimeState: PluginRuntimeState.dormant,

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -39,6 +39,10 @@ idle suspension, the management snapshot, and lifecycle commands.
 - Shared management metadata advertises authentication independently and reports idle,
   in-progress, or fail-closed unknown state. Device-code challenges remain request-scoped;
   only sealed completed, failed, or cancelled progress enters the global SSE stream.
+- Setup and management snapshots report the display-ready version of the exact usable local
+  runtime selected by each harness's existing inspection precedence. Older bridges and
+  configurations without a selected versioned local runtime omit it; the mobile harness card
+  shows a Version fact only when the bridge reports one.
 - The bridge exposes explicit plugin-scoped start and cancel routes. Duplicate starts join
   the active operation, management commands conflict while it runs, cancellation settles
   upstream cleanup, and setup reinspection remains authoritative before normal startup.
@@ -60,7 +64,7 @@ idle suspension, the management snapshot, and lifecycle commands.
 |---|---|
 | L1 Smoke | A started bridge inspects every registered harness and publishes coherent setup and management snapshots. A ready fixture has a selectable default; a fixture with no usable harness has zero selectable entries and no default without failing startup. Headless bridge; all registered harnesses listed. |
 | L2 Routine | Demand-driven start of a ready harness, setup refresh, and the disable list surviving restart with eligibility and ordering intact. Headless bridge; representative harness for start, every registered harness for listing and ordering. |
-| L3 Release | The management surface as rendered: per-harness setup, runtime and work state, capability-appropriate controls, built-in name and light/dark artwork, default badge, enable/disable, restart, and idle-timeout default plus override persisted across a bridge restart. Client end to end; every harness declaring the relevant capability must pass. |
+| L3 Release | The management surface as rendered: per-harness selected runtime version when reported, setup, runtime and work state, capability-appropriate controls, built-in name and light/dark artwork, default badge, enable/disable, restart, and idle-timeout default plus override persisted across a bridge restart. Client end to end; every harness declaring the relevant capability must pass. |
 | L4 Extended | Busy conflict with force confirmation and cancellation, authentication start/join/cancel plus shutdown cleanup, idle suspension elapsing then returning on demand, harnesses blocked by missing runtime or authentication, a terminally failed harness leaving others usable, a bridge with no usable harness, an externally managed configuration, two harnesses active at once, second mobile platform. Live plugin where a real backend must start or be interrupted, client end to end where card state is claimed. |
 | L5 Full | Every registered production harness through inspect, enable, disable, restart, refresh, and idle behavior on a supported platform, plus forward-compatible presentation of an unknown harness or capability and the reported state of a session interrupted by a forced disable. Live plugin and client end to end as each entry requires. |
 
@@ -79,6 +83,8 @@ timeouts, and sessions afterwards.
   output; resolution mutating runtime files; a disabled harness probed or started.
 - An eligible harness dropped from listings, a drifting or unselectable default, or
   snapshot tokens that miss real changes.
+- A harness card showing raw version-probe output, a rejected runtime's version, or a version
+  different from the executable selected by setup inspection and runtime resolution.
 - A control offered for an undeclared capability, a supported control missing, a busy
   harness accepting a safe command, or idle suspension on a resident or busy harness.
 - A missing authentication state from an older bridge decoding as anything but idle, a

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_setup_response.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_setup_response.dart
@@ -18,6 +18,10 @@ sealed class PluginSetupMetadata with _$PluginSetupMetadata {
     required String id,
     required String displayName,
     @JsonKey(unknownEnumValue: PluginSetupState.unknown) required PluginSetupState state,
+    // COMPATIBILITY 2026-08-17 (v1.9.0): Older bridge payloads omit
+    // runtimeVersion; null means that peer did not report the selected harness
+    // runtime. Remove the nullable fallback when those bridges are unsupported.
+    required String? runtimeVersion,
     required String? actionHint,
   }) = _PluginSetupMetadata;
 

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_setup_response.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_setup_response.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$PluginSetupMetadata {
 
- String get id; String get displayName;@JsonKey(unknownEnumValue: PluginSetupState.unknown) PluginSetupState get state; String? get actionHint;
+ String get id; String get displayName;@JsonKey(unknownEnumValue: PluginSetupState.unknown) PluginSetupState get state; String? get runtimeVersion; String? get actionHint;
 /// Create a copy of PluginSetupMetadata
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +29,16 @@ $PluginSetupMetadataCopyWith<PluginSetupMetadata> get copyWith => _$PluginSetupM
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginSetupMetadata&&(identical(other.id, id) || other.id == id)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.state, state) || other.state == state)&&(identical(other.actionHint, actionHint) || other.actionHint == actionHint));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginSetupMetadata&&(identical(other.id, id) || other.id == id)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.state, state) || other.state == state)&&(identical(other.runtimeVersion, runtimeVersion) || other.runtimeVersion == runtimeVersion)&&(identical(other.actionHint, actionHint) || other.actionHint == actionHint));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,displayName,state,actionHint);
+int get hashCode => Object.hash(runtimeType,id,displayName,state,runtimeVersion,actionHint);
 
 @override
 String toString() {
-  return 'PluginSetupMetadata(id: $id, displayName: $displayName, state: $state, actionHint: $actionHint)';
+  return 'PluginSetupMetadata(id: $id, displayName: $displayName, state: $state, runtimeVersion: $runtimeVersion, actionHint: $actionHint)';
 }
 
 
@@ -49,7 +49,7 @@ abstract mixin class $PluginSetupMetadataCopyWith<$Res>  {
   factory $PluginSetupMetadataCopyWith(PluginSetupMetadata value, $Res Function(PluginSetupMetadata) _then) = _$PluginSetupMetadataCopyWithImpl;
 @useResult
 $Res call({
- String id, String displayName,@JsonKey(unknownEnumValue: PluginSetupState.unknown) PluginSetupState state, String? actionHint
+ String id, String displayName,@JsonKey(unknownEnumValue: PluginSetupState.unknown) PluginSetupState state, String? runtimeVersion, String? actionHint
 });
 
 
@@ -66,12 +66,13 @@ class _$PluginSetupMetadataCopyWithImpl<$Res>
 
 /// Create a copy of PluginSetupMetadata
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? displayName = null,Object? state = null,Object? actionHint = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? displayName = null,Object? state = null,Object? runtimeVersion = freezed,Object? actionHint = freezed,}) {
   return _then(PluginSetupMetadata(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,displayName: null == displayName ? _self.displayName : displayName // ignore: cast_nullable_to_non_nullable
 as String,state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
-as PluginSetupState,actionHint: freezed == actionHint ? _self.actionHint : actionHint // ignore: cast_nullable_to_non_nullable
+as PluginSetupState,runtimeVersion: freezed == runtimeVersion ? _self.runtimeVersion : runtimeVersion // ignore: cast_nullable_to_non_nullable
+as String?,actionHint: freezed == actionHint ? _self.actionHint : actionHint // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }
@@ -84,12 +85,13 @@ as String?,
 @JsonSerializable()
 
 class _PluginSetupMetadata implements PluginSetupMetadata {
-  const _PluginSetupMetadata({required this.id, required this.displayName, @JsonKey(unknownEnumValue: PluginSetupState.unknown) required this.state, required this.actionHint});
+  const _PluginSetupMetadata({required this.id, required this.displayName, @JsonKey(unknownEnumValue: PluginSetupState.unknown) required this.state, required this.runtimeVersion, required this.actionHint});
   factory _PluginSetupMetadata.fromJson(Map<String, dynamic> json) => _$PluginSetupMetadataFromJson(json);
 
 @override final  String id;
 @override final  String displayName;
 @override@JsonKey(unknownEnumValue: PluginSetupState.unknown) final  PluginSetupState state;
+@override final  String? runtimeVersion;
 @override final  String? actionHint;
 
 /// Create a copy of PluginSetupMetadata
@@ -105,16 +107,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginSetupMetadata&&(identical(other.id, id) || other.id == id)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.state, state) || other.state == state)&&(identical(other.actionHint, actionHint) || other.actionHint == actionHint));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginSetupMetadata&&(identical(other.id, id) || other.id == id)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.state, state) || other.state == state)&&(identical(other.runtimeVersion, runtimeVersion) || other.runtimeVersion == runtimeVersion)&&(identical(other.actionHint, actionHint) || other.actionHint == actionHint));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,displayName,state,actionHint);
+int get hashCode => Object.hash(runtimeType,id,displayName,state,runtimeVersion,actionHint);
 
 @override
 String toString() {
-  return 'PluginSetupMetadata(id: $id, displayName: $displayName, state: $state, actionHint: $actionHint)';
+  return 'PluginSetupMetadata(id: $id, displayName: $displayName, state: $state, runtimeVersion: $runtimeVersion, actionHint: $actionHint)';
 }
 
 
@@ -125,7 +127,7 @@ abstract mixin class _$PluginSetupMetadataCopyWith<$Res> implements $PluginSetup
   factory _$PluginSetupMetadataCopyWith(_PluginSetupMetadata value, $Res Function(_PluginSetupMetadata) _then) = __$PluginSetupMetadataCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String displayName,@JsonKey(unknownEnumValue: PluginSetupState.unknown) PluginSetupState state, String? actionHint
+ String id, String displayName,@JsonKey(unknownEnumValue: PluginSetupState.unknown) PluginSetupState state, String? runtimeVersion, String? actionHint
 });
 
 
@@ -142,12 +144,13 @@ class __$PluginSetupMetadataCopyWithImpl<$Res>
 
 /// Create a copy of PluginSetupMetadata
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? displayName = null,Object? state = null,Object? actionHint = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? displayName = null,Object? state = null,Object? runtimeVersion = freezed,Object? actionHint = freezed,}) {
   return _then(_PluginSetupMetadata(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,displayName: null == displayName ? _self.displayName : displayName // ignore: cast_nullable_to_non_nullable
 as String,state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
-as PluginSetupState,actionHint: freezed == actionHint ? _self.actionHint : actionHint // ignore: cast_nullable_to_non_nullable
+as PluginSetupState,runtimeVersion: freezed == runtimeVersion ? _self.runtimeVersion : runtimeVersion // ignore: cast_nullable_to_non_nullable
+as String?,actionHint: freezed == actionHint ? _self.actionHint : actionHint // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_setup_response.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_setup_response.g.dart
@@ -15,6 +15,7 @@ _PluginSetupMetadata _$PluginSetupMetadataFromJson(Map json) =>
         json['state'],
         unknownValue: PluginSetupState.unknown,
       ),
+      runtimeVersion: json['runtimeVersion'] as String?,
       actionHint: json['actionHint'] as String?,
     );
 
@@ -24,6 +25,7 @@ Map<String, dynamic> _$PluginSetupMetadataToJson(
   'id': instance.id,
   'displayName': instance.displayName,
   'state': _$PluginSetupStateEnumMap[instance.state]!,
+  'runtimeVersion': ?instance.runtimeVersion,
   'actionHint': ?instance.actionHint,
 };
 

--- a/shared/sesori_shared/test/models/plugin_management_contract_test.dart
+++ b/shared/sesori_shared/test/models/plugin_management_contract_test.dart
@@ -7,6 +7,7 @@ void main() {
       id: "opencode",
       displayName: "OpenCode",
       state: PluginSetupState.ready,
+      runtimeVersion: "1.18.11",
       actionHint: null,
     ),
     runtimeState: PluginRuntimeState.active,

--- a/shared/sesori_shared/test/models/plugin_runtime_contract_test.dart
+++ b/shared/sesori_shared/test/models/plugin_runtime_contract_test.dart
@@ -97,18 +97,23 @@ void main() {
           id: "codex",
           displayName: "Codex",
           state: PluginSetupState.authenticationRequired,
+          runtimeVersion: "0.42.0",
           actionHint: "Run codex login on this machine.",
         ),
         PluginSetupMetadata(
           id: "opencode",
           displayName: "OpenCode",
           state: PluginSetupState.ready,
+          runtimeVersion: "1.18.11",
           actionHint: null,
         ),
       ],
     );
 
     expect(PluginSetupResponse.fromJson(response.toJson()), response);
+    final oldPayload = response.toJson();
+    ((oldPayload["plugins"] as List<Object?>).first! as Map<String, dynamic>).remove("runtimeVersion");
+    expect(PluginSetupResponse.fromJson(oldPayload).plugins.first.runtimeVersion, isNull);
     expect(
       PluginSetupMetadata.fromJson(const {
         "id": "future",


### PR DESCRIPTION
## Complexity

⚙️ Moderate. The UI change crosses the plugin inspection boundary and the client/bridge wire contract so every harness reports the version of the runtime it actually selected.

## What

- Preserve each harness's already-parsed selected runtime version during setup inspection.
- Add the optional runtime version to plugin setup and management responses.
- Show a localized Version fact on Harnesses settings cards when the bridge reports one.
- Cover PATH, managed-runtime fallback, authentication-blocked, unknown-auth, legacy payload, lifecycle mapping, and widget presentation paths.
- Update the plugin setup and lifecycle regression contract.

## Why

Users need to see which installed harness runtime the connected bridge selected and is using without checking the computer manually.

## Risk and test focus

The main risks are reporting a rejected runtime instead of the selected one, leaking raw probe output, and breaking mixed client/bridge versions. Plugins expose only parsed display-ready version tokens from their existing selection probes. Older bridge payloads decode the omitted field as null, and older clients ignore the additive field.

This has a user-visible Harnesses settings impact. There is no database impact and no analytics event; raw provider versions are not appropriate bounded analytics data.

## Expected result

Harness cards show the selected runtime version beside setup/runtime facts when available. Missing, unsupported, externally attached, and older-bridge cases continue without a Version row.

## Verification

- Focused tests for the shared wire models, plugin interface, all affected harness descriptors, bridge lifecycle/routes, module_core management flow, and Flutter Harnesses settings screen.
- `dart analyze` passed for `shared/sesori_shared`, `client/module_core`, and `client/app`.
- `dart analyze --fatal-infos` passed for `bridge/app`, `sesori_plugin_interface`, OpenCode, Codex, Cursor, Claude, Hermes, and OMP packages.
- Architecture plan and implementation reviews approved with no findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the selected runtime version for each harness in Harnesses settings and hardens probe modeling. Previously versions were hidden and probes allowed “ready” without a version; now the bridge reports the selected version via setup states, probes use sealed results where only Ready carries a version, and the client shows a Version fact when present, with no behavior change for older peers.

- Adds optional runtimeVersion to `PluginSetupMetadata` in `shared/sesori_shared` and threads it through management responses and `PluginLifecycleService`; older bridges omit it and decode to null.
- Extends `PluginSetupStatus` with a `runtimeVersion` property and `.versioned` factories for `PluginSetupReady`, `PluginSetupAuthenticationRequired`, and `PluginSetupUnknown`; existing non-versioned constructors remain for cases without a selected runtime.
- Refactors Cursor, Hermes, and OMP runtime probes to sealed types that carry a non-null version only in the Ready variant; OpenCode now returns the managed version directly. Claude, Codex, Cursor, Hermes, OpenCode, and OMP descriptors emit versioned setup states using the selected display-ready version only; no raw probe output is exposed.
- Client adds a localized Version fact row guarded for null; no database or analytics changes. Regression docs and tests reflect the new field.

**Review and rollout**
- Verify mixed-version compatibility: management JSON may omit `runtimeVersion`; clients treat it as optional.
- Plugin authors must use the `.versioned` setup constructors when a usable local runtime is selected; use non-versioned constructors when no versioned runtime is selected.

<sup>Written for commit f691f0a3d54607bb6a794a0783009e7f11566c5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

