### PR TITLE
⚙️ Add image drag and drop to desktop and iPad composers

### DIFF
--- a/.github/workflows/_reusable-android-internal.yml
+++ b/.github/workflows/_reusable-android-internal.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Setup Flutter
         uses: ./.github/actions/setup-flutter
         with:

--- a/.github/workflows/_reusable-android-internal.yml
+++ b/.github/workflows/_reusable-android-internal.yml
@@ -38,7 +38,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: 1.97.1
 
       - name: Setup Flutter
         uses: ./.github/actions/setup-flutter

--- a/.github/workflows/_reusable-ios-testflight.yml
+++ b/.github/workflows/_reusable-ios-testflight.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Set up Xcode ${{ env.XCODE_VERSION }}
         uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/.github/workflows/_reusable-ios-testflight.yml
+++ b/.github/workflows/_reusable-ios-testflight.yml
@@ -64,7 +64,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: 1.97.1
 
       - name: Set up Xcode ${{ env.XCODE_VERSION }}
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -36,7 +36,14 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: 1.97.1
+
+      - name: Install Linux native dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev
 
       - name: Read Flutter version from .tool-versions
         shell: bash

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -35,6 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Read Flutter version from .tool-versions
         shell: bash
         run: |

--- a/client/README.md
+++ b/client/README.md
@@ -101,6 +101,9 @@ dart pub get
 ```
 
 The exact Flutter version is pinned in the repository root `.tool-versions`.
+Native `client/app` builds also require [rustup](https://rustup.rs). Keep
+`~/.cargo/bin` ahead of other Rust installations on `PATH`; the native drag-and-drop
+dependency pins and installs its own Rust toolchain and target components.
 
 ## Analyze And Test
 

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -947,13 +947,10 @@ class _PromptInputState() extends State<PromptInput> {
     return DropRegion(
       formats: _imageDropFormats,
       hitTestBehavior: HitTestBehavior.opaque,
-      onDropOver: _handleImageDropOver,
-      onDropEnter: (_) {
-        if (!_isImageDragOver) setState(() => _isImageDragOver = true);
-      },
+      onDropOver: (event) => _handleImageDropOver(event: event),
       onDropLeave: (_) => _clearImageDragOver(),
       onDropEnded: (_) => _clearImageDragOver(),
-      onPerformDrop: _handleImageDrop,
+      onPerformDrop: (event) => _handleImageDrop(event: event),
       child: Stack(
         children: [
           composer,
@@ -998,14 +995,18 @@ class _PromptInputState() extends State<PromptInput> {
     };
   }
 
-  DropOperation _handleImageDropOver(DropOverEvent event) {
-    if (!_imageDropEnabled || !event.session.allowedOperations.contains(DropOperation.copy)) {
-      return DropOperation.none;
+  DropOperation _handleImageDropOver({required DropOverEvent event}) {
+    final acceptsDrop =
+        _imageDropEnabled &&
+        event.session.allowedOperations.contains(DropOperation.copy) &&
+        event.session.items.any((item) => _dropItemContainsImage(item: item));
+    if (_isImageDragOver != acceptsDrop && mounted) {
+      setState(() => _isImageDragOver = acceptsDrop);
     }
-    return event.session.items.any(_dropItemContainsImage) ? DropOperation.copy : DropOperation.none;
+    return acceptsDrop ? DropOperation.copy : DropOperation.none;
   }
 
-  bool _dropItemContainsImage(DropItem item) {
+  bool _dropItemContainsImage({required DropItem item}) {
     for (final format in _imageDropFormats) {
       if (item.canProvide(format)) return true;
     }
@@ -1016,7 +1017,7 @@ class _PromptInputState() extends State<PromptInput> {
     if (_isImageDragOver && mounted) setState(() => _isImageDragOver = false);
   }
 
-  Future<void> _handleImageDrop(PerformDropEvent event) {
+  Future<void> _handleImageDrop({required PerformDropEvent event}) {
     _clearImageDragOver();
     if (!_imageDropEnabled) return Future.value();
 
@@ -1024,7 +1025,7 @@ class _PromptInputState() extends State<PromptInput> {
     final attachmentInputGeneration = _attachmentInputGeneration;
     final files = <Future<_DroppedImageFile?>>[];
     for (final item in event.session.items) {
-      if (_dropItemContainsImage(item)) files.add(_requestDroppedImageFile(item: item));
+      if (_dropItemContainsImage(item: item)) files.add(_requestDroppedImageFile(item: item));
     }
     unawaited(
       _consumeDroppedImageFiles(

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -1,6 +1,7 @@
 import "dart:async";
+import "dart:typed_data";
 
-import "package:flutter/foundation.dart" show kIsWeb;
+import "package:flutter/foundation.dart" show TargetPlatform, defaultTargetPlatform, kIsWeb;
 import "package:flutter/gestures.dart" show kPrimaryButton;
 import "package:flutter/services.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
@@ -9,6 +10,7 @@ import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:material_ui/material_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:super_drag_and_drop/super_drag_and_drop.dart";
 import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
 import "package:theme_prego/interactions/prego_tappable.dart";
 import "package:theme_prego/module_prego.dart";
@@ -26,6 +28,12 @@ import "voice_cancel_button.dart";
 enum _VoiceState() { idle, recording, transcribing }
 
 enum _PasteImageResult() { noImage, handled, stale }
+
+typedef _DroppedImageFile = ({
+  VoidCallback close,
+  Stream<Uint8List> stream,
+  Future<String?> suggestedName,
+});
 
 final class _ComposerPasteAction({
     required final Future<_PasteImageResult> Function() _pasteImage,
@@ -121,11 +129,18 @@ class _PromptInputState() extends State<PromptInput> {
   static const _draftCalculator = ComposerDraftCalculator();
   static const _minimumRecordingDuration = Duration(milliseconds: 200);
   static const _successFeedbackPulseDelay = Duration(milliseconds: 100);
+  static const List<FileFormat> _imageDropFormats = [
+    Formats.jpeg,
+    Formats.png,
+    Formats.gif,
+    Formats.webp,
+    Formats.bmp,
+  ];
   final _controller = TextEditingController();
   final _textScrollController = ScrollController();
   final _focusNode = FocusNode();
   late final Action<PasteTextIntent> _pasteAction;
-  int _pasteGeneration = 0;
+  int _attachmentInputGeneration = 0;
   late ComposerDraft _draft;
   late TextEditingValue _previousEditingValue;
   bool _isApplyingDraft = false;
@@ -197,6 +212,7 @@ class _PromptInputState() extends State<PromptInput> {
   /// Images staged for the next submission. Not part of the persisted
   /// draft — they live and die with this composer.
   final List<ComposerAttachment> _attachments = [];
+  bool _isImageDragOver = false;
 
   VoiceTranscriptionService get _voiceService => getIt<VoiceTranscriptionService>();
 
@@ -410,7 +426,7 @@ class _PromptInputState() extends State<PromptInput> {
       );
     }
 
-    _pasteGeneration++;
+    _attachmentInputGeneration++;
     if (_attachments.isNotEmpty) {
       setState(_attachments.clear);
     }
@@ -433,13 +449,15 @@ class _PromptInputState() extends State<PromptInput> {
         widget.restorationKey != null && oldWidget.restorationKey != widget.restorationKey;
     final stagedCommandChanged = oldWidget.stagedCommand?.name != widget.stagedCommand?.name;
     if (oldWidget.attachmentsSupported != widget.attachmentsSupported) {
-      _pasteGeneration++;
+      _attachmentInputGeneration++;
+      _isImageDragOver = false;
     }
     if (draftChanged || restorationRequested) {
       // A draft identity change means this state moved to another composer. A
       // restoration key change means a fast failed send reused this composer.
       // Both replace authored content exactly once.
-      _pasteGeneration++;
+      _attachmentInputGeneration++;
+      _isImageDragOver = false;
       _attachments.clear();
       _restoreDraft(draft: widget.initialDraft);
       _restoreInitialAttachments();
@@ -841,7 +859,7 @@ class _PromptInputState() extends State<PromptInput> {
   Widget build(BuildContext context) {
     final prego = context.prego;
 
-    return DecoratedBox(
+    final composer = DecoratedBox(
       // Floating composer: no bar surface, no separator line. The scaffold
       // background fades up behind the floating controls so chat content
       // dissolves as it scrolls past — the same scrim the glass top navigation
@@ -923,6 +941,227 @@ class _PromptInputState() extends State<PromptInput> {
         ],
       ),
     );
+
+    if (!_imageDropEnabled) return composer;
+
+    return DropRegion(
+      formats: _imageDropFormats,
+      hitTestBehavior: HitTestBehavior.opaque,
+      onDropOver: _handleImageDropOver,
+      onDropEnter: (_) {
+        if (!_isImageDragOver) setState(() => _isImageDragOver = true);
+      },
+      onDropLeave: (_) => _clearImageDragOver(),
+      onDropEnded: (_) => _clearImageDragOver(),
+      onPerformDrop: _handleImageDrop,
+      child: Stack(
+        children: [
+          composer,
+          if (_isImageDragOver)
+            Positioned.fill(
+              child: IgnorePointer(
+                child: Semantics(
+                  liveRegion: true,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: prego.colors.bgSurface1.withValues(alpha: 0.94),
+                      border: Border.all(color: prego.colors.borderBrand, width: 2),
+                      borderRadius: BorderRadius.circular(PregoRadius.x3l),
+                    ),
+                    child: Center(
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        spacing: PregoSpacing.sm,
+                        children: [
+                          Icon(TablerRegular.photo_plus, size: 20, color: prego.colors.fgBrandPrimary),
+                          Text(
+                            context.loc.sessionDetailDropImagesToAttach,
+                            style: prego.textTheme.textSm.bold.copyWith(color: prego.colors.textBrandPrimary),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  bool get _imageDropEnabled {
+    if (kIsWeb || widget.attachmentsSupported != true) return false;
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.iOS || TargetPlatform.macOS || TargetPlatform.windows || TargetPlatform.linux => true,
+      TargetPlatform.android || TargetPlatform.fuchsia => false,
+    };
+  }
+
+  DropOperation _handleImageDropOver(DropOverEvent event) {
+    if (!_imageDropEnabled || !event.session.allowedOperations.contains(DropOperation.copy)) {
+      return DropOperation.none;
+    }
+    return event.session.items.any(_dropItemContainsImage) ? DropOperation.copy : DropOperation.none;
+  }
+
+  bool _dropItemContainsImage(DropItem item) {
+    for (final format in _imageDropFormats) {
+      if (item.canProvide(format)) return true;
+    }
+    return false;
+  }
+
+  void _clearImageDragOver() {
+    if (_isImageDragOver && mounted) setState(() => _isImageDragOver = false);
+  }
+
+  Future<void> _handleImageDrop(PerformDropEvent event) {
+    _clearImageDragOver();
+    if (!_imageDropEnabled) return Future.value();
+
+    final draftIdentity = widget.draftIdentity;
+    final attachmentInputGeneration = _attachmentInputGeneration;
+    final files = <Future<_DroppedImageFile?>>[];
+    for (final item in event.session.items) {
+      if (_dropItemContainsImage(item)) files.add(_requestDroppedImageFile(item: item));
+    }
+    unawaited(
+      _consumeDroppedImageFiles(
+        files: files,
+        draftIdentity: draftIdentity,
+        attachmentInputGeneration: attachmentInputGeneration,
+      ),
+    );
+    return Future.value();
+  }
+
+  Future<_DroppedImageFile?> _requestDroppedImageFile({required DropItem item}) {
+    final completer = Completer<_DroppedImageFile?>();
+    final reader = item.dataReader;
+    if (reader == null) return Future.value();
+
+    final formats = reader.getFormats(_imageDropFormats);
+    if (formats.isEmpty) return Future.value();
+    final format = formats.first;
+    if (format is! FileFormat) return Future.value();
+
+    try {
+      final progress = reader.getFile(
+        format,
+        (file) {
+          var ownershipTransferred = false;
+          try {
+            if (file.fileSize case final size? when size > maxComposerPromptAttachmentBytes) {
+              completer.completeError(const AttachmentTooLargeError(), StackTrace.current);
+              return;
+            }
+            if (completer.isCompleted) return;
+            completer.complete((
+              close: file.close,
+              stream: file.getStream(),
+              suggestedName: file.fileName == null ? reader.getSuggestedName() : Future.value(file.fileName),
+            ));
+            ownershipTransferred = true;
+          } catch (error, stackTrace) {
+            if (!completer.isCompleted) completer.completeError(error, stackTrace);
+          } finally {
+            if (!ownershipTransferred) file.close();
+          }
+        },
+        onError: (error) {
+          if (!completer.isCompleted) completer.completeError(error, StackTrace.current);
+        },
+      );
+      if (progress == null && !completer.isCompleted) completer.complete(null);
+    } catch (error, stackTrace) {
+      if (!completer.isCompleted) completer.completeError(error, stackTrace);
+    }
+    return completer.future;
+  }
+
+  Future<void> _consumeDroppedImageFiles({
+    required List<Future<_DroppedImageFile?>> files,
+    required String draftIdentity,
+    required int attachmentInputGeneration,
+  }) async {
+    var stale = false;
+    for (final requestedFile in files) {
+      _DroppedImageFile? droppedFile;
+      try {
+        droppedFile = await requestedFile;
+        stale = stale ||
+            _isAttachmentInputStale(
+              draftIdentity: draftIdentity,
+              attachmentInputGeneration: attachmentInputGeneration,
+            );
+        if (droppedFile == null) continue;
+        if (stale) continue;
+
+        final bytes = await _readDroppedImageBytes(
+          file: droppedFile,
+          isStale: () => _isAttachmentInputStale(
+            draftIdentity: draftIdentity,
+            attachmentInputGeneration: attachmentInputGeneration,
+          ),
+        );
+        if (bytes == null) {
+          stale = true;
+          continue;
+        }
+        final attachment = _imagePicker.attachmentFromBytes(
+          bytes: bytes,
+          filename: await droppedFile.suggestedName,
+        );
+        if (_isAttachmentInputStale(
+          draftIdentity: draftIdentity,
+          attachmentInputGeneration: attachmentInputGeneration,
+        )) {
+          stale = true;
+          continue;
+        }
+        _stageAttachment(attachment: attachment);
+      } on AttachmentTooLargeError {
+        stale = stale ||
+            _isAttachmentInputStale(
+              draftIdentity: draftIdentity,
+              attachmentInputGeneration: attachmentInputGeneration,
+            );
+        if (!stale && mounted) _showComposerNotice(context.loc.sessionDetailAttachmentTooLarge);
+      } on UnsupportedAttachmentImageError {
+        stale = stale ||
+            _isAttachmentInputStale(
+              draftIdentity: draftIdentity,
+              attachmentInputGeneration: attachmentInputGeneration,
+            );
+        if (!stale && mounted) _showComposerNotice(context.loc.sessionDetailAttachmentUnsupported);
+      } catch (error, stackTrace) {
+        loge("Failed to attach a dropped image", error, stackTrace);
+        stale = stale ||
+            _isAttachmentInputStale(
+              draftIdentity: draftIdentity,
+              attachmentInputGeneration: attachmentInputGeneration,
+            );
+        if (!stale && mounted) _showComposerNotice(context.loc.sessionDetailAttachmentPickFailed);
+      } finally {
+        droppedFile?.close();
+      }
+    }
+  }
+
+  Future<Uint8List?> _readDroppedImageBytes({
+    required _DroppedImageFile file,
+    required bool Function() isStale,
+  }) async {
+    final bytes = BytesBuilder(copy: false);
+    await for (final chunk in file.stream) {
+      if (isStale()) return null;
+      if (bytes.length + chunk.length > maxComposerPromptAttachmentBytes) {
+        throw const AttachmentTooLargeError();
+      }
+      bytes.add(chunk);
+    }
+    return bytes.takeBytes();
   }
 
   // ---------------------------------------------------------------------------
@@ -1510,20 +1749,26 @@ class _PromptInputState() extends State<PromptInput> {
   Future<_PasteImageResult> _handlePasteImage() async {
     if (widget.attachmentsSupported != true) return _PasteImageResult.noImage;
     final draftIdentity = widget.draftIdentity;
-    final pasteGeneration = _pasteGeneration;
+    final attachmentInputGeneration = _attachmentInputGeneration;
     final Uint8List? bytes;
     try {
       bytes = await _imageClipboard.readImage();
     } catch (error, stackTrace) {
       loge("Failed to read a pasted image", error, stackTrace);
-      return _isPasteStale(draftIdentity: draftIdentity, pasteGeneration: pasteGeneration)
+      return _isAttachmentInputStale(
+        draftIdentity: draftIdentity,
+        attachmentInputGeneration: attachmentInputGeneration,
+      )
           ? _PasteImageResult.stale
           : _PasteImageResult.noImage;
     }
 
     // Never let an asynchronous paste land in a composer that replaced the
     // one where the action started.
-    if (_isPasteStale(draftIdentity: draftIdentity, pasteGeneration: pasteGeneration)) {
+    if (_isAttachmentInputStale(
+      draftIdentity: draftIdentity,
+      attachmentInputGeneration: attachmentInputGeneration,
+    )) {
       return _PasteImageResult.stale;
     }
     if (!mounted) return _PasteImageResult.stale;
@@ -1574,10 +1819,13 @@ class _PromptInputState() extends State<PromptInput> {
     }
   }
 
-  bool _isPasteStale({required String draftIdentity, required int pasteGeneration}) {
+  bool _isAttachmentInputStale({
+    required String draftIdentity,
+    required int attachmentInputGeneration,
+  }) {
     return !mounted ||
         draftIdentity != widget.draftIdentity ||
-        pasteGeneration != _pasteGeneration ||
+        attachmentInputGeneration != _attachmentInputGeneration ||
         widget.attachmentsSupported != true;
   }
 

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -467,6 +467,10 @@
   "@sessionDetailAttachImage": {
     "description": "Accessibility label of the advanced-options action that opens the gallery picker to attach an image to the next message."
   },
+  "sessionDetailDropImagesToAttach": "Drop images to attach",
+  "@sessionDetailDropImagesToAttach": {
+    "description": "Label shown over the composer while supported image files are dragged over its native desktop or iPad drop target."
+  },
   "sessionDetailRemoveAttachment": "Remove attachment",
   "@sessionDetailRemoveAttachment": {
     "description": "Accessibility label of the badge on a staged attachment thumbnail that removes it from the composer."

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -1591,6 +1591,12 @@ abstract class AppLocalizations {
   /// **'Attach image'**
   String get sessionDetailAttachImage;
 
+  /// Label shown over the composer while supported image files are dragged over its native desktop or iPad drop target.
+  ///
+  /// In en, this message translates to:
+  /// **'Drop images to attach'**
+  String get sessionDetailDropImagesToAttach;
+
   /// Accessibility label of the badge on a staged attachment thumbnail that removes it from the composer.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -812,6 +812,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionDetailAttachImage => 'Attach image';
 
   @override
+  String get sessionDetailDropImagesToAttach => 'Drop images to attach';
+
+  @override
   String get sessionDetailRemoveAttachment => 'Remove attachment';
 
   @override

--- a/client/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/client/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -16,11 +16,13 @@ import firebase_messaging
 import flutter_local_notifications
 import flutter_secure_storage_darwin
 import gal
+import irondash_engine_context
 import package_info_plus
 import pasteboard
 import record_macos
 import share_plus
 import sign_in_with_apple
+import super_native_extensions
 import url_launcher_macos
 import wakelock_plus
 
@@ -36,11 +38,13 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
+  IrondashEngineContextPlugin.register(with: registry.registrar(forPlugin: "IrondashEngineContextPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PasteboardPlugin.register(with: registry.registrar(forPlugin: "PasteboardPlugin"))
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SignInWithApplePlugin.register(with: registry.registrar(forPlugin: "SignInWithApplePlugin"))
+  SuperNativeExtensionsPlugin.register(with: registry.registrar(forPlugin: "SuperNativeExtensionsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
 }

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -92,6 +92,7 @@ dependencies:
   flutter_chat_ui: ^2.11.1
   flutter_chat_core: ^2.9.0
   image_picker: ^1.2.3
+  super_drag_and_drop: 0.10.0-dev.2
   flutter_keyboard_visibility:
     git:
       url: https://github.com/vespr-wallet/flutter_keyboard_visibility.git
@@ -109,6 +110,7 @@ dev_dependencies:
   bloc_test: ^10.0.0
   build_runner: ^2.16.0
   mocktail: ^1.0.5
+  super_clipboard: 0.10.0-dev.2
   flutter_native_splash: ^2.4.8
 
   # The "flutter_lints" package below contains a set of recommended lints to

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -2317,6 +2317,59 @@ void main() {
     debugDefaultTargetPlatformOverride = null;
   });
 
+  testWidgets("rejected drags do not show the image drop overlay", (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+    final item = MockDropItem();
+    final session = MockDropSession();
+    when(() => item.canProvide(any())).thenReturn(false);
+    when(() => session.items).thenReturn([item]);
+    when(() => session.allowedOperations).thenReturn({DropOperation.copy});
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    final region = tester.widget<DropRegion>(find.byType(DropRegion));
+    expect(
+      await Future.value(
+        region.onDropOver(
+          DropOverEvent(
+            session: session,
+            position: DropPosition(local: Offset.zero, global: Offset.zero),
+          ),
+        ),
+      ),
+      DropOperation.none,
+    );
+    region.onDropEnter?.call(DropEvent(session: session));
+    await tester.pump();
+
+    expect(find.text("Drop images to attach"), findsNothing);
+
+    final imageItem = MockDropItem();
+    final noCopySession = MockDropSession();
+    when(() => imageItem.canProvide(any())).thenReturn(true);
+    when(() => noCopySession.items).thenReturn([imageItem]);
+    when(() => noCopySession.allowedOperations).thenReturn({DropOperation.move});
+
+    expect(
+      await Future.value(
+        region.onDropOver(
+          DropOverEvent(
+            session: noCopySession,
+            position: DropPosition(local: Offset.zero, global: Offset.zero),
+          ),
+        ),
+      ),
+      DropOperation.none,
+    );
+    region.onDropEnter?.call(DropEvent(session: noCopySession));
+    await tester.pump();
+
+    expect(find.text("Drop images to attach"), findsNothing);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
   testWidgets("dropping multiple images stages them in drag order", (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
     addTearDown(() => debugDefaultTargetPlatformOverride = null);

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -27,6 +27,8 @@ import "package:sesori_mobile/features/session_detail/widgets/user_message_card.
 import "package:sesori_mobile/features/session_detail/widgets/voice_cancel_button.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:super_clipboard/super_clipboard.dart";
+import "package:super_drag_and_drop/super_drag_and_drop.dart";
 import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
 import "package:theme_prego/interactions/prego_tappable.dart";
 import "package:theme_prego/module_prego.dart";
@@ -40,6 +42,22 @@ class MockVoiceTranscriptionService() extends Mock implements VoiceTranscription
 class MockComposerImagePicker() extends Mock implements ComposerImagePicker;
 
 class MockImageClipboard() extends Mock implements ImageClipboard;
+
+class MockDropItem() extends Mock implements DropItem {
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) => "MockDropItem";
+}
+
+class MockDropSession() extends Mock implements DropSession {
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) => "MockDropSession";
+}
+
+class MockDataReader() extends Mock implements DataReader;
+
+class MockDataReaderFile() extends Mock implements DataReaderFile;
+
+class MockReadProgress() extends Mock implements ReadProgress;
 
 /// A valid 1x1 transparent PNG so `Image.memory` thumbnails decode in tests.
 final Uint8List _tinyPng = Uint8List.fromList(const [
@@ -195,6 +213,67 @@ List<Object?> _captureHapticFeedback({required bool throwsPlatformException}) {
   return feedback;
 }
 
+MockDropItem _droppedImageItem({
+  required Uint8List bytes,
+  required String filename,
+  required Stream<Uint8List>? byteStream,
+  required int? reportedFileSize,
+  required VoidCallback? onClose,
+}) {
+  final item = MockDropItem();
+  final reader = MockDataReader();
+  final file = MockDataReaderFile();
+  final progress = MockReadProgress();
+
+  when(() => item.canProvide(any())).thenAnswer(
+    (invocation) => invocation.positionalArguments.single == Formats.png,
+  );
+  when(() => item.dataReader).thenReturn(reader);
+  when(() => reader.getFormats(any())).thenReturn([Formats.png]);
+  when(() => file.fileName).thenReturn(filename);
+  when(() => file.fileSize).thenReturn(reportedFileSize ?? bytes.length);
+  when(file.getStream).thenAnswer((_) => byteStream ?? Stream.value(bytes));
+  when(file.close).thenAnswer((_) => onClose?.call());
+  when(
+    () => reader.getFile(
+      Formats.png,
+      any(),
+      onError: any(named: "onError"),
+    ),
+  ).thenAnswer((invocation) {
+    final onFile = invocation.positionalArguments[1] as AsyncValueChanged<DataReaderFile>;
+    onFile(file);
+    return progress;
+  });
+  return item;
+}
+
+Future<void> _performImageDrop({required WidgetTester tester, required List<DropItem> items}) async {
+  final region = tester.widget<DropRegion>(find.byType(DropRegion));
+  final session = MockDropSession();
+  final position = DropPosition(local: Offset.zero, global: Offset.zero);
+  when(() => session.items).thenReturn(items);
+  when(() => session.allowedOperations).thenReturn({DropOperation.copy});
+
+  expect(
+    await Future.value(region.onDropOver(DropOverEvent(session: session, position: position))),
+    DropOperation.copy,
+  );
+  region.onDropEnter?.call(DropEvent(session: session));
+  await tester.pump();
+  expect(find.text("Drop images to attach"), findsOneWidget);
+
+  await region.onPerformDrop(
+    PerformDropEvent(
+      session: session,
+      position: position,
+      acceptedOperation: DropOperation.copy,
+    ),
+  );
+  await tester.pumpAndSettle();
+  expect(find.text("Drop images to attach"), findsNothing);
+}
+
 void main() {
   late MockSessionDetailCubit cubit;
   late MockVoiceTranscriptionService voiceTranscriptionService;
@@ -202,8 +281,16 @@ void main() {
   late MockImageClipboard imageClipboard;
 
   setUpAll(() {
+    void onFileFallback(DataReaderFile _) {}
+    void onErrorFallback(Object _) {}
+
     registerFallbackValue(ComposerDraft.typed(text: ""));
     registerFallbackValue(ComposerInputMode.typed);
+    registerFallbackValue(Formats.png);
+    registerFallbackValue(<DataFormat>[]);
+    registerFallbackValue(onFileFallback);
+    registerFallbackValue(onErrorFallback);
+    registerFallbackValue(_tinyPng);
   });
 
   Finder semanticsWithLabel(String label) =>
@@ -2213,6 +2300,212 @@ void main() {
     expect(editable.controller.selection, TextSelection.collapsed(offset: transcript.length));
     expect(scrollController.position.maxScrollExtent, greaterThan(0));
     expect(scrollController.offset, scrollController.position.maxScrollExtent);
+  });
+
+  testWidgets("image drop is available on native desktop and iOS", (tester) async {
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    for (final platform in [TargetPlatform.macOS, TargetPlatform.iOS]) {
+      debugDefaultTargetPlatformOverride = platform;
+      await tester.pumpWidget(_buildApp(cubit: cubit));
+      await tester.pumpAndSettle();
+      expect(find.byType(DropRegion), findsOneWidget, reason: platform.name);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+    }
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets("dropping multiple images stages them in drag order", (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+    when(
+      () => imagePicker.attachmentFromBytes(
+        bytes: any(named: "bytes"),
+        filename: any(named: "filename"),
+      ),
+    ).thenAnswer((invocation) {
+      return ComposerAttachment(
+        mime: "image/png",
+        bytes: invocation.namedArguments[#bytes]! as Uint8List,
+        filename: invocation.namedArguments[#filename]! as String,
+      );
+    });
+
+    var closedFiles = 0;
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+    await _performImageDrop(
+      tester: tester,
+      items: [
+        _droppedImageItem(
+          bytes: _tinyPng,
+          filename: "first.png",
+          byteStream: null,
+          reportedFileSize: null,
+          onClose: () => closedFiles++,
+        ),
+        _droppedImageItem(
+          bytes: _tinyPng,
+          filename: "second.png",
+          byteStream: null,
+          reportedFileSize: null,
+          onClose: () => closedFiles++,
+        ),
+      ],
+    );
+
+    final attachmentLabels = tester
+        .widgetList<Semantics>(find.byType(Semantics))
+        .map((semantics) => semantics.properties.label)
+        .whereType<String>();
+    expect(attachmentLabels, containsAllInOrder(["first.png", "second.png"]));
+    expect(closedFiles, 2);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets("a rejected dropped image does not block a later valid image", (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+    final invalidBytes = Uint8List.fromList(const [0, 1, 2, 3]);
+    when(
+      () => imagePicker.attachmentFromBytes(
+        bytes: any(named: "bytes"),
+        filename: any(named: "filename"),
+      ),
+    ).thenAnswer((invocation) {
+      final filename = invocation.namedArguments[#filename]! as String;
+      if (filename == "invalid.png") throw const UnsupportedAttachmentImageError();
+      return ComposerAttachment(
+        mime: "image/png",
+        bytes: invocation.namedArguments[#bytes]! as Uint8List,
+        filename: filename,
+      );
+    });
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+    await _performImageDrop(
+      tester: tester,
+      items: [
+        _droppedImageItem(
+          bytes: invalidBytes,
+          filename: "invalid.png",
+          byteStream: null,
+          reportedFileSize: null,
+          onClose: null,
+        ),
+        _droppedImageItem(
+          bytes: _tinyPng,
+          filename: "valid.png",
+          byteStream: null,
+          reportedFileSize: null,
+          onClose: null,
+        ),
+      ],
+    );
+
+    expect(find.text("That image format isn't supported."), findsOneWidget);
+    expect(semanticsWithLabel("invalid.png"), findsNothing);
+    expect(semanticsWithLabel("valid.png"), findsOneWidget);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets("an oversized dropped image closes without reading", (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+    var closedFiles = 0;
+    final item = _droppedImageItem(
+      bytes: _tinyPng,
+      filename: "oversized.png",
+      byteStream: null,
+      reportedFileSize: maxComposerPromptAttachmentBytes + 1,
+      onClose: () => closedFiles++,
+    );
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+    await _performImageDrop(tester: tester, items: [item]);
+
+    expect(find.text("That image is too large to attach."), findsOneWidget);
+    expect(closedFiles, 1);
+    verifyNever(
+      () => imagePicker.attachmentFromBytes(
+        bytes: any(named: "bytes"),
+        filename: any(named: "filename"),
+      ),
+    );
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets("image drop is unavailable without attachment capability", (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+    final state = _loadedState(
+      pendingQuestions: const [],
+      pendingPermissions: const [],
+      supportsPromptAttachments: false,
+    );
+    when(() => cubit.state).thenReturn(state);
+    whenListen(cubit, const Stream<SessionDetailState>.empty(), initialState: state);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(DropRegion), findsNothing);
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets("a dropped image is discarded when attachment support changes during its read", (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+    final states = StreamController<SessionDetailState>.broadcast();
+    final imageBytes = StreamController<Uint8List>();
+    addTearDown(states.close);
+    addTearDown(imageBytes.close);
+    final supported = _loadedState(
+      pendingQuestions: const [],
+      pendingPermissions: const [],
+      supportsPromptAttachments: true,
+    );
+    when(() => cubit.state).thenReturn(supported);
+    whenListen(cubit, states.stream, initialState: supported);
+    when(
+      () => imagePicker.attachmentFromBytes(
+        bytes: any(named: "bytes"),
+        filename: any(named: "filename"),
+      ),
+    ).thenReturn(ComposerAttachment(mime: "image/png", bytes: _tinyPng, filename: "stale.png"));
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+    await _performImageDrop(
+      tester: tester,
+      items: [
+        _droppedImageItem(
+          bytes: _tinyPng,
+          filename: "stale.png",
+          byteStream: imageBytes.stream,
+          reportedFileSize: null,
+          onClose: null,
+        ),
+      ],
+    );
+
+    states.add(supported.copyWith(supportsPromptAttachments: false));
+    await tester.pumpAndSettle();
+    imageBytes.add(_tinyPng);
+    await tester.pump();
+
+    verifyNever(
+      () => imagePicker.attachmentFromBytes(
+        bytes: any(named: "bytes"),
+        filename: any(named: "filename"),
+      ),
+    );
+    expect(semanticsWithLabel("stale.png"), findsNothing);
+    debugDefaultTargetPlatformOverride = null;
   });
 
   testWidgets("accordion attach action stages a removable thumbnail without raising the keyboard", (tester) async {

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -1063,6 +1063,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  irondash_engine_context:
+    dependency: transitive
+    description:
+      name: irondash_engine_context
+      sha256: eccd423b2e6b821338fc3c0bf4d12192cff7a4a3f5c66c6abc704f25aa3886b1
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0-dev.0"
+  irondash_message_channel:
+    dependency: transitive
+    description:
+      name: irondash_message_channel
+      sha256: "247e07d6b8694d9fd2c372832a6c5ef057298aa9a52ed4d74861c064096ee1ab"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.0-dev.0"
   jni:
     dependency: transitive
     description:
@@ -1215,6 +1231,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  native_toolchain_rust:
+    dependency: transitive
+    description:
+      name: native_toolchain_rust
+      sha256: faa57d2258a3b0fd2a634054f54e4496c9fcbd971977e7d2b7e6916d56892857
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4+0"
   nested:
     dependency: transitive
     description:
@@ -1350,6 +1374,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.2"
+  pixel_snap:
+    dependency: transitive
+    description:
+      name: pixel_snap
+      sha256: "677410ea37b07cd37ecb6d5e6c0d8d7615a7cf3bd92ba406fd1ac57e937d1fb0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.5"
   platform:
     dependency: transitive
     description:
@@ -1683,6 +1715,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  super_clipboard:
+    dependency: transitive
+    description:
+      name: super_clipboard
+      sha256: "9c6a698aa85258a9860123a30802ad5a5c82852008244c5e6c4f589559298da2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.0-dev.2"
+  super_drag_and_drop:
+    dependency: transitive
+    description:
+      name: super_drag_and_drop
+      sha256: "2fe00592e6e7d659e8affb367df6f95c27a0a0f5fc321aac880e44ff762e1fd5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.0-dev.2"
+  super_native_extensions:
+    dependency: transitive
+    description:
+      name: super_native_extensions
+      sha256: cb633ce1150acb2c43e3457f2659a06a77f620f125bf73e15b9217483faf9ec3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.0-dev.2"
   synchronized:
     dependency: transitive
     description:
@@ -1731,6 +1787,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.11.1"
+  toml:
+    dependency: transitive
+    description:
+      name: toml
+      sha256: "35a35f782228656a2af31e8c73d1353cc4ef3d683fd68af1111b44631879c05e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.18.0"
   typed_data:
     dependency: transitive
     description:

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -229,10 +229,10 @@ packages:
     dependency: transitive
     description:
       name: code_assets
-      sha256: cfd4f5f575a49c5f10ca856e9846073f1e6c3ee94912377eea5f6cefc5272941
+      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "1.2.1"
   code_builder:
     dependency: transitive
     description:
@@ -1266,10 +1266,10 @@ packages:
     dependency: transitive
     description:
       name: objective_c
-      sha256: ad56fd53a78ff6b1472fa59ff2a4e8b8ccabafc586fc263a1dfad0b99b5553e3
+      sha256: b7fb95a6d9a4f009edd63dc5ac69f07420b23a16161c6dd8660290b59c602e8e
       url: "https://pub.dev"
     source: hosted
-    version: "9.6.0"
+    version: "9.5.0"
   package_config:
     dependency: transitive
     description:

--- a/docs/regression/attachments-and-images.md
+++ b/docs/regression/attachments-and-images.md
@@ -9,9 +9,13 @@ content the transcript renders live and after reload.
 ## Required Behavior
 
 - The composer offers image staging only for a backend declaring prompt
-  attachment support. Staged images are memory-only. They are cleared when the
-  target stops supporting attachments, the session changes, or submission
-  succeeds or settles after route exit; current-route failure instead transfers
+  attachment support. Gallery picks and clipboard images work on their existing
+  platforms; native desktop and iOS clients also accept supported image files
+  dropped on the composer, including multiple files in drag order. Dropped files
+  are read through the same per-image and aggregate bounds and content-signature
+  validation as every other composer source. Staged images are memory-only. They
+  are cleared when the target stops supporting attachments, the session changes,
+  or submission succeeds or settles after route exit; current-route failure instead transfers
   the one-shot snapshot into restoration. They never persist in a draft and travel
   inline within the staged-attachment size bound so the request fits the relay's
   message limit. The owning plugin normalizes backend-produced images into a
@@ -93,11 +97,11 @@ content the transcript renders live and after reload.
 | L2 Routine | Live plugin, one representative plugin: a backend-produced image survives the plugin boundary as a bounded client-safe attachment, live and after a cold history read. |
 | L3 Release | Client end to end on the release-target client platform, every supporting production plugin: staged composer images sent and echoed per attachment-capable plugin; a failed current-route creation restores exact attachment identities with the rest of the draft while background failure does not; generated and tool-output images display, text/image/text order is preserved live and after reload, and viewer copy/share/save works. |
 | L4 Extended | Live plugin for budget-exceeding or mixed collections, malformed types, attachment remote-URL rejection, abort, and plugin restart; relay integration for a second client loading the same transcript. Every supporting production plugin. |
-| L5 Full | Client end to end on alternate client platforms for picker, clipboard, animated formats, archive, and deletion; automated for an older bridge omitting attachment support; packaged or external for the released inline compatibility shape. Every supporting production plugin where supported. |
+| L5 Full | Client end to end on alternate client platforms for picker, clipboard, desktop/iPad drag-and-drop (single, multiple, mixed-validity, oversized, and stale-session drops), animated formats, archive, and deletion; automated for an older bridge omitting attachment support; packaged or external for the released inline compatibility shape. Every supporting production plugin where supported. |
 
 ## Exploration Guidance
 
-Vary the image source (picker, clipboard, backend-generated, tool output, remote
+Vary the image source (picker, clipboard, desktop/iPad file drop, backend-generated, tool output, remote
 reference), raster format, collection size from one image to over the candidate
 limit, and bytes from small to over budget. Vary whether the transcript is seen
 live, after paging back, or after a reopen, and vary the plugin.


### PR DESCRIPTION
## Complexity

⚙️ Moderate. This adds a native cross-platform drop dependency, bounded asynchronous file handling, and build-toolchain setup across Apple, Android, and CI environments.

## What

- Accept JPEG, PNG, GIF, WebP, and BMP file drops on attachment-capable composers on iOS, macOS, Windows, and Linux.
- Stage multiple dropped images in drag order through the existing attachment signature and aggregate-size validation path.
- Show a localized composer overlay while an acceptable drag is over the drop target.
- Bound stream reads, isolate per-file failures, fence stale results across send/session/capability changes, and close every native file handle.
- Add Rust setup for affected CI/release builds, dependency lock updates, focused widget coverage, and regression documentation.

## Why

Desktop users expect to attach screenshots and image files directly from Finder or their file manager. The same native API supports iPad drag and drop, so iOS receives the feature through the identical composer path rather than a separate implementation.

## Risk and test focus

- Focus on native plugin registration and Rust build-hook reproducibility across target platforms.
- Focus on multi-file ordering, 50 MiB stream/aggregate bounds, unsupported content, native resource closure, and stale asynchronous drops.
- User-visible impact: supported desktop and iOS composers accept dropped image files and display a drop affordance.
- No database or client/bridge wire-contract impact.

## Expected result

Dragging one or more supported image files onto a capable composer stages the same removable thumbnails as gallery and clipboard attachment flows. Unsupported, oversized, failed, or stale files do not leak into the composer, and one invalid file does not block a later valid file.

## Verification

- `dart pub get` from `client/`
- `dart analyze` from `client/app/`
- `flutter test test/features/session_detail/widgets/session_detail_body_test.dart`
- Focused final drop tests, including multi-file, mixed-validity, oversized, capability-gated, stale, and handle-closure cases
- `flutter test test/features/new_session/new_session_screen_test.dart`
- `flutter build macos --debug`
- `flutter build ios --simulator --debug`
- `flutter build apk --debug`
- `actionlint .github/workflows/mobile-ci.yml`
- YAML parse validation for the changed mobile release workflows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add native image drag‑and‑drop of images to attachment‑capable composers on macOS, Windows, Linux, and iOS/iPadOS. Previously only gallery and clipboard were accepted; now dropping JPEG/PNG/GIF/WebP/BMP stages the same removable thumbnails, shows an overlay only for acceptable copy drags, preserves drag order, enforces size limits early, fences stale inputs, and closes native handles.

- prompt_input.dart: wraps the composer in a `DropRegion`, gates by platform and `attachmentsSupported`, announces a live‑region overlay, accepts only copy ops for image formats, preserves drag order, pre‑rejects by reported size, bounds stream reads, isolates per‑file failures, fences with `draftIdentity` and `_attachmentInputGeneration`, and closes native handles.
- Tests: add multi‑file order, mixed‑validity, pre‑read oversize, capability‑gated, and mid‑read staleness cases; adds `sessionDetailDropImagesToAttach` to l10n.
- Deps/build: add `super_drag_and_drop` and dev `super_clipboard`; macOS registrant adds `super_native_extensions` and `irondash_engine_context`; resolve drag‑and‑drop transitive deps; CI sets up Rust 1.97.1 via `dtolnay/rust-toolchain` and installs `libgtk-3-dev` on Linux.
- Local: native `client/app` builds require `rustup` with `~/.cargo/bin` early on PATH.
- Rollout: enabled on iOS/macOS/Windows/Linux when attachments are supported; disabled on Android, web, and Fuchsia. No API or wire‑contract changes.

<sup>Written for commit be38cc3249a18ab59c4668fc31c45e8d037c6fd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

