### PR TITLE
🌿 Keep Codex keepalives local

### DIFF
--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -480,7 +480,13 @@ class CodexPlugin._({
     // Keep this local-only: `model/list` can refresh Codex's remote model cache,
     // turning weak connectivity into a repeated child-process timeout.
     unawaited(
-      client.request(method: "thread/loaded/list", timeout: _keepaliveInterval).catchError((Object _) => null),
+      client
+          .request(
+            method: "thread/loaded/list",
+            params: const <String, dynamic>{},
+            timeout: _keepaliveInterval,
+          )
+          .catchError((Object _) => null),
     );
   }
 

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -477,11 +477,10 @@ class CodexPlugin._({
   void _sendKeepalive() {
     final client = _client;
     if (client == null) return;
-    // `model/list` is a cheap local capability query (no model inference, so no
-    // usage cost). The response is irrelevant — the point is the traffic; a
-    // failure (e.g. transport already gone) is swallowed.
+    // Keep this local-only: `model/list` can refresh Codex's remote model cache,
+    // turning weak connectivity into a repeated child-process timeout.
     unawaited(
-      client.request(method: "model/list", timeout: _keepaliveInterval).catchError((Object _) => null),
+      client.request(method: "thread/loaded/list", timeout: _keepaliveInterval).catchError((Object _) => null),
     );
   }
 

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -2232,15 +2232,17 @@ void main() {
         ),
         keepaliveInterval: const Duration(milliseconds: 20),
       );
-      // Only `initialize` is canned; keepalive thread/loaded/list calls get an error
-      // response, which the plugin swallows — exactly the production behaviour.
-      kaFake.respondInOrder([const _Response(result: _initOk)]);
+      kaFake.respondInOrder([
+        const _Response(result: _initOk),
+        ...List<_Response>.filled(6, const _Response(result: {"data": <Object>[]})),
+      ]);
 
       await kaPlugin.healthCheck(); // connect → starts keepalive
       await Future<void>.delayed(const Duration(milliseconds: 90));
 
       final firedWhileConnected = kaFake.sentMethods.where((m) => m == "thread/loaded/list").length;
       expect(firedWhileConnected, greaterThanOrEqualTo(2));
+      expect(kaFake.sentRequestHasParams("thread/loaded/list"), isTrue);
       expect(kaFake.sentMethods, isNot(contains("model/list")));
 
       await kaPlugin.dispose();
@@ -2675,6 +2677,9 @@ class _FakeAppServer() {
     final frame = _sent.firstWhere((f) => f.method == method);
     return frame.params ?? const {};
   }
+
+  bool sentRequestHasParams(String method) =>
+      _sent.firstWhere((frame) => frame.method == method).params != null;
 
   Map<String, dynamic> serverResponseFor(Object id) =>
       _serverResponses[id] ?? (throw StateError("no response for $id"));

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -2219,7 +2219,7 @@ void main() {
       await subscription.cancel();
     });
 
-    test("keepalive sends periodic model/list RPCs while connected, stops on dispose", () async {
+    test("keepalive sends local RPCs while connected, stops on dispose", () async {
       final kaFake = _FakeAppServer();
       const serverUrl = "ws://127.0.0.1:0";
       final kaPlugin = createInjectedCodexPlugin(
@@ -2232,22 +2232,23 @@ void main() {
         ),
         keepaliveInterval: const Duration(milliseconds: 20),
       );
-      // Only `initialize` is canned; keepalive model/list calls get an error
+      // Only `initialize` is canned; keepalive thread/loaded/list calls get an error
       // response, which the plugin swallows — exactly the production behaviour.
       kaFake.respondInOrder([const _Response(result: _initOk)]);
 
       await kaPlugin.healthCheck(); // connect → starts keepalive
       await Future<void>.delayed(const Duration(milliseconds: 90));
 
-      final firedWhileConnected = kaFake.sentMethods.where((m) => m == "model/list").length;
+      final firedWhileConnected = kaFake.sentMethods.where((m) => m == "thread/loaded/list").length;
       expect(firedWhileConnected, greaterThanOrEqualTo(2));
+      expect(kaFake.sentMethods, isNot(contains("model/list")));
 
       await kaPlugin.dispose();
-      final afterDispose = kaFake.sentMethods.where((m) => m == "model/list").length;
+      final afterDispose = kaFake.sentMethods.where((m) => m == "thread/loaded/list").length;
       await Future<void>.delayed(const Duration(milliseconds: 60));
       // No further keepalives once disposed.
       expect(
-        kaFake.sentMethods.where((m) => m == "model/list").length,
+        kaFake.sentMethods.where((m) => m == "thread/loaded/list").length,
         equals(afterDispose),
       );
     });

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -59,6 +59,8 @@ idle suspension, the management snapshot, and lifecycle commands.
 - Deliberate bridge shutdown enters each live harness's lifecycle shutdown before closing
   its transport directly. Managed runtime monitors disarm before transport or process
   teardown, so a clean owned-runtime exit is neither reported nor restarted as a crash.
+- Codex keeps its long-lived app-server connection active with a local in-memory RPC;
+  idle keepalives never trigger remote model discovery, and stop when the plugin is disposed.
 - Interactive authentication is optional per descriptor. A capable harness owns its
   backend process and credentials, exposes only a safe challenge and sanitized terminal
   state, cancels cooperatively, and settles process cleanup before the operation ends.
@@ -89,7 +91,7 @@ idle suspension, the management snapshot, and lifecycle commands.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | A started bridge inspects every registered harness and publishes coherent setup and management snapshots. A ready fixture has a selectable default; a fixture with no usable harness has zero selectable entries and no default without failing startup. Headless bridge; all registered harnesses listed. |
-| L2 Routine | Demand-driven start of a ready harness, clean lifecycle-owned bridge shutdown, setup refresh, and the disable list surviving restart with eligibility and ordering intact. Headless bridge; representative managed harness for start and shutdown, every registered harness for listing and ordering. |
+| L2 Routine | Demand-driven start of a ready harness, clean lifecycle-owned bridge shutdown, Codex keepalive traffic remaining local and stopping on disposal, setup refresh, and the disable list surviving restart with eligibility and ordering intact. Headless bridge; representative managed harness for start and shutdown, every registered harness for listing and ordering. |
 | L3 Release | The management surface as rendered: per-harness selected runtime version when reported, setup, runtime and work state, capability-appropriate controls, built-in name and light/dark artwork, default badge, enable/disable, restart, and idle-timeout default plus override persisted across a bridge restart. Client end to end; every harness declaring the relevant capability must pass. |
 | L4 Extended | Busy conflict with force confirmation and cancellation, authentication start/join/cancel plus shutdown cleanup, idle suspension elapsing then returning on demand, harnesses blocked by missing runtime or authentication, a terminally failed harness leaving others usable, a bridge with no usable harness, an externally managed configuration, two harnesses active at once, second mobile platform. Live plugin where a real backend must start or be interrupted, client end to end where card state is claimed. |
 | L5 Full | Every registered production harness through inspect, enable, disable, restart, refresh, and idle behavior on a supported platform, plus forward-compatible presentation of an unknown harness or capability and the reported state of a session interrupted by a forced disable. Live plugin and client end to end as each entry requires. |
@@ -151,6 +153,7 @@ timeouts, and sessions afterwards.
 - `bridge/app/lib/src/services/plugin_lifecycle_service.dart`,
   `bridge/app/lib/src/bridge/runtime/plugin_registry.dart`
 - `bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart` and its tests
+- `bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart` and `codex_plugin_write_path_test.dart`
 - `client/module_core/.../plugin_management_service.dart`, `PregoBrandLogo`, and the
   harness settings screen
 - Tests: `plugin_lifecycle_service_test.dart`, per-plugin setup and client suites


### PR DESCRIPTION
## Complexity

🌿 Straightforward: a localized Codex keepalive RPC change with focused regression coverage.

## What

- Replace the periodic Codex `model/list` keepalive with local `thread/loaded/list` traffic.
- Verify keepalives never invoke model discovery and stop after plugin disposal.
- Record the lifecycle invariant in the regression catalog.

## Why

Codex's `model/list` uses an online-if-uncached strategy. When connectivity is weak and the five-minute model cache is cold, Sesori's 30-second keepalive can repeatedly trigger Codex's upstream model refresh and its `timeout waiting for child process to exit` failure. A keepalive should preserve the local app-server connection without starting network work.

Upstream context: https://github.com/openai/codex/issues/23119

## Risk and test focus

Low. `thread/loaded/list` is a local in-memory read supported by Sesori's minimum Codex app-server version. Actual provider discovery continues to use `model/list`. There is no UI or database impact.

## Expected result

Unreliable connectivity no longer turns Sesori's periodic keepalive into repeated model-catalog refresh attempts. Codex's own background refresh may still emit the upstream error on its independent cadence.

## Verification

- `dart test test/codex_plugin_write_path_test.dart`
- `dart analyze --fatal-infos`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Codex keepalives local to avoid triggering remote model discovery on weak networks. Old behavior sent periodic `model/list`; new behavior sends `thread/loaded/list` with empty params, swallows errors, and stops after plugin disposal.

- Tests verify only `thread/loaded/list` fires (with `{}` params), no `model/list` is sent, errors are swallowed, and traffic stops after dispose.
- Provider discovery still uses `model/list`; no UI or database changes. Supported by the minimum Codex app-server version. Regression docs record the lifecycle invariant.

<sup>Written for commit 0544831213d16cba546e681845eb77e54bceb9eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

