### PR TITLE
🌱 Refresh activity summary on Claude approval transitions

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/claude_approval_registry.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_approval_registry.dart
@@ -141,7 +141,7 @@ final class ClaudeApprovalRegistry({
       };
       _pending[id] = pending;
       _emitActivity(
-        BridgeSseQuestionAsked(
+        event: BridgeSseQuestionAsked(
           id: id,
           sessionID: attributedSessionId,
           displaySessionId: attributedSessionId,
@@ -164,7 +164,7 @@ final class ClaudeApprovalRegistry({
     );
     _pending[id] = pending;
     _emitActivity(
-      BridgeSsePermissionAsked(
+      event: BridgeSsePermissionAsked(
         requestID: id,
         sessionID: attributedSessionId,
         displaySessionId: attributedSessionId,
@@ -256,7 +256,7 @@ final class ClaudeApprovalRegistry({
     }
     _pending.remove(id);
     _emitActivity(
-      BridgeSsePermissionReplied(
+      event: BridgeSsePermissionReplied(
         requestID: id,
         sessionID: entry.sessionId,
         displaySessionId: entry.sessionId,
@@ -281,7 +281,7 @@ final class ClaudeApprovalRegistry({
     }
     _pending.remove(id);
     _emitActivity(
-      BridgeSseQuestionReplied(requestID: id, sessionID: entry.sessionId, displaySessionId: entry.sessionId),
+      event: BridgeSseQuestionReplied(requestID: id, sessionID: entry.sessionId, displaySessionId: entry.sessionId),
     );
     return true;
   }
@@ -292,7 +292,7 @@ final class ClaudeApprovalRegistry({
     if (!_deny(entry: entry, message: "User rejected the request.")) return false;
     _pending.remove(id);
     _emitActivity(
-      BridgeSseQuestionRejected(requestID: id, sessionID: entry.sessionId, displaySessionId: entry.sessionId),
+      event: BridgeSseQuestionRejected(requestID: id, sessionID: entry.sessionId, displaySessionId: entry.sessionId),
     );
     return true;
   }
@@ -326,7 +326,7 @@ final class ClaudeApprovalRegistry({
     switch (entry) {
       case _PendingPermission():
         _emitActivity(
-          BridgeSsePermissionReplied(
+          event: BridgeSsePermissionReplied(
             requestID: entry.id,
             sessionID: entry.sessionId,
             displaySessionId: entry.sessionId,
@@ -335,7 +335,7 @@ final class ClaudeApprovalRegistry({
         );
       case _PendingQuestion():
         _emitActivity(
-          BridgeSseQuestionRejected(
+          event: BridgeSseQuestionRejected(
             requestID: entry.id,
             sessionID: entry.sessionId,
             displaySessionId: entry.sessionId,
@@ -346,7 +346,7 @@ final class ClaudeApprovalRegistry({
 
   /// Pending approvals feed the awaiting-input flag in the activity summary,
   /// so invalidate that summary after every approval transition.
-  void _emitActivity(BridgeSseEvent event) {
+  void _emitActivity({required BridgeSseEvent event}) {
     _emit(event);
     _emit(const BridgeSseProjectUpdated());
   }

--- a/bridge/sesori_plugin_claude/lib/src/claude_approval_registry.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_approval_registry.dart
@@ -140,7 +140,7 @@ final class ClaudeApprovalRegistry({
         ),
       };
       _pending[id] = pending;
-      _emit(
+      _emitActivity(
         BridgeSseQuestionAsked(
           id: id,
           sessionID: attributedSessionId,
@@ -163,7 +163,7 @@ final class ClaudeApprovalRegistry({
       allowAlways: request["suppress_always_allow_rule"] != true,
     );
     _pending[id] = pending;
-    _emit(
+    _emitActivity(
       BridgeSsePermissionAsked(
         requestID: id,
         sessionID: attributedSessionId,
@@ -255,7 +255,7 @@ final class ClaudeApprovalRegistry({
       if (allowedTools.isEmpty) _allowedTools.remove(entry.sessionId);
     }
     _pending.remove(id);
-    _emit(
+    _emitActivity(
       BridgeSsePermissionReplied(
         requestID: id,
         sessionID: entry.sessionId,
@@ -280,7 +280,9 @@ final class ClaudeApprovalRegistry({
       return false;
     }
     _pending.remove(id);
-    _emit(BridgeSseQuestionReplied(requestID: id, sessionID: entry.sessionId, displaySessionId: entry.sessionId));
+    _emitActivity(
+      BridgeSseQuestionReplied(requestID: id, sessionID: entry.sessionId, displaySessionId: entry.sessionId),
+    );
     return true;
   }
 
@@ -289,7 +291,9 @@ final class ClaudeApprovalRegistry({
     if (entry is! _PendingQuestion) return false;
     if (!_deny(entry: entry, message: "User rejected the request.")) return false;
     _pending.remove(id);
-    _emit(BridgeSseQuestionRejected(requestID: id, sessionID: entry.sessionId, displaySessionId: entry.sessionId));
+    _emitActivity(
+      BridgeSseQuestionRejected(requestID: id, sessionID: entry.sessionId, displaySessionId: entry.sessionId),
+    );
     return true;
   }
 
@@ -321,7 +325,7 @@ final class ClaudeApprovalRegistry({
     }
     switch (entry) {
       case _PendingPermission():
-        _emit(
+        _emitActivity(
           BridgeSsePermissionReplied(
             requestID: entry.id,
             sessionID: entry.sessionId,
@@ -330,7 +334,7 @@ final class ClaudeApprovalRegistry({
           ),
         );
       case _PendingQuestion():
-        _emit(
+        _emitActivity(
           BridgeSseQuestionRejected(
             requestID: entry.id,
             sessionID: entry.sessionId,
@@ -338,6 +342,13 @@ final class ClaudeApprovalRegistry({
           ),
         );
     }
+  }
+
+  /// Pending approvals feed the awaiting-input flag in the activity summary,
+  /// so invalidate that summary after every approval transition.
+  void _emitActivity(BridgeSseEvent event) {
+    _emit(event);
+    _emit(const BridgeSseProjectUpdated());
   }
 
   bool _deny({required _PendingApproval entry, required String message}) {

--- a/bridge/sesori_plugin_claude/test/claude_approval_registry_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_approval_registry_test.dart
@@ -40,7 +40,7 @@ void main() {
         isTrue,
       );
 
-      final asked = events.single as BridgeSsePermissionAsked;
+      final asked = events.whereType<BridgeSsePermissionAsked>().single;
       expect(asked.requestID, "br-1");
       expect(asked.sessionID, "session-1");
       expect(asked.tool, "Write");
@@ -59,7 +59,16 @@ void main() {
         "behavior": "allow",
         "updatedInput": {"file_path": "a.dart"},
       });
-      expect(events.last, isA<BridgeSsePermissionReplied>());
+      expect(events.whereType<BridgeSsePermissionReplied>(), hasLength(1));
+    });
+
+    test("every approval transition invalidates the activity summary", () {
+      handle(sessionId: "session-1", message: _permission());
+      expect(events.whereType<BridgeSseProjectUpdated>(), hasLength(1));
+
+      expect(registry.replyPermission(id: "br-1", reply: PluginPermissionReply.once), isTrue);
+      expect(registry.hasPendingInput(sessionId: "session-1"), isFalse);
+      expect(events.whereType<BridgeSseProjectUpdated>(), hasLength(2));
     });
 
     test("always sends only session-scoped addRules suggestions", () {
@@ -173,7 +182,7 @@ void main() {
         ),
       );
 
-      final asked = events.single as BridgeSseQuestionAsked;
+      final asked = events.whereType<BridgeSseQuestionAsked>().single;
       expect(asked.questions.single.question, "Which strategy?");
       expect(asked.questions.single.options.map((option) => option.label), ["Unit", "Integration"]);
       expect(
@@ -207,7 +216,7 @@ void main() {
         ),
       );
 
-      final asked = events.single as BridgeSseQuestionAsked;
+      final asked = events.whereType<BridgeSseQuestionAsked>().single;
       expect(asked.questions.single.question, contains("Implement it"));
       registry.replyQuestion(
         id: "br-1",

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -33,7 +33,9 @@ reaches the backend so the turn continues.
   boundary. A backend requiring exact form correlation must serialize prompts
   process-wide so another session cannot become the attribution target.
 - Resolving a request retires it in the pending list, on every open surface, and
-  in completion-notification suppression.
+  in completion-notification suppression. Raising and resolving a request also
+  refreshes the activity summary, so the session's awaiting-input state appears
+  and clears without waiting for the turn to end.
 - Normalized question and permission replies or rejections feed the existing
   durable user-side activity marker. Lifecycle cleanup that emits those events
   to retire pending UI on abort, thread close, process exit, or disposal can


### PR DESCRIPTION
## Complexity

Trivial: one emit wrapper in the Claude approval registry.

## What

`ClaudeApprovalRegistry` now emits `BridgeSseProjectUpdated` alongside every
approval transition (permission/question asked, replied, rejected, cancelled),
the same way the Codex and ACP plugins already do.

## Why

The client's awaiting-input badge comes only from `SesoriProjectsSummary`, and
the orchestrator rebuilds that summary only when a plugin emits
`BridgeSseProjectUpdated`. The Claude plugin emitted it on busy/idle turn
transitions but not on approval transitions, so `awaitingInput` never changed
until the turn ended — answering a question left the session showing "awaiting
input" even though the turn continued normally.

## Risk and test focus

Low. Slightly more projects-summary rebuilds per turn on Claude, matching the
existing Codex/ACP cost. No database impact. User-visible impact is the
awaiting-input badge appearing and clearing at the right time.

## Expected result

On a Claude session, the awaiting-input state appears when a permission or
question is raised and clears as soon as it is answered or rejected.

## Verification

- `dart test` for `claude_approval_registry`, `claude_plugin_impl`,
  `claude_session_service` — all pass.
- `dart analyze lib test` in `sesori_plugin_claude` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the activity summary after every Claude approval transition so the awaiting-input badge updates immediately. Previously it emitted `BridgeSseProjectUpdated` only on busy/idle transitions; now `ClaudeApprovalRegistry` emits it on ask/reply/reject/cancel, matching Codex and ACP.

- Adds `_emitActivity` to emit the original SSE event and `BridgeSseProjectUpdated`; applied to all approval transitions.
- Updates tests to select typed SSE events and assert one `BridgeSseProjectUpdated` per transition; adds coverage for pending state clearing on reply.
- Revises docs to state that raising and resolving requests refresh the activity summary.
- Slightly increases summary rebuilds per turn on Claude; no database changes or migrations.

<sup>Written for commit 9485ded2a9e411ca37c4e1ea4de94045db4e1a23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

