### PR TITLE
⚙️ [bridge-owned-prompt-queue] contracts: prompt ids and queued-prompt wire surface [step 2/7]

### DIFF
--- a/.plan/active/bridge-owned-prompt-queue/TRACKER.md
+++ b/.plan/active/bridge-owned-prompt-queue/TRACKER.md
@@ -2,8 +2,8 @@
 
 | Step | PR title | Status | PR | Notes |
 |---|---|---|---|---|
-| 1/7 | 🌱 [bridge-owned-prompt-queue] docs: raise the bridge-owned prompt queue plan [step 1/7] | Planned | — | |
-| 2/7 | ⚙️ [bridge-owned-prompt-queue] contracts: prompt ids and queued-prompt wire surface [step 2/7] | Planned | — | |
+| 1/7 | 🌱 [bridge-owned-prompt-queue] docs: raise the bridge-owned prompt queue plan [step 1/7] | Merged | #946 | |
+| 2/7 | ⚙️ [bridge-owned-prompt-queue] contracts: prompt ids and queued-prompt wire surface [step 2/7] | In review | #948 | ACP stamps promptId on its acceptance echo already |
 | 3/7 | ⚙️ [bridge-owned-prompt-queue] bridge: route and relay the queued-prompt surface [step 3/7] | Planned | — | |
 | 4/7 | 🚧 [bridge-owned-prompt-queue] claude: accept prompts at enqueue and own the queue [step 4/7] | Planned | — | |
 | 5/7 | 🚧 [bridge-owned-prompt-queue] client: render the bridge queue and transform states seamlessly [step 5/7] | Planned | — | |

--- a/bridge/app/lib/src/bridge/repositories/mappers/plugin_message_mapper.dart
+++ b/bridge/app/lib/src/bridge/repositories/mappers/plugin_message_mapper.dart
@@ -6,11 +6,12 @@ import "../../plugin_to_shared_mapping.dart";
 /// Maps plugin-level message types to shared [Message] types.
 extension PluginMessageMapper on PluginMessage {
   Message toSharedMessage({required String sessionId}) => switch (this) {
-    PluginMessageUser(:final id, :final agent, :final time) => Message.user(
+    PluginMessageUser(:final id, :final agent, :final time, :final promptId) => Message.user(
       id: id,
       sessionID: sessionId,
       agent: agent,
       time: time.toShared(),
+      promptId: promptId,
     ),
     PluginMessageAssistant(:final id, :final agent, :final modelID, :final providerID, :final time) =>
       Message.assistant(

--- a/bridge/app/lib/src/bridge/repositories/mappers/session_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/repositories/mappers/session_event_mapper.dart
@@ -29,6 +29,7 @@ class const SessionEventMapper() {
       BridgeSseMessageRemoved(:final sessionID) ||
       BridgeSseMessagePartDelta(:final sessionID) ||
       BridgeSseMessagePartRemoved(:final sessionID) ||
+      BridgeSseQueuedPromptsUpdated(:final sessionID) ||
       BridgeSseTodoUpdated(:final sessionID) => {sessionID},
       BridgeSseSessionError(:final sessionID) => {?sessionID},
       BridgeSseMessageUpdated(:final info) => {Message.fromJson(info).sessionID},
@@ -136,14 +137,15 @@ class const SessionEventMapper() {
         :final sessionID,
         :final agent,
         :final model,
-      ) => switch (mapped(sessionID)) {
-        final sessionId? => BridgeSseSessionPromptDefaultsChanged(
-          sessionID: sessionId,
-          agent: agent,
-          model: model,
-        ),
-        null => null,
-      },
+      ) =>
+        switch (mapped(sessionID)) {
+          final sessionId? => BridgeSseSessionPromptDefaultsChanged(
+            sessionID: sessionId,
+            agent: agent,
+            model: model,
+          ),
+          null => null,
+        },
       BridgeSseSessionStatus(:final sessionID, :final status) => switch (mapped(sessionID)) {
         final sessionId? => BridgeSseSessionStatus(sessionID: sessionId, status: status),
         null => null,
@@ -171,6 +173,10 @@ class const SessionEventMapper() {
       },
       BridgeSseMessageRemoved(:final sessionID, :final messageID) => switch (mapped(sessionID)) {
         final sessionId? => BridgeSseMessageRemoved(sessionID: sessionId, messageID: messageID),
+        null => null,
+      },
+      BridgeSseQueuedPromptsUpdated(:final sessionID, :final prompts) => switch (mapped(sessionID)) {
+        final sessionId? => BridgeSseQueuedPromptsUpdated(sessionID: sessionId, prompts: prompts),
         null => null,
       },
       BridgeSseMessagePartUpdated(:final part) => switch (mapped(part.sessionID)) {

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -285,6 +285,7 @@ class SessionRepository({
 
   Future<void> sendCommand({
     required String sessionId,
+    required String promptId,
     required String command,
     required String arguments,
     required String? userVisibleArguments,
@@ -303,6 +304,7 @@ class SessionRepository({
         _primeDerivedSessionDirectory(binding: binding, plugin: plugin);
         return plugin.sendCommand(
           sessionId: binding.backendSessionId,
+          promptId: promptId,
           command: command,
           arguments: arguments,
           userVisibleArguments: userVisibleArguments,
@@ -319,6 +321,7 @@ class SessionRepository({
 
   Future<void> sendPrompt({
     required String sessionId,
+    required String promptId,
     required List<PromptPart> parts,
     required SessionVariant? variant,
     required String? agent,
@@ -335,6 +338,7 @@ class SessionRepository({
         _primeDerivedSessionDirectory(binding: binding, plugin: plugin);
         return plugin.sendPrompt(
           sessionId: binding.backendSessionId,
+          promptId: promptId,
           parts: parts.map((part) => part.toPlugin()).toList(growable: false),
           variant: _toPluginVariant(variant),
           agent: agent,

--- a/bridge/app/lib/src/bridge/routing/send_prompt_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/send_prompt_handler.dart
@@ -28,6 +28,7 @@ class SendPromptHandler({required final SessionPromptService _sessionPromptServi
 
     await _sessionPromptService.sendPrompt(
       sessionId: sessionId,
+      promptId: body.promptId,
       parts: body.parts,
       variant: body.variant,
       agent: body.agent,

--- a/bridge/app/lib/src/bridge/services/session_creation_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_creation_service.dart
@@ -7,6 +7,7 @@ import "../../repositories/session_metadata_repository.dart";
 import "../repositories/models/session_operation.dart";
 import "../repositories/session_repository.dart";
 import "session_mutation_dispatcher.dart";
+import "session_prompt_service.dart";
 import "worktree_service.dart";
 
 class SessionCreationService({
@@ -157,6 +158,7 @@ class SessionCreationService({
     }
     await _sessionRepository.sendCommand(
       sessionId: session.id,
+      promptId: SessionPromptService.generatePromptId(),
       command: command,
       arguments: arguments,
       userVisibleArguments: userVisibleArguments,

--- a/bridge/app/lib/src/bridge/services/session_prompt_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_prompt_service.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:math";
 
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart";
@@ -25,6 +26,7 @@ class SessionPromptService({
 
   Future<void> sendPrompt({
     required String sessionId,
+    required String? promptId,
     required List<PromptPart> parts,
     required SessionVariant? variant,
     required String? agent,
@@ -39,6 +41,9 @@ class SessionPromptService({
           : SessionOperation.sendCommand,
       body: () => _sendPrompt(
         sessionId: sessionId,
+        // Clients that predate prompt ids omit them; plugins always receive
+        // one so queue entries and dedupe stay uniformly keyed.
+        promptId: promptId ?? generatePromptId(),
         parts: parts,
         variant: variant,
         agent: agent,
@@ -50,6 +55,7 @@ class SessionPromptService({
 
   Future<void> _sendPrompt({
     required String sessionId,
+    required String promptId,
     required List<PromptPart> parts,
     required SessionVariant? variant,
     required String? agent,
@@ -62,6 +68,7 @@ class SessionPromptService({
     if (normalizedCommand == null || normalizedCommand.isEmpty) {
       await _sessionRepository.sendPrompt(
         sessionId: sessionId,
+        promptId: promptId,
         parts: parts,
         variant: variant,
         agent: agent,
@@ -84,6 +91,7 @@ class SessionPromptService({
     // duration of the command's agent run.
     await _sessionRepository.sendCommand(
       sessionId: sessionId,
+      promptId: promptId,
       command: normalizedCommand,
       arguments: arguments ?? '',
       userVisibleArguments: arguments == null || arguments.trim().isEmpty ? null : arguments,
@@ -134,5 +142,17 @@ class SessionPromptService({
 
   Future<void> dispose() async {
     await _promptDefaultsChangesController.close();
+  }
+
+  static final Random _secureRandom = Random.secure();
+
+  /// Bridge-generated prompt identity for sends that carry none (old clients,
+  /// bridge-originated initial commands).
+  static String generatePromptId() {
+    final buffer = StringBuffer("prm_");
+    for (var index = 0; index < 16; index++) {
+      buffer.write(_secureRandom.nextInt(256).toRadixString(16).padLeft(2, "0"));
+    }
+    return buffer.toString();
   }
 }

--- a/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
@@ -145,6 +145,19 @@ class BridgeEventMapper({
             displaySessionId: displaySessionId,
           ),
         BridgeSseTodoUpdated(:final sessionID) => SesoriSseEvent.todoUpdated(sessionID: sessionID),
+        BridgeSseQueuedPromptsUpdated(:final sessionID, :final prompts) => SesoriSseEvent.sessionQueuedPrompts(
+          sessionID: sessionID,
+          prompts: [
+            for (final prompt in prompts)
+              QueuedSessionPrompt(
+                id: prompt.id,
+                text: prompt.text,
+                command: prompt.command,
+                attachmentCount: prompt.attachmentCount,
+                createdAt: prompt.createdAt,
+              ),
+          ],
+        ),
         // BridgeSseProjectUpdated triggers a full projects-summary rebuild, but
         // the summary needs repository data (the bridge's session→project
         // attribution) — the orchestrator fetches it and builds the event via

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -454,6 +454,7 @@ void main() {
       plugin.messagesResult = [
         const PluginMessageWithParts(
           info: PluginMessage.user(
+            promptId: null,
             id: "m1",
             sessionID: "s1",
             agent: null,
@@ -1066,6 +1067,12 @@ abstract interface class _SubscriptionAwarePlugin() {
 }
 
 class _FakeBridgePlugin() implements NativeProjectsPluginApi, _SubscriptionAwarePlugin {
+  @override
+  Future<List<PluginQueuedPrompt>> getQueuedPrompts({required String sessionId}) async => const [];
+
+  @override
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async => false;
+
   final _controller = StreamController<BridgeSseEvent>.broadcast();
   final Completer<void> _eventsSubscribed = Completer<void>();
 
@@ -1161,6 +1168,7 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi, _SubscriptionAware
 
   @override
   Future<void> sendPrompt({
+    required String promptId,
     required String sessionId,
     required List<PluginPromptPart> parts,
     required PluginSessionVariant? variant,
@@ -1227,6 +1235,7 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi, _SubscriptionAware
 
   @override
   Future<void> sendCommand({
+    required String promptId,
     required String sessionId,
     required String command,
     required String arguments,
@@ -1308,6 +1317,12 @@ class _BlockingRoutesPlugin() extends _FakeBridgePlugin {
 
 /// Plugin that tracks subscribe/unsubscribe counts via a wrapping stream.
 class _TrackingBridgePlugin() implements NativeProjectsPluginApi, _SubscriptionAwarePlugin {
+  @override
+  Future<List<PluginQueuedPrompt>> getQueuedPrompts({required String sessionId}) async => const [];
+
+  @override
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async => false;
+
   final _eventController = StreamController<BridgeSseEvent>.broadcast();
   final Completer<void> _eventsSubscribed = Completer<void>();
   int subscribeCount = 0;
@@ -1403,6 +1418,7 @@ class _TrackingBridgePlugin() implements NativeProjectsPluginApi, _SubscriptionA
 
   @override
   Future<void> sendPrompt({
+    required String promptId,
     required String sessionId,
     required List<PluginPromptPart> parts,
     required PluginSessionVariant? variant,
@@ -1462,6 +1478,7 @@ class _TrackingBridgePlugin() implements NativeProjectsPluginApi, _SubscriptionA
 
   @override
   Future<void> sendCommand({
+    required String promptId,
     required String sessionId,
     required String command,
     required String arguments,

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -278,6 +278,7 @@ void main() {
     harness.plugins.single.emitEvent(
       BridgeSseMessageUpdated(
         info: const Message.user(
+          promptId: null,
           id: "message",
           sessionID: "session",
           agent: null,

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -384,6 +384,12 @@ class _TestHarness._({
 }
 
 class _ThrowingSummaryPlugin() implements NativeProjectsPluginApi {
+  @override
+  Future<List<PluginQueuedPrompt>> getQueuedPrompts({required String sessionId}) async => const [];
+
+  @override
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async => false;
+
   final _controller = StreamController<BridgeSseEvent>.broadcast();
 
   int subscribeCount = 0;
@@ -480,6 +486,7 @@ class _ThrowingSummaryPlugin() implements NativeProjectsPluginApi {
 
   @override
   Future<void> sendPrompt({
+    required String promptId,
     required String sessionId,
     required List<PluginPromptPart> parts,
     required PluginSessionVariant? variant,
@@ -547,6 +554,7 @@ class _ThrowingSummaryPlugin() implements NativeProjectsPluginApi {
 
   @override
   Future<void> sendCommand({
+    required String promptId,
     required String sessionId,
     required String command,
     required String arguments,

--- a/bridge/app/test/bridge/repositories/mappers/plugin_message_mapper_test.dart
+++ b/bridge/app/test/bridge/repositories/mappers/plugin_message_mapper_test.dart
@@ -7,6 +7,7 @@ void main() {
   group("PluginMessageMapper.toSharedMessage()", () {
     test("preserves time on a user message", () {
       const message = PluginMessage.user(
+        promptId: null,
         id: "m1",
         sessionID: "s1",
         agent: null,
@@ -17,6 +18,7 @@ void main() {
         message.toSharedMessage(sessionId: "stable-session"),
         equals(
           const Message.user(
+            promptId: null,
             id: "m1",
             sessionID: "stable-session",
             agent: null,
@@ -82,6 +84,7 @@ void main() {
 
     test("maps a null time to null", () {
       const message = PluginMessage.user(
+        promptId: null,
         id: "m4",
         sessionID: "s1",
         agent: null,

--- a/bridge/app/test/bridge/repositories/mappers/session_event_mapper_test.dart
+++ b/bridge/app/test/bridge/repositories/mappers/session_event_mapper_test.dart
@@ -17,6 +17,7 @@ void main() {
         parentId: "backend-parent",
       );
       final messageInfo = const Message.user(
+        promptId: null,
         id: "message",
         sessionID: "backend-session",
         agent: null,

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -1117,7 +1117,6 @@ void main() {
       // the existing persisted timestamp.
       expect(result.single.time?.updated, persistedActivity!.updatedAt);
     });
-
   });
 
   group("ProjectRepository getRemoteIdentity", () {
@@ -1208,6 +1207,12 @@ PluginSession _session(
 /// Minimal [BridgePluginApi] fake for plugin activity evidence. Every other
 /// member throws so accidental project open/rename delegation is loud.
 class _FakeBridgePlugin() implements NativeProjectsPluginApi {
+  @override
+  Future<List<PluginQueuedPrompt>> getQueuedPrompts({required String sessionId}) async => const [];
+
+  @override
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async => false;
+
   List<PluginProject> projectsResult = const [];
   Future<List<PluginProject>>? getProjectsFuture;
   Object? getProjectsError;
@@ -1286,6 +1291,7 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi {
 
   @override
   Future<void> sendPrompt({
+    required String promptId,
     required String sessionId,
     required List<PluginPromptPart> parts,
     required PluginSessionVariant? variant,
@@ -1295,6 +1301,7 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi {
 
   @override
   Future<void> sendCommand({
+    required String promptId,
     required String sessionId,
     required String command,
     required String arguments,

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -1420,6 +1420,7 @@ void main() {
 
       for (final variant in cases) {
         await repository.sendPrompt(
+          promptId: "prompt-1",
           sessionId: "stable-s1",
           parts: const [PromptPart.text(text: "Prompt")],
           variant: variant,
@@ -1430,6 +1431,7 @@ void main() {
         expect(plugin.lastSendPromptSessionId, equals("backend-s1"));
 
         await repository.sendCommand(
+          promptId: "prompt-1",
           sessionId: "stable-s1",
           command: "review",
           arguments: "Prompt",
@@ -1456,6 +1458,7 @@ void main() {
 
       await expectLater(
         repository.sendPrompt(
+          promptId: "prompt-1",
           sessionId: "missing",
           parts: const [],
           variant: null,
@@ -1480,6 +1483,7 @@ void main() {
       );
       await expectLater(
         repository.sendPrompt(
+          promptId: "prompt-1",
           sessionId: "wrong-plugin",
           parts: const [],
           variant: null,
@@ -1517,7 +1521,7 @@ void main() {
       );
       plugin.messagesResult = const [
         PluginMessageWithParts(
-          info: PluginMessageUser(id: "message-1", sessionID: "backend-s1", agent: null, time: null),
+          info: PluginMessageUser(promptId: null, id: "message-1", sessionID: "backend-s1", agent: null, time: null),
           parts: [
             PluginMessagePart(
               id: "part-1",
@@ -2097,7 +2101,14 @@ void main() {
       );
 
       // The worktree session primes with its worktree path...
-      await repository.sendPrompt(sessionId: "w1", parts: const [], variant: null, agent: null, model: null);
+      await repository.sendPrompt(
+        promptId: "prompt-1",
+        sessionId: "w1",
+        parts: const [],
+        variant: null,
+        agent: null,
+        model: null,
+      );
       expect(plugin.primedDirectories.last, (sessionId: "w1", directory: worktree));
 
       // ...a plain session primes with the owning project directory...
@@ -2105,6 +2116,7 @@ void main() {
       expect(plugin.primedDirectories.last, (sessionId: "p1", directory: parent));
 
       await repository.sendCommand(
+        promptId: "prompt-1",
         sessionId: "w1",
         command: "review",
         arguments: "",
@@ -2119,7 +2131,14 @@ void main() {
       final primesBefore = plugin.primedDirectories.length;
       final sendsBefore = plugin.sendPromptCalls;
       await expectLater(
-        repository.sendPrompt(sessionId: "ghost", parts: const [], variant: null, agent: null, model: null),
+        repository.sendPrompt(
+          promptId: "prompt-1",
+          sessionId: "ghost",
+          parts: const [],
+          variant: null,
+          agent: null,
+          model: null,
+        ),
         throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 404)),
       );
       expect(plugin.primedDirectories.length, primesBefore);
@@ -2362,6 +2381,7 @@ void main() {
 
       final guardedOperations = <Future<void> Function()>[
         () => repository.sendCommand(
+          promptId: "prompt-1",
           sessionId: "gone",
           command: "test",
           arguments: "",
@@ -2371,6 +2391,7 @@ void main() {
           model: null,
         ),
         () => repository.sendPrompt(
+          promptId: "prompt-1",
           sessionId: "gone",
           parts: const [],
           variant: null,
@@ -2759,6 +2780,7 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi {
 
   @override
   Future<void> sendPrompt({
+    required String promptId,
     required String sessionId,
     required List<PluginPromptPart> parts,
     required PluginSessionVariant? variant,
@@ -2772,6 +2794,7 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi {
 
   @override
   Future<void> sendCommand({
+    required String promptId,
     required String sessionId,
     required String command,
     required String arguments,
@@ -2969,6 +2992,7 @@ class _FakeDerivedPlugin({
 
   @override
   Future<void> sendPrompt({
+    required String promptId,
     required String sessionId,
     required List<PluginPromptPart> parts,
     required PluginSessionVariant? variant,
@@ -2980,6 +3004,7 @@ class _FakeDerivedPlugin({
 
   @override
   Future<void> sendCommand({
+    required String promptId,
     required String sessionId,
     required String command,
     required String arguments,

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -1384,6 +1384,7 @@ class _OrderCheckingCommandPlugin({required final AppDatabase _database}) extend
 
   @override
   Future<void> sendCommand({
+    required String promptId,
     required String sessionId,
     required String command,
     required String arguments,
@@ -1398,6 +1399,7 @@ class _OrderCheckingCommandPlugin({required final AppDatabase _database}) extend
     );
     hadStoredRowWhenCommandSent = session != null;
     await super.sendCommand(
+      promptId: "prompt-1",
       sessionId: sessionId,
       command: command,
       arguments: arguments,

--- a/bridge/app/test/bridge/routing/get_session_messages_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_session_messages_handler_test.dart
@@ -104,6 +104,7 @@ void main() {
       plugin.messagesResult = [
         const PluginMessageWithParts(
           info: PluginMessage.user(
+            promptId: null,
             id: "m1",
             sessionID: "s1",
             agent: null,
@@ -139,6 +140,7 @@ void main() {
       plugin.messagesResult = [
         PluginMessageWithParts(
           info: const PluginMessage.user(
+            promptId: null,
             id: "m1",
             sessionID: "s1",
             agent: null,

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -118,6 +118,12 @@ extension RequestHandlerTestMatching on RequestHandlerBase {
 
 /// Hand-written fake [BridgePluginApi] used across routing handler tests.
 class FakeBridgePlugin() implements NativeProjectsPluginApi {
+  @override
+  Future<List<PluginQueuedPrompt>> getQueuedPrompts({required String sessionId}) async => const [];
+
+  @override
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async => false;
+
   final _controller = StreamController<BridgeSseEvent>.broadcast();
 
   // ── Configurable return values ───────────────────────────────────────────
@@ -368,6 +374,7 @@ class FakeBridgePlugin() implements NativeProjectsPluginApi {
 
   @override
   Future<void> sendPrompt({
+    required String promptId,
     required String sessionId,
     required List<PluginPromptPart> parts,
     required PluginSessionVariant? variant,
@@ -383,6 +390,7 @@ class FakeBridgePlugin() implements NativeProjectsPluginApi {
 
   @override
   Future<void> sendCommand({
+    required String promptId,
     required String sessionId,
     required String command,
     required String arguments,
@@ -1044,6 +1052,7 @@ class _NoopSessionRepository() implements SessionRepository {
 
   @override
   Future<void> sendCommand({
+    required String promptId,
     required String sessionId,
     required String command,
     required String arguments,
@@ -1059,6 +1068,7 @@ class _NoopSessionRepository() implements SessionRepository {
 
   @override
   Future<void> sendPrompt({
+    required String promptId,
     required String sessionId,
     required List<PromptPart> parts,
     required SessionVariant? variant,
@@ -1558,6 +1568,7 @@ class FakeSessionRepository({
 
   @override
   Future<void> sendCommand({
+    required String promptId,
     required String sessionId,
     required String command,
     required String arguments,
@@ -1567,6 +1578,7 @@ class FakeSessionRepository({
     required PromptModel? model,
   }) async {
     await _plugin.sendCommand(
+      promptId: "prompt-1",
       sessionId: sessionId,
       command: command,
       arguments: arguments,
@@ -1593,6 +1605,7 @@ class FakeSessionRepository({
 
   @override
   Future<void> sendPrompt({
+    required String promptId,
     required String sessionId,
     required List<PromptPart> parts,
     required SessionVariant? variant,
@@ -1600,6 +1613,7 @@ class FakeSessionRepository({
     required PromptModel? model,
   }) async {
     await _plugin.sendPrompt(
+      promptId: "prompt-1",
       sessionId: sessionId,
       parts: parts.map((part) => part.toPlugin()).toList(growable: false),
       variant: _toPluginVariant(variant),

--- a/bridge/app/test/bridge/routing/send_prompt_handler_test.dart
+++ b/bridge/app/test/bridge/routing/send_prompt_handler_test.dart
@@ -71,6 +71,7 @@ void main() {
       await handler.handle(
         makeRequest("POST", "/session/prompt_async"),
         body: const SendPromptRequest(
+          promptId: null,
           sessionId: "s1",
           parts: [PromptPart.text(text: "Hello")],
           variant: null,
@@ -90,6 +91,7 @@ void main() {
       await handler.handle(
         makeRequest("POST", "/session/prompt_async"),
         body: const SendPromptRequest(
+          promptId: null,
           sessionId: "s1",
           parts: [
             PromptPart.text(text: "Hello"),
@@ -116,6 +118,7 @@ void main() {
       await handler.handle(
         makeRequest("POST", "/session/prompt_async"),
         body: const SendPromptRequest(
+          promptId: null,
           sessionId: "s1",
           parts: [PromptPart.text(text: "Hello")],
           variant: null,
@@ -150,6 +153,7 @@ void main() {
       final response = await handler.handle(
         makeRequest("POST", "/session/prompt_async"),
         body: const SendPromptRequest(
+          promptId: null,
           sessionId: "s-defaults-prompt",
           parts: [PromptPart.text(text: "Hello")],
           variant: SessionVariant(id: "xhigh"),
@@ -176,6 +180,7 @@ void main() {
       await handler.handle(
         makeRequest("POST", "/session/prompt_async"),
         body: const SendPromptRequest(
+          promptId: null,
           sessionId: "s42",
           parts: [PromptPart.text(text: "Ship it")],
           variant: null,
@@ -203,6 +208,7 @@ void main() {
       final response = await handler.handle(
         makeRequest("POST", "/session/prompt_async"),
         body: const SendPromptRequest(
+          promptId: null,
           sessionId: "s1",
           parts: [PromptPart.text(text: "Hello")],
           variant: null,
@@ -222,6 +228,7 @@ void main() {
       await handler.handle(
         makeRequest("POST", "/session/prompt_async"),
         body: const SendPromptRequest(
+          promptId: null,
           sessionId: "s1",
           parts: [PromptPart.text(text: "Hello")],
           variant: null,
@@ -243,6 +250,7 @@ void main() {
       await handler.handle(
         makeRequest("POST", "/session/prompt_async"),
         body: const SendPromptRequest(
+          promptId: null,
           sessionId: "s7",
           parts: [PromptPart.text(text: "review this")],
           variant: SessionVariant(id: "xhigh"),
@@ -268,6 +276,7 @@ void main() {
       await handler.handle(
         makeRequest("POST", "/session/prompt_async"),
         body: const SendPromptRequest(
+          promptId: null,
           sessionId: "s8",
           parts: [
             PromptPart.filePath(mime: "text/plain", path: "/tmp/f.txt", filename: null),
@@ -292,6 +301,7 @@ void main() {
       await handler.handle(
         makeRequest("POST", "/session/prompt_async"),
         body: const SendPromptRequest(
+          promptId: null,
           sessionId: "s8",
           parts: [PromptPart.text(text: "   ")],
           variant: null,
@@ -311,6 +321,7 @@ void main() {
       await handler.handle(
         makeRequest("POST", "/session/prompt_async"),
         body: const SendPromptRequest(
+          promptId: null,
           sessionId: "s10",
           parts: [PromptPart.text(text: "review this")],
           variant: null,
@@ -346,6 +357,7 @@ void main() {
       final response = await handler.handle(
         makeRequest("POST", "/session/prompt_async"),
         body: const SendPromptRequest(
+          promptId: null,
           sessionId: "s-defaults-command",
           parts: [PromptPart.text(text: "review this")],
           variant: SessionVariant(id: "high"),
@@ -397,6 +409,7 @@ void main() {
         () => localHandler.handle(
           makeRequest("POST", "/session/prompt_async"),
           body: const SendPromptRequest(
+            promptId: null,
             sessionId: "s-failing-prompt",
             parts: [PromptPart.text(text: "Hello")],
             variant: SessionVariant(id: "new-variant"),
@@ -449,6 +462,7 @@ void main() {
         () => localHandler.handle(
           makeRequest("POST", "/session/prompt_async"),
           body: const SendPromptRequest(
+            promptId: null,
             sessionId: "s-failing-command",
             parts: [PromptPart.text(text: "review this")],
             variant: SessionVariant(id: "new-variant"),
@@ -489,6 +503,7 @@ void main() {
       final response = await localHandler.handle(
         makeRequest("POST", "/session/prompt_async"),
         body: const SendPromptRequest(
+          promptId: null,
           sessionId: "s-update-fails",
           parts: [PromptPart.text(text: "Hello")],
           variant: SessionVariant(id: "xhigh"),
@@ -511,6 +526,7 @@ void main() {
       await handler.handle(
         makeRequest("POST", "/session/prompt_async"),
         body: const SendPromptRequest(
+          promptId: null,
           sessionId: "s9",
           parts: [PromptPart.text(text: "Hello")],
           variant: null,
@@ -535,6 +551,7 @@ void main() {
         () => handler.handle(
           makeRequest("POST", "/session/prompt_async"),
           body: const SendPromptRequest(
+            promptId: null,
             sessionId: "",
             parts: [PromptPart.text(text: "Hello")],
             variant: null,
@@ -557,6 +574,7 @@ void main() {
           "/session/prompt_async",
           body: jsonEncode(
             const SendPromptRequest(
+              promptId: null,
               sessionId: "missing",
               parts: [PromptPart.text(text: "Hello")],
               variant: null,
@@ -592,6 +610,7 @@ void main() {
           "/session/prompt_async",
           body: jsonEncode(
             const SendPromptRequest(
+              promptId: null,
               sessionId: "stale-plugin-session",
               parts: [PromptPart.text(text: "Hello")],
               variant: null,
@@ -652,6 +671,7 @@ Future<void> _insertStoredSession({
 class _ThrowingSendPromptPlugin() extends FakeBridgePlugin {
   @override
   Future<void> sendPrompt({
+    required String promptId,
     required String sessionId,
     required List<PluginPromptPart> parts,
     required PluginSessionVariant? variant,
@@ -665,6 +685,7 @@ class _ThrowingSendPromptPlugin() extends FakeBridgePlugin {
 class _ThrowingSendCommandPlugin() extends FakeBridgePlugin {
   @override
   Future<void> sendCommand({
+    required String promptId,
     required String sessionId,
     required String command,
     required String arguments,
@@ -678,23 +699,24 @@ class _ThrowingSendCommandPlugin() extends FakeBridgePlugin {
 }
 
 class _ThrowingUpdateSessionRepository({
-    required BridgePluginApi plugin,
-    required AppDatabase database,
-    required super.unseenCalculator,
-  }) extends SessionRepository {
+  required BridgePluginApi plugin,
+  required AppDatabase database,
+  required super.unseenCalculator,
+}) extends SessionRepository {
   int updatePromptDefaultsCallCount = 0;
 
-  this : super(
-         runtime: createTestPluginRuntime(plugins: [plugin]),
-         bridgeDerivedProjectPluginIds: {
-           if (plugin is BridgeDerivedProjectsPluginApi) plugin.id,
-         },
-         sessionDao: database.sessionDao,
-         projectsDao: database.projectsDao,
-         pullRequestDao: database.pullRequestDao,
-         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
-         aggregateSourceDeadline: const Duration(seconds: 5),
-       );
+  this
+    : super(
+        runtime: createTestPluginRuntime(plugins: [plugin]),
+        bridgeDerivedProjectPluginIds: {
+          if (plugin is BridgeDerivedProjectsPluginApi) plugin.id,
+        },
+        sessionDao: database.sessionDao,
+        projectsDao: database.projectsDao,
+        pullRequestDao: database.pullRequestDao,
+        projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
+        aggregateSourceDeadline: const Duration(seconds: 5),
+      );
 
   @override
   Future<void> updatePromptDefaults({

--- a/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
+++ b/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
@@ -909,6 +909,12 @@ class _FakeWorktreeService({required AppDatabase database}) extends WorktreeServ
 
 class _FakeBridgePlugin() implements NativeProjectsPluginApi {
   @override
+  Future<List<PluginQueuedPrompt>> getQueuedPrompts({required String sessionId}) async => const [];
+
+  @override
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async => false;
+
+  @override
   String get id => "fake";
 
   @override
@@ -971,6 +977,7 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi {
 
   @override
   Future<void> sendPrompt({
+    required String promptId,
     required String sessionId,
     required List<PluginPromptPart> parts,
     required PluginSessionVariant? variant,
@@ -980,6 +987,7 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi {
 
   @override
   Future<void> sendCommand({
+    required String promptId,
     required String sessionId,
     required String command,
     required String arguments,

--- a/bridge/app/test/bridge/services/chat_history_archive_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_archive_test.dart
@@ -450,8 +450,13 @@ Map<String, dynamic> _storedSessionJson() => {
   "updatedAt": 2,
 };
 
-Message _message({required String id}) =>
-    Message.user(id: id, sessionID: "ses_a", agent: null, time: const MessageTime(created: 1, completed: null));
+Message _message({required String id}) => Message.user(
+  promptId: null,
+  id: id,
+  sessionID: "ses_a",
+  agent: null,
+  time: const MessageTime(created: 1, completed: null),
+);
 
 MessagePart _part({
   required String id,

--- a/bridge/app/test/bridge/services/chat_history_attachment_delivery_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_attachment_delivery_test.dart
@@ -323,6 +323,7 @@ Future<void> _export({required TestChatHistory history}) {
 }
 
 Message _message({required String id}) => Message.user(
+  promptId: null,
   id: id,
   sessionID: "ses_a",
   agent: null,

--- a/bridge/app/test/bridge/services/chat_history_capture_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_capture_test.dart
@@ -523,8 +523,13 @@ Future<List<MessageWithParts>> _storedMessages({
   storageScope: testAttachmentStorageScope(sessionId: sessionId),
 )).messages;
 
-Message _message({required String id}) =>
-    Message.user(id: id, sessionID: "ses_a", agent: null, time: const MessageTime(created: 1, completed: null));
+Message _message({required String id}) => Message.user(
+  promptId: null,
+  id: id,
+  sessionID: "ses_a",
+  agent: null,
+  time: const MessageTime(created: 1, completed: null),
+);
 
 MessagePart _part({
   required String id,

--- a/bridge/app/test/bridge/services/chat_history_live_delivery_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_live_delivery_test.dart
@@ -462,6 +462,7 @@ void main() {
 }
 
 Message _message({required String id}) => Message.user(
+  promptId: null,
   id: id,
   sessionID: "ses_a",
   agent: null,

--- a/bridge/app/test/bridge/services/chat_history_no_harness_start_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_no_harness_start_test.dart
@@ -19,6 +19,7 @@ void main() {
       ..messagesResult = const [
         PluginMessageWithParts(
           info: PluginMessage.user(
+            promptId: null,
             id: "m1",
             sessionID: "backend-a",
             agent: null,

--- a/bridge/app/test/bridge/services/chat_history_pagination_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_pagination_test.dart
@@ -140,8 +140,13 @@ void main() {
   });
 }
 
-Message _message({required String id}) =>
-    Message.user(id: id, sessionID: "ses_a", agent: null, time: const MessageTime(created: 1, completed: null));
+Message _message({required String id}) => Message.user(
+  promptId: null,
+  id: id,
+  sessionID: "ses_a",
+  agent: null,
+  time: const MessageTime(created: 1, completed: null),
+);
 
 MessageWithParts _messageWithParts({required String id}) => MessageWithParts(
   info: _message(id: id),

--- a/bridge/app/test/bridge/services/chat_history_rename_staleness_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_rename_staleness_test.dart
@@ -19,6 +19,7 @@ void main() {
       ..messagesResult = const [
         PluginMessageWithParts(
           info: PluginMessage.user(
+            promptId: null,
             id: "m1",
             sessionID: "backend-a",
             agent: null,

--- a/bridge/app/test/bridge/services/chat_history_serving_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_serving_test.dart
@@ -184,8 +184,13 @@ void main() {
   });
 }
 
-Message _message({required String id}) =>
-    Message.user(id: id, sessionID: "ses_a", agent: null, time: const MessageTime(created: 1, completed: null));
+Message _message({required String id}) => Message.user(
+  promptId: null,
+  id: id,
+  sessionID: "ses_a",
+  agent: null,
+  time: const MessageTime(created: 1, completed: null),
+);
 
 MessagePart _part({required String id, required String messageId}) => MessagePart(
   id: id,

--- a/bridge/app/test/bridge/services/project_activity_service_test.dart
+++ b/bridge/app/test/bridge/services/project_activity_service_test.dart
@@ -51,6 +51,7 @@ void main() {
     await service.handleEvent(
       const SesoriSseEvent.messageUpdated(
         info: Message.user(
+          promptId: null,
           id: "user",
           sessionID: "root",
           agent: null,
@@ -89,7 +90,7 @@ void main() {
     );
     await service.handleEvent(
       const SesoriSseEvent.messageUpdated(
-        info: Message.user(id: "missing-time", sessionID: "root", agent: null, time: null),
+        info: Message.user(promptId: null, id: "missing-time", sessionID: "root", agent: null, time: null),
       ),
     );
 
@@ -282,6 +283,7 @@ void main() {
     await service.handleEvent(
       const SesoriSseEvent.messageUpdated(
         info: Message.user(
+          promptId: null,
           id: "child-message",
           sessionID: "child",
           agent: null,
@@ -322,6 +324,7 @@ void main() {
       service.handleEvent(
         const SesoriSseEvent.messageUpdated(
           info: Message.user(
+            promptId: null,
             id: "newer",
             sessionID: "root",
             agent: null,

--- a/bridge/app/test/bridge/services/session_event_service_test.dart
+++ b/bridge/app/test/bridge/services/session_event_service_test.dart
@@ -650,6 +650,7 @@ void main() {
       );
       final message = BridgeSseMessageUpdated(
         info: const Message.user(
+          promptId: null,
           id: "backend-message",
           sessionID: "backend-root",
           agent: null,

--- a/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
+++ b/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
@@ -557,6 +557,12 @@ class _FakeWorktreeService({required AppDatabase database}) extends WorktreeServ
 }
 
 class _FakeBridgePlugin() implements NativeProjectsPluginApi {
+  @override
+  Future<List<PluginQueuedPrompt>> getQueuedPrompts({required String sessionId}) async => const [];
+
+  @override
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async => false;
+
   String? lastArchivedSessionId;
 
   @override
@@ -624,6 +630,7 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi {
 
   @override
   Future<void> sendPrompt({
+    required String promptId,
     required String sessionId,
     required List<PluginPromptPart> parts,
     required PluginSessionVariant? variant,
@@ -633,6 +640,7 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi {
 
   @override
   Future<void> sendCommand({
+    required String promptId,
     required String sessionId,
     required String command,
     required String arguments,

--- a/bridge/app/test/bridge/services/session_prompt_service_test.dart
+++ b/bridge/app/test/bridge/services/session_prompt_service_test.dart
@@ -62,6 +62,7 @@ void main() {
 
     Future<void> sendCommand({String command = "review"}) {
       return service.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "s1",
         parts: const [PromptPart.text(text: "extra args")],
         variant: null,
@@ -85,6 +86,7 @@ void main() {
 
       await expectLater(
         service.sendPrompt(
+          promptId: "prompt-1",
           sessionId: "s1",
           parts: const [PromptPart.text(text: "hello")],
           variant: null,
@@ -143,6 +145,7 @@ void main() {
         agentModel: null,
       );
       await service.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "s-defaults-command",
         parts: const [PromptPart.text(text: "")],
         variant: const SessionVariant(id: "low"),
@@ -177,6 +180,7 @@ void main() {
       final changeFuture = service.promptDefaultsChanges.first;
 
       await service.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "s-defaults-event",
         parts: const [PromptPart.text(text: "Hello")],
         variant: const SessionVariant(id: "high"),
@@ -212,6 +216,7 @@ void main() {
       plugin.sendCommandCompleter = commandGate;
 
       final command = service.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "s1",
         parts: const [PromptPart.text(text: "arguments")],
         variant: null,
@@ -224,6 +229,7 @@ void main() {
       }
       final abort = abortService.abortSession(sessionId: "s1");
       final prompt = service.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "s1",
         parts: const [PromptPart.text(text: "later")],
         variant: null,
@@ -244,6 +250,7 @@ void main() {
 
     test("plain prompts are unaffected and delegate to sendPrompt", () async {
       await service.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "s1",
         parts: const [PromptPart.text(text: "Hello")],
         variant: null,

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -1262,6 +1262,12 @@ class _GeneratedRenameWorktreeRepository() implements WorktreeRepository {
 
 class _FakeBridgePluginApi() implements NativeProjectsPluginApi {
   @override
+  Future<List<PluginQueuedPrompt>> getQueuedPrompts({required String sessionId}) async => const [];
+
+  @override
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async => false;
+
+  @override
   String get id => "fake";
 
   @override
@@ -1334,6 +1340,7 @@ class _FakeBridgePluginApi() implements NativeProjectsPluginApi {
 
   @override
   Future<void> sendPrompt({
+    required String promptId,
     required String sessionId,
     required List<PluginPromptPart> parts,
     required PluginSessionVariant? variant,
@@ -1343,6 +1350,7 @@ class _FakeBridgePluginApi() implements NativeProjectsPluginApi {
 
   @override
   Future<void> sendCommand({
+    required String promptId,
     required String sessionId,
     required String command,
     required String arguments,

--- a/bridge/app/test/integration/pr_sync_fk_regression_test.dart
+++ b/bridge/app/test/integration/pr_sync_fk_regression_test.dart
@@ -295,6 +295,12 @@ PluginSession _session({
 class _FakeBridgePlugin({required final List<PluginProject> _projects, required final List<PluginSession> _sessions})
     implements NativeProjectsPluginApi {
   @override
+  Future<List<PluginQueuedPrompt>> getQueuedPrompts({required String sessionId}) async => const [];
+
+  @override
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async => false;
+
+  @override
   Future<List<PluginProject>> getProjects() async => _projects;
 
   @override
@@ -355,6 +361,7 @@ class _FakeBridgePlugin({required final List<PluginProject> _projects, required 
 
   @override
   Future<void> sendPrompt({
+    required String promptId,
     required String sessionId,
     required List<PluginPromptPart> parts,
     required PluginSessionVariant? variant,
@@ -364,6 +371,7 @@ class _FakeBridgePlugin({required final List<PluginProject> _projects, required 
 
   @override
   Future<void> sendCommand({
+    required String promptId,
     required String sessionId,
     required String command,
     required String arguments,

--- a/bridge/app/test/push/push_session_state_tracker_test.dart
+++ b/bridge/app/test/push/push_session_state_tracker_test.dart
@@ -782,6 +782,7 @@ void main() {
         ..handleEvent(
           const SesoriSseEvent.messageUpdated(
             info: Message.user(
+              promptId: null,
               id: "m-1",
               sessionID: "session-a",
               agent: null,

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -258,7 +258,7 @@ class AcpEventMapper({
     final messageId = initialUserMessageId(sessionId);
     return [
       BridgeSseMessageUpdated(
-        info: _messageFor(_ChunkRole.user, messageId, sessionId).toJson(),
+        info: _messageFor(_ChunkRole.user, messageId, sessionId, promptId: null).toJson(),
       ),
       BridgeSseMessagePartUpdated(
         part: _part(
@@ -276,6 +276,7 @@ class AcpEventMapper({
   /// Maps an accepted outbound prompt to its canonical live user message.
   List<BridgeSseEvent> mapSentPrompt({
     required String sessionId,
+    required String promptId,
     required List<PluginPromptPart> parts,
   }) {
     final textParts = parts.whereType<PluginPromptPartText>().where((part) => part.text.isNotEmpty).toList();
@@ -286,7 +287,7 @@ class AcpEventMapper({
     final messageId = "$sessionId-sent-$sequence-user";
     return [
       BridgeSseMessageUpdated(
-        info: _messageFor(_ChunkRole.user, messageId, sessionId).toJson(),
+        info: _messageFor(_ChunkRole.user, messageId, sessionId, promptId: promptId).toJson(),
       ),
       for (var index = 0; index < textParts.length; index++)
         BridgeSseMessagePartUpdated(
@@ -516,7 +517,7 @@ class AcpEventMapper({
     if (started.add(identity.messageId)) {
       events.add(
         BridgeSseMessageUpdated(
-          info: _messageFor(_ChunkRole.assistant, identity.messageId, sessionId).toJson(),
+          info: _messageFor(_ChunkRole.assistant, identity.messageId, sessionId, promptId: null).toJson(),
         ),
       );
     }
@@ -612,7 +613,7 @@ class AcpEventMapper({
     if (started.add(partId)) {
       if (started.add(messageId)) {
         events.add(
-          BridgeSseMessageUpdated(info: _messageFor(role, messageId, sessionId).toJson()),
+          BridgeSseMessageUpdated(info: _messageFor(role, messageId, sessionId, promptId: null).toJson()),
         );
       }
       events.add(
@@ -884,13 +885,14 @@ class AcpEventMapper({
     );
   }
 
-  shared.Message _messageFor(_ChunkRole role, String messageId, String sessionId) {
+  shared.Message _messageFor(_ChunkRole role, String messageId, String sessionId, {required String? promptId}) {
     return switch (role) {
       _ChunkRole.user => shared.Message.user(
         id: messageId,
         sessionID: sessionId,
         agent: null,
         time: null,
+        promptId: promptId,
       ),
       _ChunkRole.assistant => shared.Message.assistant(
         id: messageId,

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -839,6 +839,7 @@ abstract class AcpPlugin({
   @override
   Future<void> sendPrompt({
     required String sessionId,
+    required String promptId,
     required List<PluginPromptPart> parts,
     required PluginSessionVariant? variant,
     required String? agent,
@@ -848,7 +849,7 @@ abstract class AcpPlugin({
     // re-resolves the client at dispatch time (see [_runTurn]).
     await _connectedClient();
     _recordSessionActivity(sessionId);
-    eventMapper.mapSentPrompt(sessionId: sessionId, parts: parts).forEach(_eventBuffer.add);
+    eventMapper.mapSentPrompt(sessionId: sessionId, promptId: promptId, parts: parts).forEach(_eventBuffer.add);
     _enqueueTurn(
       sessionId: sessionId,
       parts: parts,
@@ -861,6 +862,7 @@ abstract class AcpPlugin({
   @override
   Future<void> sendCommand({
     required String sessionId,
+    required String promptId,
     required String command,
     required String arguments,
     required String? userVisibleArguments,
@@ -877,6 +879,7 @@ abstract class AcpPlugin({
     eventMapper
         .mapSentPrompt(
           sessionId: sessionId,
+          promptId: promptId,
           parts: [PluginPromptPart.text(text: visibleBody)],
         )
         .forEach(_eventBuffer.add);

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -292,6 +292,7 @@ class AcpReplayCollector({
         sessionID: sessionId,
         agent: null,
         time: null,
+        promptId: null,
       );
     }
     return PluginMessage.assistant(

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -48,32 +48,42 @@ void main() {
 
     test("subsequent chunks emit only a delta on the same part", () {
       mapper.beginTurn("s1");
-      mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "Hel"},
-      }));
-      final second = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "lo"},
-      }));
+      mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "Hel"},
+        }),
+      );
+      final second = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "lo"},
+        }),
+      );
       expect(second.whereType<BridgeSseMessageUpdated>(), isEmpty);
       expect(second.whereType<BridgeSseMessagePartDelta>().single.delta, "lo");
     });
 
     test("finalizeTurn emits complete text and reasoning snapshots", () {
       mapper.beginTurn("s1");
-      mapper.map(update({
-        "sessionUpdate": "agent_thought_chunk",
-        "content": {"type": "text", "text": "thinking"},
-      }));
-      mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "Hello "},
-      }));
-      mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "world"},
-      }));
+      mapper.map(
+        update({
+          "sessionUpdate": "agent_thought_chunk",
+          "content": {"type": "text", "text": "thinking"},
+        }),
+      );
+      mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "Hello "},
+        }),
+      );
+      mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "world"},
+        }),
+      );
 
       final parts = mapper
           .finalizeTurn(sessionId: "s1")
@@ -95,10 +105,12 @@ void main() {
 
     test("forgetSession drops pending text snapshots", () {
       mapper.beginTurn("s1");
-      mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "discarded"},
-      }));
+      mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "discarded"},
+        }),
+      );
 
       mapper.forgetSession("s1");
 
@@ -107,20 +119,22 @@ void main() {
 
     test("agent message content preserves mixed text and image order", () {
       mapper.beginTurn("s1");
-      final events = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "messageId": "mixed",
-        "content": [
-          {"type": "text", "text": "before"},
-          {
-            "type": "image",
-            "data": "AA==",
-            "mimeType": "image/png",
-            "uri": "file:///private/output.png",
-          },
-          {"type": "text", "text": "after"},
-        ],
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "mixed",
+          "content": [
+            {"type": "text", "text": "before"},
+            {
+              "type": "image",
+              "data": "AA==",
+              "mimeType": "image/png",
+              "uri": "file:///private/output.png",
+            },
+            {"type": "text", "text": "after"},
+          ],
+        }),
+      );
 
       expect(events.whereType<BridgeSseMessageUpdated>(), hasLength(1));
       final parts = events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part).toList();
@@ -140,21 +154,25 @@ void main() {
 
     test("message trackers persist across chunks and reset at turn boundaries", () {
       mapper.beginTurn("s1");
-      mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "messageId": "m1",
-        "content": {
-          "type": "image",
-          "data": "AA==",
-          "mimeType": "image/png",
-          "uri": null,
-        },
-      }));
-      final text = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "messageId": "m1",
-        "content": {"type": "text", "text": "after"},
-      }));
+      mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "m1",
+          "content": {
+            "type": "image",
+            "data": "AA==",
+            "mimeType": "image/png",
+            "uri": null,
+          },
+        }),
+      );
+      final text = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "m1",
+          "content": {"type": "text", "text": "after"},
+        }),
+      );
       expect(text.whereType<BridgeSseMessageUpdated>(), isEmpty);
       expect(
         text.whereType<BridgeSseMessagePartUpdated>().single.part.id,
@@ -162,16 +180,18 @@ void main() {
       );
 
       mapper.beginTurn("s1");
-      final reset = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "messageId": "m1",
-        "content": {
-          "type": "image",
-          "data": "AA==",
-          "mimeType": "image/png",
-          "uri": null,
-        },
-      }));
+      final reset = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "m1",
+          "content": {
+            "type": "image",
+            "data": "AA==",
+            "mimeType": "image/png",
+            "uri": null,
+          },
+        }),
+      );
       expect(
         reset.whereType<BridgeSseMessagePartUpdated>().single.part.id,
         "s1-mm1-assistant-image-1",
@@ -180,16 +200,19 @@ void main() {
 
     test("agent_thought_chunk maps to a reasoning part", () {
       mapper.beginTurn("s1");
-      final events = mapper.map(update({
-        "sessionUpdate": "agent_thought_chunk",
-        "content": {"type": "text", "text": "thinking"},
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "agent_thought_chunk",
+          "content": {"type": "text", "text": "thinking"},
+        }),
+      );
       final part = events.whereType<BridgeSseMessagePartUpdated>().single.part;
       expect(part.type, PluginMessagePartType.reasoning);
     });
 
     test("an accepted prompt maps to one canonical live user message", () {
       final events = mapper.mapSentPrompt(
+        promptId: "prompt-1",
         sessionId: "s1",
         parts: [
           const PluginPromptPart.text(text: "Hello"),
@@ -202,9 +225,7 @@ void main() {
       );
       expect(message, isA<shared.MessageUser>());
       expect(
-        events
-            .whereType<BridgeSseMessagePartUpdated>()
-            .map((event) => event.part.text),
+        events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part.text),
         ["Hello", "Cursor"],
       );
     });
@@ -227,39 +248,48 @@ void main() {
 
     test("a live agent user echo is dropped", () {
       mapper.mapSentPrompt(
+        promptId: "prompt-1",
         sessionId: "s1",
         parts: [const PluginPromptPart.text(text: "Hello")],
       );
 
-      final events = mapper.map(update({
-        "sessionUpdate": "user_message_chunk",
-        "content": {"type": "text", "text": "Hello"},
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "user_message_chunk",
+          "content": {"type": "text", "text": "Hello"},
+        }),
+      );
 
       expect(events, isEmpty);
     });
 
     test("id-less assistant content after a tool opens a later envelope", () {
       mapper.beginTurn("s1");
-      final beforeTool = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {
-          "type": "image",
-          "data": "AA==",
-          "mimeType": "image/png",
-          "uri": null,
-        },
-      }));
-      mapper.map(update({
-        "sessionUpdate": "tool_call",
-        "toolCallId": "tc-order",
-        "kind": "read",
-        "status": "completed",
-      }));
-      final afterTool = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "After"},
-      }));
+      final beforeTool = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {
+            "type": "image",
+            "data": "AA==",
+            "mimeType": "image/png",
+            "uri": null,
+          },
+        }),
+      );
+      mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tc-order",
+          "kind": "read",
+          "status": "completed",
+        }),
+      );
+      final afterTool = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "After"},
+        }),
+      );
 
       final beforeId = shared.Message.fromJson(
         beforeTool.whereType<BridgeSseMessageUpdated>().single.info,
@@ -276,24 +306,30 @@ void main() {
 
     test("an explicit assistant message closes the prior id-less envelope", () {
       mapper.beginTurn("s1");
-      final before = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "before"},
-      }));
-      mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "messageId": "m1",
-        "content": {"type": "text", "text": "explicit"},
-      }));
-      final after = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {
-          "type": "image",
-          "data": "AA==",
-          "mimeType": "image/png",
-          "uri": null,
-        },
-      }));
+      final before = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "before"},
+        }),
+      );
+      mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "m1",
+          "content": {"type": "text", "text": "explicit"},
+        }),
+      );
+      final after = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {
+            "type": "image",
+            "data": "AA==",
+            "mimeType": "image/png",
+            "uri": null,
+          },
+        }),
+      );
 
       final beforeId = shared.Message.fromJson(
         before.whereType<BridgeSseMessageUpdated>().single.info,
@@ -306,13 +342,15 @@ void main() {
     });
 
     test("tool_call maps to an assistant message with a tool part", () {
-      final events = mapper.map(update({
-        "sessionUpdate": "tool_call",
-        "toolCallId": "tc-1",
-        "title": "Read file",
-        "kind": "read",
-        "status": "pending",
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tc-1",
+          "title": "Read file",
+          "kind": "read",
+          "status": "pending",
+        }),
+      );
       final updated = events.whereType<BridgeSseMessageUpdated>().single;
       expect(shared.Message.fromJson(updated.info), isA<shared.MessageAssistant>());
       final part = events.whereType<BridgeSseMessagePartUpdated>().single.part;
@@ -325,26 +363,30 @@ void main() {
       // Same fail-soft name resolution as tool_call_update: an empty-string
       // `kind` must fall through to `title`, and a non-string `kind` must not
       // throw during live mapping.
-      final emptyKind = mapper.map(update({
-        "sessionUpdate": "tool_call",
-        "toolCallId": "tc-empty",
-        "kind": "",
-        "title": "Search files",
-        "status": "pending",
-      }));
+      final emptyKind = mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tc-empty",
+          "kind": "",
+          "title": "Search files",
+          "status": "pending",
+        }),
+      );
       expect(
         emptyKind.whereType<BridgeSseMessagePartUpdated>().single.part.tool,
         "Search files",
       );
 
-      final nonStringKind = mapper.map(update({
-        "sessionUpdate": "tool_call",
-        "toolCallId": "tc-bad",
-        "kind": 123,
-        // A non-string title must not throw either — it renders as null.
-        "title": {"unexpected": "object"},
-        "status": "pending",
-      }));
+      final nonStringKind = mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tc-bad",
+          "kind": 123,
+          // A non-string title must not throw either — it renders as null.
+          "title": {"unexpected": "object"},
+          "status": "pending",
+        }),
+      );
       final badPart = nonStringKind.whereType<BridgeSseMessagePartUpdated>().single.part;
       expect(badPart.tool, "tool");
       expect(badPart.state?.title, isNull);
@@ -355,40 +397,46 @@ void main() {
       // content: [{type:content, content:{type:text, text:...}}] rather than
       // Cursor's rawOutput. The nested wrapper must be unwrapped, else the tool
       // card renders blank.
-      final events = mapper.map(update({
-        "sessionUpdate": "tool_call",
-        "toolCallId": "tc-wrap",
-        "kind": "read",
-        "status": "completed",
-        "content": [
-          {
-            "type": "content",
-            "content": {"type": "text", "text": "wrapped output"},
-          },
-        ],
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tc-wrap",
+          "kind": "read",
+          "status": "completed",
+          "content": [
+            {
+              "type": "content",
+              "content": {"type": "text", "text": "wrapped output"},
+            },
+          ],
+        }),
+      );
       final part = events.whereType<BridgeSseMessagePartUpdated>().single.part;
       expect(part.state?.output, "wrapped output");
     });
 
     test("a partial tool_call_update preserves the tool's prior name/title/output", () {
       // Seed the tool card.
-      mapper.map(update({
-        "sessionUpdate": "tool_call",
-        "toolCallId": "tc-1",
-        "kind": "execute",
-        "title": "Run tests",
-        "status": "pending",
-        "rawOutput": {"stdout": "starting"},
-      }));
+      mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tc-1",
+          "kind": "execute",
+          "title": "Run tests",
+          "status": "pending",
+          "rawOutput": {"stdout": "starting"},
+        }),
+      );
 
       // A status-only update (the common shape) must NOT reset the name/title
       // to defaults or drop the earlier output.
-      final events = mapper.map(update({
-        "sessionUpdate": "tool_call_update",
-        "toolCallId": "tc-1",
-        "status": "completed",
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-1",
+          "status": "completed",
+        }),
+      );
       final part = events.whereType<BridgeSseMessagePartUpdated>().single.part;
       expect(part.tool, "execute", reason: "name preserved across a partial update");
       expect(part.state?.title, "Run tests", reason: "title preserved");
@@ -397,21 +445,25 @@ void main() {
     });
 
     test("a title-only tool_call_update keeps the canonical tool id", () {
-      mapper.map(update({
-        "sessionUpdate": "tool_call",
-        "toolCallId": "tc-2",
-        "kind": "edit",
-        "title": "Edit main.dart",
-        "status": "pending",
-      }));
+      mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tc-2",
+          "kind": "edit",
+          "title": "Edit main.dart",
+          "status": "pending",
+        }),
+      );
       // An update with a new title but no kind must not overwrite the canonical
       // "edit" identifier with the title text.
-      final events = mapper.map(update({
-        "sessionUpdate": "tool_call_update",
-        "toolCallId": "tc-2",
-        "title": "Edit main.dart (revised)",
-        "status": "in_progress",
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-2",
+          "title": "Edit main.dart (revised)",
+          "status": "in_progress",
+        }),
+      );
       final part = events.whereType<BridgeSseMessagePartUpdated>().single.part;
       expect(part.tool, "edit", reason: "no kind → canonical id preserved");
       expect(part.state?.title, "Edit main.dart (revised)");
@@ -421,37 +473,45 @@ void main() {
       // No prior tool_call (reordered on reconnect/resume/replay, or after the
       // completed entry was pruned): the update must still carry an envelope so
       // the client can render the part instead of dropping an orphan.
-      final events = mapper.map(update({
-        "sessionUpdate": "tool_call_update",
-        "toolCallId": "tc-orphan",
-        "kind": "read",
-        "status": "in_progress",
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-orphan",
+          "kind": "read",
+          "status": "in_progress",
+        }),
+      );
       expect(events.whereType<BridgeSseMessageUpdated>(), hasLength(1));
       expect(events.whereType<BridgeSseMessagePartUpdated>(), hasLength(1));
     });
 
     test("a completed tool retains its state for a late in-turn update; beginTurn clears it", () {
       mapper.beginTurn("s1");
-      mapper.map(update({
-        "sessionUpdate": "tool_call",
-        "toolCallId": "tc-3",
-        "kind": "read",
-        "status": "pending",
-      }));
-      mapper.map(update({
-        "sessionUpdate": "tool_call_update",
-        "toolCallId": "tc-3",
-        "status": "completed",
-        "rawOutput": {"stdout": "done"},
-      }));
+      mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tc-3",
+          "kind": "read",
+          "status": "pending",
+        }),
+      );
+      mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-3",
+          "status": "completed",
+          "rawOutput": {"stdout": "done"},
+        }),
+      );
       // A late, reordered output-only update must merge onto the retained
       // terminal state, not blank the finished card.
-      final late = mapper.map(update({
-        "sessionUpdate": "tool_call_update",
-        "toolCallId": "tc-3",
-        "rawOutput": {"stdout": "final"},
-      }));
+      final late = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-3",
+          "rawOutput": {"stdout": "final"},
+        }),
+      );
       expect(late.whereType<BridgeSseMessageUpdated>(), isEmpty, reason: "retained → not first-seen");
       final latePart = late.whereType<BridgeSseMessagePartUpdated>().single.part;
       expect(latePart.state?.status, PluginToolStatus.completed, reason: "terminal status preserved");
@@ -460,27 +520,33 @@ void main() {
 
       // The next turn clears the prior turn's tools to keep the cache bounded.
       mapper.beginTurn("s1");
-      final afterTurn = mapper.map(update({
-        "sessionUpdate": "tool_call_update",
-        "toolCallId": "tc-3",
-        "status": "in_progress",
-      }));
+      final afterTurn = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-3",
+          "status": "in_progress",
+        }),
+      );
       expect(afterTurn.whereType<BridgeSseMessageUpdated>(), hasLength(1), reason: "cleared on beginTurn → first-seen");
     });
 
     test("forgetSession drops live tool state for the session", () {
-      mapper.map(update({
-        "sessionUpdate": "tool_call",
-        "toolCallId": "tc-4",
-        "kind": "read",
-        "status": "pending",
-      }));
+      mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tc-4",
+          "kind": "read",
+          "status": "pending",
+        }),
+      );
       mapper.forgetSession("s1");
-      final after = mapper.map(update({
-        "sessionUpdate": "tool_call_update",
-        "toolCallId": "tc-4",
-        "status": "in_progress",
-      }));
+      final after = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-4",
+          "status": "in_progress",
+        }),
+      );
       expect(after.whereType<BridgeSseMessageUpdated>(), hasLength(1), reason: "state cleared → first-seen");
     });
 
@@ -490,12 +556,16 @@ void main() {
 
       // "s1" and "s1:2" collide under a naive "s1:" composite-key prefix match.
       mapper.map(updFor("s1", {"sessionUpdate": "tool_call", "toolCallId": "a", "kind": "read", "status": "pending"}));
-      mapper.map(updFor("s1:2", {"sessionUpdate": "tool_call", "toolCallId": "b", "kind": "read", "status": "pending"}));
+      mapper.map(
+        updFor("s1:2", {"sessionUpdate": "tool_call", "toolCallId": "b", "kind": "read", "status": "pending"}),
+      );
 
       mapper.forgetSession("s1");
 
       // "s1:2"'s tool must survive → a follow-up update for it is NOT first-seen.
-      final ev = mapper.map(updFor("s1:2", {"sessionUpdate": "tool_call_update", "toolCallId": "b", "status": "in_progress"}));
+      final ev = mapper.map(
+        updFor("s1:2", {"sessionUpdate": "tool_call_update", "toolCallId": "b", "status": "in_progress"}),
+      );
       expect(
         ev.whereType<BridgeSseMessageUpdated>(),
         isEmpty,
@@ -504,12 +574,14 @@ void main() {
     });
 
     test("tool_call_update on an edit emits a session diff", () {
-      final events = mapper.map(update({
-        "sessionUpdate": "tool_call_update",
-        "toolCallId": "tc-2",
-        "kind": "edit",
-        "status": "completed",
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-2",
+          "kind": "edit",
+          "status": "completed",
+        }),
+      );
       expect(events.whereType<BridgeSseSessionDiff>(), hasLength(1));
     });
 
@@ -517,109 +589,131 @@ void main() {
       // An agent may report the whole mutation as one complete tool_call with
       // no follow-up update — the diff signal must fire on the initial
       // notification too.
-      final events = mapper.map(update({
-        "sessionUpdate": "tool_call",
-        "toolCallId": "tc-init-edit",
-        "kind": "edit",
-        "status": "completed",
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tc-init-edit",
+          "kind": "edit",
+          "status": "completed",
+        }),
+      );
       expect(events.whereType<BridgeSseSessionDiff>(), hasLength(1));
 
-      final nonMutating = mapper.map(update({
-        "sessionUpdate": "tool_call",
-        "toolCallId": "tc-init-read",
-        "kind": "read",
-        "status": "completed",
-      }));
+      final nonMutating = mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tc-init-read",
+          "kind": "read",
+          "status": "completed",
+        }),
+      );
       expect(nonMutating.whereType<BridgeSseSessionDiff>(), isEmpty);
     });
 
     test("a mutating tool emits its diff when a later status-only update completes it", () {
-      final initial = mapper.map(update({
-        "sessionUpdate": "tool_call",
-        "toolCallId": "tc-progress-edit",
-        "kind": "edit",
-        "status": "in_progress",
-      }));
+      final initial = mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tc-progress-edit",
+          "kind": "edit",
+          "status": "in_progress",
+        }),
+      );
       expect(initial.whereType<BridgeSseSessionDiff>(), isEmpty);
 
-      final completed = mapper.map(update({
-        "sessionUpdate": "tool_call_update",
-        "toolCallId": "tc-progress-edit",
-        "status": "completed",
-      }));
+      final completed = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-progress-edit",
+          "status": "completed",
+        }),
+      );
       expect(completed.whereType<BridgeSseSessionDiff>(), hasLength(1));
 
-      final late = mapper.map(update({
-        "sessionUpdate": "tool_call_update",
-        "toolCallId": "tc-progress-edit",
-        "rawOutput": {"stdout": "done"},
-      }));
+      final late = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-progress-edit",
+          "rawOutput": {"stdout": "done"},
+        }),
+      );
       expect(late.whereType<BridgeSseSessionDiff>(), isEmpty);
     });
 
     test("a diff content entry marks the tool call as a file mutation", () {
       // Spec-compliant agents can report an edit purely through the standard
       // tool content shape (type: "diff") with no mutating kind.
-      final events = mapper.map(update({
-        "sessionUpdate": "tool_call_update",
-        "toolCallId": "tc-diff",
-        "status": "completed",
-        "content": [
-          {"type": "diff", "path": "/repo/a.dart", "oldText": "a", "newText": "b"},
-        ],
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-diff",
+          "status": "completed",
+          "content": [
+            {"type": "diff", "path": "/repo/a.dart", "oldText": "a", "newText": "b"},
+          ],
+        }),
+      );
       expect(events.whereType<BridgeSseSessionDiff>(), hasLength(1));
     });
 
     test("diff content emits a session diff when status is omitted", () {
-      final events = mapper.map(update({
-        "sessionUpdate": "tool_call_update",
-        "toolCallId": "tc-statusless-diff",
-        "content": [
-          {"type": "diff", "path": "/repo/a.dart", "oldText": "a", "newText": "b"},
-        ],
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-statusless-diff",
+          "content": [
+            {"type": "diff", "path": "/repo/a.dart", "oldText": "a", "newText": "b"},
+          ],
+        }),
+      );
 
       expect(events.whereType<BridgeSseSessionDiff>(), hasLength(1));
     });
 
     test("chunks group by ACP messageId when present", () {
       mapper.beginTurn("s1");
-      final first = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "messageId": "m1",
-        "content": {"type": "text", "text": "one"},
-      }));
+      final first = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "m1",
+          "content": {"type": "text", "text": "one"},
+        }),
+      );
       final firstEnvelope = first.whereType<BridgeSseMessageUpdated>().single;
       final firstId = shared.Message.fromJson(firstEnvelope.info).id;
 
       // Same id, same role → same message, delta only.
-      final more = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "messageId": "m1",
-        "content": {"type": "text", "text": " more"},
-      }));
+      final more = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "m1",
+          "content": {"type": "text", "text": " more"},
+        }),
+      );
       expect(more.whereType<BridgeSseMessageUpdated>(), isEmpty);
 
       // A change in messageId starts a NEW message even within one turn and
       // one role — the spec's message-boundary signal.
-      final second = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "messageId": "m2",
-        "content": {"type": "text", "text": "two"},
-      }));
+      final second = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "m2",
+          "content": {"type": "text", "text": "two"},
+        }),
+      );
       final secondEnvelope = second.whereType<BridgeSseMessageUpdated>().single;
       final secondId = shared.Message.fromJson(secondEnvelope.info).id;
       expect(secondId, isNot(firstId));
 
       // A later chunk for the FIRST message merges back into it (no envelope,
       // delta targets the first message id).
-      final late = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "messageId": "m1",
-        "content": {"type": "text", "text": " tail"},
-      }));
+      final late = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "m1",
+          "content": {"type": "text", "text": " tail"},
+        }),
+      );
       expect(late.whereType<BridgeSseMessageUpdated>(), isEmpty);
       expect(late.whereType<BridgeSseMessagePartDelta>().single.messageID, firstId);
     });
@@ -638,14 +732,16 @@ void main() {
     });
 
     test("tool_call_update surfaces rawOutput stdout/stderr as the part output", () {
-      final events = mapper.map(update({
-        "sessionUpdate": "tool_call_update",
-        "toolCallId": "tc-3",
-        "kind": "execute",
-        "title": "ls",
-        "status": "completed",
-        "rawOutput": {"exitCode": 0, "stdout": "a.dart\nb.dart\n", "stderr": ""},
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-3",
+          "kind": "execute",
+          "title": "ls",
+          "status": "completed",
+          "rawOutput": {"exitCode": 0, "stdout": "a.dart\nb.dart\n", "stderr": ""},
+        }),
+      );
       final part = events.whereType<BridgeSseMessagePartUpdated>().single.part;
       expect(part.state?.status, PluginToolStatus.completed);
       expect(part.state?.output, "a.dart\nb.dart");
@@ -653,26 +749,30 @@ void main() {
     });
 
     test("read-style tool surfaces rawOutput.content", () {
-      final events = mapper.map(update({
-        "sessionUpdate": "tool_call_update",
-        "toolCallId": "tc-read",
-        "kind": "read",
-        "title": "Read notes.txt",
-        "status": "completed",
-        "rawOutput": {"content": "hello from cursor e2e\n"},
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-read",
+          "kind": "read",
+          "title": "Read notes.txt",
+          "status": "completed",
+          "rawOutput": {"content": "hello from cursor e2e\n"},
+        }),
+      );
       final part = events.whereType<BridgeSseMessagePartUpdated>().single.part;
       expect(part.state?.output, "hello from cursor e2e");
     });
 
     test("failed tool_call_update mirrors output into error", () {
-      final events = mapper.map(update({
-        "sessionUpdate": "tool_call_update",
-        "toolCallId": "tc-4",
-        "kind": "execute",
-        "status": "failed",
-        "rawOutput": {"exitCode": 1, "stdout": "", "stderr": "boom"},
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-4",
+          "kind": "execute",
+          "status": "failed",
+          "rawOutput": {"exitCode": 1, "stdout": "", "stderr": "boom"},
+        }),
+      );
       final part = events.whereType<BridgeSseMessagePartUpdated>().single.part;
       expect(part.state?.status, PluginToolStatus.error);
       expect(part.state?.output, "boom");
@@ -681,23 +781,27 @@ void main() {
 
     test("oversized tool output is truncated", () {
       final big = "x" * (maxToolOutputLength + 50);
-      final events = mapper.map(update({
-        "sessionUpdate": "tool_call_update",
-        "toolCallId": "tc-5",
-        "kind": "execute",
-        "status": "completed",
-        "rawOutput": {"stdout": big, "stderr": ""},
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-5",
+          "kind": "execute",
+          "status": "completed",
+          "rawOutput": {"stdout": big, "stderr": ""},
+        }),
+      );
       final output = events.whereType<BridgeSseMessagePartUpdated>().single.part.state?.output;
       expect(output, hasLength(maxToolOutputLength + 1)); // 500 chars + ellipsis
       expect(output, endsWith("…"));
     });
 
     test("session_info_update surfaces the title as a session update", () {
-      final events = mapper.map(update({
-        "sessionUpdate": "session_info_update",
-        "title": "Fix the parser",
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "session_info_update",
+          "title": "Fix the parser",
+        }),
+      );
       final updated = events.whereType<BridgeSseSessionUpdated>().single;
       expect(updated.titleChanged, isTrue);
       final session = shared.Session.fromJson(updated.info);
@@ -714,12 +818,13 @@ void main() {
       // that project's id, or the mobile session list (which drops updates whose
       // projectID != the active project) ignores it.
       mapper.setSessionProject("s1", "/repo/opened-elsewhere");
-      final events = mapper.map(update({
-        "sessionUpdate": "session_info_update",
-        "title": "Title in opened project",
-      }));
-      final session =
-          shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "session_info_update",
+          "title": "Title in opened project",
+        }),
+      );
+      final session = shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
       expect(session.projectID, "/repo/opened-elsewhere");
       expect(session.directory, "/repo/opened-elsewhere");
     });
@@ -727,22 +832,25 @@ void main() {
     test("clearing a session's project reverts to the launch cwd", () {
       mapper.setSessionProject("s1", "/repo/opened-elsewhere");
       mapper.setSessionProject("s1", null);
-      final events = mapper.map(update({
-        "sessionUpdate": "session_info_update",
-        "title": "Back to default",
-      }));
-      final session =
-          shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "session_info_update",
+          "title": "Back to default",
+        }),
+      );
+      final session = shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
       expect(session.projectID, "/repo");
     });
 
     test("session_info_update with an explicit null title forwards a clear", () {
       // ACP v1: title is nullable, null clears it. Dropping the update would
       // leave the phone showing the stale title until a refresh.
-      final events = mapper.map(update({
-        "sessionUpdate": "session_info_update",
-        "title": null,
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "session_info_update",
+          "title": null,
+        }),
+      );
       final session = shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
       expect(session.title, isNull);
     });
@@ -754,10 +862,12 @@ void main() {
         createdMs: 1000,
         updatedMs: 2000,
       );
-      final events = mapper.map(update({
-        "sessionUpdate": "session_info_update",
-        "updatedAt": DateTime.fromMillisecondsSinceEpoch(3000, isUtc: true).toIso8601String(),
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "session_info_update",
+          "updatedAt": DateTime.fromMillisecondsSinceEpoch(3000, isUtc: true).toIso8601String(),
+        }),
+      );
       final updated = events.whereType<BridgeSseSessionUpdated>().single;
       expect(updated.titleChanged, isFalse);
       final session = shared.Session.fromJson(updated.info);
@@ -799,10 +909,12 @@ void main() {
     });
 
     test("session_info_update without a title or timestamp emits nothing", () {
-      final events = mapper.map(update({
-        "sessionUpdate": "session_info_update",
-        "_meta": {"tags": <String>[]},
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "session_info_update",
+          "_meta": {"tags": <String>[]},
+        }),
+      );
       expect(events, isEmpty);
     });
 
@@ -816,12 +928,13 @@ void main() {
         createdMs: 1000,
         updatedMs: 2000,
       );
-      final events = mapper.map(update({
-        "sessionUpdate": "session_info_update",
-        "title": "New title",
-      }));
-      final session =
-          shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "session_info_update",
+          "title": "New title",
+        }),
+      );
+      final session = shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
       expect(session.title, "New title");
       expect(session.time?.created, 1000);
       expect(session.time?.updated, 2000);
@@ -835,13 +948,14 @@ void main() {
         updatedMs: 2000,
       );
       final at = DateTime.fromMillisecondsSinceEpoch(5000, isUtc: true);
-      final events = mapper.map(update({
-        "sessionUpdate": "session_info_update",
-        "title": "Fresh",
-        "updatedAt": at.toIso8601String(),
-      }));
-      final session =
-          shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "session_info_update",
+          "title": "Fresh",
+          "updatedAt": at.toIso8601String(),
+        }),
+      );
+      final session = shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
       expect(session.time?.updated, 5000);
       expect(session.time?.created, 1000, reason: "creation time is kept, not dragged forward");
     });
@@ -852,23 +966,25 @@ void main() {
       // drag either timestamp backwards.
       mapper.setSessionSnapshot(sessionId: "s1", title: null, createdMs: 1000, updatedMs: 4000);
       mapper.setSessionSnapshot(sessionId: "s1", title: null, createdMs: 5000, updatedMs: 3500);
-      final events = mapper.map(update({
-        "sessionUpdate": "session_info_update",
-        "title": "T",
-      }));
-      final session =
-          shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "session_info_update",
+          "title": "T",
+        }),
+      );
+      final session = shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
       expect(session.time?.created, 1000);
       expect(session.time?.updated, 4000);
     });
 
     test("with no snapshot at all the emitted time stays null", () {
-      final events = mapper.map(update({
-        "sessionUpdate": "session_info_update",
-        "title": "Unknown session",
-      }));
-      final session =
-          shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "session_info_update",
+          "title": "Unknown session",
+        }),
+      );
+      final session = shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
       expect(session.time, isNull);
     });
 
@@ -881,13 +997,14 @@ void main() {
           providerId: "cursor",
         );
       mapper.beginTurn("s1");
-      final events = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "hi"},
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "hi"},
+        }),
+      );
       final message =
-          shared.Message.fromJson(events.whereType<BridgeSseMessageUpdated>().single.info)
-              as shared.MessageAssistant;
+          shared.Message.fromJson(events.whereType<BridgeSseMessageUpdated>().single.info) as shared.MessageAssistant;
       expect(message.modelID, "claude-opus-4-8");
       expect(message.providerID, "cursor");
     });
@@ -918,10 +1035,12 @@ void main() {
 
     test("a classified halt notice becomes a lone error message, not assistant text", () {
       mapper.beginTurn("s1");
-      final events = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "\n\nHALT: fix it"},
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "\n\nHALT: fix it"},
+        }),
+      );
 
       final message = shared.Message.fromJson(
         events.whereType<BridgeSseMessageUpdated>().single.info,
@@ -935,36 +1054,46 @@ void main() {
 
     test("a repeated identical halt chunk does not stack duplicate error cards", () {
       mapper.beginTurn("s1");
-      mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "HALT: fix it"},
-      }));
-      final again = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "HALT: fix it"},
-      }));
+      mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "HALT: fix it"},
+        }),
+      );
+      final again = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "HALT: fix it"},
+        }),
+      );
       expect(again, isEmpty);
     });
 
     test("a tool clears unrendered id-less state before a later halt", () {
       mapper.beginTurn("s1");
       expect(
-        mapper.map(update({
-          "sessionUpdate": "agent_message_chunk",
-          "content": {"type": "audio", "data": "private", "mimeType": "audio/wav"},
-        })),
+        mapper.map(
+          update({
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "audio", "data": "private", "mimeType": "audio/wav"},
+          }),
+        ),
         isEmpty,
       );
-      mapper.map(update({
-        "sessionUpdate": "tool_call",
-        "toolCallId": "t1",
-        "kind": "read",
-        "status": "completed",
-      }));
-      final halt = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "HALT: fix it"},
-      }));
+      mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "t1",
+          "kind": "read",
+          "status": "completed",
+        }),
+      );
+      final halt = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "HALT: fix it"},
+        }),
+      );
 
       expect(
         shared.Message.fromJson(halt.whereType<BridgeSseMessageUpdated>().single.info),
@@ -974,18 +1103,24 @@ void main() {
 
     test("id-less assistant text after a halt opens a fresh envelope", () {
       mapper.beginTurn("s1");
-      final before = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "Before"},
-      }));
-      mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "HALT: fix it"},
-      }));
-      final after = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "After"},
-      }));
+      final before = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "Before"},
+        }),
+      );
+      mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "HALT: fix it"},
+        }),
+      );
+      final after = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "After"},
+        }),
+      );
 
       final beforeId = shared.Message.fromJson(
         before.whereType<BridgeSseMessageUpdated>().single.info,
@@ -1002,10 +1137,12 @@ void main() {
 
     test("a reasoning chunk is never classified as a halt notice", () {
       mapper.beginTurn("s1");
-      final events = mapper.map(update({
-        "sessionUpdate": "agent_thought_chunk",
-        "content": {"type": "text", "text": "HALT: fix it"},
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "agent_thought_chunk",
+          "content": {"type": "text", "text": "HALT: fix it"},
+        }),
+      );
       expect(
         events.whereType<BridgeSseMessagePartUpdated>().single.part.type,
         PluginMessagePartType.reasoning,
@@ -1014,18 +1151,20 @@ void main() {
 
     test("an image-bearing halt-like message remains an assistant message", () {
       mapper.beginTurn("s1");
-      final events = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": [
-          {
-            "type": "image",
-            "data": "AA==",
-            "mimeType": "image/png",
-            "uri": null,
-          },
-          {"type": "text", "text": "HALT: fix it"},
-        ],
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": [
+            {
+              "type": "image",
+              "data": "AA==",
+              "mimeType": "image/png",
+              "uri": null,
+            },
+            {"type": "text", "text": "HALT: fix it"},
+          ],
+        }),
+      );
 
       final message = shared.Message.fromJson(
         events.whereType<BridgeSseMessageUpdated>().single.info,
@@ -1039,21 +1178,25 @@ void main() {
 
     test("an identified halt-like text chunk can receive a later image", () {
       mapper.beginTurn("s1");
-      final text = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "messageId": "mixed",
-        "content": {"type": "text", "text": "HALT: fix it"},
-      }));
-      final image = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "messageId": "mixed",
-        "content": {
-          "type": "image",
-          "data": "AA==",
-          "mimeType": "image/png",
-          "uri": null,
-        },
-      }));
+      final text = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "mixed",
+          "content": {"type": "text", "text": "HALT: fix it"},
+        }),
+      );
+      final image = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "mixed",
+          "content": {
+            "type": "image",
+            "data": "AA==",
+            "mimeType": "image/png",
+            "uri": null,
+          },
+        }),
+      );
 
       expect(
         shared.Message.fromJson(text.whereType<BridgeSseMessageUpdated>().single.info),
@@ -1066,10 +1209,12 @@ void main() {
 
     test("ordinary assistant text still streams as an assistant message", () {
       mapper.beginTurn("s1");
-      final events = mapper.map(update({
-        "sessionUpdate": "agent_message_chunk",
-        "content": {"type": "text", "text": "real answer"},
-      }));
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "real answer"},
+        }),
+      );
       final message = shared.Message.fromJson(
         events.whereType<BridgeSseMessageUpdated>().single.info,
       );

--- a/bridge/sesori_plugin_acp/test/acp_initialize_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_initialize_test.dart
@@ -125,6 +125,7 @@ void main() {
           .having((error) => error.statusCode, "statusCode", 503)
           .having((error) => error.actionHint, "actionHint", isNotEmpty);
       final sending = plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "session-1",
         parts: const [PluginPromptPart.text(text: "hello")],
         variant: null,
@@ -195,6 +196,7 @@ void main() {
 
     test("a process exit during authentication remains a connection failure", () async {
       final sending = plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "session-1",
         parts: const [PluginPromptPart.text(text: "hello")],
         variant: null,

--- a/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
@@ -101,6 +101,7 @@ void main() {
       // Dispatch a prompt and withhold the session/prompt response so the turn
       // stays in flight (ACP has no turn-complete event: busy == future pending).
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: sessionId,
         parts: const [PluginPromptPart.text(text: "hi")],
         variant: null,

--- a/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
@@ -398,6 +398,7 @@ void main() {
       expect(s1.projectID, home);
 
       final sending = plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "s1",
         parts: const [PluginPromptPart.text(text: "resume me")],
         variant: null,
@@ -455,6 +456,7 @@ void main() {
       addTearDown(sub.cancel);
 
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "s1",
         parts: const [PluginPromptPart.text(text: "hi")],
         variant: null,
@@ -499,6 +501,7 @@ void main() {
 
       // A running turn surfaces under that project's activity row, not the CWD.
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: session.id,
         parts: const [PluginPromptPart.text(text: "hi")],
         variant: null,
@@ -530,6 +533,7 @@ void main() {
       expect(sessions.single.projectID, opened);
 
       final sending = plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "old-s",
         parts: const [PluginPromptPart.text(text: "again")],
         variant: null,
@@ -563,6 +567,7 @@ void main() {
       );
 
       final sending = plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "cold-s",
         parts: const [PluginPromptPart.text(text: "resume me")],
         variant: null,
@@ -603,6 +608,7 @@ void main() {
         },
       );
       final sending = plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "cold-s",
         parts: const [PluginPromptPart.text(text: "resume me")],
         variant: null,
@@ -631,6 +637,7 @@ void main() {
       plugin.primeSessionDirectory(sessionId: "cold-s", directory: stored);
 
       final sending = plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "cold-s",
         parts: const [PluginPromptPart.text(text: "resume me")],
         variant: null,
@@ -681,6 +688,7 @@ void main() {
       );
 
       final sending = plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "cold-s",
         parts: const [PluginPromptPart.text(text: "resume me")],
         variant: null,
@@ -715,6 +723,7 @@ void main() {
       plugin.primeSessionDirectory(sessionId: "old-s", directory: "/somewhere/stale");
 
       final sending = plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "old-s",
         parts: const [PluginPromptPart.text(text: "again")],
         variant: null,

--- a/bridge/sesori_plugin_acp/test/acp_resume_only_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_only_test.dart
@@ -85,6 +85,7 @@ void main() {
     }
 
     Future<void> sendPrompt(String text) => plugin.sendPrompt(
+      promptId: "prompt-1",
       sessionId: "old-1",
       parts: [PluginPromptPart.text(text: text)],
       variant: null,

--- a/bridge/sesori_plugin_acp/test/acp_resume_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_test.dart
@@ -79,6 +79,7 @@ void main() {
 
       // Prompt a session this process never created.
       final sending = plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "old-session",
         parts: const [PluginPromptPart.text(text: "hi")],
         variant: null,
@@ -146,6 +147,7 @@ void main() {
       // A second prompt on the now-resident session does NOT re-load.
       final loadsBefore = fake.written.where((f) => f["method"] == "session/load").length;
       final again = plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "old-session",
         parts: const [PluginPromptPart.text(text: "again")],
         variant: null,
@@ -167,6 +169,7 @@ void main() {
       expect(await connecting, isTrue);
 
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "missing-session",
         parts: const [PluginPromptPart.text(text: "first")],
         variant: null,
@@ -184,6 +187,7 @@ void main() {
       await pump();
 
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "missing-session",
         parts: const [PluginPromptPart.text(text: "retry")],
         variant: null,

--- a/bridge/sesori_plugin_acp/test/acp_step5_policy_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_step5_policy_test.dart
@@ -153,6 +153,7 @@ void main() {
     }
 
     Future<void> send(String sessionId, String text) => plugin.sendPrompt(
+      promptId: "prompt-1",
       sessionId: sessionId,
       parts: [PluginPromptPart.text(text: text)],
       variant: null,

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -8,16 +8,16 @@ import "package:test/test.dart";
 /// An [AcpPlugin] whose [applyTurnSelection] blocks on a test-controlled gate,
 /// so a test can land an abort while a turn is mid-selection.
 class _GatedSelectionPlugin({
-    required super.id,
-    required super.agentDisplayName,
-    required super.launchSpec,
-    required super.launchDirectory,
-    required super.eventMapper,
-    required super.contentMapper,
-    required super.commandTracker,
-    required super.sessionOptionsService,
-    required AcpProcessFactory super.processFactory,
-  }) extends TestAcpPlugin {
+  required super.id,
+  required super.agentDisplayName,
+  required super.launchSpec,
+  required super.launchDirectory,
+  required super.eventMapper,
+  required super.contentMapper,
+  required super.commandTracker,
+  required super.sessionOptionsService,
+  required AcpProcessFactory super.processFactory,
+}) extends TestAcpPlugin {
   Completer<void>? selectionGate;
 
   @override
@@ -141,6 +141,7 @@ void main() {
     }
 
     Future<void> sendPrompt(String sessionId, String text) => plugin.sendPrompt(
+      promptId: "prompt-1",
       sessionId: sessionId,
       parts: [PluginPromptPart.text(text: text)],
       variant: null,
@@ -224,6 +225,7 @@ void main() {
       emitted.clear();
 
       await plugin.sendCommand(
+        promptId: "prompt-1",
         sessionId: sessionId,
         command: "review",
         arguments: "[SYSTEM CONTEXT — IMPORTANT] internal\n\nuser arguments",
@@ -558,6 +560,7 @@ void main() {
       final gate = Completer<void>();
       gated.selectionGate = gate;
       await gated.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "s1",
         parts: const [PluginPromptPart.text(text: "hi")],
         variant: null,
@@ -814,6 +817,7 @@ void main() {
       await creating;
 
       Future<void> send(String text) => respawning.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "s1",
         parts: [PluginPromptPart.text(text: text)],
         variant: null,

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -314,6 +314,7 @@ final class ClaudeEventDispatcher({
           sessionID: sessionId,
           agent: null,
           time: _messageTime(message.timestamp),
+          promptId: null,
         ).toJson(),
       ),
       for (final part in parts) BridgeSseMessagePartUpdated(part: part),

--- a/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
@@ -70,6 +70,7 @@ final class const ClaudeHistoryMapper({
                   sessionID: sessionId,
                   agent: null,
                   time: _messageTime(record.timestamp),
+                  promptId: null,
                 ),
                 parts: parts,
               ),

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -220,6 +220,7 @@ final class ClaudePlugin({
   @override
   Future<void> sendPrompt({
     required String sessionId,
+    required String promptId,
     required List<PluginPromptPart> parts,
     required PluginSessionVariant? variant,
     required String? agent,
@@ -244,6 +245,7 @@ final class ClaudePlugin({
   @override
   Future<void> sendCommand({
     required String sessionId,
+    required String promptId,
     required String command,
     required String arguments,
     required String? userVisibleArguments,
@@ -524,6 +526,7 @@ final class ClaudePlugin({
           sessionID: sessionId,
           agent: null,
           time: PluginMessageTime(created: now, completed: now),
+          promptId: null,
         ).toJson(),
       ),
     );

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -170,6 +170,7 @@ void main() {
       final subscription = harness.plugin.events.listen(events.add);
 
       await harness.plugin.sendCommand(
+        promptId: "prompt-1",
         sessionId: testSessionId,
         command: "review",
         arguments: "${_worktreeContext.trimRight()}\n\nsrc",
@@ -204,6 +205,7 @@ void main() {
 
       await expectLater(
         harness.plugin.sendCommand(
+          promptId: "prompt-1",
           sessionId: session.id,
           command: "review",
           arguments: "src",
@@ -230,6 +232,7 @@ void main() {
       final subscription = harness.plugin.events.listen(events.add);
 
       await harness.plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: testSessionId,
         parts: const [PluginPromptPart.text(text: "follow-up")],
         variant: null,
@@ -260,6 +263,7 @@ void main() {
       await pump();
 
       await harness.plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: testSessionId,
         parts: const [PluginPromptPart.text(text: "deeper")],
         variant: const PluginSessionVariant(id: "high"),
@@ -279,6 +283,7 @@ void main() {
     test("throws not found instead of creating a process for an unknown session", () async {
       await expectLater(
         harness.plugin.sendPrompt(
+          promptId: "prompt-1",
           sessionId: otherTestSessionId,
           parts: const [PluginPromptPart.text(text: "hello")],
           variant: null,
@@ -450,6 +455,7 @@ void main() {
         process,
       ).where((subtype) => subtype == "set_permission_mode").length;
       await harness.plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: testSessionId,
         parts: const [PluginPromptPart.text(text: "plan again")],
         variant: null,

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -389,6 +389,7 @@ class CodexEventMapper({
             // Live notifications carry no per-message timestamp; the rollout
             // re-fetch is authoritative and fills this in.
             time: null,
+            promptId: null,
           ),
           partType: PluginMessagePartType.text,
           partSuffix: "text",

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -671,6 +671,7 @@ class CodexPlugin._({
   @override
   Future<void> sendPrompt({
     required String sessionId,
+    required String promptId,
     required List<PluginPromptPart> parts,
     required PluginSessionVariant? variant,
     required String? agent,
@@ -687,8 +688,15 @@ class CodexPlugin._({
   }
 
   @override
+  Future<List<PluginQueuedPrompt>> getQueuedPrompts({required String sessionId}) async => const [];
+
+  @override
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async => false;
+
+  @override
   Future<void> sendCommand({
     required String sessionId,
+    required String promptId,
     required String command,
     required String arguments,
     required String? userVisibleArguments,

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
@@ -151,6 +151,7 @@ class CodexMessageRepository({
                 sessionID: sessionId,
                 agent: null,
                 time: _messageTimeFrom(lineTimestamp),
+                promptId: null,
               ),
               messageId: messageId,
               sessionId: sessionId,
@@ -170,6 +171,7 @@ class CodexMessageRepository({
               sessionID: sessionId,
               agent: null,
               time: pending.time,
+              promptId: null,
             ),
             messageId: messageId,
             sessionId: sessionId,
@@ -349,6 +351,7 @@ class CodexMessageRepository({
                   sessionID: sessionId,
                   agent: null,
                   time: messageTime,
+                  promptId: null,
                 )
               : assistantInfo(id: messageId, time: messageTime);
           messages.add(
@@ -386,6 +389,7 @@ class CodexMessageRepository({
           sessionID: sessionId,
           agent: null,
           time: pending.time,
+          promptId: null,
         ),
         messageId: messageId,
         sessionId: sessionId,

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -216,6 +216,7 @@ void main() {
       for (final part in invalidParts) {
         await expectLater(
           plugin.sendPrompt(
+            promptId: "prompt-1",
             sessionId: "t-invalid-image",
             parts: [part],
             variant: null,
@@ -266,6 +267,7 @@ void main() {
 
       final commands = await plugin.getCommands(projectId: "/work/sample");
       await plugin.sendCommand(
+        promptId: "prompt-1",
         sessionId: "t-existing",
         command: "review",
         arguments: "staged changes",
@@ -275,6 +277,7 @@ void main() {
         model: null,
       );
       await plugin.sendCommand(
+        promptId: "prompt-1",
         sessionId: "t-existing",
         command: "compact",
         arguments: "",
@@ -525,6 +528,7 @@ void main() {
       ]);
 
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "t-existing",
         parts: const [PluginPromptPart.text(text: "go on")],
         variant: null,
@@ -557,6 +561,7 @@ void main() {
       ]);
 
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "t-default-mode",
         parts: const [PluginPromptPart.text(text: "implement it")],
         variant: null,
@@ -632,6 +637,7 @@ void main() {
       addTearDown(subscription.cancel);
 
       await resolvedPlugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: sessionId,
         parts: const [PluginPromptPart.text(text: "plan this")],
         variant: null,
@@ -670,6 +676,7 @@ void main() {
       ]);
 
       await plugin.sendCommand(
+        promptId: "prompt-1",
         sessionId: "t-command",
         command: "review",
         arguments: "recent changes",
@@ -698,6 +705,7 @@ void main() {
         const _Response(result: null),
       ]);
       await plugin.sendCommand(
+        promptId: "prompt-1",
         sessionId: "t-command-force",
         command: "review",
         arguments: "recent changes",
@@ -746,6 +754,7 @@ void main() {
 
       await expectLater(
         plugin.sendPrompt(
+          promptId: "prompt-1",
           sessionId: "t-rejected",
           parts: const [PluginPromptPart.text(text: "go on")],
           variant: null,
@@ -774,6 +783,7 @@ void main() {
       ]);
 
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "t-delayed",
         parts: const [PluginPromptPart.text(text: "go on")],
         variant: null,
@@ -816,6 +826,7 @@ void main() {
       };
 
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "t-early-complete",
         parts: const [PluginPromptPart.text(text: "quick task")],
         variant: null,
@@ -845,6 +856,7 @@ void main() {
       };
 
       final send = plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "t-deleted",
         parts: const [PluginPromptPart.text(text: "quick task")],
         variant: null,
@@ -927,6 +939,7 @@ void main() {
       ]);
 
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "t-terminal",
         parts: const [PluginPromptPart.text(text: "go on")],
         variant: null,
@@ -972,6 +985,7 @@ void main() {
         model: null,
       );
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "t-fresh",
         parts: const [PluginPromptPart.text(text: "continue")],
         variant: null,
@@ -1019,6 +1033,7 @@ void main() {
         model: null,
       );
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "t-dropped",
         parts: const [PluginPromptPart.text(text: "are you there")],
         variant: null,
@@ -1052,6 +1067,7 @@ void main() {
       ]);
 
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "t-1",
         parts: const [PluginPromptPart.text(text: "long task")],
         variant: null,
@@ -1091,6 +1107,7 @@ void main() {
         const _Response(result: null),
       ]);
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "t-force",
         parts: const [PluginPromptPart.text(text: "long task")],
         variant: null,
@@ -1132,6 +1149,7 @@ void main() {
         ),
       ]);
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "t-overlap",
         parts: const [PluginPromptPart.text(text: "first task")],
         variant: null,
@@ -1154,6 +1172,7 @@ void main() {
         const _Response(result: null),
       ]);
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "t-overlap",
         parts: const [PluginPromptPart.text(text: "second task")],
         variant: null,
@@ -1206,6 +1225,7 @@ void main() {
 
       await expectLater(
         plugin.sendPrompt(
+          promptId: "prompt-1",
           sessionId: "t-whitespace",
           parts: const [PluginPromptPart.text(text: "continue")],
           variant: null,
@@ -1261,6 +1281,7 @@ void main() {
       final subscription = plugin.events.listen(events.add);
       addTearDown(subscription.cancel);
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: sessionId,
         parts: const [PluginPromptPart.text(text: "run a tool")],
         variant: null,
@@ -1423,6 +1444,7 @@ void main() {
       final subscription = plugin.events.listen(events.add);
 
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: sessionId,
         parts: const [PluginPromptPart.text(text: "run the live event fixture")],
         variant: null,
@@ -1929,6 +1951,7 @@ void main() {
       ]);
 
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "t-effort",
         parts: const [PluginPromptPart.text(text: "think hard")],
         variant: const PluginSessionVariant(id: "high"),
@@ -1963,6 +1986,7 @@ void main() {
       ]);
 
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "t-default",
         parts: const [PluginPromptPart.text(text: "hi")],
         variant: null,

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
@@ -198,6 +198,7 @@ void main() {
       final session = await creating;
 
       await plugin.sendCommand(
+        promptId: "prompt-1",
         sessionId: session.id,
         command: "compact",
         arguments: "focus on the current task",

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
@@ -171,6 +171,7 @@ void main() {
       expect(session.id, "s1");
 
       final prompting = plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: session.id,
         parts: const [PluginPromptPart.text(text: "Hello")],
         variant: null,

--- a/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
+++ b/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
@@ -39,6 +39,7 @@ export "src/models/plugin_project.dart";
 export "src/models/plugin_project_activity_summary.dart";
 export "src/models/plugin_prompt_part.dart";
 export "src/models/plugin_provider.dart";
+export "src/models/plugin_queued_prompt.dart";
 export "src/models/plugin_session.dart";
 export "src/models/plugin_session_options.dart";
 export "src/models/plugin_session_status.dart";

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -8,6 +8,7 @@ import "models/plugin_project.dart";
 import "models/plugin_project_activity_summary.dart";
 import "models/plugin_prompt_part.dart";
 import "models/plugin_provider.dart";
+import "models/plugin_queued_prompt.dart";
 import "models/plugin_session.dart";
 import "models/plugin_session_options.dart";
 import "models/plugin_session_status.dart";
@@ -106,8 +107,25 @@ sealed class BridgePluginApi() {
   /// stay distinguishable from "no messages yet".
   Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId);
 
+  /// Sends a prompt to a session.
+  ///
+  /// The returned future MUST complete once the prompt is **accepted** —
+  /// durably enqueued by the plugin or taken by the backend — not when its
+  /// agent run (or the runs queued ahead of it) finishes. Callers (bridge
+  /// request handlers serving phones) await this future while holding a
+  /// client request open, so an implementation must never block for the
+  /// duration of a turn. A prompt accepted while another turn runs is
+  /// queued; queue-owning plugins expose it via [getQueuedPrompts] and
+  /// surface later dispatch failures through their [events] stream.
+  ///
+  /// [promptId] is the prompt's stable identity: queue-owning plugins key
+  /// their queued entries by it, refuse a duplicate (already queued or
+  /// recently dispatched) as an idempotent success, and stamp it on the
+  /// resulting user message's `promptId`. Plugins without a queue may
+  /// ignore it.
   Future<void> sendPrompt({
     required String sessionId,
+    required String promptId,
     required List<PluginPromptPart> parts,
     required PluginSessionVariant? variant,
     required String? agent,
@@ -127,12 +145,15 @@ sealed class BridgePluginApi() {
   /// Dispatch failures (unknown command, missing session, backend down) MUST
   /// be thrown so callers can report the send as failed.
   ///
+  /// [promptId] carries the same identity contract as [sendPrompt]'s.
+  ///
   /// [arguments] is the exact backend execution payload and may include
   /// bridge-owned context. [userVisibleArguments] is only the user-authored
   /// portion, or `null` when none was supplied. Implementations that synthesize
   /// a client-facing command message MUST use that value, never [arguments].
   Future<void> sendCommand({
     required String sessionId,
+    required String promptId,
     required String command,
     required String arguments,
     required String? userVisibleArguments,
@@ -140,6 +161,20 @@ sealed class BridgePluginApi() {
     required String? agent,
     required ({String providerID, String modelID})? model,
   });
+
+  /// Returns the prompts accepted for [sessionId] but not yet dispatched to
+  /// the backend, in dispatch order.
+  ///
+  /// The default is an empty list: a plugin that hands every prompt to its
+  /// backend immediately has nothing queued to expose.
+  Future<List<PluginQueuedPrompt>> getQueuedPrompts({required String sessionId}) async => const [];
+
+  /// Cancels the queued prompt [promptId] on [sessionId] before dispatch.
+  ///
+  /// Returns whether an entry was removed. The default is `false`: a plugin
+  /// without a queue has nothing to cancel — including an entry that already
+  /// dispatched, which callers treat as benign (the prompt became a turn).
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async => false;
 
   Future<void> abortSession({required String sessionId});
 

--- a/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
@@ -1,6 +1,7 @@
 import "models/plugin_agent.dart";
 import "models/plugin_message.dart";
 import "models/plugin_pending_question.dart";
+import "models/plugin_queued_prompt.dart";
 
 sealed class const BridgeSseEvent();
 
@@ -64,6 +65,17 @@ class const BridgeSseCommandExecuted({
   required final String sessionID,
   required final String arguments,
   required final String messageID,
+}) extends BridgeSseEvent;
+
+/// Full replacement of [sessionID]'s queued-prompt list.
+///
+/// Emitted by queue-owning plugins on every change (accept, cancel, dispatch,
+/// abort, failure) with the complete current list, so a missed event
+/// self-heals on the next one. [sessionID] is the backend session identity;
+/// bridge core translates it to the stable binding before relaying.
+class const BridgeSseQueuedPromptsUpdated({
+  required final String sessionID,
+  required final List<PluginQueuedPrompt> prompts,
 }) extends BridgeSseEvent;
 
 class const BridgeSseMessageUpdated({required final Map<String, dynamic> info}) extends BridgeSseEvent;

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_message.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_message.dart
@@ -151,6 +151,12 @@ sealed class PluginMessage with _$PluginMessage {
     required String sessionID,
     required String? agent,
     required PluginMessageTime? time,
+
+    /// The `sendPrompt`/`sendCommand` prompt id this message fulfilled, when
+    /// known. Attached on the live event that consumes a queued prompt so
+    /// clients can swap the queued bubble for this message atomically.
+    /// History reads that cannot reconstruct it carry null.
+    required String? promptId,
   }) = PluginMessageUser;
 
   const factory assistant({

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_message.freezed.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_message.freezed.dart
@@ -904,13 +904,18 @@ $PluginMessageTimeCopyWith<$Res>? get time {
 @JsonSerializable(createFactory: false)
 
 class PluginMessageUser implements PluginMessage {
-  const PluginMessageUser({required this.id, required this.sessionID, required this.agent, required this.time,  String? $type}): $type = $type ?? 'user';
+  const PluginMessageUser({required this.id, required this.sessionID, required this.agent, required this.time, required this.promptId,  String? $type}): $type = $type ?? 'user';
   
 
 @override final  String id;
 @override final  String sessionID;
 @override final  String? agent;
 @override final  PluginMessageTime? time;
+/// The `sendPrompt`/`sendCommand` prompt id this message fulfilled, when
+/// known. Attached on the live event that consumes a queued prompt so
+/// clients can swap the queued bubble for this message atomically.
+/// History reads that cannot reconstruct it carry null.
+ final  String? promptId;
 
 @JsonKey(name: 'role')
 final String $type;
@@ -929,16 +934,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginMessageUser&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.time, time) || other.time == time));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginMessageUser&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.time, time) || other.time == time)&&(identical(other.promptId, promptId) || other.promptId == promptId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,sessionID,agent,time);
+int get hashCode => Object.hash(runtimeType,id,sessionID,agent,time,promptId);
 
 @override
 String toString() {
-  return 'PluginMessage.user(id: $id, sessionID: $sessionID, agent: $agent, time: $time)';
+  return 'PluginMessage.user(id: $id, sessionID: $sessionID, agent: $agent, time: $time, promptId: $promptId)';
 }
 
 
@@ -949,7 +954,7 @@ abstract mixin class $PluginMessageUserCopyWith<$Res> implements $PluginMessageC
   factory $PluginMessageUserCopyWith(PluginMessageUser value, $Res Function(PluginMessageUser) _then) = _$PluginMessageUserCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String sessionID, String? agent, PluginMessageTime? time
+ String id, String sessionID, String? agent, PluginMessageTime? time, String? promptId
 });
 
 
@@ -966,13 +971,14 @@ class _$PluginMessageUserCopyWithImpl<$Res>
 
 /// Create a copy of PluginMessage
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? agent = freezed,Object? time = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? agent = freezed,Object? time = freezed,Object? promptId = freezed,}) {
   return _then(PluginMessageUser(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
 as String,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullable_to_non_nullable
 as String?,time: freezed == time ? _self.time : time // ignore: cast_nullable_to_non_nullable
-as PluginMessageTime?,
+as PluginMessageTime?,promptId: freezed == promptId ? _self.promptId : promptId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_message.g.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_message.g.dart
@@ -96,6 +96,7 @@ Map<String, dynamic> _$PluginMessageUserToJson(PluginMessageUser instance) =>
       'sessionID': instance.sessionID,
       'agent': ?instance.agent,
       'time': ?instance.time?.toJson(),
+      'promptId': ?instance.promptId,
       'role': instance.$type,
     };
 

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_queued_prompt.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_queued_prompt.dart
@@ -1,0 +1,34 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "plugin_queued_prompt.freezed.dart";
+
+part "plugin_queued_prompt.g.dart";
+
+/// One prompt a plugin has accepted for a session but not yet dispatched to
+/// its backend.
+///
+/// Plugins that queue (accept at enqueue and dispatch later) expose these via
+/// [BridgePluginApi.getQueuedPrompts] and announce changes with
+/// `BridgeSseQueuedPromptsUpdated`. Plugins that hand prompts to their backend
+/// immediately never surface any.
+@freezed
+sealed class PluginQueuedPrompt with _$PluginQueuedPrompt {
+  const factory({
+    /// The prompt id handed to `sendPrompt`/`sendCommand`.
+    required String id,
+
+    /// User-visible prompt text. Null for an attachment-only prompt — never
+    /// an empty string.
+    required String? text,
+
+    /// Bare slash-command name for a command send, without the leading `/`.
+    /// Null for a plain prompt.
+    required String? command,
+
+    /// Number of file attachments carried by the prompt.
+    required int attachmentCount,
+
+    /// Acceptance time in milliseconds since the Unix epoch.
+    required int createdAt,
+  }) = _PluginQueuedPrompt;
+}

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_queued_prompt.freezed.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_queued_prompt.freezed.dart
@@ -1,0 +1,174 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint, type=warning, deprecated_member_use, deprecated_member_use_from_same_package
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'plugin_queued_prompt.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$PluginQueuedPrompt {
+
+/// The prompt id handed to `sendPrompt`/`sendCommand`.
+ String get id;/// User-visible prompt text. Null for an attachment-only prompt — never
+/// an empty string.
+ String? get text;/// Bare slash-command name for a command send, without the leading `/`.
+/// Null for a plain prompt.
+ String? get command;/// Number of file attachments carried by the prompt.
+ int get attachmentCount;/// Acceptance time in milliseconds since the Unix epoch.
+ int get createdAt;
+/// Create a copy of PluginQueuedPrompt
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PluginQueuedPromptCopyWith<PluginQueuedPrompt> get copyWith => _$PluginQueuedPromptCopyWithImpl<PluginQueuedPrompt>(this as PluginQueuedPrompt, _$identity);
+
+  /// Serializes this PluginQueuedPrompt to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginQueuedPrompt&&(identical(other.id, id) || other.id == id)&&(identical(other.text, text) || other.text == text)&&(identical(other.command, command) || other.command == command)&&(identical(other.attachmentCount, attachmentCount) || other.attachmentCount == attachmentCount)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,text,command,attachmentCount,createdAt);
+
+@override
+String toString() {
+  return 'PluginQueuedPrompt(id: $id, text: $text, command: $command, attachmentCount: $attachmentCount, createdAt: $createdAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PluginQueuedPromptCopyWith<$Res>  {
+  factory $PluginQueuedPromptCopyWith(PluginQueuedPrompt value, $Res Function(PluginQueuedPrompt) _then) = _$PluginQueuedPromptCopyWithImpl;
+@useResult
+$Res call({
+ String id, String? text, String? command, int attachmentCount, int createdAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$PluginQueuedPromptCopyWithImpl<$Res>
+    implements $PluginQueuedPromptCopyWith<$Res> {
+  _$PluginQueuedPromptCopyWithImpl(this._self, this._then);
+
+  final PluginQueuedPrompt _self;
+  final $Res Function(PluginQueuedPrompt) _then;
+
+/// Create a copy of PluginQueuedPrompt
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? text = freezed,Object? command = freezed,Object? attachmentCount = null,Object? createdAt = null,}) {
+  return _then(PluginQueuedPrompt(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,text: freezed == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
+as String?,command: freezed == command ? _self.command : command // ignore: cast_nullable_to_non_nullable
+as String?,attachmentCount: null == attachmentCount ? _self.attachmentCount : attachmentCount // ignore: cast_nullable_to_non_nullable
+as int,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createFactory: false)
+
+class _PluginQueuedPrompt implements PluginQueuedPrompt {
+  const _PluginQueuedPrompt({required this.id, required this.text, required this.command, required this.attachmentCount, required this.createdAt});
+  
+
+/// The prompt id handed to `sendPrompt`/`sendCommand`.
+@override final  String id;
+/// User-visible prompt text. Null for an attachment-only prompt — never
+/// an empty string.
+@override final  String? text;
+/// Bare slash-command name for a command send, without the leading `/`.
+/// Null for a plain prompt.
+@override final  String? command;
+/// Number of file attachments carried by the prompt.
+@override final  int attachmentCount;
+/// Acceptance time in milliseconds since the Unix epoch.
+@override final  int createdAt;
+
+/// Create a copy of PluginQueuedPrompt
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PluginQueuedPromptCopyWith<_PluginQueuedPrompt> get copyWith => __$PluginQueuedPromptCopyWithImpl<_PluginQueuedPrompt>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PluginQueuedPromptToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginQueuedPrompt&&(identical(other.id, id) || other.id == id)&&(identical(other.text, text) || other.text == text)&&(identical(other.command, command) || other.command == command)&&(identical(other.attachmentCount, attachmentCount) || other.attachmentCount == attachmentCount)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,text,command,attachmentCount,createdAt);
+
+@override
+String toString() {
+  return 'PluginQueuedPrompt(id: $id, text: $text, command: $command, attachmentCount: $attachmentCount, createdAt: $createdAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PluginQueuedPromptCopyWith<$Res> implements $PluginQueuedPromptCopyWith<$Res> {
+  factory _$PluginQueuedPromptCopyWith(_PluginQueuedPrompt value, $Res Function(_PluginQueuedPrompt) _then) = __$PluginQueuedPromptCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String? text, String? command, int attachmentCount, int createdAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$PluginQueuedPromptCopyWithImpl<$Res>
+    implements _$PluginQueuedPromptCopyWith<$Res> {
+  __$PluginQueuedPromptCopyWithImpl(this._self, this._then);
+
+  final _PluginQueuedPrompt _self;
+  final $Res Function(_PluginQueuedPrompt) _then;
+
+/// Create a copy of PluginQueuedPrompt
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? text = freezed,Object? command = freezed,Object? attachmentCount = null,Object? createdAt = null,}) {
+  return _then(_PluginQueuedPrompt(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,text: freezed == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
+as String?,command: freezed == command ? _self.command : command // ignore: cast_nullable_to_non_nullable
+as String?,attachmentCount: null == attachmentCount ? _self.attachmentCount : attachmentCount // ignore: cast_nullable_to_non_nullable
+as int,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_queued_prompt.g.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_queued_prompt.g.dart
@@ -1,0 +1,16 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'plugin_queued_prompt.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Map<String, dynamic> _$PluginQueuedPromptToJson(_PluginQueuedPrompt instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'text': ?instance.text,
+      'command': ?instance.command,
+      'attachmentCount': instance.attachmentCount,
+      'createdAt': instance.createdAt,
+    };

--- a/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
@@ -80,6 +80,7 @@ void main() {
     }
 
     Future<void> send(String sessionId, String text) => plugin.sendPrompt(
+      promptId: "prompt-1",
       sessionId: sessionId,
       parts: [PluginPromptPart.text(text: text)],
       variant: null,
@@ -147,6 +148,7 @@ void main() {
       await creating;
 
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "session-1",
         parts: const [PluginPromptPart.text(text: "private prompt")],
         variant: null,

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -379,6 +379,7 @@ class OpenCodePlugin._({
   @override
   Future<void> sendPrompt({
     required String sessionId,
+    required String promptId,
     required List<PluginPromptPart> parts,
     required String? agent,
     required PluginSessionVariant? variant,
@@ -396,8 +397,15 @@ class OpenCodePlugin._({
   }
 
   @override
+  Future<List<PluginQueuedPrompt>> getQueuedPrompts({required String sessionId}) async => const [];
+
+  @override
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async => false;
+
+  @override
   Future<void> sendCommand({
     required String sessionId,
+    required String promptId,
     required String command,
     required String arguments,
     required String? userVisibleArguments,

--- a/bridge/sesori_plugin_opencode/lib/src/plugin_model_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/plugin_model_mapper.dart
@@ -119,6 +119,7 @@ class const PluginModelMapper({
         sessionID: sessionID,
         agent: agent,
         time: _mapUserMessageTime(time),
+        promptId: null,
       ),
       AssistantMessage() => _assistantMessageMapper.map(info),
       MessageUnknown(:final raw) => throw FormatException("Unknown message role: $raw"),

--- a/bridge/sesori_plugin_opencode/lib/src/sse_event_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse_event_mapper.dart
@@ -36,6 +36,7 @@ class SseEventMapper({final AssistantMessageMapper _assistantMessageMapper = con
         sessionID: sessionID,
         agent: agent,
         time: PluginMessageTime(created: time.created.toInt(), completed: null),
+        promptId: null,
       ),
       AssistantMessage() => _assistantMessageMapper.map(info),
       // Unknown roles from a newer OpenCode server: fall through to the raw

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -239,6 +239,7 @@ void main() {
       server.requestLog.clear();
 
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "s-root",
         parts: const [PluginPromptPart.text(text: "Continue")],
         agent: null,
@@ -271,6 +272,7 @@ void main() {
       expect(plugin.currentWorkState, PluginWorkState.idle);
 
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "s-root",
         parts: const [PluginPromptPart.text(text: "Continue")],
         agent: null,
@@ -296,6 +298,7 @@ void main() {
       await server.waitForSseConnection();
 
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "s-root",
         parts: const [PluginPromptPart.text(text: "Continue")],
         agent: null,
@@ -344,6 +347,7 @@ void main() {
 
       await expectLater(
         plugin.sendPrompt(
+          promptId: "prompt-1",
           sessionId: "s-root",
           parts: const [PluginPromptPart.text(text: "Continue")],
           agent: null,
@@ -363,6 +367,7 @@ void main() {
       server.holdCommand = Completer<void>();
 
       await plugin.sendCommand(
+        promptId: "prompt-1",
         sessionId: "s-root",
         command: "/review-work",
         arguments: "recent changes",
@@ -395,6 +400,7 @@ void main() {
       server.holdCommand = Completer<void>();
 
       await plugin.sendCommand(
+        promptId: "prompt-1",
         sessionId: "s-root",
         command: "/review-work",
         arguments: "",
@@ -602,6 +608,7 @@ void main() {
       addTearDown(subscription.cancel);
       await initialProjectUpdated.future;
       await plugin.sendPrompt(
+        promptId: "prompt-1",
         sessionId: "s-root",
         parts: const [PluginPromptPart.text(text: "long task")],
         agent: null,

--- a/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_history_mapper.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_history_mapper.dart
@@ -124,6 +124,7 @@ final class PiHistoryMapper({
         sessionID: sessionId,
         agent: null,
         time: _time(message.timestamp),
+        promptId: null,
       ),
       parts: parts,
     );

--- a/client/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/client/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -1056,6 +1056,7 @@ void main() {
       act: (cubit) async {
         await _awaitLoaded(cubit);
         const message = Message.user(
+          promptId: null,
           id: "msg-new",
           sessionID: sessionId,
           agent: null,

--- a/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
+++ b/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
@@ -1344,6 +1344,7 @@ void main() {
   testWidgets("renders normalized user file attachments", (tester) async {
     const message = MessageWithParts(
       info: Message.user(
+        promptId: null,
         id: "message-1",
         sessionID: "session-1",
         agent: null,

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -380,6 +380,7 @@ void main() {
       messages: const [
         MessageWithParts(
           info: Message.user(
+            promptId: null,
             id: "empty-user-envelope",
             sessionID: "session-1",
             agent: null,
@@ -467,6 +468,7 @@ void main() {
       messages: const [
         MessageWithParts(
           info: Message.user(
+            promptId: null,
             id: "markdown-user",
             sessionID: "session-1",
             agent: null,
@@ -511,6 +513,7 @@ void main() {
       messages: const [
         MessageWithParts(
           info: Message.user(
+            promptId: null,
             id: "remote-image-user",
             sessionID: "session-1",
             agent: null,
@@ -553,6 +556,7 @@ void main() {
       messages: const [
         MessageWithParts(
           info: Message.user(
+            promptId: null,
             id: "unknown-attachment-user",
             sessionID: "session-1",
             agent: null,
@@ -593,6 +597,7 @@ void main() {
       messages: const [
         MessageWithParts(
           info: Message.user(
+            promptId: null,
             id: "empty-user",
             sessionID: "session-1",
             agent: null,

--- a/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -123,7 +123,7 @@ MessageWithParts _message({
   final time = createdAtMs == null ? null : MessageTime(created: createdAtMs, completed: null);
 
   final info = role == "user"
-      ? Message.user(id: messageId, sessionID: "session-1", agent: null, time: time)
+      ? Message.user(promptId: null, id: messageId, sessionID: "session-1", agent: null, time: time)
       : Message.assistant(
           id: messageId,
           sessionID: "session-1",
@@ -157,6 +157,7 @@ MessageWithParts _message({
 
 const _emptyUserMessage = MessageWithParts(
   info: Message.user(
+    promptId: null,
     id: "empty-user",
     sessionID: "session-1",
     agent: null,

--- a/client/module_core/lib/src/api/session_api.dart
+++ b/client/module_core/lib/src/api/session_api.dart
@@ -153,6 +153,9 @@ class SessionApi({required final RelayHttpApiClient _client}) {
         model: model,
         variant: variant,
         command: command,
+        // Client-generated prompt identity lands with the bridge-owned queue
+        // rendering (plan step 5); until then the bridge generates one.
+        promptId: null,
       ),
     );
   }

--- a/client/module_core/lib/src/capabilities/server_connection/models/sse_event.dart
+++ b/client/module_core/lib/src/capabilities/server_connection/models/sse_event.dart
@@ -28,6 +28,7 @@ class SseEvent({required final SesoriSseEvent data, final String? directory}) {
     SesoriTodoUpdated(:final sessionID) => sessionID,
     SesoriPermissionReplied(:final sessionID) => sessionID,
     SesoriSessionPromptDefaultsChanged(:final sessionID) => sessionID,
+    SesoriSessionQueuedPrompts(:final sessionID) => sessionID,
     SesoriServerConnected() ||
     SesoriServerHeartbeat() ||
     SesoriServerInstanceDisposed() ||

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -763,6 +763,7 @@ class SessionDetailCubit(
             SesoriSessionDiff() ||
             SesoriSessionError() ||
             SesoriSessionCompacted() ||
+            SesoriSessionQueuedPrompts() ||
             SesoriTodoUpdated():
           break;
       }
@@ -882,6 +883,9 @@ class SessionDetailCubit(
       SesoriWorktreeReady() ||
       SesoriWorktreeFailed() ||
       SesoriSessionPromptDefaultsChanged() ||
+      // Queued prompts render only for the session itself; own-session events
+      // arrive through the session-scoped stream, not this global path.
+      SesoriSessionQueuedPrompts() ||
       // Unseen-state changes are list-level concerns handled by the tracker;
       // the detail screen does not react to them.
       SesoriSessionUnseenChanged() => false,
@@ -967,6 +971,7 @@ class SessionDetailCubit(
             SesoriWorktreeReady() ||
             SesoriWorktreeFailed() ||
             SesoriSessionUnseenChanged() ||
+            SesoriSessionQueuedPrompts() ||
             SesoriSessionPromptDefaultsChanged():
           break;
       }

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -123,6 +123,7 @@ class SessionListCubit({
             SesoriCommandExecuted() ||
             SesoriTodoUpdated() ||
             SesoriSessionPromptDefaultsChanged() ||
+            SesoriSessionQueuedPrompts() ||
             SesoriProjectsSummary() ||
             SesoriProjectUpdated() ||
             SesoriVcsBranchUpdated() ||

--- a/client/module_core/lib/src/services/sse_event_tracker.dart
+++ b/client/module_core/lib/src/services/sse_event_tracker.dart
@@ -127,6 +127,7 @@ class SseEventTracker(
             SesoriCommandExecuted() ||
             SesoriTodoUpdated() ||
             SesoriSessionPromptDefaultsChanged() ||
+            SesoriSessionQueuedPrompts() ||
             SesoriVcsBranchUpdated() ||
             SesoriSessionsUpdated() ||
             SesoriSessionUnseenChanged() ||

--- a/client/module_core/test/consumers/analytics/session_activity_analytics_listener_test.dart
+++ b/client/module_core/test/consumers/analytics/session_activity_analytics_listener_test.dart
@@ -37,6 +37,7 @@ const _emptyState = SessionDetailState.loaded(
   messages: [
     MessageWithParts(
       info: Message.user(
+        promptId: null,
         id: "empty-user-envelope",
         sessionID: "session-1",
         agent: null,

--- a/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
@@ -1250,6 +1250,7 @@ void main() {
             messages: [
               MessageWithParts(
                 info: const Message.user(
+                  promptId: null,
                   id: "message-1",
                   sessionID: _sessionId,
                   agent: "build",
@@ -1331,6 +1332,7 @@ void main() {
       sessionEvents.add(
         const SesoriMessageUpdated(
           info: Message.user(
+            promptId: null,
             id: "message-1",
             sessionID: _sessionId,
             agent: "build",
@@ -1415,6 +1417,7 @@ void main() {
       sessionEvents.add(
         const SesoriMessageUpdated(
           info: Message.user(
+            promptId: null,
             id: "message-1",
             sessionID: _sessionId,
             agent: "build",
@@ -1476,6 +1479,7 @@ void main() {
       sessionEvents.add(
         const SesoriMessageUpdated(
           info: Message.user(
+            promptId: null,
             id: "message-1",
             sessionID: _sessionId,
             agent: "build",
@@ -1550,6 +1554,7 @@ void main() {
       sessionEvents.add(
         const SesoriMessageUpdated(
           info: Message.user(
+            promptId: null,
             id: "z-user",
             sessionID: _sessionId,
             agent: "build",
@@ -1570,6 +1575,7 @@ void main() {
       const messages = <MessageWithParts>[
         MessageWithParts(
           info: Message.user(
+            promptId: null,
             id: "user-1",
             sessionID: _sessionId,
             agent: "build",
@@ -1623,6 +1629,7 @@ void main() {
       sessionEvents.add(
         const SesoriMessageUpdated(
           info: Message.user(
+            promptId: null,
             id: "user-2",
             sessionID: _sessionId,
             agent: "build",

--- a/client/module_core/test/cubits/session_detail/session_detail_paging_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_paging_test.dart
@@ -60,7 +60,10 @@ void main() {
     when(() => connectionService.status).thenAnswer((_) => connectionStatus);
     when(() => connectionService.currentStatus).thenAnswer((_) => connectionStatus.value);
     when(
-      () => loadService.load(sessionId: any(named: "sessionId"), projectId: any(named: "projectId")),
+      () => loadService.load(
+        sessionId: any(named: "sessionId"),
+        projectId: any(named: "projectId"),
+      ),
     ).thenAnswer(
       (_) async => SessionDetailLoadResult.loaded(
         snapshot: _snapshot(messages: messages, olderMessagesCursor: olderMessagesCursor),
@@ -68,7 +71,10 @@ void main() {
       ),
     );
     when(
-      () => loadService.reload(sessionId: any(named: "sessionId"), projectId: any(named: "projectId")),
+      () => loadService.reload(
+        sessionId: any(named: "sessionId"),
+        projectId: any(named: "projectId"),
+      ),
     ).thenAnswer(
       (_) async => SessionDetailLoadResult.loaded(
         snapshot: _snapshot(messages: messages, olderMessagesCursor: olderMessagesCursor),
@@ -98,14 +104,23 @@ void main() {
   group("session detail paging", () {
     setUp(() async {
       await openSession(
-        messages: [_message(id: "m5"), _message(id: "m6")],
+        messages: [
+          _message(id: "m5"),
+          _message(id: "m6"),
+        ],
         olderMessagesCursor: 5,
       );
     });
 
     test("loading older messages prepends them and advances the cursor", () async {
       when(() => loadService.loadOlderMessages(sessionId: _sessionId, before: 5)).thenAnswer(
-        (_) async => (messages: [_message(id: "m3"), _message(id: "m4")], olderMessagesCursor: 3),
+        (_) async => (
+          messages: [
+            _message(id: "m3"),
+            _message(id: "m4"),
+          ],
+          olderMessagesCursor: 3,
+        ),
       );
 
       await cubit.loadOlderMessages();
@@ -152,7 +167,13 @@ void main() {
       // The bridge's cursor is exclusive, but a live event may have appended
       // the same message while the page was in flight.
       when(() => loadService.loadOlderMessages(sessionId: _sessionId, before: 5)).thenAnswer(
-        (_) async => (messages: [_message(id: "m4"), _message(id: "m5")], olderMessagesCursor: null),
+        (_) async => (
+          messages: [
+            _message(id: "m4"),
+            _message(id: "m5"),
+          ],
+          olderMessagesCursor: null,
+        ),
       );
 
       await cubit.loadOlderMessages();
@@ -214,7 +235,13 @@ Future<void> _awaitLoaded(SessionDetailCubit cubit) async {
 }
 
 MessageWithParts _message({required String id}) => MessageWithParts(
-  info: Message.user(id: id, sessionID: _sessionId, agent: null, time: const MessageTime(created: 1, completed: null)),
+  info: Message.user(
+    promptId: null,
+    id: id,
+    sessionID: _sessionId,
+    agent: null,
+    time: const MessageTime(created: 1, completed: null),
+  ),
   parts: const [],
 );
 

--- a/shared/sesori_shared/lib/sesori_shared.dart
+++ b/shared/sesori_shared/lib/sesori_shared.dart
@@ -65,6 +65,7 @@ export "src/models/sesori/provider_info.dart";
 export "src/models/sesori/pull_request_info.dart";
 export "src/models/sesori/pull_request_refresh_settings.dart";
 export "src/models/sesori/question.dart";
+export "src/models/sesori/queued_prompt.dart";
 export "src/models/sesori/rename_project_request.dart";
 export "src/models/sesori/rename_session_request.dart";
 export "src/models/sesori/reply_to_permission_request.dart";

--- a/shared/sesori_shared/lib/src/models/sesori/message.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message.dart
@@ -28,6 +28,13 @@ sealed class const Message._() with _$Message {
     required String sessionID,
     required String? agent,
     required MessageTime? time,
+
+    /// The `SendPromptRequest.promptId` this message fulfilled, when known.
+    ///
+    /// Attached on the live event that consumes a bridge-queued prompt so
+    /// clients can swap the queued bubble for this message atomically.
+    /// History reads that cannot reconstruct it carry null.
+    required String? promptId,
   }) = MessageUser;
 
   const factory assistant({

--- a/shared/sesori_shared/lib/src/models/sesori/message.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message.freezed.dart
@@ -123,13 +123,19 @@ $MessageTimeCopyWith<$Res>? get time {
 @JsonSerializable()
 
 class MessageUser extends Message {
-  const MessageUser({required this.id, required this.sessionID, required this.agent, required this.time,  String? $type}): $type = $type ?? 'user',super._();
+  const MessageUser({required this.id, required this.sessionID, required this.agent, required this.time, required this.promptId,  String? $type}): $type = $type ?? 'user',super._();
   factory MessageUser.fromJson(Map<String, dynamic> json) => _$MessageUserFromJson(json);
 
 @override final  String id;
 @override final  String sessionID;
 @override final  String? agent;
 @override final  MessageTime? time;
+/// The `SendPromptRequest.promptId` this message fulfilled, when known.
+///
+/// Attached on the live event that consumes a bridge-queued prompt so
+/// clients can swap the queued bubble for this message atomically.
+/// History reads that cannot reconstruct it carry null.
+ final  String? promptId;
 
 @JsonKey(name: 'role')
 final String $type;
@@ -148,16 +154,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MessageUser&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.time, time) || other.time == time));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MessageUser&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.time, time) || other.time == time)&&(identical(other.promptId, promptId) || other.promptId == promptId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,sessionID,agent,time);
+int get hashCode => Object.hash(runtimeType,id,sessionID,agent,time,promptId);
 
 @override
 String toString() {
-  return 'Message.user(id: $id, sessionID: $sessionID, agent: $agent, time: $time)';
+  return 'Message.user(id: $id, sessionID: $sessionID, agent: $agent, time: $time, promptId: $promptId)';
 }
 
 
@@ -168,7 +174,7 @@ abstract mixin class $MessageUserCopyWith<$Res> implements $MessageCopyWith<$Res
   factory $MessageUserCopyWith(MessageUser value, $Res Function(MessageUser) _then) = _$MessageUserCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String sessionID, String? agent, MessageTime? time
+ String id, String sessionID, String? agent, MessageTime? time, String? promptId
 });
 
 
@@ -185,13 +191,14 @@ class _$MessageUserCopyWithImpl<$Res>
 
 /// Create a copy of Message
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? agent = freezed,Object? time = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? agent = freezed,Object? time = freezed,Object? promptId = freezed,}) {
   return _then(MessageUser(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
 as String,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullable_to_non_nullable
 as String?,time: freezed == time ? _self.time : time // ignore: cast_nullable_to_non_nullable
-as MessageTime?,
+as MessageTime?,promptId: freezed == promptId ? _self.promptId : promptId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/message.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message.g.dart
@@ -13,6 +13,7 @@ MessageUser _$MessageUserFromJson(Map json) => MessageUser(
   time: json['time'] == null
       ? null
       : MessageTime.fromJson(Map<String, dynamic>.from(json['time'] as Map)),
+  promptId: json['promptId'] as String?,
   $type: json['role'] as String?,
 );
 
@@ -22,6 +23,7 @@ Map<String, dynamic> _$MessageUserToJson(MessageUser instance) =>
       'sessionID': instance.sessionID,
       'agent': ?instance.agent,
       'time': ?instance.time?.toJson(),
+      'promptId': ?instance.promptId,
       'role': instance.$type,
     };
 

--- a/shared/sesori_shared/lib/src/models/sesori/queued_prompt.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/queued_prompt.dart
@@ -1,0 +1,58 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "queued_prompt.freezed.dart";
+
+part "queued_prompt.g.dart";
+
+/// One prompt the bridge has accepted for a session but not yet dispatched to
+/// the backend.
+///
+/// The bridge owns this state: clients render it, cancel it, and drop their
+/// local copy once it appears. When the prompt dispatches, the transcript's
+/// user message carries the same [id] as its `promptId` so clients can
+/// transform the queued bubble into the sent message without a remove/re-add.
+@Freezed(fromJson: true, toJson: true)
+sealed class QueuedSessionPrompt with _$QueuedSessionPrompt {
+  const factory({
+    /// The prompt id: client-supplied `SendPromptRequest.promptId`, or a
+    /// bridge-generated fallback for clients that predate it.
+    required String id,
+
+    /// User-visible prompt text. Null for an attachment-only prompt — never
+    /// an empty string.
+    required String? text,
+
+    /// Bare slash-command name for a command send, without the leading `/`.
+    /// Null for a plain prompt.
+    required String? command,
+
+    /// Number of file attachments carried by the prompt.
+    @Default(0) int attachmentCount,
+
+    /// Bridge acceptance time in milliseconds since the Unix epoch.
+    required int createdAt,
+  }) = _QueuedSessionPrompt;
+
+  factory fromJson(Map<String, dynamic> json) => _$QueuedSessionPromptFromJson(json);
+}
+
+/// Response body for `POST /session/queued_prompts`.
+@Freezed(fromJson: true, toJson: true)
+sealed class QueuedPromptResponse with _$QueuedPromptResponse {
+  const factory({
+    required List<QueuedSessionPrompt> data,
+  }) = _QueuedPromptResponse;
+
+  factory fromJson(Map<String, dynamic> json) => _$QueuedPromptResponseFromJson(json);
+}
+
+/// Request body for `POST /session/prompt/cancel`.
+@Freezed(fromJson: true, toJson: true)
+sealed class CancelQueuedPromptRequest with _$CancelQueuedPromptRequest {
+  const factory({
+    required String sessionId,
+    required String promptId,
+  }) = _CancelQueuedPromptRequest;
+
+  factory fromJson(Map<String, dynamic> json) => _$CancelQueuedPromptRequestFromJson(json);
+}

--- a/shared/sesori_shared/lib/src/models/sesori/queued_prompt.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/queued_prompt.freezed.dart
@@ -1,0 +1,454 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint, type=warning, deprecated_member_use, deprecated_member_use_from_same_package
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'queued_prompt.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$QueuedSessionPrompt {
+
+/// The prompt id: client-supplied `SendPromptRequest.promptId`, or a
+/// bridge-generated fallback for clients that predate it.
+ String get id;/// User-visible prompt text. Null for an attachment-only prompt — never
+/// an empty string.
+ String? get text;/// Bare slash-command name for a command send, without the leading `/`.
+/// Null for a plain prompt.
+ String? get command;/// Number of file attachments carried by the prompt.
+ int get attachmentCount;/// Bridge acceptance time in milliseconds since the Unix epoch.
+ int get createdAt;
+/// Create a copy of QueuedSessionPrompt
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$QueuedSessionPromptCopyWith<QueuedSessionPrompt> get copyWith => _$QueuedSessionPromptCopyWithImpl<QueuedSessionPrompt>(this as QueuedSessionPrompt, _$identity);
+
+  /// Serializes this QueuedSessionPrompt to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is QueuedSessionPrompt&&(identical(other.id, id) || other.id == id)&&(identical(other.text, text) || other.text == text)&&(identical(other.command, command) || other.command == command)&&(identical(other.attachmentCount, attachmentCount) || other.attachmentCount == attachmentCount)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,text,command,attachmentCount,createdAt);
+
+@override
+String toString() {
+  return 'QueuedSessionPrompt(id: $id, text: $text, command: $command, attachmentCount: $attachmentCount, createdAt: $createdAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $QueuedSessionPromptCopyWith<$Res>  {
+  factory $QueuedSessionPromptCopyWith(QueuedSessionPrompt value, $Res Function(QueuedSessionPrompt) _then) = _$QueuedSessionPromptCopyWithImpl;
+@useResult
+$Res call({
+ String id, String? text, String? command, int attachmentCount, int createdAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$QueuedSessionPromptCopyWithImpl<$Res>
+    implements $QueuedSessionPromptCopyWith<$Res> {
+  _$QueuedSessionPromptCopyWithImpl(this._self, this._then);
+
+  final QueuedSessionPrompt _self;
+  final $Res Function(QueuedSessionPrompt) _then;
+
+/// Create a copy of QueuedSessionPrompt
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? text = freezed,Object? command = freezed,Object? attachmentCount = null,Object? createdAt = null,}) {
+  return _then(QueuedSessionPrompt(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,text: freezed == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
+as String?,command: freezed == command ? _self.command : command // ignore: cast_nullable_to_non_nullable
+as String?,attachmentCount: null == attachmentCount ? _self.attachmentCount : attachmentCount // ignore: cast_nullable_to_non_nullable
+as int,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _QueuedSessionPrompt implements QueuedSessionPrompt {
+  const _QueuedSessionPrompt({required this.id, required this.text, required this.command, this.attachmentCount = 0, required this.createdAt});
+  factory _QueuedSessionPrompt.fromJson(Map<String, dynamic> json) => _$QueuedSessionPromptFromJson(json);
+
+/// The prompt id: client-supplied `SendPromptRequest.promptId`, or a
+/// bridge-generated fallback for clients that predate it.
+@override final  String id;
+/// User-visible prompt text. Null for an attachment-only prompt — never
+/// an empty string.
+@override final  String? text;
+/// Bare slash-command name for a command send, without the leading `/`.
+/// Null for a plain prompt.
+@override final  String? command;
+/// Number of file attachments carried by the prompt.
+@override@JsonKey() final  int attachmentCount;
+/// Bridge acceptance time in milliseconds since the Unix epoch.
+@override final  int createdAt;
+
+/// Create a copy of QueuedSessionPrompt
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$QueuedSessionPromptCopyWith<_QueuedSessionPrompt> get copyWith => __$QueuedSessionPromptCopyWithImpl<_QueuedSessionPrompt>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$QueuedSessionPromptToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _QueuedSessionPrompt&&(identical(other.id, id) || other.id == id)&&(identical(other.text, text) || other.text == text)&&(identical(other.command, command) || other.command == command)&&(identical(other.attachmentCount, attachmentCount) || other.attachmentCount == attachmentCount)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,text,command,attachmentCount,createdAt);
+
+@override
+String toString() {
+  return 'QueuedSessionPrompt(id: $id, text: $text, command: $command, attachmentCount: $attachmentCount, createdAt: $createdAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$QueuedSessionPromptCopyWith<$Res> implements $QueuedSessionPromptCopyWith<$Res> {
+  factory _$QueuedSessionPromptCopyWith(_QueuedSessionPrompt value, $Res Function(_QueuedSessionPrompt) _then) = __$QueuedSessionPromptCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String? text, String? command, int attachmentCount, int createdAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$QueuedSessionPromptCopyWithImpl<$Res>
+    implements _$QueuedSessionPromptCopyWith<$Res> {
+  __$QueuedSessionPromptCopyWithImpl(this._self, this._then);
+
+  final _QueuedSessionPrompt _self;
+  final $Res Function(_QueuedSessionPrompt) _then;
+
+/// Create a copy of QueuedSessionPrompt
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? text = freezed,Object? command = freezed,Object? attachmentCount = null,Object? createdAt = null,}) {
+  return _then(_QueuedSessionPrompt(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,text: freezed == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
+as String?,command: freezed == command ? _self.command : command // ignore: cast_nullable_to_non_nullable
+as String?,attachmentCount: null == attachmentCount ? _self.attachmentCount : attachmentCount // ignore: cast_nullable_to_non_nullable
+as int,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$QueuedPromptResponse {
+
+ List<QueuedSessionPrompt> get data;
+/// Create a copy of QueuedPromptResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$QueuedPromptResponseCopyWith<QueuedPromptResponse> get copyWith => _$QueuedPromptResponseCopyWithImpl<QueuedPromptResponse>(this as QueuedPromptResponse, _$identity);
+
+  /// Serializes this QueuedPromptResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is QueuedPromptResponse&&const DeepCollectionEquality().equals(other.data, data));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(data));
+
+@override
+String toString() {
+  return 'QueuedPromptResponse(data: $data)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $QueuedPromptResponseCopyWith<$Res>  {
+  factory $QueuedPromptResponseCopyWith(QueuedPromptResponse value, $Res Function(QueuedPromptResponse) _then) = _$QueuedPromptResponseCopyWithImpl;
+@useResult
+$Res call({
+ List<QueuedSessionPrompt> data
+});
+
+
+
+
+}
+/// @nodoc
+class _$QueuedPromptResponseCopyWithImpl<$Res>
+    implements $QueuedPromptResponseCopyWith<$Res> {
+  _$QueuedPromptResponseCopyWithImpl(this._self, this._then);
+
+  final QueuedPromptResponse _self;
+  final $Res Function(QueuedPromptResponse) _then;
+
+/// Create a copy of QueuedPromptResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? data = null,}) {
+  return _then(QueuedPromptResponse(
+data: null == data ? _self.data : data // ignore: cast_nullable_to_non_nullable
+as List<QueuedSessionPrompt>,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _QueuedPromptResponse implements QueuedPromptResponse {
+  const _QueuedPromptResponse({required  List<QueuedSessionPrompt> data}): _data = data;
+  factory _QueuedPromptResponse.fromJson(Map<String, dynamic> json) => _$QueuedPromptResponseFromJson(json);
+
+ final  List<QueuedSessionPrompt> _data;
+@override List<QueuedSessionPrompt> get data {
+  if (_data is EqualUnmodifiableListView) return _data;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_data);
+}
+
+
+/// Create a copy of QueuedPromptResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$QueuedPromptResponseCopyWith<_QueuedPromptResponse> get copyWith => __$QueuedPromptResponseCopyWithImpl<_QueuedPromptResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$QueuedPromptResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _QueuedPromptResponse&&const DeepCollectionEquality().equals(other._data, _data));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_data));
+
+@override
+String toString() {
+  return 'QueuedPromptResponse(data: $data)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$QueuedPromptResponseCopyWith<$Res> implements $QueuedPromptResponseCopyWith<$Res> {
+  factory _$QueuedPromptResponseCopyWith(_QueuedPromptResponse value, $Res Function(_QueuedPromptResponse) _then) = __$QueuedPromptResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ List<QueuedSessionPrompt> data
+});
+
+
+
+
+}
+/// @nodoc
+class __$QueuedPromptResponseCopyWithImpl<$Res>
+    implements _$QueuedPromptResponseCopyWith<$Res> {
+  __$QueuedPromptResponseCopyWithImpl(this._self, this._then);
+
+  final _QueuedPromptResponse _self;
+  final $Res Function(_QueuedPromptResponse) _then;
+
+/// Create a copy of QueuedPromptResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? data = null,}) {
+  return _then(_QueuedPromptResponse(
+data: null == data ? _self._data : data // ignore: cast_nullable_to_non_nullable
+as List<QueuedSessionPrompt>,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$CancelQueuedPromptRequest {
+
+ String get sessionId; String get promptId;
+/// Create a copy of CancelQueuedPromptRequest
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CancelQueuedPromptRequestCopyWith<CancelQueuedPromptRequest> get copyWith => _$CancelQueuedPromptRequestCopyWithImpl<CancelQueuedPromptRequest>(this as CancelQueuedPromptRequest, _$identity);
+
+  /// Serializes this CancelQueuedPromptRequest to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CancelQueuedPromptRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.promptId, promptId) || other.promptId == promptId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,sessionId,promptId);
+
+@override
+String toString() {
+  return 'CancelQueuedPromptRequest(sessionId: $sessionId, promptId: $promptId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CancelQueuedPromptRequestCopyWith<$Res>  {
+  factory $CancelQueuedPromptRequestCopyWith(CancelQueuedPromptRequest value, $Res Function(CancelQueuedPromptRequest) _then) = _$CancelQueuedPromptRequestCopyWithImpl;
+@useResult
+$Res call({
+ String sessionId, String promptId
+});
+
+
+
+
+}
+/// @nodoc
+class _$CancelQueuedPromptRequestCopyWithImpl<$Res>
+    implements $CancelQueuedPromptRequestCopyWith<$Res> {
+  _$CancelQueuedPromptRequestCopyWithImpl(this._self, this._then);
+
+  final CancelQueuedPromptRequest _self;
+  final $Res Function(CancelQueuedPromptRequest) _then;
+
+/// Create a copy of CancelQueuedPromptRequest
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? sessionId = null,Object? promptId = null,}) {
+  return _then(CancelQueuedPromptRequest(
+sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String,promptId: null == promptId ? _self.promptId : promptId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _CancelQueuedPromptRequest implements CancelQueuedPromptRequest {
+  const _CancelQueuedPromptRequest({required this.sessionId, required this.promptId});
+  factory _CancelQueuedPromptRequest.fromJson(Map<String, dynamic> json) => _$CancelQueuedPromptRequestFromJson(json);
+
+@override final  String sessionId;
+@override final  String promptId;
+
+/// Create a copy of CancelQueuedPromptRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CancelQueuedPromptRequestCopyWith<_CancelQueuedPromptRequest> get copyWith => __$CancelQueuedPromptRequestCopyWithImpl<_CancelQueuedPromptRequest>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$CancelQueuedPromptRequestToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CancelQueuedPromptRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.promptId, promptId) || other.promptId == promptId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,sessionId,promptId);
+
+@override
+String toString() {
+  return 'CancelQueuedPromptRequest(sessionId: $sessionId, promptId: $promptId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CancelQueuedPromptRequestCopyWith<$Res> implements $CancelQueuedPromptRequestCopyWith<$Res> {
+  factory _$CancelQueuedPromptRequestCopyWith(_CancelQueuedPromptRequest value, $Res Function(_CancelQueuedPromptRequest) _then) = __$CancelQueuedPromptRequestCopyWithImpl;
+@override @useResult
+$Res call({
+ String sessionId, String promptId
+});
+
+
+
+
+}
+/// @nodoc
+class __$CancelQueuedPromptRequestCopyWithImpl<$Res>
+    implements _$CancelQueuedPromptRequestCopyWith<$Res> {
+  __$CancelQueuedPromptRequestCopyWithImpl(this._self, this._then);
+
+  final _CancelQueuedPromptRequest _self;
+  final $Res Function(_CancelQueuedPromptRequest) _then;
+
+/// Create a copy of CancelQueuedPromptRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? sessionId = null,Object? promptId = null,}) {
+  return _then(_CancelQueuedPromptRequest(
+sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String,promptId: null == promptId ? _self.promptId : promptId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/shared/sesori_shared/lib/src/models/sesori/queued_prompt.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/queued_prompt.g.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'queued_prompt.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_QueuedSessionPrompt _$QueuedSessionPromptFromJson(Map json) =>
+    _QueuedSessionPrompt(
+      id: json['id'] as String,
+      text: json['text'] as String?,
+      command: json['command'] as String?,
+      attachmentCount: (json['attachmentCount'] as num?)?.toInt() ?? 0,
+      createdAt: (json['createdAt'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$QueuedSessionPromptToJson(
+  _QueuedSessionPrompt instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'text': ?instance.text,
+  'command': ?instance.command,
+  'attachmentCount': instance.attachmentCount,
+  'createdAt': instance.createdAt,
+};
+
+_QueuedPromptResponse _$QueuedPromptResponseFromJson(Map json) =>
+    _QueuedPromptResponse(
+      data: (json['data'] as List<dynamic>)
+          .map(
+            (e) => QueuedSessionPrompt.fromJson(
+              Map<String, dynamic>.from(e as Map),
+            ),
+          )
+          .toList(),
+    );
+
+Map<String, dynamic> _$QueuedPromptResponseToJson(
+  _QueuedPromptResponse instance,
+) => <String, dynamic>{'data': instance.data.map((e) => e.toJson()).toList()};
+
+_CancelQueuedPromptRequest _$CancelQueuedPromptRequestFromJson(Map json) =>
+    _CancelQueuedPromptRequest(
+      sessionId: json['sessionId'] as String,
+      promptId: json['promptId'] as String,
+    );
+
+Map<String, dynamic> _$CancelQueuedPromptRequestToJson(
+  _CancelQueuedPromptRequest instance,
+) => <String, dynamic>{
+  'sessionId': instance.sessionId,
+  'promptId': instance.promptId,
+};

--- a/shared/sesori_shared/lib/src/models/sesori/send_prompt_request.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/send_prompt_request.dart
@@ -6,7 +6,7 @@ part "send_prompt_request.freezed.dart";
 
 part "send_prompt_request.g.dart";
 
-/// Request body for `POST /session/prompt`.
+/// Request body for `POST /session/prompt_async`.
 @Freezed(fromJson: true, toJson: true)
 sealed class SendPromptRequest with _$SendPromptRequest {
   const factory({
@@ -16,6 +16,13 @@ sealed class SendPromptRequest with _$SendPromptRequest {
     required PromptModel? model,
     required String? command,
     required SessionVariant? variant,
+
+    /// Client-generated identity for this prompt, stable across retries.
+    ///
+    /// The bridge queues, dedupes, and correlates the eventual transcript
+    /// message under this id. Null from clients that predate it; the bridge
+    /// generates a fallback so plugins always receive one.
+    required String? promptId,
   }) = _SendPromptRequest;
 
   factory fromJson(Map<String, dynamic> json) => _$SendPromptRequestFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/send_prompt_request.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/send_prompt_request.freezed.dart
@@ -16,7 +16,12 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$SendPromptRequest {
 
- String get sessionId; List<PromptPart> get parts; String? get agent; PromptModel? get model; String? get command; SessionVariant? get variant;
+ String get sessionId; List<PromptPart> get parts; String? get agent; PromptModel? get model; String? get command; SessionVariant? get variant;/// Client-generated identity for this prompt, stable across retries.
+///
+/// The bridge queues, dedupes, and correlates the eventual transcript
+/// message under this id. Null from clients that predate it; the bridge
+/// generates a fallback so plugins always receive one.
+ String? get promptId;
 /// Create a copy of SendPromptRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +34,16 @@ $SendPromptRequestCopyWith<SendPromptRequest> get copyWith => _$SendPromptReques
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SendPromptRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&const DeepCollectionEquality().equals(other.parts, parts)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.model, model) || other.model == model)&&(identical(other.command, command) || other.command == command)&&(identical(other.variant, variant) || other.variant == variant));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SendPromptRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&const DeepCollectionEquality().equals(other.parts, parts)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.model, model) || other.model == model)&&(identical(other.command, command) || other.command == command)&&(identical(other.variant, variant) || other.variant == variant)&&(identical(other.promptId, promptId) || other.promptId == promptId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,sessionId,const DeepCollectionEquality().hash(parts),agent,model,command,variant);
+int get hashCode => Object.hash(runtimeType,sessionId,const DeepCollectionEquality().hash(parts),agent,model,command,variant,promptId);
 
 @override
 String toString() {
-  return 'SendPromptRequest(sessionId: $sessionId, parts: $parts, agent: $agent, model: $model, command: $command, variant: $variant)';
+  return 'SendPromptRequest(sessionId: $sessionId, parts: $parts, agent: $agent, model: $model, command: $command, variant: $variant, promptId: $promptId)';
 }
 
 
@@ -49,7 +54,7 @@ abstract mixin class $SendPromptRequestCopyWith<$Res>  {
   factory $SendPromptRequestCopyWith(SendPromptRequest value, $Res Function(SendPromptRequest) _then) = _$SendPromptRequestCopyWithImpl;
 @useResult
 $Res call({
- String sessionId, List<PromptPart> parts, String? agent, PromptModel? model, String? command, SessionVariant? variant
+ String sessionId, List<PromptPart> parts, String? agent, PromptModel? model, String? command, SessionVariant? variant, String? promptId
 });
 
 
@@ -66,7 +71,7 @@ class _$SendPromptRequestCopyWithImpl<$Res>
 
 /// Create a copy of SendPromptRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? sessionId = null,Object? parts = null,Object? agent = freezed,Object? model = freezed,Object? command = freezed,Object? variant = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? sessionId = null,Object? parts = null,Object? agent = freezed,Object? model = freezed,Object? command = freezed,Object? variant = freezed,Object? promptId = freezed,}) {
   return _then(SendPromptRequest(
 sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
 as String,parts: null == parts ? _self.parts : parts // ignore: cast_nullable_to_non_nullable
@@ -74,7 +79,8 @@ as List<PromptPart>,agent: freezed == agent ? _self.agent : agent // ignore: cas
 as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as PromptModel?,command: freezed == command ? _self.command : command // ignore: cast_nullable_to_non_nullable
 as String?,variant: freezed == variant ? _self.variant : variant // ignore: cast_nullable_to_non_nullable
-as SessionVariant?,
+as SessionVariant?,promptId: freezed == promptId ? _self.promptId : promptId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 /// Create a copy of SendPromptRequest
@@ -110,7 +116,7 @@ $SessionVariantCopyWith<$Res>? get variant {
 @JsonSerializable()
 
 class _SendPromptRequest implements SendPromptRequest {
-  const _SendPromptRequest({required this.sessionId, required  List<PromptPart> parts, required this.agent, required this.model, required this.command, required this.variant}): _parts = parts;
+  const _SendPromptRequest({required this.sessionId, required  List<PromptPart> parts, required this.agent, required this.model, required this.command, required this.variant, required this.promptId}): _parts = parts;
   factory _SendPromptRequest.fromJson(Map<String, dynamic> json) => _$SendPromptRequestFromJson(json);
 
 @override final  String sessionId;
@@ -125,6 +131,12 @@ class _SendPromptRequest implements SendPromptRequest {
 @override final  PromptModel? model;
 @override final  String? command;
 @override final  SessionVariant? variant;
+/// Client-generated identity for this prompt, stable across retries.
+///
+/// The bridge queues, dedupes, and correlates the eventual transcript
+/// message under this id. Null from clients that predate it; the bridge
+/// generates a fallback so plugins always receive one.
+@override final  String? promptId;
 
 /// Create a copy of SendPromptRequest
 /// with the given fields replaced by the non-null parameter values.
@@ -139,16 +151,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SendPromptRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&const DeepCollectionEquality().equals(other._parts, _parts)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.model, model) || other.model == model)&&(identical(other.command, command) || other.command == command)&&(identical(other.variant, variant) || other.variant == variant));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SendPromptRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&const DeepCollectionEquality().equals(other._parts, _parts)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.model, model) || other.model == model)&&(identical(other.command, command) || other.command == command)&&(identical(other.variant, variant) || other.variant == variant)&&(identical(other.promptId, promptId) || other.promptId == promptId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,sessionId,const DeepCollectionEquality().hash(_parts),agent,model,command,variant);
+int get hashCode => Object.hash(runtimeType,sessionId,const DeepCollectionEquality().hash(_parts),agent,model,command,variant,promptId);
 
 @override
 String toString() {
-  return 'SendPromptRequest(sessionId: $sessionId, parts: $parts, agent: $agent, model: $model, command: $command, variant: $variant)';
+  return 'SendPromptRequest(sessionId: $sessionId, parts: $parts, agent: $agent, model: $model, command: $command, variant: $variant, promptId: $promptId)';
 }
 
 
@@ -159,7 +171,7 @@ abstract mixin class _$SendPromptRequestCopyWith<$Res> implements $SendPromptReq
   factory _$SendPromptRequestCopyWith(_SendPromptRequest value, $Res Function(_SendPromptRequest) _then) = __$SendPromptRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String sessionId, List<PromptPart> parts, String? agent, PromptModel? model, String? command, SessionVariant? variant
+ String sessionId, List<PromptPart> parts, String? agent, PromptModel? model, String? command, SessionVariant? variant, String? promptId
 });
 
 
@@ -176,7 +188,7 @@ class __$SendPromptRequestCopyWithImpl<$Res>
 
 /// Create a copy of SendPromptRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? sessionId = null,Object? parts = null,Object? agent = freezed,Object? model = freezed,Object? command = freezed,Object? variant = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? sessionId = null,Object? parts = null,Object? agent = freezed,Object? model = freezed,Object? command = freezed,Object? variant = freezed,Object? promptId = freezed,}) {
   return _then(_SendPromptRequest(
 sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
 as String,parts: null == parts ? _self._parts : parts // ignore: cast_nullable_to_non_nullable
@@ -184,7 +196,8 @@ as List<PromptPart>,agent: freezed == agent ? _self.agent : agent // ignore: cas
 as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as PromptModel?,command: freezed == command ? _self.command : command // ignore: cast_nullable_to_non_nullable
 as String?,variant: freezed == variant ? _self.variant : variant // ignore: cast_nullable_to_non_nullable
-as SessionVariant?,
+as SessionVariant?,promptId: freezed == promptId ? _self.promptId : promptId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/send_prompt_request.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/send_prompt_request.g.dart
@@ -21,6 +21,7 @@ _SendPromptRequest _$SendPromptRequestFromJson(Map json) => _SendPromptRequest(
       : SessionVariant.fromJson(
           Map<String, dynamic>.from(json['variant'] as Map),
         ),
+  promptId: json['promptId'] as String?,
 );
 
 Map<String, dynamic> _$SendPromptRequestToJson(_SendPromptRequest instance) =>
@@ -31,6 +32,7 @@ Map<String, dynamic> _$SendPromptRequestToJson(_SendPromptRequest instance) =>
       'model': ?instance.model?.toJson(),
       'command': ?instance.command,
       'variant': ?instance.variant?.toJson(),
+      'promptId': ?instance.promptId,
     };
 
 PromptPartText _$PromptPartTextFromJson(Map json) => PromptPartText(

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
@@ -6,6 +6,7 @@ import "message_part.dart";
 import "plugin_management.dart";
 import "project_activity_summary.dart";
 import "question.dart";
+import "queued_prompt.dart";
 import "session.dart";
 import "session_status.dart";
 
@@ -144,6 +145,18 @@ sealed class SesoriSseEvent with _$SesoriSseEvent {
     required String arguments,
     required String messageID,
   }) = SesoriCommandExecuted;
+
+  /// Full replacement of the session's bridge-owned queued-prompt list.
+  ///
+  /// Emitted whenever the queue changes (accept, cancel, dispatch, abort,
+  /// failure). Carries the complete current list rather than a delta so a
+  /// missed event self-heals on the next one.
+  @FreezedUnionValue("session.queued-prompts")
+  @Implements<SesoriSessionEvent>()
+  const factory sessionQueuedPrompts({
+    required String sessionID,
+    required List<QueuedSessionPrompt> prompts,
+  }) = SesoriSessionQueuedPrompts;
 
   // ---------------------------------------------------------------------------
   // Message — all implement SesoriSessionEvent

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
@@ -88,6 +88,10 @@ SesoriSseEvent _$SesoriSseEventFromJson(
           return SesoriCommandExecuted.fromJson(
             json
           );
+                case 'session.queued-prompts':
+          return SesoriSessionQueuedPrompts.fromJson(
+            json
+          );
                 case 'message.updated':
           return SesoriMessageUpdated.fromJson(
             json
@@ -1538,6 +1542,87 @@ as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: 
 as String,arguments: null == arguments ? _self.arguments : arguments // ignore: cast_nullable_to_non_nullable
 as String,messageID: null == messageID ? _self.messageID : messageID // ignore: cast_nullable_to_non_nullable
 as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class SesoriSessionQueuedPrompts implements SesoriSseEvent, SesoriSessionEvent {
+  const SesoriSessionQueuedPrompts({required this.sessionID, required  List<QueuedSessionPrompt> prompts,  String? $type}): _prompts = prompts,$type = $type ?? 'session.queued-prompts';
+  factory SesoriSessionQueuedPrompts.fromJson(Map<String, dynamic> json) => _$SesoriSessionQueuedPromptsFromJson(json);
+
+ final  String sessionID;
+ final  List<QueuedSessionPrompt> _prompts;
+ List<QueuedSessionPrompt> get prompts {
+  if (_prompts is EqualUnmodifiableListView) return _prompts;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_prompts);
+}
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of SesoriSseEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SesoriSessionQueuedPromptsCopyWith<SesoriSessionQueuedPrompts> get copyWith => _$SesoriSessionQueuedPromptsCopyWithImpl<SesoriSessionQueuedPrompts>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SesoriSessionQueuedPromptsToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SesoriSessionQueuedPrompts&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&const DeepCollectionEquality().equals(other._prompts, _prompts));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,sessionID,const DeepCollectionEquality().hash(_prompts));
+
+@override
+String toString() {
+  return 'SesoriSseEvent.sessionQueuedPrompts(sessionID: $sessionID, prompts: $prompts)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SesoriSessionQueuedPromptsCopyWith<$Res> implements $SesoriSseEventCopyWith<$Res> {
+  factory $SesoriSessionQueuedPromptsCopyWith(SesoriSessionQueuedPrompts value, $Res Function(SesoriSessionQueuedPrompts) _then) = _$SesoriSessionQueuedPromptsCopyWithImpl;
+@useResult
+$Res call({
+ String sessionID, List<QueuedSessionPrompt> prompts
+});
+
+
+
+
+}
+/// @nodoc
+class _$SesoriSessionQueuedPromptsCopyWithImpl<$Res>
+    implements $SesoriSessionQueuedPromptsCopyWith<$Res> {
+  _$SesoriSessionQueuedPromptsCopyWithImpl(this._self, this._then);
+
+  final SesoriSessionQueuedPrompts _self;
+  final $Res Function(SesoriSessionQueuedPrompts) _then;
+
+/// Create a copy of SesoriSseEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? sessionID = null,Object? prompts = null,}) {
+  return _then(SesoriSessionQueuedPrompts(
+sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
+as String,prompts: null == prompts ? _self._prompts : prompts // ignore: cast_nullable_to_non_nullable
+as List<QueuedSessionPrompt>,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
@@ -240,6 +240,27 @@ Map<String, dynamic> _$SesoriCommandExecutedToJson(
   'type': instance.$type,
 };
 
+SesoriSessionQueuedPrompts _$SesoriSessionQueuedPromptsFromJson(Map json) =>
+    SesoriSessionQueuedPrompts(
+      sessionID: json['sessionID'] as String,
+      prompts: (json['prompts'] as List<dynamic>)
+          .map(
+            (e) => QueuedSessionPrompt.fromJson(
+              Map<String, dynamic>.from(e as Map),
+            ),
+          )
+          .toList(),
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$SesoriSessionQueuedPromptsToJson(
+  SesoriSessionQueuedPrompts instance,
+) => <String, dynamic>{
+  'sessionID': instance.sessionID,
+  'prompts': instance.prompts.map((e) => e.toJson()).toList(),
+  'type': instance.$type,
+};
+
 SesoriMessageUpdated _$SesoriMessageUpdatedFromJson(Map json) =>
     SesoriMessageUpdated(
       info: Message.fromJson(Map<String, dynamic>.from(json['info'] as Map)),

--- a/shared/sesori_shared/test/models/queued_prompt_test.dart
+++ b/shared/sesori_shared/test/models/queued_prompt_test.dart
@@ -1,0 +1,135 @@
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("QueuedSessionPrompt", () {
+    test("round-trips all fields through JSON", () {
+      const prompt = QueuedSessionPrompt(
+        id: "prm_1234",
+        text: "fix the tests",
+        command: null,
+        attachmentCount: 2,
+        createdAt: 1755450000000,
+      );
+
+      final decoded = QueuedSessionPrompt.fromJson(prompt.toJson());
+
+      expect(decoded, equals(prompt));
+    });
+
+    test("round-trips a command entry with null text", () {
+      const prompt = QueuedSessionPrompt(
+        id: "prm_5678",
+        text: null,
+        command: "review",
+        attachmentCount: 0,
+        createdAt: 1755450000000,
+      );
+
+      final json = prompt.toJson();
+      final decoded = QueuedSessionPrompt.fromJson(json);
+
+      expect(json.containsKey("text"), isFalse, reason: "null text must be omitted, never an empty string");
+      expect(decoded, equals(prompt));
+    });
+
+    test("decodes a payload without attachmentCount to zero", () {
+      final decoded = QueuedSessionPrompt.fromJson({
+        "id": "prm_9",
+        "createdAt": 1,
+      });
+
+      expect(decoded.attachmentCount, 0);
+      expect(decoded.text, isNull);
+      expect(decoded.command, isNull);
+    });
+  });
+
+  group("QueuedPromptResponse", () {
+    test("round-trips its data list through JSON", () {
+      const response = QueuedPromptResponse(
+        data: [
+          QueuedSessionPrompt(id: "prm_1", text: "a", command: null, attachmentCount: 0, createdAt: 1),
+          QueuedSessionPrompt(id: "prm_2", text: null, command: "compact", attachmentCount: 0, createdAt: 2),
+        ],
+      );
+
+      expect(QueuedPromptResponse.fromJson(response.toJson()), equals(response));
+    });
+  });
+
+  group("CancelQueuedPromptRequest", () {
+    test("round-trips through JSON", () {
+      const request = CancelQueuedPromptRequest(sessionId: "ses_1", promptId: "prm_1");
+
+      expect(CancelQueuedPromptRequest.fromJson(request.toJson()), equals(request));
+    });
+  });
+
+  group("SendPromptRequest.promptId", () {
+    test("round-trips when present and is omitted from JSON when null", () {
+      const withId = SendPromptRequest(
+        sessionId: "ses_1",
+        parts: [PromptPart.text(text: "hello")],
+        agent: null,
+        model: null,
+        command: null,
+        variant: null,
+        promptId: "prm_abc",
+      );
+
+      expect(SendPromptRequest.fromJson(withId.toJson()).promptId, "prm_abc");
+
+      final withoutId = withId.copyWith(promptId: null).toJson();
+      expect(withoutId.containsKey("promptId"), isFalse);
+    });
+
+    test("decodes an old-client payload without promptId to null", () {
+      final decoded = SendPromptRequest.fromJson({
+        "sessionId": "ses_1",
+        "parts": [
+          {"type": "text", "text": "hello"},
+        ],
+      });
+
+      expect(decoded.promptId, isNull);
+    });
+  });
+
+  group("MessageUser.promptId", () {
+    test("round-trips when present and decodes old payloads to null", () {
+      const message = Message.user(
+        id: "msg_1",
+        sessionID: "ses_1",
+        agent: null,
+        time: null,
+        promptId: "prm_abc",
+      );
+
+      final decoded = Message.fromJson(message.toJson());
+      expect(decoded, isA<MessageUser>());
+      expect((decoded as MessageUser).promptId, "prm_abc");
+
+      final old = Message.fromJson({"role": "user", "id": "msg_1", "sessionID": "ses_1"});
+      expect((old as MessageUser).promptId, isNull);
+    });
+  });
+
+  group("SesoriSessionQueuedPrompts", () {
+    test("round-trips through the SSE union with its wire type tag", () {
+      const event = SesoriSseEvent.sessionQueuedPrompts(
+        sessionID: "ses_1",
+        prompts: [
+          QueuedSessionPrompt(id: "prm_1", text: "queued text", command: null, attachmentCount: 1, createdAt: 7),
+        ],
+      );
+
+      final json = event.toJson();
+      expect(json["type"], "session.queued-prompts");
+
+      final decoded = SesoriSseEvent.fromJson(json);
+      expect(decoded, equals(event));
+      expect(decoded, isA<SesoriSessionEvent>());
+    });
+  });
+}

--- a/shared/sesori_shared/test/models/sesori_sse_event_test.dart
+++ b/shared/sesori_shared/test/models/sesori_sse_event_test.dart
@@ -642,7 +642,7 @@ void main() {
 
     test('messageUpdated implements SesoriSessionEvent', () {
       const event = SesoriSseEvent.messageUpdated(
-        info: Message.user(id: 'm', sessionID: 's', agent: null, time: null),
+        info: Message.user(promptId: null, id: 'm', sessionID: 's', agent: null, time: null),
       );
       expect(event, isA<SesoriSessionEvent>());
     });
@@ -913,7 +913,7 @@ void main() {
 
     test('messageUpdated uses message.updated', () {
       final json = const SesoriSseEvent.messageUpdated(
-        info: Message.user(id: 'm', sessionID: 's', agent: null, time: null),
+        info: Message.user(promptId: null, id: 'm', sessionID: 's', agent: null, time: null),
       ).toJson();
       expect(json['type'], 'message.updated');
     });


### PR DESCRIPTION
## Complexity

⚙️ Moderate — wide but almost entirely mechanical surface: new wire/interface models and one SSE variant, a lockstep `promptId` parameter on the plugin send contract across every implementer and test fake, and no-op/pass-through switch arms. No behavior change on any send path.

## What

Step 2 of the bridge-owned prompt queue ([plan](.plan/active/bridge-owned-prompt-queue/PLAN.md)):

- `sesori_shared`: `SendPromptRequest.promptId` (optional), `QueuedSessionPrompt` + `QueuedPromptResponse` + `CancelQueuedPromptRequest`, `MessageUser.promptId` (optional), and the `session.queued-prompts` SSE union variant (session-scoped, full-list replace semantics).
- `sesori_plugin_interface`: `PluginQueuedPrompt`, `BridgeSseQueuedPromptsUpdated`, `sendPrompt`/`sendCommand` gain `required String promptId` with the accept-not-run-completion contract now documented on `sendPrompt` too, and `getQueuedPrompts`/`cancelQueuedPrompt` with concrete empty/false default bodies.
- Bridge app: `SendPromptHandler → SessionPromptService → SessionRepository` thread `promptId`, generating a `prm_…` fallback when the client omits it (old clients, bridge-originated initial commands); the session-event and bridge-event mappers translate/relay the new event.
- Plugins, lockstep: ACP stamps `promptId` onto its acceptance-time user echo (its `mapSentPrompt` already fulfills the correlation contract); Claude/Codex/OpenCode accept and ignore it for now (Claude consumes it in step 4); all `Message.user`/`PluginMessage.user` construction sites and test fakes updated.
- Client: exhaustive-switch arms for the new event (no-op until step 5); `SessionApi` sends `promptId: null` until step 5 threads real ids.

## Why

The plan's contracts must land first so the bridge (step 3), the Claude queue owner (step 4), and the client rendering (step 5) can build on a stable wire surface. The `promptId` identity is what makes queued→sent transforms atomic and client retries idempotent.

## Risk and test focus

Low. No send-path behavior changes: acceptance timing, queueing, and rendering are untouched. Focus: wire compatibility of the new optional fields (`include_if_null: false` keeps them off the wire when null; omitted keys decode to null/`@Default(0)`), the old-client unknown-SSE-type skip (verified against the shipped decoder in `connection_service.dart:563-604`), and that the ACP echo now carrying `promptId` changes nothing for clients that ignore the field.

## Expected result

No user-visible or database impact. All suites green: shared (409 tests incl. new round-trips in `test/models/queued_prompt_test.dart`), full bridge matrix, client `module_core` and `app`. A reviewer should see identical runtime behavior with the new contract surface compiled in everywhere.

## Verification

- `dart analyze`: clean on shared, all bridge packages, and all client modules.
- `dart test` shared (409 passed), full bridge `make test`, client `module_core` suite, `flutter test` app suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce prompt IDs and the queued‑prompt wire surface without changing send behavior. Previously `sendPrompt`/`sendCommand` had no ID and no queue events; now plugins receive a `promptId`, and the bridge can relay session‑scoped queued‑prompt updates.

- `sesori_shared`: add `SendPromptRequest.promptId` (optional), `Message.user.promptId` (optional), `QueuedSessionPrompt`, and `SesoriSseEvent.session.queued-prompts`.
- `sesori_plugin_interface`: add `PluginQueuedPrompt` and `BridgeSseQueuedPromptsUpdated`; make `sendPrompt`/`sendCommand` require `promptId`; add `getQueuedPrompts`/`cancelQueuedPrompt` with empty/false defaults.
- Bridge: thread `promptId` from `SendPromptHandler` → `SessionPromptService` (generates fallback when null) → `SessionRepository` → plugins; map `BridgeSseQueuedPromptsUpdated` to `SesoriSseEvent.session.queued-prompts`.
- Plugins: ACP tags its acceptance‑time user echo with `promptId`; other plugins accept and ignore it for now; fakes/tests updated.
- Client: `SessionApi` sends `promptId: null` for now; new SSE event is no‑op until rendering lands; older clients stay compatible (null fields omitted, unknown SSE types skipped).

**Migration notes**
- Update all plugins to the new `sendPrompt({..., required String promptId, ...})` and `sendCommand({..., required String promptId, ...})` signatures.
- Queue‑owning plugins should emit `BridgeSseQueuedPromptsUpdated` and implement `getQueuedPrompts`/`cancelQueuedPrompt`; non‑queuing plugins may return `[]`/`false`.
- When a queued prompt is consumed, include `promptId` on `PluginMessage.user` so clients can atomically swap the queued bubble for the sent message.

<sup>Written for commit 6e9b20e9969d23717084b85e3aba91c926067dec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

