### PR TITLE
🌱 Model Claude tool progress frames

### DIFF
--- a/.plan/completed/claude-code-plugin/PROTOCOL.md
+++ b/.plan/completed/claude-code-plugin/PROTOCOL.md
@@ -88,6 +88,7 @@ supervised child. Not yet probed; resolve before the descriptor lands.
 |---|---|---|
 | `system` / `init` | `session_id`, `model`, `permissionMode`, `capabilities`, `tools`, `slash_commands`, `agents`, `skills`, `plugins`, `mcp_servers`, `output_style`, `apiKeySource`, `claude_code_version`, `cwd`, `memory_paths`, `uuid` | init handshake, capability detection |
 | `system` / `status` | `status` (e.g. `"requesting"`) | work-state signal |
+| `tool_progress` | `tool_use_id`, `tool_name`, `parent_tool_use_id`, `elapsed_time_seconds`, optional task/subagent metadata | parsed progress signal; not surfaced to clients |
 | `rate_limit_event` | `rate_limit_info` = `{status, resetsAt, rateLimitType, overageStatus, overageDisabledReason, isUsingOverage}` | rate-limit surface |
 | `assistant` | `message` (full Anthropic message), `parent_tool_use_id`, `timestamp`, `request_id` | complete message envelope plus parts |
 | `user` | echoed message; carries `tool_result` blocks | tool completion, matched by `tool_use_id` |

--- a/bridge/sesori_plugin_claude/lib/src/api/claude_stream_client.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/claude_stream_client.dart
@@ -288,6 +288,7 @@ class ClaudeStreamClient({
       case ClaudeStatusMessage():
       case ClaudeThinkingTokensMessage():
       case ClaudeTaskProgressMessage():
+      case ClaudeToolProgressMessage():
       case ClaudeHookStartedMessage():
       case ClaudeHookOutputMessage():
       case ClaudeApiRetryMessage():

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
@@ -76,6 +76,8 @@ sealed class const ClaudeStreamMessage({
           ),
           _ => ClaudeUnknownMessage(type: type, subtype: subtype, sessionId: sessionId, uuid: uuid, raw: json),
         };
+      case "tool_progress":
+        return ClaudeToolProgressMessage.fromJson(json, sessionId: sessionId, uuid: uuid);
       case "assistant":
         return ClaudeAssistantMessage.fromJson(json, sessionId: sessionId, uuid: uuid);
       case "user":
@@ -111,6 +113,10 @@ sealed class const ClaudeStreamMessage({
 String? _stringOrNull(Object? value) => value is String ? value : null;
 
 int? _intOrNull(Object? value) => value is num ? value.toInt() : null;
+
+double? _doubleOrNull(Object? value) => value is num ? value.toDouble() : null;
+
+bool? _boolOrNull(Object? value) => value is bool ? value : null;
 
 DateTime? _dateTimeOrNull(Object? value) => value is String ? DateTime.tryParse(value) : null;
 
@@ -218,6 +224,37 @@ final class const ClaudeTaskProgressMessage({
       raw: json,
     );
   }
+}
+
+/// `tool_progress` — periodic elapsed-time progress for a running tool call.
+final class const ClaudeToolProgressMessage({
+  required final String? toolUseId,
+  required final String? toolName,
+  required final String? parentToolUseId,
+  required final double? elapsedTimeSeconds,
+  required final String? taskId,
+  required final bool? heartbeat,
+  required final String? subagentType,
+  required super.sessionId,
+  required super.uuid,
+  required super.raw,
+}) extends ClaudeStreamMessage {
+  factory fromJson(
+    Map<String, Object?> json, {
+    required String? sessionId,
+    required String? uuid,
+  }) => ClaudeToolProgressMessage(
+    toolUseId: _stringOrNull(json["tool_use_id"]),
+    toolName: _stringOrNull(json["tool_name"]),
+    parentToolUseId: _stringOrNull(json["parent_tool_use_id"]),
+    elapsedTimeSeconds: _doubleOrNull(json["elapsed_time_seconds"]),
+    taskId: _stringOrNull(json["task_id"]),
+    heartbeat: _boolOrNull(json["heartbeat"]),
+    subagentType: _stringOrNull(json["subagent_type"]),
+    sessionId: sessionId,
+    uuid: uuid,
+    raw: json,
+  );
 }
 
 /// `system`/`hook_started` — a hook began running for a lifecycle event.

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -99,9 +99,10 @@ final class ClaudeEventDispatcher({
         ClaudeInitMessage() ||
         ClaudeStatusMessage() ||
         // ponytail: parsed but not surfaced — no client UI consumes thinking
-        // token estimates, subagent task progress, or hook output yet.
+        // token estimates, task/tool progress, or hook output yet.
         ClaudeThinkingTokensMessage() ||
         ClaudeTaskProgressMessage() ||
+        ClaudeToolProgressMessage() ||
         ClaudeHookStartedMessage() ||
         ClaudeHookOutputMessage() ||
         ClaudeControlRequestMessage() ||

--- a/bridge/sesori_plugin_claude/test/claude_stream_message_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_stream_message_test.dart
@@ -238,6 +238,29 @@ void main() {
       expect(message.durationMs, 4500);
     });
 
+    test("reads top-level tool progress", () {
+      final message =
+          ClaudeStreamMessage.parse({
+                "type": "tool_progress",
+                "tool_use_id": "toolu_1",
+                "tool_name": "Bash",
+                "parent_tool_use_id": "toolu_parent",
+                "elapsed_time_seconds": 2.5,
+                "task_id": "task-1",
+                "heartbeat": true,
+                "subagent_type": "Explore",
+              })
+              as ClaudeToolProgressMessage;
+
+      expect(message.toolUseId, "toolu_1");
+      expect(message.toolName, "Bash");
+      expect(message.parentToolUseId, "toolu_parent");
+      expect(message.elapsedTimeSeconds, 2.5);
+      expect(message.taskId, "task-1");
+      expect(message.heartbeat, isTrue);
+      expect(message.subagentType, "Explore");
+    });
+
     test("reads hook start and hook output frames", () {
       final started =
           ClaudeStreamMessage.parse({


### PR DESCRIPTION
## Complexity

Trivial. This adds one known Claude stream-json transport variant and classifies it alongside existing progress-only frames.

## What

- Parse top-level `tool_progress` frames into `ClaudeToolProgressMessage`.
- Keep their stable SDK fields and raw payload available to plugin code.
- Explicitly ignore them in client logging and bridge-neutral event mapping until a client surface consumes tool progress.
- Document and test the protocol shape.

## Why

Claude emits `tool_progress` during ordinary long-running tool calls. Treating it as unknown produced repeated `unmodelled frame type=tool_progress subtype=null` debug messages even though the frame is part of the pinned SDK contract.

## Risk and test focus

Low risk. The frame remains progress-only and does not alter client events, tool completion tracking, transport compatibility, persisted data, or database state. There is no user-visible impact beyond removing noisy bridge debug output.

## Expected result

Claude tool progress frames parse as a known transport variant and no longer emit the unmodelled-frame debug line. Existing turn and tool behavior remains unchanged.

## Verification

- `dart test test/claude_stream_message_test.dart test/claude_stream_client_test.dart test/claude_event_dispatcher_test.dart`
- `dart analyze --fatal-infos`
- Architecture implementation review: approved with no findings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Model and parse Claude `tool_progress` frames to stop noisy “unmodelled frame” logs and keep progress-only behavior unchanged.

- Parse `tool_progress` into `ClaudeToolProgressMessage`, exposing `tool_use_id`, `tool_name`, `parent_tool_use_id`, `elapsed_time_seconds`, `task_id`, `heartbeat`, `subagent_type`, plus the raw payload for plugins.
- Exclude `tool_progress` from client logging and bridge-neutral event mapping in `ClaudeEventDispatcher` and `ClaudeStreamClient` until a client surface consumes it.
- Update protocol docs and add unit tests; no changes to tool completion, persisted data, transport, or user-visible behavior.

<sup>Written for commit 2d3d8e0897d0f9c46257482e6f52488bd3db38d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

