### PR TITLE
⚙️ Name every agent and effort option, defaulting Claude to Opus + high

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_backend_catalog_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_backend_catalog_repository.dart
@@ -14,15 +14,29 @@ final class const ClaudeBackendCatalog({
 final class const ClaudeBackendCatalogRepository() {
   static const String providerId = "anthropic";
 
+  /// Claude's own catalog entry that resolves to whichever model and effort the
+  /// CLI configuration currently prefers. It is dropped rather than surfaced:
+  /// a picker entry named "Default" tells the user nothing about what will run.
+  static const String _cliDefaultModelId = "default";
+
+  /// Sesori's default selection, named explicitly in place of [_cliDefaultModelId].
+  static const String _defaultModelIdPrefix = "opus";
+  static const ClaudeEffortLevel _defaultEffort = ClaudeEffortLevel.high;
+
   ClaudeBackendCatalog map({required Map<String, Object?> handshake}) {
     final dto = ClaudeBackendCatalogDto.fromJson(handshake);
     final models = [
       for (final model in dto.models) ?_model(model),
     ];
-    final defaultModelId = models.any((model) => model.id == "default") ? "default" : models.firstOrNull?.id;
-    final agentModel = defaultModelId == null
+    final defaultModel =
+        models.where((model) => model.id.startsWith(_defaultModelIdPrefix)).firstOrNull ?? models.firstOrNull;
+    final agentModel = defaultModel == null
         ? null
-        : PluginAgentModel(modelID: defaultModelId, providerID: providerId, variant: null);
+        : PluginAgentModel(
+            modelID: defaultModel.id,
+            providerID: providerId,
+            variant: defaultModel.variants.contains(_defaultEffort.wireValue) ? _defaultEffort.wireValue : null,
+          );
 
     return ClaudeBackendCatalog(
       agents: List.unmodifiable([
@@ -44,7 +58,7 @@ final class const ClaudeBackendCatalogRepository() {
                   name: "Anthropic",
                   authType: PluginProviderAuthType.oauth,
                   models: models,
-                  defaultModelID: defaultModelId,
+                  defaultModelID: defaultModel?.id,
                 ),
               ],
       ),
@@ -56,7 +70,7 @@ final class const ClaudeBackendCatalogRepository() {
 
   PluginModel? _model(ClaudeModelDto dto) {
     final id = dto.value?.trim();
-    if (id == null || id.isEmpty) return null;
+    if (id == null || id.isEmpty || id == _cliDefaultModelId) return null;
     final displayName = dto.displayName?.trim();
     final resolvedModel = dto.resolvedModel?.trim();
     final variants = dto.supportsEffort ?? false

--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_backend_catalog_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_backend_catalog_repository.dart
@@ -78,7 +78,10 @@ final class const ClaudeBackendCatalogRepository() {
             for (final raw in dto.supportedEffortLevels)
               if (ClaudeEffortLevel.tryParse(raw) case final level?) level.wireValue,
           ]
-        : const <String>[];
+        : <String>[];
+    // Default-first, matching the ordering clients rely on to resolve an
+    // unspecified variant.
+    if (variants.remove(_defaultEffort.wireValue)) variants.insert(0, _defaultEffort.wireValue);
     return PluginModel(
       id: id,
       name: displayName?.isNotEmpty ?? false

--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
@@ -158,7 +158,7 @@ final class ClaudeSessionProcessRepository({
     if (process.appliedModel != model) {
       await process.client.sendControlRequest(
         subtype: "set_model",
-        params: {"model": model == "default" ? null : model},
+        params: {"model": model},
       );
       process.appliedModel = model;
     }

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_catalog_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_catalog_service.dart
@@ -94,16 +94,15 @@ final class ClaudeCatalogService({
     required String sessionId,
     required String modelId,
   }) async {
-    final isDefault = modelId == "default";
     await _processes.sendControlRequest(
       sessionId: sessionId,
       subtype: "set_model",
-      params: {"model": isDefault ? null : modelId},
+      params: {"model": modelId},
     );
     final applied = _processes.appliedSelection(sessionId: sessionId);
     _processes.recordAppliedSelection(
       sessionId: sessionId,
-      model: isDefault ? null : modelId,
+      model: modelId,
       effort: applied?.effort,
       permissionMode: applied?.permissionMode,
     );

--- a/bridge/sesori_plugin_claude/test/claude_backend_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_backend_catalog_repository_test.dart
@@ -49,7 +49,7 @@ void main() {
       expect(provider.defaultModelID, "opus[1m]");
       expect(provider.models.map((model) => model.id), ["haiku", "opus[1m]"]);
       expect(provider.models.first.variants, isEmpty);
-      expect(provider.models.last.variants, ["low", "medium", "high", "xhigh", "max"]);
+      expect(provider.models.last.variants, ["high", "low", "medium", "xhigh", "max"]);
       expect(
         catalog.commands,
         const [

--- a/bridge/sesori_plugin_claude/test/claude_backend_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_backend_catalog_repository_test.dart
@@ -28,20 +28,28 @@ void main() {
               "resolvedModel": "claude-haiku-test",
               "displayName": "Haiku",
             },
+            {
+              "value": "opus[1m]",
+              "resolvedModel": "claude-opus-test",
+              "displayName": "Opus (1M context)",
+              "supportsEffort": true,
+              "supportedEffortLevels": ["low", "medium", "future", "high", "xhigh", "max"],
+            },
           ],
           "account": {"email": "private@example.com"},
         },
       );
 
       expect(catalog.agents.map((agent) => agent.name), ["Agent", "Plan"]);
-      expect(catalog.agents.every((agent) => agent.model?.modelID == "default"), isTrue);
+      expect(catalog.agents.every((agent) => agent.model?.modelID == "opus[1m]"), isTrue);
+      expect(catalog.agents.every((agent) => agent.model?.variant == "high"), isTrue);
       final provider = catalog.providers.providers.single;
       expect(provider, isA<PluginProviderAnthropic>());
       expect(provider.id, "anthropic");
-      expect(provider.defaultModelID, "default");
-      expect(provider.models.map((model) => model.id), ["default", "haiku"]);
-      expect(provider.models.first.variants, ["low", "medium", "high", "xhigh", "max"]);
-      expect(provider.models.last.variants, isEmpty);
+      expect(provider.defaultModelID, "opus[1m]");
+      expect(provider.models.map((model) => model.id), ["haiku", "opus[1m]"]);
+      expect(provider.models.first.variants, isEmpty);
+      expect(provider.models.last.variants, ["low", "medium", "high", "xhigh", "max"]);
       expect(
         catalog.commands,
         const [

--- a/bridge/sesori_plugin_claude/test/claude_catalog_service_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_catalog_service_test.dart
@@ -140,19 +140,6 @@ void main() {
       expect(applied.permissionMode, ClaudePermissionMode.standard);
     });
 
-    test("resets the default model without discarding launch selections", () async {
-      final selected = service.selectModel(sessionId: testSessionId, modelId: "default");
-      final request = await _waitForControl(process, "set_model");
-      expect(_request(request), containsPair("model", null));
-      process.emitControlResponse(requestId: request["request_id"]! as String, payload: const {});
-      await selected;
-
-      final applied = processes.appliedSelection(sessionId: testSessionId)!;
-      expect(applied.model, isNull);
-      expect(applied.effort, ClaudeEffortLevel.low);
-      expect(applied.permissionMode, ClaudePermissionMode.standard);
-    });
-
     test("maps Plan to the control protocol and preserves model selection", () async {
       final selected = service.selectAgent(sessionId: testSessionId, agent: "Plan");
       final request = await _waitForControl(process, "set_permission_mode");

--- a/bridge/sesori_plugin_claude/test/claude_stream_client_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_stream_client_test.dart
@@ -19,7 +19,7 @@ void main() {
       // One handshake yields commands, agents and models together, which is
       // why the catalog service needs no separate startup probes.
       expect(connected.client.handshake, isNotNull);
-      expect(connected.client.handshake!["models"], hasLength(2));
+      expect(connected.client.handshake!["models"], hasLength(3));
       expect(connected.client.handshake!["commands"], hasLength(1));
       expect(connected.client.isConnected, isTrue);
     });

--- a/bridge/sesori_plugin_claude/test/support/claude_stream_client_test_factory.dart
+++ b/bridge/sesori_plugin_claude/test/support/claude_stream_client_test_factory.dart
@@ -104,6 +104,14 @@ Map<String, Object?> get sampleHandshake => {
       "supportedEffortLevels": ["low", "medium", "high", "xhigh", "max"],
     },
     {
+      "value": "opus[1m]",
+      "resolvedModel": "test-model-large",
+      "displayName": "Opus (1M context)",
+      "description": "Best for everyday tasks",
+      "supportsEffort": true,
+      "supportedEffortLevels": ["low", "medium", "high", "xhigh", "max"],
+    },
+    {
       "value": "small",
       "resolvedModel": "test-model-small",
       "displayName": "Small",

--- a/bridge/sesori_plugin_codex/lib/src/models/codex_collaboration_mode.dart
+++ b/bridge/sesori_plugin_codex/lib/src/models/codex_collaboration_mode.dart
@@ -5,7 +5,7 @@ enum CodexCollaborationMode({
   required final String? defaultReasoningEffort,
 }) {
   defaultMode(
-    agentName: "Default",
+    agentName: "Agent",
     wireValue: "default",
     description: "Executes tasks, making project changes when needed",
     defaultReasoningEffort: null,
@@ -24,6 +24,9 @@ enum CodexCollaborationMode({
       // expect normal execution. Remove this mapping when those app versions
       // are no longer supported.
       null => defaultMode,
+      "agent" => defaultMode,
+      // COMPATIBILITY 2026-08-19 (v1.7.0): This mode was named "Default" until
+      // it was renamed to "Agent". Remove once no supported app can send it.
       "default" => defaultMode,
       "plan" => plan,
       // COMPATIBILITY 2026-07-24 (v1.6.0): Earlier Codex plugins persisted

--- a/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
@@ -67,7 +67,7 @@ void main() {
         // With no config, rollout history, or live connection, Codex exposes
         // only Default because Plan requires a resolved model.
         final agents = await plugin.getAgents(projectId: "/repo/example");
-        expect(agents.map((agent) => agent.name), equals(["Default"]));
+        expect(agents.map((agent) => agent.name), equals(["Agent"]));
         expect(agents.every((agent) => agent.model == null), isTrue);
         expect(
           (await plugin.getProviders(projectId: "/repo/example")).providers,
@@ -142,9 +142,9 @@ void main() {
         );
 
         final agents = await plugin.getAgents(projectId: "/repo/example");
-        expect(agents.map((agent) => agent.name), equals(["Default", "Plan"]));
+        expect(agents.map((agent) => agent.name), equals(["Agent", "Plan"]));
         final agent = agents.first;
-        expect(agent.name, equals("Default"));
+        expect(agent.name, equals("Agent"));
         expect(agent.model?.modelID, equals("gpt-5.4-codex"));
         expect(agent.model?.providerID, equals("openai"));
         expect(agents.last.model, equals(agent.model));

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -110,7 +110,7 @@ void main() {
         parts: const [PluginPromptPart.text(text: "hello codex")],
         userVisibleText: "hello codex",
         variant: null,
-        agent: "Default",
+        agent: "Agent",
         model: null,
       );
 
@@ -162,7 +162,7 @@ void main() {
         ],
         userVisibleText: "describe this",
         variant: null,
-        agent: "Default",
+        agent: "Agent",
         model: null,
       );
 
@@ -1825,7 +1825,7 @@ void main() {
       await plugin.healthCheck();
       final agents = await plugin.getAgents(projectId: "/work/sample");
 
-      expect(agents.map((agent) => agent.name), ["Default", "Plan"]);
+      expect(agents.map((agent) => agent.name), ["Agent", "Plan"]);
       expect(agents.every((agent) => agent.model?.modelID == "gpt-5.5"), isTrue);
     });
 
@@ -1872,7 +1872,7 @@ void main() {
       final options = (result as PluginSessionOptionsDiscoveryObserved).options;
       expect(options.completeness, PluginSessionOptionsCompleteness.complete);
       expect(options.providers.providers.single.models.single.id, "gpt-5.5");
-      expect(options.agents.map((agent) => agent.name), ["Default", "Plan"]);
+      expect(options.agents.map((agent) => agent.name), ["Agent", "Plan"]);
       expect(options.commands.map((command) => command.name), ["review", "compact"]);
       expect(fake.sentMethods.where((method) => method == "model/list"), hasLength(1));
     });

--- a/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
@@ -182,7 +182,7 @@ void main() {
     expect(result, isA<PluginSessionOptionsDiscoveryObserved>());
     final options = (result as PluginSessionOptionsDiscoveryObserved).options;
     expect(options.completeness, PluginSessionOptionsCompleteness.complete);
-    expect(options.agents.map((agent) => agent.name), ["Default", "Plan"]);
+    expect(options.agents.map((agent) => agent.name), ["Agent", "Plan"]);
     expect(
       options.agents.map((agent) => agent.model?.modelID),
       everyElement("gpt-project"),

--- a/client/app/lib/core/widgets/agent_model_buttons.dart
+++ b/client/app/lib/core/widgets/agent_model_buttons.dart
@@ -25,7 +25,7 @@ class const AgentModelButtons({
   required final AgentModel? selectedAgentModel,
   required final void Function({required String providerID, required String modelID}) onModelSelected,
   required final List<SessionVariant> availableVariants,
-  required final ValueChanged<SessionVariant?> onVariantSelected,
+  required final ValueChanged<SessionVariant> onVariantSelected,
 }) extends StatefulWidget {
   @override
   State<AgentModelButtons> createState() => _AgentModelButtonsState();
@@ -231,7 +231,7 @@ class const _VariantMenu({
   required final PregoComposerSurfaceStyle surfaceStyle,
   required final List<SessionVariant> availableVariants,
   required final String? selectedVariant,
-  required final ValueChanged<SessionVariant?> onVariantSelected,
+  required final ValueChanged<SessionVariant> onVariantSelected,
 }) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -242,18 +242,12 @@ class const _VariantMenu({
       menuMaxHeight: _pickerMaxHeight,
       triggerBuilder: (context, toggle) => PregoPickerButton(
         leadingIcon: Icons.speed_outlined,
-        label: selectedVariant ?? loc.sessionDetailVariantDefault,
+        label: selectedVariant ?? availableVariants.first.id,
         surfaceStyle: surfaceStyle,
         onPressed: toggle,
       ),
       entriesBuilder: () => [
         PregoMenuLabel(text: loc.sessionDetailPickerVariant),
-        PregoMenuItem(
-          title: loc.sessionDetailVariantDefault,
-          subtitle: null,
-          isSelected: selectedVariant == null,
-          onTap: () => onVariantSelected(null),
-        ),
         for (final variant in availableVariants)
           PregoMenuItem(
             title: variant.id,

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -615,7 +615,6 @@
   "sessionDetailPickerAgent": "Agent",
   "sessionDetailPickerModel": "Model",
   "sessionDetailPickerVariant": "Variant",
-  "sessionDetailVariantDefault": "Default",
   "sessionDetailSelectModel": "Select Model",
   "sessionDetailModelSearch": "Search models...",
   "backgroundTasksRunning": "{count, plural, =1{1 Task Running} other{{count} Tasks Running}}",

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -2011,12 +2011,6 @@ abstract class AppLocalizations {
   /// **'Variant'**
   String get sessionDetailPickerVariant;
 
-  /// No description provided for @sessionDetailVariantDefault.
-  ///
-  /// In en, this message translates to:
-  /// **'Default'**
-  String get sessionDetailVariantDefault;
-
   /// No description provided for @sessionDetailSelectModel.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -1039,9 +1039,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionDetailPickerVariant => 'Variant';
 
   @override
-  String get sessionDetailVariantDefault => 'Default';
-
-  @override
   String get sessionDetailSelectModel => 'Select Model';
 
   @override

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -728,9 +728,7 @@ void main() {
     await tester.tap(find.widgetWithText(PregoPickerButton, "xhigh"));
     await tester.pumpAndSettle();
 
-    // Tapping the variant pill opens a popup listing the Default option plus
-    // the model's variants.
-    expect(_pickerMenuItem("Default"), findsOneWidget);
+    // Tapping the variant pill opens a popup listing the model's variants.
     expect(_pickerMenuItem("xhigh"), findsOneWidget);
 
     await tester.tap(_pickerMenuItem("xhigh"));
@@ -903,7 +901,7 @@ void main() {
 
     expect(find.byIcon(Icons.smart_toy_outlined), findsNothing);
     expect(find.widgetWithText(PregoPickerButton, "Claude 3.5 Sonnet"), findsOneWidget);
-    expect(find.widgetWithText(PregoPickerButton, "Default"), findsOneWidget);
+    expect(find.widgetWithText(PregoPickerButton, "xhigh"), findsOneWidget);
   });
 
   testWidgets("scrolls plugin and worktree options while keeping the composer pinned", (tester) async {
@@ -1472,7 +1470,7 @@ void main() {
     expect(find.widgetWithText(PregoPickerButton, "xhigh"), findsNothing);
   });
 
-  testWidgets("selecting Default clears the displayed variant", (tester) async {
+  testWidgets("selecting another variant updates the displayed variant", (tester) async {
     when(
       () => sessionService.listProviders(
         projectId: any(named: "projectId"),
@@ -1513,12 +1511,11 @@ void main() {
     await tester.tap(find.widgetWithText(PregoPickerButton, "xhigh"));
     await tester.pumpAndSettle();
 
-    // Select Default (null variant).
-    await tester.tap(_pickerMenuItem("Default"));
+    // Select the model's other variant.
+    await tester.tap(_pickerMenuItem("low"));
     await tester.pumpAndSettle();
 
-    // The UI should now show "Default".
-    expect(find.widgetWithText(PregoPickerButton, "Default"), findsOneWidget);
+    expect(find.widgetWithText(PregoPickerButton, "low"), findsOneWidget);
     expect(find.widgetWithText(PregoPickerButton, "xhigh"), findsNothing);
   });
 

--- a/client/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/client/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -308,7 +308,7 @@ void main() {
             agent: "coder",
             providerID: "anthropic",
             modelID: "claude-3-5-sonnet",
-            variant: null,
+            variant: const SessionVariant(id: "xhigh"),
             command: null,
           ),
         ).called(1);
@@ -535,7 +535,7 @@ void main() {
             agent: "coder",
             providerID: "anthropic",
             modelID: "claude-3-5-sonnet",
-            variant: null,
+            variant: const SessionVariant(id: "xhigh"),
             command: "review",
           ),
         ).called(1);
@@ -634,7 +634,7 @@ void main() {
             agent: "coder",
             providerID: "anthropic",
             modelID: "claude-3-5-sonnet",
-            variant: null,
+            variant: const SessionVariant(id: "xhigh"),
             command: null,
           ),
         ).called(1);
@@ -788,90 +788,18 @@ void main() {
       },
       act: (cubit) async {
         await _awaitLoaded(cubit);
-        cubit.selectVariant(const SessionVariant(id: "fast"));
+        cubit.selectVariant(const SessionVariant(id: "slow"));
       },
       expect: () => [
         isA<SessionDetailLoaded>().having(
           (state) => state.selectedAgentModel?.variant,
           "initial variant",
-          isNull,
+          "fast",
         ),
         isA<SessionDetailLoaded>().having(
           (state) => state.selectedAgentModel?.variant,
           "variant",
-          "fast",
-        ),
-      ],
-    );
-
-    blocTest<SessionDetailCubit, SessionDetailState>(
-      "selectVariant to null clears selectedAgentModel variant",
-      build: () {
-        when(
-          () => mockSessionService.listProviders(
-            projectId: any(named: "projectId"),
-            pluginId: any(named: "pluginId"),
-          ),
-        ).thenAnswer(
-          (_) async => ApiResponse.success(
-            const ProviderListResponse(
-              connectedOnly: false,
-              items: [
-                ProviderInfo(
-                  id: "openai",
-                  name: "OpenAI",
-                  defaultModelID: "gpt-4",
-                  models: {
-                    "gpt-4": ProviderModel(
-                      id: "gpt-4",
-                      providerID: "openai",
-                      name: "GPT-4",
-                      variants: ["fast", "slow"],
-                      family: null,
-                      releaseDate: null,
-                    ),
-                  },
-                ),
-              ],
-            ),
-          ),
-        );
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
-      },
-      act: (cubit) async {
-        await _awaitLoaded(cubit);
-        cubit.selectVariant(const SessionVariant(id: "fast"));
-        cubit.selectVariant(null);
-      },
-      expect: () => [
-        isA<SessionDetailLoaded>().having(
-          (state) => state.selectedAgentModel?.variant,
-          "initial variant",
-          isNull,
-        ),
-        isA<SessionDetailLoaded>().having(
-          (state) => state.selectedAgentModel?.variant,
-          "variant after fast",
-          "fast",
-        ),
-        isA<SessionDetailLoaded>().having(
-          (state) => state.selectedAgentModel?.variant,
-          "variant after null",
-          isNull,
+          "slow",
         ),
       ],
     );
@@ -1715,7 +1643,7 @@ void main() {
             agent: "coder",
             providerID: "anthropic",
             modelID: "claude-3-5-sonnet",
-            variant: null,
+            variant: const SessionVariant(id: "xhigh"),
             command: null,
           ),
         ).called(1);
@@ -1888,7 +1816,7 @@ void main() {
             agent: "coder",
             providerID: "anthropic",
             modelID: "claude-3-5-sonnet",
-            variant: null,
+            variant: const SessionVariant(id: "xhigh"),
             command: null,
           ),
         ).called(1);
@@ -1963,7 +1891,7 @@ void main() {
           agent: "coder",
           providerID: "anthropic",
           modelID: "claude-3-5-sonnet",
-          variant: null,
+          variant: const SessionVariant(id: "xhigh"),
           command: null,
         ),
       ).called(1);
@@ -2062,7 +1990,7 @@ void main() {
           agent: "coder",
           providerID: "anthropic",
           modelID: "claude-3-5-sonnet",
-          variant: null,
+          variant: const SessionVariant(id: "xhigh"),
           command: "review",
         ),
       ).called(1);
@@ -2248,7 +2176,7 @@ void main() {
           agent: "coder",
           providerID: "anthropic",
           modelID: "claude-3-5-sonnet",
-          variant: null,
+          variant: const SessionVariant(id: "xhigh"),
           command: null,
         ),
       ).called(1);

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -148,7 +148,7 @@ SessionDetailLoaded _loadedState({
     ),
     stagedCommand: null,
     isRefreshing: false,
-    availableVariants: const [SessionVariant(id: "xhigh")],
+    availableVariants: const [SessionVariant(id: "xhigh"), SessionVariant(id: "low")],
     retryErrorMessage: null,
   );
 }
@@ -664,11 +664,11 @@ void main() {
       selectedAgentModel: const AgentModel(
         providerID: "anthropic",
         modelID: "claude-3-5-sonnet",
-        variant: null,
+        variant: "low",
       ),
       stagedCommand: null,
       isRefreshing: false,
-      availableVariants: const [SessionVariant(id: "xhigh")],
+      availableVariants: const [SessionVariant(id: "xhigh"), SessionVariant(id: "low")],
       retryErrorMessage: null,
     );
 
@@ -687,19 +687,19 @@ void main() {
     await tester.tap(find.widgetWithText(PregoPickerButton, "xhigh"));
     await tester.pumpAndSettle();
 
-    // Select Default (null variant).
-    await tester.tap(_pickerMenuItem("Default"));
+    // Select the other available variant.
+    await tester.tap(_pickerMenuItem("low"));
     await tester.pumpAndSettle();
 
-    verify(() => cubit.selectVariant(null)).called(1);
+    verify(() => cubit.selectVariant(const SessionVariant(id: "low"))).called(1);
 
     // Emit the updated state to simulate the cubit update.
     when(() => cubit.state).thenReturn(updatedState);
     controller.add(updatedState);
     await tester.pumpAndSettle();
 
-    // The UI should now show "Default".
-    expect(find.widgetWithText(PregoPickerButton, "Default"), findsOneWidget);
+    // The UI should now show the newly selected variant.
+    expect(find.widgetWithText(PregoPickerButton, "low"), findsOneWidget);
     expect(find.widgetWithText(PregoPickerButton, "xhigh"), findsNothing);
   });
 

--- a/client/module_core/lib/src/cubits/new_session/new_session_cubit.dart
+++ b/client/module_core/lib/src/cubits/new_session/new_session_cubit.dart
@@ -657,7 +657,7 @@ class NewSessionCubit({
     }
   }
 
-  void selectVariant(SessionVariant? variant) {
+  void selectVariant(SessionVariant variant) {
     if (!_canEditComposer) return;
     final options = state.agentModelData?.optionsState.data;
     if (options == null) return;
@@ -669,9 +669,7 @@ class NewSessionCubit({
       _selectionTracker.recordVariant(
         projectId: _projectId,
         pluginId: pluginId,
-        variant: variant == null
-            ? const NewSessionDefaultVariantIntent()
-            : NewSessionNamedVariantIntent(id: variant.id),
+        variant: NewSessionVariantIntent(id: variant.id),
       );
     }
   }

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -2131,8 +2131,7 @@ class SessionDetailCubit(
   }) {
     if (model == null) return null;
     if (availableVariants.any((variant) => variant.id == model.variant)) return model;
-    final fallback = availableVariants.firstOrNull;
-    return fallback == null ? model : model.copyWith(variant: fallback.id);
+    return model.copyWith(variant: availableVariants.firstOrNull?.id);
   }
 
   List<SessionVariant> _deriveAvailableVariants({

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -1901,16 +1901,17 @@ class SessionDetailCubit(
     if (agentInfo == null) return;
     // A null model means this agent has no model preference of its own.
     final agentModel = agentInfo.model ?? current.selectedAgentModel;
+    final availableVariants = _deriveAvailableVariants(
+      providers: current.availableProviders,
+      model: agentModel,
+    );
 
     if (isClosed) return;
     emit(
       current.copyWith(
         selectedAgent: agent,
-        selectedAgentModel: agentModel,
-        availableVariants: _deriveAvailableVariants(
-          providers: current.availableProviders,
-          model: agentModel,
-        ),
+        selectedAgentModel: _withResolvedVariant(model: agentModel, availableVariants: availableVariants),
+        availableVariants: availableVariants,
       ),
     );
   }
@@ -1925,9 +1926,9 @@ class SessionDetailCubit(
       providers: current.availableProviders,
       model: newModel,
     );
-    final variant = previousVariant != null && availableVariants.any((v) => v.id == previousVariant)
+    final variant = availableVariants.any((v) => v.id == previousVariant)
         ? previousVariant
-        : null;
+        : availableVariants.firstOrNull?.id;
 
     final agentModel = _resolveAgentModel(
       agents: current.availableAgents,
@@ -1944,14 +1945,14 @@ class SessionDetailCubit(
     );
   }
 
-  void selectVariant(SessionVariant? variant) {
+  void selectVariant(SessionVariant variant) {
     final current = state;
     if (current is! SessionDetailLoaded) return;
     final agentModel = current.selectedAgentModel;
     if (agentModel == null) return;
 
     if (isClosed) return;
-    emit(current.copyWith(selectedAgentModel: agentModel.copyWith(variant: variant?.id)));
+    emit(current.copyWith(selectedAgentModel: agentModel.copyWith(variant: variant.id)));
   }
 
   void stageCommand(CommandInfo command) {
@@ -2112,11 +2113,26 @@ class SessionDetailCubit(
       availableProviders: providers,
       availableCommands: snapshot.commands,
       selectedAgent: defaultAgent,
-      selectedAgentModel: defaultAgentModel,
+      selectedAgentModel: _withResolvedVariant(
+        model: defaultAgentModel,
+        availableVariants: availableVariants,
+      ),
       stagedCommand: null,
       isRefreshing: false,
       availableVariants: availableVariants,
     );
+  }
+
+  /// A model that offers variants always runs at a named one. An unset variant
+  /// resolves to the first available, which plugins declare default-first.
+  AgentModel? _withResolvedVariant({
+    required AgentModel? model,
+    required List<SessionVariant> availableVariants,
+  }) {
+    if (model == null) return null;
+    if (availableVariants.any((variant) => variant.id == model.variant)) return model;
+    final fallback = availableVariants.firstOrNull;
+    return fallback == null ? model : model.copyWith(variant: fallback.id);
   }
 
   List<SessionVariant> _deriveAvailableVariants({

--- a/client/module_core/lib/src/services/models/new_session_selection_intent.dart
+++ b/client/module_core/lib/src/services/models/new_session_selection_intent.dart
@@ -1,10 +1,6 @@
 final class const NewSessionModelIntent({required final String providerId, required final String modelId});
 
-sealed class const NewSessionVariantIntent();
-
-final class const NewSessionDefaultVariantIntent() extends NewSessionVariantIntent;
-
-final class const NewSessionNamedVariantIntent({required final String id}) extends NewSessionVariantIntent;
+final class const NewSessionVariantIntent({required final String id});
 
 final class NewSessionSelectionIntent {
   const new({

--- a/client/module_core/lib/src/services/new_session_options_service.dart
+++ b/client/module_core/lib/src/services/new_session_options_service.dart
@@ -244,12 +244,10 @@ class NewSessionOptionsService({
     required NewSessionVariantIntent? variantIntent,
   }) {
     if (model == null || variantIntent == null) return model;
-    return switch (variantIntent) {
-      NewSessionDefaultVariantIntent() => model.copyWith(variant: null),
-      NewSessionNamedVariantIntent(:final id) => model.copyWith(
-        variant: availableVariants(providers: providers, model: model).any((variant) => variant.id == id) ? id : null,
-      ),
-    };
+    final id = variantIntent.id;
+    return availableVariants(providers: providers, model: model).any((variant) => variant.id == id)
+        ? model.copyWith(variant: id)
+        : model;
   }
 
   NewSessionOptionsData? selectAgent({
@@ -325,19 +323,17 @@ class NewSessionOptionsService({
 
   NewSessionOptionsData? selectVariant({
     required NewSessionOptionsData options,
-    required SessionVariant? variant,
+    required SessionVariant variant,
   }) {
     final model = options.selectedAgentModel;
     if (model == null) return null;
-    if (variant != null && !options.availableVariants.any((available) => available.id == variant.id)) {
-      return null;
-    }
+    if (!options.availableVariants.any((available) => available.id == variant.id)) return null;
     return NewSessionOptionsData(
       agents: options.agents,
       providers: options.providers,
       commands: options.commands,
       selectedAgent: options.selectedAgent,
-      selectedAgentModel: model.copyWith(variant: variant?.id),
+      selectedAgentModel: model.copyWith(variant: variant.id),
       stagedCommand: options.stagedCommand,
       availableVariants: options.availableVariants,
     );
@@ -396,7 +392,7 @@ class NewSessionOptionsService({
     final variants = availableVariants(providers: providers, model: model);
     final variant = model.variant;
     return model.copyWith(
-      variant: variant != null && variants.any((available) => available.id == variant) ? variant : null,
+      variant: variants.any((available) => available.id == variant) ? variant : variants.firstOrNull?.id,
     );
   }
 
@@ -407,7 +403,10 @@ class NewSessionOptionsService({
         defaultModelID: provider.defaultModelID,
       );
       if (model != null) {
-        return AgentModel(providerID: provider.id, modelID: model.id, variant: null);
+        return _validatedModel(
+          providers: providers,
+          model: AgentModel(providerID: provider.id, modelID: model.id, variant: null),
+        );
       }
     }
     return null;

--- a/client/module_core/lib/src/services/new_session_options_service.dart
+++ b/client/module_core/lib/src/services/new_session_options_service.dart
@@ -303,7 +303,7 @@ class NewSessionOptionsService({
         ? previousVariant
         : agentVariant != null && variants.any((variant) => variant.id == agentVariant)
         ? agentVariant
-        : null;
+        : variants.firstOrNull?.id;
     final selectedAgentModel = _applyVariantIntent(
       providers: options.providers,
       model: requested.copyWith(variant: selectedVariant),

--- a/client/module_core/test/cubits/new_session/new_session_cubit_test.dart
+++ b/client/module_core/test/cubits/new_session/new_session_cubit_test.dart
@@ -1434,7 +1434,7 @@ void main() {
     });
 
     blocTest<NewSessionCubit, NewSessionState>(
-      "selectModel leaves provider-only model variant at Default",
+      "selectModel resolves a provider-only model to its first variant",
       skip: 2,
       build: () {
         when(
@@ -1495,7 +1495,7 @@ void main() {
             .having(
               (state) => state.selectedAgentModel,
               "selectedAgentModel",
-              const AgentModel(providerID: "openai", modelID: "gpt-5", variant: null),
+              const AgentModel(providerID: "openai", modelID: "gpt-5", variant: "provisional-effort"),
             ),
       ],
     );

--- a/client/module_core/test/cubits/new_session/new_session_cubit_test.dart
+++ b/client/module_core/test/cubits/new_session/new_session_cubit_test.dart
@@ -1096,7 +1096,7 @@ void main() {
             projectId: any(named: "projectId"),
             pluginId: any(named: "pluginId"),
           ),
-        ).thenAnswer((_) async => ApiResponse.success(_providerResponseWithVariants(["xhigh"])));
+        ).thenAnswer((_) async => ApiResponse.success(_providerResponseWithVariants(["high", "xhigh"])));
         when(
           () => mockSessionService.createSessionWithMessage(
             attachments: const [],
@@ -1127,7 +1127,7 @@ void main() {
         isA<NewSessionIdle>().having(
           (state) => state.selectedAgentModel?.variant,
           "selectedAgentModel.variant",
-          isNull,
+          "high",
         ),
         isA<NewSessionIdle>().having(
           (state) => state.selectedAgentModel?.variant,
@@ -1168,7 +1168,7 @@ void main() {
             projectId: any(named: "projectId"),
             pluginId: any(named: "pluginId"),
           ),
-        ).thenAnswer((_) async => ApiResponse.success(_providerResponseWithVariants(["xhigh"])));
+        ).thenAnswer((_) async => ApiResponse.success(_providerResponseWithVariants(["high", "xhigh"])));
         when(
           () => mockSessionService.listAgents(
             projectId: any(named: "projectId"),
@@ -1205,7 +1205,7 @@ void main() {
         isA<NewSessionIdle>().having(
           (state) => state.selectedAgentModel?.variant,
           "initial selectedAgentModel.variant",
-          isNull,
+          "high",
         ),
         isA<NewSessionIdle>().having(
           (state) => state.selectedAgentModel?.variant,
@@ -1332,12 +1332,7 @@ void main() {
       ],
     );
 
-    test("selectModel preserves an explicit Default variant intent", () async {
-      selectionTracker.recordVariant(
-        projectId: "project-1",
-        pluginId: "plugin-1",
-        variant: const NewSessionDefaultVariantIntent(),
-      );
+    test("selectModel resolves the new model's first variant when the previous one is unavailable", () async {
       when(
         () => mockSessionService.listAgents(
           projectId: any(named: "projectId"),
@@ -1377,11 +1372,7 @@ void main() {
 
       expect(
         cubit.state.agentModelData?.agentModel,
-        const AgentModel(providerID: "anthropic", modelID: "claude-3", variant: null),
-      );
-      expect(
-        selectionTracker.read(projectId: "project-1", pluginId: "plugin-1")?.variant,
-        isA<NewSessionDefaultVariantIntent>(),
+        const AgentModel(providerID: "anthropic", modelID: "claude-3", variant: "deep"),
       );
     });
 
@@ -1432,7 +1423,7 @@ void main() {
       expect(cubit.state.agentModelData?.agent, "plan");
       expect(
         cubit.state.agentModelData?.agentModel,
-        const AgentModel(providerID: "openai", modelID: "gpt-4", variant: null),
+        const AgentModel(providerID: "openai", modelID: "gpt-4", variant: "fast"),
       );
       expect(
         selectionTracker.read(projectId: "project-1", pluginId: "plugin-1")?.model,
@@ -1510,79 +1501,7 @@ void main() {
     );
 
     blocTest<NewSessionCubit, NewSessionState>(
-      "selectVariant updates selectedAgentModel variant",
-      skip: 2,
-      build: () {
-        when(
-          () => mockSessionService.listAgents(
-            projectId: any(named: "projectId"),
-            pluginId: any(named: "pluginId"),
-          ),
-        ).thenAnswer(
-          (_) async => ApiResponse.success(
-            const Agents(
-              agents: [
-                AgentInfo(
-                  name: "build",
-                  description: "Build",
-                  model: AgentModel(providerID: "openai", modelID: "gpt-4", variant: null),
-                  mode: AgentMode.primary,
-                ),
-              ],
-            ),
-          ),
-        );
-        when(
-          () => mockSessionService.listProviders(
-            projectId: any(named: "projectId"),
-            pluginId: any(named: "pluginId"),
-          ),
-        ).thenAnswer(
-          (_) async => ApiResponse.success(
-            const ProviderListResponse(
-              connectedOnly: false,
-              items: [
-                ProviderInfo(
-                  id: "openai",
-                  name: "OpenAI",
-                  defaultModelID: "gpt-4",
-                  models: {
-                    "gpt-4": ProviderModel(
-                      id: "gpt-4",
-                      providerID: "openai",
-                      name: "GPT-4",
-                      variants: ["fast", "slow"],
-                      family: null,
-                      releaseDate: null,
-                    ),
-                  },
-                ),
-              ],
-            ),
-          ),
-        );
-        return buildCubit();
-      },
-      act: (cubit) async {
-        await Future<void>.delayed(Duration.zero);
-        cubit.selectVariant(const SessionVariant(id: "fast"));
-      },
-      expect: () => [
-        isA<NewSessionIdle>().having(
-          (state) => state.selectedAgentModel?.variant,
-          "initial variant",
-          isNull,
-        ),
-        isA<NewSessionIdle>().having(
-          (state) => state.selectedAgentModel?.variant,
-          "variant",
-          "fast",
-        ),
-      ],
-    );
-
-    blocTest<NewSessionCubit, NewSessionState>(
-      "selectVariant to null clears selectedAgentModel variant",
+      "selectVariant switches selectedAgentModel to another available variant",
       skip: 2,
       build: () {
         when(
@@ -1637,7 +1556,7 @@ void main() {
       },
       act: (cubit) async {
         await Future<void>.delayed(Duration.zero);
-        cubit.selectVariant(null);
+        cubit.selectVariant(const SessionVariant(id: "slow"));
       },
       expect: () => [
         isA<NewSessionIdle>().having(
@@ -1648,7 +1567,7 @@ void main() {
         isA<NewSessionIdle>().having(
           (state) => state.selectedAgentModel?.variant,
           "variant",
-          isNull,
+          "slow",
         ),
       ],
     );
@@ -1780,7 +1699,7 @@ void main() {
         expect(saved?.model, isNull);
         expect(
           saved?.variant,
-          isA<NewSessionNamedVariantIntent>().having((variant) => variant.id, "id", "xhigh"),
+          isA<NewSessionVariantIntent>().having((variant) => variant.id, "id", "xhigh"),
         );
       },
     );
@@ -1903,7 +1822,7 @@ void main() {
     );
 
     blocTest<NewSessionCubit, NewSessionState>(
-      "drops a persisted variant the restored model no longer offers",
+      "replaces a persisted variant the restored model no longer offers",
       skip: 2,
       build: () {
         // Seed a model from a DIFFERENT provider than the computed default
@@ -1968,8 +1887,9 @@ void main() {
         isA<NewSessionIdle>().having(
           (state) => state.selectedAgentModel,
           "selectedAgentModel",
-          // Saved model restored; the no-longer-offered "legacy" variant dropped.
-          const AgentModel(providerID: "anthropic", modelID: "claude-3", variant: null),
+          // Saved model restored; the no-longer-offered "legacy" variant falls
+          // back to the model's first available one.
+          const AgentModel(providerID: "anthropic", modelID: "claude-3", variant: "fast"),
         ),
       ],
     );
@@ -2101,7 +2021,7 @@ void main() {
         isA<NewSessionIdle>().having(
           (state) => state.selectedAgentModel,
           "selectedAgentModel",
-          const AgentModel(providerID: "openai", modelID: "gpt-4", variant: null),
+          const AgentModel(providerID: "openai", modelID: "gpt-4", variant: "fast"),
         ),
       ],
     );
@@ -2248,7 +2168,7 @@ void main() {
       expect(saved?.model?.modelId, "gpt-4");
       expect(
         saved?.variant,
-        isA<NewSessionNamedVariantIntent>().having((variant) => variant.id, "id", "high"),
+        isA<NewSessionVariantIntent>().having((variant) => variant.id, "id", "high"),
       );
     });
 
@@ -2299,7 +2219,7 @@ void main() {
       expect(saved?.model?.modelId, model.modelID);
       expect(
         saved?.variant,
-        isA<NewSessionNamedVariantIntent>().having((variant) => variant.id, "id", model.variant),
+        isA<NewSessionVariantIntent>().having((variant) => variant.id, "id", model.variant),
       );
     });
   });
@@ -2318,11 +2238,7 @@ NewSessionSelectionIntent _selectionIntentFromSnapshot({
             providerId: agentModel.providerID,
             modelId: agentModel.modelID,
           ),
-    variant: agentModel == null
-        ? null
-        : variant == null
-        ? const NewSessionDefaultVariantIntent()
-        : NewSessionNamedVariantIntent(id: variant),
+    variant: variant == null ? null : NewSessionVariantIntent(id: variant),
   );
 }
 

--- a/client/module_core/test/cubits/new_session/new_session_plugin_selection_test.dart
+++ b/client/module_core/test/cubits/new_session/new_session_plugin_selection_test.dart
@@ -1552,15 +1552,15 @@ void main() {
       final cubit = buildCubit();
       addTearDown(cubit.close);
       await _waitForComposer(cubit);
-      cubit.selectVariant(const SessionVariant(id: "high"));
-      expect(cubit.state.agentModelData?.agentModel?.variant, "high");
+      cubit.selectVariant(const SessionVariant(id: "max"));
+      expect(cubit.state.agentModelData?.agentModel?.variant, "max");
 
       connectionStatus
         ..add(const ConnectionStatus.disconnected())
         ..add(connectedStatus);
       await _waitUntil(() => discoveryCalls == 2 && cubit.state.agentModelData?.isLoading == false);
 
-      expect(cubit.state.agentModelData?.agentModel?.variant, isNull);
+      expect(cubit.state.agentModelData?.agentModel?.variant, "high");
     });
 
     test("reconnect during a failed send invalidates affinity and rediscovers afterward", () async {
@@ -1786,7 +1786,7 @@ ProviderListResponse _providerResponse() {
             id: "model",
             providerID: "provider",
             name: "Model",
-            variants: ["high"],
+            variants: ["high", "max"],
             family: null,
             releaseDate: null,
           ),

--- a/client/module_core/test/services/new_session_options_service_test.dart
+++ b/client/module_core/test/services/new_session_options_service_test.dart
@@ -269,7 +269,7 @@ void main() {
                 restoredSelection: const NewSessionSelectionIntent(
                   agentName: "review",
                   model: NewSessionModelIntent(providerId: "provider-a", modelId: "model-a"),
-                  variant: NewSessionNamedVariantIntent(id: "low"),
+                  variant: NewSessionVariantIntent(id: "low"),
                 ),
                 previousOptions: null,
               )
@@ -312,7 +312,7 @@ void main() {
                 restoredSelection: const NewSessionSelectionIntent(
                   agentName: "missing",
                   model: NewSessionModelIntent(providerId: "provider-a", modelId: "unavailable"),
-                  variant: NewSessionDefaultVariantIntent(),
+                  variant: NewSessionVariantIntent(id: "stale"),
                 ),
                 previousOptions: null,
               )
@@ -323,7 +323,7 @@ void main() {
       expect(result.options.selectedAgentModel?.modelID, "model-a");
     });
 
-    test("drops stale variants and revalidates a staged command by name", () async {
+    test("replaces stale variants and revalidates a staged command by name", () async {
       final priorCommand = _command(name: "review", description: "old");
       final refreshedCommand = _command(name: "review", description: "new");
       final previous = NewSessionOptionsData(
@@ -358,13 +358,13 @@ void main() {
                 restoredSelection: const NewSessionSelectionIntent(
                   agentName: "build",
                   model: NewSessionModelIntent(providerId: "provider-a", modelId: "model-a"),
-                  variant: NewSessionNamedVariantIntent(id: "removed"),
+                  variant: NewSessionVariantIntent(id: "removed"),
                 ),
                 previousOptions: previous,
               )
               as NewSessionOptionsLoaded;
 
-      expect(result.options.selectedAgentModel?.variant, isNull);
+      expect(result.options.selectedAgentModel?.variant, "high");
       expect(identical(result.options.stagedCommand, refreshedCommand), isTrue);
     });
 

--- a/client/module_core/test/services/new_session_selection_tracker_test.dart
+++ b/client/module_core/test/services/new_session_selection_tracker_test.dart
@@ -20,7 +20,7 @@ void main() {
         selection: const NewSessionSelectionIntent(
           agentName: "build",
           model: NewSessionModelIntent(providerId: "openai", modelId: "gpt-4"),
-          variant: NewSessionNamedVariantIntent(id: "fast"),
+          variant: NewSessionVariantIntent(id: "fast"),
         ),
       );
       tracker.write(
@@ -29,7 +29,7 @@ void main() {
         selection: const NewSessionSelectionIntent(
           agentName: "plan",
           model: NewSessionModelIntent(providerId: "anthropic", modelId: "claude-3"),
-          variant: NewSessionDefaultVariantIntent(),
+          variant: NewSessionVariantIntent(id: "slow"),
         ),
       );
 
@@ -39,14 +39,14 @@ void main() {
       expect(first?.model?.modelId, "gpt-4");
       expect(
         first?.variant,
-        isA<NewSessionNamedVariantIntent>().having((variant) => variant.id, "id", "fast"),
+        isA<NewSessionVariantIntent>().having((variant) => variant.id, "id", "fast"),
       );
 
       final second = tracker.read(projectId: "project-2", pluginId: "plugin-1");
       expect(second?.agentName, "plan");
       expect(second?.model?.providerId, "anthropic");
       expect(second?.model?.modelId, "claude-3");
-      expect(second?.variant, isA<NewSessionDefaultVariantIntent>());
+      expect(second?.variant, isA<NewSessionVariantIntent>().having((variant) => variant.id, "id", "slow"));
     });
 
     test("recordAgent does not write model or variant defaults", () {
@@ -77,7 +77,7 @@ void main() {
       tracker.recordVariant(
         projectId: "project-1",
         pluginId: "plugin-1",
-        variant: const NewSessionNamedVariantIntent(id: "fast"),
+        variant: const NewSessionVariantIntent(id: "fast"),
       );
 
       final saved = tracker.read(projectId: "project-1", pluginId: "plugin-1");
@@ -85,7 +85,7 @@ void main() {
       expect(saved?.model, isNull);
       expect(
         saved?.variant,
-        isA<NewSessionNamedVariantIntent>().having((variant) => variant.id, "id", "fast"),
+        isA<NewSessionVariantIntent>().having((variant) => variant.id, "id", "fast"),
       );
     });
 
@@ -100,7 +100,7 @@ void main() {
       tracker.recordVariant(
         projectId: "project-1",
         pluginId: "plugin-1",
-        variant: const NewSessionNamedVariantIntent(id: "fast"),
+        variant: const NewSessionVariantIntent(id: "fast"),
       );
 
       tracker.recordAgent(projectId: "project-1", pluginId: "plugin-1", agentName: "plan");
@@ -113,14 +113,14 @@ void main() {
       tracker.recordVariant(
         projectId: "project-1",
         pluginId: "plugin-1",
-        variant: const NewSessionDefaultVariantIntent(),
+        variant: const NewSessionVariantIntent(id: "slow"),
       );
 
       final saved = tracker.read(projectId: "project-1", pluginId: "plugin-1");
       expect(saved?.agentName, "plan");
       expect(saved?.model?.providerId, "anthropic");
       expect(saved?.model?.modelId, "claude-3");
-      expect(saved?.variant, isA<NewSessionDefaultVariantIntent>());
+      expect(saved?.variant, isA<NewSessionVariantIntent>().having((variant) => variant.id, "id", "slow"));
     });
 
     test("write overwrites the previous selection for a project", () {
@@ -130,7 +130,7 @@ void main() {
         selection: const NewSessionSelectionIntent(
           agentName: "build",
           model: NewSessionModelIntent(providerId: "openai", modelId: "gpt-4"),
-          variant: NewSessionDefaultVariantIntent(),
+          variant: NewSessionVariantIntent(id: "slow"),
         ),
       );
       tracker.write(
@@ -139,7 +139,7 @@ void main() {
         selection: const NewSessionSelectionIntent(
           agentName: "plan",
           model: NewSessionModelIntent(providerId: "anthropic", modelId: "claude-3"),
-          variant: NewSessionNamedVariantIntent(id: "deep"),
+          variant: NewSessionVariantIntent(id: "deep"),
         ),
       );
 
@@ -149,7 +149,7 @@ void main() {
       expect(saved?.model?.modelId, "claude-3");
       expect(
         saved?.variant,
-        isA<NewSessionNamedVariantIntent>().having((variant) => variant.id, "id", "deep"),
+        isA<NewSessionVariantIntent>().having((variant) => variant.id, "id", "deep"),
       );
     });
 

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -13,6 +13,9 @@ variant, and worktree mode, and creating the session with its first input.
 - Claude's plugin-scoped discovery runs in its host-created state directory,
   never a selected project or the bridge process's launch directory. This keeps
   its global option probe on a valid, stable path when projects move or disappear.
+- Claude's catalog drops the CLI's own `default` model entry and names the
+  selection instead: Opus is the default model and `high` the default effort, so
+  every picker entry states what will actually run.
 - Read intents stay distinct: a normal load may serve a valid cache or discover,
   a cache-only read never discovers and reports cache-unavailable, and an
   explicit refresh forces fresh discovery.

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -16,6 +16,10 @@ variant, and worktree mode, and creating the session with its first input.
 - Claude's catalog drops the CLI's own `default` model entry and names the
   selection instead: Opus is the default model and `high` the default effort, so
   every picker entry states what will actually run.
+- No picker offers an unnamed "Default" option. Plugins declare effort variants
+  default-first, and a model that offers variants always has one selected: the
+  agent's declared variant when valid, otherwise the first available. Selecting a
+  variant is therefore a switch between named levels, never a reset to unset.
 - Read intents stay distinct: a normal load may serve a valid cache or discover,
   a cache-only read never discovers and reports cache-unavailable, and an
   explicit refresh forces fresh discovery.


### PR DESCRIPTION
## Complexity

Moderate. Two plugin catalog changes plus the shared client selection logic they let us delete.

## What

Removes every picker option literally labelled "Default", because none of them could say what they meant.

**Claude plugin**
- Drops Claude's own `default` model entry from the mapped catalog. It resolves to whichever model and effort the CLI configuration currently prefers, so a picker entry labelled "Default (recommended)" told the user nothing about what would run.
- Declares Opus as the default model and `high` as the default effort on its agents, and emits effort variants default-first.
- Removes the now-unreachable `modelId == "default"` reset branches in `ClaudeCatalogService.selectModel` and `ClaudeSessionProcessRepository._applySelection`.

**Codex plugin**
- Renames the default collaboration mode's agent from `Default` to `Agent`, matching Claude and Cursor. `CodexCollaborationMode.fromAgent` accepts both spellings.

**Client**
- The variant picker no longer offers an unnamed "Default" entry; it lists only named levels.
- A model that offers variants always has one selected: the agent's declared variant when valid, otherwise the first available. Plugins declare variants default-first (Codex already did; Claude now does), so the fallback lands on the intended default rather than an arbitrary level.
- `NewSessionVariantIntent` collapses from a sealed pair to a single named intent, since "the user deliberately chose unset" is no longer expressible. The tracker is in-memory for one app run, so nothing persisted needs migrating.
- `selectVariant` is non-nullable in both the new-session and session-detail cubits.

## Why

The agent picker and the effort picker both showed "Default", and neither could explain it. The bridge cannot resolve the effort one either: Claude's `initialize` handshake declares `supportsEffort` and `supportedEffortLevels` per model but never reports which level is the default. "Default" was an unresolvable placeholder, not a choice — so it is replaced by the named value it actually stood for.

## Risk and test focus

User-visible: new Claude sessions start on `Opus (1M context)` + `high`; Codex's agent pill reads `Agent`; the effort pill always shows a named level and the picker lists only named levels. Sessions whose model offers variants but had none selected now resolve to the model's first (default-first) variant, which is sent with the next prompt.

Not covered: Oh My Pi surfaces its collaboration modes verbatim from its own backend catalog, so a mode that backend names "Default" still appears as such. Renaming it would mean overriding another backend's own naming.

No database impact. No wire-contract break: `PluginAgentModel.variant` already existed and is already parsed by the client, and the Codex bridge still accepts the old `"default"` agent spelling from an older app.

## Expected result

Neither the agent picker nor the effort picker offers an option named "Default", and every pill states the model, agent, and effort that will actually run.

## Verification

- `dart analyze lib test` + `dart test` in `bridge/sesori_plugin_claude` — 239 pass
- `dart test` in `bridge/sesori_plugin_codex` — 361 pass
- `flutter analyze lib test` + `flutter test` in `client/module_core` — 1144 pass
- `flutter analyze lib test` + `flutter test` in `client/app` — 998 pass
- Claude catalog shape confirmed against the live CLI's `initialize` response (`default`, `opus[1m]`, `claude-fable-5[1m]`, `sonnet`, `haiku`; no default-effort field on any entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
