### PR TITLE
🌿 Close the image viewer with Escape and keep Android back inside the session

### DIFF
--- a/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
+++ b/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
@@ -1,6 +1,7 @@
 import "dart:async";
 import "dart:typed_data";
 
+import "package:flutter/services.dart" show LogicalKeyboardKey;
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:material_ui/material_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
@@ -100,10 +101,19 @@ Future<void> showImageAttachmentViewer({
   // ignore: no_slop_linter/avoid_raw_go_router, this transient Hero route carries an in-memory ImageProvider that cannot be represented in a URL
   final result = rootNavigator.push<void>(viewerRoute);
   sourceRoute.addLocalHistoryEntry(historyEntry);
-  return result.whenComplete(() {
-    shouldDismissViewerWithHistory = false;
-    historyEntry.remove();
-  });
+  // Hold the mirror entry until the viewer's exit transition finishes, not just
+  // until it is popped. Android's back gesture can deliver a second pop right
+  // after the one that dismissed the viewer; while the entry is still there the
+  // session route absorbs it instead of leaving the session.
+  unawaited(
+    viewerRoute.completed.whenComplete(() {
+      shouldDismissViewerWithHistory = false;
+      // The transition also completes when the whole navigator is torn down,
+      // where the session route is already gone and has nothing left to update.
+      if (sourceRoute.isActive) historyEntry.remove();
+    }),
+  );
+  return result;
 }
 
 ImageAttachmentActionsCubit _createActionsCubit({required LoadedMessageImage image}) => ImageAttachmentActionsCubit(
@@ -802,6 +812,13 @@ class _ImageAttachmentViewerState() extends State<ImageAttachmentViewer> with Ti
         ),
       ),
     );
-    return viewer;
+    return CallbackShortcuts(
+      bindings: <ShortcutActivator, VoidCallback>{
+        const SingleActivator(LogicalKeyboardKey.escape): _dismiss,
+      },
+      // The viewer holds no focusable chrome of its own, so claim focus for the
+      // route to give Escape somewhere to land.
+      child: Focus(autofocus: true, child: viewer),
+    );
   }
 }

--- a/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
+++ b/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
@@ -3,6 +3,7 @@ import "dart:convert";
 import "dart:typed_data";
 import "dart:ui" show SemanticsAction;
 
+import "package:flutter/services.dart" show LogicalKeyboardKey;
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:get_it/get_it.dart";
@@ -93,6 +94,58 @@ Widget _app({required Widget child, ThemeMode themeMode = ThemeMode.light}) {
 Future<void> _finishAsyncDecode({required WidgetTester tester}) async {
   await tester.runAsync(() => Future<void>.delayed(const Duration(milliseconds: 50)));
   await tester.pumpAndSettle();
+}
+
+Future<GoRouter> _pumpSessionShellApp({
+  required WidgetTester tester,
+  required MessageAttachment attachment,
+  required GlobalKey<NavigatorState> rootNavigatorKey,
+  required GlobalKey<NavigatorState> sessionNavigatorKey,
+}) async {
+  final router = GoRouter(
+    navigatorKey: rootNavigatorKey,
+    initialLocation: "/sessions/chat",
+    routes: [
+      ShellRoute(
+        navigatorKey: sessionNavigatorKey,
+        builder: (_, _, child) => Scaffold(
+          body: Row(
+            children: [
+              const SizedBox(
+                width: 300,
+                child: Center(child: Text("Session list pane")),
+              ),
+              Expanded(child: child),
+            ],
+          ),
+        ),
+        routes: [
+          GoRoute(
+            path: "/sessions",
+            builder: (_, _) => const Scaffold(body: Text("Session list route")),
+            routes: [
+              GoRoute(
+                path: "chat",
+                builder: (_, _) => Scaffold(
+                  body: FilePartWidget(sessionId: "session-1", attachment: attachment),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  );
+  addTearDown(router.dispose);
+  await tester.pumpWidget(
+    MaterialApp.router(
+      routerConfig: router,
+      theme: ThemeData(extensions: [PregoDesignSystem.light]),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+    ),
+  );
+  return router;
 }
 
 Future<void> _openImageViewer({required WidgetTester tester}) async {
@@ -890,48 +943,11 @@ void main() {
     );
     final rootNavigatorKey = GlobalKey<NavigatorState>();
     final sessionNavigatorKey = GlobalKey<NavigatorState>();
-    final router = GoRouter(
-      navigatorKey: rootNavigatorKey,
-      initialLocation: "/sessions/chat",
-      routes: [
-        ShellRoute(
-          navigatorKey: sessionNavigatorKey,
-          builder: (_, _, child) => Scaffold(
-            body: Row(
-              children: [
-                const SizedBox(
-                  width: 300,
-                  child: Center(child: Text("Session list pane")),
-                ),
-                Expanded(child: child),
-              ],
-            ),
-          ),
-          routes: [
-            GoRoute(
-              path: "/sessions",
-              builder: (_, _) => const Scaffold(body: Text("Session list route")),
-              routes: [
-                GoRoute(
-                  path: "chat",
-                  builder: (_, _) => const Scaffold(
-                    body: FilePartWidget(sessionId: "session-1", attachment: attachment),
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
-      ],
-    );
-    addTearDown(router.dispose);
-    await tester.pumpWidget(
-      MaterialApp.router(
-        routerConfig: router,
-        theme: ThemeData(extensions: [PregoDesignSystem.light]),
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-      ),
+    final router = await _pumpSessionShellApp(
+      tester: tester,
+      attachment: attachment,
+      rootNavigatorKey: rootNavigatorKey,
+      sessionNavigatorKey: sessionNavigatorKey,
     );
     await _openImageViewer(tester: tester);
     final sessionRoute = ModalRoute.of(tester.element(find.byKey(FilePartWidget.previewTapTargetKey)))!;
@@ -957,6 +973,54 @@ void main() {
 
     expect(find.text("Session list route"), findsOneWidget);
     expect(router.routeInformationProvider.value.uri.path, "/sessions");
+  });
+
+  testWidgets("a second system back during the viewer dismissal stays in the session", (tester) async {
+    const attachment = MessageAttachment.inlineImage(
+      mime: "image/png",
+      base64: _pngBase64,
+      filename: "image.png",
+    );
+    final router = await _pumpSessionShellApp(
+      tester: tester,
+      attachment: attachment,
+      rootNavigatorKey: GlobalKey<NavigatorState>(),
+      sessionNavigatorKey: GlobalKey<NavigatorState>(),
+    );
+    await _openImageViewer(tester: tester);
+    expect(find.byType(ImageAttachmentViewer), findsOneWidget);
+
+    // Android's back gesture can deliver a second pop right behind the one that
+    // dismissed the viewer; it must not carry on out of the session.
+    await tester.binding.handlePopRoute();
+    await tester.pump(const Duration(milliseconds: 50));
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ImageAttachmentViewer), findsNothing);
+    expect(find.byKey(FilePartWidget.previewTapTargetKey), findsOneWidget);
+    expect(router.routeInformationProvider.value.uri.path, "/sessions/chat");
+  });
+
+  testWidgets("escape closes the image viewer", (tester) async {
+    const attachment = MessageAttachment.inlineImage(
+      mime: "image/png",
+      base64: _pngBase64,
+      filename: "image.png",
+    );
+    await tester.pumpWidget(
+      _app(
+        child: const FilePartWidget(sessionId: "session-1", attachment: attachment),
+      ),
+    );
+    await _openImageViewer(tester: tester);
+    expect(find.byType(ImageAttachmentViewer), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ImageAttachmentViewer), findsNothing);
+    expect(find.byKey(FilePartWidget.previewTapTargetKey), findsOneWidget);
   });
 
   testWidgets("free-form image drag follows the pointer, snaps back, or dismisses", (tester) async {

--- a/docs/regression/attachments-and-images.md
+++ b/docs/regression/attachments-and-images.md
@@ -59,6 +59,10 @@ content the transcript renders live and after reload.
   image provider from Flutter's image cache, and scrolling never starts an
   original request. Reduced motion skips the viewer route and image-swap
   animations.
+- The viewer closes through its close button, a free-form drag, a hardware
+  Escape key, and system back. Back closes only the viewer and keeps the session
+  open, including when the Android back gesture delivers a second pop while the
+  viewer is still fading out.
 - User, tool, and each maximal contiguous run of assistant file attachments use
   the same left-aligned square collection, capped at 320 px and constrained by
   the available parent width. One attachment spans the collection, two split a


### PR DESCRIPTION
## Complexity

🌿 Straightforward: one shortcut binding and one lifetime change on an existing local-history mirror, plus tests.

## What

- Escape now closes the full-screen image viewer on desktop.
- The session route's mirrored `LocalHistoryEntry` is held until the viewer route's exit transition completes, instead of being released the moment the viewer is popped.

## Why

The viewer route lives on the root navigator, and a mirror entry on the session route lets whichever navigator receives Android back dismiss the viewer. That entry used to be removed on the push future's completion, which fires as soon as the route is popped — leaving a ~220 ms window during the fade-out where the session route no longer absorbs a pop. A back gesture that delivers a second pop in that window (or a drag-dismiss followed by the system's back commit) popped the session detail screen too, which matches the "often, but not always" report. Holding the entry until `TransitionRoute.completed` makes the session route swallow that trailing pop.

The viewer had no keyboard affordance at all, so on desktop the only exits were the close button and a pointer drag.

## Risk and test focus

- Navigation only; no database, wire contract, or persisted state impact.
- Escape is scoped to the viewer route's focus scope, so it cannot reach the session composer behind it.
- The mirror entry is skipped when the session route is already inactive, which is the navigator-teardown case.
- Focus: opening and closing the viewer through every path — close button, drag dismiss, Escape, Android back — and confirming the session detail screen survives back.

## Expected result

Escape closes the full-screen image on desktop. On Android the back gesture closes only the image and leaves the session detail screen open, including on the fast flick gestures that used to pop both.

## Verification

- `flutter test test/features/session_detail/widgets/file_part_widget_test.dart` (33 passed), including two new tests: a second system back during the viewer dismissal stays in the session, and Escape closes the viewer.
- `flutter test test/features/session_detail/widgets/assistant_message_card_test.dart test/features/session_detail/widgets/session_detail_body_test.dart` (92 passed).
- `flutter analyze` on both changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escape closes the full-screen image viewer, and Android back/gestures now close only the viewer instead of sometimes popping the session detail screen. Previously the viewer had no keyboard exit and a trailing back during the fade-out could exit the session.

- Hold the session route’s mirrored local history entry until the viewer’s exit transition completes; skip removal if the session route is inactive.
- Scope Escape to the viewer’s focus so it never reaches the session composer.
- Add tests for duplicate back during viewer dismissal and for Escape; update regression docs; navigation-only change.

<sup>Written for commit 2841c450ae10c7229f246822c4a742ea1228c3f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

