### PR TITLE
🌿 Accept Codex aborts without turn IDs

### DIFF
--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
@@ -106,7 +106,7 @@ sealed class CodexRolloutEventDto with _$CodexRolloutEventDto {
 
   @FreezedUnionValue("turn_aborted")
   const factory turnAborted({
-    @JsonKey(name: "turn_id") required String turnId,
+    @JsonKey(name: "turn_id") required String? turnId,
   }) = CodexRolloutTurnAbortedEventDto;
 
   const factory unknown() = CodexRolloutUnknownEventDto;

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
@@ -1065,7 +1065,7 @@ class CodexRolloutTurnAbortedEventDto implements CodexRolloutEventDto {
   const CodexRolloutTurnAbortedEventDto({@JsonKey(name: "turn_id") required this.turnId,  String? $type}): $type = $type ?? 'turn_aborted';
   factory CodexRolloutTurnAbortedEventDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutTurnAbortedEventDtoFromJson(json);
 
-@JsonKey(name: "turn_id") final  String turnId;
+@JsonKey(name: "turn_id") final  String? turnId;
 
 @JsonKey(name: 'type')
 final String $type;
@@ -1101,7 +1101,7 @@ abstract mixin class $CodexRolloutTurnAbortedEventDtoCopyWith<$Res> implements $
   factory $CodexRolloutTurnAbortedEventDtoCopyWith(CodexRolloutTurnAbortedEventDto value, $Res Function(CodexRolloutTurnAbortedEventDto) _then) = _$CodexRolloutTurnAbortedEventDtoCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(name: "turn_id") String turnId
+@JsonKey(name: "turn_id") String? turnId
 });
 
 
@@ -1118,10 +1118,10 @@ class _$CodexRolloutTurnAbortedEventDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexRolloutEventDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? turnId = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? turnId = freezed,}) {
   return _then(CodexRolloutTurnAbortedEventDto(
-turnId: null == turnId ? _self.turnId : turnId // ignore: cast_nullable_to_non_nullable
-as String,
+turnId: freezed == turnId ? _self.turnId : turnId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
@@ -111,7 +111,7 @@ CodexRolloutTaskCompleteEventDto _$CodexRolloutTaskCompleteEventDtoFromJson(
 CodexRolloutTurnAbortedEventDto _$CodexRolloutTurnAbortedEventDtoFromJson(
   Map json,
 ) => CodexRolloutTurnAbortedEventDto(
-  turnId: json['turn_id'] as String,
+  turnId: json['turn_id'] as String?,
   $type: json['type'] as String?,
 );
 

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_tool_lifecycle_tracker.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_tool_lifecycle_tracker.dart
@@ -492,7 +492,7 @@ class CodexToolLifecycleTracker({
       ),
       CodexRolloutTurnAbortedEventDto(:final turnId) => _finishTurn(
         thread: thread,
-        turnId: turnId,
+        turnId: turnId ?? thread.activeTurnId,
         status: PluginToolStatus.error,
       ),
       CodexRolloutImageGenerationEndEventDto() => _observeImageGenerationEnd(
@@ -566,7 +566,7 @@ class CodexToolLifecycleTracker({
 
   List<CodexProjectedTool> _finishTurn({
     required _ThreadToolLifecycle thread,
-    required String turnId,
+    required String? turnId,
     required PluginToolStatus status,
   }) {
     final usefulTurnId = _usefulText(value: turnId);

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -572,7 +572,7 @@ void main() {
         path: "sessions/2026/07/22/rollout-current.jsonl",
         sessionId: "019a0000-1111-2222-3333-aaaaaaaaaaaa",
         cwd: "/repo/app",
-        cliVersion: "0.144.1",
+        cliVersion: "0.147.0",
         extraLines: [
           jsonEncode({
             "type": "response_item",
@@ -594,6 +594,13 @@ void main() {
               ],
             },
           }),
+          jsonEncode({
+            "type": "event_msg",
+            "payload": {
+              "type": "turn_aborted",
+              "reason": "interrupted",
+            },
+          }),
         ],
       );
 
@@ -605,12 +612,20 @@ void main() {
       }, level: LogLevel.verbose);
 
       expect(output, isNot(contains("malformed rollout")));
-      expect(header, hasLength(3));
-      expect(transcript, hasLength(3));
+      expect(header, hasLength(4));
+      expect(transcript, hasLength(4));
       expect(transcript[1], isA<CodexRolloutResponseItemLineDto>());
       expect(_responseItemPayload(line: transcript[1]), isA<CodexRolloutCustomToolCallOutputDto>());
       expect(transcript[2], isA<CodexRolloutResponseItemLineDto>());
       expect(_responseItemPayload(line: transcript[2]), isA<CodexRolloutReasoningDto>());
+      expect(
+        (transcript[3] as CodexRolloutEventMessageLineDto).payload,
+        isA<CodexRolloutTurnAbortedEventDto>().having(
+          (event) => event.turnId,
+          "turnId",
+          isNull,
+        ),
+      );
     });
 
     test("rollout content decodes closed text, image, and unknown variants", () {

--- a/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
@@ -1192,6 +1192,42 @@ void main() {
     expect(aborted.status, PluginToolStatus.error);
   });
 
+  test("identifier-less abort errors tools in the active turn", () {
+    final target = tracker();
+    target
+      ..observeRolloutLine(
+        threadId: "thread-1",
+        line: _taskEvent(type: "task_started", turnId: "turn-1"),
+      )
+      ..observeRolloutLine(
+        threadId: "thread-1",
+        line: _rawExecCall(callId: "call-exec", turnId: "turn-1"),
+      )
+      ..observeRolloutLine(
+        threadId: "thread-1",
+        line: _toolOutput(
+          callId: "call-exec",
+          output: "Script running with cell ID 7\nOutput:\n",
+        ),
+      );
+
+    final aborted = target
+        .observeRolloutLine(
+          threadId: "thread-1",
+          line: CodexRolloutLineDto.fromJson({
+            "type": "event_msg",
+            "payload": {
+              "type": "turn_aborted",
+              "reason": "interrupted",
+            },
+          }),
+        )
+        .single;
+
+    expect(aborted.canonicalId, "call-exec");
+    expect(aborted.status, PluginToolStatus.error);
+  });
+
   test("late app-server completion retains the aborted canonical identity", () {
     final target = tracker();
     target

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -21,7 +21,8 @@ signal that a tool changed files.
 - Sub-agent, subtask, and agent parts identify their agent and stay attributed
   to the correct session, including work done by a child. Tool state survives a
   reload with the same identity, status, and output; unknown status renders as
-  the fallback.
+  the fallback. A backend abort without a turn identifier still finalizes tools
+  in the active turn.
 
 ## Regression Levels
 


### PR DESCRIPTION
## Complexity

Straightforward. This aligns one Codex rollout DTO with Codex 0.147.0 and preserves the existing tool-lifecycle fallback semantics.

## What

- Accept `turn_aborted` rollout events whose optional `turn_id` is absent.
- Apply an identifier-less abort to the tracker's active turn so running tools become errors rather than remaining open.
- Add import-decoding and lifecycle regression coverage and update the tool regression contract.

## Why

Codex 0.147.0 defines `TurnAbortedEvent.turn_id` as optional and emits records containing only the abort reason. Sesori required a string, skipped those valid records, and printed the malformed-header warning reported in #961.

This addresses that warning only. It does not claim to resolve #961's changing catalog totals or live updates for sessions running in an external Codex CLI process.

## Risk and test focus

Risk is limited to Codex abort replay. Identified aborts retain their existing matching behavior; identifier-less aborts now target only the active turn. There is no database or wire-contract impact.

## Expected result

Valid Codex 0.147.0 abort records no longer produce malformed rollout warnings, and replayed running tools in the active aborted turn settle as errors.

## Verification

- `dart pub get` from `bridge/`
- `dart test` from `bridge/sesori_plugin_codex/` (362 tests)
- `dart test test/codex_rollout_api_test.dart test/codex_tool_lifecycle_tracker_test.dart`
- `dart analyze --fatal-infos`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts Codex `turn_aborted` events without a `turn_id` to match Codex 0.147.0. Previously we required a `turn_id` and logged malformed rollout warnings; now we decode these events and abort the active turn so running tools settle as errors.

- Updates the rollout DTO to make `turn_id` optional and adjusts JSON decode/copy semantics.
- In the lifecycle tracker, falls back to `activeTurnId` when `turn_id` is absent; behavior for identified aborts is unchanged.
- Adds decoding and lifecycle regression tests; notes in docs that identifier-less aborts finalize tools in the active turn.
- No database or wire-contract changes. Compatible with Codex 0.147.0. Fixes the malformed warning from #961 only (does not address catalog totals or live updates).

<sup>Written for commit 5a2c0376f54255f1d39bee2be23efea1c276dadd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

