### PR TITLE
🌿 Preserve plugin shutdown ordering

### DIFF
--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -210,13 +210,13 @@ class const BridgeRuntimeRunner._() {
     SupervisedExitCode? requestedSupervisedExit;
     // Shared by the ordered pluginDispose phase and the backstop's emergency
     // disposal so the two cannot drift.
-    Future<void> disposePluginApis() => pluginRuntime?.disposeStartedApis() ?? Future<void>.value();
+    Future<void> shutdownStartedPlugins() => pluginRuntime?.shutdownStartedPlugins() ?? Future<void>.value();
     final shutdownCoordinator = BridgeShutdownCoordinator(
       startAbortSignal: startAbortController.signal,
       backstopExitCode: () => requestedSupervisedExit?.code ?? 0,
       // Last resort before a forced exit: stop plugin backends so their agent
       // processes are not orphaned when the teardown (or a phase) hangs.
-      emergencyDisposal: disposePluginApis,
+      emergencyDisposal: shutdownStartedPlugins,
     );
     shutdownCoordinator
       ..addPhase(
@@ -260,7 +260,7 @@ class const BridgeRuntimeRunner._() {
       )
       ..addPhase(
         phase: BridgeShutdownPhase.pluginDispose,
-        action: disposePluginApis,
+        action: shutdownStartedPlugins,
         budget: _pluginShutdownBudget,
       )
       ..addPhase(

--- a/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_runtime.dart
@@ -84,12 +84,10 @@ class PluginRuntime({
   final PublishSubject<SourcedPluginProvisionProgress> _provisionProgressSubject =
       PublishSubject<SourcedPluginProvisionProgress>();
   bool _shuttingDown = false;
-  Future<void>? _disposeStartedApisFuture;
+  Future<void>? _shutdownStartedPluginsFuture;
   Future<void>? _disposeFuture;
-  bool _apiDisposalStarted = false;
   final Set<StartAbortController> _installAbortControllers = <StartAbortController>{};
   final Set<StartAbortController> _authenticationAbortControllers = <StartAbortController>{};
-  final Map<BridgePluginApi, Future<void>> _apiDisposals = Map<BridgePluginApi, Future<void>>.identity();
 
   Stream<List<PluginRuntimeSnapshot>> get snapshots => _snapshotsSubject.stream;
   List<PluginRuntimeSnapshot> get snapshot => List<PluginRuntimeSnapshot>.unmodifiable(_buildSnapshots());
@@ -643,11 +641,11 @@ class PluginRuntime({
     }
   }
 
-  Future<void> disposeStartedApis() => _disposeStartedApisFuture ??= _disposeStartedApis();
+  Future<void> shutdownStartedPlugins() => _shutdownStartedPluginsFuture ??= _shutdownStartedPlugins();
 
-  Future<void> _disposeStartedApis() async {
-    _apiDisposalStarted = true;
+  Future<void> _shutdownStartedPlugins() async {
     final errors = <({Object error, StackTrace stackTrace})>[];
+    final shutdowns = Map<BridgePlugin, Future<void>>.identity();
 
     Future<void> capture(Future<void> operation) async {
       try {
@@ -659,23 +657,28 @@ class PluginRuntime({
       }
     }
 
+    Future<void> shutdown(BridgePlugin plugin) {
+      if (shutdowns.containsKey(plugin)) {
+        return Future<void>.value();
+      }
+      final operation = Future<void>.sync(() => plugin.shutdown(budget: _shutdownBudget));
+      shutdowns[plugin] = operation;
+      return capture(operation);
+    }
+
     final starts = [for (final slot in _slots.values) ?slot.startFuture];
     await Future.wait([
       for (final slot in _slots.values)
-        if (slot.plugin case final plugin?) capture(_disposeApi(plugin.api)),
+        if (slot.plugin case final plugin?) shutdown(plugin),
       for (final start in starts) capture(start.then<void>((_) {})),
     ]);
     await Future.wait([
       for (final slot in _slots.values)
-        if (slot.plugin case final plugin?) capture(_disposeApi(plugin.api)),
+        if (slot.plugin case final plugin?) shutdown(plugin),
     ]);
     if (errors case [final first, ...]) {
       Error.throwWithStackTrace(first.error, first.stackTrace);
     }
-  }
-
-  Future<void> _disposeApi(BridgePluginApi api) {
-    return _apiDisposals.putIfAbsent(api, () => Future<void>.sync(api.dispose));
   }
 
   Future<void> dispose() => _disposeFuture ??= _dispose();
@@ -1494,7 +1497,6 @@ class PluginRuntime({
       );
       _applyStatus(slot: slot, generation: generation, status: started.currentStatus);
       Log.d('Plugin "$pluginId" generation $generation started (${slot.state.name})');
-      if (_apiDisposalStarted) await _disposeApi(started.api);
       return started;
     } on PluginStartAbortedException {
       slot.state = PluginRuntimeState.failed;

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -609,7 +609,7 @@ void main() {
       expect(debugDrained, isTrue);
     });
 
-    test("drains and persists a routed mutation before disposing its plugin API", () async {
+    test("drains and persists a routed mutation before plugin teardown", () async {
       final db = createTestDatabase();
       String? persistedTitleAtDispose;
       final plugin = _BlockingMutationPlugin(
@@ -665,7 +665,7 @@ void main() {
             )
             ..addPhase(
               phase: BridgeShutdownPhase.pluginDispose,
-              action: runtimeForLifecycleService(service: harness.lifecycleService).disposeStartedApis,
+              action: runtimeForLifecycleService(service: harness.lifecycleService).shutdownStartedPlugins,
             );
       await debugServer.start();
 

--- a/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
@@ -1564,7 +1564,7 @@ void main() {
     expect(factory.plugins.single.shutdownCount, 1);
   });
 
-  test("shutdown cleans up a plugin that returns after API disposal begins", () async {
+  test("shutdown cleans up a plugin that returns after plugin shutdown begins", () async {
     final startGate = Completer<void>();
     final factory = _FakeGenerationFactory(
       startGate: startGate.future,
@@ -1575,16 +1575,39 @@ void main() {
     await _waitUntil(() => factory.startCount == 1);
 
     runtime.beginShutdown();
-    final disposingApis = runtime.disposeStartedApis();
+    final shuttingDownPlugins = runtime.shutdownStartedPlugins();
     startGate.complete();
 
     await expectLater(starting, throwsA(isA<PluginStartAbortedException>()));
-    await disposingApis;
+    await shuttingDownPlugins;
     expect(factory.plugins.single.shutdownCount, 1);
     await runtime.dispose();
   });
 
-  test("event closure during API disposal does not hide a later shutdown failure", () async {
+  test("plugin shutdown owns API disposal before runtime lifecycle cleanup", () async {
+    final shutdownGate = Completer<void>();
+    final factory = _FakeGenerationFactory(
+      startGate: Future<void>.value(),
+      pluginFactory: (_) => _FakePlugin(
+        api: _FakeApi(),
+        shutdownGate: shutdownGate.future,
+      ),
+    );
+    final runtime = _runtime(factory: factory);
+    await runtime.startEager(pluginIds: const ["one"]);
+
+    runtime.beginShutdown();
+    final shuttingDownPlugins = runtime.shutdownStartedPlugins();
+    await _waitUntil(() => factory.plugins.single.shutdownCount == 1);
+
+    expect(factory.api.disposeCount, 0, reason: "core must not bypass the plugin's teardown ordering");
+    shutdownGate.complete();
+    await shuttingDownPlugins;
+    expect(factory.api.disposeCount, 1);
+    await runtime.dispose();
+  });
+
+  test("event closure during plugin shutdown does not hide its failure", () async {
     final shutdownError = StateError("runtime shutdown failed");
     final factory = _FakeGenerationFactory(
       startGate: Future<void>.value(),
@@ -1597,7 +1620,7 @@ void main() {
     await runtime.startEager(pluginIds: const ["one"]);
 
     runtime.beginShutdown();
-    await runtime.disposeStartedApis();
+    await expectLater(runtime.shutdownStartedPlugins(), throwsA(same(shutdownError)));
     expect(runtime.snapshot.single.state, PluginRuntimeState.active);
 
     await expectLater(runtime.dispose(), throwsA(same(shutdownError)));

--- a/bridge/app/test/helpers/plugin_runtime_test_support.dart
+++ b/bridge/app/test/helpers/plugin_runtime_test_support.dart
@@ -171,7 +171,7 @@ class TestPluginRuntime({
   Stream<SourcedPluginProvisionProgress> get provisionProgress => const Stream.empty();
 
   @override
-  Future<void> disposeStartedApis() => Future.wait([
+  Future<void> shutdownStartedPlugins() => Future.wait([
     for (final plugin in _plugins.values) plugin.dispose(),
   ]);
 

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin.dart
@@ -66,16 +66,17 @@ abstract class BridgePlugin() {
   /// [budget] bounds the complete interruption and quiescence operation.
   Future<Set<String>> interruptActiveWork({required Duration budget});
 
-  /// Stops the plugin in order: api teardown, then any managed runtime,
-  /// releasing everything `start()` acquired.
+  /// Stops the plugin in its backend-defined order, including API teardown and
+  /// any managed runtime, releasing everything `start()` acquired. Bridge
+  /// lifecycle owners call this method rather than disposing [api] directly so
+  /// the plugin can disarm monitors and sequence transport/process teardown.
   ///
   /// Contract:
   ///
   /// - **Idempotent.** Repeated calls return the same (or an equivalent
   ///   completed) future.
-  /// - **Safe in either order with [BridgePluginApi.dispose].** During the
-  ///   migration window the bridge core may still call `dispose()` directly
-  ///   before or after `shutdown()`; neither call may break the other.
+  /// - **Owns API teardown.** Implementations dispose [api] as part of this
+  ///   operation and remain safe if that API was already disposed independently.
   /// - [budget] is the soft deadline the caller grants; implementations
   ///   should degrade to forceful termination rather than overrun it.
   ///   `null` means the caller imposes no deadline.

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -56,6 +56,9 @@ idle suspension, the management snapshot, and lifecycle commands.
 - A busy harness conflicts explicitly, forcing needs confirmation and is sent once, the
   snapshot changes only on real content change with a new token, and a terminal failure
   removes only that harness's routing and new-session choice.
+- Deliberate bridge shutdown enters each live harness's lifecycle shutdown before closing
+  its transport directly. Managed runtime monitors disarm before transport or process
+  teardown, so a clean owned-runtime exit is neither reported nor restarted as a crash.
 - Interactive authentication is optional per descriptor. A capable harness owns its
   backend process and credentials, exposes only a safe challenge and sanitized terminal
   state, cancels cooperatively, and settles process cleanup before the operation ends.
@@ -86,7 +89,7 @@ idle suspension, the management snapshot, and lifecycle commands.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | A started bridge inspects every registered harness and publishes coherent setup and management snapshots. A ready fixture has a selectable default; a fixture with no usable harness has zero selectable entries and no default without failing startup. Headless bridge; all registered harnesses listed. |
-| L2 Routine | Demand-driven start of a ready harness, setup refresh, and the disable list surviving restart with eligibility and ordering intact. Headless bridge; representative harness for start, every registered harness for listing and ordering. |
+| L2 Routine | Demand-driven start of a ready harness, clean lifecycle-owned bridge shutdown, setup refresh, and the disable list surviving restart with eligibility and ordering intact. Headless bridge; representative managed harness for start and shutdown, every registered harness for listing and ordering. |
 | L3 Release | The management surface as rendered: per-harness selected runtime version when reported, setup, runtime and work state, capability-appropriate controls, built-in name and light/dark artwork, default badge, enable/disable, restart, and idle-timeout default plus override persisted across a bridge restart. Client end to end; every harness declaring the relevant capability must pass. |
 | L4 Extended | Busy conflict with force confirmation and cancellation, authentication start/join/cancel plus shutdown cleanup, idle suspension elapsing then returning on demand, harnesses blocked by missing runtime or authentication, a terminally failed harness leaving others usable, a bridge with no usable harness, an externally managed configuration, two harnesses active at once, second mobile platform. Live plugin where a real backend must start or be interrupted, client end to end where card state is claimed. |
 | L5 Full | Every registered production harness through inspect, enable, disable, restart, refresh, and idle behavior on a supported platform, plus forward-compatible presentation of an unknown harness or capability and the reported state of a session interrupted by a forced disable. Live plugin and client end to end as each entry requires. |
@@ -121,6 +124,8 @@ timeouts, and sessions afterwards.
   browser/copy failure removing the challenge before the user can retry.
 - One failing harness taking down the rest of the bridge, or an empty picker
   instead of the explicit no-harness state when none is usable.
+- Direct API disposal bypassing lifecycle shutdown, or a deliberate owned-runtime exit
+  being logged, failed, or restarted as an unexpected crash.
 
 ## Known Limitations
 


### PR DESCRIPTION
## Complexity

Straightforward. The bridge keeps its existing phased shutdown structure but enters the existing plugin lifecycle owner instead of bypassing it through the request API.

## What

- Replace early `BridgePluginApi.dispose()` calls with concurrent `BridgePlugin.shutdown()` calls for every started or late-returning generation.
- Use the same lifecycle-owned shutdown for the coordinator backstop.
- Preserve later runtime subscription and subject cleanup, error propagation, and idempotent teardown.
- Add regression coverage for plugin-owned API disposal ordering and document the lifecycle invariant.

## Why

Disposing Codex's API closes its only WebSocket, which makes `codex app-server` exit cleanly with code 0. The old API-first phase did that while `ManagedRuntimeMonitor` was still armed, so a deliberate bridge shutdown was logged and classified as an unexpected runtime exit before `CodexBridgePlugin.shutdown()` could disarm the monitor.

## Risk and test focus

The risk is limited to bridge plugin teardown ordering. Focus review on in-flight or late plugin starts, per-plugin shutdown failures, and emergency backstop behavior. There is no database impact. User-visible impact is limited to clean plugin shutdown behavior and removal of the false Codex crash diagnostic.

## Expected result

A bridge shutdown enters each plugin's lifecycle teardown first. Codex disarms its managed-runtime monitor before closing the WebSocket, so the resulting clean app-server exit is not reported or handled as a crash.

## Verification

- `dart test test/bridge/runtime/plugin_runtime_test.dart`
- `dart test test/bridge/debug_server_test.dart --name "drains and persists a routed mutation before plugin teardown"`
- `dart test test/lifecycle/steady_plugin_lifecycle_test.dart`
- `dart analyze --fatal-infos` in `bridge/app`
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_interface`
- Architecture plan and implementation reviews: approved with no findings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves plugin shutdown ordering so lifecycle owners disarm monitors before transport teardown. Previously the bridge disposed plugin APIs first, closing the single WebSocket and causing clean owned-runtime exits to be logged as unexpected crashes; now it shuts down plugins first and lets plugins own API disposal.

- Replaces `disposeStartedApis()` with `shutdownStartedPlugins()` and routes both the ordered phase and the emergency backstop through plugin-owned shutdown.
- `PluginRuntime` shuts down every started or late-returning generation, waits for in-flight starts, captures failures, and preserves later runtime cleanup and idempotent teardown.
- Updates tests and docs to assert lifecycle-owned shutdown and remove the false crash diagnostic.

Bold migration is not needed for most callers, but plugin authors must:
- Ensure `BridgePlugin.shutdown()` owns API disposal, is idempotent, and remains safe if the API was already disposed.

<sup>Written for commit c23333ad0bcb40227a707e63dbe54a73064ee23e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

