### PR TITLE
🌿 docs(readme): add Hermes Agent and drop stale beta statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ A lightweight Bridge runs on your laptop alongside your AI coding assistant. It 
 
 ```mermaid
 graph LR
-  OC["AI Assistant<br/>on your machine"] -- "HTTP + SSE" --> B["Bridge CLI<br/>your laptop"]
+  OC["AI Assistant<br/>on your machine"] -- "Local transport" --> B["Bridge CLI<br/>your laptop"]
   B -- "WSS · E2E encrypted" --> R["Relay Server<br/>cloud router"]
   R -- "WSS · E2E encrypted" --> M["Sesori App<br/>your phone"]
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">Run your AI coding agents from your phone.</h1>
 
 <p align="center">
-  Sesori is the mobile cockpit for your AI coding sessions — <a href="https://opencode.ai" target="_blank" rel="noopener">OpenCode</a>, <a href="https://github.com/openai/codex" target="_blank" rel="noopener">OpenAI Codex CLI</a>, <a href="https://cursor.com" target="_blank" rel="noopener">Cursor</a>, <a href="https://claude.com" target="_blank" rel="noopener">Claude Code</a>, <a href="https://github.com/badlogic/pi-mono" target="_blank" rel="noopener">Pi</a>, and <a href="https://github.com/can1357/oh-my-pi" target="_blank" rel="noopener">Oh My Pi</a>.<br/>
+  Sesori is the mobile cockpit for your AI coding sessions — <a href="https://opencode.ai" target="_blank" rel="noopener">OpenCode</a>, <a href="https://github.com/openai/codex" target="_blank" rel="noopener">OpenAI Codex CLI</a>, <a href="https://cursor.com" target="_blank" rel="noopener">Cursor</a>, <a href="https://claude.com" target="_blank" rel="noopener">Claude Code</a>, <a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener">Hermes Agent</a>, <a href="https://github.com/badlogic/pi-mono" target="_blank" rel="noopener">Pi</a>, and <a href="https://github.com/can1357/oh-my-pi" target="_blank" rel="noopener">Oh My Pi</a>.<br/>
   Leave your laptop. Take the session.
 </p>
 
@@ -67,7 +67,7 @@ Requires iOS 15 or later, or Android 8.0 or later.
 
 ### 2. Install the Bridge CLI on your machine
 
-The Bridge is a small source-available command-line tool that connects the app to your AI coding assistants ([OpenCode](https://opencode.ai), [OpenAI Codex CLI](https://github.com/openai/codex), [Cursor](https://cursor.com), [Claude Code](https://claude.com), [Pi](https://github.com/badlogic/pi-mono), and [Oh My Pi](https://github.com/can1357/oh-my-pi)).
+The Bridge is a small source-available command-line tool that connects the app to your AI coding assistants — the full list is [below](#supported-ai-assistants).
 
 **macOS / Linux:**
 
@@ -99,7 +99,7 @@ Sign in with the **same account** on your phone and your machine. The two pair a
 
 | Feature | What it means |
 |---|---|
-| **Browse projects & sessions** | See projects and active sessions from [OpenCode](https://opencode.ai), [OpenAI Codex CLI](https://github.com/openai/codex), [Cursor](https://cursor.com), [Claude Code](https://claude.com), [Pi](https://github.com/badlogic/pi-mono), and [Oh My Pi](https://github.com/can1357/oh-my-pi) on your phone. |
+| **Browse projects & sessions** | See your projects and active sessions across every supported assistant, right on your phone. |
 | **Keep agents moving** | Answer questions, approve steps, and stop or restart tasks without returning to your desk. |
 | **Review code and PR status** | Read diffs and keep tabs on pull requests without opening your laptop. |
 | **Voice or type** | Talk to your assistant naturally or use the keyboard — whatever works in the moment. |
@@ -110,7 +110,7 @@ Sign in with the **same account** on your phone and your machine. The two pair a
 
 ## How it works
 
-A lightweight Bridge runs on your laptop alongside OpenCode. It connects to a relay server over WebSocket, and your phone connects to the same relay. The relay routes encrypted traffic between them — it never sees your application data.
+A lightweight Bridge runs on your laptop alongside your AI coding assistant. It connects to a relay server over WebSocket, and your phone connects to the same relay. The relay routes encrypted traffic between them — it never sees your application data.
 
 ```mermaid
 graph LR
@@ -139,14 +139,17 @@ Your laptop and phone perform an ephemeral X25519 key exchange, then encrypt eve
 
 ## Supported AI assistants
 
-| Assistant | Status | Notes |
-|---|---|---|
-| [OpenCode](https://opencode.ai) | Available | Deep native integration. |
-| [OpenAI Codex CLI](https://github.com/openai/codex) | Beta | Enabled by default in an upcoming release. |
-| [Cursor](https://cursor.com) | Beta | ACP-based Cursor plugin; enabled by default in an upcoming release. |
-| [Claude Code](https://claude.com) | Beta | Native stream-json integration; enabled by default in an upcoming release. |
-| [Pi](https://github.com/badlogic/pi-mono) | Beta | Native JSONL RPC integration; see the notes below. |
-| [Oh My Pi](https://github.com/can1357/oh-my-pi) | Beta | ACP-based integration; see the notes below. |
+| Assistant | Integration |
+|---|---|
+| [OpenCode](https://opencode.ai) | Deep native integration with a bridge-managed runtime. |
+| [OpenAI Codex CLI](https://github.com/openai/codex) | Native integration over Codex's local protocol. |
+| [Cursor](https://cursor.com) | ACP-based integration. |
+| [Claude Code](https://claude.com) | Native stream-json integration. |
+| [Hermes Agent](https://github.com/NousResearch/hermes-agent) | ACP-based integration with Nous Research's coding agent. |
+| [Pi](https://github.com/badlogic/pi-mono) | Native JSONL RPC integration. |
+| [Oh My Pi](https://github.com/can1357/oh-my-pi) | ACP-based integration. |
+
+Every integration ships enabled by default — pick your assistant when you start a session, and run several at once on the same Bridge.
 
 <details>
 <summary><strong>Pi notes</strong></summary>
@@ -187,6 +190,24 @@ Your laptop and phone perform an ephemeral X25519 key exchange, then encrypt eve
   is not shown because ACP session listings do not expose it.
 - **Terminal handoff:** as with Pi, exit a terminal OMP session before
   continuing it from Sesori.
+
+</details>
+
+<details>
+<summary><strong>Hermes Agent notes</strong></summary>
+
+- **Version:** requires Hermes Agent 0.20.0 or later.
+- **Install:** Sesori never installs or updates Hermes. It uses the `hermes`
+  CLI from your PATH; point `--hermes-bin <path>` at a specific binary to make
+  it authoritative.
+- **Model & login:** pick your model and provider, and log in, with the Hermes
+  CLI itself — Sesori inherits that configuration and never handles provider
+  credentials.
+- **Sessions:** sessions you start from Sesori are always visible, and other
+  persisted ACP sessions can be imported explicitly. Ordinary Hermes CLI/TUI
+  sessions are not discovered automatically.
+- **Deletion:** deleting a Hermes session removes Sesori's copy of it; Hermes
+  keeps its own record until upstream offers a delete API.
 
 </details>
 


### PR DESCRIPTION
## Complexity

Straightforward — documentation-only change to the root README.

## What

- Adds **Hermes Agent** (Nous Research) to every place the supported-assistant list appears: the hero paragraph, the supported-assistants table, and a new collapsible "Hermes Agent notes" section alongside the existing Pi and Oh My Pi notes.
- Replaces the assistant table's `Status` column (with its stale "Beta / enabled by default in an upcoming release" rows) with an `Integration` column describing how each backend is integrated. All integrations are stable and ship enabled by default, so the beta labels were no longer accurate; a line under the table now states that directly.
- De-duplicates the full seven-assistant list that was repeated three times (hero, install step 2, feature table). The install step and the "Browse projects & sessions" row now reference the canonical list in the supported-assistants section instead of repeating it — this is what let the list go stale.
- Makes the "How it works" prose assistant-neutral ("alongside your AI coding assistant") to match the diagram next to it.

Hermes facts are taken from the plugin source of truth (`bridge/sesori_plugin_hermes`): ACP v1 over `hermes acp`, minimum version 0.20.0, no managed install (PATH or `--hermes-bin`), model/provider configuration and login done locally with the Hermes CLI, ACP-source session visibility with explicit import, and Sesori-side-only deletion.

## Why

The README predates the Hermes Agent plugin and still described Codex, Cursor, and Claude Code as beta with a future enablement promise that has since shipped. The README is the project's front door; it must match reality and showcase the current breadth of support.

## Risk and test focus

No code, wire, or product behavior changes. Risk is limited to inaccurate docs copy. Reviewers should verify the Hermes claims against `bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart` and the integration descriptions against each plugin package.

No user-visible or database impact beyond the rendered README itself.

## Expected result

A README that lists all seven supported assistants including Hermes Agent, presents every integration as stable and enabled by default, and keeps per-harness caveats accurate.

## Follow-ups noticed while editing (not in this PR)

- `docs/HOW_IT_WORKS.md` still says only OpenCode is supported with Codex/Cursor in beta.
- `docs/ARCHITECTURE.md` plugin listing does not mention the Claude, Pi, or Hermes plugin packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Hermes Agent to the supported assistants and replaces stale “Beta” statuses with an Integration column so the README reflects current, stable support. Also makes “How it works” assistant‑neutral in both copy and the diagram (“Local transport”).

- Verify Hermes details against `bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart` (ACP v1 via `hermes acp`, min 0.20.0, no managed install, `hermes` on PATH or `--hermes-bin`, config/login via Hermes CLI, import-only visibility for non-Sesori ACP sessions, Sesori-side delete).
- Confirm the hero, install step 2, features row, and supported-assistants table use the same canonical list and links render correctly. Check the diagram transport label is “Local transport.”
- No code, product, or data changes; no migration required.

<sup>Written for commit 388e1bb767292e37f466ccf7f0946db56f2cbb7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

