### PR TITLE
⚙️ Discover and switch Hermes models

### DIFF
--- a/bridge/sesori_plugin_hermes/build.yaml
+++ b/bridge/sesori_plugin_hermes/build.yaml
@@ -1,0 +1,13 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          any_map: true
+          explicit_to_json: true
+          include_if_null: false
+      freezed:
+        options:
+          format: false
+          map: false
+          when: false

--- a/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
+++ b/bridge/sesori_plugin_hermes/lib/hermes_plugin.dart
@@ -1,8 +1,7 @@
 // Hermes Agent backend for the Sesori bridge.
 //
-// Drives `hermes acp` over the generic ACP machinery (acp_plugin). Hermes is
-// a stock ACP v1 server (protocol version 1), so the plugin core is policy
-// only, with no harness-specific protocol extensions.
+// Drives `hermes acp` over the generic ACP machinery (acp_plugin), with
+// Hermes-local handling for its unstable model catalog and set-model surface.
 export "src/hermes_binary.dart";
 export "src/hermes_plugin_impl.dart";
 // Plugin-lifecycle entry point: the const descriptor the bridge registers.

--- a/bridge/sesori_plugin_hermes/lib/src/api/hermes_acp_api.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/api/hermes_acp_api.dart
@@ -1,0 +1,152 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show CommandExecutor;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginOperationException;
+
+import "../hermes_binary.dart";
+
+/// Hermes CLI and ACP operations used by model discovery and selection.
+class HermesAcpApi({
+  required final String _binaryPath,
+  required final AcpProcessFactory _processFactory,
+  required final CommandExecutor _commandExecutor,
+  required final Map<String, String> _environment,
+}) {
+  static const String _sessionSetModel = "session/set_model";
+  AcpStdioClient? _scratchClient;
+  bool _disposed = false;
+
+  Future<void> openScratch({
+    required String cwd,
+    required Duration timeout,
+  }) async {
+    if (_disposed) throw StateError("HermesAcpApi is disposed");
+    if (_scratchClient != null) throw StateError("Hermes scratch ACP lease is already open");
+    final stopwatch = Stopwatch()..start();
+    final client = AcpStdioClient(
+      launchSpec: HermesBinary.launchSpec(
+        binary: _binaryPath,
+        cwd: cwd,
+        environment: const {},
+      ),
+      processFactory: _processFactory,
+      logTag: "hermes-catalog",
+    );
+    _scratchClient = client;
+    await client.connect().timeout(_remaining(timeout: timeout, stopwatch: stopwatch));
+    final raw = await client.request(
+      method: AcpMethods.initialize,
+      params: buildInitializeParams(
+        clientName: "sesori-bridge",
+        clientVersion: "0.0.0",
+        formElicitation: false,
+      ),
+      timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
+    );
+    final result = AcpInitializeResult.fromJson(
+      raw is Map ? raw.cast<String, dynamic>() : const {},
+    );
+    if (result.protocolVersion != acpProtocolVersion) {
+      throw StateError(
+        "Hermes negotiated ACP v${result.protocolVersion}; expected v$acpProtocolVersion",
+      );
+    }
+    if (!result.requiresAuth) return;
+    final methodId = _authMethodId(result);
+    if (methodId == null) {
+      throw StateError("Hermes model discovery requires non-terminal authentication");
+    }
+    await client.request(
+      method: AcpMethods.authenticate,
+      params: {"methodId": methodId},
+      timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
+    );
+  }
+
+  Future<AcpNewSessionResult> newScratchSession({
+    required String cwd,
+    required Duration timeout,
+  }) async {
+    final raw = await _scratchRequest(
+      method: AcpMethods.sessionNew,
+      params: {"cwd": cwd, "mcpServers": const <Object?>[]},
+      timeout: timeout,
+    );
+    return AcpNewSessionResult.fromJson(
+      raw is Map ? raw.cast<String, dynamic>() : const {},
+    );
+  }
+
+  Future<void> setModel({
+    required AcpStdioClient liveClient,
+    required String sessionId,
+    required String modelId,
+    required Duration timeout,
+  }) async {
+    await liveClient.request(
+      method: _sessionSetModel,
+      params: {"sessionId": sessionId, "modelId": modelId},
+      timeout: timeout,
+    );
+  }
+
+  Future<void> settleScratch({required Duration timeout}) async {
+    final client = _scratchClient;
+    _scratchClient = null;
+    if (client == null) return;
+    final processExit = client.processExit;
+    await client.dispose(gracefulTimeout: timeout);
+    await processExit.timeout(timeout);
+  }
+
+  Future<void> deletePersistedSession({
+    required String sessionId,
+    required Duration timeout,
+  }) async {
+    final result = await _commandExecutor.run(
+      _binaryPath,
+      ["sessions", "delete", sessionId, "--yes"],
+      environment: _environment,
+      timeout: timeout,
+    );
+    if (result.exitCode == 0) return;
+    throw PluginOperationException(
+      "hermes sessions delete",
+      message: "Hermes exited with code ${result.exitCode}: ${result.stderr.trim()}",
+    );
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await settleScratch(timeout: const Duration(seconds: 5));
+  }
+
+  Future<dynamic> _scratchRequest({
+    required String method,
+    required Object? params,
+    required Duration timeout,
+  }) {
+    final client = _scratchClient;
+    if (client == null || !client.isConnected) {
+      throw StateError("Hermes scratch ACP lease is not open");
+    }
+    return client.request(method: method, params: params, timeout: timeout);
+  }
+
+  String? _authMethodId(AcpInitializeResult result) {
+    for (final method in result.authMethods) {
+      if (method.type != AcpAuthMethodType.terminal) return method.id;
+    }
+    return null;
+  }
+
+  Duration _remaining({required Duration timeout, required Stopwatch stopwatch}) {
+    final remaining = timeout - stopwatch.elapsed;
+    if (remaining <= Duration.zero) {
+      throw TimeoutException("Hermes scratch ACP lease exceeded its operation deadline");
+    }
+    return remaining;
+  }
+}

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
@@ -1,9 +1,8 @@
-import "dart:io" show Directory;
-
 import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
-import "hermes_binary.dart";
 import "hermes_identity.dart";
+import "services/hermes_session_options_service.dart";
 
 /// Hermes Agent backend over ACP.
 ///
@@ -11,11 +10,11 @@ import "hermes_identity.dart";
 /// fork/prompt capabilities and streams turns via `session/update`
 /// notifications, so the base [AcpPlugin] machinery owns sessions and turns.
 /// This class declares Hermes-specific protocol policies, including excluding
-/// interactive terminal setup from headless authentication. Version 1 exposes
-/// Hermes's configured model as its sole model option while Hermes remains
-/// authoritative for model/mode changes. It has no managed runtime (Hermes
-/// installs itself; the bridge resolves it on PATH).
-class HermesPlugin._({
+/// interactive terminal setup from headless authentication. Hermes model
+/// discovery and its unstable `session/set_model` extension stay isolated in
+/// this package. It has no managed runtime (Hermes installs itself; the bridge
+/// resolves it on PATH).
+class HermesPlugin({
   required super.launchSpec,
   required super.launchDirectory,
   required super.contentMapper,
@@ -23,51 +22,8 @@ class HermesPlugin._({
   required super.commandTracker,
   required super.sessionOptionsService,
   required super.processFactory,
+  required final HermesSessionOptionsService _hermesSessionOptionsService,
 }) extends AcpPlugin {
-  factory({
-    required String binaryPath,
-    required String? launchDirectory,
-    required AcpProcessFactory processFactory,
-    required String? configuredModelId,
-    required String? configuredProviderId,
-  }) {
-    final cwd = launchDirectory ?? Directory.current.path;
-    final launchSpec = HermesBinary.launchSpec(
-      binary: binaryPath,
-      cwd: cwd,
-      environment: const {},
-    );
-    final commandTracker = AcpCommandTracker();
-    final configurationTracker = AcpSessionConfigurationTracker()
-      ..setProcessDefaults(
-        modelId: configuredModelId,
-        providerId: configuredProviderId,
-      );
-    const contentMapper = AcpContentMapper();
-    final sessionOptionsService = AcpSessionOptionsService(
-      configurationTracker: configurationTracker,
-      commandTracker: commandTracker,
-      pluginId: HermesPluginIdentity.id,
-      agentDisplayName: HermesPluginIdentity.displayName,
-    );
-    final mapper = AcpEventMapper(
-      launchDirectory: cwd,
-      agentId: HermesPluginIdentity.id,
-      pluginId: HermesPluginIdentity.id,
-      configurationTracker: configurationTracker,
-      contentMapper: contentMapper,
-    );
-    return HermesPlugin._(
-      launchSpec: launchSpec,
-      launchDirectory: cwd,
-      contentMapper: contentMapper,
-      eventMapper: mapper,
-      commandTracker: commandTracker,
-      sessionOptionsService: sessionOptionsService,
-      processFactory: processFactory,
-    );
-  }
-
   this
     : super(
         id: HermesPluginIdentity.id,
@@ -109,11 +65,69 @@ class HermesPlugin._({
   @override
   bool get cancelsActiveTurnForQueuedInput => false;
 
-  /// No harness-specific turn selection exists (base [applyTurnSelection] is
-  /// a no-op), so a selection can never fail a turn.
   @override
-  bool get failsTurnOnSelectionError => false;
+  bool get failsTurnOnSelectionError => true;
 
   @override
   Duration get sessionCloseSettlementTimeout => const Duration(seconds: 5);
+
+  @override
+  void captureSessionConfig(
+    AcpNewSessionResult result, {
+    String? sessionId,
+    bool fromNewSession = false,
+  }) => _hermesSessionOptionsService.captureSessionConfig(
+    result,
+    sessionId: sessionId,
+    fromNewSession: fromNewSession,
+  );
+
+  @override
+  Future<void> applyTurnSelection({
+    required AcpSessionConfigRepository configRepository,
+    required String sessionId,
+    required ({String providerID, String modelID})? model,
+    required PluginSessionVariant? variant,
+    required String? agent,
+  }) async {
+    final liveClient = client;
+    if (liveClient == null) throw StateError("Hermes ACP client is not connected");
+    await _hermesSessionOptionsService.applyTurnSelection(
+      liveClient: liveClient,
+      sessionId: sessionId,
+      model: model,
+    );
+  }
+
+  @override
+  Future<PluginSessionOptionsDiscoveryResult> getSessionOptions({
+    required String projectId,
+    required PluginSessionOptionsDiscoveryMode discoveryMode,
+  }) => _hermesSessionOptionsService.getSessionOptions(discoveryMode: discoveryMode);
+
+  @override
+  Future<List<PluginAgent>> getAgents({required String projectId}) => _hermesSessionOptionsService.listAgents();
+
+  @override
+  Future<PluginProvidersResult> getProviders({required String projectId}) =>
+      _hermesSessionOptionsService.listProviders();
+
+  @override
+  Future<void> deleteSession(String sessionId) async {
+    await super.deleteSession(sessionId);
+    _hermesSessionOptionsService.forgetSession(sessionId: sessionId);
+  }
+
+  @override
+  void onConnectionReset() => _hermesSessionOptionsService.resetConnection();
+
+  @override
+  Future<void> dispose() async {
+    try {
+      await _hermesSessionOptionsService.dispose();
+    } on Object catch (error, stackTrace) {
+      Log.w("[${HermesPluginIdentity.id}] failed to dispose session options service", error, stackTrace);
+    }
+    await super.dispose();
+  }
 }

--- a/bridge/sesori_plugin_hermes/lib/src/models/hermes_model_catalog.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/models/hermes_model_catalog.dart
@@ -1,0 +1,30 @@
+class const HermesCatalogModel({
+  required final String value,
+  required final String providerId,
+  required final String providerName,
+  required final String modelId,
+  required final String name,
+});
+
+class HermesModelCatalog({
+  required List<HermesCatalogModel> models,
+  required final String? currentModelValue,
+}) {
+  final List<HermesCatalogModel> models = List.unmodifiable(models);
+
+  HermesCatalogModel? get currentModel {
+    final current = currentModelValue;
+    if (current == null) return null;
+    for (final model in models) {
+      if (model.value == current) return model;
+    }
+    return null;
+  }
+}
+
+sealed class const HermesCatalogDiscoveryResult();
+
+final class const HermesCatalogObserved({required final HermesModelCatalog catalog})
+    extends HermesCatalogDiscoveryResult;
+
+final class const HermesCatalogDiscoveryFailed() extends HermesCatalogDiscoveryResult;

--- a/bridge/sesori_plugin_hermes/lib/src/models/hermes_model_state_dto.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/models/hermes_model_state_dto.dart
@@ -1,0 +1,25 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "hermes_model_state_dto.freezed.dart";
+part "hermes_model_state_dto.g.dart";
+
+@freezed
+sealed class HermesModelInfoDto with _$HermesModelInfoDto {
+  const factory({
+    @Default("") String modelId,
+    @Default("") String name,
+    required String? description,
+  }) = _HermesModelInfoDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$HermesModelInfoDtoFromJson(json);
+}
+
+@freezed
+sealed class HermesSessionModelStateDto with _$HermesSessionModelStateDto {
+  const factory({
+    @Default(<HermesModelInfoDto>[]) List<HermesModelInfoDto> availableModels,
+    @Default("") String currentModelId,
+  }) = _HermesSessionModelStateDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$HermesSessionModelStateDtoFromJson(json);
+}

--- a/bridge/sesori_plugin_hermes/lib/src/models/hermes_model_state_dto.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/models/hermes_model_state_dto.dart
@@ -6,8 +6,8 @@ part "hermes_model_state_dto.g.dart";
 @freezed
 sealed class HermesModelInfoDto with _$HermesModelInfoDto {
   const factory({
-    @Default("") String modelId,
-    @Default("") String name,
+    required String? modelId,
+    required String? name,
     required String? description,
   }) = _HermesModelInfoDto;
 
@@ -18,7 +18,7 @@ sealed class HermesModelInfoDto with _$HermesModelInfoDto {
 sealed class HermesSessionModelStateDto with _$HermesSessionModelStateDto {
   const factory({
     @Default(<HermesModelInfoDto>[]) List<HermesModelInfoDto> availableModels,
-    @Default("") String currentModelId,
+    required String? currentModelId,
   }) = _HermesSessionModelStateDto;
 
   factory fromJson(Map<String, dynamic> json) => _$HermesSessionModelStateDtoFromJson(json);

--- a/bridge/sesori_plugin_hermes/lib/src/models/hermes_model_state_dto.freezed.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/models/hermes_model_state_dto.freezed.dart
@@ -1,0 +1,298 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint, type=warning, deprecated_member_use, deprecated_member_use_from_same_package
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'hermes_model_state_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$HermesModelInfoDto {
+
+ String get modelId; String get name; String? get description;
+/// Create a copy of HermesModelInfoDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$HermesModelInfoDtoCopyWith<HermesModelInfoDto> get copyWith => _$HermesModelInfoDtoCopyWithImpl<HermesModelInfoDto>(this as HermesModelInfoDto, _$identity);
+
+  /// Serializes this HermesModelInfoDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HermesModelInfoDto&&(identical(other.modelId, modelId) || other.modelId == modelId)&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,modelId,name,description);
+
+@override
+String toString() {
+  return 'HermesModelInfoDto(modelId: $modelId, name: $name, description: $description)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $HermesModelInfoDtoCopyWith<$Res>  {
+  factory $HermesModelInfoDtoCopyWith(HermesModelInfoDto value, $Res Function(HermesModelInfoDto) _then) = _$HermesModelInfoDtoCopyWithImpl;
+@useResult
+$Res call({
+ String modelId, String name, String? description
+});
+
+
+
+
+}
+/// @nodoc
+class _$HermesModelInfoDtoCopyWithImpl<$Res>
+    implements $HermesModelInfoDtoCopyWith<$Res> {
+  _$HermesModelInfoDtoCopyWithImpl(this._self, this._then);
+
+  final HermesModelInfoDto _self;
+  final $Res Function(HermesModelInfoDto) _then;
+
+/// Create a copy of HermesModelInfoDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? modelId = null,Object? name = null,Object? description = freezed,}) {
+  return _then(HermesModelInfoDto(
+modelId: null == modelId ? _self.modelId : modelId // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _HermesModelInfoDto implements HermesModelInfoDto {
+  const _HermesModelInfoDto({this.modelId = "", this.name = "", required this.description});
+  factory _HermesModelInfoDto.fromJson(Map<String, dynamic> json) => _$HermesModelInfoDtoFromJson(json);
+
+@override@JsonKey() final  String modelId;
+@override@JsonKey() final  String name;
+@override final  String? description;
+
+/// Create a copy of HermesModelInfoDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$HermesModelInfoDtoCopyWith<_HermesModelInfoDto> get copyWith => __$HermesModelInfoDtoCopyWithImpl<_HermesModelInfoDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$HermesModelInfoDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HermesModelInfoDto&&(identical(other.modelId, modelId) || other.modelId == modelId)&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,modelId,name,description);
+
+@override
+String toString() {
+  return 'HermesModelInfoDto(modelId: $modelId, name: $name, description: $description)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$HermesModelInfoDtoCopyWith<$Res> implements $HermesModelInfoDtoCopyWith<$Res> {
+  factory _$HermesModelInfoDtoCopyWith(_HermesModelInfoDto value, $Res Function(_HermesModelInfoDto) _then) = __$HermesModelInfoDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String modelId, String name, String? description
+});
+
+
+
+
+}
+/// @nodoc
+class __$HermesModelInfoDtoCopyWithImpl<$Res>
+    implements _$HermesModelInfoDtoCopyWith<$Res> {
+  __$HermesModelInfoDtoCopyWithImpl(this._self, this._then);
+
+  final _HermesModelInfoDto _self;
+  final $Res Function(_HermesModelInfoDto) _then;
+
+/// Create a copy of HermesModelInfoDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? modelId = null,Object? name = null,Object? description = freezed,}) {
+  return _then(_HermesModelInfoDto(
+modelId: null == modelId ? _self.modelId : modelId // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$HermesSessionModelStateDto {
+
+ List<HermesModelInfoDto> get availableModels; String get currentModelId;
+/// Create a copy of HermesSessionModelStateDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$HermesSessionModelStateDtoCopyWith<HermesSessionModelStateDto> get copyWith => _$HermesSessionModelStateDtoCopyWithImpl<HermesSessionModelStateDto>(this as HermesSessionModelStateDto, _$identity);
+
+  /// Serializes this HermesSessionModelStateDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is HermesSessionModelStateDto&&const DeepCollectionEquality().equals(other.availableModels, availableModels)&&(identical(other.currentModelId, currentModelId) || other.currentModelId == currentModelId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(availableModels),currentModelId);
+
+@override
+String toString() {
+  return 'HermesSessionModelStateDto(availableModels: $availableModels, currentModelId: $currentModelId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $HermesSessionModelStateDtoCopyWith<$Res>  {
+  factory $HermesSessionModelStateDtoCopyWith(HermesSessionModelStateDto value, $Res Function(HermesSessionModelStateDto) _then) = _$HermesSessionModelStateDtoCopyWithImpl;
+@useResult
+$Res call({
+ List<HermesModelInfoDto> availableModels, String currentModelId
+});
+
+
+
+
+}
+/// @nodoc
+class _$HermesSessionModelStateDtoCopyWithImpl<$Res>
+    implements $HermesSessionModelStateDtoCopyWith<$Res> {
+  _$HermesSessionModelStateDtoCopyWithImpl(this._self, this._then);
+
+  final HermesSessionModelStateDto _self;
+  final $Res Function(HermesSessionModelStateDto) _then;
+
+/// Create a copy of HermesSessionModelStateDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? availableModels = null,Object? currentModelId = null,}) {
+  return _then(HermesSessionModelStateDto(
+availableModels: null == availableModels ? _self.availableModels : availableModels // ignore: cast_nullable_to_non_nullable
+as List<HermesModelInfoDto>,currentModelId: null == currentModelId ? _self.currentModelId : currentModelId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _HermesSessionModelStateDto implements HermesSessionModelStateDto {
+  const _HermesSessionModelStateDto({ List<HermesModelInfoDto> availableModels = const <HermesModelInfoDto>[], this.currentModelId = ""}): _availableModels = availableModels;
+  factory _HermesSessionModelStateDto.fromJson(Map<String, dynamic> json) => _$HermesSessionModelStateDtoFromJson(json);
+
+ final  List<HermesModelInfoDto> _availableModels;
+@override@JsonKey() List<HermesModelInfoDto> get availableModels {
+  if (_availableModels is EqualUnmodifiableListView) return _availableModels;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_availableModels);
+}
+
+@override@JsonKey() final  String currentModelId;
+
+/// Create a copy of HermesSessionModelStateDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$HermesSessionModelStateDtoCopyWith<_HermesSessionModelStateDto> get copyWith => __$HermesSessionModelStateDtoCopyWithImpl<_HermesSessionModelStateDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$HermesSessionModelStateDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _HermesSessionModelStateDto&&const DeepCollectionEquality().equals(other._availableModels, _availableModels)&&(identical(other.currentModelId, currentModelId) || other.currentModelId == currentModelId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_availableModels),currentModelId);
+
+@override
+String toString() {
+  return 'HermesSessionModelStateDto(availableModels: $availableModels, currentModelId: $currentModelId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$HermesSessionModelStateDtoCopyWith<$Res> implements $HermesSessionModelStateDtoCopyWith<$Res> {
+  factory _$HermesSessionModelStateDtoCopyWith(_HermesSessionModelStateDto value, $Res Function(_HermesSessionModelStateDto) _then) = __$HermesSessionModelStateDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ List<HermesModelInfoDto> availableModels, String currentModelId
+});
+
+
+
+
+}
+/// @nodoc
+class __$HermesSessionModelStateDtoCopyWithImpl<$Res>
+    implements _$HermesSessionModelStateDtoCopyWith<$Res> {
+  __$HermesSessionModelStateDtoCopyWithImpl(this._self, this._then);
+
+  final _HermesSessionModelStateDto _self;
+  final $Res Function(_HermesSessionModelStateDto) _then;
+
+/// Create a copy of HermesSessionModelStateDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? availableModels = null,Object? currentModelId = null,}) {
+  return _then(_HermesSessionModelStateDto(
+availableModels: null == availableModels ? _self._availableModels : availableModels // ignore: cast_nullable_to_non_nullable
+as List<HermesModelInfoDto>,currentModelId: null == currentModelId ? _self.currentModelId : currentModelId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/sesori_plugin_hermes/lib/src/models/hermes_model_state_dto.freezed.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/models/hermes_model_state_dto.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$HermesModelInfoDto {
 
- String get modelId; String get name; String? get description;
+ String? get modelId; String? get name; String? get description;
 /// Create a copy of HermesModelInfoDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -49,7 +49,7 @@ abstract mixin class $HermesModelInfoDtoCopyWith<$Res>  {
   factory $HermesModelInfoDtoCopyWith(HermesModelInfoDto value, $Res Function(HermesModelInfoDto) _then) = _$HermesModelInfoDtoCopyWithImpl;
 @useResult
 $Res call({
- String modelId, String name, String? description
+ String? modelId, String? name, String? description
 });
 
 
@@ -66,11 +66,11 @@ class _$HermesModelInfoDtoCopyWithImpl<$Res>
 
 /// Create a copy of HermesModelInfoDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? modelId = null,Object? name = null,Object? description = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? modelId = freezed,Object? name = freezed,Object? description = freezed,}) {
   return _then(HermesModelInfoDto(
-modelId: null == modelId ? _self.modelId : modelId // ignore: cast_nullable_to_non_nullable
-as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
-as String,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+modelId: freezed == modelId ? _self.modelId : modelId // ignore: cast_nullable_to_non_nullable
+as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }
@@ -83,11 +83,11 @@ as String?,
 @JsonSerializable()
 
 class _HermesModelInfoDto implements HermesModelInfoDto {
-  const _HermesModelInfoDto({this.modelId = "", this.name = "", required this.description});
+  const _HermesModelInfoDto({required this.modelId, required this.name, required this.description});
   factory _HermesModelInfoDto.fromJson(Map<String, dynamic> json) => _$HermesModelInfoDtoFromJson(json);
 
-@override@JsonKey() final  String modelId;
-@override@JsonKey() final  String name;
+@override final  String? modelId;
+@override final  String? name;
 @override final  String? description;
 
 /// Create a copy of HermesModelInfoDto
@@ -123,7 +123,7 @@ abstract mixin class _$HermesModelInfoDtoCopyWith<$Res> implements $HermesModelI
   factory _$HermesModelInfoDtoCopyWith(_HermesModelInfoDto value, $Res Function(_HermesModelInfoDto) _then) = __$HermesModelInfoDtoCopyWithImpl;
 @override @useResult
 $Res call({
- String modelId, String name, String? description
+ String? modelId, String? name, String? description
 });
 
 
@@ -140,11 +140,11 @@ class __$HermesModelInfoDtoCopyWithImpl<$Res>
 
 /// Create a copy of HermesModelInfoDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? modelId = null,Object? name = null,Object? description = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? modelId = freezed,Object? name = freezed,Object? description = freezed,}) {
   return _then(_HermesModelInfoDto(
-modelId: null == modelId ? _self.modelId : modelId // ignore: cast_nullable_to_non_nullable
-as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
-as String,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+modelId: freezed == modelId ? _self.modelId : modelId // ignore: cast_nullable_to_non_nullable
+as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }
@@ -156,7 +156,7 @@ as String?,
 /// @nodoc
 mixin _$HermesSessionModelStateDto {
 
- List<HermesModelInfoDto> get availableModels; String get currentModelId;
+ List<HermesModelInfoDto> get availableModels; String? get currentModelId;
 /// Create a copy of HermesSessionModelStateDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -189,7 +189,7 @@ abstract mixin class $HermesSessionModelStateDtoCopyWith<$Res>  {
   factory $HermesSessionModelStateDtoCopyWith(HermesSessionModelStateDto value, $Res Function(HermesSessionModelStateDto) _then) = _$HermesSessionModelStateDtoCopyWithImpl;
 @useResult
 $Res call({
- List<HermesModelInfoDto> availableModels, String currentModelId
+ List<HermesModelInfoDto> availableModels, String? currentModelId
 });
 
 
@@ -206,11 +206,11 @@ class _$HermesSessionModelStateDtoCopyWithImpl<$Res>
 
 /// Create a copy of HermesSessionModelStateDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? availableModels = null,Object? currentModelId = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? availableModels = null,Object? currentModelId = freezed,}) {
   return _then(HermesSessionModelStateDto(
 availableModels: null == availableModels ? _self.availableModels : availableModels // ignore: cast_nullable_to_non_nullable
-as List<HermesModelInfoDto>,currentModelId: null == currentModelId ? _self.currentModelId : currentModelId // ignore: cast_nullable_to_non_nullable
-as String,
+as List<HermesModelInfoDto>,currentModelId: freezed == currentModelId ? _self.currentModelId : currentModelId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 
@@ -222,7 +222,7 @@ as String,
 @JsonSerializable()
 
 class _HermesSessionModelStateDto implements HermesSessionModelStateDto {
-  const _HermesSessionModelStateDto({ List<HermesModelInfoDto> availableModels = const <HermesModelInfoDto>[], this.currentModelId = ""}): _availableModels = availableModels;
+  const _HermesSessionModelStateDto({ List<HermesModelInfoDto> availableModels = const <HermesModelInfoDto>[], required this.currentModelId}): _availableModels = availableModels;
   factory _HermesSessionModelStateDto.fromJson(Map<String, dynamic> json) => _$HermesSessionModelStateDtoFromJson(json);
 
  final  List<HermesModelInfoDto> _availableModels;
@@ -232,7 +232,7 @@ class _HermesSessionModelStateDto implements HermesSessionModelStateDto {
   return EqualUnmodifiableListView(_availableModels);
 }
 
-@override@JsonKey() final  String currentModelId;
+@override final  String? currentModelId;
 
 /// Create a copy of HermesSessionModelStateDto
 /// with the given fields replaced by the non-null parameter values.
@@ -267,7 +267,7 @@ abstract mixin class _$HermesSessionModelStateDtoCopyWith<$Res> implements $Herm
   factory _$HermesSessionModelStateDtoCopyWith(_HermesSessionModelStateDto value, $Res Function(_HermesSessionModelStateDto) _then) = __$HermesSessionModelStateDtoCopyWithImpl;
 @override @useResult
 $Res call({
- List<HermesModelInfoDto> availableModels, String currentModelId
+ List<HermesModelInfoDto> availableModels, String? currentModelId
 });
 
 
@@ -284,11 +284,11 @@ class __$HermesSessionModelStateDtoCopyWithImpl<$Res>
 
 /// Create a copy of HermesSessionModelStateDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? availableModels = null,Object? currentModelId = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? availableModels = null,Object? currentModelId = freezed,}) {
   return _then(_HermesSessionModelStateDto(
 availableModels: null == availableModels ? _self._availableModels : availableModels // ignore: cast_nullable_to_non_nullable
-as List<HermesModelInfoDto>,currentModelId: null == currentModelId ? _self.currentModelId : currentModelId // ignore: cast_nullable_to_non_nullable
-as String,
+as List<HermesModelInfoDto>,currentModelId: freezed == currentModelId ? _self.currentModelId : currentModelId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/bridge/sesori_plugin_hermes/lib/src/models/hermes_model_state_dto.g.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/models/hermes_model_state_dto.g.dart
@@ -8,15 +8,15 @@ part of 'hermes_model_state_dto.dart';
 
 _HermesModelInfoDto _$HermesModelInfoDtoFromJson(Map json) =>
     _HermesModelInfoDto(
-      modelId: json['modelId'] as String? ?? "",
-      name: json['name'] as String? ?? "",
+      modelId: json['modelId'] as String?,
+      name: json['name'] as String?,
       description: json['description'] as String?,
     );
 
 Map<String, dynamic> _$HermesModelInfoDtoToJson(_HermesModelInfoDto instance) =>
     <String, dynamic>{
-      'modelId': instance.modelId,
-      'name': instance.name,
+      'modelId': ?instance.modelId,
+      'name': ?instance.name,
       'description': ?instance.description,
     };
 
@@ -31,12 +31,12 @@ _HermesSessionModelStateDto _$HermesSessionModelStateDtoFromJson(Map json) =>
               )
               .toList() ??
           const <HermesModelInfoDto>[],
-      currentModelId: json['currentModelId'] as String? ?? "",
+      currentModelId: json['currentModelId'] as String?,
     );
 
 Map<String, dynamic> _$HermesSessionModelStateDtoToJson(
   _HermesSessionModelStateDto instance,
 ) => <String, dynamic>{
   'availableModels': instance.availableModels.map((e) => e.toJson()).toList(),
-  'currentModelId': instance.currentModelId,
+  'currentModelId': ?instance.currentModelId,
 };

--- a/bridge/sesori_plugin_hermes/lib/src/models/hermes_model_state_dto.g.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/models/hermes_model_state_dto.g.dart
@@ -1,0 +1,42 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'hermes_model_state_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_HermesModelInfoDto _$HermesModelInfoDtoFromJson(Map json) =>
+    _HermesModelInfoDto(
+      modelId: json['modelId'] as String? ?? "",
+      name: json['name'] as String? ?? "",
+      description: json['description'] as String?,
+    );
+
+Map<String, dynamic> _$HermesModelInfoDtoToJson(_HermesModelInfoDto instance) =>
+    <String, dynamic>{
+      'modelId': instance.modelId,
+      'name': instance.name,
+      'description': ?instance.description,
+    };
+
+_HermesSessionModelStateDto _$HermesSessionModelStateDtoFromJson(Map json) =>
+    _HermesSessionModelStateDto(
+      availableModels:
+          (json['availableModels'] as List<dynamic>?)
+              ?.map(
+                (e) => HermesModelInfoDto.fromJson(
+                  Map<String, dynamic>.from(e as Map),
+                ),
+              )
+              .toList() ??
+          const <HermesModelInfoDto>[],
+      currentModelId: json['currentModelId'] as String? ?? "",
+    );
+
+Map<String, dynamic> _$HermesSessionModelStateDtoToJson(
+  _HermesSessionModelStateDto instance,
+) => <String, dynamic>{
+  'availableModels': instance.availableModels.map((e) => e.toJson()).toList(),
+  'currentModelId': instance.currentModelId,
+};

--- a/bridge/sesori_plugin_hermes/lib/src/repositories/hermes_catalog_repository.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/repositories/hermes_catalog_repository.dart
@@ -1,0 +1,164 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, PluginOperationException;
+
+import "../api/hermes_acp_api.dart";
+import "../models/hermes_model_catalog.dart";
+import "../models/hermes_model_state_dto.dart";
+
+/// Maps Hermes's model state and owns one disposable discovery transaction.
+class HermesCatalogRepository({required final HermesAcpApi _api}) {
+  Future<HermesModelCatalog> discoverCatalog({
+    required String cwd,
+    required Duration timeout,
+  }) async {
+    final stopwatch = Stopwatch()..start();
+    String? sessionId;
+    HermesModelCatalog? catalog;
+    Object? discoveryError;
+    StackTrace? discoveryStack;
+
+    try {
+      await _api.openScratch(
+        cwd: cwd,
+        timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
+      );
+      final result = await _api.newScratchSession(
+        cwd: cwd,
+        timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
+      );
+      sessionId = result.sessionId;
+      if (sessionId.isEmpty) throw StateError("Hermes catalog session/new omitted sessionId");
+      catalog = mapSessionResult(result: result);
+      if (catalog == null || catalog.models.isEmpty) {
+        throw StateError("Hermes catalog session/new omitted model state");
+      }
+    } on Object catch (error, stackTrace) {
+      discoveryError = error;
+      discoveryStack = stackTrace;
+    }
+
+    Object? cleanupError;
+    StackTrace? cleanupStack;
+    var processExited = false;
+    try {
+      await _api.settleScratch(
+        timeout: _cleanupTimeout(timeout: timeout, stopwatch: stopwatch),
+      );
+      processExited = true;
+      if (sessionId != null) {
+        await _api.deletePersistedSession(
+          sessionId: sessionId,
+          timeout: _cleanupTimeout(timeout: timeout, stopwatch: stopwatch),
+        );
+      }
+    } on Object catch (error, stackTrace) {
+      cleanupError = PluginOperationException(
+        "hermes catalog cleanup",
+        message: processExited
+            ? "Could not delete Hermes discovery session $sessionId"
+            : "Hermes discovery process did not exit; session $sessionId was not deleted",
+        cause: error,
+      );
+      cleanupStack = stackTrace;
+    }
+
+    if (discoveryError != null) {
+      if (cleanupError != null) {
+        Log.w("[hermes] cleanup also failed after model discovery failed", cleanupError, cleanupStack);
+      }
+      Error.throwWithStackTrace(discoveryError, discoveryStack!);
+    }
+    if (cleanupError != null) {
+      Error.throwWithStackTrace(cleanupError, cleanupStack!);
+    }
+    return catalog!;
+  }
+
+  Future<void> setModel({
+    required AcpStdioClient liveClient,
+    required String sessionId,
+    required String modelId,
+    required Duration timeout,
+  }) => _api.setModel(
+    liveClient: liveClient,
+    sessionId: sessionId,
+    modelId: modelId,
+    timeout: timeout,
+  );
+
+  HermesModelCatalog? mapSessionResult({required AcpNewSessionResult result}) {
+    final rawModels = result.raw["models"];
+    if (rawModels is! Map) return null;
+    final state = HermesSessionModelStateDto.fromJson(rawModels.cast<String, dynamic>());
+    final models = <HermesCatalogModel>[];
+    for (final entry in state.availableModels) {
+      final value = entry.modelId.trim();
+      if (value.isEmpty) continue;
+      final split = _splitModelValue(value);
+      final display = _splitDisplayName(entry.name);
+      models.add(
+        HermesCatalogModel(
+          value: value,
+          providerId: split.providerId,
+          providerName: display.providerName ?? split.providerId,
+          modelId: split.modelId,
+          name: display.modelName ?? split.modelId,
+        ),
+      );
+    }
+    final current = state.currentModelId.trim();
+    return HermesModelCatalog(
+      models: models,
+      currentModelValue: current.isEmpty ? null : current,
+    );
+  }
+
+  Future<void> dispose() => _api.dispose();
+
+  ({String providerId, String modelId}) _splitModelValue(String value) {
+    if (value.startsWith("custom:")) {
+      final separator = value.indexOf(":", "custom:".length);
+      if (separator > "custom:".length && separator < value.length - 1) {
+        return (
+          providerId: value.substring(0, separator),
+          modelId: value.substring(separator + 1),
+        );
+      }
+    }
+    final separator = value.indexOf(":");
+    if (separator <= 0 || separator == value.length - 1) {
+      return (providerId: "hermes", modelId: value);
+    }
+    return (
+      providerId: value.substring(0, separator),
+      modelId: value.substring(separator + 1),
+    );
+  }
+
+  ({String? providerName, String? modelName}) _splitDisplayName(String value) {
+    const separatorToken = " \u00b7 ";
+    final separator = value.indexOf(separatorToken);
+    if (separator <= 0 || separator == value.length - separatorToken.length) {
+      return (providerName: null, modelName: value.trim().isEmpty ? null : value.trim());
+    }
+    return (
+      providerName: value.substring(0, separator).trim(),
+      modelName: value.substring(separator + separatorToken.length).trim(),
+    );
+  }
+
+  Duration _remaining({required Duration timeout, required Stopwatch stopwatch}) {
+    final remaining = timeout - stopwatch.elapsed;
+    if (remaining <= Duration.zero) {
+      throw TimeoutException("Hermes model discovery exceeded $timeout");
+    }
+    return remaining;
+  }
+
+  Duration _cleanupTimeout({required Duration timeout, required Stopwatch stopwatch}) {
+    final remaining = timeout - stopwatch.elapsed;
+    return remaining > const Duration(seconds: 5) ? remaining : const Duration(seconds: 5);
+  }
+}

--- a/bridge/sesori_plugin_hermes/lib/src/repositories/hermes_catalog_repository.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/repositories/hermes_catalog_repository.dart
@@ -9,6 +9,8 @@ import "../models/hermes_model_state_dto.dart";
 
 /// Maps Hermes's model state and owns one disposable discovery transaction.
 class HermesCatalogRepository({required final HermesAcpApi _api}) {
+  /// Hermes Agent 0.20.4 has no pre-session route that lists agents, models,
+  /// or variants, so discovery creates and then deletes a disposable session.
   Future<HermesModelCatalog> discoverCatalog({
     required String cwd,
     required Duration timeout,
@@ -47,7 +49,7 @@ class HermesCatalogRepository({required final HermesAcpApi _api}) {
         timeout: _cleanupTimeout(timeout: timeout, stopwatch: stopwatch),
       );
       processExited = true;
-      if (sessionId != null) {
+      if (sessionId != null && sessionId.isNotEmpty) {
         await _api.deletePersistedSession(
           sessionId: sessionId,
           timeout: _cleanupTimeout(timeout: timeout, stopwatch: stopwatch),
@@ -94,8 +96,8 @@ class HermesCatalogRepository({required final HermesAcpApi _api}) {
     final state = HermesSessionModelStateDto.fromJson(rawModels.cast<String, dynamic>());
     final models = <HermesCatalogModel>[];
     for (final entry in state.availableModels) {
-      final value = entry.modelId.trim();
-      if (value.isEmpty) continue;
+      final value = entry.modelId?.trim();
+      if (value == null || value.isEmpty) continue;
       final split = _splitModelValue(value);
       final display = _splitDisplayName(entry.name);
       models.add(
@@ -108,10 +110,10 @@ class HermesCatalogRepository({required final HermesAcpApi _api}) {
         ),
       );
     }
-    final current = state.currentModelId.trim();
+    final current = state.currentModelId?.trim();
     return HermesModelCatalog(
       models: models,
-      currentModelValue: current.isEmpty ? null : current,
+      currentModelValue: current == null || current.isEmpty ? null : current,
     );
   }
 
@@ -137,15 +139,19 @@ class HermesCatalogRepository({required final HermesAcpApi _api}) {
     );
   }
 
-  ({String? providerName, String? modelName}) _splitDisplayName(String value) {
+  ({String? providerName, String? modelName}) _splitDisplayName(String? value) {
+    final displayValue = value?.trim();
+    if (displayValue == null || displayValue.isEmpty) {
+      return (providerName: null, modelName: null);
+    }
     const separatorToken = " \u00b7 ";
-    final separator = value.indexOf(separatorToken);
-    if (separator <= 0 || separator == value.length - separatorToken.length) {
-      return (providerName: null, modelName: value.trim().isEmpty ? null : value.trim());
+    final separator = displayValue.indexOf(separatorToken);
+    if (separator <= 0 || separator == displayValue.length - separatorToken.length) {
+      return (providerName: null, modelName: displayValue);
     }
     return (
-      providerName: value.substring(0, separator).trim(),
-      modelName: value.substring(separator + separatorToken.length).trim(),
+      providerName: displayValue.substring(0, separator).trim(),
+      modelName: displayValue.substring(separator + separatorToken.length).trim(),
     );
   }
 

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -6,9 +6,12 @@ import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart"
     show CommandResult, HostProcessCommandExecutor, SemanticVersion;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
+import "../api/hermes_acp_api.dart";
 import "../hermes_binary.dart";
 import "../hermes_identity.dart";
 import "../hermes_plugin_impl.dart";
+import "../repositories/hermes_catalog_repository.dart";
+import "../services/hermes_session_options_service.dart";
 
 const int _setupProbeOutputLimit = 64 * 1024;
 
@@ -24,9 +27,8 @@ const int _setupProbeOutputLimit = 64 * 1024;
 class const HermesPluginDescriptor() extends BridgePluginDescriptor {
   static const Duration _connectBudget = Duration(seconds: 15);
   static const Duration _versionProbeTimeout = Duration(seconds: 10);
-
   /// Oldest Hermes Agent release with the ACP behavior this plugin requires.
-  static const String minVersion = "0.20.0";
+  static const String minVersion = "0.20.4";
 
   /// Latest stable Hermes Agent release validated against this plugin.
   static const String targetVersion = "0.20.4";
@@ -345,20 +347,70 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
 
     // Route the agent subprocess through the host process seam rather than
     // io.Process.start, so the bridge owns identity capture and signalling.
+    final cwd = io.Directory.current.path;
     final processFactory = hostProcessAcpFactory(
       processes: host.processes,
       environment: host.environment,
     );
+    final commandExecutor = HostProcessCommandExecutor(
+      processes: host.processes,
+      runInShell: io.Platform.isWindows,
+      maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
+    );
+    final configurationTracker = AcpSessionConfigurationTracker()
+      ..setProcessDefaults(
+        modelId: hasConfiguredModel ? status.model : null,
+        providerId: hasConfiguredModel ? status.provider : null,
+      );
+    final commandTracker = AcpCommandTracker();
+    const contentMapper = AcpContentMapper();
+    final acpSessionOptionsService = AcpSessionOptionsService(
+      configurationTracker: configurationTracker,
+      commandTracker: commandTracker,
+      pluginId: HermesPluginIdentity.id,
+      agentDisplayName: HermesPluginIdentity.displayName,
+    );
+    final eventMapper = AcpEventMapper(
+      launchDirectory: cwd,
+      agentId: HermesPluginIdentity.id,
+      pluginId: HermesPluginIdentity.id,
+      configurationTracker: configurationTracker,
+      contentMapper: contentMapper,
+    );
+    final catalogRepository = HermesCatalogRepository(
+      api: HermesAcpApi(
+        binaryPath: binaryPath,
+        processFactory: processFactory,
+        commandExecutor: commandExecutor,
+        environment: host.environment,
+      ),
+    );
+    final sessionOptionsService = HermesSessionOptionsService(
+      repository: catalogRepository,
+      configurationTracker: configurationTracker,
+      commandTracker: commandTracker,
+      launchDirectory: cwd,
+      pluginId: HermesPluginIdentity.id,
+      agentDisplayName: HermesPluginIdentity.displayName,
+      discoveryTimeout: const Duration(seconds: 20),
+    );
 
     final hermes = HermesPlugin(
-      binaryPath: binaryPath,
+      launchSpec: HermesBinary.launchSpec(
+        binary: binaryPath,
+        cwd: cwd,
+        environment: const {},
+      ),
       // The bridge seeds the launch directory as an always-present project;
       // the bridge itself owns all project/session persistence for this
       // derive-style plugin, so the plugin needs no store of its own.
-      launchDirectory: io.Directory.current.path,
+      launchDirectory: cwd,
+      contentMapper: contentMapper,
+      eventMapper: eventMapper,
+      commandTracker: commandTracker,
+      sessionOptionsService: acpSessionOptionsService,
       processFactory: processFactory,
-      configuredModelId: hasConfiguredModel ? status.model : null,
-      configuredProviderId: hasConfiguredModel ? status.provider : null,
+      hermesSessionOptionsService: sessionOptionsService,
     );
 
     final plugin = AcpBridgePlugin(

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -27,8 +27,9 @@ const int _setupProbeOutputLimit = 64 * 1024;
 class const HermesPluginDescriptor() extends BridgePluginDescriptor {
   static const Duration _connectBudget = Duration(seconds: 15);
   static const Duration _versionProbeTimeout = Duration(seconds: 10);
+
   /// Oldest Hermes Agent release with the ACP behavior this plugin requires.
-  static const String minVersion = "0.20.4";
+  static const String minVersion = "0.20.0";
 
   /// Latest stable Hermes Agent release validated against this plugin.
   static const String targetVersion = "0.20.4";

--- a/bridge/sesori_plugin_hermes/lib/src/services/hermes_session_options_service.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/services/hermes_session_options_service.dart
@@ -84,8 +84,7 @@ class HermesSessionOptionsService({
     if (model == null) return;
     final requested = model.modelID;
     final currentValue = _configurationTracker.snapshotForSession(sessionId: sessionId).modelId;
-    final current = _catalog?.currentModel;
-    if (requested == currentValue || requested == current?.value) return;
+    if (requested == currentValue) return;
     try {
       await _repository.setModel(
         liveClient: liveClient,

--- a/bridge/sesori_plugin_hermes/lib/src/services/hermes_session_options_service.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/services/hermes_session_options_service.dart
@@ -17,6 +17,7 @@ class HermesSessionOptionsService({
   HermesModelCatalog? _catalog;
   Future<HermesCatalogDiscoveryResult>? _inFlight;
   final Set<String> _sessionIds = {};
+  int _catalogRevision = 0;
   bool _disposed = false;
 
   Future<PluginSessionOptionsDiscoveryResult> getSessionOptions({
@@ -57,6 +58,7 @@ class HermesSessionOptionsService({
     final current = catalog.currentModel;
     if (fromNewSession) {
       _catalog = catalog;
+      _catalogRevision++;
       if (current != null) {
         _configurationTracker.setProcessDefaults(
           modelId: current.value,
@@ -83,7 +85,7 @@ class HermesSessionOptionsService({
     final requested = model.modelID;
     final currentValue = _configurationTracker.snapshotForSession(sessionId: sessionId).modelId;
     final current = _catalog?.currentModel;
-    if (requested == currentValue || requested == current?.modelId) return;
+    if (requested == currentValue || requested == current?.value) return;
     try {
       await _repository.setModel(
         liveClient: liveClient,
@@ -141,19 +143,23 @@ class HermesSessionOptionsService({
     if (pending != null) return pending;
     if (_disposed) return Future.value(const HermesCatalogDiscoveryFailed());
     late final Future<HermesCatalogDiscoveryResult> operation;
-    operation = _probe().whenComplete(() {
+    operation = _probe(catalogRevision: _catalogRevision).whenComplete(() {
       if (identical(_inFlight, operation)) _inFlight = null;
     });
     _inFlight = operation;
     return operation;
   }
 
-  Future<HermesCatalogDiscoveryResult> _probe() async {
+  Future<HermesCatalogDiscoveryResult> _probe({required int catalogRevision}) async {
     try {
       final catalog = await _repository.discoverCatalog(
         cwd: _launchDirectory,
         timeout: _discoveryTimeout,
       );
+      if (catalogRevision != _catalogRevision) {
+        final liveCatalog = _catalog;
+        return liveCatalog == null ? const HermesCatalogDiscoveryFailed() : HermesCatalogObserved(catalog: liveCatalog);
+      }
       _catalog = catalog;
       final current = catalog.currentModel;
       if (current != null) {

--- a/bridge/sesori_plugin_hermes/lib/src/services/hermes_session_options_service.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/services/hermes_session_options_service.dart
@@ -1,0 +1,269 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../models/hermes_model_catalog.dart";
+import "../repositories/hermes_catalog_repository.dart";
+
+/// Owns Hermes's process-scoped model catalog and exact per-session writes.
+class HermesSessionOptionsService({
+  required final HermesCatalogRepository _repository,
+  required final AcpSessionConfigurationTracker _configurationTracker,
+  required final AcpCommandTracker _commandTracker,
+  required final String _launchDirectory,
+  required final String _pluginId,
+  required final String _agentDisplayName,
+  required final Duration _discoveryTimeout,
+}) {
+  HermesModelCatalog? _catalog;
+  Future<HermesCatalogDiscoveryResult>? _inFlight;
+  final Set<String> _sessionIds = {};
+  bool _disposed = false;
+
+  Future<PluginSessionOptionsDiscoveryResult> getSessionOptions({
+    required PluginSessionOptionsDiscoveryMode discoveryMode,
+  }) async {
+    final discovery = switch (discoveryMode) {
+      PluginSessionOptionsDiscoveryMode.reuse => await _ensureCatalog(),
+      PluginSessionOptionsDiscoveryMode.refresh => await _refreshCatalog(),
+    };
+    return switch (discovery) {
+      HermesCatalogObserved(:final catalog) => PluginSessionOptionsDiscoveryResult.observed(
+        options: _options(catalog: catalog),
+      ),
+      HermesCatalogDiscoveryFailed() when _catalog != null => const PluginSessionOptionsDiscoveryResult.failed(),
+      HermesCatalogDiscoveryFailed() when _configurationTracker.processDefaults.modelId != null =>
+        PluginSessionOptionsDiscoveryResult.observed(options: _options(catalog: null)),
+      HermesCatalogDiscoveryFailed() => const PluginSessionOptionsDiscoveryResult.failed(),
+    };
+  }
+
+  Future<List<PluginAgent>> listAgents() async {
+    final result = await _ensureCatalog();
+    return _options(catalog: result is HermesCatalogObserved ? result.catalog : _catalog).agents;
+  }
+
+  Future<PluginProvidersResult> listProviders() async {
+    final result = await _ensureCatalog();
+    return _options(catalog: result is HermesCatalogObserved ? result.catalog : _catalog).providers;
+  }
+
+  void captureSessionConfig(
+    AcpNewSessionResult result, {
+    required String? sessionId,
+    required bool fromNewSession,
+  }) {
+    final catalog = _repository.mapSessionResult(result: result);
+    if (catalog == null) return;
+    final current = catalog.currentModel;
+    if (fromNewSession) {
+      _catalog = catalog;
+      if (current != null) {
+        _configurationTracker.setProcessDefaults(
+          modelId: current.value,
+          providerId: current.providerId,
+        );
+      }
+    }
+    if (sessionId != null && current != null) {
+      _sessionIds.add(sessionId);
+      _configurationTracker.setSessionOverride(
+        sessionId: sessionId,
+        modelId: current.value,
+        providerId: current.providerId,
+      );
+    }
+  }
+
+  Future<void> applyTurnSelection({
+    required AcpStdioClient liveClient,
+    required String sessionId,
+    required ({String providerID, String modelID})? model,
+  }) async {
+    if (model == null) return;
+    final requested = model.modelID;
+    final currentValue = _configurationTracker.snapshotForSession(sessionId: sessionId).modelId;
+    final current = _catalog?.currentModel;
+    if (requested == currentValue || requested == current?.modelId) return;
+    try {
+      await _repository.setModel(
+        liveClient: liveClient,
+        sessionId: sessionId,
+        modelId: requested,
+        timeout: const Duration(seconds: 30),
+      );
+    } on Object catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        PluginOperationException(
+          "session/set_model",
+          message: "Hermes rejected the requested model",
+          cause: error,
+        ),
+        stackTrace,
+      );
+    }
+    _sessionIds.add(sessionId);
+    _configurationTracker.setSessionOverride(
+      sessionId: sessionId,
+      modelId: requested,
+      providerId: model.providerID,
+    );
+  }
+
+  void forgetSession({required String sessionId}) {
+    _sessionIds.remove(sessionId);
+    _configurationTracker.forgetSession(sessionId: sessionId);
+  }
+
+  void resetConnection() {
+    for (final sessionId in _sessionIds) {
+      _configurationTracker.forgetSession(sessionId: sessionId);
+    }
+    _sessionIds.clear();
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await _inFlight;
+    await _repository.dispose();
+  }
+
+  Future<HermesCatalogDiscoveryResult> _ensureCatalog() {
+    final existing = _catalog;
+    if (existing != null) return Future.value(HermesCatalogObserved(catalog: existing));
+    return _coalescedProbe();
+  }
+
+  Future<HermesCatalogDiscoveryResult> _refreshCatalog() => _coalescedProbe();
+
+  Future<HermesCatalogDiscoveryResult> _coalescedProbe() {
+    final pending = _inFlight;
+    if (pending != null) return pending;
+    if (_disposed) return Future.value(const HermesCatalogDiscoveryFailed());
+    late final Future<HermesCatalogDiscoveryResult> operation;
+    operation = _probe().whenComplete(() {
+      if (identical(_inFlight, operation)) _inFlight = null;
+    });
+    _inFlight = operation;
+    return operation;
+  }
+
+  Future<HermesCatalogDiscoveryResult> _probe() async {
+    try {
+      final catalog = await _repository.discoverCatalog(
+        cwd: _launchDirectory,
+        timeout: _discoveryTimeout,
+      );
+      _catalog = catalog;
+      final current = catalog.currentModel;
+      if (current != null) {
+        _configurationTracker.setProcessDefaults(
+          modelId: current.value,
+          providerId: current.providerId,
+        );
+      }
+      return HermesCatalogObserved(catalog: catalog);
+    } on Object catch (error, stackTrace) {
+      Log.w("[$_pluginId] model catalog discovery failed", error, stackTrace);
+      return const HermesCatalogDiscoveryFailed();
+    }
+  }
+
+  PluginSessionOptions _options({required HermesModelCatalog? catalog}) {
+    final defaults = _configurationTracker.processDefaults;
+    final fallbackModelId = defaults.modelId;
+    final fallbackProviderId = defaults.providerId ?? _pluginId;
+    final current = catalog?.currentModel;
+    return PluginSessionOptions(
+      agents: [
+        PluginAgent(
+          name: _pluginId,
+          description: "$_agentDisplayName session",
+          model: current != null
+              ? PluginAgentModel(
+                  modelID: current.value,
+                  providerID: current.providerId,
+                  variant: null,
+                )
+              : fallbackModelId == null
+              ? null
+              : PluginAgentModel(
+                  modelID: fallbackModelId,
+                  providerID: fallbackProviderId,
+                  variant: null,
+                ),
+          mode: PluginAgentMode.primary,
+          hidden: false,
+        ),
+      ],
+      providers: PluginProvidersResult(
+        providers: catalog == null
+            ? _fallbackProviders(modelId: fallbackModelId, providerId: fallbackProviderId)
+            : _providers(catalog),
+      ),
+      commands: _commandTracker.commands,
+      completeness: catalog != null && _commandTracker.hasSnapshot
+          ? PluginSessionOptionsCompleteness.complete
+          : PluginSessionOptionsCompleteness.partial,
+    );
+  }
+
+  List<PluginProvider> _providers(HermesModelCatalog catalog) {
+    final modelsByProvider = <String, List<HermesCatalogModel>>{};
+    final providerNames = <String, String>{};
+    for (final model in catalog.models) {
+      (modelsByProvider[model.providerId] ??= []).add(model);
+      providerNames[model.providerId] = model.providerName;
+    }
+    final current = catalog.currentModel;
+    final entries = modelsByProvider.entries.toList(growable: true);
+    if (current != null) {
+      final currentIndex = entries.indexWhere((entry) => entry.key == current.providerId);
+      if (currentIndex > 0) entries.insert(0, entries.removeAt(currentIndex));
+    }
+    return [
+      for (final entry in entries)
+        PluginProvider.custom(
+          id: entry.key,
+          name: providerNames[entry.key] ?? entry.key,
+          authType: PluginProviderAuthType.unknown,
+          models: [
+            for (final model in entry.value)
+              PluginModel(
+                id: model.value,
+                name: model.name,
+                variants: const [],
+                family: null,
+                isAvailable: true,
+                releaseDate: null,
+              ),
+          ],
+          defaultModelID: current?.providerId == entry.key ? current?.value : null,
+        ),
+    ];
+  }
+
+  List<PluginProvider> _fallbackProviders({
+    required String? modelId,
+    required String providerId,
+  }) => modelId == null
+      ? const []
+      : [
+          PluginProvider.custom(
+            id: providerId,
+            name: _agentDisplayName,
+            authType: PluginProviderAuthType.unknown,
+            models: [
+              PluginModel(
+                id: modelId,
+                name: modelId,
+                variants: const [],
+                family: null,
+                isAvailable: true,
+                releaseDate: null,
+              ),
+            ],
+            defaultModelID: modelId,
+          ),
+        ];
+}

--- a/bridge/sesori_plugin_hermes/pubspec.yaml
+++ b/bridge/sesori_plugin_hermes/pubspec.yaml
@@ -7,6 +7,8 @@ environment:
   sdk: ^3.13.1
 
 dependencies:
+  freezed_annotation: ^3.1.0
+  json_annotation: ^4.12.0
   sesori_plugin_interface:
     path: ../sesori_plugin_interface
   sesori_bridge_foundation:
@@ -15,5 +17,8 @@ dependencies:
     path: ../sesori_plugin_acp
 
 dev_dependencies:
+  build_runner: any
+  freezed: 4.0.0-dev.3
+  json_serializable: ^6.14.1
   test: ^1.31.2
   lints: ^6.1.0

--- a/bridge/sesori_plugin_hermes/test/hermes_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_catalog_repository_test.dart
@@ -1,0 +1,140 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:hermes_plugin/src/api/hermes_acp_api.dart";
+import "package:hermes_plugin/src/repositories/hermes_catalog_repository.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("maps exact model IDs and deletes only after the scratch process exits", () async {
+    final api = _FakeHermesAcpApi(result: _modelResult());
+    final repository = HermesCatalogRepository(api: api);
+
+    final catalog = await repository.discoverCatalog(
+      cwd: "/repo",
+      timeout: const Duration(seconds: 2),
+    );
+
+    expect(api.operations, ["open", "new", "settle", "delete:catalog-session"]);
+    expect(catalog.currentModel?.value, "custom:team:org/model:v2");
+    expect(catalog.currentModel?.providerId, "custom:team");
+    expect(catalog.currentModel?.modelId, "org/model:v2");
+    expect(catalog.currentModel?.providerName, "Team Gateway");
+    expect(catalog.currentModel?.name, "Model V2");
+    expect(catalog.models.last.providerId, "openrouter");
+    expect(catalog.models.last.modelId, "anthropic/claude:beta");
+  });
+
+  test("a failed persisted-session delete fails discovery", () async {
+    final api = _FakeHermesAcpApi(
+      result: _modelResult(),
+      deleteError: StateError("database busy"),
+    );
+    final repository = HermesCatalogRepository(api: api);
+
+    await expectLater(
+      repository.discoverCatalog(
+        cwd: "/repo",
+        timeout: const Duration(seconds: 2),
+      ),
+      throwsA(
+        isA<PluginOperationException>().having(
+          (error) => error.operation,
+          "operation",
+          "hermes catalog cleanup",
+        ),
+      ),
+    );
+    expect(api.operations, ["open", "new", "settle", "delete:catalog-session"]);
+  });
+
+  test("a scratch process that does not settle is never deleted", () async {
+    final api = _FakeHermesAcpApi(
+      result: _modelResult(),
+      settleError: TimeoutException("process still running"),
+    );
+    final repository = HermesCatalogRepository(api: api);
+
+    await expectLater(
+      repository.discoverCatalog(
+        cwd: "/repo",
+        timeout: const Duration(seconds: 2),
+      ),
+      throwsA(isA<PluginOperationException>()),
+    );
+    expect(api.operations, ["open", "new", "settle"]);
+  });
+}
+
+AcpNewSessionResult _modelResult() => const AcpNewSessionResult(
+  sessionId: "catalog-session",
+  modes: [],
+  configOptions: [],
+  raw: {
+    "sessionId": "catalog-session",
+    "models": {
+      "currentModelId": "custom:team:org/model:v2",
+      "availableModels": [
+        {
+          "modelId": "custom:team:org/model:v2",
+          "name": "Team Gateway · Model V2",
+          "description": "Provider: Team Gateway • current",
+        },
+        {
+          "modelId": "openrouter:anthropic/claude:beta",
+          "name": "OpenRouter · Claude Beta",
+          "description": "Provider: OpenRouter",
+        },
+      ],
+    },
+  },
+);
+
+class _FakeHermesAcpApi({
+  required final AcpNewSessionResult result,
+  final Object? deleteError,
+  final Object? settleError,
+}) implements HermesAcpApi {
+  final List<String> operations = [];
+  bool _processExited = false;
+
+  @override
+  Future<void> openScratch({required String cwd, required Duration timeout}) async {
+    operations.add("open");
+  }
+
+  @override
+  Future<AcpNewSessionResult> newScratchSession({
+    required String cwd,
+    required Duration timeout,
+  }) async {
+    operations.add("new");
+    return result;
+  }
+
+  @override
+  Future<void> settleScratch({required Duration timeout}) async {
+    operations.add("settle");
+    final error = settleError;
+    if (error != null) throw error;
+    _processExited = true;
+  }
+
+  @override
+  Future<void> deletePersistedSession({
+    required String sessionId,
+    required Duration timeout,
+  }) async {
+    if (!_processExited) throw StateError("delete ran before process exit");
+    operations.add("delete:$sessionId");
+    final error = deleteError;
+    if (error != null) throw error;
+  }
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/sesori_plugin_hermes/test/hermes_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_catalog_repository_test.dart
@@ -2,6 +2,7 @@ import "dart:async";
 
 import "package:acp_plugin/acp_plugin.dart";
 import "package:hermes_plugin/src/api/hermes_acp_api.dart";
+import "package:hermes_plugin/src/models/hermes_model_state_dto.dart";
 import "package:hermes_plugin/src/repositories/hermes_catalog_repository.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
@@ -62,6 +63,39 @@ void main() {
         timeout: const Duration(seconds: 2),
       ),
       throwsA(isA<PluginOperationException>()),
+    );
+    expect(api.operations, ["open", "new", "settle"]);
+  });
+
+  test("omitted Hermes model fields remain absent at the transport boundary", () {
+    final state = HermesSessionModelStateDto.fromJson({
+      "availableModels": [
+        {"description": null},
+      ],
+    });
+
+    expect(state.availableModels.single.modelId, isNull);
+    expect(state.availableModels.single.name, isNull);
+    expect(state.currentModelId, isNull);
+  });
+
+  test("an omitted scratch session ID is not sent to the delete command", () async {
+    final api = _FakeHermesAcpApi(
+      result: const AcpNewSessionResult(
+        sessionId: "",
+        modes: [],
+        configOptions: [],
+        raw: {},
+      ),
+    );
+    final repository = HermesCatalogRepository(api: api);
+
+    await expectLater(
+      repository.discoverCatalog(
+        cwd: "/repo",
+        timeout: const Duration(seconds: 2),
+      ),
+      throwsA(isA<StateError>()),
     );
     expect(api.operations, ["open", "new", "settle"]);
   });

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
@@ -26,7 +26,7 @@ void main() {
         isTrue,
         reason: "Hermes advertises prompt image support",
       );
-      expect(HermesPluginDescriptor.minVersion, "0.20.4");
+      expect(HermesPluginDescriptor.minVersion, "0.20.0");
       expect(HermesPluginDescriptor.targetVersion, "0.20.4");
     });
 

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
@@ -26,7 +26,7 @@ void main() {
         isTrue,
         reason: "Hermes advertises prompt image support",
       );
-      expect(HermesPluginDescriptor.minVersion, "0.20.0");
+      expect(HermesPluginDescriptor.minVersion, "0.20.4");
       expect(HermesPluginDescriptor.targetVersion, "0.20.4");
     });
 

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_descriptor_test.dart
@@ -464,7 +464,7 @@ void main() {
       expect(processes.spawnedExecutables, ["/custom/hermes", "/custom/hermes"]);
     });
 
-    test("start exposes the configured model before creating a session", () async {
+    test("start discovers models before the user creates a session", () async {
       const descriptor = HermesPluginDescriptor();
       final processes = _ProbeProcessService(
         spawnError: null,
@@ -493,18 +493,29 @@ void main() {
       );
       final options = (discovery as PluginSessionOptionsDiscoveryObserved).options;
       final provider = options.providers.providers.single;
-      expect(provider.id, "OpenCode Go");
-      expect(provider.defaultModelID, "DeepSeek-V4-Flash");
-      expect(provider.models.single.id, "DeepSeek-V4-Flash");
+      expect(provider.id, "opencode-go");
+      expect(provider.name, "OpenCode Go");
+      expect(provider.defaultModelID, "opencode-go:deepseek-v4-flash");
+      expect(
+        provider.models.map((model) => model.id),
+        ["opencode-go:deepseek-v4-flash", "opencode-go:gpt-5"],
+      );
 
-      expect(processes.spawnedExecutables, ["/resolved/hermes", "/resolved/hermes"]);
+      expect(processes.spawnedExecutables, [
+        "/resolved/hermes",
+        "/resolved/hermes",
+        "/resolved/hermes",
+        "/resolved/hermes",
+      ]);
       expect(processes.spawnedArguments, [
         const ["status"],
         const ["acp"],
+        const ["acp"],
+        const ["sessions", "delete", "catalog-session", "--yes"],
       ]);
 
       await plugin.shutdown(budget: null);
-      expect(processes.gracefulSignals, [1]);
+      expect(processes.gracefulSignals, [101, 100]);
     });
   });
 }
@@ -535,7 +546,8 @@ class _ProbeProcessService({
   required final bool servesAcp,
 }) implements HostProcessService {
   int _nextProcess = 0;
-  _AcpProcess? _acpProcess;
+  final Map<int, _AcpProcess> _acpProcesses = {};
+  int _nextAcpPid = 100;
   final List<String> spawnedExecutables = <String>[];
   final List<List<String>> spawnedArguments = <List<String>>[];
   final List<int> gracefulSignals = <int>[];
@@ -554,13 +566,21 @@ class _ProbeProcessService({
     if (error != null) {
       throw error;
     }
+    if (servesAcp && arguments.length == 1 && arguments.single == "acp") {
+      final process = _AcpProcess(pid: _nextAcpPid++);
+      _acpProcesses[process.pid] = process;
+      return process;
+    }
+    if (servesAcp && arguments.length == 4 && arguments[0] == "sessions" && arguments[1] == "delete") {
+      return _ProbeProcess(
+        pid: 200,
+        stdoutBytes: utf8.encode("Deleted ${arguments[2]}\n"),
+        stderrBytes: const [],
+        exitCode: Future<int>.value(0),
+      );
+    }
     if (_nextProcess < processSequence.length) {
       return processSequence[_nextProcess++];
-    }
-    if (servesAcp) {
-      final process = _AcpProcess();
-      _acpProcess = process;
-      return process;
     }
     throw StateError("No canned process remains");
   }
@@ -571,7 +591,7 @@ class _ProbeProcessService({
   @override
   Future<SignalResult> signalGraceful({required int pid}) async {
     gracefulSignals.add(pid);
-    _acpProcess?.exit(-15);
+    _acpProcesses[pid]?.exit(-15);
     return _signal(
       pid: pid,
       requestedSignal: ShutdownSignal.graceful,
@@ -581,7 +601,7 @@ class _ProbeProcessService({
 
   @override
   Future<SignalResult> signalForce({required int pid}) async {
-    _acpProcess?.exit(-9);
+    _acpProcesses[pid]?.exit(-9);
     return _signal(
       pid: pid,
       requestedSignal: ShutdownSignal.force,
@@ -626,7 +646,7 @@ class _ProbeProcess({
   ProcessIdentity get identity => throw UnimplementedError();
 }
 
-class _AcpProcess() implements SpawnedProcess {
+class _AcpProcess({@override required final int pid}) implements SpawnedProcess {
   this {
     stdin = IOSink(_InputSink(onLine: _handleLine));
   }
@@ -643,6 +663,35 @@ class _AcpProcess() implements SpawnedProcess {
       _stdout.add(
         utf8.encode(
           "${jsonEncode({"jsonrpc": "2.0", "id": frame["id"], "result": <String, dynamic>{}})}\n",
+        ),
+      );
+      return;
+    }
+    if (frame["method"] == AcpMethods.sessionNew) {
+      _stdout.add(
+        utf8.encode(
+          "${jsonEncode({
+            "jsonrpc": "2.0",
+            "id": frame["id"],
+            "result": {
+              "sessionId": "catalog-session",
+              "models": {
+                "currentModelId": "opencode-go:deepseek-v4-flash",
+                "availableModels": [
+                  {
+                    "modelId": "opencode-go:deepseek-v4-flash",
+                    "name": "OpenCode Go · deepseek-v4-flash",
+                    "description": "Provider: OpenCode Go • current",
+                  },
+                  {
+                    "modelId": "opencode-go:gpt-5",
+                    "name": "OpenCode Go · GPT-5",
+                    "description": "Provider: OpenCode Go",
+                  },
+                ],
+              },
+            },
+          })}\n",
         ),
       );
       return;
@@ -683,9 +732,6 @@ class _AcpProcess() implements SpawnedProcess {
 
   @override
   ProcessIdentity get identity => throw UnimplementedError();
-
-  @override
-  int get pid => 1;
 
   @override
   Stream<List<int>> get stderr => const Stream.empty();

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
@@ -1,12 +1,17 @@
 import "dart:async";
 
+import "package:acp_plugin/acp_plugin.dart";
 import "package:acp_plugin/acp_testing.dart";
 import "package:hermes_plugin/hermes_plugin.dart";
+import "package:hermes_plugin/src/api/hermes_acp_api.dart";
+import "package:hermes_plugin/src/repositories/hermes_catalog_repository.dart";
+import "package:hermes_plugin/src/services/hermes_session_options_service.dart";
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
-/// The `initialize` result Hermes actually advertises (verified 2026-08-15
-/// against Hermes Agent 0.20.1): load/list/resume/fork session capabilities,
+/// The `initialize` result Hermes actually advertises (verified 2026-08-20
+/// against Hermes Agent 0.20.4): load/list/resume/fork session capabilities,
 /// image prompt support, and no `closeSession`. The base must therefore
 /// never call `session/close`. Auth mirrors `build_auth_methods()`: the
 /// configured provider as an agent method first, then a terminal-setup
@@ -46,13 +51,7 @@ void main() {
     setUp(() {
       fake = FakeAcpProcess();
       handledFrameIds = {};
-      plugin = HermesPlugin(
-        binaryPath: HermesBinary.defaultBinary,
-        launchDirectory: "/repo",
-        processFactory: (_) async => fake,
-        configuredModelId: null,
-        configuredProviderId: null,
-      );
+      plugin = _plugin(fake: fake);
     });
 
     tearDown(() async {
@@ -124,7 +123,7 @@ void main() {
       expect(plugin.initializeCapabilityMeta, isNull);
       expect(plugin.supportsFormElicitation, isFalse, reason: "no elicitation/create on Hermes");
       expect(plugin.serializesPromptsProcessWide, isFalse);
-      expect(plugin.failsTurnOnSelectionError, isFalse);
+      expect(plugin.failsTurnOnSelectionError, isTrue);
       expect(plugin.sessionCloseSettlementTimeout, const Duration(seconds: 5));
     });
 
@@ -234,5 +233,186 @@ void main() {
         reason: "Hermes does not advertise closeSession, so deletion must be local-only",
       );
     });
+
+    test("a selected catalog model is applied before session creation completes", () async {
+      await connect();
+
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: const (
+          providerID: "opencode-go",
+          modelID: "opencode-go:gpt-5",
+        ),
+      );
+      await respond(
+        method: "session/new",
+        result: const {
+          "sessionId": "s1",
+          "models": {
+            "currentModelId": "opencode-go:deepseek-v4-flash",
+            "availableModels": [
+              {
+                "modelId": "opencode-go:deepseek-v4-flash",
+                "name": "OpenCode Go · deepseek-v4-flash",
+                "description": "Provider: OpenCode Go • current",
+              },
+              {
+                "modelId": "opencode-go:gpt-5",
+                "name": "OpenCode Go · GPT-5",
+                "description": "Provider: OpenCode Go",
+              },
+            ],
+          },
+        },
+      );
+
+      final setModelFrame = await waitForFrame(method: "session/set_model");
+      expect(
+        (setModelFrame["params"] as Map).cast<String, dynamic>(),
+        {"sessionId": "s1", "modelId": "opencode-go:gpt-5"},
+      );
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": setModelFrame["id"],
+        "result": <String, dynamic>{},
+      });
+
+      expect((await creating).id, "s1");
+    });
+
+    test("a rejected model switch fails the turn before session/prompt", () async {
+      await connect();
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond(
+        method: "session/new",
+        result: const {
+          "sessionId": "s1",
+          "models": {
+            "currentModelId": "opencode-go:deepseek-v4-flash",
+            "availableModels": [
+              {
+                "modelId": "opencode-go:deepseek-v4-flash",
+                "name": "OpenCode Go · deepseek-v4-flash",
+                "description": "Provider: OpenCode Go • current",
+              },
+              {
+                "modelId": "opencode-go:gpt-5",
+                "name": "OpenCode Go · GPT-5",
+                "description": "Provider: OpenCode Go",
+              },
+            ],
+          },
+        },
+      );
+      await creating;
+      final failedTurn = plugin.events.where((event) => event is BridgeSseSessionError).first;
+
+      await plugin.sendPrompt(
+        promptId: "prompt-1",
+        sessionId: "s1",
+        parts: const [PluginPromptPart.text(text: "Hello")],
+        variant: null,
+        agent: null,
+        model: const (
+          providerID: "opencode-go",
+          modelID: "opencode-go:gpt-5",
+        ),
+      );
+      final setModelFrame = await waitForFrame(method: "session/set_model");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": setModelFrame["id"],
+        "error": {
+          "code": -32603,
+          "message": "Internal error",
+        },
+      });
+
+      await failedTurn.timeout(const Duration(seconds: 1));
+      expect(
+        fake.written.where((frame) => frame["method"] == "session/prompt"),
+        isEmpty,
+      );
+    });
   });
+}
+
+HermesPlugin _plugin({
+  required FakeAcpProcess fake,
+  String? configuredModelId,
+  String? configuredProviderId,
+}) {
+  final configurationTracker = AcpSessionConfigurationTracker()
+    ..setProcessDefaults(
+      modelId: configuredModelId,
+      providerId: configuredProviderId,
+    );
+  final commandTracker = AcpCommandTracker();
+  final repository = HermesCatalogRepository(
+    api: HermesAcpApi(
+      binaryPath: HermesBinary.defaultBinary,
+      processFactory: (_) async => throw StateError("scratch discovery not expected"),
+      commandExecutor: const _UnusedCommandExecutor(),
+      environment: const {},
+    ),
+  );
+  final optionsService = HermesSessionOptionsService(
+    repository: repository,
+    configurationTracker: configurationTracker,
+    commandTracker: commandTracker,
+    launchDirectory: "/repo",
+    pluginId: "hermes",
+    agentDisplayName: "Hermes Agent",
+    discoveryTimeout: const Duration(seconds: 2),
+  );
+  const contentMapper = AcpContentMapper();
+  return HermesPlugin(
+    launchSpec: HermesBinary.launchSpec(
+      binary: HermesBinary.defaultBinary,
+      cwd: "/repo",
+      environment: const {},
+    ),
+    launchDirectory: "/repo",
+    contentMapper: contentMapper,
+    eventMapper: AcpEventMapper(
+      launchDirectory: "/repo",
+      agentId: "hermes",
+      pluginId: "hermes",
+      configurationTracker: configurationTracker,
+      contentMapper: contentMapper,
+    ),
+    commandTracker: commandTracker,
+    sessionOptionsService: AcpSessionOptionsService(
+      configurationTracker: configurationTracker,
+      commandTracker: commandTracker,
+      pluginId: "hermes",
+      agentDisplayName: "Hermes Agent",
+    ),
+    processFactory: (_) async => fake,
+    hermesSessionOptionsService: optionsService,
+  );
+}
+
+class const _UnusedCommandExecutor() implements CommandExecutor {
+  @override
+  Future<CommandResult> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    Duration? timeout,
+  }) => throw StateError("command execution not expected");
 }

--- a/bridge/sesori_plugin_hermes/test/hermes_session_options_service_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_session_options_service_test.dart
@@ -127,6 +127,31 @@ void main() {
 
     expect(repository.appliedModels, ["deepseek-v4-flash"]);
   });
+
+  test("a session can switch back to the catalog default model", () async {
+    final repository = _FakeCatalogRepository()..discoveries.add(Future.value(_catalog()));
+    final service = _service(repository: repository);
+    addTearDown(service.dispose);
+    await service.getSessionOptions(
+      discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+    );
+    service.captureSessionConfig(
+      _sessionResult(currentModelId: "opencode-go:gpt-5"),
+      sessionId: "s1",
+      fromNewSession: false,
+    );
+
+    await service.applyTurnSelection(
+      liveClient: _FakeAcpStdioClient(),
+      sessionId: "s1",
+      model: const (
+        providerID: "opencode-go",
+        modelID: "opencode-go:deepseek-v4-flash",
+      ),
+    );
+
+    expect(repository.appliedModels, ["opencode-go:deepseek-v4-flash"]);
+  });
 }
 
 HermesSessionOptionsService _service({required _FakeCatalogRepository repository}) {

--- a/bridge/sesori_plugin_hermes/test/hermes_session_options_service_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_session_options_service_test.dart
@@ -1,0 +1,143 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:hermes_plugin/src/models/hermes_model_catalog.dart";
+import "package:hermes_plugin/src/repositories/hermes_catalog_repository.dart";
+import "package:hermes_plugin/src/services/hermes_session_options_service.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("coalesces first discovery and reuses the process-scoped catalog", () async {
+    final discovery = Completer<HermesModelCatalog>();
+    final repository = _FakeCatalogRepository()..discoveries.add(discovery.future);
+    final service = _service(repository: repository);
+    addTearDown(service.dispose);
+
+    final first = service.getSessionOptions(
+      discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+    );
+    final concurrent = service.getSessionOptions(
+      discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+    );
+    expect(repository.discoveryCount, 1);
+
+    discovery.complete(_catalog());
+    final firstOptions = (await first as PluginSessionOptionsDiscoveryObserved).options;
+    final concurrentOptions = (await concurrent as PluginSessionOptionsDiscoveryObserved).options;
+    final provider = firstOptions.providers.providers.single;
+    expect(provider.id, "opencode-go");
+    expect(provider.name, "OpenCode Go");
+    expect(provider.defaultModelID, "opencode-go:deepseek-v4-flash");
+    expect(provider.models.map((model) => model.id), [
+      "opencode-go:deepseek-v4-flash",
+      "opencode-go:gpt-5",
+    ]);
+    expect(concurrentOptions, firstOptions);
+
+    await service.getSessionOptions(
+      discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+    );
+    expect(repository.discoveryCount, 1);
+  });
+
+  test("cleanup failure preserves the configured-model fallback", () async {
+    final repository = _FakeCatalogRepository()..discoveries.add(Future.error(StateError("delete failed")));
+    final service = _service(repository: repository);
+    addTearDown(service.dispose);
+
+    final result = await service.getSessionOptions(
+      discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+    );
+    final options = (result as PluginSessionOptionsDiscoveryObserved).options;
+
+    expect(options.providers.providers.single.id, "OpenCode Go");
+    expect(options.providers.providers.single.models.single.id, "DeepSeek-V4-Flash");
+  });
+
+  test("failed explicit refresh retains but does not report the cached catalog", () async {
+    final repository = _FakeCatalogRepository()
+      ..discoveries.add(Future.value(_catalog()))
+      ..discoveries.add(Future.error(StateError("refresh failed")));
+    final service = _service(repository: repository);
+    addTearDown(service.dispose);
+
+    expect(
+      await service.getSessionOptions(
+        discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+      ),
+      isA<PluginSessionOptionsDiscoveryObserved>(),
+    );
+    expect(
+      await service.getSessionOptions(
+        discoveryMode: PluginSessionOptionsDiscoveryMode.refresh,
+      ),
+      isA<PluginSessionOptionsDiscoveryFailed>(),
+    );
+    expect(
+      await service.getSessionOptions(
+        discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+      ),
+      isA<PluginSessionOptionsDiscoveryObserved>(),
+    );
+    expect(repository.discoveryCount, 2);
+  });
+}
+
+HermesSessionOptionsService _service({required _FakeCatalogRepository repository}) {
+  final configurationTracker = AcpSessionConfigurationTracker()
+    ..setProcessDefaults(
+      modelId: "DeepSeek-V4-Flash",
+      providerId: "OpenCode Go",
+    );
+  return HermesSessionOptionsService(
+    repository: repository,
+    configurationTracker: configurationTracker,
+    commandTracker: AcpCommandTracker(),
+    launchDirectory: "/repo",
+    pluginId: "hermes",
+    agentDisplayName: "Hermes Agent",
+    discoveryTimeout: const Duration(seconds: 2),
+  );
+}
+
+HermesModelCatalog _catalog() => HermesModelCatalog(
+  models: const [
+    HermesCatalogModel(
+      value: "opencode-go:deepseek-v4-flash",
+      providerId: "opencode-go",
+      providerName: "OpenCode Go",
+      modelId: "deepseek-v4-flash",
+      name: "deepseek-v4-flash",
+    ),
+    HermesCatalogModel(
+      value: "opencode-go:gpt-5",
+      providerId: "opencode-go",
+      providerName: "OpenCode Go",
+      modelId: "gpt-5",
+      name: "GPT-5",
+    ),
+  ],
+  currentModelValue: "opencode-go:deepseek-v4-flash",
+);
+
+class _FakeCatalogRepository() implements HermesCatalogRepository {
+  final List<Future<HermesModelCatalog>> discoveries = [];
+  int discoveryCount = 0;
+
+  @override
+  Future<HermesModelCatalog> discoverCatalog({
+    required String cwd,
+    required Duration timeout,
+  }) {
+    final result = discoveries[discoveryCount];
+    discoveryCount++;
+    return result;
+  }
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/sesori_plugin_hermes/test/hermes_session_options_service_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_session_options_service_test.dart
@@ -1,6 +1,7 @@
 import "dart:async";
 
 import "package:acp_plugin/acp_plugin.dart";
+import "package:hermes_plugin/src/api/hermes_acp_api.dart";
 import "package:hermes_plugin/src/models/hermes_model_catalog.dart";
 import "package:hermes_plugin/src/repositories/hermes_catalog_repository.dart";
 import "package:hermes_plugin/src/services/hermes_session_options_service.dart";
@@ -82,6 +83,50 @@ void main() {
     );
     expect(repository.discoveryCount, 2);
   });
+
+  test("live session capture wins over an older scratch discovery", () async {
+    final discovery = Completer<HermesModelCatalog>();
+    final repository = _FakeCatalogRepository()..discoveries.add(discovery.future);
+    final service = _service(repository: repository);
+    addTearDown(service.dispose);
+
+    final refresh = service.getSessionOptions(
+      discoveryMode: PluginSessionOptionsDiscoveryMode.refresh,
+    );
+    service.captureSessionConfig(
+      _sessionResult(currentModelId: "opencode-go:gpt-5"),
+      sessionId: "live-session",
+      fromNewSession: true,
+    );
+    discovery.complete(_catalog());
+
+    final options = (await refresh as PluginSessionOptionsDiscoveryObserved).options;
+    expect(options.agents.single.model?.modelID, "opencode-go:gpt-5");
+    final reused = await service.getSessionOptions(
+      discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+    );
+    expect(
+      (reused as PluginSessionOptionsDiscoveryObserved).options.agents.single.model?.modelID,
+      "opencode-go:gpt-5",
+    );
+  });
+
+  test("a provideless value is not confused with a prefixed current model", () async {
+    final repository = _FakeCatalogRepository()..discoveries.add(Future.value(_catalog()));
+    final service = _service(repository: repository);
+    addTearDown(service.dispose);
+    await service.getSessionOptions(
+      discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+    );
+
+    await service.applyTurnSelection(
+      liveClient: _FakeAcpStdioClient(),
+      sessionId: "s1",
+      model: const (providerID: "hermes", modelID: "deepseek-v4-flash"),
+    );
+
+    expect(repository.appliedModels, ["deepseek-v4-flash"]);
+  });
 }
 
 HermesSessionOptionsService _service({required _FakeCatalogRepository repository}) {
@@ -121,8 +166,36 @@ HermesModelCatalog _catalog() => HermesModelCatalog(
   currentModelValue: "opencode-go:deepseek-v4-flash",
 );
 
+AcpNewSessionResult _sessionResult({required String currentModelId}) => AcpNewSessionResult(
+  sessionId: "live-session",
+  modes: const [],
+  configOptions: const [],
+  raw: {
+    "sessionId": "live-session",
+    "models": {
+      "currentModelId": currentModelId,
+      "availableModels": const [
+        {
+          "modelId": "opencode-go:deepseek-v4-flash",
+          "name": "OpenCode Go · deepseek-v4-flash",
+          "description": null,
+        },
+        {
+          "modelId": "opencode-go:gpt-5",
+          "name": "OpenCode Go · GPT-5",
+          "description": null,
+        },
+      ],
+    },
+  },
+);
+
 class _FakeCatalogRepository() implements HermesCatalogRepository {
   final List<Future<HermesModelCatalog>> discoveries = [];
+  final List<String> appliedModels = [];
+  final HermesCatalogRepository _mapper = HermesCatalogRepository(
+    api: _FakeHermesAcpApi(),
+  );
   int discoveryCount = 0;
 
   @override
@@ -138,6 +211,30 @@ class _FakeCatalogRepository() implements HermesCatalogRepository {
   @override
   Future<void> dispose() async {}
 
+  @override
+  HermesModelCatalog? mapSessionResult({required AcpNewSessionResult result}) =>
+      _mapper.mapSessionResult(result: result);
+
+  @override
+  Future<void> setModel({
+    required AcpStdioClient liveClient,
+    required String sessionId,
+    required String modelId,
+    required Duration timeout,
+  }) async {
+    appliedModels.add(modelId);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeAcpStdioClient() implements AcpStdioClient {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeHermesAcpApi() implements HermesAcpApi {
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -16,7 +16,7 @@ idle suspension, the management snapshot, and lifecycle commands.
   never downloads or mutates files, and failure there is non-fatal. The persisted disable
   list is the only durable eligibility policy, with setup deciding blocked versus routable.
 - Hermes is a direct-CLI harness with no managed install. Setup distinguishes a missing or
-  pre-ACP binary, a Hermes Agent release below `0.20.4`, and missing model/provider
+  pre-ACP binary, a Hermes Agent release below `0.20.0`, and missing model/provider
   configuration; startup revalidates the effective PATH or explicit `--hermes-bin` executable
   while preserving an explicit path as authoritative.
   Provider setup remains an out-of-band Hermes CLI action, so authentication-required
@@ -96,7 +96,7 @@ idle suspension, the management snapshot, and lifecycle commands.
 Vary which harness runs first and which stays disabled, and the configuration: default
 managed, explicit binary path, externally managed backend. Vary the trigger between app
 and management API, whether a session is idle or working, and fresh versus reused data
-directories. For Hermes, vary missing and pre-ACP installs, a release below `0.20.4`, an
+directories. For Hermes, vary missing and pre-ACP installs, a release below `0.20.0`, an
 unconfigured model/provider, PATH discovery, and `--hermes-bin`. Restore eligibility,
 timeouts, and sessions afterwards.
 

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -16,10 +16,10 @@ idle suspension, the management snapshot, and lifecycle commands.
   never downloads or mutates files, and failure there is non-fatal. The persisted disable
   list is the only durable eligibility policy, with setup deciding blocked versus routable.
 - Hermes is a direct-CLI harness with no managed install. Setup distinguishes a missing or
-  pre-ACP binary, a Hermes Agent release below `0.20.0`, and missing model/provider
+  pre-ACP binary, a Hermes Agent release below `0.20.4`, and missing model/provider
   configuration; startup revalidates the effective PATH or explicit `--hermes-bin` executable
   while preserving an explicit path as authoritative.
-  Model/provider setup remains an out-of-band Hermes CLI action, so authentication-required
+  Provider setup remains an out-of-band Hermes CLI action, so authentication-required
   Hermes entries give local setup guidance rather than offering bridge-managed login.
 - Pi and Oh My Pi are registered harnesses with managed installs where a platform
   archive exists and explicit `--pi-bin`/`--omp-bin` paths stay authoritative. Pi
@@ -96,7 +96,7 @@ idle suspension, the management snapshot, and lifecycle commands.
 Vary which harness runs first and which stays disabled, and the configuration: default
 managed, explicit binary path, externally managed backend. Vary the trigger between app
 and management API, whether a session is idle or working, and fresh versus reused data
-directories. For Hermes, vary missing and pre-ACP installs, a release below `0.20.0`, an
+directories. For Hermes, vary missing and pre-ACP installs, a release below `0.20.4`, an
 unconfigured model/provider, PATH discovery, and `--hermes-bin`. Restore eligibility,
 timeouts, and sessions afterwards.
 

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -20,10 +20,15 @@ variant, and worktree mode, and creating the session with its first input.
   default-first, and a model that offers variants always has one selected: the
   agent's declared variant when valid, otherwise the first available. Selecting a
   variant is therefore a switch between named levels, never a reset to unset.
-- Hermes Agent resolves its configured model and provider by running
-  `hermes status` before starting ACP, then exposes that model through the base
-  single-agent option synthesis. Hermes remains authoritative for model changes;
-  Sesori does not advertise a separate catalog or switch models. Hermes also
+- Hermes Agent seeds its configured model and provider from `hermes status`,
+  then discovers the available model catalog in a separate empty ACP session
+  before the user creates one. The discovery process must exit before Sesori
+  deletes that exact persisted Hermes session; failed cleanup fails discovery
+  rather than caching a catalog that left a known artifact. Reuse is
+  process-scoped, explicit refresh creates a fresh probe, and a failed first
+  probe retains the configured-model fallback. Picker IDs remain the exact
+  Hermes values accepted by `session/set_model`, including named custom
+  providers, and a selected model is applied before the turn. Hermes also
   advertises image prompt capability so inline attachments are accepted.
 - Read intents stay distinct: a normal load may serve a valid cache or discover,
   a cache-only read never discovers and reports cache-unavailable, and an

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -79,8 +79,10 @@ defaults and queued client sends coherent.
 - Hermes runs turns through ACP v1 over `hermes acp`: initialization uses the
   first non-terminal provider authentication method, image prompt parts remain
   available, streamed updates use the shared ACP normalization, and abort uses
-  session cancellation. Version 1 uses the model/mode configured in Hermes and
-  offers no per-turn picker; Sesori does not call form-elicitation or unadvertised
+  session cancellation. Available models come from Hermes's ACP session model
+  state, and the selected exact model ID is applied through Hermes's
+  `session/set_model` extension before each changed-model turn. A rejected model
+  fails before prompting. Sesori does not call form-elicitation or unadvertised
   session-close methods to complete an ordinary turn.
 - Existing-session ACP prompts remain bridge-queued while an earlier turn,
   process-wide lane, resume, or selection blocks their `session/prompt` frame.


### PR DESCRIPTION
## Complexity

Moderate. This adds a Hermes-specific ACP discovery lifecycle and composes it with the existing generic ACP session flow without changing shared plugin contracts.

## What

- Discover the complete Hermes model catalog before the first user session through a disposable ACP session.
- Stop the scratch ACP process before deleting its persisted session with `hermes sessions delete <id> --yes`.
- Cache and coalesce catalog discovery, support explicit refresh, and retain the configured model as a failure fallback.
- Apply the exact selected Hermes model ID through `session/set_model` before prompting, including custom-provider IDs.
- Document the discovery and switching behavior while retaining the supported Hermes Agent floor at `0.20.0`.

## Why

Hermes previously exposed only its configured model before session creation, while its complete catalog becomes available only after `session/new`. Users therefore could not choose another available model from the initial session picker, and selections needed a Hermes-owned exact-ID write path.

## Risk and test focus

The main risk is leaving a scratch Hermes session behind or applying a transformed model identifier. Tests verify process exit before deletion, deletion-failure handling, stubborn-process cleanup, exact IDs containing `/` and `:`, custom-provider IDs, discovery coalescing and refresh behavior, and rejection before `session/prompt` when `session/set_model` fails.

This has a user-visible model-picker and model-switching impact. It has no database impact and does not change shared ACP or client/bridge wire contracts.

## Expected result

The initial Hermes session screen shows the available model catalog, refreshes without discarding a valid cached catalog, and starts turns with the exact selected model. Failed scratch-session cleanup does not populate the cache.

## Verification

- `dart analyze --fatal-infos` in `bridge/sesori_plugin_hermes`
- `dart test` in `bridge/sesori_plugin_hermes` (38 tests)
- `git diff --check origin/main...HEAD`
- Architecture implementation review approved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Discover Hermes’s full model catalog before the first session and switch models by exact ID via Hermes’s session/set_model before prompting. Previously we only exposed the configured model and never switched at turn start; now we surface the catalog, apply the selected model per turn, and fail the turn if Hermes rejects a model change.

- Introduces Hermes-specific `HermesAcpApi`, `HermesCatalogRepository`, and `HermesSessionOptionsService` to isolate catalog discovery and model switching from the generic ACP flow.
- Discovers the catalog via a disposable ACP session; settles the process first, then deletes the persisted session with `hermes sessions delete <id> --yes`. Discovery coalesces, caches per process, supports explicit refresh, and does not cache on cleanup failure. If the first probe fails, we fall back to the configured model.
- Applies the exact model ID (including custom-provider IDs) with `session/set_model` before each changed-model turn; skip logic is scoped to the session. `failsTurnOnSelectionError` is now true to prevent prompting on a rejected switch.
- Session options now surface providers/models from Hermes’s catalog; the agent model defaults to the current catalog model or the configured-model fallback. No changes to shared ACP contracts or the database. New deps: `freezed_annotation`, `json_annotation`, `freezed`, `json_serializable`, `build_runner`. Docs/tests updated for cleanup ordering, custom-provider IDs, discovery refresh, per-session skip, and pre-prompt failure paths.

- Retains Hermes Agent >= 0.20.0.

<sup>Written for commit 474509313ca452aea5f5dd01d43ec5d10786a59c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

