### PR TITLE
⚙️ Reconcile stale Codex turns and preserve timestamps

### DIFF
--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -716,11 +716,12 @@ class CodexEventMapper({
   }
 
   PluginMessageTime? _turnMessageTime(Map<String, dynamic>? turn) {
-    final created = _secondsToMilliseconds(turn?["startedAt"]);
+    final completed = _secondsToMilliseconds(turn?["completedAt"]);
+    final created = completed ?? _secondsToMilliseconds(turn?["startedAt"]);
     if (created == null) return null;
     return PluginMessageTime(
       created: created,
-      completed: _secondsToMilliseconds(turn?["completedAt"]),
+      completed: completed,
     );
   }
 

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -62,6 +62,11 @@ class CodexEventMapper({
   final Map<String, int> _threadCreatedAt = {};
   final Map<String, int> _threadUpdatedAt = {};
 
+  /// Live app-server updates carry item lifecycle timestamps separately from
+  /// the item itself. Retain them so completion and canonical tool upserts do
+  /// not replace a timestamped message envelope with an undated one.
+  final Map<({String threadId, String itemId}), shared.MessageTime> _itemTimes = {};
+
   /// Records the model codex resolved for [threadId] so subsequent
   /// live-streamed assistant messages are stamped with the model actually in
   /// use. Passing a null/empty [model] clears the override (falls back to the
@@ -126,7 +131,10 @@ class CodexEventMapper({
     _threadModel.remove(threadId);
     _threadProvider.remove(threadId);
     _threadDirectory.remove(threadId);
+    _forgetItemTimes(threadId);
   }
+
+  void resetLiveItemTimes() => _itemTimes.clear();
 
   /// The project id a live session event should carry for [threadId]: the
   /// plugin-fed directory, else the notification's own [cwd], else the launch
@@ -207,11 +215,22 @@ class CodexEventMapper({
         final item = _asMap(params["item"]);
         final threadId = params["threadId"] as String?;
         if (item == null || threadId == null) return const [];
-        return _itemToEvents(
+        final itemId = item["id"] as String?;
+        _recordAppServerItemTime(
+          params: params,
+          threadId: threadId,
+          itemId: itemId,
+          completed: method == "item/completed",
+        );
+        final events = _itemToEvents(
           item: item,
           threadId: threadId,
           completed: method == "item/completed",
         );
+        if (method == "item/completed" && itemId != null) {
+          _itemTimes.remove((threadId: threadId, itemId: itemId));
+        }
+        return events;
 
       case "item/agentMessage/delta":
         return _deltaEvent(params: params, partSuffix: "text");
@@ -222,6 +241,11 @@ class CodexEventMapper({
 
       case "error":
         return [BridgeSseSessionError(sessionID: params["threadId"] as String?)];
+
+      case "thread/closed":
+        final threadId = params["threadId"] as String?;
+        if (threadId != null) _forgetItemTimes(threadId);
+        return const [];
 
       case "turn/diff/updated":
         final threadId = params["threadId"] as String?;
@@ -267,7 +291,7 @@ class CodexEventMapper({
       providerID: _threadProvider[threadId] ?? config.modelProvider ?? "openai",
       errorName: "CodexError",
       errorMessage: message,
-      time: null,
+      time: _turnMessageTime(turn),
     );
   }
 
@@ -282,6 +306,7 @@ class CodexEventMapper({
     title: tool.title,
     status: tool.status,
     output: tool.output,
+    time: _sharedMessageTime(tool.time),
     attachments: tool.attachments,
   );
 
@@ -316,6 +341,7 @@ class CodexEventMapper({
   }) {
     final itemId = item["id"] as String?;
     if (itemId == null || itemId.isEmpty) return const [];
+    final time = _itemTimes[(threadId: threadId, itemId: itemId)];
 
     final imageBearingItem = _imageBearingItemParser.parse(item: item);
     switch (imageBearingItem) {
@@ -333,6 +359,7 @@ class CodexEventMapper({
           itemId: itemId,
           tool: "image_generation",
           status: toolStatus,
+          time: time,
           attachments: toolStatus == PluginToolStatus.completed
               ? _imageAttachmentMapper.map(
                   candidates: [
@@ -358,6 +385,7 @@ class CodexEventMapper({
           tool: tool ?? "mcp",
           title: _mcpToolTitle(server: server, tool: tool),
           status: _parsedToolStatus(status: status, completed: completed),
+          time: time,
           output: _imageBearingToolOutput(content: content),
           error: error,
           attachments: _imageAttachmentMapper.map(
@@ -387,6 +415,7 @@ class CodexEventMapper({
             status: status,
             completed: completed,
           ),
+          time: time,
           output: _rolloutToolMapper.clipOutput(
             _imageBearingToolOutput(content: content),
           ),
@@ -413,9 +442,7 @@ class CodexEventMapper({
             id: itemId,
             sessionID: threadId,
             agent: null,
-            // Live notifications carry no per-message timestamp; the rollout
-            // re-fetch is authoritative and fills this in.
-            time: null,
+            time: time == null ? null : shared.MessageTime(created: time.created, completed: null),
             promptId: null,
           ),
           partType: PluginMessagePartType.text,
@@ -426,7 +453,7 @@ class CodexEventMapper({
         return _messageEvents(
           threadId: threadId,
           itemId: itemId,
-          message: _assistantMessage(itemId: itemId, threadId: threadId),
+          message: _assistantMessage(itemId: itemId, threadId: threadId, time: time),
           partType: PluginMessagePartType.text,
           partSuffix: "text",
           text: item["text"] as String? ?? _extractContentText(item["content"]),
@@ -435,7 +462,7 @@ class CodexEventMapper({
         return _messageEvents(
           threadId: threadId,
           itemId: itemId,
-          message: _assistantMessage(itemId: itemId, threadId: threadId),
+          message: _assistantMessage(itemId: itemId, threadId: threadId, time: time),
           partType: PluginMessagePartType.reasoning,
           partSuffix: "reasoning",
           text: _extractReasoningText(item),
@@ -453,6 +480,7 @@ class CodexEventMapper({
             item["command"] as String?,
           ),
           status: appServerStatus,
+          time: time,
           output: _rolloutToolMapper.clipOutput(
             item["aggregatedOutput"] as String?,
           ),
@@ -465,6 +493,7 @@ class CodexEventMapper({
           tool: "edit",
           title: _fileChangeTitle(item["changes"]),
           status: _toolStatus(item["status"], completed: completed),
+          time: time,
           output: _fileChangeOutput(item["changes"]),
           attachments: const [],
         );
@@ -476,6 +505,7 @@ class CodexEventMapper({
           title: item["query"] as String?,
           // webSearch items carry no status field.
           status: completed ? PluginToolStatus.completed : PluginToolStatus.running,
+          time: time,
           attachments: const [],
         );
       case "contextCompaction":
@@ -486,6 +516,7 @@ class CodexEventMapper({
             tool: "compact",
             title: completed ? "Context compacted" : "Compacting context",
             status: completed ? PluginToolStatus.completed : PluginToolStatus.running,
+            time: time,
             attachments: const [],
           ),
           if (completed) BridgeSseSessionCompacted(sessionID: threadId),
@@ -509,6 +540,7 @@ class CodexEventMapper({
     required String itemId,
     required String tool,
     required PluginToolStatus status,
+    required shared.MessageTime? time,
     required List<PluginMessageAttachment> attachments,
     String? title,
     String? output,
@@ -516,7 +548,7 @@ class CodexEventMapper({
   }) {
     return [
       BridgeSseMessageUpdated(
-        info: _assistantMessage(itemId: itemId, threadId: threadId).toJson(),
+        info: _assistantMessage(itemId: itemId, threadId: threadId, time: time).toJson(),
       ),
       BridgeSseMessagePartUpdated(
         part: PluginMessagePart(
@@ -652,6 +684,7 @@ class CodexEventMapper({
   shared.Message _assistantMessage({
     required String itemId,
     required String threadId,
+    required shared.MessageTime? time,
   }) {
     return shared.Message.assistant(
       id: itemId,
@@ -659,11 +692,50 @@ class CodexEventMapper({
       agent: "codex",
       modelID: _threadModel[threadId] ?? config.model,
       providerID: _threadProvider[threadId] ?? config.modelProvider ?? "openai",
-      // Live notifications carry no per-message timestamp; the rollout
-      // re-fetch is authoritative and fills this in.
-      time: null,
+      time: time,
     );
   }
+
+  shared.MessageTime? _recordAppServerItemTime({
+    required Map<String, dynamic> params,
+    required String threadId,
+    required String? itemId,
+    required bool completed,
+  }) {
+    if (itemId == null || itemId.isEmpty) return null;
+    final key = (threadId: threadId, itemId: itemId);
+    final previous = _itemTimes[key];
+    final created = _milliseconds(params["startedAtMs"]) ?? previous?.created;
+    if (created == null) return previous;
+    final time = shared.MessageTime(
+      created: created,
+      completed: completed ? _milliseconds(params["completedAtMs"]) ?? previous?.completed : previous?.completed,
+    );
+    _itemTimes[key] = time;
+    return time;
+  }
+
+  PluginMessageTime? _turnMessageTime(Map<String, dynamic>? turn) {
+    final created = _secondsToMilliseconds(turn?["startedAt"]);
+    if (created == null) return null;
+    return PluginMessageTime(
+      created: created,
+      completed: _secondsToMilliseconds(turn?["completedAt"]),
+    );
+  }
+
+  int? _milliseconds(Object? value) => value is num ? value.round() : null;
+
+  int? _secondsToMilliseconds(Object? value) => value is num ? (value * Duration.millisecondsPerSecond).round() : null;
+
+  shared.MessageTime? _sharedMessageTime(PluginMessageTime? time) => time == null
+      ? null
+      : shared.MessageTime(
+          created: time.created,
+          completed: time.completed,
+        );
+
+  void _forgetItemTimes(String threadId) => _itemTimes.removeWhere((key, _) => key.threadId == threadId);
 
   /// Emits the message envelope and its (single) content part. The part id
   /// matches the `$itemId-$partSuffix` convention used by [_deltaEvent] so

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -295,6 +295,24 @@ class CodexEventMapper({
     );
   }
 
+  BridgeSseMessageUpdated mapRolloutTerminalError({
+    required String threadId,
+    required String turnId,
+    required String message,
+    required String? timestamp,
+  }) => BridgeSseMessageUpdated(
+    info: PluginMessage.error(
+      id: turnId,
+      sessionID: threadId,
+      agent: "codex",
+      modelID: _threadModel[threadId] ?? config.model,
+      providerID: _threadProvider[threadId] ?? config.modelProvider ?? "openai",
+      errorName: "CodexError",
+      errorMessage: message,
+      time: _rolloutMessageTime(timestamp),
+    ).toJson(),
+  );
+
   /// Renders a complete repository-owned canonical tool upsert.
   List<BridgeSseEvent> mapProjectedTool({
     required String threadId,
@@ -723,6 +741,17 @@ class CodexEventMapper({
       created: created,
       completed: completed,
     );
+  }
+
+  PluginMessageTime? _rolloutMessageTime(String? raw) {
+    if (raw == null || raw.isEmpty) return null;
+    final parsed = DateTime.tryParse(raw);
+    return parsed == null
+        ? null
+        : PluginMessageTime(
+            created: parsed.millisecondsSinceEpoch,
+            completed: null,
+          );
   }
 
   int? _milliseconds(Object? value) => value is num ? value.round() : null;

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -244,6 +244,7 @@ class CodexPlugin._({
     _sessionService.detachAppServerRepositories();
     _rolloutTailer.stopAll();
     _toolLifecycleTracker.clear();
+    _eventMapper.resetLiveItemTimes();
     _keepaliveTimer?.cancel();
     _keepaliveTimer = null;
     _approvalRegistry = null;
@@ -345,6 +346,7 @@ class CodexPlugin._({
           )
         : _toolLifecycleTracker.observeCorrelatableAppServerItem(
             event: correlatableItem,
+            notification: notification,
           );
     if (command != null && projectedTool != null && !_deletedThreadIds.contains(command.threadId)) {
       try {
@@ -471,6 +473,9 @@ class CodexPlugin._({
 
     final activeTurnId = _activeTurnByThread[threadId];
     final notificationTurnId = _notificationTurnId(notification.params);
+    if (notification.method == "turn/started" && _provisionalAcceptedTurnThreadIds.contains(threadId)) {
+      return false;
+    }
     if (activeTurnId != null && notificationTurnId != null && activeTurnId != notificationTurnId) {
       return true;
     }
@@ -755,6 +760,7 @@ class CodexPlugin._({
       _syncWorkState();
       return;
     }
+    var backendAlreadyIdle = false;
     try {
       await client.request(
         method: "turn/interrupt",
@@ -763,10 +769,84 @@ class CodexPlugin._({
     } on CodexRpcException catch (error) {
       // If the turn already completed before our interrupt arrived,
       // codex returns a "not found" — treat as already-aborted.
-      if (error.code != -32602) rethrow;
+      final noActiveTurn = error.code == -32600 && error.message == "no active turn to interrupt";
+      if (error.code != -32602 && !noActiveTurn) rethrow;
+      backendAlreadyIdle = true;
+      await _queueAlreadyIdleTurnReconciliation(
+        sessionId: sessionId,
+        turnId: turnId,
+      );
     } finally {
-      _activeTurnByThread.remove(sessionId);
+      if (!backendAlreadyIdle && _activeTurnByThread[sessionId] == turnId) {
+        _activeTurnByThread.remove(sessionId);
+      }
       _syncWorkState();
+    }
+  }
+
+  Future<void> _queueAlreadyIdleTurnReconciliation({
+    required String sessionId,
+    required String turnId,
+  }) async {
+    int? retiredTurnRevision;
+    final drain = _notificationWork.then<void>((_) async {
+      if (_activeTurnByThread[sessionId] != turnId) return;
+      if (!_recordAuthoritativeTurnEvidence(sessionId)) return;
+      _activeTurnByThread.remove(sessionId);
+      retiredTurnRevision = _turnEvidenceRevisionByThread[sessionId];
+      await _finishAlreadyIdleTurn(sessionId: sessionId, turnId: turnId);
+    });
+    final guardedDrain = drain.catchError((Object error, StackTrace stackTrace) {
+      Log.e(
+        "[codex] failed to drain an already-completed abort for $sessionId/$turnId",
+        error,
+        stackTrace,
+      );
+    });
+    _notificationWork = guardedDrain;
+    await guardedDrain;
+
+    final revision = retiredTurnRevision;
+    if (revision == null) return;
+    final reconciliation = _notificationWork.then<void>((_) {
+      if ((_turnEvidenceRevisionByThread[sessionId] ?? 0) != revision || _activeTurnByThread.containsKey(sessionId)) {
+        return;
+      }
+      final activityChanged = _setSessionStatus(sessionId, const PluginSessionStatus.idle());
+      _eventBuffer.add(BridgeSseSessionIdle(sessionID: sessionId));
+      if (activityChanged) _eventBuffer.add(const BridgeSseProjectUpdated());
+    });
+    final guarded = reconciliation.catchError((Object error, StackTrace stackTrace) {
+      Log.e(
+        "[codex] failed to reconcile an already-completed abort for $sessionId/$turnId",
+        error,
+        stackTrace,
+      );
+    });
+    _notificationWork = guarded;
+    await guarded;
+  }
+
+  Future<void> _finishAlreadyIdleTurn({required String sessionId, required String turnId}) async {
+    try {
+      await _rolloutTailer.finish(sessionId: sessionId);
+    } on Object catch (error, stackTrace) {
+      _rolloutTailer.stop(sessionId: sessionId);
+      Log.w(
+        "[codex] failed to drain the completed rollout while reconciling abort for $sessionId",
+        error,
+        stackTrace,
+      );
+    }
+    final terminal = CodexServerNotification(
+      method: "turn/completed",
+      params: {
+        "threadId": sessionId,
+        "turn": {"id": turnId, "status": "interrupted"},
+      },
+    );
+    for (final tool in _toolLifecycleTracker.observeTerminalNotification(notification: terminal)) {
+      _eventMapper.mapProjectedTool(threadId: sessionId, tool: tool).forEach(_eventBuffer.add);
     }
   }
 
@@ -859,8 +939,13 @@ class CodexPlugin._({
     if (_deletedThreadIds.contains(threadId) || (_turnEvidenceRevisionByThread[threadId] ?? 0) != evidenceRevision) {
       return;
     }
-    _activeTurnByThread[threadId] = turnId;
-    _provisionalAcceptedTurnThreadIds.add(threadId);
+    // COMPATIBILITY 2026-08-20 (Codex app-server <=0.147): a steered input can
+    // return a fresh submission id instead of the existing active turn id.
+    // Preserve authoritative lifecycle evidence until its terminal event.
+    if (!_activeTurnByThread.containsKey(threadId)) {
+      _activeTurnByThread[threadId] = turnId;
+      _provisionalAcceptedTurnThreadIds.add(threadId);
+    }
   }
 
   bool _recordAuthoritativeTurnEvidence(String threadId) {

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -7,6 +7,7 @@ import "package:sesori_shared/sesori_shared.dart" show Harness;
 import "api/codex_app_server_api.dart";
 import "api/models/codex_correlatable_item_event_dto.dart";
 import "api/models/codex_image_bearing_item_dto.dart";
+import "api/models/codex_rollout_dto.dart";
 import "api/parsers/codex_command_execution_parser.dart";
 import "api/parsers/codex_file_change_parser.dart";
 import "api/parsers/codex_image_bearing_item_parser.dart";
@@ -410,6 +411,25 @@ class CodexPlugin._({
             tool: tool,
           )
           .forEach(_eventBuffer.add);
+    }
+    if (append.line case CodexRolloutEventMessageLineDto(
+      :final timestamp,
+      payload: CodexRolloutTaskCompleteEventDto(
+        :final turnId,
+        error: final error?,
+      ),
+    )) {
+      final message = error.message;
+      if (turnId.isNotEmpty && message.trim().isNotEmpty) {
+        _eventBuffer.add(
+          _eventMapper.mapRolloutTerminalError(
+            threadId: append.sessionId,
+            turnId: turnId,
+            message: message,
+            timestamp: timestamp,
+          ),
+        );
+      }
     }
   }
 

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -768,6 +768,11 @@ class CodexPlugin._({
           turnId: turnId,
           evidenceRevision: evidenceRevision,
         );
+      } else {
+        _clearPendingTurnRequest(
+          threadId: sessionId,
+          evidenceRevision: evidenceRevision,
+        );
       }
       _syncWorkState();
     } on Object {

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -104,6 +104,10 @@ class CodexPlugin._({
   /// exposing codex turn identifiers outside the plugin.
   final Set<String> _provisionalAcceptedTurnThreadIds = {};
 
+  /// In-flight turn requests authorize the next authoritative `turn/started`
+  /// to replace a stale active id left behind by a missing terminal event.
+  final Map<String, int> _pendingTurnRequestRevisionByThread = {};
+
   /// Advances whenever authoritative turn evidence wins a `turn/start`
   /// response race, preventing that response from restoring stale busy state.
   final Map<String, int> _turnEvidenceRevisionByThread = {};
@@ -258,6 +262,7 @@ class CodexPlugin._({
       _eventBuffer.add(const BridgeSseProjectUpdated());
     }
     _provisionalAcceptedTurnThreadIds.clear();
+    _pendingTurnRequestRevisionByThread.clear();
     _turnEvidenceRevisionByThread.keys.toList().forEach(_advanceTurnEvidenceRevision);
     _workState.set(PluginWorkState.unknown);
     _onDisconnected?.call();
@@ -473,7 +478,9 @@ class CodexPlugin._({
 
     final activeTurnId = _activeTurnByThread[threadId];
     final notificationTurnId = _notificationTurnId(notification.params);
-    if (notification.method == "turn/started" && _provisionalAcceptedTurnThreadIds.contains(threadId)) {
+    final hasPendingTurnRequest = _hasCurrentPendingTurnRequest(threadId);
+    if (notification.method == "turn/started" &&
+        (_provisionalAcceptedTurnThreadIds.contains(threadId) || hasPendingTurnRequest)) {
       return false;
     }
     if (activeTurnId != null && notificationTurnId != null && activeTurnId != notificationTurnId) {
@@ -482,7 +489,7 @@ class CodexPlugin._({
     return notification.method == "thread/status/changed" &&
         _eventMapper.isIdleThreadStatus(notification.params["status"]) &&
         notificationTurnId == null &&
-        (activeTurnId != null || _provisionalAcceptedTurnThreadIds.contains(threadId));
+        (activeTurnId != null || _provisionalAcceptedTurnThreadIds.contains(threadId) || hasPendingTurnRequest);
   }
 
   String? _notificationTurnId(Map<String, dynamic> params) {
@@ -518,8 +525,10 @@ class CodexPlugin._({
         return _setSessionStatus(threadId, const PluginSessionStatus.idle());
       case "thread/status/changed":
         if (threadId == null) return false;
-        if (!_recordAuthoritativeTurnEvidence(threadId)) return false;
         final idle = _eventMapper.isIdleThreadStatus(params["status"]);
+        if ((idle || !_hasCurrentPendingTurnRequest(threadId)) && !_recordAuthoritativeTurnEvidence(threadId)) {
+          return false;
+        }
         if (idle) _activeTurnByThread.remove(threadId);
         return _setSessionStatus(
           threadId,
@@ -714,7 +723,7 @@ class CodexPlugin._({
       _eventMapper.setThreadModel(sessionId, model.modelID);
     }
     _rolloutTailer.start(sessionId: sessionId);
-    final evidenceRevision = _turnEvidenceRevisionByThread[sessionId] ?? 0;
+    final evidenceRevision = _recordPendingTurnRequest(sessionId);
     try {
       final dispatch = await _sessionService.sendCommand(
         threadId: sessionId,
@@ -742,6 +751,10 @@ class CodexPlugin._({
       }
       _syncWorkState();
     } on Object {
+      _clearPendingTurnRequest(
+        threadId: sessionId,
+        evidenceRevision: evidenceRevision,
+      );
       _rolloutTailer.stop(sessionId: sessionId);
       rethrow;
     }
@@ -788,13 +801,23 @@ class CodexPlugin._({
     required String sessionId,
     required String turnId,
   }) async {
+    final terminal = CodexServerNotification(
+      method: "turn/completed",
+      params: {
+        "threadId": sessionId,
+        "turn": {"id": turnId, "status": "interrupted"},
+      },
+    );
     int? retiredTurnRevision;
     final drain = _notificationWork.then<void>((_) async {
       if (_activeTurnByThread[sessionId] != turnId) return;
       if (!_recordAuthoritativeTurnEvidence(sessionId)) return;
       _activeTurnByThread.remove(sessionId);
       retiredTurnRevision = _turnEvidenceRevisionByThread[sessionId];
-      await _finishAlreadyIdleTurn(sessionId: sessionId, turnId: turnId);
+      await _finishAlreadyIdleTurn(
+        sessionId: sessionId,
+        terminal: terminal,
+      );
     });
     final guardedDrain = drain.catchError((Object error, StackTrace stackTrace) {
       Log.e(
@@ -813,7 +836,7 @@ class CodexPlugin._({
         return;
       }
       final activityChanged = _setSessionStatus(sessionId, const PluginSessionStatus.idle());
-      _eventBuffer.add(BridgeSseSessionIdle(sessionID: sessionId));
+      _eventMapper.map(terminal).forEach(_eventBuffer.add);
       if (activityChanged) _eventBuffer.add(const BridgeSseProjectUpdated());
     });
     final guarded = reconciliation.catchError((Object error, StackTrace stackTrace) {
@@ -827,7 +850,10 @@ class CodexPlugin._({
     await guarded;
   }
 
-  Future<void> _finishAlreadyIdleTurn({required String sessionId, required String turnId}) async {
+  Future<void> _finishAlreadyIdleTurn({
+    required String sessionId,
+    required CodexServerNotification terminal,
+  }) async {
     try {
       await _rolloutTailer.finish(sessionId: sessionId);
     } on Object catch (error, stackTrace) {
@@ -838,13 +864,6 @@ class CodexPlugin._({
         stackTrace,
       );
     }
-    final terminal = CodexServerNotification(
-      method: "turn/completed",
-      params: {
-        "threadId": sessionId,
-        "turn": {"id": turnId, "status": "interrupted"},
-      },
-    );
     for (final tool in _toolLifecycleTracker.observeTerminalNotification(notification: terminal)) {
       _eventMapper.mapProjectedTool(threadId: sessionId, tool: tool).forEach(_eventBuffer.add);
     }
@@ -895,7 +914,7 @@ class CodexPlugin._({
     // Capture the current EOF before Codex can append this turn's response
     // items. `start` is idempotent when turn/started arrives afterwards.
     _rolloutTailer.start(sessionId: threadId);
-    final evidenceRevision = _turnEvidenceRevisionByThread[threadId] ?? 0;
+    final evidenceRevision = _recordPendingTurnRequest(threadId);
     try {
       final dispatch = await _sessionService.startTurn(
         threadId: threadId,
@@ -905,6 +924,10 @@ class CodexPlugin._({
         collaborationMode: collaborationMode,
       );
       if (!dispatch.started) {
+        _clearPendingTurnRequest(
+          threadId: threadId,
+          evidenceRevision: evidenceRevision,
+        );
         _rolloutTailer.stop(sessionId: threadId);
         return;
       }
@@ -926,6 +949,10 @@ class CodexPlugin._({
       }
       _syncWorkState();
     } on Object {
+      _clearPendingTurnRequest(
+        threadId: threadId,
+        evidenceRevision: evidenceRevision,
+      );
       _rolloutTailer.stop(sessionId: threadId);
       rethrow;
     }
@@ -951,6 +978,7 @@ class CodexPlugin._({
   bool _recordAuthoritativeTurnEvidence(String threadId) {
     if (_deletedThreadIds.contains(threadId)) return false;
     _provisionalAcceptedTurnThreadIds.remove(threadId);
+    _pendingTurnRequestRevisionByThread.remove(threadId);
     _advanceTurnEvidenceRevision(threadId);
     return true;
   }
@@ -958,7 +986,26 @@ class CodexPlugin._({
   void _recordAuthoritativeThreadCreation(String threadId) {
     _deletedThreadIds.remove(threadId);
     _provisionalAcceptedTurnThreadIds.remove(threadId);
+    _pendingTurnRequestRevisionByThread.remove(threadId);
     _advanceTurnEvidenceRevision(threadId);
+  }
+
+  int _recordPendingTurnRequest(String threadId) {
+    final revision = _turnEvidenceRevisionByThread[threadId] ?? 0;
+    _pendingTurnRequestRevisionByThread[threadId] = revision;
+    return revision;
+  }
+
+  bool _hasCurrentPendingTurnRequest(String threadId) =>
+      _pendingTurnRequestRevisionByThread[threadId] == (_turnEvidenceRevisionByThread[threadId] ?? 0);
+
+  void _clearPendingTurnRequest({
+    required String threadId,
+    required int evidenceRevision,
+  }) {
+    if (_pendingTurnRequestRevisionByThread[threadId] == evidenceRevision) {
+      _pendingTurnRequestRevisionByThread.remove(threadId);
+    }
   }
 
   void _advanceTurnEvidenceRevision(String threadId) {
@@ -1076,6 +1123,7 @@ class CodexPlugin._({
   Future<void> deleteSession(String sessionId) async {
     _deletedThreadIds.add(sessionId);
     _provisionalAcceptedTurnThreadIds.remove(sessionId);
+    _pendingTurnRequestRevisionByThread.remove(sessionId);
     _advanceTurnEvidenceRevision(sessionId);
     if (_activeTurnByThread.containsKey(sessionId)) {
       try {

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_tool_lifecycle_tracker.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_tool_lifecycle_tracker.dart
@@ -173,17 +173,19 @@ class CodexToolLifecycleTracker({
       );
       final generationId = generation.id;
       if (generationId == null) return null;
+      final turnId = _usefulText(value: params["turnId"]);
       final tool = thread.tools.putIfAbsent(
         generationId,
         () => _TrackedTool(
           id: generationId,
           tool: "image_generation",
           title: null,
-          turnId: null,
+          turnId: turnId,
           chronologySegment: thread.chronologySegment,
           isRolloutCall: false,
         ),
       );
+      tool.turnId ??= turnId;
       _recordAppServerTime(tool: tool, notification: notification);
       tool.status = _mergeStatus(
         previous: tool.status,
@@ -554,20 +556,25 @@ class CodexToolLifecycleTracker({
     required _ThreadToolLifecycle thread,
     required String turnId,
   }) {
-    final updates = _advanceChronologySegment(thread: thread);
-    thread.activeTurnId = _usefulText(value: turnId);
+    final usefulTurnId = _usefulText(value: turnId);
+    final updates = _advanceChronologySegment(
+      thread: thread,
+      nextTurnId: usefulTurnId,
+    );
+    thread.activeTurnId = usefulTurnId;
     return updates;
   }
 
   List<CodexProjectedTool> _advanceChronologySegment({
     required _ThreadToolLifecycle thread,
     bool includeNonRolloutCalls = false,
+    String? nextTurnId,
   }) {
     final updates = <CodexProjectedTool>[];
     for (final tool in thread.tools.values) {
       final appliesToCurrentReplay = tool.isRolloutCall
           ? tool.chronologySegment == thread.chronologySegment
-          : includeNonRolloutCalls;
+          : includeNonRolloutCalls || (nextTurnId != null && tool.turnId != null && tool.turnId != nextTurnId);
       if (!appliesToCurrentReplay || tool.status != PluginToolStatus.running) {
         continue;
       }
@@ -821,7 +828,7 @@ class _TrackedTool({
   required final String id,
   required final String tool,
   required var String? title,
-  required final String? turnId,
+  required var String? turnId,
   required final int chronologySegment,
   required final bool isRolloutCall,
 }) {

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_tool_lifecycle_tracker.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_tool_lifecycle_tracker.dart
@@ -28,14 +28,17 @@ class CodexToolLifecycleTracker({
     required CodexRolloutLineDto line,
   }) {
     final thread = _threads.putIfAbsent(threadId, _ThreadToolLifecycle.new);
+    final time = _rolloutTime(line.timestamp);
     return switch (line) {
       CodexRolloutResponseItemLineDto(:final payload) => _observeRolloutPayload(
         thread: thread,
         payload: payload,
+        time: time,
       ),
       CodexRolloutEventMessageLineDto(payload: final event) => _observeRolloutEvent(
         thread: thread,
         event: event,
+        time: time,
       ),
       CodexRolloutSessionMetadataLineDto() ||
       CodexRolloutTurnContextLineDto() ||
@@ -51,6 +54,7 @@ class CodexToolLifecycleTracker({
   /// and continue through the existing native event mapping.
   CodexProjectedTool? observeCorrelatableAppServerItem({
     required CodexCorrelatableItemEventDto event,
+    required CodexServerNotification notification,
   }) {
     if (event.lifecycle == CodexCorrelatableItemLifecycle.completed) {
       final retainedCommands = _retainedCommandsByThread[event.threadId];
@@ -59,6 +63,7 @@ class CodexToolLifecycleTracker({
         if (retainedCommands!.isEmpty) {
           _retainedCommandsByThread.remove(event.threadId);
         }
+        _recordAppServerTime(tool: retainedTool, notification: notification);
         return _applyCorrelatableAppServerItem(
           tool: retainedTool,
           event: event,
@@ -108,6 +113,7 @@ class CodexToolLifecycleTracker({
     final tool = thread.tools[canonicalId];
     if (tool == null || !tool.isRolloutCall) return null;
 
+    _recordAppServerTime(tool: tool, notification: notification);
     final snapshot = _applyCorrelatableAppServerItem(
       tool: tool,
       event: event,
@@ -178,6 +184,7 @@ class CodexToolLifecycleTracker({
           isRolloutCall: false,
         ),
       );
+      _recordAppServerTime(tool: tool, notification: notification);
       tool.status = _mergeStatus(
         previous: tool.status,
         current: generation.status,
@@ -201,6 +208,7 @@ class CodexToolLifecycleTracker({
         if (retainedCommands!.isEmpty) {
           _retainedCommandsByThread.remove(threadId);
         }
+        _recordAppServerTime(tool: retainedTool, notification: notification);
         return _applyAppServerTool(
           tool: retainedTool,
           item: item,
@@ -217,6 +225,7 @@ class CodexToolLifecycleTracker({
     if (item["type"] == "dynamicToolCall") {
       final tool = thread.tools[itemId];
       if (tool == null || !tool.hasRolloutResult) return null;
+      _recordAppServerTime(tool: tool, notification: notification);
       tool.status = _mergeStatus(
         previous: tool.status,
         current: _appServerStatus(
@@ -333,6 +342,7 @@ class CodexToolLifecycleTracker({
   List<CodexProjectedTool> _observeRolloutPayload({
     required _ThreadToolLifecycle thread,
     required CodexRolloutResponseItemDto payload,
+    required PluginMessageTime? time,
   }) {
     if (payload case final CodexRolloutImageGenerationDto item) {
       final generation = _rolloutToolMapper.mapImageGeneration(item: item);
@@ -349,6 +359,7 @@ class CodexToolLifecycleTracker({
           isRolloutCall: false,
         ),
       );
+      tool.time ??= time;
       tool.status = _mergeStatus(
         previous: tool.status,
         current: generation.status,
@@ -395,6 +406,7 @@ class CodexToolLifecycleTracker({
           isRolloutCall: true,
         ),
       );
+      tool.time ??= time;
       tool.title ??= call.title;
       if (fileChangePatch != null) {
         tool.rolloutOutput ??= _rolloutToolMapper.clipOutput(fileChangePatch);
@@ -428,6 +440,7 @@ class CodexToolLifecycleTracker({
     final canonicalId = waitTarget ?? result.callId;
     final tool = thread.tools[canonicalId];
     if (tool == null || !tool.isRolloutCall) return const [];
+    tool.time ??= time;
 
     final cellIds = switch (result) {
       CodexRolloutToolRunningResult(:final cellIds) => cellIds,
@@ -477,6 +490,7 @@ class CodexToolLifecycleTracker({
   List<CodexProjectedTool> _observeRolloutEvent({
     required _ThreadToolLifecycle thread,
     required CodexRolloutEventDto event,
+    required PluginMessageTime? time,
   }) {
     return switch (event) {
       CodexRolloutUserMessageEventDto() =>
@@ -498,6 +512,7 @@ class CodexToolLifecycleTracker({
       CodexRolloutImageGenerationEndEventDto() => _observeImageGenerationEnd(
         thread: thread,
         event: event,
+        time: time,
       ),
       CodexRolloutUnknownEventDto() => const [],
     };
@@ -506,6 +521,7 @@ class CodexToolLifecycleTracker({
   List<CodexProjectedTool> _observeImageGenerationEnd({
     required _ThreadToolLifecycle thread,
     required CodexRolloutImageGenerationEndEventDto event,
+    required PluginMessageTime? time,
   }) {
     final generation = _rolloutToolMapper.mapImageGenerationEnd(event: event);
     final id = generation.id;
@@ -521,6 +537,7 @@ class CodexToolLifecycleTracker({
         isRolloutCall: false,
       ),
     );
+    tool.time ??= time;
     tool.status = _mergeStatus(
       previous: tool.status,
       current: generation.status,
@@ -752,6 +769,34 @@ class CodexToolLifecycleTracker({
     final trimmed = value.trim();
     return trimmed.isEmpty ? null : trimmed;
   }
+
+  void _recordAppServerTime({
+    required _TrackedTool tool,
+    required CodexServerNotification notification,
+  }) {
+    final previous = tool.time;
+    final created = _milliseconds(notification.params["startedAtMs"]) ?? previous?.created;
+    if (created == null) return;
+    tool.time = PluginMessageTime(
+      created: created,
+      completed: notification.method == "item/completed"
+          ? _milliseconds(notification.params["completedAtMs"]) ?? previous?.completed
+          : previous?.completed,
+    );
+  }
+
+  PluginMessageTime? _rolloutTime(String? raw) {
+    if (raw == null || raw.isEmpty) return null;
+    final parsed = DateTime.tryParse(raw);
+    return parsed == null
+        ? null
+        : PluginMessageTime(
+            created: parsed.millisecondsSinceEpoch,
+            completed: null,
+          );
+  }
+
+  int? _milliseconds(Object? value) => value is num ? value.round() : null;
 }
 
 class _ThreadToolLifecycle() {
@@ -783,6 +828,7 @@ class _TrackedTool({
   PluginToolStatus status = PluginToolStatus.running;
   String? rolloutOutput;
   String? appServerOutput;
+  PluginMessageTime? time;
   bool hasRolloutResult = false;
   final List<PluginMessageAttachment> attachments = [];
   final Set<String> outstandingCellIds = {};
@@ -793,6 +839,7 @@ class _TrackedTool({
     title: title,
     status: status,
     output: rolloutOutput ?? appServerOutput,
+    time: time,
     attachments: attachments,
   );
 }

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_tool_lifecycle_tracker.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_tool_lifecycle_tracker.dart
@@ -311,7 +311,7 @@ class CodexToolLifecycleTracker({
     final updates = <CodexProjectedTool>[];
     if (thread != null) {
       for (final tool in thread.tools.values) {
-        if (!tool.isRolloutCall || tool.status != PluginToolStatus.running) {
+        if (tool.status != PluginToolStatus.running) {
           continue;
         }
         tool.status = terminalStatus;

--- a/bridge/sesori_plugin_codex/lib/src/repositories/models/codex_projected_tool.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/models/codex_projected_tool.dart
@@ -7,6 +7,7 @@ final class CodexProjectedTool({
   required final String? title,
   required final PluginToolStatus status,
   required final String? output,
+  required final PluginMessageTime? time,
   required List<PluginMessageAttachment> attachments,
 }) {
   final List<PluginMessageAttachment> attachments = List.unmodifiable(attachments);

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -355,6 +355,111 @@ void main() {
       expect(part.text, "hey");
     });
 
+    test("item lifecycle timestamps survive live message updates", () {
+      const threadId = "t-timestamps";
+      final userStarted = mapper.map(
+        const CodexServerNotification(
+          method: "item/started",
+          params: {
+            "threadId": threadId,
+            "startedAtMs": 1779293100123,
+            "item": {"type": "userMessage", "id": "i-user-time", "content": <Object?>[]},
+          },
+        ),
+      );
+      final userCompleted = mapper.map(
+        const CodexServerNotification(
+          method: "item/completed",
+          params: {
+            "threadId": threadId,
+            "completedAtMs": 1779293100456,
+            "item": {"type": "userMessage", "id": "i-user-time", "content": <Object?>[]},
+          },
+        ),
+      );
+      final assistantStarted = mapper.map(
+        const CodexServerNotification(
+          method: "item/started",
+          params: {
+            "threadId": threadId,
+            "startedAtMs": 1779293101000,
+            "item": {"type": "agentMessage", "id": "i-agent-time", "text": ""},
+          },
+        ),
+      );
+      final assistantCompleted = mapper.map(
+        const CodexServerNotification(
+          method: "item/completed",
+          params: {
+            "threadId": threadId,
+            "completedAtMs": 1779293102000,
+            "item": {"type": "agentMessage", "id": "i-agent-time", "text": "done"},
+          },
+        ),
+      );
+
+      final startedUser = shared.Message.fromJson((userStarted.first as BridgeSseMessageUpdated).info);
+      final completedUser = shared.Message.fromJson((userCompleted.first as BridgeSseMessageUpdated).info);
+      final startedAssistant = shared.Message.fromJson((assistantStarted.first as BridgeSseMessageUpdated).info);
+      final completedAssistant = shared.Message.fromJson((assistantCompleted.first as BridgeSseMessageUpdated).info);
+      expect(startedUser.time, const shared.MessageTime(created: 1779293100123, completed: null));
+      expect(completedUser.time, startedUser.time);
+      expect(startedAssistant.time, const shared.MessageTime(created: 1779293101000, completed: null));
+      expect(
+        completedAssistant.time,
+        const shared.MessageTime(created: 1779293101000, completed: 1779293102000),
+      );
+    });
+
+    test("late native tool completion keeps its start time after turn completion", () {
+      const threadId = "t-late-tool-time";
+      mapper.map(
+        const CodexServerNotification(
+          method: "item/started",
+          params: {
+            "threadId": threadId,
+            "startedAtMs": 1779293103000,
+            "item": {
+              "type": "commandExecution",
+              "id": "i-late-tool-time",
+              "command": "sleep 1",
+              "status": "inProgress",
+            },
+          },
+        ),
+      );
+      mapper.map(
+        const CodexServerNotification(
+          method: "turn/completed",
+          params: {
+            "threadId": threadId,
+            "turn": {"id": "u-late-tool-time"},
+          },
+        ),
+      );
+
+      final completed = mapper.map(
+        const CodexServerNotification(
+          method: "item/completed",
+          params: {
+            "threadId": threadId,
+            "completedAtMs": 1779293104000,
+            "item": {
+              "type": "commandExecution",
+              "id": "i-late-tool-time",
+              "command": "sleep 1",
+              "status": "completed",
+            },
+          },
+        ),
+      );
+
+      expect(
+        shared.Message.fromJson((completed.first as BridgeSseMessageUpdated).info).time,
+        const shared.MessageTime(created: 1779293103000, completed: 1779293104000),
+      );
+    });
+
     test("contextCompaction emits a durable tool lifecycle and completion signal", () {
       final started = mapper.map(
         const CodexServerNotification(
@@ -652,6 +757,10 @@ void main() {
         (running[1] as BridgeSseMessagePartUpdated).part.state?.title,
         "/usr/bin/false",
       );
+      expect(
+        shared.Message.fromJson((running[0] as BridgeSseMessageUpdated).info).time,
+        shared.MessageTime(created: DateTime.utc(2026, 7, 23, 8).millisecondsSinceEpoch, completed: null),
+      );
       final rawPart = (completed[1] as BridgeSseMessagePartUpdated).part;
       final latePart = (lateItem[1] as BridgeSseMessagePartUpdated).part;
       expect(rawPart.state?.status, PluginToolStatus.error);
@@ -895,11 +1004,27 @@ void main() {
           line: running,
         );
 
+      rolloutLifecycle.map(
+        const CodexServerNotification(
+          method: "item/started",
+          params: {
+            "threadId": "t-completed",
+            "startedAtMs": 1779293200000,
+            "item": {
+              "type": "commandExecution",
+              "id": "call-completed",
+              "status": "inProgress",
+            },
+          },
+        ),
+      );
+
       final events = rolloutLifecycle.map(
         const CodexServerNotification(
           method: "item/completed",
           params: {
             "threadId": "t-completed",
+            "completedAtMs": 1779293201000,
             "item": {
               "type": "commandExecution",
               "id": "call-completed",
@@ -912,6 +1037,10 @@ void main() {
 
       final part = (events[1] as BridgeSseMessagePartUpdated).part;
       expect(part.state?.status, PluginToolStatus.completed);
+      expect(
+        shared.Message.fromJson((events[0] as BridgeSseMessageUpdated).info).time,
+        const shared.MessageTime(created: 1779293200000, completed: 1779293201000),
+      );
       rolloutLifecycle.clearRolloutTurn(threadId: "t-completed");
     });
 
@@ -1450,6 +1579,7 @@ void main() {
                 "message": "You've hit your usage limit.",
                 "codexErrorInfo": "usageLimitExceeded",
               },
+              "startedAt": 1700000005,
               "completedAt": 1700000010,
             },
           },
@@ -1463,6 +1593,7 @@ void main() {
       expect(message.sessionID, "t-quota");
       expect(message.errorName, "CodexError");
       expect(message.errorMessage, "You've hit your usage limit.");
+      expect(message.time, const shared.MessageTime(created: 1700000005000, completed: 1700000010000));
       expect(parseAsSesori(event), isA<shared.SesoriMessageUpdated>());
     });
 
@@ -1586,6 +1717,7 @@ class _ToolLifecycleHarness({
           )
         : _toolTracker.observeCorrelatableAppServerItem(
             event: correlatableItem,
+            notification: notification,
           );
     final threadId = correlatableItem?.threadId ?? notification.params["threadId"];
     if (tool == null || threadId is! String) {

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -1593,7 +1593,7 @@ void main() {
       expect(message.sessionID, "t-quota");
       expect(message.errorName, "CodexError");
       expect(message.errorMessage, "You've hit your usage limit.");
-      expect(message.time, const shared.MessageTime(created: 1700000005000, completed: 1700000010000));
+      expect(message.time, const shared.MessageTime(created: 1700000010000, completed: 1700000010000));
       expect(parseAsSesori(event), isA<shared.SesoriMessageUpdated>());
     });
 

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -1486,6 +1486,97 @@ void main() {
       await eventSubscription.cancel();
     });
 
+    test("already-idle reconciliation emits a drained rollout failure", () async {
+      const sessionId = "019a0000-1111-2222-3333-dddddddddddd";
+      final rollout = File(
+        p.join(
+          codexHome.path,
+          "sessions/2026/08/20/"
+          "rollout-2026-08-20T08-00-00-$sessionId.jsonl",
+        ),
+      )..createSync(recursive: true);
+      rollout.writeAsStringSync(
+        "${jsonEncode({
+          "timestamp": "2026-08-20T08:00:00Z",
+          "type": "session_meta",
+          "payload": {
+            "id": sessionId,
+            "timestamp": "2026-08-20T08:00:00Z",
+            "cwd": "/work/sample",
+            "model_provider": "openai",
+            "cli_version": "0.146.0",
+          },
+        })}\n",
+      );
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "thread": {"id": sessionId, "cwd": "/work/sample"},
+          },
+        ),
+        const _Response(
+          result: {
+            "turn": {"id": "u-failed"},
+          },
+        ),
+        const _Response(error: {"code": -32600, "message": "no active turn to interrupt"}),
+      ]);
+      await plugin.sendPrompt(
+        promptId: "prompt-1",
+        sessionId: sessionId,
+        parts: const [PluginPromptPart.text(text: "task")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      fake.pushNotification("turn/started", {
+        "threadId": sessionId,
+        "turn": {"id": "u-failed"},
+      });
+      await Future<void>.delayed(Duration.zero);
+      final emittedEvents = <BridgeSseEvent>[];
+      final eventSubscription = plugin.events.listen(emittedEvents.add);
+      final idle = plugin.events.firstWhere((event) => event is BridgeSseSessionIdle);
+      rollout.writeAsStringSync(
+        "${jsonEncode({
+          "timestamp": "2026-08-20T08:00:05Z",
+          "type": "event_msg",
+          "payload": {
+            "type": "task_complete",
+            "turn_id": "u-failed",
+            "error": {"message": "You've hit your usage limit."},
+          },
+        })}\n",
+        mode: FileMode.append,
+      );
+
+      await plugin.abortSession(sessionId: sessionId);
+      await idle;
+
+      final errorIndex = emittedEvents.indexWhere(
+        (event) =>
+            event is BridgeSseMessageUpdated &&
+            switch (shared.Message.fromJson(event.info)) {
+              shared.MessageError(errorMessage: "You've hit your usage limit.") => true,
+              _ => false,
+            },
+      );
+      final idleIndex = emittedEvents.indexWhere((event) => event is BridgeSseSessionIdle);
+      expect(errorIndex, greaterThanOrEqualTo(0));
+      expect(idleIndex, greaterThan(errorIndex));
+      final error = shared.Message.fromJson((emittedEvents[errorIndex] as BridgeSseMessageUpdated).info);
+      expect(error.id, "u-failed");
+      expect(
+        error.time,
+        shared.MessageTime(
+          created: DateTime.utc(2026, 8, 20, 8, 0, 5).millisecondsSinceEpoch,
+          completed: null,
+        ),
+      );
+      await eventSubscription.cancel();
+    });
+
     test("stale abort reconciliation preserves a newer external turn", () async {
       fake.respondInOrder([
         const _Response(result: _initOk),

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -1228,6 +1228,244 @@ void main() {
       expect(await interruption, {"t-overlap"});
     });
 
+    test("steered turn response cannot hide the active turn completion", () async {
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "thread": {"id": "t-steered", "cwd": "/work/sample"},
+          },
+        ),
+        const _Response(
+          result: {
+            "turn": {"id": "u-active"},
+          },
+        ),
+      ]);
+      await plugin.sendPrompt(
+        promptId: "prompt-1",
+        sessionId: "t-steered",
+        parts: const [PluginPromptPart.text(text: "first task")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      fake.pushNotification("turn/started", {
+        "threadId": "t-steered",
+        "turn": {"id": "u-active"},
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      fake.respondInOrder([
+        const _Response(
+          result: {
+            // Codex <=0.147 returned the submission id even though it steered
+            // this input into u-active.
+            "turn": {"id": "u-submission"},
+          },
+        ),
+      ]);
+      await plugin.sendPrompt(
+        promptId: "prompt-2",
+        sessionId: "t-steered",
+        parts: const [PluginPromptPart.text(text: "follow up")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+
+      final idle = plugin.workState.firstWhere((state) => state == PluginWorkState.idle);
+      fake.pushNotification("turn/completed", {
+        "threadId": "t-steered",
+        "turn": {"id": "u-active"},
+      });
+      await idle.timeout(const Duration(seconds: 1));
+
+      expect((await plugin.getSessionStatuses())["t-steered"], isA<PluginSessionStatusIdle>());
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+      await plugin.abortSession(sessionId: "t-steered");
+      expect(fake.sentMethods.where((method) => method == "turn/interrupt"), isEmpty);
+    });
+
+    test("authoritative turn start replaces a provisional submission id", () async {
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "thread": {"id": "t-provisional", "cwd": "/work/sample"},
+          },
+        ),
+        const _Response(
+          result: {
+            "turn": {"id": "u-submission"},
+          },
+        ),
+      ]);
+      await plugin.sendPrompt(
+        promptId: "prompt-1",
+        sessionId: "t-provisional",
+        parts: const [PluginPromptPart.text(text: "continue active work")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+
+      fake.pushNotification("turn/started", {
+        "threadId": "t-provisional",
+        "turn": {"id": "u-active"},
+      });
+      await Future<void>.delayed(Duration.zero);
+      final idle = plugin.workState.firstWhere((state) => state == PluginWorkState.idle);
+      fake.pushNotification("turn/completed", {
+        "threadId": "t-provisional",
+        "turn": {"id": "u-active"},
+      });
+      await idle.timeout(const Duration(seconds: 1));
+
+      expect((await plugin.getSessionStatuses())["t-provisional"], isA<PluginSessionStatusIdle>());
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+    });
+
+    test("abort reconciles an already-idle Codex turn", () async {
+      const sessionId = "019a0000-1111-2222-3333-cccccccccccc";
+      final rollout = File(
+        p.join(
+          codexHome.path,
+          "sessions/2026/07/23/"
+          "rollout-2026-07-23T08-00-00-$sessionId.jsonl",
+        ),
+      )..createSync(recursive: true);
+      rollout.writeAsStringSync(
+        "${jsonEncode({
+          "timestamp": "2026-07-23T08:00:00Z",
+          "type": "session_meta",
+          "payload": {
+            "id": sessionId,
+            "timestamp": "2026-07-23T08:00:00Z",
+            "cwd": "/work/sample",
+            "model_provider": "openai",
+            "cli_version": "0.146.0",
+          },
+        })}\n",
+      );
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "thread": {"id": sessionId, "cwd": "/work/sample"},
+          },
+        ),
+        const _Response(
+          result: {
+            "turn": {"id": "u-stale"},
+          },
+        ),
+        const _Response(error: {"code": -32600, "message": "no active turn to interrupt"}),
+      ]);
+      await plugin.sendPrompt(
+        promptId: "prompt-1",
+        sessionId: sessionId,
+        parts: const [PluginPromptPart.text(text: "task")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      fake.pushNotification("turn/started", {
+        "threadId": sessionId,
+        "turn": {"id": "u-stale"},
+      });
+      await Future<void>.delayed(Duration.zero);
+      final idleEvent = plugin.events
+          .where((event) => event is BridgeSseSessionIdle)
+          .cast<BridgeSseSessionIdle>()
+          .first;
+      final terminalTool = plugin.events
+          .where(
+            (event) =>
+                event is BridgeSseMessagePartUpdated &&
+                event.part.messageID == "call-abort" &&
+                event.part.state?.status == PluginToolStatus.error,
+          )
+          .cast<BridgeSseMessagePartUpdated>()
+          .first;
+      rollout.writeAsStringSync(
+        "${jsonEncode(_toolCall(
+          id: "fc-abort",
+          callId: "call-abort",
+          name: "exec_command",
+          arguments: '{"cmd":"sleep 30"}',
+          turnId: "u-stale",
+        ))}\n",
+        mode: FileMode.append,
+      );
+
+      await plugin.abortSession(sessionId: sessionId);
+
+      expect((await terminalTool.timeout(const Duration(seconds: 1))).part.state?.status, PluginToolStatus.error);
+      expect((await idleEvent).sessionID, sessionId);
+      expect((await plugin.getSessionStatuses())[sessionId], isA<PluginSessionStatusIdle>());
+      expect(plugin.currentWorkState, PluginWorkState.idle);
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+    });
+
+    test("stale abort reconciliation preserves a newer external turn", () async {
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "thread": {"id": "t-abort-race", "cwd": "/work/sample"},
+          },
+        ),
+        const _Response(
+          result: {
+            "turn": {"id": "u-old"},
+          },
+        ),
+        const _Response(error: {"code": -32600, "message": "no active turn to interrupt"}),
+      ]);
+      await plugin.sendPrompt(
+        promptId: "prompt-1",
+        sessionId: "t-abort-race",
+        parts: const [PluginPromptPart.text(text: "old work")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      fake.pushNotification("turn/started", {
+        "threadId": "t-abort-race",
+        "turn": {"id": "u-old"},
+      });
+      await Future<void>.delayed(Duration.zero);
+      final interruptRequested = Completer<void>();
+      fake.onRequest = (method) {
+        if (method == "turn/interrupt") interruptRequested.complete();
+      };
+      final emittedEvents = <BridgeSseEvent>[];
+      final eventSubscription = plugin.events.listen(emittedEvents.add);
+
+      final abort = plugin.abortSession(sessionId: "t-abort-race");
+      await interruptRequested.future;
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      fake.pushNotification("turn/started", {
+        "threadId": "t-abort-race",
+        "turn": {"id": "u-new"},
+      });
+      await abort;
+
+      expect((await plugin.getSessionStatuses())["t-abort-race"], isA<PluginSessionStatusBusy>());
+      expect(plugin.currentWorkState, PluginWorkState.busy);
+      expect(plugin.getActiveSessionsSummary().single.activeSessions.single.id, "t-abort-race");
+      expect(emittedEvents.whereType<BridgeSseSessionIdle>(), isEmpty);
+
+      final idle = plugin.workState.firstWhere((state) => state == PluginWorkState.idle);
+      fake.pushNotification("turn/completed", {
+        "threadId": "t-abort-race",
+        "turn": {"id": "u-new"},
+      });
+      await idle.timeout(const Duration(seconds: 1));
+      await eventSubscription.cancel();
+    });
+
     test("turn/start rejects a whitespace-only nested turn id", () async {
       fake.respondInOrder([
         const _Response(result: _initOk),

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -309,6 +309,45 @@ void main() {
       });
     });
 
+    test("native compaction clears pending turn evidence", () async {
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "thread": {"id": "t-compact", "cwd": "/work/sample"},
+          },
+        ),
+        const _Response(result: {}),
+      ]);
+
+      await plugin.sendCommand(
+        promptId: "prompt-1",
+        sessionId: "t-compact",
+        command: "compact",
+        arguments: "",
+        userVisibleArguments: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final idle = plugin.events.firstWhere(
+        (event) =>
+            event is BridgeSseSessionStatus &&
+            shared.SessionStatus.fromJson(event.status) is shared.SessionStatusIdle,
+      );
+      fake.pushNotification("thread/status/changed", {
+        "threadId": "t-compact",
+        "status": {"type": "active"},
+      });
+      fake.pushNotification("thread/status/changed", {
+        "threadId": "t-compact",
+        "status": {"type": "idle"},
+      });
+      await idle.timeout(const Duration(seconds: 1));
+
+      expect(plugin.currentWorkState, PluginWorkState.idle);
+    });
+
     test("a live event emitted during the first turn is scoped to the new session's directory", () async {
       fake.respondInOrder([
         const _Response(result: _initOk),

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -1326,6 +1326,80 @@ void main() {
       expect(plugin.getActiveSessionsSummary(), isEmpty);
     });
 
+    test("a fresh turn start replaces a stale active turn before its response", () async {
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "thread": {"id": "t-stale-active", "cwd": "/work/sample"},
+          },
+        ),
+        const _Response(
+          result: {
+            "turn": {"id": "u-stale"},
+          },
+        ),
+      ]);
+      await plugin.sendPrompt(
+        promptId: "prompt-1",
+        sessionId: "t-stale-active",
+        parts: const [PluginPromptPart.text(text: "first task")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      fake.pushNotification("turn/started", {
+        "threadId": "t-stale-active",
+        "turn": {"id": "u-stale"},
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      fake.holdNextResponse("turn/start");
+      final secondPrompt = plugin.sendPrompt(
+        promptId: "prompt-2",
+        sessionId: "t-stale-active",
+        parts: const [PluginPromptPart.text(text: "fresh task")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      for (
+        var attempt = 0;
+        attempt < 100 && fake.sentMethods.where((method) => method == "turn/start").length < 2;
+        attempt++
+      ) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      fake.pushNotification("thread/status/changed", {
+        "threadId": "t-stale-active",
+        "status": {"type": "active"},
+      });
+      fake.pushNotification("turn/started", {
+        "threadId": "t-stale-active",
+        "turn": {"id": "u-fresh"},
+      });
+      await Future<void>.delayed(Duration.zero);
+      fake.respondToHeld(
+        "turn/start",
+        const _Response(
+          result: {
+            "turn": {"id": "u-fresh"},
+          },
+        ),
+      );
+      await secondPrompt;
+
+      final idle = plugin.workState.firstWhere((state) => state == PluginWorkState.idle);
+      fake.pushNotification("turn/completed", {
+        "threadId": "t-stale-active",
+        "turn": {"id": "u-fresh"},
+      });
+      await idle.timeout(const Duration(seconds: 1));
+
+      expect((await plugin.getSessionStatuses())["t-stale-active"], isA<PluginSessionStatusIdle>());
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+    });
+
     test("abort reconciles an already-idle Codex turn", () async {
       const sessionId = "019a0000-1111-2222-3333-cccccccccccc";
       final rollout = File(
@@ -1388,6 +1462,8 @@ void main() {
           )
           .cast<BridgeSseMessagePartUpdated>()
           .first;
+      final emittedEvents = <BridgeSseEvent>[];
+      final eventSubscription = plugin.events.listen(emittedEvents.add);
       rollout.writeAsStringSync(
         "${jsonEncode(_toolCall(
           id: "fc-abort",
@@ -1406,6 +1482,8 @@ void main() {
       expect((await plugin.getSessionStatuses())[sessionId], isA<PluginSessionStatusIdle>());
       expect(plugin.currentWorkState, PluginWorkState.idle);
       expect(plugin.getActiveSessionsSummary(), isEmpty);
+      expect(emittedEvents.whereType<BridgeSseSessionUpdated>(), hasLength(1));
+      await eventSubscription.cancel();
     });
 
     test("stale abort reconciliation preserves a newer external turn", () async {

--- a/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
@@ -1293,6 +1293,10 @@ void main() {
     expect(aborted.status, PluginToolStatus.error);
     expect(lateCompletion?.canonicalId, "call-exec");
     expect(lateCompletion?.status, PluginToolStatus.error);
+    expect(
+      lateCompletion?.time,
+      const PluginMessageTime(created: 1779293200000, completed: 1779293201000),
+    );
     expect(lateCompletion?.output, contains("late command output"));
     expect(
       RegExp("early output").allMatches(lateCompletion?.output ?? ""),
@@ -2001,6 +2005,8 @@ CodexServerNotification _commandNotification({
     params: {
       "threadId": "thread-1",
       "turnId": ?turnId,
+      if (method == "item/started") "startedAtMs": 1779293200000,
+      if (method == "item/completed") "completedAtMs": 1779293201000,
       "item": {
         "type": "commandExecution",
         "id": itemId,
@@ -2055,7 +2061,10 @@ extension on CodexToolLifecycleTracker {
             notification: notification,
             imageGeneration: imageGeneration,
           )
-        : observeCorrelatableAppServerItem(event: correlatableItem);
+        : observeCorrelatableAppServerItem(
+            event: correlatableItem,
+            notification: notification,
+          );
   }
 }
 

--- a/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
@@ -525,8 +525,7 @@ void main() {
         "type": "custom_tool_call",
         "call_id": "call-directed-image-wrapper-with-trailing-code",
         "name": "exec",
-        "input":
-            "// @exec: {\"yield-time_ms\": 120000}\nawait tools.image_gen__imagegen({prompt: 'private'}); console.log('keep visible');",
+        "input": "// @exec: {\"yield-time_ms\": 120000}\nawait tools.image_gen__imagegen({prompt: 'private'}); console.log('keep visible');",
       },
     });
     final directedWrapperWithCallLikePrompt = CodexRolloutLineDto.fromJson({
@@ -717,6 +716,39 @@ void main() {
     );
     final attachment = durable.single.attachments.single as PluginMessageAttachmentInlineImage;
     expect(attachment.filename, "final.png");
+  });
+
+  test("terminal notification errors a running app-server image", () {
+    final target = tracker();
+    target.observeAppServerTool(
+      notification: const CodexServerNotification(
+        method: "item/started",
+        params: {
+          "threadId": "thread-1",
+          "startedAtMs": 1779293200000,
+          "item": {
+            "type": "imageGeneration",
+            "id": "image-running",
+          },
+        },
+      ),
+      imageGeneration: const CodexImageGenerationItemDto(
+        id: "image-running",
+        status: CodexImageGenerationStatus.inProgress,
+        revisedPrompt: null,
+        result: "",
+        savedPath: null,
+      ),
+    );
+
+    final terminal = target
+        .observeTerminalNotification(
+          notification: _terminalNotification(method: "error"),
+        )
+        .single;
+
+    expect(terminal.canonicalId, "image-running");
+    expect(terminal.status, PluginToolStatus.error);
   });
 
   test("suppresses wait calls and projects their result onto the shell call", () {

--- a/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_tool_lifecycle_tracker_test.dart
@@ -725,6 +725,7 @@ void main() {
         method: "item/started",
         params: {
           "threadId": "thread-1",
+          "turnId": "turn-1",
           "startedAtMs": 1779293200000,
           "item": {
             "type": "imageGeneration",
@@ -749,6 +750,75 @@ void main() {
 
     expect(terminal.canonicalId, "image-running");
     expect(terminal.status, PluginToolStatus.error);
+  });
+
+  test("a fresh task start errors only running images from the prior turn", () {
+    final target = tracker();
+    target.observeRolloutLine(
+      threadId: "thread-1",
+      line: _taskEvent(type: "task_started", turnId: "turn-old"),
+    );
+    target.observeAppServerTool(
+      notification: const CodexServerNotification(
+        method: "item/started",
+        params: {
+          "threadId": "thread-1",
+          "turnId": "turn-old",
+          "item": {
+            "type": "imageGeneration",
+            "id": "image-old",
+          },
+        },
+      ),
+      imageGeneration: const CodexImageGenerationItemDto(
+        id: "image-old",
+        status: CodexImageGenerationStatus.inProgress,
+        revisedPrompt: null,
+        result: "",
+        savedPath: null,
+      ),
+    );
+    target.observeAppServerTool(
+      notification: const CodexServerNotification(
+        method: "item/started",
+        params: {
+          "threadId": "thread-1",
+          "turnId": "turn-new",
+          "item": {
+            "type": "imageGeneration",
+            "id": "image-new",
+          },
+        },
+      ),
+      imageGeneration: const CodexImageGenerationItemDto(
+        id: "image-new",
+        status: CodexImageGenerationStatus.inProgress,
+        revisedPrompt: null,
+        result: "",
+        savedPath: null,
+      ),
+    );
+
+    final retired = target
+        .observeRolloutLine(
+          threadId: "thread-1",
+          line: _taskEvent(type: "task_started", turnId: "turn-new"),
+        )
+        .single;
+    final freshTerminal = target.observeTerminalNotification(
+      notification: const CodexServerNotification(
+        method: "turn/completed",
+        params: {
+          "threadId": "thread-1",
+          "turn": {"id": "turn-new", "status": "completed"},
+        },
+      ),
+    );
+
+    expect(retired.canonicalId, "image-old");
+    expect(retired.status, PluginToolStatus.error);
+    expect(freshTerminal.single.canonicalId, "image-new");
+    expect(freshTerminal.single.status, PluginToolStatus.completed);
   });
 
   test("suppresses wait calls and projects their result onto the shell call", () {

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -30,7 +30,9 @@ defaults and queued client sends coherent.
   transition back to idle; retry carries attempt, message, and timing, and
   finalized messages enter durable history matching a history read. A terminal
   provider failure appears as an inline error message and remains visible after
-  refresh or reopen. Internal backend command records are not rendered as
+  refresh or reopen. Backend-provided message timestamps remain present through
+  live updates and durable-history reloads, using the backend's authoritative
+  source for each path. Internal backend command records are not rendered as
   conversation messages or used as assistant model attribution.
 - Claude user prompts appear in the live transcript from the CLI's replayed
   stdin echo under their transcript uuid, so a follow-up prompt stays visible
@@ -147,7 +149,8 @@ has started.
 - Streaming stalls, duplicates or loses parts, shows an empty user bubble, or
   orders a late envelope at the wrong transcript position; the session never
   returns to idle. A terminal provider failure returns to idle without showing
-  its error, or the error disappears after refresh or reopen.
+  its error, the error disappears after refresh or reopen, or a live update
+  removes a backend-provided message timestamp.
 - Internal backend command records or synthetic model attribution appear in
   the conversation or replayed history.
 - Prompt defaults regress, an approved plan exit does not restore Default


### PR DESCRIPTION
## Complexity
Moderate. This changes Codex turn lifecycle ordering and timestamp propagation across live and rollout-backed messages.

## What
- Preserve authoritative app-server turn IDs when Codex 0.147 and earlier return a steering submission ID.
- Reconcile already-idle interrupt responses into terminal tool and idle events without overwriting a newer turn.
- Carry app-server and rollout timestamps through live message and tool upserts, including late completions.
- Document the timestamp and terminal-lifecycle regression coverage.

## Why
Codex steering could leave a Sesori session permanently busy because the returned submission ID replaced the real active turn ID, causing the real terminal notification to look stale. Codex can also report `no active turn to interrupt` after completing without delivering the expected terminal lifecycle. Separately, live updates were overwriting backend-provided message timestamps with null values.

The steering response behavior is tracked upstream in https://github.com/openai/codex/issues/36866.

## Risk and test focus
Focus review on notification ordering during abort and steering, late tool completions, and seconds-to-milliseconds conversion.

User-visible impact: affected Codex sessions return to idle and live messages retain their timestamps. There is no database impact and no wire-contract shape change; existing optional timestamp fields are now populated.

## Expected result
Codex sessions converge to the backend's authoritative lifecycle even around steered prompts and already-completed aborts, while message timestamps remain stable between live updates and durable-history reloads.

## Verification
- `dart test` in `bridge/sesori_plugin_codex` (372 tests)
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_codex`
- `git diff --check`
- Focused independent review of the final concurrency and timestamp changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles stale Codex turns and preserves backend timestamps and rollout evidence so sessions reliably return to idle and live history matches durable history. Previously steering or start/finish races could swap active turn IDs, aborts could report “no active turn to interrupt” without a terminal, and rollout failures or timestamps could be lost; now the plugin keeps the authoritative turn, drains rollout on already-idle aborts, and carries timestamps end to end without changing the API or schema.

- Keep the authoritative turn: ignore provisional submission IDs (Codex ≤0.147); track pending turn requests so the next authoritative `turn/started` replaces stale state; suppress conflicting `turn/started` while a request is pending; clear pending-evidence on native compaction, thread creation/deletion, teardown, and idle status.
- Reconcile already-idle aborts: when interrupt returns “no active turn,” drain rollout and synthesize a terminal tool/error and idle only if no newer turn exists; emit rollout `task_complete` errors as terminal error messages with rollout timestamps.
- Preserve timestamps: record `startedAtMs`/`completedAtMs` from live updates and rollout ISO times; attach to messages and tools (including late completions); convert turn seconds→milliseconds; cache per-thread item times; clear on `thread/closed`, item completion, and plugin teardown.
- Tool lifecycle: retire or error running tools from the prior turn when a new task starts; propagate app-server times to tool updates; include `time` in projected tools and message envelopes. Tests and docs cover abort/steering ordering, compaction, timestamp retention, and rollout error emission.

<sup>Written for commit 462c8205dbe686ab474930d95dc27baf5f26c13a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

