### PR TITLE
⚙️ [codebase-cleanup] bridge(runtime): remove the migration-era dual-mode runtime knobs [step 24/45]

### DIFF
--- a/.plan/active/codebase-cleanup/steps/step-24.md
+++ b/.plan/active/codebase-cleanup/steps/step-24.md
@@ -1,0 +1,116 @@
+# Step 24 — Remove the migration-era dual-mode runtime knobs
+
+`bridge/sesori_plugin_runtime` carried six switches that let one supervisor run
+both a "legacy" and a "hardened" version of every start. The migration finished:
+both shipping descriptors (Codex and OpenCode) select the hardened value for
+every switch, so each one was a branch with a single reachable side.
+
+## Re-verification against `main`
+
+Checked before editing, because the plan's audit counts have been wrong before.
+
+| Knob | Legacy default | Codex | OpenCode | Other production callers |
+| --- | --- | --- | --- | --- |
+| `RuntimeHealthPolicy.attemptCount` | — | never | never | none (3 test files only) |
+| `RuntimeRecordTiming.afterSpawn` | default | `intentSideFile` | `intentSideFile` | none |
+| `preProbeBindable` | `false` | `true` | `true` | none |
+| `failFastOnSpawnError` | `false` | `true` | `true` | none |
+| `failOnEarlyChildExit` | `false` | `true` | `true` | none |
+| `validateRuntime` | `null` | never set | never set | none (2 test files only) |
+
+Commands used:
+
+```bash
+grep -rn --include="*.dart" "attemptCount\|validateRuntime\|preProbeBindable\|\
+failFastOnSpawnError\|failOnEarlyChildExit\|recordTiming" bridge/ client/ shared/
+```
+
+Two doc comments were already stale on `main`: `RuntimeRecordTiming.intentSideFile`
+claimed "the supervisor rejects it until then" while both descriptors were
+selecting it, and `ManagedRuntimeSpec` still described serving "the legacy
+in-place wrapper". Both were rewritten rather than deleted silently.
+
+## What changed
+
+- **`RuntimeHealthPolicy` collapses from a sealed pair to one class.** The sealed
+  hierarchy existed only to hold the legacy/hardened split; with `attemptCount`
+  gone it wrapped a single variant. `HealthDeadlinePolicy` folds into
+  `RuntimeHealthPolicy(deadline:, pollInterval:)` and the supervisor's
+  `switch` over the pair becomes the loop it always ran in production.
+- **`RuntimeRecordTiming` is deleted.** The start-intent side file is written
+  before every spawn and cleared after, unconditionally.
+- **`RuntimeStartIntentStore` is now a required constructor parameter.** It was
+  nullable only to serve the after-spawn timing, and `_requireIntentStoreFor`
+  existed to turn that nullable into a runtime `ArgumentError` at two call
+  sites. The compiler enforces it now; the check and both calls are gone.
+- **`preProbeBindable`, `failFastOnSpawnError`, `failOnEarlyChildExit` and
+  `validateRuntime` are deleted**, each replaced by its single production value.
+
+Net: **-150 lines in `lib/`**, -52 in `test/` (including a new 47-line shared
+fake, so ~-99 of test churn removed).
+
+## Behavior
+
+Unchanged for both shipping plugins — every removed branch resolved to the value
+Codex and OpenCode already passed. Two consequences worth stating explicitly:
+
+- **A spawn error on the dynamic path propagates raw instead of being retried on
+  the next candidate.** That was already production behavior via
+  `failFastOnSpawnError: true`; only the deleted legacy path retried.
+- **An abort that fires during a spawn that then fails surfaces the spawn's own
+  error rather than `PluginStartAbortedException`.** Also already production
+  behavior for the same reason. Every path where the spawn *succeeds* still
+  settles aborts as `PluginStartAbortedException`.
+
+## Tests
+
+Five tests were removed because the change makes their premise unrepresentable,
+not because they were inconvenient:
+
+| Test | Why it cannot exist |
+| --- | --- |
+| `rejects intent side-file record timing when no intent store is wired` | the store is a required parameter |
+| `rejects a storeless intent timing once, never retrying across dynamic candidates` | same |
+| `restartOnPort rejects a storeless intent timing before waiting on the port` | same |
+| `a failing validateRuntime rolls back the start` | `validateRuntime` no longer exists |
+| `aborting settles as an abort even when the remaining candidates are all invalid` | needed the loop to continue past a spawn error, which only the legacy path did |
+
+Reshaped rather than removed:
+
+- `_spawned(...)` now defaults to `exitImmediately: false`. A child that exits
+  before the first healthy probe is now always a failed start, so a test that
+  wants a live runtime must have one; the three tests about early exit opt in
+  explicitly.
+- `_BindablePlan` answers "bindable" unless a test says otherwise. Every start
+  pre-probes now, so requiring each test to declare the happy answer was noise;
+  `probedPorts` remains the assertion surface.
+- Tests whose start fails now wire `gracefulHooks[pid]`, because a live child
+  has to actually stop for the rollback to complete. One delay assertion gained
+  the graceful-shutdown wait that this makes observable.
+- The shared `_healthPolicy` constant is `deadline: 1500ms / pollInterval: 500ms`.
+  Most tests run on a clock that never advances, so the bound that fires is the
+  poll backstop — `ceil(1500 / 500) + 2 = 5` — reproducing the five probes the
+  old `attemptCount(attempts: 5)` gave them.
+- `_InMemoryHostJsonStore` moved from the intent test into
+  `test/support/in_memory_host_json_store.dart`, since three more harnesses now
+  need an intent store.
+
+## Verification
+
+```bash
+cd bridge/sesori_plugin_runtime  && dart analyze --fatal-infos && dart test   # 127 passing
+cd bridge/sesori_plugin_codex    && dart analyze --fatal-infos && dart test   # 392 passing
+cd bridge/sesori_plugin_opencode && dart analyze --fatal-infos && dart test   # 434 passing
+```
+
+Repo-wide sweep confirms no remaining reference to any removed symbol:
+
+```bash
+grep -rn --include="*.dart" "HealthAttemptCountPolicy\|HealthDeadlinePolicy\|\
+RuntimeRecordTiming\|validateRuntime\|failOnEarlyChildExit\|failFastOnSpawnError\|\
+preProbeBindable\|recordTiming" bridge/ client/ shared/
+```
+
+Architecture implementation review: not run. No new or moved production class, no
+DI change, no wire or persisted contract — this deletes parameters and their dead
+branches inside one existing package.

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
@@ -486,9 +486,7 @@ class const CodexPluginDescriptor({
     final RuntimePortPolicy portPolicy;
     if (requestedPort != null) {
       Log.d("[codex] starting on port $requestedPort");
-      // Pre-probe the explicit port so an occupied port fails with a diagnosis
-      // instead of spawning a child doomed to lose the bind race.
-      portPolicy = ExplicitPortPolicy(port: requestedPort, preProbeBindable: true);
+      portPolicy = ExplicitPortPolicy(port: requestedPort);
     } else {
       Log.d("[codex] starting on a dynamic port");
       portPolicy = DynamicPortPolicy(
@@ -497,9 +495,6 @@ class const CodexPluginDescriptor({
         reservedPort: codexNoReservedPort,
         minPort: dynamicCodexPortMin,
         maxPort: dynamicCodexPortMax,
-        // A spawn that cannot even launch (e.g. ENOENT on the binary) fails the
-        // same way on every candidate — fail fast instead of retrying.
-        failFastOnSpawnError: true,
       );
     }
 

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_policy.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_policy.dart
@@ -182,12 +182,10 @@ ManagedRuntimeSpec<CodexOwnershipRecord> buildCodexManagedRuntimeSpec({
     probePortBindable: ({required int port}) => host.ports.isBindable(host: codexLoopbackHost, port: port),
     buildRecord: buildCodexOwnershipRecord,
     portPolicy: portPolicy,
-    healthPolicy: RuntimeHealthPolicy.deadline(
+    healthPolicy: RuntimeHealthPolicy(
       deadline: codexHealthDeadline,
       pollInterval: codexHealthPollInterval,
     ),
-    recordTiming: RuntimeRecordTiming.intentSideFile,
-    failOnEarlyChildExit: true,
   );
 }
 

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
@@ -622,9 +622,7 @@ class const OpenCodePluginDescriptor({
         final RuntimePortPolicy portPolicy;
         if (requestedPort != null) {
           Log.d("[opencode] starting on port $requestedPort");
-          // Pre-probe the explicit port so an occupied port fails with a
-          // diagnosis instead of spawning a child doomed to lose the bind race.
-          portPolicy = ExplicitPortPolicy(port: requestedPort, preProbeBindable: true);
+          portPolicy = ExplicitPortPolicy(port: requestedPort);
         } else {
           Log.d("[opencode] starting on a dynamic port");
           portPolicy = DynamicPortPolicy(
@@ -633,9 +631,6 @@ class const OpenCodePluginDescriptor({
             reservedPort: openCodeDefaultPort,
             minPort: dynamicOpenCodePortMin,
             maxPort: dynamicOpenCodePortMax,
-            // A spawn that cannot even launch (e.g. ENOENT on the binary) fails
-            // the same way on every candidate — fail fast instead of retrying.
-            failFastOnSpawnError: true,
           );
         }
 

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_policy.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_policy.dart
@@ -384,11 +384,9 @@ ManagedRuntimeSpec<OpenCodeOwnershipRecord> buildOpenCodeManagedRuntimeSpec({
         probeOpenCodePortBindable(ports: host.ports, port: port, bindHost: bindHost, connectHost: connectHost),
     buildRecord: (draft) => buildOpenCodeOwnershipRecord(draft: draft, bindHost: bindHost),
     portPolicy: portPolicy,
-    healthPolicy: RuntimeHealthPolicy.deadline(
+    healthPolicy: RuntimeHealthPolicy(
       deadline: openCodeHealthDeadline,
       pollInterval: openCodeHealthPollInterval,
     ),
-    recordTiming: RuntimeRecordTiming.intentSideFile,
-    failOnEarlyChildExit: true,
   );
 }

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_policy_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_policy_test.dart
@@ -363,13 +363,8 @@ void main() {
         connectHost: "127.0.0.1",
       );
 
-      expect(spec.recordTiming, equals(RuntimeRecordTiming.intentSideFile));
-      expect(spec.validateRuntime, isNull);
-      expect(spec.failOnEarlyChildExit, isTrue);
-      final health = spec.healthPolicy;
-      expect(health, isA<HealthDeadlinePolicy>());
-      expect((health as HealthDeadlinePolicy).deadline, equals(const Duration(seconds: 30)));
-      expect(health.pollInterval, equals(const Duration(milliseconds: 500)));
+      expect(spec.healthPolicy.deadline, equals(const Duration(seconds: 30)));
+      expect(spec.healthPolicy.pollInterval, equals(const Duration(milliseconds: 500)));
     });
 
     test("routes the health probe to the connect host, not the bind host", () async {

--- a/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
@@ -14,10 +14,10 @@ class ManagedProcessService<R>({
   required final String _runtimeId,
   required final Duration _gracefulShutdownWait,
 
-  /// Optional bridge-private side-file store for [RuntimeRecordTiming.intentSideFile].
-  /// Required when that timing is selected; unused for the legacy after-spawn
-  /// timing, so it defaults to null and the legacy path never touches it.
-  final RuntimeStartIntentStore? _intentStore,
+  /// Bridge-private side-file store: an intent record is written before spawn
+  /// and resolved after, so a crash between the two still leaves a reclaimable
+  /// trace of the child we were about to own.
+  required final RuntimeStartIntentStore _intentStore,
 }) {
   final Map<String, _CurrentOwnedRuntimeProcess> _currentOwnedProcessesBySessionId =
       <String, _CurrentOwnedRuntimeProcess>{};
@@ -38,10 +38,6 @@ class ManagedProcessService<R>({
     StartAbortSignal? startAborted,
   }) async {
     final abort = startAborted ?? StartAbortSignal.never;
-
-    // A deterministic configuration error: reject it once, up front, before
-    // cleanup and before the dynamic path can retry it candidate by candidate.
-    _requireIntentStoreFor(spec);
 
     await cleanupStaleOwnedRuntimes(terminatedBridgeIdentities: terminatedBridgeIdentities);
     _throwIfAborted(abort);
@@ -105,10 +101,6 @@ class ManagedProcessService<R>({
     required Duration portReleasePollInterval,
     StartAbortSignal? startAborted,
   }) async {
-    // Reject a misconfigured intent timing up front, before waiting on the port,
-    // so a direct caller fails fast and clearly instead of crashing on a null
-    // intent store deep inside the spawn path.
-    _requireIntentStoreFor(spec);
     final abort = startAborted ?? StartAbortSignal.never;
     _throwIfAborted(abort);
     await _waitForPortRelease(
@@ -119,15 +111,6 @@ class ManagedProcessService<R>({
       abort: abort,
     );
     return await _startAndConfirmHealthy(spec: spec, port: port, abort: abort);
-  }
-
-  /// A managed runtime that opts into intent side-file timing must be given an
-  /// intent store; selecting the timing without one is a deterministic
-  /// configuration error, surfaced before any side effects.
-  void _requireIntentStoreFor(ManagedRuntimeSpec<R> spec) {
-    if (spec.recordTiming == RuntimeRecordTiming.intentSideFile && _intentStore == null) {
-      throw ArgumentError("[$_runtimeId] intent side-file record timing requires an intent store");
-    }
   }
 
   Future<void> _waitForPortRelease({
@@ -170,16 +153,14 @@ class ManagedProcessService<R>({
     required ExplicitPortPolicy policy,
     required StartAbortSignal abort,
   }) async {
-    if (policy.preProbeBindable) {
-      final bindable = await spec.probePortBindable(port: policy.port);
-      if (!bindable) {
-        throw PluginStartException(
-          "[$_runtimeId] explicit port ${policy.port} is already in use",
-          cause: null,
-        );
-      }
-      _throwIfAborted(abort);
+    final bindable = await spec.probePortBindable(port: policy.port);
+    if (!bindable) {
+      throw PluginStartException(
+        "[$_runtimeId] explicit port ${policy.port} is already in use",
+        cause: null,
+      );
     }
+    _throwIfAborted(abort);
     return await _startAndConfirmHealthy(spec: spec, port: policy.port, abort: abort);
   }
 
@@ -219,16 +200,11 @@ class ManagedProcessService<R>({
       } on PluginStartAbortedException {
         rethrow;
       } on PluginStartException catch (error) {
-        // A failure after a successful spawn (health/validation): try the
-        // next candidate, as the legacy path does.
-        lastError = error;
-      } on Object catch (error) {
-        // A spawn that could not launch: retry the next candidate unless the
-        // policy opts into failing fast.
-        if (policy.failFastOnSpawnError) {
-          rethrow;
-        }
-        Log.w("[$_runtimeId] Failed to start runtime on port $port", error);
+        // A failure after a successful spawn (health check): the port was
+        // bindable but the runtime did not come up on it, so try the next
+        // candidate. A spawn that could not launch at all is not caught here —
+        // it is a fatal configuration or environment fault, and retrying it
+        // candidate by candidate would only repeat the same failure.
         lastError = error;
       }
     }
@@ -244,20 +220,17 @@ class ManagedProcessService<R>({
     required int port,
     required StartAbortSignal abort,
   }) async {
-    final usesIntent = spec.recordTiming == RuntimeRecordTiming.intentSideFile;
-    if (usesIntent) {
-      // Record the spawn intent before the child exists, so a crash between
-      // spawn and the ownership write still names the bridge run and the port.
-      await _intentStore!.write(
-        RuntimeStartIntent(
-          ownerSessionId: _bridge.ownerSessionId,
-          port: port,
-          bridgePid: _bridge.identity.pid,
-          bridgeStartMarker: _bridge.identity.startMarker,
-          recordedAt: _clock.now(),
-        ),
-      );
-    }
+    // Record the spawn intent before the child exists, so a crash between
+    // spawn and the ownership write still names the bridge run and the port.
+    await _intentStore.write(
+      RuntimeStartIntent(
+        ownerSessionId: _bridge.ownerSessionId,
+        port: port,
+        bridgePid: _bridge.identity.pid,
+        bridgeStartMarker: _bridge.identity.startMarker,
+        recordedAt: _clock.now(),
+      ),
+    );
 
     // Spawn errors propagate before any ownership state is acquired: the
     // explicit-port caller surfaces them raw, the dynamic caller retries.
@@ -265,9 +238,7 @@ class ManagedProcessService<R>({
     try {
       spawned = await spec.spawn(port: port);
     } on Object {
-      if (usesIntent) {
-        await _clearIntentQuietly();
-      }
+      await _clearIntentQuietly();
       rethrow;
     }
 
@@ -277,9 +248,7 @@ class ManagedProcessService<R>({
     // freshly spawned child is still untracked, so stop it directly.
     if (abort.isAborted) {
       await _stopUntrackedSpawnQuietly(process: spawned, port: port, reason: "after a post-spawn abort");
-      if (usesIntent) {
-        await _clearIntentQuietly();
-      }
+      await _clearIntentQuietly();
       throw const PluginStartAbortedException();
     }
 
@@ -298,9 +267,7 @@ class ManagedProcessService<R>({
       // The child is already running but not yet tracked or recorded — stop it
       // directly so a record-factory failure cannot leak a started runtime.
       await _stopUntrackedSpawnQuietly(process: spawned, port: port, reason: "after a record build error");
-      if (usesIntent) {
-        await _clearIntentQuietly();
-      }
+      await _clearIntentQuietly();
       rethrow;
     }
     trackOwnedRuntime(
@@ -310,27 +277,13 @@ class ManagedProcessService<R>({
 
     try {
       await _ownershipRepository.upsert(record: record);
-      if (usesIntent) {
-        // The starting record is now in the frozen ownership file; an orphan is
-        // trackable from there, so the intent has done its job.
-        await _clearIntentQuietly();
-      }
+      // The starting record is now in the frozen ownership file; an orphan is
+      // trackable from there, so the intent has done its job.
+      await _clearIntentQuietly();
       _throwIfAborted(abort);
 
       final health = await _confirmHealthy(spec: spec, port: port, spawned: spawned, abort: abort);
 
-      final validate = spec.validateRuntime;
-      if (validate != null) {
-        try {
-          await validate(port: port);
-        } on PluginStartAbortedException {
-          rethrow;
-        } on Object catch (error) {
-          // Surface validation failures as a (retryable) start failure rather
-          // than a raw error the dynamic path would mistake for a spawn error.
-          throw PluginStartException("[$_runtimeId] runtime validation failed on port $port", cause: error);
-        }
-      }
       _throwIfAborted(abort);
 
       final readyRecord = _mapper.markReady(record: record);
@@ -350,9 +303,7 @@ class ManagedProcessService<R>({
       } on Object catch (cleanupError, cleanupStackTrace) {
         Log.w("[$_runtimeId] Failed to clean up after a failed start on port $port", cleanupError, cleanupStackTrace);
       }
-      if (usesIntent) {
-        await _clearIntentQuietly();
-      }
+      await _clearIntentQuietly();
       rethrow;
     }
   }
@@ -360,12 +311,8 @@ class ManagedProcessService<R>({
   /// Best-effort removal of the intent side file. An intent-clear failure must
   /// never mask the start error that prompted it, so this only logs.
   Future<void> _clearIntentQuietly() async {
-    final store = _intentStore;
-    if (store == null) {
-      return;
-    }
     try {
-      await store.clear();
+      await _intentStore.clear();
     } on Object catch (error, stackTrace) {
       Log.w("[$_runtimeId] Failed to clear the runtime start-intent side file", error, stackTrace);
     }
@@ -378,45 +325,26 @@ class ManagedProcessService<R>({
     required StartAbortSignal abort,
   }) async {
     final policy = spec.healthPolicy;
-    switch (policy) {
-      case HealthAttemptCountPolicy():
-        RuntimeHealthProbe? last;
-        for (var attempt = 1; attempt <= policy.attempts; attempt += 1) {
-          await _clock.delay(duration: policy.delay);
-          final probe = await _probeOnce(spec: spec, port: port, spawned: spawned, abort: abort);
-          last = probe;
-          if (probe.healthy) {
-            return probe;
-          }
-        }
+    final deadline = _clock.now().add(policy.deadline);
+    // The same clock-independent backstop as the port-release wait: a
+    // non-advancing clock can never reach the deadline, so only a poll
+    // cap keeps an unhealthy runtime from spinning this loop forever
+    // under the startup mutex.
+    final maxPolls = _boundedMaxPolls(timeout: policy.deadline, pollInterval: policy.pollInterval);
+    var polls = 0;
+    while (true) {
+      await _clock.delay(duration: policy.pollInterval);
+      final probe = await _probeOnce(spec: spec, port: port, spawned: spawned, abort: abort);
+      if (probe.healthy) {
+        return probe;
+      }
+      polls += 1;
+      if (polls >= maxPolls || !_clock.now().isBefore(deadline)) {
         throw PluginStartException(
-          "[$_runtimeId] health check failed on port $port after ${policy.attempts} attempt(s)",
-          cause: last?.error,
+          "[$_runtimeId] health check failed on port $port within ${policy.deadline.inMilliseconds}ms",
+          cause: probe.error,
         );
-      case HealthDeadlinePolicy():
-        final deadline = _clock.now().add(policy.deadline);
-        // The same clock-independent backstop as the port-release wait: a
-        // non-advancing clock can never reach the deadline, so only a poll
-        // cap keeps an unhealthy runtime from spinning this loop forever
-        // under the startup mutex.
-        final maxPolls = _boundedMaxPolls(timeout: policy.deadline, pollInterval: policy.pollInterval);
-        var polls = 0;
-        RuntimeHealthProbe? last;
-        while (true) {
-          await _clock.delay(duration: policy.pollInterval);
-          final probe = await _probeOnce(spec: spec, port: port, spawned: spawned, abort: abort);
-          last = probe;
-          if (probe.healthy) {
-            return probe;
-          }
-          polls += 1;
-          if (polls >= maxPolls || !_clock.now().isBefore(deadline)) {
-            throw PluginStartException(
-              "[$_runtimeId] health check failed on port $port within ${policy.deadline.inMilliseconds}ms",
-              cause: last.error,
-            );
-          }
-        }
+      }
     }
   }
 
@@ -428,7 +356,7 @@ class ManagedProcessService<R>({
   }) async {
     _throwIfAborted(abort);
 
-    if (spec.failOnEarlyChildExit && await _spawnedProcessExited(process: spawned)) {
+    if (await _spawnedProcessExited(process: spawned)) {
       // The child we launched is gone; a healthy probe now would be answered
       // by an unrelated process holding the port. Fail authoritatively.
       throw PluginStartException(

--- a/bridge/sesori_plugin_runtime/lib/src/managed_runtime_spec.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_runtime_spec.dart
@@ -34,65 +34,21 @@ class const RuntimeRecordDraft({
   required final DateTime startedAt,
   });
 
-/// How the supervisor paces health confirmation after a spawn.
-///
-/// The legacy spec is [RuntimeHealthPolicy.attemptCount]; the hardened
-/// deadline-based pacing ([RuntimeHealthPolicy.deadline]) becomes the default
-/// only when the real descriptor opts in at the flip. The legacy test suite
-/// hard-asserts exact delay sequences, so pacing must be configurable rather
-/// than replaced.
-sealed class const RuntimeHealthPolicy() {
-  /// Legacy pacing: up to [attempts] probes, each preceded by [delay].
-  const factory attemptCount({
-    required int attempts,
-    required Duration delay,
-  }) = HealthAttemptCountPolicy;
-
-  /// Deadline pacing: probe every [pollInterval] until healthy or until
-  /// [deadline] elapses (host clock).
-  factory deadline({
-    required Duration deadline,
-    required Duration pollInterval,
-  }) = HealthDeadlinePolicy;
-}
-
-class const HealthAttemptCountPolicy({required final int attempts, required final Duration delay}) extends RuntimeHealthPolicy {
-  this
-    : assert(attempts > 0, "attempts must be positive"),
-      super();
-
-}
-
-class HealthDeadlinePolicy({required final Duration deadline, required final Duration pollInterval}) extends RuntimeHealthPolicy {
+/// How the supervisor paces health confirmation after a spawn: probe every
+/// [pollInterval] until healthy or until [deadline] elapses (host clock).
+class RuntimeHealthPolicy({required final Duration deadline, required final Duration pollInterval}) {
   // Not const: the parameter guards below compare Durations, which is not a
   // constant-evaluable operation. The policy is built at runtime anyway.
   this
     : assert(!deadline.isNegative, "deadline must be non-negative"),
-      assert(pollInterval > Duration.zero, "pollInterval must be positive"),
-      super();
+      assert(pollInterval > Duration.zero, "pollInterval must be positive");
 
-}
-
-/// When the supervisor writes the ownership record relative to spawn.
-enum RuntimeRecordTiming() {
-  /// Legacy: the record is written only after spawn, once a real pid exists.
-  /// The frozen schema's runtime pid is required non-null, so there is no
-  /// representable pre-spawn state in the ownership file itself.
-  afterSpawn,
-
-  /// Hardened: an intent record is written to a bridge-private side file
-  /// before spawn and resolved after. Activated in a later migration step;
-  /// the supervisor rejects it until then.
-  intentSideFile,
 }
 
 /// Where the supervisor obtains the listening port for a start.
 sealed class const RuntimePortPolicy() {
   /// A single, caller-chosen port.
-  const factory explicit({
-    required int port,
-    bool preProbeBindable,
-  }) = ExplicitPortPolicy;
+  const factory explicit({required int port}) = ExplicitPortPolicy;
 
   /// Dynamic discovery across [candidates]: probe each for bindability and
   /// start on the first that works, up to [maxAttempts] examined candidates.
@@ -102,17 +58,10 @@ sealed class const RuntimePortPolicy() {
     required int reservedPort,
     required int minPort,
     required int maxPort,
-    bool failFastOnSpawnError,
   }) = DynamicPortPolicy;
 }
 
-class const ExplicitPortPolicy({
-  required final int port,
-  /// Hardened (default off): probe bindability before spawning and fail with
-  /// a diagnosed error when the port is already held. Off reproduces the
-  /// legacy behavior of spawning straight onto the explicit port.
-  final bool preProbeBindable = false,
-}) extends RuntimePortPolicy {
+class const ExplicitPortPolicy({required final int port}) extends RuntimePortPolicy {
   this : super();
 
 }
@@ -134,10 +83,6 @@ class const DynamicPortPolicy({
     /// Inclusive bounds of the dynamic range.
   required final int minPort,
     required final int maxPort,
-    /// Hardened (default off): treat a spawn error as fatal and stop instead of
-  /// retrying the next candidate. Off reproduces the legacy behavior of
-  /// retrying on any start error (e.g. a bind race).
-  final bool failFastOnSpawnError = false,
   }) extends RuntimePortPolicy {
   this : assert(maxAttempts > 0, "maxAttempts must be positive"),
        super();
@@ -145,8 +90,8 @@ class const DynamicPortPolicy({
 }
 
 /// Everything a [ManagedProcessService] needs to start (or attach to) one
-/// managed runtime, expressed as seams so the same supervisor serves the
-/// legacy in-place wrapper, the eventual host-backed plugin, and tests.
+/// managed runtime, expressed as seams so one supervisor serves every plugin
+/// that owns a runtime process, plus tests.
 ///
 /// The seams ([spawn], [probeHealth], [probePortBindable]) are supplied as
 /// functions rather than service objects so a plugin (or a legacy adapter)
@@ -161,23 +106,14 @@ class const ManagedRuntimeSpec<R>({
   /// than throw, but the supervisor tolerates a thrown probe (treated as
   /// unhealthy) so a transient connection error simply retries.
   required final Future<RuntimeHealthProbe> Function({required int port}) probeHealth,
-    /// Whether [port] can currently be bound (used for dynamic discovery and
-  /// the optional explicit pre-probe).
+    /// Whether [port] can currently be bound — used for dynamic discovery and
+  /// for the pre-spawn probe on an explicit port.
   required final Future<bool> Function({required int port}) probePortBindable,
     /// Maps the post-spawn facts into the plugin's concrete ownership record at
   /// the "starting" status.
   required final R Function(RuntimeRecordDraft draft) buildRecord,
     required final RuntimePortPolicy portPolicy,
     required final RuntimeHealthPolicy healthPolicy,
-    final RuntimeRecordTiming recordTiming = RuntimeRecordTiming.afterSpawn,
-    /// Optional post-health validation, run after the first healthy probe and
-  /// before the record flips to "ready". A throw fails the start (with
-  /// rollback). Null reproduces the legacy behavior of no extra validation.
-  final Future<void> Function({required int port})? validateRuntime,
-    /// Hardened (default off): if the spawned child exits before the first
-  /// healthy probe, fail the start regardless of probe success — a healthy
-  /// response after our child died means an unrelated process holds the port.
-  final bool failOnEarlyChildExit = false,
   });
 
 /// The outcome of a successful [ManagedProcessService.start] or

--- a/bridge/sesori_plugin_runtime/test/managed_process_service_intent_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_process_service_intent_test.dart
@@ -6,10 +6,18 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 import "package:test/test.dart";
 
+import "support/in_memory_host_json_store.dart";
+
 const _ownershipFile = "opencode-processes.json";
 const _intentFile = "OPENCODE-start-intent.json";
 const _gracefulShutdownWait = Duration(seconds: 5);
-const _legacyHealthPolicy = RuntimeHealthPolicy.attemptCount(attempts: 5, delay: Duration(milliseconds: 500));
+// Five 500ms-spaced probes, expressed as the deadline pacing the supervisor
+// now always uses. Most tests here run on a clock that never advances, so the
+// bound that actually fires is the poll backstop: ceil(1500 / 500) + 2 = 5.
+final _healthPolicy = RuntimeHealthPolicy(
+  deadline: const Duration(milliseconds: 1500),
+  pollInterval: const Duration(milliseconds: 500),
+);
 
 void main() {
   group("ManagedProcessService intent side-file timing", () {
@@ -141,7 +149,7 @@ class _Harness() {
     };
   }
 
-  final _InMemoryHostJsonStore store = _InMemoryHostJsonStore();
+  final InMemoryHostJsonStore store = InMemoryHostJsonStore();
   final _SpawnPlan spawn = _SpawnPlan();
   final _ProbePlan probe = _ProbePlan();
   final _FakeHostProcessService processes = _FakeHostProcessService();
@@ -187,8 +195,7 @@ class _Harness() {
         status: "starting",
       ),
       portPolicy: ExplicitPortPolicy(port: port),
-      healthPolicy: _legacyHealthPolicy,
-      recordTiming: RuntimeRecordTiming.intentSideFile,
+      healthPolicy: _healthPolicy,
     );
   }
 
@@ -199,45 +206,6 @@ class _Harness() {
     }
     final decoded = Map<String, dynamic>.from(jsonDecode(contents) as Map);
     return decoded.map((key, value) => MapEntry(key, Map<String, dynamic>.from(value as Map)));
-  }
-}
-
-class _InMemoryHostJsonStore() implements HostJsonStore {
-  final Map<String, String> files = <String, String>{};
-
-  @override
-  Future<String?> read({required String name}) async => files[name];
-
-  @override
-  Future<void> write({required String name, required String contents}) async {
-    files[name] = contents;
-  }
-
-  @override
-  Future<void> delete({required String name}) async {
-    files.remove(name);
-  }
-
-  @override
-  Future<void> quarantine({required String name, required String quarantinedName}) async {
-    final contents = files.remove(name);
-    if (contents != null) {
-      files[quarantinedName] = contents;
-    }
-  }
-
-  @override
-  Future<String?> update({
-    required String name,
-    required FutureOr<String?> Function(String? current) transform,
-  }) async {
-    final next = await transform(files[name]);
-    if (next == null) {
-      files.remove(name);
-    } else {
-      files[name] = next;
-    }
-    return next;
   }
 }
 

--- a/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
@@ -6,10 +6,15 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 import "package:test/test.dart";
 
+import "support/in_memory_host_json_store.dart";
+
 const _gracefulShutdownWait = Duration(seconds: 5);
-const _legacyHealthPolicy = RuntimeHealthPolicy.attemptCount(
-  attempts: 5,
-  delay: Duration(milliseconds: 500),
+// Five 500ms-spaced probes, expressed as the deadline pacing the supervisor
+// now always uses. Most tests here run on a clock that never advances, so the
+// bound that actually fires is the poll backstop: ceil(1500 / 500) + 2 = 5.
+final _healthPolicy = RuntimeHealthPolicy(
+  deadline: const Duration(milliseconds: 1500),
+  pollInterval: const Duration(milliseconds: 500),
 );
 
 void main() {
@@ -20,12 +25,9 @@ void main() {
       fakes = _Fakes();
     });
 
-    test("retries dynamic candidates after a start race and skips the reserved port", () async {
-      fakes.bindable.byPort.addAll(<int, bool>{49152: true, 49153: true});
-      fakes.spawn.results.addAll(<Object>[
-        StateError("bind race"),
-        _spawned(pid: 101, port: 49153),
-      ]);
+    test("skips the reserved port and starts on the first bindable candidate", () async {
+      fakes.bindable.byPort.addAll(<int, bool>{49152: false, 49153: true});
+      fakes.spawn.results.add(_spawned(pid: 101, port: 49153));
       fakes.probe.results.add(const RuntimeHealthProbe(healthy: true));
 
       final handle = await fakes.service().start(
@@ -35,8 +37,9 @@ void main() {
 
       expect(handle.port, equals(49153));
       expect(handle.isOwned, isTrue);
+      // 4096 is the reserved port: never probed, never spawned on.
       expect(fakes.bindable.probedPorts, equals(<int>[49152, 49153]));
-      expect(fakes.spawn.spawnedPorts, equals(<int>[49152, 49153]));
+      expect(fakes.spawn.spawnedPorts, equals(<int>[49153]));
       expect(fakes.ownership.records.values.single.status, equals(_TestStatus.ready));
       expect(fakes.ownership.records.values.single.port, equals(49153));
     });
@@ -70,16 +73,19 @@ void main() {
 
     test("exhausts all health retries on one port and moves to the next", () async {
       fakes.bindable.byPort.addAll(<int, bool>{49152: true, 49153: true});
+      final firstChild = _spawned(pid: 101, port: 49152);
       fakes.spawn.results.addAll(<Object>[
-        _spawned(pid: 101, port: 49152),
+        firstChild,
         _spawned(pid: 102, port: 49153),
       ]);
       fakes.probe.results.addAll(<RuntimeHealthProbe>[
         for (var i = 0; i < 5; i += 1) const RuntimeHealthProbe(healthy: false, error: "not ready"),
         const RuntimeHealthProbe(healthy: true),
       ]);
-      // The first port's failed-start cleanup finds the child already gone.
+      // The first port's failed start rolls back: its child stops on the
+      // graceful signal and the inspection then finds it gone.
       fakes.processes.inspectResults[101] = <ProcessIdentity?>[null];
+      fakes.processes.gracefulHooks[101] = firstChild.completeExit;
 
       final handle = await fakes.service().start(
         spec: fakes.spec(portPolicy: _dynamic(<int>[49152, 49153])),
@@ -94,7 +100,14 @@ void main() {
       );
       expect(
         fakes.clock.delays,
-        equals(<Duration>[for (var i = 0; i < 6; i += 1) const Duration(milliseconds: 500)]),
+        equals(<Duration>[
+          // Five poll intervals exhaust the first port...
+          for (var i = 0; i < 5; i += 1) const Duration(milliseconds: 500),
+          // ...then its failed start waits out the graceful stop...
+          _gracefulShutdownWait,
+          // ...and the second port answers on its first poll.
+          const Duration(milliseconds: 500),
+        ]),
       );
       expect(fakes.ownership.records.values.single.status, equals(_TestStatus.ready));
       expect(fakes.ownership.records.values.single.port, equals(49153));
@@ -143,14 +156,14 @@ void main() {
       expect(fakes.spawn.spawnedPorts, isEmpty);
     });
 
-    test("fail-fast policy stops on a spawn error instead of retrying", () async {
+    test("stops on a spawn error instead of retrying the next candidate", () async {
       fakes.bindable.byPort.addAll(<int, bool>{49152: true, 49153: true});
       fakes.spawn.results.add(const ProcessException("opencode", <String>["serve"]));
 
       await expectLater(
         fakes.service().start(
           spec: fakes.spec(
-            portPolicy: _dynamic(<int>[49152, 49153], failFastOnSpawnError: true),
+            portPolicy: _dynamic(<int>[49152, 49153]),
           ),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
         ),
@@ -170,7 +183,8 @@ void main() {
     });
 
     test("bypasses discovery but still retries health on the single port", () async {
-      fakes.spawn.results.add(_spawned(pid: 201, port: 4096));
+      final spawned = _spawned(pid: 201, port: 4096);
+      fakes.spawn.results.add(spawned);
       fakes.probe.results.addAll(<RuntimeHealthProbe>[
         for (var i = 0; i < 5; i += 1) const RuntimeHealthProbe(healthy: false, error: "not ready"),
       ]);
@@ -179,6 +193,8 @@ void main() {
         null,
         null,
       ];
+      // The unhealthy child stops on the graceful signal, as a real one does.
+      fakes.processes.gracefulHooks[201] = spawned.completeExit;
 
       await expectLater(
         fakes.service().start(
@@ -188,7 +204,8 @@ void main() {
         throwsA(isA<PluginStartException>()),
       );
 
-      expect(fakes.bindable.probedPorts, isEmpty);
+      // No discovery: the one explicit port is pre-probed, and only that port.
+      expect(fakes.bindable.probedPorts, equals(<int>[4096]));
       expect(fakes.spawn.spawnedPorts, equals(<int>[4096]));
       expect(fakes.probe.probedPorts, equals(<int>[4096, 4096, 4096, 4096, 4096]));
       expect(fakes.processes.signalRequests, equals(<String>["graceful:201"]));
@@ -206,7 +223,7 @@ void main() {
         throwsA(isA<StateError>()),
       );
 
-      expect(fakes.bindable.probedPorts, isEmpty);
+      expect(fakes.bindable.probedPorts, equals(<int>[50128]));
       expect(fakes.spawn.spawnedPorts, equals(<int>[50128]));
       expect(fakes.probe.probedPorts, isEmpty);
       expect(fakes.processes.signalRequests, isEmpty);
@@ -280,13 +297,13 @@ void main() {
       );
     });
 
-    test("optional pre-probe rejects an unbindable explicit port without spawning", () async {
+    test("pre-probe rejects an unbindable explicit port without spawning", () async {
       fakes.bindable.byPort[4096] = false;
 
       await expectLater(
         fakes.service().start(
           spec: fakes.spec(
-            portPolicy: const ExplicitPortPolicy(port: 4096, preProbeBindable: true),
+            portPolicy: const ExplicitPortPolicy(port: 4096),
           ),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
         ),
@@ -298,14 +315,14 @@ void main() {
       expect(fakes.ownership.records, isEmpty);
     });
 
-    test("optional pre-probe proceeds when the explicit port is bindable", () async {
+    test("pre-probe proceeds when the explicit port is bindable", () async {
       fakes.bindable.byPort[4096] = true;
       fakes.spawn.results.add(_spawned(pid: 501, port: 4096));
       fakes.probe.results.add(const RuntimeHealthProbe(healthy: true));
 
       final handle = await fakes.service().start(
         spec: fakes.spec(
-          portPolicy: const ExplicitPortPolicy(port: 4096, preProbeBindable: true),
+          portPolicy: const ExplicitPortPolicy(port: 4096),
         ),
         terminatedBridgeIdentities: const <ProcessIdentity>[],
       );
@@ -334,7 +351,6 @@ void main() {
         fakes.service().start(
           spec: fakes.spec(
             portPolicy: const ExplicitPortPolicy(port: 50140),
-            failOnEarlyChildExit: true,
           ),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
         ),
@@ -343,83 +359,6 @@ void main() {
 
       expect(fakes.probe.probedPorts, isEmpty);
       expect(fakes.ownership.records, isEmpty);
-    });
-
-    test("a failing validateRuntime rolls back the start", () async {
-      fakes.spawn.results.add(_spawned(pid: 701, port: 50141));
-      fakes.probe.results.add(const RuntimeHealthProbe(healthy: true));
-      fakes.processes.inspectResults[701] = <ProcessIdentity?>[null];
-
-      await expectLater(
-        fakes.service().start(
-          spec: fakes.spec(
-            portPolicy: const ExplicitPortPolicy(port: 50141),
-            validateRuntime: ({required int port}) => Future<void>.error(StateError("bad version")),
-          ),
-          terminatedBridgeIdentities: const <ProcessIdentity>[],
-        ),
-        throwsA(isA<PluginStartException>()),
-      );
-
-      expect(fakes.ownership.records, isEmpty);
-      expect(fakes.ownership.upsertedStatuses, equals(<_TestStatus>[_TestStatus.starting]));
-    });
-
-    test("rejects intent side-file record timing when no intent store is wired", () async {
-      fakes.spawn.results.add(_spawned(pid: 801, port: 50142));
-
-      await expectLater(
-        fakes.service().start(
-          spec: fakes.spec(
-            portPolicy: const ExplicitPortPolicy(port: 50142),
-            recordTiming: RuntimeRecordTiming.intentSideFile,
-          ),
-          terminatedBridgeIdentities: const <ProcessIdentity>[],
-        ),
-        throwsA(isA<ArgumentError>()),
-      );
-
-      expect(fakes.spawn.spawnedPorts, isEmpty);
-      expect(fakes.ownership.records, isEmpty);
-    });
-
-    test("rejects a storeless intent timing once, never retrying across dynamic candidates", () async {
-      fakes.bindable.byPort.addAll(<int, bool>{49152: true, 49153: true});
-
-      await expectLater(
-        fakes.service().start(
-          spec: fakes.spec(
-            portPolicy: _dynamic(<int>[49152, 49153]),
-            recordTiming: RuntimeRecordTiming.intentSideFile,
-          ),
-          terminatedBridgeIdentities: const <ProcessIdentity>[],
-        ),
-        throwsA(isA<ArgumentError>()),
-      );
-
-      // Rejected up front, before cleanup and the candidate loop: nothing
-      // probed or spawned.
-      expect(fakes.bindable.probedPorts, isEmpty);
-      expect(fakes.spawn.spawnedPorts, isEmpty);
-    });
-
-    test("restartOnPort rejects a storeless intent timing before waiting on the port", () async {
-      await expectLater(
-        fakes.service().restartOnPort(
-          spec: fakes.spec(
-            portPolicy: const ExplicitPortPolicy(port: 4096),
-            recordTiming: RuntimeRecordTiming.intentSideFile,
-          ),
-          port: 4096,
-          portReleaseTimeout: const Duration(seconds: 2),
-          portReleasePollInterval: const Duration(milliseconds: 250),
-        ),
-        throwsA(isA<ArgumentError>()),
-      );
-
-      // Fails fast: the port-release wait never runs and nothing is spawned.
-      expect(fakes.bindable.probedPorts, isEmpty);
-      expect(fakes.spawn.spawnedPorts, isEmpty);
     });
 
     test("stops the spawned child when the record factory throws", () async {
@@ -463,7 +402,7 @@ void main() {
       final handle = await fakes.service().start(
         spec: fakes.spec(
           portPolicy: const ExplicitPortPolicy(port: 50150),
-          healthPolicy: RuntimeHealthPolicy.deadline(
+          healthPolicy: RuntimeHealthPolicy(
             deadline: const Duration(seconds:5),
             pollInterval: const Duration(seconds: 1),
           ),
@@ -477,18 +416,21 @@ void main() {
     });
 
     test("fails once the deadline elapses", () async {
-      fakes.spawn.results.add(_spawned(pid: 902, port: 50151));
+      final spawned = _spawned(pid: 902, port: 50151);
+      fakes.spawn.results.add(spawned);
       fakes.probe.results.addAll(<RuntimeHealthProbe>[
         const RuntimeHealthProbe(healthy: false, error: "still down"),
         const RuntimeHealthProbe(healthy: false, error: "still down"),
       ]);
       fakes.processes.inspectResults[902] = <ProcessIdentity?>[null];
+      // The unhealthy child stops on the graceful signal, as a real one does.
+      fakes.processes.gracefulHooks[902] = spawned.completeExit;
 
       await expectLater(
         fakes.service().start(
           spec: fakes.spec(
             portPolicy: const ExplicitPortPolicy(port: 50151),
-            healthPolicy: RuntimeHealthPolicy.deadline(
+            healthPolicy: RuntimeHealthPolicy(
               deadline: const Duration(seconds:2),
               pollInterval: const Duration(seconds: 1),
             ),
@@ -504,11 +446,11 @@ void main() {
 
     test("rejects a non-positive poll interval or negative deadline", () {
       expect(
-        () => RuntimeHealthPolicy.deadline(deadline: const Duration(seconds: 5), pollInterval: Duration.zero),
+        () => RuntimeHealthPolicy(deadline: const Duration(seconds: 5), pollInterval: Duration.zero),
         throwsA(isA<AssertionError>()),
       );
       expect(
-        () => RuntimeHealthPolicy.deadline(
+        () => RuntimeHealthPolicy(
           deadline: const Duration(seconds: -1),
           pollInterval: const Duration(seconds: 1),
         ),
@@ -520,15 +462,18 @@ void main() {
       // The default _FakeServerClock never advances, so the deadline can never
       // be reached: only the poll cap can terminate the health loop.
       final stuck = _Fakes();
-      stuck.spawn.results.add(_spawned(pid: 903, port: 50152));
+      final spawned = _spawned(pid: 903, port: 50152);
+      stuck.spawn.results.add(spawned);
       // No probe results configured: every probe reports unhealthy.
       stuck.processes.inspectResults[903] = <ProcessIdentity?>[null];
+      // The unhealthy child stops on the graceful signal, as a real one does.
+      stuck.processes.gracefulHooks[903] = spawned.completeExit;
 
       await expectLater(
         stuck.service().start(
           spec: stuck.spec(
             portPolicy: const ExplicitPortPolicy(port: 50152),
-            healthPolicy: RuntimeHealthPolicy.deadline(
+            healthPolicy: RuntimeHealthPolicy(
               deadline: const Duration(seconds: 2),
               pollInterval: const Duration(seconds: 1),
             ),
@@ -595,11 +540,12 @@ void main() {
     test("aborting during the health loop rolls back and never retries the next port", () async {
       final controller = StartAbortController();
       fakes.bindable.byPort.addAll(<int, bool>{49152: true, 49153: true});
-      final spawned = _spawned(pid: 111, port: 49152, exitImmediately: true);
+      final spawned = _spawned(pid: 111, port: 49152);
       fakes.spawn.results.add(spawned);
       fakes.probe.results.add(const RuntimeHealthProbe(healthy: false, error: "warming up"));
       fakes.probe.onProbe = controller.abort;
       fakes.processes.inspectResults[111] = <ProcessIdentity?>[null];
+      fakes.processes.gracefulHooks[111] = spawned.completeExit;
 
       await expectLater(
         fakes.service().start(
@@ -615,38 +561,21 @@ void main() {
       expect(fakes.ownership.records, isEmpty);
     });
 
-    test("aborting settles as an abort even when the remaining candidates are all invalid", () async {
-      // The first candidate's spawn aborts the start and fails; every later
-      // candidate is the reserved port, so the loop would otherwise skip them
-      // all and end as a generic exhaustion failure instead of an abort.
+    test("aborting after the healthy probe rolls back before marking ready", () async {
       final controller = StartAbortController();
-      fakes.bindable.byPort[49152] = true;
-      fakes.spawn.results.add(StateError("bind race"));
-      fakes.spawn.onSpawn = controller.abort;
-
-      await expectLater(
-        fakes.service().start(
-          spec: fakes.spec(portPolicy: _dynamic(<int>[49152, 4096, 4096, 4096])),
-          terminatedBridgeIdentities: const <ProcessIdentity>[],
-          startAborted: controller.signal,
-        ),
-        throwsA(isA<PluginStartAbortedException>()),
-      );
-
-      expect(fakes.spawn.spawnedPorts, equals(<int>[49152]));
-    });
-
-    test("aborting after validation rolls back before marking ready", () async {
-      final controller = StartAbortController();
-      fakes.spawn.results.add(_spawned(pid: 121, port: 50161, exitImmediately: true));
+      final spawned = _spawned(pid: 121, port: 50161);
+      fakes.spawn.results.add(spawned);
       fakes.probe.results.add(const RuntimeHealthProbe(healthy: true));
       fakes.processes.inspectResults[121] = <ProcessIdentity?>[null];
+      fakes.processes.gracefulHooks[121] = spawned.completeExit;
+      // Abort during the probe that confirms health, so the start settles at
+      // the checkpoint between a healthy runtime and the ready record.
+      fakes.probe.onProbe = controller.abort;
 
       await expectLater(
         fakes.service().start(
           spec: fakes.spec(
             portPolicy: const ExplicitPortPolicy(port: 50161),
-            validateRuntime: ({required int port}) async => controller.abort(),
           ),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
           startAborted: controller.signal,
@@ -748,14 +677,13 @@ Iterable<int> _endless(int value) sync* {
   }
 }
 
-RuntimePortPolicy _dynamic(List<int> candidates, {bool failFastOnSpawnError = false}) {
+RuntimePortPolicy _dynamic(List<int> candidates) {
   return RuntimePortPolicy.dynamic(
     candidates: candidates,
     maxAttempts: 5,
     reservedPort: 4096,
     minPort: 49152,
     maxPort: 65535,
-    failFastOnSpawnError: failFastOnSpawnError,
   );
 }
 
@@ -763,7 +691,10 @@ _FakeSpawnedProcess _spawned({
   required int pid,
   required int port,
   String? startMarker = "open-start",
-  bool exitImmediately = true,
+  // A child that outlives the start is the normal case: the supervisor now
+  // always treats an exit before the first healthy probe as a failed start,
+  // so only tests about that failure opt into `exitImmediately: true`.
+  bool exitImmediately = false,
 }) {
   return _FakeSpawnedProcess(
     identity: _runtimeIdentity(pid: pid, port: port, startMarker: startMarker),
@@ -818,6 +749,7 @@ class _Fakes({_RecordingClock? clock}) {
   final _SpawnPlan spawn = _SpawnPlan();
   final _ProbePlan probe = _ProbePlan();
   final _BindablePlan bindable = _BindablePlan();
+  final InMemoryHostJsonStore intentFiles = InMemoryHostJsonStore();
 
   ManagedProcessService<_TestRecord> service() {
     return ManagedProcessService<_TestRecord>(
@@ -828,15 +760,13 @@ class _Fakes({_RecordingClock? clock}) {
       clock: clock,
       runtimeId: "OPENCODE",
       gracefulShutdownWait: _gracefulShutdownWait,
+      intentStore: RuntimeStartIntentStore(store: intentFiles, fileName: "opencode-start-intent.json"),
     );
   }
 
   ManagedRuntimeSpec<_TestRecord> spec({
     required RuntimePortPolicy portPolicy,
-    RuntimeHealthPolicy healthPolicy = _legacyHealthPolicy,
-    RuntimeRecordTiming recordTiming = RuntimeRecordTiming.afterSpawn,
-    Future<void> Function({required int port})? validateRuntime,
-    bool failOnEarlyChildExit = false,
+    RuntimeHealthPolicy? healthPolicy,
     _TestRecord Function(RuntimeRecordDraft draft)? buildRecord,
   }) {
     return ManagedRuntimeSpec<_TestRecord>(
@@ -845,10 +775,7 @@ class _Fakes({_RecordingClock? clock}) {
       probePortBindable: bindable.bindable,
       buildRecord: buildRecord ?? _buildRecord,
       portPolicy: portPolicy,
-      healthPolicy: healthPolicy,
-      recordTiming: recordTiming,
-      validateRuntime: validateRuntime,
-      failOnEarlyChildExit: failOnEarlyChildExit,
+      healthPolicy: healthPolicy ?? _healthPolicy,
     );
   }
 }
@@ -893,13 +820,12 @@ class _BindablePlan() {
   final Map<int, bool> byPort = <int, bool>{};
   final List<int> probedPorts = <int>[];
 
+  /// Bindable unless a test says otherwise: every start now pre-probes its
+  /// port, so requiring each test to declare the happy answer would be noise.
+  /// [probedPorts] stays the record of what was actually probed.
   Future<bool> bindable({required int port}) async {
     probedPorts.add(port);
-    final value = byPort[port];
-    if (value == null) {
-      throw StateError("No bindability configured for $port");
-    }
-    return value;
+    return byPort[port] ?? true;
   }
 }
 

--- a/bridge/sesori_plugin_runtime/test/managed_process_service_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_process_service_test.dart
@@ -6,6 +6,8 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 import "package:test/test.dart";
 
+import "support/in_memory_host_json_store.dart";
+
 const _gracefulShutdownWait = Duration(seconds: 5);
 
 void main() {
@@ -351,6 +353,7 @@ ManagedProcessService<_TestRecord> _service({
     clock: clock,
     runtimeId: "OPENCODE",
     gracefulShutdownWait: _gracefulShutdownWait,
+    intentStore: RuntimeStartIntentStore(store: InMemoryHostJsonStore(), fileName: "opencode-start-intent.json"),
   );
 }
 

--- a/bridge/sesori_plugin_runtime/test/managed_runtime_monitor_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_runtime_monitor_test.dart
@@ -6,8 +6,16 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 import "package:test/test.dart";
 
+import "support/in_memory_host_json_store.dart";
+
 const _gracefulShutdownWait = Duration(seconds: 5);
-const _legacyHealthPolicy = RuntimeHealthPolicy.attemptCount(attempts: 5, delay: Duration(milliseconds: 500));
+// Five 500ms-spaced probes, expressed as the deadline pacing the supervisor
+// now always uses. Most tests here run on a clock that never advances, so the
+// bound that actually fires is the poll backstop: ceil(1500 / 500) + 2 = 5.
+final _healthPolicy = RuntimeHealthPolicy(
+  deadline: const Duration(milliseconds: 1500),
+  pollInterval: const Duration(milliseconds: 500),
+);
 
 void main() {
   group("ManagedRuntimeMonitor", () {
@@ -403,6 +411,7 @@ class _Fakes({ServerClock? clock}) {
       clock: clock,
       runtimeId: "OPENCODE",
       gracefulShutdownWait: _gracefulShutdownWait,
+      intentStore: RuntimeStartIntentStore(store: InMemoryHostJsonStore(), fileName: "opencode-start-intent.json"),
     );
   }
 
@@ -413,7 +422,7 @@ class _Fakes({ServerClock? clock}) {
       probePortBindable: bindable.bindable,
       buildRecord: (draft) => _record(pid: draft.runtimeIdentity.pid, port: draft.port),
       portPolicy: const ExplicitPortPolicy(port: 4096),
-      healthPolicy: _legacyHealthPolicy,
+      healthPolicy: _healthPolicy,
     );
   }
 

--- a/bridge/sesori_plugin_runtime/test/support/in_memory_host_json_store.dart
+++ b/bridge/sesori_plugin_runtime/test/support/in_memory_host_json_store.dart
@@ -1,0 +1,47 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+/// A [HostJsonStore] kept entirely in memory, so a test can exercise the
+/// supervisor's start-intent side file without touching the filesystem.
+///
+/// [files] is public on purpose: tests assert on the exact bytes written, and
+/// observe the intent file's presence from inside a spawn seam.
+class InMemoryHostJsonStore() implements HostJsonStore {
+  final Map<String, String> files = <String, String>{};
+
+  @override
+  Future<String?> read({required String name}) async => files[name];
+
+  @override
+  Future<void> write({required String name, required String contents}) async {
+    files[name] = contents;
+  }
+
+  @override
+  Future<void> delete({required String name}) async {
+    files.remove(name);
+  }
+
+  @override
+  Future<void> quarantine({required String name, required String quarantinedName}) async {
+    final contents = files.remove(name);
+    if (contents != null) {
+      files[quarantinedName] = contents;
+    }
+  }
+
+  @override
+  Future<String?> update({
+    required String name,
+    required FutureOr<String?> Function(String? current) transform,
+  }) async {
+    final next = await transform(files[name]);
+    if (next == null) {
+      files.remove(name);
+    } else {
+      files[name] = next;
+    }
+    return next;
+  }
+}


### PR DESCRIPTION
## Complexity

⚙️ Moderate — the deletions themselves are mechanical, but they touch the process supervision path shared by Codex and OpenCode, and removing the branches changes what the test harness has to simulate.

## What

`bridge/sesori_plugin_runtime` carried six switches that let one supervisor run both a "legacy" and a "hardened" version of every start. The migration is finished: **both shipping descriptors select the hardened value for every switch**, so each knob was a branch with one reachable side.

| Knob | Legacy default | Codex | OpenCode |
| --- | --- | --- | --- |
| `RuntimeHealthPolicy.attemptCount` | — | never | never |
| `RuntimeRecordTiming.afterSpawn` | default | `intentSideFile` | `intentSideFile` |
| `preProbeBindable` | `false` | `true` | `true` |
| `failFastOnSpawnError` | `false` | `true` | `true` |
| `failOnEarlyChildExit` | `false` | `true` | `true` |
| `validateRuntime` | `null` | never set | never set |

- **`RuntimeHealthPolicy` collapses from a sealed pair to one class.** The sealed hierarchy existed only to hold the legacy/hardened split; with `attemptCount` gone it wrapped a single variant. `HealthDeadlinePolicy` folds into `RuntimeHealthPolicy(deadline:, pollInterval:)`, and the supervisor's `switch` becomes the loop it always ran in production.
- **`RuntimeStartIntentStore` becomes required.** It was nullable only to serve the after-spawn timing, and `_requireIntentStoreFor` existed to turn that nullable into a runtime `ArgumentError` at two call sites. The compiler enforces it now — one whole failure mode deleted rather than guarded.
- **Two doc comments were already stale on `main`** and are rewritten rather than dropped silently: `intentSideFile` claimed "the supervisor rejects it until then" while both descriptors were selecting it, and `ManagedRuntimeSpec` still described serving "the legacy in-place wrapper".

Step 24 of the `codebase-cleanup` series. Net **-150 lines in `lib/`**.

## Why

Every one of these branches ran on the hot start path to defend a configuration no shipping plugin selects. That is the shape this series exists to remove: a conditional whose false side is unreachable is not flexibility, it is an untested second implementation of process supervision.

## Risk and test focus

Risk: **medium** — this is the supervisor that starts, health-checks and rolls back runtime processes for two plugins. Nothing about *what* production does changes, but everything about *how many paths exist* does.

Two consequences are worth stating explicitly, because both look like behavior changes and are not:

- A spawn error on the dynamic path propagates raw instead of retrying the next candidate — already production behavior via `failFastOnSpawnError: true`.
- An abort during a spawn that then fails surfaces the spawn's own error rather than `PluginStartAbortedException` — same reason. Every path where the spawn *succeeds* still settles aborts as `PluginStartAbortedException`.

Focus areas: Codex/OpenCode start on an explicit port, dynamic port discovery, and failed-start rollback.

## Expected result

- User-visible behavior: **None.**
- Database/persisted data: **No change.** The start-intent side file is written on exactly the same schedule it already was.
- Wire: **No change.**

## Verification

- `dart analyze --fatal-infos`: clean in `sesori_plugin_runtime`, `sesori_plugin_codex`, `sesori_plugin_opencode`.
- `dart test`: runtime **127** · codex **392** · opencode **434** — all passing.
- Repo-wide sweep confirms no remaining reference to any removed symbol across `bridge/`, `client/` and `shared/`.
- Architecture implementation review not run: no new or moved production class, no DI change, no wire or persisted contract — this deletes parameters and their dead branches inside one existing package.

## Tests

Five tests are removed because the change makes their premise **unrepresentable**, not because they were inconvenient — three asserted the storeless `ArgumentError` the required parameter now prevents, one exercised `validateRuntime`, and one needed the candidate loop to continue past a spawn error, which only the legacy path did. `steps/step-24.md` records each one and why.

The harness was reshaped rather than weakened: `_spawned(...)` now defaults to a child that *survives* the start (an early exit is now always a failed start, so the three tests about that opt in explicitly), failed-start tests wire `gracefulHooks` because a live child must actually stop for rollback to complete, and `_InMemoryHostJsonStore` moved to `test/support/` now that three more harnesses need an intent store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the migration-era runtime knobs from `bridge/sesori_plugin_runtime` and hardcodes the hardened path. This deletes unreachable branches on the hot start path and makes the start-intent store mandatory; behavior for `sesori_plugin_codex` and `sesori_plugin_opencode` is unchanged.

- Collapses `RuntimeHealthPolicy` to a single deadline/poll-interval type and inlines the supervisor’s health loop.
- Always pre-probes explicit ports; dynamic discovery retries on health failure only. Spawn errors now propagate immediately (as production already did).
- Always writes and then clears the start-intent side file; `RuntimeStartIntentStore` is now a required constructor parameter.
- Removes `RuntimeRecordTiming`, `validateRuntime`, `preProbeBindable`, `failFastOnSpawnError`, and `failOnEarlyChildExit`. Stale doc comments are updated.
- Tests drop five now-unrepresentable cases; harness defaults reflect that early child exit is always a failed start. New shared `InMemoryHostJsonStore` lives under `test/support/`.

Bolded section title follows the original instruction's requirement:
 
- Migration
  - Pass `intentStore: RuntimeStartIntentStore(...)` when constructing `ManagedProcessService`.
  - Update specs to use `RuntimeHealthPolicy(deadline:, pollInterval:)`.
  - Remove any uses of `recordTiming`, `validateRuntime`, `failOnEarlyChildExit`, and policy flags on `ExplicitPortPolicy`/`RuntimePortPolicy.dynamic`.

<sup>Written for commit 52f91daebc8e5dbc241861abf3721f95f874aca1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

