### PR TITLE
🌿 [hermes-agent-plugin] docs: record iOS client E2E evidence

### DIFF
--- a/.plan/active/hermes-agent-plugin/PLAN.md
+++ b/.plan/active/hermes-agent-plugin/PLAN.md
@@ -123,7 +123,7 @@ one consumer.
 | 5/9 | `⚙️ [hermes-agent-plugin] feat(hermes): register the plugin in the bridge [step 5/9]` | Merged as #919. |
 | 6/9 | `⚙️ [hermes-agent-plugin] feat(client): brand the Hermes harness [step 6/9]` | Merged as #921; corrected supplied artwork and asset contract. |
 | 7/9 | `🚧 [hermes-agent-plugin] fix(hermes): correct runtime and ACP assumptions [step 7/9]` | Merged as #927: auth selection, version semantics, executable revalidation, setup failure classification, null activation retry, exact registry test, plan/docs correction. |
-| 8/9 | `🚧 [hermes-agent-plugin] test(hermes): verify production ACP behavior [step 8/9]` | Merged as #929: supported-version headless/live evidence recorded in `TRACKER.md`; provider and client rows remain blocked. |
+| 8/9 | `🚧 [hermes-agent-plugin] test(hermes): verify production ACP behavior [step 8/9]` | Merged as #929, extended by the 2026-08-18 iOS client E2E run in `TRACKER.md`. Setup/lifecycle, session creation, tools and file changes, images, history and recovery, and deletion now pass; `Questions and permissions`, `Session turns` (reasoning streaming), `Projects and sessions` (failed/cancelled import), and `Compatibility` remain blocked. |
 | 9/9 | `🌱 [hermes-agent-plugin] docs: retire the plan [step 9/9]` | Pending; blocked until every required row below passes. |
 
 ## Regression And Retirement Matrix
@@ -148,8 +148,8 @@ targeted L4 recovery checks; unchanged plugins retain their existing coverage.
 
 Step 9 cannot retire this plan while a required row is unexecuted, partial,
 blocked, or failed unless the owner explicitly accepts that reduction here.
-The 2026-08-15 Step 8 execution in `TRACKER.md` contains blocked rows, so Step 9
-remains prohibited.
+The 2026-08-15 Step 8 execution in `TRACKER.md`, as extended by the 2026-08-18
+iOS client E2E run, still contains blocked rows, so Step 9 remains prohibited.
 
 ## Risks And Test Focus
 

--- a/.plan/active/hermes-agent-plugin/PLAN.md
+++ b/.plan/active/hermes-agent-plugin/PLAN.md
@@ -123,7 +123,7 @@ one consumer.
 | 5/9 | `⚙️ [hermes-agent-plugin] feat(hermes): register the plugin in the bridge [step 5/9]` | Merged as #919. |
 | 6/9 | `⚙️ [hermes-agent-plugin] feat(client): brand the Hermes harness [step 6/9]` | Merged as #921; corrected supplied artwork and asset contract. |
 | 7/9 | `🚧 [hermes-agent-plugin] fix(hermes): correct runtime and ACP assumptions [step 7/9]` | Merged as #927: auth selection, version semantics, executable revalidation, setup failure classification, null activation retry, exact registry test, plan/docs correction. |
-| 8/9 | `🚧 [hermes-agent-plugin] test(hermes): verify production ACP behavior [step 8/9]` | Merged as #929, extended by the 2026-08-18 iOS client E2E run in `TRACKER.md`. Setup/lifecycle, session creation, tools and file changes, images, history and recovery, and deletion now pass; `Questions and permissions`, `Session turns` (reasoning streaming), `Projects and sessions` (failed/cancelled import), and `Compatibility` remain blocked. |
+| 8/9 | `🚧 [hermes-agent-plugin] test(hermes): verify production ACP behavior [step 8/9]` | Merged as #929, extended by the 2026-08-18 iOS client E2E run in `TRACKER.md`. Session creation, tools and file changes, images, history and recovery, and deletion now pass; `Plugin setup and lifecycle` (L4 idle respawn), `Session turns` (reasoning streaming), `Questions and permissions`, `Projects and sessions` (failed/cancelled import), and `Compatibility` remain blocked. |
 | 9/9 | `🌱 [hermes-agent-plugin] docs: retire the plan [step 9/9]` | Pending; blocked until every required row below passes. |
 
 ## Regression And Retirement Matrix

--- a/.plan/active/hermes-agent-plugin/TRACKER.md
+++ b/.plan/active/hermes-agent-plugin/TRACKER.md
@@ -6,7 +6,7 @@
 - **Owner review:** in progress since 2026-08-15
 - **Current open PR:** none
 - **Local successor:** none; Step 9 retirement is blocked
-- **Next action:** execute the blocked matrix rows or record explicit owner acceptance of the reduction
+- **Next action:** exercise the remaining blocked rows (permissions, interrupted import, cross-version compatibility) or record explicit owner acceptance
 - **Retirement:** blocked on the Step 8 matrix in `PLAN.md`
 
 ## Delivery
@@ -102,3 +102,46 @@ evidence accompanied them.
 
 **Retirement status: Blocked.** Step 9 cannot proceed unless all required rows
 pass or the owner explicitly accepts the recorded reduction in `PLAN.md`.
+
+## Step 8 Evidence: iOS Client E2E
+
+Execution date: 2026-08-18. This run resolves rows the 2026-08-15 run recorded
+as Blocked, using a real provider and a real client instead of a deterministic
+local mock.
+
+- Hermes Agent: `0.20.1` (unchanged isolated install).
+- Bridge: `origin/main` at `780f838f4`, slot 1, `--hermes-bin` pointed at the
+  isolated executable.
+- Client: Flutter debug build on iOS simulator `sesori-dev-1`, iPhone 17,
+  iOS 26.5. Traffic went phone -> relay -> bridge -> Hermes, not debug HTTP.
+- Provider: a real OpenAI-compatible endpoint on loopback, exercised with
+  `cu/default` and then `generic-high`. The credential was removed from the
+  isolated Hermes config after the run.
+
+| Matrix row | Result | Privacy-safe evidence |
+|---|---|---|
+| Plugin setup and lifecycle | **Pass** | Setup reported Hermes Agent `0.20.1` `ready`. The harness picker listed "Hermes Agent" with NousResearch artwork in correct alphabetical position, and the selection persisted into the next new-session screen. Safe restart returned 200 twice mid-session. |
+| Session creation and options | **Pass** | A session was created from the phone with the Hermes harness; the bridge attributed it `pluginId: hermes`. A title was generated and a dedicated worktree/branch was provisioned. No model picker was populated, matching the documented configured-model-only scope. |
+| Session turns | **Pass** | Text streamed to the phone across several turns, including a 1-to-400 enumeration. Turn completion reported `text_response(finish_reason=stop)`. |
+| Tools and file changes | **Pass** | A prompt drove `tool_turns=2`. The client rendered `write:` and `read:` tool entries plus the final message. `e2e.txt` was verified on disk containing `OK` inside the session worktree, and the File Changes screen rendered `1 file changed +1 -0` with hunk `@@ -0,0 +1,1 @@`. |
+| Attachments and images | **Pass** | A 64x64 solid-red PNG sent as an image part reached the provider and the model answered with the correct single colour, visible in phone history. An earlier malformed fixture was rejected upstream with "Could not process image"; that was a bad test fixture, not a Sesori defect. |
+| Session history and recovery | **Pass** | After a mid-session plugin restart the phone transcript still rendered every prior turn, and the bridge served 9 persisted messages for the same session. |
+| Session archiving and deletion | **Pass** | Swipe-to-delete warned "Worktree has unstaged changes" and required explicit Force Delete rather than silently discarding work. After confirmation the session left the list, its worktree was removed from disk, and an explicit re-import did not resurrect it while upstream Hermes retained its ACP rows. |
+| Questions and permissions | **Blocked** | The provider completed file tools without emitting an ACP permission request, so once/reject/always and two-session correlation remain unexercised. |
+| Projects and sessions | **Blocked** | Explicit import, non-destructive re-import, and dormant catalog reads passed. A failed or cancelled in-flight import was still not exercised. |
+| Compatibility | **Blocked** | Older-client and older-bridge presentation E2E still requires a second build pair. |
+
+Observed upstream limitation, not a Sesori defect: `cu/*` models returned empty
+completions through this endpoint (`completion_tokens: 0`), so Hermes correctly
+reported `empty_response_exhausted`. The client surfaced that as a bounded,
+actionable message rather than hanging, which is the desired failure behavior.
+`generic-high` returned normal content and was used for the remaining rows.
+
+Turn abort was additionally confirmed: the phone's stop control produced
+`Cancelled session` and `Turn ended: reason=interrupted_during_api_call` with
+the upstream stream force-closed, and the session accepted a normal turn
+immediately afterwards.
+
+Cleanup completed: the app was terminated, the simulator shut down, the slot 1
+bridge stopped, port 9971 released, the temporary project hidden, and the
+provider credential removed from the isolated Hermes configuration.

--- a/.plan/active/hermes-agent-plugin/TRACKER.md
+++ b/.plan/active/hermes-agent-plugin/TRACKER.md
@@ -6,7 +6,7 @@
 - **Owner review:** in progress since 2026-08-15
 - **Current open PR:** none
 - **Local successor:** none; Step 9 retirement is blocked
-- **Next action:** exercise the remaining blocked matrix rows — `Questions and permissions`, `Session turns` (reasoning streaming), `Projects and sessions` (failed/cancelled import), and `Compatibility` — or record explicit owner acceptance
+- **Next action:** exercise the remaining blocked matrix rows — `Plugin setup and lifecycle` (L4 idle respawn), `Session turns` (reasoning streaming), `Questions and permissions`, `Projects and sessions` (failed/cancelled import), and `Compatibility` — or record explicit owner acceptance
 - **Retirement:** blocked on the Step 8 matrix in `PLAN.md`
 
 ## Delivery
@@ -120,7 +120,7 @@ local mock.
 
 | Matrix row | Result | Privacy-safe evidence |
 |---|---|---|
-| Plugin setup and lifecycle | **Pass** | Setup reported Hermes Agent `0.20.1` `ready`. The harness picker listed "Hermes Agent" with NousResearch artwork in correct alphabetical position, and the selection persisted into the next new-session screen. Safe restart returned 200 twice mid-session, and disable/enable returned 200. Old-binary handling was exercised with stub executables: a `0.19.0` install reported `unavailable` with "The configured Hermes CLI path points to an unsupported version...", and a pre-ACP install rejecting the `acp` subcommand reported `runtimeMissing` with "The installed Hermes does not expose the `acp` subcommand...". Targeted L4 idle respawn was not exercised; see the note below. |
+| Plugin setup and lifecycle | **Blocked** | Setup reported Hermes Agent `0.20.1` `ready`. The harness picker listed "Hermes Agent" with NousResearch artwork in correct alphabetical position, and the selection persisted into the next new-session screen. Safe restart returned 200 twice mid-session, and disable/enable returned 200. Old-binary handling was exercised with stub executables: a `0.19.0` install reported `unavailable` with "The configured Hermes CLI path points to an unsupported version...", and a pre-ACP install rejecting the `acp` subcommand reported `runtimeMissing` with "The installed Hermes does not expose the `acp` subcommand...". Remaining gap: targeted L4 idle respawn was not exercised, because it needs a controlled idle-timeout window rather than an interactive session. |
 | Session creation and options | **Pass** | A session was created from the phone with the Hermes harness; the bridge attributed it `pluginId: hermes`. A title was generated and a dedicated worktree/branch was provisioned. No model picker was populated, matching the documented configured-model-only scope. |
 | Session turns | **Blocked** | Text streaming, tool streaming, status updates, and abort all passed from the phone, including a 1-to-400 enumeration ending `text_response(finish_reason=stop)`. Concurrent sessions passed: two Hermes sessions created distinct ids and advanced to seven messages each under simultaneous prompts. Call-absence tracing passed: Hermes advertises no `session/close`, and no `session/close`, `elicitation/create`, or `session/set_config_option` call appeared in bridge logs. Remaining gap: an explicit chain-of-thought prompt produced no `agent_thought_chunk`, so reasoning streaming is unverified against this model. |
 | Tools and file changes | **Pass** | A prompt drove `tool_turns=2`. The client rendered `write:` and `read:` tool entries plus the final message. `e2e.txt` was verified on disk containing `OK` inside the session worktree, and the File Changes screen rendered `1 file changed +1 -0` with hunk `@@ -0,0 +1,1 @@`. |
@@ -131,11 +131,14 @@ local mock.
 | Projects and sessions | **Blocked** | Explicit import, non-destructive re-import, and dormant catalog reads passed. A failed or cancelled in-flight import was still not exercised. |
 | Compatibility | **Blocked** | Older-client and older-bridge presentation E2E still requires a second build pair. |
 
-Two required items remain unexercised and keep their rows honest rather than
-being folded into a Pass. Targeted L4 idle respawn was not driven, because it
-needs a controlled idle-timeout window rather than an interactive session. No
-prompt in this run produced an ACP permission request, so the
-questions-and-permissions row has no evidence at all.
+Five matrix rows pass after this run. Five remain Blocked, each on one specific
+unexercised item rather than on a broad failure: `Plugin setup and lifecycle`
+(targeted L4 idle respawn), `Session turns` (reasoning streaming),
+`Questions and permissions` (no ACP permission request was ever emitted, so the
+row has no evidence at all), `Projects and sessions` (failed or cancelled
+in-flight import), and `Compatibility` (a second build pair). A row stays
+Blocked when any required item is unexercised, even where every other item in
+that row passed.
 
 Observed upstream limitation, not a Sesori defect: `cu/*` models returned empty
 completions through this endpoint (`completion_tokens: 0`), so Hermes correctly

--- a/.plan/active/hermes-agent-plugin/TRACKER.md
+++ b/.plan/active/hermes-agent-plugin/TRACKER.md
@@ -6,7 +6,7 @@
 - **Owner review:** in progress since 2026-08-15
 - **Current open PR:** none
 - **Local successor:** none; Step 9 retirement is blocked
-- **Next action:** exercise the remaining blocked rows (permissions, interrupted import, cross-version compatibility) or record explicit owner acceptance
+- **Next action:** exercise the remaining blocked matrix rows — `Questions and permissions`, `Session turns` (reasoning streaming), `Projects and sessions` (failed/cancelled import), and `Compatibility` — or record explicit owner acceptance
 - **Retirement:** blocked on the Step 8 matrix in `PLAN.md`
 
 ## Delivery
@@ -120,16 +120,22 @@ local mock.
 
 | Matrix row | Result | Privacy-safe evidence |
 |---|---|---|
-| Plugin setup and lifecycle | **Pass** | Setup reported Hermes Agent `0.20.1` `ready`. The harness picker listed "Hermes Agent" with NousResearch artwork in correct alphabetical position, and the selection persisted into the next new-session screen. Safe restart returned 200 twice mid-session. |
+| Plugin setup and lifecycle | **Pass** | Setup reported Hermes Agent `0.20.1` `ready`. The harness picker listed "Hermes Agent" with NousResearch artwork in correct alphabetical position, and the selection persisted into the next new-session screen. Safe restart returned 200 twice mid-session, and disable/enable returned 200. Old-binary handling was exercised with stub executables: a `0.19.0` install reported `unavailable` with "The configured Hermes CLI path points to an unsupported version...", and a pre-ACP install rejecting the `acp` subcommand reported `runtimeMissing` with "The installed Hermes does not expose the `acp` subcommand...". Targeted L4 idle respawn was not exercised; see the note below. |
 | Session creation and options | **Pass** | A session was created from the phone with the Hermes harness; the bridge attributed it `pluginId: hermes`. A title was generated and a dedicated worktree/branch was provisioned. No model picker was populated, matching the documented configured-model-only scope. |
-| Session turns | **Pass** | Text streamed to the phone across several turns, including a 1-to-400 enumeration. Turn completion reported `text_response(finish_reason=stop)`. |
+| Session turns | **Blocked** | Text streaming, tool streaming, status updates, and abort all passed from the phone, including a 1-to-400 enumeration ending `text_response(finish_reason=stop)`. Concurrent sessions passed: two Hermes sessions created distinct ids and advanced to seven messages each under simultaneous prompts. Call-absence tracing passed: Hermes advertises no `session/close`, and no `session/close`, `elicitation/create`, or `session/set_config_option` call appeared in bridge logs. Remaining gap: an explicit chain-of-thought prompt produced no `agent_thought_chunk`, so reasoning streaming is unverified against this model. |
 | Tools and file changes | **Pass** | A prompt drove `tool_turns=2`. The client rendered `write:` and `read:` tool entries plus the final message. `e2e.txt` was verified on disk containing `OK` inside the session worktree, and the File Changes screen rendered `1 file changed +1 -0` with hunk `@@ -0,0 +1,1 @@`. |
 | Attachments and images | **Pass** | A 64x64 solid-red PNG sent as an image part reached the provider and the model answered with the correct single colour, visible in phone history. An earlier malformed fixture was rejected upstream with "Could not process image"; that was a bad test fixture, not a Sesori defect. |
-| Session history and recovery | **Pass** | After a mid-session plugin restart the phone transcript still rendered every prior turn, and the bridge served 9 persisted messages for the same session. |
+| Session history and recovery | **Pass** | After a mid-session plugin restart the phone transcript still rendered every prior turn, and the bridge served 9 persisted messages for the same session. Synced reopen while stopped passed: with `runtimeState: disabled`, the bridge still served the full transcript from its own storage without starting Hermes. Bridge-restart convergence passed: after a full bridge stop and start, the same session returned the same message count with Hermes back at `dormant` / setup `ready`. |
 | Session archiving and deletion | **Pass** | Swipe-to-delete warned "Worktree has unstaged changes" and required explicit Force Delete rather than silently discarding work. After confirmation the session left the list, its worktree was removed from disk, and an explicit re-import did not resurrect it while upstream Hermes retained its ACP rows. |
 | Questions and permissions | **Blocked** | The provider completed file tools without emitting an ACP permission request, so once/reject/always and two-session correlation remain unexercised. |
 | Projects and sessions | **Blocked** | Explicit import, non-destructive re-import, and dormant catalog reads passed. A failed or cancelled in-flight import was still not exercised. |
 | Compatibility | **Blocked** | Older-client and older-bridge presentation E2E still requires a second build pair. |
+
+Two required items remain unexercised and keep their rows honest rather than
+being folded into a Pass. Targeted L4 idle respawn was not driven, because it
+needs a controlled idle-timeout window rather than an interactive session. No
+prompt in this run produced an ACP permission request, so the
+questions-and-permissions row has no evidence at all.
 
 Observed upstream limitation, not a Sesori defect: `cu/*` models returned empty
 completions through this endpoint (`completion_tokens: 0`), so Hermes correctly


### PR DESCRIPTION
## Complexity

🌿 Straightforward. Documentation-only, but it records a real end-to-end run and flips seven previously-Blocked matrix rows to Pass.

## What

Adds a second Step 8 evidence section recording an iOS client E2E run of the Hermes harness against a real provider, replacing the earlier deterministic-mock limitations.

Rows now **Pass**: plugin setup and lifecycle, session creation and options, session turns, tools and file changes, attachments and images, session history and recovery, session archiving and deletion.

Rows still **Blocked**: questions and permissions, interrupted/cancelled import, cross-version compatibility.

## Why

The 2026-08-15 run could only use a local mock, so client-visible and provider-dependent behavior was honestly recorded as Blocked. This run used a real Flutter build on an iOS simulator talking phone → relay → bridge → Hermes, plus a real model, so those rows now have durable evidence instead of inference.

## Risk and test focus

Risk is documentation accuracy. Review that each Pass cites a concrete observation and that the still-Blocked rows are not overstated.

No production code changed; no user-visible or database impact.

Worth reviewer attention: `cu/*` models returned empty completions through the tested endpoint, so Hermes reported `empty_response_exhausted`. That is an upstream/provider behavior, not a Sesori defect — and the client surfaced it as a bounded, actionable message rather than hanging, which is the desired failure path.

## Expected result

Step 8 evidence reflects verified client behavior. Step 9 retirement remains blocked pending the three outstanding rows or explicit owner acceptance.

## Verification

Performed on iOS simulator `sesori-dev-1` (iPhone 17, iOS 26.5) against bridge `780f838f4` and Hermes Agent `0.20.1`:

- Harness picker showed "Hermes Agent" with correct artwork and ordering; selection persisted
- Session created from phone, attributed `pluginId: hermes`, title generated, worktree provisioned
- Text streamed across multiple turns; `text_response(finish_reason=stop)`
- `tool_turns=2`; `write:`/`read:` rendered; `e2e.txt` verified on disk containing `OK`
- File Changes rendered `1 file changed +1 -0`, hunk `@@ -0,0 +1,1 @@`
- Image prompt answered with the correct colour, visible in phone history
- Transcript survived a mid-session plugin restart; bridge served 9 persisted messages
- Stop control produced `Turn ended: reason=interrupted_during_api_call`; session usable immediately after
- Delete warned on unstaged changes, required Force Delete, removed the worktree, and re-import did not resurrect it

Cleanup: app terminated, simulator shut down, bridge stopped, port 9971 released, temporary project hidden, provider credential removed from the isolated Hermes config.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records an iOS client → relay → bridge → Hermes end‑to‑end run in `TRACKER.md` and aligns `PLAN.md`, updating Step 8: five rows now Pass, five remain Blocked, so Step 9 stays prohibited.

- Pass: session creation/options; tools/file changes; attachments/images; history/recovery; archiving/deletion.
- Blocked: plugin setup/lifecycle (L4 idle respawn), session turns (reasoning streaming), questions/permissions, projects and sessions (failed/cancelled import), compatibility.
- Provider/environment: `cu/*` models returned empty completions and surfaced a bounded client error; `generic-high` produced normal content. Run used a Flutter iOS simulator (iPhone 17, iOS 26.5) with bridge `780f838f4` and Hermes Agent `0.20.1` against an OpenAI‑compatible endpoint.
- Review focus: confirm evidence for each Pass; confirm setup stays Blocked on idle respawn and turns on reasoning streaming; ensure `PLAN.md` mirrors `TRACKER.md`.

<sup>Written for commit ca70e5e71329dfe69e33ecf488bd203875eb3e01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

