### PR TITLE
🌱 Bump shared version to v1.8.1

### DIFF
--- a/bridge/app/lib/src/version.dart
+++ b/bridge/app/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '1.8.0';
+const String appVersion = '1.8.1';

--- a/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-arm64",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS ARM64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.0",
+    "releaseTag": "v1.8.1",
     "releaseArtifact": "sesori-bridge-macos-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-darwin-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-x64",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS x64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.0",
+    "releaseTag": "v1.8.1",
     "releaseArtifact": "sesori-bridge-macos-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-arm64",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux ARM64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.0",
+    "releaseTag": "v1.8.1",
     "releaseArtifact": "sesori-bridge-linux-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-x64",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux x64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.0",
+    "releaseTag": "v1.8.1",
     "releaseArtifact": "sesori-bridge-linux-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-arm64",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows ARM64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.0",
+    "releaseTag": "v1.8.1",
     "releaseArtifact": "sesori-bridge-windows-arm64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-x64",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows x64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.0",
+    "releaseTag": "v1.8.1",
     "releaseArtifact": "sesori-bridge-windows-x64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge/package.json
+++ b/bridge/app/npm/sesori-bridge/package.json
@@ -1,22 +1,22 @@
 {
   "name": "@sesori/bridge",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Bootstrap launcher for the managed Sesori Bridge runtime",
   "bin": {
     "sesori-bridge": "bin/bridge.js"
   },
   "optionalDependencies": {
-    "@sesori/bridge-darwin-arm64": "1.8.0",
-    "@sesori/bridge-darwin-x64": "1.8.0",
-    "@sesori/bridge-linux-x64": "1.8.0",
-    "@sesori/bridge-linux-arm64": "1.8.0",
-    "@sesori/bridge-win32-x64": "1.8.0",
-    "@sesori/bridge-win32-arm64": "1.8.0"
+    "@sesori/bridge-darwin-arm64": "1.8.1",
+    "@sesori/bridge-darwin-x64": "1.8.1",
+    "@sesori/bridge-linux-x64": "1.8.1",
+    "@sesori/bridge-linux-arm64": "1.8.1",
+    "@sesori/bridge-win32-x64": "1.8.1",
+    "@sesori/bridge-win32-arm64": "1.8.1"
   },
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.0",
+    "releaseTag": "v1.8.1",
     "runtimeBundleSource": "github-release-assets"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sesori_bridge
 description: Dart implementation of the Sesori Bridge CLI for WebSocket communication.
-version: 1.8.0
+version: 1.8.1
 publish_to: none
 resolution: workspace
 

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -17,7 +17,7 @@ resolution: workspace
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.8.0+1
+version: 1.8.1+1
 environment:
   sdk: ^3.13.1
 


### PR DESCRIPTION
## Complexity

🌱 Trivial metadata-only release version sync.

## What

- Bump bridge version from `1.8.0` to `1.8.1`.
- Bump client version from `1.8.0+1` to `1.8.1+1`, preserving build number.
- Update managed bridge npm package versions and release tags to `v1.8.1`.

## Why

Prepare synchronized app and bridge metadata for release `v1.8.1`.

## Risk and test focus

Low risk: version metadata only. User-visible impact is limited to displayed version metadata. No database impact.

## Expected result

App, bridge, and managed bridge npm packages consistently report version `1.8.1`.

## Verification

- `make bump-version-check VERSION=1.8.1`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synchronizes app, bridge, and managed bridge packages to release v1.8.1. Previously reported 1.8.0 (client 1.8.0+1); now all report 1.8.1 (client 1.8.1+1). Behavior is unchanged; only version metadata and npm release tags update.

- Review and rollout
  - Verify all version strings are 1.8.1, including Dart `appVersion`, `pubspec.yaml`, and `sesoriBridge.releaseTag` set to `v1.8.1` across `@sesori/bridge` and platform packages.
  - Confirm the client build number remains `+1`.
  - Publish `@sesori/bridge` and platform packages at 1.8.1 and create/tag the `v1.8.1` release.
  - No migrations or database changes.

<sup>Written for commit b53da5c98fdccccdf1aa25984030aeaa95977e87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

