### PR TITLE
⚙️ Fix truthful queued prompt delivery across ACP and Pi

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:collection";
 
 import "package:path/path.dart" as p;
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show normalizeProjectDirectory;
@@ -193,6 +194,14 @@ abstract class AcpPlugin({
 
   /// Whether prompts across all sessions share one dispatch lane.
   bool get serializesPromptsProcessWide;
+
+  /// Whether accepting another input should cancel this session's active turn.
+  ///
+  /// OMP gives a concurrent ACP prompt this replacement behavior itself. The
+  /// shared adapter serializes requests, so its concrete adapter declares the
+  /// same policy here and the bridge sends the equivalent standard cancel
+  /// before dispatching the queued input.
+  bool get cancelsActiveTurnForQueuedInput;
 
   /// Whether a turn must stop when its requested selection cannot be applied.
   bool get failsTurnOnSelectionError;
@@ -821,6 +830,7 @@ abstract class AcpPlugin({
         model: model,
         variant: variant,
         agent: agent,
+        queuedPrompt: null,
       );
     }
     return created;
@@ -848,15 +858,32 @@ abstract class AcpPlugin({
     // Acceptance gate: an unreachable agent fails the send itself; the turn
     // re-resolves the client at dispatch time (see [_runTurn]).
     await _connectedClient();
+    if (_turnStates[sessionId]?.hasAcceptedPrompt(promptId: promptId) ?? false) return;
     _recordSessionActivity(sessionId);
-    eventMapper.mapSentPrompt(sessionId: sessionId, promptId: promptId, parts: parts).forEach(_eventBuffer.add);
-    _enqueueTurn(
+    final text = parts
+        .whereType<PluginPromptPartText>()
+        .map((part) => part.text)
+        .where((part) => part.trim().isNotEmpty)
+        .join("\n")
+        .trim();
+    final enqueued = _enqueueTurn(
       sessionId: sessionId,
       parts: parts,
       model: model,
       variant: variant,
       agent: agent,
+      queuedPrompt: _QueuedAcpPrompt(
+        presentation: PluginQueuedPrompt(
+          id: promptId,
+          text: text.isEmpty ? null : text,
+          command: null,
+          attachmentCount: parts.where((part) => part is! PluginPromptPartText).length,
+          createdAt: DateTime.now().millisecondsSinceEpoch,
+        ),
+        visibleParts: List.unmodifiable(parts),
+      ),
     );
+    if (enqueued) _cancelActiveTurnForQueuedInput(sessionId: sessionId);
   }
 
   @override
@@ -872,24 +899,60 @@ abstract class AcpPlugin({
   }) async {
     final backendCommand = commandForDispatch(command: command);
     final body = arguments.isEmpty ? "/$backendCommand" : "/$backendCommand $arguments";
-    final visibleBody = userVisibleArguments == null ? "/$command" : "/$command $userVisibleArguments";
+    final visibleArguments = userVisibleArguments?.trim();
+    final visibleBody = visibleArguments == null || visibleArguments.isEmpty
+        ? "/$command"
+        : "/$command $userVisibleArguments";
     // Acceptance gate — see [sendPrompt].
     await _connectedClient();
+    if (_turnStates[sessionId]?.hasAcceptedPrompt(promptId: promptId) ?? false) return;
     _recordSessionActivity(sessionId);
-    eventMapper
-        .mapSentPrompt(
-          sessionId: sessionId,
-          promptId: promptId,
-          parts: [PluginPromptPart.text(text: visibleBody)],
-        )
-        .forEach(_eventBuffer.add);
-    _enqueueTurn(
+    final enqueued = _enqueueTurn(
       sessionId: sessionId,
       parts: [PluginPromptPart.text(text: body)],
       model: model,
       variant: variant,
       agent: agent,
+      queuedPrompt: _QueuedAcpPrompt(
+        presentation: PluginQueuedPrompt(
+          id: promptId,
+          text: visibleArguments == null || visibleArguments.isEmpty ? null : visibleArguments,
+          command: command,
+          attachmentCount: 0,
+          createdAt: DateTime.now().millisecondsSinceEpoch,
+        ),
+        visibleParts: [PluginPromptPart.text(text: visibleBody)],
+      ),
     );
+    if (enqueued) _cancelActiveTurnForQueuedInput(sessionId: sessionId);
+  }
+
+  @override
+  Future<List<PluginQueuedPrompt>> getQueuedPrompts({required String sessionId}) async {
+    final state = _turnStates[sessionId];
+    if (state == null) return const [];
+    return List.unmodifiable(state.queue.map((entry) => entry.presentation));
+  }
+
+  @override
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async {
+    final state = _turnStates[sessionId];
+    if (state == null) return false;
+    final index = state.queue.indexWhere((entry) => entry.presentation.id == promptId);
+    if (index == -1) return false;
+    final entry = state.queue.removeAt(index);
+    entry.cancelled = true;
+    _emitQueueUpdate(sessionId: sessionId, state: state);
+    return true;
+  }
+
+  void _cancelActiveTurnForQueuedInput({required String sessionId}) {
+    if (!cancelsActiveTurnForQueuedInput || !_inFlightTurnSessions.contains(sessionId)) return;
+    _client?.notify(
+      method: AcpMethods.sessionCancel,
+      params: {"sessionId": sessionId},
+    );
+    _approvalRegistry?.cancelForSession(sessionId);
   }
 
   void _recordSessionActivity(String sessionId) {
@@ -1054,23 +1117,31 @@ abstract class AcpPlugin({
     }
   }
 
-  /// Queues a prompt turn on [sessionId]'s serialization chain: marks the
-  /// session busy now (the user's send is accepted), dispatches once the
-  /// session's previous turn finishes, and flips to idle when the last queued
-  /// turn resolves (ACP carries no turn-complete event). Overlapping
-  /// `session/prompt` requests for one session are rejected or dropped by ACP
-  /// agents, so turns must never interleave per session.
-  void _enqueueTurn({
+  /// Queues a prompt turn on [sessionId]'s serialization chain. Accepted
+  /// existing-session prompts stay in [getQueuedPrompts] until their ACP frame
+  /// is written; an initial create turn has no separate queue presentation.
+  bool _enqueueTurn({
     required String sessionId,
     required List<PluginPromptPart> parts,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
     required String? agent,
+    required _QueuedAcpPrompt? queuedPrompt,
   }) {
     final blocks = parts.map(_promptPartToContentBlock).whereType<Map<String, dynamic>>().toList(growable: false);
-    if (blocks.isEmpty) return;
+    if (blocks.isEmpty) return false;
 
     final state = _turnStates.putIfAbsent(sessionId, _SessionTurnState.new);
+    final turn = _AcpTurn(
+      blocks: blocks,
+      model: model,
+      variant: variant,
+      agent: agent,
+      queuedPrompt: queuedPrompt,
+    );
+    if (queuedPrompt != null) {
+      state.queue.add(queuedPrompt);
+    }
     state.pending++;
     if (state.pending == 1) {
       _workState.set(PluginWorkState.busy);
@@ -1083,6 +1154,9 @@ abstract class AcpPlugin({
       );
       _eventBuffer.add(const BridgeSseProjectUpdated());
     }
+    if (queuedPrompt != null) {
+      _emitQueueUpdate(sessionId: sessionId, state: state);
+    }
     final expectedGeneration = state.generation;
     // Each link isolates its own failure (_runTurn never throws), so one
     // failed turn cannot poison the chain for the turns queued behind it.
@@ -1090,12 +1164,10 @@ abstract class AcpPlugin({
       sessionId: sessionId,
       state: state,
       expectedGeneration: expectedGeneration,
-      blocks: blocks,
-      model: model,
-      variant: variant,
-      agent: agent,
+      turn: turn,
     );
     state.tail = serializesPromptsProcessWide ? _runOnProcessLane(operation) : state.tail.then((_) => operation());
+    return true;
   }
 
   /// Runs one serialized turn: resolves the live client, makes the session
@@ -1115,15 +1187,12 @@ abstract class AcpPlugin({
     required String sessionId,
     required _SessionTurnState state,
     required int expectedGeneration,
-    required List<Map<String, dynamic>> blocks,
-    required ({String providerID, String modelID})? model,
-    required PluginSessionVariant? variant,
-    required String? agent,
+    required _AcpTurn turn,
   }) async {
     // Aborted turns were never dispatched, so no per-turn error event — just
     // settle the accounting (idle emission when the count reaches 0).
-    if (state.generation != expectedGeneration) {
-      _finishTurn(sessionId: sessionId, state: state, failed: false, refused: false);
+    if (_turnWasCancelled(state: state, expectedGeneration: expectedGeneration, turn: turn)) {
+      _finishTurn(sessionId: sessionId, state: state, turn: turn, failed: false, refused: false);
       return;
     }
     state.activeSettlement = Completer<void>();
@@ -1134,9 +1203,9 @@ abstract class AcpPlugin({
       // An abort that landed while the reconnect was in flight already
       // discarded this turn — settle it silently instead of surfacing a
       // session error for a prompt the user cancelled.
-      if (state.generation != expectedGeneration) {
+      if (_turnWasCancelled(state: state, expectedGeneration: expectedGeneration, turn: turn)) {
         Log.d("[$id] queued turn on $sessionId aborted during reconnect: $error");
-        _finishTurn(sessionId: sessionId, state: state, failed: false, refused: false);
+        _finishTurn(sessionId: sessionId, state: state, turn: turn, failed: false, refused: false);
         return;
       }
       // The send was already accepted, so a dead/unrespawnable agent must
@@ -1145,22 +1214,22 @@ abstract class AcpPlugin({
         _eventBuffer.addError(error, stack);
       }
       Log.w("[$id] could not reach the agent for a queued turn on $sessionId", error, stack);
-      _finishTurn(sessionId: sessionId, state: state, failed: true, refused: false);
+      _finishTurn(sessionId: sessionId, state: state, turn: turn, failed: true, refused: false);
       return;
     }
-    if (state.generation != expectedGeneration) {
-      _finishTurn(sessionId: sessionId, state: state, failed: false, refused: false);
+    if (_turnWasCancelled(state: state, expectedGeneration: expectedGeneration, turn: turn)) {
+      _finishTurn(sessionId: sessionId, state: state, turn: turn, failed: false, refused: false);
       return;
     }
     await _ensureResident(client, sessionId);
-    if (state.generation != expectedGeneration) {
-      _finishTurn(sessionId: sessionId, state: state, failed: false, refused: false);
+    if (_turnWasCancelled(state: state, expectedGeneration: expectedGeneration, turn: turn)) {
+      _finishTurn(sessionId: sessionId, state: state, turn: turn, failed: false, refused: false);
       return;
     }
     final pendingSelection = _pendingSelections[sessionId];
-    final selectedModel = model ?? pendingSelection?.model;
-    final selectedVariant = variant ?? pendingSelection?.variant;
-    final selectedAgent = agent ?? pendingSelection?.agent;
+    final selectedModel = turn.model ?? pendingSelection?.model;
+    final selectedVariant = turn.variant ?? pendingSelection?.variant;
+    final selectedAgent = turn.agent ?? pendingSelection?.agent;
     try {
       await applyTurnSelection(
         configRepository: AcpSessionConfigRepository(client: client),
@@ -1173,7 +1242,7 @@ abstract class AcpPlugin({
     } on Object catch (error, stack) {
       if (failsTurnOnSelectionError) {
         Log.w("[$id] applyTurnSelection for $sessionId failed; dropping turn", error, stack);
-        _finishTurn(sessionId: sessionId, state: state, failed: true, refused: false);
+        _finishTurn(sessionId: sessionId, state: state, turn: turn, failed: true, refused: false);
         return;
       }
       Log.w(
@@ -1182,37 +1251,74 @@ abstract class AcpPlugin({
         stack,
       );
     }
-    if (state.generation != expectedGeneration) {
-      _finishTurn(sessionId: sessionId, state: state, failed: false, refused: false);
+    if (_turnWasCancelled(state: state, expectedGeneration: expectedGeneration, turn: turn)) {
+      _finishTurn(sessionId: sessionId, state: state, turn: turn, failed: false, refused: false);
       return;
     }
     eventMapper.beginTurn(sessionId);
     _inFlightTurnSessions.add(sessionId);
     _lastTurnSessionId = sessionId;
     try {
-      final raw = await client.request(
+      final response = client.dispatchRequest(
         method: AcpMethods.sessionPrompt,
-        params: {"sessionId": sessionId, "prompt": blocks},
+        params: {"sessionId": sessionId, "prompt": turn.blocks},
         timeout: const Duration(minutes: 30),
       );
+      _markTurnDispatched(sessionId: sessionId, state: state, turn: turn);
+      final raw = await response;
       final result = AcpPromptResult.fromJson(
         (raw as Map?)?.cast<String, dynamic>() ?? const {},
       );
       _finishTurn(
         sessionId: sessionId,
         state: state,
+        turn: turn,
         failed: false,
         refused: result.stopReason == AcpStopReason.refusal,
       );
     } on Object catch (error, stack) {
-      // The frame was already accepted (the phone's send returned success),
-      // so a later rejection (auth expiry, stale session, bad payload) would
-      // otherwise stop the run with no signal. Log and surface it as a
-      // session error, not a silent idle.
-      Log.w("[$id] session/prompt for $sessionId failed after dispatch", error, stack);
-      _finishTurn(sessionId: sessionId, state: state, failed: true, refused: false);
+      // The phone's send already returned success, so a dispatch or later
+      // backend failure must remain observable rather than silently dropping
+      // the accepted prompt.
+      Log.w("[$id] accepted session/prompt for $sessionId failed", error, stack);
+      _finishTurn(sessionId: sessionId, state: state, turn: turn, failed: true, refused: false);
       mapPromptFailure(sessionId: sessionId, error: error).forEach(_eventBuffer.add);
     }
+  }
+
+  bool _turnWasCancelled({
+    required _SessionTurnState state,
+    required int expectedGeneration,
+    required _AcpTurn turn,
+  }) => state.generation != expectedGeneration || (turn.queuedPrompt?.cancelled ?? false);
+
+  void _markTurnDispatched({
+    required String sessionId,
+    required _SessionTurnState state,
+    required _AcpTurn turn,
+  }) {
+    final queuedPrompt = turn.queuedPrompt;
+    if (queuedPrompt == null) return;
+    eventMapper
+        .mapSentPrompt(
+          sessionId: sessionId,
+          promptId: queuedPrompt.presentation.id,
+          parts: queuedPrompt.visibleParts,
+        )
+        .forEach(_eventBuffer.add);
+    if (state.queue.remove(queuedPrompt)) {
+      state.recordDispatchedPrompt(promptId: queuedPrompt.presentation.id);
+      _emitQueueUpdate(sessionId: sessionId, state: state);
+    }
+  }
+
+  void _emitQueueUpdate({required String sessionId, required _SessionTurnState state}) {
+    _eventBuffer.add(
+      BridgeSseQueuedPromptsUpdated(
+        sessionID: sessionId,
+        prompts: [for (final entry in state.queue) entry.presentation],
+      ),
+    );
   }
 
   /// Settles one finished (or dropped) turn: removes the in-flight marker,
@@ -1221,6 +1327,7 @@ abstract class AcpPlugin({
   void _finishTurn({
     required String sessionId,
     required _SessionTurnState state,
+    required _AcpTurn turn,
     required bool failed,
     required bool refused,
   }) {
@@ -1236,6 +1343,10 @@ abstract class AcpPlugin({
     if (!identical(_turnStates[sessionId], state)) {
       _syncWorkState();
       return;
+    }
+    final queuedPrompt = turn.queuedPrompt;
+    if (queuedPrompt != null && state.queue.remove(queuedPrompt)) {
+      _emitQueueUpdate(sessionId: sessionId, state: state);
     }
     eventMapper.finalizeTurn(sessionId: sessionId).forEach(_eventBuffer.add);
     if (state.pending == 0) {
@@ -1288,7 +1399,17 @@ abstract class AcpPlugin({
     // undispatched turns first so they don't dispatch after the cancel. The
     // in-flight turn (if any) ends via the agent's cancellation, which
     // resolves its `session/prompt` future and settles the accounting.
-    _turnStates[sessionId]?.generation++;
+    final state = _turnStates[sessionId];
+    if (state != null) {
+      state.generation++;
+      if (state.queue.isNotEmpty) {
+        for (final entry in state.queue) {
+          entry.cancelled = true;
+        }
+        state.queue.clear();
+        _emitQueueUpdate(sessionId: sessionId, state: state);
+      }
+    }
     final client = _client;
     if (client == null) return;
     client.notify(
@@ -1749,6 +1870,8 @@ abstract class AcpPlugin({
 /// count of unfinished turns, and the abort generation used to drop
 /// queued-but-undispatched turns.
 class _SessionTurnState() {
+  static const int _recentPromptLimit = 64;
+
   /// Completion of the session's most recently queued turn.
   Future<void> tail = Future<void>.value();
 
@@ -1760,9 +1883,39 @@ class _SessionTurnState() {
   /// Turns enqueued but not yet finished (including the running one).
   int pending = 0;
 
+  /// Existing-session prompts accepted but not yet dispatched to ACP.
+  final List<_QueuedAcpPrompt> queue = [];
+
+  final Queue<String> _recentPromptIds = Queue<String>();
+
+  bool hasAcceptedPrompt({required String promptId}) =>
+      queue.any((entry) => entry.presentation.id == promptId) || _recentPromptIds.contains(promptId);
+
+  void recordDispatchedPrompt({required String promptId}) {
+    _recentPromptIds.addLast(promptId);
+    while (_recentPromptIds.length > _recentPromptLimit) {
+      _recentPromptIds.removeFirst();
+    }
+  }
+
   /// Bumped by abort/delete; a queued turn dispatches only if the generation
   /// it captured at enqueue time is still current.
   int generation = 0;
+}
+
+class const _AcpTurn({
+  required final List<Map<String, dynamic>> blocks,
+  required final ({String providerID, String modelID})? model,
+  required final PluginSessionVariant? variant,
+  required final String? agent,
+  required final _QueuedAcpPrompt? queuedPrompt,
+});
+
+class _QueuedAcpPrompt({
+  required final PluginQueuedPrompt presentation,
+  required final List<PluginPromptPart> visibleParts,
+}) {
+  bool cancelled = false;
 }
 
 class const _TurnSelection({

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -824,14 +824,18 @@ abstract class AcpPlugin({
     } else {
       // A fresh session has an empty chain, so this dispatches immediately;
       // the selection is applied inside the turn like every other prompt.
-      _enqueueTurn(
-        sessionId: session.sessionId,
-        parts: parts,
-        model: model,
-        variant: variant,
-        agent: agent,
-        queuedPrompt: null,
-      );
+      final blocks = _contentBlocks(parts);
+      if (blocks.isNotEmpty) {
+        _enqueueTurn(
+          sessionId: session.sessionId,
+          turn: _InitialAcpTurn(
+            blocks: blocks,
+            model: model,
+            variant: variant,
+            agent: agent,
+          ),
+        );
+      }
     }
     return created;
   }
@@ -855,9 +859,11 @@ abstract class AcpPlugin({
     required String? agent,
     required ({String providerID, String modelID})? model,
   }) async {
+    if (_turnStates[sessionId]?.hasAcceptedPrompt(promptId: promptId) ?? false) return;
     // Acceptance gate: an unreachable agent fails the send itself; the turn
     // re-resolves the client at dispatch time (see [_runTurn]).
     await _connectedClient();
+    // Another matching send may have been admitted while connection awaited.
     if (_turnStates[sessionId]?.hasAcceptedPrompt(promptId: promptId) ?? false) return;
     _recordSessionActivity(sessionId);
     final text = parts
@@ -866,24 +872,28 @@ abstract class AcpPlugin({
         .where((part) => part.trim().isNotEmpty)
         .join("\n")
         .trim();
-    final enqueued = _enqueueTurn(
+    final blocks = _contentBlocks(parts);
+    if (blocks.isEmpty) return;
+    _enqueueTurn(
       sessionId: sessionId,
-      parts: parts,
-      model: model,
-      variant: variant,
-      agent: agent,
-      queuedPrompt: _QueuedAcpPrompt(
-        presentation: PluginQueuedPrompt(
-          id: promptId,
-          text: text.isEmpty ? null : text,
-          command: null,
-          attachmentCount: parts.where((part) => part is! PluginPromptPartText).length,
-          createdAt: DateTime.now().millisecondsSinceEpoch,
+      turn: _QueuedAcpTurn(
+        blocks: blocks,
+        model: model,
+        variant: variant,
+        agent: agent,
+        queuedPrompt: _QueuedAcpPrompt(
+          presentation: PluginQueuedPrompt(
+            id: promptId,
+            text: text.isEmpty ? null : text,
+            command: null,
+            attachmentCount: parts.where((part) => part is! PluginPromptPartText).length,
+            createdAt: DateTime.now().millisecondsSinceEpoch,
+          ),
+          visibleParts: List.unmodifiable(parts),
         ),
-        visibleParts: List.unmodifiable(parts),
       ),
     );
-    if (enqueued) _cancelActiveTurnForQueuedInput(sessionId: sessionId);
+    _cancelActiveTurnForQueuedInput(sessionId: sessionId);
   }
 
   @override
@@ -897,6 +907,7 @@ abstract class AcpPlugin({
     required String? agent,
     required ({String providerID, String modelID})? model,
   }) async {
+    if (_turnStates[sessionId]?.hasAcceptedPrompt(promptId: promptId) ?? false) return;
     final backendCommand = commandForDispatch(command: command);
     final body = arguments.isEmpty ? "/$backendCommand" : "/$backendCommand $arguments";
     final visibleArguments = userVisibleArguments?.trim();
@@ -905,26 +916,31 @@ abstract class AcpPlugin({
         : "/$command $userVisibleArguments";
     // Acceptance gate — see [sendPrompt].
     await _connectedClient();
+    // Another matching send may have been admitted while connection awaited.
     if (_turnStates[sessionId]?.hasAcceptedPrompt(promptId: promptId) ?? false) return;
     _recordSessionActivity(sessionId);
-    final enqueued = _enqueueTurn(
+    final blocks = _contentBlocks([PluginPromptPart.text(text: body)]);
+    if (blocks.isEmpty) return;
+    _enqueueTurn(
       sessionId: sessionId,
-      parts: [PluginPromptPart.text(text: body)],
-      model: model,
-      variant: variant,
-      agent: agent,
-      queuedPrompt: _QueuedAcpPrompt(
-        presentation: PluginQueuedPrompt(
-          id: promptId,
-          text: visibleArguments == null || visibleArguments.isEmpty ? null : visibleArguments,
-          command: command,
-          attachmentCount: 0,
-          createdAt: DateTime.now().millisecondsSinceEpoch,
+      turn: _QueuedAcpTurn(
+        blocks: blocks,
+        model: model,
+        variant: variant,
+        agent: agent,
+        queuedPrompt: _QueuedAcpPrompt(
+          presentation: PluginQueuedPrompt(
+            id: promptId,
+            text: visibleArguments == null || visibleArguments.isEmpty ? null : visibleArguments,
+            command: command,
+            attachmentCount: 0,
+            createdAt: DateTime.now().millisecondsSinceEpoch,
+          ),
+          visibleParts: [PluginPromptPart.text(text: visibleBody)],
         ),
-        visibleParts: [PluginPromptPart.text(text: visibleBody)],
       ),
     );
-    if (enqueued) _cancelActiveTurnForQueuedInput(sessionId: sessionId);
+    _cancelActiveTurnForQueuedInput(sessionId: sessionId);
   }
 
   @override
@@ -1120,26 +1136,12 @@ abstract class AcpPlugin({
   /// Queues a prompt turn on [sessionId]'s serialization chain. Accepted
   /// existing-session prompts stay in [getQueuedPrompts] until their ACP frame
   /// is written; an initial create turn has no separate queue presentation.
-  bool _enqueueTurn({
+  void _enqueueTurn({
     required String sessionId,
-    required List<PluginPromptPart> parts,
-    required ({String providerID, String modelID})? model,
-    required PluginSessionVariant? variant,
-    required String? agent,
-    required _QueuedAcpPrompt? queuedPrompt,
+    required _AcpTurn turn,
   }) {
-    final blocks = parts.map(_promptPartToContentBlock).whereType<Map<String, dynamic>>().toList(growable: false);
-    if (blocks.isEmpty) return false;
-
     final state = _turnStates.putIfAbsent(sessionId, _SessionTurnState.new);
-    final turn = _AcpTurn(
-      blocks: blocks,
-      model: model,
-      variant: variant,
-      agent: agent,
-      queuedPrompt: queuedPrompt,
-    );
-    if (queuedPrompt != null) {
+    if (turn case _QueuedAcpTurn(:final queuedPrompt)) {
       state.queue.add(queuedPrompt);
     }
     state.pending++;
@@ -1154,7 +1156,7 @@ abstract class AcpPlugin({
       );
       _eventBuffer.add(const BridgeSseProjectUpdated());
     }
-    if (queuedPrompt != null) {
+    if (turn is _QueuedAcpTurn) {
       _emitQueueUpdate(sessionId: sessionId, state: state);
     }
     final expectedGeneration = state.generation;
@@ -1167,7 +1169,6 @@ abstract class AcpPlugin({
       turn: turn,
     );
     state.tail = serializesPromptsProcessWide ? _runOnProcessLane(operation) : state.tail.then((_) => operation());
-    return true;
   }
 
   /// Runs one serialized turn: resolves the live client, makes the session
@@ -1290,15 +1291,20 @@ abstract class AcpPlugin({
     required _SessionTurnState state,
     required int expectedGeneration,
     required _AcpTurn turn,
-  }) => state.generation != expectedGeneration || (turn.queuedPrompt?.cancelled ?? false);
+  }) =>
+      state.generation != expectedGeneration ||
+      switch (turn) {
+        _InitialAcpTurn() => false,
+        _QueuedAcpTurn(:final queuedPrompt) => queuedPrompt.cancelled,
+      };
 
   void _markTurnDispatched({
     required String sessionId,
     required _SessionTurnState state,
     required _AcpTurn turn,
   }) {
+    if (turn is! _QueuedAcpTurn) return;
     final queuedPrompt = turn.queuedPrompt;
-    if (queuedPrompt == null) return;
     eventMapper
         .mapSentPrompt(
           sessionId: sessionId,
@@ -1344,8 +1350,7 @@ abstract class AcpPlugin({
       _syncWorkState();
       return;
     }
-    final queuedPrompt = turn.queuedPrompt;
-    if (queuedPrompt != null && state.queue.remove(queuedPrompt)) {
+    if (turn case _QueuedAcpTurn(:final queuedPrompt) when state.queue.remove(queuedPrompt)) {
       _emitQueueUpdate(sessionId: sessionId, state: state);
     }
     eventMapper.finalizeTurn(sessionId: sessionId).forEach(_eventBuffer.add);
@@ -1382,6 +1387,9 @@ abstract class AcpPlugin({
       PluginPromptPartFileData(:final mime, :final base64) => _inlineContentBlock(mime, base64),
     };
   }
+
+  List<Map<String, dynamic>> _contentBlocks(List<PluginPromptPart> parts) =>
+      parts.map(_promptPartToContentBlock).whereType<Map<String, dynamic>>().toList(growable: false);
 
   Map<String, dynamic>? _inlineContentBlock(String mime, String base64) {
     final type = switch (mime.split("/").first.toLowerCase()) {
@@ -1903,13 +1911,27 @@ class _SessionTurnState() {
   int generation = 0;
 }
 
-class const _AcpTurn({
+sealed class const _AcpTurn({
   required final List<Map<String, dynamic>> blocks,
   required final ({String providerID, String modelID})? model,
   required final PluginSessionVariant? variant,
   required final String? agent,
-  required final _QueuedAcpPrompt? queuedPrompt,
 });
+
+final class const _InitialAcpTurn({
+  required super.blocks,
+  required super.model,
+  required super.variant,
+  required super.agent,
+}) extends _AcpTurn;
+
+final class const _QueuedAcpTurn({
+  required super.blocks,
+  required super.model,
+  required super.variant,
+  required super.agent,
+  required final _QueuedAcpPrompt queuedPrompt,
+}) extends _AcpTurn;
 
 class _QueuedAcpPrompt({
   required final PluginQueuedPrompt presentation,

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1308,6 +1308,7 @@ abstract class AcpPlugin({
     required _SessionTurnState state,
     required _AcpTurn turn,
   }) {
+    if (!identical(_turnStates[sessionId], state)) return;
     if (turn is! _QueuedAcpTurn) return;
     final queuedPrompt = turn.queuedPrompt;
     eventMapper

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -956,8 +956,10 @@ abstract class AcpPlugin({
     if (state == null) return false;
     final index = state.queue.indexWhere((entry) => entry.presentation.id == promptId);
     if (index == -1) return false;
-    final entry = state.queue.removeAt(index);
-    entry.cancelled = true;
+    final entry = state.queue[index];
+    if (entry.phase != _QueuedAcpPromptPhase.queued) return false;
+    state.queue.removeAt(index);
+    entry.phase = _QueuedAcpPromptPhase.cancelled;
     _emitQueueUpdate(sessionId: sessionId, state: state);
     return true;
   }
@@ -1260,13 +1262,16 @@ abstract class AcpPlugin({
     _inFlightTurnSessions.add(sessionId);
     _lastTurnSessionId = sessionId;
     try {
-      final response = client.dispatchRequest(
+      if (turn case _QueuedAcpTurn(:final queuedPrompt)) {
+        queuedPrompt.phase = _QueuedAcpPromptPhase.writing;
+      }
+      final dispatched = await client.dispatchRequest(
         method: AcpMethods.sessionPrompt,
         params: {"sessionId": sessionId, "prompt": turn.blocks},
         timeout: const Duration(minutes: 30),
       );
       _markTurnDispatched(sessionId: sessionId, state: state, turn: turn);
-      final raw = await response;
+      final raw = await dispatched.response;
       final result = AcpPromptResult.fromJson(
         (raw as Map?)?.cast<String, dynamic>() ?? const {},
       );
@@ -1295,7 +1300,7 @@ abstract class AcpPlugin({
       state.generation != expectedGeneration ||
       switch (turn) {
         _InitialAcpTurn() => false,
-        _QueuedAcpTurn(:final queuedPrompt) => queuedPrompt.cancelled,
+        _QueuedAcpTurn(:final queuedPrompt) => queuedPrompt.phase == _QueuedAcpPromptPhase.cancelled,
       };
 
   void _markTurnDispatched({
@@ -1410,11 +1415,15 @@ abstract class AcpPlugin({
     final state = _turnStates[sessionId];
     if (state != null) {
       state.generation++;
-      if (state.queue.isNotEmpty) {
-        for (final entry in state.queue) {
-          entry.cancelled = true;
+      var removedQueuedPrompt = false;
+      for (final entry in state.queue) {
+        if (entry.phase == _QueuedAcpPromptPhase.queued) {
+          entry.phase = _QueuedAcpPromptPhase.cancelled;
+          removedQueuedPrompt = true;
         }
-        state.queue.clear();
+      }
+      if (removedQueuedPrompt) {
+        state.queue.removeWhere((entry) => entry.phase == _QueuedAcpPromptPhase.cancelled);
         _emitQueueUpdate(sessionId: sessionId, state: state);
       }
     }
@@ -1937,8 +1946,10 @@ class _QueuedAcpPrompt({
   required final PluginQueuedPrompt presentation,
   required final List<PluginPromptPart> visibleParts,
 }) {
-  bool cancelled = false;
+  _QueuedAcpPromptPhase phase = _QueuedAcpPromptPhase.queued;
 }
+
+enum _QueuedAcpPromptPhase() { queued, writing, cancelled }
 
 class const _TurnSelection({
   required final ({String providerID, String modelID})? model,

--- a/bridge/sesori_plugin_acp/lib/src/acp_stdio_client.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_stdio_client.dart
@@ -163,18 +163,22 @@ class AcpStdioClient({
     required String method,
     Object? params,
     Duration timeout = const Duration(seconds: 60),
-  }) async => await dispatchRequest(method: method, params: params, timeout: timeout);
+  }) async {
+    final dispatched = await dispatchRequest(method: method, params: params, timeout: timeout);
+    return await dispatched.response;
+  }
 
-  /// Writes a JSON-RPC request frame before returning its response future.
+  /// Writes a JSON-RPC request frame and completes after it flushes.
   ///
-  /// Unlike [request], write failures throw synchronously. Turn dispatchers use
-  /// that distinction to publish a user message only after the frame actually
-  /// left the bridge.
-  Future<dynamic> dispatchRequest({
+  /// The returned handle separates successful delivery from the eventual
+  /// response. Turn dispatchers use that boundary to publish a user message
+  /// once the frame has actually left the bridge, without waiting for the turn
+  /// response.
+  Future<({Future<dynamic> response})> dispatchRequest({
     required String method,
     Object? params,
     Duration timeout = const Duration(seconds: 60),
-  }) {
+  }) async {
     final process = _process;
     if (process == null) {
       throw StateError("AcpStdioClient not connected");
@@ -203,7 +207,18 @@ class AcpStdioClient({
       throw StateError("AcpStdioClient failed to write request frame for $method");
     }
 
-    return _awaitResponse(id: id, response: completer.future, timeout: timeout);
+    final response = _awaitResponse(id: id, response: completer.future, timeout: timeout);
+    response.ignore();
+    try {
+      await process.stdin.flush();
+    } on Object catch (error, stack) {
+      _pending.remove(id);
+      if (!completer.isCompleted) completer.completeError(error, stack);
+      rethrow;
+    }
+    return (
+      response: response,
+    );
   }
 
   Future<dynamic> _awaitResponse({

--- a/bridge/sesori_plugin_acp/lib/src/acp_stdio_client.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_stdio_client.dart
@@ -163,7 +163,18 @@ class AcpStdioClient({
     required String method,
     Object? params,
     Duration timeout = const Duration(seconds: 60),
-  }) async {
+  }) async => await dispatchRequest(method: method, params: params, timeout: timeout);
+
+  /// Writes a JSON-RPC request frame before returning its response future.
+  ///
+  /// Unlike [request], write failures throw synchronously. Turn dispatchers use
+  /// that distinction to publish a user message only after the frame actually
+  /// left the bridge.
+  Future<dynamic> dispatchRequest({
+    required String method,
+    Object? params,
+    Duration timeout = const Duration(seconds: 60),
+  }) {
     final process = _process;
     if (process == null) {
       throw StateError("AcpStdioClient not connected");
@@ -192,8 +203,16 @@ class AcpStdioClient({
       throw StateError("AcpStdioClient failed to write request frame for $method");
     }
 
+    return _awaitResponse(id: id, response: completer.future, timeout: timeout);
+  }
+
+  Future<dynamic> _awaitResponse({
+    required int id,
+    required Future<dynamic> response,
+    required Duration timeout,
+  }) async {
     try {
-      return await completer.future.timeout(timeout);
+      return await response.timeout(timeout);
     } on TimeoutException {
       _pending.remove(id);
       rethrow;

--- a/bridge/sesori_plugin_acp/lib/src/testing/test_acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/testing/test_acp_plugin.dart
@@ -2,16 +2,16 @@ import "../acp_plugin.dart";
 
 /// Neutral ACP adapter for testing the reusable base behavior.
 class TestAcpPlugin({
-    required super.id,
-    required super.agentDisplayName,
-    required super.launchSpec,
-    required super.launchDirectory,
-    required super.eventMapper,
-    required super.contentMapper,
-    required super.commandTracker,
-    required super.sessionOptionsService,
-    super.processFactory,
-  }) extends AcpPlugin {
+  required super.id,
+  required super.agentDisplayName,
+  required super.launchSpec,
+  required super.launchDirectory,
+  required super.eventMapper,
+  required super.contentMapper,
+  required super.commandTracker,
+  required super.sessionOptionsService,
+  super.processFactory,
+}) extends AcpPlugin {
   @override
   String get clientName => "sesori-bridge";
 
@@ -29,6 +29,9 @@ class TestAcpPlugin({
 
   @override
   bool get serializesPromptsProcessWide => false;
+
+  @override
+  bool get cancelsActiveTurnForQueuedInput => false;
 
   @override
   bool get failsTurnOnSelectionError => false;

--- a/bridge/sesori_plugin_acp/test/acp_resume_only_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_only_test.dart
@@ -84,8 +84,8 @@ void main() {
       expect(await connecting, isTrue);
     }
 
-    Future<void> sendPrompt(String text) => plugin.sendPrompt(
-      promptId: "prompt-1",
+    Future<void> sendPrompt(String promptId, String text) => plugin.sendPrompt(
+      promptId: promptId,
       sessionId: "old-1",
       parts: [PluginPromptPart.text(text: text)],
       variant: null,
@@ -96,7 +96,7 @@ void main() {
     test("a prior-run session is resumed (not loaded) before the prompt, unsuppressed", () async {
       await connect();
 
-      final sending = sendPrompt("hi");
+      final sending = sendPrompt("prompt-1", "hi");
       final resumeFrame = await waitForFrameCount("session/resume", 1);
       final params = (resumeFrame["params"] as Map).cast<String, dynamic>();
       expect(params["sessionId"], "old-1");
@@ -135,7 +135,7 @@ void main() {
       await pump();
 
       // The now-resident session is not re-resumed on the next turn.
-      final again = sendPrompt("again");
+      final again = sendPrompt("prompt-2", "again");
       final secondPrompt = await waitForFrameCount("session/prompt", 2);
       fake.emit({
         "jsonrpc": "2.0",
@@ -149,7 +149,7 @@ void main() {
     test("a transiently failed resume is retried on the next turn", () async {
       await connect();
 
-      final sending = sendPrompt("hi");
+      final sending = sendPrompt("prompt-1", "hi");
       final firstResume = await waitForFrameCount("session/resume", 1);
       fake.emit({
         "jsonrpc": "2.0",
@@ -165,7 +165,7 @@ void main() {
       });
       await pump();
 
-      final again = sendPrompt("again");
+      final again = sendPrompt("prompt-2", "again");
       final secondResume = await waitForFrameCount("session/resume", 2);
       fake.emit({"jsonrpc": "2.0", "id": secondResume["id"], "result": const <String, dynamic>{}});
       await again;
@@ -175,7 +175,7 @@ void main() {
     test("an unsupported resume (-32601) is memoized", () async {
       await connect();
 
-      final sending = sendPrompt("hi");
+      final sending = sendPrompt("prompt-1", "hi");
       final firstResume = await waitForFrameCount("session/resume", 1);
       fake.emit({
         "jsonrpc": "2.0",
@@ -191,7 +191,7 @@ void main() {
       });
       await pump();
 
-      final again = sendPrompt("again");
+      final again = sendPrompt("prompt-2", "again");
       await waitForFrameCount("session/prompt", 2);
       await again;
       expect(frames("session/resume"), hasLength(1));

--- a/bridge/sesori_plugin_acp/test/acp_resume_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_test.dart
@@ -147,7 +147,7 @@ void main() {
       // A second prompt on the now-resident session does NOT re-load.
       final loadsBefore = fake.written.where((f) => f["method"] == "session/load").length;
       final again = plugin.sendPrompt(
-        promptId: "prompt-1",
+        promptId: "prompt-2",
         sessionId: "old-session",
         parts: const [PluginPromptPart.text(text: "again")],
         variant: null,
@@ -187,7 +187,7 @@ void main() {
       await pump();
 
       await plugin.sendPrompt(
-        promptId: "prompt-1",
+        promptId: "prompt-2",
         sessionId: "missing-session",
         parts: const [PluginPromptPart.text(text: "retry")],
         variant: null,

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -52,6 +52,7 @@ void main() {
     final emitted = <BridgeSseEvent>[];
     final streamErrors = <Object>[];
     const cwd = "/repo";
+    var promptSequence = 0;
 
     setUp(() {
       fake = FakeAcpProcess();
@@ -81,6 +82,7 @@ void main() {
       );
       emitted.clear();
       streamErrors.clear();
+      promptSequence = 0;
       plugin.events.listen(emitted.add, onError: streamErrors.add);
     });
 
@@ -140,34 +142,42 @@ void main() {
       return session.id;
     }
 
-    Future<void> sendPrompt(String sessionId, String text) => plugin.sendPrompt(
-      promptId: "prompt-1",
-      sessionId: sessionId,
-      parts: [PluginPromptPart.text(text: text)],
-      variant: null,
-      agent: null,
-      model: null,
-    );
+    Future<String> sendPrompt(String sessionId, String text) async {
+      final promptId = "prompt-${++promptSequence}";
+      await plugin.sendPrompt(
+        promptId: promptId,
+        sessionId: sessionId,
+        parts: [PluginPromptPart.text(text: text)],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      return promptId;
+    }
 
     int busyCount() => emitted.whereType<BridgeSseSessionStatus>().length;
     int idleCount() => emitted.whereType<BridgeSseSessionIdle>().length;
 
-    test("an accepted prompt is emitted immediately as a user message", () async {
+    test("a prompt becomes a user message only when its ACP frame is dispatched", () async {
       await connect();
       final sessionId = await createSession(cwd, "s1");
       emitted.clear();
 
-      await sendPrompt(sessionId, "visible immediately");
-      await pump();
+      final promptId = await sendPrompt(sessionId, "visible on dispatch");
+      final prompt = await waitForFrame("session/prompt");
 
       final message = emitted.whereType<BridgeSseMessageUpdated>().single;
       expect(message.info["role"], "user");
+      expect(message.info["promptId"], promptId);
       expect(
         emitted.whereType<BridgeSseMessagePartUpdated>().single.part.text,
-        "visible immediately",
+        "visible on dispatch",
       );
+      final queueUpdates = emitted.whereType<BridgeSseQueuedPromptsUpdated>().toList();
+      expect(queueUpdates.first.prompts.single.id, promptId);
+      expect(queueUpdates.last.prompts, isEmpty);
+      expect(emitted.indexOf(message), lessThan(emitted.indexOf(queueUpdates.last)));
 
-      final prompt = await waitForFrame("session/prompt");
       respondTo(prompt, {"stopReason": "end_turn"});
     });
 
@@ -337,7 +347,7 @@ void main() {
       final firstPrompt = await waitForFrame("session/prompt");
       expect(busyCount(), 1);
 
-      await sendPrompt(sessionId, "second");
+      final secondPromptId = await sendPrompt(sessionId, "second");
       for (var i = 0; i < 10; i++) {
         await pump();
       }
@@ -346,6 +356,12 @@ void main() {
         hasLength(1),
         reason: "the second prompt must wait for the first turn to complete",
       );
+      expect((await plugin.getQueuedPrompts(sessionId: sessionId)).single.id, secondPromptId);
+      expect(
+        emitted.whereType<BridgeSseMessageUpdated>().where((event) => event.info["promptId"] == secondPromptId),
+        isEmpty,
+        reason: "an adapter-owned prompt must remain queued, not sent",
+      );
       expect(busyCount(), 1, reason: "queued turn keeps the one busy signal");
       expect(idleCount(), 0);
 
@@ -353,6 +369,14 @@ void main() {
       final secondPrompt = await waitForFrameCount("session/prompt", 2);
       expect((secondPrompt["params"] as Map)["sessionId"], sessionId);
       await pump();
+      expect(await plugin.getQueuedPrompts(sessionId: sessionId), isEmpty);
+      expect(
+        emitted
+            .whereType<BridgeSseMessageUpdated>()
+            .singleWhere((event) => event.info["promptId"] == secondPromptId)
+            .info["promptId"],
+        secondPromptId,
+      );
       expect(
         idleCount(),
         0,
@@ -369,6 +393,60 @@ void main() {
       expect(idleCount(), 1, reason: "idle only after the last queued turn settles");
       expect(plugin.getActiveSessionsSummary(), isEmpty);
       expect(plugin.currentWorkState, PluginWorkState.idle);
+    });
+
+    test("a queued prompt can be cancelled before ACP dispatch", () async {
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+
+      await sendPrompt(sessionId, "first");
+      final firstPrompt = await waitForFrame("session/prompt");
+      final queuedPromptId = await sendPrompt(sessionId, "cancel me");
+      expect((await plugin.getQueuedPrompts(sessionId: sessionId)).single.id, queuedPromptId);
+
+      expect(
+        await plugin.cancelQueuedPrompt(sessionId: sessionId, promptId: queuedPromptId),
+        isTrue,
+      );
+      expect(await plugin.getQueuedPrompts(sessionId: sessionId), isEmpty);
+
+      respondTo(firstPrompt, {"stopReason": "end_turn"});
+      for (var i = 0; i < 10; i++) {
+        await pump();
+      }
+      expect(frames("session/prompt"), hasLength(1));
+      expect(
+        emitted.whereType<BridgeSseMessageUpdated>().where((event) => event.info["promptId"] == queuedPromptId),
+        isEmpty,
+      );
+    });
+
+    test("a retried ACP prompt id remains one queued or dispatched turn", () async {
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+
+      await sendPrompt(sessionId, "first");
+      final firstPrompt = await waitForFrame("session/prompt");
+      Future<void> sendRetry() => plugin.sendPrompt(
+        promptId: "retry-id",
+        sessionId: sessionId,
+        parts: const [PluginPromptPart.text(text: "only once")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+
+      await sendRetry();
+      await sendRetry();
+      expect(await plugin.getQueuedPrompts(sessionId: sessionId), hasLength(1));
+
+      respondTo(firstPrompt, {"stopReason": "end_turn"});
+      final retriedPrompt = await waitForFrameCount("session/prompt", 2);
+      await sendRetry();
+      await pump();
+      expect(frames("session/prompt"), hasLength(2));
+
+      respondTo(retriedPrompt, {"stopReason": "end_turn"});
     });
 
     test("queued reconnect authentication failure surfaces on the event stream", () async {
@@ -816,8 +894,9 @@ void main() {
       });
       await creating;
 
+      var respawnPromptSequence = 0;
       Future<void> send(String text) => respawning.sendPrompt(
-        promptId: "prompt-1",
+        promptId: "respawn-prompt-${++respawnPromptSequence}",
         sessionId: "s1",
         parts: [PluginPromptPart.text(text: text)],
         variant: null,

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -768,20 +768,29 @@ void main() {
       await connect();
       final sessionId = await createSession(cwd, "s1");
 
-      await sendPrompt(sessionId, "hi");
+      final flush = fake.holdNextFlush();
+      final promptId = await sendPrompt(sessionId, "hi");
       final promptFrame = await waitForFrame("session/prompt");
 
       await plugin.deleteSession(sessionId);
       expect(frames("session/cancel"), hasLength(1));
+      final queueUpdateCount = emitted.whereType<BridgeSseQueuedPromptsUpdated>().length;
 
-      // The cancelled prompt settles after the delete: its accounting must not
-      // re-create the deleted session's status entry or emit idle for it.
+      // The prompt flushes and settles after the delete: neither dispatch nor
+      // accounting may publish lifecycle events for the detached session.
+      flush.complete();
+      await pump();
       respondTo(promptFrame, {"stopReason": "cancelled"});
       for (var i = 0; i < 10; i++) {
         await pump();
       }
       expect(await plugin.getSessionStatuses(), isEmpty);
       expect(emitted.whereType<BridgeSseSessionIdle>(), isEmpty);
+      expect(
+        emitted.whereType<BridgeSseMessageUpdated>().where((event) => event.info["promptId"] == promptId),
+        isEmpty,
+      );
+      expect(emitted.whereType<BridgeSseQueuedPromptsUpdated>(), hasLength(queueUpdateCount));
     });
 
     test("a queued turn retries a transiently failed resume-load at dispatch", () async {

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -421,7 +421,7 @@ void main() {
       );
     });
 
-    test("a retried ACP prompt id remains one queued or dispatched turn", () async {
+    test("a retried ACP prompt id remains one turn while disconnected", () async {
       await connect();
       final sessionId = await createSession(cwd, "s1");
 
@@ -447,6 +447,23 @@ void main() {
       expect(frames("session/prompt"), hasLength(2));
 
       respondTo(retriedPrompt, {"stopReason": "end_turn"});
+      for (var i = 0; i < 10; i++) {
+        await pump();
+      }
+      expect(plugin.currentWorkState, PluginWorkState.idle);
+      await plugin.resetConnectionAfterExit();
+      await sendRetry();
+      await plugin.sendCommand(
+        sessionId: sessionId,
+        promptId: "retry-id",
+        command: "deploy",
+        arguments: "",
+        userVisibleArguments: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      expect(frames("initialize"), hasLength(1));
     });
 
     test("queued reconnect authentication failure surfaces on the event stream", () async {

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -33,6 +33,35 @@ class _GatedSelectionPlugin({
   }
 }
 
+class _FlushControlledAcpProcess() extends FakeAcpProcess {
+  final _FlushControlledIOSink _controlledStdin = _FlushControlledIOSink();
+
+  @override
+  _FlushControlledIOSink get stdin => _controlledStdin;
+
+  @override
+  List<Map<String, dynamic>> get written => _controlledStdin.frames;
+
+  Completer<void> holdNextFlush() => _controlledStdin.holdNextFlush();
+}
+
+class _FlushControlledIOSink() extends CapturingIOSink {
+  Completer<void>? _nextFlush;
+
+  Completer<void> holdNextFlush() {
+    final gate = Completer<void>();
+    _nextFlush = gate;
+    return gate;
+  }
+
+  @override
+  Future<void> flush() {
+    final gate = _nextFlush;
+    _nextFlush = null;
+    return gate?.future ?? Future<void>.value();
+  }
+}
+
 /// Turn-lifecycle robustness:
 ///
 ///  - prompts on one session are serialized (agents reject or drop overlapping
@@ -47,7 +76,7 @@ class _GatedSelectionPlugin({
 ///    turn is in flight.
 void main() {
   group("AcpPlugin turn serialization", () {
-    late FakeAcpProcess fake;
+    late _FlushControlledAcpProcess fake;
     late AcpPlugin plugin;
     final emitted = <BridgeSseEvent>[];
     final streamErrors = <Object>[];
@@ -55,7 +84,7 @@ void main() {
     var promptSequence = 0;
 
     setUp(() {
-      fake = FakeAcpProcess();
+      fake = _FlushControlledAcpProcess();
       final configurationTracker = AcpSessionConfigurationTracker();
       final commandTracker = AcpCommandTracker();
       plugin = TestAcpPlugin(
@@ -179,6 +208,65 @@ void main() {
       expect(emitted.indexOf(message), lessThan(emitted.indexOf(queueUpdates.last)));
 
       respondTo(prompt, {"stopReason": "end_turn"});
+    });
+
+    test("a prompt remains queued until its ACP frame flushes", () async {
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+      emitted.clear();
+
+      final flush = fake.holdNextFlush();
+      final promptId = await sendPrompt(sessionId, "wait for flush");
+      final prompt = await waitForFrame("session/prompt");
+      await pump();
+
+      expect((await plugin.getQueuedPrompts(sessionId: sessionId)).single.id, promptId);
+      expect(
+        emitted.whereType<BridgeSseMessageUpdated>().where((event) => event.info["promptId"] == promptId),
+        isEmpty,
+      );
+      expect(
+        await plugin.cancelQueuedPrompt(sessionId: sessionId, promptId: promptId),
+        isFalse,
+        reason: "the frame write has started and can no longer be withdrawn",
+      );
+
+      flush.complete();
+      for (var i = 0; i < 20 && (await plugin.getQueuedPrompts(sessionId: sessionId)).isNotEmpty; i++) {
+        await pump();
+      }
+
+      expect(await plugin.getQueuedPrompts(sessionId: sessionId), isEmpty);
+      expect(
+        emitted
+            .whereType<BridgeSseMessageUpdated>()
+            .singleWhere((event) => event.info["promptId"] == promptId)
+            .info["promptId"],
+        promptId,
+      );
+      respondTo(prompt, {"stopReason": "end_turn"});
+    });
+
+    test("a failed ACP frame flush never marks the prompt sent", () async {
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+      emitted.clear();
+
+      final flush = fake.holdNextFlush();
+      final promptId = await sendPrompt(sessionId, "broken pipe");
+      await waitForFrame("session/prompt");
+      flush.completeError(StateError("broken pipe"));
+      for (var i = 0; i < 20 && idleCount() == 0; i++) {
+        await pump();
+      }
+
+      expect(await plugin.getQueuedPrompts(sessionId: sessionId), isEmpty);
+      expect(
+        emitted.whereType<BridgeSseMessageUpdated>().where((event) => event.info["promptId"] == promptId),
+        isEmpty,
+      );
+      expect(emitted.whereType<BridgeSseSessionError>(), hasLength(1));
+      expect(streamErrors, isEmpty);
     });
 
     test("an initial create prompt emits its user-visible text only once", () async {

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
@@ -148,6 +148,9 @@ class CursorPlugin._({
   bool get serializesPromptsProcessWide => false;
 
   @override
+  bool get cancelsActiveTurnForQueuedInput => false;
+
+  @override
   bool get failsTurnOnSelectionError => false;
 
   @override

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
@@ -99,6 +99,9 @@ class HermesPlugin._({
   @override
   bool get serializesPromptsProcessWide => false;
 
+  @override
+  bool get cancelsActiveTurnForQueuedInput => false;
+
   /// No harness-specific turn selection exists (base [applyTurnSelection] is
   /// a no-op), so a selection can never fail a turn.
   @override

--- a/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
+++ b/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
@@ -127,6 +127,9 @@ class OmpPlugin._({
   bool get serializesPromptsProcessWide => true;
 
   @override
+  bool get cancelsActiveTurnForQueuedInput => true;
+
+  @override
   bool get failsTurnOnSelectionError => true;
 
   @override

--- a/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
@@ -115,6 +115,7 @@ void main() {
 
     test("uses OMP's process-wide and fail-closed policies", () {
       expect(plugin.serializesPromptsProcessWide, isTrue);
+      expect(plugin.cancelsActiveTurnForQueuedInput, isTrue);
       expect(plugin.failsTurnOnSelectionError, isTrue);
       expect(plugin.supportsFormElicitation, isTrue);
     });
@@ -253,6 +254,47 @@ void main() {
       final secondPrompt = await waitForFrame(AcpMethods.sessionPrompt, count: 2);
       expect((secondPrompt["params"] as Map)["sessionId"], second.id);
       respond(secondPrompt, {"stopReason": "end_turn"});
+    });
+
+    test("a prompt queued on the active session cancels that turn before dispatch", () async {
+      await connect();
+      final session = await create("session");
+
+      await plugin.sendPrompt(
+        promptId: "prompt-1",
+        sessionId: session.id,
+        parts: const [PluginPromptPart.text(text: "keep searching")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final firstPrompt = await waitForFrame(AcpMethods.sessionPrompt);
+
+      await plugin.sendPrompt(
+        promptId: "prompt-2",
+        sessionId: session.id,
+        parts: const [PluginPromptPart.text(text: "stop")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final cancel = await waitForFrame(AcpMethods.sessionCancel);
+      expect(cancel["params"], {"sessionId": session.id});
+      expect(frames(AcpMethods.sessionPrompt), hasLength(1));
+      expect((await plugin.getQueuedPrompts(sessionId: session.id)).single.id, "prompt-2");
+
+      respond(firstPrompt, {"stopReason": "cancelled"});
+      final replacement = await waitForFrame(AcpMethods.sessionPrompt, count: 2);
+      expect((replacement["params"] as Map)["sessionId"], session.id);
+      expect(await plugin.getQueuedPrompts(sessionId: session.id), isEmpty);
+      expect(
+        events
+            .whereType<BridgeSseMessageUpdated>()
+            .singleWhere((event) => event.info["promptId"] == "prompt-2")
+            .info["role"],
+        "user",
+      );
+      respond(replacement, {"stopReason": "end_turn"});
     });
 
     test("maps live reasoning, tools, images, and final text", () async {

--- a/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
+++ b/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
@@ -188,7 +188,7 @@ final class PiPlugin._({
     _eventBuffer.add(BridgeSseSessionCreated(info: session.toJson()));
     if (parts.isNotEmpty) {
       try {
-        await _sessionService.sendPrompt(
+        await _sessionService.sendInitialPrompt(
           sessionId: sessionId,
           // createSession carries no client prompt id; a fresh random id keys
           // this initial turn without ever colliding with client-supplied ids.
@@ -319,6 +319,14 @@ final class PiPlugin._({
       model: model,
     );
   }
+
+  @override
+  Future<List<PluginQueuedPrompt>> getQueuedPrompts({required String sessionId}) async =>
+      _sessionService.queuedPrompts(sessionId: sessionId);
+
+  @override
+  Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async =>
+      _sessionService.cancelQueuedPrompt(sessionId: sessionId, promptId: promptId);
 
   @override
   Future<void> sendCommand({

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
@@ -317,7 +317,11 @@ final class PiEventDispatcher({
     final state = _session(sessionId);
     final textContent = message.content.whereType<PiTextContentDto>().singleOrNull;
     final visibleText = state.userVisibleText;
-    final isTurnEcho = textContent?.text == state.executionText;
+    final isAttachmentOnlyEcho =
+        (state.executionText?.isEmpty ?? false) &&
+        message.content.isNotEmpty &&
+        message.content.every((content) => content is PiImageContentDto);
+    final isTurnEcho = textContent?.text == state.executionText || isAttachmentOnlyEcho;
     final exactText = isTurnEcho ? visibleText : null;
     // Consumed on the first echo so a later replay with identical text does
     // not correlate to the same prompt again.

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -57,23 +57,49 @@ final class _PiSessionTurnState({required final String initialDirectory}) {
   }
 }
 
-final class _PiTurn({
+sealed class _PiTurn({
   required final String promptId,
-  required final PluginQueuedPrompt? presentation,
   required final PiPromptPayload payload,
   required final ({String providerID, String modelID})? model,
   required final PluginSessionVariant? variant,
   required final String? userVisibleText,
-  required final Completer<void>? commandAcceptance,
 }) {
   PiSessionConnection? connection;
   bool promptDispatched = false;
+  bool userMessageEmitted = false;
   bool responseSucceeded = false;
   bool agentStarted = false;
   bool agentSettled = false;
   bool settled = false;
+}
+
+final class _PiInitialTurn({
+  required super.promptId,
+  required super.payload,
+  required super.model,
+  required super.variant,
+  required super.userVisibleText,
+}) extends _PiTurn;
+
+final class _PiQueuedPromptTurn({
+  required super.promptId,
+  required super.payload,
+  required super.model,
+  required super.variant,
+  required super.userVisibleText,
+  required final PluginQueuedPrompt presentation,
+}) extends _PiTurn {
   _PiQueueState queueState = _PiQueueState.visible;
 }
+
+final class _PiCommandTurn({
+  required super.promptId,
+  required super.payload,
+  required super.model,
+  required super.variant,
+  required super.userVisibleText,
+  required final Completer<void> acceptance,
+}) extends _PiTurn;
 
 final class PiSessionService({
   required final PiSessionProcessRepository processRepository,
@@ -113,7 +139,7 @@ final class PiSessionService({
     if (state == null) return const [];
     return [
       for (final turn in [?state.active, ...state.queue])
-        if (turn.queueState == _PiQueueState.visible && turn.presentation != null) turn.presentation!,
+        if (turn is _PiQueuedPromptTurn && turn.queueState == _PiQueueState.visible) turn.presentation,
     ];
   }
 
@@ -121,8 +147,7 @@ final class PiSessionService({
     final state = _sessions[sessionId];
     if (state == null) return false;
     final active = state.active;
-    if (active != null &&
-        active.presentation != null &&
+    if (active is _PiQueuedPromptTurn &&
         active.promptId == promptId &&
         !active.promptDispatched &&
         active.queueState == _PiQueueState.visible) {
@@ -130,15 +155,13 @@ final class PiSessionService({
       return true;
     }
     final index = state.queue.indexWhere(
-      (turn) => turn.presentation != null && turn.promptId == promptId && turn.queueState == _PiQueueState.visible,
+      (turn) =>
+          turn is _PiQueuedPromptTurn &&
+          turn.promptId == promptId &&
+          turn.queueState == _PiQueueState.visible,
     );
     if (index == -1) return false;
-    final turn = state.queue.removeAt(index);
-    state.recordSettledPromptId(promptId: turn.promptId);
-    final acceptance = turn.commandAcceptance;
-    if (acceptance != null && !acceptance.isCompleted) {
-      acceptance.completeError(PiTurnCancelledException(sessionId: sessionId), StackTrace.current);
-    }
+    final turn = state.queue.removeAt(index) as _PiQueuedPromptTurn;
     _cancelQueuedPresentation(sessionId: sessionId, state: state, turn: turn);
     return true;
   }
@@ -230,23 +253,28 @@ final class PiSessionService({
     required PluginSessionVariant? variant,
     required ({String providerID, String modelID})? model,
   }) {
+    if (_disposed) return Future.error(const PiRpcDisposedException());
     final visibleText = userVisibleText?.trim();
-    return _sendPrompt(
+    final payload = _processes.mapPrompt(parts: parts, userVisibleText: userVisibleText);
+    _admit(
       sessionId: sessionId,
-      promptId: promptId,
       directory: directory,
-      parts: parts,
-      userVisibleText: userVisibleText,
-      variant: variant,
-      model: model,
-      presentation: PluginQueuedPrompt(
-        id: promptId,
-        text: visibleText == null || visibleText.isEmpty ? null : visibleText,
-        command: null,
-        attachmentCount: parts.where((part) => part is! PluginPromptPartText).length,
-        createdAt: _clock.now().millisecondsSinceEpoch,
+      turn: _PiQueuedPromptTurn(
+        promptId: promptId,
+        payload: payload,
+        model: model,
+        variant: variant,
+        userVisibleText: userVisibleText,
+        presentation: PluginQueuedPrompt(
+          id: promptId,
+          text: visibleText == null || visibleText.isEmpty ? null : visibleText,
+          command: null,
+          attachmentCount: parts.where((part) => part is! PluginPromptPartText).length,
+          createdAt: _clock.now().millisecondsSinceEpoch,
+        ),
       ),
     );
+    return Future.value();
   }
 
   Future<void> sendInitialPrompt({
@@ -257,40 +285,18 @@ final class PiSessionService({
     required String? userVisibleText,
     required PluginSessionVariant? variant,
     required ({String providerID, String modelID})? model,
-  }) => _sendPrompt(
-    sessionId: sessionId,
-    promptId: promptId,
-    directory: directory,
-    parts: parts,
-    userVisibleText: userVisibleText,
-    variant: variant,
-    model: model,
-    presentation: null,
-  );
-
-  Future<void> _sendPrompt({
-    required String sessionId,
-    required String promptId,
-    required String directory,
-    required List<PluginPromptPart> parts,
-    required String? userVisibleText,
-    required PluginSessionVariant? variant,
-    required ({String providerID, String modelID})? model,
-    required PluginQueuedPrompt? presentation,
   }) {
     if (_disposed) return Future.error(const PiRpcDisposedException());
     final payload = _processes.mapPrompt(parts: parts, userVisibleText: userVisibleText);
     _admit(
       sessionId: sessionId,
       directory: directory,
-      turn: _PiTurn(
+      turn: _PiInitialTurn(
         promptId: promptId,
-        presentation: presentation,
         payload: payload,
         model: model,
         variant: variant,
         userVisibleText: userVisibleText,
-        commandAcceptance: null,
       ),
     );
     return Future.value();
@@ -322,20 +328,13 @@ final class PiSessionService({
     _admit(
       sessionId: sessionId,
       directory: directory,
-      turn: _PiTurn(
+      turn: _PiCommandTurn(
         promptId: promptId,
-        presentation: PluginQueuedPrompt(
-          id: promptId,
-          text: visibleArguments == null || visibleArguments.isEmpty ? null : visibleArguments,
-          command: command,
-          attachmentCount: 0,
-          createdAt: _clock.now().millisecondsSinceEpoch,
-        ),
         payload: payload,
         model: model,
         variant: variant,
         userVisibleText: visible,
-        commandAcceptance: acceptance,
+        acceptance: acceptance,
       ),
     );
     return acceptance.future;
@@ -346,8 +345,9 @@ final class PiSessionService({
     if (state.isAdmitted(promptId: turn.promptId)) {
       // The retry of a send whose response was lost: the turn is already
       // admitted (queued, running, or finished), so accept idempotently.
-      final acceptance = turn.commandAcceptance;
-      if (acceptance != null && !acceptance.isCompleted) acceptance.complete();
+      if (turn is _PiCommandTurn && !turn.acceptance.isCompleted) {
+        turn.acceptance.complete();
+      }
       return;
     }
     state.directory = directory;
@@ -364,7 +364,7 @@ final class PiSessionService({
       _emit(const BridgeSseProjectUpdated());
     }
     _syncWorkState();
-    if (turn.presentation != null) _emitQueueUpdate(sessionId: sessionId, state: state);
+    if (turn is _PiQueuedPromptTurn) _emitQueueUpdate(sessionId: sessionId, state: state);
     _startNext(sessionId: sessionId, state: state);
   }
 
@@ -416,8 +416,9 @@ final class PiSessionService({
       await response;
       if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
       turn.responseSucceeded = true;
-      final acceptance = turn.commandAcceptance;
-      if (acceptance != null && !acceptance.isCompleted) acceptance.complete();
+      if (turn is _PiCommandTurn && !turn.acceptance.isCompleted) {
+        turn.acceptance.complete();
+      }
       await Future<void>.delayed(Duration.zero);
       if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
       if (turn.agentSettled) {
@@ -431,15 +432,20 @@ final class PiSessionService({
         }
       }
     } on PiTurnCancelledException catch (error, stack) {
-      final acceptance = turn.commandAcceptance;
-      if (acceptance != null && !acceptance.isCompleted) acceptance.completeError(error, stack);
+      if (turn is _PiCommandTurn && !turn.acceptance.isCompleted) {
+        turn.acceptance.completeError(error, stack);
+      }
       if (_ownsTurn(sessionId: sessionId, state: state, turn: turn, generation: generation)) {
         _finish(sessionId: sessionId, state: state, turn: turn, failed: false, failure: null);
       }
     } on Object catch (error, stack) {
       if (error is PiRpcProcessExitException) {
         await Future<void>.delayed(Duration.zero);
-        if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
+      }
+      if (!_ownsTurn(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
+      if (turn is _PiQueuedPromptTurn && turn.queueState == _PiQueueState.cancelled) {
+        _finish(sessionId: sessionId, state: state, turn: turn, failed: false, failure: null);
+        return;
       }
       if (error is TimeoutException && turn.promptDispatched) {
         final connection = turn.connection;
@@ -452,8 +458,9 @@ final class PiSessionService({
           if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
         }
       }
-      final acceptance = turn.commandAcceptance;
-      if (acceptance != null && !acceptance.isCompleted) acceptance.completeError(error, stack);
+      if (turn is _PiCommandTurn && !turn.acceptance.isCompleted) {
+        turn.acceptance.completeError(error, stack);
+      }
       if (_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) {
         final presented = _processes.presentTurnFailure(sessionId: sessionId, error: error);
         Log.w("[pi] admitted turn failed for session id=$sessionId", presented.cause, stack);
@@ -498,12 +505,16 @@ final class PiSessionService({
               (mapped is BridgeSseSessionStatus || mapped is BridgeSseSessionIdle);
           if (!serviceOwnsLifecycle) _emit(mapped);
         }
-        if (turn.promptDispatched &&
-            turn.queueState == _PiQueueState.visible &&
+        final userMessageEmitted =
+            turn.promptDispatched &&
             mappedEvents.any(
               (mapped) => mapped is BridgeSseMessageUpdated && mapped.info["promptId"] == turn.promptId,
-            )) {
-          _releaseQueuedPresentation(sessionId: processFrame.sessionId, state: state, turn: turn);
+            );
+        if (userMessageEmitted) {
+          turn.userMessageEmitted = true;
+          if (turn is _PiQueuedPromptTurn && turn.queueState == _PiQueueState.visible) {
+            _releaseQueuedPresentation(sessionId: processFrame.sessionId, state: state, turn: turn);
+          }
         }
         if (statusChanged) _emit(const BridgeSseProjectUpdated());
         if (turn.promptDispatched && event is PiAgentSettledEvent) {
@@ -519,12 +530,11 @@ final class PiSessionService({
           }
         }
       case PiExtensionUiFrame(:final request):
-        final acceptance = turn.commandAcceptance;
-        if (turn.promptDispatched &&
+        if (turn is _PiCommandTurn &&
+            turn.promptDispatched &&
             request is PiExtensionDialogRequest &&
-            acceptance != null &&
-            !acceptance.isCompleted) {
-          acceptance.complete();
+            !turn.acceptance.isCompleted) {
+          turn.acceptance.complete();
         }
         unawaited(
           _extensionUi
@@ -549,7 +559,8 @@ final class PiSessionService({
     final state = _sessions[exit.sessionId];
     final turn = state?.active;
     if (state == null || turn == null || turn.connection?.generation != exit.generation) return;
-    if (exit.authUnavailable) {
+    final cancelled = turn is _PiQueuedPromptTurn && turn.queueState == _PiQueueState.cancelled;
+    if (!cancelled && exit.authUnavailable) {
       _emit(
         const BridgeSseTuiToastShow(
           title: "Pi login required",
@@ -559,13 +570,15 @@ final class PiSessionService({
       );
     }
     final failure = PiRpcProcessExitException(exitCode: exit.exitCode);
-    Log.w("[pi] resident process exited during active turn for session id=${exit.sessionId}", failure);
+    if (!cancelled) {
+      Log.w("[pi] resident process exited during active turn for session id=${exit.sessionId}", failure);
+    }
     _finish(
       sessionId: exit.sessionId,
       state: state,
       turn: turn,
-      failed: true,
-      failure: failure,
+      failed: !cancelled,
+      failure: cancelled ? null : failure,
     );
   }
 
@@ -578,14 +591,23 @@ final class PiSessionService({
   }) {
     if (turn.settled) return;
     turn.settled = true;
-    state.recordSettledPromptId(promptId: turn.promptId);
-    final acceptance = turn.commandAcceptance;
-    if (acceptance != null && !acceptance.isCompleted && failed) {
-      acceptance.completeError(failure ?? StateError("Pi command failed before acceptance"), StackTrace.current);
+    if (turn.promptDispatched) {
+      state.recordSettledPromptId(promptId: turn.promptId);
+    }
+    if (turn is _PiCommandTurn && !turn.acceptance.isCompleted && failed) {
+      turn.acceptance.completeError(
+        failure ?? StateError("Pi command failed before acceptance"),
+        StackTrace.current,
+      );
     }
     if (!identical(_sessions[sessionId], state) || !identical(state.active, turn)) return;
+    if (!failed && turn.promptDispatched && !turn.userMessageEmitted) {
+      _emitMissingUserMessage(sessionId: sessionId, turn: turn);
+    }
     state.active = null;
-    _releaseQueuedPresentation(sessionId: sessionId, state: state, turn: turn);
+    if (turn is _PiQueuedPromptTurn) {
+      _releaseQueuedPresentation(sessionId: sessionId, state: state, turn: turn);
+    }
     if (failed) _emit(BridgeSseSessionError(sessionID: sessionId));
     unawaited(_clearPendingWhenPersisted(sessionId: sessionId, directory: state.directory));
     if (state.queue.isNotEmpty) {
@@ -606,6 +628,28 @@ final class PiSessionService({
     _emit(const BridgeSseProjectUpdated());
     _syncWorkState();
     _scheduleIdleReap(sessionId: sessionId, state: state);
+  }
+
+  void _emitMissingUserMessage({required String sessionId, required _PiTurn turn}) {
+    final now = _clock.now();
+    final message = <String, Object?>{
+      "role": "user",
+      "content": <Object?>[
+        if (turn.payload.message.isNotEmpty) {"type": "text", "text": turn.payload.message},
+        ...turn.payload.images,
+      ],
+      "timestamp": now.millisecondsSinceEpoch,
+    };
+    final raw = <String, Object?>{"type": "message_end", "message": message};
+    final mappedEvents = _dispatcher.map(
+      sessionId: sessionId,
+      event: PiMessageEndEvent(message: message, raw: raw),
+      now: now,
+    );
+    mappedEvents.forEach(_emit);
+    turn.userMessageEmitted = mappedEvents.any(
+      (mapped) => mapped is BridgeSseMessageUpdated && mapped.info["promptId"] == turn.promptId,
+    );
   }
 
   Future<void> _clearPendingWhenPersisted({required String sessionId, required String directory}) async {
@@ -631,18 +675,17 @@ final class PiSessionService({
     state.idleGeneration++;
     final cancelled = [?state.active, ...state.queue];
     final hadQueuedPresentations = cancelled.any(
-      (turn) => turn.presentation != null && turn.queueState == _PiQueueState.visible,
+      (turn) => turn is _PiQueuedPromptTurn && turn.queueState == _PiQueueState.visible,
     );
     for (final turn in cancelled) {
-      turn.queueState = _PiQueueState.cancelled;
+      if (turn is _PiQueuedPromptTurn) turn.queueState = _PiQueueState.cancelled;
     }
     state.active = null;
     state.queue.clear();
     state.status = const PluginSessionStatus.idle();
     for (final turn in cancelled) {
-      final acceptance = turn.commandAcceptance;
-      if (acceptance != null && !acceptance.isCompleted) {
-        acceptance.completeError(PiTurnCancelledException(sessionId: sessionId), StackTrace.current);
+      if (turn is _PiCommandTurn && !turn.acceptance.isCompleted) {
+        turn.acceptance.completeError(PiTurnCancelledException(sessionId: sessionId), StackTrace.current);
       }
     }
     if (hadQueuedPresentations) _emitQueueUpdate(sessionId: sessionId, state: state);
@@ -692,9 +735,8 @@ final class PiSessionService({
       state.generation++;
       state.idleGeneration++;
       for (final turn in [?state.active, ...state.queue]) {
-        final acceptance = turn.commandAcceptance;
-        if (acceptance != null && !acceptance.isCompleted) {
-          acceptance.completeError(PiTurnCancelledException(sessionId: sessionId), StackTrace.current);
+        if (turn is _PiCommandTurn && !turn.acceptance.isCompleted) {
+          turn.acceptance.completeError(PiTurnCancelledException(sessionId: sessionId), StackTrace.current);
         }
       }
       state.active = null;
@@ -768,7 +810,7 @@ final class PiSessionService({
     required int generation,
   }) =>
       _ownsTurn(sessionId: sessionId, state: state, turn: turn, generation: generation) &&
-      turn.queueState != _PiQueueState.cancelled;
+      (turn is! _PiQueuedPromptTurn || turn.queueState != _PiQueueState.cancelled);
 
   bool _ownsTurn({
     required String sessionId,
@@ -784,19 +826,18 @@ final class PiSessionService({
   void _releaseQueuedPresentation({
     required String sessionId,
     required _PiSessionTurnState state,
-    required _PiTurn turn,
+    required _PiQueuedPromptTurn turn,
   }) {
     if (turn.queueState != _PiQueueState.visible) return;
     turn.queueState = _PiQueueState.released;
-    if (turn.presentation != null) _emitQueueUpdate(sessionId: sessionId, state: state);
+    _emitQueueUpdate(sessionId: sessionId, state: state);
   }
 
   void _cancelQueuedPresentation({
     required String sessionId,
     required _PiSessionTurnState state,
-    required _PiTurn turn,
+    required _PiQueuedPromptTurn turn,
   }) {
-    assert(turn.presentation != null);
     if (turn.queueState != _PiQueueState.visible) return;
     turn.queueState = _PiQueueState.cancelled;
     _emitQueueUpdate(sessionId: sessionId, state: state);
@@ -831,9 +872,8 @@ final class PiSessionService({
       state.generation++;
       state.idleGeneration++;
       for (final turn in [?state.active, ...state.queue]) {
-        final acceptance = turn.commandAcceptance;
-        if (acceptance != null && !acceptance.isCompleted) {
-          acceptance.completeError(const PiRpcDisposedException(), StackTrace.current);
+        if (turn is _PiCommandTurn && !turn.acceptance.isCompleted) {
+          turn.acceptance.completeError(const PiRpcDisposedException(), StackTrace.current);
         }
       }
     }

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -44,10 +44,15 @@ final class _PiSessionTurnState({required final String initialDirectory}) {
   /// settled ids need this bounded window.
   final Queue<String> recentPromptIds = Queue<String>();
 
-  bool isAdmitted({required String promptId}) =>
-      active?.promptId == promptId ||
-      queue.any((turn) => turn.promptId == promptId) ||
-      recentPromptIds.contains(promptId);
+  bool isAdmitted({required String promptId}) {
+    final activeTurn = active;
+    final activeAccepted =
+        activeTurn?.promptId == promptId &&
+        (activeTurn is! _PiQueuedPromptTurn || activeTurn.queueState != _PiQueueState.cancelled);
+    return activeAccepted ||
+        queue.any((turn) => turn.promptId == promptId) ||
+        recentPromptIds.contains(promptId);
+  }
 
   void recordSettledPromptId({required String promptId}) {
     recentPromptIds.addLast(promptId);

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -23,6 +23,8 @@ final class const PiTurnCancelledException({required final String sessionId}) im
   String toString() => "Pi turn was cancelled";
 }
 
+enum _PiQueueState() { visible, released, cancelled }
+
 final class _PiSessionTurnState({required final String initialDirectory}) {
   /// See [recentPromptIds]. 64 comfortably exceeds any realistic gap between
   /// a lost acceptance response and its retry.
@@ -57,6 +59,7 @@ final class _PiSessionTurnState({required final String initialDirectory}) {
 
 final class _PiTurn({
   required final String promptId,
+  required final PluginQueuedPrompt? presentation,
   required final PiPromptPayload payload,
   required final ({String providerID, String modelID})? model,
   required final PluginSessionVariant? variant,
@@ -69,6 +72,7 @@ final class _PiTurn({
   bool agentStarted = false;
   bool agentSettled = false;
   bool settled = false;
+  _PiQueueState queueState = _PiQueueState.visible;
 }
 
 final class PiSessionService({
@@ -103,6 +107,41 @@ final class PiSessionService({
   Stream<BridgeSseEvent> get events => _events.stream;
   Stream<PluginWorkState> get workState => _workState.stream;
   PluginWorkState get currentWorkState => _workState.current;
+
+  List<PluginQueuedPrompt> queuedPrompts({required String sessionId}) {
+    final state = _sessions[sessionId];
+    if (state == null) return const [];
+    return [
+      for (final turn in [?state.active, ...state.queue])
+        if (turn.queueState == _PiQueueState.visible && turn.presentation != null) turn.presentation!,
+    ];
+  }
+
+  bool cancelQueuedPrompt({required String sessionId, required String promptId}) {
+    final state = _sessions[sessionId];
+    if (state == null) return false;
+    final active = state.active;
+    if (active != null &&
+        active.presentation != null &&
+        active.promptId == promptId &&
+        !active.promptDispatched &&
+        active.queueState == _PiQueueState.visible) {
+      _cancelQueuedPresentation(sessionId: sessionId, state: state, turn: active);
+      return true;
+    }
+    final index = state.queue.indexWhere(
+      (turn) => turn.presentation != null && turn.promptId == promptId && turn.queueState == _PiQueueState.visible,
+    );
+    if (index == -1) return false;
+    final turn = state.queue.removeAt(index);
+    state.recordSettledPromptId(promptId: turn.promptId);
+    final acceptance = turn.commandAcceptance;
+    if (acceptance != null && !acceptance.isCompleted) {
+      acceptance.completeError(PiTurnCancelledException(sessionId: sessionId), StackTrace.current);
+    }
+    _cancelQueuedPresentation(sessionId: sessionId, state: state, turn: turn);
+    return true;
+  }
 
   String? directoryForSession({required String sessionId}) =>
       _sessions[sessionId]?.directory ?? _pendingNewDirectories[sessionId];
@@ -191,6 +230,54 @@ final class PiSessionService({
     required PluginSessionVariant? variant,
     required ({String providerID, String modelID})? model,
   }) {
+    final visibleText = userVisibleText?.trim();
+    return _sendPrompt(
+      sessionId: sessionId,
+      promptId: promptId,
+      directory: directory,
+      parts: parts,
+      userVisibleText: userVisibleText,
+      variant: variant,
+      model: model,
+      presentation: PluginQueuedPrompt(
+        id: promptId,
+        text: visibleText == null || visibleText.isEmpty ? null : visibleText,
+        command: null,
+        attachmentCount: parts.where((part) => part is! PluginPromptPartText).length,
+        createdAt: _clock.now().millisecondsSinceEpoch,
+      ),
+    );
+  }
+
+  Future<void> sendInitialPrompt({
+    required String sessionId,
+    required String promptId,
+    required String directory,
+    required List<PluginPromptPart> parts,
+    required String? userVisibleText,
+    required PluginSessionVariant? variant,
+    required ({String providerID, String modelID})? model,
+  }) => _sendPrompt(
+    sessionId: sessionId,
+    promptId: promptId,
+    directory: directory,
+    parts: parts,
+    userVisibleText: userVisibleText,
+    variant: variant,
+    model: model,
+    presentation: null,
+  );
+
+  Future<void> _sendPrompt({
+    required String sessionId,
+    required String promptId,
+    required String directory,
+    required List<PluginPromptPart> parts,
+    required String? userVisibleText,
+    required PluginSessionVariant? variant,
+    required ({String providerID, String modelID})? model,
+    required PluginQueuedPrompt? presentation,
+  }) {
     if (_disposed) return Future.error(const PiRpcDisposedException());
     final payload = _processes.mapPrompt(parts: parts, userVisibleText: userVisibleText);
     _admit(
@@ -198,6 +285,7 @@ final class PiSessionService({
       directory: directory,
       turn: _PiTurn(
         promptId: promptId,
+        presentation: presentation,
         payload: payload,
         model: model,
         variant: variant,
@@ -225,8 +313,10 @@ final class PiSessionService({
       return Future.error(PiSessionBusyException(sessionId: sessionId));
     }
     final execution = arguments.isEmpty ? "/$command" : "/$command $arguments";
-    final visibleArguments = userVisibleArguments;
-    final visible = visibleArguments == null || visibleArguments.isEmpty ? "/$command" : "/$command $visibleArguments";
+    final visibleArguments = userVisibleArguments?.trim();
+    final visible = visibleArguments == null || visibleArguments.isEmpty
+        ? "/$command"
+        : "/$command $userVisibleArguments";
     final acceptance = Completer<void>();
     final payload = PiPromptPayload(message: execution, images: const []);
     _admit(
@@ -234,6 +324,13 @@ final class PiSessionService({
       directory: directory,
       turn: _PiTurn(
         promptId: promptId,
+        presentation: PluginQueuedPrompt(
+          id: promptId,
+          text: visibleArguments == null || visibleArguments.isEmpty ? null : visibleArguments,
+          command: command,
+          attachmentCount: 0,
+          createdAt: _clock.now().millisecondsSinceEpoch,
+        ),
         payload: payload,
         model: model,
         variant: variant,
@@ -267,6 +364,7 @@ final class PiSessionService({
       _emit(const BridgeSseProjectUpdated());
     }
     _syncWorkState();
+    if (turn.presentation != null) _emitQueueUpdate(sessionId: sessionId, state: state);
     _startNext(sessionId: sessionId, state: state);
   }
 
@@ -335,6 +433,9 @@ final class PiSessionService({
     } on PiTurnCancelledException catch (error, stack) {
       final acceptance = turn.commandAcceptance;
       if (acceptance != null && !acceptance.isCompleted) acceptance.completeError(error, stack);
+      if (_ownsTurn(sessionId: sessionId, state: state, turn: turn, generation: generation)) {
+        _finish(sessionId: sessionId, state: state, turn: turn, failed: false, failure: null);
+      }
     } on Object catch (error, stack) {
       if (error is PiRpcProcessExitException) {
         await Future<void>.delayed(Duration.zero);
@@ -390,11 +491,19 @@ final class PiSessionService({
             event is! PiAgentSettledEvent &&
             state.status != mappedStatus;
         if (statusChanged) state.status = mappedStatus;
-        for (final mapped in _dispatcher.map(sessionId: processFrame.sessionId, event: event, now: now)) {
+        final mappedEvents = _dispatcher.map(sessionId: processFrame.sessionId, event: event, now: now);
+        for (final mapped in mappedEvents) {
           final serviceOwnsLifecycle =
               (event is PiAgentStartEvent || event is PiAgentSettledEvent) &&
               (mapped is BridgeSseSessionStatus || mapped is BridgeSseSessionIdle);
           if (!serviceOwnsLifecycle) _emit(mapped);
+        }
+        if (turn.promptDispatched &&
+            turn.queueState == _PiQueueState.visible &&
+            mappedEvents.any(
+              (mapped) => mapped is BridgeSseMessageUpdated && mapped.info["promptId"] == turn.promptId,
+            )) {
+          _releaseQueuedPresentation(sessionId: processFrame.sessionId, state: state, turn: turn);
         }
         if (statusChanged) _emit(const BridgeSseProjectUpdated());
         if (turn.promptDispatched && event is PiAgentSettledEvent) {
@@ -476,6 +585,7 @@ final class PiSessionService({
     }
     if (!identical(_sessions[sessionId], state) || !identical(state.active, turn)) return;
     state.active = null;
+    _releaseQueuedPresentation(sessionId: sessionId, state: state, turn: turn);
     if (failed) _emit(BridgeSseSessionError(sessionID: sessionId));
     unawaited(_clearPendingWhenPersisted(sessionId: sessionId, directory: state.directory));
     if (state.queue.isNotEmpty) {
@@ -520,6 +630,12 @@ final class PiSessionService({
     state.generation++;
     state.idleGeneration++;
     final cancelled = [?state.active, ...state.queue];
+    final hadQueuedPresentations = cancelled.any(
+      (turn) => turn.presentation != null && turn.queueState == _PiQueueState.visible,
+    );
+    for (final turn in cancelled) {
+      turn.queueState = _PiQueueState.cancelled;
+    }
     state.active = null;
     state.queue.clear();
     state.status = const PluginSessionStatus.idle();
@@ -529,6 +645,7 @@ final class PiSessionService({
         acceptance.completeError(PiTurnCancelledException(sessionId: sessionId), StackTrace.current);
       }
     }
+    if (hadQueuedPresentations) _emitQueueUpdate(sessionId: sessionId, state: state);
     _extensionUi.cancelForOwner(sessionId: sessionId, processGeneration: null);
     final connection = cancelled.firstOrNull?.connection;
     try {
@@ -650,10 +767,49 @@ final class PiSessionService({
     required _PiTurn turn,
     required int generation,
   }) =>
+      _ownsTurn(sessionId: sessionId, state: state, turn: turn, generation: generation) &&
+      turn.queueState != _PiQueueState.cancelled;
+
+  bool _ownsTurn({
+    required String sessionId,
+    required _PiSessionTurnState state,
+    required _PiTurn turn,
+    required int generation,
+  }) =>
       !_disposed &&
       identical(_sessions[sessionId], state) &&
       identical(state.active, turn) &&
       state.generation == generation;
+
+  void _releaseQueuedPresentation({
+    required String sessionId,
+    required _PiSessionTurnState state,
+    required _PiTurn turn,
+  }) {
+    if (turn.queueState != _PiQueueState.visible) return;
+    turn.queueState = _PiQueueState.released;
+    if (turn.presentation != null) _emitQueueUpdate(sessionId: sessionId, state: state);
+  }
+
+  void _cancelQueuedPresentation({
+    required String sessionId,
+    required _PiSessionTurnState state,
+    required _PiTurn turn,
+  }) {
+    assert(turn.presentation != null);
+    if (turn.queueState != _PiQueueState.visible) return;
+    turn.queueState = _PiQueueState.cancelled;
+    _emitQueueUpdate(sessionId: sessionId, state: state);
+  }
+
+  void _emitQueueUpdate({required String sessionId, required _PiSessionTurnState state}) {
+    _emit(
+      BridgeSseQueuedPromptsUpdated(
+        sessionID: sessionId,
+        prompts: queuedPrompts(sessionId: sessionId),
+      ),
+    );
+  }
 
   void _syncWorkState() => _workState.set(
     _sessions.values.any((state) => state.active != null || state.queue.isNotEmpty)

--- a/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
@@ -57,6 +57,7 @@ void main() {
       await pump();
       expect(events.first, isA<BridgeSseSessionCreated>());
       expect(events[1], isA<BridgeSseSessionStatus>());
+      expect(events.whereType<BridgeSseQueuedPromptsUpdated>(), isEmpty);
       expect(harness.plugin.getActiveSessionsSummary().single.activeSessions.single.mainAgentRunning, isTrue);
       await subscription.cancel();
     });

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -386,6 +386,90 @@ void main() {
     expect(prompt["message"], "selected");
   });
 
+  test("accepted prompt stays queued until Pi echoes its user message", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+    final events = <BridgeSseEvent>[];
+    service.events.listen(events.add);
+
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "queued-visible",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "wait for echo")],
+      userVisibleText: "wait for echo",
+      variant: null,
+      model: null,
+    );
+    expect(service.queuedPrompts(sessionId: "session").single.id, "queued-visible");
+
+    await _answerEntries(process);
+    final prompt = await waitForCommand(process: process, type: "prompt");
+    expect(
+      service.queuedPrompts(sessionId: "session").single.id,
+      "queued-visible",
+      reason: "dispatch alone must not blank the queued bubble before Pi's echo",
+    );
+
+    process.emit(
+      frame: {
+        "type": "message_end",
+        "message": {
+          "role": "user",
+          "content": [
+            {"type": "text", "text": "wait for echo"},
+          ],
+          "timestamp": 1,
+        },
+      },
+    );
+    await pump();
+
+    expect(service.queuedPrompts(sessionId: "session"), isEmpty);
+    expect(events.whereType<BridgeSseQueuedPromptsUpdated>().first.prompts.single.id, "queued-visible");
+    expect(events.whereType<BridgeSseQueuedPromptsUpdated>().last.prompts, isEmpty);
+    final message = events.whereType<BridgeSseMessageUpdated>().single;
+    final emptyQueue = events.whereType<BridgeSseQueuedPromptsUpdated>().last;
+    expect(events.indexOf(message), lessThan(events.indexOf(emptyQueue)));
+
+    process.emitResponse(id: prompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: "session");
+  });
+
+  test("an undispatched Pi prompt can be cancelled from the bridge queue", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "cancel-queued",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "cancel me")],
+      userVisibleText: "cancel me",
+      variant: null,
+      model: null,
+    );
+    expect(service.queuedPrompts(sessionId: "session"), hasLength(1));
+    expect(
+      service.cancelQueuedPrompt(sessionId: "session", promptId: "cancel-queued"),
+      isTrue,
+    );
+    expect(service.queuedPrompts(sessionId: "session"), isEmpty);
+
+    await _answerEntries(process);
+    await _waitForIdle(service: service, sessionId: "session");
+    expect(process.written.where((frame) => frame["type"] == "prompt"), isEmpty);
+    expect(
+      service.cancelQueuedPrompt(sessionId: "session", promptId: "cancel-queued"),
+      isFalse,
+    );
+  });
+
   test("selection failure prevents prompt dispatch and settles the lane", () async {
     final process = FakePiProcess();
     final fixture = _Fixture(processes: [process]);

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -439,7 +439,7 @@ void main() {
     await _waitForIdle(service: service, sessionId: "session");
   });
 
-  test("an undispatched Pi prompt can be cancelled from the bridge queue", () async {
+  test("an active undispatched Pi prompt can be cancelled and immediately retried", () async {
     final process = FakePiProcess();
     final fixture = _Fixture(processes: [process]);
     addTearDown(fixture.dispose);
@@ -461,9 +461,24 @@ void main() {
     );
     expect(service.queuedPrompts(sessionId: "session"), isEmpty);
 
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "cancel-queued",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "retry me")],
+      userVisibleText: "retry me",
+      variant: null,
+      model: null,
+    );
+    expect(service.queuedPrompts(sessionId: "session"), hasLength(1));
+
     await _answerEntries(process);
+    final retried = await waitForCommand(process: process, type: "prompt");
+    expect(retried["message"], "retry me");
+    process.emitResponse(id: retried["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_settled"});
     await _waitForIdle(service: service, sessionId: "session");
-    expect(process.written.where((frame) => frame["type"] == "prompt"), isEmpty);
+    expect(process.written.where((frame) => frame["type"] == "prompt"), hasLength(1));
     expect(
       service.cancelQueuedPrompt(sessionId: "session", promptId: "cancel-queued"),
       isFalse,

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -470,6 +470,88 @@ void main() {
     );
   });
 
+  test("a cancelled undispatched prompt id remains retryable", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "first",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "first")],
+      userVisibleText: "first",
+      variant: null,
+      model: null,
+    );
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "retryable",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "retry me")],
+      userVisibleText: "retry me",
+      variant: null,
+      model: null,
+    );
+
+    expect(
+      service.cancelQueuedPrompt(sessionId: "session", promptId: "retryable"),
+      isTrue,
+    );
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "retryable",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "retry me")],
+      userVisibleText: "retry me",
+      variant: null,
+      model: null,
+    );
+
+    await _answerEntries(process);
+    final first = await waitForCommand(process: process, type: "prompt");
+    process.emitResponse(id: first["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_settled"});
+    final retried = await _waitForNthCommand(process: process, type: "prompt", count: 2);
+    expect(retried["message"], "retry me");
+    process.emitResponse(id: retried["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: "session");
+  });
+
+  test("a cancelled prompt settles when its selecting process exits", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+    final events = <BridgeSseEvent>[];
+    service.events.listen(events.add);
+
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "cancel-during-selection",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "cancel me")],
+      userVisibleText: "cancel me",
+      variant: null,
+      model: (providerID: "provider", modelID: "model"),
+    );
+    await _answerEntries(process);
+    final model = await waitForCommand(process: process, type: "set_model");
+
+    expect(
+      service.cancelQueuedPrompt(sessionId: "session", promptId: "cancel-during-selection"),
+      isTrue,
+    );
+    expect(model["type"], "set_model");
+    process.exit(code: 9);
+    await _waitForIdle(service: service, sessionId: "session");
+
+    expect(process.written.where((frame) => frame["type"] == "prompt"), isEmpty);
+    expect(events.whereType<BridgeSseSessionError>(), isEmpty);
+  });
+
   test("selection failure prevents prompt dispatch and settles the lane", () async {
     final process = FakePiProcess();
     final fixture = _Fixture(processes: [process]);
@@ -522,8 +604,14 @@ void main() {
 
     final statuses = events.whereType<BridgeSseSessionStatus>().toList();
     final idleIndex = events.indexWhere((event) => event is BridgeSseSessionIdle);
+    final userMessage = events.whereType<BridgeSseMessageUpdated>().singleWhere(
+      (event) => event.info["promptId"] == "prompt-5",
+    );
+    final emptyQueue = events.whereType<BridgeSseQueuedPromptsUpdated>().last;
     expect(statuses.first.status["type"], "busy");
     expect(statuses.last.status["type"], "idle");
+    expect(userMessage.info["role"], "user");
+    expect(events.indexOf(userMessage), lessThan(events.indexOf(emptyQueue)));
     expect(events.indexOf(statuses.last), lessThan(idleIndex));
   });
 
@@ -545,6 +633,8 @@ void main() {
     );
     var completed = false;
     unawaited(accepted.then((_) => completed = true));
+    expect(service.queuedPrompts(sessionId: "session"), isEmpty);
+    expect(service.cancelQueuedPrompt(sessionId: "session", promptId: "prompt-6"), isFalse);
     await _answerEntries(process);
     final firstPrompt = await waitForCommand(process: process, type: "prompt");
     process.emit(frame: {"type": "agent_start"});

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -866,6 +866,51 @@ void main() {
     );
   });
 
+  test("an attachment-only echo correlates without a fallback duplicate", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+    final events = <BridgeSseEvent>[];
+    service.events.listen(events.add);
+
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "image-only",
+      directory: "/project",
+      parts: [
+        const PluginPromptPart.fileData(mime: "image/png", base64: "cG5n", filename: null),
+      ],
+      userVisibleText: null,
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    final prompt = await waitForCommand(process: process, type: "prompt");
+    process.emit(
+      frame: {
+        "type": "message_end",
+        "message": {
+          "role": "user",
+          "content": [
+            {"type": "image", "data": "cG5n", "mimeType": "image/png"},
+          ],
+          "timestamp": 1,
+        },
+      },
+    );
+    process.emitResponse(id: prompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: "session");
+
+    final userMessages = events
+        .whereType<BridgeSseMessageUpdated>()
+        .where((event) => event.info["role"] == "user")
+        .toList();
+    expect(userMessages, hasLength(1));
+    expect(userMessages.single.info["promptId"], "image-only");
+  });
+
   test("command rejects busy, accepts dialog-first, and uses no-run state barrier", () async {
     final process = FakePiProcess();
     final fixture = _Fixture(processes: [process]);

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -83,9 +83,10 @@ defaults and queued client sends coherent.
 - Existing-session ACP prompts remain bridge-queued while an earlier turn,
   process-wide lane, resume, or selection blocks their `session/prompt` frame.
   Their synthetic user transcript message is published only after that frame
-  is written. OMP preserves its active-prompt replacement semantics by cancelling
-  the active turn immediately, then dispatching the newly queued input after
-  cancellation settles; Cursor and Hermes retain ordinary FIFO turn boundaries.
+  flushes successfully to the agent's stdin. OMP preserves its active-prompt
+  replacement semantics by cancelling the active turn immediately, then
+  dispatching the newly queued input after cancellation settles; Cursor and
+  Hermes retain ordinary FIFO turn boundaries.
 - Normalized user-message events feed the durable user-side activity marker used
   to order running roots. Known event times are applied monotonically. Backend
   input represented as a user message, including automatic compaction or other

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -48,7 +48,9 @@ defaults and queued client sends coherent.
 - Pi keeps at most one lazy resident RPC process per active session and allows
   different sessions to run concurrently. Startup replays and hydrates message
   identity before live frames attach or a turn dispatches; same-session prompts
-  remain FIFO. Process exit settles current work before queued work reconnects.
+  remain FIFO. An accepted prompt remains bridge-queued through startup and
+  selection until Pi echoes its correlated user message; it can be cancelled
+  before dispatch. Process exit settles current work before queued work reconnects.
 - Pi slash commands are accepted by their correlated response or a matching
   extension dialog. Commands reject while that session is busy, and a successful
   command with no agent run crosses `get_state` before returning the lane idle.
@@ -72,6 +74,12 @@ defaults and queued client sends coherent.
   session cancellation. Version 1 uses the model/mode configured in Hermes and
   offers no per-turn picker; Sesori does not call form-elicitation or unadvertised
   session-close methods to complete an ordinary turn.
+- Existing-session ACP prompts remain bridge-queued while an earlier turn,
+  process-wide lane, resume, or selection blocks their `session/prompt` frame.
+  Their synthetic user transcript message is published only after that frame
+  is written. OMP preserves its active-prompt replacement semantics by cancelling
+  the active turn immediately, then dispatching the newly queued input after
+  cancellation settles; Cursor and Hermes retain ordinary FIFO turn boundaries.
 - Normalized user-message events feed the durable user-side activity marker used
   to order running roots. Known event times are applied monotonically. Backend
   input represented as a user message, including automatic compaction or other
@@ -93,10 +101,11 @@ defaults and queued client sends coherent.
   leaving the screen, locking the phone, and reconnecting, and is visible to
   every client of that bridge. A normal Claude prompt usually dispatches as
   steering immediately and remains represented only until its replayed user
-  message lands. Entries still waiting for process startup, an earlier command,
-  or a selection boundary can be cancelled individually; cancellation after
-  dispatch is refused as benign because the prompt is then governed by Stop.
-  Aborting the session clears every remaining entry and Claude's internal queue.
+  message lands; Pi similarly remains represented until its correlated echo.
+  Entries still waiting for process startup, an earlier turn or command, or a
+  selection boundary can be cancelled individually; cancellation after dispatch
+  is refused as benign because the prompt is then governed by Stop. Aborting the
+  session clears every remaining plugin-owned entry.
 - One prompt renders as one bubble that transforms in place: sending (staged
   locally while the POST is in flight) → queued (bridge-owned) → sent (the
   transcript message). The dispatched message carries the prompt id and
@@ -183,9 +192,9 @@ has started.
 - Session-detail refresh behavior is under active investigation, so refresh
   churn is recorded as evidence rather than judged pass or fail.
 - The bridge's queued prompts live in plugin memory and do not survive a
-  bridge restart (the backend process dies with the bridge). Claude is the
-  queue-owning plugin; harnesses whose backends take prompts immediately
-  (OpenCode, ACP-family, Codex) never surface queued entries.
+  bridge restart (the backend process dies with the bridge). Claude, Pi, and
+  the ACP family surface adapter-owned entries; OpenCode and Codex hand prompts
+  to their backends immediately and therefore do not.
 - A send staged locally (POST not yet accepted) is dropped if the session
   screen is left inside that sub-second window; while disconnected, staged
   sends survive only as long as the session-detail cubit is alive.

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -50,10 +50,15 @@ defaults and queued client sends coherent.
   identity before live frames attach or a turn dispatches; same-session prompts
   remain FIFO. An accepted prompt remains bridge-queued through startup and
   selection until Pi echoes its correlated user message; it can be cancelled
-  before dispatch. Process exit settles current work before queued work reconnects.
+  before dispatch, and its undispatched prompt id remains retryable. If a
+  successful turn omits that echo, Pi maps the stored payload through the same
+  user-message path before clearing the queue. Process exit settles current work
+  before queued work reconnects.
 - Pi slash commands are accepted by their correlated response or a matching
-  extension dialog. Commands reject while that session is busy, and a successful
-  command with no agent run crosses `get_state` before returning the lane idle.
+  extension dialog and remain in the request's sending state until then rather
+  than exposing a cancellable bridge-queue entry. Commands reject while that
+  session is busy, and a successful command with no agent run crosses `get_state`
+  before returning the lane idle.
   Abort rejects queued work and replaces the process so hidden steering or
   follow-up input cannot leak into the next turn.
 - Pi accepts only bounded, valid inline GIF, JPEG, PNG, and WebP data. Paths,

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -51,10 +51,10 @@ defaults and queued client sends coherent.
   remain FIFO. An accepted prompt remains bridge-queued through startup and
   selection until Pi echoes its correlated user message, including an
   attachment-only echo; it can be cancelled before dispatch, and its
-  undispatched prompt id remains retryable. If a successful turn omits that
-  echo, Pi maps the stored payload through the same user-message path before
-  clearing the queue. Process exit settles current work before queued work
-  reconnects.
+  undispatched prompt id remains immediately retryable while cancellation
+  settles. If a successful turn omits that echo, Pi maps the stored payload
+  through the same user-message path before clearing the queue. Process exit
+  settles current work before queued work reconnects.
 - Pi slash commands are accepted by their correlated response or a matching
   extension dialog and remain in the request's sending state until then rather
   than exposing a cancellable bridge-queue entry. Commands reject while that

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -49,11 +49,12 @@ defaults and queued client sends coherent.
   different sessions to run concurrently. Startup replays and hydrates message
   identity before live frames attach or a turn dispatches; same-session prompts
   remain FIFO. An accepted prompt remains bridge-queued through startup and
-  selection until Pi echoes its correlated user message; it can be cancelled
-  before dispatch, and its undispatched prompt id remains retryable. If a
-  successful turn omits that echo, Pi maps the stored payload through the same
-  user-message path before clearing the queue. Process exit settles current work
-  before queued work reconnects.
+  selection until Pi echoes its correlated user message, including an
+  attachment-only echo; it can be cancelled before dispatch, and its
+  undispatched prompt id remains retryable. If a successful turn omits that
+  echo, Pi maps the stored payload through the same user-message path before
+  clearing the queue. Process exit settles current work before queued work
+  reconnects.
 - Pi slash commands are accepted by their correlated response or a matching
   extension dialog and remain in the request's sending state until then rather
   than exposing a cancellable bridge-queue entry. Commands reject while that


### PR DESCRIPTION
## Complexity

Moderate. The fix is localized to the existing ACP and Pi turn lanes, but it changes when accepted prompts cross the queued-to-sent boundary and preserves OMP's backend-specific replacement behavior.

## What

- Keep ACP-family prompts in the bridge queue until their `session/prompt` frame is written, then publish the synthetic user message and remove the queued entry in order.
- Expose cancellation and stable prompt-id deduplication through the existing ACP queue contract.
- Preserve OMP steering semantics by cancelling the active same-session turn when a replacement prompt is accepted; Cursor and Hermes retain FIFO behavior.
- Surface Pi's existing internal prompt lane through the queue contract until Pi emits the correlated user-message echo, while keeping initial session prompts out of the visible queue.
- Document the audited behavior across Claude, ACP-family, Pi, OpenCode, and Codex plugins.

## Why

Sesori previously marked ACP prompts as sent as soon as its adapter accepted them, even when the actual ACP request was still blocked behind an active turn. In OMP this made a steering prompt look delivered while the active run continued and the replacement had not reached OMP. Pi had the same hidden-queue mismatch during startup and selection.

## Risk and test focus

The main risk is lifecycle ordering: a queued bubble must remain cancellable before dispatch, transform into exactly one user message at the backend boundary, and clear without a blank or duplicate state. Tests cover ACP dispatch ordering, FIFO serialization, cancellation, idempotent retries, OMP active-turn replacement, Pi echo ordering, and initial Pi session behavior.

There is no database, schema, authentication, encryption, or wire-shape change. The user-visible impact is limited to truthful queued/sent state and working OMP steering.

## Expected result

`Queued` means the plugin owns an accepted prompt that has not yet crossed its backend delivery boundary. `Sent` appears only when the corresponding user message has reached the transcript path. Sending `stop` to an active OMP session cancels that turn promptly and dispatches the replacement when cancellation settles.

## Verification

- `dart analyze --fatal-infos` in `sesori_plugin_acp`, `sesori_plugin_cursor`, `sesori_plugin_hermes`, `sesori_plugin_omp`, and `sesori_plugin_pi`
- `dart test` in all five affected packages
- Focused ACP, OMP, and Pi lifecycle regression tests
- Architecture implementation review: approved with no findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes queued vs sent prompt delivery truthful for ACP-family and Pi. ACP now stays queued until the `session/prompt` frame flushes, Pi stays queued until the correlated user-message echo, and we suppress ACP dispatch/user-message events after a session is deleted.

- `sesori_plugin_acp`: Publishes the synthetic user message only after the prompt frame flushes; surfaces queue via `getQueuedPrompts`/`cancelQueuedPrompt` and emits `BridgeSseQueuedPromptsUpdated`; deduplicates stable prompt ids; abort clears queued entries and guards undispatched turns; splits frame write (`dispatchRequest`) from awaiting the response; cancels the active turn on queued input when `cancelsActiveTurnForQueuedInput` is true; suppresses dispatch and accounting events for detached sessions; initial prompts do not surface in the queue.
- `sesori_plugin_pi`: Surfaces its internal prompt lane via the queue until Pi’s user-message echo; correlates attachment-only echoes; if Pi omits the echo, synthesizes a user message before clearing the queue; adds queue inspection/cancellation. Canceling an undispatched prompt keeps its id retryable and settles without a session error. Initial session prompts stay off the visible queue. Commands remain request-bound (not queued).
- `sesori_plugin_omp`: Cancels the active same-session turn when a new prompt is accepted, then dispatches the replacement after cancellation settles.
- `sesori_plugin_cursor`, `sesori_plugin_hermes`: No behavior change; retain FIFO; declare `cancelsActiveTurnForQueuedInput` as false.
- Docs: Updated `docs/regression/session-turns.md`.

- Migration
  - Plugin adapters must implement `cancelsActiveTurnForQueuedInput` to declare replacement behavior.
  - No schema or wire-shape changes.

<sup>Written for commit 981ef37037c0be7ed03dd0df39a508230ec0ecb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

