### PR TITLE
🌿 Keep unanswerable YOLO permissions visible

### DIFF
--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -577,7 +577,7 @@ class Orchestrator({
         GetProjectQuestionsHandler(questionRepository: questionRepository),
         GetSessionPermissionsHandler(
           permissionRepository: permissionRepository,
-          yoloSettingsService: yoloSettingsService,
+          permissionAutoApprovalService: permissionAutoApprovalService,
         ),
         ReplyToQuestionHandler(pendingInteractionService: pendingInteractionService),
         RejectQuestionHandler(pendingInteractionService: pendingInteractionService),

--- a/bridge/app/lib/src/bridge/routing/get_session_permissions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_session_permissions_handler.dart
@@ -1,15 +1,19 @@
 import "package:sesori_shared/sesori_shared.dart";
 
-import "../../services/yolo_settings_service.dart";
 import "../repositories/permission_repository.dart";
+import "../services/permission_auto_approval_service.dart";
 import "request_handler.dart";
 
 /// Handles `POST /session/permissions` — returns the pending permission
 /// requests to surface on a session's screen: its own plus any descendant
 /// (sub-agent) session whose top-most root resolves to this session.
+///
+/// Under YOLO the snapshot is resolved through auto-approval first: approved
+/// requests disappear from the response, while any request YOLO could not
+/// answer stays visible so it can be answered manually.
 class GetSessionPermissionsHandler({
   required final PermissionRepository _permissionRepository,
-  required final YoloSettingsService _yoloSettingsService,
+  required final PermissionAutoApprovalService _permissionAutoApprovalService,
 }) extends BodyRequestHandler<SessionIdRequest, PendingPermissionResponse> {
   this
     : super(
@@ -32,12 +36,8 @@ class GetSessionPermissionsHandler({
     }
 
     final permissions = await _permissionRepository.getPendingPermissions(sessionId: sessionId);
-
-    // Query first to preserve binding/plugin errors; YOLO suppresses only the snapshot response payload.
-    if (_yoloSettingsService.currentSettings.enabled) {
-      return const PendingPermissionResponse(data: []);
-    }
-
-    return PendingPermissionResponse(data: permissions);
+    return PendingPermissionResponse(
+      data: await _permissionAutoApprovalService.resolveSnapshot(permissions: permissions),
+    );
   }
 }

--- a/bridge/app/lib/src/bridge/services/permission_auto_approval_service.dart
+++ b/bridge/app/lib/src/bridge/services/permission_auto_approval_service.dart
@@ -50,6 +50,12 @@ class PermissionAutoApprovalService({
     if (_disposed || permissions.isEmpty || !_bridgeSettingsRepository.currentSettings.yolo) return permissions;
     final unresolved = <PendingPermission>[];
     for (final permission in permissions) {
+      // Re-read per item: disabling YOLO mid-snapshot makes approve() a no-op,
+      // and hiding the untouched remainder would leave it unanswerable.
+      if (_disposed || !_bridgeSettingsRepository.currentSettings.yolo) {
+        unresolved.add(permission);
+        continue;
+      }
       try {
         await approve(requestId: permission.id, sessionId: permission.sessionID);
       } on Object catch (error, stackTrace) {

--- a/bridge/app/lib/src/bridge/services/permission_auto_approval_service.dart
+++ b/bridge/app/lib/src/bridge/services/permission_auto_approval_service.dart
@@ -38,6 +38,32 @@ class PermissionAutoApprovalService({
     }
   }
 
+  /// Resolves a pending-permission snapshot under YOLO before it is served.
+  ///
+  /// With YOLO off the snapshot passes through untouched. With YOLO on, each
+  /// permission is auto-approved and the ones that could not be approved are
+  /// returned, so a request YOLO cannot answer — one asked before YOLO was
+  /// enabled while no phone listened, or one whose reply failed — surfaces for
+  /// manual action instead of staying invisible behind an "awaiting input"
+  /// badge forever.
+  Future<List<PendingPermission>> resolveSnapshot({required List<PendingPermission> permissions}) async {
+    if (_disposed || permissions.isEmpty || !_bridgeSettingsRepository.currentSettings.yolo) return permissions;
+    final unresolved = <PendingPermission>[];
+    for (final permission in permissions) {
+      try {
+        await approve(requestId: permission.id, sessionId: permission.sessionID);
+      } on Object catch (error, stackTrace) {
+        Log.w(
+          "[permissions] failed to auto-approve snapshot request ${permission.id}; leaving it visible",
+          error,
+          stackTrace,
+        );
+        unresolved.add(permission);
+      }
+    }
+    return unresolved;
+  }
+
   Future<void> approvePending() async {
     if (_disposed) return;
 

--- a/bridge/app/test/bridge/routing/get_session_permissions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_session_permissions_handler_test.dart
@@ -1,6 +1,6 @@
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/bridge/routing/get_session_permissions_handler.dart";
-import "package:sesori_bridge/src/services/yolo_settings_service.dart";
+import "package:sesori_bridge/src/bridge/services/permission_auto_approval_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -13,12 +13,12 @@ void main() {
     late FakeBridgePlugin plugin;
     late AppDatabase db;
     late GetSessionPermissionsHandler handler;
-    late _FakeYoloSettingsService yoloSettingsService;
+    late _FakePermissionAutoApprovalService autoApprovalService;
 
     setUp(() async {
       plugin = FakeBridgePlugin();
       db = createTestDatabase();
-      yoloSettingsService = _FakeYoloSettingsService(enabled: false);
+      autoApprovalService = _FakePermissionAutoApprovalService();
       await recordSessionBinding(
         database: db,
         sessionId: "root",
@@ -37,7 +37,7 @@ void main() {
       );
       handler = GetSessionPermissionsHandler(
         permissionRepository: singlePluginPermissionRepository(plugin: plugin, sessionDao: db.sessionDao),
-        yoloSettingsService: yoloSettingsService,
+        permissionAutoApprovalService: autoApprovalService,
       );
     });
 
@@ -67,32 +67,9 @@ void main() {
       );
     });
 
-    test("returns 400 for an empty session id when pending permissions are suppressed", () async {
-      final suppressedHandler = GetSessionPermissionsHandler(
-        permissionRepository: singlePluginPermissionRepository(plugin: plugin, sessionDao: db.sessionDao),
-        yoloSettingsService: _FakeYoloSettingsService(enabled: true),
-      );
-
+    test("preserves not-found for an unknown session", () async {
       await expectLater(
-        () => suppressedHandler.handle(
-          makeRequest("POST", "/session/permissions"),
-          body: const SessionIdRequest(sessionId: ""),
-          pathParams: {},
-          queryParams: {},
-          fragment: null,
-        ),
-        throwsA(isA<RelayResponse>().having((r) => r.status, "status", equals(400))),
-      );
-    });
-
-    test("preserves not-found for an unknown session when pending permissions are suppressed", () async {
-      final suppressedHandler = GetSessionPermissionsHandler(
-        permissionRepository: singlePluginPermissionRepository(plugin: plugin, sessionDao: db.sessionDao),
-        yoloSettingsService: _FakeYoloSettingsService(enabled: true),
-      );
-
-      await expectLater(
-        suppressedHandler.handle(
+        handler.handle(
           makeRequest("POST", "/session/permissions"),
           body: const SessionIdRequest(sessionId: "unknown"),
           pathParams: {},
@@ -103,34 +80,7 @@ void main() {
       );
     });
 
-    test("returns no pending permissions when snapshot suppression is enabled", () async {
-      plugin.pendingPermissionsResult = [
-        const PluginPendingPermission(
-          id: "p-1",
-          sessionID: "backend-root",
-          displaySessionId: "backend-root",
-          tool: "bash",
-          description: "Run ls",
-          allowAlways: true,
-        ),
-      ];
-      final suppressedHandler = GetSessionPermissionsHandler(
-        permissionRepository: singlePluginPermissionRepository(plugin: plugin, sessionDao: db.sessionDao),
-        yoloSettingsService: _FakeYoloSettingsService(enabled: true),
-      );
-
-      final response = await suppressedHandler.handle(
-        makeRequest("POST", "/session/permissions"),
-        body: const SessionIdRequest(sessionId: "root"),
-        pathParams: {},
-        queryParams: {},
-        fragment: null,
-      );
-
-      expect(response, const PendingPermissionResponse(data: []));
-    });
-
-    test("reads snapshot suppression from the live setting", () async {
+    test("serves the auto-approval-resolved snapshot", () async {
       plugin.pendingPermissionsResult = const [
         PluginPendingPermission(
           id: "p-1",
@@ -141,17 +91,9 @@ void main() {
           allowAlways: true,
         ),
       ];
+      autoApprovalService.resolvedSnapshot = const [];
 
-      await yoloSettingsService.update(enabled: true);
-      final suppressed = await handler.handle(
-        makeRequest("POST", "/session/permissions"),
-        body: const SessionIdRequest(sessionId: "root"),
-        pathParams: {},
-        queryParams: {},
-        fragment: null,
-      );
-      await yoloSettingsService.update(enabled: false);
-      final forwarded = await handler.handle(
+      final response = await handler.handle(
         makeRequest("POST", "/session/permissions"),
         body: const SessionIdRequest(sessionId: "root"),
         pathParams: {},
@@ -159,8 +101,8 @@ void main() {
         fragment: null,
       );
 
-      expect(suppressed.data, isEmpty);
-      expect(forwarded.data.single.id, "p-1");
+      expect(response, const PendingPermissionResponse(data: []));
+      expect(autoApprovalService.resolveCalls.single.single.id, "p-1");
     });
 
     test("maps plugin permissions to shared, preserving displaySessionId", () async {
@@ -206,7 +148,7 @@ void main() {
       );
       final derivedHandler = GetSessionPermissionsHandler(
         permissionRepository: repository,
-        yoloSettingsService: _FakeYoloSettingsService(enabled: false),
+        permissionAutoApprovalService: _FakePermissionAutoApprovalService(),
       );
 
       await expectLater(
@@ -287,7 +229,7 @@ void main() {
           plugin: derivedPlugin,
           sessionDao: db.sessionDao,
         ),
-        yoloSettingsService: _FakeYoloSettingsService(enabled: false),
+        permissionAutoApprovalService: _FakePermissionAutoApprovalService(),
       );
 
       final response = await derivedHandler.handle(
@@ -387,19 +329,20 @@ void main() {
   });
 }
 
-class _FakeYoloSettingsService({required bool enabled}) implements YoloSettingsService {
-  YoloSettingsResponse _settings = YoloSettingsResponse(enabled: enabled);
+class _FakePermissionAutoApprovalService() implements PermissionAutoApprovalService {
+  final List<List<PendingPermission>> resolveCalls = [];
+
+  /// The snapshot to return, or null to pass the input through untouched.
+  List<PendingPermission>? resolvedSnapshot;
 
   @override
-  YoloSettingsResponse get currentSettings => _settings;
-
-  @override
-  Future<YoloSettingsResponse> readCommittedSettings() async => _settings;
-
-  @override
-  Future<YoloSettingsResponse> update({required bool enabled}) async {
-    return _settings = YoloSettingsResponse(enabled: enabled);
+  Future<List<PendingPermission>> resolveSnapshot({required List<PendingPermission> permissions}) async {
+    resolveCalls.add(permissions);
+    return resolvedSnapshot ?? permissions;
   }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _DerivedPermissionPlugin() implements BridgeDerivedProjectsPluginApi {

--- a/bridge/app/test/bridge/services/pending_interaction_service_test.dart
+++ b/bridge/app/test/bridge/services/pending_interaction_service_test.dart
@@ -196,6 +196,32 @@ void main() {
       expect(permissionRepository.requestIds, ["working"]);
     });
 
+    test("disabling yolo mid-snapshot keeps the remaining permissions visible", () async {
+      const first = PendingPermission(
+        id: "first",
+        sessionID: "session-one",
+        displaySessionId: null,
+        tool: "tool",
+        description: "first",
+      );
+      const second = PendingPermission(
+        id: "second",
+        sessionID: "session-one",
+        displaySessionId: null,
+        tool: "tool",
+        description: "second",
+      );
+      permissionRepository.onReply = ({required requestId, required sessionId, required reply}) async {
+        permissionRepository.requestIds.add(requestId);
+        await settingsRepository.updateYolo(enabled: false);
+      };
+
+      final unresolved = await autoApproval.resolveSnapshot(permissions: const [first, second]);
+
+      expect(permissionRepository.requestIds, ["first"]);
+      expect(unresolved.map((permission) => permission.id), ["second"]);
+    });
+
     test("the snapshot passes through untouched when yolo is off", () async {
       await settingsRepository.updateYolo(enabled: false);
       const permission = PendingPermission(

--- a/bridge/app/test/bridge/services/pending_interaction_service_test.dart
+++ b/bridge/app/test/bridge/services/pending_interaction_service_test.dart
@@ -151,6 +151,66 @@ void main() {
 
       expect(permissionRepository.requestIds, ["first"]);
     });
+
+    test("a resolved snapshot approves each permission and hides the approved ones", () async {
+      const permission = PendingPermission(
+        id: "first",
+        sessionID: "session-one",
+        displaySessionId: null,
+        tool: "tool",
+        description: "first",
+      );
+      permissionRepository.onReply = ({required requestId, required sessionId, required reply}) async {
+        permissionRepository.requestIds.add(requestId);
+      };
+
+      final unresolved = await autoApproval.resolveSnapshot(permissions: const [permission]);
+
+      expect(unresolved, isEmpty);
+      expect(permissionRepository.requestIds, ["first"]);
+    });
+
+    test("a snapshot permission whose approval fails stays visible", () async {
+      const failing = PendingPermission(
+        id: "failing",
+        sessionID: "session-one",
+        displaySessionId: null,
+        tool: "tool",
+        description: "failing",
+      );
+      const working = PendingPermission(
+        id: "working",
+        sessionID: "session-one",
+        displaySessionId: null,
+        tool: "tool",
+        description: "working",
+      );
+      permissionRepository.onReply = ({required requestId, required sessionId, required reply}) async {
+        if (requestId == "failing") throw StateError("backend rejected the reply");
+        permissionRepository.requestIds.add(requestId);
+      };
+
+      final unresolved = await autoApproval.resolveSnapshot(permissions: const [failing, working]);
+
+      expect(unresolved.map((permission) => permission.id), ["failing"]);
+      expect(permissionRepository.requestIds, ["working"]);
+    });
+
+    test("the snapshot passes through untouched when yolo is off", () async {
+      await settingsRepository.updateYolo(enabled: false);
+      const permission = PendingPermission(
+        id: "first",
+        sessionID: "session-one",
+        displaySessionId: null,
+        tool: "tool",
+        description: "first",
+      );
+
+      final unresolved = await autoApproval.resolveSnapshot(permissions: const [permission]);
+
+      expect(unresolved, [permission]);
+      expect(permissionRepository.requestIds, isEmpty);
+    });
   });
 }
 

--- a/client/module_core/lib/src/services/session_detail_load_service.dart
+++ b/client/module_core/lib/src/services/session_detail_load_service.dart
@@ -143,11 +143,17 @@ class SessionDetailLoadService({
 
       final pendingQuestions = switch (questionsResponse) {
         SuccessResponse(:final data) => data.data,
-        ErrorResponse() => <PendingQuestion>[],
+        ErrorResponse(:final error) => () {
+          logw("Failed to load pending questions; treating the session as having none", error);
+          return <PendingQuestion>[];
+        }(),
       };
       final pendingPermissions = switch (permissionsResponse) {
         SuccessResponse(:final data) => data.data,
-        ErrorResponse() => <PendingPermission>[],
+        ErrorResponse(:final error) => () {
+          logw("Failed to load pending permissions; treating the session as having none", error);
+          return <PendingPermission>[];
+        }(),
       };
       // An error is also the old-bridge (unknown route) path: no queue info.
       final bridgeQueuedPrompts = switch (queuedPromptsResponse) {
@@ -156,11 +162,17 @@ class SessionDetailLoadService({
       };
       final childSessions = switch (childrenResponse) {
         SuccessResponse(:final data) => data.items,
-        ErrorResponse() => <Session>[],
+        ErrorResponse(:final error) => () {
+          logw("Failed to load child sessions; treating the session as having none", error);
+          return <Session>[];
+        }(),
       };
       final statuses = switch (statusesResponse) {
         SuccessResponse(:final data) => data.statuses,
-        ErrorResponse() => <String, SessionStatus>{},
+        ErrorResponse(:final error) => () {
+          logw("Failed to load session statuses; falling back to none", error);
+          return <String, SessionStatus>{};
+        }(),
       };
       return SessionDetailLoadResult.loaded(
         snapshot: SessionDetailSnapshot(

--- a/docs/regression/permission-auto-approval.md
+++ b/docs/regression/permission-auto-approval.md
@@ -15,6 +15,10 @@ user present. It is a bridge policy, not a client feature.
   clients as answerable, and its reply is not surfaced as user activity.
 - Enabling also resolves already-pending permissions, including child-session
   ones, and the same sweep runs when a backend event stream reconnects.
+- A pending-permission snapshot served while the setting is on is resolved
+  through auto-approval first: approved requests disappear from the response,
+  and a request auto-approval could not answer stays visible and answerable
+  instead of being hidden behind a stale awaiting-input badge.
 - Each request is approved at most once. A failed approval is not recorded as
   approved and can be retried.
 - Questions are never auto-answered.


### PR DESCRIPTION
## Complexity

Straightforward: one handler dependency swap, one new service method on an existing owner, and client-side logging of previously silent fetch failures.

## What

- `GetSessionPermissionsHandler` no longer blanks the pending-permission snapshot under YOLO. It resolves the snapshot through `PermissionAutoApprovalService.resolveSnapshot`: each pending permission is auto-approved, approved ones disappear from the response, and any request auto-approval could not answer stays visible and answerable.
- Client `SessionDetailLoadService` now logs pending questions/permissions/child-sessions/statuses fetch failures instead of silently mapping `ErrorResponse` to an empty list.

## Why

With YOLO on, `POST /session/permissions` returned `[]` unconditionally. A permission the sweep never caught — asked before YOLO was enabled while no phone listened, or whose auto-reply failed — became invisible and unanswerable while the session list showed "Awaiting input" forever, and the Claude turn stayed blocked (observed in production). Client-side, transient fetch errors silently erased the pending banner with no trace in logs.

## Risk and test focus

- Snapshot resolution reuses the existing `approve` path (at-most-once bookkeeping, `consumeReply` suppression), so no double replies.
- YOLO off: snapshot passes through untouched — behavior unchanged.
- Test focus: `pending_interaction_service_test.dart` (resolveSnapshot approve/failure/off cases), `get_session_permissions_handler_test.dart` (handler serves the resolved snapshot, not-found preserved).

## Expected result

Under YOLO, opening a session with an unanswerable pending permission shows the permission banner/modal so the user can act, instead of an "Awaiting input" badge with an empty session. No user-visible change with YOLO off. No database impact; no wire contract change.

## Verification

- `dart analyze --fatal-infos` clean in `bridge/app`; `dart analyze` clean in `client/module_core`.
- `dart test` in `bridge/app`: 2652 tests pass. `dart test test/services/session_detail_load_service_test.dart` in `client/module_core`: pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps unanswerable permissions visible under YOLO by resolving the pending-permission snapshot instead of suppressing it. Previously `POST /session/permissions` returned `[]` when YOLO was on; now it auto-approves what it can and returns unresolved requests so users can act. If YOLO turns off mid-resolve, remaining items pass through. YOLO off is unchanged.

- Handler now uses `PermissionAutoApprovalService.resolveSnapshot`; orchestrator wires `permissionAutoApprovalService`.
- Auto-approval approves each request when YOLO is on, re-reads the setting per item, and leaves failures or post-disable items visible; reuses the existing approve path (at-most-once, no double replies).
- Client `SessionDetailLoadService` logs fetch failures for pending questions/permissions/children/statuses and still falls back to empty data.
- No API or database changes; not-found behavior preserved. Tests updated for snapshot resolution, mid-resolve disable, and handler behavior; docs note the new flow.

<sup>Written for commit a42156123d96bbf33a9f2efb2e865d2bb9ad82bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

