### PR TITLE
🌿 Prevent duplicate transcript rows after steering

### DIFF
--- a/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -196,8 +196,10 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
   /// flush — recompute only when the underlying [ThemeData] changes.
   (ThemeData, chat_core.ChatTheme)? _chatThemeCache;
 
-  /// The chat controller needs string IDs; object identity keeps one row stable
-  /// as the queue moves the same submission from pending to sending.
+  /// Prompts whose queued row would have to move during delivery use the
+  /// backend message id from then on. `flutter_chat_ui` cannot safely move and
+  /// update one animated row together.
+  final Set<String> _promptsUsingMessageEntryId = <String>{};
 
   @override
   void initState() {
@@ -216,6 +218,7 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
         queuedMessages: widget.queuedMessages,
         bridgeQueuedPrompts: widget.bridgeQueuedPrompts,
         hasRetryError: widget.retryErrorMessage != null,
+        currentEntries: const <chat_core.Message>[],
       ),
     );
   }
@@ -382,14 +385,15 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
     required List<QueuedSessionPrompt> bridgeQueuedPrompts,
     required bool hasRetryError,
   }) {
+    final current = _chatController.messages;
     final target = _chatEntriesFor(
       messages: messages,
       sendingSubmission: sendingSubmission,
       queuedMessages: queuedMessages,
       bridgeQueuedPrompts: bridgeQueuedPrompts,
       hasRetryError: hasRetryError,
+      currentEntries: current,
     );
-    final current = _chatController.messages;
     if (_entriesMatch(current: current, target: target)) return;
     unawaited(
       _chatController
@@ -421,11 +425,32 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
     required List<QueuedSessionSubmission> queuedMessages,
     required List<QueuedSessionPrompt> bridgeQueuedPrompts,
     required bool hasRetryError,
+    required List<chat_core.Message> currentEntries,
   }) {
-    // A prompt keeps one row id from staged send through bridge queue to its
-    // delivered user message, so the animated list updates that row in place
-    // instead of removing one entry and inserting another — the queued→sent
-    // handoff must never blink through a frame with neither rendered.
+    final transientEntryIndexes = <String, int>{
+      for (final (index, entry) in currentEntries.indexed)
+        if (entry.metadata?[_kRoleMetadataKey] == _kTransientSubmissionRole) entry.id: index,
+    };
+    var targetMessageIndex = 0;
+    for (final message in messages) {
+      if (!message.hasRenderableUserContent) continue;
+      if (message.info case MessageUser(promptId: final promptId?)) {
+        final promptEntryId = "$_kPromptRowPrefix$promptId";
+        final currentIndex = transientEntryIndexes[promptEntryId];
+        if (currentIndex != null && currentIndex != targetMessageIndex) {
+          _promptsUsingMessageEntryId.add(promptId);
+        }
+      }
+      targetMessageIndex++;
+    }
+    final deliveredPromptIds = <String>{
+      for (final message in messages)
+        if (message.hasRenderableUserContent)
+          if (message.info case MessageUser(promptId: final promptId?)) promptId,
+    };
+    // Staged and bridge-queued states share one prompt row. The delivered
+    // message keeps it when the handoff is in place, but uses its message id
+    // when a late replay must move backward through the transcript.
     final entries = <chat_core.Message>[
       for (final message in messages)
         if (message.hasRenderableUserContent)
@@ -439,8 +464,8 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
             // Role discriminates assistant from error under the shared
             // agent authorId, so a live assistant→error transition on the
             // same message id is no longer value-equal and forces the row
-            // to re-render as the error card. The same inequality drives the
-            // transient-submission→user transform on a stable prompt row id.
+            // to re-render as the error card. The same inequality drives an
+            // in-place transient-submission→user transform.
             metadata: <String, String>{
               _kRoleMetadataKey: switch (message.info) {
                 MessageUser() => _kUserRole,
@@ -451,16 +476,19 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
           ),
       if (hasRetryError) const chat_core.Message.custom(id: _kRetryErrorRowId, authorId: _kAgentAuthorId),
       // Bridge-accepted prompts render before locally staged ones: they were
-      // accepted earlier and dispatch first. A prompt whose message already
-      // landed owns that row id above and renders only as the message.
+      // accepted earlier and dispatch first. A delivered prompt renders only
+      // as its message even if a stale queue copy is still being reconciled.
       for (final prompt in bridgeQueuedPrompts)
-        chat_core.Message.custom(
-          id: "$_kPromptRowPrefix${prompt.id}",
-          authorId: _kUserAuthorId,
-          metadata: const <String, String>{_kRoleMetadataKey: _kTransientSubmissionRole},
-        ),
-      if (sendingSubmission != null) _chatEntryFor(submission: sendingSubmission),
-      for (final submission in queuedMessages) _chatEntryFor(submission: submission),
+        if (!deliveredPromptIds.contains(prompt.id))
+          chat_core.Message.custom(
+            id: "$_kPromptRowPrefix${prompt.id}",
+            authorId: _kUserAuthorId,
+            metadata: const <String, String>{_kRoleMetadataKey: _kTransientSubmissionRole},
+          ),
+      if (sendingSubmission != null && !deliveredPromptIds.contains(sendingSubmission.promptId))
+        _chatEntryFor(submission: sendingSubmission),
+      for (final submission in queuedMessages)
+        if (!deliveredPromptIds.contains(submission.promptId)) _chatEntryFor(submission: submission),
     ];
     // One row per id: a prompt momentarily present in two sources (its message
     // landed while the queue copy is still being reconciled) keeps its most
@@ -483,7 +511,8 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
   }
 
   String _entryIdForMessage({required Message info}) => switch (info) {
-    MessageUser(promptId: final promptId?) => "$_kPromptRowPrefix$promptId",
+    MessageUser(promptId: final promptId?) =>
+      _promptsUsingMessageEntryId.contains(promptId) ? info.id : "$_kPromptRowPrefix$promptId",
     MessageUser() || MessageAssistant() || MessageError() => info.id,
   };
 
@@ -656,7 +685,10 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
       final index = indexById[entry.id];
       if (index != null && index < messages.length && messages[index].hasRenderableUserContent) {
         final message = messages[index];
-        return _revealable(createdAtMs: message.info.time?.created, child: UserMessageCard(message: message));
+        return _revealable(
+          createdAtMs: message.info.time?.created,
+          child: UserMessageCard(message: message),
+        );
       }
       final promptId = entry.id.substring(_kPromptRowPrefix.length);
       final prompt = widget.bridgeQueuedPrompts.where((candidate) => candidate.id == promptId).firstOrNull;

--- a/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -94,9 +94,13 @@ class _SessionDetailMessageListHarnessState() extends State<_SessionDetailMessag
 
   /// Mirrors the cubit's atomic queued→sent swap: the delivered user message
   /// lands and the bridge entry leaves in one state emission.
-  void deliverBridgePrompt({required String promptId, required MessageWithParts message}) {
+  void deliverBridgePrompt({
+    required String promptId,
+    required MessageWithParts message,
+    required int insertionIndex,
+  }) {
     setState(() {
-      _messages = [..._messages, message];
+      _messages = [..._messages]..insert(insertionIndex, message);
       _bridgeQueuedPrompts = [..._bridgeQueuedPrompts.where((prompt) => prompt.id != promptId)];
     });
   }
@@ -294,6 +298,7 @@ void main() {
     harnessKey.currentState?.deliverBridgePrompt(
       promptId: "prm_1",
       message: _message(messageId: "replay-user-1", role: "user", text: "steer it", promptId: "prm_1"),
+      insertionIndex: 1,
     );
 
     // The prompt's text must stay on screen through every frame of the
@@ -306,6 +311,51 @@ void main() {
     expect(find.text("steer it"), findsOneWidget);
     expect(find.byType(QueuedMessageBubble), findsNothing);
     expect(find.byType(UserMessageCard), findsOneWidget);
+  });
+
+  testWidgets("moving a delivered bridge prompt through assistant rows keeps every row unique", (tester) async {
+    final harnessKey = GlobalKey<_SessionDetailMessageListHarnessState>();
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        key: harnessKey,
+        initialMessages: [
+          _message(messageId: "assistant-before", role: "assistant", text: "Before steer", createdAtMs: 100),
+          _message(messageId: "assistant-after-1", role: "assistant", text: "First reply", createdAtMs: 300),
+          _message(messageId: "assistant-after-2", role: "assistant", text: "Second reply", createdAtMs: 400),
+        ],
+        initialStreamingText: const {},
+        initialBridgeQueuedPrompts: const [
+          QueuedSessionPrompt(id: "prm_1", text: "steer it", command: null, attachmentCount: 0, createdAt: 200),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    harnessKey.currentState?.deliverBridgePrompt(
+      promptId: "prm_1",
+      message: _message(
+        messageId: "replay-user-1",
+        role: "user",
+        text: "steer it",
+        promptId: "prm_1",
+        createdAtMs: 200,
+      ),
+      insertionIndex: 1,
+    );
+
+    for (var frame = 0; frame < 3; frame++) {
+      await tester.pump();
+      expect(find.text("steer it"), findsOneWidget);
+      expect(find.text("Before steer"), findsOneWidget);
+      expect(find.text("First reply"), findsOneWidget);
+      expect(find.text("Second reply"), findsOneWidget);
+    }
+    await tester.pumpAndSettle();
+    expect(find.byType(UserMessageCard), findsOneWidget);
+    expect(find.text("First reply"), findsOneWidget);
+    expect(find.text("Second reply"), findsOneWidget);
+    expect(tester.getTopLeft(find.text("Before steer")).dy, lessThan(tester.getTopLeft(find.text("steer it")).dy));
+    expect(tester.getTopLeft(find.text("steer it")).dy, lessThan(tester.getTopLeft(find.text("First reply")).dy));
   });
 
   testWidgets("does not render a user envelope until it has visible parts", (tester) async {


### PR DESCRIPTION
## Complexity

🌿 Straightforward - localized transcript row identity handling plus a widget regression.

## What

- Uses the backend message id when a delivered prompt must move from the queued edge into an earlier transcript position.
- Keeps the stable prompt row id for ordinary in-place queued-to-sent handoffs, preserving the existing no-blank transition.
- Prevents stale queue copies from rendering beside an already delivered prompt.
- Adds a regression that moves a steering prompt through assistant rows and verifies every row remains unique and chronologically ordered.

## Why

`flutter_chat_ui` corrupts its reversed animated list when one stable row changes role and moves in the same diff. A late replay of a steering prompt exercises exactly that path, leaving duplicated assistant bubbles until the session screen is remounted.

## Risk and test focus

Low. The change is limited to client-side transcript row identity and does not alter bridge behavior, wire contracts, persisted data, or databases. Test focus is the late replay reorder and the existing normal queued-to-sent transition.

## Expected result

Steering prompts settle into their chronological transcript position without duplicating surrounding assistant bubbles. Ordinary prompt handoffs remain continuous with no blank frame.

## Verification

- `flutter test test/features/session_detail/widgets/session_detail_message_list_test.dart` (30 passed)
- `dart analyze --fatal-infos` in `client/app` (clean)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate chat bubbles when a steering prompt is delivered late and must move earlier in the transcript. Previously the queued prompt’s row moved and changed role in the same diff, and `flutter_chat_ui` duplicated rows; now we switch to the backend message id when movement is required, while keeping the stable prompt row id for in-place handoffs to preserve the no-blank transition.

- Detects when a delivered prompt would move relative to its transient queued row and uses the message id for that row; otherwise keeps the prompt row id.
- Suppresses stale queue copies once the delivered message is present, avoiding duplicates across the bridge queue, sending, and local queue sources.
- Adds a regression test that replays a steering prompt through assistant rows and asserts unique, chronologically ordered rows; updates the harness to insert at a target index.
- Client-only change; no API, persistence, or migration impact.

<sup>Written for commit 85d7bfb895640fc7e25c2c9ac8020f6073c519bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

