### PR TITLE
⚙️ [pi-harness] test(harness): verify Pi and OMP integration [step 20/21]

### DIFF
--- a/.plan/active/pi-harness/OMP_PROTOCOL.md
+++ b/.plan/active/pi-harness/OMP_PROTOCOL.md
@@ -436,6 +436,39 @@ release and matched the published digest. In an isolated temporary cwd and
 
 The probe did not use real credentials or send a provider request.
 
+### Step 20 live verification (2026-08-19)
+
+A source-run bridge and development iOS client exercised the production OMP
+descriptor on macOS arm64. Evidence was inspected live and retained only as the
+redacted outcomes below; no credential, raw ACP frame, prompt, transcript,
+project path, or provider/account identifier is committed.
+
+- The production managed-install command downloaded, verified, installed, and
+  enabled official OMP `17.2.13`; a repeated install adopted the existing
+  managed binary. Restart and full bridge restart both reprovisioned that
+  binary and returned OMP to active/idle.
+- The normal inherited OMP profile has no configured provider/model. The bridge
+  reports zero connected providers and explicit options refresh returns
+  `refreshFailedUnavailable`. Selecting Oh My Pi on iOS renders the
+  design-system popup guidance to open OMP locally and run `/login`; creating
+  with defaults remains possible and returns to idle without a partial model
+  selection.
+- Empty-session creation, local-only rename, safe plugin restart, resume/list,
+  idle abort, deletion, and post-restart cleanup all succeeded through
+  production bridge routes. Deleted OMP sessions remained absent after restart
+  and catalog import.
+- Text and PNG requests reached the no-model rejection path without dispatching
+  a provider turn. This verifies bounded missing-model behavior but does not
+  claim successful image replay. A direct terminal OMP prompt also stopped at
+  missing-model setup and created no durable session, so terminal handoff cannot
+  be verified until a model is configured.
+- No Linux, Windows, Docker, glibc, or musl host is available in this workspace.
+  The automated platform-selection/install tests remain the evidence for those
+  targets; no unavailable host check is claimed as live coverage.
+- Successful authenticated text/image/reasoning/tool turns, model/thinking
+  sweeps, permissions, forms, replay, and terminal handoff remain blocked until
+  local OMP provider setup is completed. No success fixture is claimed.
+
 ## 12. Verification Still Required During Implementation
 
 - Refresh source/assets against the exact stable pin selected in Step 9.

--- a/.plan/active/pi-harness/OMP_PROTOCOL.md
+++ b/.plan/active/pi-harness/OMP_PROTOCOL.md
@@ -447,27 +447,33 @@ project path, or provider/account identifier is committed.
   enabled official OMP `17.2.13`; a repeated install adopted the existing
   managed binary. Restart and full bridge restart both reprovisioned that
   binary and returned OMP to active/idle.
-- The normal inherited OMP profile has no configured provider/model. The bridge
-  reports zero connected providers and explicit options refresh returns
-  `refreshFailedUnavailable`. Selecting Oh My Pi on iOS renders the
-  design-system popup guidance to open OMP locally and run `/login`; creating
-  with defaults remains possible and returns to idle without a partial model
-  selection.
+- The normal inherited OMP profile initially had no configured provider/model.
+  The bridge reported zero connected providers, explicit refresh returned
+  `refreshFailedUnavailable`, and iOS rendered the design-system `/login`
+  guidance without a partial model selection. A local OpenAI-compatible provider
+  added afterward was discovered as the phone default and completed authenticated
+  text, reasoning-display, and tool turns through the production bridge.
 - Empty-session creation, local-only rename, safe plugin restart, resume/list,
   idle abort, deletion, and post-restart cleanup all succeeded through
   production bridge routes. Deleted OMP sessions remained absent after restart
   and catalog import.
-- Text and PNG requests reached the no-model rejection path without dispatching
-  a provider turn. This verifies bounded missing-model behavior but does not
-  claim successful image replay. A direct terminal OMP prompt also stopped at
-  missing-model setup and created no durable session, so terminal handoff cannot
-  be verified until a model is configured.
+- Text and PNG requests first reached the no-model rejection path without
+  dispatching a provider turn. After provider setup, text and tool turns
+  completed. OMP emitted a correctly typed OpenAI-compatible image request, but
+  the selected upstream returned a rate-limit error and entered bounded retry;
+  successful image replay is therefore not claimed.
+- A provider-backed terminal OMP session exited before explicit import, appeared
+  in the iOS project/session list with its transcript and model, and resumed
+  successfully from the phone. This verifies terminal-to-Sesori handoff without
+  concurrent ownership.
 - No Linux, Windows, Docker, glibc, or musl host is available in this workspace.
   The automated platform-selection/install tests remain the evidence for those
   targets; no unavailable host check is claimed as live coverage.
-- Successful authenticated text/image/reasoning/tool turns, model/thinking
-  sweeps, permissions, forms, replay, and terminal handoff remain blocked until
-  local OMP provider setup is completed. No success fixture is claimed.
+- The configured test model exposed only its single model and `off` thinking.
+  OMP ACP did not expose the `ask` tool to that model, so a requested form became
+  plain text; the development bridge auto-approved permissions. Automated OMP/
+  ACP coverage remains authoritative for form, permission, and broader option
+  sweeps that this live profile could not produce.
 
 ## 12. Verification Still Required During Implementation
 

--- a/.plan/active/pi-harness/PROTOCOL.md
+++ b/.plan/active/pi-harness/PROTOCOL.md
@@ -589,26 +589,31 @@ redacted outcomes below; no credential, raw frame, prompt, transcript, project
 path, or provider/account identifier is committed.
 
 - PATH Pi `0.84.2` satisfied the `0.84.1` floor, started active, and imported
-  its catalog. A direct RPC probe reported a selected model, seven available
-  models from one connected provider, and an idle stream. The bridge session
-  options path exposed the same seven models and three commands; the iOS
-  composer rendered Pi, its model, and thinking selector.
+  its catalog. The inherited profile initially exposed seven models, one
+  connected provider, and three commands. A local OpenAI-compatible provider
+  added for verification was discovered after refresh, selected on iOS, and
+  completed authenticated text and tool turns through the production bridge.
 - Empty-session creation, local rename, safe plugin restart, bridge restart,
   resume/list, idle abort, deletion, and post-restart tombstone suppression all
   succeeded through production bridge routes. The development client lost and
   re-established its encrypted relay session across the bridge restart.
 - A one-pixel PNG plus text reached the persisted Pi transcript as text and an
-  `image/png` inline-image part before provider execution failed, verifying the
-  bridge/plugin attachment seam without retaining the image payload.
+  `image/png` inline-image part before the original provider rejected execution.
+  A separate authenticated direct Pi image turn against the local compatible
+  provider identified the fixture correctly. Together these verify attachment
+  mapping and provider image support without retaining the image payload; the
+  iOS system photo picker did not accept automation input, so no successful
+  phone-originated image turn is claimed.
 - A terminal Pi process created a persisted session and exited before explicit
-  bridge import. Sesori imported its user/error history, allowed a local rename,
-  deleted it, and did not re-import the tombstoned artifact. This verifies the
-  documented terminal-to-Sesori handoff ordering, never concurrent ownership.
-- Provider execution currently returns the demonstrated typed Codex
-  usage-limit error. Error mapping remained visible and the session returned to
-  idle, but a successful authenticated response, reasoning/tool stream,
-  extension dialogs, model/provider sweep, and successful image response remain
-  blocked until provider quota is available. No success fixture is claimed.
+  bridge import. The initial fixture was renamed, deleted, and suppressed by its
+  tombstone. A provider-backed fixture was then imported into a visible project,
+  rendered its transcript/model on iOS, and resumed successfully from the phone
+  after a client correction preserved the transcript model over a stale catalog
+  default. Terminal and Sesori processes never owned the session concurrently.
+- The original Codex provider still supplies the typed usage-limit error path.
+  The local compatible provider supplies successful text, tool, image, import,
+  and resume evidence. Live extension dialogs and a reasoning-capable model were
+  unavailable; their automated fixture coverage remains authoritative.
 
 ## 12. Verification Still Required During Implementation
 

--- a/.plan/active/pi-harness/PROTOCOL.md
+++ b/.plan/active/pi-harness/PROTOCOL.md
@@ -581,6 +581,35 @@ package tree listed above, and reported `0.84.2`. An isolated launch with
 `get_state` request returned a successful response. No credential, prompt, or
 transcript content was retained.
 
+### Step 20 live verification (2026-08-19)
+
+A source-run bridge and development iOS client used the normal inherited Pi
+profile on macOS arm64. Evidence was inspected live and retained only as the
+redacted outcomes below; no credential, raw frame, prompt, transcript, project
+path, or provider/account identifier is committed.
+
+- PATH Pi `0.84.2` satisfied the `0.84.1` floor, started active, and imported
+  its catalog. A direct RPC probe reported a selected model, seven available
+  models from one connected provider, and an idle stream. The bridge session
+  options path exposed the same seven models and three commands; the iOS
+  composer rendered Pi, its model, and thinking selector.
+- Empty-session creation, local rename, safe plugin restart, bridge restart,
+  resume/list, idle abort, deletion, and post-restart tombstone suppression all
+  succeeded through production bridge routes. The development client lost and
+  re-established its encrypted relay session across the bridge restart.
+- A one-pixel PNG plus text reached the persisted Pi transcript as text and an
+  `image/png` inline-image part before provider execution failed, verifying the
+  bridge/plugin attachment seam without retaining the image payload.
+- A terminal Pi process created a persisted session and exited before explicit
+  bridge import. Sesori imported its user/error history, allowed a local rename,
+  deleted it, and did not re-import the tombstoned artifact. This verifies the
+  documented terminal-to-Sesori handoff ordering, never concurrent ownership.
+- Provider execution currently returns the demonstrated typed Codex
+  usage-limit error. Error mapping remained visible and the session returned to
+  idle, but a successful authenticated response, reasoning/tool stream,
+  extension dialogs, model/provider sweep, and successful image response remain
+  blocked until provider quota is available. No success fixture is claimed.
+
 ## 12. Verification Still Required During Implementation
 
 - Capture redacted authenticated event ordering and model readiness for API-key,

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -3,9 +3,9 @@
 ## Current State
 
 - **Plan slug:** `pi-harness`
-- **Implementation base:** current `origin/main` with Step 15 merged
-- **Series state:** Step 18/21 ready to raise
-- **Current step:** 18/21, Pi and OMP registration implemented
+- **Implementation base:** current `origin/main` with Step 19 merged
+- **Series state:** Step 20/21 open as PR #979; Step 21 local
+- **Current step:** 20/21, integration verification in review
 - **Plan PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/811
 - **Step 2 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/819
 - **Step 3 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/820
@@ -24,7 +24,10 @@
 - **Step 15 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/920
 - **Step 16 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/925
 - **Step 17 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/963
-- **Next action:** raise Step 18 PR and monitor it
+- **Step 18 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/967
+- **Step 19 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/973
+- **Step 20 PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/979
+- **Next action:** monitor Step 20 PR, then retire the plan in Step 21
 
 ## Locked Decisions
 
@@ -657,9 +660,12 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   module_prego, and mobile app; shared plain analysis also passes. Full suites:
   bridge app 2,675, Pi 255, OMP 51, ACP 242, shared 409, module_core 1,149,
   module_prego 209, and mobile app 998 tests.
-- Product diff excluding this tracker evidence is +187/-19 = 206 changed
-  lines, below the 300-700 estimate because most verification produced only
-  redacted evidence; generated lines: 0.
+- Product diff commands: `base=$(git merge-base origin/main HEAD)`, then
+  `git diff --numstat "$base"..HEAD -- . ':(exclude).plan/active/pi-harness/TRACKER.md'`.
+  They report +252/-24 = 276
+  changed lines, below the 300-700 estimate because most verification produced
+  only redacted evidence; generated lines: 0.
+- `git diff --check "$base"..HEAD` passes.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -657,8 +657,9 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   module_prego, and mobile app; shared plain analysis also passes. Full suites:
   bridge app 2,675, Pi 255, OMP 51, ACP 242, shared 409, module_core 1,149,
   module_prego 209, and mobile app 998 tests.
-- Product diff excluding this tracker evidence is +375/-285 = 660 changed
-  lines, within the 300-700 estimate; generated lines: 0.
+- Product diff excluding this tracker evidence is +187/-19 = 206 changed
+  lines, below the 300-700 estimate because most verification produced only
+  redacted evidence; generated lines: 0.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -658,7 +658,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   evidence for those targets.
 - Focused fatal analysis passes for bridge app, Pi, OMP, ACP, module_core,
   module_prego, and mobile app; shared plain analysis also passes. Full suites:
-  bridge app 2,675, Pi 255, OMP 51, ACP 242, shared 409, module_core 1,149,
+  bridge app 2,675, Pi 255, OMP 51, ACP 242, shared 409, module_core 1,150,
   module_prego 209, and mobile app 998 tests.
 - Product diff commands: `base=$(git merge-base origin/main HEAD)`, then
   `git diff --numstat "$base"..HEAD -- . ':(exclude).plan/active/pi-harness/TRACKER.md'`.

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -70,7 +70,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 | [x] | 17/21 | `🚧 [pi-harness] feat(pi): add managed runtime and lifecycle [step 17/21]` | 1,100-1,500 | Merged as PR #963 |
 | [x] | 18/21 | `⚙️ [pi-harness] feat(bridge): register Pi and OMP [step 18/21]` | 800-1,200 (over-estimate) | Merged as PR #967 |
 | [x] | 19/21 | `🌿 [pi-harness] feat(client): add Pi and OMP branding and guidance [step 19/21]` | 500-900 (over-estimate) | Merged as PR #973 |
-| [ ] | 20/21 | `⚙️ [pi-harness] test(harness): verify Pi and OMP integration [step 20/21]` | 300-700 | In progress; live verification complete and one resume correction implemented |
+| [ ] | 20/21 | `⚙️ [pi-harness] test(harness): verify Pi and OMP integration [step 20/21]` | 300-700 | Open as PR #979 |
 | [ ] | 21/21 | `🌱 [pi-harness] docs: retire the Pi and OMP harness plan [step 21/21]` | 50-200 | Not started |
 
 ## Working Rules

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -69,8 +69,8 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 | [x] | 16/21 | `🚧 [pi-harness] feat(pi): implement the plugin API [step 16/21]` | 1,100-1,500 (recorded slight overage) | Merged as PR #925 |
 | [x] | 17/21 | `🚧 [pi-harness] feat(pi): add managed runtime and lifecycle [step 17/21]` | 1,100-1,500 | Merged as PR #963 |
 | [x] | 18/21 | `⚙️ [pi-harness] feat(bridge): register Pi and OMP [step 18/21]` | 800-1,200 (over-estimate) | Merged as PR #967 |
-| [ ] | 19/21 | `🌿 [pi-harness] feat(client): add Pi and OMP branding and guidance [step 19/21]` | 500-900 (over-estimate) | Open as PR #973 |
-| [ ] | 20/21 | `⚙️ [pi-harness] test(harness): verify Pi and OMP integration [step 20/21]` | 300-700 | In progress; provider-backed live turns blocked by Pi quota and missing OMP model |
+| [x] | 19/21 | `🌿 [pi-harness] feat(client): add Pi and OMP branding and guidance [step 19/21]` | 500-900 (over-estimate) | Merged as PR #973 |
+| [ ] | 20/21 | `⚙️ [pi-harness] test(harness): verify Pi and OMP integration [step 20/21]` | 300-700 | In progress; live verification complete and one resume correction implemented |
 | [ ] | 21/21 | `🌱 [pi-harness] docs: retire the Pi and OMP harness plan [step 21/21]` | 50-200 | Not started |
 
 ## Working Rules
@@ -634,19 +634,31 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   imported, renamed, and deleted a terminal-created session after the terminal
   process exited; its text-plus-PNG transcript retained an inline image before
   provider rejection.
-- Pi exposes one connected provider with seven models and three commands, but
-  its selected provider returns a usage-limit error. OMP exposes no connected
-  provider/model and explicit refresh returns `refreshFailedUnavailable` with
-  correct local-login guidance. Provider-backed success fixtures and dependent
-  reasoning/tool/dialog/form/replay sweeps remain blocked; no credentials or
-  raw captures are retained or committed.
+- Missing-provider guidance and the original Pi provider's usage-limit error
+  were verified before a local OpenAI-compatible provider was configured for
+  both CLIs. Both then completed authenticated phone text/tool turns; OMP also
+  rendered reasoning and completed terminal import/resume, while Pi completed
+  direct image inference and terminal import/resume. No credentials, provider
+  account identifiers, raw frames, prompts, or transcripts are committed.
+- Live testing found that a terminal-imported Pi session rendered its transcript
+  model but selected a stale project-catalog default for the next send. The
+  client now prefers a latest assistant/error transcript model after valid
+  persisted prompt defaults and before agent/catalog fallbacks. A regression
+  verifies that the resumed send retains a model absent from the stale cache;
+  the rebuilt iOS client resumed the imported session successfully.
+- OMP emitted an image request but its selected upstream rate-limited it. Its ACP
+  model did not expose `ask`, and the dev bridge auto-approved permissions, so
+  successful OMP image replay, live forms, and live permission cards are not
+  claimed; automated OMP/ACP coverage remains authoritative for those paths.
 - macOS arm64 is the only available live host. Docker/Linux/Windows and live
-  glibc/musl selection are unavailable; automated platform tests remain pending
-  in the final focused suite.
+  glibc/musl selection are unavailable; passing automated platform tests are the
+  evidence for those targets.
 - Focused fatal analysis passes for bridge app, Pi, OMP, ACP, module_core,
   module_prego, and mobile app; shared plain analysis also passes. Full suites:
-  bridge app 2,675, Pi 255, OMP 51, ACP 242, shared 409, module_core 1,148,
+  bridge app 2,675, Pi 255, OMP 51, ACP 242, shared 409, module_core 1,149,
   module_prego 209, and mobile app 998 tests.
+- Product diff excluding this tracker evidence is +375/-285 = 660 changed
+  lines, within the 300-700 estimate; generated lines: 0.
 
 ## Findings And Plan Deltas
 

--- a/.plan/active/pi-harness/TRACKER.md
+++ b/.plan/active/pi-harness/TRACKER.md
@@ -70,7 +70,7 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
 | [x] | 17/21 | `🚧 [pi-harness] feat(pi): add managed runtime and lifecycle [step 17/21]` | 1,100-1,500 | Merged as PR #963 |
 | [x] | 18/21 | `⚙️ [pi-harness] feat(bridge): register Pi and OMP [step 18/21]` | 800-1,200 (over-estimate) | Merged as PR #967 |
 | [ ] | 19/21 | `🌿 [pi-harness] feat(client): add Pi and OMP branding and guidance [step 19/21]` | 500-900 (over-estimate) | Open as PR #973 |
-| [ ] | 20/21 | `⚙️ [pi-harness] test(harness): verify Pi and OMP integration [step 20/21]` | 300-700 | Not started |
+| [ ] | 20/21 | `⚙️ [pi-harness] test(harness): verify Pi and OMP integration [step 20/21]` | 300-700 | In progress; provider-backed live turns blocked by Pi quota and missing OMP model |
 | [ ] | 21/21 | `🌱 [pi-harness] docs: retire the Pi and OMP harness plan [step 21/21]` | 50-200 | Not started |
 
 ## Working Rules
@@ -619,6 +619,34 @@ binary install. `OMP_PROTOCOL.md` records the supporting evidence.
   Step 18 already absorbed the shared activation/notification prerequisites;
   this step reused the existing brand catalog and needed only localized assets,
   mappings, tests, and guidance. The original budget was an over-estimate.
+
+### Step 20/21 (in progress)
+
+- Source-run bridge slot 1 authenticated, registered, and paired with the
+  dedicated `sesori-dev-1` iOS simulator. Pi used PATH `0.84.2`; OMP installed
+  official managed `17.2.13` through the production lifecycle route and reused
+  it after plugin/bridge restart.
+- Phone verification covered the complete harness picker, current Pi/OMP marks,
+  Pi model/thinking controls, OMP missing-model popup guidance, and encrypted
+  reconnect after bridge restart. Screenshot evidence remains local only.
+- Both plugins passed empty-session create/list, local rename, safe restart,
+  idle abort, delete cleanup, and restart/import non-resurrection. Pi additionally
+  imported, renamed, and deleted a terminal-created session after the terminal
+  process exited; its text-plus-PNG transcript retained an inline image before
+  provider rejection.
+- Pi exposes one connected provider with seven models and three commands, but
+  its selected provider returns a usage-limit error. OMP exposes no connected
+  provider/model and explicit refresh returns `refreshFailedUnavailable` with
+  correct local-login guidance. Provider-backed success fixtures and dependent
+  reasoning/tool/dialog/form/replay sweeps remain blocked; no credentials or
+  raw captures are retained or committed.
+- macOS arm64 is the only available live host. Docker/Linux/Windows and live
+  glibc/musl selection are unavailable; automated platform tests remain pending
+  in the final focused suite.
+- Focused fatal analysis passes for bridge app, Pi, OMP, ACP, module_core,
+  module_prego, and mobile app; shared plain analysis also passes. Full suites:
+  bridge app 2,675, Pi 255, OMP 51, ACP 242, shared 409, module_core 1,148,
+  module_prego 209, and mobile app 998 tests.
 
 ## Findings And Plan Deltas
 

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -489,7 +489,7 @@ class SessionDetailCubit(
       switch (result) {
         case SessionDetailLoadResultLoaded(:final snapshot):
           _waitingForConnection = false;
-          final latestAssistant = _latestAssistantMessage(snapshot.messages);
+          final latestAssistant = _latestAssistantOrErrorMessage(snapshot.messages);
           final childIds = snapshot.childSessions.map((c) => c.id).toSet();
           final childStatuses = Map<String, SessionStatus>.fromEntries(
             snapshot.statuses.entries.where((e) => childIds.contains(e.key)),
@@ -709,11 +709,11 @@ class SessionDetailCubit(
     return availableCommands.firstWhereOrNull((c) => c.name == stagedCommand.name);
   }
 
-  /// Returns the latest assistant [Message] from the list, or null if none.
-  Message? _latestAssistantMessage(List<MessageWithParts> messages) {
+  /// Returns the latest assistant or error [Message] from the list, or null if none.
+  Message? _latestAssistantOrErrorMessage(List<MessageWithParts> messages) {
     for (var i = messages.length - 1; i >= 0; i--) {
       final info = messages[i].info;
-      if (info is MessageAssistant) return info;
+      if (info is MessageAssistant || info is MessageError) return info;
     }
     return null;
   }
@@ -2006,7 +2006,7 @@ class SessionDetailCubit(
 
   SessionDetailLoaded _buildLoadedState({required SessionDetailSnapshot snapshot}) {
     _reconcileStagedWithSnapshot(snapshot: snapshot);
-    final latestAssistant = _latestAssistantMessage(snapshot.messages);
+    final latestAssistant = _latestAssistantOrErrorMessage(snapshot.messages);
     final childSessions = [...snapshot.childSessions];
     _sortChildrenByUpdatedDesc(childSessions);
     final childIds = childSessions.map((c) => c.id).toSet();
@@ -2032,9 +2032,25 @@ class SessionDetailCubit(
         ? persistedAgent
         : (agents.isNotEmpty ? agents.first.name : "build");
 
+    final assistantAgentModel = switch (latestAssistant) {
+      MessageAssistant(:final modelID, :final providerID) => _resolveAgentModel(
+        agents: agents,
+        providerID: providerID,
+        modelID: modelID,
+      ),
+      MessageError(:final modelID, :final providerID) => _resolveAgentModel(
+        agents: agents,
+        providerID: providerID,
+        modelID: modelID,
+      ),
+      MessageUser() || null => null,
+    };
+
     final AgentModel? defaultAgentModel;
     if (hasValidPersistedModel) {
       defaultAgentModel = persistedModel;
+    } else if (assistantAgentModel != null) {
+      defaultAgentModel = assistantAgentModel;
     } else if (agents.isNotEmpty && agents.first.model != null) {
       defaultAgentModel = agents.first.model;
     } else if (providers.isNotEmpty) {
@@ -2061,20 +2077,6 @@ class SessionDetailCubit(
     } else {
       defaultAgentModel = null;
     }
-
-    final assistantAgentModel = switch (latestAssistant) {
-      MessageAssistant(:final modelID, :final providerID) => _resolveAgentModel(
-        agents: agents,
-        providerID: providerID,
-        modelID: modelID,
-      ),
-      MessageError(:final modelID, :final providerID) => _resolveAgentModel(
-        agents: agents,
-        providerID: providerID,
-        modelID: modelID,
-      ),
-      MessageUser() || null => null,
-    };
 
     final availableVariants = _deriveAvailableVariants(
       providers: providers,

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -1118,18 +1118,20 @@ class SessionDetailCubit(
 
     if (isClosed) return;
 
-    if (message is MessageAssistant) {
-      final assistantAgentModel = message.providerID != null && message.modelID != null
+    if (message case
+        MessageAssistant(:final providerID, :final modelID, :final agent) ||
+        MessageError(:final providerID, :final modelID, :final agent)) {
+      final assistantAgentModel = providerID != null && modelID != null
           ? _resolveAgentModel(
               agents: current.availableAgents,
-              providerID: message.providerID,
-              modelID: message.modelID,
+              providerID: providerID,
+              modelID: modelID,
             )
           : current.assistantAgentModel;
       emit(
         current.copyWith(
           messages: messages,
-          agent: message.agent ?? current.agent,
+          agent: agent ?? current.agent,
           assistantAgentModel: assistantAgentModel,
         ),
       );

--- a/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
@@ -168,6 +168,64 @@ void main() {
       expect(state.agent, "build");
     });
 
+    test("a live error updates assistant model attribution", () async {
+      final mockLoadService = MockSessionDetailLoadService();
+      when(
+        () => mockLoadService.load(
+          sessionId: _sessionId,
+          projectId: any(named: "projectId"),
+        ),
+      ).thenAnswer(
+        (_) async => const SessionDetailLoadResult.loaded(
+          snapshot: SessionDetailSnapshot(
+            bridgeQueuedPrompts: [],
+            projectId: "project-1",
+            pluginId: "opencode",
+            supportsPromptAttachments: false,
+            messages: [],
+            olderMessagesCursor: null,
+            pendingQuestions: [],
+            pendingPermissions: [],
+            childSessions: [],
+            statuses: {},
+            agents: [],
+            providerData: null,
+            commands: [],
+            canonicalSessionTitle: null,
+            promptDefaults: null,
+            isRootSession: true,
+            isArchived: false,
+          ),
+          isBridgeConnected: true,
+        ),
+      );
+      final cubit = createCubit(loadService: mockLoadService);
+      await _awaitLoaded(cubit);
+
+      sessionEvents.add(
+        const SesoriMessageUpdated(
+          info: Message.error(
+            id: "msg-error",
+            sessionID: _sessionId,
+            agent: "build",
+            modelID: "test-model",
+            providerID: "sesori-local",
+            errorName: "ProviderError",
+            errorMessage: "request failed",
+            time: null,
+          ),
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final state = cubit.state as SessionDetailLoaded;
+      expect(state.agent, "build");
+      expect(
+        state.assistantAgentModel,
+        const AgentModel(providerID: "sesori-local", modelID: "test-model", variant: null),
+      );
+    });
+
     test("buffers global SSE events during loading and replays after loaded", () async {
       final mockLoadService = MockSessionDetailLoadService();
       final completer = Completer<SessionDetailLoadResult>();

--- a/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
@@ -430,6 +430,92 @@ void main() {
       ).called(1);
     });
 
+    test("resume forwards the transcript model when the provider cache is stale", () async {
+      when(
+        () => mockSessionService.getMessages(
+          sessionId: sessionId,
+          limit: any(named: "limit"),
+          before: any(named: "before"),
+        ),
+      ).thenAnswer(
+        (_) async => ApiResponse.success(
+          const MessageWithPartsResponse(
+            messages: [
+              MessageWithParts(
+                info: Message.error(
+                  id: "msg-custom-model",
+                  sessionID: sessionId,
+                  agent: null,
+                  modelID: "test-model",
+                  providerID: "sesori-local",
+                  errorName: "ProviderError",
+                  errorMessage: "request failed",
+                  time: null,
+                ),
+                parts: [],
+              ),
+            ],
+            nextCursor: null,
+          ),
+        ),
+      );
+      when(
+        () => mockSessionRepository.sendMessage(
+          promptId: any(named: "promptId"),
+          attachments: const [],
+          sessionId: sessionId,
+          text: "resume",
+          agent: "coder",
+          model: const PromptModel(providerID: "sesori-local", modelID: "test-model"),
+          variant: null,
+          command: null,
+        ),
+      ).thenAnswer((_) async => ApiResponse<void>.success(null));
+
+      final cubit = SessionDetailCubit(
+        mockConnectionService,
+        loadService: loadService,
+        promptDispatcher: promptDispatcher,
+        permissionRepository: mockPermissionRepository,
+        sessionViewingService: stubbedSessionViewingService(),
+        projectViewingService: stubbedProjectViewingService(),
+        lifecycleSource: FakeLifecycleSource(),
+        composerDraftRepository: inMemoryComposerDraftRepository(),
+        productAnalyticsService: stubbedProductAnalyticsService(),
+        sessionId: sessionId,
+        projectId: "project-1",
+        notificationCanceller: mockNotificationCanceller,
+        failureReporter: MockFailureReporter(),
+      );
+      addTearDown(cubit.close);
+
+      await _awaitLoaded(cubit);
+      expect(
+        (cubit.state as SessionDetailLoaded).selectedAgentModel,
+        const AgentModel(providerID: "sesori-local", modelID: "test-model", variant: null),
+      );
+
+      await cubit.sendMessage(
+        attachments: const [],
+        text: "resume",
+        command: null,
+        inputMode: ComposerInputMode.typed,
+      );
+
+      verify(
+        () => mockSessionRepository.sendMessage(
+          promptId: any(named: "promptId"),
+          attachments: const [],
+          sessionId: sessionId,
+          text: "resume",
+          agent: "coder",
+          model: const PromptModel(providerID: "sesori-local", modelID: "test-model"),
+          variant: null,
+          command: null,
+        ),
+      ).called(1);
+    });
+
     test("delta race: streaming deltas arriving during refresh are preserved", () async {
       final cubit = SessionDetailCubit(
         mockConnectionService,

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -75,6 +75,11 @@ defaults and queued client sends coherent.
   failure must not fail the send. Abort stops the turn with an observable
   outcome and no completion notification, and the next turn starts without
   recovery output from the interrupted backend process.
+- Opening an existing session selects valid persisted prompt defaults first and
+  otherwise continues with the latest assistant/error transcript model before
+  falling back to agent or catalog defaults. The transcript model remains
+  authoritative when a retained provider cache does not list it, so a terminal-
+  imported session cannot silently resume on a different provider.
 - The bridge owns queued prompts. A send accepted while another turn runs
   becomes a bridge-queued entry: it appears in the session snapshot and in
   full-list `session.queued-prompts` events, survives leaving the screen,
@@ -136,6 +141,8 @@ has started.
   the conversation or replayed history.
 - Prompt defaults regress, an approved plan exit does not restore Default
   across clients and restart, or a defaults-write failure fails the send.
+- Reopening or importing a session silently switches its latest transcript
+  model to a stale catalog default on the next send.
 - A send or cancel succeeds against an archived session, an aborted turn
   triggers a completion notification, or queued sends reorder, vanish, or
   resend. A send to a busy session blocks until the running turn finishes, a


### PR DESCRIPTION
## Complexity

⚙️ Moderate. The production correction is localized, but verification spans two live backends, managed runtime lifecycle, encrypted relay/client flows, terminal imports, and redacted evidence.

## What

- Records redacted live Pi and OMP verification across setup, lifecycle, sessions, tools, errors, attachments, deletion, restart, and terminal handoff.
- Makes existing-session model selection prefer the latest assistant/error transcript model after valid persisted prompt defaults and before stale agent/catalog fallbacks.
- Adds a regression proving a resumed send retains a transcript model that is absent from a stale provider cache.
- Updates the session-turn regression contract and plan tracker.

## Why

Live terminal-import testing found that Pi restored its custom session model correctly, but the client selected and explicitly sent the cached project default on resume. That silently changed provider and caused the next turn to fail against an unrelated provider quota.

## Risk and test focus

Risk is moderate and localized to initial model selection when opening existing sessions. Focus on valid persisted defaults remaining highest priority, assistant and error transcript attribution, stale provider caches, resumed sends, and ordinary new-session options remaining unchanged.

Live limitations are recorded rather than hidden: no non-macOS host was available; the OMP image upstream rate-limited; the test ACP profile did not expose `ask`; and the development bridge auto-approved permissions.

## Expected result

Existing and terminal-imported sessions resume with their latest transcript model instead of silently switching to a stale catalog default. There is no wire-contract or database change. User-visible impact is limited to correct model selection and successful resume behavior; verification evidence is documentation-only otherwise.

## Verification

- `client/module_core`: `dart analyze --fatal-infos`; 1,150 tests
- `client/app`: `dart analyze --fatal-infos`; 998 tests
- Previously completed Step 20 matrix: bridge app 2,675; Pi 255; OMP 51; ACP 242; shared 409; module_prego 209
- Rebuilt iOS simulator app: fresh Pi terminal session imported with `test-model` selected and resumed successfully
- OMP iOS text, reasoning display, tool turn, terminal import, and phone resume succeeded
- `git diff --check`
