### PR TITLE
🌿 Finalize Hermes text before ACP tool calls

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -364,7 +364,7 @@ class AcpEventMapper({
         // is reconstructed separately by AcpReplayCollector.
         return const [];
       case "tool_call":
-        return _afterReasoning(
+        return _beforeTool(
           sessionId: sessionId,
           events: _toolCall(sessionId: sessionId, update: update),
         );
@@ -425,16 +425,43 @@ class AcpEventMapper({
     required List<BridgeSseEvent> events,
   }) {
     if (events.isEmpty) return events;
-    return [..._finalizeActiveReasoning(sessionId: sessionId), ...events];
+    return [
+      ..._finalizeActiveTextParts(
+        sessionId: sessionId,
+        partType: PluginMessagePartType.reasoning,
+      ),
+      ...events,
+    ];
   }
 
-  List<BridgeSseEvent> _finalizeActiveReasoning({required String sessionId}) {
+  List<BridgeSseEvent> _beforeTool({
+    required String sessionId,
+    required List<BridgeSseEvent> events,
+  }) {
+    if (events.isEmpty) return events;
+    return [
+      ..._finalizeActiveTextParts(
+        sessionId: sessionId,
+        partType: PluginMessagePartType.reasoning,
+      ),
+      ..._finalizeActiveTextParts(
+        sessionId: sessionId,
+        partType: PluginMessagePartType.text,
+      ),
+      ...events,
+    ];
+  }
+
+  List<BridgeSseEvent> _finalizeActiveTextParts({
+    required String sessionId,
+    required PluginMessagePartType partType,
+  }) {
     final accumulators = _textPartAccumulators[sessionId];
     if (accumulators == null) return const [];
 
     final events = <BridgeSseEvent>[];
     for (final accumulator in accumulators.values) {
-      if (accumulator.type != PluginMessagePartType.reasoning || !accumulator.isStreaming) continue;
+      if (accumulator.type != partType || !accumulator.isStreaming) continue;
       accumulator.isStreaming = false;
       events.add(
         BridgeSseMessagePartUpdated(

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -364,7 +364,7 @@ class AcpEventMapper({
         // is reconstructed separately by AcpReplayCollector.
         return const [];
       case "tool_call":
-        return _beforeTool(
+        return _afterReasoning(
           sessionId: sessionId,
           events: _toolCall(sessionId: sessionId, update: update),
         );
@@ -429,24 +429,7 @@ class AcpEventMapper({
       ..._finalizeActiveTextParts(
         sessionId: sessionId,
         partType: PluginMessagePartType.reasoning,
-      ),
-      ...events,
-    ];
-  }
-
-  List<BridgeSseEvent> _beforeTool({
-    required String sessionId,
-    required List<BridgeSseEvent> events,
-  }) {
-    if (events.isEmpty) return events;
-    return [
-      ..._finalizeActiveTextParts(
-        sessionId: sessionId,
-        partType: PluginMessagePartType.reasoning,
-      ),
-      ..._finalizeActiveTextParts(
-        sessionId: sessionId,
-        partType: PluginMessagePartType.text,
+        messageId: null,
       ),
       ...events,
     ];
@@ -455,13 +438,18 @@ class AcpEventMapper({
   List<BridgeSseEvent> _finalizeActiveTextParts({
     required String sessionId,
     required PluginMessagePartType partType,
+    required String? messageId,
   }) {
     final accumulators = _textPartAccumulators[sessionId];
     if (accumulators == null) return const [];
 
     final events = <BridgeSseEvent>[];
     for (final accumulator in accumulators.values) {
-      if (accumulator.type != partType || !accumulator.isStreaming) continue;
+      if (accumulator.type != partType ||
+          !accumulator.isStreaming ||
+          (messageId != null && accumulator.messageId != messageId)) {
+        continue;
+      }
       accumulator.isStreaming = false;
       events.add(
         BridgeSseMessagePartUpdated(
@@ -477,6 +465,15 @@ class AcpEventMapper({
       );
     }
     return events;
+  }
+
+  List<BridgeSseEvent> _finalizeCurrentIdlessAssistantText({required String sessionId}) {
+    if (!_openIdlessAssistant.contains(sessionId)) return const [];
+    return _finalizeActiveTextParts(
+      sessionId: sessionId,
+      partType: PluginMessagePartType.text,
+      messageId: _currentIdlessAssistantMessageId(sessionId),
+    );
   }
 
   /// Hook for non-`session/update` notifications (harness extensions such as
@@ -800,6 +797,9 @@ class AcpEventMapper({
     final toolCallId = update["toolCallId"] as String?;
     if (toolCallId == null || toolCallId.isEmpty) return const [];
     final prior = _liveTools[sessionId]?[toolCallId];
+    final boundaryEvents = prior == null
+        ? _finalizeCurrentIdlessAssistantText(sessionId: sessionId)
+        : const <BridgeSseEvent>[];
     if (prior == null) {
       _closeCurrentIdlessAssistantContent(sessionId: sessionId);
     }
@@ -830,6 +830,7 @@ class AcpEventMapper({
     );
     (_liveTools[sessionId] ??= {})[toolCallId] = state;
     final events = <BridgeSseEvent>[
+      ...boundaryEvents,
       if (prior == null) _toolEnvelope(sessionId: sessionId, messageId: messageId),
       _toolPartEvent(sessionId: sessionId, messageId: messageId, state: state),
     ];
@@ -855,6 +856,9 @@ class AcpEventMapper({
     // which would blank an existing tool card. Mirrors the replay collector,
     // which already merges — keeping live and history renderings consistent.
     final prior = _liveTools[sessionId]?[toolCallId];
+    final boundaryEvents = prior == null
+        ? _finalizeCurrentIdlessAssistantText(sessionId: sessionId)
+        : const <BridgeSseEvent>[];
     if (prior == null) {
       _closeCurrentIdlessAssistantContent(sessionId: sessionId);
     }
@@ -885,6 +889,7 @@ class AcpEventMapper({
       hasExplicitStatus: (prior?.hasExplicitStatus ?? false) || mappedStatus != null,
     );
     final events = <BridgeSseEvent>[
+      ...boundaryEvents,
       // ACP events can be reordered (reconnect / resume / replay), so a
       // `tool_call_update` may arrive before its `tool_call`. When it is
       // first-seen, synthesize the message envelope — like `_textChunk` does —
@@ -912,13 +917,15 @@ class AcpEventMapper({
   }
 
   void _closeCurrentIdlessAssistantContent({required String sessionId}) {
-    final messageId =
-        "$sessionId-t${_turn(sessionId)}-${_ChunkRole.assistant.name}-a${_idlessAssistantSeq[sessionId] ?? 0}";
+    final messageId = _currentIdlessAssistantMessageId(sessionId);
     final sessionTrackers = _contentTrackers[sessionId];
     sessionTrackers?.remove(messageId);
     if (sessionTrackers?.isEmpty ?? false) _contentTrackers.remove(sessionId);
     _closeIdlessAssistantEnvelope(sessionId);
   }
+
+  String _currentIdlessAssistantMessageId(String sessionId) =>
+      "$sessionId-t${_turn(sessionId)}-${_ChunkRole.assistant.name}-a${_idlessAssistantSeq[sessionId] ?? 0}";
 
   BridgeSseMessageUpdated _toolEnvelope({required String sessionId, required String messageId}) {
     return BridgeSseMessageUpdated(

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -192,6 +192,69 @@ void main() {
       );
     });
 
+    test("a first-seen tool update finalizes active id-less assistant text", () {
+      mapper.beginTurn("s1");
+      mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "Before the reordered tool update."},
+        }),
+      );
+
+      final toolEvents = mapper.map(
+        update({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tool-1",
+          "kind": "search",
+          "status": "completed",
+        }),
+      );
+
+      expect(
+        toolEvents.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part.text).whereType<String>(),
+        contains("Before the reordered tool update."),
+      );
+    });
+
+    test("a tool call does not finalize an explicit assistant message", () {
+      mapper.beginTurn("s1");
+      mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "m1",
+          "content": {"type": "text", "text": "Before the tool."},
+        }),
+      );
+
+      final toolEvents = mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tool-1",
+          "kind": "search",
+          "status": "completed",
+        }),
+      );
+      expect(
+        toolEvents.whereType<BridgeSseMessagePartUpdated>().where(
+          (event) => event.part.type == PluginMessagePartType.text,
+        ),
+        isEmpty,
+      );
+
+      final afterTool = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "m1",
+          "content": {"type": "text", "text": " After the tool."},
+        }),
+      );
+      expect(afterTool.whereType<BridgeSseMessagePartDelta>().single.delta, " After the tool.");
+      expect(
+        mapper.finalizeTurn(sessionId: "s1").whereType<BridgeSseMessagePartUpdated>().single.part.text,
+        "Before the tool. After the tool.",
+      );
+    });
+
     test("forgetSession drops pending text snapshots", () {
       mapper.beginTurn("s1");
       mapper.map(

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -150,6 +150,48 @@ void main() {
       );
     });
 
+    test("tool activity finalizes active assistant text before the turn ends", () {
+      mapper.beginTurn("s1");
+      mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "Before the first tool."},
+        }),
+      );
+
+      final firstToolEvents = mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tool-1",
+          "kind": "search",
+          "status": "completed",
+        }),
+      );
+      expect(
+        firstToolEvents.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part.text).whereType<String>(),
+        contains("Before the first tool."),
+      );
+
+      mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "Before the second tool."},
+        }),
+      );
+      final secondToolEvents = mapper.map(
+        update({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tool-2",
+          "kind": "read",
+          "status": "completed",
+        }),
+      );
+      expect(
+        secondToolEvents.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part.text).whereType<String>(),
+        contains("Before the second tool."),
+      );
+    });
+
     test("forgetSession drops pending text snapshots", () {
       mapper.beginTurn("s1");
       mapper.map(

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -82,7 +82,9 @@ defaults and queued client sends coherent.
   session cancellation. Available models come from Hermes's ACP session model
   state, and the selected exact model ID is applied through Hermes's
   `session/set_model` extension before each changed-model turn. A rejected model
-  fails before prompting. Sesori does not call form-elicitation or unadvertised
+  fails before prompting. Completed assistant text is finalized at each tool
+  boundary, so earlier prose in a multi-tool turn does not depend on the final
+  turn snapshot. Sesori does not call form-elicitation or unadvertised
   session-close methods to complete an ordinary turn.
 - Existing-session ACP prompts remain bridge-queued while an earlier turn,
   process-wide lane, resume, or selection blocks their `session/prompt` frame.


### PR DESCRIPTION
## Complexity

🌿 Straightforward — one event-ordering change inside the existing ACP mapper, plus focused regression coverage. No client, wire-contract, database, migration, or compatibility impact.

## What

- Emit a complete assistant text-part snapshot immediately before each ACP `tool_call` event.
- Reuse the mapper's existing accumulated-text lifecycle for both reasoning and assistant text.
- Cover two consecutive Hermes-style text/tool boundaries without relying on turn finalization.
- Document the tool-boundary finalization contract.

## Why

Hermes streams an empty text part followed by deltas. Before this change, text completed before a tool call remained transient until the entire turn finished. A multi-tool response therefore left every earlier prose segment dependent on one final end-of-turn snapshot; if that event was missed, the text disappeared from the settled transcript.

The rejected client-side approach in #991 tried to reconstruct canonical transcript state inside `SessionDetailCubit`. This replacement fixes the authoritative ACP producer instead, without adding a second transcript source or reconnect state machine.

## Risk and test focus

The event ordering changes for ACP tool calls: any active reasoning and assistant text snapshots now precede the tool event. End-of-turn finalization remains intact and idempotent. Test focus is multiple text/tool boundaries and the existing ACP mapper, turn lifecycle, replay, Cursor/OMP behavior, and Hermes plugin suites.

No database or transport schema changes. No compatibility path or migration is required.

## Expected result

Completed prose before each Hermes tool call is already represented by a complete part snapshot, so an unavailable final turn snapshot cannot erase all earlier text segments.

## Verification

- `dart analyze --fatal-infos` in `bridge/sesori_plugin_acp`
- `dart test` in `bridge/sesori_plugin_acp` — 248 tests pass
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_hermes`
- `dart test` in `bridge/sesori_plugin_hermes` — 38 tests pass
- Architecture implementation review: approved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalizes assistant text before ACP tool boundaries and scopes snapshots to the current id-less assistant message, so Hermes multi-tool turns keep earlier prose even if the final turn snapshot is missed. Before: text before a tool stayed transient until turn end. Now: the mapper emits a complete text-part snapshot immediately before the first-seen `tool_call` or `tool_call_update`; end-of-turn finalization is unchanged.

- Only id-less assistant text is finalized at tool boundaries; explicit `messageId` messages continue streaming until turn end.
- Uses a generalized finalizer that scopes by part type and message ID; reuses existing accumulators; no client, transport, or database changes.
- Emits boundary snapshots only on first-seen tool activity to handle reorder/replay.
- Adds regression tests for consecutive tools, reordered `tool_call_update`, and non-finalization with explicit `messageId`; updates docs to state tool-boundary finalization.

<sup>Written for commit 6a605aae516d5de777d8e4fa426a8eda244e7bfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

