### PR TITLE
🌱 Model system/hook_started, hook_progress and hook_response frames

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/api/claude_stream_client.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/claude_stream_client.dart
@@ -288,6 +288,8 @@ class ClaudeStreamClient({
       case ClaudeStatusMessage():
       case ClaudeThinkingTokensMessage():
       case ClaudeTaskProgressMessage():
+      case ClaudeHookStartedMessage():
+      case ClaudeHookOutputMessage():
       case ClaudeApiRetryMessage():
       case ClaudeAssistantMessage():
       case ClaudeUserMessage():

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
@@ -58,6 +58,22 @@ sealed class const ClaudeStreamMessage({
             raw: json,
           ),
           "task_progress" => ClaudeTaskProgressMessage.fromJson(json, sessionId: sessionId, uuid: uuid),
+          "hook_started" => ClaudeHookStartedMessage(
+            hookId: _stringOrNull(json["hook_id"]),
+            hookName: _stringOrNull(json["hook_name"]),
+            hookEvent: _stringOrNull(json["hook_event"]),
+            sessionId: sessionId,
+            uuid: uuid,
+            raw: json,
+          ),
+          // `hook_progress` shares the output shape and the same emitter, so it
+          // is modelled here rather than left to surface as a later unknown.
+          "hook_progress" || "hook_response" => ClaudeHookOutputMessage.fromJson(
+            json,
+            phase: subtype == "hook_progress" ? ClaudeHookPhase.progress : ClaudeHookPhase.response,
+            sessionId: sessionId,
+            uuid: uuid,
+          ),
           _ => ClaudeUnknownMessage(type: type, subtype: subtype, sessionId: sessionId, uuid: uuid, raw: json),
         };
       case "assistant":
@@ -202,6 +218,53 @@ final class const ClaudeTaskProgressMessage({
       raw: json,
     );
   }
+}
+
+/// `system`/`hook_started` — a hook began running for a lifecycle event.
+final class const ClaudeHookStartedMessage({
+  required final String? hookId,
+  required final String? hookName,
+
+  /// The lifecycle event that triggered the hook, e.g. `PreToolUse`.
+  required final String? hookEvent,
+  required super.sessionId,
+  required super.uuid,
+  required super.raw,
+}) extends ClaudeStreamMessage;
+
+enum ClaudeHookPhase() { progress, response }
+
+/// `system`/`hook_progress` and `system`/`hook_response` — streamed and final
+/// output from a running hook. `exitCode` only arrives with the final frame.
+final class const ClaudeHookOutputMessage({
+  required final ClaudeHookPhase phase,
+  required final String? hookId,
+  required final String? hookName,
+  required final String? hookEvent,
+  required final String? stdout,
+  required final String? stderr,
+  required final int? exitCode,
+  required super.sessionId,
+  required super.uuid,
+  required super.raw,
+}) extends ClaudeStreamMessage {
+  factory fromJson(
+    Map<String, Object?> json, {
+    required ClaudeHookPhase phase,
+    required String? sessionId,
+    required String? uuid,
+  }) => ClaudeHookOutputMessage(
+    phase: phase,
+    hookId: _stringOrNull(json["hook_id"]),
+    hookName: _stringOrNull(json["hook_name"]),
+    hookEvent: _stringOrNull(json["hook_event"]),
+    stdout: _stringOrNull(json["stdout"]),
+    stderr: _stringOrNull(json["stderr"]),
+    exitCode: _intOrNull(json["exit_code"]),
+    sessionId: sessionId,
+    uuid: uuid,
+    raw: json,
+  );
 }
 
 enum ClaudeAssistantError() {

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -72,9 +72,11 @@ final class ClaudeEventDispatcher({
         ClaudeInitMessage() ||
         ClaudeStatusMessage() ||
         // ponytail: parsed but not surfaced — no client UI consumes thinking
-        // token estimates or subagent task progress yet.
+        // token estimates, subagent task progress, or hook output yet.
         ClaudeThinkingTokensMessage() ||
         ClaudeTaskProgressMessage() ||
+        ClaudeHookStartedMessage() ||
+        ClaudeHookOutputMessage() ||
         ClaudeControlRequestMessage() ||
         ClaudeControlResponseMessage() ||
         ClaudeRateLimitMessage() ||

--- a/bridge/sesori_plugin_claude/test/claude_stream_message_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_stream_message_test.dart
@@ -238,6 +238,49 @@ void main() {
       expect(message.durationMs, 4500);
     });
 
+    test("reads hook start and hook output frames", () {
+      final started =
+          ClaudeStreamMessage.parse({
+                "type": "system",
+                "subtype": "hook_started",
+                "hook_id": "hook-1",
+                "hook_name": "format",
+                "hook_event": "PostToolUse",
+              })
+              as ClaudeHookStartedMessage;
+
+      expect(started.hookId, "hook-1");
+      expect(started.hookName, "format");
+      expect(started.hookEvent, "PostToolUse");
+
+      final progress =
+          ClaudeStreamMessage.parse({
+                "type": "system",
+                "subtype": "hook_progress",
+                "hook_id": "hook-1",
+                "stdout": "formatting",
+              })
+              as ClaudeHookOutputMessage;
+
+      expect(progress.phase, ClaudeHookPhase.progress);
+      expect(progress.stdout, "formatting");
+      expect(progress.exitCode, isNull);
+
+      final response =
+          ClaudeStreamMessage.parse({
+                "type": "system",
+                "subtype": "hook_response",
+                "hook_id": "hook-1",
+                "stderr": "warning",
+                "exit_code": 2,
+              })
+              as ClaudeHookOutputMessage;
+
+      expect(response.phase, ClaudeHookPhase.response);
+      expect(response.stderr, "warning");
+      expect(response.exitCode, 2);
+    });
+
     test("absorbs unknown types and unknown system subtypes", () {
       final unknownType = ClaudeStreamMessage.parse({"type": "some_future_event", "session_id": "s"});
       expect(unknownType, isA<ClaudeUnknownMessage>());


### PR DESCRIPTION
## Complexity
Trivial: two more sealed variants in the existing hand-written stream-message union, plus their switch arms. Follow-up to #945.

## What
Parses `system`/`hook_started` into `ClaudeHookStartedMessage` (`hook_id`, `hook_name`, `hook_event`) and `system`/`hook_progress` + `system`/`hook_response` into `ClaudeHookOutputMessage` (same identity fields plus `stdout`, `stderr`, and the response-only `exit_code`), discriminated by a `ClaudeHookPhase` enum.

## Why
Hook lifecycle frames are emitted on ordinary turns and were falling through to `ClaudeUnknownMessage`, logging `unmodelled frame type=system subtype=hook_started` / `hook_response` repeatedly. `hook_progress` shares the emitter and payload shape of `hook_response` in the CLI, so it is modelled now rather than surfacing as the next unknown subtype.

## Risk and test focus
No user-visible impact and no database impact: the dispatcher maps both variants to no SSE events, so client behavior is unchanged. Hook stdout/stderr are parsed but never logged. Field names were read from the CLI 2.1.233 emit sites; misshaped payloads still degrade to nulls rather than throwing. Focus: `claude_stream_message_test.dart`.

## Expected result
The three hook subtypes no longer appear as `unmodelled frame` in bridge logs, and their fields are available typed for a future UI surface.

## Verification
- `dart analyze lib test` in `bridge/sesori_plugin_claude` — no errors or warnings
- `dart test test/claude_stream_message_test.dart` — 19 passing, including the new hook case


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Models `system/hook_started`, `system/hook_progress`, and `system/hook_response` stream frames so they no longer fall into `ClaudeUnknownMessage`. Previously these frames logged as “unmodelled”; now they parse to typed messages without changing client behavior.

- Adds `ClaudeHookStartedMessage` (`hook_id`, `hook_name`, `hook_event`) and `ClaudeHookOutputMessage` (`phase`, `hook_id`, `hook_name`, `hook_event`, `stdout`, `stderr`, `exit_code`) with `ClaudeHookPhase` (`progress`/`response`).
- Parses `hook_progress` and `hook_response` via the same factory, reflecting their shared payload shape; tolerant parsing degrades missing/invalid fields to null.
- Updates the dispatcher to ignore these frames (no SSE events), matching thinking-token and task-progress handling; no UI, DB, or API changes.
- Adds tests covering start/progress/response parsing and exit code; all existing tests pass.

<sup>Written for commit c0b46bb8494c71f83d7036634a1d540d2f06d692. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

