### PR TITLE
🌱 [hermes-agent-plugin] docs: record Hermes session-option behavior

### DIFF
--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -13,6 +13,10 @@ variant, and worktree mode, and creating the session with its first input.
 - Claude's plugin-scoped discovery runs in its host-created state directory,
   never a selected project or the bridge process's launch directory. This keeps
   its global option probe on a valid, stable path when projects move or disappear.
+- Hermes Agent is a stock ACP v1 server: its option discovery uses the base
+  single-agent synthesis (no model picker — the backend's configured model is
+  authoritative), and it advertises image prompt capability so inline attachments
+  are accepted.
 - Read intents stay distinct: a normal load may serve a valid cache or discover,
   a cache-only read never discovers and reports cache-unavailable, and an
   explicit refresh forces fresh discovery.


### PR DESCRIPTION
## Complexity

🌱 Trivial. A single four-line documentation note.

## What

Restores the Hermes Agent entry in `docs/regression/session-creation-and-options.md`, recording that Hermes uses base single-agent option synthesis with no model picker (its configured model is authoritative) and advertises image prompt capability.

Original wording by @eexxio in the superseded step 7 PR #901, preserved verbatim and credited via `Co-authored-by`.

## Why

Every other part of #901 reached `main` through the corrective step 7 PR (#927), but this paragraph was dropped: the file currently has no Hermes entry at all, while `plugin-setup-and-lifecycle.md`, `session-turns.md`, and `session-archiving-and-deletion.md` all carry theirs.

Both claims were independently confirmed during the 2026-08-18 iOS client E2E run: the new-session screen populated no model list for Hermes, and an image part was accepted and answered correctly. Restoring it before closing #901 keeps that behavior documented where reviewers expect it.

## Risk and test focus

Documentation only. No production code, user-visible behavior, or database impact. Worth confirming the note matches the harness-specific style of the neighbouring Claude entry.

## Expected result

`session-creation-and-options.md` documents Hermes option behavior alongside the other harnesses, so #901 can be closed as superseded without losing content.

## Verification

- Restored text is byte-identical to the paragraph in #901
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the Hermes Agent entry in docs/regression/session-creation-and-options.md so its session-option behavior is documented alongside other harnesses. Previously this file had no Hermes entry; now it clarifies option synthesis and image support.

**Review notes**
- Records Hermes as a stock ACP v1 server using base single-agent option synthesis with no model picker (the backend-configured model is authoritative).
- States Hermes advertises image prompt capability so inline attachments are accepted.
- Docs-only change; verify style and placement match neighboring harness notes.

<sup>Written for commit eaf7bc61a274dbe191a219c7edef9a0345b87bf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

