### PR TITLE
🌿 Fix flaky OpenCode SSE delivery assertions

### DIFF
--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -6,6 +6,31 @@ import "package:opencode_plugin/opencode_plugin.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
+
+/// Waits until [count] events of type [T] have been delivered, or fails.
+///
+/// These tests drive a real loopback `HttpServer`, so SSE bytes arrive on
+/// socket I/O rather than on the microtask queue. `pumpEventQueue` bounds the
+/// number of event-loop turns, not delivery, so on a loaded machine it can
+/// return before the bytes land — which is exactly how this suite flaked on CI.
+Future<void> _awaitEvents<T>(
+  List<BridgeSseEvent> events, {
+  required int count,
+  Duration timeout = const Duration(seconds: 10),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (events.whereType<T>().length < count) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail(
+        "timed out waiting for $count $T event(s); got ${events.whereType<T>().length}",
+      );
+    }
+    await pumpEventQueue();
+  }
+  // Let any trailing event settle so "exactly N" assertions stay meaningful.
+  await pumpEventQueue();
+}
+
 void main() {
   group("OpenCodePlugin", () {
     late _FakeOpenCodeServer server;
@@ -309,7 +334,7 @@ void main() {
       await emitMessage(messageId);
       await emitMessage(messageId);
       await emitMessage("msg_typed_in_the_tui");
-      await pumpEventQueue();
+      await _awaitEvents<BridgeSseMessageUpdated>(events, count: 3);
 
       final stamped = events.whereType<BridgeSseMessageUpdated>().toList();
       expect(stamped, hasLength(3));
@@ -483,7 +508,7 @@ void main() {
           }),
         );
       }
-      await pumpEventQueue();
+      await _awaitEvents<BridgeSseMessageUpdated>(events, count: 2);
 
       expect(
         events.whereType<BridgeSseMessageUpdated>().map((event) => event.info["promptId"]),
@@ -533,7 +558,7 @@ void main() {
           },
         }),
       );
-      await pumpEventQueue();
+      await _awaitEvents<BridgeSseMessageUpdated>(events, count: 1);
 
       final echoed = events.whereType<BridgeSseMessageUpdated>().single;
       expect(echoed.info.containsKey("promptId"), isFalse);
@@ -604,7 +629,7 @@ void main() {
           },
         }),
       );
-      await pumpEventQueue();
+      await _awaitEvents<BridgeSseMessageUpdated>(events, count: 1);
 
       final compactEcho = events.whereType<BridgeSseMessageUpdated>().single;
       expect(compactEcho.info["promptId"], equals("prompt-compact"));


### PR DESCRIPTION
## Complexity

🌿 Straightforward — replaces event-loop pumping with a bounded wait on the condition each test already asserts. Test-only.

## What

`opencode_plugin_impl_test.dart` drives a **real loopback `HttpServer`** (`test/opencode_plugin_impl_test.dart:1198`), so SSE bytes arrive on socket I/O. Four assertions synchronized with `await pumpEventQueue()`, which bounds the number of event-loop turns — not delivery. On a loaded runner it can return before the bytes arrive.

Each site now waits for the event count it is about to assert, with a 10-second timeout and a clear failure message, via a local `_awaitEvents<T>` helper.

## Why

This failed **main CI** on `d47feda74`:

```
❌ OpenCodePlugin sendCommand detaches with the tracked directory and marks the turn busy
Expected: ['prompt-1', 'prompt-1']
  Actual: MappedIterable<BridgeSseMessageUpdated, dynamic>:[]
```

while passing locally on the same commit — the signature of a timing-dependent test rather than a regression. The three sibling sites in the file have the same pattern and the same exposure, so they are fixed together.

This is the class of problem Step 14 of the `codebase-cleanup` plan targets (187 real-duration sleeps and event-loop-count synchronization across the suites); it is pulled forward as a standalone fix because it is currently breaking main.

## Risk and test focus

Risk: very low — test-only, no production code touched, and the assertions are unchanged. The helper can only make a test wait longer, never pass something that previously failed: if the events never arrive it fails with an explicit timeout message instead of an empty-list mismatch.

## Expected result

- User-visible behavior: **None.**
- Database/persisted data: **No change.**
- CI: this suite no longer depends on how many event-loop turns the runner happens to need.

## Verification

- `dart analyze --fatal-infos` clean in `sesori_plugin_opencode`.
- The affected file passes **five consecutive runs**.
- Full `sesori_plugin_opencode` suite: **434 tests pass**.

## Note on the other main failure

`609358a58` (#1023) shows a failed `status` check, but its log shows the desktop `analyze-test` and `build` jobs with `result: "cancelled"` — that run was superseded when the next PR merged moments later, and the status job fails on cancelled jobs. That one is a back-to-back-merge artifact, not a code failure, and needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky SSE assertions by replacing `pumpEventQueue()` in `opencode_plugin_impl_test.dart` with a bounded wait for the expected event count. This matters because SSE bytes arrive via socket I/O, so event-loop turns didn’t guarantee delivery on CI.

**Review notes**
- Adds `_awaitEvents<T>` that waits until `count` events are present (10s timeout) and fails with a clear message.
- Replaces four `pumpEventQueue()` calls with `_awaitEvents` for counts 3, 2, 1, and 1.
- Test-only change; no production code or user-visible behavior changes. Stabilizes the `sesori_plugin_opencode` SSE tests across loaded runners.

<sup>Written for commit 4d54b5487e17e3337841132465bd1ef13f2a4690. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

