### PR TITLE
⚙️ Finalize tool parts stranded by an ended turn

### DIFF
--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -1428,6 +1428,19 @@ class OrchestratorSession._({
         await _permissionAutoApprovalService.approvePending();
       }
 
+      // An ended turn can strand tool parts in a non-terminal state — a
+      // permission never answered, an abort, a backend process death. The
+      // backend will never complete them, so finalize the stored snapshots and
+      // tell subscribers before the idle event lands.
+      if (event case BridgeSseSessionIdle(:final sessionID)) {
+        await _finalizeOpenToolParts(
+          sessionId: sessionID,
+          pluginId: pluginId,
+          generation: generation,
+          allowDuringStop: allowDuringStop,
+        );
+      }
+
       final refreshProjectsSummary = event is BridgeSseProjectUpdated || event is BridgeSseSessionDeleted;
       final SseEventDelivery? delivery;
       if (event is BridgeSseMessagePartUpdated) {
@@ -1512,6 +1525,34 @@ class OrchestratorSession._({
               information: [event.runtimeType.toString()],
             )
             .catchError((_) {}),
+      );
+    }
+  }
+
+  /// Finalizes tool parts stranded by the ended turn and delivers each
+  /// rewritten part to subscribers as an ordinary part update.
+  Future<void> _finalizeOpenToolParts({
+    required String sessionId,
+    required String? pluginId,
+    required int? generation,
+    required bool allowDuringStop,
+  }) async {
+    final List<CapturedPartShapes> finalized;
+    try {
+      finalized = await _chatHistoryService.finalizeOpenToolParts(sessionId: sessionId);
+    } catch (e, st) {
+      Log.w("failed to finalize open tool parts for session $sessionId", e, st);
+      return;
+    }
+    for (final shapes in finalized) {
+      await _deliverSseEvent(
+        delivery: SseEventDelivery.attachmentShaped(
+          inlineEvent: _mapper.buildMessagePartEvent(part: shapes.inlinePart),
+          storedReferenceEvent: _mapper.buildMessagePartEvent(part: shapes.storedReferencePart),
+        ),
+        pluginId: pluginId,
+        generation: generation,
+        allowDuringStop: allowDuringStop,
       );
     }
   }

--- a/bridge/app/lib/src/bridge/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/chat_history_repository.dart
@@ -28,6 +28,9 @@ class ChatHistoryArchiveVersionException({
 /// older page (null when the caller has reached the start of the transcript).
 typedef ChatHistoryPage = ({List<MessageWithParts> messages, int? nextCursor});
 
+/// Identity of one stored part inside its session.
+typedef StoredPartRef = ({String messageId, String partId});
+
 /// How fresh a session's stored transcript is.
 ///
 /// [syncedAt] is null until a backfill completes, so a row created by live
@@ -280,6 +283,52 @@ class ChatHistoryRepository({
       remainingInlineBytes = projected.remainingInlineBytes;
     }
     return null;
+  }
+
+  /// Rewrites every stored tool part still in a non-terminal state to a
+  /// terminal error, and returns the identity of each rewritten row.
+  ///
+  /// A tool part left `pending`/`running` after its turn ended can never
+  /// receive a result — the backend reports tool completion only within the
+  /// turn that ran it — so keeping the stored snapshot open would render an
+  /// eternal spinner on every later read.
+  Future<List<StoredPartRef>> finalizeOpenToolParts({
+    required String sessionId,
+    required int updatedAt,
+  }) async {
+    final rows = await _chatHistoryDao.getParts(sessionId: sessionId);
+    final finalized = <StoredPartRef>[];
+    for (final row in rows) {
+      // Cheap prefilter so an idle sweep does not decode a whole transcript;
+      // the decoded check below remains the only authority.
+      if (!row.partJson.contains('"status":"pending"') && !row.partJson.contains('"status":"running"')) {
+        continue;
+      }
+      final Map<String, dynamic> json;
+      try {
+        json = jsonDecodeMap(row.partJson);
+      } on Object catch (error, stackTrace) {
+        Log.w(
+          "Skipping an undecodable stored part ${row.partId} of session $sessionId during tool finalization",
+          error,
+          stackTrace,
+        );
+        continue;
+      }
+      if (json["type"] != "tool") continue;
+      final Object? rawState = json["state"];
+      if (rawState is! Map<String, dynamic>) continue;
+      final status = rawState["status"];
+      if (status != "pending" && status != "running") continue;
+
+      rawState["status"] = "error";
+      rawState["error"] = "The turn ended before this tool reported a result.";
+      await _chatHistoryDao.upsertPart(
+        row: row.copyWith(partJson: jsonEncode(json), updatedAt: updatedAt),
+      );
+      finalized.add((messageId: row.messageId, partId: row.partId));
+    }
+    return finalized;
   }
 
   Future<void> deleteMessage({required String sessionId, required String messageId}) {

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -27,6 +27,7 @@ import "package:sesori_shared/sesori_shared.dart"
         PullRequestInfo,
         QueuedSessionPrompt,
         Session,
+        SessionStatus,
         SessionStatusResponse,
         SessionVariant;
 
@@ -1015,6 +1016,25 @@ class SessionRepository({
           if (result.statuses == null) result.pluginId,
       ],
     );
+  }
+
+  /// The single session's live status, or null when it cannot be observed —
+  /// the session has no binding, its plugin is not active, or the plugin read
+  /// failed. The caller owns the policy for that uncertainty.
+  Future<SessionStatus?> getSessionStatus({required String sessionId}) async {
+    final binding = await _sessionDao.getSession(sessionId: sessionId);
+    if (binding == null) return null;
+    try {
+      final pluginStatuses = await _runtime.useIfActive(
+        pluginId: binding.pluginId,
+        operation: SessionOperation.getSessionStatuses,
+        body: (plugin, _) => plugin.getSessionStatuses().timeout(_aggregateSourceDeadline),
+      );
+      return pluginStatuses?[binding.backendSessionId]?.toSharedSessionStatus();
+    } on Object catch (error, stackTrace) {
+      Log.w("Could not read the status of session $sessionId from plugin ${binding.pluginId}", error, stackTrace);
+      return null;
+    }
   }
 
   Future<List<Session>> enrichSessions({

--- a/bridge/app/lib/src/bridge/services/chat_history_service.dart
+++ b/bridge/app/lib/src/bridge/services/chat_history_service.dart
@@ -109,20 +109,30 @@ class ChatHistoryService({
         );
       },
     );
-    if (decided != null) return decided;
+    if (decided != null) {
+      // A store that stayed "fresh" across an abrupt bridge death still holds
+      // the dead turn's open tool parts — no idle event ever fired and no
+      // backfill will run. The page is already in memory, so detecting them is
+      // free; only a page that actually contains one pays for a status read.
+      if (!_containsOpenToolPart(page: decided)) return decided;
+      if (!await _sweepUnlessTurnRunning(sessionId: sessionId)) return decided;
+      final storageScope = await _requireStorageScope(sessionId: sessionId);
+      return await _enqueueRead(
+        sessionId: sessionId,
+        read: () => _chatHistoryRepository.getSessionMessages(
+          sessionId: sessionId,
+          storageScope: storageScope,
+          limit: limit,
+          before: before,
+          attachmentProjection: attachmentProjection,
+        ),
+      );
+    }
 
     await backfillSession(sessionId: sessionId);
     // A backend transcript reports no result for a tool whose turn died, so a
     // fresh backfill can import open tool parts that will never complete.
-    // Finalize them unless a turn is actually running right now. Null status —
-    // no binding, stopped plugin, failed read — cannot host a live tool, so it
-    // sweeps too. A turn that starts between this check and the sweep may
-    // transiently mark its first tool as errored; the next live capture of
-    // that part overwrites it, which is proportional to the damage.
-    final status = await _sessionRepository.getSessionStatus(sessionId: sessionId);
-    if (status is! SessionStatusBusy && status is! SessionStatusRetry) {
-      await finalizeOpenToolParts(sessionId: sessionId);
-    }
+    await _sweepUnlessTurnRunning(sessionId: sessionId);
     final storageScope = await _requireStorageScope(sessionId: sessionId);
     // The backfill is itself queued, so this read lands after it and after
     // any capture that raced its fetch.
@@ -481,6 +491,55 @@ class ChatHistoryService({
           );
           await _clearSyncedAtQuietly(sessionId: sessionId);
           return const <CapturedPartShapes>[];
+        }
+      },
+    );
+  }
+
+  /// Whether any served part is a tool still reported as `pending`/`running`.
+  bool _containsOpenToolPart({required ChatHistoryPage page}) {
+    for (final message in page.messages) {
+      for (final part in message.parts) {
+        if (part.type != MessagePartType.tool) continue;
+        final status = part.state?.status;
+        if (status == ToolStatus.pending || status == ToolStatus.running) return true;
+      }
+    }
+    return false;
+  }
+
+  /// Finalizes the session's open tool parts unless a turn is running now, and
+  /// reports whether anything was rewritten.
+  ///
+  /// A read-path sweep, so it mutates rows without projecting delivery shapes:
+  /// the caller re-reads the page itself, and projection could fail for
+  /// reasons — an unregistered bridge — that must not fail the sweep. A null
+  /// status — no binding, stopped plugin, failed read — cannot host a live
+  /// tool, so it sweeps too. A turn that starts between the check and the
+  /// sweep may transiently mark its first tool as errored; the next live
+  /// capture of that part overwrites it, which is proportional to the damage.
+  Future<bool> _sweepUnlessTurnRunning({required String sessionId}) async {
+    final status = await _sessionRepository.getSessionStatus(sessionId: sessionId);
+    if (status is SessionStatusBusy || status is SessionStatusRetry) return false;
+    final observedAt = DateTime.now().millisecondsSinceEpoch;
+    return await _enqueueRead(
+      sessionId: sessionId,
+      read: () async {
+        try {
+          final refs = await _chatHistoryRepository.finalizeOpenToolParts(
+            sessionId: sessionId,
+            updatedAt: observedAt,
+          );
+          return refs.isNotEmpty;
+        } on Object catch (error, stackTrace) {
+          Log.w(
+            "Failed to finalize open tool parts for session $sessionId; "
+            "dropping the synced marker so the next read re-backfills",
+            error,
+            stackTrace,
+          );
+          await _clearSyncedAtQuietly(sessionId: sessionId);
+          return false;
         }
       },
     );

--- a/bridge/app/lib/src/bridge/services/chat_history_service.dart
+++ b/bridge/app/lib/src/bridge/services/chat_history_service.dart
@@ -112,6 +112,17 @@ class ChatHistoryService({
     if (decided != null) return decided;
 
     await backfillSession(sessionId: sessionId);
+    // A backend transcript reports no result for a tool whose turn died, so a
+    // fresh backfill can import open tool parts that will never complete.
+    // Finalize them unless a turn is actually running right now. Null status —
+    // no binding, stopped plugin, failed read — cannot host a live tool, so it
+    // sweeps too. A turn that starts between this check and the sweep may
+    // transiently mark its first tool as errored; the next live capture of
+    // that part overwrites it, which is proportional to the damage.
+    final status = await _sessionRepository.getSessionStatus(sessionId: sessionId);
+    if (status is! SessionStatusBusy && status is! SessionStatusRetry) {
+      await finalizeOpenToolParts(sessionId: sessionId);
+    }
     final storageScope = await _requireStorageScope(sessionId: sessionId);
     // The backfill is itself queued, so this read lands after it and after
     // any capture that raced its fetch.
@@ -417,6 +428,61 @@ class ChatHistoryService({
           : state.copyWith(
               attachments: state.attachments.map((attachment) => bound(attachment: attachment)).toList(),
             ),
+    );
+  }
+
+  /// Finalizes tool parts left open after the session's turn ended, returning
+  /// each rewritten part in both delivery shapes for live emission.
+  ///
+  /// A stored `pending`/`running` tool part whose turn is over can never
+  /// receive a result, so it would spin forever on every later read. The
+  /// sweep does not touch the session's freshness marks: rewriting local rows
+  /// is neither a live capture nor backend activity, and advancing the
+  /// watermark here could make a stale store look current.
+  Future<List<CapturedPartShapes>> finalizeOpenToolParts({required String sessionId}) {
+    final observedAt = DateTime.now().millisecondsSinceEpoch;
+    return _enqueueRead(
+      sessionId: sessionId,
+      read: () async {
+        try {
+          final refs = await _chatHistoryRepository.finalizeOpenToolParts(
+            sessionId: sessionId,
+            updatedAt: observedAt,
+          );
+          if (refs.isEmpty) return const <CapturedPartShapes>[];
+          final storageScope = await _requireStorageScope(sessionId: sessionId);
+          final shapes = <CapturedPartShapes>[];
+          for (final ref in refs) {
+            final inlinePart = await _chatHistoryRepository.projectStoredPart(
+              sessionId: sessionId,
+              storageScope: storageScope,
+              messageId: ref.messageId,
+              partId: ref.partId,
+              attachmentProjection: _attachmentProjectionFor(delivery: MessageAttachmentDelivery.inline),
+            );
+            final storedReferencePart = await _chatHistoryRepository.projectStoredPart(
+              sessionId: sessionId,
+              storageScope: storageScope,
+              messageId: ref.messageId,
+              partId: ref.partId,
+              attachmentProjection: _attachmentProjectionFor(delivery: MessageAttachmentDelivery.storedReference),
+            );
+            if (inlinePart != null && storedReferencePart != null) {
+              shapes.add(CapturedPartShapes(inlinePart: inlinePart, storedReferencePart: storedReferencePart));
+            }
+          }
+          return shapes;
+        } on Object catch (error, stackTrace) {
+          Log.w(
+            "Failed to finalize open tool parts for session $sessionId; "
+            "dropping the synced marker so the next read re-backfills",
+            error,
+            stackTrace,
+          );
+          await _clearSyncedAtQuietly(sessionId: sessionId);
+          return const <CapturedPartShapes>[];
+        }
+      },
     );
   }
 

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -906,6 +906,9 @@ class _NoopSessionRepository() implements SessionRepository {
   Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async => const <MessageWithParts>[];
 
   @override
+  Future<SessionStatus?> getSessionStatus({required String sessionId}) async => null;
+
+  @override
   Future<List<ProjectActivitySummary>> getProjectActivitySummaries() async => const <ProjectActivitySummary>[];
 
   @override
@@ -1506,6 +1509,13 @@ class FakeSessionRepository({
             stored.sessionId: entry.value.toSharedSessionStatus(),
       },
     );
+  }
+
+  @override
+  Future<SessionStatus?> getSessionStatus({required String sessionId}) async {
+    final stored = await _sessionDao.getSession(sessionId: sessionId);
+    if (stored == null) return null;
+    return (await _plugin.getSessionStatuses())[stored.backendSessionId]?.toSharedSessionStatus();
   }
 
   @override

--- a/bridge/app/test/bridge/services/chat_history_serving_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_serving_test.dart
@@ -232,6 +232,9 @@ class _FakeSessionRepository({required var List<MessageWithParts> transcript, fi
   }
 
   @override
+  Future<SessionStatus?> getSessionStatus({required String sessionId}) async => const SessionStatus.idle();
+
+  @override
   Future<StoredSession?> getStoredSession({required String sessionId}) async => StoredSession(
     id: sessionId,
     backendSessionId: sessionId,

--- a/bridge/app/test/bridge/services/chat_history_tool_finalization_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_tool_finalization_test.dart
@@ -129,6 +129,55 @@ void main() {
       expect(served.single.parts.single.state!.status, ToolStatus.running);
     });
 
+    test("a fresh store still finalizes open tool parts left by an abrupt death", () async {
+      // Live captures keep the store fresh, so no backfill runs. A bridge that
+      // died mid-turn never saw an idle event; the stranded part must still be
+      // finalized when the transcript is served from the store.
+      final repository = _FakeSessionRepository(transcript: const [], status: const SessionStatus.idle());
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.backfillSession(sessionId: "ses_a");
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "m1"));
+      await history.service.capturePart(
+        sessionId: "ses_a",
+        part: _toolPart(id: "t1", messageId: "m1", status: ToolStatus.running),
+      );
+
+      final served = (await history.service.getSessionMessages(sessionId: "ses_a")).messages;
+
+      expect(served.single.parts.single.state!.status, ToolStatus.error);
+    });
+
+    test("a fresh store with a busy session keeps its running tool", () async {
+      final repository = _FakeSessionRepository(transcript: const [], status: const SessionStatus.busy());
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.backfillSession(sessionId: "ses_a");
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "m1"));
+      await history.service.capturePart(
+        sessionId: "ses_a",
+        part: _toolPart(id: "t1", messageId: "m1", status: ToolStatus.running),
+      );
+
+      final served = (await history.service.getSessionMessages(sessionId: "ses_a")).messages;
+
+      expect(served.single.parts.single.state!.status, ToolStatus.running);
+    });
+
+    test("a fresh store without open tool parts is served without a status read", () async {
+      final repository = _FakeSessionRepository(transcript: const [], status: null);
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.backfillSession(sessionId: "ses_a");
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "m1"));
+      await history.service.capturePart(
+        sessionId: "ses_a",
+        part: _toolPart(id: "t1", messageId: "m1", status: ToolStatus.completed, output: "done"),
+      );
+
+      final served = (await history.service.getSessionMessages(sessionId: "ses_a")).messages;
+
+      expect(served.single.parts.single.state!.status, ToolStatus.completed);
+      expect(repository.statusReads, isZero, reason: "a page with no open tool needs no status query");
+    });
+
     test("an unobservable session status sweeps: a stopped backend hosts no live tool", () async {
       final repository = _FakeSessionRepository(
         transcript: [
@@ -214,11 +263,16 @@ class _FakeSessionRepository({
   required final List<MessageWithParts> transcript,
   required final SessionStatus? status,
 }) implements SessionRepository {
+  int statusReads = 0;
+
   @override
   Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async => transcript;
 
   @override
-  Future<SessionStatus?> getSessionStatus({required String sessionId}) async => status;
+  Future<SessionStatus?> getSessionStatus({required String sessionId}) async {
+    statusReads++;
+    return status;
+  }
 
   @override
   Future<StoredSession?> getStoredSession({required String sessionId}) async => StoredSession(

--- a/bridge/app/test/bridge/services/chat_history_tool_finalization_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_tool_finalization_test.dart
@@ -162,8 +162,13 @@ Future<Map<String, MessagePart>> _storedParts({
   };
 }
 
-Message _message({required String id}) =>
-    Message.user(id: id, sessionID: "ses_a", agent: null, time: const MessageTime(created: 1, completed: null));
+Message _message({required String id}) => Message.user(
+  id: id,
+  sessionID: "ses_a",
+  agent: null,
+  promptId: null,
+  time: const MessageTime(created: 1, completed: null),
+);
 
 MessagePart _toolPart({
   required String id,

--- a/bridge/app/test/bridge/services/chat_history_tool_finalization_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_tool_finalization_test.dart
@@ -1,0 +1,236 @@
+import "package:sesori_bridge/src/bridge/repositories/models/stored_session.dart";
+import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "../../helpers/test_chat_history.dart";
+
+void main() {
+  group("open tool part finalization", () {
+    test("rewrites stored pending and running tool parts to error", () async {
+      final history = createTestChatHistory();
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "m1"));
+      await history.service.capturePart(
+        sessionId: "ses_a",
+        part: _toolPart(id: "t1", messageId: "m1", status: ToolStatus.running),
+      );
+      await history.service.capturePart(
+        sessionId: "ses_a",
+        part: _toolPart(id: "t2", messageId: "m1", status: ToolStatus.pending),
+      );
+      await history.service.capturePart(
+        sessionId: "ses_a",
+        part: _toolPart(id: "t3", messageId: "m1", status: ToolStatus.completed, output: "done"),
+      );
+
+      final finalized = await history.service.finalizeOpenToolParts(sessionId: "ses_a");
+
+      expect(finalized, hasLength(2));
+      final stored = await _storedParts(history: history, sessionId: "ses_a");
+      expect(stored["t1"]!.state!.status, ToolStatus.error);
+      expect(stored["t1"]!.state!.error, "The turn ended before this tool reported a result.");
+      expect(stored["t2"]!.state!.status, ToolStatus.error);
+      expect(stored["t3"]!.state!.status, ToolStatus.completed);
+      expect(stored["t3"]!.state!.output, "done", reason: "terminal parts stay untouched");
+    });
+
+    test("keeps title and output of a finalized part", () async {
+      final history = createTestChatHistory();
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "m1"));
+      await history.service.capturePart(
+        sessionId: "ses_a",
+        part: _toolPart(id: "t1", messageId: "m1", status: ToolStatus.running, title: "Edit", output: "partial"),
+      );
+
+      await history.service.finalizeOpenToolParts(sessionId: "ses_a");
+
+      final stored = await _storedParts(history: history, sessionId: "ses_a");
+      expect(stored["t1"]!.state!.title, "Edit");
+      expect(stored["t1"]!.state!.output, "partial");
+    });
+
+    test("returns both delivery shapes for each finalized part", () async {
+      final history = createTestChatHistory();
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "m1"));
+      await history.service.capturePart(
+        sessionId: "ses_a",
+        part: _toolPart(id: "t1", messageId: "m1", status: ToolStatus.running),
+      );
+
+      final finalized = await history.service.finalizeOpenToolParts(sessionId: "ses_a");
+
+      final shapes = finalized.single;
+      expect(shapes.inlinePart.state!.status, ToolStatus.error);
+      expect(shapes.storedReferencePart.state!.status, ToolStatus.error);
+      expect(shapes.inlinePart.id, "t1");
+    });
+
+    test("ignores non-tool parts and sessions with nothing open", () async {
+      final history = createTestChatHistory();
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "m1"));
+      await history.service.capturePart(
+        sessionId: "ses_a",
+        part: _textPart(id: "p1", messageId: "m1", text: "running"),
+      );
+
+      expect(await history.service.finalizeOpenToolParts(sessionId: "ses_a"), isEmpty);
+      final stored = await _storedParts(history: history, sessionId: "ses_a");
+      expect(stored["p1"]!.text, "running");
+    });
+
+    test("does not advance the session's freshness marks", () async {
+      final history = createTestChatHistory();
+      await history.service.captureMessage(sessionId: "ses_a", message: _message(id: "m1"));
+      await history.service.capturePart(
+        sessionId: "ses_a",
+        part: _toolPart(id: "t1", messageId: "m1", status: ToolStatus.running),
+      );
+      final before = await history.repository.getSyncState(sessionId: "ses_a");
+
+      await history.service.finalizeOpenToolParts(sessionId: "ses_a");
+
+      final after = await history.repository.getSyncState(sessionId: "ses_a");
+      expect(after!.watermark, before!.watermark);
+      expect(after.backendActivityAt, before.backendActivityAt);
+      expect(after.syncedAt, before.syncedAt);
+    });
+
+    test("a backfill read finalizes imported open tool parts when the session is not busy", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [
+          MessageWithParts(
+            info: _message(id: "m1"),
+            parts: [_toolPart(id: "t1", messageId: "m1", status: ToolStatus.pending)],
+          ),
+        ],
+        status: const SessionStatus.idle(),
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+
+      final served = (await history.service.getSessionMessages(sessionId: "ses_a")).messages;
+
+      expect(served.single.parts.single.state!.status, ToolStatus.error);
+    });
+
+    test("a backfill read leaves open tool parts alone while the session is busy", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [
+          MessageWithParts(
+            info: _message(id: "m1"),
+            parts: [_toolPart(id: "t1", messageId: "m1", status: ToolStatus.running)],
+          ),
+        ],
+        status: const SessionStatus.busy(),
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+
+      final served = (await history.service.getSessionMessages(sessionId: "ses_a")).messages;
+
+      expect(served.single.parts.single.state!.status, ToolStatus.running);
+    });
+
+    test("an unobservable session status sweeps: a stopped backend hosts no live tool", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [
+          MessageWithParts(
+            info: _message(id: "m1"),
+            parts: [_toolPart(id: "t1", messageId: "m1", status: ToolStatus.running)],
+          ),
+        ],
+        status: null,
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+
+      final served = (await history.service.getSessionMessages(sessionId: "ses_a")).messages;
+
+      expect(served.single.parts.single.state!.status, ToolStatus.error);
+    });
+  });
+}
+
+Future<Map<String, MessagePart>> _storedParts({
+  required TestChatHistory history,
+  required String sessionId,
+}) async {
+  final page = await history.repository.getSessionMessages(
+    sessionId: sessionId,
+    storageScope: testAttachmentStorageScope(sessionId: sessionId),
+  );
+  return {
+    for (final message in page.messages)
+      for (final part in message.parts) part.id: part,
+  };
+}
+
+Message _message({required String id}) =>
+    Message.user(id: id, sessionID: "ses_a", agent: null, time: const MessageTime(created: 1, completed: null));
+
+MessagePart _toolPart({
+  required String id,
+  required String messageId,
+  required ToolStatus status,
+  String? title,
+  String? output,
+}) => MessagePart(
+  id: id,
+  sessionID: "ses_a",
+  messageID: messageId,
+  type: MessagePartType.tool,
+  text: null,
+  tool: "Edit",
+  state: ToolState(status: status, title: title, output: output, error: null),
+  prompt: null,
+  description: null,
+  agent: null,
+  agentName: null,
+  attempt: null,
+  retryError: null,
+  attachment: null,
+);
+
+MessagePart _textPart({required String id, required String messageId, required String text}) => MessagePart(
+  id: id,
+  sessionID: "ses_a",
+  messageID: messageId,
+  type: MessagePartType.text,
+  text: text,
+  tool: null,
+  state: null,
+  prompt: null,
+  description: null,
+  agent: null,
+  agentName: null,
+  attempt: null,
+  retryError: null,
+  attachment: null,
+);
+
+class _FakeSessionRepository({
+  required final List<MessageWithParts> transcript,
+  required final SessionStatus? status,
+}) implements SessionRepository {
+  @override
+  Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async => transcript;
+
+  @override
+  Future<SessionStatus?> getSessionStatus({required String sessionId}) async => status;
+
+  @override
+  Future<StoredSession?> getStoredSession({required String sessionId}) async => StoredSession(
+    id: sessionId,
+    backendSessionId: sessionId,
+    pluginId: "opencode",
+    projectId: "project-1",
+    parentSessionId: null,
+    directory: "/tmp/project-1",
+    worktreePath: null,
+    branchName: null,
+    isDedicated: false,
+    archivedAt: null,
+    baseBranch: null,
+    baseCommit: null,
+  );
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -25,8 +25,10 @@ and rejoined after a client reconnect, plugin restart, or bridge restart.
   never blocks unrelated requests, other plugins, key exchange, or reconnects.
 - A tool part stranded in `pending`/`running` after its turn ended is finalized
   to a terminal error, for every backend. The sweep runs when the session goes
-  idle (finalized parts are also delivered live as part updates) and after a
-  backfill whose session is not currently busy — including when its status is
+  idle (finalized parts are also delivered live as part updates) and on a
+  history read whose page still holds an open tool part while the session is
+  not currently busy — whether the page came from a backfill or from a store
+  kept fresh across an abrupt bridge death — including when the status is
   unobservable, since a stopped backend hosts no live tool. Finalization never
   advances the session's freshness marks, and a genuinely running tool swept by
   the turn-start race is corrected by its next live capture.

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -23,6 +23,13 @@ and rejoined after a client reconnect, plugin restart, or bridge restart.
 - Binary and attachment payloads are never stored inline in database tables; they
   round-trip through spill storage and still render. A slow or stuck request
   never blocks unrelated requests, other plugins, key exchange, or reconnects.
+- A tool part stranded in `pending`/`running` after its turn ended is finalized
+  to a terminal error, for every backend. The sweep runs when the session goes
+  idle (finalized parts are also delivered live as part updates) and after a
+  backfill whose session is not currently busy — including when its status is
+  unobservable, since a stopped backend hosts no live tool. Finalization never
+  advances the session's freshness marks, and a genuinely running tool swept by
+  the turn-start race is corrected by its next live capture.
 - Pi history follows the active `leafId` branch while retaining visible
   pre-compaction messages and omitting compaction and branch-summary payloads.
   File fallback is allowed only for Pi's exact no-model startup failure, applies


### PR DESCRIPTION
## Complexity

Moderate: one new repository/service/orchestrator seam in the chat-history path plus a single-session status read; behavior is additive and backend-neutral.

## What

Finalizes tool message parts left in a non-terminal state (`pending`/`running`) after their turn ended, for every backend:

- `ChatHistoryRepository.finalizeOpenToolParts` rewrites stored open tool parts to `status: error` ("The turn ended before this tool reported a result."), preserving title/output/attachments.
- `ChatHistoryService.finalizeOpenToolParts` runs the sweep inside the per-session write queue and returns both delivery shapes (`CapturedPartShapes`) for live emission. It deliberately does not advance the session's freshness marks.
- The Orchestrator sweeps on `BridgeSseSessionIdle` and delivers each finalized part to subscribed phones as an ordinary part update.
- `ChatHistoryService.getSessionMessages` sweeps after a backfill when the session is not busy (`SessionRepository.getSessionStatus`, a new mapping-only single-session read; an unobservable status sweeps too, since a stopped backend hosts no live tool).

## Why

A turn that dies without a tool result — unanswered permission, abort, backend process exit, bridge restart — left the persisted tool part `running` forever. The store's freshness gate then served that snapshot on every open, so phones rendered an eternal spinner for a tool that ended hours earlier (observed with the Claude Code harness; the gap is backend-neutral).

## Risk and test focus

- Accepted, documented race: a turn starting between the busy check and the sweep can transiently mark a genuinely running tool as errored; the next live part capture overwrites it.
- Sweep never advances watermark/backendActivityAt/syncedAt, so staleness detection is unchanged.
- Test focus: `bridge/app/test/bridge/services/chat_history_tool_finalization_test.dart` (rewrite semantics, delivery shapes, freshness marks, busy/idle/unobservable backfill policies).

## Expected result

Opening a session whose turn died shows the stranded tool as errored ("The turn ended before this tool reported a result.") instead of a spinner stuck on Running. Connected phones receive the finalized part live when the session goes idle. No database schema change; no wire contract change (existing `ToolStatus.error` value).

## Verification

- `dart analyze --fatal-infos` clean in `bridge/app`.
- `dart test` in `bridge/app`: 2651 tests pass.
- Architecture plan review and implementation review passed (findings applied: repository owns the JSON rewrite, no DAO predicate, null-status policy in the service).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalizes tool parts left pending/running after a turn ends to prevent endless spinners. Previously, stranded tools stayed open; now they are rewritten to status: error with a clear message and, when applicable, sent as ordinary part updates.

- On `BridgeSseSessionIdle`, the orchestrator finalizes and delivers each rewritten part via standard part-update SSE (inline and stored-reference).
- On reads, `getSessionMessages` now finalizes open tool parts before serving when the page contains any and the session is not busy; this applies to backfill and fresh-store reads. An unobservable status sweeps too. The read-path sweep mutates rows only (no delivery projection).
- `ChatHistoryRepository.finalizeOpenToolParts` rewrites stored `tool` parts in `pending`/`running` to error with the message and returns `(messageId, partId)` refs; `ChatHistoryService.finalizeOpenToolParts` runs in the per-session queue, preserves title/output/attachments, returns delivery shapes, and drops the synced marker on failure to force a re-backfill.
- `SessionRepository.getSessionStatus` adds a single-session status read to drive the read-path policy.
- Compatible change: no schema or wire changes; freshness marks are unchanged.
- Known race: a turn starting between the status check and sweep may briefly mark a real tool as errored; the next live capture corrects it.

<sup>Written for commit 358caedb8b2377515c72bfaf1fbb0237bd03908b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

