### PR TITLE
⚙️ Keep Claude ScheduleWakeup loops alive and route the idle timeout per session

### DIFF
--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -634,6 +634,8 @@ class const BridgeRuntimeRunner._() {
         clock: serverClock,
         environment: environment,
         currentUser: currentUser,
+        resolveIdleTimeoutMins: ({required pluginId}) =>
+            bridgeSettingsRepository.currentSettings.plugins.idleTimeoutMinsFor(pluginId: pluginId),
       );
       final activePluginRuntime = PluginRuntime(
         registrations: [

--- a/bridge/app/lib/src/bridge/runtime/plugin_generation_factory.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_generation_factory.dart
@@ -54,6 +54,11 @@ class PluginGenerationFactory({
   required final ServerClock _clock,
   required Map<String, String> environment,
   required final ProcessUser? _currentUser,
+
+  /// Resolves the currently configured idle timeout for a plugin, in minutes.
+  /// Read live at each [PluginHost.pluginIdleTimeout] access so runtime
+  /// settings changes reach plugins without a restart.
+  required final int Function({required String pluginId}) _resolveIdleTimeoutMins,
 }) {
   final Map<String, String> _environment = Map<String, String>.unmodifiable(environment);
   final Map<String, RuntimeFileApi> _fileApisByStateDirectory = <String, RuntimeFileApi>{
@@ -264,6 +269,10 @@ class PluginGenerationFactory({
       ),
       ports: const BridgeHostPortService(loopbackPortApi: LoopbackPortApi()),
       store: BridgeHostJsonStore(fileApi: fileApi),
+      resolveIdleTimeout: () {
+        final minutes = _resolveIdleTimeoutMins(pluginId: descriptor.id);
+        return minutes > 0 ? Duration(minutes: minutes) : null;
+      },
     );
   }
 }

--- a/bridge/app/lib/src/server/host/bridge_plugin_host_impl.dart
+++ b/bridge/app/lib/src/server/host/bridge_plugin_host_impl.dart
@@ -44,6 +44,7 @@ class BridgePluginHostImpl({
   @override required final HostProcessService processes,
   @override required final HostPortService ports,
   @override required final HostJsonStore store,
+  required final Duration? Function() _resolveIdleTimeout,
 }) implements PluginHost {
   static Future<BridgePluginHostImpl> create({
     required PluginConfig config,
@@ -60,6 +61,7 @@ class BridgePluginHostImpl({
     required ProcessUser? currentUser,
     required bool isWindows,
     required String platform,
+    required Duration? Function() resolveIdleTimeout,
   }) async {
     if (!p.isAbsolute(stateDirectory)) {
       throw ArgumentError.value(stateDirectory, "stateDirectory", "must be an absolute path");
@@ -90,8 +92,14 @@ class BridgePluginHostImpl({
       store: BridgeHostJsonStore(
         fileApi: RuntimeFileApi(runtimeDirectory: stateDirectory),
       ),
+      resolveIdleTimeout: resolveIdleTimeout,
     );
   }
+
+  /// Live view over the bridge's runtime-mutable per-plugin idle timeout, so
+  /// a settings change reaches the plugin without a restart.
+  @override
+  Duration? get pluginIdleTimeout => _resolveIdleTimeout();
 
   /// Set by the bridge runner from `ensureRuntime`'s [ProvisionReady] result,
   /// after the host is built and before `start()` runs; `null` when the plugin

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -1327,7 +1327,7 @@ class PluginLifecycleService({
     final currentIds = snapshots.map((snapshot) => snapshot.pluginId).toSet();
     _idleTimers.keys.where((pluginId) => !currentIds.contains(pluginId)).toList().forEach(_cancelIdleTimer);
     for (final snapshot in snapshots) {
-      final timeoutMins = _effectiveIdleTimeoutMins(snapshot.pluginId);
+      final timeoutMins = _suspensionIdleTimeoutMins(snapshot.pluginId);
       if (!_supportsIdleSuspension(pluginId: snapshot.pluginId) || timeoutMins <= 0 || !_isIdleCandidate(snapshot)) {
         _cancelIdleTimer(snapshot.pluginId);
         continue;
@@ -1362,11 +1362,26 @@ class PluginLifecycleService({
         (snapshot.state == PluginRuntimeState.active || snapshot.state == PluginRuntimeState.degraded);
   }
 
+  /// The user-facing configured idle timeout, as shown and edited by clients.
+  ///
+  /// Independent of residency: a resident plugin that keeps the `idleTimeout`
+  /// capability (Claude) consumes this value through
+  /// `PluginHost.pluginIdleTimeout` for its own internal reclamation, so the
+  /// knob stays real even though whole-plugin suspension never runs.
   int _effectiveIdleTimeoutMins(String pluginId) {
+    return _bridgeSettingsRepository.currentSettings.plugins.idleTimeoutMinsFor(pluginId: pluginId);
+  }
+
+  /// The timeout driving whole-plugin idle suspension; `0` disables it.
+  ///
+  /// Resident plugins are never suspended: they either attach to an external
+  /// backend the bridge does not own (OpenCode attach mode) or own idle
+  /// reclamation internally (Claude's per-session process reap).
+  int _suspensionIdleTimeoutMins(String pluginId) {
     final residencyPolicy = _residencyPolicyById?[pluginId];
     if (residencyPolicy == null) throw StateError("Plugin lifecycle has not been registered.");
     if (residencyPolicy == PluginResidencyPolicy.resident) return 0;
-    return _bridgeSettingsRepository.currentSettings.plugins.idleTimeoutMinsFor(pluginId: pluginId);
+    return _effectiveIdleTimeoutMins(pluginId);
   }
 
   Future<void> _stopAfterIdleWindow({
@@ -1377,7 +1392,7 @@ class PluginLifecycleService({
     _idleTimers.remove(pluginId);
     if (!_supportsIdleSuspension(pluginId: pluginId)) return;
     final snapshot = _lifecycleRepository.snapshot.where((entry) => entry.pluginId == pluginId).firstOrNull;
-    final timeoutMins = _effectiveIdleTimeoutMins(pluginId);
+    final timeoutMins = _suspensionIdleTimeoutMins(pluginId);
     if (snapshot == null || timeoutMins <= 0 || !_isIdleCandidate(snapshot)) return;
     Log.d('Plugin "$pluginId" idle timeout elapsed (${timeoutMins}m); requesting safe suspension');
     try {

--- a/bridge/app/test/bridge/runtime/plugin_generation_factory_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_generation_factory_test.dart
@@ -65,6 +65,7 @@ void main() {
         clock: const ServerClock(),
         environment: const <String, String>{"HOME": "/home/alex"},
         currentUser: ProcessUser.fromRawUser("alex"),
+        resolveIdleTimeoutMins: ({required pluginId}) => 10,
       );
       BridgePlugin? startedPlugin;
       await for (final event in factory.start(
@@ -144,6 +145,7 @@ void main() {
         clock: const ServerClock(),
         environment: const <String, String>{},
         currentUser: null,
+        resolveIdleTimeoutMins: ({required pluginId}) => 10,
       );
       await factory.enforceBridgeOwnership();
 

--- a/bridge/app/test/server/host/bridge_plugin_host_impl_test.dart
+++ b/bridge/app/test/server/host/bridge_plugin_host_impl_test.dart
@@ -42,6 +42,7 @@ void main() {
         bridgeIdentity: bridgeIdentity,
         ownerSessionId: '100:bridge-start-marker',
         terminatedBridgeIdentities: const [],
+        resolveIdleTimeout: () => const Duration(minutes: 10),
         processRepository: _UnusedProcessRepository(),
         loopbackPortApi: const LoopbackPortApi(),
         processStarter: _failingStarter,

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -632,7 +632,9 @@ void main() {
     expect(alpha.actionHint, "Install Alpha.");
     expect(beta.runtimeState, shared.PluginRuntimeState.disabled);
     expect(opencode.runtimeState, shared.PluginRuntimeState.dormant);
-    expect(opencode.idleTimeoutMins, 0);
+    // Residency no longer zeroes the reported timeout: the configured value is
+    // surfaced so resident plugins that consume it internally show the real knob.
+    expect(opencode.idleTimeoutMins, 45);
     expect(opencode.hasIdleTimeoutOverride, isTrue);
     expect(settingsRepository.currentSettings.plugins.idleTimeoutMinsFor(pluginId: "opencode"), 45);
     expect(runtime.activePluginIds, isEmpty);
@@ -1174,7 +1176,7 @@ void main() {
     expect(snapshotTokens, hasLength(3));
   });
 
-  test("resident plugins persist timeout edits while retaining effective zero", () async {
+  test("resident plugins persist timeout edits and report the configured value", () async {
     final repository = _IdleLifecycleRepository();
     addTearDown(repository.dispose);
     final settingsRepository = _MutableBridgeSettingsRepository(
@@ -1201,7 +1203,10 @@ void main() {
     );
 
     expect(settingsRepository.settings.plugins.settingsByPluginId["one"]?.idleTimeoutMins, 20);
-    expect(response.plugins.single.idleTimeoutMins, 0);
+    // The configured value is reported (a resident plugin may consume it for
+    // internal reclamation via PluginHost.pluginIdleTimeout); only the
+    // whole-plugin suspension timer stays disarmed.
+    expect(response.plugins.single.idleTimeoutMins, 20);
     expect(response.plugins.single.hasIdleTimeoutOverride, isTrue);
     expect(timerScheduler.timers, isEmpty);
   });

--- a/bridge/app/tool/benchmarks/multi_plugin_startup_benchmark.dart
+++ b/bridge/app/tool/benchmarks/multi_plugin_startup_benchmark.dart
@@ -105,6 +105,7 @@ Future<_StartupSample> _runFixture({required int selectedCount}) async {
     clock: const ServerClock(),
     environment: const <String, String>{},
     currentUser: null,
+    resolveIdleTimeoutMins: ({required pluginId}) => 10,
   );
   final runtime =
       PluginRuntime(

--- a/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
@@ -49,7 +49,6 @@ ClaudeBridgePlugin _defaultBuildBridgePlugin({
 /// Descriptor and composition root for the local Claude Code CLI plugin.
 final class const ClaudePluginDescriptor({
   final Duration _probeTimeout = const Duration(seconds: 10),
-  final Duration _sessionIdleTimeout = const Duration(minutes: 5),
   final Duration _statusDebounce = const Duration(seconds: 5),
   final ClaudeBridgePluginFactory? _buildBridgePlugin,
 }) extends BridgePluginDescriptor {
@@ -83,6 +82,16 @@ final class const ClaudePluginDescriptor({
 
   @override
   bool get supportsPromptAttachments => true;
+
+  /// Claude owns idle reclamation per session: the service reaps individual
+  /// CLI child processes on the user-configured idle timeout
+  /// ([PluginHost.pluginIdleTimeout]) and resumes them transparently with
+  /// `--resume`. Whole-plugin suspension would add nothing (an all-reaped
+  /// plugin holds no processes, timers, or ports) and would silently kill any
+  /// pending in-process `ScheduleWakeup` timer, so the bridge-level idle
+  /// suspension must never arm.
+  @override
+  PluginResidencyPolicy residencyPolicy({required PluginConfig config}) => PluginResidencyPolicy.resident;
 
   @override
   List<PluginOption> get options => cliOptions;
@@ -191,7 +200,7 @@ final class const ClaudePluginDescriptor({
       processes: processes,
       approvals: approvals,
       clock: host.clock,
-      idleTimeout: _sessionIdleTimeout,
+      resolveIdleTimeout: () => host.pluginIdleTimeout,
     );
     const content = ClaudeContentMapper();
     final plugin = ClaudePlugin(

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -3,6 +3,7 @@ import "dart:async";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" as shared;
 
+import "../api/models/claude_stream_message.dart";
 import "../claude_approval_registry.dart";
 import "../models/claude_effort_level.dart";
 import "../models/claude_permission_mode.dart";
@@ -13,6 +14,23 @@ final class _SessionTurnState() {
   int pending = 0;
   int generation = 0;
   int idleGeneration = 0;
+
+  /// True while the CLI runs a turn the bridge did not enqueue.
+  ///
+  /// A `ScheduleWakeup` loop wakeup starts a turn inside the resident process
+  /// with no `enqueueTurn` call: frames stream while [pending] is zero. The
+  /// flag keeps that turn visible (busy status, work state, abort) until its
+  /// `result` frame lands.
+  bool selfStarted = false;
+
+  /// When the CLI's pending `ScheduleWakeup` timer fires, or null when none
+  /// is scheduled.
+  ///
+  /// The timer lives only inside the resident process — killing the process
+  /// kills the wakeup, and `--resume` does not rearm it (verified against CLI
+  /// 2.1.233) — so the idle reap must not tear the process down before the
+  /// wakeup fires.
+  DateTime? wakeupAt;
 }
 
 /// Serializes Claude turns and owns session work/idle lifecycle policy.
@@ -20,7 +38,11 @@ final class ClaudeSessionService({
   required final ClaudeSessionProcessRepository _processes,
   required final ClaudeApprovalRegistry _approvals,
   required final ServerClock _clock,
-  required final Duration _idleTimeout,
+
+  /// Resolves the current per-session idle timeout, or null when idle reaping
+  /// is disabled. Read at every timer arm so a runtime settings change takes
+  /// effect at the next idle transition.
+  required final Duration? Function() _resolveIdleTimeout,
 }) {
   this {
     _processEvents = _processes.events.listen(_handleProcessEvent);
@@ -44,7 +66,9 @@ final class ClaudeSessionService({
     for (final entry in _turns.entries)
       entry.key:
           _retryStatuses[entry.key] ??
-          (entry.value.pending > 0 ? const PluginSessionStatus.busy() : const PluginSessionStatus.idle()),
+          (entry.value.pending > 0 || entry.value.selfStarted
+              ? const PluginSessionStatus.busy()
+              : const PluginSessionStatus.idle()),
   });
 
   Future<void> enqueueTurn({
@@ -143,12 +167,15 @@ final class ClaudeSessionService({
   Future<void> abort({required String sessionId}) async {
     final state = _turns[sessionId];
     if (state == null) return;
-    if (state.pending == 0) {
+    if (state.pending == 0 && !state.selfStarted) {
       _approvals.cancelForSession(sessionId: sessionId);
       return;
     }
     state.generation++;
     state.idleGeneration++;
+    // Teardown kills the CLI's in-process wakeup timer, and `--resume` does
+    // not rearm it, so a pending wakeup cannot survive an abort.
+    state.wakeupAt = null;
     _approvals.cancelForSession(sessionId: sessionId);
     try {
       await _processes.interrupt(sessionId: sessionId);
@@ -160,13 +187,16 @@ final class ClaudeSessionService({
       // allowing that transport backlog to enter the next user turn.
       await _processes.teardown(sessionId: sessionId);
     }
+    if (state.selfStarted && identical(_turns[sessionId], state)) {
+      _endSelfStartedTurn(sessionId: sessionId, state: state);
+    }
   }
 
   Future<Set<String>> interruptActiveWork({required Duration budget}) {
     return () async {
       final activeSessionIds = <String>{
         for (final entry in _turns.entries)
-          if (entry.value.pending > 0) entry.key,
+          if (entry.value.pending > 0 || entry.value.selfStarted) entry.key,
       };
       if (activeSessionIds.isEmpty) return const <String>{};
       await Future.wait([
@@ -218,7 +248,7 @@ final class ClaudeSessionService({
     if (state.pending > 0) state.pending--;
     if (!identical(_turns[sessionId], state)) return;
     if (outcome is ClaudeTurnFailed) _emit(BridgeSseSessionError(sessionID: sessionId));
-    if (state.pending == 0) {
+    if (state.pending == 0 && !state.selfStarted) {
       _emit(BridgeSseSessionIdle(sessionID: sessionId));
       _emit(const BridgeSseProjectUpdated());
       _syncWorkState();
@@ -228,13 +258,26 @@ final class ClaudeSessionService({
 
   void _scheduleIdleReap({required String sessionId, required _SessionTurnState state}) {
     final generation = ++state.idleGeneration;
+    final idleTimeout = _resolveIdleTimeout();
+    if (idleTimeout == null) return;
     unawaited(() async {
-      await _clock.delay(duration: _idleTimeout);
-      if (_disposed ||
-          !identical(_turns[sessionId], state) ||
-          state.pending != 0 ||
-          state.idleGeneration != generation) {
-        return;
+      while (true) {
+        await _clock.delay(duration: idleTimeout);
+        if (_disposed ||
+            !identical(_turns[sessionId], state) ||
+            state.pending != 0 ||
+            state.selfStarted ||
+            state.idleGeneration != generation) {
+          return;
+        }
+        final wakeupAt = state.wakeupAt;
+        if (wakeupAt == null) break;
+        // Teardown would silently kill the CLI's in-process wakeup timer, so
+        // keep the process resident until the wakeup fires (the fired turn
+        // rearms this reap). A wakeup that never fires — the loop ended
+        // without a frame the bridge observed — stops deferring one idle
+        // timeout past its fire time instead of pinning the process forever.
+        if (_clock.now().isAfter(wakeupAt.add(idleTimeout))) break;
       }
       final teardown = _processes.teardown(sessionId: sessionId);
       _inFlightTeardowns.add(teardown);
@@ -253,8 +296,11 @@ final class ClaudeSessionService({
     }());
   }
 
-  void _syncWorkState() =>
-      _workState.set(_turns.values.any((state) => state.pending > 0) ? PluginWorkState.busy : PluginWorkState.idle);
+  void _syncWorkState() => _workState.set(
+    _turns.values.any((state) => state.pending > 0 || state.selfStarted)
+        ? PluginWorkState.busy
+        : PluginWorkState.idle,
+  );
 
   void _emit(BridgeSseEvent event) {
     if (!_events.isClosed) _events.add(event);
@@ -267,10 +313,80 @@ final class ClaudeSessionService({
   void _handleProcessEvent(ClaudeSessionProcessEvent event) {
     switch (event) {
       case final ClaudeSessionProcessMessage event:
+        // Transition before arming: a frame that both begins a self-started
+        // turn and carries a new `ScheduleWakeup` must keep the new schedule.
+        _trackSelfStartedTurn(sessionId: event.sessionId, message: event.message);
+        _trackWakeupSchedule(sessionId: event.sessionId, message: event.message);
         final request = event.controlRequest;
         if (request != null) _approvals.handle(sessionId: event.sessionId, message: request);
       case ClaudeSessionProcessExited():
+        final state = _turns[event.sessionId];
+        if (state != null) {
+          // The wakeup timer died with the process and `--resume` does not
+          // rearm it.
+          state.wakeupAt = null;
+          if (state.selfStarted) _endSelfStartedTurn(sessionId: event.sessionId, state: state);
+        }
         _approvals.cancelForSession(sessionId: event.sessionId);
     }
+  }
+
+  /// Mirrors the CLI's pending `ScheduleWakeup` timer from the tool calls that
+  /// arm and disarm it.
+  ///
+  /// The CLI clamps the requested delay, so [_SessionTurnState.wakeupAt] is a
+  /// lower-bound estimate; the reap deferral adds the idle timeout as margin.
+  void _trackWakeupSchedule({required String sessionId, required ClaudeStreamMessage message}) {
+    if (message is! ClaudeAssistantMessage) return;
+    final state = _turns[sessionId];
+    if (state == null) return;
+    final content = message.message["content"];
+    if (content is! List) return;
+    for (final block in content) {
+      if (block is! Map || block["type"] != "tool_use" || block["name"] != "ScheduleWakeup") continue;
+      final rawInput = block["input"];
+      if (rawInput is! Map) continue;
+      final input = rawInput.cast<String, Object?>();
+      if (input["stop"] == true) {
+        state.wakeupAt = null;
+      } else if (input["delaySeconds"] case final num delaySeconds) {
+        state.wakeupAt = _clock.now().add(Duration(seconds: delaySeconds.toInt()));
+      }
+    }
+  }
+
+  /// Surfaces a turn the CLI started on its own — a fired `ScheduleWakeup` —
+  /// as busy/idle exactly like an enqueued turn.
+  ///
+  /// Only frames that prove turn activity begin one: token stream, assistant
+  /// content, or a permission ask. Bookkeeping frames (`init`, `status`,
+  /// unknown types) do not, so post-turn stragglers cannot re-busy a session.
+  void _trackSelfStartedTurn({required String sessionId, required ClaudeStreamMessage message}) {
+    final state = _turns[sessionId];
+    if (state == null) return;
+    switch (message) {
+      case ClaudeStreamEventMessage() || ClaudeAssistantMessage() || ClaudeControlRequestMessage():
+        if (state.selfStarted || state.pending > 0) return;
+        state.selfStarted = true;
+        // A live turn supersedes the pending-wakeup estimate that started it.
+        state.wakeupAt = null;
+        state.idleGeneration++;
+        _workState.set(PluginWorkState.busy);
+        _emit(BridgeSseSessionStatus(sessionID: sessionId, status: const shared.SessionStatus.busy().toJson()));
+        _emit(const BridgeSseProjectUpdated());
+      case ClaudeResultMessage():
+        if (state.selfStarted) _endSelfStartedTurn(sessionId: sessionId, state: state);
+      case ClaudeStreamMessage():
+        break;
+    }
+  }
+
+  void _endSelfStartedTurn({required String sessionId, required _SessionTurnState state}) {
+    state.selfStarted = false;
+    if (state.pending != 0) return;
+    _emit(BridgeSseSessionIdle(sessionID: sessionId));
+    _emit(const BridgeSseProjectUpdated());
+    _syncWorkState();
+    _scheduleIdleReap(sessionId: sessionId, state: state);
   }
 }

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -521,7 +521,7 @@ final class _PluginHarness({final bool failInitialize = false, bool failTranscri
       processes: processRepository,
       approvals: approvals,
       clock: const _NeverIdleClock(),
-      idleTimeout: const Duration(minutes: 5),
+      resolveIdleTimeout: () => const Duration(minutes: 5),
     );
     const content = ClaudeContentMapper();
     final transcripts = ClaudeTranscriptCatalogRepository(

--- a/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
@@ -203,6 +203,143 @@ void main() {
       expect(completed, isTrue);
     });
 
+    test("defers the idle reap while a ScheduleWakeup is pending", () async {
+      harness.enqueue("first");
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      process.emit(_scheduleWakeupFrame(delaySeconds: 600));
+      process.emit(_result());
+      await harness.waitForIdle();
+
+      harness.clock.elapse();
+      await pump();
+
+      expect(harness.repository.isResident(sessionId: testSessionId), isTrue);
+    });
+
+    test("reaps a process whose wakeup is one idle timeout stale", () async {
+      harness.enqueue("first");
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      process.emit(_scheduleWakeupFrame(delaySeconds: -100000));
+      process.emit(_result());
+      await harness.waitForIdle();
+
+      harness.clock.elapse();
+      await pump();
+
+      expect(harness.repository.isResident(sessionId: testSessionId), isFalse);
+    });
+
+    test("surfaces a CLI self-started wakeup turn as busy and idle again on its result", () async {
+      harness.enqueue("first");
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      process.emit(_scheduleWakeupFrame(delaySeconds: 600));
+      process.emit(_result());
+      await harness.waitForIdle();
+      harness.events.clear();
+
+      // The wakeup fires: the CLI streams a turn the bridge never enqueued.
+      process.emit(_assistantTextFrame(text: "waking up"));
+      await harness.waitForBusy();
+
+      expect(harness.service.currentWorkState, PluginWorkState.busy);
+      expect(await _status(harness), isA<PluginSessionStatusBusy>());
+      expect(harness.events.whereType<BridgeSseSessionStatus>(), isNotEmpty);
+
+      process.emit(_result());
+      await harness.waitForIdle();
+
+      expect(await _status(harness), isA<PluginSessionStatusIdle>());
+      expect(harness.events.whereType<BridgeSseSessionIdle>(), hasLength(1));
+
+      // The finished self-started turn cleared the wakeup and rearmed the reap.
+      harness.clock.elapse();
+      await pump();
+      expect(harness.repository.isResident(sessionId: testSessionId), isFalse);
+    });
+
+    test("abort interrupts a self-started wakeup turn", () async {
+      harness.enqueue("first");
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      process.emit(_scheduleWakeupFrame(delaySeconds: 600));
+      process.emit(_result());
+      await harness.waitForIdle();
+
+      process.emit(_assistantTextFrame(text: "waking up"));
+      await harness.waitForBusy();
+
+      final abort = harness.service.abort(sessionId: testSessionId);
+      final interrupt = await _waitForControlSubtype(process, "interrupt");
+      process.emitControlResponse(requestId: interrupt["request_id"]! as String, payload: const {});
+      await abort;
+      await harness.waitForIdle();
+
+      expect(harness.repository.isResident(sessionId: testSessionId), isFalse);
+      expect(harness.service.currentWorkState, PluginWorkState.idle);
+    });
+
+    test("a ScheduleWakeup stop call clears the pending wakeup", () async {
+      harness.enqueue("first");
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      process.emit(_scheduleWakeupFrame(delaySeconds: 600));
+      process.emit(_result());
+      await harness.waitForIdle();
+
+      // The fired turn ends the loop: ScheduleWakeup({stop: true}) then result.
+      process.emit(_scheduleWakeupStopFrame());
+      await harness.waitForBusy();
+      process.emit(_result());
+      await harness.waitForIdle();
+
+      harness.clock.elapse();
+      await pump();
+      expect(harness.repository.isResident(sessionId: testSessionId), isFalse);
+    });
+
+    test("reads the idle timeout live at each reap arm", () async {
+      harness.idleTimeout = null;
+      harness.enqueue("first");
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      process.emit(_result());
+      await harness.waitForIdle();
+
+      // Reaping disabled: no delay armed, process stays resident.
+      harness.clock.elapse();
+      await pump();
+      expect(harness.repository.isResident(sessionId: testSessionId), isTrue);
+
+      // Settings change takes effect at the next idle transition.
+      harness.idleTimeout = const Duration(minutes: 1);
+      harness.enqueue("second");
+      await _waitForUserFrames(process, 2);
+      process.emit(_result());
+      await harness.waitForIdle();
+      harness.clock.elapse();
+      await pump();
+      expect(harness.repository.isResident(sessionId: testSessionId), isFalse);
+    });
+
+    test("a process exit clears the pending wakeup", () async {
+      harness.enqueue("first");
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      process.emit(_scheduleWakeupFrame(delaySeconds: 600));
+      process.emit(_result());
+      await harness.waitForIdle();
+
+      process.exit(0);
+      await pump();
+
+      harness.clock.elapse();
+      await pump();
+      expect(harness.repository.isResident(sessionId: testSessionId), isFalse);
+    });
+
     test("delete waits for an in-flight idle teardown", () async {
       await harness.dispose();
       harness = _ServiceHarness(stdinCloseCompletes: false);
@@ -228,6 +365,9 @@ void main() {
 }
 
 final class _ServiceHarness({final bool stdinCloseCompletes = true, final bool failInterrupt = false}) {
+  /// Mutable so tests can exercise runtime settings changes.
+  Duration? idleTimeout = const Duration(minutes: 5);
+
   this {
     repository = ClaudeSessionProcessRepository(
       processFactory: _spawn,
@@ -243,7 +383,7 @@ final class _ServiceHarness({final bool stdinCloseCompletes = true, final bool f
       processes: repository,
       approvals: approvals,
       clock: clock,
-      idleTimeout: const Duration(minutes: 5),
+      resolveIdleTimeout: () => idleTimeout,
     );
     subscription = service.events.listen(events.add);
   }
@@ -301,6 +441,10 @@ final class _ServiceHarness({final bool stdinCloseCompletes = true, final bool f
   Future<void> waitForIdle() => service.currentWorkState == PluginWorkState.idle
       ? Future<void>.value()
       : service.workState.firstWhere((state) => state == PluginWorkState.idle);
+
+  Future<void> waitForBusy() => service.currentWorkState == PluginWorkState.busy
+      ? Future<void>.value()
+      : service.workState.firstWhere((state) => state == PluginWorkState.busy);
 
   Future<void> dispose() async {
     await service.dispose();
@@ -371,3 +515,40 @@ Map<String, Object?> _result() => {
   "session_id": testSessionId,
   "is_error": false,
 };
+
+Future<PluginSessionStatus> _status(_ServiceHarness harness) async =>
+    harness.service.sessionStatuses[testSessionId]!;
+
+Map<String, Object?> _scheduleWakeupFrame({required int delaySeconds}) => _assistantFrame(content: [
+  {
+    "type": "tool_use",
+    "id": "wakeup-1",
+    "name": "ScheduleWakeup",
+    "input": {"delaySeconds": delaySeconds, "prompt": "continue the loop"},
+  },
+]);
+
+Map<String, Object?> _scheduleWakeupStopFrame() => _assistantFrame(content: [
+  {
+    "type": "tool_use",
+    "id": "wakeup-2",
+    "name": "ScheduleWakeup",
+    "input": {"stop": true},
+  },
+]);
+
+Map<String, Object?> _assistantTextFrame({required String text}) => _assistantFrame(content: [
+  {"type": "text", "text": text},
+]);
+
+Map<String, Object?> _assistantFrame({required List<Map<String, Object?>> content}) => {
+  "type": "assistant",
+  "session_id": testSessionId,
+  "message": {
+    "id": "msg-${_frameSequence++}",
+    "model": "claude-sonnet-4-5",
+    "content": content,
+  },
+};
+
+int _frameSequence = 0;

--- a/bridge/sesori_plugin_interface/lib/src/host/plugin_host.dart
+++ b/bridge/sesori_plugin_interface/lib/src/host/plugin_host.dart
@@ -61,4 +61,15 @@ abstract class PluginHost() {
   /// Atomic JSON-file persistence under [stateDirectory], with a locked
   /// read-modify-write primitive.
   HostJsonStore get store;
+
+  /// The user-configured idle timeout for this plugin, or null when idle
+  /// cleanup is disabled.
+  ///
+  /// A live getter over the bridge's runtime-mutable settings: read it when
+  /// arming an idle timer rather than caching it, so a settings change takes
+  /// effect at the next idle transition without a plugin restart. Plugins
+  /// whose descriptor declares `PluginResidencyPolicy.resident` own idle
+  /// cleanup themselves (the bridge's whole-plugin suspension timer never
+  /// arms) and use this value for their internal reclamation instead.
+  Duration? get pluginIdleTimeout;
 }

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_test.dart
@@ -1024,6 +1024,9 @@ class _FakeHost({@override required final PluginConfig config}) implements Plugi
   final String stateDirectory = "/runtime";
 
   @override
+  Duration? get pluginIdleTimeout => null;
+
+  @override
   String? provisionedRuntimePath;
 
   @override

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -30,6 +30,17 @@ idle suspension, the management snapshot, and lifecycle commands.
   idle window and a resident one never does, and idle timeouts survive restart.
   Enable, disable, restart, and refresh are offered only where declared, with enable
   persisting eligibility, re-inspecting setup, then starting when ready.
+- A resident harness that keeps the idle-timeout capability (Claude Code) reports the
+  configured timeout instead of zero and consumes it internally through the host: the
+  Claude plugin reaps each idle session's CLI child process after that window and
+  transparently resumes it on the next prompt, so the settings knob stays effective
+  even though whole-plugin suspension never runs. A runtime timeout change applies at
+  each session's next idle transition without a plugin restart.
+- A Claude session whose CLI scheduled a `ScheduleWakeup` loop wakeup is not reaped
+  before the wakeup fires (the in-process timer would die and `--resume` cannot rearm
+  it); a wakeup that never fires stops deferring one idle window past its fire time.
+  The wakeup-fired turn the CLI starts on its own is surfaced busy, then idle on its
+  result, and abort interrupts it like any enqueued turn.
 - A busy harness conflicts explicitly, forcing needs confirmation and is sent once, the
   snapshot changes only on real content change with a new token, and a terminal failure
   removes only that harness's routing and new-session choice.


### PR DESCRIPTION
## Complexity
⚙️ Moderate — one new interface member, plugin-internal lifecycle logic, and a lifecycle-service reporting change, all covered by unit tests.

## What
Fixes the Claude `ScheduleWakeup` (loop wakeup) integration and routes the existing per-plugin idle-timeout setting into the Claude plugin's per-session process reap.

- `ClaudeSessionService` tracks `ScheduleWakeup` schedule/stop tool calls and defers the per-session idle reap while a wakeup is pending (plus one idle window of slack for wakeups that never fire).
- CLI **self-started turns** (a fired wakeup) are surfaced as busy, go idle on their `result`, and can be aborted like enqueued turns. Previously they were invisible: the session stayed "idle" while its `can_use_tool` asks registered as pending input — the "Awaiting input with nothing shown" symptom.
- New `PluginHost.pluginIdleTimeout`: a live getter over the runtime-mutable per-plugin idle-timeout setting. The Claude session reap consumes it (was a hardcoded 5 minutes), so the existing settings knob now controls Claude session-process cleanup and a change applies at the next idle transition without a restart.
- The Claude descriptor now declares `PluginResidencyPolicy.resident`, disabling whole-plugin idle suspension. Management rows report the configured timeout for resident plugins instead of `0`, so the client knob remains visible and truthful.

## Why
Protocol behavior verified live against Claude CLI 2.1.233: the wakeup timer lives only inside the resident CLI process — teardown kills it and `--resume` does not rearm it. The bridge previously killed pending wakeups twice (per-session reap at 5 min, whole-plugin suspension at the configured timeout). Whole-plugin suspension for Claude frees essentially nothing: with all session children reaped the plugin holds no processes, timers, or ports, and restart is automatic on demand.

Incident report also included all sessions freezing at once; no bridge-side coupling between Claude sessions exists (per-session process and turn chain), that part was not reproducible, and the bridge stderr logs were lost with the restart — not addressed here.

## Risk and test focus
- Claude turn lifecycle: new `selfStarted` state participates in status, work state, abort, and `interruptActiveWork`. Regression risk is a session stuck busy or a reap firing early; both covered by new `ClaudeSessionService` tests (defer, stale-wakeup fallback, self-started busy/idle/abort, stop-call clear, exit clear, live timeout re-read).
- `PluginHost` gained a member: in-repo implementors and fakes updated in lockstep; no wire or persisted contract changed.
- Lifecycle reporting: resident plugins now report the configured timeout rather than `0`. Client UI reads the same fields, no client change needed.

## Expected result
Claude `/loop` wakeups survive bridge idle housekeeping and fire on schedule; the fired turn shows as busy and its permission asks are actionable; the harness settings idle-timeout knob governs Claude per-session process cleanup, including runtime changes. No database impact.

## Verification
- `dart analyze --fatal-infos` clean on all touched modules (interface, claude, runtime, opencode, omp, cursor, hermes, app).
- `dart test`: claude (223), app (2649), interface (152), opencode (421) — all pass.
- Live protocol repro against CLI 2.1.233 (stream-json, real wakeup cycle): turn ends with `result` after scheduling; CLI self-starts the fired turn; timer does not survive process teardown/`--resume`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Claude `ScheduleWakeup` loops alive and routes the per‑plugin idle‑timeout to per‑session reaping. Previously, sessions were reaped (hardcoded 5‑minute timer plus whole‑plugin suspension), killing pending wakeups and hiding wakeup‑fired turns; now reaping defers until wakeups fire, those turns are visible and abortable, and timeout edits apply on the next idle transition without a restart.

- Adds `PluginHost.pluginIdleTimeout` (live getter). The runner/factory plumb `resolveIdleTimeoutMins`, the host exposes `pluginIdleTimeout`, and Claude reaps per session using it (read at arm time).
- Tracks `ScheduleWakeup` schedule/stop per session and defers idle reap while a wakeup is pending, with one idle‑window slack if it never fires; abort and process exit clear the pending wakeup.
- Surfaces CLI self‑started turns as busy, idles on `result`, and includes them in abort and `interruptActiveWork`.
- Declares Claude `PluginResidencyPolicy.resident`. Lifecycle reports the configured timeout for resident plugins and never arms whole‑plugin suspension; splits effective user‑facing timeout vs suspension timer.
- Updates tests and docs for the new lifecycle and reporting.

**Migration**
- Implement `pluginIdleTimeout` on any out‑of‑tree `PluginHost` implementations.

<sup>Written for commit 6036529df9816e8ebf46a8423a2729b1d6211e7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

