### PR TITLE
⚙️ Simplify the ACP plugin base across Cursor, Hermes, and OMP

### DIFF
--- a/bridge/sesori_plugin_acp/lib/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/acp_plugin.dart
@@ -16,10 +16,12 @@
 //     `xxx/*` notification extensions), the neutral AcpSessionOptionsService,
 //     and any harness catalog service.
 //  3. Catalog discovery / persisted cleanup that needs its own agent process:
-//     an AcpStdioClient + AcpAgentApi (initialize, session/new, load, list,
-//     set_config_option, close) wrapped in a harness-specific lease API.
-//     Services write session config through AcpSessionConfigRepository, never
-//     the api directly.
+//     an AcpStdioClient + AcpAgentApi (initialize, session/new, load/resume,
+//     list, set_config_option, close) wrapped in a harness-specific lease API.
+//     Standard session/set_config_option writes go through
+//     AcpSessionConfigRepository; a harness extension (Hermes's
+//     session/set_model) goes through the harness's own repository over
+//     `api.client`. Services never call the api directly.
 //  4. A descriptor whose `start` builds the plugin and returns
 //     `AcpBridgePlugin.start(...)`; custom server requests go in an
 //     AcpApprovalRegistry subclass via `buildApprovalRegistry`.

--- a/bridge/sesori_plugin_acp/lib/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/acp_plugin.dart
@@ -1,9 +1,28 @@
 // Generic ACP (Agent Client Protocol) backend machinery for the Sesori bridge.
 //
-// Provides a reusable stdio JSON-RPC transport, protocol builders/parsers, a
-// base session/update -> BridgeSseEvent mapper, a base permission registry,
-// session/load history replay, and a concrete AcpPlugin. Concrete harnesses
-// (e.g. cursor_plugin) consume these and layer on their own quirks.
+// Provides a reusable stdio JSON-RPC transport, a typed standard-ACP request
+// surface (AcpAgentApi), protocol builders/parsers, a base session/update ->
+// BridgeSseEvent mapper, a base permission registry, session/load history
+// replay, and the AcpPlugin base. Concrete harnesses (cursor, hermes, omp)
+// consume these and layer on their own quirks.
+//
+// Adding an ACP harness:
+//  1. An `XxxBinary` with the launch spec (binary + `acp` args) and any fixed
+//     handshake policy (auth method id, capability meta).
+//  2. A subclass of AcpPlugin. Every policy and hook has a stock-ACP default;
+//     override only what the agent does differently (see the AcpPlugin doc).
+//     The composer builds one AcpSessionConfigurationTracker + AcpCommandTracker
+//     and shares them between the AcpEventMapper (subclass the mapper only for
+//     `xxx/*` notification extensions), the neutral AcpSessionOptionsService,
+//     and any harness catalog service.
+//  3. Catalog discovery / persisted cleanup that needs its own agent process:
+//     an AcpStdioClient + AcpAgentApi (initialize, session/new, load, list,
+//     set_config_option, close) wrapped in a harness-specific lease API.
+//     Services write session config through AcpSessionConfigRepository, never
+//     the api directly.
+//  4. A descriptor whose `start` builds the plugin and returns
+//     `AcpBridgePlugin.start(...)`; custom server requests go in an
+//     AcpApprovalRegistry subclass via `buildApprovalRegistry`.
 export "src/acp_approval_registry.dart";
 export "src/acp_command_listener.dart";
 export "src/acp_command_tracker.dart";
@@ -15,6 +34,7 @@ export "src/acp_session_configuration_tracker.dart";
 export "src/acp_session_loader.dart";
 export "src/acp_session_options_service.dart";
 export "src/acp_stdio_client.dart";
+export "src/api/acp_agent_api.dart";
 export "src/repositories/acp_session_config_repository.dart";
 export "src/repositories/mappers/acp_content_mapper.dart";
 // Plugin-lifecycle housing: the BridgePlugin wrapper + the host-backed process

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -47,13 +47,16 @@ class const AcpHaltNotice({
 /// Harness-specific notifications (e.g. Cursor's `cursor/*`) are routed to
 /// [mapExtension], which subclasses override.
 class AcpEventMapper({
-    required String launchDirectory,
-    /// Agent name stamped on assistant messages (e.g. "cursor").
-  required final String agentId,
-    required final String pluginId,
-    required final AcpSessionConfigurationTracker _configurationTracker,
-    required final AcpContentMapper _contentMapper,
-  }) {
+  required String launchDirectory,
+
+  /// The owning plugin's id — also the `agent` stamped on every message this
+  /// mapper emits (the cross-plugin convention: codex stamps "codex", pi its
+  /// plugin id), and what history replay must stamp to match the live stream.
+  required final String pluginId,
+  required final AcpSessionConfigurationTracker _configurationTracker,
+}) {
+  static const AcpContentMapper _contentMapper = AcpContentMapper();
+
   /// The bridge launch directory (canonicalized) — the fallback project
   /// attribution for sessions whose own directory is not (yet) known. Matches
   /// the canonical project id the bridge derives for the same directory.
@@ -807,7 +810,7 @@ class AcpEventMapper({
         info: shared.Message.error(
           id: messageId,
           sessionID: sessionId,
-          agent: agentId,
+          agent: pluginId,
           modelID: modelForSession(sessionId: sessionId),
           providerID: providerForSession(sessionId: sessionId),
           errorName: notice.errorName,
@@ -960,7 +963,7 @@ class AcpEventMapper({
       info: shared.Message.assistant(
         id: messageId,
         sessionID: sessionId,
-        agent: agentId,
+        agent: pluginId,
         modelID: modelForSession(sessionId: sessionId),
         providerID: providerForSession(sessionId: sessionId),
         // ACP carries no per-message timestamps; the mobile model treats a null
@@ -1005,7 +1008,7 @@ class AcpEventMapper({
       _ChunkRole.assistant => shared.Message.assistant(
         id: messageId,
         sessionID: sessionId,
-        agent: agentId,
+        agent: pluginId,
         modelID: modelForSession(sessionId: sessionId),
         providerID: providerForSession(sessionId: sessionId),
         time: null,

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -15,8 +15,7 @@ import "acp_protocol.dart";
 import "acp_session_loader.dart";
 import "acp_session_options_service.dart";
 import "acp_stdio_client.dart";
-import "repositories/acp_session_config_repository.dart";
-import "repositories/mappers/acp_content_mapper.dart";
+import "api/acp_agent_api.dart";
 
 /// Base [BridgeDerivedProjectsPluginApi] implementation for any ACP (Agent
 /// Client Protocol) agent driven over stdio.
@@ -25,12 +24,16 @@ import "repositories/mappers/acp_content_mapper.dart";
 /// so the bridge derives the project list from [listAllSessions] and owns all
 /// project/session persistence itself; the plugin stores nothing on disk.
 ///
-/// Backend adapters subclass this and must declare their protocol policies.
-/// Harnesses with quirks (e.g. Cursor's model selection and `cursor/*`
-/// extensions) also override the relevant behavior hooks:
-/// [buildApprovalRegistry], [applyTurnSelection], [authMethodId],
-/// [initializeCapabilityMeta], [commandForDispatch], [getAgents],
-/// [getProviders].
+/// Every policy and behavior hook has a stock-ACP default, so a compliant agent
+/// needs only identity, launch spec, and trackers. A harness overrides what
+/// differs: protocol policies ([authMethodId], [initializeCapabilityMeta],
+/// [supportsFormElicitation], [serializesPromptsProcessWide],
+/// [cancelsActiveTurnForQueuedInput], [failsTurnOnSelectionError],
+/// [sessionCloseSettlementTimeout]) and behavior hooks ([buildApprovalRegistry],
+/// [captureSessionConfig], [applyTurnSelection], [mapPromptFailure],
+/// [onConnectionReset], [commandForDispatch]), plus the option/catalog surface
+/// ([getSessionOptions], [getAgents], [getProviders], [getCommands]) when the
+/// agent exposes a richer model catalog than the neutral process default.
 ///
 /// Unlike the codex plugin (which connects to a process listening on a ws
 /// port), this owns the agent subprocess: it spawns lazily on first use and
@@ -43,13 +46,18 @@ abstract class AcpPlugin({
   required final AcpLaunchSpec launchSpec,
   required String launchDirectory,
 
-  /// The live event mapper (subclasses may pass a specialized one).
+  /// The live event mapper (subclasses may pass a specialized one). Its
+  /// `pluginId` is also the `agent` stamped on live and replayed messages.
   required final AcpEventMapper eventMapper,
-  required final AcpContentMapper _contentMapper,
 
   /// Snapshot of the agent's advertised slash commands, fed by the
   /// notification listener and served by [getCommands].
   required final AcpCommandTracker _commandTracker,
+
+  /// Neutral process-scoped options (one agent, the process-default model),
+  /// served unless a harness overrides the option getters with its catalog;
+  /// also forgets a deleted session's model override. Built by the composer
+  /// over the same configuration/command trackers as [eventMapper].
   required final AcpSessionOptionsService _sessionOptionsService,
   final AcpProcessFactory? _processFactory,
 }) extends BridgeDerivedProjectsPluginApi {
@@ -169,31 +177,24 @@ abstract class AcpPlugin({
   /// enumeration; reset on respawn since a replacement process may comply.
   bool _bareSessionListUnsupported = false;
 
-  // --- Required backend policies and overridable hooks ---
-
-  String get clientName;
-  String get clientVersion;
+  // --- Protocol policies (stock-ACP defaults; override what differs) ---
 
   /// Auth method id to call if the agent reports it requires auth. `null`
-  /// uses the first advertised method.
-  String? get authMethodId;
-
-  /// Chooses an advertised authentication method for this agent.
-  ///
-  /// Agents that advertise interactive terminal setup can exclude it because
-  /// the headless bridge cannot complete that flow.
-  String? selectAuthMethod({required AcpInitializeResult init}) =>
-      authMethodId ?? (init.authMethods.isNotEmpty ? init.authMethods.first.id : null);
+  /// picks the first advertised non-terminal method — the headless bridge can
+  /// never complete an interactive terminal flow (see [AcpAgentApi.initialize]).
+  String? get authMethodId => null;
 
   /// Non-standard capability hints sent under `clientCapabilities._meta`
   /// (e.g. Cursor's `parameterizedModelPicker`).
-  Map<String, dynamic>? get initializeCapabilityMeta;
+  Map<String, dynamic>? get initializeCapabilityMeta => null;
 
-  /// Whether this agent should be told the client supports standard ACP forms.
-  bool get supportsFormElicitation;
+  /// Whether this agent should be told the client supports standard ACP forms
+  /// (`elicitation/create`).
+  bool get supportsFormElicitation => false;
 
-  /// Whether prompts across all sessions share one dispatch lane.
-  bool get serializesPromptsProcessWide;
+  /// Whether prompts across all sessions share one dispatch lane. Stock ACP
+  /// serializes per session only.
+  bool get serializesPromptsProcessWide => false;
 
   /// Whether accepting another input should cancel this session's active turn.
   ///
@@ -201,13 +202,17 @@ abstract class AcpPlugin({
   /// shared adapter serializes requests, so its concrete adapter declares the
   /// same policy here and the bridge sends the equivalent standard cancel
   /// before dispatching the queued input.
-  bool get cancelsActiveTurnForQueuedInput;
+  bool get cancelsActiveTurnForQueuedInput => false;
 
   /// Whether a turn must stop when its requested selection cannot be applied.
-  bool get failsTurnOnSelectionError;
+  /// Fail closed by default: a prompt should not silently run on a model/mode
+  /// the user did not pick. Only matters when [applyTurnSelection] can throw.
+  bool get failsTurnOnSelectionError => true;
 
   /// Maximum time deletion waits for a cancelled target turn before close.
-  Duration get sessionCloseSettlementTimeout;
+  Duration get sessionCloseSettlementTimeout => const Duration(seconds: 5);
+
+  // --- Behavior hooks ---
 
   /// Maps the user-selected slash command to the command name sent to the ACP
   /// agent. The original name remains authoritative for client-facing events.
@@ -236,21 +241,23 @@ abstract class AcpPlugin({
   /// `session/load` (resume or history replay), which replays some existing
   /// session's own model and must never redefine the default. The
   /// `sessionId`'s presence alone can't tell them apart because both new and
-  /// load operations can supply one. Base does nothing; Cursor overrides for
-  /// its `configOptions` picker.
+  /// load operations can supply one. Base does nothing; harnesses with a model
+  /// catalog (Cursor's `configOptions` picker, OMP, Hermes) override.
   void captureSessionConfig(
     AcpNewSessionResult result, {
-    String? sessionId,
-    bool fromNewSession = false,
+    required String? sessionId,
+    required bool fromNewSession,
   }) {}
 
   /// Applies the requested [model], [variant], and [agent] for a turn on
-  /// [sessionId] before the prompt is dispatched. Called from [createSession]
-  /// and from [sendPrompt]/[sendCommand], so a mid-conversation switch takes
-  /// effect. Base does nothing (the agent's defaults are used). Cursor overrides
-  /// to drive its model / mode / effort `session/set_config_option` calls.
+  /// [sessionId] before the prompt is dispatched, through [api] — the typed
+  /// surface of the connection the turn runs on (harness extensions go through
+  /// `api.client`). Called from [createSession] and from
+  /// [sendPrompt]/[sendCommand], so a mid-conversation switch takes effect.
+  /// Base does nothing (the agent's defaults are used). Cursor overrides to
+  /// drive its model / mode / effort `session/set_config_option` calls.
   Future<void> applyTurnSelection({
-    required AcpSessionConfigRepository configRepository,
+    required AcpAgentApi api,
     required String sessionId,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
@@ -360,60 +367,17 @@ abstract class AcpPlugin({
   }
 
   /// Runs the ACP `initialize` handshake (and `authenticate` if the agent
-  /// advertises an auth method) on [client], returning the parsed result. Does
-  /// not store it — the caller decides (the live connect persists it as
-  /// [_initResult]; the replay client in [getSessionMessages] keeps it local so
-  /// it never clobbers the live capabilities).
-  Future<AcpInitializeResult> _initialize(AcpStdioClient client) async {
-    final raw = await client.request(
-      method: AcpMethods.initialize,
-      params: buildInitializeParams(
-        clientName: clientName,
-        clientVersion: clientVersion,
-        formElicitation: supportsFormElicitation,
-        capabilityMeta: initializeCapabilityMeta,
-      ),
-    );
-    final init = AcpInitializeResult.fromJson(
-      raw is Map ? raw.cast<String, dynamic>() : const {},
-    );
-    // We only speak ACP v1. The agent echoes the protocol version it will use;
-    // if that is not v1 it cannot understand our v1-shaped session/* calls, so
-    // fail the handshake (degrading the plugin) rather than driving it with a
-    // protocol it rejected. A missing version parses as v1, so agents that omit
-    // the field (some cursor-agent builds) still connect.
-    if (init.protocolVersion != acpProtocolVersion) {
-      throw StateError(
-        "ACP agent negotiated protocol version ${init.protocolVersion}, "
-        "but this client only speaks v$acpProtocolVersion",
-      );
-    }
-    if (init.requiresAuth) {
-      final methodId = selectAuthMethod(init: init);
-      if (methodId == null) {
-        throw PluginAuthenticationRequiredException(
-          AcpMethods.authenticate,
-          actionHint: "Authenticate the configured agent locally, then retry.",
-          message: "$id requires an authentication method the bridge cannot complete",
-        );
-      }
-      try {
-        await client.request(
-          method: AcpMethods.authenticate,
-          params: {"methodId": methodId},
-        );
-      } on AcpRpcException catch (error) {
-        if (error.method != "<response>") rethrow;
-        throw PluginAuthenticationRequiredException(
-          AcpMethods.authenticate,
-          actionHint: "Authenticate the configured agent locally, then retry.",
-          message: "$id authentication failed",
-          cause: error,
-        );
-      }
-    }
-    return init;
-  }
+  /// advertises an auth method) on [client] with this plugin's policies,
+  /// returning the parsed result. Does not store it — the caller decides (the
+  /// live connect persists it as [_initResult]; the replay client in
+  /// [getSessionMessages] keeps it local so it never clobbers the live
+  /// capabilities). A non-v1 negotiation fails the handshake (degrading the
+  /// plugin) rather than driving the agent with a protocol it rejected.
+  Future<AcpInitializeResult> _initialize(AcpStdioClient client) => AcpAgentApi(client: client).initialize(
+    formElicitation: supportsFormElicitation,
+    capabilityMeta: initializeCapabilityMeta,
+    authMethodId: authMethodId,
+  );
 
   Future<AcpStdioClient> _connectedClient() async {
     final ok = await ensureConnected();
@@ -447,7 +411,22 @@ abstract class AcpPlugin({
     // Let subclasses drop any process-global state cached against the dead agent
     // (e.g. Cursor's applied model/mode) so it is re-applied on the next turn.
     onConnectionReset();
-    final sub = _notificationSubscription;
+    await _teardownConnection();
+  }
+
+  /// Detaches and disposes the live connection's collaborators (notification
+  /// subscription, command listener, approval registry, client). The fields are
+  /// cleared before the first await so a concurrent [ensureConnected] never
+  /// sees a stale connection, and each step is isolated so a failure in one
+  /// (e.g. a hung subscription) cannot skip a later one (e.g. reaping the agent
+  /// subprocess). Never throws — log and continue.
+  Future<void> _teardownConnection() async {
+    Future<void>? notificationCancellation;
+    try {
+      notificationCancellation = _notificationSubscription?.cancel();
+    } on Object catch (e, st) {
+      Log.w("[$id] failed to cancel notification subscription", e, st);
+    }
     _notificationSubscription = null;
     final commandListener = _commandListener;
     _commandListener = null;
@@ -456,24 +435,24 @@ abstract class AcpPlugin({
     final client = _client;
     _client = null;
     try {
-      await sub?.cancel();
+      await notificationCancellation;
     } on Object catch (e, st) {
-      Log.w("[$id] failed to cancel notification subscription on reset", e, st);
+      Log.w("[$id] failed to cancel notification subscription", e, st);
     }
     try {
       await commandListener?.dispose();
     } on Object catch (e, st) {
-      Log.w("[$id] failed to cancel command subscription on reset", e, st);
+      Log.w("[$id] failed to cancel command subscription", e, st);
     }
     try {
       await registry?.dispose();
     } on Object catch (e, st) {
-      Log.w("[$id] failed to dispose approval registry on reset", e, st);
+      Log.w("[$id] failed to dispose approval registry", e, st);
     }
     try {
       await client?.dispose();
     } on Object catch (e, st) {
-      Log.w("[$id] failed to dispose client on reset", e, st);
+      Log.w("[$id] failed to dispose client", e, st);
     }
   }
 
@@ -638,20 +617,12 @@ abstract class AcpPlugin({
   }) async {
     const maxPages = 50;
     final infos = <AcpSessionInfo>[];
+    final api = AcpAgentApi(client: client);
     String? cursor;
     for (var page = 0; page < maxPages; page++) {
       final AcpSessionListResult result;
       try {
-        final raw = await client.request(
-          method: AcpMethods.sessionList,
-          params: {
-            "cwd": ?cwd,
-            "cursor": ?cursor,
-          },
-        );
-        result = AcpSessionListResult.fromJson(
-          raw is Map ? raw.cast<String, dynamic>() : const {},
-        );
+        result = await api.listSessionsPage(cwd: cwd, cursor: cursor);
       } on PluginAuthenticationRequiredException {
         rethrow;
       } on Object catch (error, stack) {
@@ -741,16 +712,7 @@ abstract class AcpPlugin({
     // derives from it; the bridge's stored row folds a worktree session back
     // under the project the user opened.
     final canonicalDirectory = normalizeProjectDirectory(directory: directory);
-    final raw = await client.request(
-      method: AcpMethods.sessionNew,
-      params: {"cwd": directory, "mcpServers": const <Object?>[]},
-    );
-    final session = AcpNewSessionResult.fromJson(
-      raw is Map ? raw.cast<String, dynamic>() : const {},
-    );
-    if (session.sessionId.isEmpty) {
-      throw StateError("session/new response missing sessionId");
-    }
+    final session = await AcpAgentApi(client: client).newSession(cwd: directory);
     final createdAt = DateTime.now().millisecondsSinceEpoch;
     _sessionDirectories[session.sessionId] = canonicalDirectory;
     eventMapper.setSessionProject(session.sessionId, canonicalDirectory);
@@ -796,9 +758,7 @@ abstract class AcpPlugin({
       try {
         await _runOnProcessLane(
           () async => await applyTurnSelection(
-            configRepository: AcpSessionConfigRepository(
-              client: await _connectedClient(),
-            ),
+            api: AcpAgentApi(client: await _connectedClient()),
             sessionId: session.sessionId,
             model: model,
             variant: variant,
@@ -1047,23 +1007,14 @@ abstract class AcpPlugin({
     _suppressedSessions.add(sessionId);
     _suppressedReplayCounts.remove(sessionId);
     try {
-      final raw = await client.request(
-        method: AcpMethods.sessionLoad,
-        params: {
-          "sessionId": sessionId,
-          "cwd": directoryForSession(sessionId: sessionId),
-          "mcpServers": const <Object?>[],
-        },
+      final result = await AcpAgentApi(client: client).loadSession(
+        sessionId: sessionId,
+        cwd: directoryForSession(sessionId: sessionId),
         timeout: const Duration(minutes: 2),
       );
       // A resume load: capture the catalog + this session's own model, but do
       // not let it redefine the new-session default.
-      final result = _parseSessionActivationResult(
-        raw: raw,
-        sessionId: sessionId,
-        operation: AcpMethods.sessionLoad,
-      );
-      captureSessionConfig(result, sessionId: sessionId);
+      captureSessionConfig(result, sessionId: sessionId, fromNewSession: false);
       // Keep suppressing until the (post-response) replay stream goes quiet.
       await _drainReplay(() => _suppressedReplayCounts[sessionId] ?? 0);
       _residentSessions.add(sessionId);
@@ -1088,17 +1039,6 @@ abstract class AcpPlugin({
     }
   }
 
-  AcpNewSessionResult _parseSessionActivationResult({
-    required Object? raw,
-    required String sessionId,
-    required String operation,
-  }) {
-    if (raw is! Map) {
-      throw StateError("$id $operation returned no session for $sessionId");
-    }
-    return AcpNewSessionResult.fromJson(raw.cast<String, dynamic>());
-  }
-
   /// Re-activates [sessionId] via `session/resume` for an agent that
   /// advertises `sessionCapabilities.resume` but not `loadSession`. Without
   /// this, the session would be marked resident with no RPC at all and the
@@ -1108,24 +1048,15 @@ abstract class AcpPlugin({
   /// failures retry on the next turn.
   Future<void> _resumeResident(AcpStdioClient client, String sessionId) async {
     try {
-      final raw = await client.request(
-        method: AcpMethods.sessionResume,
-        params: {
-          "sessionId": sessionId,
-          "cwd": directoryForSession(sessionId: sessionId),
-          "mcpServers": const <Object?>[],
-        },
+      final result = await AcpAgentApi(client: client).resumeSession(
+        sessionId: sessionId,
+        cwd: directoryForSession(sessionId: sessionId),
         timeout: const Duration(minutes: 2),
       );
       // The resume result carries the modes/configOptions catalog (and this
       // session's current selection) — capture it, but never as the
       // new-session default.
-      final result = _parseSessionActivationResult(
-        raw: raw,
-        sessionId: sessionId,
-        operation: AcpMethods.sessionResume,
-      );
-      captureSessionConfig(result, sessionId: sessionId);
+      captureSessionConfig(result, sessionId: sessionId, fromNewSession: false);
       _residentSessions.add(sessionId);
     } on AcpRpcException catch (error, stack) {
       if (error.code == -32601 || error.code == -32602) {
@@ -1239,7 +1170,7 @@ abstract class AcpPlugin({
     final selectedAgent = turn.agent ?? pendingSelection?.agent;
     try {
       await applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: sessionId,
         model: selectedModel,
         variant: selectedVariant,
@@ -1494,11 +1425,7 @@ abstract class AcpPlugin({
         await state?.activeSettlement?.future.timeout(
           sessionCloseSettlementTimeout,
         );
-        final client = await _connectedClient();
-        await client.request(
-          method: AcpMethods.sessionClose,
-          params: {"sessionId": sessionId},
-        );
+        await AcpAgentApi(client: await _connectedClient()).closeSession(sessionId: sessionId);
       } on Object catch (error, stackTrace) {
         Error.throwWithStackTrace(
           PluginOperationException(
@@ -1566,7 +1493,9 @@ abstract class AcpPlugin({
     );
     final collector = AcpReplayCollector(
       sessionId: sessionId,
-      agentId: agentDisplayName,
+      // Replayed messages must carry the same `agent` the live mapper stamps,
+      // or a reloaded session reports a different agent than the live one did.
+      agentId: eventMapper.pluginId,
       modelId: eventMapper.modelForSession(sessionId: sessionId),
       providerId: eventMapper.providerForSession(sessionId: sessionId),
       initialUserMessageId: _syntheticInitialPromptSessions.contains(sessionId)
@@ -1575,7 +1504,6 @@ abstract class AcpPlugin({
       // Reclassify a halt notice (e.g. Cursor's account/plan gate) the same way
       // the live stream does, so reloaded history renders it identically.
       haltClassifier: eventMapper.classifyHaltNotice,
-      contentMapper: _contentMapper,
     );
     StreamSubscription<AcpNotification>? sub;
     AcpCommandListener? commandListener;
@@ -1615,15 +1543,11 @@ abstract class AcpPlugin({
           }
         }
       });
-      final Object? raw;
+      final AcpNewSessionResult result;
       try {
-        raw = await replayClient.request(
-          method: AcpMethods.sessionLoad,
-          params: {
-            "sessionId": sessionId,
-            "cwd": directoryForSession(sessionId: sessionId),
-            "mcpServers": const <Object?>[],
-          },
+        result = await AcpAgentApi(client: replayClient).loadSession(
+          sessionId: sessionId,
+          cwd: directoryForSession(sessionId: sessionId),
           timeout: const Duration(minutes: 2),
         );
       } on AcpRpcException catch (error, stackTrace) {
@@ -1658,12 +1582,7 @@ abstract class AcpPlugin({
       // The load result also carries the model/mode catalog (and the loaded
       // session's current model) — capture it so the picker is populated and
       // replayed messages are stamped with the session's real model.
-      final result = _parseSessionActivationResult(
-        raw: raw,
-        sessionId: sessionId,
-        operation: AcpMethods.sessionLoad,
-      );
-      captureSessionConfig(result, sessionId: sessionId);
+      captureSessionConfig(result, sessionId: sessionId, fromNewSession: false);
       // The ACP spec replays the whole thread via `session/update` BEFORE the
       // `session/load` response resolves, but cursor-agent streams later turns
       // AFTER it. Drain until the replay stream goes quiet so multi-turn history
@@ -1832,37 +1751,9 @@ abstract class AcpPlugin({
 
   @override
   Future<void> dispose() async {
-    // Each teardown step is isolated so a failure in one (e.g. a hung
-    // subscription) cannot skip a later one (e.g. reaping the agent
-    // subprocess). dispose() must not throw — log and continue.
-    try {
-      await _notificationSubscription?.cancel();
-    } on Object catch (e, st) {
-      Log.w("[$id] failed to cancel notification subscription", e, st);
-    } finally {
-      _notificationSubscription = null;
-    }
-    try {
-      await _commandListener?.dispose();
-    } on Object catch (e, st) {
-      Log.w("[$id] failed to cancel command subscription", e, st);
-    } finally {
-      _commandListener = null;
-    }
-    try {
-      await _approvalRegistry?.dispose();
-    } on Object catch (e, st) {
-      Log.w("[$id] failed to dispose approval registry", e, st);
-    } finally {
-      _approvalRegistry = null;
-    }
-    try {
-      await _client?.dispose();
-    } on Object catch (e, st) {
-      Log.w("[$id] failed to dispose client", e, st);
-    } finally {
-      _client = null;
-    }
+    // dispose() must not throw — every step below is isolated (see
+    // [_teardownConnection]); the stream closes are best-effort too.
+    await _teardownConnection();
     try {
       await _eventBuffer.close();
     } on Object catch (e, st) {

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -16,6 +16,7 @@ import "acp_session_loader.dart";
 import "acp_session_options_service.dart";
 import "acp_stdio_client.dart";
 import "api/acp_agent_api.dart";
+import "repositories/acp_session_config_repository.dart";
 
 /// Base [BridgeDerivedProjectsPluginApi] implementation for any ACP (Agent
 /// Client Protocol) agent driven over stdio.
@@ -250,14 +251,16 @@ abstract class AcpPlugin({
   }) {}
 
   /// Applies the requested [model], [variant], and [agent] for a turn on
-  /// [sessionId] before the prompt is dispatched, through [api] — the typed
-  /// surface of the connection the turn runs on (harness extensions go through
-  /// `api.client`). Called from [createSession] and from
-  /// [sendPrompt]/[sendCommand], so a mid-conversation switch takes effect.
-  /// Base does nothing (the agent's defaults are used). Cursor overrides to
-  /// drive its model / mode / effort `session/set_config_option` calls.
+  /// [sessionId] before the prompt is dispatched. [configRepository] writes
+  /// standard `session/set_config_option` on the connection the turn runs on;
+  /// a harness extension (Hermes's `session/set_model`) goes through the
+  /// harness's own repository over the live [client]. Called from
+  /// [createSession] and from [sendPrompt]/[sendCommand], so a
+  /// mid-conversation switch takes effect. Base does nothing (the agent's
+  /// defaults are used). Cursor overrides to drive its model / mode / effort
+  /// config writes.
   Future<void> applyTurnSelection({
-    required AcpAgentApi api,
+    required AcpSessionConfigRepository configRepository,
     required String sessionId,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
@@ -377,6 +380,7 @@ abstract class AcpPlugin({
     formElicitation: supportsFormElicitation,
     capabilityMeta: initializeCapabilityMeta,
     authMethodId: authMethodId,
+    timeout: AcpAgentApi.defaultRequestTimeout,
   );
 
   Future<AcpStdioClient> _connectedClient() async {
@@ -622,7 +626,11 @@ abstract class AcpPlugin({
     for (var page = 0; page < maxPages; page++) {
       final AcpSessionListResult result;
       try {
-        result = await api.listSessionsPage(cwd: cwd, cursor: cursor);
+        result = await api.listSessionsPage(
+          cwd: cwd,
+          cursor: cursor,
+          timeout: AcpAgentApi.defaultRequestTimeout,
+        );
       } on PluginAuthenticationRequiredException {
         rethrow;
       } on Object catch (error, stack) {
@@ -712,7 +720,10 @@ abstract class AcpPlugin({
     // derives from it; the bridge's stored row folds a worktree session back
     // under the project the user opened.
     final canonicalDirectory = normalizeProjectDirectory(directory: directory);
-    final session = await AcpAgentApi(client: client).newSession(cwd: directory);
+    final session = await AcpAgentApi(client: client).newSession(
+      cwd: directory,
+      timeout: AcpAgentApi.defaultRequestTimeout,
+    );
     final createdAt = DateTime.now().millisecondsSinceEpoch;
     _sessionDirectories[session.sessionId] = canonicalDirectory;
     eventMapper.setSessionProject(session.sessionId, canonicalDirectory);
@@ -758,7 +769,9 @@ abstract class AcpPlugin({
       try {
         await _runOnProcessLane(
           () async => await applyTurnSelection(
-            api: AcpAgentApi(client: await _connectedClient()),
+            configRepository: AcpSessionConfigRepository(
+              api: AcpAgentApi(client: await _connectedClient()),
+            ),
             sessionId: session.sessionId,
             model: model,
             variant: variant,
@@ -1170,7 +1183,7 @@ abstract class AcpPlugin({
     final selectedAgent = turn.agent ?? pendingSelection?.agent;
     try {
       await applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: sessionId,
         model: selectedModel,
         variant: selectedVariant,
@@ -1425,7 +1438,10 @@ abstract class AcpPlugin({
         await state?.activeSettlement?.future.timeout(
           sessionCloseSettlementTimeout,
         );
-        await AcpAgentApi(client: await _connectedClient()).closeSession(sessionId: sessionId);
+        await AcpAgentApi(client: await _connectedClient()).closeSession(
+          sessionId: sessionId,
+          timeout: AcpAgentApi.defaultRequestTimeout,
+        );
       } on Object catch (error, stackTrace) {
         Error.throwWithStackTrace(
           PluginOperationException(

--- a/bridge/sesori_plugin_acp/lib/src/acp_protocol.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_protocol.dart
@@ -12,6 +12,11 @@ part "acp_protocol.g.dart";
 /// The ACP protocol version this bridge implements.
 const int acpProtocolVersion = 1;
 
+/// The `clientInfo` identity every Sesori ACP connection (live plugin and
+/// isolated scratch processes alike) reports at `initialize`.
+const String acpClientName = "sesori-bridge";
+const String acpClientVersion = "0.0.0";
+
 /// Standard ACP JSON-RPC method names.
 abstract final class AcpMethods() {
   static const String initialize = "initialize";
@@ -244,13 +249,11 @@ Map<String, dynamic> buildClientCapabilities({
   };
 }
 
-/// Builds `initialize` params.
+/// Builds `initialize` params. The client identity is fixed
+/// ([acpClientName]/[acpClientVersion]); only the capabilities vary per agent.
 Map<String, dynamic> buildInitializeParams({
-  required String clientName,
-  required String clientVersion,
   required bool formElicitation,
-  String? clientTitle,
-  Map<String, dynamic>? capabilityMeta,
+  required Map<String, dynamic>? capabilityMeta,
 }) {
   return <String, dynamic>{
     "protocolVersion": acpProtocolVersion,
@@ -259,9 +262,8 @@ Map<String, dynamic> buildInitializeParams({
       meta: capabilityMeta,
     ),
     "clientInfo": {
-      "name": clientName,
-      "title": clientTitle,
-      "version": clientVersion,
+      "name": acpClientName,
+      "version": acpClientVersion,
     },
   };
 }

--- a/bridge/sesori_plugin_acp/lib/src/acp_protocol.g.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_protocol.g.dart
@@ -22,13 +22,10 @@ Map<String, dynamic> _$AcpSessionInfoToJson(
   'updatedAt': ?const AcpTimestampMsConverter().toJson(instance.updatedAtMs),
 };
 
-_AcpSessionListResult _$AcpSessionListResultFromJson(Map json) =>
-    _AcpSessionListResult(
-      sessions: json['sessions'] == null
-          ? const <AcpSessionInfo>[]
-          : _sessionInfosFromJson(json['sessions']),
-      nextCursor: json['nextCursor'] as String?,
-    );
+_AcpSessionListResult _$AcpSessionListResultFromJson(Map json) => _AcpSessionListResult(
+  sessions: json['sessions'] == null ? const <AcpSessionInfo>[] : _sessionInfosFromJson(json['sessions']),
+  nextCursor: json['nextCursor'] as String?,
+);
 
 Map<String, dynamic> _$AcpSessionListResultToJson(
   _AcpSessionListResult instance,

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -27,8 +27,9 @@ class AcpReplayCollector({
   /// notice as an error message exactly as it appeared live. Null on backends
   /// with no halt notices.
   required final AcpHaltNotice? Function({required String text})? haltClassifier,
-  required final AcpContentMapper _contentMapper,
 }) {
+  static const AcpContentMapper _contentMapper = AcpContentMapper();
+
   final List<_Draft> _drafts = [];
   int _seq = 0;
   bool _hasUserDraft = false;

--- a/bridge/sesori_plugin_acp/lib/src/acp_stdio_client.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_stdio_client.dart
@@ -60,6 +60,10 @@ class AcpStdioClient({
   final StreamController<AcpServerRequest> _serverRequests = StreamController.broadcast();
   Completer<int> _exited = Completer<int>();
 
+  /// Identifies this connection in logs and error messages (the plugin id for
+  /// the live connection, `<id>-replay` / `<id>-catalog` for scratch ones).
+  String get logTag => _logTag;
+
   /// Server-originated notifications (broadcast).
   Stream<AcpNotification> get notifications => _notifications.stream;
 

--- a/bridge/sesori_plugin_acp/lib/src/api/acp_agent_api.dart
+++ b/bridge/sesori_plugin_acp/lib/src/api/acp_agent_api.dart
@@ -1,0 +1,191 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginAuthenticationRequiredException;
+
+import "../acp_protocol.dart";
+import "../acp_stdio_client.dart";
+
+/// Typed standard-ACP requests over one connected [AcpStdioClient].
+///
+/// Owns the wire shape of every standard `initialize`/`authenticate`/
+/// `session/*` request and the parsing of its result, so the live plugin and
+/// the per-harness scratch processes (catalog discovery, persisted cleanup)
+/// speak the protocol identically instead of each re-encoding params and
+/// re-parsing results. Harness extensions (`cursor/*`, Hermes's
+/// `session/set_model`) go straight to [client].
+///
+/// `session/prompt` is deliberately absent: the live plugin drives it through
+/// [AcpStdioClient.dispatchRequest] to separate frame delivery from the turn
+/// result, which no other caller needs.
+class AcpAgentApi({required final AcpStdioClient client}) {
+  static const Duration _defaultTimeout = Duration(seconds: 60);
+
+  /// Runs the ACP `initialize` handshake and, when the agent advertises auth
+  /// methods, `authenticate`.
+  ///
+  /// [authMethodId] names the method to authenticate with; `null` picks the
+  /// first advertised non-terminal method, because the headless bridge can
+  /// never complete an interactive terminal flow.
+  ///
+  /// Throws [StateError] when the agent negotiates a protocol version other
+  /// than v1 (it could not understand our v1-shaped `session/*` calls), and
+  /// [PluginAuthenticationRequiredException] when no usable auth method exists
+  /// or the agent rejects authentication.
+  Future<AcpInitializeResult> initialize({
+    required bool formElicitation,
+    required Map<String, dynamic>? capabilityMeta,
+    required String? authMethodId,
+    Duration timeout = _defaultTimeout,
+  }) async {
+    final raw = await client.request(
+      method: AcpMethods.initialize,
+      params: buildInitializeParams(
+        formElicitation: formElicitation,
+        capabilityMeta: capabilityMeta,
+      ),
+      timeout: timeout,
+    );
+    final init = AcpInitializeResult.fromJson(_asJson(raw));
+    // A missing version parses as v1, so agents that omit the field (some
+    // cursor-agent builds) still connect.
+    if (init.protocolVersion != acpProtocolVersion) {
+      throw StateError(
+        "ACP agent negotiated protocol version ${init.protocolVersion}, "
+        "but this client only speaks v$acpProtocolVersion",
+      );
+    }
+    if (!init.requiresAuth) return init;
+    final methodId = authMethodId ?? _firstNonTerminalAuthMethod(init);
+    if (methodId == null) {
+      throw const PluginAuthenticationRequiredException(
+        AcpMethods.authenticate,
+        actionHint: "Authenticate the configured agent locally, then retry.",
+        message: "The ACP agent requires an authentication method the bridge cannot complete",
+      );
+    }
+    try {
+      await client.request(
+        method: AcpMethods.authenticate,
+        params: {"methodId": methodId},
+        timeout: timeout,
+      );
+    } on AcpRpcException catch (error) {
+      if (error.method != "<response>") rethrow;
+      throw PluginAuthenticationRequiredException(
+        AcpMethods.authenticate,
+        actionHint: "Authenticate the configured agent locally, then retry.",
+        message: "ACP agent authentication failed",
+        cause: error,
+      );
+    }
+    return init;
+  }
+
+  /// `session/new` in [cwd]. Throws [StateError] when the agent answers
+  /// without a session id, since nothing can be done with such a session.
+  Future<AcpNewSessionResult> newSession({
+    required String cwd,
+    Duration timeout = _defaultTimeout,
+  }) async {
+    final raw = await client.request(
+      method: AcpMethods.sessionNew,
+      params: _sessionActivationParams(cwd: cwd),
+      timeout: timeout,
+    );
+    final session = AcpNewSessionResult.fromJson(_asJson(raw));
+    if (session.sessionId.isEmpty) {
+      throw StateError("session/new response missing sessionId");
+    }
+    return session;
+  }
+
+  /// `session/load` — re-activates [sessionId] with history replay. Throws
+  /// [StateError] on a non-object result: the session's modes/config catalog
+  /// rides in that object, and a null/void answer is treated as a failed load
+  /// (the caller decides whether to retry).
+  Future<AcpNewSessionResult> loadSession({
+    required String sessionId,
+    required String cwd,
+    Duration timeout = _defaultTimeout,
+  }) => _activateSession(method: AcpMethods.sessionLoad, sessionId: sessionId, cwd: cwd, timeout: timeout);
+
+  /// `session/resume` — re-activates [sessionId] without history replay. Same
+  /// result contract as [loadSession].
+  Future<AcpNewSessionResult> resumeSession({
+    required String sessionId,
+    required String cwd,
+    Duration timeout = _defaultTimeout,
+  }) => _activateSession(method: AcpMethods.sessionResume, sessionId: sessionId, cwd: cwd, timeout: timeout);
+
+  /// One `session/list` page; [cwd] null means the unfiltered form.
+  Future<AcpSessionListResult> listSessionsPage({
+    required String? cwd,
+    required String? cursor,
+    Duration timeout = _defaultTimeout,
+  }) async {
+    final raw = await client.request(
+      method: AcpMethods.sessionList,
+      params: {"cwd": ?cwd, "cursor": ?cursor},
+      timeout: timeout,
+    );
+    return AcpSessionListResult.fromJson(_asJson(raw));
+  }
+
+  /// `session/set_config_option`. Returns the agent's updated config state, or
+  /// null when it answered without one.
+  Future<AcpNewSessionResult?> setConfigOption({
+    required String sessionId,
+    required String configId,
+    required String value,
+    Duration timeout = _defaultTimeout,
+  }) async {
+    final raw = await client.request(
+      method: AcpMethods.sessionSetConfigOption,
+      params: {"sessionId": sessionId, "configId": configId, "value": value},
+      timeout: timeout,
+    );
+    return raw is Map ? AcpNewSessionResult.fromJson(raw.cast<String, dynamic>()) : null;
+  }
+
+  Future<void> closeSession({
+    required String sessionId,
+    Duration timeout = _defaultTimeout,
+  }) => client.request(
+    method: AcpMethods.sessionClose,
+    params: {"sessionId": sessionId},
+    timeout: timeout,
+  );
+
+  Future<AcpNewSessionResult> _activateSession({
+    required String method,
+    required String sessionId,
+    required String cwd,
+    required Duration timeout,
+  }) async {
+    final raw = await client.request(
+      method: method,
+      params: {
+        "sessionId": sessionId,
+        ..._sessionActivationParams(cwd: cwd),
+      },
+      timeout: timeout,
+    );
+    if (raw is! Map) throw StateError("$method returned no session for $sessionId");
+    return AcpNewSessionResult.fromJson(raw.cast<String, dynamic>());
+  }
+
+  /// The bridge never injects MCP servers, but the field is required by the
+  /// spec for `session/new`, `session/load`, and `session/resume`.
+  static Map<String, dynamic> _sessionActivationParams({required String cwd}) => {
+    "cwd": cwd,
+    "mcpServers": const <Object?>[],
+  };
+
+  static Map<String, dynamic> _asJson(Object? raw) =>
+      raw is Map ? raw.cast<String, dynamic>() : const <String, dynamic>{};
+
+  static String? _firstNonTerminalAuthMethod(AcpInitializeResult init) {
+    for (final method in init.authMethods) {
+      if (method.type != AcpAuthMethodType.terminal) return method.id;
+    }
+    return null;
+  }
+}

--- a/bridge/sesori_plugin_acp/lib/src/api/acp_agent_api.dart
+++ b/bridge/sesori_plugin_acp/lib/src/api/acp_agent_api.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginAuthenticationRequiredException;
 
 import "../acp_protocol.dart";
@@ -16,25 +18,32 @@ import "../acp_stdio_client.dart";
 /// [AcpStdioClient.dispatchRequest] to separate frame delivery from the turn
 /// result, which no other caller needs.
 class AcpAgentApi({required final AcpStdioClient client}) {
-  static const Duration _defaultTimeout = Duration(seconds: 60);
+  /// Per-request budget for a live (non-scratch) connection — the same value
+  /// [AcpStdioClient.request] defaults to. Callers with their own deadline
+  /// (scratch catalog/cleanup leases) pass their remaining budget instead.
+  static const Duration defaultRequestTimeout = Duration(seconds: 60);
 
   /// Runs the ACP `initialize` handshake and, when the agent advertises auth
-  /// methods, `authenticate`.
+  /// methods, `authenticate` — both within one [timeout] deadline, so a caller
+  /// with a remaining budget (the scratch catalog/cleanup leases) cannot
+  /// overrun it by a second full timeout on the auth round trip.
   ///
   /// [authMethodId] names the method to authenticate with; `null` picks the
   /// first advertised non-terminal method, because the headless bridge can
   /// never complete an interactive terminal flow.
   ///
   /// Throws [StateError] when the agent negotiates a protocol version other
-  /// than v1 (it could not understand our v1-shaped `session/*` calls), and
+  /// than v1 (it could not understand our v1-shaped `session/*` calls),
   /// [PluginAuthenticationRequiredException] when no usable auth method exists
-  /// or the agent rejects authentication.
+  /// or the agent rejects authentication, and [TimeoutException] when the
+  /// deadline passes.
   Future<AcpInitializeResult> initialize({
     required bool formElicitation,
     required Map<String, dynamic>? capabilityMeta,
     required String? authMethodId,
-    Duration timeout = _defaultTimeout,
+    required Duration timeout,
   }) async {
+    final deadline = Stopwatch()..start();
     final raw = await client.request(
       method: AcpMethods.initialize,
       params: buildInitializeParams(
@@ -55,24 +64,28 @@ class AcpAgentApi({required final AcpStdioClient client}) {
     if (!init.requiresAuth) return init;
     final methodId = authMethodId ?? _firstNonTerminalAuthMethod(init);
     if (methodId == null) {
-      throw const PluginAuthenticationRequiredException(
+      throw PluginAuthenticationRequiredException(
         AcpMethods.authenticate,
         actionHint: "Authenticate the configured agent locally, then retry.",
-        message: "The ACP agent requires an authentication method the bridge cannot complete",
+        message: "${client.logTag} requires an authentication method the bridge cannot complete",
       );
+    }
+    final remaining = timeout - deadline.elapsed;
+    if (remaining <= Duration.zero) {
+      throw TimeoutException("${client.logTag} initialize handshake exceeded its deadline before authenticate");
     }
     try {
       await client.request(
         method: AcpMethods.authenticate,
         params: {"methodId": methodId},
-        timeout: timeout,
+        timeout: remaining,
       );
     } on AcpRpcException catch (error) {
       if (error.method != "<response>") rethrow;
       throw PluginAuthenticationRequiredException(
         AcpMethods.authenticate,
         actionHint: "Authenticate the configured agent locally, then retry.",
-        message: "ACP agent authentication failed",
+        message: "${client.logTag} authentication failed",
         cause: error,
       );
     }
@@ -83,7 +96,7 @@ class AcpAgentApi({required final AcpStdioClient client}) {
   /// without a session id, since nothing can be done with such a session.
   Future<AcpNewSessionResult> newSession({
     required String cwd,
-    Duration timeout = _defaultTimeout,
+    required Duration timeout,
   }) async {
     final raw = await client.request(
       method: AcpMethods.sessionNew,
@@ -104,7 +117,7 @@ class AcpAgentApi({required final AcpStdioClient client}) {
   Future<AcpNewSessionResult> loadSession({
     required String sessionId,
     required String cwd,
-    Duration timeout = _defaultTimeout,
+    required Duration timeout,
   }) => _activateSession(method: AcpMethods.sessionLoad, sessionId: sessionId, cwd: cwd, timeout: timeout);
 
   /// `session/resume` — re-activates [sessionId] without history replay. Same
@@ -112,14 +125,14 @@ class AcpAgentApi({required final AcpStdioClient client}) {
   Future<AcpNewSessionResult> resumeSession({
     required String sessionId,
     required String cwd,
-    Duration timeout = _defaultTimeout,
+    required Duration timeout,
   }) => _activateSession(method: AcpMethods.sessionResume, sessionId: sessionId, cwd: cwd, timeout: timeout);
 
   /// One `session/list` page; [cwd] null means the unfiltered form.
   Future<AcpSessionListResult> listSessionsPage({
     required String? cwd,
     required String? cursor,
-    Duration timeout = _defaultTimeout,
+    required Duration timeout,
   }) async {
     final raw = await client.request(
       method: AcpMethods.sessionList,
@@ -135,7 +148,7 @@ class AcpAgentApi({required final AcpStdioClient client}) {
     required String sessionId,
     required String configId,
     required String value,
-    Duration timeout = _defaultTimeout,
+    required Duration timeout,
   }) async {
     final raw = await client.request(
       method: AcpMethods.sessionSetConfigOption,
@@ -147,7 +160,7 @@ class AcpAgentApi({required final AcpStdioClient client}) {
 
   Future<void> closeSession({
     required String sessionId,
-    Duration timeout = _defaultTimeout,
+    required Duration timeout,
   }) => client.request(
     method: AcpMethods.sessionClose,
     params: {"sessionId": sessionId},

--- a/bridge/sesori_plugin_acp/lib/src/api/models/acp_content_block_dto.g.dart
+++ b/bridge/sesori_plugin_acp/lib/src/api/models/acp_content_block_dto.g.dart
@@ -6,30 +6,26 @@ part of 'acp_content_block_dto.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-AcpTextContentBlockDto _$AcpTextContentBlockDtoFromJson(Map json) =>
-    AcpTextContentBlockDto(
-      text: json['text'] as String,
-      $type: json['type'] as String?,
-    );
+AcpTextContentBlockDto _$AcpTextContentBlockDtoFromJson(Map json) => AcpTextContentBlockDto(
+  text: json['text'] as String,
+  $type: json['type'] as String?,
+);
 
-AcpImageContentBlockDto _$AcpImageContentBlockDtoFromJson(Map json) =>
-    AcpImageContentBlockDto(
-      data: json['data'] as String,
-      mimeType: json['mimeType'] as String,
-      uri: json['uri'] as String?,
-      $type: json['type'] as String?,
-    );
+AcpImageContentBlockDto _$AcpImageContentBlockDtoFromJson(Map json) => AcpImageContentBlockDto(
+  data: json['data'] as String,
+  mimeType: json['mimeType'] as String,
+  uri: json['uri'] as String?,
+  $type: json['type'] as String?,
+);
 
 AcpUnsupportedAudioContentBlockDto _$AcpUnsupportedAudioContentBlockDtoFromJson(
   Map json,
 ) => AcpUnsupportedAudioContentBlockDto($type: json['type'] as String?);
 
-AcpUnsupportedResourceContentBlockDto
-_$AcpUnsupportedResourceContentBlockDtoFromJson(Map json) =>
+AcpUnsupportedResourceContentBlockDto _$AcpUnsupportedResourceContentBlockDtoFromJson(Map json) =>
     AcpUnsupportedResourceContentBlockDto($type: json['type'] as String?);
 
-AcpUnsupportedResourceLinkContentBlockDto
-_$AcpUnsupportedResourceLinkContentBlockDtoFromJson(Map json) =>
+AcpUnsupportedResourceLinkContentBlockDto _$AcpUnsupportedResourceLinkContentBlockDtoFromJson(Map json) =>
     AcpUnsupportedResourceLinkContentBlockDto($type: json['type'] as String?);
 
 AcpUnknownContentBlockDto _$AcpUnknownContentBlockDtoFromJson(Map json) =>

--- a/bridge/sesori_plugin_acp/lib/src/api/models/acp_tool_content_dto.g.dart
+++ b/bridge/sesori_plugin_acp/lib/src/api/models/acp_tool_content_dto.g.dart
@@ -6,27 +6,24 @@ part of 'acp_tool_content_dto.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-AcpStandardToolContentDto _$AcpStandardToolContentDtoFromJson(Map json) =>
-    AcpStandardToolContentDto(
-      content: AcpContentBlockDto.fromJson(
-        Map<String, dynamic>.from(json['content'] as Map),
-      ),
-      $type: json['type'] as String?,
-    );
+AcpStandardToolContentDto _$AcpStandardToolContentDtoFromJson(Map json) => AcpStandardToolContentDto(
+  content: AcpContentBlockDto.fromJson(
+    Map<String, dynamic>.from(json['content'] as Map),
+  ),
+  $type: json['type'] as String?,
+);
 
-AcpDiffToolContentDto _$AcpDiffToolContentDtoFromJson(Map json) =>
-    AcpDiffToolContentDto(
-      path: json['path'] as String,
-      oldText: json['oldText'] as String?,
-      newText: json['newText'] as String,
-      $type: json['type'] as String?,
-    );
+AcpDiffToolContentDto _$AcpDiffToolContentDtoFromJson(Map json) => AcpDiffToolContentDto(
+  path: json['path'] as String,
+  oldText: json['oldText'] as String?,
+  newText: json['newText'] as String,
+  $type: json['type'] as String?,
+);
 
-AcpTerminalToolContentDto _$AcpTerminalToolContentDtoFromJson(Map json) =>
-    AcpTerminalToolContentDto(
-      terminalId: json['terminalId'] as String,
-      $type: json['type'] as String?,
-    );
+AcpTerminalToolContentDto _$AcpTerminalToolContentDtoFromJson(Map json) => AcpTerminalToolContentDto(
+  terminalId: json['terminalId'] as String,
+  $type: json['type'] as String?,
+);
 
 AcpUnknownToolContentDto _$AcpUnknownToolContentDtoFromJson(Map json) =>
     AcpUnknownToolContentDto($type: json['type'] as String?);

--- a/bridge/sesori_plugin_acp/lib/src/repositories/acp_session_config_repository.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/acp_session_config_repository.dart
@@ -1,21 +1,15 @@
 import "../acp_protocol.dart";
-import "../acp_stdio_client.dart";
+import "../api/acp_agent_api.dart";
 
-/// Connection-scoped access to standard ACP session configuration writes.
-class AcpSessionConfigRepository({required final AcpStdioClient _client}) {
+/// Connection-scoped access to standard ACP session configuration writes — the
+/// repository harness option services consume for `session/set_config_option`
+/// (the wire shape itself lives in [AcpAgentApi]).
+class AcpSessionConfigRepository({required final AcpAgentApi _api}) {
+  /// Returns the agent's updated config state, or null when it answered
+  /// without one.
   Future<AcpNewSessionResult?> setConfigOption({
     required String sessionId,
     required String configId,
     required String value,
-  }) async {
-    final raw = await _client.request(
-      method: AcpMethods.sessionSetConfigOption,
-      params: {
-        "sessionId": sessionId,
-        "configId": configId,
-        "value": value,
-      },
-    );
-    return raw is Map ? AcpNewSessionResult.fromJson(raw.cast<String, dynamic>()) : null;
-  }
+  }) => _api.setConfigOption(sessionId: sessionId, configId: configId, value: value);
 }

--- a/bridge/sesori_plugin_acp/lib/src/repositories/acp_session_config_repository.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/acp_session_config_repository.dart
@@ -11,5 +11,10 @@ class AcpSessionConfigRepository({required final AcpAgentApi _api}) {
     required String sessionId,
     required String configId,
     required String value,
-  }) => _api.setConfigOption(sessionId: sessionId, configId: configId, value: value);
+  }) => _api.setConfigOption(
+    sessionId: sessionId,
+    configId: configId,
+    value: value,
+    timeout: AcpAgentApi.defaultRequestTimeout,
+  );
 }

--- a/bridge/sesori_plugin_acp/lib/src/runtime/acp_bridge_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/runtime/acp_bridge_plugin.dart
@@ -35,7 +35,16 @@ class AcpBridgePlugin({
     required Duration connectBudget,
   }) async {
     final wrapper = AcpBridgePlugin(plugin: plugin, clock: host.clock);
-    await wrapper.connect(budget: connectBudget, startAborted: host.startAborted);
+    // Race the eager connect against the abort signal: an abort that lands
+    // while the handshake hangs must start the rollback now, not after the
+    // whole connect budget — the bridge's startup mutex is held meanwhile.
+    // connect() never throws, and once aborted it returns without marking
+    // status, so the rollback below disposes a plugin whose connect is either
+    // settled or failing fast against the disposed client.
+    await Future.any<void>([
+      wrapper.connect(budget: connectBudget, startAborted: host.startAborted),
+      host.startAborted.whenAborted,
+    ]);
     if (!host.startAborted.isAborted) return wrapper;
     try {
       await wrapper.shutdown(budget: null);
@@ -63,11 +72,12 @@ class AcpBridgePlugin({
 
   @override
   PluginDiagnostics describe() {
-    final spec = _plugin.launchSpec;
     return PluginDiagnostics(
       pluginId: _plugin.id,
-      // The agent command line is the "endpoint" of a stdio transport.
-      endpoint: [spec.command, ...spec.args].join(" "),
+      // The agent executable is the "endpoint" of a stdio transport. Only the
+      // command: launch arguments can carry operator-supplied values (Cursor's
+      // `-e <endpoint>` URL) that must not land in the startup console line.
+      endpoint: _plugin.launchSpec.command,
       details: {
         "transport": "acp-stdio",
         "agent": _plugin.agentDisplayName,

--- a/bridge/sesori_plugin_acp/lib/src/runtime/acp_bridge_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/runtime/acp_bridge_plugin.dart
@@ -17,12 +17,34 @@ import "../acp_plugin.dart";
 /// lifetime; it owns the agent subprocess (spawned lazily, or eagerly via
 /// [connect]) and reaps it on [dispose]. This wrapper adds the lifecycle
 /// surface: it drives the status state machine off the ACP connection and the
-/// child's exit, and owns the ordered, idempotent [shutdown].
+/// child's exit, and owns the ordered, idempotent [shutdown]. Descriptors
+/// obtain a connected instance through [start].
 class AcpBridgePlugin({
   required final AcpPlugin _plugin,
   required final ServerClock _clock,
-  final String? _endpoint,
 }) with SteadyPluginLifecycle implements BridgePlugin {
+  /// Wraps [plugin], eagerly connects it within [connectBudget] (a timeout or
+  /// failure leaves it degraded, not failed — see [connect]), and honours an
+  /// abort that arrived while connecting by rolling the agent back and throwing
+  /// [PluginStartAbortedException] instead of returning a live plugin. This is
+  /// the one place the "start an ACP agent under the bridge lifecycle" sequence
+  /// lives, so every ACP descriptor's `start` reduces to building its plugin.
+  static Future<AcpBridgePlugin> start({
+    required AcpPlugin plugin,
+    required PluginHost host,
+    required Duration connectBudget,
+  }) async {
+    final wrapper = AcpBridgePlugin(plugin: plugin, clock: host.clock);
+    await wrapper.connect(budget: connectBudget, startAborted: host.startAborted);
+    if (!host.startAborted.isAborted) return wrapper;
+    try {
+      await wrapper.shutdown(budget: null);
+    } on Object catch (error, stackTrace) {
+      Log.e("[${plugin.id}] rollback after aborted start failed", error, stackTrace);
+    }
+    throw const PluginStartAbortedException();
+  }
+
   StreamSubscription<int>? _exitSubscription;
   StreamSubscription<void>? _connectedSubscription;
   var _stopping = false;
@@ -41,9 +63,11 @@ class AcpBridgePlugin({
 
   @override
   PluginDiagnostics describe() {
+    final spec = _plugin.launchSpec;
     return PluginDiagnostics(
       pluginId: _plugin.id,
-      endpoint: _endpoint,
+      // The agent command line is the "endpoint" of a stdio transport.
+      endpoint: [spec.command, ...spec.args].join(" "),
       details: {
         "transport": "acp-stdio",
         "agent": _plugin.agentDisplayName,
@@ -96,7 +120,7 @@ class AcpBridgePlugin({
       Log.w("[${_plugin.id}] eager connect failed; starting degraded", error, stackTrace);
       connected = false;
     }
-    // An abort observed here is handled by the caller (descriptor), which rolls
+    // An abort observed here is handled by the caller ([start]), which rolls
     // back via shutdown() and throws PluginStartAbortedException.
     if (startAborted.isAborted) {
       return;

--- a/bridge/sesori_plugin_acp/lib/src/testing/test_acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/testing/test_acp_plugin.dart
@@ -1,41 +1,14 @@
 import "../acp_plugin.dart";
 
-/// Neutral ACP adapter for testing the reusable base behavior.
+/// Neutral ACP adapter for testing the reusable base behavior: every policy
+/// keeps the [AcpPlugin] stock default.
 class TestAcpPlugin({
   required super.id,
   required super.agentDisplayName,
   required super.launchSpec,
   required super.launchDirectory,
   required super.eventMapper,
-  required super.contentMapper,
   required super.commandTracker,
   required super.sessionOptionsService,
   super.processFactory,
-}) extends AcpPlugin {
-  @override
-  String get clientName => "sesori-bridge";
-
-  @override
-  String get clientVersion => "0.0.0";
-
-  @override
-  String? get authMethodId => null;
-
-  @override
-  Map<String, dynamic>? get initializeCapabilityMeta => null;
-
-  @override
-  bool get supportsFormElicitation => false;
-
-  @override
-  bool get serializesPromptsProcessWide => false;
-
-  @override
-  bool get cancelsActiveTurnForQueuedInput => false;
-
-  @override
-  bool get failsTurnOnSelectionError => false;
-
-  @override
-  Duration get sessionCloseSettlementTimeout => const Duration(seconds: 5);
-}
+}) extends AcpPlugin;

--- a/bridge/sesori_plugin_acp/test/acp_agent_api_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_agent_api_test.dart
@@ -1,0 +1,131 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("AcpAgentApi.initialize", () {
+    late FakeAcpProcess fake;
+    late AcpStdioClient client;
+    late AcpAgentApi api;
+
+    setUp(() async {
+      fake = FakeAcpProcess();
+      client = AcpStdioClient(
+        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+        processFactory: (_) async => fake,
+        logTag: "acp-test",
+      );
+      await client.connect();
+      api = AcpAgentApi(client: client);
+    });
+
+    tearDown(() async {
+      await client.dispose();
+      await fake.close();
+    });
+
+    Future<Map<String, dynamic>> waitForFrame(String method) async {
+      for (var i = 0; i < 400; i++) {
+        final matches = fake.written.where((frame) => frame["method"] == method);
+        if (matches.isNotEmpty) return matches.last;
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+      throw StateError("agent never wrote a '$method' frame");
+    }
+
+    Map<String, dynamic> initializeResult({required List<Map<String, dynamic>> authMethods}) => {
+      "protocolVersion": 1,
+      "agentCapabilities": <String, dynamic>{},
+      "authMethods": authMethods,
+    };
+
+    test("picks the first non-terminal auth method when none is configured", () async {
+      final initializing = api.initialize(
+        formElicitation: false,
+        capabilityMeta: null,
+        authMethodId: null,
+        timeout: const Duration(seconds: 5),
+      );
+      final initialize = await waitForFrame("initialize");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": initialize["id"],
+        "result": initializeResult(
+          authMethods: [
+            {"type": "terminal", "id": "setup", "name": "Interactive setup"},
+            {"id": "provider", "name": "Configured provider"},
+          ],
+        ),
+      });
+      final authenticate = await waitForFrame("authenticate");
+      expect(authenticate["params"], {"methodId": "provider"});
+      fake.emit({"jsonrpc": "2.0", "id": authenticate["id"], "result": <String, dynamic>{}});
+      await initializing;
+    });
+
+    test("a terminal-only agent fails typed, naming the connection", () async {
+      final initializing = api.initialize(
+        formElicitation: false,
+        capabilityMeta: null,
+        authMethodId: null,
+        timeout: const Duration(seconds: 5),
+      );
+      final initialize = await waitForFrame("initialize");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": initialize["id"],
+        "result": initializeResult(
+          authMethods: [
+            {"type": "terminal", "id": "setup", "name": "Interactive setup"},
+          ],
+        ),
+      });
+      await expectLater(
+        initializing,
+        throwsA(
+          isA<PluginAuthenticationRequiredException>().having(
+            (error) => error.message,
+            "message",
+            contains("acp-test"),
+          ),
+        ),
+      );
+      expect(fake.written.where((frame) => frame["method"] == "authenticate"), isEmpty);
+    });
+
+    test("authenticate runs inside the same deadline as initialize", () async {
+      const timeout = Duration(milliseconds: 600);
+      final stopwatch = Stopwatch()..start();
+      final initializing = api.initialize(
+        formElicitation: false,
+        capabilityMeta: null,
+        authMethodId: "login",
+        timeout: timeout,
+      );
+      final initialize = await waitForFrame("initialize");
+      // Spend half the budget before answering, then never answer authenticate:
+      // the handshake must give up at ~the original deadline, not a full
+      // timeout after the initialize reply.
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": initialize["id"],
+        "result": initializeResult(
+          authMethods: [
+            {"id": "login", "name": "Login"},
+          ],
+        ),
+      });
+      await waitForFrame("authenticate");
+      await expectLater(initializing, throwsA(isA<TimeoutException>()));
+      expect(
+        stopwatch.elapsed,
+        lessThan(const Duration(milliseconds: 850)),
+        reason: "a fresh per-request timeout would let authenticate run until ~900 ms",
+      );
+    });
+  });
+}

--- a/bridge/sesori_plugin_acp/test/acp_bridge_plugin_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_bridge_plugin_test.dart
@@ -1,0 +1,84 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("AcpBridgePlugin", () {
+    late FakeAcpProcess fake;
+    late TestAcpPlugin plugin;
+
+    setUp(() {
+      fake = FakeAcpProcess();
+      final configurationTracker = AcpSessionConfigurationTracker();
+      final commandTracker = AcpCommandTracker();
+      plugin = TestAcpPlugin(
+        id: "acp",
+        agentDisplayName: "ACP",
+        launchSpec: const AcpLaunchSpec(command: "/opt/agent", args: ["-e", "https://user:secret@host/api", "acp"]),
+        launchDirectory: "/repo",
+        eventMapper: AcpEventMapper(
+          launchDirectory: "/repo",
+          pluginId: "acp",
+          configurationTracker: configurationTracker,
+        ),
+        commandTracker: commandTracker,
+        sessionOptionsService: AcpSessionOptionsService(
+          configurationTracker: configurationTracker,
+          commandTracker: commandTracker,
+          pluginId: "acp",
+          agentDisplayName: "ACP",
+        ),
+        processFactory: (_) async => fake,
+      );
+    });
+
+    tearDown(() async {
+      await fake.close();
+    });
+
+    Future<void> waitForFrame(String method) async {
+      for (var i = 0; i < 400; i++) {
+        if (fake.written.any((frame) => frame["method"] == method)) return;
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+      throw StateError("agent never wrote a '$method' frame");
+    }
+
+    test("describe exposes the agent executable, not its launch arguments", () async {
+      final wrapper = AcpBridgePlugin(plugin: plugin, clock: const ServerClock());
+      addTearDown(() => wrapper.shutdown(budget: null));
+      final diagnostics = wrapper.describe();
+      expect(diagnostics.endpoint, "/opt/agent");
+      expect(diagnostics.details, {"transport": "acp-stdio", "agent": "ACP"});
+    });
+
+    test("start rolls back as soon as the start is aborted during a hanging handshake", () async {
+      final controller = StartAbortController();
+      final stopwatch = Stopwatch()..start();
+      final starting = AcpBridgePlugin.start(
+        plugin: plugin,
+        host: _Host(startAborted: controller.signal),
+        connectBudget: const Duration(seconds: 30),
+      );
+      // The agent never answers `initialize`; abort while the handshake hangs.
+      await waitForFrame("initialize");
+      controller.abort();
+
+      await expectLater(starting, throwsA(isA<PluginStartAbortedException>()));
+      expect(
+        stopwatch.elapsed,
+        lessThan(const Duration(seconds: 5)),
+        reason: "the abort must not wait out the connect budget",
+      );
+    });
+  });
+}
+
+class _Host({@override required final StartAbortSignal startAborted}) implements PluginHost {
+  @override
+  ServerClock get clock => const ServerClock();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/sesori_plugin_acp/test/acp_commands_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_commands_test.dart
@@ -99,13 +99,10 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
-          agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
-          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(
@@ -237,13 +234,10 @@ void main() {
       agentDisplayName: "ACP",
       launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
       launchDirectory: "/repo",
-      contentMapper: const AcpContentMapper(),
       eventMapper: AcpEventMapper(
         launchDirectory: "/repo",
-        agentId: "acp",
         pluginId: "acp",
         configurationTracker: configurationTracker,
-        contentMapper: const AcpContentMapper(),
       ),
       commandTracker: commandTracker,
       sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
@@ -257,34 +257,32 @@ void main() {
     test("bounds tool images before scanning trailing text and diff content", () {
       late AcpReplaceToolContentMutation replacement;
       final output = _captureWarnings(() {
-        replacement =
-            mapper.toolContent(
-                  update: {
-                    "content": [
-                      for (var index = 0; index < 5; index++)
-                        {
-                          "type": "content",
-                          "content": {
-                            "type": "image",
-                            "data": "AA==",
-                            "mimeType": "image/png",
-                            "uri": "file:///private/image-$index.png",
-                          },
-                        },
-                      {
-                        "type": "content",
-                        "content": {"type": "text", "text": "after images"},
-                      },
-                      {
-                        "type": "diff",
-                        "path": "/private/source.dart",
-                        "oldText": "old",
-                        "newText": "new",
-                      },
-                    ],
+        replacement = mapper.toolContent(
+          update: {
+            "content": [
+              for (var index = 0; index < 5; index++)
+                {
+                  "type": "content",
+                  "content": {
+                    "type": "image",
+                    "data": "AA==",
+                    "mimeType": "image/png",
+                    "uri": "file:///private/image-$index.png",
                   },
-                )
-                as AcpReplaceToolContentMutation;
+                },
+              {
+                "type": "content",
+                "content": {"type": "text", "text": "after images"},
+              },
+              {
+                "type": "diff",
+                "path": "/private/source.dart",
+                "oldText": "old",
+                "newText": "new",
+              },
+            ],
+          },
+        ) as AcpReplaceToolContentMutation;
       });
 
       expect(replacement.imageCandidates, hasLength(4));
@@ -311,34 +309,28 @@ void main() {
       );
       expect(
         (mapper.toolContent(
-                  update: {
-                    "rawOutput": {"stdout": "out\n", "stderr": "error\n"},
-                  },
-                )
-                as AcpUpdateToolOutputMutation)
-            .output,
+          update: {
+            "rawOutput": {"stdout": "out\n", "stderr": "error\n"},
+          },
+        ) as AcpUpdateToolOutputMutation).output,
         "out\nerror",
       );
       expect(
         (mapper.toolContent(
-                  update: {
-                    "rawOutput": {
-                      "content": {"type": "text", "text": "nested\n"},
-                    },
-                  },
-                )
-                as AcpUpdateToolOutputMutation)
-            .output,
+          update: {
+            "rawOutput": {
+              "content": {"type": "text", "text": "nested\n"},
+            },
+          },
+        ) as AcpUpdateToolOutputMutation).output,
         "nested",
       );
       expect(
         (mapper.toolContent(
-                  update: {
-                    "rawOutput": {"exitCode": 7},
-                  },
-                )
-                as AcpUpdateToolOutputMutation)
-            .output,
+          update: {
+            "rawOutput": {"exitCode": 7},
+          },
+        ) as AcpUpdateToolOutputMutation).output,
         "exited with code 7",
       );
 
@@ -369,15 +361,27 @@ void main() {
         ),
       );
       expect(
-        mapper.toolContent(update: {"rawOutput": {"stdout": 42}}),
+        mapper.toolContent(
+          update: {
+            "rawOutput": {"stdout": 42},
+          },
+        ),
         isA<AcpUnchangedToolContentMutation>(),
       );
       expect(
-        mapper.toolContent(update: {"rawOutput": {"content": 42}}),
+        mapper.toolContent(
+          update: {
+            "rawOutput": {"content": 42},
+          },
+        ),
         isA<AcpUnchangedToolContentMutation>(),
       );
       expect(
-        mapper.toolContent(update: {"rawOutput": {"stdout": 42, "stderr": "usable"}}),
+        mapper.toolContent(
+          update: {
+            "rawOutput": {"stdout": 42, "stderr": "usable"},
+          },
+        ),
         isA<AcpUpdateToolOutputMutation>().having(
           (mutation) => mutation.output,
           "output",
@@ -396,23 +400,21 @@ void main() {
             .having((mutation) => mutation.hasDiff, "hasDiff", isFalse),
       );
 
-      final imageOnly =
-          mapper.toolContent(
-                update: {
-                  "content": [
-                    {
-                      "type": "content",
-                      "content": {
-                        "type": "image",
-                        "data": "AA==",
-                        "mimeType": "image/png",
-                        "uri": null,
-                      },
-                    },
-                  ],
-                },
-              )
-              as AcpReplaceToolContentMutation;
+      final imageOnly = mapper.toolContent(
+        update: {
+          "content": [
+            {
+              "type": "content",
+              "content": {
+                "type": "image",
+                "data": "AA==",
+                "mimeType": "image/png",
+                "uri": null,
+              },
+            },
+          ],
+        },
+      ) as AcpReplaceToolContentMutation;
       expect(imageOnly.output, isNull);
       expect(imageOnly.imageCandidates, hasLength(1));
     });
@@ -437,37 +439,33 @@ void main() {
     });
 
     test("uses raw output only when replacement content has no text", () {
-      final withText =
-          mapper.toolContent(
-                update: {
-                  "content": [
-                    {
-                      "type": "content",
-                      "content": {"type": "text", "text": "standard"},
-                    },
-                  ],
-                  "rawOutput": "fallback",
-                },
-              )
-              as AcpReplaceToolContentMutation;
-      final imageOnly =
-          mapper.toolContent(
-                update: {
-                  "content": [
-                    {
-                      "type": "content",
-                      "content": {
-                        "type": "image",
-                        "data": "AA==",
-                        "mimeType": "image/png",
-                        "uri": null,
-                      },
-                    },
-                  ],
-                  "rawOutput": "fallback",
-                },
-              )
-              as AcpReplaceToolContentMutation;
+      final withText = mapper.toolContent(
+        update: {
+          "content": [
+            {
+              "type": "content",
+              "content": {"type": "text", "text": "standard"},
+            },
+          ],
+          "rawOutput": "fallback",
+        },
+      ) as AcpReplaceToolContentMutation;
+      final imageOnly = mapper.toolContent(
+        update: {
+          "content": [
+            {
+              "type": "content",
+              "content": {
+                "type": "image",
+                "data": "AA==",
+                "mimeType": "image/png",
+                "uri": null,
+              },
+            },
+          ],
+          "rawOutput": "fallback",
+        },
+      ) as AcpReplaceToolContentMutation;
 
       expect(withText.output, "standard");
       expect(imageOnly.output, "fallback");

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -15,10 +15,8 @@ void main() {
         ..setProcessDefaults(modelId: "gpt-5.4", providerId: "cursor");
       mapper = AcpEventMapper(
         launchDirectory: "/repo",
-        agentId: "cursor",
         pluginId: "cursor",
         configurationTracker: configurationTracker,
-        contentMapper: const AcpContentMapper(),
       );
     });
 
@@ -1417,9 +1415,7 @@ class _HaltMapper({required super.configurationTracker}) extends AcpEventMapper 
   this
     : super(
         launchDirectory: "/repo",
-        agentId: "cursor",
         pluginId: "cursor",
-        contentMapper: const AcpContentMapper(),
       );
 
   @override

--- a/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
@@ -25,13 +25,10 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
-          agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
-          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(
@@ -219,6 +216,13 @@ void main() {
 
       final messages = await loading;
       expect(messages, hasLength(3));
+      // Replayed messages carry the same `agent` the live mapper stamps (the
+      // plugin id, "acp"), not the display name ("ACP") — otherwise a reloaded
+      // session would report a different agent than it did live.
+      expect(
+        messages.first.info,
+        isA<PluginMessageAssistant>().having((message) => message.agent, "agent", "acp"),
+      );
       expect(messages.first.parts.map((part) => part.type), [
         PluginMessagePartType.text,
         PluginMessagePartType.file,
@@ -333,13 +337,10 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
-          agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
-          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_acp/test/acp_initialize_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_initialize_test.dart
@@ -22,13 +22,10 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
-          agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
-          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
@@ -24,13 +24,10 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
-          agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
-          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
@@ -27,13 +27,10 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
-          agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
-          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(
@@ -749,13 +746,10 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
-          agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
-          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(
@@ -878,7 +872,6 @@ class _RegistryCapturingAcpPlugin({
   required super.launchSpec,
   required super.launchDirectory,
   required super.eventMapper,
-  required super.contentMapper,
   required super.commandTracker,
   required super.sessionOptionsService,
   super.processFactory,

--- a/bridge/sesori_plugin_acp/test/acp_reconnect_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_reconnect_test.dart
@@ -21,13 +21,10 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
-          agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
-          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_acp/test/acp_resume_only_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_only_test.dart
@@ -24,13 +24,10 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
-          agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
-          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_acp/test/acp_resume_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_test.dart
@@ -23,13 +23,10 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
-          agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
-          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -77,17 +77,14 @@ void main() {
         final configurationTracker = AcpSessionConfigurationTracker();
         final mapper = AcpEventMapper(
           launchDirectory: "/repo",
-          agentId: "ACP",
           pluginId: "acp",
           configurationTracker: configurationTracker,
-          contentMapper: const AcpContentMapper(),
         )..beginTurn("s1");
         final collector = AcpReplayCollector(
           sessionId: "s1",
           agentId: "ACP",
           initialUserMessageId: null,
           haltClassifier: null,
-          contentMapper: const AcpContentMapper(),
         );
         final liveEvents = <BridgeSseEvent>[];
 
@@ -122,87 +119,90 @@ void main() {
         {"type": "image", "data": "AA==", "mimeType": "image/png", "uri": "file:///private/image.png"},
       ],
     ]) {
-      test("replays ${content.length == 1 ? "attachment-only" : "mixed"} user content with stable initial identity", () {
-        final collector = AcpReplayCollector(
-          sessionId: "s1",
-          agentId: "Cursor",
-          modelId: null,
-          providerId: null,
-          initialUserMessageId: "s1-initial-user",
-          haltClassifier: null,
-          contentMapper: const AcpContentMapper(),
-        )
-          ..consume(
-            upd({
-              "sessionUpdate": "user_message_chunk",
-              "content": content,
-            }),
-          )
-          ..consume(
-            upd({
-              "sessionUpdate": "agent_message_chunk",
-              "content": {"type": "text", "text": "Hi"},
-            }),
-          );
+      test(
+        "replays ${content.length == 1 ? "attachment-only" : "mixed"} user content with stable initial identity",
+        () {
+          final collector =
+              AcpReplayCollector(
+                  sessionId: "s1",
+                  agentId: "Cursor",
+                  modelId: null,
+                  providerId: null,
+                  initialUserMessageId: "s1-initial-user",
+                  haltClassifier: null,
+                )
+                ..consume(
+                  upd({
+                    "sessionUpdate": "user_message_chunk",
+                    "content": content,
+                  }),
+                )
+                ..consume(
+                  upd({
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": "Hi"},
+                  }),
+                );
 
-        final messages = collector.build();
-        final initial = messages.first;
-        expect(initial.info.id, "s1-initial-user");
-        expect(initial.parts.map((part) => part.type), [
-          if (content.length > 1) PluginMessagePartType.text,
-          PluginMessagePartType.file,
-          if (content.length > 1) PluginMessagePartType.text,
-        ]);
-        expect(initial.parts.first.id, content.length == 1 ? "s1-initial-user-image-1" : "s1-initial-user-text");
-        expect(initial.parts.every((part) => part.messageID == initial.info.id), isTrue);
-        final attachment = initial.parts.where((part) => part.type == PluginMessagePartType.file).single.attachment;
-        expect(attachment, isA<PluginMessageAttachmentInlineImage>());
-        expect((attachment! as PluginMessageAttachmentInlineImage).base64, "AA==");
-        expect(attachment.filename, isNull);
-        expect(initial.parts.toString(), isNot(contains("/private/image.png")));
-        expect(messages.last.info.id, "s1-h1-assistant");
-      });
+          final messages = collector.build();
+          final initial = messages.first;
+          expect(initial.info.id, "s1-initial-user");
+          expect(initial.parts.map((part) => part.type), [
+            if (content.length > 1) PluginMessagePartType.text,
+            PluginMessagePartType.file,
+            if (content.length > 1) PluginMessagePartType.text,
+          ]);
+          expect(initial.parts.first.id, content.length == 1 ? "s1-initial-user-image-1" : "s1-initial-user-text");
+          expect(initial.parts.every((part) => part.messageID == initial.info.id), isTrue);
+          final attachment = initial.parts.where((part) => part.type == PluginMessagePartType.file).single.attachment;
+          expect(attachment, isA<PluginMessageAttachmentInlineImage>());
+          expect((attachment! as PluginMessageAttachmentInlineImage).base64, "AA==");
+          expect(attachment.filename, isNull);
+          expect(initial.parts.toString(), isNot(contains("/private/image.png")));
+          expect(messages.last.info.id, "s1-h1-assistant");
+        },
+      );
     }
 
     test("reconstructs a user/tool/assistant exchange in order", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        modelId: "gpt-5.5",
-        providerId: "cursor",
-        initialUserMessageId: null,
-        haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
-      )
-        ..consume(
-          upd({
-            "sessionUpdate": "user_message_chunk",
-            "content": {"type": "text", "text": "list md files"},
-          }),
-        )
-        ..consume(
-          upd({
-            "sessionUpdate": "tool_call",
-            "toolCallId": "t1",
-            "kind": "execute",
-            "title": "find . -name '*.md'",
-            "status": "pending",
-          }),
-        )
-        ..consume(
-          upd({
-            "sessionUpdate": "tool_call_update",
-            "toolCallId": "t1",
-            "status": "completed",
-            "rawOutput": {"exitCode": 0, "stdout": "README.md\n", "stderr": ""},
-          }),
-        )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "text", "text": "There is 1 file."},
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+              sessionId: "s1",
+              agentId: "Cursor",
+              modelId: "gpt-5.5",
+              providerId: "cursor",
+              initialUserMessageId: null,
+              haltClassifier: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "user_message_chunk",
+                "content": {"type": "text", "text": "list md files"},
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "tool_call",
+                "toolCallId": "t1",
+                "kind": "execute",
+                "title": "find . -name '*.md'",
+                "status": "pending",
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "t1",
+                "status": "completed",
+                "rawOutput": {"exitCode": 0, "stdout": "README.md\n", "stderr": ""},
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "There is 1 file."},
+              }),
+            );
 
       final messages = collector.build();
       expect(messages, hasLength(3));
@@ -220,33 +220,33 @@ void main() {
     });
 
     test("replays standard tool content text without materializing other variants", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        initialUserMessageId: null,
-        haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
-      )..consume(
-          upd({
-            "sessionUpdate": "tool_call",
-            "toolCallId": "t1",
-            "kind": "read",
-            "status": "completed",
-            "content": [
-              {
-                "type": "content",
-                "content": {"type": "text", "text": "replayed output"},
-              },
-              {
-                "type": "diff",
-                "path": "/private/source.dart",
-                "oldText": "old",
-                "newText": "new",
-              },
-              {"type": "terminal", "terminalId": "private-terminal"},
-            ],
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+            sessionId: "s1",
+            agentId: "Cursor",
+            initialUserMessageId: null,
+            haltClassifier: null,
+          )..consume(
+            upd({
+              "sessionUpdate": "tool_call",
+              "toolCallId": "t1",
+              "kind": "read",
+              "status": "completed",
+              "content": [
+                {
+                  "type": "content",
+                  "content": {"type": "text", "text": "replayed output"},
+                },
+                {
+                  "type": "diff",
+                  "path": "/private/source.dart",
+                  "oldText": "old",
+                  "newText": "new",
+                },
+                {"type": "terminal", "terminalId": "private-terminal"},
+              ],
+            }),
+          );
 
       final tool = collector.build().single.parts.single;
       expect(tool.state?.output, "replayed output");
@@ -254,33 +254,33 @@ void main() {
     });
 
     test("id-less text after a tool stays chronologically after the tool", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        initialUserMessageId: null,
-        haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
-      )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "text", "text": "Before"},
-          }),
-        )
-        ..consume(
-          upd({
-            "sessionUpdate": "tool_call",
-            "toolCallId": "t1",
-            "kind": "read",
-            "status": "completed",
-          }),
-        )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "text", "text": "After"},
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+              sessionId: "s1",
+              agentId: "Cursor",
+              initialUserMessageId: null,
+              haltClassifier: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "Before"},
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "tool_call",
+                "toolCallId": "t1",
+                "kind": "read",
+                "status": "completed",
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "After"},
+              }),
+            );
 
       final messages = collector.build();
       expect(messages, hasLength(3));
@@ -290,37 +290,37 @@ void main() {
     });
 
     test("a partial (output-only) update does not reset a completed tool to pending", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        initialUserMessageId: null,
-        haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
-      )
-        ..consume(
-          upd({
-            "sessionUpdate": "tool_call",
-            "toolCallId": "t1",
-            "kind": "execute",
-            "status": "pending",
-          }),
-        )
-        ..consume(
-          upd({
-            "sessionUpdate": "tool_call_update",
-            "toolCallId": "t1",
-            "status": "completed",
-            "rawOutput": {"stdout": "done"},
-          }),
-        )
-        // An output-only update with NO status must keep the completed state.
-        ..consume(
-          upd({
-            "sessionUpdate": "tool_call_update",
-            "toolCallId": "t1",
-            "rawOutput": {"stdout": "done (final)"},
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+              sessionId: "s1",
+              agentId: "Cursor",
+              initialUserMessageId: null,
+              haltClassifier: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "tool_call",
+                "toolCallId": "t1",
+                "kind": "execute",
+                "status": "pending",
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "t1",
+                "status": "completed",
+                "rawOutput": {"stdout": "done"},
+              }),
+            )
+            // An output-only update with NO status must keep the completed state.
+            ..consume(
+              upd({
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "t1",
+                "rawOutput": {"stdout": "done (final)"},
+              }),
+            );
 
       final toolPart = collector.build().single.parts.firstWhere((p) => p.type == PluginMessagePartType.tool);
       expect(
@@ -332,73 +332,73 @@ void main() {
     });
 
     test("a title-only tool_call_update merges onto an existing draft (matches live)", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        initialUserMessageId: null,
-        haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
-      )
-        ..consume(
-          upd({
-            "sessionUpdate": "tool_call",
-            "toolCallId": "t1",
-            "kind": "edit",
-            "status": "pending",
-          }),
-        )
-        // A separate title-only update after the tool_call: replay must apply it
-        // (the live mapper does), not silently drop it.
-        ..consume(
-          upd({
-            "sessionUpdate": "tool_call_update",
-            "toolCallId": "t1",
-            "title": "Edit main.dart",
-            "status": "in_progress",
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+              sessionId: "s1",
+              agentId: "Cursor",
+              initialUserMessageId: null,
+              haltClassifier: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "tool_call",
+                "toolCallId": "t1",
+                "kind": "edit",
+                "status": "pending",
+              }),
+            )
+            // A separate title-only update after the tool_call: replay must apply it
+            // (the live mapper does), not silently drop it.
+            ..consume(
+              upd({
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "t1",
+                "title": "Edit main.dart",
+                "status": "in_progress",
+              }),
+            );
       final toolPart = collector.build().single.parts.firstWhere((p) => p.type == PluginMessagePartType.tool);
       expect(toolPart.tool, "edit");
       expect(toolPart.state?.title, "Edit main.dart");
     });
 
     test("a non-string tool title does not throw mid-replay", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        initialUserMessageId: null,
-        haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
-      )..consume(
-          upd({
-            "sessionUpdate": "tool_call",
-            "toolCallId": "t1",
-            "kind": "read",
-            "title": {"unexpected": "object"},
-            "status": "completed",
-            "rawOutput": {"stdout": "x"},
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+            sessionId: "s1",
+            agentId: "Cursor",
+            initialUserMessageId: null,
+            haltClassifier: null,
+          )..consume(
+            upd({
+              "sessionUpdate": "tool_call",
+              "toolCallId": "t1",
+              "kind": "read",
+              "title": {"unexpected": "object"},
+              "status": "completed",
+              "rawOutput": {"stdout": "x"},
+            }),
+          );
       final toolPart = collector.build().single.parts.firstWhere((p) => p.type == PluginMessagePartType.tool);
       expect(toolPart.tool, "read");
       expect(toolPart.state?.title, isNull);
     });
 
     test("stamps replayed assistant messages with the loaded session model", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        modelId: "claude-opus-4-8",
-        providerId: "cursor",
-        initialUserMessageId: null,
-        haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
-      )..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "text", "text": "hi"},
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+            sessionId: "s1",
+            agentId: "Cursor",
+            modelId: "claude-opus-4-8",
+            providerId: "cursor",
+            initialUserMessageId: null,
+            haltClassifier: null,
+          )..consume(
+            upd({
+              "sessionUpdate": "agent_message_chunk",
+              "content": {"type": "text", "text": "hi"},
+            }),
+          );
       final assistant = collector.build().single.info as PluginMessageAssistant;
       expect(assistant.modelID, "claude-opus-4-8");
       expect(assistant.providerID, "cursor");
@@ -407,34 +407,34 @@ void main() {
     test("a messageId change splits consecutive same-role chunks into two messages", () {
       // ACP v1: chunks of one message share a messageId; a change starts a new
       // message. Without honouring it, distinct same-role messages collapse.
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        initialUserMessageId: null,
-        haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
-      )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "messageId": "m1",
-            "content": {"type": "text", "text": "first"},
-          }),
-        )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "messageId": "m1",
-            "content": {"type": "text", "text": " message"},
-          }),
-        )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "messageId": "m2",
-            "content": {"type": "text", "text": "second message"},
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+              sessionId: "s1",
+              agentId: "Cursor",
+              initialUserMessageId: null,
+              haltClassifier: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "messageId": "m1",
+                "content": {"type": "text", "text": "first"},
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "messageId": "m1",
+                "content": {"type": "text", "text": " message"},
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "messageId": "m2",
+                "content": {"type": "text", "text": "second message"},
+              }),
+            );
 
       final messages = collector.build();
       expect(messages, hasLength(2));
@@ -444,48 +444,48 @@ void main() {
     });
 
     test("chunks without a messageId keep the role-grouping behaviour", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        initialUserMessageId: null,
-        haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
-      )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "text", "text": "one"},
-          }),
-        )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "text", "text": " flow"},
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+              sessionId: "s1",
+              agentId: "Cursor",
+              initialUserMessageId: null,
+              haltClassifier: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "one"},
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": " flow"},
+              }),
+            );
       expect(collector.build().single.parts.single.text, "one flow");
     });
 
     test("unrenderable assistant chunks do not create empty replay messages", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        initialUserMessageId: null,
-        haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
-      )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "text", "text": ""},
-          }),
-        )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "audio", "data": "private", "mimeType": "audio/wav"},
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+              sessionId: "s1",
+              agentId: "Cursor",
+              initialUserMessageId: null,
+              haltClassifier: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": ""},
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "audio", "data": "private", "mimeType": "audio/wav"},
+              }),
+            );
 
       expect(collector.build(), isEmpty);
     });
@@ -496,7 +496,6 @@ void main() {
         agentId: "Cursor",
         initialUserMessageId: null,
         haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
       );
 
       expect(
@@ -512,7 +511,6 @@ void main() {
         agentId: "Cursor",
         initialUserMessageId: null,
         haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
       );
       final output = _captureWarnings(() {
         for (var index = 0; index < 2; index++) {
@@ -532,39 +530,39 @@ void main() {
     });
 
     test("replay materializes mixed assistant images in order", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        initialUserMessageId: null,
-        haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
-      )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "messageId": "mixed",
-            "content": {"type": "text", "text": "before"},
-          }),
-        )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "messageId": "mixed",
-            "content": {
-              "type": "image",
-              "data": "AA==",
-              "mimeType": "image/png",
-              "uri": "file:///private/output.png",
-            },
-          }),
-        )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "messageId": "mixed",
-            "content": {"type": "text", "text": "after"},
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+              sessionId: "s1",
+              agentId: "Cursor",
+              initialUserMessageId: null,
+              haltClassifier: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "messageId": "mixed",
+                "content": {"type": "text", "text": "before"},
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "messageId": "mixed",
+                "content": {
+                  "type": "image",
+                  "data": "AA==",
+                  "mimeType": "image/png",
+                  "uri": "file:///private/output.png",
+                },
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "messageId": "mixed",
+                "content": {"type": "text", "text": "after"},
+              }),
+            );
 
       final message = collector.build().single;
       expect(message.parts, hasLength(3));
@@ -632,43 +630,43 @@ void main() {
 
     for (final testCase in stampedAssistantChronologyCases) {
       test("preserves ${testCase.name} chronology in one stamped assistant draft", () {
-        final collector = AcpReplayCollector(
-          sessionId: "s1",
-          agentId: "Cursor",
-          initialUserMessageId: null,
-          haltClassifier: null,
-          contentMapper: const AcpContentMapper(),
-        )
-          ..consume(
-            upd({
-              "sessionUpdate": "agent_message_chunk",
-              "messageId": "m1",
-              "content": testCase.beforeTool,
-            }),
-          )
-          ..consume(
-            upd({
-              "sessionUpdate": "tool_call_update",
-              "toolCallId": "t1",
-              "status": "completed",
-              "rawOutput": {"stdout": "done"},
-            }),
-          )
-          ..consume(
-            upd({
-              "sessionUpdate": "agent_message_chunk",
-              "messageId": "m1",
-              "content": testCase.afterTool,
-            }),
-          )
-          ..consume(
-            upd({
-              "sessionUpdate": "tool_call",
-              "toolCallId": "t1",
-              "kind": "read",
-              "title": "Read source.dart",
-            }),
-          );
+        final collector =
+            AcpReplayCollector(
+                sessionId: "s1",
+                agentId: "Cursor",
+                initialUserMessageId: null,
+                haltClassifier: null,
+              )
+              ..consume(
+                upd({
+                  "sessionUpdate": "agent_message_chunk",
+                  "messageId": "m1",
+                  "content": testCase.beforeTool,
+                }),
+              )
+              ..consume(
+                upd({
+                  "sessionUpdate": "tool_call_update",
+                  "toolCallId": "t1",
+                  "status": "completed",
+                  "rawOutput": {"stdout": "done"},
+                }),
+              )
+              ..consume(
+                upd({
+                  "sessionUpdate": "agent_message_chunk",
+                  "messageId": "m1",
+                  "content": testCase.afterTool,
+                }),
+              )
+              ..consume(
+                upd({
+                  "sessionUpdate": "tool_call",
+                  "toolCallId": "t1",
+                  "kind": "read",
+                  "title": "Read source.dart",
+                }),
+              );
 
         final message = collector.build().single;
         expect(message.info.id, "s1-mm1-assistant");
@@ -683,32 +681,32 @@ void main() {
     }
 
     test("an id-less image closes its replay draft before a following tool", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        initialUserMessageId: null,
-        haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
-      )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {
-              "type": "image",
-              "data": "AA==",
-              "mimeType": "image/png",
-              "uri": null,
-            },
-          }),
-        )
-        ..consume(
-          upd({
-            "sessionUpdate": "tool_call",
-            "toolCallId": "t1",
-            "kind": "read",
-            "status": "completed",
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+              sessionId: "s1",
+              agentId: "Cursor",
+              initialUserMessageId: null,
+              haltClassifier: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "content": {
+                  "type": "image",
+                  "data": "AA==",
+                  "mimeType": "image/png",
+                  "uri": null,
+                },
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "tool_call",
+                "toolCallId": "t1",
+                "kind": "read",
+                "status": "completed",
+              }),
+            );
 
       final messages = collector.build();
       expect(messages, hasLength(2));
@@ -721,26 +719,26 @@ void main() {
     });
 
     test("an explicit messageId after id-less text starts a new message", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        initialUserMessageId: null,
-        haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
-      )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "text", "text": "id-less draft"},
-          }),
-        )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "messageId": "m2",
-            "content": {"type": "text", "text": "identified message"},
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+              sessionId: "s1",
+              agentId: "Cursor",
+              initialUserMessageId: null,
+              haltClassifier: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "id-less draft"},
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "messageId": "m2",
+                "content": {"type": "text", "text": "identified message"},
+              }),
+            );
 
       final messages = collector.build();
       expect(messages, hasLength(2));
@@ -749,26 +747,26 @@ void main() {
     });
 
     test("id-less text after an explicit messageId starts a new message", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        initialUserMessageId: null,
-        haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
-      )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "messageId": "m1",
-            "content": {"type": "text", "text": "identified message"},
-          }),
-        )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "text", "text": "id-less message"},
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+              sessionId: "s1",
+              agentId: "Cursor",
+              initialUserMessageId: null,
+              haltClassifier: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "messageId": "m1",
+                "content": {"type": "text", "text": "identified message"},
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "id-less message"},
+              }),
+            );
 
       final messages = collector.build();
       expect(messages, hasLength(2));
@@ -777,35 +775,35 @@ void main() {
     });
 
     test("a same-message thought and text share the message; tools attach without an id", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        initialUserMessageId: null,
-        haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
-      )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_thought_chunk",
-            "messageId": "m1",
-            "content": {"type": "text", "text": "thinking"},
-          }),
-        )
-        ..consume(
-          upd({
-            "sessionUpdate": "tool_call",
-            "toolCallId": "t1",
-            "kind": "read",
-            "status": "completed",
-          }),
-        )
-        ..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "messageId": "m1",
-            "content": {"type": "text", "text": "answer"},
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+              sessionId: "s1",
+              agentId: "Cursor",
+              initialUserMessageId: null,
+              haltClassifier: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_thought_chunk",
+                "messageId": "m1",
+                "content": {"type": "text", "text": "thinking"},
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "tool_call",
+                "toolCallId": "t1",
+                "kind": "read",
+                "status": "completed",
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "messageId": "m1",
+                "content": {"type": "text", "text": "answer"},
+              }),
+            );
 
       final message = collector.build().single;
       expect(
@@ -819,22 +817,22 @@ void main() {
     });
 
     test("a halt notice replays as an error message with no text part", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        modelId: "claude-fable-5",
-        providerId: "cursor",
-        initialUserMessageId: null,
-        haltClassifier: ({required text}) => text.trim() == "Check your settings to continue"
-            ? const AcpHaltNotice(errorName: "cursor_gate", message: "Check your settings to continue")
-            : null,
-        contentMapper: const AcpContentMapper(),
-      )..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "text", "text": "\n\nCheck your settings to continue"},
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+            sessionId: "s1",
+            agentId: "Cursor",
+            modelId: "claude-fable-5",
+            providerId: "cursor",
+            initialUserMessageId: null,
+            haltClassifier: ({required text}) => text.trim() == "Check your settings to continue"
+                ? const AcpHaltNotice(errorName: "cursor_gate", message: "Check your settings to continue")
+                : null,
+          )..consume(
+            upd({
+              "sessionUpdate": "agent_message_chunk",
+              "content": {"type": "text", "text": "\n\nCheck your settings to continue"},
+            }),
+          );
 
       final message = collector.build().single;
       expect(message.info, isA<PluginMessageError>());
@@ -843,44 +841,44 @@ void main() {
     });
 
     test("an identified halt-like message remains assistant content", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        initialUserMessageId: null,
-        haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate", message: "gate"),
-        contentMapper: const AcpContentMapper(),
-      )..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "messageId": "m1",
-            "content": {"type": "text", "text": "Check your settings to continue"},
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+            sessionId: "s1",
+            agentId: "Cursor",
+            initialUserMessageId: null,
+            haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate", message: "gate"),
+          )..consume(
+            upd({
+              "sessionUpdate": "agent_message_chunk",
+              "messageId": "m1",
+              "content": {"type": "text", "text": "Check your settings to continue"},
+            }),
+          );
 
       expect(collector.build().single.info, isA<PluginMessageAssistant>());
     });
 
     test("an image-bearing halt-like message remains an assistant message", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        initialUserMessageId: null,
-        haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate", message: "gate"),
-        contentMapper: const AcpContentMapper(),
-      )..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "content": [
-              {
-                "type": "image",
-                "data": "AA==",
-                "mimeType": "image/png",
-                "uri": null,
-              },
-              {"type": "text", "text": "Check your settings to continue"},
-            ],
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+            sessionId: "s1",
+            agentId: "Cursor",
+            initialUserMessageId: null,
+            haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate", message: "gate"),
+          )..consume(
+            upd({
+              "sessionUpdate": "agent_message_chunk",
+              "content": [
+                {
+                  "type": "image",
+                  "data": "AA==",
+                  "mimeType": "image/png",
+                  "uri": null,
+                },
+                {"type": "text", "text": "Check your settings to continue"},
+              ],
+            }),
+          );
 
       final message = collector.build().single;
       expect(message.info, isA<PluginMessageAssistant>());
@@ -892,21 +890,21 @@ void main() {
     });
 
     test("unsupported content keeps halt-like replay text as an assistant message", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        initialUserMessageId: null,
-        haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate", message: "gate"),
-        contentMapper: const AcpContentMapper(),
-      )..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "content": [
-              {"type": "text", "text": "Check your settings to continue"},
-              {"type": "audio", "data": "private", "mimeType": "audio/wav"},
-            ],
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+            sessionId: "s1",
+            agentId: "Cursor",
+            initialUserMessageId: null,
+            haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate", message: "gate"),
+          )..consume(
+            upd({
+              "sessionUpdate": "agent_message_chunk",
+              "content": [
+                {"type": "text", "text": "Check your settings to continue"},
+                {"type": "audio", "data": "private", "mimeType": "audio/wav"},
+              ],
+            }),
+          );
 
       final message = collector.build().single;
       expect(message.info, isA<PluginMessageAssistant>());
@@ -914,18 +912,18 @@ void main() {
     });
 
     test("without a halt classifier the same chunk stays assistant text", () {
-      final collector = AcpReplayCollector(
-        sessionId: "s1",
-        agentId: "Cursor",
-        initialUserMessageId: null,
-        haltClassifier: null,
-        contentMapper: const AcpContentMapper(),
-      )..consume(
-          upd({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "text", "text": "Check your settings to continue"},
-          }),
-        );
+      final collector =
+          AcpReplayCollector(
+            sessionId: "s1",
+            agentId: "Cursor",
+            initialUserMessageId: null,
+            haltClassifier: null,
+          )..consume(
+            upd({
+              "sessionUpdate": "agent_message_chunk",
+              "content": {"type": "text", "text": "Check your settings to continue"},
+            }),
+          );
       final message = collector.build().single;
       expect(message.info, isA<PluginMessageAssistant>());
       expect(message.parts, isNotEmpty);
@@ -940,12 +938,11 @@ List<PluginMessagePart> _materializedLiveParts({
   for (final event in events) {
     if (event case BridgeSseMessagePartUpdated(:final part)) {
       parts[part.id] = part;
-    } else if (event
-        case BridgeSseMessagePartDelta(
-          :final partID,
-          field: "text",
-          :final delta,
-        )) {
+    } else if (event case BridgeSseMessagePartDelta(
+      :final partID,
+      field: "text",
+      :final delta,
+    )) {
       final prior = parts[partID]!;
       parts[partID] = prior.copyWith(text: "${prior.text ?? ""}$delta");
     }

--- a/bridge/sesori_plugin_acp/test/acp_session_options_service_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_options_service_test.dart
@@ -14,24 +14,18 @@ void main() {
       );
     final mapper = AcpEventMapper(
       launchDirectory: "/repo",
-      agentId: "agent",
       pluginId: "plugin",
       configurationTracker: tracker,
-      contentMapper: const AcpContentMapper(),
     );
 
     final defaultEvents = mapper.map(_messageUpdate(sessionId: "other"));
     final overrideEvents = mapper.map(_messageUpdate(sessionId: "session"));
-    final defaultMessage =
-        shared.Message.fromJson(
-              defaultEvents.whereType<BridgeSseMessageUpdated>().single.info,
-            )
-            as shared.MessageAssistant;
-    final overrideMessage =
-        shared.Message.fromJson(
-              overrideEvents.whereType<BridgeSseMessageUpdated>().single.info,
-            )
-            as shared.MessageAssistant;
+    final defaultMessage = shared.Message.fromJson(
+      defaultEvents.whereType<BridgeSseMessageUpdated>().single.info,
+    ) as shared.MessageAssistant;
+    final overrideMessage = shared.Message.fromJson(
+      overrideEvents.whereType<BridgeSseMessageUpdated>().single.info,
+    ) as shared.MessageAssistant;
 
     expect((defaultMessage.modelID, defaultMessage.providerID), ("default-model", "provider"));
     expect((overrideMessage.modelID, overrideMessage.providerID), ("session-model", "session-provider"));

--- a/bridge/sesori_plugin_acp/test/acp_stdio_client_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_stdio_client_test.dart
@@ -35,7 +35,11 @@ void main() {
       expect(frame["jsonrpc"], "2.0");
       final id = frame["id"];
 
-      fake.emit({"jsonrpc": "2.0", "id": id, "result": {"ok": true}});
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": {"ok": true},
+      });
       final result = await future;
       expect((result as Map)["ok"], true);
     });
@@ -126,9 +130,11 @@ void main() {
       });
       await expectLater(
         future,
-        throwsA(isA<AcpRpcException>()
-            .having((e) => e.code, "code", -32603)
-            .having((e) => e.message, "message", "unknown error")),
+        throwsA(
+          isA<AcpRpcException>()
+              .having((e) => e.code, "code", -32603)
+              .having((e) => e.message, "message", "unknown error"),
+        ),
       );
     });
   });
@@ -182,7 +188,11 @@ void main() {
 
       final request = client.request(method: "initialize");
       final id = replacement.written.single["id"];
-      replacement.emit({"jsonrpc": "2.0", "id": id, "result": {"ok": true}});
+      replacement.emit({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": {"ok": true},
+      });
       expect((await request as Map)["ok"], isTrue);
       expect(spawnIndex, 2);
     });
@@ -207,10 +217,12 @@ void main() {
 
       var replacementExited = false;
       unawaited(client.processExit.then((_) => replacementExited = true));
-      final outcome = client.request(method: "initialize").then<Object>(
-        (result) => result as Object,
-        onError: (Object error, StackTrace _) => error,
-      );
+      final outcome = client
+          .request(method: "initialize")
+          .then<Object>(
+            (result) => result as Object,
+            onError: (Object error, StackTrace _) => error,
+          );
       final id = replacement.written.single["id"];
 
       old.exit(23);
@@ -218,7 +230,11 @@ void main() {
       expect(client.isConnected, isTrue);
       expect(replacementExited, isFalse);
 
-      replacement.emit({"jsonrpc": "2.0", "id": id, "result": {"ok": true}});
+      replacement.emit({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": {"ok": true},
+      });
       expect((await outcome as Map)["ok"], isTrue);
     });
   });

--- a/bridge/sesori_plugin_acp/test/acp_step5_policy_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_step5_policy_test.dart
@@ -39,7 +39,7 @@ class _PolicyPlugin({
 
   @override
   Future<void> applyTurnSelection({
-    required AcpAgentApi api,
+    required AcpSessionConfigRepository configRepository,
     required String sessionId,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,

--- a/bridge/sesori_plugin_acp/test/acp_step5_policy_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_step5_policy_test.dart
@@ -11,7 +11,6 @@ class _PolicyPlugin({
   required final bool forms,
   required final Duration closeTimeout,
   required super.eventMapper,
-  required super.contentMapper,
   required super.commandTracker,
   required super.sessionOptionsService,
   required AcpProcessFactory super.processFactory,
@@ -40,7 +39,7 @@ class _PolicyPlugin({
 
   @override
   Future<void> applyTurnSelection({
-    required AcpSessionConfigRepository configRepository,
+    required AcpAgentApi api,
     required String sessionId,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
@@ -72,13 +71,10 @@ void main() {
         failClosed: failClosed,
         forms: forms,
         closeTimeout: closeTimeout,
-        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: "/repo",
-          agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
-          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_acp/test/acp_tool_content_integration_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_tool_content_integration_test.dart
@@ -127,10 +127,8 @@ void main() {
       test("matches live tool attachment state for ${testCase.name}", () {
         final mapper = AcpEventMapper(
           launchDirectory: "/repo",
-          agentId: "ACP",
           pluginId: "acp",
           configurationTracker: AcpSessionConfigurationTracker(),
-          contentMapper: const AcpContentMapper(),
         );
         final collector = _collector();
         PluginMessagePart? livePart;
@@ -160,10 +158,8 @@ void main() {
     setUp(() {
       mapper = AcpEventMapper(
         launchDirectory: "/repo",
-        agentId: "acp",
         pluginId: "acp",
         configurationTracker: AcpSessionConfigurationTracker(),
-        contentMapper: const AcpContentMapper(),
       );
     });
 
@@ -617,7 +613,6 @@ AcpReplayCollector _collector() => AcpReplayCollector(
   agentId: "ACP",
   initialUserMessageId: null,
   haltClassifier: null,
-  contentMapper: const AcpContentMapper(),
 );
 
 PluginToolState _replayState({required AcpReplayCollector collector}) => collector.build().single.parts.single.state!;

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -13,7 +13,6 @@ class _GatedSelectionPlugin({
   required super.launchSpec,
   required super.launchDirectory,
   required super.eventMapper,
-  required super.contentMapper,
   required super.commandTracker,
   required super.sessionOptionsService,
   required AcpProcessFactory super.processFactory,
@@ -22,7 +21,7 @@ class _GatedSelectionPlugin({
 
   @override
   Future<void> applyTurnSelection({
-    required AcpSessionConfigRepository configRepository,
+    required AcpAgentApi api,
     required String sessionId,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
@@ -92,13 +91,10 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
-          agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
-          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(
@@ -318,46 +314,49 @@ void main() {
     });
 
     for (final attachmentOnly in [false, true]) {
-      test("an initial ${attachmentOnly ? "attachment-only" : "mixed"} prompt dispatches and projects images", () async {
-        await connect();
-        emitted.clear();
+      test(
+        "an initial ${attachmentOnly ? "attachment-only" : "mixed"} prompt dispatches and projects images",
+        () async {
+          await connect();
+          emitted.clear();
 
-        final creating = plugin.createSession(
-          directory: cwd,
-          parentSessionId: null,
-          parts: [
-            const PluginPromptPart.text(text: "[SYSTEM CONTEXT — IMPORTANT] internal"),
-            if (!attachmentOnly) const PluginPromptPart.text(text: "visible prompt"),
-            const PluginPromptPart.fileData(
-              mime: "image/png",
-              base64: "AA==",
-              filename: "/private/image.png",
-            ),
-          ],
-          userVisibleText: attachmentOnly ? null : "visible prompt",
-          variant: null,
-          agent: null,
-          model: null,
-        );
-        respondTo(await waitForFrame("session/new"), {"sessionId": "s1"});
-        await creating;
+          final creating = plugin.createSession(
+            directory: cwd,
+            parentSessionId: null,
+            parts: [
+              const PluginPromptPart.text(text: "[SYSTEM CONTEXT — IMPORTANT] internal"),
+              if (!attachmentOnly) const PluginPromptPart.text(text: "visible prompt"),
+              const PluginPromptPart.fileData(
+                mime: "image/png",
+                base64: "AA==",
+                filename: "/private/image.png",
+              ),
+            ],
+            userVisibleText: attachmentOnly ? null : "visible prompt",
+            variant: null,
+            agent: null,
+            model: null,
+          );
+          respondTo(await waitForFrame("session/new"), {"sessionId": "s1"});
+          await creating;
 
-        final prompt = await waitForFrame("session/prompt");
-        final content = (prompt["params"] as Map)["prompt"] as List;
-        expect(content.where((block) => (block as Map)["type"] == "image"), hasLength(1));
-        final projected = emitted.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part).toList();
-        expect(projected.map((part) => part.type), [
-          if (!attachmentOnly) PluginMessagePartType.text,
-          PluginMessagePartType.file,
-        ]);
-        expect(
-          projected.where((part) => part.type == PluginMessagePartType.file).single.attachment,
-          isA<PluginMessageAttachmentInlineImage>(),
-        );
-        expect(emitted.toString(), isNot(contains("SYSTEM CONTEXT")));
-        expect(emitted.toString(), isNot(contains("/private/image.png")));
-        respondTo(prompt, {"stopReason": "end_turn"});
-      });
+          final prompt = await waitForFrame("session/prompt");
+          final content = (prompt["params"] as Map)["prompt"] as List;
+          expect(content.where((block) => (block as Map)["type"] == "image"), hasLength(1));
+          final projected = emitted.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part).toList();
+          expect(projected.map((part) => part.type), [
+            if (!attachmentOnly) PluginMessagePartType.text,
+            PluginMessagePartType.file,
+          ]);
+          expect(
+            projected.where((part) => part.type == PluginMessagePartType.file).single.attachment,
+            isA<PluginMessageAttachmentInlineImage>(),
+          );
+          expect(emitted.toString(), isNot(contains("SYSTEM CONTEXT")));
+          expect(emitted.toString(), isNot(contains("/private/image.png")));
+          respondTo(prompt, {"stopReason": "end_turn"});
+        },
+      );
     }
 
     test("a command emits only its user-visible arguments", () async {
@@ -607,13 +606,10 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
-          agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
-          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(
@@ -738,13 +734,10 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
-          agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
-          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(
@@ -976,13 +969,10 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        contentMapper: const AcpContentMapper(),
         eventMapper: AcpEventMapper(
           launchDirectory: cwd,
-          agentId: "acp",
           pluginId: "acp",
           configurationTracker: configurationTracker,
-          contentMapper: const AcpContentMapper(),
         ),
         commandTracker: commandTracker,
         sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -21,7 +21,7 @@ class _GatedSelectionPlugin({
 
   @override
   Future<void> applyTurnSelection({
-    required AcpAgentApi api,
+    required AcpSessionConfigRepository configRepository,
     required String sessionId,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,

--- a/bridge/sesori_plugin_acp/test/repositories/trackers/acp_content_tracker_test.dart
+++ b/bridge/sesori_plugin_acp/test/repositories/trackers/acp_content_tracker_test.dart
@@ -125,25 +125,21 @@ class _BufferingStdout() implements Stdout {
 
 AcpMappedInlineImageContentBlock _inline({required int decodedBytes}) {
   return AcpMappedInlineImageContentBlock(
-    attachment:
-        const PluginMessageAttachment.inlineImage(
-              mime: "image/png",
-              base64: "AA==",
-              filename: "image.png",
-            )
-            as PluginMessageAttachmentInlineImage,
+    attachment: const PluginMessageAttachment.inlineImage(
+      mime: "image/png",
+      base64: "AA==",
+      filename: "image.png",
+    ) as PluginMessageAttachmentInlineImage,
     decodedBytes: decodedBytes,
   );
 }
 
 AcpMappedMetadataImageContentBlock _metadata() {
   return const AcpMappedMetadataImageContentBlock(
-    attachment:
-        PluginMessageAttachment.metadata(
-              mime: "image/png",
-              filename: "image.png",
-            )
-            as PluginMessageAttachmentMetadata,
+    attachment: PluginMessageAttachment.metadata(
+      mime: "image/png",
+      filename: "image.png",
+    ) as PluginMessageAttachmentMetadata,
     reason: AcpImageDegradationReason.invalid,
   );
 }

--- a/bridge/sesori_plugin_acp/test/repositories/trackers/acp_tool_content_tracker_test.dart
+++ b/bridge/sesori_plugin_acp/test/repositories/trackers/acp_tool_content_tracker_test.dart
@@ -150,25 +150,21 @@ AcpMappedInlineImageContentBlock _inline({
   required int decodedBytes,
 }) {
   return AcpMappedInlineImageContentBlock(
-    attachment:
-        PluginMessageAttachment.inlineImage(
-              mime: "image/png",
-              base64: "AA==",
-              filename: filename,
-            )
-            as PluginMessageAttachmentInlineImage,
+    attachment: PluginMessageAttachment.inlineImage(
+      mime: "image/png",
+      base64: "AA==",
+      filename: filename,
+    ) as PluginMessageAttachmentInlineImage,
     decodedBytes: decodedBytes,
   );
 }
 
 AcpMappedMetadataImageContentBlock _metadata() {
   return const AcpMappedMetadataImageContentBlock(
-    attachment:
-        PluginMessageAttachment.metadata(
-              mime: "image/png",
-              filename: "private.png",
-            )
-            as PluginMessageAttachmentMetadata,
+    attachment: PluginMessageAttachment.metadata(
+      mime: "image/png",
+      filename: "private.png",
+    ) as PluginMessageAttachmentMetadata,
     reason: AcpImageDegradationReason.invalid,
   );
 }

--- a/bridge/sesori_plugin_cursor/lib/src/api/cursor_catalog_probe_api.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/api/cursor_catalog_probe_api.dart
@@ -2,6 +2,7 @@ import "dart:async";
 
 import "package:acp_plugin/acp_plugin.dart";
 
+import "../cursor_binary.dart";
 import "models/cursor_available_models_dto.dart";
 
 /// Layer-1 ACP operations used by Cursor's isolated catalog-probe process.
@@ -23,39 +24,12 @@ class CursorCatalogProbeApi({required final AcpStdioClient _client}) {
       _initializeResult = null;
       await _client.connect().timeout(_remaining(timeout: timeout, stopwatch: stopwatch));
     }
-
-    var initializeResult = _initializeResult;
-    if (initializeResult == null) {
-      final raw = await _client.request(
-        method: AcpMethods.initialize,
-        params: buildInitializeParams(
-          clientName: "sesori-bridge",
-          clientVersion: "0.0.0",
-          formElicitation: false,
-          capabilityMeta: const {"parameterizedModelPicker": true},
-        ),
-        timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
-      );
-      initializeResult = AcpInitializeResult.fromJson(
-        raw is Map ? raw.cast<String, dynamic>() : const {},
-      );
-      if (initializeResult.protocolVersion != acpProtocolVersion) {
-        throw StateError(
-          "ACP agent negotiated protocol version ${initializeResult.protocolVersion}, "
-          "but this client only speaks v$acpProtocolVersion",
-        );
-      }
-      if (initializeResult.requiresAuth) {
-        await _client.request(
-          method: AcpMethods.authenticate,
-          params: const {"methodId": "cursor_login"},
-          timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
-        );
-      }
-      _initializeResult = initializeResult;
-    }
-
-    return initializeResult;
+    return _initializeResult ??= await AcpAgentApi(client: _client).initialize(
+      formElicitation: false,
+      capabilityMeta: CursorBinary.acpCapabilityMeta,
+      authMethodId: CursorBinary.acpAuthMethodId,
+      timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
+    );
   }
 
   /// Lists every page for the required nullable Cursor cwd filter.
@@ -63,23 +37,15 @@ class CursorCatalogProbeApi({required final AcpStdioClient _client}) {
     required String? cwd,
     required Duration timeout,
   }) async {
-    if (_initializeResult == null || !_client.isConnected) {
-      throw StateError("Cursor catalog probe is not initialized");
-    }
+    final api = _initializedApi();
     final stopwatch = Stopwatch()..start();
     final sessions = <AcpSessionInfo>[];
     String? cursor;
     for (var page = 0; page < _maxPages; page++) {
-      final raw = await _client.request(
-        method: AcpMethods.sessionList,
-        params: {
-          "cwd": ?cwd,
-          "cursor": ?cursor,
-        },
+      final result = await api.listSessionsPage(
+        cwd: cwd,
+        cursor: cursor,
         timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
-      );
-      final result = AcpSessionListResult.fromJson(
-        raw is Map ? raw.cast<String, dynamic>() : const {},
       );
       sessions.addAll(result.sessions);
       final nextCursor = result.nextCursor;
@@ -91,10 +57,7 @@ class CursorCatalogProbeApi({required final AcpStdioClient _client}) {
 
   /// Reads Cursor's account model catalog without creating a session.
   Future<CursorAvailableModelsDto> listAvailableModels({required Duration timeout}) async {
-    if (_initializeResult == null || !_client.isConnected) {
-      throw StateError("Cursor catalog probe is not initialized");
-    }
-    final raw = await _client.request(
+    final raw = await _initializedApi().client.request(
       method: _listAvailableModelsMethod,
       timeout: timeout,
     );
@@ -108,23 +71,7 @@ class CursorCatalogProbeApi({required final AcpStdioClient _client}) {
     required String sessionId,
     required String cwd,
     required Duration timeout,
-  }) async {
-    if (_initializeResult == null || !_client.isConnected) {
-      throw StateError("Cursor catalog probe is not initialized");
-    }
-    final raw = await _client.request(
-      method: AcpMethods.sessionLoad,
-      params: {
-        "sessionId": sessionId,
-        "cwd": cwd,
-        "mcpServers": const <Object?>[],
-      },
-      timeout: timeout,
-    );
-    return AcpNewSessionResult.fromJson(
-      raw is Map ? raw.cast<String, dynamic>() : const {},
-    );
-  }
+  }) => _initializedApi().loadSession(sessionId: sessionId, cwd: cwd, timeout: timeout);
 
   Future<void> reset() async {
     if (_disposed) return;
@@ -137,6 +84,13 @@ class CursorCatalogProbeApi({required final AcpStdioClient _client}) {
     _disposed = true;
     _initializeResult = null;
     await _client.dispose();
+  }
+
+  AcpAgentApi _initializedApi() {
+    if (_initializeResult == null || !_client.isConnected) {
+      throw StateError("Cursor catalog probe is not initialized");
+    }
+    return AcpAgentApi(client: _client);
   }
 
   Duration _remaining({required Duration timeout, required Stopwatch stopwatch}) {

--- a/bridge/sesori_plugin_cursor/lib/src/api/models/cursor_available_models_dto.g.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/api/models/cursor_available_models_dto.g.dart
@@ -6,55 +6,51 @@ part of 'cursor_available_models_dto.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_CursorAvailableModelsDto _$CursorAvailableModelsDtoFromJson(Map json) =>
-    _CursorAvailableModelsDto(
-      models:
-          (json['models'] as List<dynamic>?)
-              ?.map(
-                (e) => CursorAvailableModelDto.fromJson(
-                  Map<String, dynamic>.from(e as Map),
-                ),
-              )
-              .toList() ??
-          const <CursorAvailableModelDto>[],
-    );
+_CursorAvailableModelsDto _$CursorAvailableModelsDtoFromJson(Map json) => _CursorAvailableModelsDto(
+  models:
+      (json['models'] as List<dynamic>?)
+          ?.map(
+            (e) => CursorAvailableModelDto.fromJson(
+              Map<String, dynamic>.from(e as Map),
+            ),
+          )
+          .toList() ??
+      const <CursorAvailableModelDto>[],
+);
 
-_CursorAvailableModelDto _$CursorAvailableModelDtoFromJson(Map json) =>
-    _CursorAvailableModelDto(
-      value: json['value'] as String,
-      name: json['name'] as String?,
-      configOptions:
-          (json['configOptions'] as List<dynamic>?)
-              ?.map(
-                (e) => CursorModelConfigOptionDto.fromJson(
-                  Map<String, dynamic>.from(e as Map),
-                ),
-              )
-              .toList() ??
-          const <CursorModelConfigOptionDto>[],
-    );
+_CursorAvailableModelDto _$CursorAvailableModelDtoFromJson(Map json) => _CursorAvailableModelDto(
+  value: json['value'] as String,
+  name: json['name'] as String?,
+  configOptions:
+      (json['configOptions'] as List<dynamic>?)
+          ?.map(
+            (e) => CursorModelConfigOptionDto.fromJson(
+              Map<String, dynamic>.from(e as Map),
+            ),
+          )
+          .toList() ??
+      const <CursorModelConfigOptionDto>[],
+);
 
-_CursorModelConfigOptionDto _$CursorModelConfigOptionDtoFromJson(Map json) =>
-    _CursorModelConfigOptionDto(
-      id: json['id'] as String,
-      name: json['name'] as String?,
-      description: json['description'] as String?,
-      category: json['category'] as String?,
-      currentValue: json['currentValue'] as String?,
-      options:
-          (json['options'] as List<dynamic>?)
-              ?.map(
-                (e) => CursorConfigOptionValueDto.fromJson(
-                  Map<String, dynamic>.from(e as Map),
-                ),
-              )
-              .toList() ??
-          const <CursorConfigOptionValueDto>[],
-    );
+_CursorModelConfigOptionDto _$CursorModelConfigOptionDtoFromJson(Map json) => _CursorModelConfigOptionDto(
+  id: json['id'] as String,
+  name: json['name'] as String?,
+  description: json['description'] as String?,
+  category: json['category'] as String?,
+  currentValue: json['currentValue'] as String?,
+  options:
+      (json['options'] as List<dynamic>?)
+          ?.map(
+            (e) => CursorConfigOptionValueDto.fromJson(
+              Map<String, dynamic>.from(e as Map),
+            ),
+          )
+          .toList() ??
+      const <CursorConfigOptionValueDto>[],
+);
 
-_CursorConfigOptionValueDto _$CursorConfigOptionValueDtoFromJson(Map json) =>
-    _CursorConfigOptionValueDto(
-      value: json['value'] as String,
-      name: json['name'] as String?,
-      description: json['description'] as String?,
-    );
+_CursorConfigOptionValueDto _$CursorConfigOptionValueDtoFromJson(Map json) => _CursorConfigOptionValueDto(
+  value: json['value'] as String,
+  name: json['name'] as String?,
+  description: json['description'] as String?,
+);

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_binary.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_binary.dart
@@ -1,6 +1,8 @@
 import "package:acp_plugin/acp_plugin.dart";
 
-/// Builds the launch spec for `cursor-agent acp`.
+/// Builds the launch spec for `cursor-agent acp` and declares the handshake
+/// policies every Sesori ACP connection to it (live plugin and catalog probe)
+/// uses.
 ///
 /// Auth is out of band: the default process factory inherits the bridge's
 /// environment, so `CURSOR_API_KEY` / `CURSOR_AUTH_TOKEN` (or a prior
@@ -9,6 +11,13 @@ abstract final class CursorBinary() {
   /// The current installer exposes both names for the same payload. Use
   /// `cursor-agent` because older installs may not provide the `agent` symlink.
   static const String defaultBinary = "cursor-agent";
+
+  /// The ACP auth method cursor-agent advertises for its local login state.
+  static const String acpAuthMethodId = "cursor_login";
+
+  /// Non-standard `clientCapabilities._meta` hint that unlocks cursor-agent's
+  /// per-model `configOptions` picker.
+  static const Map<String, dynamic> acpCapabilityMeta = {"parameterizedModelPicker": true};
 
   static AcpLaunchSpec launchSpec({
     String binary = defaultBinary,

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
@@ -17,7 +17,6 @@ class CursorEventMapper({
   required super.launchDirectory,
   required super.pluginId,
   required super.configurationTracker,
-  required super.contentMapper,
   required final CursorGeneratedImageReader _generatedImageReader,
 
   /// The plugin's active-turn resolver ([AcpPlugin.activeTurnSessionId]) — the
@@ -29,8 +28,6 @@ class CursorEventMapper({
   /// session is deleted.
   required final String? Function() _activeSessionResolver,
 }) extends AcpEventMapper {
-  this : super(agentId: pluginId);
-
   @override
   List<BridgeSseEvent> mapExtension(AcpNotification notification) {
     switch (notification.method) {

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
@@ -17,10 +17,13 @@ import "services/cursor_session_options_service.dart";
 import "trackers/cursor_catalog_tracker.dart";
 
 /// Cursor backend over ACP plus Cursor's config-option model picker.
+///
+/// Cursor keeps every stock ACP turn policy. Its selection writes are
+/// best-effort (`_setConfig` never throws), so `failsTurnOnSelectionError` is
+/// moot and left at the base default.
 class CursorPlugin._({
   required super.launchSpec,
   required super.launchDirectory,
-  required super.contentMapper,
   required CursorEventMapper mapper,
   required final CursorCatalogService _catalogService,
   required final AcpCommandListener _catalogCommandListener,
@@ -63,7 +66,6 @@ class CursorPlugin._({
     final commandTracker = AcpCommandTracker();
     final stagedCommandTracker = AcpCommandTracker();
     final configurationTracker = AcpSessionConfigurationTracker();
-    const contentMapper = AcpContentMapper();
     final acpSessionOptionsService = AcpSessionOptionsService(
       configurationTracker: configurationTracker,
       commandTracker: commandTracker,
@@ -96,7 +98,6 @@ class CursorPlugin._({
       launchDirectory: cwd,
       pluginId: pluginId,
       configurationTracker: configurationTracker,
-      contentMapper: contentMapper,
       generatedImageReader: const CursorGeneratedImageReader(),
       activeSessionResolver: () => plugin.activeTurnSessionId,
     );
@@ -104,7 +105,6 @@ class CursorPlugin._({
       launchSpec: launchSpec,
       launchDirectory: cwd,
       mapper: mapper,
-      contentMapper: contentMapper,
       processFactory: processFactory,
       catalogService: catalogService,
       catalogCommandListener: catalogCommandListener,
@@ -130,31 +130,10 @@ class CursorPlugin._({
   String? _appliedThoughtLevelId;
 
   @override
-  String get clientName => "sesori-bridge";
+  String? get authMethodId => CursorBinary.acpAuthMethodId;
 
   @override
-  String get clientVersion => "0.0.0";
-
-  @override
-  String? get authMethodId => "cursor_login";
-
-  @override
-  Map<String, dynamic>? get initializeCapabilityMeta => const {"parameterizedModelPicker": true};
-
-  @override
-  bool get supportsFormElicitation => false;
-
-  @override
-  bool get serializesPromptsProcessWide => false;
-
-  @override
-  bool get cancelsActiveTurnForQueuedInput => false;
-
-  @override
-  bool get failsTurnOnSelectionError => false;
-
-  @override
-  Duration get sessionCloseSettlementTimeout => const Duration(seconds: 5);
+  Map<String, dynamic>? get initializeCapabilityMeta => CursorBinary.acpCapabilityMeta;
 
   @override
   AcpApprovalRegistry buildApprovalRegistry(AcpStdioClient client) {
@@ -169,8 +148,8 @@ class CursorPlugin._({
   @override
   void captureSessionConfig(
     AcpNewSessionResult result, {
-    String? sessionId,
-    bool fromNewSession = false,
+    required String? sessionId,
+    required bool fromNewSession,
   }) {
     final capture = _catalogService.captureSessionConfig(
       result: result,
@@ -201,12 +180,13 @@ class CursorPlugin._({
 
   @override
   Future<void> applyTurnSelection({
-    required AcpSessionConfigRepository configRepository,
+    required AcpAgentApi api,
     required String sessionId,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
     required String? agent,
   }) async {
+    final configRepository = AcpSessionConfigRepository(api: api);
     final requestedModel = model?.modelID;
     final useDefault = requestedModel == null || requestedModel.isEmpty;
     final targetModel = useDefault

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
@@ -180,13 +180,12 @@ class CursorPlugin._({
 
   @override
   Future<void> applyTurnSelection({
-    required AcpAgentApi api,
+    required AcpSessionConfigRepository configRepository,
     required String sessionId,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
     required String? agent,
   }) async {
-    final configRepository = AcpSessionConfigRepository(api: api);
     final requestedModel = model?.modelID;
     final useDefault = requestedModel == null || requestedModel.isEmpty;
     final targetModel = useDefault

--- a/bridge/sesori_plugin_cursor/lib/src/repositories/cursor_generated_image_reader.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/repositories/cursor_generated_image_reader.dart
@@ -75,13 +75,11 @@ final class const CursorGeneratedImageReader() {
       }
       return [
         AcpMappedInlineImageContentBlock(
-          attachment:
-              PluginMessageAttachment.inlineImage(
-                    mime: mime,
-                    base64: base64,
-                    filename: basename,
-                  )
-                  as PluginMessageAttachmentInlineImage,
+          attachment: PluginMessageAttachment.inlineImage(
+            mime: mime,
+            base64: base64,
+            filename: basename,
+          ) as PluginMessageAttachmentInlineImage,
           decodedBytes: bytes.length,
         ),
       ];

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
@@ -63,13 +63,14 @@ CursorPlugin _defaultBuildPlugin({
 /// The optional constructor parameters are test seams; the registered instance
 /// is `const CursorPluginDescriptor()`.
 class const CursorPluginDescriptor({
-    final CursorPluginFactory? _buildPlugin,
-    final Duration _connectBudget = const Duration(seconds: 15),
-    final Duration _versionProbeTimeout = const Duration(seconds: 10),
-    /// Test seam for existing-runtime resolution. Production builds a default in
-    /// [ensureRuntime] from the host's process service.
-    final ManagedRuntimeProvisionService? _provisionService,
-  }) extends BridgePluginDescriptor {
+  final CursorPluginFactory? _buildPlugin,
+  final Duration _connectBudget = const Duration(seconds: 15),
+  final Duration _versionProbeTimeout = const Duration(seconds: 10),
+
+  /// Test seam for existing-runtime resolution. Production builds a default in
+  /// [ensureRuntime] from the host's process service.
+  final ManagedRuntimeProvisionService? _provisionService,
+}) extends BridgePluginDescriptor {
   /// Minimum Cursor CLI build the bridge supports, owned by
   /// [CursorRuntimeManifest.minPathVersion]. Earlier builds (e.g.
   /// `2026.05.28`) advertise the `acp` model picker and `session/load` but
@@ -248,6 +249,7 @@ class const CursorPluginDescriptor({
       processes: processes,
       environment: environment,
     );
+
     /// The pinned managed runtime's version when it is already installed and
     /// runnable, or null. Only consulted without an explicit `--cursor-bin`,
     /// which is authoritative when set.
@@ -450,34 +452,11 @@ class const CursorPluginDescriptor({
       processFactory: processFactory,
       sessionCleanupService: sessionCleanupService,
     );
-
-    final plugin = AcpBridgePlugin(
-      plugin: cursor,
-      clock: host.clock,
-      endpoint: "$binaryPath acp",
-    );
-
-    // Rolls back the spawned agent and surfaces an abort that arrived while
-    // connecting rather than returning a live plugin.
-    Future<Never> rollbackAborted() async {
-      try {
-        await plugin.shutdown(budget: null);
-      } on Object catch (error) {
-        Log.e("[cursor] rollback after aborted start failed: $error");
-      }
-      throw const PluginStartAbortedException();
-    }
-
-    // Eagerly spawn the agent and run the ACP handshake (bounded), so the first
-    // mobile request is fast and the status reflects reality. A timeout/failure
-    // leaves the plugin degraded rather than failing the bridge.
-    await plugin.connect(budget: _connectBudget, startAborted: host.startAborted);
-
-    if (host.startAborted.isAborted) {
-      await rollbackAborted();
-    }
-
-    return plugin;
+    // Eagerly spawns the agent and runs the ACP handshake (bounded), so the
+    // first mobile request is fast and the status reflects reality; a
+    // timeout/failure leaves the plugin degraded rather than failing the bridge,
+    // and an abort that lands while connecting is rolled back.
+    return await AcpBridgePlugin.start(plugin: cursor, host: host, connectBudget: _connectBudget);
   }
 }
 

--- a/bridge/sesori_plugin_cursor/test/cursor_approval_registry_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_approval_registry_test.dart
@@ -84,7 +84,9 @@ void main() {
 
       expect(registry.pendingForSession("s1"), hasLength(1));
 
-      registry.replyQuestion(asked.id, [["Yes"]]);
+      registry.replyQuestion(asked.id, [
+        ["Yes"],
+      ]);
       final reply = fake.written.last;
       expect(reply["id"], 1);
       final questions = (reply["result"] as Map)["questions"] as List;
@@ -103,7 +105,9 @@ void main() {
       final asked = emitted.single as BridgeSseQuestionAsked;
       expect(asked.questions.single.header, "Plan A");
 
-      registry.replyQuestion(asked.id, [["Accept"]]);
+      registry.replyQuestion(asked.id, [
+        ["Accept"],
+      ]);
       final reply = fake.written.last;
       expect((reply["result"] as Map)["accepted"], true);
     });
@@ -243,8 +247,7 @@ void main() {
       await pump();
       final pending = registry.pendingForSession("s1").single;
       final labels = pending.questions.single.options.map((o) => o.label).toList();
-      expect(labels, ["Option", "Option (2)"],
-          reason: "duplicate labels are made unique so label->id stays 1:1");
+      expect(labels, ["Option", "Option (2)"], reason: "duplicate labels are made unique so label->id stays 1:1");
     });
 
     test("questions with no usable text are dropped", () async {

--- a/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
@@ -15,7 +15,6 @@ void main() {
         launchDirectory: "/repo",
         pluginId: CursorPlugin.pluginId,
         configurationTracker: AcpSessionConfigurationTracker(),
-        contentMapper: const AcpContentMapper(),
         generatedImageReader: const CursorGeneratedImageReader(),
         activeSessionResolver: activeSessionResolver ?? () => null,
       );

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
@@ -336,7 +336,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -363,7 +363,7 @@ void main() {
       expect(sets[2]["value"], "high");
 
       final again = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -385,7 +385,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: null,
@@ -419,7 +419,7 @@ void main() {
       await client.connect();
 
       final first = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: const PluginSessionVariant(id: "high"),
@@ -434,7 +434,7 @@ void main() {
       await first;
 
       final second = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -467,7 +467,7 @@ void main() {
       await client.connect();
 
       final first = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: const PluginSessionVariant(id: "high"),
@@ -501,7 +501,7 @@ void main() {
       await first;
 
       final second = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -553,7 +553,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -585,7 +585,7 @@ void main() {
       await client.connect();
 
       final selectingHigh = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -618,7 +618,7 @@ void main() {
       await selectingHigh;
 
       final restoringDefault = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: null,
@@ -647,7 +647,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "not-a-real-model"),
         variant: null,
@@ -692,7 +692,7 @@ void main() {
       );
 
       await plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "s1",
         model: null,
         variant: null,
@@ -713,7 +713,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: const PluginSessionVariant(id: "not-a-real-effort"),
@@ -744,7 +744,7 @@ void main() {
       await client.connect();
 
       final selecting = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "sA",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: null,
@@ -759,7 +759,7 @@ void main() {
       await selecting;
 
       final defaulting = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "sB",
         model: null,
         variant: null,
@@ -792,7 +792,7 @@ void main() {
       await client.connect();
 
       final a = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "sA",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: null,
@@ -807,7 +807,7 @@ void main() {
       await a;
 
       final b = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "sB",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: null,
@@ -821,7 +821,7 @@ void main() {
       await b;
 
       final aAgain = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "sA",
         model: null,
         variant: null,
@@ -854,7 +854,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: null,
@@ -885,7 +885,7 @@ void main() {
       await client.connect();
 
       final a = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "sA",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: null,
@@ -900,7 +900,7 @@ void main() {
       await a;
 
       final b = plugin.applyTurnSelection(
-        api: AcpAgentApi(client: client),
+        configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
         sessionId: "sB",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: null,
@@ -930,7 +930,7 @@ void main() {
 
       Future<void> applyOnce() async {
         final applying = plugin.applyTurnSelection(
-          api: AcpAgentApi(client: client),
+          configRepository: AcpSessionConfigRepository(api: AcpAgentApi(client: client)),
           sessionId: "s1",
           model: (providerID: "cursor", modelID: "sonnet-4.6"),
           variant: const PluginSessionVariant(id: "high"),

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
@@ -336,7 +336,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -363,7 +363,7 @@ void main() {
       expect(sets[2]["value"], "high");
 
       final again = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -385,7 +385,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: null,
@@ -419,7 +419,7 @@ void main() {
       await client.connect();
 
       final first = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: const PluginSessionVariant(id: "high"),
@@ -434,7 +434,7 @@ void main() {
       await first;
 
       final second = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -467,7 +467,7 @@ void main() {
       await client.connect();
 
       final first = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: const PluginSessionVariant(id: "high"),
@@ -501,7 +501,7 @@ void main() {
       await first;
 
       final second = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -553,7 +553,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -585,7 +585,7 @@ void main() {
       await client.connect();
 
       final selectingHigh = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: const PluginSessionVariant(id: "high"),
@@ -618,7 +618,7 @@ void main() {
       await selectingHigh;
 
       final restoringDefault = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: null,
@@ -647,7 +647,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "not-a-real-model"),
         variant: null,
@@ -692,7 +692,7 @@ void main() {
       );
 
       await plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "s1",
         model: null,
         variant: null,
@@ -713,7 +713,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: const PluginSessionVariant(id: "not-a-real-effort"),
@@ -744,7 +744,7 @@ void main() {
       await client.connect();
 
       final selecting = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "sA",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: null,
@@ -759,7 +759,7 @@ void main() {
       await selecting;
 
       final defaulting = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "sB",
         model: null,
         variant: null,
@@ -792,7 +792,7 @@ void main() {
       await client.connect();
 
       final a = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "sA",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: null,
@@ -807,7 +807,7 @@ void main() {
       await a;
 
       final b = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "sB",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: null,
@@ -821,7 +821,7 @@ void main() {
       await b;
 
       final aAgain = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "sA",
         model: null,
         variant: null,
@@ -854,7 +854,7 @@ void main() {
       await client.connect();
 
       final applying = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "s1",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: null,
@@ -885,7 +885,7 @@ void main() {
       await client.connect();
 
       final a = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "sA",
         model: (providerID: "cursor", modelID: "sonnet-4.6"),
         variant: null,
@@ -900,7 +900,7 @@ void main() {
       await a;
 
       final b = plugin.applyTurnSelection(
-        configRepository: AcpSessionConfigRepository(client: client),
+        api: AcpAgentApi(client: client),
         sessionId: "sB",
         model: (providerID: "cursor", modelID: "gpt-5.4"),
         variant: null,
@@ -930,7 +930,7 @@ void main() {
 
       Future<void> applyOnce() async {
         final applying = plugin.applyTurnSelection(
-          configRepository: AcpSessionConfigRepository(client: client),
+          api: AcpAgentApi(client: client),
           sessionId: "s1",
           model: (providerID: "cursor", modelID: "sonnet-4.6"),
           variant: const PluginSessionVariant(id: "high"),

--- a/bridge/sesori_plugin_hermes/lib/src/api/hermes_acp_api.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/api/hermes_acp_api.dart
@@ -35,31 +35,13 @@ class HermesAcpApi({
     );
     _scratchClient = client;
     await client.connect().timeout(_remaining(timeout: timeout, stopwatch: stopwatch));
-    final raw = await client.request(
-      method: AcpMethods.initialize,
-      params: buildInitializeParams(
-        clientName: "sesori-bridge",
-        clientVersion: "0.0.0",
-        formElicitation: false,
-      ),
-      timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
-    );
-    final result = AcpInitializeResult.fromJson(
-      raw is Map ? raw.cast<String, dynamic>() : const {},
-    );
-    if (result.protocolVersion != acpProtocolVersion) {
-      throw StateError(
-        "Hermes negotiated ACP v${result.protocolVersion}; expected v$acpProtocolVersion",
-      );
-    }
-    if (!result.requiresAuth) return;
-    final methodId = _authMethodId(result);
-    if (methodId == null) {
-      throw StateError("Hermes model discovery requires non-terminal authentication");
-    }
-    await client.request(
-      method: AcpMethods.authenticate,
-      params: {"methodId": methodId},
+    // Same stock handshake as the live plugin: no capability meta, and the
+    // first non-terminal auth method (Hermes advertises its configured provider
+    // first, then an interactive terminal setup the bridge cannot complete).
+    await AcpAgentApi(client: client).initialize(
+      formElicitation: false,
+      capabilityMeta: null,
+      authMethodId: null,
       timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
     );
   }
@@ -67,16 +49,7 @@ class HermesAcpApi({
   Future<AcpNewSessionResult> newScratchSession({
     required String cwd,
     required Duration timeout,
-  }) async {
-    final raw = await _scratchRequest(
-      method: AcpMethods.sessionNew,
-      params: {"cwd": cwd, "mcpServers": const <Object?>[]},
-      timeout: timeout,
-    );
-    return AcpNewSessionResult.fromJson(
-      raw is Map ? raw.cast<String, dynamic>() : const {},
-    );
-  }
+  }) => AcpAgentApi(client: _openScratchClient()).newSession(cwd: cwd, timeout: timeout);
 
   Future<void> setModel({
     required AcpStdioClient liveClient,
@@ -123,23 +96,12 @@ class HermesAcpApi({
     await settleScratch(timeout: const Duration(seconds: 5));
   }
 
-  Future<dynamic> _scratchRequest({
-    required String method,
-    required Object? params,
-    required Duration timeout,
-  }) {
+  AcpStdioClient _openScratchClient() {
     final client = _scratchClient;
     if (client == null || !client.isConnected) {
       throw StateError("Hermes scratch ACP lease is not open");
     }
-    return client.request(method: method, params: params, timeout: timeout);
-  }
-
-  String? _authMethodId(AcpInitializeResult result) {
-    for (final method in result.authMethods) {
-      if (method.type != AcpAuthMethodType.terminal) return method.id;
-    }
-    return null;
+    return client;
   }
 
   Duration _remaining({required Duration timeout, required Stopwatch stopwatch}) {

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
@@ -41,18 +41,25 @@ class HermesPlugin({
     fromNewSession: fromNewSession,
   );
 
+  /// Hermes selects models through its `session/set_model` extension, so the
+  /// standard config repository is unused; the write goes through the Hermes
+  /// repository over the live client.
   @override
   Future<void> applyTurnSelection({
-    required AcpAgentApi api,
+    required AcpSessionConfigRepository configRepository,
     required String sessionId,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
     required String? agent,
-  }) => _hermesSessionOptionsService.applyTurnSelection(
-    liveClient: api.client,
-    sessionId: sessionId,
-    model: model,
-  );
+  }) async {
+    final liveClient = client;
+    if (liveClient == null) throw StateError("Hermes ACP client is not connected");
+    await _hermesSessionOptionsService.applyTurnSelection(
+      liveClient: liveClient,
+      sessionId: sessionId,
+      model: model,
+    );
+  }
 
   @override
   Future<PluginSessionOptionsDiscoveryResult> getSessionOptions({

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
@@ -8,16 +8,16 @@ import "services/hermes_session_options_service.dart";
 ///
 /// Hermes is a stock ACP v1 server: `hermes acp` advertises load/list/resume/
 /// fork/prompt capabilities and streams turns via `session/update`
-/// notifications, so the base [AcpPlugin] machinery owns sessions and turns.
-/// This class declares Hermes-specific protocol policies, including excluding
-/// interactive terminal setup from headless authentication. Hermes model
-/// discovery and its unstable `session/set_model` extension stay isolated in
-/// this package. It has no managed runtime (Hermes installs itself; the bridge
-/// resolves it on PATH).
+/// notifications, so the base [AcpPlugin] machinery — including every stock
+/// protocol policy (per-session turn serialization, no form elicitation, no
+/// capability meta, first non-terminal auth method, fail-closed selection) —
+/// applies unchanged. Only Hermes model discovery and its unstable
+/// `session/set_model` extension are layered on here, isolated in this package.
+/// It has no managed runtime (Hermes installs itself; the bridge resolves it on
+/// PATH).
 class HermesPlugin({
   required super.launchSpec,
   required super.launchDirectory,
-  required super.contentMapper,
   required super.eventMapper,
   required super.commandTracker,
   required super.sessionOptionsService,
@@ -31,51 +31,10 @@ class HermesPlugin({
       );
 
   @override
-  String get clientName => "sesori-bridge";
-
-  @override
-  String get clientVersion => "0.0.0";
-
-  /// Hermes provider method ids are dynamic, so there is no fixed preferred
-  /// id. [selectAuthMethod] chooses Hermes's first non-terminal provider.
-  @override
-  String? get authMethodId => null;
-
-  @override
-  String? selectAuthMethod({required AcpInitializeResult init}) {
-    for (final method in init.authMethods) {
-      if (method.type != AcpAuthMethodType.terminal) return method.id;
-    }
-    return null;
-  }
-
-  @override
-  Map<String, dynamic>? get initializeCapabilityMeta => null;
-
-  /// Hermes has no `elicitation/create`; permissions arrive as
-  /// `session/request_permission`, which the base approval registry handles.
-  @override
-  bool get supportsFormElicitation => false;
-
-  /// Hermes serializes turns per session (one agent loop per session), so
-  /// concurrent sessions may prompt in parallel.
-  @override
-  bool get serializesPromptsProcessWide => false;
-
-  @override
-  bool get cancelsActiveTurnForQueuedInput => false;
-
-  @override
-  bool get failsTurnOnSelectionError => true;
-
-  @override
-  Duration get sessionCloseSettlementTimeout => const Duration(seconds: 5);
-
-  @override
   void captureSessionConfig(
     AcpNewSessionResult result, {
-    String? sessionId,
-    bool fromNewSession = false,
+    required String? sessionId,
+    required bool fromNewSession,
   }) => _hermesSessionOptionsService.captureSessionConfig(
     result,
     sessionId: sessionId,
@@ -84,20 +43,16 @@ class HermesPlugin({
 
   @override
   Future<void> applyTurnSelection({
-    required AcpSessionConfigRepository configRepository,
+    required AcpAgentApi api,
     required String sessionId,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
     required String? agent,
-  }) async {
-    final liveClient = client;
-    if (liveClient == null) throw StateError("Hermes ACP client is not connected");
-    await _hermesSessionOptionsService.applyTurnSelection(
-      liveClient: liveClient,
-      sessionId: sessionId,
-      model: model,
-    );
-  }
+  }) => _hermesSessionOptionsService.applyTurnSelection(
+    liveClient: api.client,
+    sessionId: sessionId,
+    model: model,
+  );
 
   @override
   Future<PluginSessionOptionsDiscoveryResult> getSessionOptions({

--- a/bridge/sesori_plugin_hermes/lib/src/models/hermes_model_state_dto.g.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/models/hermes_model_state_dto.g.dart
@@ -6,33 +6,30 @@ part of 'hermes_model_state_dto.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_HermesModelInfoDto _$HermesModelInfoDtoFromJson(Map json) =>
-    _HermesModelInfoDto(
-      modelId: json['modelId'] as String?,
-      name: json['name'] as String?,
-      description: json['description'] as String?,
-    );
+_HermesModelInfoDto _$HermesModelInfoDtoFromJson(Map json) => _HermesModelInfoDto(
+  modelId: json['modelId'] as String?,
+  name: json['name'] as String?,
+  description: json['description'] as String?,
+);
 
-Map<String, dynamic> _$HermesModelInfoDtoToJson(_HermesModelInfoDto instance) =>
-    <String, dynamic>{
-      'modelId': ?instance.modelId,
-      'name': ?instance.name,
-      'description': ?instance.description,
-    };
+Map<String, dynamic> _$HermesModelInfoDtoToJson(_HermesModelInfoDto instance) => <String, dynamic>{
+  'modelId': ?instance.modelId,
+  'name': ?instance.name,
+  'description': ?instance.description,
+};
 
-_HermesSessionModelStateDto _$HermesSessionModelStateDtoFromJson(Map json) =>
-    _HermesSessionModelStateDto(
-      availableModels:
-          (json['availableModels'] as List<dynamic>?)
-              ?.map(
-                (e) => HermesModelInfoDto.fromJson(
-                  Map<String, dynamic>.from(e as Map),
-                ),
-              )
-              .toList() ??
-          const <HermesModelInfoDto>[],
-      currentModelId: json['currentModelId'] as String?,
-    );
+_HermesSessionModelStateDto _$HermesSessionModelStateDtoFromJson(Map json) => _HermesSessionModelStateDto(
+  availableModels:
+      (json['availableModels'] as List<dynamic>?)
+          ?.map(
+            (e) => HermesModelInfoDto.fromJson(
+              Map<String, dynamic>.from(e as Map),
+            ),
+          )
+          .toList() ??
+      const <HermesModelInfoDto>[],
+  currentModelId: json['currentModelId'] as String?,
+);
 
 Map<String, dynamic> _$HermesSessionModelStateDtoToJson(
   _HermesSessionModelStateDto instance,

--- a/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart
@@ -364,7 +364,6 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
         providerId: hasConfiguredModel ? status.provider : null,
       );
     final commandTracker = AcpCommandTracker();
-    const contentMapper = AcpContentMapper();
     final acpSessionOptionsService = AcpSessionOptionsService(
       configurationTracker: configurationTracker,
       commandTracker: commandTracker,
@@ -373,10 +372,8 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
     );
     final eventMapper = AcpEventMapper(
       launchDirectory: cwd,
-      agentId: HermesPluginIdentity.id,
       pluginId: HermesPluginIdentity.id,
       configurationTracker: configurationTracker,
-      contentMapper: contentMapper,
     );
     final catalogRepository = HermesCatalogRepository(
       api: HermesAcpApi(
@@ -406,42 +403,17 @@ class const HermesPluginDescriptor() extends BridgePluginDescriptor {
       // the bridge itself owns all project/session persistence for this
       // derive-style plugin, so the plugin needs no store of its own.
       launchDirectory: cwd,
-      contentMapper: contentMapper,
       eventMapper: eventMapper,
       commandTracker: commandTracker,
       sessionOptionsService: acpSessionOptionsService,
       processFactory: processFactory,
       hermesSessionOptionsService: sessionOptionsService,
     );
-
-    final plugin = AcpBridgePlugin(
-      plugin: hermes,
-      clock: host.clock,
-      endpoint: "$binaryPath acp",
-    );
-
-    // Rolls back the spawned agent and surfaces an abort that arrived while
-    // connecting rather than returning a live plugin.
-    Future<Never> rollbackAborted() async {
-      try {
-        await plugin.shutdown(budget: null);
-      } on Object catch (error, stackTrace) {
-        Log.e("[hermes] rollback after aborted start failed", error, stackTrace);
-      }
-      throw const PluginStartAbortedException();
-    }
-
-    // Eagerly spawn the agent and run the ACP handshake (bounded), so the
-    // first mobile request is fast and the status reflects reality. A
-    // timeout/failure leaves the plugin degraded rather than failing the
-    // bridge.
-    await plugin.connect(budget: _connectBudget, startAborted: host.startAborted);
-
-    if (host.startAborted.isAborted) {
-      await rollbackAborted();
-    }
-
-    return plugin;
+    // Eagerly spawns the agent and runs the ACP handshake (bounded), so the
+    // first mobile request is fast and the status reflects reality; a
+    // timeout/failure leaves the plugin degraded rather than failing the bridge,
+    // and an abort that lands while connecting is rolled back.
+    return await AcpBridgePlugin.start(plugin: hermes, host: host, connectBudget: _connectBudget);
   }
 }
 

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
@@ -89,8 +89,8 @@ void main() {
       final connecting = plugin.ensureConnected();
       await respond(method: "initialize", result: hermesInitializeResult);
       // Hermes advertises the configured provider method first, then a
-      // terminal-setup method; the handshake authenticates against the first
-      // advertised method because authMethodId is null.
+      // terminal-setup method; with authMethodId null the handshake picks the
+      // first non-terminal method.
       final authFrame = await waitForFrame(method: "authenticate");
       expect(
         (authFrame["params"] as Map).cast<String, dynamic>()["methodId"],
@@ -116,13 +116,12 @@ void main() {
       expect(spec.args, ["acp"]);
     });
 
-    test("declares the neutral ACP policies for a stock v1 server", () {
-      expect(plugin.clientName, "sesori-bridge");
-      expect(plugin.clientVersion, "0.0.0");
+    test("keeps the stock ACP policies of a v1 server", () {
       expect(plugin.authMethodId, isNull, reason: "Hermes provider ids are dynamic");
       expect(plugin.initializeCapabilityMeta, isNull);
       expect(plugin.supportsFormElicitation, isFalse, reason: "no elicitation/create on Hermes");
       expect(plugin.serializesPromptsProcessWide, isFalse);
+      expect(plugin.cancelsActiveTurnForQueuedInput, isFalse);
       expect(plugin.failsTurnOnSelectionError, isTrue);
       expect(plugin.sessionCloseSettlementTimeout, const Duration(seconds: 5));
     });
@@ -378,7 +377,6 @@ HermesPlugin _plugin({
     agentDisplayName: "Hermes Agent",
     discoveryTimeout: const Duration(seconds: 2),
   );
-  const contentMapper = AcpContentMapper();
   return HermesPlugin(
     launchSpec: HermesBinary.launchSpec(
       binary: HermesBinary.defaultBinary,
@@ -386,13 +384,10 @@ HermesPlugin _plugin({
       environment: const {},
     ),
     launchDirectory: "/repo",
-    contentMapper: contentMapper,
     eventMapper: AcpEventMapper(
       launchDirectory: "/repo",
-      agentId: "hermes",
       pluginId: "hermes",
       configurationTracker: configurationTracker,
-      contentMapper: contentMapper,
     ),
     commandTracker: commandTracker,
     sessionOptionsService: AcpSessionOptionsService(

--- a/bridge/sesori_plugin_omp/lib/src/api/omp_acp_api.dart
+++ b/bridge/sesori_plugin_omp/lib/src/api/omp_acp_api.dart
@@ -6,7 +6,9 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 import "../omp_binary.dart";
 
-/// Layer-1 ACP operations used by OMP's bounded isolated workflows.
+/// Layer-1 ACP operations used by OMP's bounded isolated workflows: owns one
+/// scratch `omp acp` lease (process plus optional isolated session directory)
+/// and exposes the typed standard requests on it.
 class OmpAcpApi({
   required final String _binaryPath,
   required final AcpProcessFactory _processFactory,
@@ -18,11 +20,7 @@ class OmpAcpApi({
   Directory? _sessionDirectory;
   bool _disposed = false;
 
-  Stream<AcpNotification> get notifications {
-    final client = _client;
-    if (client == null) throw StateError("OMP ACP lease is not open");
-    return client.notifications;
-  }
+  Stream<AcpNotification> get notifications => _openClient().notifications;
 
   Future<AcpInitializeResult> open({
     required String cwd,
@@ -50,84 +48,55 @@ class OmpAcpApi({
     );
     _client = client;
     await client.connect().timeout(_remaining(timeout: timeout, stopwatch: stopwatch));
-    final raw = await client.request(
-      method: AcpMethods.initialize,
-      params: buildInitializeParams(
-        clientName: "sesori-bridge",
-        clientVersion: "0.0.0",
-        formElicitation: false,
-      ),
+    // Same handshake as the live plugin minus form elicitation, which these
+    // scratch flows never answer.
+    return await AcpAgentApi(client: client).initialize(
+      formElicitation: false,
+      capabilityMeta: null,
+      authMethodId: OmpBinary.acpAuthMethodId,
       timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
     );
-    final result = AcpInitializeResult.fromJson(
-      raw is Map ? raw.cast<String, dynamic>() : const {},
-    );
-    if (result.protocolVersion != acpProtocolVersion) {
-      throw StateError(
-        "OMP negotiated ACP v${result.protocolVersion}; expected v$acpProtocolVersion",
-      );
-    }
-    if (result.requiresAuth) {
-      await client.request(
-        method: AcpMethods.authenticate,
-        params: const {"methodId": "agent"},
-        timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
-      );
-    }
-    return result;
   }
 
   Future<AcpNewSessionResult> newSession({
     required String cwd,
     required Duration timeout,
-  }) async => await _sessionResult(
-    method: AcpMethods.sessionNew,
-    params: {"cwd": cwd, "mcpServers": const <Object?>[]},
-    timeout: timeout,
-  );
+  }) => _api().newSession(cwd: cwd, timeout: timeout);
 
   Future<AcpNewSessionResult> setConfigOption({
     required String sessionId,
     required String configId,
     required String value,
     required Duration timeout,
-  }) async => await _sessionResult(
-    method: AcpMethods.sessionSetConfigOption,
-    params: {"sessionId": sessionId, "configId": configId, "value": value},
-    timeout: timeout,
-  );
+  }) async {
+    final result = await _api().setConfigOption(
+      sessionId: sessionId,
+      configId: configId,
+      value: value,
+      timeout: timeout,
+    );
+    if (result == null) throw StateError("OMP returned no config state");
+    return result;
+  }
 
   Future<AcpSessionListResult> listSessionsPage({
     required String? cwd,
     required String? cursor,
     required Duration timeout,
-  }) async {
-    final raw = await _request(
-      method: AcpMethods.sessionList,
-      params: {"cwd": ?cwd, "cursor": ?cursor},
-      timeout: timeout,
-    );
-    return AcpSessionListResult.fromJson(
-      raw is Map ? raw.cast<String, dynamic>() : const {},
-    );
-  }
+  }) => _api().listSessionsPage(cwd: cwd, cursor: cursor, timeout: timeout);
 
   Future<AcpNewSessionResult> resumeSession({
     required String sessionId,
     required String cwd,
     required Duration timeout,
-  }) async => await _sessionResult(
-    method: AcpMethods.sessionResume,
-    params: {"sessionId": sessionId, "cwd": cwd, "mcpServers": const <Object?>[]},
-    timeout: timeout,
-  );
+  }) => _api().resumeSession(sessionId: sessionId, cwd: cwd, timeout: timeout);
 
   Future<AcpPromptResult> prompt({
     required String sessionId,
     required String text,
     required Duration timeout,
   }) async {
-    final raw = await _request(
+    final raw = await _openClient().request(
       method: AcpMethods.sessionPrompt,
       params: {
         "sessionId": sessionId,
@@ -143,11 +112,7 @@ class OmpAcpApi({
   Future<void> closeSession({
     required String sessionId,
     required Duration timeout,
-  }) => _request(
-    method: AcpMethods.sessionClose,
-    params: {"sessionId": sessionId},
-    timeout: timeout,
-  );
+  }) => _api().closeSession(sessionId: sessionId, timeout: timeout);
 
   Future<Directory> createScratchDirectory({required String prefix}) => _createScratch(prefix: prefix);
 
@@ -177,27 +142,14 @@ class OmpAcpApi({
     await settle();
   }
 
-  Future<AcpNewSessionResult> _sessionResult({
-    required String method,
-    required Map<String, dynamic> params,
-    required Duration timeout,
-  }) async {
-    final raw = await _request(method: method, params: params, timeout: timeout);
-    return AcpNewSessionResult.fromJson(
-      raw is Map ? raw.cast<String, dynamic>() : const {},
-    );
-  }
+  AcpAgentApi _api() => AcpAgentApi(client: _openClient());
 
-  Future<dynamic> _request({
-    required String method,
-    required Object? params,
-    required Duration timeout,
-  }) {
+  AcpStdioClient _openClient() {
     final client = _client;
     if (client == null || !client.isConnected) {
       throw StateError("OMP ACP lease is not open");
     }
-    return client.request(method: method, params: params, timeout: timeout);
+    return client;
   }
 
   Future<Directory> _createScratch({required String prefix}) async {

--- a/bridge/sesori_plugin_omp/lib/src/omp_binary.dart
+++ b/bridge/sesori_plugin_omp/lib/src/omp_binary.dart
@@ -1,7 +1,12 @@
 import "package:acp_plugin/acp_plugin.dart";
 
+/// Builds the launch spec for `omp acp` and declares the handshake policy every
+/// Sesori ACP connection to it (live plugin, catalog and cleanup leases) uses.
 abstract final class OmpBinary() {
   static const String defaultBinary = "omp";
+
+  /// The ACP auth method OMP advertises for its locally configured agent.
+  static const String acpAuthMethodId = "agent";
 
   static AcpLaunchSpec launchSpec({
     required String binary,

--- a/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
+++ b/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
@@ -134,14 +134,14 @@ class OmpPlugin._({
 
   @override
   Future<void> applyTurnSelection({
-    required AcpAgentApi api,
+    required AcpSessionConfigRepository configRepository,
     required String sessionId,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
     required String? agent,
   }) async {
     await _ompSessionOptionsService.applyTurnSelection(
-      configRepository: AcpSessionConfigRepository(api: api),
+      configRepository: configRepository,
       sessionId: sessionId,
       projectId: directoryForSession(sessionId: sessionId),
       model: model,

--- a/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
+++ b/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
@@ -14,10 +14,15 @@ import "services/omp_session_cleanup_service.dart";
 import "services/omp_session_options_service.dart";
 import "trackers/omp_catalog_tracker.dart";
 
+/// Oh My Pi backend over ACP.
+///
+/// OMP diverges from stock ACP in three policies: it serializes every prompt
+/// process-wide, replaces an in-flight turn when another input arrives, and
+/// supports standard form elicitation. Its project-scoped model/mode/thinking
+/// catalog and persisted-session cleanup run over isolated scratch processes.
 class OmpPlugin._({
   required super.launchSpec,
   required super.launchDirectory,
-  required super.contentMapper,
   required super.eventMapper,
   required super.commandTracker,
   required super.sessionOptionsService,
@@ -76,17 +81,13 @@ class OmpPlugin._({
       totalTimeout: const Duration(seconds: 20),
       maxPages: 50,
     );
-    const contentMapper = AcpContentMapper();
     return OmpPlugin._(
       launchSpec: launchSpec,
       launchDirectory: cwd,
-      contentMapper: contentMapper,
       eventMapper: AcpEventMapper(
         launchDirectory: cwd,
-        agentId: OmpPluginIdentity.id,
         pluginId: OmpPluginIdentity.id,
         configurationTracker: configurationTracker,
-        contentMapper: contentMapper,
       ),
       commandTracker: commandTracker,
       sessionOptionsService: AcpSessionOptionsService(
@@ -109,16 +110,7 @@ class OmpPlugin._({
       );
 
   @override
-  String get clientName => "sesori-bridge";
-
-  @override
-  String get clientVersion => "0.0.0";
-
-  @override
-  String? get authMethodId => "agent";
-
-  @override
-  Map<String, dynamic>? get initializeCapabilityMeta => null;
+  String? get authMethodId => OmpBinary.acpAuthMethodId;
 
   @override
   bool get supportsFormElicitation => true;
@@ -130,16 +122,10 @@ class OmpPlugin._({
   bool get cancelsActiveTurnForQueuedInput => true;
 
   @override
-  bool get failsTurnOnSelectionError => true;
-
-  @override
-  Duration get sessionCloseSettlementTimeout => const Duration(seconds: 5);
-
-  @override
   void captureSessionConfig(
     AcpNewSessionResult result, {
-    String? sessionId,
-    bool fromNewSession = false,
+    required String? sessionId,
+    required bool fromNewSession,
   }) => _ompSessionOptionsService.captureSessionConfig(
     result,
     sessionId: sessionId,
@@ -148,14 +134,14 @@ class OmpPlugin._({
 
   @override
   Future<void> applyTurnSelection({
-    required AcpSessionConfigRepository configRepository,
+    required AcpAgentApi api,
     required String sessionId,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
     required String? agent,
   }) async {
     await _ompSessionOptionsService.applyTurnSelection(
-      configRepository: configRepository,
+      configRepository: AcpSessionConfigRepository(api: api),
       sessionId: sessionId,
       projectId: directoryForSession(sessionId: sessionId),
       model: model,

--- a/bridge/sesori_plugin_omp/lib/src/runtime/omp_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_omp/lib/src/runtime/omp_plugin_descriptor.dart
@@ -291,15 +291,7 @@ final class const OmpPluginDescriptor({
       scratchDirectory: null,
       processFactory: hostProcessAcpFactory(processes: host.processes, environment: host.environment),
     );
-    final plugin = AcpBridgePlugin(plugin: omp, clock: host.clock, endpoint: "$binaryPath acp");
-    await plugin.connect(budget: _connectBudget, startAborted: host.startAborted);
-    if (!host.startAborted.isAborted) return plugin;
-    try {
-      await plugin.shutdown(budget: null);
-    } on Object catch (error, stackTrace) {
-      Log.e("[omp] rollback after aborted start failed", error, stackTrace);
-    }
-    throw const PluginStartAbortedException();
+    return await AcpBridgePlugin.start(plugin: omp, host: host, connectBudget: _connectBudget);
   }
 }
 


### PR DESCRIPTION
## Complexity

⚙️ Moderate — a cross-package refactor of the shared ACP base and its three
consumers (`cursor`, `hermes`, `omp`). Mechanical in most places; the
behavior-bearing parts are the shared handshake, the hook signature, and the
stock-policy defaults.

## What

Review of the ACP base against the three concrete harnesses, folding the
duplicated protocol plumbing back into `sesori_plugin_acp`:

- **`AcpAgentApi`** (new, Layer 1): one typed surface for
  `initialize`+`authenticate`, `session/new`, `load`, `resume`, `list` (page),
  `set_config_option`, and `close`. Replaces four hand-rolled handshakes (live
  plugin + Cursor/Hermes/OMP scratch APIs) and ~15 scattered
  `raw is Map ? X.fromJson : {}` / `"mcpServers": []` sites. The default auth
  selection (first advertised **non-terminal** method) is now shared — the
  headless bridge can never finish a terminal flow. `AcpSessionConfigRepository`
  stays as the Layer-2 delegate services use for config writes and is built over
  the api; `applyTurnSelection` hands a harness the connection's `AcpAgentApi`.
- **Stock-ACP policy defaults on `AcpPlugin`**: `authMethodId`,
  `initializeCapabilityMeta`, `supportsFormElicitation`,
  `serializesPromptsProcessWide`, `cancelsActiveTurnForQueuedInput`,
  `failsTurnOnSelectionError` (fail closed), `sessionCloseSettlementTimeout`
  (5 s). A harness overrides only what differs — Hermes now overrides nothing
  protocol-related. Removed the always-identical `clientName`/`clientVersion`
  getters (`acpClientName`/`acpClientVersion` constants) and the
  `selectAuthMethod` hook (Hermes's version is the default).
- **Less constructor threading**: the stateless `AcpContentMapper` is no longer
  passed through `AcpPlugin`/`AcpEventMapper`/`AcpReplayCollector`; the
  always-equal `agentId` is gone from `AcpEventMapper` (uses `pluginId`).
- **`AcpBridgePlugin.start(plugin:, host:, connectBudget:)`** owns the
  wrap → connect → abort-rollback sequence each descriptor copied; the
  diagnostics endpoint is derived from the launch spec.
- `AcpPlugin` shares one `_teardownConnection` between `dispose` and
  `resetConnectionAfterExit`.
- `CursorBinary`/`OmpBinary` carry the agent's fixed handshake policy
  (`acpAuthMethodId`, Cursor's `acpCapabilityMeta`) so the live plugin and the
  scratch APIs can no longer drift.
- `captureSessionConfig` params are `required` per the repo convention; the
  `acp_plugin.dart` library doc now has an "adding an ACP harness" checklist.

Net −233 lines across 49 files (−177 in production code); every behavior stays wire-identical except the
two items called out below.

## Why

With three ACP harnesses we could finally see what was duplicated (the
handshake ×4, the client identity ×7, the 5 s settlement ×4, every policy
getter re-declared in each plugin, the start/abort sequence ×3) and what
genuinely diverges (catalog discovery strategy, approval/mapper extensions,
persisted cleanup, OMP's process-wide serialization). The base now defaults to
stock ACP and exposes typed building blocks, so a fourth harness is: a
`XxxBinary`, an `AcpPlugin` subclass overriding only its quirks, an optional
scratch API over `AcpAgentApi`, and a descriptor returning
`AcpBridgePlugin.start(...)`.

## Risk and test focus

- **Behavior change 1:** replayed history (`getSessionMessages`) now stamps
  `agent` with the plugin id (`"cursor"`, `"hermes"`, `"omp"`) like the live
  mapper — previously it stamped the display name (`"Cursor"`, …), so a reloaded
  session reported a different agent than the live stream (the client seeds
  `SessionDetailLoaded.agent` from the latest assistant message). Now asserted in
  `acp_history_replay_test.dart`.
- **Behavior change 2:** the Cursor catalog probe's `session/load` and OMP's
  scratch `session/resume` now parse strictly (a null result throws) like the
  live plugin always did; both callers already catch and log per candidate.
- Diagnostics only: `PluginDiagnostics.endpoint` is now the full agent command
  line (e.g. `cursor-agent -e <url> acp`), shown in `Target [...]` console lines.
- No database impact, no wire-contract change toward the client.
- Test focus: ACP handshake/auth paths (terminal-only auth stays blocked,
  non-terminal picked first, auth rejection stays typed), resume/load retry
  semantics, Cursor model/mode/effort selection, OMP fail-closed selection,
  descriptor start/abort rollback.

## Expected result

No user-visible change beyond the replayed-history `agent` stamp matching the
live one. The three plugins behave exactly as before on the wire; the ACP
package is smaller and a new ACP harness needs materially less code.

## Verification

- `dart analyze --fatal-infos` clean in `sesori_plugin_acp`, `sesori_plugin_cursor`,
  `sesori_plugin_hermes`, `sesori_plugin_omp`, and `app`.
- `dart test`: acp 255/255, cursor 136/136, hermes 38/38, omp 52/52.
- `architecture-implementation-review` run via sub-agent; its two findings
  (service → api layer skip; options service built inside the base) are applied
  in this revision. Accepted as-is: `AcpAgentApi` placement, the binary-level
  handshake constants, the hook signature, `AcpBridgePlugin.start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the ACP base across `sesori_plugin_cursor`, `sesori_plugin_hermes`, and `sesori_plugin_omp` by adding a typed Layer‑1 `AcpAgentApi`, defaulting stock ACP policies in the base, and centralizing connect/abort in `AcpBridgePlugin.start`. Behavior is wire‑identical except: replayed history now stamps `agent` with the plugin id (was display name), and diagnostics now report the agent executable only (was full command line).

- Introduces `AcpAgentApi` owning typed `initialize`/`authenticate` and `session/*` calls; each request has a required timeout, `initialize`+`authenticate` share one deadline, and auth errors include the connection `logTag`.
- Defaults ACP policies on `AcpPlugin`: first non‑terminal auth, no capability meta, no forms, per‑session serialization, fail‑closed selection, 5 s close settlement. Hermes no longer overrides protocol policy; its `session/set_model` remains on the live client.
- Centralizes wrap → connect → abort rollback via `AcpBridgePlugin.start` (races connect against an abort and rolls back immediately); `describe()` now shows the executable from the launch spec.
- Moves fixed handshake constants to binaries: `CursorBinary.acpAuthMethodId`, `CursorBinary.acpCapabilityMeta`, `OmpBinary.acpAuthMethodId`.
- Removes constructor threading: `AcpContentMapper` is static; event mappers and replay collectors take `pluginId` only. Tightens parsing for Cursor catalog `session/load` and OMP scratch `session/resume` (null results throw).
- No database changes and no client‑facing wire‑contract changes.

- Migration:
  - Keep `applyTurnSelection` accepting `AcpSessionConfigRepository`; construct it with `AcpAgentApi(client)`.
  - Stop passing `AcpContentMapper` and `agentId` into mappers and replay collectors; use `pluginId` only.
  - Use `CursorBinary.acpAuthMethodId`/`acpCapabilityMeta` and `OmpBinary.acpAuthMethodId` for handshake policy.

<sup>Written for commit ee2326be4292a51d2871fa8bcde87797c537a086. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

