### PR TITLE
🌱 Retain Claude content finalized after block stop

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -240,6 +240,7 @@ final class ClaudeEventDispatcher({
     final messageId = _messageIds[sessionId];
     final index = message.blockIndex;
     if (messageId == null || index == null) return const [];
+    _streamedBlocks[messageId]?.remove(index);
     final tool = _tools.stopInput(sessionId: sessionId, messageId: messageId, blockIndex: index);
     final completed = _completedStreamedParts[messageId]?.remove(index);
     return [

--- a/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
@@ -156,6 +156,47 @@ void main() {
       expect(replayed.whereType<BridgeSseMessagePartUpdated>().single.part.text, "next answer");
     });
 
+    test("finalizes streamed text when Claude sends the assistant after block stop", () {
+      _startMessage(mapper, messageId: "msg-late-assistant");
+      _map(
+        mapper,
+        _stream(
+          "content_block_start",
+          event: {
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+          },
+        ),
+      );
+      _map(
+        mapper,
+        _stream(
+          "content_block_delta",
+          event: {
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "persisted answer"},
+          },
+        ),
+      );
+
+      final stopped = _map(
+        mapper,
+        _stream("content_block_stop", event: const {"index": 0}),
+      );
+      final complete = _map(
+        mapper,
+        _assistant(
+          id: "msg-late-assistant",
+          content: const [
+            {"type": "text", "text": "persisted answer"},
+          ],
+        ),
+      );
+
+      expect(stopped.whereType<BridgeSseMessagePartUpdated>(), isEmpty);
+      expect(complete.whereType<BridgeSseMessagePartUpdated>().single.part.text, "persisted answer");
+    });
+
     test("hides local command records and keeps the last real model", () {
       _startMessage(mapper, messageId: "msg-real", model: "claude-opus-5");
       _startMessage(mapper, messageId: "msg-command", model: "<synthetic>");

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -14,8 +14,10 @@ and rejoined after a client reconnect, plugin restart, or bridge restart.
   advanced outside Sesori is detected as stale, re-read, and re-cached.
 - Live streamed messages and parts become queryable immediately after they
   finalize, with the same visibility filtering and tool-output bound a backend
-  fetch returns. Clients request the latest page and page older messages on
-  demand; a client predating pagination gets the full transcript.
+  fetch returns. Final text and reasoning snapshots are retained whether a
+  backend emits them before or after its stream block-stop event. Clients request
+  the latest page and page older messages on demand; a client predating
+  pagination gets the full transcript.
 - After a reconnect inside the replay window, buffered events are delivered;
   after a longer gap, a refresh reconciles without losing finalized content.
   After a backend event-stream gap, that plugin's stored transcripts stay marked


### PR DESCRIPTION
## Complexity

🌱 Trivial. The production change is one streamed-block lifecycle transition with focused regression coverage.

## What

- Mark a Claude content block closed when `content_block_stop` arrives.
- Allow a full `assistant` envelope received after that stop to emit its finalized part snapshot immediately.
- Preserve the existing full-envelope-before-stop behavior and document the durable-history invariant.

## Why

Claude Code 2.1.235 can emit the complete `assistant` envelope after `content_block_stop`, while the ordering previously observed by the plugin put the envelope before the stop. The dispatcher left the block marked as streamed and deferred the late finalized snapshot forever. Streaming deltas still rendered live, but history capture intentionally ignores deltas, so finalized text and reasoning were empty after leaving and reopening the session.

## Risk and test focus

Risk is low and scoped to Claude streamed-part finalization. Coverage exercises the newly observed stop-before-assistant ordering, while the existing test continues to cover assistant-before-stop ordering. There is no database schema or wire-contract impact.

## Expected result

Claude text and reasoning that render live remain available after a session is closed and reopened, regardless of whether the complete assistant envelope arrives before or after its block-stop event.

## Verification

- `dart pub get` from `bridge/sesori_plugin_claude` (resolved the bridge workspace)
- `dart test test/claude_event_dispatcher_test.dart`
- `dart test` (241 tests)
- `dart analyze --fatal-infos`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retains finalized Claude text and reasoning when the full assistant envelope arrives after a `content_block_stop`. Previously the block stayed marked as streaming and never emitted a finalized snapshot, so reopened sessions showed empty finalized content; now the block closes on stop and the following assistant envelope finalizes immediately.

- Marks the block closed on `content_block_stop` by removing its index from the streamed set; preserves the assistant-before-stop flow.
- Adds a test for stop-before-assistant ordering; updates docs to state snapshots are retained regardless of ordering.
- No schema or wire-contract changes; streaming deltas and live rendering are unchanged; risk is scoped to Claude streamed-part finalization.

<sup>Written for commit 29b2e43ed560d5dd9a2242c82baa5165145bec23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

