### PR TITLE
🚧 [bridge-owned-prompt-queue] claude: accept prompts at enqueue and own the queue [step 4/7]

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -21,8 +21,18 @@ final class ClaudeEventDispatcher({
   void beginTurn({required String sessionId}) {
     _messageIds.remove(sessionId);
     _announcedMessageIds.remove(sessionId);
+    // A leftover expectation belongs to a turn whose echo never arrived
+    // (interrupted between stdin write and CLI read); the new turn must not
+    // inherit it.
+    _expectedUserEcho.remove(sessionId);
     _clearStreamedMessages(sessionId: sessionId);
     _tools.beginTurn(sessionId: sessionId);
+  }
+
+  /// Drops a pending echo expectation whose turn was aborted, so a late
+  /// buffered frame cannot be stamped with the aborted prompt id.
+  void clearExpectedUserEcho({required String sessionId}) {
+    _expectedUserEcho.remove(sessionId);
   }
 
   /// Declares that the session's next replayed stdin echo fulfills

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -16,6 +16,7 @@ final class ClaudeEventDispatcher({
   final Map<String, Set<int>> _streamedBlocks = {};
   final Map<String, Map<int, PluginMessagePart>> _completedStreamedParts = {};
   final Map<String, Set<String>> _streamedMessageIds = {};
+  final Map<String, ({String promptId, void Function() onConsumed})> _expectedUserEcho = {};
 
   void beginTurn({required String sessionId}) {
     _messageIds.remove(sessionId);
@@ -24,10 +25,26 @@ final class ClaudeEventDispatcher({
     _tools.beginTurn(sessionId: sessionId);
   }
 
+  /// Declares that the session's next replayed stdin echo fulfills
+  /// [promptId]: the echoed user message carries it, and [onConsumed] runs
+  /// after the message events are built (its queue update trails them).
+  ///
+  /// Dispatch is serialized per session, so at most one expectation is live;
+  /// a new dispatch overwrites the previous turn's expectation when its echo
+  /// never arrived (interrupt between stdin write and CLI read).
+  void expectUserEcho({
+    required String sessionId,
+    required String promptId,
+    required void Function() onConsumed,
+  }) {
+    _expectedUserEcho[sessionId] = (promptId: promptId, onConsumed: onConsumed);
+  }
+
   void forgetSession({required String sessionId}) {
     _messageIds.remove(sessionId);
     _announcedMessageIds.remove(sessionId);
     _models.remove(sessionId);
+    _expectedUserEcho.remove(sessionId);
     _clearStreamedMessages(sessionId: sessionId);
     _tools.forgetSession(sessionId: sessionId);
   }
@@ -307,18 +324,21 @@ final class ClaudeEventDispatcher({
       messageId: messageId,
     );
     if (!parts.any((part) => part.type.isVisible)) return const [];
-    return [
+    final expectation = _expectedUserEcho.remove(sessionId);
+    final events = [
       BridgeSseMessageUpdated(
         info: PluginMessage.user(
           id: messageId,
           sessionID: sessionId,
           agent: null,
           time: _messageTime(message.timestamp),
-          promptId: null,
+          promptId: expectation?.promptId,
         ).toJson(),
       ),
       for (final part in parts) BridgeSseMessagePartUpdated(part: part),
     ];
+    expectation?.onConsumed();
+    return events;
   }
 
   List<BridgeSseEvent> _mapRetry({

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -308,8 +308,11 @@ final class ClaudePlugin({
 
   @override
   Future<void> abortSession({required String sessionId}) async {
-    await _sessions.abort(sessionId: sessionId);
+    // Before the await: the aborted turn's expectation must go now, and a
+    // prompt enqueued while the abort settles may install its own, which a
+    // late clear would wrongly wipe.
     _eventDispatcher.clearExpectedUserEcho(sessionId: sessionId);
+    await _sessions.abort(sessionId: sessionId);
   }
 
   @override

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -127,10 +127,9 @@ final class ClaudePlugin({
     _eventBuffer.add(BridgeSseSessionCreated(info: session.toJson()));
     if (parts.isNotEmpty) {
       try {
-        await _enqueue(
+        await _enqueueInitial(
           sessionId: sessionId,
           directory: normalized,
-          createNew: true,
           parts: parts,
           variant: variant,
           agent: agent,
@@ -229,17 +228,35 @@ final class ClaudePlugin({
     _requireTurn(parts: parts, operation: "sendPrompt");
     final directory = _directoryForSession(sessionId);
     if (directory == null) throw const PluginOperationException.notFound("sendPrompt", message: "session not found");
-    await _enqueue(
+    final text = parts
+        .whereType<PluginPromptPartText>()
+        .map((part) => part.text)
+        .where((text) => text.trim().isNotEmpty)
+        .join("\n")
+        .trim();
+    await _enqueueQueued(
       sessionId: sessionId,
       directory: directory,
-      createNew: _unstartedSessions.contains(sessionId),
       parts: parts,
       variant: variant,
       agent: agent,
       model: model,
       operation: "sendPrompt",
+      promptId: promptId,
+      displayText: text.isEmpty ? null : text,
+      command: null,
+      attachmentCount: parts.length - parts.whereType<PluginPromptPartText>().length,
+      onDispatched: () {
+        _unstartedSessions.remove(sessionId);
+        _eventDispatcher.beginTurn(sessionId: sessionId);
+        _eventDispatcher.expectUserEcho(
+          sessionId: sessionId,
+          promptId: promptId,
+          onConsumed: () => _sessions.consumeQueuedPrompt(sessionId: sessionId, promptId: promptId),
+        );
+        return ClaudeQueuedDispatch.awaitsUserEcho;
+      },
     );
-    _unstartedSessions.remove(sessionId);
   }
 
   @override
@@ -255,23 +272,39 @@ final class ClaudePlugin({
   }) async {
     final directory = _directoryForSession(sessionId);
     if (directory == null) throw const PluginOperationException.notFound("sendCommand", message: "session not found");
-    await _enqueue(
+    final visible = userVisibleArguments?.trim();
+    await _enqueueQueued(
       sessionId: sessionId,
       directory: directory,
-      createNew: _unstartedSessions.contains(sessionId),
       parts: [PluginPromptPart.text(text: arguments.isEmpty ? "/$command" : "/$command $arguments")],
       variant: variant,
       agent: agent,
       model: model,
       operation: "sendCommand",
-    );
-    _unstartedSessions.remove(sessionId);
-    final visible = userVisibleArguments?.trim();
-    _emitVisibleUserMessage(
-      sessionId: sessionId,
-      text: visible == null || visible.isEmpty ? "/$command" : "/$command $visible",
+      promptId: promptId,
+      displayText: visible == null || visible.isEmpty ? null : visible,
+      command: command,
+      attachmentCount: 0,
+      onDispatched: () {
+        _unstartedSessions.remove(sessionId);
+        _eventDispatcher.beginTurn(sessionId: sessionId);
+        _emitVisibleUserMessage(
+          sessionId: sessionId,
+          text: visible == null || visible.isEmpty ? "/$command" : "/$command $visible",
+          promptId: promptId,
+        );
+        return ClaudeQueuedDispatch.emittedVisibleMessage;
+      },
     );
   }
+
+  @override
+  Future<List<PluginQueuedPrompt>> getQueuedPrompts({required String sessionId}) async =>
+      _sessions.queuedPrompts(sessionId: sessionId);
+
+  @override
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async =>
+      _sessions.cancelQueuedPrompt(sessionId: sessionId, promptId: promptId);
 
   @override
   Future<void> abortSession({required String sessionId}) => _sessions.abort(sessionId: sessionId);
@@ -403,10 +436,52 @@ final class ClaudePlugin({
     await _eventBuffer.close();
   }
 
-  Future<void> _enqueue({
+  /// Queues a send to an existing session, accepted at enqueue.
+  Future<void> _enqueueQueued({
     required String sessionId,
     required String directory,
-    required bool createNew,
+    required List<PluginPromptPart> parts,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+    required String operation,
+    required String promptId,
+    required String? displayText,
+    required String? command,
+    required int attachmentCount,
+    required ClaudeQueuedDispatch Function() onDispatched,
+  }) async {
+    _validateModel(model, operation: operation);
+    final effort = _effort(variant, operation: operation);
+    final permissionMode = _permissionMode(agent, operation: operation);
+    final createNew = _unstartedSessions.contains(sessionId);
+    try {
+      await _sessions.enqueueTurn(
+        sessionId: sessionId,
+        directory: directory,
+        createNew: createNew,
+        parts: parts,
+        model: model?.modelID,
+        effort: effort,
+        permissionMode: permissionMode,
+        promptId: promptId,
+        displayText: displayText,
+        command: command,
+        attachmentCount: attachmentCount,
+        onDispatched: onDispatched,
+      );
+    } on PluginOperationException {
+      rethrow;
+    } on Object catch (error) {
+      throw PluginOperationException(operation, message: "Claude did not accept the turn", cause: error);
+    }
+  }
+
+  /// Runs a new session's first turn with acceptance at dispatch, so session
+  /// creation can roll back when the initial prompt never starts.
+  Future<void> _enqueueInitial({
+    required String sessionId,
+    required String directory,
     required List<PluginPromptPart> parts,
     required PluginSessionVariant? variant,
     required String? agent,
@@ -418,10 +493,10 @@ final class ClaudePlugin({
     final permissionMode = _permissionMode(agent, operation: operation);
     _eventDispatcher.beginTurn(sessionId: sessionId);
     try {
-      await _sessions.enqueueTurn(
+      await _sessions.enqueueInitialTurn(
         sessionId: sessionId,
         directory: directory,
-        createNew: createNew,
+        createNew: true,
         parts: parts,
         model: model?.modelID,
         effort: effort,
@@ -508,13 +583,13 @@ final class ClaudePlugin({
     }
   }
 
-  /// Synthesizes the visible user bubble for a slash command.
+  /// Synthesizes the visible user bubble for a slash command at dispatch.
   ///
   /// Plain prompts never need this: `--replay-user-messages` echoes them under
   /// their transcript uuid. A command's echo (and its transcript row) is the
   /// CLI's `<command-name>` envelope, which both mapping paths drop, so this
   /// synthetic message stays the turn's only user row and cannot duplicate.
-  void _emitVisibleUserMessage({required String sessionId, required String? text}) {
+  void _emitVisibleUserMessage({required String sessionId, required String? text, required String? promptId}) {
     final visible = text?.trim();
     if (visible == null || visible.isEmpty) return;
     final messageId = "sesori-user-${++_messageSequence}";
@@ -526,7 +601,7 @@ final class ClaudePlugin({
           sessionID: sessionId,
           agent: null,
           time: PluginMessageTime(created: now, completed: now),
-          promptId: null,
+          promptId: promptId,
         ).toJson(),
       ),
     );

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -307,7 +307,10 @@ final class ClaudePlugin({
       _sessions.cancelQueuedPrompt(sessionId: sessionId, promptId: promptId);
 
   @override
-  Future<void> abortSession({required String sessionId}) => _sessions.abort(sessionId: sessionId);
+  Future<void> abortSession({required String sessionId}) async {
+    await _sessions.abort(sessionId: sessionId);
+    _eventDispatcher.clearExpectedUserEcho(sessionId: sessionId);
+  }
 
   @override
   // Claude declares plugin-scoped options, so projectId does not select a catalog.

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:collection";
 
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" as shared;
@@ -8,14 +9,45 @@ import "../models/claude_effort_level.dart";
 import "../models/claude_permission_mode.dart";
 import "../repositories/claude_session_process_repository.dart";
 
+/// How a dispatched queued turn made its user message visible.
+enum ClaudeQueuedDispatch() {
+  /// The caller emitted the visible user message itself (slash commands emit
+  /// a synthetic bubble); the queued entry is consumed immediately.
+  emittedVisibleMessage,
+
+  /// The CLI's replayed stdin echo will carry the visible user message; the
+  /// queued entry is consumed when that echo arrives.
+  awaitsUserEcho,
+}
+
+/// One prompt accepted for a session but not yet visible as a transcript
+/// message. Stays queued (and cancellable until dispatch) from acceptance
+/// until its user message is emitted.
+final class _QueuedPrompt({
+  required final String id,
+  required final String? displayText,
+  required final String? command,
+  required final int attachmentCount,
+  required final int createdAt,
+}) {
+  bool dispatched = false;
+}
+
 final class _SessionTurnState() {
   Future<void> tail = Future<void>.value();
   int pending = 0;
   int generation = 0;
   int idleGeneration = 0;
+  final List<_QueuedPrompt> queue = [];
+
+  /// Prompt ids dispatched most recently, newest last. Bounds the idempotent
+  /// retry window: a client that lost the acceptance response can re-send the
+  /// same prompt id and be refused as an already-done no-op.
+  final Queue<String> recentlyDispatched = Queue<String>();
 }
 
-/// Serializes Claude turns and owns session work/idle lifecycle policy.
+/// Serializes Claude turns and owns session work/idle lifecycle policy plus
+/// the bridge-owned queued-prompt state.
 final class ClaudeSessionService({
   required final ClaudeSessionProcessRepository _processes,
   required final ClaudeApprovalRegistry _approvals,
@@ -25,6 +57,11 @@ final class ClaudeSessionService({
   this {
     _processEvents = _processes.events.listen(_handleProcessEvent);
   }
+
+  /// See [_SessionTurnState.recentlyDispatched]. 64 comfortably exceeds any
+  /// realistic gap between a lost acceptance response and its retry (the
+  /// retry fires on the next reconnect/refresh drain).
+  static const int _recentlyDispatchedLimit = 64;
 
   final Map<String, _SessionTurnState> _turns = {};
   final Map<String, PluginSessionStatus> _retryStatuses = {};
@@ -47,7 +84,116 @@ final class ClaudeSessionService({
           (entry.value.pending > 0 ? const PluginSessionStatus.busy() : const PluginSessionStatus.idle()),
   });
 
+  /// The session's accepted-but-not-yet-visible prompts, in dispatch order.
+  List<PluginQueuedPrompt> queuedPrompts({required String sessionId}) {
+    final state = _turns[sessionId];
+    if (state == null) return const [];
+    return [
+      for (final entry in state.queue)
+        PluginQueuedPrompt(
+          id: entry.id,
+          text: entry.displayText,
+          command: entry.command,
+          attachmentCount: entry.attachmentCount,
+          createdAt: entry.createdAt,
+        ),
+    ];
+  }
+
+  /// Cancels the not-yet-dispatched queued prompt [promptId].
+  ///
+  /// Returns whether an entry was removed. A dispatched entry refuses: from
+  /// that moment the prompt is a turn, governed by [abort].
+  bool cancelQueuedPrompt({required String sessionId, required String promptId}) {
+    final state = _turns[sessionId];
+    if (state == null) return false;
+    final index = state.queue.indexWhere((entry) => entry.id == promptId && !entry.dispatched);
+    if (index == -1) return false;
+    state.queue.removeAt(index);
+    _emitQueueUpdate(sessionId: sessionId, state: state);
+    return true;
+  }
+
+  /// Removes [promptId]'s queued entry once its user message became visible.
+  ///
+  /// Emits the queue update on the service stream, whose async delivery lands
+  /// after the caller's directly-buffered message events — clients therefore
+  /// always see the message before the entry disappears and can transform the
+  /// queued bubble in place.
+  void consumeQueuedPrompt({required String sessionId, required String promptId}) {
+    final state = _turns[sessionId];
+    if (state == null) return;
+    final index = state.queue.indexWhere((entry) => entry.id == promptId);
+    if (index == -1) return;
+    state.queue.removeAt(index);
+    _emitQueueUpdate(sessionId: sessionId, state: state);
+  }
+
+  /// Queues a prompt or command turn and accepts it immediately.
+  ///
+  /// The returned future completes at enqueue — never after the turns ahead
+  /// of it — so callers holding a client request open respond instantly. A
+  /// [promptId] already queued or recently dispatched is an idempotent
+  /// success no-op (the retry of a send whose response was lost).
+  ///
+  /// [onDispatched] runs right after the turn is written to the CLI and says
+  /// how its user message becomes visible; the queued entry is consumed
+  /// accordingly. Dispatch failures surface as a session error and remove
+  /// the entry — acceptance is not revoked.
   Future<void> enqueueTurn({
+    required String sessionId,
+    required String directory,
+    required bool createNew,
+    required List<PluginPromptPart> parts,
+    required String? model,
+    required ClaudeEffortLevel? effort,
+    required ClaudePermissionMode? permissionMode,
+    required String promptId,
+    required String? displayText,
+    required String? command,
+    required int attachmentCount,
+    required ClaudeQueuedDispatch Function() onDispatched,
+  }) {
+    if (_disposed || parts.isEmpty) {
+      return Future.error(StateError("Claude session cannot accept the turn"));
+    }
+    final state = _turns.putIfAbsent(sessionId, _SessionTurnState.new);
+    final isDuplicate =
+        state.queue.any((entry) => entry.id == promptId) || state.recentlyDispatched.contains(promptId);
+    if (isDuplicate) return Future.value();
+
+    final entry = _QueuedPrompt(
+      id: promptId,
+      displayText: displayText,
+      command: command,
+      attachmentCount: attachmentCount,
+      createdAt: _clock.now().millisecondsSinceEpoch,
+    );
+    state.queue.add(entry);
+    _beginTurnAccounting(sessionId: sessionId, state: state);
+    _emitQueueUpdate(sessionId: sessionId, state: state);
+    final generation = state.generation;
+    state.tail = state.tail.then(
+      (_) => _runTurn(
+        sessionId: sessionId,
+        directory: directory,
+        createNew: createNew,
+        parts: parts,
+        model: model,
+        effort: effort,
+        permissionMode: permissionMode,
+        state: state,
+        generation: generation,
+        mode: _QueuedTurnMode(entry: entry, onDispatched: onDispatched),
+      ),
+    );
+    return Future.value();
+  }
+
+  /// Queues a session's very first turn and completes only when the backend
+  /// accepted it, so session creation can roll back a session whose initial
+  /// prompt never started. Never used for sends to existing sessions.
+  Future<void> enqueueInitialTurn({
     required String sessionId,
     required String directory,
     required bool createNew,
@@ -61,14 +207,7 @@ final class ClaudeSessionService({
     }
     final acceptance = Completer<void>();
     final state = _turns.putIfAbsent(sessionId, _SessionTurnState.new);
-    _retryStatuses.remove(sessionId);
-    state.pending++;
-    state.idleGeneration++;
-    if (state.pending == 1) {
-      _workState.set(PluginWorkState.busy);
-      _emit(BridgeSseSessionStatus(sessionID: sessionId, status: const shared.SessionStatus.busy().toJson()));
-      _emit(const BridgeSseProjectUpdated());
-    }
+    _beginTurnAccounting(sessionId: sessionId, state: state);
     final generation = state.generation;
     state.tail = state.tail.then(
       (_) => _runTurn(
@@ -81,10 +220,21 @@ final class ClaudeSessionService({
         permissionMode: permissionMode,
         state: state,
         generation: generation,
-        acceptance: acceptance,
+        mode: _BlockingTurnMode(acceptance: acceptance),
       ),
     );
     return acceptance.future;
+  }
+
+  void _beginTurnAccounting({required String sessionId, required _SessionTurnState state}) {
+    _retryStatuses.remove(sessionId);
+    state.pending++;
+    state.idleGeneration++;
+    if (state.pending == 1) {
+      _workState.set(PluginWorkState.busy);
+      _emit(BridgeSseSessionStatus(sessionID: sessionId, status: const shared.SessionStatus.busy().toJson()));
+      _emit(const BridgeSseProjectUpdated());
+    }
   }
 
   Future<void> _runTurn({
@@ -97,10 +247,10 @@ final class ClaudeSessionService({
     required ClaudePermissionMode? permissionMode,
     required _SessionTurnState state,
     required int generation,
-    required Completer<void> acceptance,
+    required _TurnMode mode,
   }) async {
-    if (!_isCurrent(sessionId: sessionId, state: state, generation: generation)) {
-      if (!acceptance.isCompleted) acceptance.completeError(StateError("Claude turn was cancelled before acceptance"));
+    if (!_isCurrent(sessionId: sessionId, state: state, generation: generation) || _isCancelled(mode, state)) {
+      mode.settleUnaccepted();
       return _finish(sessionId, state, null);
     }
     try {
@@ -113,24 +263,33 @@ final class ClaudeSessionService({
         permissionMode: permissionMode,
         allowedTools: _approvals.allowedToolsForSession(sessionId: sessionId),
       );
-      if (!_isCurrent(sessionId: sessionId, state: state, generation: generation)) {
-        if (!acceptance.isCompleted) {
-          acceptance.completeError(StateError("Claude turn was cancelled before acceptance"));
-        }
+      if (!_isCurrent(sessionId: sessionId, state: state, generation: generation) || _isCancelled(mode, state)) {
+        mode.settleUnaccepted();
         return _finish(sessionId, state, null);
       }
       final dispatch = _processes.sendTurn(sessionId: sessionId, parts: parts);
       if (!dispatch.accepted) {
         throw StateError("Claude rejected the turn before dispatch");
       }
-      if (!acceptance.isCompleted) acceptance.complete();
+      switch (mode) {
+        case _BlockingTurnMode(:final acceptance):
+          if (!acceptance.isCompleted) acceptance.complete();
+        case _QueuedTurnMode(:final entry, :final onDispatched):
+          entry.dispatched = true;
+          _recordDispatched(state: state, promptId: entry.id);
+          if (onDispatched() == ClaudeQueuedDispatch.emittedVisibleMessage) {
+            consumeQueuedPrompt(sessionId: sessionId, promptId: entry.id);
+          }
+      }
       final outcome = await dispatch.outcome;
+      _settleQueuedEntry(sessionId: sessionId, state: state, mode: mode);
       if (!_isCurrent(sessionId: sessionId, state: state, generation: generation)) {
         return _finish(sessionId, state, null);
       }
       _finish(sessionId, state, outcome);
     } on Object catch (error, stack) {
-      if (!acceptance.isCompleted) acceptance.completeError(error, stack);
+      mode.settleError(error, stack);
+      _settleQueuedEntry(sessionId: sessionId, state: state, mode: mode);
       if (_isCurrent(sessionId: sessionId, state: state, generation: generation)) {
         Log.w("[claude] queued turn failed for $sessionId", error, stack);
         _finish(sessionId, state, const ClaudeTurnFailed());
@@ -138,6 +297,27 @@ final class ClaudeSessionService({
         _finish(sessionId, state, null);
       }
     }
+  }
+
+  /// A cancelled queued entry was already removed from the queue; its chained
+  /// link must settle without dispatching.
+  bool _isCancelled(_TurnMode mode, _SessionTurnState state) =>
+      mode is _QueuedTurnMode && !state.queue.contains(mode.entry) && !mode.entry.dispatched;
+
+  void _recordDispatched({required _SessionTurnState state, required String promptId}) {
+    state.recentlyDispatched.addLast(promptId);
+    while (state.recentlyDispatched.length > _recentlyDispatchedLimit) {
+      state.recentlyDispatched.removeFirst();
+    }
+  }
+
+  /// Removes a queued entry that never became a visible message (interrupt or
+  /// failure between dispatch and echo, or a dispatch that threw).
+  void _settleQueuedEntry({required String sessionId, required _SessionTurnState state, required _TurnMode mode}) {
+    if (mode is! _QueuedTurnMode) return;
+    if (!state.queue.contains(mode.entry)) return;
+    state.queue.remove(mode.entry);
+    _emitQueueUpdate(sessionId: sessionId, state: state);
   }
 
   Future<void> abort({required String sessionId}) async {
@@ -149,6 +329,10 @@ final class ClaudeSessionService({
     }
     state.generation++;
     state.idleGeneration++;
+    if (state.queue.isNotEmpty) {
+      state.queue.clear();
+      _emitQueueUpdate(sessionId: sessionId, state: state);
+    }
     _approvals.cancelForSession(sessionId: sessionId);
     try {
       await _processes.interrupt(sessionId: sessionId);
@@ -260,6 +444,15 @@ final class ClaudeSessionService({
     if (!_events.isClosed) _events.add(event);
   }
 
+  void _emitQueueUpdate({required String sessionId, required _SessionTurnState state}) {
+    _emit(
+      BridgeSseQueuedPromptsUpdated(
+        sessionID: sessionId,
+        prompts: queuedPrompts(sessionId: sessionId),
+      ),
+    );
+  }
+
   void recordRetryStatus({required String sessionId, required PluginSessionStatus status}) {
     if (_turns.containsKey(sessionId)) _retryStatuses[sessionId] = status;
   }
@@ -272,5 +465,42 @@ final class ClaudeSessionService({
       case ClaudeSessionProcessExited():
         _approvals.cancelForSession(sessionId: event.sessionId);
     }
+  }
+}
+
+/// How one chained turn reports acceptance and visibility.
+sealed class const _TurnMode() {
+  /// Settles a turn that was dropped before dispatch (stale generation or a
+  /// cancelled queued entry).
+  void settleUnaccepted();
+
+  /// Settles a turn whose dispatch threw.
+  void settleError(Object error, StackTrace stack);
+}
+
+/// A queued-entry turn: accepted at enqueue, visible via [onDispatched].
+final class const _QueuedTurnMode({
+  required final _QueuedPrompt entry,
+  required final ClaudeQueuedDispatch Function() onDispatched,
+}) extends _TurnMode {
+  @override
+  void settleUnaccepted() {}
+
+  @override
+  void settleError(Object error, StackTrace stack) {}
+}
+
+/// The blocking initial turn: acceptance completes only at dispatch.
+final class const _BlockingTurnMode({required final Completer<void> acceptance}) extends _TurnMode {
+  @override
+  void settleUnaccepted() {
+    if (!acceptance.isCompleted) {
+      acceptance.completeError(StateError("Claude turn was cancelled before acceptance"));
+    }
+  }
+
+  @override
+  void settleError(Object error, StackTrace stack) {
+    if (!acceptance.isCompleted) acceptance.completeError(error, stack);
   }
 }

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -315,6 +315,9 @@ final class ClaudeSessionService({
   /// failure between dispatch and echo, or a dispatch that threw).
   void _settleQueuedEntry({required String sessionId, required _SessionTurnState state, required _TurnMode mode}) {
     if (mode is! _QueuedTurnMode) return;
+    // A deleted/reset session already dropped this state; a stale turn must
+    // not publish queue updates after BridgeSseSessionDeleted.
+    if (!identical(_turns[sessionId], state)) return;
     if (!state.queue.contains(mode.entry)) return;
     state.queue.remove(mode.entry);
     _emitQueueUpdate(sessionId: sessionId, state: state);

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -353,6 +353,43 @@ void main() {
       await subscription.cancel();
     });
 
+    test("a late echo after abort is not stamped with the aborted prompt id", () async {
+      await harness.createSession();
+      final first = harness.processes.single;
+      await waitForFrame(first, "user");
+      first.emit(_result());
+      await pump();
+
+      await harness.plugin.sendPrompt(
+        promptId: "prm_aborted",
+        sessionId: testSessionId,
+        parts: const [PluginPromptPart.text(text: "interrupted early")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await _waitForUserText(first, "interrupted early");
+      final abort = harness.plugin.abortSession(sessionId: testSessionId);
+      final interrupt = await _waitForControl(first, "interrupt");
+      first.emitControlResponse(requestId: interrupt["request_id"]! as String, payload: const {});
+      await abort;
+
+      final events = <BridgeSseEvent>[];
+      final subscription = harness.plugin.events.listen(events.add);
+      // A buffered frame arriving after the abort must not inherit the
+      // aborted turn's identity.
+      final written = first.written.lastWhere((frame) => frame["type"] == "user");
+      first.emit(_replayOf(written, uuid: "late-echo"));
+      await pump();
+      await pump();
+
+      final lateEchoes = events.whereType<BridgeSseMessageUpdated>().where((event) => event.info["id"] == "late-echo");
+      for (final message in lateEchoes) {
+        expect(message.info["promptId"], isNull);
+      }
+      await subscription.cancel();
+    });
+
     test("cancelQueuedPrompt removes a pending steering prompt before dispatch", () async {
       await harness.createSession();
       final first = harness.processes.single;

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -190,7 +190,7 @@ void main() {
       await subscription.cancel();
     });
 
-    test("creates an empty session and reports command initialization failure", () async {
+    test("creates an empty session and surfaces command initialization failure as a session error", () async {
       await harness.close();
       harness = _PluginHarness(failInitialize: true);
       final session = await harness.plugin.createSession(
@@ -202,24 +202,30 @@ void main() {
         agent: "Default",
         model: (providerID: "anthropic", modelID: "default"),
       );
+      final events = <BridgeSseEvent>[];
+      final subscription = harness.plugin.events.listen(events.add);
 
-      await expectLater(
-        harness.plugin.sendCommand(
-          promptId: "prompt-1",
-          sessionId: session.id,
-          command: "review",
-          arguments: "src",
-          userVisibleArguments: "src",
-          variant: null,
-          agent: "Default",
-          model: (providerID: "anthropic", modelID: "default"),
-        ),
-        throwsA(
-          isA<PluginOperationException>()
-              .having((error) => error.operation, "operation", "sendCommand")
-              .having((error) => error.cause, "cause", isNotNull),
-        ),
+      // Accepted at enqueue: the spawn failure surfaces on the event stream
+      // (queue removal plus session error), not as a send failure.
+      await harness.plugin.sendCommand(
+        promptId: "prompt-1",
+        sessionId: session.id,
+        command: "review",
+        arguments: "src",
+        userVisibleArguments: "src",
+        variant: null,
+        agent: "Default",
+        model: (providerID: "anthropic", modelID: "default"),
       );
+      for (var attempt = 0; attempt < 100; attempt++) {
+        if (events.whereType<BridgeSseSessionError>().isNotEmpty) break;
+        await pump();
+      }
+
+      expect(events.whereType<BridgeSseSessionError>().single.sessionID, session.id);
+      expect(events.whereType<BridgeSseQueuedPromptsUpdated>().last.prompts, isEmpty);
+      expect(await harness.plugin.getQueuedPrompts(sessionId: session.id), isEmpty);
+      await subscription.cancel();
     });
 
     test("renders a follow-up prompt from its replayed user frame", () async {
@@ -253,6 +259,121 @@ void main() {
       );
       expect(message, hasLength(1));
       await subscription.cancel();
+    });
+
+    test("queues a steering prompt, stamps its echo, and consumes the entry after the message", () async {
+      await harness.createSession();
+      final first = harness.processes.single;
+      await waitForFrame(first, "user");
+      final events = <BridgeSseEvent>[];
+      final subscription = harness.plugin.events.listen(events.add);
+
+      // Accepted instantly while the first turn is still running.
+      await harness.plugin.sendPrompt(
+        promptId: "prm_steer",
+        sessionId: testSessionId,
+        parts: const [PluginPromptPart.text(text: "steer it")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final entry = (await harness.plugin.getQueuedPrompts(sessionId: testSessionId)).single;
+      expect(entry.id, "prm_steer");
+      expect(entry.text, "steer it");
+      expect(entry.command, isNull);
+      expect(entry.attachmentCount, 0);
+      await pump();
+      expect(
+        events.whereType<BridgeSseQueuedPromptsUpdated>().last.prompts.single.id,
+        "prm_steer",
+      );
+
+      first.emit(_result());
+      await _waitForUserText(first, "steer it");
+      final written = first.written.lastWhere((frame) => frame["type"] == "user");
+      first.emit(_replayOf(written, uuid: "replay-steer"));
+      await pump();
+      await pump();
+
+      final messageIndex = events.indexWhere(
+        (event) => event is BridgeSseMessageUpdated && event.info["id"] == "replay-steer",
+      );
+      final message = events[messageIndex] as BridgeSseMessageUpdated;
+      expect(message.info["promptId"], "prm_steer");
+      final emptyQueueIndex = events.indexWhere(
+        (event) => event is BridgeSseQueuedPromptsUpdated && event.prompts.isEmpty,
+      );
+      expect(emptyQueueIndex, greaterThan(messageIndex), reason: "the message must land before its entry disappears");
+      expect(await harness.plugin.getQueuedPrompts(sessionId: testSessionId), isEmpty);
+
+      first.emit(_result());
+      await pump();
+      await subscription.cancel();
+    });
+
+    test("queues a steering command and consumes the entry after its synthetic message", () async {
+      await harness.createSession();
+      final first = harness.processes.single;
+      await waitForFrame(first, "user");
+      final events = <BridgeSseEvent>[];
+      final subscription = harness.plugin.events.listen(events.add);
+
+      await harness.plugin.sendCommand(
+        promptId: "prm_cmd",
+        sessionId: testSessionId,
+        command: "review",
+        arguments: "src",
+        userVisibleArguments: "src",
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final queued = await harness.plugin.getQueuedPrompts(sessionId: testSessionId);
+      expect(queued.single.command, "review");
+      expect(queued.single.text, "src");
+
+      first.emit(_result());
+      await _waitForUserText(first, "/review src");
+      await pump();
+      await pump();
+
+      final messageIndex = events.indexWhere(
+        (event) =>
+            event is BridgeSseMessageUpdated && event.info["role"] == "user" && event.info["promptId"] == "prm_cmd",
+      );
+      expect(messageIndex, greaterThanOrEqualTo(0));
+      final emptyQueueIndex = events.indexWhere(
+        (event) => event is BridgeSseQueuedPromptsUpdated && event.prompts.isEmpty,
+      );
+      expect(emptyQueueIndex, greaterThan(messageIndex));
+      expect(await harness.plugin.getQueuedPrompts(sessionId: testSessionId), isEmpty);
+
+      first.emit(_result());
+      await pump();
+      await subscription.cancel();
+    });
+
+    test("cancelQueuedPrompt removes a pending steering prompt before dispatch", () async {
+      await harness.createSession();
+      final first = harness.processes.single;
+      await waitForFrame(first, "user");
+
+      await harness.plugin.sendPrompt(
+        promptId: "prm_cancel",
+        sessionId: testSessionId,
+        parts: const [PluginPromptPart.text(text: "never runs")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      expect(await harness.plugin.cancelQueuedPrompt(sessionId: testSessionId, promptId: "prm_cancel"), isTrue);
+      expect(await harness.plugin.cancelQueuedPrompt(sessionId: testSessionId, promptId: "prm_cancel"), isFalse);
+      expect(await harness.plugin.getQueuedPrompts(sessionId: testSessionId), isEmpty);
+
+      first.emit(_result());
+      await pump();
+      final userFrames = first.written.where((frame) => frame["type"] == "user");
+      expect(userFrames, hasLength(1), reason: "the cancelled prompt must never reach the CLI");
     });
 
     test("respawns between turns when launch-only effort changes", () async {

--- a/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
@@ -20,8 +20,8 @@ void main() {
     });
 
     test("serializes queued turns for one session", () async {
-      harness.enqueue("first", model: "haiku");
-      harness.enqueue("second", model: "haiku");
+      unawaited(harness.enqueue("first", model: "haiku"));
+      unawaited(harness.enqueue("second", model: "haiku"));
       final process = await harness.firstProcess;
       await waitForFrame(process, "user");
 
@@ -36,8 +36,8 @@ void main() {
     });
 
     test("abort fences a queued turn and cancels the running turn", () async {
-      harness.enqueue("first", model: "haiku");
-      harness.enqueue("second", model: "haiku");
+      unawaited(harness.enqueue("first", model: "haiku"));
+      unawaited(harness.enqueue("second", model: "haiku"));
       final process = await harness.firstProcess;
       await waitForFrame(process, "user");
 
@@ -53,7 +53,7 @@ void main() {
     });
 
     test("next turn resumes in a fresh process after abort", () async {
-      harness.enqueue("first", model: "haiku");
+      unawaited(harness.enqueue("first", model: "haiku"));
       final first = await harness.firstProcess;
       await waitForFrame(first, "user");
 
@@ -63,7 +63,7 @@ void main() {
       await abort;
       await harness.waitForIdle();
 
-      harness.enqueue("second", model: "haiku");
+      unawaited(harness.enqueue("second", model: "haiku"));
       final second = await harness.processAt(1);
       await waitForFrame(second, "user");
 
@@ -74,7 +74,7 @@ void main() {
     test("abort tears down the process when interrupt fails", () async {
       await harness.dispose();
       harness = _ServiceHarness(failInterrupt: true);
-      harness.enqueue("first");
+      unawaited(harness.enqueue("first"));
       final process = await harness.firstProcess;
       await waitForFrame(process, "user");
 
@@ -85,7 +85,7 @@ void main() {
     });
 
     test("interruptActiveWork aborts and waits for active sessions within its budget", () async {
-      harness.enqueue("first");
+      unawaited(harness.enqueue("first"));
       final process = await harness.firstProcess;
       await waitForFrame(process, "user");
 
@@ -101,7 +101,7 @@ void main() {
     });
 
     test("routes control asks and clears them when the process exits", () async {
-      harness.enqueue("first");
+      unawaited(harness.enqueue("first"));
       final process = await harness.firstProcess;
       await waitForFrame(process, "user");
       process.emit({
@@ -124,7 +124,7 @@ void main() {
     });
 
     test("reaps an idle process and transparently resumes the next turn", () async {
-      harness.enqueue("first", model: "haiku");
+      unawaited(harness.enqueue("first", model: "haiku"));
       final first = await harness.firstProcess;
       await waitForFrame(first, "user");
       first.emit({
@@ -156,7 +156,7 @@ void main() {
       await pump();
       expect(harness.repository.isResident(sessionId: testSessionId), isFalse);
 
-      harness.enqueue("second", model: "haiku");
+      unawaited(harness.enqueue("second", model: "haiku"));
       final second = await harness.processAt(1);
       await waitForFrame(second, "user");
 
@@ -166,7 +166,7 @@ void main() {
     });
 
     test("aborting an idle session preserves its scheduled reap", () async {
-      harness.enqueue("first");
+      unawaited(harness.enqueue("first"));
       final process = await harness.firstProcess;
       await waitForFrame(process, "user");
       process.emit(_result());
@@ -182,7 +182,7 @@ void main() {
     test("concurrent disposal waits for an in-flight idle teardown", () async {
       await harness.dispose();
       harness = _ServiceHarness(stdinCloseCompletes: false);
-      harness.enqueue("first");
+      unawaited(harness.enqueue("first"));
       final process = await harness.firstProcess;
       await waitForFrame(process, "user");
       process.emit(_result());
@@ -203,10 +203,168 @@ void main() {
       expect(completed, isTrue);
     });
 
+    test("accepts a steering send at enqueue while a turn is running", () async {
+      unawaited(harness.enqueue("first", model: "haiku"));
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+
+      var accepted = false;
+      unawaited(harness.enqueue("second", model: "haiku").then((_) => accepted = true));
+      await pump();
+
+      expect(accepted, isTrue, reason: "acceptance must not wait for the running turn");
+      expect(_userFrames(process), hasLength(1), reason: "the queued turn must not dispatch mid-turn");
+    });
+
+    test("exposes queued entries until dispatch settles and emits full-list updates", () async {
+      unawaited(harness.enqueue("first"));
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      unawaited(harness.enqueue("second"));
+      await pump();
+
+      expect(
+        harness.service.queuedPrompts(sessionId: testSessionId).map((prompt) => prompt.id),
+        ["prompt-first", "prompt-second"],
+      );
+      final updates = harness.events.whereType<BridgeSseQueuedPromptsUpdated>().toList();
+      expect(updates.last.prompts.map((prompt) => prompt.id), ["prompt-first", "prompt-second"]);
+
+      process.emit(_result());
+      await _waitForUserFrames(process, 2);
+      process.emit(_result());
+      await harness.waitForIdle();
+
+      expect(harness.service.queuedPrompts(sessionId: testSessionId), isEmpty);
+      final finalUpdate = harness.events.whereType<BridgeSseQueuedPromptsUpdated>().last;
+      expect(finalUpdate.prompts, isEmpty);
+    });
+
+    test("refuses a duplicate prompt id as an accepted no-op", () async {
+      unawaited(harness.enqueue("first", promptId: "prm_dup"));
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+
+      await harness.enqueue("first-again", promptId: "prm_dup");
+      process.emit(_result());
+      await harness.waitForIdle();
+
+      expect(_userFrames(process), hasLength(1), reason: "the retry must not become a second turn");
+    });
+
+    test("refuses a recently dispatched prompt id after its turn completed", () async {
+      unawaited(harness.enqueue("first", promptId: "prm_done"));
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      process.emit(_result());
+      await harness.waitForIdle();
+
+      await harness.enqueue("first-retry", promptId: "prm_done");
+      await pump();
+
+      expect(_userFrames(process), hasLength(1));
+    });
+
+    test("cancels a pending entry before dispatch and refuses a dispatched one", () async {
+      unawaited(harness.enqueue("first"));
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      unawaited(harness.enqueue("second"));
+      await pump();
+
+      expect(
+        harness.service.cancelQueuedPrompt(sessionId: testSessionId, promptId: "prompt-second"),
+        isTrue,
+      );
+      expect(
+        harness.service.cancelQueuedPrompt(sessionId: testSessionId, promptId: "prompt-first"),
+        isFalse,
+        reason: "the dispatched running turn is governed by abort, not cancel",
+      );
+      expect(
+        harness.service.queuedPrompts(sessionId: testSessionId).map((prompt) => prompt.id),
+        ["prompt-first"],
+      );
+
+      process.emit(_result());
+      await harness.waitForIdle();
+
+      expect(_userFrames(process), hasLength(1), reason: "the cancelled turn must never dispatch");
+    });
+
+    test("consumes an entry via emittedVisibleMessage at dispatch", () async {
+      unawaited(
+        harness.enqueue("run-command", onDispatched: () => ClaudeQueuedDispatch.emittedVisibleMessage),
+      );
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      await pump();
+
+      expect(harness.service.queuedPrompts(sessionId: testSessionId), isEmpty);
+      process.emit(_result());
+      await harness.waitForIdle();
+    });
+
+    test("consumeQueuedPrompt removes the echoed entry", () async {
+      unawaited(harness.enqueue("first"));
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      expect(harness.service.queuedPrompts(sessionId: testSessionId), hasLength(1));
+
+      harness.service.consumeQueuedPrompt(sessionId: testSessionId, promptId: "prompt-first");
+
+      expect(harness.service.queuedPrompts(sessionId: testSessionId), isEmpty);
+      process.emit(_result());
+      await harness.waitForIdle();
+    });
+
+    test("abort clears queued entries and announces the empty queue", () async {
+      unawaited(harness.enqueue("first"));
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      unawaited(harness.enqueue("second"));
+      await pump();
+
+      final abort = harness.service.abort(sessionId: testSessionId);
+      final interrupt = await _waitForControlSubtype(process, "interrupt");
+      process.emitControlResponse(requestId: interrupt["request_id"]! as String, payload: const {});
+      await abort;
+      process.emit(_result());
+      await harness.waitForIdle();
+
+      expect(harness.service.queuedPrompts(sessionId: testSessionId), isEmpty);
+      expect(harness.events.whereType<BridgeSseQueuedPromptsUpdated>().last.prompts, isEmpty);
+      expect(_userFrames(process), hasLength(1));
+    });
+
+    test("blocking initial turn completes acceptance only at dispatch", () async {
+      var accepted = false;
+      final acceptance = harness.service
+          .enqueueInitialTurn(
+            sessionId: testSessionId,
+            directory: "/tmp/project",
+            createNew: true,
+            parts: [const PluginPromptPart.text(text: "initial")],
+            model: null,
+            effort: null,
+            permissionMode: null,
+          )
+          .then((_) => accepted = true);
+      await pump();
+      expect(accepted, isFalse, reason: "acceptance waits for the spawn and stdin write");
+
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      await acceptance;
+      expect(accepted, isTrue);
+      process.emit(_result());
+      await harness.waitForIdle();
+    });
+
     test("delete waits for an in-flight idle teardown", () async {
       await harness.dispose();
       harness = _ServiceHarness(stdinCloseCompletes: false);
-      harness.enqueue("first");
+      unawaited(harness.enqueue("first"));
       final process = await harness.firstProcess;
       await waitForFrame(process, "user");
       process.emit(_result());
@@ -274,20 +432,28 @@ final class _ServiceHarness({final bool stdinCloseCompletes = true, final bool f
     return process;
   }
 
-  void enqueue(String text, {String? model}) {
-    unawaited(
-      service
-          .enqueueTurn(
-            sessionId: testSessionId,
-            directory: "/tmp/project",
-            createNew: true,
-            parts: [PluginPromptPart.text(text: text)],
-            model: model,
-            effort: null,
-            permissionMode: null,
-          )
-          .catchError((Object _) {}),
-    );
+  Future<void> enqueue(
+    String text, {
+    String? model,
+    String? promptId,
+    ClaudeQueuedDispatch Function()? onDispatched,
+  }) {
+    return service
+        .enqueueTurn(
+          sessionId: testSessionId,
+          directory: "/tmp/project",
+          createNew: true,
+          parts: [PluginPromptPart.text(text: text)],
+          model: model,
+          effort: null,
+          permissionMode: null,
+          promptId: promptId ?? "prompt-$text",
+          displayText: text,
+          command: null,
+          attachmentCount: 0,
+          onDispatched: onDispatched ?? () => ClaudeQueuedDispatch.awaitsUserEcho,
+        )
+        .catchError((Object _) {});
   }
 
   Future<FakeClaudeProcess> processAt(int index) async {

--- a/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
@@ -337,6 +337,21 @@ void main() {
       expect(_userFrames(process), hasLength(1));
     });
 
+    test("a turn settling after deleteSession publishes no queue update", () async {
+      unawaited(harness.enqueue("first"));
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+
+      await harness.service.deleteSession(sessionId: testSessionId);
+      final eventCountAfterDelete = harness.events.length;
+      process.emit(_result());
+      await pump();
+      await pump();
+
+      final lateEvents = harness.events.skip(eventCountAfterDelete);
+      expect(lateEvents.whereType<BridgeSseQueuedPromptsUpdated>(), isEmpty);
+    });
+
     test("blocking initial turn completes acceptance only at dispatch", () async {
       var accepted = false;
       final acceptance = harness.service


### PR DESCRIPTION
## Complexity

🚧 Complex — reworks the Claude turn lifecycle: acceptance timing, a new queue-entry state machine with cancel/dedupe, event-ordering guarantees between message and queue events, and interrupt/failure edge paths.

## What

Step 4 of the bridge-owned prompt queue ([plan](.plan/active/bridge-owned-prompt-queue/PLAN.md)) — the Claude plugin becomes the queue owner:

- `ClaudeSessionService.enqueueTurn` (sends to existing sessions) now **accepts at enqueue**: the returned future completes immediately, never behind the running turn. Session creation keeps its blocking semantics via a separate `enqueueInitialTurn`, preserving rollback when a first prompt never starts.
- Each send records an explicit queued entry (`promptId`, display text/command, attachment count, created-at) exposed through `getQueuedPrompts`, cancellable pre-dispatch via `cancelQueuedPrompt`, and announced on every change with full-list `BridgeSseQueuedPromptsUpdated` events.
- Duplicate `promptId`s (already queued, or in a per-session set of the last 64 dispatched) are refused as idempotent successes — the safe-retry contract from the plan.
- Queued→sent transform: at dispatch the plugin registers the pending echo with the event dispatcher; the CLI's replayed stdin echo then carries `promptId` on its user message, and the entry is consumed so the queue update always trails the message events (async service-stream delivery lands after the directly-buffered message; pinned by ordering tests). Slash commands emit their synthetic bubble (now at dispatch time, with `promptId`) and consume the entry the same way.
- Abort clears queued entries and announces the empty queue; interrupt/failure between dispatch and echo settles the leftover entry; dispatch failures keep the existing `BridgeSseSessionError` surface (the acceptance-reversal trade-off recorded in the plan's Risks).
- Fixes a latent steering bug: `beginTurn` (dispatcher per-turn state reset) previously ran at enqueue time, clobbering the running turn's streaming state whenever a prompt arrived mid-turn; it now runs at dispatch.

## Why

This is the root cause of the reported production defects: acceptance used to complete only when the previous turn finished, holding `/session/prompt_async` open until the phone's 30 s timeout — producing the lost/duplicated queued messages and letting permission replies deadlock behind blocked prompts in the session lane. With acceptance at enqueue the lane frees instantly and the bridge owns the queued state the client renders in step 5.

## Risk and test focus

Medium-high: turn lifecycle and event ordering on the busiest bridge path. Focus: steering while busy (instant acceptance, FIFO dispatch), duplicate-retry no-ops, cancel vs dispatched races, abort clearing, echo `promptId` attachment and message-before-queue-update ordering, command synthetics, spawn-failure surfacing, and unchanged idle-reap/teardown behavior. `createSession` initial-prompt semantics are intentionally unchanged.

## Expected result

No database impact. With a current bridge and any client: sends to a busy Claude session are acknowledged in milliseconds and the permission-reply deadlock disappears (old clients simply see their "Sending" spinner resolve instantly). Queued entries flow on the wire (`session.queued-prompts`, `/session/queued_prompts`, cancel endpoint) — rendered by the client in step 5.

## Verification

- `dart analyze --fatal-infos` clean on `sesori_plugin_claude`.
- Full plugin suite green: 233 tests, including 9 new service tests (accept-at-enqueue, queue exposure/events, dedupe both pre- and post-dispatch, cancel semantics, `emittedVisibleMessage` consumption, abort clearing, blocking initial turn) and 3 new plugin tests (echo `promptId` + ordering, command synthetic + ordering, cancel before dispatch); the spawn-failure test updated to the accepted-then-session-error contract.
- Full bridge `make test` matrix green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts prompts at enqueue and makes the Claude plugin the prompt-queue owner to eliminate long-held HTTP requests and session-lane deadlocks. Previously, sends were accepted only after the prior turn finished; now sends to existing sessions accept immediately, while initial session creation keeps its blocking semantics.

- `ClaudeSessionService.enqueueTurn` accepts at enqueue; new `enqueueInitialTurn` blocks for a session’s first turn. Adds an in-memory queue with entries (id, display text/command, attachment count, created-at), exposed via `getQueuedPrompts` and `cancelQueuedPrompt`, and announced with full-list `BridgeSseQueuedPromptsUpdated` events.
- Idempotent retries: duplicate `promptId`s (queued or among the last 64 dispatched) are accepted as no-ops.
- Dispatch behavior: the dispatcher expects a replayed user echo, stamps its `promptId`, and consumes the queued entry after building the message events so queue updates trail them. Commands emit a synthetic user message with `promptId` at dispatch and consume immediately.
- Abort and delete: abort clears queued entries and announces an empty queue; it now clears any pending echo expectation immediately (before awaiting abort) so late echoes are not stamped and a new enqueue can set its own expectation. Queue updates are suppressed after `deleteSession`.
- Interrupt/failure between dispatch and echo settles any leftover entry. Dispatch failures surface as `BridgeSseSessionError`; acceptance is not revoked.
- Fix: move `beginTurn` from enqueue to dispatch to avoid clobbering an active turn’s streaming state. No database changes.

<sup>Written for commit 456b8944cfb15930dcce19630789d81e329004d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

