### PR TITLE
🌿 Keep backend event invalidations scoped

### DIFF
--- a/bridge/app/lib/src/bridge/repositories/mappers/session_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/repositories/mappers/session_event_mapper.dart
@@ -19,7 +19,6 @@ class const SessionEventMapper() {
     }
     return switch (event) {
       BridgeSseTerminalHandoff(:final event) => backendSessionIds(event: event),
-      BridgeSseSessionsUpdated(:final sessionID) ||
       BridgeSseSessionDiff(:final sessionID) ||
       BridgeSseSessionCompacted(:final sessionID) ||
       BridgeSseSessionPromptDefaultsChanged(:final sessionID) ||
@@ -112,10 +111,6 @@ class const SessionEventMapper() {
       },
       BridgeSseSessionDeleted(:final info) => switch (mappedSession(info)) {
         final session? => BridgeSseSessionDeleted(info: session.toJson()),
-        null => null,
-      },
-      BridgeSseSessionsUpdated(:final sessionID, :final projectID) => switch (mapped(sessionID)) {
-        final sessionId? => BridgeSseSessionsUpdated(sessionID: sessionId, projectID: projectID),
         null => null,
       },
       BridgeSseSessionDiff(:final sessionID) => switch (mapped(sessionID)) {

--- a/bridge/app/lib/src/bridge/services/session_event_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_event_service.dart
@@ -469,12 +469,6 @@ class SessionEventService({
         ),
         null => null,
       },
-      BridgeSseSessionsUpdated(:final sessionID) => switch (await _sessionRepository.findProjectIdForSession(
-        sessionId: sessionID,
-      )) {
-        final projectId? => BridgeSseSessionsUpdated(sessionID: sessionID, projectID: projectId),
-        null => null,
-      },
       _ => translated,
     };
   }

--- a/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
@@ -24,7 +24,6 @@ class BridgeEventMapper({
         BridgeSseCommandCatalogUpdated() => SesoriSseEvent.commandCatalogUpdated(pluginId: pluginId),
         BridgeSseSessionCreated(:final info) => _tryParseSseEvent({"type": "session.created", "info": info}),
         BridgeSseSessionUpdated(:final info) => _tryParseSseEvent({"type": "session.updated", "info": info}),
-        BridgeSseSessionsUpdated(:final projectID) => SesoriSseEvent.sessionsUpdated(projectID: projectID),
         BridgeSseSessionOptionsChanged() => null,
         BridgeSseSessionPromptDefaultsChanged(
           :final sessionID,

--- a/bridge/app/test/bridge/repositories/mappers/session_event_mapper_test.dart
+++ b/bridge/app/test/bridge/repositories/mappers/session_event_mapper_test.dart
@@ -56,11 +56,6 @@ void main() {
           expectedBackendIds: ids.keys.toSet(),
         ),
         (
-          name: "sessions updated",
-          event: const BridgeSseSessionsUpdated(sessionID: "backend-session", projectID: "project"),
-          expectedBackendIds: {"backend-session"},
-        ),
-        (
           name: "session diff",
           event: const BridgeSseSessionDiff(sessionID: "backend-session"),
           expectedBackendIds: {"backend-session"},

--- a/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
+++ b/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
@@ -167,15 +167,6 @@ void main() {
       expect((result! as SesoriSessionDiff).sessionID, equals("s1"));
     });
 
-    test("maps stale project sessions to sessions.updated", () {
-      final result = mapEvent(
-        const BridgeSseSessionsUpdated(sessionID: "s1", projectID: "p1"),
-      );
-
-      expect(result, isA<SesoriSessionsUpdated>());
-      expect((result! as SesoriSessionsUpdated).projectID, "p1");
-    });
-
     test("maps command.executed events", () {
       final result = mapEvent(
         const BridgeSseCommandExecuted(

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -229,8 +229,10 @@ class CodexEventMapper({
         return [BridgeSseSessionDiff(sessionID: threadId)];
 
       case "skills/changed":
+        return const [BridgeSseCommandCatalogUpdated()];
+
       case "mcpServer/startupStatus/updated":
-        return const [BridgeSseProjectUpdated()];
+        return const [BridgeSseMcpToolsChanged()];
     }
 
     // Everything else is dropped intentionally:

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -1481,6 +1481,22 @@ void main() {
       }
     });
 
+    test("skills/changed invalidates the command catalog", () {
+      final events = mapper.map(
+        const CodexServerNotification(method: "skills/changed", params: {}),
+      );
+
+      expect(events, const [BridgeSseCommandCatalogUpdated()]);
+    });
+
+    test("MCP startup changes invalidate MCP tools", () {
+      final events = mapper.map(
+        const CodexServerNotification(method: "mcpServer/startupStatus/updated", params: {}),
+      );
+
+      expect(events, const [BridgeSseMcpToolsChanged()]);
+    });
+
     test("regression: real bug-log payloads parse cleanly", () {
       // The exact thread/started payload from the bug report.
       final created = mapThreadStarted(

--- a/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
@@ -28,12 +28,6 @@ class const BridgeSseSessionCreated({required final Map<String, dynamic> info}) 
 class const BridgeSseSessionUpdated({required final Map<String, dynamic> info, required final bool titleChanged})
     extends BridgeSseEvent;
 
-/// Signals that every session under [projectID] should be re-fetched.
-class const BridgeSseSessionsUpdated({
-  required final String sessionID,
-  required final String projectID,
-}) extends BridgeSseEvent;
-
 /// Signals that session-creation options changed for a backend session.
 ///
 /// This is an internal plugin event. [sessionID] is the backend's session

--- a/client/app/lib/features/session_diffs/session_diffs_screen.dart
+++ b/client/app/lib/features/session_diffs/session_diffs_screen.dart
@@ -18,6 +18,7 @@ class const SessionDiffsScreen({
         connectionService: getIt<ConnectionService>(),
         productAnalyticsService: getIt<ProductAnalyticsService>(),
         sessionId: sessionId,
+        staleRetryDelay: const Duration(seconds: 5),
       ),
       // SessionDiffsBody owns the PregoGlassScaffold so its bar subtitle can
       // react to the loaded file/addition/deletion stats.

--- a/client/module_core/lib/src/cubits/session_diffs/diff_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_diffs/diff_cubit.dart
@@ -19,12 +19,15 @@ class DiffCubit({
     required final ConnectionService _connectionService,
     required final ProductAnalyticsService _productAnalyticsService,
     required final String sessionId,
+    required final Duration staleRetryDelay,
   }) extends Cubit<DiffState> {
   late final StreamSubscription<SesoriSessionEvent> _eventSubscription;
   late final StreamSubscription<bool> _analyticsStateSubscription;
   Future<void>? _activeRefresh;
+  Timer? _staleRetryTimer;
   bool _refreshQueued = false;
   bool _queuedShowLoading = false;
+  bool _staleRefreshPending = false;
   _DiffAnalyticsGuard _emptyDiffAnalytics = _DiffAnalyticsGuard.ready;
   _DiffAnalyticsGuard _nonEmptyDiffAnalytics = _DiffAnalyticsGuard.ready;
 
@@ -40,6 +43,7 @@ class DiffCubit({
 
   void _handleEvent(SesoriSessionEvent event) {
     if (event is! SesoriSessionDiff) return;
+    _staleRefreshPending = true;
     unawaited(_refresh(showLoading: false));
   }
 
@@ -57,38 +61,62 @@ class DiffCubit({
       _queuedShowLoading = _queuedShowLoading || showLoading;
       return active;
     }
+    _staleRetryTimer?.cancel();
+    _staleRetryTimer = null;
     return _activeRefresh = _drainRefreshes(showLoading: showLoading);
   }
 
   Future<void> _drainRefreshes({required bool showLoading}) async {
     var nextShowLoading = showLoading;
-    do {
-      _refreshQueued = false;
-      _queuedShowLoading = false;
-      await _fetchAndEmit(showLoading: nextShowLoading);
-      nextShowLoading = _queuedShowLoading;
-    } while (_refreshQueued && !isClosed);
-    _activeRefresh = null;
+    try {
+      do {
+        final consumedStaleSignal = _staleRefreshPending;
+        _staleRefreshPending = false;
+        _refreshQueued = false;
+        _queuedShowLoading = false;
+        final applied = await _fetchAndEmit(showLoading: nextShowLoading);
+        nextShowLoading = _queuedShowLoading;
+        if (!applied && consumedStaleSignal) {
+          _staleRefreshPending = true;
+          break;
+        }
+      } while (_refreshQueued && !isClosed);
+    } finally {
+      _activeRefresh = null;
+    }
+    if (_staleRefreshPending) _scheduleStaleRetry(showLoading: nextShowLoading);
   }
 
-  Future<void> _fetchAndEmit({required bool showLoading}) async {
+  void _scheduleStaleRetry({required bool showLoading}) {
+    if (isClosed || _staleRetryTimer != null) return;
+    _staleRetryTimer = Timer(staleRetryDelay, () {
+      _staleRetryTimer = null;
+      if (isClosed || !_staleRefreshPending) return;
+      unawaited(_refresh(showLoading: showLoading));
+    });
+  }
+
+  Future<bool> _fetchAndEmit({required bool showLoading}) async {
     if (showLoading) {
       emit(const DiffState.loading());
     }
     try {
       final response = await _sessionRepository.getSessionDiffs(sessionId: sessionId);
-      if (isClosed) return;
+      if (isClosed) return false;
 
       switch (response) {
         case SuccessResponse(:final data):
           emit(DiffState.loaded(files: data.diffs));
           _reportDiffLoaded(isEmpty: data.diffs.isEmpty);
+          return true;
         case ErrorResponse(:final error):
           emit(DiffState.failed(error: error));
+          return false;
       }
     } catch (e) {
-      if (isClosed) return;
+      if (isClosed) return false;
       emit(DiffState.failed(error: e));
+      return false;
     }
   }
 
@@ -152,6 +180,7 @@ class DiffCubit({
 
   @override
   Future<void> close() async {
+    _staleRetryTimer?.cancel();
     await Future.wait([
       _eventSubscription.cancel(),
       _analyticsStateSubscription.cancel(),

--- a/client/module_core/lib/src/cubits/session_diffs/diff_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_diffs/diff_cubit.dart
@@ -23,6 +23,8 @@ class DiffCubit({
   late final StreamSubscription<SesoriSessionEvent> _eventSubscription;
   late final StreamSubscription<bool> _analyticsStateSubscription;
   Future<void>? _activeRefresh;
+  bool _refreshQueued = false;
+  bool _queuedShowLoading = false;
   _DiffAnalyticsGuard _emptyDiffAnalytics = _DiffAnalyticsGuard.ready;
   _DiffAnalyticsGuard _nonEmptyDiffAnalytics = _DiffAnalyticsGuard.ready;
 
@@ -49,11 +51,24 @@ class DiffCubit({
   Future<void> refresh() => _refresh(showLoading: true);
 
   Future<void> _refresh({required bool showLoading}) {
-    final queued = (_activeRefresh ?? Future<void>.value())
-        .catchError((_) {})
-        .then((_) => _fetchAndEmit(showLoading: showLoading));
-    _activeRefresh = queued;
-    return queued;
+    final active = _activeRefresh;
+    if (active != null) {
+      _refreshQueued = true;
+      _queuedShowLoading = _queuedShowLoading || showLoading;
+      return active;
+    }
+    return _activeRefresh = _drainRefreshes(showLoading: showLoading);
+  }
+
+  Future<void> _drainRefreshes({required bool showLoading}) async {
+    var nextShowLoading = showLoading;
+    do {
+      _refreshQueued = false;
+      _queuedShowLoading = false;
+      await _fetchAndEmit(showLoading: nextShowLoading);
+      nextShowLoading = _queuedShowLoading;
+    } while (_refreshQueued && !isClosed);
+    _activeRefresh = null;
   }
 
   Future<void> _fetchAndEmit({required bool showLoading}) async {

--- a/client/module_core/test/cubits/session_diffs/diff_cubit_test.dart
+++ b/client/module_core/test/cubits/session_diffs/diff_cubit_test.dart
@@ -37,11 +37,12 @@ void main() {
       await sessionEvents.close();
     });
 
-    DiffCubit buildCubit() => DiffCubit(
+    DiffCubit buildCubit({Duration staleRetryDelay = const Duration(milliseconds: 10)}) => DiffCubit(
       sessionRepository: mockSessionRepository,
       connectionService: mockConnectionService,
       productAnalyticsService: mockProductAnalyticsService,
       sessionId: sessionId,
+      staleRetryDelay: staleRetryDelay,
     );
 
     FileDiff testFileDiff({String? file}) => FileDiff.content(
@@ -351,6 +352,46 @@ void main() {
             (state) => state.files.single.file,
             "latest refresh wins",
             "lib/src/request-2.dart",
+          ),
+        );
+      },
+    );
+
+    blocTest<DiffCubit, DiffState>(
+      "failed trailing refresh preserves staleness until a retry succeeds",
+      build: () {
+        var requestCount = 0;
+        when(() => mockSessionRepository.getSessionDiffs(sessionId: sessionId)).thenAnswer((_) async {
+          requestCount++;
+          if (requestCount == 1) {
+            await Future<void>.delayed(const Duration(milliseconds: 20));
+          }
+          if (requestCount == 2) return ApiResponse.error(ApiError.generic());
+          return ApiResponse.success(
+            SessionDiffsResponse(
+              diffs: [testFileDiff(file: "lib/src/request-$requestCount.dart")],
+            ),
+          );
+        });
+        return buildCubit();
+      },
+      act: (cubit) async {
+        await Future<void>.delayed(Duration.zero);
+        sessionEvents.add(const SesoriSessionDiff(sessionID: sessionId));
+        sessionEvents.add(const SesoriSessionDiff(sessionID: sessionId));
+        await Future<void>.delayed(const Duration(milliseconds: 80));
+      },
+      skip: 1,
+      verify: (cubit) {
+        verify(
+          () => mockSessionRepository.getSessionDiffs(sessionId: sessionId),
+        ).called(3);
+        expect(
+          cubit.state,
+          isA<DiffStateLoaded>().having(
+            (state) => state.files.single.file,
+            "retried file",
+            "lib/src/request-3.dart",
           ),
         );
       },

--- a/client/module_core/test/cubits/session_diffs/diff_cubit_test.dart
+++ b/client/module_core/test/cubits/session_diffs/diff_cubit_test.dart
@@ -317,7 +317,7 @@ void main() {
     );
 
     blocTest<DiffCubit, DiffState>(
-      "session.diff SSE burst: serializes refreshes and keeps latest result",
+      "session.diff SSE burst: coalesces into one trailing refresh",
       build: () {
         var requestCount = 0;
         when(() => mockSessionRepository.getSessionDiffs(sessionId: sessionId)).thenAnswer((_) async {
@@ -342,12 +342,15 @@ void main() {
       },
       skip: 1,
       verify: (cubit) {
+        verify(
+          () => mockSessionRepository.getSessionDiffs(sessionId: sessionId),
+        ).called(2);
         expect(
           cubit.state,
           isA<DiffStateLoaded>().having(
             (state) => state.files.single.file,
             "latest refresh wins",
-            "lib/src/request-4.dart",
+            "lib/src/request-2.dart",
           ),
         );
       },

--- a/docs/regression/diffs-and-source-control.md
+++ b/docs/regression/diffs-and-source-control.md
@@ -32,8 +32,8 @@ that baseline, and the branch and worktree facts a session carries.
   initial dedicated branch without moving the worktree; durable and current
   branch facts then update together through the existing session update. Other
   live current-branch and PR refreshes belong to pull request monitoring. A
-  mutating tool emits the diff refresh signal, and diffs stay encrypted from the
-  relay.
+  mutating tool emits the diff refresh signal; bursts during an in-flight read
+  coalesce into one trailing refresh, and diffs stay encrypted from the relay.
 
 ## Regression Levels
 

--- a/docs/regression/diffs-and-source-control.md
+++ b/docs/regression/diffs-and-source-control.md
@@ -33,7 +33,9 @@ that baseline, and the branch and worktree facts a session carries.
   branch facts then update together through the existing session update. Other
   live current-branch and PR refreshes belong to pull request monitoring. A
   mutating tool emits the diff refresh signal; bursts during an in-flight read
-  coalesce into one trailing refresh, and diffs stay encrypted from the relay.
+  coalesce into one trailing refresh, a failed event-driven refresh retries
+  after a delay while the diff screen remains open, and diffs stay encrypted
+  from the relay.
 
 ## Regression Levels
 

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -29,6 +29,9 @@ variant, and worktree mode, and creating the session with its first input.
   explicit refresh forces fresh discovery.
 - Concurrent requests coalesce; an incomplete observation never replaces a
   complete cached one, and a moved project invalidates its entries.
+- Backend notifications use scoped event domains: Codex skill changes emit a
+  command-catalog invalidation rather than project activity, while MCP startup
+  changes remain MCP-tool events.
 - Failure with a valid cache still serves it; failure without one is an explicit
   error, never an empty option set. Automatic refresh never starts a stopped
   backend and no-ops for a superseded generation.


### PR DESCRIPTION
## Complexity

Straightforward. This corrects two existing event mappings, removes one unused internal event path, and coalesces duplicate diff refresh requests without changing shared wire schemas.

## What

- Map Codex `skills/changed` to `command.catalog.updated` and MCP startup changes to `mcp.tools.changed`.
- Remove the producer-less internal `BridgeSseSessionsUpdated` variant and its bridge mapping path. PR synchronization continues to produce the shared `sessions.updated` event directly.
- Coalesce `session.diff` bursts into at most one trailing diff fetch while a request is in flight, preserving event-driven staleness through failed fetches with a bounded delayed retry while the screen remains open.
- Update regression documentation and focused tests.

## Why

Codex skill changes were incorrectly rebuilding project activity instead of invalidating the slash-command catalog, leaving an open session's commands stale. The unused internal sessions-updated path also preserved the same shortcut that previously allowed ACP command changes to masquerade as PR-data invalidations. New Claude and Pi diff producers make duplicate diff signals more common, so replaying one network request per signal adds cost without improving freshness; failed coalesced requests must retain their stale marker until a snapshot applies.

## Risk and test focus

The main risks are mapping a Codex notification to the wrong domain, accidentally removing the legitimate PR-sync `sessions.updated` wire event, dropping the trailing diff refresh, or spinning after a failed request. Tests cover the corrected Codex mappings, bridge event exhaustiveness after internal variant removal, a burst that resolves to exactly one trailing diff fetch, and a failed trailing request that retries to the latest result.

There is no database impact. User-visible impact is limited to fresher Codex slash commands and fewer redundant requests while viewing diffs.

## Expected result

Backend notifications invalidate only their matching domain, the old internal sessions-updated shortcut cannot be reused, and diff-event bursts preserve current data with one trailing request while transient failures retry at a bounded cadence.

## Verification

- `dart test test/codex_event_mapper_test.dart` in `bridge/sesori_plugin_codex`
- `dart test test/bridge/sse/bridge_event_mapper_test.dart test/bridge/repositories/mappers/session_event_mapper_test.dart` in `bridge/app`
- `dart test test/cubits/session_diffs/diff_cubit_test.dart` in `client/module_core`
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_interface`, `bridge/app`, and `bridge/sesori_plugin_codex`
- `dart analyze` in `client/module_core` and `client/app`
