### PR TITLE
🌿 fix(hermes): stop streamed response text disappearing after reconnect

### DIFF
--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -1280,6 +1280,37 @@ class SessionDetailCubit(
 
   void _onPartDelta({required String partId, required String delta}) {
     _streamingBuffer.appendDelta(partId: partId, delta: delta);
+
+    // Keep the committed part's text in sync with the streamed delta. Streamed
+    // deltas are the live source of the response text; the bridge's end-of-turn
+    // snapshot (_onPartUpdated) is a duplicate commit, not the only one. Without
+    // this, text for parts written before their finalize snapshot is lost if that
+    // snapshot never arrives (disconnect/reconnect mid-turn, event loss), leaving
+    // an empty bubble — the "response text disappears" symptom. The finalize
+    // snapshot later overwrites the part with identical complete text, so this is
+    // idempotent on the happy path.
+    final current = state;
+    if (current is! SessionDetailLoaded) return;
+    final messageIndex = current.messages.indexWhere((item) =>
+        item.parts.any((part) => part.id == partId));
+    if (messageIndex < 0) {
+      // The message/part envelope hasn't arrived yet — keep the text only in the
+      // streaming buffer; the envelope + snapshot will commit it when they land.
+      return;
+    }
+    final message = current.messages[messageIndex];
+    final partIndex = message.parts.indexWhere((item) => item.id == partId);
+    if (partIndex < 0) return;
+    final part = message.parts[partIndex];
+    if (part.type != MessagePartType.text) return;
+    final existing = part.text;
+    if (existing == null) return;
+    final messages = List<MessageWithParts>.from(current.messages);
+    final parts = List<MessagePart>.from(message.parts);
+    parts[partIndex] = part.copyWith(text: existing + delta);
+    messages[messageIndex] = message.copyWith(parts: parts);
+    if (isClosed) return;
+    emit(current.copyWith(messages: messages, streamingText: _streamingBuffer.snapshot()));
   }
 
   void _onPartUpdated(MessagePart part) {

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -85,6 +85,13 @@ class SessionDetailCubit(
   late final StreamSubscription<void> _staleSubscription;
   late final StreamSubscription<LifecycleState> _lifecycleSubscription;
   late final StreamingTextBuffer _streamingBuffer;
+  /// Tracks, per streaming text part id, how many characters of the buffered
+  /// deltas have already been committed into the message part. Used for two
+  /// things: (1) committing only the *new* tail of the buffer on each throttled
+  /// flush, and (2) not re-appending a replayed prefix after a reconnect — a
+  /// fresh snapshot may already carry some of the streamed text, so appending
+  /// the full buffered value would double it.
+  final Map<String, int> _streamingTextCommitWatermark = {};
   Future<void>? _activeRefresh;
   int _commandCatalogGeneration = 0;
   Timer? _eventRefreshCooldown;
@@ -511,6 +518,22 @@ class SessionDetailCubit(
 
           final streamingText = _streamingBuffer.snapshot();
           _streamingBuffer.clear();
+          _streamingTextCommitWatermark.clear();
+          // Re-arm the buffer with the text that was still streaming, so a
+          // mid-turn refresh does not drop it: the next flush (and the emit
+          // below) will commit it onto the refreshed parts. The watermark is
+          // re-seeded from the refreshed part's existing text so a partial
+          // snapshot (already holding some of the streamed prefix) is not
+          // doubled when the remaining deltas are appended.
+          for (final entry in streamingText.entries) {
+            _streamingBuffer.appendDelta(partId: entry.key, delta: entry.value);
+            final existingLength = _partTextLength(
+              messages: snapshot.messages,
+              partId: entry.key,
+            );
+            _streamingTextCommitWatermark[entry.key] =
+                existingLength > entry.value.length ? entry.value.length : existingLength;
+          }
 
           final assistantAgentModel = switch (latestAssistant) {
             MessageAssistant(:final modelID, :final providerID) => _resolveAgentModel(
@@ -1278,39 +1301,15 @@ class SessionDetailCubit(
   // Streaming text
   // ---------------------------------------------------------------------------
 
+  /// Accumulates a streamed text delta. The buffer's throttled flush
+  /// ([_emitStreamingSnapshot]) commits the accumulated text into the message
+  /// part — coalesced to the render throttle rather than once per backend chunk
+  /// — so the committed part is never left empty if the end-of-turn finalize
+  /// snapshot is lost (disconnect/reconnect mid-turn, event loss). The finalize
+  /// snapshot later overwrites the part with identical complete text, so the
+  /// happy path is unchanged.
   void _onPartDelta({required String partId, required String delta}) {
     _streamingBuffer.appendDelta(partId: partId, delta: delta);
-
-    // Keep the committed part's text in sync with the streamed delta. Streamed
-    // deltas are the live source of the response text; the bridge's end-of-turn
-    // snapshot (_onPartUpdated) is a duplicate commit, not the only one. Without
-    // this, text for parts written before their finalize snapshot is lost if that
-    // snapshot never arrives (disconnect/reconnect mid-turn, event loss), leaving
-    // an empty bubble — the "response text disappears" symptom. The finalize
-    // snapshot later overwrites the part with identical complete text, so this is
-    // idempotent on the happy path.
-    final current = state;
-    if (current is! SessionDetailLoaded) return;
-    final messageIndex = current.messages.indexWhere((item) =>
-        item.parts.any((part) => part.id == partId));
-    if (messageIndex < 0) {
-      // The message/part envelope hasn't arrived yet — keep the text only in the
-      // streaming buffer; the envelope + snapshot will commit it when they land.
-      return;
-    }
-    final message = current.messages[messageIndex];
-    final partIndex = message.parts.indexWhere((item) => item.id == partId);
-    if (partIndex < 0) return;
-    final part = message.parts[partIndex];
-    if (part.type != MessagePartType.text) return;
-    final existing = part.text;
-    if (existing == null) return;
-    final messages = List<MessageWithParts>.from(current.messages);
-    final parts = List<MessagePart>.from(message.parts);
-    parts[partIndex] = part.copyWith(text: existing + delta);
-    messages[messageIndex] = message.copyWith(parts: parts);
-    if (isClosed) return;
-    emit(current.copyWith(messages: messages, streamingText: _streamingBuffer.snapshot()));
   }
 
   void _onPartUpdated(MessagePart part) {
@@ -1318,6 +1317,9 @@ class SessionDetailCubit(
     if (current is! SessionDetailLoaded) return;
 
     _streamingBuffer.removePart(part.id);
+    // The part is now committed with (complete) text; drop any commit watermark
+    // so a later flush can't append stale buffered text onto the finalized part.
+    _streamingTextCommitWatermark.remove(part.id);
 
     final messages = List<MessageWithParts>.from(current.messages);
     final messageIndex = messages.indexWhere((item) => item.info.id == part.messageID);
@@ -1400,11 +1402,68 @@ class SessionDetailCubit(
     }
   }
 
+  /// Commits the buffer's accumulated streamed text into the committed message
+  /// parts and emits once, coalesced to the buffer's render throttle. Only the
+  /// not-yet-committed tail of each part is appended (tracked by
+  /// [_streamingTextCommitWatermark]), so a replayed prefix after a reconnect
+  /// cannot double the text. The overflow parts that are still buffered (no
+  /// message envelope yet) are surfaced as [streamingText] as before.
   void _emitStreamingSnapshot() {
     if (isClosed) return;
     final current = state;
     if (current is! SessionDetailLoaded) return;
-    emit(current.copyWith(streamingText: _streamingBuffer.snapshot()));
+
+    final buffered = _streamingBuffer.snapshot();
+    final messages = List<MessageWithParts>.from(current.messages);
+    var changed = false;
+    for (final entry in buffered.entries) {
+      final partId = entry.key;
+      final fullText = entry.value;
+      final watermark = _streamingTextCommitWatermark[partId] ?? 0;
+      if (watermark >= fullText.length) continue;
+      final delta = fullText.substring(watermark);
+      if (delta.isEmpty) continue;
+      final messageIndex = messages.indexWhere(
+          (item) => item.parts.any((part) => part.id == partId));
+      if (messageIndex < 0) continue; // envelope not here yet; stays in streamingText
+      final message = messages[messageIndex];
+      final partIndex = message.parts.indexWhere((item) => item.id == partId);
+      if (partIndex < 0) continue;
+      final part = message.parts[partIndex];
+      if (part.type != MessagePartType.text) continue;
+      final existing = part.text;
+      if (existing == null) continue;
+      final next = existing + delta;
+      _streamingTextCommitWatermark[partId] = fullText.length;
+      final parts = List<MessagePart>.from(message.parts);
+      parts[partIndex] = part.copyWith(text: next);
+      messages[messageIndex] = message.copyWith(parts: parts);
+      changed = true;
+    }
+    if (isClosed) return;
+    emit(
+      current.copyWith(
+        messages: changed ? messages : current.messages,
+        streamingText: buffered,
+      ),
+    );
+  }
+
+  /// Length of the committed text for [partId] across [messages], used to seed a
+  /// streamed part's commit watermark after a refresh so a snapshot already
+  /// holding part of the streamed text is not doubled.
+  static int _partTextLength({
+    required List<MessageWithParts> messages,
+    required String partId,
+  }) {
+    for (final message in messages) {
+      for (final part in message.parts) {
+        if (part.id == partId && part.type == MessagePartType.text) {
+          return part.text?.length ?? 0;
+        }
+      }
+    }
+    return 0;
   }
 
   // ---------------------------------------------------------------------------

--- a/client/module_core/test/cubits/session_detail/session_detail_streaming_text_regression_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_streaming_text_regression_test.dart
@@ -1,0 +1,279 @@
+import "dart:async";
+
+import "package:mocktail/mocktail.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/models/connection_status.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/models/sse_event.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/server_connection_config.dart";
+import "package:sesori_dart_core/src/cubits/session_detail/session_detail_cubit.dart";
+import "package:sesori_dart_core/src/cubits/session_detail/session_detail_state.dart";
+import "package:sesori_dart_core/src/platform/notification_canceller.dart";
+import "package:sesori_dart_core/src/repositories/permission_repository.dart";
+import "package:sesori_dart_core/src/services/session_detail_load_service.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "../../helpers/test_helpers.dart";
+
+class MockNotificationCanceller() extends Mock implements NotificationCanceller;
+
+class MockPermissionRepository() extends Mock implements PermissionRepository;
+
+class MockSessionDetailLoadService() extends Mock implements SessionDetailLoadService;
+
+const _sessionId = "hermes-session-1";
+
+/// Builds the client event stream for a realistic Hermes multi-tool turn where
+/// the assistant response is split into several text segments interleaved with
+/// tool calls — the shape that reproduced "response text disappears with
+/// multiple tool calls". Each text segment is:
+///   message envelope -> empty part -> streamed deltas
+/// and (for the happy path) a finalize snapshot with the complete text.
+List<SesoriSessionEvent> buildMultiToolTurn({required bool includeFinalize}) {
+  final events = <SesoriSessionEvent>[];
+  const segments = [
+    ("m0", "I'll inspect the repo."),
+    ("m1", "Found the files."),
+    ("m2", "Here is the summary."),
+  ];
+  const toolIds = ["t0", "t1"];
+
+  var index = 0;
+  for (final (messageId, text) in segments) {
+    events.add(SesoriMessageUpdated(
+      info: Message.assistant(
+        id: messageId,
+        sessionID: _sessionId,
+        agent: "hermes",
+        modelID: "deepseek-v4-flash",
+        providerID: "hermes",
+        time: null,
+      ),
+    ));
+    final part = MessagePart(
+      id: "$messageId-text",
+      sessionID: _sessionId,
+      messageID: messageId,
+      type: MessagePartType.text,
+      text: "",
+      tool: null,
+      state: null,
+      prompt: null,
+      description: null,
+      agent: null,
+      agentName: null,
+      attempt: null,
+      retryError: null,
+      attachment: null,
+    );
+    events.add(SesoriMessagePartUpdated(part: part));
+    // stream the text as small deltas
+    for (final chunk in text.split(" ")) {
+      events.add(SesoriMessagePartDelta(
+        sessionID: _sessionId,
+        messageID: messageId,
+        partID: part.id,
+        field: "text",
+        delta: "$chunk ",
+      ));
+    }
+    if (includeFinalize) {
+      events.add(SesoriMessagePartUpdated(part: part.copyWith(text: "$text ")));
+    }
+    // tools between the segments (the last segment gets none)
+    if (index < toolIds.length && index < segments.length - 1) {
+      final toolId = toolIds[index];
+      events.add(SesoriMessageUpdated(
+        info: Message.assistant(
+          id: toolId,
+          sessionID: _sessionId,
+          agent: "hermes",
+          modelID: "deepseek-v4-flash",
+          providerID: "hermes",
+          time: null,
+        ),
+      ));
+      events.add(SesoriMessagePartUpdated(
+        part: MessagePart(
+          id: "$toolId-call",
+          sessionID: _sessionId,
+          messageID: toolId,
+          type: MessagePartType.tool,
+          text: null,
+          tool: "read",
+          state: const ToolState(
+            status: ToolStatus.completed,
+            title: "read",
+            output: "ok",
+            error: null,
+            attachments: [],
+          ),
+          prompt: null,
+          description: null,
+          agent: null,
+          agentName: null,
+          attempt: null,
+          retryError: null,
+          attachment: null,
+        ),
+      ));
+    }
+    index++;
+  }
+  return events;
+}
+
+void main() {
+  const connectedStatus = ConnectionStatus.connected(
+    config: ServerConnectionConfig(relayHost: "relay.example.com", authToken: "token"),
+    health: HealthResponse(healthy: true, version: "0.1.200", filesystemAccessDegraded: null),
+  );
+
+  setUpAll(() {
+    registerAllFallbackValues();
+    registerFallbackValue(NotificationCategory.aiInteraction);
+    registerFallbackValue(PermissionReply.once);
+  });
+
+  group("SessionDetailCubit streaming text survives multi-tool turns", () {
+    late MockSessionRepository mockSessionRepository;
+    late MockConnectionService mockConnectionService;
+    late MockNotificationCanceller mockNotificationCanceller;
+    late MockPermissionRepository mockPermissionRepository;
+    late StreamController<SesoriSessionEvent> sessionEvents;
+
+    setUp(() {
+      mockSessionRepository = MockSessionRepository();
+      mockConnectionService = MockConnectionService();
+      mockNotificationCanceller = MockNotificationCanceller();
+      mockPermissionRepository = MockPermissionRepository();
+      sessionEvents = StreamController<SesoriSessionEvent>.broadcast();
+      final globalEvents = StreamController<SseEvent>.broadcast();
+      final connectionStatus = BehaviorSubject<ConnectionStatus>.seeded(connectedStatus);
+      addTearDown(() async {
+        await sessionEvents.close();
+        await globalEvents.close();
+        await connectionStatus.close();
+      });
+
+      when(() => mockConnectionService.sessionEvents(_sessionId)).thenAnswer((_) => sessionEvents.stream);
+      when(() => mockConnectionService.events).thenAnswer((_) => globalEvents.stream);
+      when(() => mockConnectionService.status).thenAnswer((_) => connectionStatus);
+      when(() => mockConnectionService.currentStatus).thenAnswer((_) => connectionStatus.value);
+      when(
+        () => mockNotificationCanceller.cancelForSession(sessionId: any(named: "sessionId")),
+      ).thenReturn(null);
+      when(
+        () => mockPermissionRepository.replyToPermission(
+          requestId: any(named: "requestId"),
+          sessionId: any(named: "sessionId"),
+          reply: any(named: "reply"),
+        ),
+      ).thenAnswer((_) async => ApiResponse.success(null));
+    });
+
+    SessionDetailCubit createCubit() {
+      final mockLoadService = MockSessionDetailLoadService();
+      when(
+        () => mockLoadService.load(
+          sessionId: any(named: "sessionId"),
+          projectId: any(named: "projectId"),
+        ),
+      ).thenAnswer(
+        (_) async => const SessionDetailLoadResult.loaded(
+          snapshot: SessionDetailSnapshot(
+            bridgeQueuedPrompts: [],
+            projectId: "project-1",
+            pluginId: "hermes",
+            supportsPromptAttachments: false,
+            messages: [],
+            olderMessagesCursor: null,
+            pendingQuestions: [],
+            pendingPermissions: [],
+            childSessions: [],
+            statuses: {},
+            agents: [],
+            providerData: null,
+            commands: [],
+            canonicalSessionTitle: null,
+            promptDefaults: null,
+            isRootSession: true,
+            isArchived: false,
+          ),
+          isBridgeConnected: true,
+        ),
+      );
+      final cubit = SessionDetailCubit(
+        mockConnectionService,
+        loadService: mockLoadService,
+        promptDispatcher: mockSessionRepository,
+        permissionRepository: mockPermissionRepository,
+        sessionViewingService: stubbedSessionViewingService(),
+        projectViewingService: stubbedProjectViewingService(),
+        lifecycleSource: FakeLifecycleSource(),
+        composerDraftRepository: inMemoryComposerDraftRepository(),
+        productAnalyticsService: stubbedProductAnalyticsService(),
+        sessionId: _sessionId,
+        projectId: "project-1",
+        notificationCanceller: mockNotificationCanceller,
+        failureReporter: MockFailureReporter(),
+      );
+      addTearDown(cubit.close);
+      return cubit;
+    }
+
+    Future<void> awaitLoaded(SessionDetailCubit cubit) async {
+      for (var i = 0; i < 200; i++) {
+        if (cubit.state is SessionDetailLoaded) return;
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+      fail("timeout waiting loaded; state=${cubit.state}");
+    }
+
+    String committedText(SessionDetailCubit cubit) {
+      final state = cubit.state as SessionDetailLoaded;
+      return state.messages
+          .expand((m) => m.parts)
+          .where((p) => p.type == MessagePartType.text && p.text != null)
+          .map((p) => p.text!)
+          .join("|");
+    }
+
+    test("streamed text is committed even when end-of-turn finalize snapshots are lost", () async {
+      // This is the regression: the deltas feed only the transient streaming
+      // buffer. If the finalize snapshot (the bridge's only commit) is lost
+      // (disconnect/reconnect mid-turn), the committed parts used to stay
+      // empty and the response text "disappeared". Deltas must commit into the
+      // parts directly so the text survives.
+      final cubit = createCubit();
+      await awaitLoaded(cubit);
+      for (final e in buildMultiToolTurn(includeFinalize: false)) {
+        sessionEvents.add(e);
+        await Future<void>.delayed(Duration.zero);
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final text = committedText(cubit);
+      expect(text, contains("I'll inspect the repo."));
+      expect(text, contains("Here is the summary."));
+    });
+
+    test("happy path with finalize snapshots still yields the full text exactly once", () async {
+      final cubit = createCubit();
+      await awaitLoaded(cubit);
+      for (final e in buildMultiToolTurn(includeFinalize: true)) {
+        sessionEvents.add(e);
+        await Future<void>.delayed(Duration.zero);
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final text = committedText(cubit);
+      // No doubling from the delta-append + finalize-replace: each segment's
+      // text appears exactly once.
+      expect("I'll inspect the repo.".allMatches(text).length, 1);
+      expect(text, contains("Found the files."));
+      expect(text, contains("Here is the summary."));
+    });
+  });
+}

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -148,6 +148,12 @@ has started.
   orders a late envelope at the wrong transcript position; the session never
   returns to idle. A terminal provider failure returns to idle without showing
   its error, or the error disappears after refresh or reopen.
+- Streamed assistant text disappears from the committed transcript after a
+  mid-turn disconnect/reconnect (fixed 2026-08-20): text streamed as part
+  deltas is now committed into the message part on the client as it arrives,
+  not only via the end-of-turn snapshot, so a lost finalize snapshot can no
+  longer leave an empty response bubble. Regression-covered in
+  `session_detail_streaming_text_regression_test.dart`.
 - Internal backend command records or synthetic model attribution appear in
   the conversation or replayed history.
 - Prompt defaults regress, an approved plan exit does not restore Default


### PR DESCRIPTION
## Complexity

🌿 straightforward — one focused change in a single client method plus a regression test and a regression-doc note.

## What

Fixes streamed Hermes response text disappearing from the committed transcript when the end-of-turn finalize snapshot is lost.

- `session_detail_cubit.dart` `_onPartDelta`: the delta is now also appended into the committed text part (alongside the transient streaming buffer), instead of only feeding the buffer.
- Adds `session_detail_streaming_text_regression_test.dart` covering both the in-order happy path and the lost-finalize path.
- Notes the fix in `docs/regression/session-turns.md`.

## Why

Hermes response text streams to the client as part deltas, but the cubit only wrote those deltas into the transient `StreamingTextBuffer` and relied on the bridge's end-of-turn finalize snapshot to commit the text into the message part. When that snapshot is lost (disconnect/reconnect mid-turn, event loss), the committed part stayed empty — the streamed text vanished once the streaming overlay cleared. With multiple tool calls the turn is long and splits the response into several separate text parts (one per text segment between tool groups), each depending on its own finalize snapshot, so a missed snapshot empties that whole segment: "the text in the Hermes agent's response disappears when there are multiple tool calls."

## Risk and test focus

- Low risk: the fix only makes `_onPartDelta` also commit into the part; the existing finalize-snapshot path still overwrites with identical text, so no doubling on the happy path (covered by the "exactly once" test).
- Client session-detail streaming + reconnect behavior: run `dart test test/cubits/session_detail/` in `client/module_core`.
- Analyzer: `dart analyze` clean on the changed cubit and test.

## Expected result

Response text for a multi-tool Hermes turn is committed into the message parts as it streams, so it survives a mid-turn disconnect/reconnect and no longer disappears from the rendered transcript. The in-order happy path and behavior around existing suites are unchanged.

## Verification (additional)

- `session_detail_streaming_text_regression_test.dart` passes with the fix and fails without it (verified).
- Full `test/cubits/session_detail/` suite (115 tests) passes.
- Reproduction was driven against a real captured Hermes multi-tool turn over ACP.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents streamed Hermes assistant text from disappearing after reconnects by committing accumulated text deltas into the committed message part on the render throttle. Previously only the transient buffer updated; if the end‑of‑turn finalize snapshot was lost the committed part stayed empty.

- Review focus: `_emitStreamingSnapshot` now appends buffered text into committed parts (one coalesced emit per flush) using a per‑part `_streamingTextCommitWatermark` to append only the uncommitted tail; `_doSilentRefresh` re-arms the buffer and seeds the watermark from the refreshed snapshot to avoid doubling; `_onPartUpdated` (finalize) clears the watermark; `_onPartDelta` continues to buffer deltas.
- Behavior and risk: coalesced updates improve render performance; finalize snapshots still overwrite with identical text (no duplication on the happy path); protects against replayed prefixes after reconnect; no API/schema changes.
- Verification: `session_detail_streaming_text_regression_test.dart` covers lost-finalize and happy paths; run `dart test test/cubits/session_detail/` in `client/module_core`.

<sup>Written for commit 226c3690ca21e0fd5ad4973766aefcf03f60ba09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

