### PR TITLE
🌿 Keep one transcript row across a prompt's queued-to-sent handoff

### DIFF
--- a/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -127,8 +127,7 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
   /// pinned at the newest edge. Domain message ids come from the
   /// assistant backend and cannot collide with this.
   static const _kRetryErrorRowId = "session-detail-retry-error-row";
-  static const _kTransientSubmissionRowPrefix = "session-detail-transient-submission-";
-  static const _kBridgeQueuedRowPrefix = "session-detail-bridge-queued-";
+  static const _kPromptRowPrefix = "session-detail-prompt-";
 
   static const _kUserAuthorId = "user";
   static const _kAgentAuthorId = "agent";
@@ -199,8 +198,6 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
 
   /// The chat controller needs string IDs; object identity keeps one row stable
   /// as the queue moves the same submission from pending to sending.
-  final Expando<String> _transientSubmissionEntryIds = Expando<String>();
-  int _nextTransientSubmissionEntryId = 0;
 
   @override
   void initState() {
@@ -425,11 +422,15 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
     required List<QueuedSessionPrompt> bridgeQueuedPrompts,
     required bool hasRetryError,
   }) {
-    return <chat_core.Message>[
+    // A prompt keeps one row id from staged send through bridge queue to its
+    // delivered user message, so the animated list updates that row in place
+    // instead of removing one entry and inserting another — the queued→sent
+    // handoff must never blink through a frame with neither rendered.
+    final entries = <chat_core.Message>[
       for (final message in messages)
         if (message.hasRenderableUserContent)
           chat_core.Message.custom(
-            id: message.info.id,
+            id: _entryIdForMessage(info: message.info),
             authorId: switch (message.info) {
               MessageUser() => _kUserAuthorId,
               MessageAssistant() => _kAgentAuthorId,
@@ -438,7 +439,8 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
             // Role discriminates assistant from error under the shared
             // agent authorId, so a live assistant→error transition on the
             // same message id is no longer value-equal and forces the row
-            // to re-render as the error card.
+            // to re-render as the error card. The same inequality drives the
+            // transient-submission→user transform on a stable prompt row id.
             metadata: <String, String>{
               _kRoleMetadataKey: switch (message.info) {
                 MessageUser() => _kUserRole,
@@ -449,21 +451,30 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
           ),
       if (hasRetryError) const chat_core.Message.custom(id: _kRetryErrorRowId, authorId: _kAgentAuthorId),
       // Bridge-accepted prompts render before locally staged ones: they were
-      // accepted earlier and dispatch first.
+      // accepted earlier and dispatch first. A prompt whose message already
+      // landed owns that row id above and renders only as the message.
       for (final prompt in bridgeQueuedPrompts)
         chat_core.Message.custom(
-          id: "$_kBridgeQueuedRowPrefix${prompt.id}",
+          id: "$_kPromptRowPrefix${prompt.id}",
           authorId: _kUserAuthorId,
           metadata: const <String, String>{_kRoleMetadataKey: _kTransientSubmissionRole},
         ),
       if (sendingSubmission != null) _chatEntryFor(submission: sendingSubmission),
       for (final submission in queuedMessages) _chatEntryFor(submission: submission),
     ];
+    // One row per id: a prompt momentarily present in two sources (its message
+    // landed while the queue copy is still being reconciled) keeps its most
+    // settled entry. The chat controller hard-rejects duplicate ids.
+    final seenIds = <String>{};
+    return [
+      for (final entry in entries)
+        if (seenIds.add(entry.id)) entry,
+    ];
   }
 
   chat_core.Message _chatEntryFor({required QueuedSessionSubmission submission}) {
     return chat_core.Message.custom(
-      id: _entryIdFor(submission: submission),
+      id: "$_kPromptRowPrefix${submission.promptId}",
       authorId: _kUserAuthorId,
       metadata: const <String, String>{
         _kRoleMetadataKey: _kTransientSubmissionRole,
@@ -471,19 +482,16 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
     );
   }
 
+  String _entryIdForMessage({required Message info}) => switch (info) {
+    MessageUser(promptId: final promptId?) => "$_kPromptRowPrefix$promptId",
+    MessageUser() || MessageAssistant() || MessageError() => info.id,
+  };
+
   static String? _bridgePromptDisplayText(QueuedSessionPrompt prompt) {
     final command = prompt.command;
     final text = prompt.text;
     if (command == null) return text;
     return text == null ? "/$command" : "/$command $text";
-  }
-
-  String _entryIdFor({required QueuedSessionSubmission submission}) {
-    final existing = _transientSubmissionEntryIds[submission];
-    if (existing != null) return existing;
-    final id = "$_kTransientSubmissionRowPrefix${_nextTransientSubmissionEntryId++}";
-    _transientSubmissionEntryIds[submission] = id;
-    return id;
   }
 
   static Future<chat_core.User?> _resolveUser(String id) async => chat_core.User(id: id);
@@ -503,9 +511,9 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
     final indexById = _indexByIdFor(messages: messages);
     final transientSubmissions = <String, _TransientSubmission>{
       if (sendingSubmission != null)
-        _entryIdFor(submission: sendingSubmission): (submission: sendingSubmission, isSending: true),
+        "$_kPromptRowPrefix${sendingSubmission.promptId}": (submission: sendingSubmission, isSending: true),
       for (final submission in queuedMessages)
-        _entryIdFor(submission: submission): (submission: submission, isSending: false),
+        "$_kPromptRowPrefix${submission.promptId}": (submission: submission, isSending: false),
     };
 
     // Coalesced post-frame pin-to-edge while following. The scheduler
@@ -639,23 +647,34 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
       // Synthetic row: no timestamp, but it still slides with the rest.
       return _revealable(createdAtMs: null, child: RetryErrorMessageCard(message: retryErrorMessage));
     }
-    if (entry.id.startsWith(_kBridgeQueuedRowPrefix)) {
-      final promptId = entry.id.substring(_kBridgeQueuedRowPrefix.length);
+    if (entry.id.startsWith(_kPromptRowPrefix)) {
+      // One row serves the prompt's whole lifecycle. Resolve the most settled
+      // state first: the delivered message, else the bridge-queued entry, else
+      // the locally staged submission. A mid-handoff frame (entry updated
+      // before the next widget rebuild, or vice versa) then renders the
+      // previous state instead of collapsing to an empty box.
+      final index = indexById[entry.id];
+      if (index != null && index < messages.length && messages[index].hasRenderableUserContent) {
+        final message = messages[index];
+        return _revealable(createdAtMs: message.info.time?.created, child: UserMessageCard(message: message));
+      }
+      final promptId = entry.id.substring(_kPromptRowPrefix.length);
       final prompt = widget.bridgeQueuedPrompts.where((candidate) => candidate.id == promptId).firstOrNull;
-      if (prompt == null) return const SizedBox.shrink();
-      final onCancel = widget.onCancelBridgeQueuedPrompt;
-      return _revealable(
-        createdAtMs: prompt.createdAt,
-        child: QueuedMessageBubble(
-          key: ValueKey(entry.id),
-          displayText: _bridgePromptDisplayText(prompt),
-          isCommand: prompt.command != null,
-          attachmentCount: prompt.attachmentCount,
-          presentation: onCancel == null
-              ? const QueuedMessageBubblePresentation.pendingReadOnly()
-              : QueuedMessageBubblePresentation.pending(onCancel: () => onCancel(prompt.id)),
-        ),
-      );
+      if (prompt != null) {
+        final onCancel = widget.onCancelBridgeQueuedPrompt;
+        return _revealable(
+          createdAtMs: prompt.createdAt,
+          child: QueuedMessageBubble(
+            key: ValueKey(entry.id),
+            displayText: _bridgePromptDisplayText(prompt),
+            isCommand: prompt.command != null,
+            attachmentCount: prompt.attachmentCount,
+            presentation: onCancel == null
+                ? const QueuedMessageBubblePresentation.pendingReadOnly()
+                : QueuedMessageBubblePresentation.pending(onCancel: () => onCancel(prompt.id)),
+          ),
+        );
+      }
     }
     final transientSubmission = transientSubmissions[entry.id];
     if (transientSubmission != null) {
@@ -664,7 +683,7 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
       return _revealable(
         createdAtMs: null,
         child: QueuedMessageBubble(
-          key: ObjectKey(submission),
+          key: ValueKey(entry.id),
           displayText: submission.displayText,
           isCommand: submission.isCommand,
           attachmentCount: submission.attachments.length,
@@ -892,6 +911,8 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
     _indexSignature = signature;
     return _indexById = <String, int>{
       for (var i = 0; i < messages.length; i++) messages[i].info.id: i,
+      for (var i = 0; i < messages.length; i++)
+        if (messages[i].info case MessageUser(promptId: final promptId?)) "$_kPromptRowPrefix$promptId": i,
     };
   }
 

--- a/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -919,8 +919,18 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
   int _signatureOf({required List<MessageWithParts> messages}) {
     // Hash every id so the cache invalidates on any structural change —
     // including a middle insert/delete/replace that preserves length and the
-    // first/last ids. Cheap for chat-sized transcripts and bounded by maxLines
-    // at the render layer.
-    return Object.hashAll(messages.map((m) => m.info.id));
+    // first/last ids. A user message's promptId is part of the map's keys
+    // (the stable prompt row resolves through it), so it participates too:
+    // a live upsert that stamps promptId onto an existing id must rebuild.
+    // Cheap for chat-sized transcripts and bounded by maxLines at the render
+    // layer.
+    return Object.hashAll(
+      messages.map(
+        (m) => switch (m.info) {
+          MessageUser(:final id, :final promptId) => Object.hash(id, promptId),
+          MessageAssistant(:final id) || MessageError(:final id) => id,
+        },
+      ),
+    );
   }
 }

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -2796,7 +2796,7 @@ void main() {
       agentModel: null,
     );
     const followingSubmission = QueuedSessionSubmission.text(
-      promptId: "prompt-1",
+      promptId: "prompt-2",
       text: "Next prompt",
       inputMode: ComposerInputMode.typed,
       attachments: [],
@@ -2814,7 +2814,9 @@ void main() {
     await tester.pumpWidget(_buildApp(cubit: cubit));
     await tester.pumpAndSettle();
 
-    final submissionFinder = find.byKey(const ObjectKey(submission));
+    final submissionFinder = find.byWidgetPredicate(
+      (widget) => widget is QueuedMessageBubble && widget.key == const ValueKey("session-detail-prompt-prompt-1"),
+    );
     final before = tester.element(submissionFinder);
     expect(
       find.descendant(of: find.byType(SessionDetailMessageList), matching: submissionFinder),

--- a/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -6,6 +6,7 @@ import "package:sesori_mobile/features/session_detail/widgets/message_timestamp_
 import "package:sesori_mobile/features/session_detail/widgets/queued_message_bubble.dart";
 import "package:sesori_mobile/features/session_detail/widgets/retry_error_message_card.dart";
 import "package:sesori_mobile/features/session_detail/widgets/session_detail_message_list.dart";
+import "package:sesori_mobile/features/session_detail/widgets/user_message_card.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
@@ -91,6 +92,15 @@ class _SessionDetailMessageListHarnessState() extends State<_SessionDetailMessag
     });
   }
 
+  /// Mirrors the cubit's atomic queued→sent swap: the delivered user message
+  /// lands and the bridge entry leaves in one state emission.
+  void deliverBridgePrompt({required String promptId, required MessageWithParts message}) {
+    setState(() {
+      _messages = [..._messages, message];
+      _bridgeQueuedPrompts = [..._bridgeQueuedPrompts.where((prompt) => prompt.id != promptId)];
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -130,12 +140,13 @@ MessageWithParts _message({
   required String text,
   String? partId,
   int? createdAtMs,
+  String? promptId,
 }) {
   final resolvedPartId = partId ?? "$messageId-part";
   final time = createdAtMs == null ? null : MessageTime(created: createdAtMs, completed: null);
 
   final info = role == "user"
-      ? Message.user(promptId: null, id: messageId, sessionID: "session-1", agent: null, time: time)
+      ? Message.user(promptId: promptId, id: messageId, sessionID: "session-1", agent: null, time: time)
       : Message.assistant(
           id: messageId,
           sessionID: "session-1",
@@ -262,6 +273,39 @@ void main() {
     expect(harnessKey.currentState?.cancelledBridgePromptIds, ["prm_1"]);
     expect(find.text("steer it"), findsNothing);
     expect(find.text("/review src"), findsOneWidget);
+  });
+
+  testWidgets("a bridge-queued prompt transforms into its message without a blank frame", (tester) async {
+    final harnessKey = GlobalKey<_SessionDetailMessageListHarnessState>();
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        key: harnessKey,
+        initialMessages: [_message(messageId: "assistant-1", role: "assistant", text: "working on it")],
+        initialStreamingText: const {},
+        initialBridgeQueuedPrompts: const [
+          QueuedSessionPrompt(id: "prm_1", text: "steer it", command: null, attachmentCount: 0, createdAt: 100),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text("steer it"), findsOneWidget);
+    expect(find.byType(QueuedMessageBubble), findsOneWidget);
+
+    harnessKey.currentState?.deliverBridgePrompt(
+      promptId: "prm_1",
+      message: _message(messageId: "replay-user-1", role: "user", text: "steer it", promptId: "prm_1"),
+    );
+
+    // The prompt's text must stay on screen through every frame of the
+    // handoff — the row transforms in place, it never blinks out.
+    await tester.pump();
+    expect(find.text("steer it"), findsOneWidget);
+    await tester.pump();
+    expect(find.text("steer it"), findsOneWidget);
+    await tester.pumpAndSettle();
+    expect(find.text("steer it"), findsOneWidget);
+    expect(find.byType(QueuedMessageBubble), findsNothing);
+    expect(find.byType(UserMessageCard), findsOneWidget);
   });
 
   testWidgets("does not render a user envelope until it has visible parts", (tester) async {


### PR DESCRIPTION
## Complexity

🌿 Straightforward — one widget file: row-identity unification in the session transcript list, plus test updates.

## What

Gives a prompt **one stable transcript row id** (`session-detail-prompt-<promptId>`) across its whole lifecycle — locally staged send → bridge-queued bubble → delivered user message — instead of three different entry ids. The animated chat list now updates that row in place rather than removing one entry and inserting another, and the row builder resolves the most settled state available (message, else bridge entry, else staged submission), so no handoff frame can collapse to an empty box. Entry building also skips duplicate ids defensively (the chat controller hard-rejects them), and the staged bubble key switched from object identity to the stable row id.

## Why

Live testing of the merged bridge-owned prompt queue showed a visible blink when a queued message became sent: the old remove+insert handoff could span two frames — one frame rendered neither the queued bubble nor the message. Reported on-device against latest main.

## Risk and test focus

Low. Behavior-neutral for rows without a prompt id (assistant, error, historical user messages keep message-id rows). Focus: the queued→sent transform, sending→queued promotion in place, cancel of a queued bubble, and pagination/detach flows (all covered by the existing 83 body tests and 29 list tests).

## Expected result

No database impact. On-device: a sent message's bubble transforms smoothly from Sending → Queued → sent text with no disappear/reappear at any hop. New regression test pins that the prompt text stays present through every frame of the handoff.

## Verification

- `dart analyze --fatal-infos` clean on `client/app`.
- Full `client/app` suite: 999 tests passed, including the new "transforms into its message without a blank frame" test; the two-submission fixture that reused one prompt id was corrected to unique ids (real sends always are).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps a single transcript row per prompt from staged send through bridge queue to the delivered user message to remove the queued→sent blink. Previously each phase used a different row id; now all share session-detail-prompt-<promptId> and the row updates in place.

- Resolves row state by stability: render the delivered user message first, else the bridge-queued entry, else the staged submission.
- Maps user messages with a promptId to session-detail-prompt-<promptId>; other messages keep message.id.
- Deduplicates entries by id to prefer the most settled state during brief overlap.
- Keys `QueuedMessageBubble` with ValueKey(rowId) so the bubble transforms in place.
- Indexing: adds the prompt row id to the id→index map and includes promptId in the index-cache signature to rebuild when a promptId is upserted.
- Tests: adds a handoff test that pins no blank frame; updates a body test to use unique promptIds and assert the new key.

<sup>Written for commit 47930f5dc5ad66b8923ecf58f3bc32abe17a9e4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

