### PR TITLE
🌿 [bridge-owned-prompt-queue] docs: reconcile session-turns regression coverage [step 6/7]

### DIFF
--- a/.plan/active/bridge-owned-prompt-queue/TRACKER.md
+++ b/.plan/active/bridge-owned-prompt-queue/TRACKER.md
@@ -4,10 +4,10 @@
 |---|---|---|---|---|
 | 1/7 | 🌱 [bridge-owned-prompt-queue] docs: raise the bridge-owned prompt queue plan [step 1/7] | Merged | #946 | |
 | 2/7 | ⚙️ [bridge-owned-prompt-queue] contracts: prompt ids and queued-prompt wire surface [step 2/7] | In review | #948 | ACP stamps promptId on its acceptance echo already |
-| 3/7 | ⚙️ [bridge-owned-prompt-queue] bridge: route and relay the queued-prompt surface [step 3/7] | Planned | — | |
-| 4/7 | 🚧 [bridge-owned-prompt-queue] claude: accept prompts at enqueue and own the queue [step 4/7] | Planned | — | |
-| 5/7 | 🚧 [bridge-owned-prompt-queue] client: render the bridge queue and transform states seamlessly [step 5/7] | Planned | — | |
-| 6/7 | 🌿 [bridge-owned-prompt-queue] docs: reconcile session-turns regression coverage [step 6/7] | Planned | — | |
+| 3/7 | ⚙️ [bridge-owned-prompt-queue] bridge: route and relay the queued-prompt surface [step 3/7] | In review | #950 | archived-cancel guard added in review |
+| 4/7 | 🚧 [bridge-owned-prompt-queue] claude: accept prompts at enqueue and own the queue [step 4/7] | In review | #951 | echo-expectation and settle fences added in review |
+| 5/7 | 🚧 [bridge-owned-prompt-queue] client: render the bridge queue and transform states seamlessly [step 5/7] | In review | #952 | |
+| 6/7 | 🌿 [bridge-owned-prompt-queue] docs: reconcile session-turns regression coverage [step 6/7] | In review | — | merge after steps 3–5 |
 | 7/7 | ⚙️ [bridge-owned-prompt-queue] verify: run recorded regression coverage and retire the plan [step 7/7] | Planned | — | |
 
 ## Coverage Run Record (Step 7)

--- a/.plan/active/bridge-owned-prompt-queue/TRACKER.md
+++ b/.plan/active/bridge-owned-prompt-queue/TRACKER.md
@@ -4,10 +4,10 @@
 |---|---|---|---|---|
 | 1/7 | 🌱 [bridge-owned-prompt-queue] docs: raise the bridge-owned prompt queue plan [step 1/7] | Merged | #946 | |
 | 2/7 | ⚙️ [bridge-owned-prompt-queue] contracts: prompt ids and queued-prompt wire surface [step 2/7] | Merged | #948 | ACP stamps promptId on its acceptance echo already |
-| 3/7 | ⚙️ [bridge-owned-prompt-queue] bridge: route and relay the queued-prompt surface [step 3/7] | In review | #950 | archived-cancel guard added in review |
-| 4/7 | 🚧 [bridge-owned-prompt-queue] claude: accept prompts at enqueue and own the queue [step 4/7] | In review | #951 | echo-expectation and settle fences added in review |
+| 3/7 | ⚙️ [bridge-owned-prompt-queue] bridge: route and relay the queued-prompt surface [step 3/7] | Merged | #950 | archived-cancel guard added in review |
+| 4/7 | 🚧 [bridge-owned-prompt-queue] claude: accept prompts at enqueue and own the queue [step 4/7] | Merged | #951 | echo-expectation and settle fences added in review |
 | 5/7 | 🚧 [bridge-owned-prompt-queue] client: render the bridge queue and transform states seamlessly [step 5/7] | In review | #952 | |
-| 6/7 | 🌿 [bridge-owned-prompt-queue] docs: reconcile session-turns regression coverage [step 6/7] | In review | — | merge after steps 3–5 |
+| 6/7 | 🌿 [bridge-owned-prompt-queue] docs: reconcile session-turns regression coverage [step 6/7] | In review | #953 | merge after step 5 (#952) |
 | 7/7 | ⚙️ [bridge-owned-prompt-queue] verify: run recorded regression coverage and retire the plan [step 7/7] | Planned | — | |
 
 ## Coverage Run Record (Step 7)

--- a/.plan/active/bridge-owned-prompt-queue/TRACKER.md
+++ b/.plan/active/bridge-owned-prompt-queue/TRACKER.md
@@ -3,7 +3,7 @@
 | Step | PR title | Status | PR | Notes |
 |---|---|---|---|---|
 | 1/7 | 🌱 [bridge-owned-prompt-queue] docs: raise the bridge-owned prompt queue plan [step 1/7] | Merged | #946 | |
-| 2/7 | ⚙️ [bridge-owned-prompt-queue] contracts: prompt ids and queued-prompt wire surface [step 2/7] | In review | #948 | ACP stamps promptId on its acceptance echo already |
+| 2/7 | ⚙️ [bridge-owned-prompt-queue] contracts: prompt ids and queued-prompt wire surface [step 2/7] | Merged | #948 | ACP stamps promptId on its acceptance echo already |
 | 3/7 | ⚙️ [bridge-owned-prompt-queue] bridge: route and relay the queued-prompt surface [step 3/7] | In review | #950 | archived-cancel guard added in review |
 | 4/7 | 🚧 [bridge-owned-prompt-queue] claude: accept prompts at enqueue and own the queue [step 4/7] | In review | #951 | echo-expectation and settle fences added in review |
 | 5/7 | 🚧 [bridge-owned-prompt-queue] client: render the bridge queue and transform states seamlessly [step 5/7] | In review | #952 | |

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -66,6 +66,9 @@ different combination than the previous recorded run.
 
 ## Failure Signals
 
+- A permission or question reply stalls behind a prompt sent to the same busy
+  session (the send must be accepted at enqueue and release the session lane
+  immediately).
 - A request never appears, appears under the wrong session, or omits options the
   backend actually offered.
 - An answer does not reach the backend, arrives with a different scope than the

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -8,9 +8,17 @@ defaults and queued client sends coherent.
 
 ## Required Behavior
 
-- A prompt send targets one session with optional agent, model, and variant. A
-  slash-command send completes on backend acceptance, not run completion, so no
-  client request is held open for a whole agent run.
+- A prompt send targets one session with optional agent, model, and variant.
+  Prompt and slash-command sends complete on acceptance — durably enqueued by
+  the plugin or taken by the backend — never on run completion, so no client
+  request is held open for a running or queued agent turn. Acceptance while
+  another turn runs therefore returns in sub-seconds, and session-lane
+  operations queued behind a send (abort, permission and question replies)
+  are never blocked for the duration of a turn.
+- Every send carries a client-generated prompt id, stable across retries. A
+  queue-owning plugin refuses a duplicate id (already queued or recently
+  dispatched) as an idempotent success, so a retry of a send whose response
+  was lost cannot become a second turn.
 - Sends to an archived session are refused in the serialized lane archiving
   uses, so a send cannot slip past a concurrent archive.
 - Work enters a short per-plugin admission lane in arrival order, then execution
@@ -63,17 +71,28 @@ defaults and queued client sends coherent.
   failure must not fail the send. Abort stops the turn with an observable
   outcome and no completion notification, and the next turn starts without
   recovery output from the interrupted backend process.
-- While the session-detail cubit remains alive, queued client sends preserve order,
-  survive a transient disconnection, can be cancelled individually, and are never
-  dropped. Each queued send retains the agent, model, and variant selected when
-  it was submitted. A submitted prompt remains visible while the bridge is
-  accepting it, including during a cold backend startup, and a failed acceptance
-  returns it to the head of the queue. Queued and sending text render as the
-  newest rows inside the scrollable transcript, never as controls pinned above
-  the composer. It uses the same brand bubble and Markdown rendering as settled
-  user text; a compact status rail and subtle queued outline carry the transient
-  state, with the outline change animated when reduced motion is not requested.
-  A turn started on one client is visible to every other client of that bridge.
+- The bridge owns queued prompts. A send accepted while another turn runs
+  becomes a bridge-queued entry: it appears in the session snapshot and in
+  full-list `session.queued-prompts` events, survives leaving the screen,
+  locking the phone, and reconnecting, is visible to every client of that
+  bridge, and can be cancelled individually from any client until it
+  dispatches (a cancel of an entry that already dispatched is refused as
+  benign — the prompt became a turn, governed by Stop). Aborting the session
+  clears its queued entries.
+- One prompt renders as one bubble that transforms in place: sending (staged
+  locally while the POST is in flight) → queued (bridge-owned) → sent (the
+  transcript message). The dispatched message carries the prompt id and
+  replaces the queued entry in the same client state emission, so no frame
+  shows the prompt twice or not at all. Client-staged sends preserve order,
+  survive a transient disconnection while the session-detail cubit is alive,
+  retain the agent, model, and variant selected at submission, and drain with
+  the same prompt id so retries stay idempotent.
+- Queued and sending text render as the newest rows inside the scrollable
+  transcript, never as controls pinned above the composer. They use the same
+  brand bubble and Markdown rendering as settled user text; a compact status
+  rail and subtle queued outline carry the transient state, with the outline
+  change animated when reduced motion is not requested. A turn started on one
+  client is visible to every other client of that bridge.
 - Live message envelopes render in transcript timestamp order even when events
   arrive out of order; late envelopes append after existing envelopes with the
   same timestamp rather than reordering an established turn. Finalized parts
@@ -90,14 +109,15 @@ defaults and queued client sends coherent.
 | L1 Smoke | Live plugin, representative: a prompt streams assistant output and returns the session to idle. |
 | L2 Routine | Live plugin, representative: slash command returns on acceptance; prompt defaults update; abort stops a turn and reports its outcome; finalized messages are immediately readable from history. |
 | L3 Release | Client end to end (phone), every supporting production plugin: text, reasoning, tool, and status events stream with consistent normalization and the shared output bound; agent, model, and variant apply per send; streaming, composer, sending/queued feedback, and abort render. |
-| L4 Extended | Relay integration, every supporting production plugin: a slow or unresponsive plugin leaves other sessions, plugins, and the relay responsive; archived sends are refused without racing archiving; disconnect and reconnect mid-turn resumes without lost or duplicated parts; queued sends survive in order while detail remains alive; a second client observes the same turn. |
+| L4 Extended | Relay integration, every supporting production plugin: a slow or unresponsive plugin leaves other sessions, plugins, and the relay responsive; archived sends and queued-prompt cancels are refused without racing archiving; disconnect and reconnect mid-turn resumes without lost or duplicated parts; bridge-queued prompts survive leaving and reopening the session in order and appear on a second client, which can cancel them; a permission reply lands while a send is queued behind the running turn; a second client observes the same turn. |
 | L5 Full | Client end to end, every supporting production plugin: retry status surfaces with attempt and timing; concurrent sends across sessions and plugins interleave without ordering damage; background and resume mid-turn recovers live state; an aborted turn triggers no completion notification. |
 
 ## Exploration Guidance
 
 Vary prompt shape, prompt versus slash command, explicit versus default
-agent/model, aborting early versus late, sending while busy to engage the client
-queue, turn length, and client count. For Hermes, include text and image prompts,
+agent/model, aborting early versus late, sending while busy to engage the
+bridge-owned queue (steering, cancelling, leaving and reopening mid-queue),
+turn length, and client count. For Hermes, include text and image prompts,
 tool updates, a permission decision, cold history replay, and abort after output
 has started.
 
@@ -112,12 +132,17 @@ has started.
   the conversation or replayed history.
 - Prompt defaults regress, an approved plan exit does not restore Default
   across clients and restart, or a defaults-write failure fails the send.
-- A send succeeds against an archived session, an aborted turn triggers a
-  completion notification, or queued sends reorder, vanish, or resend while the
-  session-detail cubit remains alive. Submitted text disappears while bridge
-  acceptance or backend startup is still pending, or queued feedback uses a
-  visually unrelated or composer-pinned surface, or renders authored Markdown
-  as literal syntax.
+- A send or cancel succeeds against an archived session, an aborted turn
+  triggers a completion notification, or queued sends reorder, vanish, or
+  resend. A send to a busy session blocks until the running turn finishes, a
+  bridge-queued prompt disappears after leaving and reopening the session, a
+  retried send becomes a duplicate turn, or the queued bubble and its
+  dispatched message render simultaneously. Submitted text disappears while
+  bridge acceptance or backend startup is still pending, or queued feedback
+  uses a visually unrelated or composer-pinned surface, or renders authored
+  Markdown as literal syntax.
+- An abort, permission reply, or question reply stalls behind a send to a
+  busy session on the same session lane.
 - Recovery or interruption artifacts from an aborted turn appear in the next
   user turn.
 - A normalized user message fails to advance the existing activity marker, or
@@ -132,8 +157,13 @@ has started.
   client end-to-end coverage is phone-only.
 - Session-detail refresh behavior is under active investigation, so refresh
   churn is recorded as evidence rather than judged pass or fail.
-- The prompt queue is in memory and owned by session detail; leaving that surface
-  disposes queued submissions rather than restoring them on reopen.
+- The bridge's queued prompts live in plugin memory and do not survive a
+  bridge restart (the backend process dies with the bridge). Claude is the
+  queue-owning plugin; harnesses whose backends take prompts immediately
+  (OpenCode, ACP-family, Codex) never surface queued entries.
+- A send staged locally (POST not yet accepted) is dropped if the session
+  screen is left inside that sub-second window; while disconnected, staged
+  sends survive only as long as the session-detail cubit is alive.
 - Pi persists API commands and manually typed slash prompts in the same raw
   shape. Cold replay therefore shows only the slash-command token to avoid
   exposing bridge-owned arguments; live API-command presentation retains only

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -16,9 +16,10 @@ defaults and queued client sends coherent.
   operations queued behind a send (abort, permission and question replies)
   are never blocked for the duration of a turn.
 - Every send carries a client-generated prompt id, stable across retries. A
-  queue-owning plugin refuses a duplicate id (already queued or recently
-  dispatched) as an idempotent success, so a retry of a send whose response
-  was lost cannot become a second turn.
+  queue-owning plugin refuses a duplicate id (already queued or within its
+  bounded recently-dispatched window) as an idempotent success, so a retry of
+  a send whose response was lost does not become a second turn within that
+  window.
 - Sends to an archived session are refused in the serialized lane archiving
   uses, so a send cannot slip past a concurrent archive.
 - Work enters a short per-plugin admission lane in arrival order, then execution
@@ -164,6 +165,9 @@ has started.
 - A send staged locally (POST not yet accepted) is dropped if the session
   screen is left inside that sub-second window; while disconnected, staged
   sends survive only as long as the session-detail cubit is alive.
+- Retry dedupe is bounded to the last 64 dispatched prompt ids per session; a
+  retry delayed past that window re-enqueues (accepted residual recorded in
+  the plan).
 - Pi persists API commands and manually typed slash prompts in the same raw
   shape. Cold replay therefore shows only the slash-command token to avoid
   exposing bridge-owned arguments; live API-command presentation retains only

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -137,8 +137,8 @@ has started.
   triggers a completion notification, or queued sends reorder, vanish, or
   resend. A send to a busy session blocks until the running turn finishes, a
   bridge-queued prompt disappears after leaving and reopening the session, a
-  retried send becomes a duplicate turn, or the queued bubble and its
-  dispatched message render simultaneously. Submitted text disappears while
+  retried send within the dedupe window becomes a duplicate turn, or the
+  queued bubble and its dispatched message render simultaneously. Submitted text disappears while
   bridge acceptance or backend startup is still pending, or queued feedback
   uses a visually unrelated or composer-pinned surface, or renders authored
   Markdown as literal syntax.


### PR DESCRIPTION
## Complexity

🌿 Straightforward — documentation only: reconciles the regression catalog with the bridge-owned queue behavior delivered in steps 2–5.

## What

Step 6 of the bridge-owned prompt queue ([plan](.plan/active/bridge-owned-prompt-queue/PLAN.md)):

- `docs/regression/session-turns.md`: the acceptance contract now covers prompts as well as commands (accept at enqueue, sub-second while busy, session lane never held for a turn); new required behavior for prompt-id idempotent retries, the bridge-owned queue (snapshot + `session.queued-prompts`, cross-screen/client visibility, per-entry cancel, abort clearing), and the one-bubble sending → queued → sent transform. L4 now covers queue survival across screen exits and a second client cancelling; failure signals add blocked-lane and duplicate/vanishing-prompt cases; the retired "queue is cubit-owned" limitation is replaced by the honest bridge-restart and pre-acceptance-exit residuals.
- `docs/regression/questions-and-permissions.md`: new failure signal — a permission or question reply stalling behind a send to a busy session.
- Tracker sync for steps 2–6.

## Why

The plan's penultimate step: regression docs must describe the shipped queue ownership before step 7 runs the recorded coverage against them.

**Merge after steps 3–5 (#950, #951, #952)** so the catalog never describes unlanded behavior.

## Risk and test focus

None — documentation only. Review focus: the required-behavior wording matches what steps 2–5 actually implement.

## Expected result

No user-visible or database impact. `session-turns.md` and `questions-and-permissions.md` describe the bridge-owned queue; step 7 executes their recorded L4 coverage.

## Verification

Documentation-only change; no Dart suites run per repo instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns regression docs with the bridge‑owned prompt queue shipped in steps 2–4 and scopes the bounded retry‑dedupe window so L4 coverage and failure signals match accept‑at‑enqueue behavior.

- `docs/regression/session-turns.md`: prompts and slash commands complete on acceptance; client‑generated prompt ids with idempotent duplicate refusal within a bounded window (last 64 dispatched ids per session) and a failure signal qualified to “within the window”; bridge‑owned queue appears in snapshots and `session.queued-prompts`, survives leave/reopen, is visible across clients; per‑entry cancel from any client until dispatch (post‑dispatch cancel refused as benign); abort clears queued entries; one‑bubble sending → queued → sent with no duplicate frames; L4 adds archived send/cancel refusal, cross‑client cancel, queue survival, and a permission reply landing while a send is queued; limitations call out plugin‑memory queue (Claude only), no persistence across bridge restart, and early‑leave drop of locally staged sends.
- `docs/regression/questions-and-permissions.md`: adds a failure signal that permission/question replies must not stall behind a send to the same busy session.
- `.plan/.../TRACKER.md`: updates statuses — steps 2–4 merged (#948, #950, #951); step 5 in review (#952); step 6 in review (#953).

**Review and rollout**
- Merge after step 5 lands (#952).
- Verify dedupe wording (last 64 ids per session) and narrowed duplicate‑turn failure signal.
- Documentation only; no runtime or data changes.

<sup>Written for commit 216d0b34d5fa0c11d837a8ae500a6dacf923bc5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

