### PR TITLE
⚙️ Update plugin harness targets

### DIFF
--- a/.opencode/skills/update-backend-runtimes/SKILL.md
+++ b/.opencode/skills/update-backend-runtimes/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: update-backend-runtimes
-description: Update the targeted OpenCode, Codex, Cursor, Pi, and OMP CLI runtime versions used by the Sesori bridge. Use when asked to update, bump, or refresh the coding backend runtimes, their minimum versions, or their release checksums.
+description: Update the targeted OpenCode, Codex, Cursor, Claude Code, Hermes Agent, Pi, and OMP CLI versions used by the Sesori bridge. Use when asked to update, bump, or refresh coding harness targets, minimum versions, managed runtimes, or release checksums.
 ---
 
-# Update Backend Runtimes
+# Update Plugin Harness Targets
 
-Update the bridge's OpenCode, Codex, Cursor, Pi, and OMP CLI targets to the latest stable releases. This is separate from the general Dart/Flutter dependency update workflow.
+Update every registered bridge harness target to its latest stable release. This
+includes managed-runtime pins and direct-CLI compatibility floors and is
+separate from the general Dart/Flutter dependency update workflow.
 
 ## Scope
 
@@ -19,12 +21,20 @@ Update the bridge's OpenCode, Codex, Cursor, Pi, and OMP CLI targets to the late
   `bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart`
 - Codex manifest tests:
   `bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart`
+- Claude Code direct-CLI minimum:
+  `bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart`
+- Claude Code descriptor tests:
+  `bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart`
 - Cursor managed runtime, PATH minimum, and per-platform checksums:
   `bridge/sesori_plugin_cursor/lib/src/runtime/cursor_runtime_manifest.dart`
 - Cursor manifest tests:
   `bridge/sesori_plugin_cursor/test/runtime/cursor_runtime_manifest_test.dart`
 - Cursor availability tests:
   `bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart`
+- Hermes Agent direct-CLI minimum:
+  `bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart`
+- Hermes Agent descriptor tests:
+  `bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart`
 - Pi managed runtime, PATH minimum, package archives, and per-platform checksums:
   `bridge/sesori_plugin_pi/lib/src/runtime/pi_runtime_manifest.dart`
 - Pi runtime and lifecycle tests:
@@ -35,22 +45,43 @@ Update the bridge's OpenCode, Codex, Cursor, Pi, and OMP CLI targets to the late
 - OMP runtime and lifecycle tests:
   `bridge/sesori_plugin_omp/test/omp_runtime_manifest_test.dart`
   `bridge/sesori_plugin_omp/test/omp_plugin_descriptor_test.dart`
+- Registered harness source of truth:
+  `bridge/app/lib/src/bridge/runtime/plugin_registry.dart`
+- Setup and lifecycle regression contract when a compatibility floor changes:
+  `docs/regression/plugin-setup-and-lifecycle.md`
 
 Read `bridge/AGENTS.md` before editing. Never hand-edit generated files.
+
+Before release discovery, inspect `knownPlugins` in `plugin_registry.dart` and
+confirm every concrete descriptor has a section in this skill. The current
+closed set is OpenCode, Codex, Cursor, Claude Code, Hermes Agent, Pi, and Oh My
+Pi. Shared interface, runtime, and ACP packages are not harnesses. If the
+registry has gained another harness, extend this skill for it as part of the
+same change instead of silently skipping it.
 
 ## Version Policy
 
 - Update OpenCode's `bundledVersion` to the latest stable `anomalyco/opencode` GitHub release.
 - Update Codex's `bundledVersion` to the latest stable `openai/codex` GitHub release.
+- Update Claude Code's direct-CLI `minVersion` to the latest stable
+  `anthropics/claude-code` release after the candidate stream-json surface
+  probe passes. Claude has no Sesori-managed runtime, so this floor is its
+  target version.
 - Update Cursor's bundled runtime to the current build advertised by the official installer at `https://cursor.com/install`.
+- Update Hermes Agent's direct-CLI minimum to the semantic package version in
+  the latest stable `NousResearch/hermes-agent` release after its ACP v1 probe
+  passes. Hermes has no Sesori-managed runtime, and its calendar release tag is
+  not the CLI version.
 - Update Pi's bundled runtime to the latest stable `earendil-works/pi` GitHub release only after its JSONL RPC probe passes.
 - Update OMP's bundled runtime to the latest stable `can1357/oh-my-pi` GitHub release only after its ACP v1 probe passes.
 - Do not raise OpenCode's `minPathVersion` unless the user gives a specific minimum or bridge code requires a newer API. If it changes, keep `opencode_v1_surface.json` metadata aligned.
 - Do not raise Codex's `minPathVersion` unless bridge code requires a newer app-server capability or the user explicitly requests it.
 - Do not raise Cursor's `minPathVersion` unless bridge behavior requires a newer capability or the user explicitly requests it.
 - Do not raise Pi's `minPathVersion` unless bridge behavior requires a newer JSONL RPC capability or the user explicitly requests it.
-- Do not raise OMP's `minPathVersion` unless bridge behavior requires a newer ACP capability or the user explicitly requests it.
-- Ignore prereleases. Confirm GitHub's `latest` release and the corresponding npm package version agree for OpenCode and Codex when npm is available.
+- OMP intentionally uses one verified version for both PATH compatibility and
+  the managed pin. Updating OMP therefore raises both; do not split them merely
+  to preserve the older floor.
+- Ignore prereleases. Confirm GitHub's `latest` release and the corresponding npm package version agree for OpenCode, Codex, and Claude Code when npm is available.
 
 ## Discover Releases
 
@@ -92,6 +123,28 @@ Codex release tags use `rust-vX.Y.Z`; store only `X.Y.Z` in the manifest. Requir
 
 Confirm asset filenames have not changed before editing. Do not guess mappings for renamed or missing assets.
 
+### Claude Code
+
+```bash
+gh api repos/anthropics/claude-code/releases/latest --jq '{tag: .tag_name, prerelease: .prerelease, publishedAt: .published_at}'
+npm view @anthropic-ai/claude-code version
+npm view @anthropic-ai/claude-agent-sdk version
+```
+
+Require the stable GitHub `vX.Y.Z` tag and `@anthropic-ai/claude-code` npm
+version to agree. Confirm the current Agent SDK release associated with that CLI;
+its patch currently tracks the CLI patch under the `0.3.x` line, but inspect the
+published versions rather than assuming that scheme will never change.
+
+Use the official current-host CLI package in an isolated temporary directory to
+verify `claude --version`. Check `claude --help` for every public flag in
+`ClaudeLaunchSpec`, and inspect the matching Agent SDK launch code for the
+headless stream-json and stdio permission flags. Stop if a flag the production
+launch requires disappeared or changed semantics. A version/help/source smoke
+does not re-verify wire observations, so preserve historical protocol documents
+and `Verified against` comments unless a live protocol trace was actually
+repeated.
+
 ### Cursor
 
 Fetch the official installer without executing it:
@@ -114,7 +167,8 @@ Cursor publishes no digest manifest, so the manifest's SHA-256 values are comput
 BUILD=2026.08.11-e8db854   # the installer's build identifier
 D=$(mktemp -d)
 for t in darwin/arm64 darwin/x64 linux/arm64 linux/x64; do
-  curl -fsSL -o "$D/$(echo $t | tr / -).tar.gz" \
+  name=${t//\//-}
+  curl -fsSL -o "$D/$name.tar.gz" \
     "https://downloads.cursor.com/lab/$BUILD/$t/agent-cli-package.tar.gz"
 done
 shasum -a 256 "$D"/*.tar.gz
@@ -125,6 +179,27 @@ Write `_bundledVersion` as the exact published build string (for example `2026.0
 Cursor ships a `dist-package/` directory whose `cursor-agent` entry binary loads sibling files, so its assets use `RuntimeAssetLayout.packageDirectory`. If a future build ships a single self-contained binary instead, switch the layout rather than flattening the tree.
 
 Because the digests are self-computed, a silently re-published asset fails checksum verification at install time with a clear message. That is intended: re-pin rather than relaxing verification.
+
+### Hermes Agent
+
+```bash
+gh api repos/NousResearch/hermes-agent/releases/latest --jq '{tag: .tag_name, name: .name, prerelease: .prerelease, publishedAt: .published_at}'
+```
+
+Hermes uses calendar Git tags such as `v2026.8.18` while
+`hermes acp --version` reports a semantic package version such as `0.20.4`. Read the
+semantic version from the release name and the tagged `pyproject.toml`, and
+require them to agree. PyPI is not the release source: Hermes is distributed by
+its shell installer, Docker, and Nix, and its PyPI project may lag.
+
+Do not execute the remote installer merely to discover a version. Check out the
+exact release tag in an isolated temporary directory, install the tagged source
+with its `acp` extra in an isolated environment, and verify
+`hermes acp --version`, ACP v1 `initialize`, advertised list/load capabilities, and
+`session/list`. Use an isolated `HOME` so the probe cannot read or mutate the
+user's Hermes profile. A fresh profile has no model/provider, so `session/new`
+may remain setup-blocked; when a safe configured fixture is available, also
+probe `session/new` and `session/load`. Stop on protocol regression.
 
 ### Pi
 
@@ -144,7 +219,7 @@ gh api repos/can1357/oh-my-pi/releases/latest --jq '{tag: .tag_name, prerelease:
 
 Require exactly seven bare executable assets plus `SHA256SUMS.txt`: macOS arm64/x64, Linux glibc arm64/x64, Linux musl arm64/x64, and Windows x64. OMP publishes no Windows arm64 executable. Confirm each executable digest against both GitHub's `sha256:` digest and `SHA256SUMS.txt`; never model these raw files as archives.
 
-Before changing the pin, run the official candidate in an isolated temporary cwd/profile and verify `omp/<version>`, ACP v1 `initialize`, `authenticate(agent)`, `session/list`, `session/new`, `session/load`, and persisted cleanup. Preserve normal OMP environment/profile and approval policy. Stop if any protocol check regresses.
+Before changing the pin, run the official candidate in an isolated temporary cwd/profile and verify `omp/<version>`, ACP v1 `initialize`, `authenticate(agent)`, `session/list`, `session/new`, `session/load`, and persisted cleanup. Point `PI_CODING_AGENT_DIR` at the temporary profile, inherit the remaining environment, and do not alter the user's normal profile or approval policy. Stop if any protocol check regresses.
 
 ## Edit
 
@@ -152,12 +227,14 @@ Before changing the pin, run the official candidate in an isolated temporary cwd
 2. Apply an explicitly requested OpenCode minimum and synchronize the API surface metadata comment; otherwise preserve the existing minimum.
 3. Update Codex's bundled version, release-version documentation, and all six matching SHA-256 values.
 4. Preserve the Codex minimum unless a concrete requirement says otherwise.
-5. Update `CursorRuntimeManifest`'s `_bundledVersion` to the official current build and refresh all four computed SHA-256 values. Preserve its minimum unless a concrete requirement says otherwise.
-6. Update `PiRuntimeManifest` only after the isolated JSONL RPC probe passes; refresh all six SHA-256 values and preserve complete package-directory placement.
-7. Update `OmpRuntimeManifest` only after the isolated ACP probe passes; refresh all seven SHA-256 values and preserve glibc/musl and unsupported Windows arm64 mapping.
-8. Update hard-coded version URLs, version assertions, and recent-version fixtures in all manifest/availability tests.
-9. Search the affected plugin packages for the replaced target versions. Update only references that describe the current pin; preserve historical comments and protocol-shape observations tied to older versions.
-10. Run `dart format` on changed Dart files.
+5. Update Claude Code's direct-CLI minimum and descriptor test fixtures after the candidate probe passes.
+6. Update `CursorRuntimeManifest`'s `_bundledVersion` to the official current build and refresh all four computed SHA-256 values. Preserve its minimum unless a concrete requirement says otherwise.
+7. Update Hermes Agent's direct-CLI minimum and descriptor test fixtures after the tagged-source ACP probe passes.
+8. Update `PiRuntimeManifest` only after the isolated JSONL RPC probe passes; refresh all six SHA-256 values and preserve complete package-directory placement.
+9. Update `OmpRuntimeManifest` only after the isolated ACP probe passes; refresh all seven SHA-256 values and preserve glibc/musl and unsupported Windows arm64 mapping.
+10. Update hard-coded version URLs, version assertions, and recent-version fixtures in all manifest/availability tests.
+11. Search the affected plugin packages for the replaced target versions. Update only references that describe the current pin or floor; preserve historical comments and protocol-shape observations tied to older versions.
+12. Update the setup/lifecycle regression document when a user-visible compatibility floor changes, then run `dart format` on changed Dart files.
 
 Use `apply_patch` for manual edits.
 
@@ -168,7 +245,9 @@ Run the plugin suites independently; they may run in parallel:
 ```bash
 (cd bridge/sesori_plugin_opencode && dart test && dart analyze --fatal-infos)
 (cd bridge/sesori_plugin_codex && dart test && dart analyze --fatal-infos)
+(cd bridge/sesori_plugin_claude && dart test && dart analyze --fatal-infos)
 (cd bridge/sesori_plugin_cursor && dart test && dart analyze --fatal-infos)
+(cd bridge/sesori_plugin_hermes && dart test && dart analyze --fatal-infos)
 (cd bridge/sesori_plugin_pi && dart test && dart analyze --fatal-infos)
 (cd bridge/sesori_plugin_omp && dart test && dart analyze --fatal-infos)
 (cd bridge/sesori_plugin_runtime && dart test && dart analyze --fatal-infos)
@@ -180,19 +259,21 @@ wrong build string 404s only at install time on a user's machine):
 
 ```bash
 BUILD=2026.08.11-e8db854
-curl -fsSI "https://downloads.cursor.com/lab/$BUILD/darwin/arm64/agent-cli-package.tar.gz" | head -1
+curl -fsSI --output /dev/null "https://downloads.cursor.com/lab/$BUILD/darwin/arm64/agent-cli-package.tar.gz"
 ```
 
 If tests fail only because old versions are hard-coded in manifest assertions or availability fixtures, update those assertions to the new targets and rerun. Investigate all other failures normally.
 
 Before finishing, report:
 
-- old and new bundled/minimum versions for each backend
+- old and new bundled/minimum versions for every registered harness
 - whether OpenCode or Codex compatibility floors changed and why
 - whether all twelve GitHub asset digests were refreshed
+- Claude Code's stable GitHub/npm version, matching Agent SDK version, direct-CLI floor, and stream-json surface probe result
 - Cursor's installer-advertised build, and whether its four managed-runtime digests were recomputed
+- Hermes Agent's calendar release tag, semantic CLI version/direct-CLI floor, and isolated ACP probe result
 - Pi's release, six verified package-archive digests, and JSONL RPC probe result
 - OMP's release, seven verified bare-executable digests, and ACP probe result
 - test and analyzer results
 
-Do not commit, push, or create a PR unless the user asks.
+Follow the repository's normal commit, push, and PR policy.

--- a/.opencode/skills/update-backend-runtimes/SKILL.md
+++ b/.opencode/skills/update-backend-runtimes/SKILL.md
@@ -1,46 +1,47 @@
 ---
 name: update-backend-runtimes
-description: Update the targeted OpenCode, Codex, Cursor, Claude Code, Hermes Agent, Pi, and OMP CLI versions used by the Sesori bridge. Use when asked to update, bump, or refresh coding harness targets, minimum versions, managed runtimes, or release checksums.
+description: Update the target OpenCode, Codex, Cursor, Claude Code, Hermes Agent, Pi, and OMP CLI versions used by the Sesori bridge. Use when asked to update, bump, or refresh coding harness targets, managed runtimes, or release checksums while preserving compatibility minimums.
 ---
 
 # Update Plugin Harness Targets
 
 Update every registered bridge harness target to its latest stable release. This
-includes managed-runtime pins and direct-CLI compatibility floors and is
-separate from the general Dart/Flutter dependency update workflow.
+includes managed-runtime pins and direct-CLI validation metadata, never an
+implicit compatibility-floor increase, and is separate from the general
+Dart/Flutter dependency update workflow.
 
 ## Scope
 
-- OpenCode managed runtime and PATH minimum:
+- OpenCode managed target and PATH minimum:
   `bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_manifest.dart`
 - OpenCode API surface metadata:
   `bridge/sesori_plugin_opencode/tool/opencode_v1_surface.json`
 - OpenCode manifest tests:
   `bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_manifest_test.dart`
-- Codex managed runtime and PATH minimum:
+- Codex managed target and PATH minimum:
   `bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart`
 - Codex manifest tests:
   `bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart`
-- Claude Code direct-CLI minimum:
+- Claude Code direct-CLI target and minimum:
   `bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart`
 - Claude Code descriptor tests:
   `bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart`
-- Cursor managed runtime, PATH minimum, and per-platform checksums:
+- Cursor managed target, PATH minimum, and per-platform checksums:
   `bridge/sesori_plugin_cursor/lib/src/runtime/cursor_runtime_manifest.dart`
 - Cursor manifest tests:
   `bridge/sesori_plugin_cursor/test/runtime/cursor_runtime_manifest_test.dart`
 - Cursor availability tests:
   `bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart`
-- Hermes Agent direct-CLI minimum:
+- Hermes Agent direct-CLI target and minimum:
   `bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart`
 - Hermes Agent descriptor tests:
   `bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart`
-- Pi managed runtime, PATH minimum, package archives, and per-platform checksums:
+- Pi managed target, PATH minimum, package archives, and per-platform checksums:
   `bridge/sesori_plugin_pi/lib/src/runtime/pi_runtime_manifest.dart`
 - Pi runtime and lifecycle tests:
   `bridge/sesori_plugin_pi/test/pi_runtime_manifest_test.dart`
   `bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart`
-- OMP managed runtime, PATH minimum, direct assets, and per-platform checksums:
+- OMP managed target, PATH minimum, direct assets, and per-platform checksums:
   `bridge/sesori_plugin_omp/lib/src/runtime/omp_runtime_manifest.dart`
 - OMP runtime and lifecycle tests:
   `bridge/sesori_plugin_omp/test/omp_runtime_manifest_test.dart`
@@ -59,28 +60,41 @@ Pi. Shared interface, runtime, and ACP packages are not harnesses. If the
 registry has gained another harness, extend this skill for it as part of the
 same change instead of silently skipping it.
 
+Every harness must expose an independent compatibility minimum and target:
+
+| Harness | Compatibility minimum | Latest target |
+| --- | --- | --- |
+| OpenCode | `OpenCodeRuntimeManifest.minPathVersion` | `OpenCodeRuntimeManifest.targetVersion` |
+| Codex | `CodexRuntimeManifest.minPathVersion` | `CodexRuntimeManifest.targetVersion` |
+| Claude Code | `ClaudePluginDescriptor.minVersion` | `ClaudePluginDescriptor.targetVersion` |
+| Cursor | `CursorRuntimeManifest.minPathVersion` | `CursorRuntimeManifest.targetVersion` |
+| Hermes Agent | `HermesPluginDescriptor.minVersion` | `HermesPluginDescriptor.targetVersion` |
+| Pi | `PiRuntimeManifest.minPathVersion` | `PiRuntimeManifest.targetVersion` |
+| Oh My Pi | `OmpRuntimeManifest.minPathVersion` | `OmpRuntimeManifest.targetVersion` |
+
+For managed runtimes, `bundledVersion` is the parsed exact target used for
+download and installation. Direct-CLI targets record the latest release whose
+surface was validated; they do not gate otherwise-compatible local installs.
+
 ## Version Policy
 
-- Update OpenCode's `bundledVersion` to the latest stable `anomalyco/opencode` GitHub release.
-- Update Codex's `bundledVersion` to the latest stable `openai/codex` GitHub release.
-- Update Claude Code's direct-CLI `minVersion` to the latest stable
+- A target refresh preserves every compatibility minimum byte-for-byte. Never
+  derive a minimum from the latest target or raise one merely because a newer
+  release exists.
+- Update OpenCode's `targetVersion` to the latest stable `anomalyco/opencode` GitHub release.
+- Update Codex's `targetVersion` to the latest stable `openai/codex` GitHub release.
+- Update Claude Code's direct-CLI `targetVersion` to the latest stable
   `anthropics/claude-code` release after the candidate stream-json surface
-  probe passes. Claude has no Sesori-managed runtime, so this floor is its
-  target version.
-- Update Cursor's bundled runtime to the current build advertised by the official installer at `https://cursor.com/install`.
-- Update Hermes Agent's direct-CLI minimum to the semantic package version in
-  the latest stable `NousResearch/hermes-agent` release after its ACP v1 probe
-  passes. Hermes has no Sesori-managed runtime, and its calendar release tag is
-  not the CLI version.
-- Update Pi's bundled runtime to the latest stable `earendil-works/pi` GitHub release only after its JSONL RPC probe passes.
-- Update OMP's bundled runtime to the latest stable `can1357/oh-my-pi` GitHub release only after its ACP v1 probe passes.
-- Do not raise OpenCode's `minPathVersion` unless the user gives a specific minimum or bridge code requires a newer API. If it changes, keep `opencode_v1_surface.json` metadata aligned.
-- Do not raise Codex's `minPathVersion` unless bridge code requires a newer app-server capability or the user explicitly requests it.
-- Do not raise Cursor's `minPathVersion` unless bridge behavior requires a newer capability or the user explicitly requests it.
-- Do not raise Pi's `minPathVersion` unless bridge behavior requires a newer JSONL RPC capability or the user explicitly requests it.
-- OMP intentionally uses one verified version for both PATH compatibility and
-  the managed pin. Updating OMP therefore raises both; do not split them merely
-  to preserve the older floor.
+  probe passes.
+- Update Cursor's `targetVersion` to the current build advertised by the official installer at `https://cursor.com/install`.
+- Update Hermes Agent's direct-CLI `targetVersion` to the semantic package
+  version in the latest stable `NousResearch/hermes-agent` release after its
+  ACP v1 probe passes. Its calendar release tag is not the CLI version.
+- Update Pi's `targetVersion` to the latest stable `earendil-works/pi` GitHub release only after its JSONL RPC probe passes.
+- Update OMP's `targetVersion` to the latest stable `can1357/oh-my-pi` GitHub release only after its ACP v1 probe passes.
+- Change a compatibility minimum only for a separate, explicit requirement
+  backed by a concrete newer capability. If OpenCode's minimum changes under
+  such a requirement, keep `opencode_v1_surface.json` metadata aligned.
 - Ignore prereleases. Confirm GitHub's `latest` release and the corresponding npm package version agree for OpenCode, Codex, and Claude Code when npm is available.
 
 ## Discover Releases
@@ -174,7 +188,7 @@ done
 shasum -a 256 "$D"/*.tar.gz
 ```
 
-Write `_bundledVersion` as the exact published build string (for example `2026.08.11-e8db854`). Preserve its `CalendarRuntimeVersion.raw` value in the download URL and version directory. There is no Windows package — leave `PlatformOs.windows` absent so the install capability stays off there.
+Write `targetVersion` as the exact published build string (for example `2026.08.11-e8db854`) and derive `_bundledVersion` from it. Preserve its `CalendarRuntimeVersion.raw` value in the download URL and version directory. There is no Windows package — leave `PlatformOs.windows` absent so the install capability stays off there.
 
 Cursor ships a `dist-package/` directory whose `cursor-agent` entry binary loads sibling files, so its assets use `RuntimeAssetLayout.packageDirectory`. If a future build ships a single self-contained binary instead, switch the layout rather than flattening the tree.
 
@@ -223,18 +237,17 @@ Before changing the pin, run the official candidate in an isolated temporary cwd
 
 ## Edit
 
-1. Update OpenCode's bundled version and all six matching SHA-256 values.
-2. Apply an explicitly requested OpenCode minimum and synchronize the API surface metadata comment; otherwise preserve the existing minimum.
-3. Update Codex's bundled version, release-version documentation, and all six matching SHA-256 values.
-4. Preserve the Codex minimum unless a concrete requirement says otherwise.
-5. Update Claude Code's direct-CLI minimum and descriptor test fixtures after the candidate probe passes.
-6. Update `CursorRuntimeManifest`'s `_bundledVersion` to the official current build and refresh all four computed SHA-256 values. Preserve its minimum unless a concrete requirement says otherwise.
-7. Update Hermes Agent's direct-CLI minimum and descriptor test fixtures after the tagged-source ACP probe passes.
-8. Update `PiRuntimeManifest` only after the isolated JSONL RPC probe passes; refresh all six SHA-256 values and preserve complete package-directory placement.
-9. Update `OmpRuntimeManifest` only after the isolated ACP probe passes; refresh all seven SHA-256 values and preserve glibc/musl and unsupported Windows arm64 mapping.
-10. Update hard-coded version URLs, version assertions, and recent-version fixtures in all manifest/availability tests.
-11. Search the affected plugin packages for the replaced target versions. Update only references that describe the current pin or floor; preserve historical comments and protocol-shape observations tied to older versions.
-12. Update the setup/lifecycle regression document when a user-visible compatibility floor changes, then run `dart format` on changed Dart files.
+1. Update OpenCode's target version and all six matching SHA-256 values.
+2. Update Codex's target version, release-version documentation, and all six matching SHA-256 values.
+3. Update Claude Code's direct-CLI target and descriptor test fixtures after the candidate probe passes.
+4. Update `CursorRuntimeManifest.targetVersion` to the official current build and refresh all four computed SHA-256 values.
+5. Update Hermes Agent's direct-CLI target and descriptor test fixtures after the tagged-source ACP probe passes.
+6. Update `PiRuntimeManifest.targetVersion` only after the isolated JSONL RPC probe passes; refresh all six SHA-256 values and preserve complete package-directory placement.
+7. Update `OmpRuntimeManifest.targetVersion` only after the isolated ACP probe passes; refresh all seven SHA-256 values and preserve glibc/musl and unsupported Windows arm64 mapping.
+8. Verify every minimum is unchanged from the base branch. A target-only update must not modify a minimum-version line or an outdated-version test boundary.
+9. Update hard-coded version URLs, version assertions, and recent-target fixtures in all manifest/availability tests.
+10. Search the affected plugin packages for the replaced target versions. Update only references that describe the current target; preserve minimum-version fixtures, historical comments, and protocol-shape observations tied to older versions.
+11. Update the setup/lifecycle regression document only for a separately requested compatibility-floor change, then run `dart format` on changed Dart files.
 
 Use `apply_patch` for manual edits.
 
@@ -266,12 +279,12 @@ If tests fail only because old versions are hard-coded in manifest assertions or
 
 Before finishing, report:
 
-- old and new bundled/minimum versions for every registered harness
-- whether OpenCode or Codex compatibility floors changed and why
+- old and new target versions plus the unchanged minimum for every registered harness
+- confirmation that no compatibility floor changed
 - whether all twelve GitHub asset digests were refreshed
-- Claude Code's stable GitHub/npm version, matching Agent SDK version, direct-CLI floor, and stream-json surface probe result
+- Claude Code's stable GitHub/npm target, matching Agent SDK version, unchanged direct-CLI floor, and stream-json surface probe result
 - Cursor's installer-advertised build, and whether its four managed-runtime digests were recomputed
-- Hermes Agent's calendar release tag, semantic CLI version/direct-CLI floor, and isolated ACP probe result
+- Hermes Agent's calendar release tag, semantic CLI target, unchanged direct-CLI floor, and isolated ACP probe result
 - Pi's release, six verified package-archive digests, and JSONL RPC probe result
 - OMP's release, seven verified bare-executable digests, and ACP probe result
 - test and analyzer results

--- a/bridge/AGENTS.md
+++ b/bridge/AGENTS.md
@@ -63,9 +63,9 @@ no-op for remote/attach plugins.
 The managed runtime is pinned in `sesori_plugin_opencode/lib/src/runtime/open_code_runtime_manifest.dart`:
 
 1. Pick the new `vX.Y.Z` release of `anomalyco/opencode`.
-2. Update `bundledVersion`.
+2. Update `targetVersion`; `bundledVersion` derives the exact managed pin from it.
 3. Replace all six per-platform `sha256` values from that release's asset digests — GitHub's release API exposes each asset's `digest: "sha256:…"` (`opencode-darwin-{arm64,x64}.zip`, `opencode-linux-{arm64,x64}.tar.gz`, `opencode-windows-{arm64,x64}.zip`).
-4. Raise `minSupportedVersion` only when new bridge code needs a newer OpenCode API than older PATH installs provide (keep it conservative — prefer the user's own install, and never force a download that would migrate a newer OpenCode's local DB).
+4. Preserve `minPathVersion` for target refreshes. Raise it only for a separate explicit requirement where new bridge code needs a newer OpenCode API than older PATH installs provide (keep it conservative — prefer the user's own install, and never force a download that would migrate a newer OpenCode's local DB).
 
 ## Testing
 

--- a/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
@@ -54,7 +54,13 @@ final class const ClaudePluginDescriptor({
 }) extends BridgePluginDescriptor {
   static const String binOption = "bin";
   static const String defaultBinary = "claude";
-  static const String minVersion = "2.1.237";
+
+  /// Oldest Claude Code release with the CLI behavior this plugin requires.
+  static const String minVersion = "2.1.221";
+
+  /// Latest stable Claude Code release validated against this plugin.
+  static const String targetVersion = "2.1.237";
+
   static final Random _secureRandom = Random.secure();
 
   static const List<PluginOption> cliOptions = [

--- a/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
@@ -54,7 +54,7 @@ final class const ClaudePluginDescriptor({
 }) extends BridgePluginDescriptor {
   static const String binOption = "bin";
   static const String defaultBinary = "claude";
-  static const String minVersion = "2.1.221";
+  static const String minVersion = "2.1.237";
   static final Random _secureRandom = Random.secure();
 
   static const List<PluginOption> cliOptions = [

--- a/bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart
@@ -19,7 +19,8 @@ void main() {
       expect(descriptor.sessionOptionsScope, PluginSessionOptionsScope.plugin);
       expect(descriptor.supportsPromptAttachments, isTrue);
       expect(descriptor.options.single.name, "bin");
-      expect(ClaudePluginDescriptor.minVersion, "2.1.237");
+      expect(ClaudePluginDescriptor.minVersion, "2.1.221");
+      expect(ClaudePluginDescriptor.targetVersion, "2.1.237");
     });
 
     test("reports ready after ordered version and typed auth probes", () async {
@@ -68,7 +69,7 @@ void main() {
 
     test("reports unavailable and skips auth for an outdated runtime", () async {
       final processes = _ProcessService([
-        _ProbeProcess(stdoutText: "2.1.236 (Claude Code)\n", exitCode: Future.value(0)),
+        _ProbeProcess(stdoutText: "2.1.220 (Claude Code)\n", exitCode: Future.value(0)),
       ]);
 
       final status = await const ClaudePluginDescriptor().inspectSetup(

--- a/bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart
@@ -19,12 +19,12 @@ void main() {
       expect(descriptor.sessionOptionsScope, PluginSessionOptionsScope.plugin);
       expect(descriptor.supportsPromptAttachments, isTrue);
       expect(descriptor.options.single.name, "bin");
-      expect(ClaudePluginDescriptor.minVersion, "2.1.221");
+      expect(ClaudePluginDescriptor.minVersion, "2.1.237");
     });
 
     test("reports ready after ordered version and typed auth probes", () async {
       final processes = _ProcessService([
-        _ProbeProcess(stdoutText: "2.1.226 (Claude Code)\n", exitCode: Future.value(0)),
+        _ProbeProcess(stdoutText: "2.1.237 (Claude Code)\n", exitCode: Future.value(0)),
         _ProbeProcess(
           stdoutText: jsonEncode({
             "loggedIn": true,
@@ -42,7 +42,7 @@ void main() {
         stateDirectory: "/state",
       );
 
-      expect(status, const PluginSetupReady.versioned(runtimeVersion: "2.1.226"));
+      expect(status, const PluginSetupReady.versioned(runtimeVersion: "2.1.237"));
       expect(processes.arguments, [
         const ["--version"],
         const ["auth", "status"],
@@ -68,7 +68,7 @@ void main() {
 
     test("reports unavailable and skips auth for an outdated runtime", () async {
       final processes = _ProcessService([
-        _ProbeProcess(stdoutText: "2.1.220 (Claude Code)\n", exitCode: Future.value(0)),
+        _ProbeProcess(stdoutText: "2.1.236 (Claude Code)\n", exitCode: Future.value(0)),
       ]);
 
       final status = await const ClaudePluginDescriptor().inspectSetup(
@@ -86,7 +86,7 @@ void main() {
 
     test("reports authentication required from loggedIn false only", () async {
       final processes = _ProcessService([
-        _ProbeProcess(stdoutText: "2.1.221 (Claude Code)\n", exitCode: Future.value(0)),
+        _ProbeProcess(stdoutText: "2.1.237 (Claude Code)\n", exitCode: Future.value(0)),
         _ProbeProcess(
           stdoutText: '{"loggedIn":false,"email":"private@example.com"}',
           exitCode: Future.value(1),
@@ -101,13 +101,13 @@ void main() {
       );
 
       _expectNonReady<PluginSetupAuthenticationRequired>(status);
-      expect(status.runtimeVersion, "2.1.221");
+      expect(status.runtimeVersion, "2.1.237");
       expect(status.actionHint, isNot(contains("private@example.com")));
     });
 
     test("reports unknown for malformed auth without exposing its payload", () async {
       final processes = _ProcessService([
-        _ProbeProcess(stdoutText: "2.1.221 (Claude Code)\n", exitCode: Future.value(0)),
+        _ProbeProcess(stdoutText: "2.1.237 (Claude Code)\n", exitCode: Future.value(0)),
         _ProbeProcess(stdoutText: "private-account-output", exitCode: Future.value(0)),
       ]);
 
@@ -119,7 +119,7 @@ void main() {
       );
 
       _expectNonReady<PluginSetupUnknown>(status);
-      expect(status.runtimeVersion, "2.1.221");
+      expect(status.runtimeVersion, "2.1.237");
       expect(status.actionHint, isNot(contains("private-account-output")));
     });
 

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart
@@ -21,13 +21,13 @@ import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 /// the downloaded archive), confirm the [_assets] filenames still match the
 /// release, raise [minPathVersion] only if the bridge starts to require a newer
 /// codex API, and re-run the integration tests. The hashes below are the
-/// published asset digests for codex `rust-v0.146.0`.
+/// published asset digests for codex `rust-v0.148.0`.
 class const CodexRuntimeManifest() extends RuntimeManifest {
   /// Minimum pre-installed codex version the bridge will use as-is.
   static final SemanticRuntimeVersion _minPathVersion = SemanticRuntimeVersion.parse(value: "0.139.0");
 
   /// The exact codex version the managed runtime installs.
-  static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: "0.146.0");
+  static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: "0.148.0");
 
   static const String _releaseBaseUrl = "https://github.com/openai/codex/releases/download";
 
@@ -41,14 +41,14 @@ class const CodexRuntimeManifest() extends RuntimeManifest {
       PlatformArch.arm64: ArchiveRuntimeAsset(
         assetName: "codex-aarch64-apple-darwin.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "2750132d300e64f1dbffb95e3d913fd9c9dc7812bc8e1bce5c61357248b7929e",
+        sha256: "758916aa38efa7ad076a050830fcbef1a7ed6f41efae9c1cceaeef63e428fc2b",
         archiveBinaryName: "codex-aarch64-apple-darwin",
         layout: RuntimeArchiveLayout.singleBinary,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
         assetName: "codex-x86_64-apple-darwin.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "710d727b0fa2b4ab2189eb1bdc5ab40177c168296af264913eb7ab3ce848d04b",
+        sha256: "54591772f242271f802f17b4dda6cecab29229ba71593e962e208549e0da1a3a",
         archiveBinaryName: "codex-x86_64-apple-darwin",
         layout: RuntimeArchiveLayout.singleBinary,
       ),
@@ -57,14 +57,14 @@ class const CodexRuntimeManifest() extends RuntimeManifest {
       PlatformArch.arm64: ArchiveRuntimeAsset(
         assetName: "codex-aarch64-unknown-linux-musl.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "975bac91562abeedeb8f79636d51a86649b31f34a9de6a3bcb059565b6cf1f87",
+        sha256: "410c6ae0c763eb39c6da17665e63f9aa4a98e6ee663d81f8e8b779c97cb175ac",
         archiveBinaryName: "codex-aarch64-unknown-linux-musl",
         layout: RuntimeArchiveLayout.singleBinary,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
         assetName: "codex-x86_64-unknown-linux-musl.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "5ba3b9405543953081f661d0854d266f76e2abbe51d41349355a36de7673776a",
+        sha256: "1a36f762f6b3bef533bb86345ad9517661c2d84d53996a250cf2ca89d2cfee5a",
         archiveBinaryName: "codex-x86_64-unknown-linux-musl",
         layout: RuntimeArchiveLayout.singleBinary,
       ),
@@ -73,14 +73,14 @@ class const CodexRuntimeManifest() extends RuntimeManifest {
       PlatformArch.arm64: ArchiveRuntimeAsset(
         assetName: "codex-aarch64-pc-windows-msvc.exe.zip",
         format: ArchiveFormat.zip,
-        sha256: "5219938c0138580611735d8c2a79b100be0929083f779a8f375aadf192175b33",
+        sha256: "73a2b150965d63ddc71f7d0b5a3845a5d5925757af6495110a32dea40d6e18c3",
         archiveBinaryName: "codex-aarch64-pc-windows-msvc.exe",
         layout: RuntimeArchiveLayout.singleBinary,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
         assetName: "codex-x86_64-pc-windows-msvc.exe.zip",
         format: ArchiveFormat.zip,
-        sha256: "4781b618fa3a16d91c892f8a1e2c82625f9286f9bb944a5690ba727c84fc5729",
+        sha256: "a3f053e70bd5073d04d08ee3a2605b4015c74b0a51f3ff5a2fb67852ee37e3b0",
         archiveBinaryName: "codex-x86_64-pc-windows-msvc.exe",
         layout: RuntimeArchiveLayout.singleBinary,
       ),

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart
@@ -12,10 +12,11 @@ import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 ///   managed runtime. `0.139.0` is the floor the bridge's `app-server` v2
 ///   protocol assumes (see `codex_app_server_client.dart`, which opts into a
 ///   capability codex added in 0.139.0).
-/// - [_bundledVersion] is the exact version the managed runtime downloads.
+/// - [targetVersion] is the latest stable release targeted by the plugin, and
+///   [_bundledVersion] is the exact version the managed runtime downloads.
 ///
 /// ## Bumping codex
-/// Bumping codex is a deliberate release-engineering act: change [_bundledVersion],
+/// Bumping codex is a deliberate release-engineering act: change [targetVersion],
 /// refresh the matching SHA-256 hashes in [_assets] from the GitHub release's
 /// published asset digests (the release asset `digest` field, verified against
 /// the downloaded archive), confirm the [_assets] filenames still match the
@@ -26,8 +27,11 @@ class const CodexRuntimeManifest() extends RuntimeManifest {
   /// Minimum pre-installed codex version the bridge will use as-is.
   static final SemanticRuntimeVersion _minPathVersion = SemanticRuntimeVersion.parse(value: "0.139.0");
 
+  /// The latest stable codex release targeted by this plugin.
+  static const String targetVersion = "0.148.0";
+
   /// The exact codex version the managed runtime installs.
-  static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: "0.148.0");
+  static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: targetVersion);
 
   static const String _releaseBaseUrl = "https://github.com/openai/codex/releases/download";
 

--- a/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
@@ -57,7 +57,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 1,
-            stdoutBytes: utf8.encode("codex 0.146.0\n"),
+            stdoutBytes: utf8.encode("codex 0.148.0\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(
@@ -75,7 +75,7 @@ void main() {
         stateDirectory: stateDirectory,
       );
 
-      expect(result, const PluginSetupReady.versioned(runtimeVersion: "0.146.0"));
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "0.148.0"));
       expect(processes.spawnedExecutables, ["codex", "codex"]);
       expect(processes.spawnedArguments, [
         const ["--version"],
@@ -138,7 +138,7 @@ void main() {
           const ProcessException("codex", ["--version"], "missing", 2),
           _ProbeProcess(
             pid: 3,
-            stdoutBytes: utf8.encode("codex-cli 0.146.0\n"),
+            stdoutBytes: utf8.encode("codex-cli 0.148.0\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(
@@ -159,7 +159,7 @@ void main() {
             stateDirectory: stateDirectory,
           );
 
-      expect(result, const PluginSetupReady.versioned(runtimeVersion: "0.146.0"));
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "0.148.0"));
       expect(processes.spawnedExecutables, ["codex", appCli, appCli]);
     });
 
@@ -281,7 +281,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 3,
-            stdoutBytes: utf8.encode("codex 0.146.0\n"),
+            stdoutBytes: utf8.encode("codex 0.148.0\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(
@@ -303,7 +303,7 @@ void main() {
         result,
         const PluginSetupAuthenticationRequired.versioned(
           actionHint: "Sign in to Codex, then retry setup detection.",
-          runtimeVersion: "0.146.0",
+          runtimeVersion: "0.148.0",
         ),
       );
       expect(processes.spawnedArguments, [
@@ -318,7 +318,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 5,
-            stdoutBytes: utf8.encode("codex 0.146.0\n"),
+            stdoutBytes: utf8.encode("codex 0.148.0\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(
@@ -337,7 +337,7 @@ void main() {
       );
 
       expect(result, isA<PluginSetupUnknown>());
-      expect(result.runtimeVersion, "0.146.0");
+      expect(result.runtimeVersion, "0.148.0");
       expect(result.actionHint, isNot(contains("account-secret-output")));
     });
 
@@ -347,7 +347,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 7,
-            stdoutBytes: utf8.encode("codex 0.146.0\n"),
+            stdoutBytes: utf8.encode("codex 0.148.0\n"),
             exitCode: Future<int>.value(0),
           ),
           _ProbeProcess(
@@ -366,7 +366,7 @@ void main() {
       );
 
       expect(result, isA<PluginSetupUnknown>());
-      expect(result.runtimeVersion, "0.146.0");
+      expect(result.runtimeVersion, "0.148.0");
     });
   });
 }

--- a/bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart
@@ -14,7 +14,7 @@ void main() {
     });
 
     test("pinned versions", () {
-      expect(manifest.bundledVersion.toString(), "0.146.0");
+      expect(manifest.bundledVersion.toString(), "0.148.0");
       expect(manifest.minPathVersion.toString(), "0.139.0");
       expect(manifest.runtimeId, const CodexPluginDescriptor().id);
       expect(manifest.pathExecutableName, "codex");
@@ -35,7 +35,10 @@ void main() {
 
     test("darwin/linux ship .tar.gz, windows ships .exe.zip", () {
       ArchiveRuntimeAsset asset(PlatformOs os, PlatformArch arch) =>
-          manifest.assetFor(target: PlatformTarget(os: os, arch: arch))! as ArchiveRuntimeAsset;
+          manifest.assetFor(
+                target: PlatformTarget(os: os, arch: arch),
+              )!
+              as ArchiveRuntimeAsset;
 
       expect(asset(PlatformOs.macos, PlatformArch.arm64).format, ArchiveFormat.tarGz);
       expect(asset(PlatformOs.macos, PlatformArch.arm64).assetName, endsWith(".tar.gz"));
@@ -51,26 +54,26 @@ void main() {
 
     test("archive member is the target-triple name (asset name minus extension)", () {
       expect(
-        (manifest
-            .assetFor(
-              target: const PlatformTarget(os: PlatformOs.macos, arch: PlatformArch.arm64),
-            )! as ArchiveRuntimeAsset)
+        (manifest.assetFor(
+                  target: const PlatformTarget(os: PlatformOs.macos, arch: PlatformArch.arm64),
+                )!
+                as ArchiveRuntimeAsset)
             .archiveBinaryName,
         "codex-aarch64-apple-darwin",
       );
       expect(
-        (manifest
-            .assetFor(
-              target: const PlatformTarget(os: PlatformOs.linux, arch: PlatformArch.x64),
-            )! as ArchiveRuntimeAsset)
+        (manifest.assetFor(
+                  target: const PlatformTarget(os: PlatformOs.linux, arch: PlatformArch.x64),
+                )!
+                as ArchiveRuntimeAsset)
             .archiveBinaryName,
         "codex-x86_64-unknown-linux-musl",
       );
       expect(
-        (manifest
-            .assetFor(
-              target: const PlatformTarget(os: PlatformOs.windows, arch: PlatformArch.x64),
-            )! as ArchiveRuntimeAsset)
+        (manifest.assetFor(
+                  target: const PlatformTarget(os: PlatformOs.windows, arch: PlatformArch.x64),
+                )!
+                as ArchiveRuntimeAsset)
             .archiveBinaryName,
         "codex-x86_64-pc-windows-msvc.exe",
       );
@@ -82,7 +85,7 @@ void main() {
       )!;
       expect(
         manifest.downloadUrlFor(asset: asset),
-        equals("https://github.com/openai/codex/releases/download/rust-v0.146.0/codex-aarch64-apple-darwin.tar.gz"),
+        equals("https://github.com/openai/codex/releases/download/rust-v0.148.0/codex-aarch64-apple-darwin.tar.gz"),
       );
     });
 

--- a/bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart
@@ -14,7 +14,8 @@ void main() {
     });
 
     test("pinned versions", () {
-      expect(manifest.bundledVersion.toString(), "0.148.0");
+      expect(CodexRuntimeManifest.targetVersion, "0.148.0");
+      expect(manifest.bundledVersion.toString(), CodexRuntimeManifest.targetVersion);
       expect(manifest.minPathVersion.toString(), "0.139.0");
       expect(manifest.runtimeId, const CodexPluginDescriptor().id);
       expect(manifest.pathExecutableName, "codex");

--- a/bridge/sesori_plugin_codex/test/runtime/codex_runtime_selection_service_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_runtime_selection_service_test.dart
@@ -139,7 +139,7 @@ void main() {
           CodexRuntimeSelectionFailure.executableMissing,
         ),
         (StateError("spawn failed"), CodexRuntimeSelectionFailure.probeFailed),
-        (_ProbeProcess(stdoutText: "codex 0.146.0\n", exitCode: 1), CodexRuntimeSelectionFailure.nonZeroExit),
+        (_ProbeProcess(stdoutText: "codex 0.148.0\n", exitCode: 1), CodexRuntimeSelectionFailure.nonZeroExit),
         (_ProbeProcess(stdoutText: "not a version\n", exitCode: 0), CodexRuntimeSelectionFailure.unrecognizedVersion),
         (_ProbeProcess(stdoutText: "codex 0.100.0\n", exitCode: 0), CodexRuntimeSelectionFailure.unsupportedVersion),
       ];
@@ -191,7 +191,7 @@ void main() {
 
     test("aborts at the boundary after a completed probe", () async {
       final processes = _FakeHostProcessService([
-        _ProbeProcess(stdoutText: "codex 0.146.0\n", exitCode: 0),
+        _ProbeProcess(stdoutText: "codex 0.148.0\n", exitCode: 0),
       ]);
 
       await expectLater(

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_runtime_manifest.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_runtime_manifest.dart
@@ -28,7 +28,7 @@ import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 /// install capability.
 ///
 /// ## Bumping Cursor
-/// Change [_bundledVersion], re-download all four assets, recompute their
+/// Change [targetVersion], re-download all four assets, recompute their
 /// SHA-256 values, and raise [minPathVersion] only when bridge behavior needs a
 /// newer Cursor capability.
 class const CursorRuntimeManifest() extends RuntimeManifest {
@@ -37,11 +37,14 @@ class const CursorRuntimeManifest() extends RuntimeManifest {
   /// silently no-op them, so the experience breaks invisibly.
   static final CalendarRuntimeVersion _minPathVersion = CalendarRuntimeVersion.parse(value: "2026.07.16");
 
+  /// The latest official-installer Cursor build targeted by this plugin.
+  static const String targetVersion = "2026.08.11-e8db854";
+
   /// The exact Cursor CLI build the managed runtime installs, preserved
   /// verbatim: [CalendarRuntimeVersion] keeps the publisher's string, so the
   /// download URL and the on-disk version directory both use it unchanged.
   static final CalendarRuntimeVersion _bundledVersion = CalendarRuntimeVersion.parse(
-    value: "2026.08.11-e8db854",
+    value: targetVersion,
   );
 
   static const String _downloadBaseUrl = "https://downloads.cursor.com/lab";

--- a/bridge/sesori_plugin_cursor/test/runtime/cursor_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_cursor/test/runtime/cursor_runtime_manifest_test.dart
@@ -12,7 +12,8 @@ void main() {
     expect(manifest.binaryFileName, "cursor-agent");
     // The publisher's exact strings survive: a normalized 2026.8.4 would 404
     // the download and mis-name the on-disk version directory.
-    expect(manifest.bundledVersion.raw, "2026.08.11-e8db854");
+    expect(CursorRuntimeManifest.targetVersion, "2026.08.11-e8db854");
+    expect(manifest.bundledVersion.raw, CursorRuntimeManifest.targetVersion);
     expect(manifest.minPathVersion.raw, "2026.07.16");
   });
 

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -24,7 +24,7 @@ const int _setupProbeOutputLimit = 64 * 1024;
 class const HermesPluginDescriptor() extends BridgePluginDescriptor {
   static const Duration _connectBudget = Duration(seconds: 15);
   static const Duration _versionProbeTimeout = Duration(seconds: 10);
-  static final SemanticVersion _minHermesVersion = SemanticVersion.parse(value: "0.20.0");
+  static final SemanticVersion _minHermesVersion = SemanticVersion.parse(value: "0.20.4");
 
   /// CLI option naming the Hermes CLI binary (path or PATH name). Declared
   /// as the bare local name; the bridge's [PluginCliOptionsMapper] namespaces

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -24,7 +24,14 @@ const int _setupProbeOutputLimit = 64 * 1024;
 class const HermesPluginDescriptor() extends BridgePluginDescriptor {
   static const Duration _connectBudget = Duration(seconds: 15);
   static const Duration _versionProbeTimeout = Duration(seconds: 10);
-  static final SemanticVersion _minHermesVersion = SemanticVersion.parse(value: "0.20.4");
+
+  /// Oldest Hermes Agent release with the ACP behavior this plugin requires.
+  static const String minVersion = "0.20.0";
+
+  /// Latest stable Hermes Agent release validated against this plugin.
+  static const String targetVersion = "0.20.4";
+
+  static final SemanticVersion _minHermesVersion = SemanticVersion.parse(value: minVersion);
 
   /// CLI option naming the Hermes CLI binary (path or PATH name). Declared
   /// as the bare local name; the bridge's [PluginCliOptionsMapper] namespaces

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
@@ -26,6 +26,8 @@ void main() {
         isTrue,
         reason: "Hermes advertises prompt image support",
       );
+      expect(HermesPluginDescriptor.minVersion, "0.20.0");
+      expect(HermesPluginDescriptor.targetVersion, "0.20.4");
     });
 
     test("declares only the binary option and no install capability", () {
@@ -271,7 +273,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 1,
-            stdoutBytes: utf8.encode("0.20.3\n"),
+            stdoutBytes: utf8.encode("0.19.0\n"),
             stderrBytes: const [],
             exitCode: Future<int>.value(0),
           ),
@@ -295,7 +297,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 1,
-            stdoutBytes: utf8.encode("0.20.3\n"),
+            stdoutBytes: utf8.encode("0.19.0\n"),
             stderrBytes: const [],
             exitCode: Future<int>.value(0),
           ),

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
@@ -45,7 +45,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 1,
-            stdoutBytes: utf8.encode("hermes-acp v0.20.0\n"),
+            stdoutBytes: utf8.encode("hermes-acp v0.20.4\n"),
             stderrBytes: const [],
             exitCode: Future<int>.value(0),
           ),
@@ -78,7 +78,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 1,
-            stdoutBytes: utf8.encode("0.20.1\n"),
+            stdoutBytes: utf8.encode("0.20.4\n"),
             stderrBytes: const [],
             exitCode: Future<int>.value(0),
           ),
@@ -114,7 +114,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 1,
-            stdoutBytes: utf8.encode("0.20.0\n"),
+            stdoutBytes: utf8.encode("0.20.4\n"),
             stderrBytes: const [],
             exitCode: Future<int>.value(0),
           ),
@@ -135,7 +135,7 @@ void main() {
         stateDirectory: stateDirectory,
       );
 
-      expect(result, const PluginSetupReady.versioned(runtimeVersion: "0.20.0"));
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "0.20.4"));
       expect(processes.spawnedExecutables, ["hermes", "hermes"]);
       expect(processes.spawnedArguments, [
         const ["acp", "--version"],
@@ -271,7 +271,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 1,
-            stdoutBytes: utf8.encode("0.19.0\n"),
+            stdoutBytes: utf8.encode("0.20.3\n"),
             stderrBytes: const [],
             exitCode: Future<int>.value(0),
           ),
@@ -295,7 +295,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 1,
-            stdoutBytes: utf8.encode("0.19.0\n"),
+            stdoutBytes: utf8.encode("0.20.3\n"),
             stderrBytes: const [],
             exitCode: Future<int>.value(0),
           ),
@@ -344,7 +344,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 1,
-            stdoutBytes: utf8.encode("0.20.0\n"),
+            stdoutBytes: utf8.encode("0.20.4\n"),
             stderrBytes: const [],
             exitCode: Future<int>.value(0),
           ),
@@ -366,7 +366,7 @@ void main() {
       );
 
       expect(result, isA<PluginSetupAuthenticationRequired>());
-      expect(result.runtimeVersion, "0.20.0");
+      expect(result.runtimeVersion, "0.20.4");
     });
 
     test("reports authentication required when a model has no provider", () async {
@@ -375,7 +375,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 1,
-            stdoutBytes: utf8.encode("0.20.0\n"),
+            stdoutBytes: utf8.encode("0.20.4\n"),
             stderrBytes: const [],
             exitCode: Future<int>.value(0),
           ),
@@ -397,7 +397,7 @@ void main() {
       );
 
       expect(result, isA<PluginSetupAuthenticationRequired>());
-      expect(result.runtimeVersion, "0.20.0");
+      expect(result.runtimeVersion, "0.20.4");
     });
 
     test("reports unknown when the status command exits nonzero", () async {
@@ -406,7 +406,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 1,
-            stdoutBytes: utf8.encode("0.20.0\n"),
+            stdoutBytes: utf8.encode("0.20.4\n"),
             stderrBytes: const [],
             exitCode: Future<int>.value(0),
           ),
@@ -428,7 +428,7 @@ void main() {
       );
 
       expect(result, isA<PluginSetupUnknown>());
-      expect(result.runtimeVersion, "0.20.0");
+      expect(result.runtimeVersion, "0.20.4");
     });
 
     test("uses an explicit --hermes-bin override for every probe", () async {
@@ -437,7 +437,7 @@ void main() {
         processSequence: [
           _ProbeProcess(
             pid: 1,
-            stdoutBytes: utf8.encode("0.20.0\n"),
+            stdoutBytes: utf8.encode("0.20.4\n"),
             stderrBytes: const [],
             exitCode: Future<int>.value(0),
           ),
@@ -458,7 +458,7 @@ void main() {
         stateDirectory: stateDirectory,
       );
 
-      expect(result, const PluginSetupReady.versioned(runtimeVersion: "0.20.0"));
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "0.20.4"));
       expect(processes.spawnedExecutables, ["/custom/hermes", "/custom/hermes"]);
     });
 

--- a/bridge/sesori_plugin_omp/lib/src/runtime/omp_runtime_manifest.dart
+++ b/bridge/sesori_plugin_omp/lib/src/runtime/omp_runtime_manifest.dart
@@ -7,7 +7,12 @@ import "../models/omp_linux_libc.dart";
 import "../omp_identity.dart";
 
 class const OmpRuntimeManifest() extends RuntimeManifest {
-  static final SemanticRuntimeVersion _version = SemanticRuntimeVersion.parse(value: "17.3.8");
+  static final SemanticRuntimeVersion _minPathVersion = SemanticRuntimeVersion.parse(value: "17.2.13");
+
+  /// The latest stable Oh My Pi release targeted by this plugin.
+  static const String targetVersion = "17.3.8";
+
+  static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: targetVersion);
 
   static const Map<PlatformOs, Map<PlatformArch, DirectBinaryRuntimeAsset>> _assets = {
     PlatformOs.macos: {
@@ -67,10 +72,10 @@ class const OmpRuntimeManifest() extends RuntimeManifest {
   String get binaryFileName => Platform.isWindows ? "omp.exe" : "omp";
 
   @override
-  RuntimeVersion get minPathVersion => _version;
+  RuntimeVersion get minPathVersion => _minPathVersion;
 
   @override
-  RuntimeVersion get bundledVersion => _version;
+  RuntimeVersion get bundledVersion => _bundledVersion;
 
   @override
   RuntimeVersion? parseVersion({required String value}) {

--- a/bridge/sesori_plugin_omp/lib/src/runtime/omp_runtime_manifest.dart
+++ b/bridge/sesori_plugin_omp/lib/src/runtime/omp_runtime_manifest.dart
@@ -7,23 +7,23 @@ import "../models/omp_linux_libc.dart";
 import "../omp_identity.dart";
 
 class const OmpRuntimeManifest() extends RuntimeManifest {
-  static final SemanticRuntimeVersion _version = SemanticRuntimeVersion.parse(value: "17.2.13");
+  static final SemanticRuntimeVersion _version = SemanticRuntimeVersion.parse(value: "17.3.8");
 
   static const Map<PlatformOs, Map<PlatformArch, DirectBinaryRuntimeAsset>> _assets = {
     PlatformOs.macos: {
       PlatformArch.arm64: DirectBinaryRuntimeAsset(
         assetName: "omp-darwin-arm64",
-        sha256: "2841151eb3381cfe094aaefef3fb7be3c926075821ba6bf3fa77dcb2ffbb8db7",
+        sha256: "84705a1ca833f59afccca2db7aff559e09cb74902e7a5aaf87077a88f3c84b84",
       ),
       PlatformArch.x64: DirectBinaryRuntimeAsset(
         assetName: "omp-darwin-x64",
-        sha256: "07d5f9603b9e3dc0dc918d94cbfd5c6ed50c13f72faed6eec83d677580739d7c",
+        sha256: "8ea335917741cdd6f5a4a671cd4c6238dfdd27b9a303e9ed357c442877768d6c",
       ),
     },
     PlatformOs.windows: {
       PlatformArch.x64: DirectBinaryRuntimeAsset(
         assetName: "omp-windows-x64.exe",
-        sha256: "1f8077b14df8d010533d4fb814de83709215f39d0d550559417eca0c3c1d01dc",
+        sha256: "0a7d4f7e491f9af906f3bdc750023bf51e8934a9e31db481b611ee2cb7909c32",
       ),
     },
   };
@@ -32,21 +32,21 @@ class const OmpRuntimeManifest() extends RuntimeManifest {
     OmpLinuxLibc.glibc: {
       PlatformArch.arm64: DirectBinaryRuntimeAsset(
         assetName: "omp-linux-arm64",
-        sha256: "f8d22cfc74d51b41185e4d7188ad88eb0e1e5e388f762ae2f90c21b095d039dd",
+        sha256: "5d97dba8068c9c3b19bc2949567798e0a839dec5f11c458b4c642bfe0f4d14a0",
       ),
       PlatformArch.x64: DirectBinaryRuntimeAsset(
         assetName: "omp-linux-x64",
-        sha256: "9c6a0ceb2995da1ba0524fc858f85c39127fd0784226ec91d54e556b8028b951",
+        sha256: "efdb54f0054e80afe1c05c09f43d5ced09ce8ec8b75c3fb6b0ca5ce4805b383f",
       ),
     },
     OmpLinuxLibc.musl: {
       PlatformArch.arm64: DirectBinaryRuntimeAsset(
         assetName: "omp-linux-musl-arm64",
-        sha256: "c199ec7b4ac4e59c86b570bae3e9fd3e95843f79fa5807354de8997438107fee",
+        sha256: "1a196dd540056a57e6264b95cc5f0f3578c9e8d0ea4ebe314a92efdbadfc2c4f",
       ),
       PlatformArch.x64: DirectBinaryRuntimeAsset(
         assetName: "omp-linux-musl-x64",
-        sha256: "fbba26125946d1a98ced8fc84c55e381ffb60ef568487e13788ec9690664b0eb",
+        sha256: "7ff5890ea47febcb70999e6d05126d7d56fb09ee86c9f9a707697135ebf917c4",
       ),
     },
   };

--- a/bridge/sesori_plugin_omp/test/omp_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_plugin_descriptor_test.dart
@@ -44,7 +44,7 @@ void main() {
     test("ensureRuntime prefers a supported PATH binary", () async {
       final processes = _Processes(
         outputs: const [
-          _Output(stdout: "omp/17.3.8\n", exitCode: 0),
+          _Output(stdout: "omp/17.2.13\n", exitCode: 0),
         ],
       );
       final events = await OmpPluginDescriptor.production().ensureRuntime(host: _Host(processes: processes)).toList();
@@ -56,7 +56,7 @@ void main() {
     test("ensureRuntime falls back to an installed managed binary", () async {
       final processes = _Processes(
         outputs: const [
-          _Output(stdout: "omp/17.3.7\n", exitCode: 0),
+          _Output(stdout: "omp/17.2.12\n", exitCode: 0),
           _Output(stdout: "omp/17.3.8\n", exitCode: 0),
         ],
       );
@@ -131,7 +131,7 @@ void main() {
       final outdated = await descriptor.inspectSetup(
         config: explicit,
         processes: _Processes(
-          outputs: const [_Output(stdout: "omp/17.3.7\n", exitCode: 0)],
+          outputs: const [_Output(stdout: "omp/17.2.12\n", exitCode: 0)],
         ),
         environment: const {},
         stateDirectory: "/state",

--- a/bridge/sesori_plugin_omp/test/omp_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_plugin_descriptor_test.dart
@@ -44,7 +44,7 @@ void main() {
     test("ensureRuntime prefers a supported PATH binary", () async {
       final processes = _Processes(
         outputs: const [
-          _Output(stdout: "omp/17.2.13\n", exitCode: 0),
+          _Output(stdout: "omp/17.3.8\n", exitCode: 0),
         ],
       );
       final events = await OmpPluginDescriptor.production().ensureRuntime(host: _Host(processes: processes)).toList();
@@ -56,20 +56,20 @@ void main() {
     test("ensureRuntime falls back to an installed managed binary", () async {
       final processes = _Processes(
         outputs: const [
-          _Output(stdout: "omp/17.2.12\n", exitCode: 0),
-          _Output(stdout: "omp/17.2.13\n", exitCode: 0),
+          _Output(stdout: "omp/17.3.7\n", exitCode: 0),
+          _Output(stdout: "omp/17.3.8\n", exitCode: 0),
         ],
       );
       final events = await OmpPluginDescriptor.production().ensureRuntime(host: _Host(processes: processes)).toList();
 
-      expect((events.last as ProvisionReady).binaryPath, contains("/state/omp/17.2.13/omp"));
-      expect(processes.executables, ["omp", contains("/state/omp/17.2.13/omp")]);
+      expect((events.last as ProvisionReady).binaryPath, contains("/state/omp/17.3.8/omp"));
+      expect(processes.executables, ["omp", contains("/state/omp/17.3.8/omp")]);
     });
 
     test("reports ready from the runtime probe without an ACP or auth probe", () async {
       final processes = _Processes(
         outputs: const [
-          _Output(stdout: "omp/17.2.13\n", exitCode: 0),
+          _Output(stdout: "omp/17.3.8\n", exitCode: 0),
         ],
       );
       final result = await OmpPluginDescriptor.production().inspectSetup(
@@ -79,7 +79,7 @@ void main() {
         stateDirectory: "/state",
       );
 
-      expect(result, const PluginSetupReady.versioned(runtimeVersion: "17.2.13"));
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "17.3.8"));
       expect(processes.arguments, [
         const ["--version"],
       ]);
@@ -90,13 +90,13 @@ void main() {
       final result = await OmpPluginDescriptor.production().inspectSetup(
         config: config,
         processes: _Processes(
-          outputs: const [_Output(stdout: "Oh My Pi omp/17.2.13 stable\n", exitCode: 0)],
+          outputs: const [_Output(stdout: "Oh My Pi omp/17.3.8 stable\n", exitCode: 0)],
         ),
         environment: const {},
         stateDirectory: "/state",
       );
 
-      expect(result, const PluginSetupReady.versioned(runtimeVersion: "17.2.13"));
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "17.3.8"));
     });
 
     test("reports an installable missing runtime after PATH and managed probes", () async {
@@ -131,7 +131,7 @@ void main() {
       final outdated = await descriptor.inspectSetup(
         config: explicit,
         processes: _Processes(
-          outputs: const [_Output(stdout: "omp/17.2.12\n", exitCode: 0)],
+          outputs: const [_Output(stdout: "omp/17.3.7\n", exitCode: 0)],
         ),
         environment: const {},
         stateDirectory: "/state",

--- a/bridge/sesori_plugin_omp/test/omp_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_runtime_manifest_test.dart
@@ -8,14 +8,14 @@ import "package:test/test.dart";
 void main() {
   const manifest = OmpRuntimeManifest();
 
-  test("pins v17.2.13 and parses only the OMP version prefix", () {
+  test("pins v17.3.8 and parses only the OMP version prefix", () {
     expect(manifest.runtimeId, "omp");
     expect(manifest.pathExecutableName, "omp");
     expect(manifest.binaryFileName, Platform.isWindows ? "omp.exe" : "omp");
-    expect(manifest.minPathVersion.raw, "17.2.13");
-    expect(manifest.bundledVersion.raw, "17.2.13");
-    expect(manifest.parseVersion(value: "omp/17.2.13")?.raw, "17.2.13");
-    expect(manifest.parseVersion(value: "17.2.13"), isNull);
+    expect(manifest.minPathVersion.raw, "17.3.8");
+    expect(manifest.bundledVersion.raw, "17.3.8");
+    expect(manifest.parseVersion(value: "omp/17.3.8")?.raw, "17.3.8");
+    expect(manifest.parseVersion(value: "17.3.8"), isNull);
     expect(manifest.parseVersion(value: "omp/not-a-version"), isNull);
   });
 
@@ -65,7 +65,7 @@ void main() {
     )!;
     expect(
       manifest.downloadUrlFor(asset: asset),
-      "https://github.com/can1357/oh-my-pi/releases/download/v17.2.13/omp-darwin-arm64",
+      "https://github.com/can1357/oh-my-pi/releases/download/v17.3.8/omp-darwin-arm64",
     );
   });
 }

--- a/bridge/sesori_plugin_omp/test/omp_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_runtime_manifest_test.dart
@@ -8,12 +8,13 @@ import "package:test/test.dart";
 void main() {
   const manifest = OmpRuntimeManifest();
 
-  test("pins v17.3.8 and parses only the OMP version prefix", () {
+  test("keeps the PATH floor and targets v17.3.8", () {
     expect(manifest.runtimeId, "omp");
     expect(manifest.pathExecutableName, "omp");
     expect(manifest.binaryFileName, Platform.isWindows ? "omp.exe" : "omp");
-    expect(manifest.minPathVersion.raw, "17.3.8");
-    expect(manifest.bundledVersion.raw, "17.3.8");
+    expect(manifest.minPathVersion.raw, "17.2.13");
+    expect(OmpRuntimeManifest.targetVersion, "17.3.8");
+    expect(manifest.bundledVersion.raw, OmpRuntimeManifest.targetVersion);
     expect(manifest.parseVersion(value: "omp/17.3.8")?.raw, "17.3.8");
     expect(manifest.parseVersion(value: "17.3.8"), isNull);
     expect(manifest.parseVersion(value: "omp/not-a-version"), isNull);

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_manifest.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_manifest.dart
@@ -28,7 +28,7 @@ class const OpenCodeRuntimeManifest() extends RuntimeManifest {
   static final SemanticRuntimeVersion _minPathVersion = SemanticRuntimeVersion.parse(value: "1.14.0");
 
   /// The exact OpenCode version the managed runtime installs.
-  static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: "1.18.11");
+  static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: "1.18.19");
 
   static const String _releaseBaseUrl = "https://github.com/anomalyco/opencode/releases/download";
 
@@ -41,14 +41,14 @@ class const OpenCodeRuntimeManifest() extends RuntimeManifest {
       PlatformArch.arm64: ArchiveRuntimeAsset(
         assetName: "opencode-darwin-arm64.zip",
         format: ArchiveFormat.zip,
-        sha256: "188ff6a716bcd40e33ac62f17f4aec9bd760164fa6a2cde66f779a5db4abc7ce",
+        sha256: "0026326bd77a3277ab3726be237410b19389f7829e8bb3c82dfaf9044162067c",
         archiveBinaryName: "opencode",
         layout: RuntimeArchiveLayout.singleBinary,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
         assetName: "opencode-darwin-x64.zip",
         format: ArchiveFormat.zip,
-        sha256: "95953ab2aca4322b90690bf34697cc9b47b6a7c72f78e7c469056fb589124d31",
+        sha256: "ee495d7c30263c2cecb81a4558a9c4d29ac7b27c1df822e9d344a69cb56a75c3",
         archiveBinaryName: "opencode",
         layout: RuntimeArchiveLayout.singleBinary,
       ),
@@ -57,14 +57,14 @@ class const OpenCodeRuntimeManifest() extends RuntimeManifest {
       PlatformArch.arm64: ArchiveRuntimeAsset(
         assetName: "opencode-linux-arm64.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "03e07aa461ac241dfa8c7ab54ed58c7a0e911c62fc3cb490b83e4fb3424eb73b",
+        sha256: "506f98a1f618551f1f6fc5dcf591f824bef9d6819d40b27928ad7febcb7c363b",
         archiveBinaryName: "opencode",
         layout: RuntimeArchiveLayout.singleBinary,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
         assetName: "opencode-linux-x64.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "a4dffcc00a5a93256c6bd06aa0c984320528f564db52a1f4becd5c7de9fb59a1",
+        sha256: "7bb35487c55f9957f5d91ae60be6fa49fc8f74629c210c1719ed75fdbf7e2bd9",
         archiveBinaryName: "opencode",
         layout: RuntimeArchiveLayout.singleBinary,
       ),
@@ -73,14 +73,14 @@ class const OpenCodeRuntimeManifest() extends RuntimeManifest {
       PlatformArch.arm64: ArchiveRuntimeAsset(
         assetName: "opencode-windows-arm64.zip",
         format: ArchiveFormat.zip,
-        sha256: "4510ccf446284f5492438c4b40b23895dc7ae78cb5eb4e7f51cbe998c1148d58",
+        sha256: "2e74619988a54f76837370862c0761c6595a1224ce4cd6da588975e1396a33a7",
         archiveBinaryName: "opencode.exe",
         layout: RuntimeArchiveLayout.singleBinary,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
         assetName: "opencode-windows-x64.zip",
         format: ArchiveFormat.zip,
-        sha256: "f3a5ea814aecc692a4e04259d9005283f364225b38456c90f9a47b7a9d83c0e9",
+        sha256: "4381328bf6d611996c33d98daef27e89d274cb8391709fa1e36723f1d2899877",
         archiveBinaryName: "opencode.exe",
         layout: RuntimeArchiveLayout.singleBinary,
       ),

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_manifest.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_manifest.dart
@@ -16,7 +16,7 @@ import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 ///
 /// ## Bumping the bundled runtime
 /// 1. Pick the new `vX.Y.Z` release of `anomalyco/opencode`.
-/// 2. Update [_bundledVersion].
+/// 2. Update [targetVersion].
 /// 3. Replace all six [_assets] SHA-256 values with that release's asset digests
 ///    (GitHub's release API exposes each asset's `digest: "sha256:…"`).
 /// 4. Raise [_minPathVersion] only if the new bridge code requires a newer
@@ -27,8 +27,11 @@ class const OpenCodeRuntimeManifest() extends RuntimeManifest {
   /// only download the managed runtime for genuinely old installs.
   static final SemanticRuntimeVersion _minPathVersion = SemanticRuntimeVersion.parse(value: "1.14.0");
 
+  /// The latest stable OpenCode release targeted by this plugin.
+  static const String targetVersion = "1.18.19";
+
   /// The exact OpenCode version the managed runtime installs.
-  static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: "1.18.19");
+  static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: targetVersion);
 
   static const String _releaseBaseUrl = "https://github.com/anomalyco/opencode/releases/download";
 

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_availability_test.dart
@@ -25,7 +25,7 @@ void main() {
       final processes = _ProbeProcessService(
         process: _ProbeProcess(
           pid: 1,
-          stdoutBytes: utf8.encode("opencode 1.18.11\n"),
+          stdoutBytes: utf8.encode("opencode 1.18.19\n"),
           exitCode: Future<int>.value(0),
         ),
       );
@@ -37,7 +37,7 @@ void main() {
         stateDirectory: stateDirectory,
       );
 
-      expect(result, const PluginSetupReady.versioned(runtimeVersion: "1.18.11"));
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "1.18.19"));
       expect(processes.spawnedExecutables, ["opencode"]);
       expect(processes.spawnedArguments, [
         const ["--version"],

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_manifest_test.dart
@@ -27,7 +27,10 @@ void main() {
 
     test("darwin/windows ship .zip, linux ships .tar.gz", () {
       ArchiveRuntimeAsset asset(PlatformOs os, PlatformArch arch) =>
-          manifest.assetFor(target: PlatformTarget(os: os, arch: arch))! as ArchiveRuntimeAsset;
+          manifest.assetFor(
+                target: PlatformTarget(os: os, arch: arch),
+              )!
+              as ArchiveRuntimeAsset;
 
       expect(asset(PlatformOs.macos, PlatformArch.arm64).format, ArchiveFormat.zip);
       expect(asset(PlatformOs.macos, PlatformArch.arm64).assetName, endsWith(".zip"));
@@ -43,7 +46,7 @@ void main() {
       )!;
       expect(
         manifest.downloadUrlFor(asset: asset),
-        equals("https://github.com/anomalyco/opencode/releases/download/v1.18.11/opencode-darwin-arm64.zip"),
+        equals("https://github.com/anomalyco/opencode/releases/download/v1.18.19/opencode-darwin-arm64.zip"),
       );
     });
 

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_manifest_test.dart
@@ -51,6 +51,8 @@ void main() {
     });
 
     test("bundled version is at least the minimum supported version", () {
+      expect(OpenCodeRuntimeManifest.targetVersion, "1.18.19");
+      expect(manifest.bundledVersion.toString(), OpenCodeRuntimeManifest.targetVersion);
       expect(manifest.minPathVersion.toString(), "1.14.0");
       expect(
         manifest.bundledVersion.compareTo(manifest.minPathVersion),

--- a/bridge/sesori_plugin_pi/lib/src/runtime/pi_runtime_manifest.dart
+++ b/bridge/sesori_plugin_pi/lib/src/runtime/pi_runtime_manifest.dart
@@ -8,7 +8,11 @@ import "../pi_identity.dart";
 /// Pinned official Pi package archives used by managed installation.
 class const PiRuntimeManifest() extends RuntimeManifest {
   static final SemanticRuntimeVersion _minPathVersion = SemanticRuntimeVersion.parse(value: "0.84.1");
-  static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: "0.84.2");
+
+  /// The latest stable Pi release targeted by this plugin.
+  static const String targetVersion = "0.84.2";
+
+  static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: targetVersion);
 
   static const Map<PlatformOs, Map<PlatformArch, RuntimeAsset>> _assets = {
     PlatformOs.macos: {

--- a/bridge/sesori_plugin_pi/test/pi_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_runtime_manifest_test.dart
@@ -13,7 +13,8 @@ void main() {
     expect(manifest.pathExecutableName, "pi");
     expect(manifest.binaryFileName, Platform.isWindows ? "pi.exe" : "pi");
     expect(manifest.minPathVersion.raw, "0.84.1");
-    expect(manifest.bundledVersion.raw, "0.84.2");
+    expect(PiRuntimeManifest.targetVersion, "0.84.2");
+    expect(manifest.bundledVersion.raw, PiRuntimeManifest.targetVersion);
     expect(manifest.parseVersion(value: "0.84.2")?.raw, "0.84.2");
     expect(manifest.parseVersion(value: "pi/0.84.2"), isNull);
   });

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -15,8 +15,9 @@ idle suspension, the management snapshot, and lifecycle commands.
 - Runtime resolution before start may resolve a suitable existing or managed binary but
   never downloads or mutates files, and failure there is non-fatal. The persisted disable
   list is the only durable eligibility policy, with setup deciding blocked versus routable.
-- Hermes is a direct-CLI harness with no managed install. Setup distinguishes a missing or
-  pre-ACP binary, a Hermes Agent release below `0.20.0`, and missing model/provider
+- Claude Code and Hermes are direct-CLI harnesses with no managed install. Claude setup
+  rejects releases below `2.1.237`. Hermes setup distinguishes a missing or
+  pre-ACP binary, a Hermes Agent release below `0.20.4`, and missing model/provider
   configuration; startup revalidates the effective PATH or explicit `--hermes-bin` executable
   while preserving an explicit path as authoritative.
   Model/provider setup remains an out-of-band Hermes CLI action, so authentication-required
@@ -96,7 +97,7 @@ idle suspension, the management snapshot, and lifecycle commands.
 Vary which harness runs first and which stays disabled, and the configuration: default
 managed, explicit binary path, externally managed backend. Vary the trigger between app
 and management API, whether a session is idle or working, and fresh versus reused data
-directories. For Hermes, vary missing and pre-ACP installs, a release below `0.20.0`, an
+directories. For Hermes, vary missing and pre-ACP installs, a release below `0.20.4`, an
 unconfigured model/provider, PATH discovery, and `--hermes-bin`. Restore eligibility,
 timeouts, and sessions afterwards.
 
@@ -142,7 +143,7 @@ timeouts, and sessions afterwards.
 ## Sources
 
 - `bridge/sesori_plugin_interface/lib/src/lifecycle/`; registered OpenCode, Codex,
-  Cursor, Claude Code, and Hermes Agent descriptors; plugin routing handlers
+  Cursor, Claude Code, Hermes Agent, Pi, and Oh My Pi descriptors; plugin routing handlers
 - `bridge/app/lib/src/services/plugin_lifecycle_service.dart`,
   `bridge/app/lib/src/bridge/runtime/plugin_registry.dart`
 - `bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart` and its tests

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -15,9 +15,8 @@ idle suspension, the management snapshot, and lifecycle commands.
 - Runtime resolution before start may resolve a suitable existing or managed binary but
   never downloads or mutates files, and failure there is non-fatal. The persisted disable
   list is the only durable eligibility policy, with setup deciding blocked versus routable.
-- Claude Code and Hermes are direct-CLI harnesses with no managed install. Claude setup
-  rejects releases below `2.1.237`. Hermes setup distinguishes a missing or
-  pre-ACP binary, a Hermes Agent release below `0.20.4`, and missing model/provider
+- Hermes is a direct-CLI harness with no managed install. Setup distinguishes a missing or
+  pre-ACP binary, a Hermes Agent release below `0.20.0`, and missing model/provider
   configuration; startup revalidates the effective PATH or explicit `--hermes-bin` executable
   while preserving an explicit path as authoritative.
   Model/provider setup remains an out-of-band Hermes CLI action, so authentication-required
@@ -97,7 +96,7 @@ idle suspension, the management snapshot, and lifecycle commands.
 Vary which harness runs first and which stays disabled, and the configuration: default
 managed, explicit binary path, externally managed backend. Vary the trigger between app
 and management API, whether a session is idle or working, and fresh versus reused data
-directories. For Hermes, vary missing and pre-ACP installs, a release below `0.20.4`, an
+directories. For Hermes, vary missing and pre-ACP installs, a release below `0.20.0`, an
 unconfigured model/provider, PATH discovery, and `--hermes-bin`. Restore eligibility,
 timeouts, and sessions afterwards.
 
@@ -143,7 +142,7 @@ timeouts, and sessions afterwards.
 ## Sources
 
 - `bridge/sesori_plugin_interface/lib/src/lifecycle/`; registered OpenCode, Codex,
-  Cursor, Claude Code, Hermes Agent, Pi, and Oh My Pi descriptors; plugin routing handlers
+  Cursor, Claude Code, and Hermes Agent descriptors; plugin routing handlers
 - `bridge/app/lib/src/services/plugin_lifecycle_service.dart`,
   `bridge/app/lib/src/bridge/runtime/plugin_registry.dart`
 - `bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart` and its tests


### PR DESCRIPTION
## Complexity

⚙️ Moderate: this refreshes managed runtime artifacts, records direct-CLI targets, validates upstream protocol surfaces, and updates the repeatable maintenance workflow across all seven registered harnesses.

## What

- Give every registered harness an explicit compatibility minimum and independent latest target.
- Derive each managed runtime's exact `bundledVersion` from its `targetVersion`.
- Refresh OpenCode from `1.18.11` to `1.18.19` with all six asset digests.
- Refresh Codex from `0.146.0` to `0.148.0` with all six asset digests.
- Record Claude Code `2.1.237` and Hermes Agent `0.20.4` as their latest validated direct-CLI targets.
- Refresh OMP's managed target from `17.2.13` to `17.3.8` with all seven executable digests.
- Confirm Cursor `2026.08.11-e8db854` and Pi `0.84.2` remain current, and expose those existing pins as explicit targets.
- Expand the runtime update skill and bridge instructions to cover every registered harness and preserve compatibility minimums during target refreshes.

| Harness | Compatibility minimum | Latest target |
| --- | --- | --- |
| OpenCode | `1.14.0` | `1.18.19` |
| Codex | `0.139.0` | `0.148.0` |
| Claude Code | `2.1.221` | `2.1.237` |
| Cursor | `2026.07.16` | `2026.08.11-e8db854` |
| Hermes Agent | `0.20.0` | `0.20.4` |
| Pi | `0.84.1` | `0.84.2` |
| Oh My Pi | `17.2.13` | `17.3.8` |

## Why

The bridge should install or validate against current stable harness releases without treating the latest release as a new compatibility floor. Keeping those concepts separate lets compatible older PATH installations continue working while managed installs use the current target.

The maintenance skill also needs a registry guard so newly registered or direct-CLI harnesses cannot be silently omitted from future refreshes.

## Risk and test focus

The main risks are incorrect platform checksum mappings and upstream CLI/protocol drift. Release metadata and candidate artifacts were verified, including isolated Claude stream-JSON, Hermes ACP, Pi JSONL RPC, and OMP ACP probes. Cursor's four digests and Pi's six package digests were recomputed or checked and remain unchanged.

All compatibility floors remain unchanged, so this introduces no new setup-blocking behavior for existing PATH installations. There is no database or client/bridge transport-contract impact.

## Expected result

Managed installs resolve the latest OpenCode, Codex, Cursor, Pi, and OMP targets with verified artifacts. Claude and Hermes retain their existing compatibility floors while recording the latest validated releases. Future target refreshes cover all registered harnesses without implicitly raising minimum versions.

## Verification

- `dart pub get` from `bridge/`
- `dart test && dart analyze --fatal-infos` in `sesori_plugin_opencode`
- `dart test && dart analyze --fatal-infos` in `sesori_plugin_codex`
- `dart test && dart analyze --fatal-infos` in `sesori_plugin_claude`
- `dart test && dart analyze --fatal-infos` in `sesori_plugin_cursor`
- `dart test && dart analyze --fatal-infos` in `sesori_plugin_hermes`
- `dart test && dart analyze --fatal-infos` in `sesori_plugin_pi`
- `dart test && dart analyze --fatal-infos` in `sesori_plugin_omp`
- `dart test && dart analyze --fatal-infos` in `sesori_plugin_runtime`
- `git diff --check`
