### PR TITLE
🌱 Model system/thinking_tokens and system/task_progress frames

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/api/claude_stream_client.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/claude_stream_client.dart
@@ -286,6 +286,8 @@ class ClaudeStreamClient({
         // frequently and a warning would drown the log on a routine upgrade.
         Log.d("[$_logTag] unmodelled frame type=$type subtype=$subtype");
       case ClaudeStatusMessage():
+      case ClaudeThinkingTokensMessage():
+      case ClaudeTaskProgressMessage():
       case ClaudeApiRetryMessage():
       case ClaudeAssistantMessage():
       case ClaudeUserMessage():

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
@@ -50,6 +50,14 @@ sealed class const ClaudeStreamMessage({
             uuid: uuid,
             raw: json,
           ),
+          "thinking_tokens" => ClaudeThinkingTokensMessage(
+            estimatedTokens: _intOrNull(json["estimated_tokens"]),
+            estimatedTokensDelta: _intOrNull(json["estimated_tokens_delta"]),
+            sessionId: sessionId,
+            uuid: uuid,
+            raw: json,
+          ),
+          "task_progress" => ClaudeTaskProgressMessage.fromJson(json, sessionId: sessionId, uuid: uuid),
           _ => ClaudeUnknownMessage(type: type, subtype: subtype, sessionId: sessionId, uuid: uuid, raw: json),
         };
       case "assistant":
@@ -147,6 +155,54 @@ final class const ClaudeStatusMessage({
   required super.uuid,
   required super.raw,
 }) extends ClaudeStreamMessage;
+
+/// `system`/`thinking_tokens` — a running estimate of the current thinking
+/// block's token count, emitted alongside thinking deltas.
+final class const ClaudeThinkingTokensMessage({
+  required final int? estimatedTokens,
+  required final int? estimatedTokensDelta,
+  required super.sessionId,
+  required super.uuid,
+  required super.raw,
+}) extends ClaudeStreamMessage;
+
+/// `system`/`task_progress` — periodic progress for a running subagent task.
+final class const ClaudeTaskProgressMessage({
+  required final String? taskId,
+  required final String? toolUseId,
+  required final String? description,
+  required final String? subagentType,
+  required final String? lastToolName,
+  required final String? summary,
+  required final int? totalTokens,
+  required final int? toolUses,
+  required final int? durationMs,
+  required super.sessionId,
+  required super.uuid,
+  required super.raw,
+}) extends ClaudeStreamMessage {
+  factory fromJson(
+    Map<String, Object?> json, {
+    required String? sessionId,
+    required String? uuid,
+  }) {
+    final usage = _mapOrEmpty(json["usage"]);
+    return ClaudeTaskProgressMessage(
+      taskId: _stringOrNull(json["task_id"]),
+      toolUseId: _stringOrNull(json["tool_use_id"]),
+      description: _stringOrNull(json["description"]),
+      subagentType: _stringOrNull(json["subagent_type"]),
+      lastToolName: _stringOrNull(json["last_tool_name"]),
+      summary: _stringOrNull(json["summary"]),
+      totalTokens: _intOrNull(usage["total_tokens"]),
+      toolUses: _intOrNull(usage["tool_uses"]),
+      durationMs: _intOrNull(usage["duration_ms"]),
+      sessionId: sessionId,
+      uuid: uuid,
+      raw: json,
+    );
+  }
+}
 
 enum ClaudeAssistantError() {
   authenticationFailed,

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -71,6 +71,10 @@ final class ClaudeEventDispatcher({
         ClaudeResultMessage() => _mapResult(sessionId: sessionId, message: message),
         ClaudeInitMessage() ||
         ClaudeStatusMessage() ||
+        // ponytail: parsed but not surfaced — no client UI consumes thinking
+        // token estimates or subagent task progress yet.
+        ClaudeThinkingTokensMessage() ||
+        ClaudeTaskProgressMessage() ||
         ClaudeControlRequestMessage() ||
         ClaudeControlResponseMessage() ||
         ClaudeRateLimitMessage() ||

--- a/bridge/sesori_plugin_claude/test/claude_stream_message_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_stream_message_test.dart
@@ -198,6 +198,46 @@ void main() {
       expect(message.status, "allowed");
     });
 
+    test("reads thinking token estimates", () {
+      final message =
+          ClaudeStreamMessage.parse({
+                "type": "system",
+                "subtype": "thinking_tokens",
+                "estimated_tokens": 512,
+                "estimated_tokens_delta": 64,
+              })
+              as ClaudeThinkingTokensMessage;
+
+      expect(message.estimatedTokens, 512);
+      expect(message.estimatedTokensDelta, 64);
+    });
+
+    test("reads subagent task progress including nested usage", () {
+      final message =
+          ClaudeStreamMessage.parse({
+                "type": "system",
+                "subtype": "task_progress",
+                "task_id": "task-1",
+                "tool_use_id": "toolu_1",
+                "description": "Explore repo",
+                "subagent_type": "Explore",
+                "last_tool_name": "Grep",
+                "summary": "searching",
+                "usage": {"total_tokens": 1200, "tool_uses": 3, "duration_ms": 4500},
+              })
+              as ClaudeTaskProgressMessage;
+
+      expect(message.taskId, "task-1");
+      expect(message.toolUseId, "toolu_1");
+      expect(message.description, "Explore repo");
+      expect(message.subagentType, "Explore");
+      expect(message.lastToolName, "Grep");
+      expect(message.summary, "searching");
+      expect(message.totalTokens, 1200);
+      expect(message.toolUses, 3);
+      expect(message.durationMs, 4500);
+    });
+
     test("absorbs unknown types and unknown system subtypes", () {
       final unknownType = ClaudeStreamMessage.parse({"type": "some_future_event", "session_id": "s"});
       expect(unknownType, isA<ClaudeUnknownMessage>());


### PR DESCRIPTION
## Complexity
Trivial: two new sealed variants in the existing hand-written stream-message union, plus their switch arms.

## What
Parses `system`/`thinking_tokens` (`estimated_tokens`, `estimated_tokens_delta`) and `system`/`task_progress` (task/tool ids, description, subagent type, last tool, summary, nested `usage`) into typed `ClaudeThinkingTokensMessage` and `ClaudeTaskProgressMessage` variants instead of letting them fall through to `ClaudeUnknownMessage`.

## Why
Both frames are emitted on ordinary turns by current Claude CLI builds, so every session logged repeated `unmodelled frame type=system subtype=...` debug lines and the payloads stayed untyped.

## Risk and test focus
No user-visible impact and no database impact: the dispatcher maps both variants to no SSE events, so client behavior is unchanged. Risk is limited to the parser; field names were read from the CLI 2.1.233 emit sites, and unknown/misshaped payloads still degrade to nulls rather than throwing. Focus: `claude_stream_message_test.dart`.

## Expected result
The two subtypes no longer appear as `unmodelled frame` in bridge logs, and their fields are available typed for a future UI surface.

## Verification
- `dart analyze lib test` in `bridge/sesori_plugin_claude` — no errors or warnings
- `dart test test/claude_stream_message_test.dart` — 18 passing, including two new cases


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Models `system/thinking_tokens` and `system/task_progress` stream frames as `ClaudeThinkingTokensMessage` and `ClaudeTaskProgressMessage`. Previously these fell through to `ClaudeUnknownMessage` with "unmodelled frame" logs; now they parse cleanly with no client-visible change.

- Parser: maps `system/thinking_tokens` (`estimated_tokens`, `estimated_tokens_delta`) and `system/task_progress` (task/tool ids, description, subagent type, last tool, summary, nested `usage` fields: `total_tokens`, `tool_uses`, `duration_ms`) into typed variants.
- Dispatcher/logging: recognizes both variants but emits no SSE, preserving behavior; removes repeated "unmodelled frame" debug lines on ordinary turns.
- Review focus: `lib/src/api/models/claude_stream_message.dart` (parsing/types), `lib/src/claude_event_dispatcher.dart` (switch arms), small fallthrough addition in `claude_stream_client.dart`.
- Safety/tests: malformed fields coerce to null; no DB or API changes. New tests in `claude_stream_message_test.dart`; `dart analyze` and `dart test` pass.

<sup>Written for commit c6abc968f9b152cf32d7251af01c445774654c6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

