### PR TITLE
Revert "🌿 Restore project and session context clicks"

### DIFF
--- a/client/app/lib/features/project_list/widgets/project_tile.dart
+++ b/client/app/lib/features/project_list/widgets/project_tile.dart
@@ -1,6 +1,5 @@
 import "dart:async";
 
-import "package:flutter/gestures.dart" show kSecondaryButton;
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:material_ui/material_ui.dart";
 import "package:path/path.dart" as p;
@@ -144,13 +143,8 @@ class const ProjectTile({
       // ListTile, whereas an InkWell contributes only the actions, not the
       // role, and leaves the row's three lines as three separate nodes to
       // swipe past.
-      child: Listener(
-        // Some desktop pointer paths report the full pressed-button mask.
-        // TapGestureRecognizer ignores combined masks, so inspect the
-        // secondary bit directly instead of waiting for onSecondaryTap.
-        onPointerDown: (event) {
-          if ((event.buttons & kSecondaryButton) != 0) openMenu();
-        },
+      child: GestureDetector(
+        onSecondaryTap: openMenu,
         child: MergeSemantics(
           child: Semantics(
             button: true,

--- a/client/app/lib/features/session_list/session_tile.dart
+++ b/client/app/lib/features/session_list/session_tile.dart
@@ -1,4 +1,3 @@
-import "package:flutter/gestures.dart" show kSecondaryButton;
 import "package:material_ui/material_ui.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
@@ -107,13 +106,8 @@ class const SessionTile({
       // Right-click is the mouse counterpart of long-press. The row announces
       // itself as one button, so its two lines aren't separate nodes to swipe
       // past.
-      child: Listener(
-        // Some desktop pointer paths report the full pressed-button mask.
-        // TapGestureRecognizer ignores combined masks, so inspect the
-        // secondary bit directly instead of waiting for onSecondaryTap.
-        onPointerDown: (event) {
-          if ((event.buttons & kSecondaryButton) != 0) openMenu();
-        },
+      child: GestureDetector(
+        onSecondaryTap: openMenu,
         child: MergeSemantics(
           child: Semantics(
             button: true,

--- a/client/app/test/features/project_list/project_tile_menu_test.dart
+++ b/client/app/test/features/project_list/project_tile_menu_test.dart
@@ -129,15 +129,8 @@ void main() {
   testWidgets("right-clicking a project opens the same anchored menu without navigating", (tester) async {
     await pumpScreen(tester);
 
-    // Desktop pointer events can carry the full pressed-button mask rather
-    // than only the button that changed. The secondary bit must still open the
-    // menu instead of being rejected as a combined-button tap.
-    final gesture = await tester.startGesture(
-      tester.getCenter(find.widgetWithText(ProjectTile, "my-app")),
-      kind: PointerDeviceKind.mouse,
-      buttons: kPrimaryButton | kSecondaryButton,
-    );
-    await gesture.up();
+    // The mouse counterpart of the long-press, for the desktop app.
+    await tester.tap(find.widgetWithText(ProjectTile, "my-app"), buttons: kSecondaryMouseButton);
     await tester.pumpAndSettle();
 
     expect(find.widgetWithText(InkWell, "Rename"), findsOneWidget);

--- a/client/app/test/features/session_list/session_tile_menu_test.dart
+++ b/client/app/test/features/session_list/session_tile_menu_test.dart
@@ -94,15 +94,8 @@ void main() {
 
     await pumpPanel(tester, session: session);
 
-    // Desktop pointer events can carry the full pressed-button mask rather
-    // than only the button that changed. The secondary bit must still open the
-    // menu instead of being rejected as a combined-button tap.
-    final gesture = await tester.startGesture(
-      tester.getCenter(find.widgetWithText(SessionTile, "My Session")),
-      kind: PointerDeviceKind.mouse,
-      buttons: kPrimaryButton | kSecondaryButton,
-    );
-    await gesture.up();
+    // The mouse counterpart of the long-press, for the desktop app.
+    await tester.tap(find.widgetWithText(SessionTile, "My Session"), buttons: kSecondaryMouseButton);
     await tester.pumpAndSettle();
 
     expect(find.widgetWithText(InkWell, "Rename"), findsOneWidget);

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -26,9 +26,6 @@ child sessions with titles, activity, statuses, and unseen state.
 - Opening validates the path and surfaces the git-initialization choice. Hiding
   delists without destroying sessions or history. Import is explicit, per
   plugin, atomic, non-destructive, cancellable, and attributes progress.
-- Project and session rows open their anchored action menu on long press or a
-  secondary mouse/trackpad click, including desktop events that carry a full
-  pressed-button mask. A context click never opens the row itself.
 - A session created in a dedicated worktree receives a system prompt identifying
   that worktree, its initial branch, and base branch. The prompt requires all
   work to remain in that worktree, while permitting use of the initial branch,
@@ -107,7 +104,6 @@ after a marker has been established.
   awaiting-only is promoted, or inactive session/project or child order changes.
 - Unseen never clears, clears without viewing, or an unavailable plugin is idle.
 - Hiding destroys sessions, or a cancelled import destroys the committed catalog.
-- A secondary click navigates into a row or fails to open its action menu.
 - A generated title/branch update fails to reach list/detail, changes unseen,
   moves the worktree, or rewrites the backend's creation-time system context.
 


### PR DESCRIPTION
Reverts sesori-ai/sesori_apps_monorepo#940

There was no need for this fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the combined-button workaround for context clicks and restores standard secondary-click handling on project and session tiles. Previously, tiles opened the anchored menu when a desktop event reported a combined primary+secondary mask via raw pointer inspection; now they rely on secondary-tap events. This simplifies code/tests and removes docs about combined-mask support.

- **Review notes**
  - Verify right-click opens the anchored menu on project/session tiles without navigating.
  - Confirm tests pass with the simplified secondary-click simulation.
  - No user or integration migrations required; docs remove the combined-mask guarantee.

<sup>Written for commit c14e27b7c15ed67944bef3ecf0c6143f0d065fe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

