### PR TITLE
🌿 Surface the configured Hermes model before session creation

### DIFF
--- a/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
@@ -11,9 +11,10 @@ import "hermes_identity.dart";
 /// fork/prompt capabilities and streams turns via `session/update`
 /// notifications, so the base [AcpPlugin] machinery owns sessions and turns.
 /// This class declares Hermes-specific protocol policies, including excluding
-/// interactive terminal setup from headless authentication. Version 1 uses
-/// Hermes's configured model/mode rather than exposing a picker, and has no
-/// managed runtime (Hermes installs itself; the bridge resolves it on PATH).
+/// interactive terminal setup from headless authentication. Version 1 exposes
+/// Hermes's configured model as its sole model option while Hermes remains
+/// authoritative for model/mode changes. It has no managed runtime (Hermes
+/// installs itself; the bridge resolves it on PATH).
 class HermesPlugin._({
   required super.launchSpec,
   required super.launchDirectory,
@@ -27,6 +28,8 @@ class HermesPlugin._({
     required String binaryPath,
     required String? launchDirectory,
     required AcpProcessFactory processFactory,
+    required String? configuredModelId,
+    required String? configuredProviderId,
   }) {
     final cwd = launchDirectory ?? Directory.current.path;
     final launchSpec = HermesBinary.launchSpec(
@@ -35,7 +38,11 @@ class HermesPlugin._({
       environment: const {},
     );
     final commandTracker = AcpCommandTracker();
-    final configurationTracker = AcpSessionConfigurationTracker();
+    final configurationTracker = AcpSessionConfigurationTracker()
+      ..setProcessDefaults(
+        modelId: configuredModelId,
+        providerId: configuredProviderId,
+      );
     const contentMapper = AcpContentMapper();
     final sessionOptionsService = AcpSessionOptionsService(
       configurationTracker: configurationTracker,

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -142,49 +142,18 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
         runtimeVersion = version;
     }
 
-    // Auth probe: `hermes status` reports the configured model/provider.
-    // Best-effort: the true gate is the ACP handshake at connect time, which
-    // degrades the plugin without failing the bridge.
-    final executor = HostProcessCommandExecutor(
+    final statusResult = await _probeHermesStatus(
+      executablePath: executablePath,
       processes: processes,
-      runInShell: io.Platform.isWindows,
-      maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
+      environment: environment,
     );
-    final CommandResult statusResult;
-    try {
-      statusResult = await executor.run(
-        executablePath,
-        const ["status"],
-        environment: environment,
-        timeout: _versionProbeTimeout,
-      );
-    } on TimeoutException catch (error, stackTrace) {
-      Log.w(
-        "[hermes] status probe '$executablePath status' did not exit within ${_versionProbeTimeout.inSeconds}s",
-        error,
-        stackTrace,
-      );
-      return PluginSetupUnknown.versioned(
-        actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
-        runtimeVersion: runtimeVersion,
-      );
-    } on Object catch (error, stackTrace) {
-      Log.w("[hermes] status probe could not launch '$executablePath status'", error, stackTrace);
+    if (statusResult == null) {
       return PluginSetupUnknown.versioned(
         actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
         runtimeVersion: runtimeVersion,
       );
     }
-    if (statusResult.exitCode != 0) {
-      Log.w("[hermes] status probe '$executablePath status' exited with code ${statusResult.exitCode}");
-      return PluginSetupUnknown.versioned(
-        actionHint: "Hermes authentication could not be determined. Run `hermes status` locally and retry.",
-        runtimeVersion: runtimeVersion,
-      );
-    }
-    final statusOutput = _normalizedStatusOutput(result: statusResult);
-    final model = _statusValue(output: statusOutput, field: "model");
-    final provider = _statusValue(output: statusOutput, field: "provider");
+    final (:model, :provider) = _statusValues(result: statusResult);
     if (_isConfiguredStatusValue(value: model) && _isConfiguredStatusValue(value: provider)) {
       return PluginSetupReady.versioned(runtimeVersion: runtimeVersion);
     }
@@ -198,6 +167,42 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
       actionHint: "Hermes setup could not be determined. Run `hermes status` locally and retry.",
       runtimeVersion: runtimeVersion,
     );
+  }
+
+  /// Best-effort configuration probe. The ACP handshake remains the runtime
+  /// authentication gate, while this command supplies the model picker label.
+  Future<CommandResult?> _probeHermesStatus({
+    required String executablePath,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+  }) async {
+    final executor = HostProcessCommandExecutor(
+      processes: processes,
+      runInShell: io.Platform.isWindows,
+      maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
+    );
+    try {
+      final result = await executor.run(
+        executablePath,
+        const ["status"],
+        environment: environment,
+        timeout: _versionProbeTimeout,
+      );
+      if (result.exitCode != 0) {
+        Log.w("[hermes] status probe '$executablePath status' exited with code ${result.exitCode}");
+        return null;
+      }
+      return result;
+    } on TimeoutException catch (error, stackTrace) {
+      Log.w(
+        "[hermes] status probe '$executablePath status' did not exit within ${_versionProbeTimeout.inSeconds}s",
+        error,
+        stackTrace,
+      );
+    } on Object catch (error, stackTrace) {
+      Log.w("[hermes] status probe could not launch '$executablePath status'", error, stackTrace);
+    }
+    return null;
   }
 
   Future<_HermesRuntimeProbe> _probeHermesRuntime({
@@ -284,16 +289,20 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
     return null;
   }
 
-  String _normalizedStatusOutput({required CommandResult result}) {
+  ({String? model, String? provider}) _statusValues({required CommandResult result}) {
     final combined = "${result.stdout}\n${result.stderr}";
-    return combined.replaceAll(RegExp(r"\x1B\[[0-?]*[ -/]*[@-~]"), "").trim().toLowerCase();
+    final output = combined.replaceAll(RegExp(r"\x1B\[[0-?]*[ -/]*[@-~]"), "").trim();
+    return (
+      model: _statusValue(output: output, field: "model"),
+      provider: _statusValue(output: output, field: "provider"),
+    );
   }
 
   String? _statusValue({required String output, required String field}) {
     for (final rawLine in output.split("\n")) {
       final line = rawLine.trim();
       final prefix = "$field:";
-      if (line.startsWith(prefix)) return line.substring(prefix.length).trim();
+      if (line.toLowerCase().startsWith(prefix)) return line.substring(prefix.length).trim();
     }
     return null;
   }
@@ -313,6 +322,19 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
     }
 
     final binaryPath = _explicitBin(config: host.config) ?? host.provisionedRuntimePath ?? HermesBinary.defaultBinary;
+    final statusResult = await _probeHermesStatus(
+      executablePath: binaryPath,
+      processes: host.processes,
+      environment: host.environment,
+    );
+    if (host.startAborted.isAborted) {
+      throw const PluginStartAbortedException();
+    }
+    final status = statusResult == null ? null : _statusValues(result: statusResult);
+    final hasConfiguredModel =
+        status != null &&
+        _isConfiguredStatusValue(value: status.model) &&
+        _isConfiguredStatusValue(value: status.provider);
 
     // Route the agent subprocess through the host process seam rather than
     // io.Process.start, so the bridge owns identity capture and signalling.
@@ -328,6 +350,8 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
       // derive-style plugin, so the plugin needs no store of its own.
       launchDirectory: io.Directory.current.path,
       processFactory: processFactory,
+      configuredModelId: hasConfiguredModel ? status.model : null,
+      configuredProviderId: hasConfiguredModel ? status.provider : null,
     );
 
     final plugin = AcpBridgePlugin(

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
@@ -462,11 +462,18 @@ void main() {
       expect(processes.spawnedExecutables, ["/custom/hermes", "/custom/hermes"]);
     });
 
-    test("start spawns exactly one `hermes acp` process and connects", () async {
+    test("start exposes the configured model before creating a session", () async {
       const descriptor = HermesPluginDescriptor();
       final processes = _ProbeProcessService(
         spawnError: null,
-        processSequence: const [],
+        processSequence: [
+          _ProbeProcess(
+            pid: 1,
+            stdoutBytes: utf8.encode("Model: DeepSeek-V4-Flash\nProvider: OpenCode Go\n"),
+            stderrBytes: const [],
+            exitCode: Future<int>.value(0),
+          ),
+        ],
         servesAcp: true,
       );
 
@@ -478,8 +485,19 @@ void main() {
         ),
       );
 
-      expect(processes.spawnedExecutables, ["/resolved/hermes"]);
+      final discovery = await plugin.api.getSessionOptions(
+        projectId: "/repo",
+        discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+      );
+      final options = (discovery as PluginSessionOptionsDiscoveryObserved).options;
+      final provider = options.providers.providers.single;
+      expect(provider.id, "OpenCode Go");
+      expect(provider.defaultModelID, "DeepSeek-V4-Flash");
+      expect(provider.models.single.id, "DeepSeek-V4-Flash");
+
+      expect(processes.spawnedExecutables, ["/resolved/hermes", "/resolved/hermes"]);
       expect(processes.spawnedArguments, [
+        const ["status"],
         const ["acp"],
       ]);
 
@@ -534,12 +552,15 @@ class _ProbeProcessService({
     if (error != null) {
       throw error;
     }
+    if (_nextProcess < processSequence.length) {
+      return processSequence[_nextProcess++];
+    }
     if (servesAcp) {
       final process = _AcpProcess();
       _acpProcess = process;
       return process;
     }
-    return processSequence[_nextProcess++];
+    throw StateError("No canned process remains");
   }
 
   @override

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
@@ -50,6 +50,8 @@ void main() {
         binaryPath: HermesBinary.defaultBinary,
         launchDirectory: "/repo",
         processFactory: (_) async => fake,
+        configuredModelId: null,
+        configuredProviderId: null,
       );
     });
 

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -20,10 +20,11 @@ variant, and worktree mode, and creating the session with its first input.
   default-first, and a model that offers variants always has one selected: the
   agent's declared variant when valid, otherwise the first available. Selecting a
   variant is therefore a switch between named levels, never a reset to unset.
-- Hermes Agent is a stock ACP v1 server: its option discovery uses the base
-  single-agent synthesis (no model picker — the backend's configured model is
-  authoritative), and it advertises image prompt capability so inline attachments
-  are accepted.
+- Hermes Agent resolves its configured model and provider by running
+  `hermes status` before starting ACP, then exposes that model through the base
+  single-agent option synthesis. Hermes remains authoritative for model changes;
+  Sesori does not advertise a separate catalog or switch models. Hermes also
+  advertises image prompt capability so inline attachments are accepted.
 - Read intents stay distinct: a normal load may serve a valid cache or discover,
   a cache-only read never discovers and reports cache-unavailable, and an
   explicit refresh forces fresh discovery.


### PR DESCRIPTION
## Complexity

🌿 Straightforward. Reuses the existing Hermes status probe and the existing ACP single-model option synthesis. No shared ACP contract, transport, persistence, database, or migration changes.

## What

- Resolve Hermes's configured model and provider with `hermes status` during plugin start.
- Seed the Hermes plugin's existing ACP configuration tracker before session options can be requested.
- Preserve model/provider display casing while keeping status-field and sentinel parsing case-insensitive.
- Keep Hermes authoritative for model changes: no model catalog and no switching.
- Add a cold-path test that reads session options before any session is created.
- Update the session-creation regression contract.

This replaces the implementation proposed in #985 while preserving its valid bug report.

## Why

The Hermes new-session picker was empty because its configuration tracker had no model before the first `session/new`. Learning a catalog from `session/new` is circular because option discovery happens before session creation. The configured model is already available from the Hermes-local status probe, so it can be surfaced without adding Hermes-specific or removed protocol behavior to the shared ACP package.

## Risk and test focus

The only new runtime operation is one bounded, host-owned `hermes status` probe during Hermes startup. If startup is aborted after the probe, ACP is not spawned. The focused regression test verifies the production order (`start` -> option discovery -> no session creation), exact model/provider values, and process sequence.

User-visible impact: the configured Hermes model now appears in new-session options. There is no model-switching, analytics, database, persistence, migration, or other-plugin impact.

## Expected result

A fresh Hermes plugin exposes its configured model and provider before the first session is created, while all backend-specific behavior remains inside `sesori_plugin_hermes`.

## Verification

- `dart analyze --fatal-infos` in `bridge/sesori_plugin_hermes`
- `dart test` in `bridge/sesori_plugin_hermes` (25 tests)
- Architecture plan review: approved
- Architecture implementation review: approved after adding the post-probe abort boundary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose Hermes’s configured model and provider in new-session options by probing `hermes status` during plugin startup. Previously the picker was empty until the first session; now it shows the configured pair before any session while Hermes remains the authority for model changes.

- Adds a best‑effort `_probeHermesStatus` in `hermes_plugin_descriptor.dart`; on failure, behavior falls back with no picker entries; ACP handshake remains the auth gate and we abort cleanly if startup is cancelled.
- Seeds `AcpSessionConfigurationTracker` via `setProcessDefaults` in `HermesPlugin._` using parsed model/provider; parsing is case-insensitive, labels keep original casing.
- No shared ACP, transport, database, or migration changes; no model catalog or switching added.
- Tests/doc: new cold‑path test validates options pre‑session; regression doc updated to reflect pre-start status probe.

<sup>Written for commit dd6b889dc7760fa158df2da2683e14966d0dd1a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

