### PR TITLE
⚙️ [pi-harness] feat(bridge): register Pi and OMP [step 18/21]

### DIFF
--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -4,8 +4,8 @@
 
 - **Plan slug:** `pi-harness`
 - **Implementation base:** current `origin/main` with Step 15 merged
-- **Series state:** Step 17/21 in review as PR #963
-- **Current step:** 17/21, Pi managed runtime in review as PR #963
+- **Series state:** Step 18/21 ready to raise
+- **Current step:** 18/21, Pi and OMP registration implemented
 - **Plan PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/811
 - **Step 2 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/819
 - **Step 3 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/820
@@ -24,7 +24,7 @@
 - **Step 15 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/920
 - **Step 16 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/925
 - **Step 17 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/963
-- **Next action:** monitor Step 17 and continue Step 18 locally
+- **Next action:** raise Step 18 PR and monitor it
 
 ## Locked Decisions
 
@@ -67,8 +67,8 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 | [x] | 14/21 | `🚧 [pi-harness] feat(pi): manage session residency and turns [step 14/21]` | 1,200-1,500 (recorded overage) | Merged as PR #914 |
 | [x] | 15/21 | `⚙️ [pi-harness] feat(pi): expose models and commands [step 15/21]` | 900-1,300 | Merged as PR #920 |
 | [x] | 16/21 | `🚧 [pi-harness] feat(pi): implement the plugin API [step 16/21]` | 1,100-1,500 (recorded slight overage) | Merged as PR #925 |
-| [ ] | 17/21 | `🚧 [pi-harness] feat(pi): add managed runtime and lifecycle [step 17/21]` | 1,100-1,500 | In review as PR #963 |
-| [ ] | 18/21 | `⚙️ [pi-harness] feat(bridge): register Pi and OMP [step 18/21]` | 800-1,200 | Not started |
+| [x] | 17/21 | `🚧 [pi-harness] feat(pi): add managed runtime and lifecycle [step 17/21]` | 1,100-1,500 | Merged as PR #963 |
+| [ ] | 18/21 | `⚙️ [pi-harness] feat(bridge): register Pi and OMP [step 18/21]` | 800-1,200 | Implemented; PR ready to raise |
 | [ ] | 19/21 | `⚙️ [pi-harness] feat(client): add Pi and OMP branding and guidance [step 19/21]` | 500-900 | Not started |
 | [ ] | 20/21 | `⚙️ [pi-harness] test(harness): verify Pi and OMP integration [step 20/21]` | 300-700 | Not started |
 | [ ] | 21/21 | `🌱 [pi-harness] docs: retire the Pi and OMP harness plan [step 21/21]` | 50-200 | Not started |
@@ -561,6 +561,34 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 - Diff before tracker/plan evidence: +1,378/-72 = 1,450 changed lines; generated
   lines: 0; tests run: 387 automated package checks plus one live managed
   artifact/version/RPC probe.
+
+
+### Step 18/21
+
+- Added `Harness.pi` and `Harness.omp`, the `pi_plugin`/`omp_plugin` app
+  dependencies, and both production descriptors to `plugin_registry.dart`.
+  The registry list became `final List.unmodifiable` because both descriptors
+  construct through non-const `production()` factories. OpenCode remains the
+  preferred default; all merged entries are preserved.
+- Added the backend-neutral `SseToastCubit` in `module_core` mapping
+  `tui.toast.show` SSE events into sealed idle/show states with a monotonic
+  sequence, so equal repeated guidance re-fires; textless toasts drop and
+  unknown variants degrade to info. The mobile shell renders shows as
+  snackbars through a new root scaffold messenger.
+- README and the plugin-setup regression doc record Pi's always-`--approve`
+  project-code trust, OMP's inherited approval policy, and local-only provider
+  login before either backend is selectable.
+- Registry exact-set fixtures updated; a new test pins every registered id to
+  a built-in `Harness` identity. Toast cubit tests cover monotonic repeats,
+  variant fallback, and empty-drop behavior.
+- Architecture implementation review approved the commit with no findings.
+- Verification: bridge app fatal analysis and full suite (2,674 tests), Pi
+  (255) and OMP (51) suites, shared (409), module_core toast tests, and the
+  mobile shell fatal analysis all pass after the post-merge sync with `main`.
+- No database, persisted-data, or wire-contract change; the app now lists Pi
+  and Oh My Pi as selectable harnesses once their setup is ready.
+- Diff before tracker/plan evidence: +393/-10 = 403 changed lines; generated
+  lines: 46 (one freezed state file).
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -573,8 +573,9 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 - Added the backend-neutral `SseToastCubit` in `module_core` mapping
   `tui.toast.show` SSE events into sealed idle/show states with a monotonic
   sequence, so equal repeated guidance re-fires; textless toasts drop and
-  unknown variants degrade to info. The mobile shell renders shows as
-  snackbars through a new root scaffold messenger.
+  unknown variants degrade to info. The mobile shell renders shows through
+  `PregoPopupAlertPresenter` on the root navigator's overlay, reusing the
+  design-system toast surface instead of a plain snackbar.
 - README and the plugin-setup regression doc record Pi's always-`--approve`
   project-code trust, OMP's inherited approval policy, and local-only provider
   login before either backend is selectable.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Your laptop and phone perform an ephemeral X25519 key exchange, then encrypt eve
 | [OpenAI Codex CLI](https://github.com/openai/codex) | Beta | Enabled by default in an upcoming release. |
 | [Cursor](https://cursor.com) | Beta | ACP-based Cursor plugin; enabled by default in an upcoming release. |
 | [Claude Code](https://claude.com) | Beta | Native stream-json integration; enabled by default in an upcoming release. |
+| [Pi](https://github.com/badlogic/pi-mono) | Beta | Native JSONL RPC integration. Sessions always run with Pi's `--approve`: project-local Pi settings, extensions, skills, and prompt templates are trusted and applied without prompts, so only open projects whose code you trust. Provider login happens locally via Pi's `/login`. |
+| [Oh My Pi](https://github.com/can1357/oh-my-pi) | Beta | ACP-based integration. Inherits your OMP `tools.approvalMode`: the default `yolo` mode asks nothing; configure a stricter mode locally for approval prompts. Provider login happens locally. |
 
 ---
 

--- a/bridge/app/lib/src/bridge/runtime/plugin_registry.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_registry.dart
@@ -2,20 +2,24 @@ import "package:claude_plugin/claude_plugin.dart" show ClaudePluginDescriptor;
 import "package:codex_plugin/codex_plugin.dart" show CodexPluginDescriptor;
 import "package:cursor_plugin/cursor_plugin.dart" show CursorPluginDescriptor;
 import "package:hermes_plugin/hermes_plugin.dart" show HermesPluginDescriptor;
+import "package:omp_plugin/omp_plugin.dart" show OmpPluginDescriptor;
 import "package:opencode_plugin/opencode_plugin.dart" show OpenCodePluginDescriptor;
+import "package:pi_plugin/pi_plugin.dart" show PiPluginDescriptor;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginDescriptor;
 
 /// Every plugin this bridge build knows how to run.
 ///
 /// Descriptors are const and side-effect free. Registration does not imply
 /// setup readiness, eligibility, or a running backend generation.
-const List<BridgePluginDescriptor> knownPlugins = [
-  OpenCodePluginDescriptor(),
-  CodexPluginDescriptor(),
-  CursorPluginDescriptor(),
-  ClaudePluginDescriptor(),
-  HermesPluginDescriptor(),
-];
+final List<BridgePluginDescriptor> knownPlugins = List.unmodifiable([
+  const OpenCodePluginDescriptor(),
+  const CodexPluginDescriptor(),
+  const CursorPluginDescriptor(),
+  const ClaudePluginDescriptor(),
+  const HermesPluginDescriptor(),
+  PiPluginDescriptor.production(),
+  OmpPluginDescriptor.production(),
+]);
 
 /// Product-preferred default when OpenCode is selectable. Lifecycle policy
 /// falls back to the first selectable registration when it is not.

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -38,6 +38,10 @@ dependencies:
     path: ../sesori_plugin_claude
   hermes_plugin:
     path: ../sesori_plugin_hermes
+  pi_plugin:
+    path: ../sesori_plugin_pi
+  omp_plugin:
+    path: ../sesori_plugin_omp
   meta: ^1.19.0
   # Keep runtime and codegen on the same patch; skew breaks the Drift schema verifier.
   drift: 2.34.3

--- a/bridge/app/test/bridge/runtime/plugin_registry_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_registry_test.dart
@@ -1,11 +1,19 @@
 import "package:sesori_bridge/src/bridge/runtime/plugin_registry.dart";
+import "package:sesori_shared/sesori_shared.dart" show Harness;
 import "package:test/test.dart";
 
 void main() {
   test("registry contains every bundled plugin exactly once", () {
     final ids = knownPlugins.map((plugin) => plugin.id).toList();
 
-    expect(ids, unorderedEquals(["opencode", "codex", "cursor", "claude", "hermes"]));
+    expect(ids, unorderedEquals(["opencode", "codex", "cursor", "claude", "hermes", "pi", "omp"]));
+  });
+
+  test("every registered plugin id is a built-in Harness identity", () {
+    final harnessNames = Harness.values.map((harness) => harness.name).toSet();
+    for (final plugin in knownPlugins) {
+      expect(harnessNames, contains(plugin.id));
+    }
   });
 
   test("registered descriptors remain inert declarations", () {

--- a/client/app/lib/core/routing/app_router.dart
+++ b/client/app/lib/core/routing/app_router.dart
@@ -29,6 +29,10 @@ import "imperative_pane_route.dart";
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
 final _sessionShellNavigatorKey = GlobalKey<NavigatorState>();
 
+/// The root navigator hosting every app route. Used to present app-wide UI
+/// (for example backend toast guidance) without a screen context.
+GlobalKey<NavigatorState> get appRootNavigatorKey => _rootNavigatorKey;
+
 const _newSessionRouteSegment = "new";
 const _sessionsRouteSegment = ":$projectIdPathParam/sessions";
 const _sessionDetailRouteSegment = ":$sessionIdPathParam";

--- a/client/app/lib/features/splash/splash_screen.dart
+++ b/client/app/lib/features/splash/splash_screen.dart
@@ -61,14 +61,19 @@ class const _SplashScreenBody() extends StatelessWidget {
 class const _SplashView() extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return const Stack(
-      children: [
-        Positioned.fill(child: SesoriBackgroundWidget()),
-        Align(
-          alignment: .center,
-          child: Hero(tag: SesoriLogo.heroTag, child: SesoriLogo()),
-        ),
-      ],
+    // A Scaffold registers the root ScaffoldMessenger's only descendant during
+    // startup, so app-wide snackbars (for example backend toast guidance) can
+    // present while the splash route is still active.
+    return const Scaffold(
+      body: Stack(
+        children: [
+          Positioned.fill(child: SesoriBackgroundWidget()),
+          Align(
+            alignment: .center,
+            child: Hero(tag: SesoriLogo.heroTag, child: SesoriLogo()),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/client/app/lib/features/splash/splash_screen.dart
+++ b/client/app/lib/features/splash/splash_screen.dart
@@ -61,19 +61,14 @@ class const _SplashScreenBody() extends StatelessWidget {
 class const _SplashView() extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    // A Scaffold registers the root ScaffoldMessenger's only descendant during
-    // startup, so app-wide snackbars (for example backend toast guidance) can
-    // present while the splash route is still active.
-    return const Scaffold(
-      body: Stack(
-        children: [
-          Positioned.fill(child: SesoriBackgroundWidget()),
-          Align(
-            alignment: .center,
-            child: Hero(tag: SesoriLogo.heroTag, child: SesoriLogo()),
-          ),
-        ],
-      ),
+    return const Stack(
+      children: [
+        Positioned.fill(child: SesoriBackgroundWidget()),
+        Align(
+          alignment: .center,
+          child: Hero(tag: SesoriLogo.heroTag, child: SesoriLogo()),
+        ),
+      ],
     );
   }
 }

--- a/client/app/lib/main.dart
+++ b/client/app/lib/main.dart
@@ -288,12 +288,17 @@ class const SesoriApp({
   }
 }
 
+/// Root messenger for toasts raised outside any screen's own scaffold context
+/// (backend SSE toast guidance rendered by [_SseToastListener]).
+final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
+
 class const _SesoriAppShell() extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final themeMode = context.watch<AppearanceCubit>().state.themeMode;
 
     return MaterialApp.router(
+      scaffoldMessengerKey: rootScaffoldMessengerKey,
       onGenerateTitle: (context) => context.loc.appTitle,
       themeMode: themeMode,
       theme: ThemeData(
@@ -336,10 +341,40 @@ class const _SesoriAppShell() extends StatelessWidget {
               getIt<ConnectionService>(),
               getIt<RegisteredBridgesService>(),
             ),
-            child: child ?? const SizedBox.shrink(),
+            child: BlocProvider(
+              create: (_) => SseToastCubit(getIt<ConnectionService>()),
+              child: _SseToastListener(child: child ?? const SizedBox.shrink()),
+            ),
           ),
         ),
       ),
+    );
+  }
+}
+
+/// Renders backend toast states as snackbars on the root messenger, so
+/// guidance such as a local `/login` hint reaches the user on any screen.
+class const _SseToastListener({required final Widget child}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<SseToastCubit, SseToastState>(
+      listener: (context, state) {
+        if (state case SseToastShow(:final title, :final message, :final variant)) {
+          final messenger = rootScaffoldMessengerKey.currentState;
+          if (messenger == null) return;
+          final text = title == null ? message : "$title\n$message";
+          messenger.showSnackBar(
+            SnackBar(
+              content: Text(text),
+              duration: switch (variant) {
+                SseToastVariant.error || SseToastVariant.warning => const Duration(seconds: 8),
+                SseToastVariant.info || SseToastVariant.success => const Duration(seconds: 4),
+              },
+            ),
+          );
+        }
+      },
+      child: child,
     );
   }
 }

--- a/client/app/lib/main.dart
+++ b/client/app/lib/main.dart
@@ -288,17 +288,12 @@ class const SesoriApp({
   }
 }
 
-/// Root messenger for toasts raised outside any screen's own scaffold context
-/// (backend SSE toast guidance rendered by [_SseToastListener]).
-final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
-
 class const _SesoriAppShell() extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final themeMode = context.watch<AppearanceCubit>().state.themeMode;
 
     return MaterialApp.router(
-      scaffoldMessengerKey: rootScaffoldMessengerKey,
       onGenerateTitle: (context) => context.loc.appTitle,
       themeMode: themeMode,
       theme: ThemeData(
@@ -352,25 +347,30 @@ class const _SesoriAppShell() extends StatelessWidget {
   }
 }
 
-/// Renders backend toast states as snackbars on the root messenger, so
-/// guidance such as a local `/login` hint reaches the user on any screen.
+/// Renders backend toast states through the design-system popup alert
+/// presenter, so guidance such as a local `/login` hint reaches the user on
+/// any screen, including startup routes with no scaffold.
 class const _SseToastListener({required final Widget child}) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocListener<SseToastCubit, SseToastState>(
       listener: (context, state) {
         if (state case SseToastShow(:final title, :final message, :final variant)) {
-          final messenger = rootScaffoldMessengerKey.currentState;
-          if (messenger == null) return;
-          final text = title == null ? message : "$title\n$message";
-          messenger.showSnackBar(
-            SnackBar(
-              content: Text(text),
-              duration: switch (variant) {
-                SseToastVariant.error || SseToastVariant.warning => const Duration(seconds: 8),
-                SseToastVariant.info || SseToastVariant.success => const Duration(seconds: 4),
-              },
-            ),
+          final overlay = appRootNavigatorKey.currentState?.overlay;
+          if (overlay == null) return;
+          PregoPopupAlertPresenter.fromOverlayState(overlay).show(
+            title: title ?? message,
+            content: title == null ? const PregoPopupAlertContent() : PregoPopupAlertContent(message: message),
+            variant: switch (variant) {
+              SseToastVariant.info => PregoPopupAlertsNotificationsVariant.info,
+              SseToastVariant.success => PregoPopupAlertsNotificationsVariant.success,
+              SseToastVariant.warning => PregoPopupAlertsNotificationsVariant.warning,
+              SseToastVariant.error => PregoPopupAlertsNotificationsVariant.error,
+            },
+            duration: switch (variant) {
+              SseToastVariant.error || SseToastVariant.warning => const Duration(seconds: 8),
+              SseToastVariant.info || SseToastVariant.success => const Duration(seconds: 4),
+            },
           );
         }
       },

--- a/client/module_core/lib/sesori_dart_core.dart
+++ b/client/module_core/lib/sesori_dart_core.dart
@@ -100,6 +100,8 @@ export "src/cubits/settings/settings_cubit.dart";
 export "src/cubits/settings/settings_state.dart";
 export "src/cubits/splash/splash_cubit.dart";
 export "src/cubits/splash/splash_state.dart";
+export "src/cubits/sse_toast/sse_toast_cubit.dart";
+export "src/cubits/sse_toast/sse_toast_state.dart";
 // DI
 export "src/di/injection.dart";
 // Errors

--- a/client/module_core/lib/src/cubits/sse_toast/sse_toast_cubit.dart
+++ b/client/module_core/lib/src/cubits/sse_toast/sse_toast_cubit.dart
@@ -26,13 +26,14 @@ class SseToastCubit(final ConnectionService _connectionService) extends Cubit<Ss
     if (event.data case SesoriTuiToastShow(:final title, :final message, :final variant)) {
       final trimmedTitle = title?.trim();
       final trimmedMessage = message?.trim();
-      final text = trimmedMessage == null || trimmedMessage.isEmpty ? trimmedTitle : trimmedMessage;
+      final normalizedTitle = trimmedTitle == null || trimmedTitle.isEmpty ? null : trimmedTitle;
+      final text = trimmedMessage == null || trimmedMessage.isEmpty ? normalizedTitle : trimmedMessage;
       if (text == null || text.isEmpty) return;
       if (isClosed) return;
       emit(
         SseToastState.show(
           sequence: ++_sequence,
-          title: trimmedMessage == null || trimmedMessage.isEmpty ? null : trimmedTitle,
+          title: trimmedMessage == null || trimmedMessage.isEmpty ? null : normalizedTitle,
           message: text,
           variant: SseToastVariant.parse(variant),
         ),

--- a/client/module_core/lib/src/cubits/sse_toast/sse_toast_cubit.dart
+++ b/client/module_core/lib/src/cubits/sse_toast/sse_toast_cubit.dart
@@ -1,0 +1,48 @@
+import "dart:async";
+
+import "package:bloc/bloc.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../../capabilities/server_connection/connection_service.dart";
+import "../../capabilities/server_connection/models/sse_event.dart";
+import "sse_toast_state.dart";
+
+/// Surfaces backend-neutral `tui.toast.show` SSE events (backend notifications
+/// and guidance such as a local `/login` hint) as app-wide toast states.
+///
+/// Every accepted event emits a new [SseToastShow] with a monotonic sequence,
+/// so equal repeated guidance is still a distinct effect. Events carrying no
+/// renderable text are dropped.
+class SseToastCubit(final ConnectionService _connectionService) extends Cubit<SseToastState> {
+  late final StreamSubscription<SseEvent> _subscription;
+  int _sequence = 0;
+
+  // ignore: no_slop_linter/prefer_required_named_parameters, public cubit constructor API
+  this : super(const SseToastState.idle()) {
+    _subscription = _connectionService.events.listen(_handleEvent);
+  }
+
+  void _handleEvent(SseEvent event) {
+    if (event.data case SesoriTuiToastShow(:final title, :final message, :final variant)) {
+      final trimmedTitle = title?.trim();
+      final trimmedMessage = message?.trim();
+      final text = trimmedMessage == null || trimmedMessage.isEmpty ? trimmedTitle : trimmedMessage;
+      if (text == null || text.isEmpty) return;
+      if (isClosed) return;
+      emit(
+        SseToastState.show(
+          sequence: ++_sequence,
+          title: trimmedMessage == null || trimmedMessage.isEmpty ? null : trimmedTitle,
+          message: text,
+          variant: SseToastVariant.parse(variant),
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<void> close() async {
+    await _subscription.cancel();
+    await super.close();
+  }
+}

--- a/client/module_core/lib/src/cubits/sse_toast/sse_toast_state.dart
+++ b/client/module_core/lib/src/cubits/sse_toast/sse_toast_state.dart
@@ -1,0 +1,36 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "sse_toast_state.freezed.dart";
+
+/// Severity of a backend toast, parsed at the boundary from the wire's raw
+/// variant string. Unknown or absent variants degrade to [info].
+enum SseToastVariant() {
+  info,
+  success,
+  warning,
+  error;
+
+  static SseToastVariant parse(String? raw) => switch (raw) {
+    "success" => SseToastVariant.success,
+    "warning" => SseToastVariant.warning,
+    "error" => SseToastVariant.error,
+    _ => SseToastVariant.info,
+  };
+}
+
+/// What the app-wide toast surface should present.
+///
+/// [SseToastShow.sequence] increases on every show so equal repeated guidance
+/// (for example the same `/login` hint twice) is still a distinct effect for
+/// listeners comparing states.
+@Freezed()
+sealed class SseToastState with _$SseToastState {
+  const factory idle() = SseToastIdle;
+
+  const factory show({
+    required int sequence,
+    required String? title,
+    required String message,
+    required SseToastVariant variant,
+  }) = SseToastShow;
+}

--- a/client/module_core/lib/src/cubits/sse_toast/sse_toast_state.freezed.dart
+++ b/client/module_core/lib/src/cubits/sse_toast/sse_toast_state.freezed.dart
@@ -1,0 +1,150 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint, type=warning, deprecated_member_use, deprecated_member_use_from_same_package
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'sse_toast_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$SseToastState {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SseToastState);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'SseToastState()';
+}
+
+
+}
+
+/// @nodoc
+class $SseToastStateCopyWith<$Res>  {
+$SseToastStateCopyWith(SseToastState _, $Res Function(SseToastState) __);
+}
+
+
+
+/// @nodoc
+
+
+class SseToastIdle implements SseToastState {
+  const SseToastIdle();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SseToastIdle);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'SseToastState.idle()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class SseToastShow implements SseToastState {
+  const SseToastShow({required this.sequence, required this.title, required this.message, required this.variant});
+  
+
+ final  int sequence;
+ final  String? title;
+ final  String message;
+ final  SseToastVariant variant;
+
+/// Create a copy of SseToastState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SseToastShowCopyWith<SseToastShow> get copyWith => _$SseToastShowCopyWithImpl<SseToastShow>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SseToastShow&&(identical(other.sequence, sequence) || other.sequence == sequence)&&(identical(other.title, title) || other.title == title)&&(identical(other.message, message) || other.message == message)&&(identical(other.variant, variant) || other.variant == variant));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,sequence,title,message,variant);
+
+@override
+String toString() {
+  return 'SseToastState.show(sequence: $sequence, title: $title, message: $message, variant: $variant)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SseToastShowCopyWith<$Res> implements $SseToastStateCopyWith<$Res> {
+  factory $SseToastShowCopyWith(SseToastShow value, $Res Function(SseToastShow) _then) = _$SseToastShowCopyWithImpl;
+@useResult
+$Res call({
+ int sequence, String? title, String message, SseToastVariant variant
+});
+
+
+
+
+}
+/// @nodoc
+class _$SseToastShowCopyWithImpl<$Res>
+    implements $SseToastShowCopyWith<$Res> {
+  _$SseToastShowCopyWithImpl(this._self, this._then);
+
+  final SseToastShow _self;
+  final $Res Function(SseToastShow) _then;
+
+/// Create a copy of SseToastState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? sequence = null,Object? title = freezed,Object? message = null,Object? variant = null,}) {
+  return _then(SseToastShow(
+sequence: null == sequence ? _self.sequence : sequence // ignore: cast_nullable_to_non_nullable
+as int,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String?,message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,variant: null == variant ? _self.variant : variant // ignore: cast_nullable_to_non_nullable
+as SseToastVariant,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/client/module_core/test/cubits/sse_toast/sse_toast_cubit_test.dart
+++ b/client/module_core/test/cubits/sse_toast/sse_toast_cubit_test.dart
@@ -1,0 +1,83 @@
+import "dart:async";
+
+import "package:bloc_test/bloc_test.dart";
+import "package:mocktail/mocktail.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/models/sse_event.dart";
+import "package:sesori_dart_core/src/cubits/sse_toast/sse_toast_cubit.dart";
+import "package:sesori_dart_core/src/cubits/sse_toast/sse_toast_state.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "../../helpers/test_helpers.dart";
+
+void main() {
+  group("SseToastCubit", () {
+    late MockConnectionService connectionService;
+    late StreamController<SseEvent> events;
+
+    setUp(() {
+      connectionService = MockConnectionService();
+      events = StreamController<SseEvent>.broadcast();
+      when(() => connectionService.events).thenAnswer((_) => events.stream);
+    });
+
+    tearDown(() async {
+      await events.close();
+    });
+
+    SseToastCubit buildCubit() => SseToastCubit(connectionService);
+
+    blocTest<SseToastCubit, SseToastState>(
+      "shows a toast with parsed variant and monotonic sequence for repeated equal guidance",
+      build: buildCubit,
+      act: (cubit) {
+        events.add(
+          SseEvent(
+            data: const SesoriSseEvent.tuiToastShow(title: "Pi login required", message: "Run /login", variant: "warning"),
+          ),
+        );
+        events.add(
+          SseEvent(
+            data: const SesoriSseEvent.tuiToastShow(title: "Pi login required", message: "Run /login", variant: "warning"),
+          ),
+        );
+      },
+      expect: () => const [
+        SseToastState.show(
+          sequence: 1,
+          title: "Pi login required",
+          message: "Run /login",
+          variant: SseToastVariant.warning,
+        ),
+        SseToastState.show(
+          sequence: 2,
+          title: "Pi login required",
+          message: "Run /login",
+          variant: SseToastVariant.warning,
+        ),
+      ],
+    );
+
+    blocTest<SseToastCubit, SseToastState>(
+      "falls back to the title as message and info variant for unknown variants",
+      build: buildCubit,
+      act: (cubit) => events.add(
+        SseEvent(data: const SesoriSseEvent.tuiToastShow(title: "Notice", message: "  ", variant: "sparkle")),
+      ),
+      expect: () => const [
+        SseToastState.show(sequence: 1, title: null, message: "Notice", variant: SseToastVariant.info),
+      ],
+    );
+
+    blocTest<SseToastCubit, SseToastState>(
+      "drops toasts with no renderable text and non-toast events",
+      build: buildCubit,
+      act: (cubit) {
+        events.add(SseEvent(data: const SesoriSseEvent.tuiToastShow(title: null, message: null, variant: "error")));
+        events.add(SseEvent(data: const SesoriSseEvent.tuiToastShow(title: " ", message: "", variant: null)));
+        events.add(SseEvent(data: const SesoriSseEvent.projectUpdated(projectID: null, updatedAt: null)));
+      },
+      expect: () => const <SseToastState>[],
+    );
+  });
+}

--- a/client/module_core/test/cubits/sse_toast/sse_toast_cubit_test.dart
+++ b/client/module_core/test/cubits/sse_toast/sse_toast_cubit_test.dart
@@ -70,6 +70,17 @@ void main() {
     );
 
     blocTest<SseToastCubit, SseToastState>(
+      "normalizes a whitespace-only title to null when the message carries the text",
+      build: buildCubit,
+      act: (cubit) => events.add(
+        SseEvent(data: const SesoriSseEvent.tuiToastShow(title: "  ", message: "Run /login", variant: "warning")),
+      ),
+      expect: () => const [
+        SseToastState.show(sequence: 1, title: null, message: "Run /login", variant: SseToastVariant.warning),
+      ],
+    );
+
+    blocTest<SseToastCubit, SseToastState>(
       "drops toasts with no renderable text and non-toast events",
       build: buildCubit,
       act: (cubit) {

--- a/client/module_prego/lib/components/alerts/prego_popup_alerts_notifications.dart
+++ b/client/module_prego/lib/components/alerts/prego_popup_alerts_notifications.dart
@@ -266,14 +266,18 @@ final class PregoPopupAlertPresenter._({
   }
 
   /// Captures an explicit overlay for callers outside any route's context,
-  /// such as app-wide listeners driven by backend events.
+  /// such as app-wide listeners driven by backend events. The alert clears
+  /// the top bar and a visible banner through the published root top-bar
+  /// geometry, falling back to the plain top-bar inset when no Prego scaffold
+  /// is mounted.
   static PregoPopupAlertPresenter fromOverlayState(OverlayState overlay) {
     return PregoPopupAlertPresenter._(
       overlay: overlay,
-      topInset: pregoTopBarInsetOf(
-        context: overlay.context,
-        fallbackTopPadding: MediaQuery.paddingOf(overlay.context).top,
-      ),
+      topInset: pregoRootTopBarInsetFor(overlay) ??
+          pregoTopBarInsetOf(
+            context: overlay.context,
+            fallbackTopPadding: MediaQuery.paddingOf(overlay.context).top,
+          ),
     );
   }
 

--- a/client/module_prego/lib/components/alerts/prego_popup_alerts_notifications.dart
+++ b/client/module_prego/lib/components/alerts/prego_popup_alerts_notifications.dart
@@ -265,6 +265,18 @@ final class PregoPopupAlertPresenter._({
     );
   }
 
+  /// Captures an explicit overlay for callers outside any route's context,
+  /// such as app-wide listeners driven by backend events.
+  static PregoPopupAlertPresenter fromOverlayState(OverlayState overlay) {
+    return PregoPopupAlertPresenter._(
+      overlay: overlay,
+      topInset: pregoTopBarInsetOf(
+        context: overlay.context,
+        fallbackTopPadding: MediaQuery.paddingOf(overlay.context).top,
+      ),
+    );
+  }
+
   /// Shows an alert above the current route and replaces any alert already
   /// visible on the same overlay.
   void show({

--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -185,6 +185,8 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
   /// The root overlay this scaffold publishes geometry for.
   OverlayState? _rootOverlay;
 
+  final top_bar.PregoRootTopBarInsetOwner _rootInsetOwner = top_bar.PregoRootTopBarInsetOwner();
+
   /// The collapsing title's rendered extent, including its bottom spacing.
   /// Used to paint the refresh indicator below the title without assuming a
   /// fixed text scale or whether a subtitle is present.
@@ -206,7 +208,7 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
     _bannerHeight.removeListener(_publishRootInset);
     final rootOverlay = _rootOverlay;
     if (rootOverlay != null) {
-      top_bar.clearPregoRootTopBarInset(overlay: rootOverlay, owner: this);
+      top_bar.clearPregoRootTopBarInset(overlay: rootOverlay, owner: _rootInsetOwner);
     }
     _scrollController.dispose();
     _bannerHeight.dispose();
@@ -222,7 +224,7 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
     if (rootOverlay == null) return;
     top_bar.publishPregoRootTopBarInset(
       overlay: rootOverlay,
-      owner: this,
+      owner: _rootInsetOwner,
       inset: _baseInset + _bannerHeight.value,
     );
   }
@@ -488,7 +490,7 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
     if (!identical(_rootOverlay, rootOverlay)) {
       final previousOverlay = _rootOverlay;
       if (previousOverlay != null) {
-        top_bar.clearPregoRootTopBarInset(overlay: previousOverlay, owner: this);
+        top_bar.clearPregoRootTopBarInset(overlay: previousOverlay, owner: _rootInsetOwner);
       }
       _rootOverlay = rootOverlay;
     }

--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -178,6 +178,13 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
   /// content tracks the moving bar and is exact at rest.
   final ValueNotifier<double> _bannerHeight = ValueNotifier<double>(0);
 
+  /// The base inset captured during the latest build, combined with
+  /// [_bannerHeight] when publishing to [top_bar.pregoRootTopBarInset].
+  double _baseInset = 0;
+
+  /// The root overlay this scaffold publishes geometry for.
+  OverlayState? _rootOverlay;
+
   /// The collapsing title's rendered extent, including its bottom spacing.
   /// Used to paint the refresh indicator below the title without assuming a
   /// fixed text scale or whether a subtitle is present.
@@ -189,10 +196,35 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
   double _refreshPulledExtent = 0;
 
   @override
+  void initState() {
+    super.initState();
+    _bannerHeight.addListener(_publishRootInset);
+  }
+
+  @override
   void dispose() {
+    _bannerHeight.removeListener(_publishRootInset);
+    final rootOverlay = _rootOverlay;
+    if (rootOverlay != null) {
+      top_bar.clearPregoRootTopBarInset(overlay: rootOverlay, owner: this);
+    }
     _scrollController.dispose();
     _bannerHeight.dispose();
     super.dispose();
+  }
+
+  /// Publishes this scaffold's live top-bar inset so app-wide presentation
+  /// outside any route can clear the top bar and a visible banner. The most
+  /// recently built (topmost) scaffold wins.
+  void _publishRootInset() {
+    if (!mounted) return;
+    final rootOverlay = _rootOverlay;
+    if (rootOverlay == null) return;
+    top_bar.publishPregoRootTopBarInset(
+      overlay: rootOverlay,
+      owner: this,
+      inset: _baseInset + _bannerHeight.value,
+    );
   }
 
   /// The floating action handed to the standalone [Scaffold], positioned per
@@ -449,6 +481,19 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
             valueListenable: _bannerHeight,
             builder: (context, bannerHeight, _) => buildScaffold(bannerHeight),
           );
+
+    // Publish the root inset seam before building the bar area so app-wide
+    // presentation created during this frame already sees current geometry.
+    final rootOverlay = Overlay.maybeOf(context, rootOverlay: true);
+    if (!identical(_rootOverlay, rootOverlay)) {
+      final previousOverlay = _rootOverlay;
+      if (previousOverlay != null) {
+        top_bar.clearPregoRootTopBarInset(overlay: previousOverlay, owner: this);
+      }
+      _rootOverlay = rootOverlay;
+    }
+    _baseInset = topPad + PregoTopNavigation.barHeight;
+    _publishRootInset();
 
     // Remove this wrapper once liquid_glass_widgets migrates from the Flutter SDK Material and Cupertino libraries to material_ui and cupertino_ui.
     return Scaffold(

--- a/client/module_prego/lib/components/navigation/prego_top_bar_inset.dart
+++ b/client/module_prego/lib/components/navigation/prego_top_bar_inset.dart
@@ -29,12 +29,16 @@ double pregoTopBarInsetOf({
 
 final Expando<_PregoRootTopBarInsets> _pregoRootTopBarInsetsByOverlay = Expando<_PregoRootTopBarInsets>();
 
+/// Opaque identity for one mounted root-inset publisher. This seam is kept out
+/// of the package barrel and used only by Prego scaffold/presenter internals.
+final class PregoRootTopBarInsetOwner();
+
 /// Publishes the current root inset for [owner]. A newly mounted publisher
 /// becomes active; updates from an older mounted scaffold retain its place so
 /// a covered route cannot displace the topmost route during a shared rebuild.
 void publishPregoRootTopBarInset({
   required OverlayState overlay,
-  required Object owner,
+  required PregoRootTopBarInsetOwner owner,
   required double inset,
 }) {
   final insets = _pregoRootTopBarInsetsByOverlay[overlay] ??= _PregoRootTopBarInsets();
@@ -43,7 +47,7 @@ void publishPregoRootTopBarInset({
 
 /// Removes [owner] and restores the previous mounted scaffold when the active
 /// route unmounts.
-void clearPregoRootTopBarInset({required OverlayState overlay, required Object owner}) {
+void clearPregoRootTopBarInset({required OverlayState overlay, required PregoRootTopBarInsetOwner owner}) {
   _pregoRootTopBarInsetsByOverlay[overlay]?.clear(owner: owner);
 }
 
@@ -52,15 +56,15 @@ void clearPregoRootTopBarInset({required OverlayState overlay, required Object o
 double? pregoRootTopBarInsetFor(OverlayState overlay) => _pregoRootTopBarInsetsByOverlay[overlay]?.activeInset;
 
 final class _PregoRootTopBarInsets() {
-  final Map<Object, double> _mounted = <Object, double>{};
+  final Map<PregoRootTopBarInsetOwner, double> _mounted = <PregoRootTopBarInsetOwner, double>{};
 
   double? get activeInset => _mounted.isEmpty ? null : _mounted.values.last;
 
-  void publish({required Object owner, required double inset}) {
+  void publish({required PregoRootTopBarInsetOwner owner, required double inset}) {
     _mounted[owner] = inset;
   }
 
-  void clear({required Object owner}) {
+  void clear({required PregoRootTopBarInsetOwner owner}) {
     _mounted.remove(owner);
   }
 }

--- a/client/module_prego/lib/components/navigation/prego_top_bar_inset.dart
+++ b/client/module_prego/lib/components/navigation/prego_top_bar_inset.dart
@@ -27,6 +27,44 @@ double pregoTopBarInsetOf({
   return scope.baseInset + scope.bannerHeight.value;
 }
 
+final Expando<_PregoRootTopBarInsets> _pregoRootTopBarInsetsByOverlay = Expando<_PregoRootTopBarInsets>();
+
+/// Publishes the current root inset for [owner]. A newly mounted publisher
+/// becomes active; updates from an older mounted scaffold retain its place so
+/// a covered route cannot displace the topmost route during a shared rebuild.
+void publishPregoRootTopBarInset({
+  required OverlayState overlay,
+  required Object owner,
+  required double inset,
+}) {
+  final insets = _pregoRootTopBarInsetsByOverlay[overlay] ??= _PregoRootTopBarInsets();
+  insets.publish(owner: owner, inset: inset);
+}
+
+/// Removes [owner] and restores the previous mounted scaffold when the active
+/// route unmounts.
+void clearPregoRootTopBarInset({required OverlayState overlay, required Object owner}) {
+  _pregoRootTopBarInsetsByOverlay[overlay]?.clear(owner: owner);
+}
+
+/// Returns the active top-bar inset published for [overlay], or `null` when no
+/// Prego scaffold is mounted in that overlay.
+double? pregoRootTopBarInsetFor(OverlayState overlay) => _pregoRootTopBarInsetsByOverlay[overlay]?.activeInset;
+
+final class _PregoRootTopBarInsets() {
+  final Map<Object, double> _mounted = <Object, double>{};
+
+  double? get activeInset => _mounted.isEmpty ? null : _mounted.values.last;
+
+  void publish({required Object owner, required double inset}) {
+    _mounted[owner] = inset;
+  }
+
+  void clear({required Object owner}) {
+    _mounted.remove(owner);
+  }
+}
+
 /// Rebuilds [builder] as the enclosing top-navigation banner changes height.
 class const PregoTopBarInsetBuilder({
   super.key,

--- a/client/module_prego/lib/module_prego.dart
+++ b/client/module_prego/lib/module_prego.dart
@@ -23,7 +23,8 @@ export 'components/navigation/prego_glass_scaffold.dart';
 export 'components/navigation/prego_nav_leading_title.dart';
 export 'components/navigation/prego_nav_subtitle.dart';
 export 'components/navigation/prego_nav_title.dart';
-export 'components/navigation/prego_top_bar_inset.dart';
+export 'components/navigation/prego_top_bar_inset.dart'
+    show PregoTopBarInsetBuilder, PregoTopBarInsetScope, pregoTopBarInsetOf;
 export 'components/navigation/prego_top_navigation.dart';
 export 'components/navigation/prego_top_navigation_sheets.dart';
 export 'components/surfaces/prego_bottom_sheet.dart';

--- a/client/module_prego/test/components/prego_popup_alerts_notifications_test.dart
+++ b/client/module_prego/test/components/prego_popup_alerts_notifications_test.dart
@@ -1,7 +1,11 @@
 import "package:flutter_test/flutter_test.dart";
 import "package:material_ui/material_ui.dart";
 import "package:theme_prego/components/navigation/prego_top_bar_inset.dart"
-    show clearPregoRootTopBarInset, pregoRootTopBarInsetFor, publishPregoRootTopBarInset;
+    show
+        PregoRootTopBarInsetOwner,
+        clearPregoRootTopBarInset,
+        pregoRootTopBarInsetFor,
+        publishPregoRootTopBarInset;
 import "package:theme_prego/module_prego.dart";
 
 void main() {
@@ -17,8 +21,8 @@ void main() {
         ),
       ),
     );
-    final underlying = Object();
-    final topmost = Object();
+    final underlying = PregoRootTopBarInsetOwner();
+    final topmost = PregoRootTopBarInsetOwner();
 
     publishPregoRootTopBarInset(overlay: overlay, owner: underlying, inset: 70);
     publishPregoRootTopBarInset(overlay: overlay, owner: topmost, inset: 90);

--- a/client/module_prego/test/components/prego_popup_alerts_notifications_test.dart
+++ b/client/module_prego/test/components/prego_popup_alerts_notifications_test.dart
@@ -1,8 +1,36 @@
 import "package:flutter_test/flutter_test.dart";
 import "package:material_ui/material_ui.dart";
+import "package:theme_prego/components/navigation/prego_top_bar_inset.dart"
+    show clearPregoRootTopBarInset, pregoRootTopBarInsetFor, publishPregoRootTopBarInset;
 import "package:theme_prego/module_prego.dart";
 
 void main() {
+  testWidgets("root top-bar inset retains and restores mounted scaffold order", (tester) async {
+    late OverlayState overlay;
+    await tester.pumpWidget(
+      _harness(
+        Builder(
+          builder: (context) {
+            overlay = Overlay.of(context, rootOverlay: true);
+            return const SizedBox.expand();
+          },
+        ),
+      ),
+    );
+    final underlying = Object();
+    final topmost = Object();
+
+    publishPregoRootTopBarInset(overlay: overlay, owner: underlying, inset: 70);
+    publishPregoRootTopBarInset(overlay: overlay, owner: topmost, inset: 90);
+    publishPregoRootTopBarInset(overlay: overlay, owner: underlying, inset: 80);
+    expect(pregoRootTopBarInsetFor(overlay), 90);
+
+    clearPregoRootTopBarInset(overlay: overlay, owner: topmost);
+    expect(pregoRootTopBarInsetFor(overlay), 80);
+    clearPregoRootTopBarInset(overlay: overlay, owner: underlying);
+    expect(pregoRootTopBarInsetFor(overlay), isNull);
+  });
+
   testWidgets("renders each visual variant and optional content", (tester) async {
     for (final variant in PregoPopupAlertsNotificationsVariant.values) {
       await tester.pumpWidget(
@@ -180,7 +208,9 @@ void main() {
       lessThan(800 - 2 * PregoSpacing.xl),
     );
     final contentRight = tester.getTopRight(find.text("Your changes were saved successfully")).dx;
-    final buttonRight = tester.getTopRight(find.ancestor(of: find.text("Open"), matching: find.byType(Semantics)).first).dx;
+    final buttonRight = tester
+        .getTopRight(find.ancestor(of: find.text("Open"), matching: find.byType(Semantics)).first)
+        .dx;
     expect(buttonRight, contentRight);
   });
 
@@ -293,6 +323,31 @@ void main() {
     await tester.pumpAndSettle();
 
     final presenter = PregoPopupAlertPresenter.of(presentationContext);
+    presenter.show(title: "Below banner", duration: null);
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.getTopLeft(find.byType(PregoPopupAlertsNotifications)).dy,
+      PregoTopNavigation.barHeight + 30 + PregoSpacing.xl,
+    );
+  });
+
+  testWidgets("explicit-overlay presenter clears the active scaffold banner", (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(extensions: [PregoDesignSystem.dark]),
+        home: const PregoGlassScaffold(
+          title: "Screen",
+          banner: SizedBox(height: 30),
+          slivers: [SliverFillRemaining(child: SizedBox.expand())],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final presenter = PregoPopupAlertPresenter.fromOverlayState(
+      tester.state<OverlayState>(find.byType(Overlay).first),
+    );
     presenter.show(title: "Below banner", duration: null);
     await tester.pumpAndSettle();
 

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -21,6 +21,15 @@ idle suspension, the management snapshot, and lifecycle commands.
   while preserving an explicit path as authoritative.
   Model/provider setup remains an out-of-band Hermes CLI action, so authentication-required
   Hermes entries give local setup guidance rather than offering bridge-managed login.
+- Pi and Oh My Pi are registered harnesses with managed installs where a platform
+  archive exists and explicit `--pi-bin`/`--omp-bin` paths stay authoritative. Pi
+  sessions always launch with `--approve` (project-local Pi settings, extensions,
+  skills, and prompt templates are trusted without prompts); OMP inherits the user's
+  `tools.approvalMode`. Provider login for both happens locally, never from the phone.
+- Backend `tui.toast.show` SSE events render app-wide through the backend-neutral
+  toast surface: every accepted toast is a new effect (equal repeated guidance
+  included), toasts with no renderable text are dropped, and unknown variants
+  degrade to info.
 - Listings order by display name case-insensitively with the identifier as tie-breaker,
   and the default is the preferred harness when selectable, else the first selectable.
 - Client-owned branding maps recognized built-in harness ids to their stable names and

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -27,7 +27,8 @@ idle suspension, the management snapshot, and lifecycle commands.
   skills, and prompt templates are trusted without prompts); OMP inherits the user's
   `tools.approvalMode`. Provider login for both happens locally, never from the phone.
 - Backend `tui.toast.show` SSE events render app-wide through the backend-neutral
-  toast surface: every accepted toast is a new effect (equal repeated guidance
+  toast surface, presented with the design-system popup alert on the root
+  navigator's overlay: every accepted toast is a new effect (equal repeated guidance
   included), toasts with no renderable text are dropped, and unknown variants
   degrade to info.
 - Listings order by display name case-insensitively with the identifier as tie-breaker,

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_identity.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_identity.dart
@@ -9,7 +9,9 @@ enum Harness() {
   codex,
   cursor,
   claude,
-  hermes;
+  hermes,
+  pi,
+  omp;
 }
 
 // COMPATIBILITY 2026-07-13 (v1.5.0): Old peers omit pluginId and mean OpenCode. Remove constant/export with defaults.


### PR DESCRIPTION
## Complexity

⚙️ Moderate: additive registration across shared enum, bridge registry, and a new client toast surface; no wire, database, or lifecycle machinery changes.

## What

- Add `Harness.pi` and `Harness.omp` to the shared built-in harness enum.
- Add `pi_plugin`/`omp_plugin` dependencies to the bridge app and register `PiPluginDescriptor.production()` and `OmpPluginDescriptor.production()` in `plugin_registry.dart` (list became `final List.unmodifiable` — both descriptors use non-const factories). OpenCode stays the preferred default; existing entries preserved.
- Add backend-neutral `SseToastCubit` in `module_core`: maps `tui.toast.show` SSE events to sealed idle/show states with a monotonic sequence so equal repeated guidance re-fires; textless toasts drop; unknown variants degrade to info. The mobile shell renders shows as snackbars via a new root scaffold messenger.
- Record mandatory activation guidance in README and the plugin-setup regression doc: Pi always runs with `--approve` (project-local Pi settings/extensions/skills/templates trusted without prompts), OMP inherits the user's `tools.approvalMode`, and provider login is local-only.
- Update registry exact-set fixtures and add a test pinning every registered id to a built-in `Harness` identity.

## Why

Step 18 of the pi-harness plan: both backend plugins are complete (Steps 16-17 merged), so the bridge can register them and the app can select them. The toast surface is the minimum safety presentation required before activation — backend notifications and local `/login` guidance must reach the user.

## Risk and test focus

Low-moderate risk. Registration is additive and inert (descriptors are side-effect free); the main flows to watch are harness listing/default selection and the new global toast rendering. Most valuable checks: registry exact set, preferred default unchanged, toast monotonic repeat/empty-drop/variant fallback, and that older clients treat the new `pi`/`omp` ids through existing data-driven fallback (generic icon, raw-id name).

## Expected result

Pi and Oh My Pi appear as selectable harnesses on the bridge and phone once their setup is ready, with their trust/approval guidance documented, and backend toast guidance reaches users on any screen. No database or persisted-data change; wire contracts unchanged (plugin ids remain strings).

## Verification

- Bridge app: `dart analyze --fatal-infos` clean; full suite 2,674 tests pass.
- Pi plugin: 255 tests; OMP plugin: 51 tests; shared: 409 tests.
- module_core: toast cubit tests pass; analyzer clean. Mobile shell: `flutter analyze --fatal-infos` clean.
- Architecture implementation review: approved, no findings.

## Diff evidence

- +393/−10 = 403 changed lines before plan/tracker evidence; generated lines: 46.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers Pi and Oh My Pi as built-in harnesses and routes backend toast guidance through design‑system popups that respect active top bars/banners. Previously Pi/OMP were not selectable and toasts were inconsistent or obscured; now both appear in listings and tui.toast.show renders app‑wide below banners on any screen.

- Bridge: add Harness.pi/Harness.omp; register `PiPluginDescriptor.production()` and `OmpPluginDescriptor.production()`; switch `knownPlugins` to `List.unmodifiable`; add `pi_plugin` and `omp_plugin`. OpenCode remains the preferred default.
- Toasts: add SseToastCubit mapping `tui.toast.show` SSE to idle/show with a monotonic sequence; drop textless toasts; normalize blank titles; unknown variants degrade to info. Render with PregoPopupAlertPresenter on the root navigator’s overlay (exposes appRootNavigatorKey and adds fromOverlayState). PregoGlassScaffold publishes live root top‑bar inset per overlay so global popups sit below active banners and restore the underlying route after a pop; publisher identities are now typed and kept out of the `module_prego` barrel. The old root‑ScaffoldMessenger path and splash scaffolding are not needed.
- Docs: document Pi’s always‑`--approve` trust, OMP’s inherited `tools.approvalMode`, and local‑only provider login in README and regression docs.
- Tests/compat: pin the registry exact set (includes `pi`/`omp`) and map each id to a built‑in Harness; add cubit tests for repeat, fallback, title normalization, and empty‑drop; add overlay/inset presenter tests. No database or wire changes; descriptors remain inert; older clients handle new ids via existing fallback.

<sup>Written for commit 2efa57327958355733adac33367ba53ab44b7e53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

