### PR TITLE
🌿 Show terminal Codex failures in session history

### DIFF
--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
@@ -102,6 +102,7 @@ sealed class CodexRolloutEventDto with _$CodexRolloutEventDto {
   @FreezedUnionValue("task_complete")
   const factory taskComplete({
     @JsonKey(name: "turn_id") required String turnId,
+    required CodexRolloutErrorDto? error,
   }) = CodexRolloutTaskCompleteEventDto;
 
   @FreezedUnionValue("turn_aborted")
@@ -112,6 +113,15 @@ sealed class CodexRolloutEventDto with _$CodexRolloutEventDto {
   const factory unknown() = CodexRolloutUnknownEventDto;
 
   factory fromJson(Map<String, dynamic> json) => _$CodexRolloutEventDtoFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexRolloutErrorDto with _$CodexRolloutErrorDto {
+  const factory({
+    required String message,
+  }) = _CodexRolloutErrorDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$CodexRolloutErrorDtoFromJson(json);
 }
 
 @Freezed(fromJson: true, toJson: false)

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
@@ -992,10 +992,11 @@ as String,
 @JsonSerializable(createToJson: false)
 
 class CodexRolloutTaskCompleteEventDto implements CodexRolloutEventDto {
-  const CodexRolloutTaskCompleteEventDto({@JsonKey(name: "turn_id") required this.turnId,  String? $type}): $type = $type ?? 'task_complete';
+  const CodexRolloutTaskCompleteEventDto({@JsonKey(name: "turn_id") required this.turnId, required this.error,  String? $type}): $type = $type ?? 'task_complete';
   factory CodexRolloutTaskCompleteEventDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutTaskCompleteEventDtoFromJson(json);
 
 @JsonKey(name: "turn_id") final  String turnId;
+ final  CodexRolloutErrorDto? error;
 
 @JsonKey(name: 'type')
 final String $type;
@@ -1011,16 +1012,16 @@ $CodexRolloutTaskCompleteEventDtoCopyWith<CodexRolloutTaskCompleteEventDto> get 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutTaskCompleteEventDto&&(identical(other.turnId, turnId) || other.turnId == turnId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutTaskCompleteEventDto&&(identical(other.turnId, turnId) || other.turnId == turnId)&&(identical(other.error, error) || other.error == error));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,turnId);
+int get hashCode => Object.hash(runtimeType,turnId,error);
 
 @override
 String toString() {
-  return 'CodexRolloutEventDto.taskComplete(turnId: $turnId)';
+  return 'CodexRolloutEventDto.taskComplete(turnId: $turnId, error: $error)';
 }
 
 
@@ -1031,11 +1032,11 @@ abstract mixin class $CodexRolloutTaskCompleteEventDtoCopyWith<$Res> implements 
   factory $CodexRolloutTaskCompleteEventDtoCopyWith(CodexRolloutTaskCompleteEventDto value, $Res Function(CodexRolloutTaskCompleteEventDto) _then) = _$CodexRolloutTaskCompleteEventDtoCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(name: "turn_id") String turnId
+@JsonKey(name: "turn_id") String turnId, CodexRolloutErrorDto? error
 });
 
 
-
+$CodexRolloutErrorDtoCopyWith<$Res>? get error;
 
 }
 /// @nodoc
@@ -1048,14 +1049,27 @@ class _$CodexRolloutTaskCompleteEventDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexRolloutEventDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? turnId = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? turnId = null,Object? error = freezed,}) {
   return _then(CodexRolloutTaskCompleteEventDto(
 turnId: null == turnId ? _self.turnId : turnId // ignore: cast_nullable_to_non_nullable
-as String,
+as String,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as CodexRolloutErrorDto?,
   ));
 }
 
+/// Create a copy of CodexRolloutEventDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CodexRolloutErrorDtoCopyWith<$Res>? get error {
+    if (_self.error == null) {
+    return null;
+  }
 
+  return $CodexRolloutErrorDtoCopyWith<$Res>(_self.error!, (value) {
+    return _then(_self.copyWith(error: value));
+  });
+}
 }
 
 /// @nodoc
@@ -1163,6 +1177,135 @@ String toString() {
 
 
 
+
+
+/// @nodoc
+mixin _$CodexRolloutErrorDto {
+
+ String get message;
+/// Create a copy of CodexRolloutErrorDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutErrorDtoCopyWith<CodexRolloutErrorDto> get copyWith => _$CodexRolloutErrorDtoCopyWithImpl<CodexRolloutErrorDto>(this as CodexRolloutErrorDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutErrorDto&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,message);
+
+@override
+String toString() {
+  return 'CodexRolloutErrorDto(message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutErrorDtoCopyWith<$Res>  {
+  factory $CodexRolloutErrorDtoCopyWith(CodexRolloutErrorDto value, $Res Function(CodexRolloutErrorDto) _then) = _$CodexRolloutErrorDtoCopyWithImpl;
+@useResult
+$Res call({
+ String message
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexRolloutErrorDtoCopyWithImpl<$Res>
+    implements $CodexRolloutErrorDtoCopyWith<$Res> {
+  _$CodexRolloutErrorDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutErrorDto _self;
+  final $Res Function(CodexRolloutErrorDto) _then;
+
+/// Create a copy of CodexRolloutErrorDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? message = null,}) {
+  return _then(CodexRolloutErrorDto(
+message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexRolloutErrorDto implements CodexRolloutErrorDto {
+  const _CodexRolloutErrorDto({required this.message});
+  factory _CodexRolloutErrorDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutErrorDtoFromJson(json);
+
+@override final  String message;
+
+/// Create a copy of CodexRolloutErrorDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexRolloutErrorDtoCopyWith<_CodexRolloutErrorDto> get copyWith => __$CodexRolloutErrorDtoCopyWithImpl<_CodexRolloutErrorDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexRolloutErrorDto&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,message);
+
+@override
+String toString() {
+  return 'CodexRolloutErrorDto(message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexRolloutErrorDtoCopyWith<$Res> implements $CodexRolloutErrorDtoCopyWith<$Res> {
+  factory _$CodexRolloutErrorDtoCopyWith(_CodexRolloutErrorDto value, $Res Function(_CodexRolloutErrorDto) _then) = __$CodexRolloutErrorDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String message
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexRolloutErrorDtoCopyWithImpl<$Res>
+    implements _$CodexRolloutErrorDtoCopyWith<$Res> {
+  __$CodexRolloutErrorDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexRolloutErrorDto _self;
+  final $Res Function(_CodexRolloutErrorDto) _then;
+
+/// Create a copy of CodexRolloutErrorDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? message = null,}) {
+  return _then(_CodexRolloutErrorDto(
+message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
 
 
 /// @nodoc

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
@@ -105,6 +105,11 @@ CodexRolloutTaskCompleteEventDto _$CodexRolloutTaskCompleteEventDtoFromJson(
   Map json,
 ) => CodexRolloutTaskCompleteEventDto(
   turnId: json['turn_id'] as String,
+  error: json['error'] == null
+      ? null
+      : CodexRolloutErrorDto.fromJson(
+          Map<String, dynamic>.from(json['error'] as Map),
+        ),
   $type: json['type'] as String?,
 );
 
@@ -117,6 +122,9 @@ CodexRolloutTurnAbortedEventDto _$CodexRolloutTurnAbortedEventDtoFromJson(
 
 CodexRolloutUnknownEventDto _$CodexRolloutUnknownEventDtoFromJson(Map json) =>
     CodexRolloutUnknownEventDto($type: json['type'] as String?);
+
+_CodexRolloutErrorDto _$CodexRolloutErrorDtoFromJson(Map json) =>
+    _CodexRolloutErrorDto(message: json['message'] as String);
 
 _CodexRolloutSessionMetadataPayloadDto
 _$CodexRolloutSessionMetadataPayloadDtoFromJson(Map json) =>

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -191,11 +191,14 @@ class CodexEventMapper({
       case "turn/completed":
         final threadId = params["threadId"] as String?;
         if (threadId == null) return const [];
+        final turn = _asMap(params["turn"]);
         return [
           _sessionActivityUpdated(
             threadId: threadId,
-            timestampSeconds: _asMap(params["turn"])?["completedAt"],
+            timestampSeconds: turn?["completedAt"],
           ),
+          if (_turnErrorMessage(threadId: threadId, turn: turn) case final errorMessage?)
+            BridgeSseMessageUpdated(info: errorMessage.toJson()),
           BridgeSseSessionIdle(sessionID: threadId),
         ];
 
@@ -242,6 +245,28 @@ class CodexEventMapper({
     //     ApprovalRegistry as permission/question events.
     //   - account/*, fs/changed, configWarning, realtime/* … — no analog.
     return const [];
+  }
+
+  PluginMessage? _turnErrorMessage({
+    required String threadId,
+    required Map<String, dynamic>? turn,
+  }) {
+    final turnId = turn?["id"] as String?;
+    final error = _asMap(turn?["error"]);
+    final message = error?["message"] as String?;
+    if (turnId == null || turnId.trim().isEmpty || message == null || message.trim().isEmpty) {
+      return null;
+    }
+    return PluginMessage.error(
+      id: _turnErrorMessageId(turnId),
+      sessionID: threadId,
+      agent: "codex",
+      modelID: _threadModel[threadId] ?? config.model,
+      providerID: _threadProvider[threadId] ?? config.modelProvider ?? "openai",
+      errorName: "CodexError",
+      errorMessage: message,
+      time: null,
+    );
   }
 
   /// Renders a complete repository-owned canonical tool upsert.
@@ -810,3 +835,5 @@ class CodexEventMapper({
     return null;
   }
 }
+
+String _turnErrorMessageId(String turnId) => "codex-turn-error-$turnId";

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -258,7 +258,7 @@ class CodexEventMapper({
       return null;
     }
     return PluginMessage.error(
-      id: _turnErrorMessageId(turnId),
+      id: turnId,
       sessionID: threadId,
       agent: "codex",
       modelID: _threadModel[threadId] ?? config.model,
@@ -835,5 +835,3 @@ class CodexEventMapper({
     return null;
   }
 }
-
-String _turnErrorMessageId(String turnId) => "codex-turn-error-$turnId";

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
@@ -181,6 +181,27 @@ class CodexMessageRepository({
           pending.resolved = true;
         }
       }
+      if (line
+          case CodexRolloutEventMessageLineDto(
+            payload: CodexRolloutTaskCompleteEventDto(:final turnId, error: final error?),
+          )
+          when error.message.trim().isNotEmpty) {
+        messages.add(
+          PluginMessageWithParts(
+            info: PluginMessage.error(
+              id: _turnErrorMessageId(turnId),
+              sessionID: sessionId,
+              agent: "codex",
+              modelID: currentModel ?? config.model,
+              providerID: sessionProvider ?? config.modelProvider ?? "openai",
+              errorName: "CodexError",
+              errorMessage: error.message,
+              time: _messageTimeFrom(lineTimestamp),
+            ),
+            parts: const [],
+          ),
+        );
+      }
 
       final CodexRolloutResponseItemDto payload;
       switch (line) {
@@ -551,6 +572,8 @@ bool _isGeneratedContext({required String text}) {
   return _GeneratedContextTag.values.any((tag) => tag.wraps(normalized)) ||
       _generatedRepositoryInstructions.hasMatch(normalized);
 }
+
+String _turnErrorMessageId(String turnId) => "codex-turn-error-$turnId";
 
 class _PendingUserMessage({
   required final int slot,

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
@@ -189,7 +189,7 @@ class CodexMessageRepository({
         messages.add(
           PluginMessageWithParts(
             info: PluginMessage.error(
-              id: _turnErrorMessageId(turnId),
+              id: turnId,
               sessionID: sessionId,
               agent: "codex",
               modelID: currentModel ?? config.model,
@@ -572,8 +572,6 @@ bool _isGeneratedContext({required String text}) {
   return _GeneratedContextTag.values.any((tag) => tag.wraps(normalized)) ||
       _generatedRepositoryInstructions.hasMatch(normalized);
 }
-
-String _turnErrorMessageId(String turnId) => "codex-turn-error-$turnId";
 
 class _PendingUserMessage({
   required final int slot,

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -1437,6 +1437,35 @@ void main() {
       expect((events.single as BridgeSseSessionError).sessionID, "t-1");
     });
 
+    test("failed turn/completed emits a visible error message", () {
+      final events = mapper.map(
+        const CodexServerNotification(
+          method: "turn/completed",
+          params: {
+            "threadId": "t-quota",
+            "turn": {
+              "id": "u-quota",
+              "status": "failed",
+              "error": {
+                "message": "You've hit your usage limit.",
+                "codexErrorInfo": "usageLimitExceeded",
+              },
+              "completedAt": 1700000010,
+            },
+          },
+        ),
+      );
+
+      expect(events, hasLength(3));
+      final event = events[1] as BridgeSseMessageUpdated;
+      final message = shared.Message.fromJson(event.info) as shared.MessageError;
+      expect(message.id, "codex-turn-error-u-quota");
+      expect(message.sessionID, "t-quota");
+      expect(message.errorName, "CodexError");
+      expect(message.errorMessage, "You've hit your usage limit.");
+      expect(parseAsSesori(event), isA<shared.SesoriMessageUpdated>());
+    });
+
     test("notifications with no bridge analog are dropped", () {
       for (final method in const [
         "account/rateLimits/updated",

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -1459,7 +1459,7 @@ void main() {
       expect(events, hasLength(3));
       final event = events[1] as BridgeSseMessageUpdated;
       final message = shared.Message.fromJson(event.info) as shared.MessageError;
-      expect(message.id, "codex-turn-error-u-quota");
+      expect(message.id, "u-quota");
       expect(message.sessionID, "t-quota");
       expect(message.errorName, "CodexError");
       expect(message.errorMessage, "You've hit your usage limit.");

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -974,7 +974,7 @@ void main() {
       await idle.timeout(const Duration(seconds: 1));
       final error = await visibleError.timeout(const Duration(seconds: 1));
       expect(plugin.currentWorkState, PluginWorkState.idle);
-      expect(error.id, "codex-turn-error-u-terminal");
+      expect(error.id, "u-terminal");
       expect(error.errorMessage, "turn failed");
     });
 

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -923,7 +923,7 @@ void main() {
       expect(fake.serverResponseFor(99)["result"], {"decision": "decline"});
     });
 
-    test("error clears provisional busy", () async {
+    test("terminal error sequence clears busy and emits the failure message", () async {
       fake.respondInOrder([
         const _Response(result: _initOk),
         const _Response(
@@ -949,13 +949,33 @@ void main() {
       expect(plugin.currentWorkState, PluginWorkState.busy);
 
       final idle = plugin.workState.firstWhere((state) => state == PluginWorkState.idle);
+      final visibleError = plugin.events
+          .where((event) => event is BridgeSseMessageUpdated)
+          .cast<BridgeSseMessageUpdated>()
+          .map((event) => shared.Message.fromJson(event.info))
+          .where((message) => message is shared.MessageError)
+          .cast<shared.MessageError>()
+          .first;
       fake.pushNotification("error", {
         "threadId": "t-terminal",
+        "turnId": "u-terminal",
         "error": {"message": "turn failed"},
+        "willRetry": false,
+      });
+      fake.pushNotification("turn/completed", {
+        "threadId": "t-terminal",
+        "turn": {
+          "id": "u-terminal",
+          "status": "failed",
+          "error": {"message": "turn failed"},
+        },
       });
 
       await idle.timeout(const Duration(seconds: 1));
+      final error = await visibleError.timeout(const Duration(seconds: 1));
       expect(plugin.currentWorkState, PluginWorkState.idle);
+      expect(error.id, "codex-turn-error-u-terminal");
+      expect(error.errorMessage, "turn failed");
     });
 
     test("sendPrompt does not re-resume a thread created in this run", () async {

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -1021,7 +1021,7 @@ void main() {
 
       expect(messages, hasLength(1));
       final error = messages.single.info as PluginMessageError;
-      expect(error.id, "codex-turn-error-turn-quota");
+      expect(error.id, "turn-quota");
       expect(error.modelID, "gpt-5.6");
       expect(error.providerID, "openai");
       expect(error.errorName, "CodexError");

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -985,6 +985,50 @@ void main() {
       expect(messages[1].parts.single.id, "assistant-1-text");
     });
 
+    test("readMessages preserves a terminal Codex failure as an error message", () {
+      const sessionId = "019a0000-1111-2222-3333-eeeeeeeeeeee";
+      final path = _writeRollout(
+        codexHome,
+        path: "sessions/2026/08/19/rollout-terminal-error.jsonl",
+        sessionId: sessionId,
+        cwd: "/repo/app",
+        extraLines: [
+          jsonEncode({
+            "type": "turn_context",
+            "payload": {"model": "gpt-5.6"},
+          }),
+          jsonEncode({
+            "timestamp": "2026-08-19T18:06:15.079Z",
+            "type": "event_msg",
+            "payload": {
+              "type": "task_complete",
+              "turn_id": "turn-quota",
+              "error": {
+                "message": "You've hit your usage limit.",
+                "codex_error_info": "usage_limit_exceeded",
+              },
+            },
+          }),
+        ],
+      );
+
+      final messages = messageRepository.readMessages(
+        rolloutPath: path,
+        sessionId: sessionId,
+        replayToolDisposition: CodexReplayToolDisposition.terminalize,
+        structuredToolStatusByCallId: const {},
+      );
+
+      expect(messages, hasLength(1));
+      final error = messages.single.info as PluginMessageError;
+      expect(error.id, "codex-turn-error-turn-quota");
+      expect(error.modelID, "gpt-5.6");
+      expect(error.providerID, "openai");
+      expect(error.errorName, "CodexError");
+      expect(error.errorMessage, "You've hit your usage limit.");
+      expect(messages.single.parts, isEmpty);
+    });
+
     test("readMessages excludes only generated Codex user context envelopes", () {
       final path = _writeRollout(
         codexHome,

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -28,9 +28,10 @@ defaults and queued client sends coherent.
   sessions, other plugins, the relay read loop, or catalog reads.
 - Streaming produces incremental message and part events and a terminal status
   transition back to idle; retry carries attempt, message, and timing, and
-  finalized messages enter durable history matching a history read. Internal
-  backend command records are not rendered as conversation messages or used as
-  assistant model attribution.
+  finalized messages enter durable history matching a history read. A terminal
+  provider failure appears as an inline error message and remains visible after
+  refresh or reopen. Internal backend command records are not rendered as
+  conversation messages or used as assistant model attribution.
 - Claude user prompts appear in the live transcript from the CLI's replayed
   stdin echo under their transcript uuid, so a follow-up prompt stays visible
   and a later transcript backfill converges on the same message instead of
@@ -136,7 +137,8 @@ has started.
   plugin blocks unrelated sessions, other plugins, or relay traffic.
 - Streaming stalls, duplicates or loses parts, shows an empty user bubble, or
   orders a late envelope at the wrong transcript position; the session never
-  returns to idle.
+  returns to idle. A terminal provider failure returns to idle without showing
+  its error, or the error disappears after refresh or reopen.
 - Internal backend command records or synthetic model attribution appear in
   the conversation or replayed history.
 - Prompt defaults regress, an approved plan exit does not restore Default


### PR DESCRIPTION
## Complexity

🌿 Straightforward: maps an existing Codex terminal-error payload into the existing transcript error-message contract on live and replay paths.

## What

- Emit a visible transcript error message when `turn/completed` carries a terminal Codex error.
- Decode persisted `task_complete.error` rollout records and replay the same stable message id.
- Add live, plugin-pipeline, and history regression coverage.
- Document terminal provider failure visibility in the session-turn regression contract.

## Why

Codex emits quota exhaustion as both an app-server `error` notification and a failed `turn/completed`, then persists it under `task_complete.error`. Sesori reduced the live notification to `session.error`, whose contract carries no message and which the session detail intentionally ignores, while history ignored the persisted error field. The session therefore returned idle with no reply or visible failure.

## Risk and test focus

The change is Codex-plugin-local and reuses the existing `MessageError` bridge/client contract. Focus is stable live-to-history convergence, terminal status returning idle, and preserving successful turn behavior. There is no database impact and no new wire shape.

## Expected result

When Codex rejects a turn because usage is exhausted or another terminal provider failure occurs, the session shows the provider error inline immediately and still shows it after refresh or reopen.

## Verification

- `dart pub get --offline` from `bridge/`
- `dart test` from `bridge/sesori_plugin_codex/` (364 tests passed)
- Focused live, plugin-pipeline, and rollout-replay regression tests
- `dart analyze --fatal-infos` from `bridge/sesori_plugin_codex/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show terminal Codex turn failures as inline transcript errors in live sessions and in history. Previously, failures returned sessions to idle with no visible message; now we emit a `MessageError` using the Codex turn id and still return to idle.

- Map `turn/completed` with an error to a `MessageError`; include it in the live stream before `session/idle`.
- On history replay, decode `task_complete.error` and emit the same error message with id = `turn_id` for live/history convergence.
- Extend rollout DTOs: add `CodexRolloutErrorDto` and nullable `error` on `task_complete`; backward compatible with existing payloads; no database or external wire-shape changes.
- Add regression tests for live notifications, plugin write path (terminal sequence), and rollout replay; update session-turn docs to include terminal provider failure visibility.

<sup>Written for commit 7f1473b1f1e636654d275bbb24b48a848ce00065. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

