### PR TITLE
⚙️ [bridge-owned-prompt-queue] bridge: route and relay the queued-prompt surface [step 3/7]

### DIFF
--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -93,6 +93,7 @@ import "repositories/trackers/session_event_tracker.dart";
 import "repositories/worktree_repository.dart";
 import "routing/abort_session_handler.dart";
 import "routing/bridge_restart_dispatcher.dart";
+import "routing/cancel_queued_prompt_handler.dart";
 import "routing/create_directory_handler.dart";
 import "routing/create_project_handler.dart";
 import "routing/create_session_handler.dart";
@@ -106,6 +107,7 @@ import "routing/get_current_project_handler.dart";
 import "routing/get_project_questions_handler.dart";
 import "routing/get_projects_handler.dart";
 import "routing/get_providers_handler.dart";
+import "routing/get_queued_prompts_handler.dart";
 import "routing/get_session_attachment_handler.dart";
 import "routing/get_session_diffs_handler.dart";
 import "routing/get_session_handler.dart";
@@ -565,6 +567,8 @@ class Orchestrator({
         ),
         DeleteSessionHandler(sessionDeletionService: sessionDeletionService),
         SendPromptHandler(sessionPromptService: sessionPromptService),
+        GetQueuedPromptsHandler(sessionRepository: sessionRepository),
+        CancelQueuedPromptHandler(sessionPromptService: sessionPromptService),
         AbortSessionHandler(sessionAbortService: sessionAbortService),
         GetProvidersHandler(providerRepository),
         GetAgentsHandler(agentRepository),

--- a/bridge/app/lib/src/bridge/plugin_to_shared_mapping.dart
+++ b/bridge/app/lib/src/bridge/plugin_to_shared_mapping.dart
@@ -114,3 +114,19 @@ extension PluginMessagePartMapping on PluginMessagePart {
     attachment: attachment?.toShared(),
   );
 }
+
+/// Maps plugin-level queued prompts to the shared wire model.
+extension PluginQueuedPromptMapping on PluginQueuedPrompt {
+  QueuedSessionPrompt toSharedQueuedPrompt() => QueuedSessionPrompt(
+    id: id,
+    text: text,
+    command: command,
+    attachmentCount: attachmentCount,
+    createdAt: createdAt,
+  );
+}
+
+extension PluginQueuedPromptsMapping on Iterable<PluginQueuedPrompt> {
+  List<QueuedSessionPrompt> toSharedQueuedPrompts() =>
+      map((prompt) => prompt.toSharedQueuedPrompt()).toList(growable: false);
+}

--- a/bridge/app/lib/src/bridge/repositories/models/session_operation.dart
+++ b/bridge/app/lib/src/bridge/repositories/models/session_operation.dart
@@ -13,6 +13,8 @@ enum SessionOperation() {
   abortSession,
   getChildSessions,
   getPendingQuestions,
+  getQueuedPrompts,
+  cancelQueuedPrompt,
   replyToQuestion,
   rejectQuestion,
   getPendingPermissions,

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -2,6 +2,7 @@ import "dart:async";
 import "dart:math";
 
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
+
     show
         BridgeDerivedProjectsPluginApi,
         BridgePluginApi,
@@ -24,6 +25,7 @@ import "package:sesori_shared/sesori_shared.dart"
         PromptModel,
         PromptPart,
         PullRequestInfo,
+        QueuedSessionPrompt,
         Session,
         SessionStatusResponse,
         SessionVariant;
@@ -35,6 +37,7 @@ import "../../api/database/tables/projects_table.dart" show ProjectDto;
 import "../../api/database/tables/pull_requests_table.dart";
 import "../../api/database/tables/session_table.dart" show SessionDto;
 import "../../repositories/project_catalog_identity_calculator.dart";
+import "../plugin_to_shared_mapping.dart";
 import "../runtime/plugin_runtime.dart";
 import "mappers/plugin_activity_summary_mapper.dart";
 import "mappers/plugin_command_mapper.dart";
@@ -349,6 +352,45 @@ class SessionRepository({
         );
       },
     );
+  }
+
+  /// The prompts accepted for [sessionId] but not yet dispatched to its
+  /// backend, in dispatch order, mapped to the shared wire model.
+  ///
+  /// Deliberately does not start a stopped backend: the queue lives in the
+  /// plugin's memory, so a stopped one holds nothing.
+  Future<List<QueuedSessionPrompt>> getQueuedPrompts({required String sessionId}) async {
+    final binding = await _requireBinding(
+      sessionId: sessionId,
+      operation: SessionOperation.getQueuedPrompts,
+    );
+    final prompts = await _runtime.useIfActive(
+      pluginId: binding.pluginId,
+      operation: SessionOperation.getQueuedPrompts,
+      body: (plugin, _) async =>
+          (await plugin.getQueuedPrompts(sessionId: binding.backendSessionId)).toSharedQueuedPrompts(),
+    );
+    return prompts ?? const [];
+  }
+
+  /// Cancels the queued prompt [promptId] on [sessionId] before dispatch.
+  ///
+  /// Returns whether an entry was removed; `false` covers an unknown id, an
+  /// already-dispatched prompt, and a stopped backend (whose queue is empty).
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async {
+    final binding = await _requireBinding(
+      sessionId: sessionId,
+      operation: SessionOperation.cancelQueuedPrompt,
+    );
+    final removed = await _runtime.useIfActive(
+      pluginId: binding.pluginId,
+      operation: SessionOperation.cancelQueuedPrompt,
+      body: (plugin, _) => plugin.cancelQueuedPrompt(
+        sessionId: binding.backendSessionId,
+        promptId: promptId,
+      ),
+    );
+    return removed ?? false;
   }
 
   /// All messages of [sessionId], mapped to the shared model. The stored

--- a/bridge/app/lib/src/bridge/routing/cancel_queued_prompt_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/cancel_queued_prompt_handler.dart
@@ -1,0 +1,40 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../services/session_prompt_service.dart";
+import "request_handler.dart";
+
+/// Handles `POST /session/prompt/cancel` — removes a bridge-queued prompt
+/// before it dispatches to the backend.
+class CancelQueuedPromptHandler({required final SessionPromptService _sessionPromptService})
+    extends BodyRequestHandler<CancelQueuedPromptRequest, SuccessEmptyResponse> {
+  this
+    : super(
+        HttpMethod.post,
+        "/session/prompt/cancel",
+        fromJson: CancelQueuedPromptRequest.fromJson,
+      );
+
+  @override
+  Future<SuccessEmptyResponse> handle(
+    RelayRequest request, {
+    required CancelQueuedPromptRequest body,
+    required Map<String, String> pathParams,
+    required Map<String, String> queryParams,
+    required String? fragment,
+  }) async {
+    if (body.sessionId.isEmpty || body.promptId.isEmpty) {
+      throw buildErrorResponse(request, 400, "empty session or prompt id");
+    }
+
+    final removed = await _sessionPromptService.cancelQueuedPrompt(
+      sessionId: body.sessionId,
+      promptId: body.promptId,
+    );
+    // Clients treat this as benign: the entry already dispatched (became a
+    // turn) or was removed by another client.
+    if (!removed) {
+      throw buildErrorResponse(request, 404, "queued prompt not found");
+    }
+    return const SuccessEmptyResponse();
+  }
+}

--- a/bridge/app/lib/src/bridge/routing/get_queued_prompts_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_queued_prompts_handler.dart
@@ -1,0 +1,33 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../repositories/session_repository.dart";
+import "request_handler.dart";
+
+/// Handles `POST /session/queued_prompts` — returns the prompts the bridge has
+/// accepted for a session but not yet dispatched to its backend.
+class GetQueuedPromptsHandler({required final SessionRepository _sessionRepository})
+    extends BodyRequestHandler<SessionIdRequest, QueuedPromptResponse> {
+  this
+    : super(
+        HttpMethod.post,
+        "/session/queued_prompts",
+        fromJson: SessionIdRequest.fromJson,
+      );
+
+  @override
+  Future<QueuedPromptResponse> handle(
+    RelayRequest request, {
+    required SessionIdRequest body,
+    required Map<String, String> pathParams,
+    required Map<String, String> queryParams,
+    required String? fragment,
+  }) async {
+    final sessionId = body.sessionId;
+    if (sessionId.isEmpty) {
+      throw buildErrorResponse(request, 400, "empty session id");
+    }
+
+    final prompts = await _sessionRepository.getQueuedPrompts(sessionId: sessionId);
+    return QueuedPromptResponse(data: prompts);
+  }
+}

--- a/bridge/app/lib/src/bridge/services/session_prompt_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_prompt_service.dart
@@ -107,6 +107,19 @@ class SessionPromptService({
     );
   }
 
+  /// Cancels the queued prompt [promptId] on [sessionId] before dispatch.
+  ///
+  /// Runs on the same serialized family lane as sends, so a cancel cannot
+  /// race the enqueue or dispatch of the entry it names. Returns whether an
+  /// entry was removed.
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) {
+    return _dispatcher.dispatch(
+      sessionId: sessionId,
+      operation: SessionOperation.cancelQueuedPrompt,
+      body: () => _sessionRepository.cancelQueuedPrompt(sessionId: sessionId, promptId: promptId),
+    );
+  }
+
   Future<void> _updatePromptDefaults({
     required String sessionId,
     required SessionVariant? variant,

--- a/bridge/app/lib/src/bridge/services/session_prompt_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_prompt_service.dart
@@ -110,13 +110,17 @@ class SessionPromptService({
   /// Cancels the queued prompt [promptId] on [sessionId] before dispatch.
   ///
   /// Runs on the same serialized family lane as sends, so a cancel cannot
-  /// race the enqueue or dispatch of the entry it names. Returns whether an
-  /// entry was removed.
+  /// race the enqueue or dispatch of the entry it names, and holds the same
+  /// archive-permanence rule as every other session mutation. Returns whether
+  /// an entry was removed.
   Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) {
     return _dispatcher.dispatch(
       sessionId: sessionId,
       operation: SessionOperation.cancelQueuedPrompt,
-      body: () => _sessionRepository.cancelQueuedPrompt(sessionId: sessionId, promptId: promptId),
+      body: () async {
+        await _archivedSessionValidator.requireNotArchived(sessionId: sessionId);
+        return await _sessionRepository.cancelQueuedPrompt(sessionId: sessionId, promptId: promptId);
+      },
     );
   }
 

--- a/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
@@ -147,16 +147,7 @@ class BridgeEventMapper({
         BridgeSseTodoUpdated(:final sessionID) => SesoriSseEvent.todoUpdated(sessionID: sessionID),
         BridgeSseQueuedPromptsUpdated(:final sessionID, :final prompts) => SesoriSseEvent.sessionQueuedPrompts(
           sessionID: sessionID,
-          prompts: [
-            for (final prompt in prompts)
-              QueuedSessionPrompt(
-                id: prompt.id,
-                text: prompt.text,
-                command: prompt.command,
-                attachmentCount: prompt.attachmentCount,
-                createdAt: prompt.createdAt,
-              ),
-          ],
+          prompts: prompts.toSharedQueuedPrompts(),
         ),
         // BridgeSseProjectUpdated triggers a full projects-summary rebuild, but
         // the summary needs repository data (the bridge's session→project

--- a/bridge/app/test/bridge/routing/cancel_queued_prompt_handler_test.dart
+++ b/bridge/app/test/bridge/routing/cancel_queued_prompt_handler_test.dart
@@ -1,3 +1,4 @@
+import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/bridge/routing/cancel_queued_prompt_handler.dart";
 import "package:sesori_bridge/src/bridge/services/archived_session_validator.dart";
@@ -14,10 +15,11 @@ void main() {
   group("CancelQueuedPromptHandler", () {
     late FakeBridgePlugin plugin;
     late CancelQueuedPromptHandler handler;
+    late AppDatabase db;
 
     setUp(() async {
       plugin = FakeBridgePlugin();
-      final db = createTestDatabase();
+      db = createTestDatabase();
       addTearDown(db.close);
       await recordSessionBinding(
         database: db,
@@ -85,6 +87,26 @@ void main() {
       expect(response, isA<SuccessEmptyResponse>());
       expect(plugin.queuedPrompts, isEmpty);
       expect(plugin.cancelQueuedPromptCalls, [(sessionId: "backend-s-1", promptId: "prm_1")]);
+    });
+
+    test("refuses to cancel on an archived session without reaching the plugin", () async {
+      plugin.queuedPrompts.add(
+        const PluginQueuedPrompt(id: "prm_1", text: "queued", command: null, attachmentCount: 0, createdAt: 1),
+      );
+      await db.sessionDao.setArchived(sessionId: "s-1", archivedAt: 5, updatedAt: 5, projectionUpdatedAt: 5);
+
+      await expectLater(
+        () => handler.handle(
+          makeRequest("POST", "/session/prompt/cancel"),
+          body: const CancelQueuedPromptRequest(sessionId: "s-1", promptId: "prm_1"),
+          pathParams: {},
+          queryParams: {},
+          fragment: null,
+        ),
+        throwsA(isA<SessionArchivedReadOnlyException>()),
+      );
+      expect(plugin.cancelQueuedPromptCalls, isEmpty);
+      expect(plugin.queuedPrompts, hasLength(1));
     });
 
     test("returns 404 when the entry no longer exists", () async {

--- a/bridge/app/test/bridge/routing/cancel_queued_prompt_handler_test.dart
+++ b/bridge/app/test/bridge/routing/cancel_queued_prompt_handler_test.dart
@@ -1,0 +1,103 @@
+import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
+import "package:sesori_bridge/src/bridge/routing/cancel_queued_prompt_handler.dart";
+import "package:sesori_bridge/src/bridge/services/archived_session_validator.dart";
+import "package:sesori_bridge/src/bridge/services/session_operation_dispatcher.dart";
+import "package:sesori_bridge/src/bridge/services/session_prompt_service.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "../../helpers/test_database.dart";
+import "routing_test_helpers.dart";
+
+void main() {
+  group("CancelQueuedPromptHandler", () {
+    late FakeBridgePlugin plugin;
+    late CancelQueuedPromptHandler handler;
+
+    setUp(() async {
+      plugin = FakeBridgePlugin();
+      final db = createTestDatabase();
+      addTearDown(db.close);
+      await recordSessionBinding(
+        database: db,
+        sessionId: "s-1",
+        backendSessionId: "backend-s-1",
+        pluginId: plugin.id,
+        projectId: "/repo",
+        parentSessionId: null,
+      );
+      final repository = singlePluginSessionRepository(
+        plugin: plugin,
+        sessionDao: db.sessionDao,
+        projectsDao: db.projectsDao,
+        pullRequestDao: db.pullRequestDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+      );
+      final dispatcher = SessionOperationDispatcher(sessionRepository: repository);
+      final service = SessionPromptService(
+        sessionRepository: repository,
+        dispatcher: dispatcher,
+        archivedSessionValidator: ArchivedSessionValidator(sessionRepository: repository),
+      );
+      addTearDown(dispatcher.dispose);
+      addTearDown(service.dispose);
+      handler = CancelQueuedPromptHandler(sessionPromptService: service);
+    });
+
+    tearDown(() => plugin.close());
+
+    test("canHandle POST /session/prompt/cancel", () {
+      expect(handler.canHandle(makeRequest("POST", "/session/prompt/cancel")), isTrue);
+    });
+
+    test("returns 400 for an empty session or prompt id", () async {
+      for (final body in const [
+        CancelQueuedPromptRequest(sessionId: "", promptId: "prm_1"),
+        CancelQueuedPromptRequest(sessionId: "s-1", promptId: ""),
+      ]) {
+        await expectLater(
+          () => handler.handle(
+            makeRequest("POST", "/session/prompt/cancel"),
+            body: body,
+            pathParams: {},
+            queryParams: {},
+            fragment: null,
+          ),
+          throwsA(isA<RelayResponse>().having((r) => r.status, "status", equals(400))),
+        );
+      }
+    });
+
+    test("removes the queued entry via the backend session id", () async {
+      plugin.queuedPrompts.add(
+        const PluginQueuedPrompt(id: "prm_1", text: "queued", command: null, attachmentCount: 0, createdAt: 1),
+      );
+
+      final response = await handler.handle(
+        makeRequest("POST", "/session/prompt/cancel"),
+        body: const CancelQueuedPromptRequest(sessionId: "s-1", promptId: "prm_1"),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(response, isA<SuccessEmptyResponse>());
+      expect(plugin.queuedPrompts, isEmpty);
+      expect(plugin.cancelQueuedPromptCalls, [(sessionId: "backend-s-1", promptId: "prm_1")]);
+    });
+
+    test("returns 404 when the entry no longer exists", () async {
+      await expectLater(
+        () => handler.handle(
+          makeRequest("POST", "/session/prompt/cancel"),
+          body: const CancelQueuedPromptRequest(sessionId: "s-1", promptId: "prm_gone"),
+          pathParams: {},
+          queryParams: {},
+          fragment: null,
+        ),
+        throwsA(isA<RelayResponse>().having((r) => r.status, "status", equals(404))),
+      );
+    });
+  });
+}

--- a/bridge/app/test/bridge/routing/get_queued_prompts_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_queued_prompts_handler_test.dart
@@ -1,0 +1,103 @@
+import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.dart";
+import "package:sesori_bridge/src/bridge/routing/get_queued_prompts_handler.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "../../helpers/test_database.dart";
+import "routing_test_helpers.dart";
+
+void main() {
+  group("GetQueuedPromptsHandler", () {
+    late FakeBridgePlugin plugin;
+    late GetQueuedPromptsHandler handler;
+
+    setUp(() async {
+      plugin = FakeBridgePlugin();
+      final db = createTestDatabase();
+      addTearDown(db.close);
+      await recordSessionBinding(
+        database: db,
+        sessionId: "s-1",
+        backendSessionId: "backend-s-1",
+        pluginId: plugin.id,
+        projectId: "/repo",
+        parentSessionId: null,
+      );
+      handler = GetQueuedPromptsHandler(
+        sessionRepository: singlePluginSessionRepository(
+          plugin: plugin,
+          sessionDao: db.sessionDao,
+          projectsDao: db.projectsDao,
+          pullRequestDao: db.pullRequestDao,
+          unseenCalculator: const SessionUnseenCalculator(),
+        ),
+      );
+    });
+
+    tearDown(() => plugin.close());
+
+    test("canHandle POST /session/queued_prompts and rejects GET", () {
+      expect(handler.canHandle(makeRequest("POST", "/session/queued_prompts")), isTrue);
+      expect(handler.canHandle(makeRequest("GET", "/session/queued_prompts")), isFalse);
+    });
+
+    test("returns 400 when session id is empty", () async {
+      await expectLater(
+        () => handler.handle(
+          makeRequest("POST", "/session/queued_prompts"),
+          body: const SessionIdRequest(sessionId: ""),
+          pathParams: {},
+          queryParams: {},
+          fragment: null,
+        ),
+        throwsA(isA<RelayResponse>().having((r) => r.status, "status", equals(400))),
+      );
+    });
+
+    test("maps plugin entries to the shared wire model in order", () async {
+      plugin.queuedPrompts.addAll(const [
+        PluginQueuedPrompt(id: "prm_1", text: "first", command: null, attachmentCount: 0, createdAt: 10),
+        PluginQueuedPrompt(id: "prm_2", text: null, command: "review", attachmentCount: 2, createdAt: 20),
+      ]);
+
+      final response = await handler.handle(
+        makeRequest("POST", "/session/queued_prompts"),
+        body: const SessionIdRequest(sessionId: "s-1"),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(response.data, const [
+        QueuedSessionPrompt(id: "prm_1", text: "first", command: null, attachmentCount: 0, createdAt: 10),
+        QueuedSessionPrompt(id: "prm_2", text: null, command: "review", attachmentCount: 2, createdAt: 20),
+      ]);
+    });
+
+    test("returns an empty list when the plugin queues nothing", () async {
+      final response = await handler.handle(
+        makeRequest("POST", "/session/queued_prompts"),
+        body: const SessionIdRequest(sessionId: "s-1"),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(response.data, isEmpty);
+    });
+
+    test("throws not-found for an unknown session", () async {
+      await expectLater(
+        () => handler.handle(
+          makeRequest("POST", "/session/queued_prompts"),
+          body: const SessionIdRequest(sessionId: "missing"),
+          pathParams: {},
+          queryParams: {},
+          fragment: null,
+        ),
+        throwsA(isA<PluginOperationException>().having((e) => e.statusCode, "statusCode", equals(404))),
+      );
+    });
+  });
+}

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -5,6 +5,7 @@ import "package:sesori_bridge/src/api/database/daos/session_dao.dart";
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/api/database/tables/pull_requests_table.dart";
 import "package:sesori_bridge/src/api/database/tables/session_table.dart";
+import "package:sesori_bridge/src/bridge/plugin_to_shared_mapping.dart";
 import "package:sesori_bridge/src/bridge/repositories/mappers/plugin_command_mapper.dart";
 import "package:sesori_bridge/src/bridge/repositories/mappers/plugin_message_mapper.dart";
 import "package:sesori_bridge/src/bridge/repositories/mappers/plugin_session_mapper.dart";
@@ -118,11 +119,23 @@ extension RequestHandlerTestMatching on RequestHandlerBase {
 
 /// Hand-written fake [BridgePluginApi] used across routing handler tests.
 class FakeBridgePlugin() implements NativeProjectsPluginApi {
-  @override
-  Future<List<PluginQueuedPrompt>> getQueuedPrompts({required String sessionId}) async => const [];
+  /// Seedable queue returned by [getQueuedPrompts]; [cancelQueuedPrompt]
+  /// removes from it like a real queue owner and records the call.
+  final List<PluginQueuedPrompt> queuedPrompts = [];
+  final List<({String sessionId, String promptId})> cancelQueuedPromptCalls = [];
 
   @override
-  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async => false;
+  Future<List<PluginQueuedPrompt>> getQueuedPrompts({required String sessionId}) async =>
+      List.unmodifiable(queuedPrompts);
+
+  @override
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async {
+    cancelQueuedPromptCalls.add((sessionId: sessionId, promptId: promptId));
+    final index = queuedPrompts.indexWhere((prompt) => prompt.id == promptId);
+    if (index == -1) return false;
+    queuedPrompts.removeAt(index);
+    return true;
+  }
 
   final _controller = StreamController<BridgeSseEvent>.broadcast();
 
@@ -841,6 +854,12 @@ class _NoopSessionRepository() implements SessionRepository {
   Stream<SessionBindingsCommitted> get bindingCommits => const Stream.empty();
 
   @override
+  Future<List<QueuedSessionPrompt>> getQueuedPrompts({required String sessionId}) async => const [];
+
+  @override
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async => false;
+
+  @override
   int captureProjectionTimestamp() => DateTime.now().millisecondsSinceEpoch;
 
   @override
@@ -1117,6 +1136,14 @@ class FakeSessionRepository({
 }) implements SessionRepository {
   @override
   Stream<SessionBindingsCommitted> get bindingCommits => const Stream.empty();
+
+  @override
+  Future<List<QueuedSessionPrompt>> getQueuedPrompts({required String sessionId}) async =>
+      (await _plugin.getQueuedPrompts(sessionId: sessionId)).toSharedQueuedPrompts();
+
+  @override
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) =>
+      _plugin.cancelQueuedPrompt(sessionId: sessionId, promptId: promptId);
 
   @override
   int captureProjectionTimestamp() => DateTime.now().millisecondsSinceEpoch;


### PR DESCRIPTION
## Complexity

⚙️ Moderate — two new routed endpoints with a serialized cancel path and Layer-2 mapping, all on established handler/repository/service patterns.

## What

Step 3 of the bridge-owned prompt queue ([plan](.plan/active/bridge-owned-prompt-queue/PLAN.md)):

- `SessionRepository.getQueuedPrompts` / `cancelQueuedPrompt`: resolve the bridge→backend session binding and call the plugin, via `useIfActive` — a stopped backend holds no queue, so it is never started just to answer "none". Mapping to the wire model lives in `plugin_to_shared_mapping.dart` (`toSharedQueuedPrompts`), now also reused by the SSE event mapper instead of its step-2 inline copy.
- `GetQueuedPromptsHandler` (`POST /session/queued_prompts`, mirrors the pending-questions read) returning `QueuedPromptResponse`.
- `CancelQueuedPromptHandler` (`POST /session/prompt/cancel`) → `SessionPromptService.cancelQueuedPrompt` → `SessionOperationDispatcher` on the same family lane as sends (a cancel cannot race the enqueue/dispatch of the entry it names) → repository → plugin. A missing entry returns 404, which clients treat as benign (the prompt already dispatched).
- New `SessionOperation.getQueuedPrompts` / `cancelQueuedPrompt` entries; both handlers registered in the orchestrator.

## Why

These are the read and cancel seams the client (step 5) consumes, pinned to the exact layer chain the plan's architecture review required. The Claude plugin starts populating them in step 4; until then every plugin's interface default answers an empty queue, so the endpoints are live but vacuous.

## Risk and test focus

Low. No existing route or send behavior changes; new endpoints only. Focus: binding translation (bridge id → backend id) on both paths, the 400/404 contracts, and that cancel rides the dispatcher lane. Old clients never call these routes.

## Expected result

No user-visible or database impact yet (no plugin owns a queue until step 4). `POST /session/queued_prompts` returns `{data: []}` for any valid session; `POST /session/prompt/cancel` returns 404 until entries exist.

## Verification

- `dart analyze --fatal-infos` clean on `bridge/app`.
- Full `bridge/app` suite: 2658 tests passed, including 9 new handler tests covering mapping/order, empty queue, 400s, 404, backend-id translation, and queue removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds routed endpoints to read and cancel a session’s queued prompts via the bridge. Previously clients could not inspect or cancel queued prompts; now POST /session/queued_prompts returns the queue and POST /session/prompt/cancel removes an entry. Reads never start a stopped backend; cancel returns 404 when the entry is missing or already dispatched, and cancels are refused on archived sessions to enforce permanence.

**Review focus**
- Orchestrator registers POST /session/queued_prompts and POST /session/prompt/cancel.
- Repository adds getQueuedPrompts/cancelQueuedPrompt with bridge→backend id translation and `_runtime.useIfActive` on both paths.
- `SessionPromptService.cancelQueuedPrompt` runs on the serialized dispatcher lane and rejects archived sessions.
- Contracts: empty ids → 400; missing queued entry on cancel → 404 (benign).
- Plugin→shared queued-prompt mapping added in `plugin_to_shared_mapping.dart` and reused by the SSE event mapper.
- No existing routes or send behavior change; until plugins populate queues (step 4), reads return an empty list.

<sup>Written for commit 8a19fa4b70b776a978da9277cd31fdfa797f33f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

