### PR TITLE
🌱 [hermes-agent-plugin] docs: retire the plan [step 9/9]

### DIFF
--- a/.plan/completed/hermes-agent-plugin/PLAN.md
+++ b/.plan/completed/hermes-agent-plugin/PLAN.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Plan slug:** `hermes-agent-plugin`
-- **Status:** complete; Steps 1-8 merged (#915-#921, #927, #929, extended by #965), Step 9 retires the plan with owner-accepted reduction
+- **Status:** complete; Steps 1-8 merged (#895, #915, #916, #917, #919, #921, #927, #929, extended by #955 and #965), Step 9 retires the plan with owner-accepted reduction
 - **Plan date:** 2026-08-13
 - **Owner review:** started 2026-08-15; the contributor-authored plan was not previously approved
 - **Implementation base:** current `origin/main`
@@ -123,7 +123,7 @@ one consumer.
 | 5/9 | `⚙️ [hermes-agent-plugin] feat(hermes): register the plugin in the bridge [step 5/9]` | Merged as #919. |
 | 6/9 | `⚙️ [hermes-agent-plugin] feat(client): brand the Hermes harness [step 6/9]` | Merged as #921; corrected supplied artwork and asset contract. |
 | 7/9 | `🚧 [hermes-agent-plugin] fix(hermes): correct runtime and ACP assumptions [step 7/9]` | Merged as #927: auth selection, version semantics, executable revalidation, setup failure classification, null activation retry, exact registry test, plan/docs correction. |
-| 8/9 | `🚧 [hermes-agent-plugin] test(hermes): verify production ACP behavior [step 8/9]` | Merged as #929, extended by the 2026-08-18 iOS client E2E run in `TRACKER.md`. Session creation, tools and file changes, images, history and recovery, and deletion now pass; `Plugin setup and lifecycle` (L4 idle respawn), `Session turns` (reasoning streaming), `Questions and permissions`, `Projects and sessions` (failed/cancelled import), and `Compatibility` remain blocked. |
+| 8/9 | `🚧 [hermes-agent-plugin] test(hermes): verify production ACP behavior [step 8/9]` | Merged as #929, extended by the 2026-08-18 iOS client E2E run recorded in `TRACKER.md` (#955) and the session-option documentation (#965). Session creation, tools and file changes, images, history and recovery, and deletion now pass; `Plugin setup and lifecycle` (L4 idle respawn), `Session turns` (reasoning streaming), `Questions and permissions`, `Projects and sessions` (failed/cancelled import), and `Compatibility` remain blocked. |
 | 9/9 | `🌱 [hermes-agent-plugin] docs: retire the plan [step 9/9]` | Done; retires the plan under the owner-accepted reduction recorded below. |
 
 ## Regression And Retirement Matrix

--- a/.plan/completed/hermes-agent-plugin/PLAN.md
+++ b/.plan/completed/hermes-agent-plugin/PLAN.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Plan slug:** `hermes-agent-plugin`
-- **Status:** corrective review complete through Step 8; Steps 1-8 merged (#921, #927, #929), Step 9 blocked
+- **Status:** complete; Steps 1-8 merged (#915-#921, #927, #929, extended by #965), Step 9 retires the plan with owner-accepted reduction
 - **Plan date:** 2026-08-13
 - **Owner review:** started 2026-08-15; the contributor-authored plan was not previously approved
 - **Implementation base:** current `origin/main`
@@ -124,7 +124,7 @@ one consumer.
 | 6/9 | `⚙️ [hermes-agent-plugin] feat(client): brand the Hermes harness [step 6/9]` | Merged as #921; corrected supplied artwork and asset contract. |
 | 7/9 | `🚧 [hermes-agent-plugin] fix(hermes): correct runtime and ACP assumptions [step 7/9]` | Merged as #927: auth selection, version semantics, executable revalidation, setup failure classification, null activation retry, exact registry test, plan/docs correction. |
 | 8/9 | `🚧 [hermes-agent-plugin] test(hermes): verify production ACP behavior [step 8/9]` | Merged as #929, extended by the 2026-08-18 iOS client E2E run in `TRACKER.md`. Session creation, tools and file changes, images, history and recovery, and deletion now pass; `Plugin setup and lifecycle` (L4 idle respawn), `Session turns` (reasoning streaming), `Questions and permissions`, `Projects and sessions` (failed/cancelled import), and `Compatibility` remain blocked. |
-| 9/9 | `🌱 [hermes-agent-plugin] docs: retire the plan [step 9/9]` | Pending; blocked until every required row below passes. |
+| 9/9 | `🌱 [hermes-agent-plugin] docs: retire the plan [step 9/9]` | Done; retires the plan under the owner-accepted reduction recorded below. |
 
 ## Regression And Retirement Matrix
 
@@ -148,8 +148,17 @@ targeted L4 recovery checks; unchanged plugins retain their existing coverage.
 
 Step 9 cannot retire this plan while a required row is unexecuted, partial,
 blocked, or failed unless the owner explicitly accepts that reduction here.
-The 2026-08-15 Step 8 execution in `TRACKER.md`, as extended by the 2026-08-18
-iOS client E2E run, still contains blocked rows, so Step 9 remains prohibited.
+
+**Owner acceptance recorded 2026-08-18:** the owner explicitly accepted
+retirement with five rows still Blocked, each on one specific unexercised
+item: `Plugin setup and lifecycle` (targeted L4 idle respawn), `Session turns`
+(reasoning streaming; no `agent_thought_chunk` observed), `Questions and
+permissions` (no ACP permission request was ever emitted), `Projects and
+sessions` (failed/cancelled in-flight import), and `Compatibility` (second
+build pair). Each gap is also recorded as a removable note in the relevant
+feature document under `docs/regression/` so it survives this retirement.
+These remain unverified; no future change may cite this plan as evidence that
+they pass.
 
 ## Risks And Test Focus
 

--- a/.plan/completed/hermes-agent-plugin/TRACKER.md
+++ b/.plan/completed/hermes-agent-plugin/TRACKER.md
@@ -3,11 +3,13 @@
 ## Current State
 
 - **Plan slug:** `hermes-agent-plugin`
-- **Owner review:** in progress since 2026-08-15
+- **Owner review:** complete
 - **Current open PR:** none
-- **Local successor:** none; Step 9 retirement is blocked
-- **Next action:** exercise the remaining blocked matrix rows — `Plugin setup and lifecycle` (L4 idle respawn), `Session turns` (reasoning streaming), `Questions and permissions`, `Projects and sessions` (failed/cancelled import), and `Compatibility` — or record explicit owner acceptance
-- **Retirement:** blocked on the Step 8 matrix in `PLAN.md`
+- **Local successor:** none; the plan is retired by Step 9 under the owner
+  acceptance recorded in `PLAN.md`
+- **Next action:** none; five unexercised matrix items remain recorded as
+  removable "Untested Hermes gap" notes in `docs/regression/`
+- **Retirement:** accepted by the owner on 2026-08-18 with five blocked rows
 
 ## Delivery
 
@@ -20,8 +22,8 @@
 | [x] | 5/9 | #919 | Merged registration and CI coverage. |
 | [x] | 6/9 | #921 | Merged branding implementation and supplied artwork corrections. |
 | [x] | 7/9 | #927 | Merged corrective plan/runtime/ACP pass. |
-| [x] | 8/9 | #929 | Merged regression evidence; blocked rows prevent retirement. |
-| [ ] | 9/9 | pending | Retirement only after required evidence passes. |
+| [x] | 8/9 | #929 | Merged regression evidence; extended by #955 (iOS E2E) and #965. |
+| [x] | 9/9 | pending | Retires the plan under the owner-accepted reduction in `PLAN.md`. |
 
 ## Owner Decisions
 
@@ -32,6 +34,7 @@
 - Setup remains out of band through Hermes CLI. The bridge never runs terminal setup as authentication.
 - Custom Hermes branding is explicitly approved (2026-08-15) as a narrow presentation exception.
 - Local deletion uses Sesori purge plus plugin-scoped tombstone; no private Hermes database mutation is added.
+- Retirement with five blocked rows is explicitly accepted (2026-08-18); the gaps live on as removable notes in `docs/regression/`.
 
 ## Audit Findings
 
@@ -100,8 +103,10 @@ the approved temporary directory so blocked rows can be resumed. Previous
 contributor claims of a completed live run remain excluded because no durable
 evidence accompanied them.
 
-**Retirement status: Blocked.** Step 9 cannot proceed unless all required rows
-pass or the owner explicitly accepts the recorded reduction in `PLAN.md`.
+**Retirement status: Accepted 2026-08-18.** The owner explicitly accepted
+retirement with the blocked rows above still open; the acceptance is recorded
+in `PLAN.md`, and each gap remains as a removable "Untested Hermes gap" note
+in the owning `docs/regression/` feature document.
 
 ## Step 8 Evidence: iOS Client E2E
 

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -119,6 +119,13 @@ timeouts, and sessions afterwards.
 - Hermes model/provider configuration is intentionally unavailable through Sesori and must
   be completed with the Hermes CLI before setup can become ready.
 - Idle windows are minutes-order, so observing a real elapse belongs at L4 or above.
+- Untested Hermes gap (remove this entry once verified): the targeted L4 idle
+  respawn was never exercised for Hermes, because it needs a controlled
+  idle-timeout window rather than an interactive session.
+- Untested Hermes gap (remove this entry once verified): older-client
+  unknown-id fallback and older-bridge presentation were never exercised end to
+  end against a second build pair; only the automated fallback and branding
+  checks passed.
 
 ## Sources
 

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -122,6 +122,9 @@ after a marker has been established.
 - A missed live patch self-heals on a later relevant event or list refresh.
 - An old bridge cannot provide per-running-root ordering facts in
   `projects.summary`, so the current app falls back to project updated time.
+- Untested Hermes gap (remove this entry once verified): a failed or cancelled
+  in-flight Hermes import was never exercised; only completed explicit imports
+  and non-destructive re-imports were verified.
 
 ## Sources
 

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -93,6 +93,10 @@ different combination than the previous recorded run.
 - Plugin scope follows currently registered plugins and their declared
   capabilities, not a fixed list. A plugin that does not expose a request kind
   is not a failure.
+- Untested Hermes gap (remove this entry once verified): no Hermes permission
+  request was ever observed. The tested provider completed file tools without
+  emitting an ACP permission request, so once/reject/always handling and
+  two-session correlation are unexercised for this harness.
 
 ## Sources
 

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -175,6 +175,10 @@ has started.
   shape. Cold replay therefore shows only the slash-command token to avoid
   exposing bridge-owned arguments; live API-command presentation retains only
   the exact user-authored arguments.
+- Untested Hermes gap (remove this entry once verified): reasoning streaming
+  was never observed from Hermes. An explicit chain-of-thought prompt produced
+  no `agent_thought_chunk` against the tested model, so thought-part
+  normalization is unverified for this harness.
 
 ## Sources
 


### PR DESCRIPTION
## Complexity

🌱 Trivial. Documentation and plan-file moves only; no production code.

## What

Retires the `hermes-agent-plugin` plan (Step 9/9):

- Moves `.plan/active/hermes-agent-plugin/` to `.plan/completed/hermes-agent-plugin/`
- Records the owner's explicit acceptance (2026-08-18) of retirement with five rows still Blocked, in `PLAN.md` where the retirement gate requires it
- Updates `TRACKER.md` to final state: all nine steps delivered, retirement accepted
- Adds one removable "Untested Hermes gap" note per gap to the owning `docs/regression/` feature document (idle respawn and compatibility in `plugin-setup-and-lifecycle.md`, reasoning streaming in `session-turns.md`, permissions in `questions-and-permissions.md`, cancelled import in `projects-and-sessions.md`)

## Why

The plan's own gate blocks retirement while any matrix row is unexercised "unless the owner explicitly accepts that reduction here." The owner accepted on 2026-08-18. The acceptance is therefore recorded in `PLAN.md` itself, and because the plan moves to `.plan/completed/` where it will no longer be read, each gap is additionally recorded in the living regression docs with an explicit instruction to remove the note once the behavior is verified. This keeps the missing coverage discoverable instead of silently buried.

## Risk and test focus

No user-visible, wire, or database impact. The only content risk is misstating what remains unverified; each note was copied from the corresponding matrix row's recorded evidence in `TRACKER.md`.

## Expected result

The Hermes integration plan is complete: steps 1–9 delivered, five unexercised items honestly recorded both in the retired plan and as actionable notes in the regression docs.

## Verification

- `git diff --check` clean
- Five "Untested Hermes gap" notes present across the four owning docs
- No references to `.plan/active/hermes-agent-plugin` remain elsewhere

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires the `hermes-agent-plugin` plan under owner-accepted reduction so we can close it while keeping five unexercised items visible. Old behavior: retirement blocked until all matrix rows passed. New behavior: retirement proceeds with owner-accepted reduction; gaps persist as removable notes in regression docs.

- Moves `.plan/active/hermes-agent-plugin/` to `.plan/completed/hermes-agent-plugin/`; updates `PLAN.md` to record acceptance dated 2026-08-18, list the five blocked items, and cite exact delivery PRs: #895, #915, #916, #917, #919, #921, #927, #929; extended by #955 and #965.
- Updates `TRACKER.md` to “owner review complete,” retirement accepted; references the removable gap notes.
- Adds “Untested Hermes gap” notes to `docs/regression/`:
  - `plugin-setup-and-lifecycle.md`: L4 idle respawn; older-client/bridge compatibility second build pair.
  - `session-turns.md`: reasoning streaming (`agent_thought_chunk`) unobserved.
  - `questions-and-permissions.md`: no ACP permission request observed.
  - `projects-and-sessions.md`: failed/cancelled import untested.
- No runtime, user-visible, or DB impact. Review to confirm accuracy of the five gap statements, correct PR citations/dates in `PLAN.md`/`TRACKER.md`, and that no references to `.plan/active/hermes-agent-plugin` remain.

<sup>Written for commit 20ec78816e9a525204f6c9392c6bdcba9b407e9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

