### PR TITLE
🌿 [codebase-cleanup] bridge(plugins): share console fakes via a testing library [step 8/45]

### DIFF
--- a/.plan/active/codebase-cleanup/steps/step-08.md
+++ b/.plan/active/codebase-cleanup/steps/step-08.md
@@ -1,0 +1,37 @@
+# Step 8/45 — Plugin-interface testing library for console fakes
+
+## Re-verification against `main`
+
+36 `Stdout` fake declarations exist across 32 files in 7 packages
+(`bridge/app` 16, `sesori_plugin_acp` 4, `sesori_plugin_codex` 4,
+`sesori_plugin_interface` 4, `sesori_plugin_claude` 2, `sesori_plugin_cursor` 1,
+`sesori_plugin_runtime` 1). Hashing the bodies shows they are not all the same
+fake:
+
+| Body hash | Copies | Shape |
+|---|---|---|
+| `bf4cebdc` | 10 | buffering, `writeln` only |
+| `52337a09` | 4 | buffering, `write` + `writeln` |
+| `bbb212bc` | 4 | capturing into a `List<String>` |
+| 13 others | 1–2 each | bespoke: terminal flags, ANSI support, throwing |
+
+Only the three identical groups (18 declarations) are migrated. The remaining
+declarations carry per-test constructor parameters — `supportsAnsiEscapes`,
+`hasTerminal`, specific throw behaviour — and are left where they are rather
+than growing the shared fakes a knob at a time.
+
+The plan also listed `HostProcessService`, `SpawnedProcess`, `BridgeHostInfo`
+and `CapturingIOSink` for this step. They are **not** here: those fakes carry
+scripted behaviour rather than being identical, so consolidating them is a
+design exercise rather than a de-duplication, and folding it into the same PR
+would bury the mechanical part. They move to a follow-up.
+
+## Verification
+
+`dart analyze --fatal-infos` clean in all seven affected packages. `dart test`:
+`sesori_plugin_interface` 153, `sesori_plugin_runtime` 132, `sesori_plugin_acp`
+260, `sesori_plugin_claude` 253, `sesori_plugin_codex` 392,
+`sesori_plugin_cursor` 136, `bridge/app` 2,684 — 4,010 tests passing.
+
+Architecture implementation review not run: the new library is test-only and
+exports no production type; no production file is touched.

--- a/.plan/active/codebase-cleanup/steps/step-08.md
+++ b/.plan/active/codebase-cleanup/steps/step-08.md
@@ -26,6 +26,21 @@ scripted behaviour rather than being identical, so consolidating them is a
 design exercise rather than a de-duplication, and folding it into the same PR
 would bury the mechanical part. They move to a follow-up.
 
+## Review corrections
+
+Two P1 findings, both applied:
+
+- **`ThrowingStdout` had no consumers.** I exported it alongside the two fakes
+  that do, but the four local `_ThrowingStdout` declarations are in the bespoke
+  group this step deliberately leaves alone, so the shared class replaced
+  nothing. Removed — this step's own rule was that a shared fake must replace
+  at least two real copies, and I broke it in the same file that states it.
+- **`CapturingStdout` took its list positionally.** That copied the shape of the
+  declarations it replaced, but a new shared API has to follow the repository's
+  required-named-parameter rule. It is now
+  `CapturingStdout({required List<String> lines})`, with the four shared call
+  sites updated.
+
 ## Verification
 
 `dart analyze --fatal-infos` clean in all seven affected packages. `dart test`:

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -15,6 +15,7 @@ import "package:sesori_bridge/src/orchestrator.dart";
 import "package:sesori_bridge/src/routing/bridge_restart_dispatcher.dart";
 import "package:sesori_bridge/src/server/services/bridge_restart_service.dart";
 import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, LogLevel, ServerClock;
 import "package:sesori_shared/sesori_shared.dart" hide PermissionReply;
 import "package:test/test.dart";
@@ -761,23 +762,8 @@ Future<RelayResponse> _nextResponse({
   throw StateError("relay closed before response $requestId");
 }
 
-class _BufferingStdout() implements Stdout {
-  final StringBuffer _buffer = StringBuffer();
-
-  String get text => _buffer.toString();
-
-  @override
-  void write(Object? object) => _buffer.write(object);
-
-  @override
-  void writeln([Object? object = ""]) => _buffer.writeln(object);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
-}
-
 Future<String> _captureLogOutput(Future<void> Function() action) async {
-  final stderrBuffer = _BufferingStdout();
+  final stderrBuffer = BufferingStdout();
   final previousLevel = Log.level;
   try {
     Log.level = LogLevel.verbose;

--- a/bridge/app/test/bridge/services/session_creation_service_test.dart
+++ b/bridge/app/test/bridge/services/session_creation_service_test.dart
@@ -11,6 +11,7 @@ import "package:sesori_bridge/src/services/session_creation_service.dart";
 import "package:sesori_bridge/src/services/session_mutation_dispatcher.dart";
 import "package:sesori_bridge/src/services/session_operation_dispatcher.dart";
 import "package:sesori_bridge/src/services/worktree_service.dart";
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -624,7 +625,7 @@ class _FakeSessionMetadataRepository() implements SessionMetadataRepository {
 }
 
 Future<String> _captureWarningLog(Future<void> Function() action) async {
-  final output = _BufferingStdout();
+  final output = BufferingStdout();
   final previousLevel = Log.level;
   try {
     Log.level = LogLevel.warning;
@@ -633,21 +634,6 @@ Future<String> _captureWarningLog(Future<void> Function() action) async {
     Log.level = previousLevel;
   }
   return output.text;
-}
-
-class _BufferingStdout() implements Stdout {
-  final StringBuffer _buffer = StringBuffer();
-
-  String get text => _buffer.toString();
-
-  @override
-  void write(Object? object) => _buffer.write(object);
-
-  @override
-  void writeln([Object? object = ""]) => _buffer.writeln(object);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
 }
 
 class _FakeWorktreeService({required super.worktreeRepository}) extends WorktreeService {

--- a/bridge/app/test/bridge/services/session_options_service_test.dart
+++ b/bridge/app/test/bridge/services/session_options_service_test.dart
@@ -4,6 +4,7 @@ import "dart:io";
 import "package:sesori_bridge/src/repositories/models/session_options_cache_key.dart";
 import "package:sesori_bridge/src/repositories/session_options_repository.dart";
 import "package:sesori_bridge/src/services/session_options_service.dart";
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -1600,8 +1601,8 @@ Future<String> _captureLogOutput({
   required LogLevel level,
   required Future<void> Function() action,
 }) async {
-  final stdoutBuffer = _BufferingStdout();
-  final stderrBuffer = _BufferingStdout();
+  final stdoutBuffer = BufferingStdout();
+  final stderrBuffer = BufferingStdout();
   final previousLevel = Log.level;
   try {
     Log.level = level;
@@ -1614,21 +1615,6 @@ Future<String> _captureLogOutput({
     Log.level = previousLevel;
   }
   return stderrBuffer.text;
-}
-
-class _BufferingStdout() implements Stdout {
-  final StringBuffer _buffer = StringBuffer();
-
-  String get text => _buffer.toString();
-
-  @override
-  void write(Object? object) => _buffer.write(object);
-
-  @override
-  void writeln([Object? object = ""]) => _buffer.writeln(object);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
 }
 
 class const _FixedClock({required final DateTime nowValue}) extends ServerClock {

--- a/bridge/app/test/listeners/viewed_project_pr_refresh_listener_test.dart
+++ b/bridge/app/test/listeners/viewed_project_pr_refresh_listener_test.dart
@@ -6,6 +6,7 @@ import "package:sesori_bridge/src/listeners/viewed_project_pr_refresh_listener.d
 import "package:sesori_bridge/src/services/pr_sync_service.dart";
 import "package:sesori_bridge/src/services/project_view_tracker.dart";
 import "package:sesori_bridge/src/services/pull_request_refresh_settings_service.dart";
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, LogLevel;
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -385,7 +386,7 @@ void _disposeHarness({required _Harness harness, required FakeAsync async}) {
 }
 
 String _captureLogOutput({required void Function() action}) {
-  final output = _BufferingStdout();
+  final output = BufferingStdout();
   final previousLevel = Log.level;
   try {
     Log.level = LogLevel.debug;
@@ -394,19 +395,4 @@ String _captureLogOutput({required void Function() action}) {
     Log.level = previousLevel;
   }
   return output.text;
-}
-
-class _BufferingStdout() implements Stdout {
-  final StringBuffer _buffer = StringBuffer();
-
-  String get text => _buffer.toString();
-
-  @override
-  void write(Object? object) => _buffer.write(object);
-
-  @override
-  void writeln([Object? object = ""]) => _buffer.writeln(object);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
 }

--- a/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_content_mapper_test.dart
@@ -3,6 +3,7 @@ import "dart:io";
 import "dart:typed_data";
 
 import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" show maxTranscriptImageBytes;
 import "package:test/test.dart";
@@ -475,7 +476,7 @@ void main() {
 
 String _captureWarnings(void Function() action) {
   final previousLevel = Log.level;
-  final stderr = _BufferingStdout();
+  final stderr = BufferingStdout();
   try {
     Log.level = LogLevel.warning;
     IOOverrides.runZoned(action, stderr: () => stderr);
@@ -483,16 +484,4 @@ String _captureWarnings(void Function() action) {
     Log.level = previousLevel;
   }
   return stderr.text;
-}
-
-class _BufferingStdout() implements Stdout {
-  final StringBuffer _buffer = StringBuffer();
-
-  String get text => _buffer.toString();
-
-  @override
-  void writeln([Object? object = ""]) => _buffer.writeln(object);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
 }

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -1,6 +1,7 @@
 import "dart:io";
 
 import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
@@ -952,7 +953,7 @@ List<PluginMessagePart> _materializedLiveParts({
 
 String _captureWarnings(void Function() action) {
   final previousLevel = Log.level;
-  final stderr = _BufferingStdout();
+  final stderr = BufferingStdout();
   try {
     Log.level = LogLevel.warning;
     IOOverrides.runZoned(action, stderr: () => stderr);
@@ -960,16 +961,4 @@ String _captureWarnings(void Function() action) {
     Log.level = previousLevel;
   }
   return stderr.text;
-}
-
-class _BufferingStdout() implements Stdout {
-  final StringBuffer _buffer = StringBuffer();
-
-  String get text => _buffer.toString();
-
-  @override
-  void writeln([Object? object = ""]) => _buffer.writeln(object);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
 }

--- a/bridge/sesori_plugin_acp/test/repositories/trackers/acp_content_tracker_test.dart
+++ b/bridge/sesori_plugin_acp/test/repositories/trackers/acp_content_tracker_test.dart
@@ -2,6 +2,7 @@ import "dart:io";
 
 import "package:acp_plugin/acp_plugin.dart";
 import "package:acp_plugin/src/repositories/trackers/acp_content_tracker.dart";
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" show maxTranscriptImageCollectionBytes;
 import "package:test/test.dart";
@@ -101,7 +102,7 @@ void main() {
 
 String _captureWarnings(void Function() action) {
   final previousLevel = Log.level;
-  final stderr = _BufferingStdout();
+  final stderr = BufferingStdout();
   try {
     Log.level = LogLevel.warning;
     IOOverrides.runZoned(action, stderr: () => stderr);
@@ -109,18 +110,6 @@ String _captureWarnings(void Function() action) {
     Log.level = previousLevel;
   }
   return stderr.text;
-}
-
-class _BufferingStdout() implements Stdout {
-  final StringBuffer _buffer = StringBuffer();
-
-  String get text => _buffer.toString();
-
-  @override
-  void writeln([Object? object = ""]) => _buffer.writeln(object);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
 }
 
 AcpMappedInlineImageContentBlock _inline({required int decodedBytes}) {

--- a/bridge/sesori_plugin_acp/test/repositories/trackers/acp_tool_content_tracker_test.dart
+++ b/bridge/sesori_plugin_acp/test/repositories/trackers/acp_tool_content_tracker_test.dart
@@ -2,6 +2,7 @@ import "dart:io";
 
 import "package:acp_plugin/acp_plugin.dart";
 import "package:acp_plugin/src/repositories/trackers/acp_tool_content_tracker.dart";
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" show maxTranscriptImageCollectionBytes;
 import "package:test/test.dart";
@@ -171,7 +172,7 @@ AcpMappedMetadataImageContentBlock _metadata() {
 
 String _captureWarnings(void Function() action) {
   final previousLevel = Log.level;
-  final stderr = _BufferingStdout();
+  final stderr = BufferingStdout();
   try {
     Log.level = LogLevel.warning;
     IOOverrides.runZoned(action, stderr: () => stderr);
@@ -179,16 +180,4 @@ String _captureWarnings(void Function() action) {
     Log.level = previousLevel;
   }
   return stderr.text;
-}
-
-class _BufferingStdout() implements Stdout {
-  final StringBuffer _buffer = StringBuffer();
-
-  String get text => _buffer.toString();
-
-  @override
-  void writeln([Object? object = ""]) => _buffer.writeln(object);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
 }

--- a/bridge/sesori_plugin_claude/test/claude_content_mapper_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_content_mapper_test.dart
@@ -4,6 +4,7 @@ import "dart:io";
 import "dart:typed_data";
 
 import "package:claude_plugin/claude_plugin.dart";
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" show maxTranscriptImageBytes;
 import "package:test/test.dart";
@@ -295,7 +296,7 @@ Map<String, Object?> _image({required String data, String mime = "image/png"}) =
 
 String _captureWarnings(void Function() action) {
   final previousLevel = Log.level;
-  final stderr = _BufferingStdout();
+  final stderr = BufferingStdout();
   try {
     Log.level = LogLevel.warning;
     IOOverrides.runZoned(action, stderr: () => stderr);
@@ -303,18 +304,6 @@ String _captureWarnings(void Function() action) {
     Log.level = previousLevel;
   }
   return stderr.text;
-}
-
-class _BufferingStdout() implements Stdout {
-  final StringBuffer _buffer = StringBuffer();
-
-  String get text => _buffer.toString();
-
-  @override
-  void writeln([Object? object = ""]) => _buffer.writeln(object);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
 }
 
 class _ThrowingCastMap(final Map<Object?, Object?> _values) extends MapBase<Object?, Object?> {

--- a/bridge/sesori_plugin_claude/test/claude_transcript_api_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_transcript_api_test.dart
@@ -3,6 +3,7 @@ import "dart:io";
 
 import "package:claude_plugin/claude_plugin.dart";
 import "package:path/path.dart" as p;
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, LogLevel;
 import "package:test/test.dart";
 
@@ -288,7 +289,7 @@ String _writeTranscript(
 
 String _captureWarnings(void Function() action) {
   final previousLevel = Log.level;
-  final stderr = _BufferingStdout();
+  final stderr = BufferingStdout();
   try {
     Log.level = LogLevel.warning;
     IOOverrides.runZoned(action, stderr: () => stderr);
@@ -296,16 +297,4 @@ String _captureWarnings(void Function() action) {
     Log.level = previousLevel;
   }
   return stderr.text;
-}
-
-class _BufferingStdout() implements Stdout {
-  final StringBuffer _buffer = StringBuffer();
-
-  String get text => _buffer.toString();
-
-  @override
-  void writeln([Object? object = ""]) => _buffer.writeln(object);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
 }

--- a/bridge/sesori_plugin_codex/test/codex_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_catalog_repository_test.dart
@@ -6,6 +6,7 @@ import "package:codex_plugin/src/api/models/codex_rollout_dto.dart";
 import "package:codex_plugin/src/repositories/codex_catalog_repository.dart";
 import "package:codex_plugin/src/repositories/models/codex_session_record.dart";
 import "package:path/path.dart" as p;
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, LogLevel, PluginSession;
 import "package:test/test.dart";
 
@@ -466,7 +467,7 @@ class _IndexWriteFailingRolloutApi() extends CodexRolloutApi {
 
 Future<String> _captureDebugLogs(Future<void> Function() action) async {
   final previousLevel = Log.level;
-  final stderr = _BufferingStdout();
+  final stderr = BufferingStdout();
   try {
     Log.level = LogLevel.debug;
     await IOOverrides.runZoned(action, stderr: () => stderr);
@@ -474,16 +475,4 @@ Future<String> _captureDebugLogs(Future<void> Function() action) async {
     Log.level = previousLevel;
   }
   return stderr.text;
-}
-
-class _BufferingStdout() implements Stdout {
-  final StringBuffer _buffer = StringBuffer();
-
-  String get text => _buffer.toString();
-
-  @override
-  void writeln([Object? object = ""]) => _buffer.writeln(object);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
 }

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -11,6 +11,7 @@ import "package:codex_plugin/src/repositories/codex_thread_repository.dart";
 import "package:codex_plugin/src/repositories/codex_tool_lifecycle_tracker.dart";
 import "package:codex_plugin/src/repositories/mappers/codex_image_attachment_mapper.dart";
 import "package:codex_plugin/src/repositories/mappers/codex_user_content_mapper.dart";
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" as shared;
 import "package:test/test.dart";
@@ -2007,7 +2008,7 @@ class _ToolLifecycleHarness({
 
 String _captureWarnings(void Function() action) {
   final previousLevel = Log.level;
-  final stderr = _BufferingStdout();
+  final stderr = BufferingStdout();
   try {
     Log.level = LogLevel.warning;
     IOOverrides.runZoned(action, stderr: () => stderr);
@@ -2015,16 +2016,4 @@ String _captureWarnings(void Function() action) {
     Log.level = previousLevel;
   }
   return stderr.text;
-}
-
-class _BufferingStdout() implements Stdout {
-  final StringBuffer _buffer = StringBuffer();
-
-  String get text => _buffer.toString();
-
-  @override
-  void writeln([Object? object = ""]) => _buffer.writeln(object);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
 }

--- a/bridge/sesori_plugin_codex/test/codex_image_attachment_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_image_attachment_mapper_test.dart
@@ -3,6 +3,7 @@ import "dart:io";
 import "dart:typed_data";
 
 import "package:codex_plugin/src/repositories/mappers/codex_image_attachment_mapper.dart";
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" show maxTranscriptImageBytes;
 import "package:test/test.dart";
@@ -337,7 +338,7 @@ void main() {
 
 String _captureWarnings(void Function() action) {
   final previousLevel = Log.level;
-  final stderr = _BufferingStdout();
+  final stderr = BufferingStdout();
   try {
     Log.level = LogLevel.warning;
     IOOverrides.runZoned(action, stderr: () => stderr);
@@ -345,16 +346,4 @@ String _captureWarnings(void Function() action) {
     Log.level = previousLevel;
   }
   return stderr.text;
-}
-
-class _BufferingStdout() implements Stdout {
-  final StringBuffer _buffer = StringBuffer();
-
-  String get text => _buffer.toString();
-
-  @override
-  void writeln([Object? object = ""]) => _buffer.writeln(object);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
 }

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -11,6 +11,7 @@ import "package:codex_plugin/src/repositories/mappers/codex_image_attachment_map
 import "package:codex_plugin/src/repositories/mappers/codex_user_content_mapper.dart";
 import "package:codex_plugin/src/repositories/models/codex_session_record.dart";
 import "package:path/path.dart" as p;
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
@@ -2594,7 +2595,7 @@ String _captureWarnings(
   LogLevel level = LogLevel.warning,
 }) {
   final previousLevel = Log.level;
-  final stderr = _BufferingStdout();
+  final stderr = BufferingStdout();
   try {
     Log.level = level;
     IOOverrides.runZoned(action, stderr: () => stderr);
@@ -2602,18 +2603,6 @@ String _captureWarnings(
     Log.level = previousLevel;
   }
   return stderr.text;
-}
-
-class _BufferingStdout() implements Stdout {
-  final StringBuffer _buffer = StringBuffer();
-
-  String get text => _buffer.toString();
-
-  @override
-  void writeln([Object? object = ""]) => _buffer.writeln(object);
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => null;
 }
 
 String _writeRollout(

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
@@ -113,7 +113,7 @@ void main() {
               const PluginSetupReady.versioned(runtimeVersion: "2026.07.23-e383d2b"),
             );
           },
-          stderr: () => CapturingStdout(stderrLines),
+          stderr: () => CapturingStdout(lines: stderrLines),
         );
       } finally {
         Log.level = previousLogLevel;

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
@@ -5,6 +5,7 @@ import "dart:io";
 import "package:acp_plugin/acp_plugin.dart";
 import "package:acp_plugin/acp_testing.dart";
 import "package:cursor_plugin/cursor_plugin.dart";
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
@@ -112,7 +113,7 @@ void main() {
               const PluginSetupReady.versioned(runtimeVersion: "2026.07.23-e383d2b"),
             );
           },
-          stderr: () => _CapturingStdout(stderrLines),
+          stderr: () => CapturingStdout(stderrLines),
         );
       } finally {
         Log.level = previousLogLevel;
@@ -536,14 +537,4 @@ class _ProbeProcess({
 
   @override
   ProcessIdentity get identity => throw UnimplementedError();
-}
-
-class _CapturingStdout(final List<String> lines) implements Stdout {
-  @override
-  void writeln([Object? object = ""]) {
-    lines.add(object.toString());
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/bridge/sesori_plugin_interface/lib/plugin_interface_testing.dart
+++ b/bridge/sesori_plugin_interface/lib/plugin_interface_testing.dart
@@ -1,0 +1,7 @@
+/// Test utilities shared by the bridge app and every plugin package.
+///
+/// Import from test code only:
+/// `package:sesori_plugin_interface/plugin_interface_testing.dart`.
+library;
+
+export "src/testing/fake_stdout.dart";

--- a/bridge/sesori_plugin_interface/lib/src/testing/fake_stdout.dart
+++ b/bridge/sesori_plugin_interface/lib/src/testing/fake_stdout.dart
@@ -26,6 +26,13 @@ class BufferingStdout() implements Stdout {
 ///
 /// Use this instead of [BufferingStdout] when a test asserts on the number or
 /// order of lines rather than on the whole text.
+///
+/// Unlike the other two fakes, an unimplemented member **throws** rather than
+/// answering `null`. That is deliberate and matches the declarations this
+/// replaced: a test asserting on exact line output wants to hear about an
+/// unexpected call to something like `supportsAnsiEscapes`, whereas returning
+/// `null` for a non-nullable getter would surface later as a confusing type
+/// error far from the cause.
 class CapturingStdout(final List<String> lines) implements Stdout {
   @override
   void writeln([Object? object = ""]) => lines.add(object.toString());

--- a/bridge/sesori_plugin_interface/lib/src/testing/fake_stdout.dart
+++ b/bridge/sesori_plugin_interface/lib/src/testing/fake_stdout.dart
@@ -33,25 +33,11 @@ class BufferingStdout() implements Stdout {
 /// unexpected call to something like `supportsAnsiEscapes`, whereas returning
 /// `null` for a non-nullable getter would surface later as a confusing type
 /// error far from the cause.
-class CapturingStdout(final List<String> lines) implements Stdout {
+class CapturingStdout({required final List<String> lines}) implements Stdout {
   @override
   void writeln([Object? object = ""]) => lines.add(object.toString());
 
   @override
   // ignore: no_slop_linter/prefer_specific_type, Stdout's own signature
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-/// [Stdout] whose writes always throw, for the paths that must survive a
-/// failing console.
-class ThrowingStdout({required final Object _error}) implements Stdout {
-  @override
-  void write(Object? object) => throw _error;
-
-  @override
-  void writeln([Object? object = ""]) => throw _error;
-
-  @override
-  // ignore: no_slop_linter/prefer_specific_type, Stdout's own signature
-  dynamic noSuchMethod(Invocation invocation) => null;
 }

--- a/bridge/sesori_plugin_interface/lib/src/testing/fake_stdout.dart
+++ b/bridge/sesori_plugin_interface/lib/src/testing/fake_stdout.dart
@@ -1,0 +1,50 @@
+import "dart:io";
+
+/// [Stdout] that collects everything written to it.
+///
+/// Covers both `write` and `writeln` so a test can assert on either; every
+/// other member is answered by [noSuchMethod] because `Stdout` is a large
+/// interface and tests only ever exercise the writing surface.
+class BufferingStdout() implements Stdout {
+  final StringBuffer _buffer = StringBuffer();
+
+  /// Everything written so far, in order.
+  String get text => _buffer.toString();
+
+  @override
+  void write(Object? object) => _buffer.write(object);
+
+  @override
+  void writeln([Object? object = ""]) => _buffer.writeln(object);
+
+  @override
+  // ignore: no_slop_linter/prefer_specific_type, Stdout's own signature
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+/// [Stdout] that appends each `writeln` to [lines] as a separate entry.
+///
+/// Use this instead of [BufferingStdout] when a test asserts on the number or
+/// order of lines rather than on the whole text.
+class CapturingStdout(final List<String> lines) implements Stdout {
+  @override
+  void writeln([Object? object = ""]) => lines.add(object.toString());
+
+  @override
+  // ignore: no_slop_linter/prefer_specific_type, Stdout's own signature
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// [Stdout] whose writes always throw, for the paths that must survive a
+/// failing console.
+class ThrowingStdout({required final Object _error}) implements Stdout {
+  @override
+  void write(Object? object) => throw _error;
+
+  @override
+  void writeln([Object? object = ""]) => throw _error;
+
+  @override
+  // ignore: no_slop_linter/prefer_specific_type, Stdout's own signature
+  dynamic noSuchMethod(Invocation invocation) => null;
+}

--- a/bridge/sesori_plugin_interface/test/console_test.dart
+++ b/bridge/sesori_plugin_interface/test/console_test.dart
@@ -12,8 +12,8 @@ void main() {
 
       IOOverrides.runZoned(
         () => Console.message("hello, user"),
-        stdout: () => CapturingStdout(out),
-        stderr: () => CapturingStdout(err),
+        stdout: () => CapturingStdout(lines: out),
+        stderr: () => CapturingStdout(lines: err),
       );
 
       expect(out, equals(["hello, user"]));
@@ -26,8 +26,8 @@ void main() {
 
       IOOverrides.runZoned(
         () => Console.warning("heads up"),
-        stdout: () => CapturingStdout(out),
-        stderr: () => CapturingStdout(err),
+        stdout: () => CapturingStdout(lines: out),
+        stderr: () => CapturingStdout(lines: err),
       );
 
       expect(err, equals(["heads up"]));
@@ -40,8 +40,8 @@ void main() {
 
       IOOverrides.runZoned(
         () => Console.error("something went wrong"),
-        stdout: () => CapturingStdout(out),
-        stderr: () => CapturingStdout(err),
+        stdout: () => CapturingStdout(lines: out),
+        stderr: () => CapturingStdout(lines: err),
       );
 
       expect(err, equals(["something went wrong"]));
@@ -56,8 +56,8 @@ void main() {
           Console.warning("warn");
           Console.error("boom");
         },
-        stdout: () => CapturingStdout(<String>[]),
-        stderr: () => CapturingStdout(err),
+        stdout: () => CapturingStdout(lines: <String>[]),
+        stderr: () => CapturingStdout(lines: err),
       );
 
       expect(
@@ -77,8 +77,8 @@ void main() {
 
       IOOverrides.runZoned(
         () => Console.message("must still be visible"),
-        stdout: () => CapturingStdout(out),
-        stderr: () => CapturingStdout(<String>[]),
+        stdout: () => CapturingStdout(lines: out),
+        stderr: () => CapturingStdout(lines: <String>[]),
       );
 
       expect(out, equals(["must still be visible"]));

--- a/bridge/sesori_plugin_interface/test/console_test.dart
+++ b/bridge/sesori_plugin_interface/test/console_test.dart
@@ -1,5 +1,6 @@
 import "dart:io";
 
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
@@ -11,8 +12,8 @@ void main() {
 
       IOOverrides.runZoned(
         () => Console.message("hello, user"),
-        stdout: () => _CapturingStdout(out),
-        stderr: () => _CapturingStdout(err),
+        stdout: () => CapturingStdout(out),
+        stderr: () => CapturingStdout(err),
       );
 
       expect(out, equals(["hello, user"]));
@@ -25,8 +26,8 @@ void main() {
 
       IOOverrides.runZoned(
         () => Console.warning("heads up"),
-        stdout: () => _CapturingStdout(out),
-        stderr: () => _CapturingStdout(err),
+        stdout: () => CapturingStdout(out),
+        stderr: () => CapturingStdout(err),
       );
 
       expect(err, equals(["heads up"]));
@@ -39,8 +40,8 @@ void main() {
 
       IOOverrides.runZoned(
         () => Console.error("something went wrong"),
-        stdout: () => _CapturingStdout(out),
-        stderr: () => _CapturingStdout(err),
+        stdout: () => CapturingStdout(out),
+        stderr: () => CapturingStdout(err),
       );
 
       expect(err, equals(["something went wrong"]));
@@ -55,8 +56,8 @@ void main() {
           Console.warning("warn");
           Console.error("boom");
         },
-        stdout: () => _CapturingStdout(<String>[]),
-        stderr: () => _CapturingStdout(err),
+        stdout: () => CapturingStdout(<String>[]),
+        stderr: () => CapturingStdout(err),
       );
 
       expect(
@@ -76,8 +77,8 @@ void main() {
 
       IOOverrides.runZoned(
         () => Console.message("must still be visible"),
-        stdout: () => _CapturingStdout(out),
-        stderr: () => _CapturingStdout(<String>[]),
+        stdout: () => CapturingStdout(out),
+        stderr: () => CapturingStdout(<String>[]),
       );
 
       expect(out, equals(["must still be visible"]));
@@ -86,12 +87,3 @@ void main() {
 }
 
 /// Captures [writeln] calls; [IOOverrides] swaps it in for stdout/stderr.
-class _CapturingStdout(final List<String> lines) implements Stdout {
-  @override
-  void writeln([Object? object = ""]) {
-    lines.add(object.toString());
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}

--- a/bridge/sesori_plugin_interface/test/log_test.dart
+++ b/bridge/sesori_plugin_interface/test/log_test.dart
@@ -24,8 +24,8 @@ void main() {
           Log.w("w-msg");
           Log.e("e-msg");
         },
-        stdout: () => CapturingStdout(out),
-        stderr: () => CapturingStdout(err),
+        stdout: () => CapturingStdout(lines: out),
+        stderr: () => CapturingStdout(lines: err),
       );
 
       expect(out, isEmpty, reason: "diagnostic logs must never pollute stdout");
@@ -44,8 +44,8 @@ void main() {
           Log.w("warning");
           Log.e("error");
         },
-        stdout: () => CapturingStdout(<String>[]),
-        stderr: () => CapturingStdout(err),
+        stdout: () => CapturingStdout(lines: <String>[]),
+        stderr: () => CapturingStdout(lines: err),
       );
 
       expect(err, hasLength(2), reason: "only warning and error pass at the warning level");
@@ -57,8 +57,8 @@ void main() {
 
       IOOverrides.runZoned(
         () => _LogCaller().emit(),
-        stdout: () => CapturingStdout(<String>[]),
-        stderr: () => CapturingStdout(err),
+        stdout: () => CapturingStdout(lines: <String>[]),
+        stderr: () => CapturingStdout(lines: err),
       );
 
       expect(err, hasLength(1));
@@ -76,8 +76,8 @@ void main() {
 
       IOOverrides.runZoned(
         () => _LogCaller().emit(),
-        stdout: () => CapturingStdout(<String>[]),
-        stderr: () => CapturingStdout(err),
+        stdout: () => CapturingStdout(lines: <String>[]),
+        stderr: () => CapturingStdout(lines: err),
       );
 
       expect(err, hasLength(1));
@@ -95,8 +95,8 @@ void main() {
 
       IOOverrides.runZoned(
         () => Log.w("operation failed", StateError("useful failure"), StackTrace.fromString("useful stack")),
-        stdout: () => CapturingStdout(<String>[]),
-        stderr: () => CapturingStdout(err),
+        stdout: () => CapturingStdout(lines: <String>[]),
+        stderr: () => CapturingStdout(lines: err),
       );
 
       expect(err.single, contains("Bad state: useful failure"));
@@ -112,8 +112,8 @@ void main() {
           Log.w("w-msg");
           Log.e("e-msg");
         },
-        stdout: () => CapturingStdout(<String>[]),
-        stderr: () => CapturingStdout(err),
+        stdout: () => CapturingStdout(lines: <String>[]),
+        stderr: () => CapturingStdout(lines: err),
       );
 
       expect(err, hasLength(2));

--- a/bridge/sesori_plugin_interface/test/log_test.dart
+++ b/bridge/sesori_plugin_interface/test/log_test.dart
@@ -1,5 +1,6 @@
 import "dart:io";
 
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
@@ -23,8 +24,8 @@ void main() {
           Log.w("w-msg");
           Log.e("e-msg");
         },
-        stdout: () => _CapturingStdout(out),
-        stderr: () => _CapturingStdout(err),
+        stdout: () => CapturingStdout(out),
+        stderr: () => CapturingStdout(err),
       );
 
       expect(out, isEmpty, reason: "diagnostic logs must never pollute stdout");
@@ -43,8 +44,8 @@ void main() {
           Log.w("warning");
           Log.e("error");
         },
-        stdout: () => _CapturingStdout(<String>[]),
-        stderr: () => _CapturingStdout(err),
+        stdout: () => CapturingStdout(<String>[]),
+        stderr: () => CapturingStdout(err),
       );
 
       expect(err, hasLength(2), reason: "only warning and error pass at the warning level");
@@ -56,8 +57,8 @@ void main() {
 
       IOOverrides.runZoned(
         () => _LogCaller().emit(),
-        stdout: () => _CapturingStdout(<String>[]),
-        stderr: () => _CapturingStdout(err),
+        stdout: () => CapturingStdout(<String>[]),
+        stderr: () => CapturingStdout(err),
       );
 
       expect(err, hasLength(1));
@@ -75,8 +76,8 @@ void main() {
 
       IOOverrides.runZoned(
         () => _LogCaller().emit(),
-        stdout: () => _CapturingStdout(<String>[]),
-        stderr: () => _CapturingStdout(err),
+        stdout: () => CapturingStdout(<String>[]),
+        stderr: () => CapturingStdout(err),
       );
 
       expect(err, hasLength(1));
@@ -94,8 +95,8 @@ void main() {
 
       IOOverrides.runZoned(
         () => Log.w("operation failed", StateError("useful failure"), StackTrace.fromString("useful stack")),
-        stdout: () => _CapturingStdout(<String>[]),
-        stderr: () => _CapturingStdout(err),
+        stdout: () => CapturingStdout(<String>[]),
+        stderr: () => CapturingStdout(err),
       );
 
       expect(err.single, contains("Bad state: useful failure"));
@@ -111,8 +112,8 @@ void main() {
           Log.w("w-msg");
           Log.e("e-msg");
         },
-        stdout: () => _CapturingStdout(<String>[]),
-        stderr: () => _CapturingStdout(err),
+        stdout: () => CapturingStdout(<String>[]),
+        stderr: () => CapturingStdout(err),
       );
 
       expect(err, hasLength(2));
@@ -131,12 +132,3 @@ class _LogCaller() {
 }
 
 /// Captures [writeln] calls; [IOOverrides] swaps it in for stdout/stderr.
-class _CapturingStdout(final List<String> lines) implements Stdout {
-  @override
-  void writeln([Object? object = ""]) {
-    lines.add(object.toString());
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}

--- a/bridge/sesori_plugin_runtime/test/provisioning/runtime_version_validator_test.dart
+++ b/bridge/sesori_plugin_runtime/test/provisioning/runtime_version_validator_test.dart
@@ -1,6 +1,7 @@
 import "dart:io";
 
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 import "package:test/test.dart";
@@ -141,7 +142,7 @@ void main() {
               result: const CommandResult(exitCode: 0, stdout: secretOutput, stderr: ""),
             ),
           ),
-          stderr: () => _CapturingStdout(stderrLines),
+          stderr: () => CapturingStdout(stderrLines),
         );
       } finally {
         Log.level = originalLevel;
@@ -159,14 +160,4 @@ void main() {
       expect(validator.parseVersionOutput(output: "codex-cli v0.144.5")?.raw, "0.144.5");
     });
   });
-}
-
-class _CapturingStdout(final List<String> lines) implements Stdout {
-  @override
-  void writeln([Object? object = ""]) {
-    lines.add(object.toString());
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/bridge/sesori_plugin_runtime/test/provisioning/runtime_version_validator_test.dart
+++ b/bridge/sesori_plugin_runtime/test/provisioning/runtime_version_validator_test.dart
@@ -142,7 +142,7 @@ void main() {
               result: const CommandResult(exitCode: 0, stdout: secretOutput, stderr: ""),
             ),
           ),
-          stderr: () => CapturingStdout(stderrLines),
+          stderr: () => CapturingStdout(lines: stderrLines),
         );
       } finally {
         Log.level = originalLevel;


### PR DESCRIPTION
## Complexity

🌿 Straightforward — a test-only library plus the migration of declarations that were byte-identical to it.

## What

Adds `bridge/sesori_plugin_interface/lib/plugin_interface_testing.dart`, following the existing `acp_testing.dart` pattern, exporting `BufferingStdout`, `CapturingStdout` and `ThrowingStdout`. `Console` and `Log` live in this package, so it is where their test doubles belong.

36 `Stdout` fakes were declared across **32 files in 7 packages**. Hashing the bodies shows they are not all the same fake:

| Body hash | Copies | Shape |
|---|---|---|
| `bf4cebdc` | 10 | buffering, `writeln` only |
| `52337a09` | 4 | buffering, `write` + `writeln` |
| `bbb212bc` | 4 | capturing into a `List<String>` |
| 13 others | 1–2 each | bespoke: `supportsAnsiEscapes`, `hasTerminal`, specific throw behaviour |

**Only the 18 identical declarations migrate.** The other 13 carry per-test constructor parameters and stay where they are — pulling them in would mean growing the shared fakes a knob at a time, which is how a shared fake becomes worse than the duplication it replaced.

Step 8 of the `codebase-cleanup` series.

## Why

A change to `Console`'s surface currently means finding and editing up to sixteen identical stand-ins in one package alone.

## Risk and test focus

Risk: low — test-only, no production file touched. The shared `BufferingStdout` is a superset of the `writeln`-only variant (it also implements `write`), which cannot change the behaviour of a test that only calls `writeln`. Every affected package's full suite is the check.

## Expected result

- User-visible behavior: **None.**
- Database/persisted data: **No change.**
- Internal: one declaration per shared console fake, importable by any bridge package.

## Verification

- `dart analyze --fatal-infos`: clean in all **seven** affected packages.
- `dart test`: `sesori_plugin_interface` 153 · `sesori_plugin_runtime` 132 · `sesori_plugin_acp` 260 · `sesori_plugin_claude` 253 · `sesori_plugin_codex` 392 · `sesori_plugin_cursor` 136 · `bridge/app` 2,684 — **4,010 tests passing**.
- Architecture implementation review not run: the new library is test-only and exports no production type.

## Scope recorded in `steps/step-08.md`

The plan also listed `HostProcessService`, `SpawnedProcess`, `BridgeHostInfo` and `CapturingIOSink` for this step. They are **not** here: unlike the console fakes those carry scripted behaviour rather than being identical, so consolidating them is a design exercise rather than a de-duplication, and folding it in would bury the mechanical part of this change. They move to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shares console Stdout fakes via a new test-only library in `sesori_plugin_interface`, removing duplication and keeping `Console`/`Log` tests consistent. Behavior is unchanged; tests now import shared fakes rather than declaring local copies.

- Adds `bridge/sesori_plugin_interface/lib/plugin_interface_testing.dart` exporting `BufferingStdout` and `CapturingStdout`; documents why `CapturingStdout` throws on unimplemented members.
- Replaces 18 identical local `Stdout` fakes across 7 packages; bespoke per-test fakes remain local.
- Changes `CapturingStdout` to require a named `lines` parameter; update tests to `CapturingStdout(lines: ...)`.
- Removes the unused `ThrowingStdout`.
- No production files changed; `BufferingStdout` implements both `write` and `writeln`.

<sup>Written for commit 732b24e1874f212a6f3b4ddf98e1f66b68dbdc36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

