### PR TITLE
⚙️ Preserve ACP user prompt attachments in transcripts

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -253,26 +253,13 @@ class AcpEventMapper({
   /// let the client upsert either arrival order instead of rendering both.
   List<BridgeSseEvent> mapInitialPrompt({
     required String sessionId,
-    required String text,
-  }) {
-    if (text.trim().isEmpty) return const [];
-    final messageId = initialUserMessageId(sessionId);
-    return [
-      BridgeSseMessageUpdated(
-        info: _messageFor(_ChunkRole.user, messageId, sessionId, promptId: null).toJson(),
-      ),
-      BridgeSseMessagePartUpdated(
-        part: _part(
-          partId: "$messageId-text",
-          messageId: messageId,
-          sessionId: sessionId,
-          type: PluginMessagePartType.text,
-          text: text,
-          attachment: null,
-        ),
-      ),
-    ];
-  }
+    required List<PluginPromptPart> parts,
+  }) => _mapUserPrompt(
+    sessionId: sessionId,
+    messageId: initialUserMessageId(sessionId),
+    promptId: null,
+    parts: parts,
+  );
 
   /// Maps an accepted outbound prompt to its canonical live user message.
   List<BridgeSseEvent> mapSentPrompt({
@@ -280,26 +267,67 @@ class AcpEventMapper({
     required String promptId,
     required List<PluginPromptPart> parts,
   }) {
-    final textParts = parts.whereType<PluginPromptPartText>().where((part) => part.text.isNotEmpty).toList();
-    if (textParts.isEmpty) return const [];
-
     final sequence = (_sentUserSeq[sessionId] ?? 0) + 1;
-    _sentUserSeq[sessionId] = sequence;
-    final messageId = "$sessionId-sent-$sequence-user";
+    final events = _mapUserPrompt(
+      sessionId: sessionId,
+      messageId: "$sessionId-sent-$sequence-user",
+      promptId: promptId,
+      parts: parts,
+    );
+    if (events.isNotEmpty) _sentUserSeq[sessionId] = sequence;
+    return events;
+  }
+
+  List<BridgeSseEvent> _mapUserPrompt({
+    required String sessionId,
+    required String messageId,
+    required String? promptId,
+    required List<PluginPromptPart> parts,
+  }) {
+    final content = <Map<String, dynamic>>[
+      for (final part in parts)
+        switch (part) {
+          PluginPromptPartText(:final text) => {"type": "text", "text": text},
+          PluginPromptPartFileData(:final mime, :final base64) => {
+            "type": "image",
+            "mimeType": mime,
+            "data": base64,
+          },
+          PluginPromptPartFilePath() || PluginPromptPartFileUrl() => const {},
+        },
+    ];
+    final tracker = AcpContentTracker();
+    final mutations = tracker.append(
+      blocks: _contentMapper.mapScoped(
+        content: content.where((block) => block.isNotEmpty).toList(growable: false),
+        scope: tracker.mappingScope,
+      ),
+    );
+    if (mutations.isEmpty) return const [];
     return [
       BridgeSseMessageUpdated(
         info: _messageFor(_ChunkRole.user, messageId, sessionId, promptId: promptId).toJson(),
       ),
-      for (var index = 0; index < textParts.length; index++)
+      for (final mutation in mutations)
         BridgeSseMessagePartUpdated(
-          part: _part(
-            partId: "$messageId-text-$index",
-            messageId: messageId,
-            sessionId: sessionId,
-            type: PluginMessagePartType.text,
-            text: textParts[index].text,
-            attachment: null,
-          ),
+          part: switch (mutation) {
+            AcpTextDeltaMutation(:final partIdSuffix, :final delta) => _part(
+              partId: "$messageId-$partIdSuffix",
+              messageId: messageId,
+              sessionId: sessionId,
+              type: PluginMessagePartType.text,
+              text: delta,
+              attachment: null,
+            ),
+            AcpImageMutation(:final partIdSuffix, :final attachment) => _part(
+              partId: "$messageId-$partIdSuffix",
+              messageId: messageId,
+              sessionId: sessionId,
+              type: PluginMessagePartType.file,
+              text: null,
+              attachment: attachment,
+            ),
+          },
         ),
     ];
   }

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -777,14 +777,18 @@ abstract class AcpPlugin({
       time: PluginSessionTime(created: createdAt, updated: createdAt, archived: null),
     );
     emitEvent(eventMapper.mapCreatedSession(session: created));
-    if (userVisibleText != null && userVisibleText.trim().isNotEmpty) {
+    final visibleParts = [
+      if (userVisibleText != null && userVisibleText.trim().isNotEmpty)
+        PluginPromptPart.text(text: userVisibleText),
+      ...parts.whereType<PluginPromptPartFileData>(),
+    ];
+    final initialPromptEvents = eventMapper.mapInitialPrompt(
+      sessionId: session.sessionId,
+      parts: visibleParts,
+    );
+    if (initialPromptEvents.isNotEmpty) {
       _syntheticInitialPromptSessions.add(session.sessionId);
-      eventMapper
-          .mapInitialPrompt(
-            sessionId: session.sessionId,
-            text: userVisibleText,
-          )
-          .forEach(emitEvent);
+      initialPromptEvents.forEach(emitEvent);
     }
     if (parts.isEmpty) {
       // No first turn to carry the selection: apply it now so the session's

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -49,8 +49,7 @@ class AcpReplayCollector({
         final t = _contentMapper.text(content: update["content"]);
         if (t != null) _assistant(messageId: _chunkMessageId(update)).reasoning.write(t);
       case "user_message_chunk":
-        final t = _contentMapper.text(content: update["content"]);
-        if (t != null) _user(messageId: _chunkMessageId(update)).text.write(t);
+        _consumeUserContent(update: update);
       case "tool_call":
         final id = update["toolCallId"] as String?;
         if (id == null) return;
@@ -124,6 +123,17 @@ class AcpReplayCollector({
         }
         if (update.containsKey("title")) draft.title = _toolTitle(update);
         draft.contentTracker.apply(mutation: contentMutation);
+    }
+  }
+
+  void _consumeUserContent({required Map<String, dynamic> update}) {
+    final draft = _user(messageId: _chunkMessageId(update));
+    final blocks = _contentMapper.mapScoped(
+      content: update["content"],
+      scope: draft.contentTracker.mappingScope,
+    );
+    for (final mutation in draft.contentTracker.append(blocks: blocks)) {
+      draft.entries.add(_AssistantContentEntry(mutation: mutation));
     }
   }
 

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -129,7 +129,7 @@ class AcpReplayCollector({
   void _consumeUserContent({required Map<String, dynamic> update}) {
     final draft = _user(messageId: _chunkMessageId(update));
     final blocks = _contentMapper.mapScoped(
-      content: update["content"],
+      content: _stripUserImageUris(update["content"]),
       scope: draft.contentTracker.mappingScope,
     );
     for (final mutation in draft.contentTracker.append(blocks: blocks)) {
@@ -479,6 +479,15 @@ class AcpReplayCollector({
   Map<String, dynamic>? _asMap(Object? value) {
     if (value is Map) return value.cast<String, dynamic>();
     return null;
+  }
+
+  Object? _stripUserImageUris(Object? content) {
+    if (content is List) {
+      return content.map(_stripUserImageUris).toList(growable: false);
+    }
+    final block = _asMap(content);
+    if (block == null || block["type"] != "image") return content;
+    return Map<String, dynamic>.of(block)..remove("uri");
   }
 
   /// Fail-soft tool title: a non-string value (schema drift / malformed agent

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -382,20 +382,55 @@ void main() {
       );
     });
 
+    for (final parts in [
+      const [
+        PluginPromptPart.text(text: "before"),
+        PluginPromptPart.fileData(mime: "image/png", base64: "AA==", filename: "private.png"),
+        PluginPromptPart.text(text: "after"),
+      ],
+      const [
+        PluginPromptPart.fileData(mime: "image/png", base64: "AA==", filename: "private.png"),
+      ],
+    ]) {
+      test("an accepted prompt preserves ${parts.length == 1 ? "attachment-only" : "mixed"} content", () {
+        final events = mapper.mapSentPrompt(
+          promptId: "prompt-1",
+          sessionId: "s1",
+          parts: parts,
+        );
+
+        final mapped = events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part).toList();
+        expect(mapped.map((part) => part.type), [
+          if (parts.length > 1) PluginMessagePartType.text,
+          PluginMessagePartType.file,
+          if (parts.length > 1) PluginMessagePartType.text,
+        ]);
+        final attachment = mapped.where((part) => part.type == PluginMessagePartType.file).single.attachment;
+        expect(attachment, isA<PluginMessageAttachmentInlineImage>());
+        expect((attachment! as PluginMessageAttachmentInlineImage).base64, "AA==");
+        expect(events.toString(), isNot(contains("private.png")));
+      });
+    }
+
     test("an initial prompt uses the history-stable message and part identity", () {
       final events = mapper.mapInitialPrompt(
         sessionId: "s1",
-        text: "Hello",
+        parts: const [
+          PluginPromptPart.text(text: "Hello"),
+          PluginPromptPart.fileData(mime: "image/png", base64: "AA==", filename: "private.png"),
+        ],
       );
 
       final message = shared.Message.fromJson(
         events.whereType<BridgeSseMessageUpdated>().single.info,
       );
-      final part = events.whereType<BridgeSseMessagePartUpdated>().single.part;
+      final parts = events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part).toList();
       expect(message.id, "s1-initial-user");
-      expect(part.id, "s1-initial-user-text");
-      expect(part.messageID, message.id);
-      expect(part.text, "Hello");
+      expect(parts.map((part) => part.id), ["s1-initial-user-text", "s1-initial-user-image-1"]);
+      expect(parts.every((part) => part.messageID == message.id), isTrue);
+      expect(parts.first.text, "Hello");
+      expect(parts.last.attachment, isA<PluginMessageAttachmentInlineImage>());
+      expect(events.toString(), isNot(contains("private.png")));
     });
 
     test("a live agent user echo is dropped", () {

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -158,6 +158,7 @@ void main() {
         final attachment = initial.parts.where((part) => part.type == PluginMessagePartType.file).single.attachment;
         expect(attachment, isA<PluginMessageAttachmentInlineImage>());
         expect((attachment! as PluginMessageAttachmentInlineImage).base64, "AA==");
+        expect(attachment.filename, isNull);
         expect(initial.parts.toString(), isNot(contains("/private/image.png")));
         expect(messages.last.info.id, "s1-h1-assistant");
       });

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -112,36 +112,56 @@ void main() {
       });
     }
 
-    test("reuses the synthetic identity for the first replayed user message", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        modelId: null,
-        providerId: null,
-        initialUserMessageId: "s1-initial-user",
-        haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
-      )
-        ..consume(
-          upd({
-            "sessionUpdate": "user_message_chunk",
-            "content": {"type": "text", "text": "Hello"},
-          }),
+    for (final content in [
+      const [
+        {"type": "text", "text": "before"},
+        {"type": "image", "data": "AA==", "mimeType": "image/png", "uri": "file:///private/image.png"},
+        {"type": "text", "text": "after"},
+      ],
+      const [
+        {"type": "image", "data": "AA==", "mimeType": "image/png", "uri": "file:///private/image.png"},
+      ],
+    ]) {
+      test("replays ${content.length == 1 ? "attachment-only" : "mixed"} user content with stable initial identity", () {
+        final collector = AcpReplayCollector(
+          sessionId: "s1",
+          agentId: "Cursor",
+          modelId: null,
+          providerId: null,
+          initialUserMessageId: "s1-initial-user",
+          haltClassifier: null,
+          contentMapper: const AcpContentMapper(),
         )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "text", "text": "Hi"},
-          }),
-        );
+          ..consume(
+            upd({
+              "sessionUpdate": "user_message_chunk",
+              "content": content,
+            }),
+          )
+          ..consume(
+            upd({
+              "sessionUpdate": "agent_message_chunk",
+              "content": {"type": "text", "text": "Hi"},
+            }),
+          );
 
-      final messages = collector.build();
-      final initial = messages.first;
-      expect(initial.info.id, "s1-initial-user");
-      expect(initial.parts.single.id, "s1-initial-user-text");
-      expect(initial.parts.single.messageID, initial.info.id);
-      expect(messages.last.info.id, "s1-h1-assistant");
-    });
+        final messages = collector.build();
+        final initial = messages.first;
+        expect(initial.info.id, "s1-initial-user");
+        expect(initial.parts.map((part) => part.type), [
+          if (content.length > 1) PluginMessagePartType.text,
+          PluginMessagePartType.file,
+          if (content.length > 1) PluginMessagePartType.text,
+        ]);
+        expect(initial.parts.first.id, content.length == 1 ? "s1-initial-user-image-1" : "s1-initial-user-text");
+        expect(initial.parts.every((part) => part.messageID == initial.info.id), isTrue);
+        final attachment = initial.parts.where((part) => part.type == PluginMessagePartType.file).single.attachment;
+        expect(attachment, isA<PluginMessageAttachmentInlineImage>());
+        expect((attachment! as PluginMessageAttachmentInlineImage).base64, "AA==");
+        expect(initial.parts.toString(), isNot(contains("/private/image.png")));
+        expect(messages.last.info.id, "s1-h1-assistant");
+      });
+    }
 
     test("reconstructs a user/tool/assistant exchange in order", () {
       final collector = AcpReplayCollector(

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -317,6 +317,49 @@ void main() {
       respondTo(prompt, {"stopReason": "end_turn"});
     });
 
+    for (final attachmentOnly in [false, true]) {
+      test("an initial ${attachmentOnly ? "attachment-only" : "mixed"} prompt dispatches and projects images", () async {
+        await connect();
+        emitted.clear();
+
+        final creating = plugin.createSession(
+          directory: cwd,
+          parentSessionId: null,
+          parts: [
+            const PluginPromptPart.text(text: "[SYSTEM CONTEXT — IMPORTANT] internal"),
+            if (!attachmentOnly) const PluginPromptPart.text(text: "visible prompt"),
+            const PluginPromptPart.fileData(
+              mime: "image/png",
+              base64: "AA==",
+              filename: "/private/image.png",
+            ),
+          ],
+          userVisibleText: attachmentOnly ? null : "visible prompt",
+          variant: null,
+          agent: null,
+          model: null,
+        );
+        respondTo(await waitForFrame("session/new"), {"sessionId": "s1"});
+        await creating;
+
+        final prompt = await waitForFrame("session/prompt");
+        final content = (prompt["params"] as Map)["prompt"] as List;
+        expect(content.where((block) => (block as Map)["type"] == "image"), hasLength(1));
+        final projected = emitted.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part).toList();
+        expect(projected.map((part) => part.type), [
+          if (!attachmentOnly) PluginMessagePartType.text,
+          PluginMessagePartType.file,
+        ]);
+        expect(
+          projected.where((part) => part.type == PluginMessagePartType.file).single.attachment,
+          isA<PluginMessageAttachmentInlineImage>(),
+        );
+        expect(emitted.toString(), isNot(contains("SYSTEM CONTEXT")));
+        expect(emitted.toString(), isNot(contains("/private/image.png")));
+        respondTo(prompt, {"stopReason": "end_turn"});
+      });
+    }
+
     test("a command emits only its user-visible arguments", () async {
       await connect();
       final sessionId = await createSession(cwd, "s1");

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -89,10 +89,14 @@ defaults and queued client sends coherent.
 - Existing-session ACP prompts remain bridge-queued while an earlier turn,
   process-wide lane, resume, or selection blocks their `session/prompt` frame.
   Their synthetic user transcript message is published only after that frame
-  flushes successfully to the agent's stdin. OMP preserves its active-prompt
-  replacement semantics by cancelling the active turn immediately, then
-  dispatching the newly queued input after cancellation settles; Cursor and
-  Hermes retain ordinary FIFO turn boundaries.
+  flushes successfully to the agent's stdin. Follow-up and replayed user
+  messages preserve ordered text and bounded data-backed image parts, including
+  attachment-only prompts. Initial projection contains only normalized
+  user-visible text plus those images; injected context, local paths, and URLs
+  remain absent. OMP preserves its active-prompt replacement semantics by
+  cancelling the active turn immediately, then dispatching the newly queued
+  input after cancellation settles; Cursor and Hermes retain ordinary FIFO turn
+  boundaries.
 - Normalized user-message events feed the durable user-side activity marker used
   to order running roots. Known event times are applied monotonically. Backend
   input represented as a user message, including automatic compaction or other


### PR DESCRIPTION
## Complexity

⚙️ Moderate. The change normalizes ordered user content across ACP live initial, live follow-up, and history replay paths while reusing existing bounded image state.

## What

- Preserve bounded data-backed image parts in ACP initial and follow-up user transcript messages, including attachment-only prompts.
- Reconstruct text and image parts from replayed `user_message_chunk` content with stable initial-message identity.
- Keep generated initial context, local paths, URLs, and prompt filenames out of projected transcript attachments.
- Add mapper, dispatch, and replay regressions and update the session-turn contract.

## Why

Current main forwards image prompt parts to Cursor, OMP, and Hermes agents but projects only text into Sesori's user transcript. Images therefore disappear live, attachment-only prompts can have no user message, and replay drops user images even when the ACP agent returns them.

## Risk and test focus

Risk is medium-low and limited to ACP-family user-message projection. Review should focus on initial context exclusion, follow-up text/image order, attachment-only prompts, replay identity, bounded image degradation, and path privacy. There is no client-to-bridge wire, database schema, persistence-write, bridge-core, or Codex change.

## Expected result

Cursor, OMP, and Hermes transcripts retain supported user prompt images live and after ACP history replay. Unsupported or over-budget images continue to follow the existing bounded degradation policy. There is no database migration or stored-data mutation.

## Verification

- `dart pub get`
- `dart test` (255 tests)
- `dart analyze --fatal-infos`
- `git diff --check origin/main...HEAD`
- Architecture implementation review: approved with no findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves ACP user prompt images in Sesori transcripts for live messages and history replay. Previously, only text was projected; images disappeared, attachment-only prompts could produce no user message, and replay dropped user images.

- Review focus
  - Initial projection includes only user-visible text plus bounded data-backed images; injected context must not appear.
  - Mixed and attachment-only prompts maintain text/image order; `filePath`/`fileUrl` parts are ignored.
  - Replayed user content uses the stable initial user message id and strips image URIs/filenames.
  - Bounded/unsupported images degrade per existing policy; no path or filename leakage.

- Rollout
  - No protocol, database, or persistence changes; scope is limited to ACP user-message projection.

<sup>Written for commit 3c3e6648040ccb1cd7280d9e197d3272e069f0a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

