### PR TITLE
🌿 Report live activity in a listed session's updated time

### DIFF
--- a/bridge/app/lib/src/bridge/repositories/mappers/session_catalog_mapper.dart
+++ b/bridge/app/lib/src/bridge/repositories/mappers/session_catalog_mapper.dart
@@ -38,18 +38,23 @@ class const SessionCatalogMapper() {
   /// session driven entirely on the laptop kept displaying the transcript time
   /// read at the last import — "2d ago" on a session prompted minutes earlier.
   ///
-  /// The unseen timestamps are written live for every plugin, so folding them
-  /// in makes the displayed recency honest for all harnesses at once. They are
+  /// `last_user_message_at` is written live for every plugin, so folding it in
+  /// makes the displayed recency honest for all harnesses at once. It is
   /// blended on read rather than written into `updated_at`, because catalog
   /// import's staleness detection depends on that column holding only
   /// backend-reported time (see CatalogImportRepository).
   ///
-  /// Both are needed: `last_activity_at` coalesces once a session is already
-  /// unseen, and a user message advances only `last_user_message_at`.
+  /// `last_activity_at` is deliberately excluded even though it covers more
+  /// events: it is an unseen-formula token, not a recency one. "Mark as
+  /// Unread" synthesizes it from the current clock (SessionDao.forceUnseen),
+  /// which would make an untouched session claim it just changed, and
+  /// SessionUnseenService coalesces it to the FIRST event of an unseen streak,
+  /// so it would not follow a long response anyway. The cost of leaving it out
+  /// is that assistant-only work does not advance the displayed time past the
+  /// prompt that started it — conservative, and self-correcting on the next
+  /// user message or import.
   static int _latestActivityAt(SessionDto row) {
-    var latest = row.updatedAt;
-    if (row.lastActivityAt case final at? when at > latest) latest = at;
-    if (row.lastUserMessageAt case final at? when at > latest) latest = at;
-    return latest;
+    if (row.lastUserMessageAt case final at? when at > row.updatedAt) return at;
+    return row.updatedAt;
   }
 }

--- a/bridge/app/lib/src/bridge/repositories/mappers/session_catalog_mapper.dart
+++ b/bridge/app/lib/src/bridge/repositories/mappers/session_catalog_mapper.dart
@@ -19,7 +19,7 @@ class const SessionCatalogMapper() {
       directory: row.directory,
       parentID: row.parentSessionId,
       title: row.title ?? row.catalogTitle,
-      time: SessionTime(created: row.createdAt, updated: row.updatedAt, archived: row.archivedAt),
+      time: SessionTime(created: row.createdAt, updated: _latestActivityAt(row), archived: row.archivedAt),
       pullRequest: pullRequest,
       promptDefaults: row.lastAgent == null && row.lastAgentModel == null
           ? null
@@ -28,5 +28,28 @@ class const SessionCatalogMapper() {
       unseen: unseen,
       lastUserActivityAt: row.lastUserMessageAt,
     );
+  }
+
+  /// The newest instant the bridge knows about for this session.
+  ///
+  /// `updated_at` only advances when a backend reports a new time: a catalog
+  /// import, or a plugin that emits an activity-bearing `session.updated`.
+  /// Codex, ACP, and OpenCode do; Claude and Pi emit one only on rename, so a
+  /// session driven entirely on the laptop kept displaying the transcript time
+  /// read at the last import — "2d ago" on a session prompted minutes earlier.
+  ///
+  /// The unseen timestamps are written live for every plugin, so folding them
+  /// in makes the displayed recency honest for all harnesses at once. They are
+  /// blended on read rather than written into `updated_at`, because catalog
+  /// import's staleness detection depends on that column holding only
+  /// backend-reported time (see CatalogImportRepository).
+  ///
+  /// Both are needed: `last_activity_at` coalesces once a session is already
+  /// unseen, and a user message advances only `last_user_message_at`.
+  static int _latestActivityAt(SessionDto row) {
+    var latest = row.updatedAt;
+    if (row.lastActivityAt case final at? when at > latest) latest = at;
+    if (row.lastUserMessageAt case final at? when at > latest) latest = at;
+    return latest;
   }
 }

--- a/bridge/app/test/bridge/repositories/mappers/catalog_mappers_test.dart
+++ b/bridge/app/test/bridge/repositories/mappers/catalog_mappers_test.dart
@@ -134,14 +134,17 @@ void main() {
     Session mapped(SessionDto row) => mapper.map(row: row, pullRequest: null, unseen: false);
 
     // A plugin that never emits an activity-bearing `session.updated` leaves
-    // `updated_at` at the last imported transcript time; the live unseen
-    // timestamps are what keep the session's recency honest.
+    // `updated_at` at the last imported transcript time; the live user-message
+    // marker is what keeps the session's recency honest.
     expect(mapped(base).time?.updated, 20);
-    expect(mapped(base.copyWith(lastActivityAt: 55)).time?.updated, 55);
     expect(mapped(base.copyWith(lastUserMessageAt: 70)).time?.updated, 70);
 
     // The backend's own time still wins when it is the newest one known.
-    expect(mapped(base.copyWith(lastActivityAt: 5, lastUserMessageAt: 8)).time?.updated, 20);
+    expect(mapped(base.copyWith(lastUserMessageAt: 8)).time?.updated, 20);
+
+    // "Mark as Unread" synthesizes `last_activity_at` from the current clock to
+    // satisfy the unseen formula, so it must never reach the displayed time.
+    expect(mapped(base.copyWith(lastActivityAt: 9999)).time?.updated, 20);
   });
 
   test("StoredSessionMapper projects the fields repository consumers need", () {

--- a/bridge/app/test/bridge/repositories/mappers/catalog_mappers_test.dart
+++ b/bridge/app/test/bridge/repositories/mappers/catalog_mappers_test.dart
@@ -102,6 +102,48 @@ void main() {
     expect(session.lastUserActivityAt, 12);
   });
 
+  test("SessionCatalogMapper reports live activity newer than the backend's updated time", () {
+    const mapper = SessionCatalogMapper();
+    const base = SessionDto(
+      sessionId: "sesori-id",
+      backendSessionId: "backend-id",
+      projectId: "project-1",
+      parentSessionId: null,
+      directory: "/projects/one",
+      worktreePath: null,
+      branchName: null,
+      currentBranchName: null,
+      currentGithubRepositoryIdentity: null,
+      isDedicated: false,
+      archivedAt: null,
+      baseBranch: null,
+      baseCommit: null,
+      lastAgent: null,
+      lastAgentModel: null,
+      createdAt: 10,
+      updatedAt: 20,
+      projectionUpdatedAt: 20,
+      lastActivityAt: null,
+      lastSeenAt: null,
+      lastUserMessageAt: null,
+      pluginId: "claude",
+      title: null,
+      catalogTitle: null,
+    );
+
+    Session mapped(SessionDto row) => mapper.map(row: row, pullRequest: null, unseen: false);
+
+    // A plugin that never emits an activity-bearing `session.updated` leaves
+    // `updated_at` at the last imported transcript time; the live unseen
+    // timestamps are what keep the session's recency honest.
+    expect(mapped(base).time?.updated, 20);
+    expect(mapped(base.copyWith(lastActivityAt: 55)).time?.updated, 55);
+    expect(mapped(base.copyWith(lastUserMessageAt: 70)).time?.updated, 70);
+
+    // The backend's own time still wins when it is the newest one known.
+    expect(mapped(base.copyWith(lastActivityAt: 5, lastUserMessageAt: 8)).time?.updated, 20);
+  });
+
   test("StoredSessionMapper projects the fields repository consumers need", () {
     const row = SessionDto(
       sessionId: "sesori-id",

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -37,11 +37,12 @@ child sessions with titles, activity, statuses, and unseen state.
   times, worktree and branch facts, prompt defaults, and unseen state that
   advances on activity and clears on view or mark-as-read.
 - A listed session's `session.updated` reports the newest instant the bridge
-  knows: the backend's own updated time, or the live activity and user-message
-  markers when those are newer. A plugin that reports an updated time only at
-  import or rename — Claude and Pi, unlike Codex, ACP, and OpenCode — therefore
-  still shows recent local work as recent, instead of the transcript time read
-  at the last import.
+  knows: the backend's own updated time, or the live user-message marker when
+  that is newer. A plugin that reports an updated time only at import or rename
+  — Claude and Pi, unlike Codex, ACP, and OpenCode — therefore still shows a
+  recently prompted session as recent, instead of the transcript time read at
+  the last import. Marking a session unread never moves that time, and
+  assistant-only work does not advance it past the prompt that started it.
 - A newly committed session can list before generated metadata. Later generated
   title and eligible dedicated-branch refinement reuse `session.updated`; lists
   and detail adopt the durable session facts without marking unseen or moving the

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -36,6 +36,12 @@ child sessions with titles, activity, statuses, and unseen state.
 - Session listings are project-scoped and pageable and carry plugin attribution,
   times, worktree and branch facts, prompt defaults, and unseen state that
   advances on activity and clears on view or mark-as-read.
+- A listed session's `session.updated` reports the newest instant the bridge
+  knows: the backend's own updated time, or the live activity and user-message
+  markers when those are newer. A plugin that reports an updated time only at
+  import or rename — Claude and Pi, unlike Codex, ACP, and OpenCode — therefore
+  still shows recent local work as recent, instead of the transcript time read
+  at the last import.
 - A newly committed session can list before generated metadata. Later generated
   title and eligible dedicated-branch refinement reuse `session.updated`; lists
   and detail adopt the durable session facts without marking unseen or moving the
@@ -102,6 +108,8 @@ after a marker has been established.
 - A running root or project stays alphabetically ordered, a stale marker masks
   newer committed activity, a null marker fails to use updated time,
   awaiting-only is promoted, or inactive session/project or child order changes.
+- A session prompted minutes ago reports a days-old updated time, or sorts to
+  the top of its list while still displaying that stale time.
 - Unseen never clears, clears without viewing, or an unavailable plugin is idle.
 - Hiding destroys sessions, or a cancelled import destroys the committed catalog.
 - A generated title/branch update fails to reach list/detail, changes unseen,


### PR DESCRIPTION
## Complexity

🌿 Straightforward. One read-side mapper change plus its test; no schema, wire,
or plugin changes.

## What

A listed session's `session.time.updated` now reports the newest instant the
bridge knows about: the backend's own updated time, or the live
`last_user_message_at` marker when that is newer.

The blend happens on read in `SessionCatalogMapper`. The `updated_at` column
itself is untouched.

## Why

The session list is served entirely from the durable catalog
(`SessionRepository.getSessionsForProject`), so the displayed time is
`sessions_table.updated_at`. That column only advances when a backend reports a
new time — a catalog import, or a plugin emitting an activity-bearing
`session.updated`.

| Plugin | Activity-driven `session.updated` |
|---|---|
| Codex | ✅ `_sessionActivityUpdated` |
| ACP (cursor / hermes / omp) | ✅ `mapSessionActivity` |
| OpenCode | ✅ native `session.updated` |
| Claude | ❌ rename only |
| Pi | ❌ rename only |

For Claude and Pi the column froze at the transcript mtime read by the last
import, so a session prompted minutes earlier displayed "2d ago". Everything
done live landed in the unseen markers instead, which were used only for the
bold indicator, never for display.

This also removes a visible inconsistency: the client already sorts by
`lastUserActivityAt ?? time.updated`, so an affected session sat at the top of
the list while showing a days-old timestamp.

### Why only `last_user_message_at`

`last_activity_at` is the broader signal and the first version of this PR used
it too. Review caught that it is an unseen-formula token rather than a recency
one, for two independent reasons:

- `SessionDao.forceUnseen` synthesizes it from the current clock so "Mark as
  Unread" satisfies the unseen formula. Displaying it would make an untouched
  session claim it just changed.
- `SessionUnseenService` coalesces it to the *first* event of an unseen streak,
  so it would not follow a long response anyway.

`last_user_message_at` is the pure marker — `forceUnseen` deliberately leaves it
untouched, and it is only ever stamped from a real user message's own creation
time. It carries the fix alone.

The deliberate limit: assistant-only work does not advance the displayed time
past the prompt that started it. That is conservative rather than wrong, and
self-correcting on the next user message or import. Persisting a separate
latest-activity column to make the label tick during a response was not worth a
new column plus a write on the hot event path.

### Why read-side

Writing activity into `updated_at` would be a smaller diff, but catalog import's
staleness detection depends on that column holding only backend-reported time —
stamping it locally would mark such sessions stale on every import and wake
their harness on the next open, which is the cost that feature exists to remove.

### Rejected alternatives

- Teaching Claude and Pi to emit activity updates like Codex/ACP: more code in
  two plugins, still writes bridge-local time into `updated_at`, and leaves the
  next backend without one broken again.
- Changing `getRootCatalogSessions` ordering: not needed. The client requests
  `start: null, limit: null` and re-sorts locally, so DB ordering never drops a
  session from the rendered list.

## Risk and test focus

Low. One expression behind a mapper that already had no `time` assertions.

- No database impact — no schema change, no migration, no new writes.
- No wire contract change — `Session.time.updated` is an existing field and
  still an ms-epoch int. Older clients read it unchanged; the value is simply
  no longer stale.
- User-visible impact is the intended fix: affected sessions now show a
  truthful relative time.

Focus on Claude and Pi sessions prompted since the last catalog import; on
"Mark as Unread" leaving the displayed time alone; and on a backend-reported
time still winning when it is the newest one known. All three are covered by the
new test.

## Expected result

A Claude or Pi session prompted two hours ago reads "2h ago", not "2d ago", and
its displayed time agrees with its position in the list. Marking a session
unread does not change its time. Codex, ACP, and OpenCode sessions are
unchanged, since their backends already report a fresh updated time.

## Verification

- `dart test test/bridge/repositories/mappers/catalog_mappers_test.dart` — 5/5 pass
- `dart test test/bridge/routing/get_sessions_handler_test.dart` — 38/38 pass
- `dart test test/bridge/repositories/session_repository_test.dart` — 53/53 pass
- `dart analyze lib/src/bridge/repositories/mappers/ test/bridge/repositories/mappers/` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
