### PR TITLE
🌿 Fit image Hero flights to contained bounds

### DIFF
--- a/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
+++ b/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
@@ -334,6 +334,9 @@ class _ImageAttachmentViewerState() extends State<ImageAttachmentViewer> with Ti
   static const _zoomDuration = Duration(milliseconds: 220);
 
   final _transformationController = TransformationController();
+  ImageStream? _flightImageStream;
+  ImageStreamListener? _flightImageStreamListener;
+  double? _flightImageAspectRatio;
   late final AnimationController _dragResetController;
   late final AnimationController _zoomController;
   Matrix4Tween? _zoomTween;
@@ -357,11 +360,58 @@ class _ImageAttachmentViewerState() extends State<ImageAttachmentViewer> with Ti
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _resolveFlightImageAspectRatio();
+  }
+
+  @override
+  void didUpdateWidget(covariant ImageAttachmentViewer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.flightImageProvider != widget.flightImageProvider) _resolveFlightImageAspectRatio();
+  }
+
+  @override
   void dispose() {
+    _removeFlightImageStreamListener();
     _dragResetController.dispose();
     _zoomController.dispose();
     _transformationController.dispose();
     super.dispose();
+  }
+
+  void _resolveFlightImageAspectRatio() {
+    final stream = widget.flightImageProvider.resolve(createLocalImageConfiguration(context));
+    if (_flightImageStream?.key == stream.key) return;
+    _removeFlightImageStreamListener();
+    _flightImageAspectRatio = null;
+    final listener = ImageStreamListener(
+      (image, _) {
+        final aspectRatio = image.image.width / image.image.height;
+        image.dispose();
+        _removeFlightImageStreamListener();
+        if (!mounted || _flightImageAspectRatio == aspectRatio) return;
+        setState(() => _flightImageAspectRatio = aspectRatio);
+      },
+      // The visible Image's errorBuilder owns decode failure presentation.
+      onError: (_, _) {
+        _removeFlightImageStreamListener();
+        if (!mounted || _flightImageAspectRatio == null) return;
+        setState(() => _flightImageAspectRatio = null);
+      },
+      reportErrors: false,
+    );
+    _flightImageStream = stream;
+    _flightImageStreamListener = listener;
+    stream.addListener(listener);
+  }
+
+  void _removeFlightImageStreamListener() {
+    final stream = _flightImageStream;
+    final listener = _flightImageStreamListener;
+    if (stream != null && listener != null) stream.removeListener(listener);
+    _flightImageStream = null;
+    _flightImageStreamListener = null;
   }
 
   void _updateDragReset() {
@@ -698,6 +748,11 @@ class _ImageAttachmentViewerState() extends State<ImageAttachmentViewer> with Ti
   Widget build(BuildContext context) {
     final prego = context.prego;
     final image = widget.image;
+    final imagePresentation = _buildImage(image: image);
+    final heroChild = switch (_flightImageAspectRatio) {
+      final aspectRatio? => AspectRatio(aspectRatio: aspectRatio, child: imagePresentation),
+      null => SizedBox.expand(child: imagePresentation),
+    };
     final dismissRange = (MediaQuery.sizeOf(context).height * 0.45).clamp(1.0, double.infinity);
     final dismissProgress = (_dragOffset.distance / dismissRange).clamp(0.0, 1.0);
     final chromeOpacity = 1 - dismissProgress;
@@ -750,11 +805,11 @@ class _ImageAttachmentViewerState() extends State<ImageAttachmentViewer> with Ti
                         onInteractionStart: (details) => _handleInteractionStart(details: details),
                         onInteractionUpdate: (details) => _handleInteractionUpdate(details: details),
                         onInteractionEnd: (details) => _handleInteractionEnd(details: details),
-                        child: Hero(
-                          tag: widget.heroTag,
-                          flightShuttleBuilder: _buildHeroFlight,
-                          child: SizedBox.expand(
-                            child: _buildImage(image: image),
+                        child: Center(
+                          child: Hero(
+                            tag: widget.heroTag,
+                            flightShuttleBuilder: _buildHeroFlight,
+                            child: heroChild,
                           ),
                         ),
                       ),

--- a/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
+++ b/client/app/test/features/session_detail/widgets/file_part_widget_test.dart
@@ -39,8 +39,8 @@ const _authUser = AuthUser(
   providerUsername: "alice",
 );
 const _pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==";
-const _widePngBase64 =
-    "iVBORw0KGgoAAAANSUhEUgAAAAQAAAACCAYAAAB/qH1jAAAAEklEQVR4nGP4z8DwHxkzoAsAAA8hD/EEN8afAAAAAElFTkSuQmCC";
+const _portraitPngBase64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAIAAAAECAIAAAArjXluAAAACXBIWXMAAAABAAAAAQBPJcTWAAAAEElEQVR4nGP8wwACLAxYKAAbdAEKX4LcXQAAAABJRU5ErkJggg==";
 
 class _FakeImageSaver() implements ImageSaver {
   Uint8List? savedBytes;
@@ -817,10 +817,10 @@ void main() {
     expect(find.text("Image copied to clipboard"), findsOneWidget);
   });
 
-  testWidgets("Hero flight reveals the contained image from the square crop", (tester) async {
+  testWidgets("Hero flight targets the contained image bounds from the square crop", (tester) async {
     const attachment = MessageAttachment.inlineImage(
       mime: "image/png",
-      base64: _widePngBase64,
+      base64: _portraitPngBase64,
       filename: "flight.png",
     );
     await tester.pumpWidget(
@@ -857,10 +857,16 @@ void main() {
       closeTo(1, 0.001),
     );
 
+    await tester.pump(const Duration(milliseconds: 129));
+    expect(tester.getSize(crop).aspectRatio, closeTo(0.5, 0.05));
+
     await tester.pumpAndSettle();
     expect(crop, findsNothing);
     expect(full, findsNothing);
-    expect(tester.widget<Image>(find.byKey(ImageAttachmentViewer.imageKey)).fit, BoxFit.contain);
+    final displayed = find.byKey(ImageAttachmentViewer.imageKey);
+    expect(tester.widget<Image>(displayed).fit, BoxFit.contain);
+    expect(tester.getSize(displayed).aspectRatio, closeTo(0.5, 0.001));
+    expect(tester.getSize(displayed).height, tester.getSize(find.byType(InteractiveViewer)).height);
   });
 
   testWidgets("reduced motion skips image viewer route transitions", (tester) async {

--- a/docs/regression/attachments-and-images.md
+++ b/docs/regression/attachments-and-images.md
@@ -52,13 +52,13 @@ content the transcript renders live and after reload.
   subscriptions. Opening a stored image keeps its thumbnail visible while the
   original loads and decodes. Stored thumbnails preserve the source aspect ratio;
   only the square collection presentation center-crops them, and the Hero flight
-  reveals the full thumbnail before the decoded original fades in without
-  resetting viewer state. Copy, share, and save enable only after that decode
-  succeeds. Failure retains the thumbnail with an explicit accessible original
-  retry; closing the viewer releases Cubit bytes and evicts the full-resolution
-  image provider from Flutter's image cache, and scrolling never starts an
-  original request. Reduced motion skips the viewer route and image-swap
-  animations.
+  reveals the full thumbnail while resizing toward its contained bounds. The
+  decoded original then fades in without resetting viewer state. Copy, share,
+  and save enable only after that decode succeeds. Failure retains the thumbnail
+  with an explicit accessible original retry; closing the viewer releases Cubit
+  bytes and evicts the full-resolution image provider from Flutter's image cache,
+  and scrolling never starts an original request. Reduced motion skips the
+  viewer route and image-swap animations.
 - The viewer closes through its close button, a free-form drag, a hardware
   Escape key, and system back. Back closes only the viewer and keeps the session
   open, including when the Android back gesture delivers a second pop while the
@@ -93,7 +93,7 @@ content the transcript renders live and after reload.
 
 | Level | Additional coverage |
 |---|---|
-| L1 Smoke | Automated, no plugin: the attachment contract's decode, size-bound, unknown-variant, typed stored-rendition request, scoped coalescing, timeout, sensitive-response redaction, persistent thumbnail cache, corruption recovery, bounded pruning, and auth cleanup behavior holds in its owning suites; maximum-size creation serialization yields across every encoding layer while preserving exact wire bytes; capable-client history and SSE requests opt into stored references while shared defaults preserve old clients; stored thumbnails preserve aspect ratio while attachment collections retain center-cropped square layouts and chronology; stored viewers morph that crop into the contained thumbnail, fade in the decoded original, preserve viewer state, gate original actions, retry decode/load failures, and evict/release originals on close. |
+| L1 Smoke | Automated, no plugin: the attachment contract's decode, size-bound, unknown-variant, typed stored-rendition request, scoped coalescing, timeout, sensitive-response redaction, persistent thumbnail cache, corruption recovery, bounded pruning, and auth cleanup behavior holds in its owning suites; maximum-size creation serialization yields across every encoding layer while preserving exact wire bytes; capable-client history and SSE requests opt into stored references while shared defaults preserve old clients; stored thumbnails preserve aspect ratio while attachment collections retain center-cropped square layouts and chronology; stored viewers morph that crop toward the contained thumbnail's fitted bounds, fade in the decoded original, preserve viewer state, gate original actions, retry decode/load failures, and evict/release originals on close. |
 | L2 Routine | Live plugin, one representative plugin: a backend-produced image survives the plugin boundary as a bounded client-safe attachment, live and after a cold history read. |
 | L3 Release | Client end to end on the release-target client platform, every supporting production plugin: staged composer images sent and echoed per attachment-capable plugin; a failed current-route creation restores exact attachment identities with the rest of the draft while background failure does not; generated and tool-output images display, text/image/text order is preserved live and after reload, and viewer copy/share/save works. |
 | L4 Extended | Live plugin for budget-exceeding or mixed collections, malformed types, attachment remote-URL rejection, abort, and plugin restart; relay integration for a second client loading the same transcript. Every supporting production plugin. |
@@ -128,10 +128,10 @@ live, after paging back, or after a reopen, and vary the plugin.
   without an accessible retry action.
 - A stored viewer fetches an original before opening, blanks the cached
   thumbnail while loading or after load/decode failure, opens a permanently
-  cropped thumbnail instead of revealing its original aspect ratio, jumps when
+  cropped thumbnail instead of revealing its original aspect ratio, expands the
+  crop beyond the full image's fitted bounds during the Hero flight, jumps when
   the original appears, resets zoom or drag, enables actions before original
-  decode succeeds, or retains original bytes/provider cache entries after
-  closing.
+  decode succeeds, or retains original bytes/provider cache entries after closing.
 - The composer offers or sends attachments to an unsupporting backend, retains
   staged images after switching to one, or the viewer acts on the wrong image.
 - Failed creation loses, duplicates, or persists submitted attachment bytes;


### PR DESCRIPTION
## Complexity

🌿 Straightforward localized Flutter layout fix. There is no wire-contract or database impact.

## What

- Resolve the decoded flight image's aspect ratio in the full-screen viewer.
- Center the destination Hero in bounds matching the image's final contained size while keeping the full viewport available for gestures.
- Strengthen portrait-image Hero coverage and update the attachment regression contract.

## Why

The square center-cropped preview currently flies toward the entire viewer viewport. For portrait and other non-square images, that makes the cropped layer grow much wider than the final contained image before the cover-to-contain crossfade finishes.

## Risk and test focus

This changes only the image viewer's Hero layout. Focus review on cropped push/pop flights for non-square images, full-viewport pan/zoom/dismiss gestures, and thumbnail-to-original replacement. There is no database, transport, or backend impact.

## Expected result

The Hero interpolates from the square preview to the full image's actual fitted bounds, so a portrait crop no longer expands beyond the width of its final full-height image. The existing cover-to-contain crossfade remains intact.

## Verification

- `flutter test test/features/session_detail/widgets/file_part_widget_test.dart` (33 tests passed)
- `flutter test test/features/session_detail/widgets/assistant_message_card_test.dart --plain-name "opens a decoded Markdown image in the full-screen viewer"`
- `dart analyze` in `client/app`
- `dart format --output=none --set-exit-if-changed lib/features/session_detail/widgets/image_attachment_viewer.dart test/features/session_detail/widgets/file_part_widget_test.dart`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fits the image viewer Hero flight to the decoded image’s contained bounds, fixing oversized flights for non‑square images. Previously the square crop flew to the full viewport; now the flight centers an aspect‑ratio–matched container while preserving full‑viewport gestures and the cover‑to‑contain crossfade.

- Resolve the flight image’s aspect ratio via an `ImageStream` and cache it; add/remove the `ImageStreamListener` to avoid leaks.
- Build the Hero child as `AspectRatio(..., child: image)` when known, else `SizedBox.expand`, and wrap in `Center` to keep the gesture hit area unchanged.
- Prevent portrait crops from expanding wider than the final contained image during the flight; zoom/drag/dismiss behavior remains unchanged.
- Strengthen portrait-image test coverage and update the regression doc to reflect the contained-bounds flight; no backend or database impact.

<sup>Written for commit 5750054370f8879a96a9df25a1c003e5029eab51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

