### PR TITLE
🌿 Add Codex catalog import diagnostics

### DIFF
--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_catalog_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_catalog_repository.dart
@@ -27,14 +27,14 @@ class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
     }
 
     final records = <CodexSessionRecord>[];
-    var missingMetadata = 0;
+    var unreadableOrMissingMetadata = 0;
     var mismatchedMetadata = 0;
     for (final id in {...rollouts.keys, ...indexEntries.keys}) {
       final rolloutPath = rollouts[id];
       if (rolloutPath == null) continue;
       final indexEntry = indexEntries[id];
       final metadata = _readMetadata(rolloutPath);
-      if (metadata == null) missingMetadata++;
+      if (metadata == null) unreadableOrMissingMetadata++;
       if (metadata != null && metadata.id != id) {
         mismatchedMetadata++;
         Log.w(
@@ -68,7 +68,7 @@ class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
       "[codex] rollout catalog scan: files=${rolloutPaths.length}, "
       "recognizedRollouts=${rollouts.length}, "
       "indexEntries=${indexEntries.length}, "
-      "missingMetadata=$missingMetadata, "
+      "unreadableOrMissingMetadata=$unreadableOrMissingMetadata, "
       "mismatchedMetadata=$mismatchedMetadata, records=${records.length}",
     );
     return records;

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_catalog_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_catalog_repository.dart
@@ -12,7 +12,8 @@ import "models/codex_session_record.dart";
 class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
   List<CodexSessionRecord> listSessionRecords() {
     final rollouts = <String, String>{};
-    for (final path in _listRolloutPaths()) {
+    final rolloutPaths = _listRolloutPaths();
+    for (final path in rolloutPaths) {
       final id = _sessionIdFromRolloutName(p.basename(path));
       if (id != null) rollouts[id] = path;
     }
@@ -26,12 +27,16 @@ class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
     }
 
     final records = <CodexSessionRecord>[];
+    var missingMetadata = 0;
+    var mismatchedMetadata = 0;
     for (final id in {...rollouts.keys, ...indexEntries.keys}) {
       final rolloutPath = rollouts[id];
       if (rolloutPath == null) continue;
       final indexEntry = indexEntries[id];
       final metadata = _readMetadata(rolloutPath);
+      if (metadata == null) missingMetadata++;
       if (metadata != null && metadata.id != id) {
+        mismatchedMetadata++;
         Log.w(
           "[codex] rollout session id mismatch: filename=$id header=${metadata.id}",
         );
@@ -59,10 +64,23 @@ class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
       if (bTime == null) return -1;
       return bTime.compareTo(aTime);
     });
+    Log.d(
+      "[codex] rollout catalog scan: files=${rolloutPaths.length}, "
+      "recognizedRollouts=${rollouts.length}, "
+      "indexEntries=${indexEntries.length}, "
+      "missingMetadata=$missingMetadata, "
+      "mismatchedMetadata=$mismatchedMetadata, records=${records.length}",
+    );
     return records;
   }
 
-  Future<List<CodexSessionRecord>> listSessionRecordsInIsolate() => Isolate.run(listSessionRecords);
+  Future<List<CodexSessionRecord>> listSessionRecordsInIsolate() {
+    final logLevel = Log.level;
+    return Isolate.run(() {
+      Log.level = logLevel;
+      return listSessionRecords();
+    });
+  }
 
   Future<List<PluginSession>> listAllSessions({required Set<String> knownDirectories}) async {
     final projectlessThreadIds = await _readProjectlessThreadIds();
@@ -75,18 +93,36 @@ class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
         ? null
         : normalizeProjectDirectory(directory: documentsCodexDirectory);
     final records = await listSessionRecordsInIsolate();
-    return records
-        .where(
-          (record) => !_isExcludedFromDiscovery(
-            record: record,
-            projectlessThreadIds: projectlessThreadIds,
-            documentsCodexDirectory: excludedDirectory,
-            knownDirectories: normalizedKnownDirectories,
-          ),
-        )
-        .map(_toPluginSession)
-        .nonNulls
-        .toList(growable: false);
+    final sessions = <PluginSession>[];
+    final projectDirectories = <String>{};
+    var noiseExcluded = 0;
+    var missingCwd = 0;
+    for (final record in records) {
+      if (_isExcludedFromDiscovery(
+        record: record,
+        projectlessThreadIds: projectlessThreadIds,
+        documentsCodexDirectory: excludedDirectory,
+        knownDirectories: normalizedKnownDirectories,
+      )) {
+        noiseExcluded++;
+        continue;
+      }
+      final session = _toPluginSession(record);
+      if (session == null) {
+        missingCwd++;
+      } else {
+        sessions.add(session);
+        projectDirectories.add(session.directory);
+      }
+    }
+    Log.d(
+      "[codex] catalog discovery: records=${records.length}, "
+      "knownDirectories=${normalizedKnownDirectories.length}, "
+      "noiseExcluded=$noiseExcluded, missingCwd=$missingCwd, "
+      "projectDirectories=${projectDirectories.length}, "
+      "sessions=${sessions.length}",
+    );
+    return sessions;
   }
 
   /// Filters by normalized rollout CWD before applying pagination.

--- a/bridge/sesori_plugin_codex/test/codex_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_catalog_repository_test.dart
@@ -81,6 +81,20 @@ void main() {
       expect(logs, isNot(contains("private-project")));
     });
 
+    test("propagates the log level into the scan isolate", () async {
+      final previousLevel = Log.level;
+      try {
+        Log.level = LogLevel.debug;
+        final repository = CodexCatalogRepository(
+          rolloutApi: _LogLevelCheckingRolloutApi(),
+        );
+
+        expect(await repository.listSessionRecordsInIsolate(), isEmpty);
+      } finally {
+        Log.level = previousLevel;
+      }
+    });
+
     test("filters normalized project directories before paginating", () async {
       final repository = _StubCodexCatalogRepository(
         [
@@ -355,6 +369,21 @@ class _DiagnosticsRolloutApi({required final String rolloutId}) extends CodexRol
       ),
     ),
   ];
+}
+
+class _LogLevelCheckingRolloutApi() extends CodexRolloutApi {
+  this : super(environment: const {});
+
+  @override
+  List<String> listRolloutPaths() {
+    if (Log.level != LogLevel.debug) {
+      throw StateError("Expected debug logging in the scan isolate");
+    }
+    return const [];
+  }
+
+  @override
+  List<CodexSessionIndexEntryDto> readSessionIndex() => const [];
 }
 
 class _DeleteFailingRolloutApi() extends CodexRolloutApi {

--- a/bridge/sesori_plugin_codex/test/codex_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_catalog_repository_test.dart
@@ -6,6 +6,7 @@ import "package:codex_plugin/src/api/models/codex_rollout_dto.dart";
 import "package:codex_plugin/src/repositories/codex_catalog_repository.dart";
 import "package:codex_plugin/src/repositories/models/codex_session_record.dart";
 import "package:path/path.dart" as p;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, LogLevel, PluginSession;
 import "package:test/test.dart";
 
 void main() {
@@ -56,6 +57,27 @@ void main() {
         updatedAt.millisecondsSinceEpoch,
       );
       expect(sessions[0].time?.archived, isNull);
+    });
+
+    test("logs privacy-safe aggregate rollout scan diagnostics", () async {
+      const rolloutId = "019a0000-1111-2222-3333-aaaaaaaaaaaa";
+      final repository = CodexCatalogRepository(
+        rolloutApi: _DiagnosticsRolloutApi(rolloutId: rolloutId),
+      );
+
+      final logs = await _captureDebugLogs(() async {
+        expect(repository.listSessionRecords(), hasLength(1));
+      });
+
+      expect(
+        logs,
+        contains(
+          "rollout catalog scan: files=3, recognizedRollouts=1, "
+          "indexEntries=2, missingMetadata=0, mismatchedMetadata=0, records=1",
+        ),
+      );
+      expect(logs, isNot(contains(rolloutId)));
+      expect(logs, isNot(contains("private-project")));
     });
 
     test("filters normalized project directories before paginating", () async {
@@ -140,14 +162,26 @@ void main() {
         ],
       );
 
-      final discovered = await repository.listAllSessions(
-        knownDirectories: {existingGeneratedChat, existingStateProject},
-      );
+      late List<PluginSession> discovered;
+      final logs = await _captureDebugLogs(() async {
+        discovered = await repository.listAllSessions(
+          knownDirectories: {existingGeneratedChat, existingStateProject},
+        );
+      });
 
       expect(
         discovered.map((session) => session.id),
         ["existing-generated", "existing-state-filtered", "normal", "date-shaped", "similar-name"],
       );
+      expect(
+        logs,
+        contains(
+          "catalog discovery: records=8, knownDirectories=2, "
+          "noiseExcluded=3, missingCwd=0, projectDirectories=5, sessions=5",
+        ),
+      );
+      expect(logs, isNot(contains("generated-child")));
+      expect(logs, isNot(contains(generatedChat)));
       expect(
         (await repository.getSessions(projectId: generatedChat, start: null, limit: null)).map(
           (session) => session.id,
@@ -271,6 +305,57 @@ class _DiscoveryRolloutApi({
   }
 }
 
+class _DiagnosticsRolloutApi({required final String rolloutId}) extends CodexRolloutApi {
+  this : super(environment: const {});
+
+  String get _firstPath => p.join(
+    Directory.systemTemp.path,
+    "private-project",
+    "rollout-2026-08-01T00-00-00-$rolloutId.jsonl",
+  );
+
+  String get _duplicatePath => p.join(
+    Directory.systemTemp.path,
+    "private-project",
+    "rollout-2026-08-02T00-00-00-$rolloutId.jsonl",
+  );
+
+  @override
+  List<String> listRolloutPaths() => [
+    _firstPath,
+    _duplicatePath,
+    p.join(Directory.systemTemp.path, "private-project", "rollout-invalid.jsonl"),
+  ];
+
+  @override
+  List<CodexSessionIndexEntryDto> readSessionIndex() => [
+    CodexSessionIndexEntryDto(
+      id: rolloutId,
+      threadName: "Private title",
+      updatedAt: null,
+    ),
+    const CodexSessionIndexEntryDto(
+      id: "019a0000-1111-2222-3333-bbbbbbbbbbbb",
+      threadName: null,
+      updatedAt: null,
+    ),
+  ];
+
+  @override
+  List<CodexRolloutLineDto> readHeader({required String rolloutPath}) => [
+    CodexRolloutLineDto.sessionMetadata(
+      timestamp: "2026-08-01T00:00:00Z",
+      payload: CodexRolloutSessionMetadataPayloadDto(
+        id: rolloutId,
+        cwd: p.join(Directory.systemTemp.path, "private-project"),
+        timestamp: "2026-08-01T00:00:00Z",
+        modelProvider: "openai",
+        cliVersion: "0.147.0",
+      ),
+    ),
+  ];
+}
+
 class _DeleteFailingRolloutApi() extends CodexRolloutApi {
   this : super(environment: const {});
 
@@ -347,4 +432,28 @@ class _IndexWriteFailingRolloutApi() extends CodexRolloutApi {
   void writeSessionIndex({required List<String> lines}) {
     throw const FileSystemException("denied");
   }
+}
+
+Future<String> _captureDebugLogs(Future<void> Function() action) async {
+  final previousLevel = Log.level;
+  final stderr = _BufferingStdout();
+  try {
+    Log.level = LogLevel.debug;
+    await IOOverrides.runZoned(action, stderr: () => stderr);
+  } finally {
+    Log.level = previousLevel;
+  }
+  return stderr.text;
+}
+
+class _BufferingStdout() implements Stdout {
+  final StringBuffer _buffer = StringBuffer();
+
+  String get text => _buffer.toString();
+
+  @override
+  void writeln([Object? object = ""]) => _buffer.writeln(object);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
 }

--- a/bridge/sesori_plugin_codex/test/codex_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_catalog_repository_test.dart
@@ -73,7 +73,8 @@ void main() {
         logs,
         contains(
           "rollout catalog scan: files=3, recognizedRollouts=1, "
-          "indexEntries=2, missingMetadata=0, mismatchedMetadata=0, records=1",
+          "indexEntries=2, unreadableOrMissingMetadata=0, "
+          "mismatchedMetadata=0, records=1",
         ),
       );
       expect(logs, isNot(contains(rolloutId)));


### PR DESCRIPTION
## Complexity

🌿 Straightforward plugin-local diagnostic logging with privacy-focused regression coverage.

## What

- Report aggregate Codex rollout-file, recognized-rollout, index, metadata, project-directory, and session counts during catalog imports at debug level.
- Propagate the configured log level into the filesystem scan isolate so debug diagnostics are emitted consistently.
- Verify diagnostic output contains counts without rollout IDs, paths, titles, or transcript content.

## Why

Issue #961 reports successive imports growing from 12 to 89 to 192 sessions even though Codex project discovery already scans the global rollout tree and derives projects from session working directories. Existing output reports only the final published count, so it cannot identify whether the changing input is filesystem enumeration, rollout-name recognition, metadata mapping, CWD mapping, or discovery filtering.

## Risk and test focus

- Catalog inclusion and persistence behavior are unchanged.
- Debug output is aggregate-only and does not expose source paths, session identifiers, titles, prompts, or transcripts.
- There is no user-visible behavior or database impact outside the additional debug diagnostics.

## Expected result

A reporter can run the existing `sesori-bridge --import-plugin codex --log-level debug` command and provide two privacy-safe count lines that identify the stage responsible for changing import totals.

## Verification

- `dart test test/codex_catalog_repository_test.dart`
- `dart test` from `bridge/sesori_plugin_codex` (367 tests)
- `dart analyze --fatal-infos` from `bridge/sesori_plugin_codex`

Related to #961.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds privacy-safe debug diagnostics for Codex catalog import and discovery to pinpoint where session counts change. Previously we logged only the final published count; now we log aggregate scan and discovery counts and preserve the current log level inside the scan isolate.

- Emits a rollout scan debug line with: files, recognizedRollouts, indexEntries, unreadableOrMissingMetadata, mismatchedMetadata, records.
- Emits a discovery debug line with: records, knownDirectories, noiseExcluded, missingCwd, projectDirectories, sessions.
- Adds tests verifying aggregate counts, isolate log-level propagation, and privacy (no rollout IDs, paths, titles, prompts, or transcripts).
- No changes to catalog inclusion, persistence, or database behavior; aids investigation of #961.
- To use, run with debug logging: `sesori-bridge --import-plugin codex --log-level debug`.

<sup>Written for commit 67a09d30cee60de9aaaeb39edd861a8d2df87600. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

