### PR TITLE
🌱 [reliability-cleanup] docs: plan the reliability cleanup series [step 1/14]

### DIFF
--- a/.plan/active/reliability-cleanup/PLAN.md
+++ b/.plan/active/reliability-cleanup/PLAN.md
@@ -395,13 +395,17 @@ New file `bridge/app/lib/src/bridge/relay_connection_coordinator.dart`.
   coordinator performs mechanics on command; it decides no auth policy.
 - **Owned state (moved, not new):** current connection, shutdown-close future,
   backoff jitter, incarnation fencing state, room key cache.
-- **Inbound seam:** exposes `Stream<RelayInbound>` — sealed variants for
-  routed request contexts, control messages, resume outcomes, and connection
-  lifecycle outcomes (`disconnected` carrying the close code/context including
-  `bridgeRevoked`, `reconnected`). Consumed by `OrchestratorSession`, which
-  keeps request routing and all SSE decisions and uses the lifecycle outcomes
-  to run today's drop cleanup (SSE subscriber orphaning, view-tracker resets)
-  and revocation re-registration unchanged.
+- **Inbound seam:** exposes acknowledged lifecycle hand-off — sealed
+  variants for routed request contexts, control messages, resume outcomes,
+  and connection outcomes (`disconnected` carrying the close code/context
+  including `bridgeRevoked`, `reconnected`). Like the pipeline seam below,
+  the coordinator's reconnect waits for OrchestratorSession to acknowledge a
+  `disconnected` outcome, preserving today's ordering where revocation
+  handling completes (and re-registration state settles) before
+  `ensureRegistered()` and the new connection run; without the ack a stream
+  producer could not await that asynchronous cleanup and reconnects would
+  race stale bridge identity. Consumed by `OrchestratorSession`, which keeps
+  request routing and all SSE decisions.
 - **Outbound seams:** `sendResponse(...)`, `sendEventFrame(...)`,
   `requestRekey()` — accept typed payloads, own encryption/framing/send-fencing
   internally. Never emits SSE; never touches plugin or database layers.
@@ -434,7 +438,11 @@ New file `bridge/app/lib/src/bridge/plugin_event_delivery_pipeline.dart`.
   It owns mechanics only — ordering, fencing, history capture, attachment
   shaping. It owns no delivery policy.
 - **Constructor dependencies (required):** runtime/plugin lookup, history
-  service, unseen-event collaborators, failure reporter. The
+  service, failure reporter. Unseen-event routing is deliberately NOT a
+  dependency: `_routeUnseenActivity(SesoriSseEvent)` consumes mapped wire
+  events, so it runs in `OrchestratorSession` after wire mapping alongside
+  delivery policy — exactly like project activity and wire mapping itself.
+  The
   project-activity collaborator is deliberately NOT a dependency:
   `ProjectActivityService.handleEvent(SesoriSseEvent)` consumes mapped wire
   events, so it is invoked by `OrchestratorSession` after wire mapping,
@@ -457,8 +465,8 @@ New file `bridge/app/lib/src/bridge/plugin_event_delivery_pipeline.dart`.
   order only fact production). This preserves today's invariant exactly: full
   same-plugin serialization of produce-through-deliver, with cross-plugin
   concurrency untouched; unrelated plugins never wait on one another. Facts
-  are typed and policy-free (captured transcript updates, summary snapshots,
-  unseen routing results); the pipeline never sees wire shapes or recipients.
+  are typed and policy-free captured facts (transcript updates, summary
+  snapshots); the pipeline never sees wire shapes or recipients.
 - **Generation fences:** each await boundary inside the pipeline is labeled
   with the validity check it requires. No existing check is deleted in this
   step; pruning provably redundant checks may happen later only with a tracker
@@ -538,11 +546,14 @@ plugins → runtime → interface/foundation; Codex already depends on runtime);
   `dispose({required String reason})` failing all pending, closing stdin,
   waiting briefly, terminating, then force-killing. Stale-generation callbacks
   are fenced internally via a generation counter bumped by
-  `attach({required NdjsonProcessHandle process})`. `attach` rejects and reaps
-  the handle (terminate + await exit) when the transport is already disposed
-  or superseded, fencing the dispose-racing-asynchronous-spawn window that all
-  three existing clients guard by hand today; adapters therefore carry no
-  lifecycle bookkeeping of their own.
+  `AttachToken beginAttach()` issued BEFORE the caller spawns, and
+  `attach({required AttachToken token, required NdjsonProcessHandle process})`.
+  `attach` rejects and reaps the handle (terminate + await exit) when the
+  transport is already disposed, reset, or superseded by a newer attempt —
+  the pre-spawn token is what makes the in-flight-spawn race recognizable
+  (connect A awaiting spawn while reset() runs, then connect B starts), which
+  is exactly why all three existing clients capture their generation before
+  spawning. Adapters therefore carry no lifecycle bookkeeping of their own.
 - **Preserved divergences:** frame classification, notification semantics,
   redaction, and malformed-policy remain explicit caller choices — nothing is
   unified by accident.
@@ -790,6 +801,8 @@ Affected feature documents (Step 13 reconciles):
 - `docs/regression/questions-and-permissions.md` — pending-input contract
   documentation, Codex disposal logging;
 - `docs/regression/attachments-and-images.md` — shared base64/MIME helper home;
+- `docs/regression/session-history-and-recovery.md` — Step 6 moves history
+  capture and attachment shaping into the delivery pipeline;
 - `docs/regression/session-turns.md` — event-delivery pipeline ownership;
 - `docs/regression/bridge-connectivity.md` — relay coordinator ownership,
   unchanged reconnect/resume semantics;
@@ -821,7 +834,12 @@ capability. Any reduction concern should be raised at plan review.
   L2 for exactly the semantics Step 5 moves (Step 5 surface).
 - **Live plugin:** one ACP-family plugin (Cursor, OMP, or Hermes), plus Codex
   and Claude: create a session, exchange turns, answer one question/permission
-  prompt, archive or delete where supported (Steps 7-8 surfaces).
+  prompt, archive or delete where supported (Steps 7-8 surfaces). The same
+  pass exercises one backend-produced image through live delivery and a cold
+  history read (Step 8 normalizers; `attachments-and-images.md` L2) and one
+  history backfill with a transcript longer than one page, immediately
+  queryable after send and paged on reopen (Step 6 capture move;
+  `session-history-and-recovery.md` L2).
 - **Client end to end:** release-target phone: open a session detail, send a
   prompt, present permission + question modals, filter and select via model and
   command pickers, render one error/retry state, record and submit one voice

--- a/.plan/active/reliability-cleanup/PLAN.md
+++ b/.plan/active/reliability-cleanup/PLAN.md
@@ -44,7 +44,7 @@ by any step** (B-Shared not applicable).
 | 9 | none | `module_core`, `app` |
 | 10 | none | `module_prego`, `app` |
 | 11 | none | `app` |
-| 12 | none (repo-root CI/installer files only) | none |
+| 12 | `app` (installer parity tests only) | none |
 | 13–14 | docs only | docs only |
 
 ## Goal
@@ -347,9 +347,12 @@ All changes inside `bridge/app` except the Step 3 helper, which lives in
    `bridge/app` already depends on it, so no new edges). Because
    `http.AbortableRequest` receives its abort trigger at construction, the
    helper constructs the request itself from request inputs:
-   `Future<http.StreamedResponse> send({required http.Client client, required String method, required Uri url, required Map<String, String>? headers, required Object? body, required Duration deadline, required Future<Object>? abortSignal})`
+   `Future<http.Response> send({required http.Client client, required String method, required Uri url, required Map<String, String>? headers, required Object? body, required Duration deadline, required Future<Object>? abortSignal})`
    builds the combined abort trigger (deadline timer plus optional external
-   signal), passes it as `abortTrigger`, and owns one finally-path cleanup.
+   signal), passes it as `abortTrigger`, buffers the response via
+   `http.Response.fromStream` before its finally-path cleanup so deadline and
+   abort coverage extend through full body consumption exactly as today
+   (auth-server JSON payloads are small), and owns one finally-path cleanup.
    The external signal is a `Future` rather than a stream so an abort that
    fires before the helper runs still cancels the request. Because today's
    `SesoriServerRequestAbortSignal` exposes only an `isAborted` flag and a
@@ -468,8 +471,13 @@ plugins → runtime → interface/foundation; Codex already depends on runtime);
 - `final class NdjsonProcessTransport` — one framed request/response channel
   over a subprocess's stdio.
 - **Process abstraction:** minimal `NdjsonProcessHandle` interface declared in
-  the same file (stdin sink, broadcast stdout line stream, done future, kill)
-  with thin adapters mapping each plugin's existing handle types onto it.
+  the same file (stdin sink, broadcast stdout line stream, broadcast stderr
+  line stream, done future, kill) with thin adapters mapping each plugin's
+  existing handle types onto it. The transport drains stderr for the attached
+  generation (a full stderr pipe can block the child) and forwards lines to
+  the injected logger at debug level honoring `redactMalformedFrames`, so
+  draining is lifecycle bookkeeping owned here rather than re-duplicated per
+  adapter.
 - **Policy via values plus one seam:** constructor takes
   `MalformedFramePolicy {discard, failPending}` (ACP/Claude discard, Codex fail
   all pending), `redactMalformedFrames` flag (Claude true, others false),
@@ -501,6 +509,10 @@ plugins → runtime → interface/foundation; Codex already depends on runtime);
   framing/lifecycle owner;
   `Stream<Map<String, dynamic>> notifications` for protocol-specific inbound
   lines the owning plugin interprets;
+  `Future<NdjsonProcessExit> get exit` exposing the attached generation's
+  process completion so plugins keep today's exit-driven behaviors (plugin
+  failure, resident-process removal, pending-turn settlement) without touching
+  raw handles;
   `dispose({required String reason})` failing all pending, closing stdin,
   waiting briefly, terminating, then force-killing. Stale-generation callbacks
   are fenced internally via a generation counter bumped by

--- a/.plan/active/reliability-cleanup/PLAN.md
+++ b/.plan/active/reliability-cleanup/PLAN.md
@@ -123,7 +123,7 @@ no new behavior, guards, retries, registries, or validation layers are added.
 ### Bridge app (`bridge/app/lib/src/bridge`)
 
 **F1 — Orchestrator owns three jobs in one file (observed).**
-`orchestrator.dart` is 2,485 lines. Two regions are cohesive state machines
+`orchestrator.dart` is 2,484 lines. Two regions are cohesive state machines
 buried inside orchestration composition and SSE decisions:
 
 - Relay connection/session transport (`orchestrator.dart:1147-1313`,
@@ -616,7 +616,7 @@ cross-owner lock, or second stream, stop and ask before expanding scope.
 | 7/14 | `🚧 [reliability-cleanup] refactor(plugins): share the ndjson subprocess transport [step 7/14]` | 600-1,100 lines | Step 7 design; acp/claude gain runtime dep; AGENTS.md order update. |
 | 8/14 | `🌿 [reliability-cleanup] refactor(plugins): consolidate shared plugin primitives [step 8/14]` | 300-550 lines | Step 8 table: helpers, descriptor policy, URLs, interface defaults, contract docs, Codex log fix. |
 | 9/14 | `🌿 [reliability-cleanup] refactor(client): remove dead code and fix observability [step 9/14]` | 250-500 lines | F10-F13 incl. cleanup-rejection layering flow. |
-| 10/14 | `⚙️ [reliability-cleanup] feat(ui): consolidate sheet, status, and picker primitives [step 10/14]` | 500-900 lines | Step 10 designs + full consumer migration. |
+| 10/14 | `⚙️ [reliability-cleanup] refactor(ui): consolidate sheet, status, and picker primitives [step 10/14]` | 500-900 lines | Step 10 designs + full consumer migration. |
 | 11/14 | `⚙️ [reliability-cleanup] refactor(app): split state-heavy composer and settings widgets [step 11/14]` | 900-1,400 changed (mostly relocation) | Step 11 collaborator table. |
 | 12/14 | `🌿 [reliability-cleanup] chore(tooling): tighten CI, codegen freshness, installer parity [step 12/14]` | 200-450 lines | F16 items. |
 | 13/14 | `🌱 [reliability-cleanup] docs: reconcile regression coverage [step 13/14]` | 80-200 lines | Penultimate reconciliation; cleanup audit vs actual merges. |

--- a/.plan/active/reliability-cleanup/PLAN.md
+++ b/.plan/active/reliability-cleanup/PLAN.md
@@ -347,19 +347,20 @@ All changes inside `bridge/app` except the Step 3 helper, which lives in
    `bridge/app` already depends on it, so no new edges). Because
    `http.AbortableRequest` receives its abort trigger at construction, the
    helper constructs the request itself from request inputs:
-   `Future<http.Response> send({required http.Client client, required String method, required Uri url, required Map<String, String>? headers, required Object? body, required Duration deadline, required Future<Object>? abortSignal})`
+   `Future<http.Response> send({required http.Client client, required String method, required Uri url, required Map<String, String>? headers, required Object? body, required Duration deadline, required AbortSignal? abortSignal})`
    builds the combined abort trigger (deadline timer plus optional external
    signal), passes it as `abortTrigger`, buffers the response via
    `http.Response.fromStream` before its finally-path cleanup so deadline and
    abort coverage extend through full body consumption exactly as today
    (auth-server JSON payloads are small), and owns one finally-path cleanup.
-   The external signal is a `Future` rather than a stream so an abort that
-   fires before the helper runs still cancels the request. Because today's
-   `SesoriServerRequestAbortSignal` exposes only an `isAborted` flag and a
-   broadcast stream, Step 3 also adds one completer-backed
-   `Future<Object> get abortFuture` to that signal (same app-local type,
-   replay-safe, no per-call subscription cleanup); call sites pass
-   `signal.abortFuture`. Callers keep status
+   The external abort arrives as a foundation-neutral `AbortSignal` value
+   exposing `bool get isAborted` plus its broadcast stream: the helper checks
+   the flag first (replay-safe against an abort that fired before the call),
+   then subscribes and cancels that subscription in its finally path — so
+   completed requests retain no listeners on a long-lived shared signal,
+   unlike an attached future listener which cannot be detached. Callers pass
+   their existing signal object directly; no per-request future bridging.
+   Callers keep status
    handling and retry policy: `SesoriServerApi`, `TokenManager`,
    `BridgeRegistrationApi`.
 
@@ -438,13 +439,13 @@ New file `bridge/app/lib/src/bridge/plugin_event_delivery_pipeline.dart`.
   It owns mechanics only — ordering, fencing, history capture, attachment
   shaping. It owns no delivery policy.
 - **Constructor dependencies (required):** runtime/plugin lookup, history
-  service, failure reporter, and one narrow neutral part-shaping seam (the
-  pure `mapMessagePart` / `isMessagePartVisible` / `buildMessagePartEvent`
-  functions the current capture path at `orchestrator.dart:1572-1599` uses).
-  These are backend-neutral transcript-modeling functions, not wire-event
-  construction; injecting just them keeps stored-part construction inside the
-  pipeline's capture invariant while `BridgeEventMapper` wire mapping stays
-  upstairs. Unseen-event routing is deliberately NOT a
+  service, failure reporter, and two narrow transcript-modeling seams (`mapMessagePart`,
+  `isMessagePartVisible` from the current capture path at
+  `orchestrator.dart:1572-1599`). `buildMessagePartEvent` is explicitly NOT
+  part of the seam — it constructs `SesoriSseEvent.messagePartUpdated`, a wire
+  shape, so it runs in `OrchestratorSession` alongside the rest of
+  `BridgeEventMapper`; the pipeline emits shaped stored parts and never sees
+  wire events. Unseen-event routing is deliberately NOT a
   dependency: `_routeUnseenActivity(SesoriSseEvent)` consumes mapped wire
   events, so it runs in `OrchestratorSession` after wire mapping alongside
   delivery policy — exactly like project activity and wire mapping itself.
@@ -565,7 +566,9 @@ plugins → runtime → interface/foundation; Codex already depends on runtime);
   are fenced internally via a generation counter bumped by
   `AttachToken beginAttach()` issued BEFORE the caller spawns, and
   `attach({required AttachToken token, required NdjsonProcessHandle process})`.
-  `attach` rejects and reaps the handle (terminate + await exit) when the
+  `attach` rejects and reaps the handle (terminate, bounded wait, then timed
+  force-kill — an unbounded exit wait could hang the original connect forever
+  while leaving the obsolete child alive) when the
   transport is already disposed, reset, or superseded by a newer attempt —
   the pre-spawn token is what makes the in-flight-spawn race recognizable
   (connect A awaiting spawn while reset() runs, then connect B starts), which
@@ -610,8 +613,9 @@ Exact homes, signatures, and affected implementors:
    new file `client/module_core/lib/src/repositories/models/session_cleanup_rejection.dart`
    (repository-layer model home: the repository constructs and throws it, so
    it must live at or below the repository, not beside the service it flows
-   through)
-   beside the domain exception it rethrows; `SessionService` passes through;
+   through). The domain exception carries the original API exception as a
+   typed `innerError` field so translation preserves the diagnostic chain;
+   `SessionService` passes through;
    `session_list_cubit.dart` deletes its API import and consumes only the
    capabilities-layer type.
 6. Catch/logging fixes mirroring Step 3 patterns (F11 citations).

--- a/.plan/active/reliability-cleanup/PLAN.md
+++ b/.plan/active/reliability-cleanup/PLAN.md
@@ -427,19 +427,22 @@ receives the coordinator instead of the ~15 scattered relay/session fields.
 Shutdown ordering remains sequenced in `OrchestratorSession._teardown` exactly
 as today; the coordinator adds no new ordering rules.
 
-### Step 6 — plugin-event delivery pipeline extraction
+### Step 6 — plugin-event delivery dispatcher extraction
 
-New file `bridge/app/lib/src/bridge/plugin_event_delivery_pipeline.dart`.
+New file `bridge/app/lib/src/bridge/plugin_event_processing_dispatcher.dart`.
 
 **Class contract:**
 
-- `final class PluginEventDeliveryPipeline` — Orchestrator-owned collaborator
+- `final class PluginEventProcessingDispatcher` — Orchestrator-owned collaborator
   (child of `OrchestratorSession`, never a global service). Owns one invariant:
   ordered, generation-valid capture and sequencing of normalized plugin events.
   It owns mechanics only — ordering, fencing, history capture, attachment
   shaping. It owns no delivery policy.
 - **Constructor dependencies (required):** runtime/plugin lookup, history
-  service, failure reporter, and two narrow transcript-modeling seams (`mapMessagePart`,
+  service, failure reporter, a narrow neutral project-summary source (the
+  `getProjectActivitySummaries` read behind `_buildProjectsSummary`, injected
+  as a function seam so snapshot building needs no repository dependency), and
+  two narrow transcript-modeling seams (`mapMessagePart`,
   `isMessagePartVisible` from the current capture path at
   `orchestrator.dart:1572-1599`). `buildMessagePartEvent` is explicitly NOT
   part of the seam — it constructs `SesoriSseEvent.messagePartUpdated`, a wire
@@ -505,13 +508,17 @@ plugins → runtime → interface/foundation; Codex already depends on runtime);
 - **Process abstraction:** minimal `NdjsonProcessHandle` interface declared in
   the same file (stdin sink, broadcast stdout line stream, broadcast stderr
   line stream, done future, kill) with thin adapters mapping each plugin's
-  existing handle types onto it. The transport drains stderr for the attached
-  generation (a full stderr pipe can block the child). Content handling is a
-  dedicated constructor value, `StderrPolicy {discard, logRedacted}`: Codex
-  discards because its stderr carries upstream account diagnostics it must not
-  retain or log (preserving its deliberate drain-without-logging behavior),
-  and adopters opt into redacted logging only where their current client
-  demonstrably logs stderr today.
+  existing handle types onto it. The client drains stderr for the attached
+  generation (a full stderr pipe can block the child). Sanitization is
+  adapter-owned: the lines an adapter delivers on the stderr stream are
+  already sanitized, because secret patterns are backend knowledge — ACP
+  forwards verbatim as today, Claude applies its selective masking from
+  `claude_stream_client.dart:310-318`, Codex contributes no lines because its
+  current client deliberately drains without logging (upstream account
+  diagnostics must not be retained). The constructor value is
+  `StderrPolicy {discard, forwardSanitized}`: Codex discards; adopters forward
+  only where their current client demonstrably logs stderr today. The shared
+  client learns no backend's secret patterns.
 - **Policy via values plus one seam:** constructor takes
   `MalformedFramePolicy {discard, failPending}` (ACP/Claude discard, Codex fail
   all pending), `NonObjectFramePolicy {silentDiscard, logWarning,
@@ -727,7 +734,7 @@ required row that cannot run keeps the plan active per
 
 - `RelayConnectionCoordinator`: owns state that already existed, giving relay
   lifecycle exactly one owner;
-- `PluginEventDeliveryPipeline` + private `_SerialTails`: same — owns existing
+- `PluginEventProcessingDispatcher` + private `_SerialTails`: same — owns existing
   tails/captures; one acknowledged per-plugin fact hand-off replaces scattered
   inline emission;
 - `AbortableRequestClient`: stateless per call;
@@ -757,7 +764,7 @@ cross-owner lock, or second stream, stop and ask before expanding scope.
 | 3/14 | `🌿 [reliability-cleanup] fix(bridge): make swallowed failures observable [step 3/14]` | 150-300 lines | F3/F4/F5: logging fixes, relay-connect error preservation, settings-repository fold, `AbortableRequestClient`. |
 | 4/14 | `⚙️ [reliability-cleanup] refactor(bridge): unify plugin command transitions [step 4/14]` | 150-300 lines | Transition skeleton + slot composite subscriptions (F2). |
 | 5/14 | `🚧 [reliability-cleanup] refactor(bridge): extract the relay connection coordinator [step 5/14]` | 1,200-2,000 changed (mostly relocation) | Step 5 design; assembly stays in `Orchestrator.create`. |
-| 6/14 | `🚧 [reliability-cleanup] refactor(bridge): extract the plugin-event delivery pipeline [step 6/14]` | 700-1,300 changed (mostly relocation) | Step 6 design; policy stays in OrchestratorSession; label fences; delete none without proof. |
+| 6/14 | `🚧 [reliability-cleanup] refactor(bridge): extract the plugin-event processing dispatcher [step 6/14]` | 700-1,300 changed (mostly relocation) | Step 6 design; policy stays in OrchestratorSession; label fences; delete none without proof. |
 | 7/14 | `🚧 [reliability-cleanup] refactor(plugins): share the ndjson subprocess transport [step 7/14]` | 600-1,100 lines | Step 7 design; acp/claude gain runtime dep; AGENTS.md order update. |
 | 8/14 | `🌿 [reliability-cleanup] refactor(plugins): consolidate shared plugin primitives [step 8/14]` | 250-450 lines | Step 8 table: helpers, descriptor policy, URLs, contract docs, Codex log fix. |
 | 9/14 | `🌿 [reliability-cleanup] refactor(client): remove dead code and fix observability [step 9/14]` | 250-500 lines | F10-F13 incl. cleanup-rejection layering flow. |
@@ -825,8 +832,8 @@ Affected feature documents (Step 13 reconciles):
   documentation, Codex disposal logging;
 - `docs/regression/attachments-and-images.md` — shared base64/MIME helper home;
 - `docs/regression/session-history-and-recovery.md` — Step 6 moves history
-  capture and attachment shaping into the delivery pipeline;
-- `docs/regression/session-turns.md` — event-delivery pipeline ownership;
+  capture and attachment shaping into the processing dispatcher;
+- `docs/regression/session-turns.md` — event-processing dispatcher ownership;
 - `docs/regression/bridge-connectivity.md` — relay coordinator ownership,
   unchanged reconnect/resume semantics;
 - `docs/regression/bridge-installation-and-updates.md` — installer env override

--- a/.plan/active/reliability-cleanup/PLAN.md
+++ b/.plan/active/reliability-cleanup/PLAN.md
@@ -468,16 +468,19 @@ plugins → runtime → interface/foundation; Codex already depends on runtime);
 
 **Class contract:**
 
-- `final class NdjsonProcessTransport` — one framed request/response channel
-  over a subprocess's stdio.
+- `final class NdjsonProcessClient` — one framed request/response channel over
+  a subprocess's stdio. Named per the bridge convention that reserves
+  `Client` for transport wrappers (`RelayClient`, `PushNotificationClient`).
 - **Process abstraction:** minimal `NdjsonProcessHandle` interface declared in
   the same file (stdin sink, broadcast stdout line stream, broadcast stderr
   line stream, done future, kill) with thin adapters mapping each plugin's
   existing handle types onto it. The transport drains stderr for the attached
-  generation (a full stderr pipe can block the child) and forwards lines to
-  the injected logger at debug level honoring `redactMalformedFrames`, so
-  draining is lifecycle bookkeeping owned here rather than re-duplicated per
-  adapter.
+  generation (a full stderr pipe can block the child). Content handling is a
+  dedicated constructor value, `StderrPolicy {discard, logRedacted}`: Codex
+  discards because its stderr carries upstream account diagnostics it must not
+  retain or log (preserving its deliberate drain-without-logging behavior),
+  and adopters opt into redacted logging only where their current client
+  demonstrably logs stderr today.
 - **Policy via values plus one seam:** constructor takes
   `MalformedFramePolicy {discard, failPending}` (ACP/Claude discard, Codex fail
   all pending), `redactMalformedFrames` flag (Claude true, others false),
@@ -671,7 +674,7 @@ required row that cannot run keeps the plan active per
 - `PluginEventDeliveryPipeline` + private `_SerialTails`: same — owns existing
   tails/captures; one outbound stream replaces scattered inline emission;
 - `AbortableRequestSender`: stateless per call;
-- `NdjsonProcessTransport` + `NdjsonProcessHandle`: one stateful class plus a
+- `NdjsonProcessClient` + `NdjsonProcessHandle`: one stateful class plus a
   thin interface replacing three drifted ones;
 - Three Prego primitives: presentation-only, stateless or timer-scoped,
   replacing five+ drifted copies;

--- a/.plan/active/reliability-cleanup/PLAN.md
+++ b/.plan/active/reliability-cleanup/PLAN.md
@@ -76,7 +76,7 @@ no new behavior, guards, retries, registries, or validation layers are added.
 
 - No new user-facing features. Behavior is preserved everywhere except three
   small, deliberate deltas, each recorded in its step and accepted as part of
-  this   series: (1) swallowed failures become logged (Steps 3, 8, 9); (2) ACP
+  this series: (1) swallowed failures become logged (Steps 3, 8, 9); (2) ACP
   teardown gains the stdin-close drain step shared by the transport adopters
   (Step 7 — teardown-only, visible solely in process exit timing/logs); and
   (3) drifted UI micro-details unify on one implementation — picker spacing

--- a/.plan/active/reliability-cleanup/PLAN.md
+++ b/.plan/active/reliability-cleanup/PLAN.md
@@ -694,7 +694,8 @@ required row that cannot run keeps the plan active per
 - `RelayConnectionCoordinator`: owns state that already existed, giving relay
   lifecycle exactly one owner;
 - `PluginEventDeliveryPipeline` + private `_SerialTails`: same — owns existing
-  tails/captures; one outbound stream replaces scattered inline emission;
+  tails/captures; one acknowledged per-plugin fact hand-off replaces scattered
+  inline emission;
 - `AbortableRequestClient`: stateless per call;
 - `NdjsonProcessClient` + `NdjsonProcessHandle`: one stateful class plus a
   thin interface replacing three drifted ones;
@@ -755,7 +756,8 @@ packages' focused tests. Additional, per step:
   and settle semantics unchanged, including the disable early-return.
 - **5-6:** orchestrator/runtime/SSE suites green without assertion changes;
   changed tests may alter wiring only; shutdown-ordering tests prove drain
-  order intact; pipeline stream consumed exactly as the old inline emission.
+  order intact; acknowledged fact hand-off consumed exactly as the old inline
+  emission.
 - **7:** each adopting plugin's protocol suites prove identical frame/error
   semantics (Codex fail-all-on-malformed, Claude redaction, ACP discard);
   fake-process round-trips cover timeout, broken pipe, stale generation, kill

--- a/.plan/active/reliability-cleanup/PLAN.md
+++ b/.plan/active/reliability-cleanup/PLAN.md
@@ -35,7 +35,7 @@ by any step** (B-Shared not applicable).
 | Step | Bridge workspace packages | Client workspace modules |
 |---|---|---|
 | 2 | `app`, `sesori_plugin_codex`, `sesori_plugin_opencode`, `sesori_plugin_runtime` | none |
-| 3 | `app` | none |
+| 3 | `app`, `sesori_bridge_foundation` | none |
 | 4 | `app` | none |
 | 5 | `app` | none |
 | 6 | `app` | none |
@@ -74,8 +74,16 @@ no new behavior, guards, retries, registries, or validation layers are added.
 
 ## Non-Goals
 
-- No new user-facing features and no product behavior changes. Every step must
-  preserve observable behavior except where a swallowed failure becomes logged.
+- No new user-facing features. Behavior is preserved everywhere except three
+  small, deliberate deltas, each recorded in its step and accepted as part of
+  this series: (1) swallowed failures become logged (Steps 3, 8); (2) ACP
+  teardown gains the stdin-close drain step shared by the transport adopters
+  (Step 7 — teardown-only, visible solely in process exit timing/logs); and
+  (3) drifted UI micro-details unify on one implementation — picker spacing
+  and empty-failure presentation take the Prego defaults (Step 10), and the
+  PowerShell installer stops accepting non-three-component release versions,
+  matching `install.sh` (Step 12). Everything else preserves observable
+  behavior exactly; no other change may ship without an owner decision.
 - No wire contract changes between client and bridge, no database migrations,
   and no changes to relay framing or crypto layouts.
 - No new defensive machinery: no retry frameworks, event buses, universal
@@ -302,7 +310,7 @@ invocations:
 | Rejection sessionId omission fallback | `pending_interaction_service.dart` legacy owner-resolution branch | clients ≤ v1.0.x omitting sessionId |
 | Codex config fallback reads | `codex_config_reader.dart` fallback branches + call sites | VERIFY: only if peer is released-Sesori-era data, not live rollout format — otherwise keep with reason |
 | OpenCode CLI flag aliases ×3 | `open_code_plugin_descriptor.dart` alias branches | user scripts predating namespaced flags (introduced v1.1.1) |
-| RuntimeStartIntent side-file model/store | `runtime_start_intent.dart` side-file classes + store | bridges ≤ v1.0.8 sharing a data directory |
+| RuntimeStartIntent side-file model/store | `runtime_start_intent.dart`: per the marker's own instruction, first move intent state into the now-changeable ownership schema (preserving crash recovery for a bridge killed between process spawn and ownership commit), then remove the side-file model/store | bridges ≤ v1.0.8 sharing a data directory |
 
 Each marker gets a one-line verification note in the `TRACKER.md` ledger. If a
 marker fails the peer check during implementation, it stays and the reason is
@@ -332,10 +340,13 @@ All changes inside `bridge/app`:
 5. **Abortable-request helper:** new final class `AbortableRequestSender` in
    `sesori_bridge_foundation/lib/src/http/abortable_request_sender.dart`
    (foundation is the documented home for bridge-wide transport primitives;
-   `bridge/app` already depends on it, so no new edges). Single method
-   `Future<http.StreamedResponse> send({required http.Client client, required http.AbortableRequest request, required Duration deadline, Stream<Object>? abortSignal})`
-   owning the deadline timer, external-abort subscription, and one finally-path
-   cleanup. Callers keep status handling and retry policy: `SesoriServerApi`
+   `bridge/app` already depends on it, so no new edges). Because
+   `http.AbortableRequest` receives its abort trigger at construction, the
+   helper constructs the request itself from request inputs:
+   `Future<http.StreamedResponse> send({required http.Client client, required String method, required Uri url, Map<String, String>? headers, Object? body, required Duration deadline, Stream<Object>? abortSignal})`
+   builds the combined abort trigger (deadline timer plus optional external
+   signal), passes it as `abortTrigger`, and owns one finally-path cleanup.
+   Callers keep status handling and retry policy: `SesoriServerApi`
    (including `_postSessionMetadata`'s merged cancellation), `TokenManager`,
    `BridgeRegistrationApi`.
 
@@ -372,20 +383,19 @@ New file `bridge/app/lib/src/bridge/relay_connection_coordinator.dart`.
 - **Outbound seams:** `sendResponse(...)`, `sendEventFrame(...)`,
   `requestRekey()` — accept typed payloads, own encryption/framing/send-fencing
   internally. Never emits SSE; never touches plugin or database layers.
-- **Lifecycle:** constructed by the composition root, started by
+- **Lifecycle:** constructed by `Orchestrator.create`, started by
   `OrchestratorSession.start`, disposed inside the existing teardown sequence
   before the shared HTTP client closes; internal subscriptions held on one
   `CompositeSubscription`.
 - **Dependency direction:** orchestrator → coordinator (downward); coordinator
   depends only on transport/crypto/token primitives.
 
-**Composition root:** graph assembly moves out of orchestration code into
-`bridge/app/lib/src/bridge/orchestrator_composition.dart` — a factory building
-the object graph (repositories, APIs, push subsystem, services, listeners,
-route handlers, session collaborators) and returning it as a typed structure
-consumed by `Orchestrator.create`. `Orchestrator.create` becomes thin startup
-sequencing; `OrchestratorSession` receives the coordinator instead of the ~15
-scattered relay/session fields.
+**Composition root:** `Orchestrator.create` remains the single cross-layer
+composition owner — graph assembly does not move to a second file or type.
+Repetitive wiring within it may be organized into private builder helpers in
+the same library so the startup sequence reads as domains rather than a flat
+wall of constructions. The concrete change is that `OrchestratorSession`
+receives the coordinator instead of the ~15 scattered relay/session fields.
 
 Shutdown ordering remains sequenced in `OrchestratorSession._teardown` exactly
 as today; the coordinator adds no new ordering rules.
@@ -398,22 +408,28 @@ New file `bridge/app/lib/src/bridge/plugin_event_delivery_pipeline.dart`.
 
 - `final class PluginEventDeliveryPipeline` — Orchestrator-owned collaborator
   (child of `OrchestratorSession`, never a global service). Owns one invariant:
-  ordered, generation-valid capture-to-delivery of normalized plugin events.
+  ordered, generation-valid capture and sequencing of normalized plugin events.
+  It owns mechanics only — ordering, fencing, history capture, attachment
+  shaping. It owns no delivery policy.
 - **Constructor dependencies (required):** runtime/plugin lookup, event mapper,
-  history service, unseen-event/project-activity collaborators, permission
-  policy, failure reporter.
+  history service, unseen-event/project-activity collaborators, failure
+  reporter. Permission/push policy is deliberately NOT a dependency: decisions
+  about what phones receive stay in `OrchestratorSession`, satisfying
+  "Orchestrator Owns SSE Decisions".
 - **Owned state (moved):** per-plugin serial tails, projects-summary tail,
   pending part captures — the two duplicated completer-chain implementations
   collapse onto one private `_SerialTails` keyed executor defined in the same
   file (single consumer, stays private).
-- **Outbound seam:** exposes `Stream<OutboundSseDelivery>`; `OrchestratorSession`
-  subscribes and forwards to the SSE manager. Push-based per repo rules; the
-  Orchestrator remains the sole SSE decision owner and emitter boundary.
+- **Outbound seam:** exposes `Stream<NormalizedPluginFact>` — typed,
+  policy-free facts (captured transcript updates, summary snapshots, unseen
+  routing results). `OrchestratorSession` subscribes, applies generation/
+  permission/delivery policy exactly as today, and constructs the outbound SSE
+  deliveries itself; the pipeline never sees wire shapes or recipients.
 - **Generation fences:** each await boundary inside the pipeline is labeled
   with the validity check it requires. No existing check is deleted in this
   step; pruning provably redundant checks may happen later only with a tracker
   note naming the await boundary that makes each removed check dead.
-- **Lifecycle:** constructed by the composition root; drained by
+- **Lifecycle:** constructed by `Orchestrator.create`; drained by
   `OrchestratorSession._teardown` at exactly today's position (before
   normalized-output cancellation), then disposed.
 
@@ -436,17 +452,22 @@ plugins → runtime → interface/foundation; Codex already depends on runtime);
 - **Process abstraction:** minimal `NdjsonProcessHandle` interface declared in
   the same file (stdin sink, broadcast stdout line stream, done future, kill)
   with thin adapters mapping each plugin's existing handle types onto it.
-- **Policy via values, not callbacks:** constructor takes
+- **Policy via values plus one seam:** constructor takes
   `MalformedFramePolicy {discard, failPending}` (ACP/Claude discard, Codex fail
-  all pending), `redactMalformedFrames` flag (Claude true, others false), and
-  `logTag`. Request timeout duration is a method argument.
-- **API:** `Future<Map<String, dynamic>> request(Map<String, dynamic> envelope, {required Duration timeout})`
-  correlating IDs through an internal pending map with timeout removal;
-  `Stream<Map<String, dynamic>> notifications` for protocol-specific inbound
-  lines the owning plugin interprets; `dispose({required String reason})`
-  failing all pending, closing stdin, waiting briefly, terminating, then
-  force-killing. Stale-generation callbacks are fenced internally via a
-  generation counter bumped by `attach(NdjsonProcessHandle)`.
+  all pending), `redactMalformedFrames` flag (Claude true, others false),
+  `logTag`, and one required correlation extractor
+  `responseCorrelationId: Object? Function(Map<String, dynamic> message)` —
+  ACP/Codex return the top-level JSON-RPC `id`, Claude returns
+  `message["response"]["request_id"]` from `control_response` frames. The
+  extractor is injected once at construction; no policy callbacks cross layers.
+- **API:** `Future<Map<String, dynamic>> request({required Map<String, dynamic> envelope, required Duration timeout})`
+  correlating replies through an internal pending map keyed by the extracted
+  ID with timeout removal; `Stream<Map<String, dynamic>> notifications` for
+  protocol-specific inbound lines the owning plugin interprets;
+  `dispose({required String reason})` failing all pending, closing stdin,
+  waiting briefly, terminating, then force-killing. Stale-generation callbacks
+  are fenced internally via a generation counter bumped by
+  `attach({required NdjsonProcessHandle process})`.
 - **Preserved divergences:** frame classification, notification semantics,
   redaction, and malformed-policy remain explicit caller choices — nothing is
   unified by accident.
@@ -464,10 +485,9 @@ Exact homes, signatures, and affected implementors:
 
 | Primitive | Exact home | Consumers migrated |
 |---|---|---|
-| Base64/MIME normalization | `sesori_plugin_interface/lib/src/messages/attachment_normalization.dart`: pure top-level functions `String? tryNormalizeBase64(String)`, `String? normalizeMimeValue(String?)`, `String mimeEssence(String)` beside existing attachment validators (interface stays pure/contract-grade — no state, no I/O) | `acp_content_mapper.dart`, `codex_image_attachment_mapper.dart`, `message_part_mapper.dart` (OpenCode); Pi variant adopted only if byte-equivalent semantics, else left with a tracker note |
+| Base64/MIME normalization | `sesori_plugin_interface/lib/src/messages/attachment_normalization.dart`: pure top-level functions with named parameters — `tryNormalizeBase64({required String value})`, `normalizeMimeValue({required String? value})`, `mimeEssence({required String value})` — beside existing attachment validators (interface stays pure/contract-grade — no state, no I/O) | `acp_content_mapper.dart`, `codex_image_attachment_mapper.dart`, `message_part_mapper.dart` (OpenCode); Pi variant adopted only if byte-equivalent semantics, else left with a tracker note |
 | Descriptor install capability | `sesori_plugin_runtime/lib/src/provisioning/descriptor_install_policy.dart`: pure function taking manifest, resolved explicit-binary path, platform target → capability set | descriptors of OpenCode, Codex, Cursor, OMP, Pi; setup-hint strings stay plugin-local |
 | Release asset URL | default member on the existing manifest base in `sesori_plugin_runtime/lib/src/provisioning/runtime_manifest.dart`: `Uri releaseAssetUrl({required String assetName})` using each manifest's publisher/repo/tag fields | all five manifests delete private URL builders; any manifest with differing tag convention overrides and notes why |
-| Unsupported-op defaults | default members on `BridgePluginApi` in `sesori_plugin_interface`: `archiveSession` no-op, `deleteWorkspace` no-op, `getChildSessions` → `const []` (matches existing default-method precedent) | trivial overrides deleted wherever the analyzer proves them redundant (known: Claude, Pi, ACP) |
 | Contract documentation | doc comments on `BridgePluginApi` question/permission methods stating pending-input lifecycle expectations (reply/dispose/cancel must resolve or log) | interface-only documentation |
 | Codex observability fix | `sesori_plugin_codex/lib/src/approval_registry.dart:122-130`: silent catch logs like ACP/Claude | Codex-local |
 
@@ -498,8 +518,11 @@ Single chosen design per primitive (no alternatives):
 
 1. `PregoCenteredStatus` — new file
    `client/module_prego/lib/components/status/prego_centered_status.dart`;
-   required title, optional message, icon, action label/callback, semantics
-   config. Consumers migrated in the same PR: `error_view.dart`,
+   required title, optional message, icon, semantics config, and one optional
+   action modeled as a single value — a `PregoStatusAction` with required
+   label and required callback — so a visible label without an action or an
+   unreachable callback without a label is unrepresentable. Consumers migrated
+   in the same PR: `error_view.dart`,
    `session_list_content.dart`, `add_project_dialog.dart`,
    `diff_error_view.dart`, `session_detail_scaffold_sections.dart`.
 2. `showPregoBottomSheetRoute(...)` — lower-level presenter added to
@@ -541,9 +564,13 @@ cubits are untouched except imports if files move.
 
 1. `.github/workflows/bridge-ci.yml`: one checked-in package list drives
    analysis and test loops preserving per-package output and fail-fast.
-2. Codegen freshness job: regenerate OpenCode generated client/event outputs
-   from committed schema/manifest inputs and fail on diff (network-based
-   acquisition excluded from CI).
+2. Codegen freshness job: regenerate the OpenCode generated outputs that are
+   fully reproducible from committed inputs (SSE events from the committed
+   manifest) and fail on diff. The client-code generator additionally requires
+   an OpenAPI document that is not committed (the Makefile fetches it or takes
+   `OPENCODE_SPEC`), so that artifact is out of scope for offline CI; the
+   tracker records this limitation rather than adding network access or a
+   pinned upstream spec to CI.
 3. `install.ps1` gains `$env:GITHUB`/`$env:GITHUB_API` handling and exact
    three-component stable-version validation matching `install.sh`.
 4. Fixture-driven parity tests (extending `bridge/app/test/tool/installers_test.dart`)
@@ -611,10 +638,10 @@ cross-owner lock, or second stream, stop and ask before expanding scope.
 | 2/14 | `⚙️ [reliability-cleanup] refactor: drop pre-v1.4 compatibility paths [step 2/14]` | 150-350 lines | Six F6 removals with per-marker peer verification; keep v1.5.x+. |
 | 3/14 | `🌿 [reliability-cleanup] fix(bridge): make swallowed failures observable [step 3/14]` | 150-300 lines | F3/F4/F5: logging fixes, relay-connect error preservation, settings-repository fold, `AbortableRequestSender`. |
 | 4/14 | `⚙️ [reliability-cleanup] refactor(bridge): unify plugin command transitions [step 4/14]` | 150-300 lines | Transition skeleton + slot composite subscriptions (F2). |
-| 5/14 | `🚧 [reliability-cleanup] refactor(bridge): extract the relay connection coordinator [step 5/14]` | 1,200-2,000 changed (mostly relocation) | Step 5 design incl. composition root. |
-| 6/14 | `🚧 [reliability-cleanup] refactor(bridge): extract the plugin-event delivery pipeline [step 6/14]` | 700-1,300 changed (mostly relocation) | Step 6 design; label fences; delete none without proof. |
+| 5/14 | `🚧 [reliability-cleanup] refactor(bridge): extract the relay connection coordinator [step 5/14]` | 1,200-2,000 changed (mostly relocation) | Step 5 design; assembly stays in `Orchestrator.create`. |
+| 6/14 | `🚧 [reliability-cleanup] refactor(bridge): extract the plugin-event delivery pipeline [step 6/14]` | 700-1,300 changed (mostly relocation) | Step 6 design; policy stays in OrchestratorSession; label fences; delete none without proof. |
 | 7/14 | `🚧 [reliability-cleanup] refactor(plugins): share the ndjson subprocess transport [step 7/14]` | 600-1,100 lines | Step 7 design; acp/claude gain runtime dep; AGENTS.md order update. |
-| 8/14 | `🌿 [reliability-cleanup] refactor(plugins): consolidate shared plugin primitives [step 8/14]` | 300-550 lines | Step 8 table: helpers, descriptor policy, URLs, interface defaults, contract docs, Codex log fix. |
+| 8/14 | `🌿 [reliability-cleanup] refactor(plugins): consolidate shared plugin primitives [step 8/14]` | 250-450 lines | Step 8 table: helpers, descriptor policy, URLs, contract docs, Codex log fix. |
 | 9/14 | `🌿 [reliability-cleanup] refactor(client): remove dead code and fix observability [step 9/14]` | 250-500 lines | F10-F13 incl. cleanup-rejection layering flow. |
 | 10/14 | `⚙️ [reliability-cleanup] refactor(ui): consolidate sheet, status, and picker primitives [step 10/14]` | 500-900 lines | Step 10 designs + full consumer migration. |
 | 11/14 | `⚙️ [reliability-cleanup] refactor(app): split state-heavy composer and settings widgets [step 11/14]` | 900-1,400 changed (mostly relocation) | Step 11 collaborator table. |
@@ -661,8 +688,10 @@ packages' focused tests. Additional, per step:
   controller-level tests only where they add confidence (voice race, draft
   restore, paging handoff).
 - **12:** CI dry-run produces identical per-package commands; freshness job
-  fails when an output is dirtied locally; parity tests prove identical
-  URL/checksum/manifest decisions from shared fixtures including PS1 overrides.
+  fails when an offline-reproducible output is dirtied locally (OpenAPI-derived
+  output explicitly out of scope, recorded in the tracker); parity tests prove
+  identical URL/checksum/manifest decisions from shared fixtures including PS1
+  overrides.
 - **13/14:** docs reconcile cleanly against merged diffs; matrix evidence
   recorded in the tracker.
 

--- a/.plan/active/reliability-cleanup/PLAN.md
+++ b/.plan/active/reliability-cleanup/PLAN.md
@@ -321,10 +321,13 @@ recorded — the step shrinks honestly instead of forcing removals.
 All changes inside `bridge/app` except the Step 3 helper, which lives in
 `sesori_bridge_foundation` (see item 5):
 
-1. **Failure-reporter swallow:** `orchestrator.dart:1528` adopts the existing
-   logged pattern from `1735-1741` (typed catch, `Log.w("msg", error, stack)`).
-   Same treatment for resume/rekey/framing silent paths (`2035-2103`) with
-   connection IDs retained.
+1. **Failure-reporter swallows:** every
+   `_failureReporter.recordFailure(...).catchError((_) {})` adopts the logged
+   pattern from `orchestrator.dart:1735-1741` (typed catch,
+   `Log.w("msg", error, stack)`) — currently `orchestrator.dart:1528`,
+   `bridge_event_mapper.dart:195`, and `sse_manager.dart:212`. Same treatment
+   for resume/rekey/framing silent paths (`2035-2103`) with connection IDs
+   retained.
 2. **Logger args:** replace every interpolated `${error}`/`${e}` citation in F3
    with `Log.w/<logger>("context", error, stackTrace)`; message keeps IDs and
    operation context, never the payload.
@@ -344,11 +347,14 @@ All changes inside `bridge/app` except the Step 3 helper, which lives in
    `bridge/app` already depends on it, so no new edges). Because
    `http.AbortableRequest` receives its abort trigger at construction, the
    helper constructs the request itself from request inputs:
-   `Future<http.StreamedResponse> send({required http.Client client, required String method, required Uri url, Map<String, String>? headers, Object? body, required Duration deadline, Stream<Object>? abortSignal})`
+   `Future<http.StreamedResponse> send({required http.Client client, required String method, required Uri url, Map<String, String>? headers, Object? body, required Duration deadline, Future<Object>? abortSignal})`
    builds the combined abort trigger (deadline timer plus optional external
    signal), passes it as `abortTrigger`, and owns one finally-path cleanup.
-   Callers keep status handling and retry policy: `SesoriServerApi`
-   (including `_postSessionMetadata`'s merged cancellation), `TokenManager`,
+   The external signal is a `Future` rather than a stream so an abort that
+   fires before the helper runs still cancels the request — matching today's
+   completer-based call sites and preserving `_postSessionMetadata`'s
+   immediate-abort semantics without a pre-send race. Callers keep status
+   handling and retry policy: `SesoriServerApi`, `TokenManager`,
    `BridgeRegistrationApi`.
 
 ### Step 4 — PluginRuntime command transitions
@@ -457,14 +463,29 @@ plugins → runtime → interface/foundation; Codex already depends on runtime);
   `MalformedFramePolicy {discard, failPending}` (ACP/Claude discard, Codex fail
   all pending), `redactMalformedFrames` flag (Claude true, others false),
   `logTag`, and one required correlation extractor
-  `responseCorrelationId: Object? Function(Map<String, dynamic> message)` —
-  ACP/Codex return the top-level JSON-RPC `id`, Claude returns
-  `message["response"]["request_id"]` from `control_response` frames. The
-  extractor is injected once at construction; no policy callbacks cross layers.
+  `responseCorrelationId: Object? Function(Map<String, dynamic> message)`. The
+  extractor is invoked only for response-shaped messages; it returns the
+  correlation ID for a response and null otherwise. Classification happens
+  before extraction exactly as today: ACP/Codex treat a frame as a response
+  only when it has an `id` and no `method` (server-originated requests carry
+  both and route to the plugin), Claude extracts
+  `message["response"]["request_id"]` from `control_response` frames and
+  routes everything else to the plugin. The extractor is injected once at
+  construction; no policy callbacks cross layers.
 - **API:** `Future<Map<String, dynamic>> request({required Map<String, dynamic> envelope, required Duration timeout})`
   correlating replies through an internal pending map keyed by the extracted
-  ID with timeout removal; `Stream<Map<String, dynamic>> notifications` for
-  protocol-specific inbound lines the owning plugin interprets;
+  ID with timeout removal;
+  `DispatchHandle dispatch({required Map<String, dynamic> envelope, required Duration timeout})`
+  returning write acceptance separately from the correlated-response future —
+  this preserves ACP's dispatch-completion boundary where the accepted prompt
+  publishes after stdin flush while the backend turn may run for minutes;
+  `void sendFrame({required Map<String, dynamic> envelope})` for one-way and
+  reply frames the protocol requires plugins to emit (ACP notifications and
+  server-request responses, Codex `initialized` and server-request replies,
+  Claude control responses) so all writes flow through the transport's single
+  framing/lifecycle owner;
+  `Stream<Map<String, dynamic>> notifications` for protocol-specific inbound
+  lines the owning plugin interprets;
   `dispose({required String reason})` failing all pending, closing stdin,
   waiting briefly, terminating, then force-killing. Stale-generation callbacks
   are fenced internally via a generation counter bumped by
@@ -487,7 +508,7 @@ Exact homes, signatures, and affected implementors:
 | Primitive | Exact home | Consumers migrated |
 |---|---|---|
 | Base64/MIME normalization | `sesori_plugin_interface/lib/src/messages/attachment_normalization.dart`: pure top-level functions with named parameters — `tryNormalizeBase64({required String value})`, `normalizeMimeValue({required String? value})`, `mimeEssence({required String value})` — beside existing attachment validators (interface stays pure/contract-grade — no state, no I/O) | `acp_content_mapper.dart`, `codex_image_attachment_mapper.dart`, `message_part_mapper.dart` (OpenCode); Pi variant adopted only if byte-equivalent semantics, else left with a tracker note |
-| Descriptor install capability | `sesori_plugin_runtime/lib/src/provisioning/descriptor_install_policy.dart`: pure function taking manifest, resolved explicit-binary path, platform target → capability set | descriptors of OpenCode, Codex, Cursor, OMP, Pi; setup-hint strings stay plugin-local |
+| Descriptor install capability | `sesori_plugin_runtime/lib/src/provisioning/descriptor_install_policy.dart`: pure function taking manifest, resolved explicit-binary path, platform target, and a plugin-supplied support verdict (a neutral `RuntimeAssetSupport` value each descriptor computes locally) → capability set. The local computation matters: OMP resolves its concrete Linux glibc/musl asset asynchronously and reports support via a separate check, so the neutral helper must not re-derive asset presence from `assetFor(target)` alone | descriptors of OpenCode, Codex, Cursor, OMP, Pi; setup-hint strings stay plugin-local |
 | Release asset URL | default member on the existing manifest base in `sesori_plugin_runtime/lib/src/provisioning/runtime_manifest.dart`: `Uri releaseAssetUrl({required String assetName})` using each manifest's publisher/repo/tag fields | all five manifests delete private URL builders; any manifest with differing tag convention overrides and notes why |
 | Contract documentation | doc comments on `BridgePluginApi` question/permission methods stating pending-input lifecycle expectations (reply/dispose/cancel must resolve or log) | interface-only documentation |
 | Codex observability fix | `sesori_plugin_codex/lib/src/approval_registry.dart:122-130`: silent catch logs like ACP/Claude | Codex-local |
@@ -564,7 +585,9 @@ cubits are untouched except imports if files move.
 ### Step 12 — tooling
 
 1. `.github/workflows/bridge-ci.yml`: one checked-in package list drives
-   analysis and test loops preserving per-package output and fail-fast.
+   analysis and test loops preserving per-package output and fail-fast; the
+   workflow path filters gain `install.sh` and `install.ps1` so later
+   installer-only changes keep triggering the parity suite.
 2. Codegen freshness job: regenerate the OpenCode generated outputs that are
    fully reproducible from committed inputs (SSE events from the committed
    manifest) and fail on diff. The client-code generator additionally requires
@@ -683,7 +706,9 @@ packages' focused tests. Additional, per step:
 - **9:** module_core + app suites green; grep proves deleted symbols unreferenced;
   analyzer/config check proves the cubit no longer imports the API package.
 - **10:** widget tests for migrated sheets/pickers/statuses prove layout,
-  keyboard, safe-area, and empty/failure presentations unchanged.
+  keyboard, safe-area behavior, and the explicitly accepted deltas — unified
+  Prego spacing and empty/failure presentation replace the per-consumer drift
+  recorded in Non-Goals — while all other presentations stay unchanged.
 - **11:** existing prompt-input/harness/question/message-list suites green;
   controller-level tests only where they add confidence (voice race, draft
   restore, paging handoff).

--- a/.plan/active/reliability-cleanup/PLAN.md
+++ b/.plan/active/reliability-cleanup/PLAN.md
@@ -76,7 +76,7 @@ no new behavior, guards, retries, registries, or validation layers are added.
 
 - No new user-facing features. Behavior is preserved everywhere except three
   small, deliberate deltas, each recorded in its step and accepted as part of
-  this series: (1) swallowed failures become logged (Steps 3, 8); (2) ACP
+  this   series: (1) swallowed failures become logged (Steps 3, 8, 9); (2) ACP
   teardown gains the stdin-close drain step shared by the transport adopters
   (Step 7 — teardown-only, visible solely in process exit timing/logs); and
   (3) drifted UI micro-details unify on one implementation — picker spacing
@@ -318,7 +318,8 @@ recorded — the step shrinks honestly instead of forcing removals.
 
 ### Step 3 — bridge observability and layer sweep
 
-All changes inside `bridge/app`:
+All changes inside `bridge/app` except the Step 3 helper, which lives in
+`sesori_bridge_foundation` (see item 5):
 
 1. **Failure-reporter swallow:** `orchestrator.dart:1528` adopts the existing
    logged pattern from `1735-1741` (typed catch, `Log.w("msg", error, stack)`).
@@ -678,8 +679,7 @@ packages' focused tests. Additional, per step:
   fake-process round-trips cover timeout, broken pipe, stale generation, kill
   ordering; teardown-order delta asserted intentionally.
 - **8:** mapper/descriptor unit tests prove identical normalization outputs and
-  capability decisions across all five descriptors; analyzer proves removed
-  overrides were trivially redundant.
+  capability decisions across all five descriptors.
 - **9:** module_core + app suites green; grep proves deleted symbols unreferenced;
   analyzer/config check proves the cubit no longer imports the API package.
 - **10:** widget tests for migrated sheets/pickers/statuses prove layout,

--- a/.plan/active/reliability-cleanup/PLAN.md
+++ b/.plan/active/reliability-cleanup/PLAN.md
@@ -438,7 +438,13 @@ New file `bridge/app/lib/src/bridge/plugin_event_delivery_pipeline.dart`.
   It owns mechanics only — ordering, fencing, history capture, attachment
   shaping. It owns no delivery policy.
 - **Constructor dependencies (required):** runtime/plugin lookup, history
-  service, failure reporter. Unseen-event routing is deliberately NOT a
+  service, failure reporter, and one narrow neutral part-shaping seam (the
+  pure `mapMessagePart` / `isMessagePartVisible` / `buildMessagePartEvent`
+  functions the current capture path at `orchestrator.dart:1572-1599` uses).
+  These are backend-neutral transcript-modeling functions, not wire-event
+  construction; injecting just them keeps stored-part construction inside the
+  pipeline's capture invariant while `BridgeEventMapper` wire mapping stays
+  upstairs. Unseen-event routing is deliberately NOT a
   dependency: `_routeUnseenActivity(SesoriSseEvent)` consumes mapped wire
   events, so it runs in `OrchestratorSession` after wire mapping alongside
   delivery policy — exactly like project activity and wire mapping itself.
@@ -464,7 +470,10 @@ New file `bridge/app/lib/src/bridge/plugin_event_delivery_pipeline.dart`.
   subscription (Dart streams do not await listeners, so a plain stream would
   order only fact production). This preserves today's invariant exactly: full
   same-plugin serialization of produce-through-deliver, with cross-plugin
-  concurrency untouched; unrelated plugins never wait on one another. Facts
+  concurrency untouched for ordinary event delivery. Summary rebuilds keep a
+  dedicated GLOBAL tail key — repository-wide snapshots stay serialized
+  across plugins exactly as `_projectsSummaryTail` does today — so the
+  cross-plugin guarantee applies only to ordinary events, never summaries. Facts
   are typed and policy-free captured facts (transcript updates, summary
   snapshots); the pipeline never sees wire shapes or recipients.
 - **Generation fences:** each await boundary inside the pipeline is labeled
@@ -528,13 +537,18 @@ plugins → runtime → interface/foundation; Codex already depends on runtime);
   returning write acceptance separately from the correlated-response future —
   this preserves ACP's dispatch-completion boundary where the accepted prompt
   publishes after stdin flush while the backend turn may run for minutes;
-  `void sendFrame({required Map<String, dynamic> envelope})` for one-way and
+  `bool sendFrame({required Map<String, dynamic> envelope})` returning write
+  acceptance (Claude retires a pending approval only when its control
+  response was actually accepted) for one-way and
   reply frames the protocol requires plugins to emit (ACP notifications and
   server-request responses, Codex `initialized` and server-request replies,
   Claude control responses) so all writes flow through the transport's single
   framing/lifecycle owner;
   `Stream<Map<String, dynamic>> notifications` for protocol-specific inbound
   lines the owning plugin interprets;
+  `bool get isAttached` mirroring today's synchronous connected checks
+  (`AcpStdioClient.isConnected` drives Cursor probe reconnect decisions and
+  replay/catalog dead-client replacement across ACP-family plugins);
   `Future<NdjsonProcessExit> get exit` exposing the attached generation's
   process completion so plugins keep today's exit-driven behaviors (plugin
   failure, resident-process removal, pending-turn settlement) without touching
@@ -543,7 +557,10 @@ plugins → runtime → interface/foundation; Codex already depends on runtime);
   reaping the current process generation, and returning the client to the
   attachable state without closing it — preserving Cursor's catalog-probe
   flow (`AcpStdioClient.reset` + reconnect on the same client);
-  `dispose({required String reason})` failing all pending, closing stdin,
+  `dispose({required String reason, required Duration gracefulTimeout})`
+  preserving each caller's remaining operation deadline
+  (`HermesAcpApi.settleScratch` forwards its own), failing all pending,
+  closing stdin,
   waiting briefly, terminating, then force-killing. Stale-generation callbacks
   are fenced internally via a generation counter bumped by
   `AttachToken beginAttach()` issued BEFORE the caller spawns, and
@@ -607,9 +624,11 @@ Single chosen design per primitive (no alternatives):
 
 1. `PregoCenteredStatus` — new file
    `client/module_prego/lib/components/status/prego_centered_status.dart`;
-   required title, optional message, icon, semantics config, and one optional
-   action modeled as a single value — a `PregoStatusAction` with required
-   label and callback plus optional leading-icon and style parameters.
+   required title and named parameters that are themselves `required` even
+   when nullable per the repo convention — message, icon, semantics config,
+   one optional-modeled action as a single `PregoStatusAction` value
+   (required label and callback plus required-nullable leading-icon and
+   style).
    Adoption is scoped to the two near-copy list error views where the
    investigation established genuine duplication — `error_view.dart` and
    `session_list_content.dart` — migrated in the same PR. The semantically
@@ -826,7 +845,10 @@ capability. Any reduction concern should be raised at plan review.
 - **Automated:** full analyze + test suites green for every touched package
   (CI-enforced; recorded here).
 - **Headless bridge:** start the bridge; exercise plugin stop/disable/restart
-  transitions and graceful shutdown drain (Steps 4-6 surfaces).
+  transitions and graceful shutdown drain (Steps 4-6 surfaces); plus setup
+  refresh, disable-list persistence across a bridge restart, and
+  eligibility/ordering across every registered harness — the L2 rows of
+  `plugin-setup-and-lifecycle.md` that Steps 2/4/8 touch.
 - **Relay integration:** exercise key exchange plus a normal relay drop and
   reconnect against a real relay, proving the coordinator extraction preserved
   resume/incarnation behavior and Orchestrator drop cleanup — the
@@ -840,6 +862,8 @@ capability. Any reduction concern should be raised at plan review.
   history backfill with a transcript longer than one page, immediately
   queryable after send and paged on reopen (Step 6 capture move;
   `session-history-and-recovery.md` L2).
+- **Web catalog:** build and render the release design catalog against the
+  edited `module_prego` components per `design-catalog.md` L2 (Step 10).
 - **Client end to end:** release-target phone: open a session detail, send a
   prompt, present permission + question modals, filter and select via model and
   command pickers, render one error/retry state, record and submit one voice

--- a/.plan/active/reliability-cleanup/PLAN.md
+++ b/.plan/active/reliability-cleanup/PLAN.md
@@ -1,0 +1,754 @@
+# Reliability Cleanup Series
+
+## Status
+
+- **Plan slug:** `reliability-cleanup`
+- **Status:** Approved by owner 2026-08-21 with an explicit vagueness waiver
+  (see Owner Waivers). Both permitted architecture-plan-review attempts
+  rejected Steps 5-6's type-level detail as too vague; the owner accepted the
+  current design level, so exact constructor signatures/seam types are pinned
+  inside each implementation PR instead and reviewed there via
+  `architecture-implementation-review`. Do not re-run plan review on this
+  basis. Ready for Step 1 when the owner says go.
+- **Plan date:** 2026-08-21
+- **Repository:** `sesori-ai/sesori_apps_monorepo`
+- **Implementation base:** `origin/main` at `084b30276`
+- **Delivery:** fourteen numbered PRs executed one by one; Step 13 reconciles
+  regression documents, Step 14 runs the recorded verification matrix and
+  retires this plan
+- **Investigation inputs:** five parallel code investigations (bridge app,
+  bridge plugins, client module_core, client UI shells, shared/tooling) plus
+  targeted verification of every high-confidence finding cited below.
+  Findings that could not be verified were excluded or explicitly deferred.
+
+This plan and `TRACKER.md` are the authority for implementation. The code and
+released product behavior remain authoritative where this document becomes
+stale.
+
+## Workspace And Package Map
+
+Applicability of workspace-level instruction sets per step. `shared/sesori_shared`,
+`client/module_auth`, `client/desktop`, `client/module_desktop_core`,
+`client/design_catalog`, and the external relay/auth servers are **not touched
+by any step** (B-Shared not applicable).
+
+| Step | Bridge workspace packages | Client workspace modules |
+|---|---|---|
+| 2 | `app`, `sesori_plugin_codex`, `sesori_plugin_opencode`, `sesori_plugin_runtime` | none |
+| 3 | `app` | none |
+| 4 | `app` | none |
+| 5 | `app` | none |
+| 6 | `app` | none |
+| 7 | `sesori_plugin_runtime` (+ pubspec dep additions), `sesori_plugin_acp`, `sesori_plugin_codex`, `sesori_plugin_claude`; `bridge/AGENTS.md` module-order doc | none |
+| 8 | `sesori_plugin_interface`, `sesori_plugin_runtime`, `sesori_plugin_acp`, `sesori_plugin_codex`, `sesori_plugin_claude`, `sesori_plugin_opencode`, `sesori_plugin_cursor`, `sesori_plugin_omp`, `sesori_plugin_pi` | none |
+| 9 | none | `module_core`, `app` |
+| 10 | none | `module_prego`, `app` |
+| 11 | none | `app` |
+| 12 | none (repo-root CI/installer files only) | none |
+| 13–14 | docs only | docs only |
+
+## Goal
+
+Spend a focused series of PRs making the existing system more reliable and
+maintainable without shipping new features:
+
+1. **Remove duplication that has already drifted.** Several subsystems exist as
+   two or three near-identical copies with concrete behavioral divergences.
+   Each copy is an independent failure surface and a place where a fix applied
+   to one silently misses the others.
+2. **Reduce failure points in oversized coordinators.** The Orchestrator,
+   PluginRuntime, and several client widgets each own too many unrelated
+   mutable concerns in one scope, so every change risks unrelated paths. Move
+   cohesive responsibilities behind single owners without changing behavior.
+3. **Delete dead and expired code.** Unused implementations, dead navigation
+   helpers, redundant delegation layers, and compatibility paths for releases
+   older than the approved baseline all add surface area that must be read,
+   tested, and reasoned about forever.
+4. **Make recovered failures observable.** A handful of catches swallow errors
+   without any trace or interpolate caught errors into strings, discarding
+   stack traces exactly where diagnosis is hardest.
+
+The series intentionally optimizes for fewer lines, fewer mutable parts, fewer
+async/error paths, and single ownership of each invariant. It is not a bug hunt:
+no new behavior, guards, retries, registries, or validation layers are added.
+
+## Non-Goals
+
+- No new user-facing features and no product behavior changes. Every step must
+  preserve observable behavior except where a swallowed failure becomes logged.
+- No wire contract changes between client and bridge, no database migrations,
+  and no changes to relay framing or crypto layouts.
+- No new defensive machinery: no retry frameworks, event buses, universal
+  async-state widgets, dedupe caches, or speculative abstractions (see
+  Complexity Budget).
+- No consolidation of the three approval/pending-input registries' stateful
+  implementations (see Deferred Work — reviewer-confirmed contract-only rule
+  for `sesori_plugin_interface` plus real policy drift makes promotion unsafe
+  without a driving bug).
+- No refactoring of `SessionDetailCubit`'s refresh state machine or
+  `NewSessionCubit`'s configuration plumbing while the active
+  `session-refresh-reconnects` plan is mid-flight on the same files (see
+  Deferred Work).
+- No decomposition of `acp_plugin.dart` immediately after PR #1013 simplified
+  it (see Deferred Work).
+- No removal of the desktop control stack — deliberate Phase 2 WIP owned by
+  `docs/desktop/PLAN.md` (owner decision recorded below).
+- No removal of compatibility paths at or after v1.5.x, and no removal of
+  managed-runtime/data-format compat markers whose peer is an on-disk artifact
+  rather than a released Sesori surface.
+
+## Owner Decisions Recorded
+
+- **Vagueness waiver (2026-08-21):** after two architecture-plan-review
+  rejections citing the same theme — exact Dart types/signatures for the Step 5
+  and Step 6 extraction contracts, transport adapter names, the voice-controller
+  callback seam, and tooling file paths — the owner explicitly waived deeper
+  design detail and approved proceeding as written. Consequence: each
+  implementation PR pins its own exact signatures/types at implementation time,
+  stays inside the contracts above, and carries its design through
+  `architecture-implementation-review`. This decision supersedes the review
+  rejections; do not re-review the plan on this basis.
+- **Compatibility baseline (2026-08-21):** remove compatibility paths for
+  pre-v1.4.0 Sesori releases only (v1.0.9–v1.3.x markers). Keep every v1.5.x+
+  marker. Managed-runtime and on-disk-data compat (Codex rollout formats,
+  OpenCode runtime events) stay regardless of marker age unless their peer is
+  itself a released Sesori surface older than v1.4.
+- **Desktop control stack:** keep `ControlChannelServer`,
+  `ControlMessageDispatcher`, and the trackers. They are shipped Phase 2
+  deliverables of the paused-but-active desktop workstream documented in
+  `docs/desktop/PLAN.md`.
+
+## Current Behavior And Findings
+
+### Bridge app (`bridge/app/lib/src/bridge`)
+
+**F1 — Orchestrator owns three jobs in one file (observed).**
+`orchestrator.dart` is 2,485 lines. Two regions are cohesive state machines
+buried inside orchestration composition and SSE decisions:
+
+- Relay connection/session transport (`orchestrator.dart:1147-1313`,
+  `1824-2461`): read/reconnect loop, shutdown close ownership, token refresh
+  and identity-triggered reauthentication, wire decoding/key exchange/resume,
+  phone incarnations, routed-response encryption/delivery, reconnect backoff,
+  send fencing. Its state (`_relayConnection`, `_shutdownRelayCloseFuture`,
+  `_backoffJitter`, incarnations, room key) is used almost exclusively by this
+  responsibility.
+- Plugin-event capture and SSE delivery (`orchestrator.dart:1358-1807`):
+  per-plugin ordering tails (`_pluginEventProcessingTails` at `1358-1380` and
+  `_projectsSummaryTail` at `1676-1687` duplicate one completer-chain
+  pattern), generation fencing checked seven separate times along one event's
+  path, history capture, policy decisions, delivery, summary rebuilding.
+
+**F2 — PluginRuntime repeats its command-transition scaffolding three times
+(observed drift).** `_stop`, `_prepareDisable`, and `_restart`
+(`plugin_runtime.dart:717-1073`) each independently repeat access-gate checks,
+force-takeover calculation, conflict checks, transition owner/completer
+creation, generation stop, failed-state conversion, and settlement. Concrete
+drift: `_prepareDisable` returns early at `plugin_runtime.dart:887` retaining
+preparation state, while `_stop`/`_restart` always settle in `finally`.
+Each `_PluginRuntimeSlot` also manually tracks three nullable subscriptions
+(`statusSubscription`, `workSubscription`, `eventSubscription`) installed at
+`1426-1497` and canceled via a temporary list at `1727-1737` instead of the
+mandated `CompositeSubscription`.
+
+**F3 — Swallowed failures and interpolated errors (observed).**
+`orchestrator.dart:1528` swallows failure-reporter errors with
+`.catchError((_) {})` while the same file demonstrates the correct logged
+pattern at `1735-1741`. Caught errors are string-interpolated instead of passed
+as logger arguments at `orchestrator.dart:869,1516,1723,1829-1848,1985-2003`,
+`bridge_event_mapper.dart:184,227`, `sse_manager.dart:201`, and
+`maintenance_push_listener.dart:74`. The relay-connect catch
+(`orchestrator.dart:963-1036`) wraps `_client.connect()` *and* listener setup,
+summary construction, permission approval, and token subscription into one
+`throw Exception("failed to connect to relay: $e")`, discarding typed errors
+and stack traces and mislabeling non-relay failures. Resume/rekey send failures
+and resume-ack framing failures silently continue (`orchestrator.dart:2035-2103`).
+
+**F4 — Redundant delegation layer (verified).**
+`default_editor_repository.dart` is a single pass-through method over
+`DefaultEditorApi`, violating the explicit "no pointless 1:1 interfaces"
+rule; tests fake the repository only because the service depends on it.
+
+**F5 — Abortable-request plumbing repeated (observed).**
+`sesori_server_api.dart`, `token_manager.dart`, and
+`bridge_registration_api.dart` each hand-roll completer + deadline timer +
+`AbortableRequest` + finally-cancel sequences; `_postSessionMetadata` adds a
+second abort subscription with repeated `isCompleted` checks.
+
+**F6 — Expired compatibility paths (owner-approved for removal).**
+Pre-v1.4 markers verified present: `BridgeIdMigrationService` +
+`readLegacyBridgeId` + two startup invocations (v1.3.0),
+`legacy_post_update_relaunch.dart` (v1.1.2), `pending_interaction_service.dart`
+legacy owner resolution (v1.1.0), `codex_config_reader.dart` fallback reads
+(v1.1.2), three `open_code_plugin_descriptor.dart` CLI flag aliases (v1.1.1),
+`runtime_start_intent.dart` side-file model/store (v1.0.9). All other markers
+(v1.5.1+) stay per the owner decision above.
+
+### Bridge plugins
+
+**F7 — NDJSON subprocess transport exists three times with real drift
+(observed).** `acp_stdio_client.dart` (454 lines),
+`codex_stdio_app_server_client.dart` (348), and `claude_stream_client.dart`
+(407) each independently implement frame writing, line decoding,
+pending-request correlation, timeout removal, stale-generation fencing,
+fail-all-pending teardown, and process kill sequencing. Verified divergences:
+malformed JSON fails all pending Codex requests but is discarded by ACP and
+Claude; Claude redacts malformed frames while ACP logs raw content; ACP kills
+the process directly and does not close stdin first, Claude closes stdin before
+signals, Codex uses `HostProcessService`; error logging styles differ. The
+transport mechanics are not backend-specific; only frame classification and
+error policy are.
+
+**F8 — Approval/pending-input registry mechanics triplicated with drift
+(observed, consolidation deferred).** `acp_approval_registry.dart`,
+`codex/approval_registry.dart`, and `claude_approval_registry.dart` repeat
+session/project indexing, pending queries, cancel-for-session, and reply
+lifecycles with real policy drift (Codex `dispose` silently catches
+`_denyPending` at `approval_registry.dart:122-130`; entry-removal timing
+relative to backend response differs per family). Only the observability fix
+ships in this series; structural consolidation is deferred with reason.
+
+**F9 — Small helpers duplicated across plugin families (observed).**
+`_tryNormalizeBase64` byte-identical in ACP/Codex/OpenCode mappers plus a Pi
+variant; identical MIME normalization/essence helpers in ACP and Codex; the
+managed-install capability decision repeated in five plugin descriptors; GitHub
+release URL assembly repeated in five runtime manifests;
+`archiveSession`/`deleteWorkspace`/`getChildSessions` implemented as trivial
+no-ops/empty lists by multiple plugins without interface defaults (the
+interface already uses default methods for `getQueuedPrompts` et al.).
+
+### Client module_core
+
+**F10 — Dead concurrency implementations (verified).**
+`ConcurrentCache` (`impl/concurrent_cache.dart`, 55 lines) and `MessageQueue`
+(`impl/message_queue.dart`, 97 lines) have zero production consumers; only old
+`client/app/test/core/concurrency/*` tests reference them. The isolate pool
+itself stays — `dto_parser.dart:17` uses `isolatesPool`.
+
+**F11 — Observability gaps in cubits/services (observed).**
+`session_detail_cubit.dart:800-814,1008-1021` swallow failure-reporter errors
+with `.catchError((_) {})`; `session_list_cubit.dart:581-585` silently ignores
+Git-context refresh failures; interpolated-error logging at
+`session_detail_load_service.dart:51-56,80-85,328-334`,
+`session_list_cubit.dart:389-459,608-615`, `project_list_cubit.dart:609,797`,
+`registered_bridges_service.dart:158-167`, `session_api.dart:258-264`.
+
+**F12 — Layer violation and dead surface (verified).**
+`session_list_cubit.dart` imports `../../api/session_api.dart` solely because
+`SessionCleanupRejection`/`SessionCleanupRejectedException` are defined there
+while the archive/delete flows run cubit → `SessionService`
+(`capabilities/session/session_service.dart`) → `SessionRepository` → API.
+`SessionDetailLoadResult.isBridgeConnected` is written but never read outside
+tests. `GoRouterNavigation` extension (`client/app/lib/core/routing/app_router.dart:245-253`)
+has no callers. Twelve barrel exports in `sesori_dart_core.dart` have no
+external references. `test_helpers.dart:535-537` declares a dead helper.
+
+**F13 — Manual subscription bookkeeping (observed).**
+`session_detail_cubit.dart` (five subscriptions), `plugin_management_cubit.dart`,
+and `diff_cubit.dart` track nullable subscriptions by hand while sibling cubits
+already use `CompositeSubscription`.
+
+### Client UI shells
+
+**F14 — Visual primitives duplicated across features (observed).**
+Centered error/retry states are near-copies in `project_list/widgets/error_view.dart`
+and `session_list_content.dart:156-187` with variants in three more screens.
+Four modals capture top inset and repeat `showModalBottomSheet` plumbing
+(`permission_modal.dart:40-71`, `question_modal.dart:36-64`,
+`reasoning_modal.dart:50-74`, `add_project_dialog.dart:24-36`) plus body-cap
+math in three of them. `model_picker_sheet.dart` and `command_picker_sheet.dart`
+repeat sheet sizing, async filtering, query caching, search-field decoration,
+and loading indicators with verified drift (4px vs 8px gap; different
+empty-failure presentation).
+
+**F15 — Oversized widgets coordinate unrelated mutable concerns (observed).**
+`prompt_input.dart` (1,795 lines) coordinates text editing, paste interception,
+attachments, voice recording state machine, gestures, animation, layout, and
+navigation from one `State`. `harnesses_settings_screen.dart` (1,172 lines)
+repeats drift-prone `isLast` boolean chains across three card sections.
+`question_modal.dart` (918 lines) mutates answer-draft controllers, focus
+nodes, sets, and disposition fields directly inside widget build state.
+`session_detail_message_list.dart` (1,015 lines) mixes detached snapshots/
+paging/controller synchronization, row resolution, and a gesture timestamp
+machine in one class.
+
+### Tooling
+
+**F16 — CI and installer drift risk (observed).** `bridge-ci.yml` duplicates 12
+analyze + 12 test steps that differ only by working directory; adding a package
+requires editing both lists. Generated OpenCode client/event outputs have no
+CI freshness assertion. `install.sh` supports `GITHUB`/`GITHUB_API` overrides
+that `install.ps1` hardcodes past, and stable-version validation differs
+(regex vs `[version]::TryParse` accepting four-component versions), so the two
+installers can select different releases from identical metadata.
+
+## Design
+
+Design rules for every step: behavior-preserving; smallest change that removes
+the duplication/failure point; backend-neutral facts move to neutral homes,
+backend-specific policies stay local; no new interfaces beyond what Dart 3
+`implements` faking requires; every extracted collaborator owns lifecycle,
+state, or an invariant — never extracted merely to shorten a file.
+
+### Step 2 — compatibility removals
+
+Deletes exactly the six F6 items plus their tests, wiring, and startup
+invocations:
+
+| Item | Files touched | Peer surface (must be released Sesori ≤ v1.3.x) |
+|---|---|---|
+| Legacy bridge-id migration | delete `bridge_id_migration_service.dart`; remove `readLegacyBridgeId` from `token.dart`; remove invocations in `bin/bridge.dart` + `bridge_runtime_runner.dart` + tests | token.json written by installs ≤ v1.3.x |
+| Post-update relaunch marker | empty `legacy_post_update_relaunch.dart`; remove consumers | environment set by pre-v1.1.2 updater binary |
+| Rejection sessionId omission fallback | `pending_interaction_service.dart` legacy owner-resolution branch | clients ≤ v1.0.x omitting sessionId |
+| Codex config fallback reads | `codex_config_reader.dart` fallback branches + call sites | VERIFY: only if peer is released-Sesori-era data, not live rollout format — otherwise keep with reason |
+| OpenCode CLI flag aliases ×3 | `open_code_plugin_descriptor.dart` alias branches | user scripts predating namespaced flags (introduced v1.1.1) |
+| RuntimeStartIntent side-file model/store | `runtime_start_intent.dart` side-file classes + store | bridges ≤ v1.0.8 sharing a data directory |
+
+Each marker gets a one-line verification note in the `TRACKER.md` ledger. If a
+marker fails the peer check during implementation, it stays and the reason is
+recorded — the step shrinks honestly instead of forcing removals.
+
+### Step 3 — bridge observability and layer sweep
+
+All changes inside `bridge/app`:
+
+1. **Failure-reporter swallow:** `orchestrator.dart:1528` adopts the existing
+   logged pattern from `1735-1741` (typed catch, `Log.w("msg", error, stack)`).
+   Same treatment for resume/rekey/framing silent paths (`2035-2103`) with
+   connection IDs retained.
+2. **Logger args:** replace every interpolated `${error}`/`${e}` citation in F3
+   with `Log.w/<logger>("context", error, stackTrace)`; message keeps IDs and
+   operation context, never the payload.
+3. **Relay-connect catch:** narrow the `catch` around `_client.connect()`;
+   post-connect setup steps get their own typed failures; the connect rethrow
+   becomes a typed wrapper carrying `innerError` + original stack trace.
+4. **Delete `DefaultEditorRepository`:** move `openFile(String)` into
+   `BridgeSettingsRepository` as `openInDefaultEditor(...)` wrapping the same
+   `DefaultEditorApi` (the repository already owns config-file lifecycle:
+   `ensureConfigExists`, `configFilePath`). `BridgeConfigService` drops the
+   second dependency and calls the settings repository. Layering preserved:
+   API → Repository → Service. Delete the repository file, its DI registration
+   in `bin/bridge.dart`, and its test fake.
+5. **Abortable-request helper:** new final class `AbortableRequestSender` in
+   `sesori_bridge_foundation/lib/src/http/abortable_request_sender.dart`
+   (foundation is the documented home for bridge-wide transport primitives;
+   `bridge/app` already depends on it, so no new edges). Single method
+   `Future<http.StreamedResponse> send({required http.Client client, required http.AbortableRequest request, required Duration deadline, Stream<Object>? abortSignal})`
+   owning the deadline timer, external-abort subscription, and one finally-path
+   cleanup. Callers keep status handling and retry policy: `SesoriServerApi`
+   (including `_postSessionMetadata`'s merged cancellation), `TokenManager`,
+   `BridgeRegistrationApi`.
+
+### Step 4 — PluginRuntime command transitions
+
+One private transition skeleton inside `plugin_runtime.dart` owning gate checks,
+takeover calculation, conflict validation, owner/completer acquisition,
+generation stop, failed-state conversion, and settlement;
+`_stop`/`_prepareDisable`/`_restart` become small outcome-specific bodies whose
+differences (including the disable early-return retaining preparation state)
+are explicit against one shared path. Each `_PluginRuntimeSlot` gains one
+`CompositeSubscription` per generation, recreated at generation start and
+canceled once at teardown, replacing the three nullable fields and temporary
+cancel list. Operation-stream callback futures stay separate (they are not
+subscriptions). No public API changes.
+
+### Step 5 — RelayConnectionCoordinator extraction
+
+New file `bridge/app/lib/src/bridge/relay_connection_coordinator.dart`.
+
+**Class contract:**
+
+- `final class RelayConnectionCoordinator` — owns exactly one invariant: the
+  bridge's relay session lifecycle.
+- **Constructor dependencies (all required):** relay connect factory/client,
+  account/room identity source, token refresher + identity-change stream,
+  session key material provider (room key), phone-incarnation registry,
+  reconnect policy (base/jitter), shutdown signal, failure reporter.
+- **Owned state (moved, not new):** current connection, shutdown-close future,
+  backoff jitter, incarnation fencing state, room key cache.
+- **Inbound seam:** exposes `Stream<RelayInbound>` — sealed variants for
+  routed request contexts, control messages, and resume outcomes. Consumed by
+  `OrchestratorSession`, which keeps request routing and all SSE decisions.
+- **Outbound seams:** `sendResponse(...)`, `sendEventFrame(...)`,
+  `requestRekey()` — accept typed payloads, own encryption/framing/send-fencing
+  internally. Never emits SSE; never touches plugin or database layers.
+- **Lifecycle:** constructed by the composition root, started by
+  `OrchestratorSession.start`, disposed inside the existing teardown sequence
+  before the shared HTTP client closes; internal subscriptions held on one
+  `CompositeSubscription`.
+- **Dependency direction:** orchestrator → coordinator (downward); coordinator
+  depends only on transport/crypto/token primitives.
+
+**Composition root:** graph assembly moves out of orchestration code into
+`bridge/app/lib/src/bridge/orchestrator_composition.dart` — a factory building
+the object graph (repositories, APIs, push subsystem, services, listeners,
+route handlers, session collaborators) and returning it as a typed structure
+consumed by `Orchestrator.create`. `Orchestrator.create` becomes thin startup
+sequencing; `OrchestratorSession` receives the coordinator instead of the ~15
+scattered relay/session fields.
+
+Shutdown ordering remains sequenced in `OrchestratorSession._teardown` exactly
+as today; the coordinator adds no new ordering rules.
+
+### Step 6 — plugin-event delivery pipeline extraction
+
+New file `bridge/app/lib/src/bridge/plugin_event_delivery_pipeline.dart`.
+
+**Class contract:**
+
+- `final class PluginEventDeliveryPipeline` — Orchestrator-owned collaborator
+  (child of `OrchestratorSession`, never a global service). Owns one invariant:
+  ordered, generation-valid capture-to-delivery of normalized plugin events.
+- **Constructor dependencies (required):** runtime/plugin lookup, event mapper,
+  history service, unseen-event/project-activity collaborators, permission
+  policy, failure reporter.
+- **Owned state (moved):** per-plugin serial tails, projects-summary tail,
+  pending part captures — the two duplicated completer-chain implementations
+  collapse onto one private `_SerialTails` keyed executor defined in the same
+  file (single consumer, stays private).
+- **Outbound seam:** exposes `Stream<OutboundSseDelivery>`; `OrchestratorSession`
+  subscribes and forwards to the SSE manager. Push-based per repo rules; the
+  Orchestrator remains the sole SSE decision owner and emitter boundary.
+- **Generation fences:** each await boundary inside the pipeline is labeled
+  with the validity check it requires. No existing check is deleted in this
+  step; pruning provably redundant checks may happen later only with a tracker
+  note naming the await boundary that makes each removed check dead.
+- **Lifecycle:** constructed by the composition root; drained by
+  `OrchestratorSession._teardown` at exactly today's position (before
+  normalized-output cancellation), then disposed.
+
+### Step 7 — shared NDJSON subprocess transport
+
+**Home decision:** `sesori_plugin_runtime/lib/src/transport/ndjson_process_transport.dart`.
+Rationale: `sesori_plugin_runtime` is the plugin-only process-infrastructure
+package (supervision today; framed subprocess transport is the same audience);
+`sesori_plugin_interface` must stay contract/foundation-only (review constraint),
+and `sesori_bridge_foundation` is for primitives shared with the main app, which
+this is not. `sesori_plugin_acp` and `sesori_plugin_claude` gain a pubspec
+dependency on `sesori_plugin_runtime` (direction stays downward:
+plugins → runtime → interface/foundation; Codex already depends on runtime);
+`bridge/AGENTS.md`'s module-order list is updated in the same PR.
+
+**Class contract:**
+
+- `final class NdjsonProcessTransport` — one framed request/response channel
+  over a subprocess's stdio.
+- **Process abstraction:** minimal `NdjsonProcessHandle` interface declared in
+  the same file (stdin sink, broadcast stdout line stream, done future, kill)
+  with thin adapters mapping each plugin's existing handle types onto it.
+- **Policy via values, not callbacks:** constructor takes
+  `MalformedFramePolicy {discard, failPending}` (ACP/Claude discard, Codex fail
+  all pending), `redactMalformedFrames` flag (Claude true, others false), and
+  `logTag`. Request timeout duration is a method argument.
+- **API:** `Future<Map<String, dynamic>> request(Map<String, dynamic> envelope, {required Duration timeout})`
+  correlating IDs through an internal pending map with timeout removal;
+  `Stream<Map<String, dynamic>> notifications` for protocol-specific inbound
+  lines the owning plugin interprets; `dispose({required String reason})`
+  failing all pending, closing stdin, waiting briefly, terminating, then
+  force-killing. Stale-generation callbacks are fenced internally via a
+  generation counter bumped by `attach(NdjsonProcessHandle)`.
+- **Preserved divergences:** frame classification, notification semantics,
+  redaction, and malformed-policy remain explicit caller choices — nothing is
+  unified by accident.
+- **One intended unification, recorded:** teardown order becomes close-stdin →
+  short drain wait → terminate → timed force-kill for all three adopters (ACP
+  currently skips the stdin-close). Teardown-only, observable solely in process
+  exit timing/logs; recorded in `TRACKER.md` as an accepted behavior delta.
+- Optional stretch within the same diff budget: converge the ACP/Claude/Pi
+  process-handle wrappers onto `HostProcessService` where their fakes prove
+  interchangeable; skipped if it inflates the diff past target.
+
+### Step 8 — plugin shared-primitive batch
+
+Exact homes, signatures, and affected implementors:
+
+| Primitive | Exact home | Consumers migrated |
+|---|---|---|
+| Base64/MIME normalization | `sesori_plugin_interface/lib/src/messages/attachment_normalization.dart`: pure top-level functions `String? tryNormalizeBase64(String)`, `String? normalizeMimeValue(String?)`, `String mimeEssence(String)` beside existing attachment validators (interface stays pure/contract-grade — no state, no I/O) | `acp_content_mapper.dart`, `codex_image_attachment_mapper.dart`, `message_part_mapper.dart` (OpenCode); Pi variant adopted only if byte-equivalent semantics, else left with a tracker note |
+| Descriptor install capability | `sesori_plugin_runtime/lib/src/provisioning/descriptor_install_policy.dart`: pure function taking manifest, resolved explicit-binary path, platform target → capability set | descriptors of OpenCode, Codex, Cursor, OMP, Pi; setup-hint strings stay plugin-local |
+| Release asset URL | default member on the existing manifest base in `sesori_plugin_runtime/lib/src/provisioning/runtime_manifest.dart`: `Uri releaseAssetUrl({required String assetName})` using each manifest's publisher/repo/tag fields | all five manifests delete private URL builders; any manifest with differing tag convention overrides and notes why |
+| Unsupported-op defaults | default members on `BridgePluginApi` in `sesori_plugin_interface`: `archiveSession` no-op, `deleteWorkspace` no-op, `getChildSessions` → `const []` (matches existing default-method precedent) | trivial overrides deleted wherever the analyzer proves them redundant (known: Claude, Pi, ACP) |
+| Contract documentation | doc comments on `BridgePluginApi` question/permission methods stating pending-input lifecycle expectations (reply/dispose/cancel must resolve or log) | interface-only documentation |
+| Codex observability fix | `sesori_plugin_codex/lib/src/approval_registry.dart:122-130`: silent catch logs like ACP/Claude | Codex-local |
+
+### Step 9 — module_core sweep
+
+1. Delete `ConcurrentCache`/`MessageQueue` impls and orphaned
+   `client/app/test/core/concurrency/*` tests; isolate pool untouched.
+2. Delete `GoRouterNavigation`; delete dead `testHealthResponse` helper.
+3. Prune the twelve unused barrel exports; delete underlying implementations
+   only where a full-workspace grep plus DI/generated-config check proves
+   orphanhood, else export-only removal.
+4. Remove `SessionDetailLoadResult.isBridgeConnected` (field + test usage).
+5. **Cleanup-rejection layering fix (exact flow):** `session_api.dart` keeps a
+   private DTO parse of the 409 body and throws its API-layer
+   `SessionCleanupRejectedException` carrying that DTO; `SessionRepository`
+   catches it and maps DTO → domain model `SessionCleanupRejection` defined in
+   new file `client/module_core/lib/src/capabilities/session/session_cleanup_rejection.dart`
+   beside the domain exception it rethrows; `SessionService` passes through;
+   `session_list_cubit.dart` deletes its API import and consumes only the
+   capabilities-layer type.
+6. Catch/logging fixes mirroring Step 3 patterns (F11 citations).
+7. `CompositeSubscription` adoption in `session_detail_cubit`,
+   `plugin_management_cubit`, `diff_cubit`.
+
+### Step 10 — Prego primitive consolidation
+
+Single chosen design per primitive (no alternatives):
+
+1. `PregoCenteredStatus` — new file
+   `client/module_prego/lib/components/status/prego_centered_status.dart`;
+   required title, optional message, icon, action label/callback, semantics
+   config. Consumers migrated in the same PR: `error_view.dart`,
+   `session_list_content.dart`, `add_project_dialog.dart`,
+   `diff_error_view.dart`, `session_detail_scaffold_sections.dart`.
+2. `showPregoBottomSheetRoute(...)` — lower-level presenter added to
+   `client/module_prego/lib/components/surfaces/prego_bottom_sheet.dart`,
+   owning top-inset capture, scroll-control, transparency, safe-area-off, and
+   height caps; the existing `showPregoBottomSheet` refactors to build on it.
+   Consumers migrated: `permission_modal.dart`, `question_modal.dart`,
+   `reasoning_modal.dart`, `add_project_dialog.dart`; body-cap duplication in
+   three modals replaced by the route's cap support.
+3. `PregoSearchablePickerBody<T>` — new file
+   `client/module_prego/lib/components/pickers/prego_searchable_picker_body.dart`;
+   bounded height, async filter slot, query caching, search field, loading and
+   empty presentation. Consumers: `model_picker_sheet.dart`,
+   `command_picker_sheet.dart` (domain builders and localized labels stay in
+   app; the 4px/8px gap and empty-failure drift unify on the Prego defaults).
+
+Feature state switches and sliver wrappers stay local; no universal
+async-state widget.
+
+### Step 11 — app-widget state-owner splits
+
+All collaborators are feature-local presentation-state owners created and
+disposed by their widget `State`; none imports services, repositories, APIs,
+or cubits; business orchestration stays in cubits (BLoC/Cubit and thin-shell
+rules intact — these own ephemeral UI invariants only):
+
+| Collaborator | File | Owns | Left behind |
+|---|---|---|---|
+| `PromptVoiceController` | `client/app/lib/features/session_detail/widgets/composer/prompt_voice_controller.dart` | recording state machine, pointer tracking, transcription-call lifecycle, cancellation, haptics triggers; rebuild signaling via injected callback | visual hold-to-talk widget, composer layout |
+| `PromptAttachmentStaging` | same folder, `prompt_attachment_staging.dart` | staged attachment list, paste interception results, initial-attachment copy-once + consumed acknowledgement | attachment strip rendering |
+| `_QuestionDraftController` | private class in `question_modal.dart` | drafts, selection sets, page index/navigation, answer conversion, controller disposal | option tiles, decline-confirm UI |
+| `_MessageListSynchronizer` | private class in `session_detail_message_list.dart` | detached snapshots, paging completion, controller synchronization, transient-submission handoff | row resolution, gesture timestamp machine (untouched) |
+| Ordered-row builder | private function in `harnesses_settings_screen.dart` | builds visible harness rows as one list; `isLast` derives from position | screen shell, sheets moved to separate private widget files in the same feature folder |
+
+Public widget facades and constructor signatures do not change; screens and
+cubits are untouched except imports if files move.
+
+### Step 12 — tooling
+
+1. `.github/workflows/bridge-ci.yml`: one checked-in package list drives
+   analysis and test loops preserving per-package output and fail-fast.
+2. Codegen freshness job: regenerate OpenCode generated client/event outputs
+   from committed schema/manifest inputs and fail on diff (network-based
+   acquisition excluded from CI).
+3. `install.ps1` gains `$env:GITHUB`/`$env:GITHUB_API` handling and exact
+   three-component stable-version validation matching `install.sh`.
+4. Fixture-driven parity tests (extending `bridge/app/test/tool/installers_test.dart`)
+   covering release selection/order, partial releases, checksum parsing,
+   archive/checksum URL construction (including env overrides), and manifest
+   writing for both scripts.
+
+### Step 13 — documentation reconciliation
+
+Wording/boundary reconciliation only, of the documents listed under Regression
+Documentation. No coverage reductions.
+
+### Step 14 — verification and retirement
+
+Run the recorded L2 matrix, record evidence and any Partial/Blocked rows
+honestly in `TRACKER.md`, then move the plan to `.plan/completed/`. Any
+required row that cannot run keeps the plan active per
+`docs/regression/README.md`.
+
+## Complexity Budget
+
+### Mutable parts removed
+
+- Three copies of plugin command-transition bookkeeping → one skeleton;
+  −3 nullable subscription fields per slot via composites;
+- Two duplicated serial-tail implementations → one private keyed executor;
+- Relay/session state scattered across ~15 `OrchestratorSession` fields →
+  moved (not added) into one coordinator;
+- Three drifted NDJSON transports → one shared implementation (net −2
+  stateful classes);
+- Dead `ConcurrentCache`/`MessageQueue`, dead navigation extension, unused
+  exports, `DefaultEditorRepository`, six legacy compat paths, orphaned tests;
+- N hand-rolled deadline-timer/abort-subscription pairs → one stateless-per-
+  call sender (timers go down, not up).
+
+### Mutable parts added (each justified)
+
+- `RelayConnectionCoordinator`: owns state that already existed, giving relay
+  lifecycle exactly one owner;
+- `PluginEventDeliveryPipeline` + private `_SerialTails`: same — owns existing
+  tails/captures; one outbound stream replaces scattered inline emission;
+- `AbortableRequestSender`: stateless per call;
+- `NdjsonProcessTransport` + `NdjsonProcessHandle`: one stateful class plus a
+  thin interface replacing three drifted ones;
+- Three Prego primitives: presentation-only, stateless or timer-scoped,
+  replacing five+ drifted copies;
+- Four app-local widget-state controllers: move existing mutable state out of
+  monolithic `State` classes; net field count does not grow.
+
+### Deliberately not added
+
+No retry framework, no event bus, no universal async-state widget, no installer
+code generation, no new DI scopes, no interface for the coordinator/pipeline/
+controllers beyond what tests need (`implements` works), no locks/registries/
+watchers anywhere, no telemetry, no approval-registry base class.
+
+If implementation reveals an extraction needs a new persistent queue,
+cross-owner lock, or second stream, stop and ask before expanding scope.
+
+## Delivery Plan
+
+| Step | Exact PR title | Target | Scope |
+|---|---|---|---|
+| 1/14 | `🌱 [reliability-cleanup] docs: plan the reliability cleanup series [step 1/14]` | plan + tracker | Raise reviewed plan only. |
+| 2/14 | `⚙️ [reliability-cleanup] refactor: drop pre-v1.4 compatibility paths [step 2/14]` | 150-350 lines | Six F6 removals with per-marker peer verification; keep v1.5.x+. |
+| 3/14 | `🌿 [reliability-cleanup] fix(bridge): make swallowed failures observable [step 3/14]` | 150-300 lines | F3/F4/F5: logging fixes, relay-connect error preservation, settings-repository fold, `AbortableRequestSender`. |
+| 4/14 | `⚙️ [reliability-cleanup] refactor(bridge): unify plugin command transitions [step 4/14]` | 150-300 lines | Transition skeleton + slot composite subscriptions (F2). |
+| 5/14 | `🚧 [reliability-cleanup] refactor(bridge): extract the relay connection coordinator [step 5/14]` | 1,200-2,000 changed (mostly relocation) | Step 5 design incl. composition root. |
+| 6/14 | `🚧 [reliability-cleanup] refactor(bridge): extract the plugin-event delivery pipeline [step 6/14]` | 700-1,300 changed (mostly relocation) | Step 6 design; label fences; delete none without proof. |
+| 7/14 | `🚧 [reliability-cleanup] refactor(plugins): share the ndjson subprocess transport [step 7/14]` | 600-1,100 lines | Step 7 design; acp/claude gain runtime dep; AGENTS.md order update. |
+| 8/14 | `🌿 [reliability-cleanup] refactor(plugins): consolidate shared plugin primitives [step 8/14]` | 300-550 lines | Step 8 table: helpers, descriptor policy, URLs, interface defaults, contract docs, Codex log fix. |
+| 9/14 | `🌿 [reliability-cleanup] refactor(client): remove dead code and fix observability [step 9/14]` | 250-500 lines | F10-F13 incl. cleanup-rejection layering flow. |
+| 10/14 | `⚙️ [reliability-cleanup] feat(ui): consolidate sheet, status, and picker primitives [step 10/14]` | 500-900 lines | Step 10 designs + full consumer migration. |
+| 11/14 | `⚙️ [reliability-cleanup] refactor(app): split state-heavy composer and settings widgets [step 11/14]` | 900-1,400 changed (mostly relocation) | Step 11 collaborator table. |
+| 12/14 | `🌿 [reliability-cleanup] chore(tooling): tighten CI, codegen freshness, installer parity [step 12/14]` | 200-450 lines | F16 items. |
+| 13/14 | `🌱 [reliability-cleanup] docs: reconcile regression coverage [step 13/14]` | 80-200 lines | Penultimate reconciliation; cleanup audit vs actual merges. |
+| 14/14 | `🌿 [reliability-cleanup] test: verify the reliability cleanup series [step 14/14]` | 60-200 lines | Run recorded L2 matrix, record evidence, retire plan. |
+
+Notes: Steps 5-7 and 11 will exceed the 1,500-line soft cap counting pure
+relocations (moved lines count twice). The overage is mechanical movement of
+existing code behind new seams, not new logic; review focus is the seam
+definition and preserved policies. If any other step exceeds its target,
+prefer splitting tests by owner over widening scope. Bridge and client
+production work never combine in one PR. Step titles carry fixed complexity
+emoji chosen now; if evidence changes an estimate before opening, update
+plan/tracker rather than publishing a stale rating.
+
+## Per-Step Verification
+
+Every step: `dart analyze --fatal-infos` in each touched module plus the owning
+packages' focused tests. Additional, per step:
+
+- **2:** removed tests deleted with paths; headless bridge start proves
+  registration/minting works without migration reads; tracker ledger complete.
+- **3:** orchestrator/mapper/listener suites green; config-service test fakes
+  the API directly through the settings repository; sender unit tests cover
+  deadline, external abort, and cleanup-without-leak.
+- **4:** plugin runtime/lifecycle suites prove stop/disable/restart outcomes
+  and settle semantics unchanged, including the disable early-return.
+- **5-6:** orchestrator/runtime/SSE suites green without assertion changes;
+  changed tests may alter wiring only; shutdown-ordering tests prove drain
+  order intact; pipeline stream consumed exactly as the old inline emission.
+- **7:** each adopting plugin's protocol suites prove identical frame/error
+  semantics (Codex fail-all-on-malformed, Claude redaction, ACP discard);
+  fake-process round-trips cover timeout, broken pipe, stale generation, kill
+  ordering; teardown-order delta asserted intentionally.
+- **8:** mapper/descriptor unit tests prove identical normalization outputs and
+  capability decisions across all five descriptors; analyzer proves removed
+  overrides were trivially redundant.
+- **9:** module_core + app suites green; grep proves deleted symbols unreferenced;
+  analyzer/config check proves the cubit no longer imports the API package.
+- **10:** widget tests for migrated sheets/pickers/statuses prove layout,
+  keyboard, safe-area, and empty/failure presentations unchanged.
+- **11:** existing prompt-input/harness/question/message-list suites green;
+  controller-level tests only where they add confidence (voice race, draft
+  restore, paging handoff).
+- **12:** CI dry-run produces identical per-package commands; freshness job
+  fails when an output is dirtied locally; parity tests prove identical
+  URL/checksum/manifest decisions from shared fixtures including PS1 overrides.
+- **13/14:** docs reconcile cleanly against merged diffs; matrix evidence
+  recorded in the tracker.
+
+## Regression Documentation And Final Matrix
+
+Affected feature documents (Step 13 reconciles):
+
+- `docs/regression/plugin-setup-and-lifecycle.md` — descriptor install-policy
+  consolidation, command-transition unification, `runtime_start_intent` cleanup;
+- `docs/regression/questions-and-permissions.md` — pending-input contract
+  documentation, Codex disposal logging;
+- `docs/regression/attachments-and-images.md` — shared base64/MIME helper home;
+- `docs/regression/session-turns.md` — event-delivery pipeline ownership;
+- `docs/regression/bridge-connectivity.md` — relay coordinator ownership,
+  unchanged reconnect/resume semantics;
+- `docs/regression/bridge-installation-and-updates.md` — installer env override
+  parity, version-validation alignment;
+- `docs/regression/voice-input.md` — composer voice-controller extraction;
+- `docs/regression/navigation-transitions.md`, `popup-alerts.md`,
+  `design-catalog.md` — new Prego primitives and modal-route ownership.
+
+### Highest required level
+
+**L2 Routine.** The series claims no user-visible behavior change; delivered
+behaviors are internal refactors proven through automated boundaries, plus
+consolidated UI components and plugin transport whose complete invariant needs
+one live pass. L3's production-plugin enumeration would re-prove unchanged
+behavior; skipping it is justified because no step changes any declared
+capability. Any reduction concern should be raised at plan review.
+
+### Required matrix (recorded for Step 14)
+
+- **Automated:** full analyze + test suites green for every touched package
+  (CI-enforced; recorded here).
+- **Headless bridge:** start the bridge; exercise plugin stop/disable/restart
+  transitions and graceful shutdown drain (Steps 4-6 surfaces).
+- **Live plugin:** one ACP-family plugin (Cursor, OMP, or Hermes), plus Codex
+  and Claude: create a session, exchange turns, answer one question/permission
+  prompt, archive or delete where supported (Steps 7-8 surfaces).
+- **Client end to end:** release-target phone: open a session detail, send a
+  prompt, present permission + question modals, filter and select via model and
+  command pickers, render one error/retry state, record and submit one voice
+  input (Steps 10-11 surfaces).
+- **Packaged/external:** `install.sh` on macOS and `install.ps1` on Windows
+  complete a real or fixture-served install (Step 12 surfaces).
+
+Compatibility rows: none newly claimed; the codegen freshness job asserts no
+wire-shape diffs (Step 12).
+
+## Risks And Accepted Limits
+
+- **Orchestrator extraction regressions** (Steps 5-6) threaten reconnect/resume
+  and SSE ordering — the highest-stakes risk in the series. Mitigation: pure
+  moves, existing lifecycle/SSE suites as the safety net, shutdown ordering
+  left sequenced in `OrchestratorSession`, one extraction per PR so bisect
+  stays trivial.
+- **Transport consolidation** could silently change per-plugin error semantics.
+  Mitigation: policies ported explicitly as constructor values with named
+  tests; the single intentional teardown-order delta is recorded.
+- **Compat removals** assume the owner-set baseline (pre-v1.4 unsupported).
+  Per-marker peer verification prevents deleting on-disk-data compat that old
+  managed runtimes still need.
+- **Widget splits** can break subtle gesture/focus/animator behavior.
+  Mitigation: facade signatures unchanged; existing widget suites gate; manual
+  L2 checklist covers voice and modals.
+- **Accepted limits:** known duplication judged not worth consolidating is left
+  alone (approval-registry internals, Claude/Pi queue-emission twins,
+  `SessionEncryptor` wrapper, oversized but cohesive Codex/Pi internals,
+  pure-delegation client repositories required by the layering rule). Deferred
+  items below are recorded, not forgotten.
+
+## Deferred Work
+
+- **Approval-registry consolidation:** the three registries are stateful with
+  real policy drift; `sesori_plugin_interface` is contract/foundation-only, and
+  no neutral stateful home fits without expanding a package mandate. Revisit
+  only with a concrete bug or a purpose-built shared home.
+- **`SessionDetailCubit` refresh-state machine + snapshot reducer,
+  `NewSessionCubit` configuration object:** blocked by the active
+  `session-refresh-reconnects` plan working the same files evidence-first.
+  Revisit once that plan concludes.
+- **`acp_plugin.dart` internal decomposition:** deferred; PR #1013 just
+  simplified the ACP base and cursor/omp/hermes should stabilize first.
+- **`MessageImageRepository` simplification:** security-sensitive machinery;
+  simplifying requires targeted evidence that registries overlap, which
+  investigation did not establish.
+- **Desktop control stack wiring/removal:** owned by `docs/desktop/PLAN.md`.
+- **Image-viewer promotion to `module_prego`:** speculative until a second
+  consumer exists.

--- a/.plan/active/reliability-cleanup/PLAN.md
+++ b/.plan/active/reliability-cleanup/PLAN.md
@@ -310,7 +310,7 @@ invocations:
 | Rejection sessionId omission fallback | `pending_interaction_service.dart` legacy owner-resolution branch | clients ≤ v1.0.x omitting sessionId |
 | Codex config fallback reads | `codex_config_reader.dart` fallback branches + call sites | VERIFY: only if peer is released-Sesori-era data, not live rollout format — otherwise keep with reason |
 | OpenCode CLI flag aliases ×3 | `open_code_plugin_descriptor.dart` alias branches | user scripts predating namespaced flags (introduced v1.1.1) |
-| RuntimeStartIntent side-file model/store | `runtime_start_intent.dart`: per the marker's own instruction, first move intent state into the now-changeable ownership schema (preserving crash recovery for a bridge killed between process spawn and ownership commit), then remove the side-file model/store | bridges ≤ v1.0.8 sharing a data directory |
+| RuntimeStartIntent side-file model/store | `runtime_start_intent.dart`: per the marker's own instruction, move intent state into the now-changeable ownership schema ONLY IF the encoding is provably ignored by every existing frozen-schema reader — `OpenCodeOwnershipRecord` requires non-null PIDs today, so intent-shaped entries may invalidate strict parsers. If no safe encoding exists, retain the side file past this series and record why | bridges ≤ v1.0.8 sharing a data directory |
 
 Each marker gets a one-line verification note in the `TRACKER.md` ledger. If a
 marker fails the peer check during implementation, it stays and the reason is
@@ -347,13 +347,16 @@ All changes inside `bridge/app` except the Step 3 helper, which lives in
    `bridge/app` already depends on it, so no new edges). Because
    `http.AbortableRequest` receives its abort trigger at construction, the
    helper constructs the request itself from request inputs:
-   `Future<http.StreamedResponse> send({required http.Client client, required String method, required Uri url, Map<String, String>? headers, Object? body, required Duration deadline, Future<Object>? abortSignal})`
+   `Future<http.StreamedResponse> send({required http.Client client, required String method, required Uri url, required Map<String, String>? headers, required Object? body, required Duration deadline, required Future<Object>? abortSignal})`
    builds the combined abort trigger (deadline timer plus optional external
    signal), passes it as `abortTrigger`, and owns one finally-path cleanup.
    The external signal is a `Future` rather than a stream so an abort that
-   fires before the helper runs still cancels the request — matching today's
-   completer-based call sites and preserving `_postSessionMetadata`'s
-   immediate-abort semantics without a pre-send race. Callers keep status
+   fires before the helper runs still cancels the request. Because today's
+   `SesoriServerRequestAbortSignal` exposes only an `isAborted` flag and a
+   broadcast stream, Step 3 also adds one completer-backed
+   `Future<Object> get abortFuture` to that signal (same app-local type,
+   replay-safe, no per-call subscription cleanup); call sites pass
+   `signal.abortFuture`. Callers keep status
    handling and retry policy: `SesoriServerApi`, `TokenManager`,
    `BridgeRegistrationApi`.
 
@@ -377,11 +380,16 @@ New file `bridge/app/lib/src/bridge/relay_connection_coordinator.dart`.
 **Class contract:**
 
 - `final class RelayConnectionCoordinator` — owns exactly one invariant: the
-  bridge's relay session lifecycle.
+  bridge's relay connection mechanics (connect, read loop, backoff, framing,
+  fencing, sends).
 - **Constructor dependencies (all required):** relay connect factory/client,
-  account/room identity source, token refresher + identity-change stream,
-  session key material provider (room key), phone-incarnation registry,
-  reconnect policy (base/jitter), shutdown signal, failure reporter.
+  account/room identity source, session key material provider (room key),
+  phone-incarnation registry, reconnect policy (base/jitter), shutdown signal,
+  failure reporter. Token-refresh and identity-change reauthentication policy
+  is deliberately NOT a dependency: it stays in `OrchestratorSession`, which
+  observes the auth seams exactly as today and drives the coordinator through
+  explicit `reconnect({required reason})` / credential-update calls. The
+  coordinator performs mechanics on command; it decides no auth policy.
 - **Owned state (moved, not new):** current connection, shutdown-close future,
   backoff jitter, incarnation fencing state, room key cache.
 - **Inbound seam:** exposes `Stream<RelayInbound>` — sealed variants for
@@ -496,7 +504,11 @@ plugins → runtime → interface/foundation; Codex already depends on runtime);
   `dispose({required String reason})` failing all pending, closing stdin,
   waiting briefly, terminating, then force-killing. Stale-generation callbacks
   are fenced internally via a generation counter bumped by
-  `attach({required NdjsonProcessHandle process})`.
+  `attach({required NdjsonProcessHandle process})`. `attach` rejects and reaps
+  the handle (terminate + await exit) when the transport is already disposed
+  or superseded, fencing the dispose-racing-asynchronous-spawn window that all
+  three existing clients guard by hand today; adapters therefore carry no
+  lifecycle bookkeeping of their own.
 - **Preserved divergences:** frame classification, notification semantics,
   redaction, and malformed-policy remain explicit caller choices — nothing is
   unified by accident.
@@ -549,15 +561,14 @@ Single chosen design per primitive (no alternatives):
    `client/module_prego/lib/components/status/prego_centered_status.dart`;
    required title, optional message, icon, semantics config, and one optional
    action modeled as a single value — a `PregoStatusAction` with required
-   label and callback plus optional leading-icon and style parameters — so a
-   visible label without an action or an unreachable callback without a label
-   is unrepresentable while each migrated consumer keeps its current action
-   presentation (plain text button on diff errors, filled icon buttons on
-   list errors, secondary solid button with refresh icon in add-project).
-   Consumers migrated
-   in the same PR: `error_view.dart`,
-   `session_list_content.dart`, `add_project_dialog.dart`,
-   `diff_error_view.dart`, `session_detail_scaffold_sections.dart`.
+   label and callback plus optional leading-icon and style parameters.
+   Adoption is scoped to the two near-copy list error views where the
+   investigation established genuine duplication — `error_view.dart` and
+   `session_list_content.dart` — migrated in the same PR. The semantically
+   different states (`diff_error_view.dart`, `_BrowseError` in
+   `add_project_dialog.dart`, `session_detail_scaffold_sections.dart`) stay
+   local rather than forcing body/layout variant knobs onto the shared widget;
+   their earlier listing as consumers was over-reach and is withdrawn.
 2. `showPregoBottomSheetRoute(...)` — lower-level presenter added to
    `client/module_prego/lib/components/surfaces/prego_bottom_sheet.dart`,
    owning top-inset capture, scroll-control, transparency, safe-area-off, and

--- a/.plan/active/reliability-cleanup/PLAN.md
+++ b/.plan/active/reliability-cleanup/PLAN.md
@@ -418,11 +418,14 @@ New file `bridge/app/lib/src/bridge/plugin_event_delivery_pipeline.dart`.
   ordered, generation-valid capture and sequencing of normalized plugin events.
   It owns mechanics only — ordering, fencing, history capture, attachment
   shaping. It owns no delivery policy.
-- **Constructor dependencies (required):** runtime/plugin lookup, event mapper,
-  history service, unseen-event/project-activity collaborators, failure
-  reporter. Permission/push policy is deliberately NOT a dependency: decisions
-  about what phones receive stay in `OrchestratorSession`, satisfying
-  "Orchestrator Owns SSE Decisions".
+- **Constructor dependencies (required):** runtime/plugin lookup, history
+  service, unseen-event/project-activity collaborators, failure reporter.
+  Wire-event mapping is deliberately NOT a dependency: `BridgeEventMapper`
+  produces SSE wire shapes, so it runs in `OrchestratorSession` alongside
+  delivery policy when constructing outbound deliveries from captured facts.
+  Permission/push policy is likewise excluded: decisions about what phones
+  receive stay in `OrchestratorSession`, satisfying "Orchestrator Owns SSE
+  Decisions".
 - **Owned state (moved):** per-plugin serial tails, projects-summary tail,
   pending part captures — the two duplicated completer-chain implementations
   collapse onto one private `_SerialTails` keyed executor defined in the same
@@ -463,19 +466,23 @@ plugins → runtime → interface/foundation; Codex already depends on runtime);
   `MalformedFramePolicy {discard, failPending}` (ACP/Claude discard, Codex fail
   all pending), `redactMalformedFrames` flag (Claude true, others false),
   `logTag`, and one required correlation extractor
-  `responseCorrelationId: Object? Function(Map<String, dynamic> message)`. The
-  extractor is invoked only for response-shaped messages; it returns the
-  correlation ID for a response and null otherwise. Classification happens
-  before extraction exactly as today: ACP/Codex treat a frame as a response
-  only when it has an `id` and no `method` (server-originated requests carry
-  both and route to the plugin), Claude extracts
-  `message["response"]["request_id"]` from `control_response` frames and
-  routes everything else to the plugin. The extractor is injected once at
-  construction; no policy callbacks cross layers.
-- **API:** `Future<Map<String, dynamic>> request({required Map<String, dynamic> envelope, required Duration timeout})`
-  correlating replies through an internal pending map keyed by the extracted
-  ID with timeout removal;
-  `DispatchHandle dispatch({required Map<String, dynamic> envelope, required Duration timeout})`
+  `responseCorrelationId: Object? Function(Map<String, dynamic> message)`.
+  This one injected function is both classifier and extractor: it returns the
+  correlation ID when the frame is a response to an outbound request and null
+  otherwise; the transport routes every null-extraction frame verbatim to the
+  notifications stream without inspecting its shape. The transport therefore
+  holds no backend frame-shape knowledge of its own — ACP/Codex implementations
+  return the top-level `id` only for frames with an `id` and no `method`
+  (server-originated requests carry both and fall through to the plugin),
+  Claude returns `message["response"]["request_id"]` from `control_response`
+  frames. Injected once at construction; no policy callbacks cross layers.
+- **API:** `Future<Map<String, dynamic>> request({required Map<String, dynamic> envelope, required Object correlationId, required Duration timeout})`
+  where the caller embeds its own protocol's outbound key (`id` for
+  ACP/Codex, top-level `request_id` for Claude) into the envelope and passes
+  the same value as `correlationId`; the transport registers the pending
+  completer under that exact value before writing, so replies resolve
+  regardless of payload layout, with timeout removal;
+  `DispatchHandle dispatch({required Map<String, dynamic> envelope, required Object correlationId, required Duration timeout})`
   returning write acceptance separately from the correlated-response future —
   this preserves ACP's dispatch-completion boundary where the accepted prompt
   publishes after stdin flush while the backend turn may run for minutes;
@@ -542,8 +549,12 @@ Single chosen design per primitive (no alternatives):
    `client/module_prego/lib/components/status/prego_centered_status.dart`;
    required title, optional message, icon, semantics config, and one optional
    action modeled as a single value — a `PregoStatusAction` with required
-   label and required callback — so a visible label without an action or an
-   unreachable callback without a label is unrepresentable. Consumers migrated
+   label and callback plus optional leading-icon and style parameters — so a
+   visible label without an action or an unreachable callback without a label
+   is unrepresentable while each migrated consumer keeps its current action
+   presentation (plain text button on diff errors, filled icon buttons on
+   list errors, secondary solid button with refresh icon in add-project).
+   Consumers migrated
    in the same PR: `error_view.dart`,
    `session_list_content.dart`, `add_project_dialog.dart`,
    `diff_error_view.dart`, `session_detail_scaffold_sections.dart`.

--- a/.plan/active/reliability-cleanup/PLAN.md
+++ b/.plan/active/reliability-cleanup/PLAN.md
@@ -456,7 +456,7 @@ New file `bridge/app/lib/src/bridge/plugin_event_delivery_pipeline.dart`.
 
 ### Step 7 — shared NDJSON subprocess transport
 
-**Home decision:** `sesori_plugin_runtime/lib/src/transport/ndjson_process_transport.dart`.
+**Home decision:** `sesori_plugin_runtime/lib/src/transport/ndjson_process_client.dart`.
 Rationale: `sesori_plugin_runtime` is the plugin-only process-infrastructure
 package (supervision today; framed subprocess transport is the same audience);
 `sesori_plugin_interface` must stay contract/foundation-only (review constraint),

--- a/.plan/active/reliability-cleanup/PLAN.md
+++ b/.plan/active/reliability-cleanup/PLAN.md
@@ -341,8 +341,8 @@ All changes inside `bridge/app` except the Step 3 helper, which lives in
    second dependency and calls the settings repository. Layering preserved:
    API → Repository → Service. Delete the repository file, its DI registration
    in `bin/bridge.dart`, and its test fake.
-5. **Abortable-request helper:** new final class `AbortableRequestSender` in
-   `sesori_bridge_foundation/lib/src/http/abortable_request_sender.dart`
+5. **Abortable-request helper:** new final class `AbortableRequestClient` in
+   `sesori_bridge_foundation/lib/src/http/abortable_request_client.dart`
    (foundation is the documented home for bridge-wide transport primitives;
    `bridge/app` already depends on it, so no new edges). Because
    `http.AbortableRequest` receives its abort trigger at construction, the
@@ -396,8 +396,12 @@ New file `bridge/app/lib/src/bridge/relay_connection_coordinator.dart`.
 - **Owned state (moved, not new):** current connection, shutdown-close future,
   backoff jitter, incarnation fencing state, room key cache.
 - **Inbound seam:** exposes `Stream<RelayInbound>` — sealed variants for
-  routed request contexts, control messages, and resume outcomes. Consumed by
-  `OrchestratorSession`, which keeps request routing and all SSE decisions.
+  routed request contexts, control messages, resume outcomes, and connection
+  lifecycle outcomes (`disconnected` carrying the close code/context including
+  `bridgeRevoked`, `reconnected`). Consumed by `OrchestratorSession`, which
+  keeps request routing and all SSE decisions and uses the lifecycle outcomes
+  to run today's drop cleanup (SSE subscriber orphaning, view-tracker resets)
+  and revocation re-registration unchanged.
 - **Outbound seams:** `sendResponse(...)`, `sendEventFrame(...)`,
   `requestRekey()` — accept typed payloads, own encryption/framing/send-fencing
   internally. Never emits SSE; never touches plugin or database layers.
@@ -430,7 +434,11 @@ New file `bridge/app/lib/src/bridge/plugin_event_delivery_pipeline.dart`.
   It owns mechanics only — ordering, fencing, history capture, attachment
   shaping. It owns no delivery policy.
 - **Constructor dependencies (required):** runtime/plugin lookup, history
-  service, unseen-event/project-activity collaborators, failure reporter.
+  service, unseen-event collaborators, failure reporter. The
+  project-activity collaborator is deliberately NOT a dependency:
+  `ProjectActivityService.handleEvent(SesoriSseEvent)` consumes mapped wire
+  events, so it is invoked by `OrchestratorSession` after wire mapping,
+  alongside delivery policy — the pipeline never handles it.
   Wire-event mapping is deliberately NOT a dependency: `BridgeEventMapper`
   produces SSE wire shapes, so it runs in `OrchestratorSession` alongside
   delivery policy when constructing outbound deliveries from captured facts.
@@ -441,11 +449,16 @@ New file `bridge/app/lib/src/bridge/plugin_event_delivery_pipeline.dart`.
   pending part captures — the two duplicated completer-chain implementations
   collapse onto one private `_SerialTails` keyed executor defined in the same
   file (single consumer, stays private).
-- **Outbound seam:** exposes `Stream<NormalizedPluginFact>` — typed,
-  policy-free facts (captured transcript updates, summary snapshots, unseen
-  routing results). `OrchestratorSession` subscribes, applies generation/
-  permission/delivery policy exactly as today, and constructs the outbound SSE
-  deliveries itself; the pipeline never sees wire shapes or recipients.
+- **Outbound seam:** exposes acknowledged fact hand-off per plugin — each
+  keyed operation completes only after `OrchestratorSession` acknowledges
+  processing (mapping, unseen routing, delivery) of the previous fact, via an
+  explicit acknowledgement on the delivered item rather than a bare stream
+  subscription (Dart streams do not await listeners, so a plain stream would
+  order only fact production). This preserves today's invariant exactly: full
+  same-plugin serialization of produce-through-deliver, with cross-plugin
+  concurrency untouched; unrelated plugins never wait on one another. Facts
+  are typed and policy-free (captured transcript updates, summary snapshots,
+  unseen routing results); the pipeline never sees wire shapes or recipients.
 - **Generation fences:** each await boundary inside the pipeline is labeled
   with the validity check it requires. No existing check is deleted in this
   step; pruning provably redundant checks may happen later only with a tracker
@@ -483,7 +496,9 @@ plugins → runtime → interface/foundation; Codex already depends on runtime);
   demonstrably logs stderr today.
 - **Policy via values plus one seam:** constructor takes
   `MalformedFramePolicy {discard, failPending}` (ACP/Claude discard, Codex fail
-  all pending), `redactMalformedFrames` flag (Claude true, others false),
+  all pending), `NonObjectFramePolicy {silentDiscard, logWarning,
+  logRedactedDebug}` (ACP silent drop, Codex warn, Claude redacted debug),
+  `redactMalformedFrames` flag (Claude true, others false),
   `logTag`, and one required correlation extractor
   `responseCorrelationId: Object? Function(Map<String, dynamic> message)`.
   This one injected function is both classifier and extractor: it returns the
@@ -516,6 +531,10 @@ plugins → runtime → interface/foundation; Codex already depends on runtime);
   process completion so plugins keep today's exit-driven behaviors (plugin
   failure, resident-process removal, pending-turn settlement) without touching
   raw handles;
+  `reset({required Duration gracefulTimeout})` failing pending requests,
+  reaping the current process generation, and returning the client to the
+  attachable state without closing it — preserving Cursor's catalog-probe
+  flow (`AcpStdioClient.reset` + reconnect on the same client);
   `dispose({required String reason})` failing all pending, closing stdin,
   waiting briefly, terminating, then force-killing. Stale-generation callbacks
   are fenced internally via a generation counter bumped by
@@ -560,7 +579,10 @@ Exact homes, signatures, and affected implementors:
    private DTO parse of the 409 body and throws its API-layer
    `SessionCleanupRejectedException` carrying that DTO; `SessionRepository`
    catches it and maps DTO → domain model `SessionCleanupRejection` defined in
-   new file `client/module_core/lib/src/capabilities/session/session_cleanup_rejection.dart`
+   new file `client/module_core/lib/src/repositories/models/session_cleanup_rejection.dart`
+   (repository-layer model home: the repository constructs and throws it, so
+   it must live at or below the repository, not beside the service it flows
+   through)
    beside the domain exception it rethrows; `SessionService` passes through;
    `session_list_cubit.dart` deletes its API import and consumes only the
    capabilities-layer type.
@@ -673,7 +695,7 @@ required row that cannot run keeps the plan active per
   lifecycle exactly one owner;
 - `PluginEventDeliveryPipeline` + private `_SerialTails`: same — owns existing
   tails/captures; one outbound stream replaces scattered inline emission;
-- `AbortableRequestSender`: stateless per call;
+- `AbortableRequestClient`: stateless per call;
 - `NdjsonProcessClient` + `NdjsonProcessHandle`: one stateful class plus a
   thin interface replacing three drifted ones;
 - Three Prego primitives: presentation-only, stateless or timer-scoped,
@@ -697,7 +719,7 @@ cross-owner lock, or second stream, stop and ask before expanding scope.
 |---|---|---|---|
 | 1/14 | `🌱 [reliability-cleanup] docs: plan the reliability cleanup series [step 1/14]` | plan + tracker | Raise reviewed plan only. |
 | 2/14 | `⚙️ [reliability-cleanup] refactor: drop pre-v1.4 compatibility paths [step 2/14]` | 150-350 lines | Six F6 removals with per-marker peer verification; keep v1.5.x+. |
-| 3/14 | `🌿 [reliability-cleanup] fix(bridge): make swallowed failures observable [step 3/14]` | 150-300 lines | F3/F4/F5: logging fixes, relay-connect error preservation, settings-repository fold, `AbortableRequestSender`. |
+| 3/14 | `🌿 [reliability-cleanup] fix(bridge): make swallowed failures observable [step 3/14]` | 150-300 lines | F3/F4/F5: logging fixes, relay-connect error preservation, settings-repository fold, `AbortableRequestClient`. |
 | 4/14 | `⚙️ [reliability-cleanup] refactor(bridge): unify plugin command transitions [step 4/14]` | 150-300 lines | Transition skeleton + slot composite subscriptions (F2). |
 | 5/14 | `🚧 [reliability-cleanup] refactor(bridge): extract the relay connection coordinator [step 5/14]` | 1,200-2,000 changed (mostly relocation) | Step 5 design; assembly stays in `Orchestrator.create`. |
 | 6/14 | `🚧 [reliability-cleanup] refactor(bridge): extract the plugin-event delivery pipeline [step 6/14]` | 700-1,300 changed (mostly relocation) | Step 6 design; policy stays in OrchestratorSession; label fences; delete none without proof. |
@@ -790,6 +812,11 @@ capability. Any reduction concern should be raised at plan review.
   (CI-enforced; recorded here).
 - **Headless bridge:** start the bridge; exercise plugin stop/disable/restart
   transitions and graceful shutdown drain (Steps 4-6 surfaces).
+- **Relay integration:** exercise key exchange plus a normal relay drop and
+  reconnect against a real relay, proving the coordinator extraction preserved
+  resume/incarnation behavior and Orchestrator drop cleanup — the
+  authoritative boundary recorded by `docs/regression/bridge-connectivity.md`
+  L2 for exactly the semantics Step 5 moves (Step 5 surface).
 - **Live plugin:** one ACP-family plugin (Cursor, OMP, or Hermes), plus Codex
   and Claude: create a session, exchange turns, answer one question/permission
   prompt, archive or delete where supported (Steps 7-8 surfaces).

--- a/.plan/active/reliability-cleanup/TRACKER.md
+++ b/.plan/active/reliability-cleanup/TRACKER.md
@@ -15,7 +15,7 @@ Plan: [PLAN.md](PLAN.md) · Slug: `reliability-cleanup` · Series total: 14 step
 | 7/14 | 🚧 refactor(plugins): share ndjson subprocess transport | ☐ Not started | — | acp/claude gain runtime dep; record teardown-order delta here when merged. |
 | 8/14 | 🌿 refactor(plugins): consolidate shared plugin primitives | ☐ Not started | — | Pi MIME variant: adopt only if byte-equivalent, else note. |
 | 9/14 | 🌿 refactor(client): remove dead code and fix observability | ☐ Not started | — | Verify barrel-export orphans against DI/tests before deleting implementations. |
-| 10/14 | ⚙️ feat(ui): consolidate sheet/status/picker primitives | ☐ Not started | — | Migrate all consumers in the same PR. |
+| 10/14 | ⚙️ refactor(ui): consolidate sheet/status/picker primitives | ☐ Not started | — | Migrate all consumers in the same PR. |
 | 11/14 | ⚙️ refactor(app): split state-heavy widgets | ☐ Not started | — | Facades unchanged; app-local collaborators only. |
 | 12/14 | 🌿 chore(tooling): CI, codegen freshness, installer parity | ☐ Not started | — | |
 | 13/14 | 🌱 docs: reconcile regression coverage | ☐ Not started | — | Penultimate: docs listed in PLAN.md; no coverage reductions. |
@@ -51,9 +51,9 @@ reason recorded here.
 | BridgeIdMigrationService + readLegacyBridgeId (v1.3.0) | `bridge/app/lib/src/auth/` | Released Sesori installs ≤ v1.3.x | TBD | |
 | LegacyPostUpdateRelaunch constant (v1.1.2) | `bridge/app/lib/src/bridge/foundation/legacy_post_update_relaunch.dart` | Pre-v1.1.2 updater binaries | TBD | |
 | Rejection sessionId omission fallback (v1.1.0) | `bridge/app/lib/src/bridge/services/pending_interaction_service.dart` | Released clients ≤ v1.0.x | TBD | |
-| Codex config fallback reads (v1.1.2) | `sesori_plugin_codex/lib/src/codex_config_reader.dart` | VERIFY: released client vs on-disk rollouts of still-supported runtimes | TBD | Keep if data-format peer is live. |
-| CLI flag aliases ×3 (v1.1.1) | `sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart` | User scripts predating namespaced flags | TBD | |
-| RuntimeStartIntent side-file model (v1.0.9) | `sesori_plugin_runtime/lib/src/runtime_start_intent.dart` | Bridges ≤ v1.0.8 sharing a data directory | TBD | |
+| Codex config fallback reads (v1.1.2) | `bridge/sesori_plugin_codex/lib/src/codex_config_reader.dart` | VERIFY: released client vs on-disk rollouts of still-supported runtimes | TBD | Keep if data-format peer is live. |
+| CLI flag aliases ×3 (v1.1.1) | `bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart` | User scripts predating namespaced flags | TBD | |
+| RuntimeStartIntent side-file model (v1.0.9) | `bridge/sesori_plugin_runtime/lib/src/runtime_start_intent.dart` | Bridges ≤ v1.0.8 sharing a data directory | TBD | |
 
 ## Verification Evidence
 

--- a/.plan/active/reliability-cleanup/TRACKER.md
+++ b/.plan/active/reliability-cleanup/TRACKER.md
@@ -1,0 +1,69 @@
+# Reliability Cleanup Series — Tracker
+
+Plan: [PLAN.md](PLAN.md) · Slug: `reliability-cleanup` · Series total: 14 steps
+
+## Execution State
+
+| Step | Title (emoji + description) | Status | PR | Notes |
+|---|---|---|---|---|
+| 1/14 | 🌱 docs: plan the series | Approved, not raised | — | Plan reviewed (2 rounds) + owner waiver recorded; raise on owner go. |
+| 2/14 | ⚙️ refactor: drop pre-v1.4 compatibility paths | ☐ Not started | — | Per-marker peer-verification notes go in the ledger below. |
+| 3/14 | 🌿 fix(bridge): make swallowed failures observable | ☐ Not started | — | Includes settings-repository fold + AbortableRequestSender. |
+| 4/14 | ⚙️ refactor(bridge): unify plugin command transitions | ☐ Not started | — | |
+| 5/14 | 🚧 refactor(bridge): extract relay connection coordinator | ☐ Not started | — | Contract in PLAN.md Step 5; composition root moves to orchestrator_composition.dart. |
+| 6/14 | 🚧 refactor(bridge): extract plugin-event delivery pipeline | ☐ Not started | — | Label generation fences; no check deletion without proof. |
+| 7/14 | 🚧 refactor(plugins): share ndjson subprocess transport | ☐ Not started | — | acp/claude gain runtime dep; record teardown-order delta here when merged. |
+| 8/14 | 🌿 refactor(plugins): consolidate shared plugin primitives | ☐ Not started | — | Pi MIME variant: adopt only if byte-equivalent, else note. |
+| 9/14 | 🌿 refactor(client): remove dead code and fix observability | ☐ Not started | — | Verify barrel-export orphans against DI/tests before deleting implementations. |
+| 10/14 | ⚙️ feat(ui): consolidate sheet/status/picker primitives | ☐ Not started | — | Migrate all consumers in the same PR. |
+| 11/14 | ⚙️ refactor(app): split state-heavy widgets | ☐ Not started | — | Facades unchanged; app-local collaborators only. |
+| 12/14 | 🌿 chore(tooling): CI, codegen freshness, installer parity | ☐ Not started | — | |
+| 13/14 | 🌱 docs: reconcile regression coverage | ☐ Not started | — | Penultimate: docs listed in PLAN.md; no coverage reductions. |
+| 14/14 | 🌿 test: verify series and retire | ☐ Not started | — | Final: run L2 matrix from PLAN.md, record evidence, move to `.plan/completed/`. |
+
+## Review Log
+
+- **2026-08-21, review 1:** REJECTED as too vague (11 gaps). All addressed in
+  Revision 2: per-step class/file/layer contracts, DefaultEditorRepository
+  folded into BridgeSettingsRepository (layering preserved), AbortableRequestSender
+  defined with exact home/signature, coordinator + pipeline contracts written,
+  transport home decided (`sesori_plugin_runtime`) with dependency-direction and
+  AGENTS.md updates, registry promotion dropped (interface stays contract-only;
+  deferred), cleanup-rejection mapping flow pinned to repository layer,
+  single Prego designs chosen, widget collaborators named with ownership and
+  layer justification, workspace/package map added.
+- **2026-08-21, review 2:** REJECTED as too vague on remaining type-level
+  detail (8 narrow gaps: exact constructor signatures/seam types for Steps 5-6,
+  adapter names for Step 7, voice callback contract, tooling paths). All
+  factual spot-checks passed.
+- **2026-08-21, owner waiver:** owner explicitly accepted the current design
+  level ("waive, proceed as-is"). Exact signatures/types get pinned inside each
+  implementation PR and reviewed via `architecture-implementation-review`.
+  Recorded in PLAN.md Owner Decisions. No further plan review.
+
+## Step 2 Peer-Verification Ledger
+
+Fill during implementation; a marker that fails verification stays with its
+reason recorded here.
+
+| Marker | Location | Peer surface | Baseline holds? | Action |
+|---|---|---|---|---|
+| BridgeIdMigrationService + readLegacyBridgeId (v1.3.0) | `bridge/app/lib/src/auth/` | Released Sesori installs ≤ v1.3.x | TBD | |
+| LegacyPostUpdateRelaunch constant (v1.1.2) | `bridge/app/lib/src/bridge/foundation/legacy_post_update_relaunch.dart` | Pre-v1.1.2 updater binaries | TBD | |
+| Rejection sessionId omission fallback (v1.1.0) | `bridge/app/lib/src/bridge/services/pending_interaction_service.dart` | Released clients ≤ v1.0.x | TBD | |
+| Codex config fallback reads (v1.1.2) | `sesori_plugin_codex/lib/src/codex_config_reader.dart` | VERIFY: released client vs on-disk rollouts of still-supported runtimes | TBD | Keep if data-format peer is live. |
+| CLI flag aliases ×3 (v1.1.1) | `sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart` | User scripts predating namespaced flags | TBD | |
+| RuntimeStartIntent side-file model (v1.0.9) | `sesori_plugin_runtime/lib/src/runtime_start_intent.dart` | Bridges ≤ v1.0.8 sharing a data directory | TBD | |
+
+## Verification Evidence
+
+(Append per step as steps merge: analyze/test commands run, suites touched,
+deviations.)
+
+## Retirement Checklist (Step 14)
+
+- [ ] All 14 steps merged or explicitly cancelled with reason
+- [ ] L2 matrix from PLAN.md executed; evidence recorded below
+- [ ] Any Partial/Blocked rows explained; plan stays active if required rows unrun
+- [ ] Regression docs reconciled (Step 13)
+- [ ] Move to `.plan/completed/reliability-cleanup/`

--- a/.plan/active/reliability-cleanup/TRACKER.md
+++ b/.plan/active/reliability-cleanup/TRACKER.md
@@ -8,7 +8,7 @@ Plan: [PLAN.md](PLAN.md) · Slug: `reliability-cleanup` · Series total: 14 step
 |---|---|---|---|---|
 | 1/14 | 🌱 docs: plan the series | Approved, not raised | — | Plan reviewed (2 rounds) + owner waiver recorded; raise on owner go. |
 | 2/14 | ⚙️ refactor: drop pre-v1.4 compatibility paths | ☐ Not started | — | Per-marker peer-verification notes go in the ledger below. |
-| 3/14 | 🌿 fix(bridge): make swallowed failures observable | ☐ Not started | — | Includes settings-repository fold + AbortableRequestSender. |
+| 3/14 | 🌿 fix(bridge): make swallowed failures observable | ☐ Not started | — | Includes settings-repository fold + AbortableRequestClient. |
 | 4/14 | ⚙️ refactor(bridge): unify plugin command transitions | ☐ Not started | — | |
 | 5/14 | 🚧 refactor(bridge): extract relay connection coordinator | ☐ Not started | — | Contract in PLAN.md Step 5; assembly stays in Orchestrator.create. |
 | 6/14 | 🚧 refactor(bridge): extract plugin-event delivery pipeline | ☐ Not started | — | Label generation fences; no check deletion without proof. |
@@ -25,7 +25,7 @@ Plan: [PLAN.md](PLAN.md) · Slug: `reliability-cleanup` · Series total: 14 step
 
 - **2026-08-21, review 1:** REJECTED as too vague (11 gaps). All addressed in
   Revision 2: per-step class/file/layer contracts, DefaultEditorRepository
-  folded into BridgeSettingsRepository (layering preserved), AbortableRequestSender
+  folded into BridgeSettingsRepository (layering preserved), AbortableRequestClient
   defined with exact home/signature, coordinator + pipeline contracts written,
   transport home decided (`sesori_plugin_runtime`) with dependency-direction and
   AGENTS.md updates, registry promotion dropped (interface stays contract-only;

--- a/.plan/active/reliability-cleanup/TRACKER.md
+++ b/.plan/active/reliability-cleanup/TRACKER.md
@@ -10,7 +10,7 @@ Plan: [PLAN.md](PLAN.md) · Slug: `reliability-cleanup` · Series total: 14 step
 | 2/14 | ⚙️ refactor: drop pre-v1.4 compatibility paths | ☐ Not started | — | Per-marker peer-verification notes go in the ledger below. |
 | 3/14 | 🌿 fix(bridge): make swallowed failures observable | ☐ Not started | — | Includes settings-repository fold + AbortableRequestSender. |
 | 4/14 | ⚙️ refactor(bridge): unify plugin command transitions | ☐ Not started | — | |
-| 5/14 | 🚧 refactor(bridge): extract relay connection coordinator | ☐ Not started | — | Contract in PLAN.md Step 5; composition root moves to orchestrator_composition.dart. |
+| 5/14 | 🚧 refactor(bridge): extract relay connection coordinator | ☐ Not started | — | Contract in PLAN.md Step 5; assembly stays in Orchestrator.create. |
 | 6/14 | 🚧 refactor(bridge): extract plugin-event delivery pipeline | ☐ Not started | — | Label generation fences; no check deletion without proof. |
 | 7/14 | 🚧 refactor(plugins): share ndjson subprocess transport | ☐ Not started | — | acp/claude gain runtime dep; record teardown-order delta here when merged. |
 | 8/14 | 🌿 refactor(plugins): consolidate shared plugin primitives | ☐ Not started | — | Pi MIME variant: adopt only if byte-equivalent, else note. |

--- a/.plan/active/reliability-cleanup/TRACKER.md
+++ b/.plan/active/reliability-cleanup/TRACKER.md
@@ -11,7 +11,7 @@ Plan: [PLAN.md](PLAN.md) · Slug: `reliability-cleanup` · Series total: 14 step
 | 3/14 | 🌿 fix(bridge): make swallowed failures observable | ☐ Not started | — | Includes settings-repository fold + AbortableRequestClient. |
 | 4/14 | ⚙️ refactor(bridge): unify plugin command transitions | ☐ Not started | — | |
 | 5/14 | 🚧 refactor(bridge): extract relay connection coordinator | ☐ Not started | — | Contract in PLAN.md Step 5; assembly stays in Orchestrator.create. |
-| 6/14 | 🚧 refactor(bridge): extract plugin-event delivery pipeline | ☐ Not started | — | Label generation fences; no check deletion without proof. |
+| 6/14 | 🚧 refactor(bridge): extract plugin-event processing dispatcher | ☐ Not started | — | Label generation fences; no check deletion without proof. |
 | 7/14 | 🚧 refactor(plugins): share ndjson subprocess transport | ☐ Not started | — | acp/claude gain runtime dep; record teardown-order delta here when merged. |
 | 8/14 | 🌿 refactor(plugins): consolidate shared plugin primitives | ☐ Not started | — | Pi MIME variant: adopt only if byte-equivalent, else note. |
 | 9/14 | 🌿 refactor(client): remove dead code and fix observability | ☐ Not started | — | Verify barrel-export orphans against DI/tests before deleting implementations. |


### PR DESCRIPTION
## Complexity

🌱 Trivial — documentation only: adds the reviewed reliability-cleanup plan and tracker under `.plan/active/reliability-cleanup/`. No production code changes.

## What

Adds `PLAN.md` (goal, verified findings, per-step design contracts, 14-step PR series, verification matrix, risks, deferred work) and `TRACKER.md` (execution state, review log, compat peer-verification ledger) for a multi-week reliability/maintainability cleanup series. The series consolidates drifted duplicate implementations (NDJSON subprocess transport across ACP/Codex/Claude, plugin helper functions), extracts cohesive collaborators from oversized coordinators (Orchestrator relay/event regions, PluginRuntime command transitions), removes dead code and pre-v1.4 compatibility paths, and fixes observability gaps.

## Why

Investigation found several subsystems exist as two or three near-identical copies with concrete behavioral drift, the Orchestrator (2,485 lines) and PluginRuntime repeat transition scaffolding three times, and a handful of catches swallow errors without trace. Each duplicated copy is an independent failure surface; this plan sequences the cleanup into small, individually verifiable PRs before any implementation starts.

## Risk and test focus

None — docs-only change; no user-visible, database, wire, or runtime impact. Review focus: the recorded owner decisions (pre-v1.4-only compatibility removal baseline; desktop control stack retained), the step ordering/sizing, and whether the deferred-work list is honest.

## Expected result

No behavior change anywhere. `.plan/active/reliability-cleanup/` exists as the durable authority for the following 13 implementation/verification steps; each future step updates the tracker as it merges.

## Verification

Docs-only: no analyze/test runs required. Plan content was grounded in five parallel code investigations with targeted verification of every cited finding, two architecture-plan-review rounds, and an explicit owner waiver recorded in both files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Plans a 14‑step reliability cleanup as docs only; no production code or behavior changes. It sequences high‑risk refactors, pins contracts, and defines verification so later PRs stay scoped and reviewable.

- `PLAN.md` is authoritative. It flags high‑risk Steps 5–6, preserves shutdown/SSE ordering, requires acknowledged relay disconnects before reconnect, and serializes project‑summary rebuilds via a global tail key.
- Step 6 introduces the `PluginEventProcessingDispatcher`: it captures normalized facts, injects a neutral project‑summary source seam, and leaves `BridgeEventMapper` to build SSE frames.
- Step 7 fully specifies the shared `NdjsonProcessClient` API (`request`, `dispatch`, `sendFrame`, `notifications`, `isAttached`, `exit`, `reset`, `dispose`) with pre‑spawn attach tokens, fenced attach/dispose, bounded reap on superseded attaches, and a `StderrPolicy` (drain with adapter‑owned sanitization and optional redacted logging). Policy remains per‑plugin via constructor values and one injected correlation extractor.
- Step 3’s `AbortableRequestClient` buffers full responses and uses a cancellable `AbortSignal` (replay‑safe check, unsubscribed on completion) to keep deadline/abort coverage; Step 12 aligns the workflow package map and adds installer‑parity path filters.
- Error handling: the relay‑connect catch is narrowed and rethrows with a typed `innerError` and original stack; Step 9 maps cleanup‑rejection at the repository layer and carries the `innerError` chain.
- Dependencies and ownership: Step 7 adds `sesori_plugin_runtime` to `sesori_plugin_acp` and `sesori_plugin_claude`; Step 6 confines facts to the dispatcher while `BridgeEventMapper` builds SSE frames.
- `TRACKER.md` captures execution state, the peer‑verification ledger, and the complete L2 verification matrix.

<sup>Written for commit 8ebdd04b37783058adc99f019a9e83ce0172caae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

