### PR TITLE
🌱 Dismiss popup alerts with an upward swipe

### DIFF
--- a/client/module_prego/lib/components/alerts/prego_popup_alerts_notifications.dart
+++ b/client/module_prego/lib/components/alerts/prego_popup_alerts_notifications.dart
@@ -400,6 +400,14 @@ class _PregoPopupAlertOverlayState() extends State<_PregoPopupAlertOverlay> with
     if (mounted) widget.onDismissed();
   }
 
+  /// [Dismissible] has already animated the card off-screen, so the entry must
+  /// leave the tree immediately instead of replaying the reverse transition.
+  void _dismissBySwipe() {
+    _dismissing = true;
+    _timer?.cancel();
+    widget.onDismissed();
+  }
+
   @override
   Widget build(BuildContext context) {
     return PositionedDirectional(
@@ -417,13 +425,19 @@ class _PregoPopupAlertOverlayState() extends State<_PregoPopupAlertOverlay> with
                   begin: const Offset(0, -0.12),
                   end: Offset.zero,
                 ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOutCubic)),
-                child: PregoPopupAlertsNotifications(
-                  title: widget.title,
-                  message: widget.message,
-                  variant: widget.variant,
-                  primaryAction: widget.primaryAction,
-                  secondaryAction: widget.secondaryAction,
-                  onClose: widget.showCloseButton ? _dismiss : null,
+                child: Dismissible(
+                  key: const ValueKey("prego_popup_alert"),
+                  direction: DismissDirection.up,
+                  resizeDuration: null,
+                  onDismissed: (_) => _dismissBySwipe(),
+                  child: PregoPopupAlertsNotifications(
+                    title: widget.title,
+                    message: widget.message,
+                    variant: widget.variant,
+                    primaryAction: widget.primaryAction,
+                    secondaryAction: widget.secondaryAction,
+                    onClose: widget.showCloseButton ? _dismiss : null,
+                  ),
                 ),
               ),
             ),
@@ -437,6 +451,9 @@ class const _CloseButton({required final VoidCallback onPressed}) extends Statel
   @override
   Widget build(BuildContext context) {
     return Semantics(
+      // The swipe-to-dismiss gesture handler above would otherwise merge this
+      // button into the alert's own semantics node.
+      container: true,
       button: true,
       label: "Close notification",
       child: PregoTappable(

--- a/client/module_prego/test/components/prego_popup_alerts_notifications_test.dart
+++ b/client/module_prego/test/components/prego_popup_alerts_notifications_test.dart
@@ -156,6 +156,28 @@ void main() {
     expect(find.text("Copied"), findsNothing);
   });
 
+  testWidgets("swiping up dismisses the alert before its duration elapses", (tester) async {
+    late PregoPopupAlertPresenter presenter;
+    await tester.pumpWidget(
+      _harness(
+        Builder(
+          builder: (context) {
+            presenter = PregoPopupAlertPresenter.of(context);
+            return const SizedBox.expand();
+          },
+        ),
+      ),
+    );
+
+    presenter.show(title: "Session deleted");
+    await tester.pumpAndSettle();
+
+    await tester.fling(find.text("Session deleted"), const Offset(0, -200), 1000);
+    await tester.pumpAndSettle();
+
+    expect(find.text("Session deleted"), findsNothing);
+  });
+
   testWidgets("sizes to short text and caps long text at 16 pixel side insets", (tester) async {
     late PregoPopupAlertPresenter presenter;
     await tester.pumpWidget(

--- a/docs/regression/popup-alerts.md
+++ b/docs/regression/popup-alerts.md
@@ -13,6 +13,8 @@ snackbars and render above the current route, below the top navigation bar.
 - A newly presented alert replaces the alert already visible on the same route.
 - Alerts dismiss after three seconds by default and dismiss immediately when
   the close button is tapped.
+- Swiping an alert upwards dismisses it, following the finger and completing on
+  release.
 - Alerts presented from asynchronous operations remain visible when the source
   row or modal is removed.
 - Alerts raised from a modal or full-screen image viewer render above that


### PR DESCRIPTION
## Complexity
Trivial. One `Dismissible` around the existing alert card plus a semantics fix.

## What
`PregoPopupAlertPresenter` alerts can now be swiped up to dismiss, in addition
to the close button and the auto-dismiss timer. The swipe follows the finger and
removes the overlay entry as soon as the card animates off, skipping the reverse
transition that the close button plays.

The close button's `Semantics` is now a container, because the swipe gesture
handler would otherwise merge it into the alert's own node and cost screen
reader users a separate close target.

## Why
Confirmations such as session deletion required tapping the small X or waiting
for the timer.

## Risk and test focus
No database impact and no wire-contract change. User-visible impact is limited
to popup alerts. Focus on: swiping up dismisses, the close button and the
auto-dismiss timer still work, and a replacement alert during a dismissal is
still safe.

## Expected result
An upward swipe on any popup alert dismisses it immediately; every other
dismissal path is unchanged.

## Verification
- `flutter test test/components/prego_popup_alerts_notifications_test.dart` in
  `client/module_prego` — 14/14 pass, including the new swipe test.
- `flutter analyze` on both changed Dart files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add upward swipe-to-dismiss for popup alerts to reduce friction. Previously alerts closed only via the X button or a 3s timer; now a swipe up dismisses immediately after the card animates off-screen, skipping the reverse transition.

- Wraps the alert card in a `Dismissible` with `DismissDirection.up`; `onDismissed` removes the overlay immediately.
- Preserves existing close button and auto-dismiss behavior; the swipe follows the finger.
- Sets the close button `Semantics` as a container to keep a distinct accessible target.
- Adds a widget test for swipe dismissal and updates the regression doc; no DB or API changes.

<sup>Written for commit b62f5e2412a802d3e0dcf283c670158c785acbe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

