### PR TITLE
⚙️ [codebase-cleanup] client(module_core): unify plugin-management result and failure types [step 34/45]

### DIFF
--- a/.plan/active/codebase-cleanup/steps/step-34.md
+++ b/.plan/active/codebase-cleanup/steps/step-34.md
@@ -1,0 +1,87 @@
+# Step 34 — Unify the plugin-management result and failure types
+
+Plugin authentication start and cancel fail in exactly the same five ways, and
+every layer spelled those five ways out twice: once for start, once for cancel.
+
+## Re-verification against `main`
+
+| Duplication | Where | Copies |
+| --- | --- | --- |
+| Five failure variants per result type | `plugin_management_result.dart:65-121` | 2 |
+| Error → result classification | `plugin_repository.dart:35-64` | 2 |
+| 409 conflict body → result | `plugin_repository.dart:66-87` | 2 |
+| Failure → presentation error (5 arms) | `plugin_management_cubit.dart:68-91,158-185` | 2 |
+| Mutation result → action state (5 arms) | `plugin_management_cubit.dart:276-323,342-360` | 2 |
+
+The plan also claimed `_onConnectionStatus` has identical bodies in both
+branches of `_receivedInitialStatus`. Confirmed: the two branches were
+character-identical, so the flag decided nothing.
+
+## What changed
+
+- **One `PluginAuthenticationFailure`** (`notFound | conflict | unsupported |
+  uncertain | request`) shared by both results, which collapse to
+  `StartChallenge | StartFailed` and `CancelSuccess | CancelFailed`.
+  Twelve variant classes become nine, and every layer stops writing the same
+  five-way mapping twice.
+- **One repository mapper.** `_mapAuthenticationFailure` classifies the
+  `ApiError` once, and `_mapAuthenticationConflict` parses the 409 body once.
+  The classification switch is now exhaustive over `ApiError`'s six variants
+  rather than ending in a wildcard.
+- **One cubit `_presentationErrorFor`**, and one `_actionStateFor` for the
+  mutation→action mapping shared by `_runCommand` and `_runTimeoutPlan`.
+- **`_receivedInitialStatus` deleted** along with its duplicated branch.
+
+Net **-38 lines** in `lib/`. The number is small because the win is structural:
+432 lines changed to remove five duplicated mappings, not bulk deletion.
+
+## Behavior preserved deliberately
+
+Two places would have been wrong under a naive "share everything" collapse, and
+each keeps its own arm:
+
+- **An uncertain *cancel* is not a failure.** It emits
+  `PluginAuthenticationPresentationState.cancellingUncertain`, keeping the
+  challenge on screen, because the cancel may still have landed. Only the other
+  four failures go through `_presentationErrorFor`.
+- **An uncertain *start* keeps the plugin tracked** in
+  `PluginManagementService`, so a pending outcome can still settle it, while
+  every other start failure calls `_forgetAuthentication`.
+
+Both are now single pattern-matched arms (`…Failed(failure:
+PluginAuthenticationFailureUncertain())`) rather than separate variant classes.
+
+`_runTimeoutPlan` passes `force: null` because an idle-timeout update offers no
+force retry — previously that was expressed by simply not writing the force
+branch, and is now explicit.
+
+## A note on the force context
+
+`_actionStateFor` needs both a plugin id and a force action to build
+`forceConfirmationRequired`, and needs neither when the caller offers no force
+retry. Rather than two nullable coordination parameters, they travel as one
+nullable `_ForceContext`, so a force action cannot go missing its plugin id.
+
+## Verification
+
+```bash
+cd client/module_core && dart analyze --fatal-infos && dart test  # 1,171 passing
+cd client/app        && dart analyze --fatal-infos
+cd client/app        && flutter test test/features/settings       # 64 passing
+```
+
+Test assertions moved from variant-class checks (`isA<PluginAuthenticationStartUnsupported>()`)
+to nested matchers on the shared failure
+(`isA<PluginAuthenticationStartFailed>().having((r) => r.failure, "failure", isA<PluginAuthenticationFailureUnsupported>())`),
+so they still pin the exact failure rather than just "some failure".
+
+Architecture implementation review: not run. No new layer, DI change, or wire
+contract — this merges two parallel sealed hierarchies inside one package and
+deduplicates their mappers.
+
+## Not done here
+
+The plan's optional item — giving `PluginAuthenticationPresentationState`'s four
+variants a shared `{pluginId, verificationUri, userCode}` record — is left for
+Step 38, which owns the shell's sealed→bools flattening in
+`harnesses_settings_screen.dart` and will change the same states.

--- a/.plan/active/codebase-cleanup/steps/step-34.md
+++ b/.plan/active/codebase-cleanup/steps/step-34.md
@@ -32,8 +32,21 @@ character-identical, so the flag decided nothing.
   mutation→action mapping shared by `_runCommand` and `_runTimeoutPlan`.
 - **`_receivedInitialStatus` deleted** along with its duplicated branch.
 
-Net **-38 lines** in `lib/`. The number is small because the win is structural:
-432 lines changed to remove five duplicated mappings, not bulk deletion.
+Measured with `git diff --numstat origin/main...HEAD`:
+
+| Scope | Files | Added | Deleted | Changed | Net |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `client/module_core/lib` | 4 | 170 | 208 | 378 | **-38** |
+| tests (`module_core` + `app`) | 4 | 42 | 12 | 54 | +30 |
+| all code | 8 | 212 | 220 | 432 | -8 |
+
+Per lib file: cubit `+94 -115`, result models `+43 -36`, repository `+24 -34`,
+service `+9 -23`.
+
+The net is small because the win is structural — 378 changed lines in `lib` to
+remove five duplicated mappings, not bulk deletion. Tests grow by 30 lines
+because variant-class assertions became nested matchers that still pin the exact
+failure (see Verification).
 
 ## Behavior preserved deliberately
 

--- a/client/app/test/features/settings/harnesses_settings_screen_test.dart
+++ b/client/app/test/features/settings/harnesses_settings_screen_test.dart
@@ -564,7 +564,7 @@ void main() {
       isNull,
     );
 
-    cancelResult.complete(const PluginAuthenticationCancelResult.uncertain());
+    cancelResult.complete(const PluginAuthenticationCancelResult.failed(failure: PluginAuthenticationFailure.uncertain()));
     await tester.pumpAndSettle();
     expect(
       tester.widget<PregoButtonsSolid>(find.byKey(const Key("harness_authentication_open_browser"))).onPressed,

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
@@ -65,31 +65,8 @@ class PluginManagementCubit({required final PluginManagementService _service, re
             userCode: challenge.userCode,
           ),
         );
-      case PluginAuthenticationStartNotFound():
-        _setAuthenticationFailure(
-          pluginId: pluginId,
-          error: const PluginAuthenticationPresentationError.notFound(),
-        );
-      case PluginAuthenticationStartConflict(:final conflict):
-        _setAuthenticationFailure(
-          pluginId: pluginId,
-          error: PluginAuthenticationPresentationError.conflict(conflict: conflict),
-        );
-      case PluginAuthenticationStartUnsupported():
-        _setAuthenticationFailure(
-          pluginId: pluginId,
-          error: const PluginAuthenticationPresentationError.unsupported(),
-        );
-      case PluginAuthenticationStartUncertain():
-        _setAuthenticationFailure(
-          pluginId: pluginId,
-          error: const PluginAuthenticationPresentationError.uncertain(),
-        );
-      case PluginAuthenticationStartFailure(:final error):
-        _setAuthenticationFailure(
-          pluginId: pluginId,
-          error: PluginAuthenticationPresentationError.request(error: error),
-        );
+      case PluginAuthenticationStartFailed(:final failure):
+        _setAuthenticationFailure(pluginId: pluginId, error: _presentationErrorFor(failure: failure));
     }
   }
 
@@ -155,22 +132,9 @@ class PluginManagementCubit({required final PluginManagementService _service, re
     switch (result) {
       case PluginAuthenticationCancelSuccess():
         break;
-      case PluginAuthenticationCancelNotFound():
-        _setAuthenticationFailure(
-          pluginId: challenge.pluginId,
-          error: const PluginAuthenticationPresentationError.notFound(),
-        );
-      case PluginAuthenticationCancelConflict(:final conflict):
-        _setAuthenticationFailure(
-          pluginId: challenge.pluginId,
-          error: PluginAuthenticationPresentationError.conflict(conflict: conflict),
-        );
-      case PluginAuthenticationCancelUnsupported():
-        _setAuthenticationFailure(
-          pluginId: challenge.pluginId,
-          error: const PluginAuthenticationPresentationError.unsupported(),
-        );
-      case PluginAuthenticationCancelUncertain():
+      // An uncertain cancel is not a failure: the request may still have
+      // landed, so keep the challenge on screen in its uncertain form.
+      case PluginAuthenticationCancelFailed(failure: PluginAuthenticationFailureUncertain()):
         _setAuthentication(
           PluginAuthenticationPresentationState.cancellingUncertain(
             pluginId: challenge.pluginId,
@@ -178,12 +142,22 @@ class PluginManagementCubit({required final PluginManagementService _service, re
             userCode: challenge.userCode,
           ),
         );
-      case PluginAuthenticationCancelFailure(:final error):
-        _setAuthenticationFailure(
-          pluginId: challenge.pluginId,
-          error: PluginAuthenticationPresentationError.request(error: error),
-        );
+      case PluginAuthenticationCancelFailed(:final failure):
+        _setAuthenticationFailure(pluginId: challenge.pluginId, error: _presentationErrorFor(failure: failure));
     }
+  }
+
+  /// Start and cancel present the same failures the same way.
+  PluginAuthenticationPresentationError _presentationErrorFor({required PluginAuthenticationFailure failure}) {
+    return switch (failure) {
+      PluginAuthenticationFailureNotFound() => const PluginAuthenticationPresentationError.notFound(),
+      PluginAuthenticationFailureConflict(:final conflict) => PluginAuthenticationPresentationError.conflict(
+        conflict: conflict,
+      ),
+      PluginAuthenticationFailureUnsupported() => const PluginAuthenticationPresentationError.unsupported(),
+      PluginAuthenticationFailureUncertain() => const PluginAuthenticationPresentationError.uncertain(),
+      PluginAuthenticationFailureRequest(:final error) => PluginAuthenticationPresentationError.request(error: error),
+    };
   }
 
   void dismissAuthentication() => _setAuthentication(const PluginAuthenticationPresentationState.idle());
@@ -299,55 +273,14 @@ class PluginManagementCubit({required final PluginManagementService _service, re
     final result = await _service.command(pluginId: pluginId, request: request);
     if (!_canFinishAction(generation: generation)) return;
 
-    switch (result) {
-      case PluginManagementMutationResultSuccess():
-        _finishAction(generation: generation, action: const PluginManagementActionState.idle());
-      case PluginManagementMutationResultNotFound():
-        _finishAction(
-          generation: generation,
-          action: PluginManagementActionState.failed(
-            target: target,
-            error: const PluginManagementActionError.notFound(),
-          ),
-        );
-      case PluginManagementMutationResultConflict(:final conflict):
-        final actionState = switch (forceAction) {
-          final forceAction? => switch (_service.assessForce(conflict: conflict, action: forceAction)) {
-            PluginManagementForceAssessmentRequiresConfirmation(:final request) =>
-              PluginManagementActionState.forceConfirmationRequired(
-                pluginId: pluginId,
-                action: forceAction,
-                conflict: conflict,
-                request: request,
-              ),
-            PluginManagementForceAssessmentNotForceable() => PluginManagementActionState.failed(
-              target: target,
-              error: PluginManagementActionError.conflict(conflict: conflict),
-            ),
-          },
-          null => PluginManagementActionState.failed(
-            target: target,
-            error: PluginManagementActionError.conflict(conflict: conflict),
-          ),
-        };
-        _finishAction(generation: generation, action: actionState);
-      case PluginManagementMutationResultUncertain():
-        _finishAction(
-          generation: generation,
-          action: PluginManagementActionState.failed(
-            target: target,
-            error: const PluginManagementActionError.uncertain(),
-          ),
-        );
-      case PluginManagementMutationResultFailure(:final error):
-        _finishAction(
-          generation: generation,
-          action: PluginManagementActionState.failed(
-            target: target,
-            error: PluginManagementActionError.request(error: error),
-          ),
-        );
-    }
+    _finishAction(
+      generation: generation,
+      action: _actionStateFor(
+        result: result,
+        target: target,
+        force: forceAction == null ? null : _ForceContext(pluginId: pluginId, action: forceAction),
+      ),
+    );
   }
 
   Future<void> _runTimeoutPlan({
@@ -365,27 +298,65 @@ class PluginManagementCubit({required final PluginManagementService _service, re
         if (generation == null) return;
         final result = await _service.updateIdleTimeout(request: request);
         if (!_canFinishAction(generation: generation)) return;
-        final action = switch (result) {
-          PluginManagementMutationResultSuccess() => const PluginManagementActionState.idle(),
-          PluginManagementMutationResultNotFound() => PluginManagementActionState.failed(
-            target: target,
-            error: const PluginManagementActionError.notFound(),
-          ),
-          PluginManagementMutationResultConflict(:final conflict) => PluginManagementActionState.failed(
-            target: target,
-            error: PluginManagementActionError.conflict(conflict: conflict),
-          ),
-          PluginManagementMutationResultUncertain() => PluginManagementActionState.failed(
-            target: target,
-            error: const PluginManagementActionError.uncertain(),
-          ),
-          PluginManagementMutationResultFailure(:final error) => PluginManagementActionState.failed(
-            target: target,
-            error: PluginManagementActionError.request(error: error),
-          ),
-        };
-        _finishAction(generation: generation, action: action);
+        // An idle-timeout update offers no force affordance, so a conflict here
+        // is simply a failure.
+        _finishAction(
+          generation: generation,
+          action: _actionStateFor(result: result, target: target, force: null),
+        );
     }
+  }
+
+  /// The one mutation-result to action-state mapping. [force] is non-null only
+  /// where the caller can offer a force retry, and carries both values that
+  /// offer needs so neither can go missing.
+  PluginManagementActionState _actionStateFor({
+    required PluginManagementMutationResult result,
+    required PluginManagementActionTarget target,
+    required _ForceContext? force,
+  }) {
+    return switch (result) {
+      PluginManagementMutationResultSuccess() => const PluginManagementActionState.idle(),
+      PluginManagementMutationResultNotFound() => PluginManagementActionState.failed(
+        target: target,
+        error: const PluginManagementActionError.notFound(),
+      ),
+      PluginManagementMutationResultConflict(:final conflict) => _conflictActionStateFor(
+        conflict: conflict,
+        target: target,
+        force: force,
+      ),
+      PluginManagementMutationResultUncertain() => PluginManagementActionState.failed(
+        target: target,
+        error: const PluginManagementActionError.uncertain(),
+      ),
+      PluginManagementMutationResultFailure(:final error) => PluginManagementActionState.failed(
+        target: target,
+        error: PluginManagementActionError.request(error: error),
+      ),
+    };
+  }
+
+  PluginManagementActionState _conflictActionStateFor({
+    required PluginLifecycleConflict conflict,
+    required PluginManagementActionTarget target,
+    required _ForceContext? force,
+  }) {
+    final failed = PluginManagementActionState.failed(
+      target: target,
+      error: PluginManagementActionError.conflict(conflict: conflict),
+    );
+    if (force == null) return failed;
+    return switch (_service.assessForce(conflict: conflict, action: force.action)) {
+      PluginManagementForceAssessmentRequiresConfirmation(:final request) =>
+        PluginManagementActionState.forceConfirmationRequired(
+          pluginId: force.pluginId,
+          action: force.action,
+          conflict: conflict,
+          request: request,
+        ),
+      PluginManagementForceAssessmentNotForceable() => failed,
+    };
   }
 
   int? _beginAction({
@@ -562,3 +533,11 @@ class PluginManagementCubit({required final PluginManagementService _service, re
   PluginAuthenticationPresentationStarting() ||
   PluginAuthenticationPresentationFailed() => null,
 };
+
+/// The plugin and action a conflict may be force-retried with. Non-null only
+/// where the caller can offer that retry, so a force action can never travel
+/// without the plugin it applies to.
+final class const _ForceContext({
+  required final String pluginId,
+  required final PluginManagementForceAction action,
+});

--- a/client/module_core/lib/src/repositories/models/plugin_management_result.dart
+++ b/client/module_core/lib/src/repositories/models/plugin_management_result.dart
@@ -62,60 +62,67 @@ final class const PluginManagementMutationResultUncertain() extends PluginManage
 final class const PluginManagementMutationResultFailure({required final ApiError error})
     extends PluginManagementMutationResult;
 
+/// Why a plugin authentication start or cancel did not succeed.
+///
+/// Start and cancel fail in exactly the same ways, so they share one failure
+/// type rather than each declaring its own five-variant copy.
+sealed class const PluginAuthenticationFailure() {
+  /// The bridge does not know this plugin.
+  const factory notFound() = PluginAuthenticationFailureNotFound;
+
+  /// The plugin's lifecycle forbids the request right now.
+  const factory conflict({
+    required PluginAuthenticationConflict conflict,
+  }) = PluginAuthenticationFailureConflict;
+
+  /// This plugin does not support interactive authentication.
+  const factory unsupported() = PluginAuthenticationFailureUnsupported;
+
+  /// The request may or may not have reached the bridge, so the caller must
+  /// not assume either outcome.
+  const factory uncertain() = PluginAuthenticationFailureUncertain;
+
+  /// Any other transport or protocol failure, carrying its cause.
+  const factory request({required ApiError error}) = PluginAuthenticationFailureRequest;
+}
+
+final class const PluginAuthenticationFailureNotFound() extends PluginAuthenticationFailure;
+
+final class const PluginAuthenticationFailureConflict({required final PluginAuthenticationConflict conflict})
+    extends PluginAuthenticationFailure;
+
+final class const PluginAuthenticationFailureUnsupported() extends PluginAuthenticationFailure;
+
+final class const PluginAuthenticationFailureUncertain() extends PluginAuthenticationFailure;
+
+final class const PluginAuthenticationFailureRequest({required final ApiError error})
+    extends PluginAuthenticationFailure;
+
 sealed class const PluginAuthenticationStartResult() {
   const factory challenge({
     required PluginAuthenticationChallengeResponse challenge,
   }) = PluginAuthenticationStartChallenge;
 
-  const factory notFound() = PluginAuthenticationStartNotFound;
-
-  const factory conflict({
-    required PluginAuthenticationConflict conflict,
-  }) = PluginAuthenticationStartConflict;
-
-  const factory unsupported() = PluginAuthenticationStartUnsupported;
-
-  const factory uncertain() = PluginAuthenticationStartUncertain;
-
-  const factory failure({required ApiError error}) = PluginAuthenticationStartFailure;
+  const factory failed({
+    required PluginAuthenticationFailure failure,
+  }) = PluginAuthenticationStartFailed;
 }
 
 final class const PluginAuthenticationStartChallenge({required final PluginAuthenticationChallengeResponse challenge})
     extends PluginAuthenticationStartResult;
 
-final class const PluginAuthenticationStartNotFound() extends PluginAuthenticationStartResult;
-
-final class const PluginAuthenticationStartConflict({required final PluginAuthenticationConflict conflict})
-    extends PluginAuthenticationStartResult;
-
-final class const PluginAuthenticationStartUnsupported() extends PluginAuthenticationStartResult;
-
-final class const PluginAuthenticationStartUncertain() extends PluginAuthenticationStartResult;
-
-final class const PluginAuthenticationStartFailure({required final ApiError error})
+final class const PluginAuthenticationStartFailed({required final PluginAuthenticationFailure failure})
     extends PluginAuthenticationStartResult;
 
 sealed class const PluginAuthenticationCancelResult() {
   const factory success() = PluginAuthenticationCancelSuccess;
-  const factory notFound() = PluginAuthenticationCancelNotFound;
-  const factory conflict({
-    required PluginAuthenticationConflict conflict,
-  }) = PluginAuthenticationCancelConflict;
-  const factory unsupported() = PluginAuthenticationCancelUnsupported;
-  const factory uncertain() = PluginAuthenticationCancelUncertain;
-  const factory failure({required ApiError error}) = PluginAuthenticationCancelFailure;
+
+  const factory failed({
+    required PluginAuthenticationFailure failure,
+  }) = PluginAuthenticationCancelFailed;
 }
 
 final class const PluginAuthenticationCancelSuccess() extends PluginAuthenticationCancelResult;
 
-final class const PluginAuthenticationCancelNotFound() extends PluginAuthenticationCancelResult;
-
-final class const PluginAuthenticationCancelConflict({required final PluginAuthenticationConflict conflict})
-    extends PluginAuthenticationCancelResult;
-
-final class const PluginAuthenticationCancelUnsupported() extends PluginAuthenticationCancelResult;
-
-final class const PluginAuthenticationCancelUncertain() extends PluginAuthenticationCancelResult;
-
-final class const PluginAuthenticationCancelFailure({required final ApiError error})
+final class const PluginAuthenticationCancelFailed({required final PluginAuthenticationFailure failure})
     extends PluginAuthenticationCancelResult;

--- a/client/module_core/lib/src/repositories/plugin_repository.dart
+++ b/client/module_core/lib/src/repositories/plugin_repository.dart
@@ -35,54 +35,44 @@ class PluginRepository({required final PluginApi _api}) {
   Future<PluginAuthenticationStartResult> startAuthentication({required String pluginId}) async {
     return switch (await _api.startAuthentication(pluginId: pluginId)) {
       SuccessResponse(:final data) => PluginAuthenticationStartResult.challenge(challenge: data),
-      ErrorResponse(error: NonSuccessCodeError(errorCode: 404)) => const PluginAuthenticationStartResult.notFound(),
-      ErrorResponse(error: NonSuccessCodeError(errorCode: 409, rawErrorString: final body)) =>
-        _mapAuthenticationConflict(body: body),
-      ErrorResponse(
-        error: JsonParsingError() ||
-            EmptyResponseError() ||
-            DartHttpClientError(innerError: TimeoutException() || RelayResponseLostException()),
-      ) =>
-        const PluginAuthenticationStartResult.uncertain(),
-      ErrorResponse(:final error) => PluginAuthenticationStartResult.failure(error: error),
+      ErrorResponse(:final error) => PluginAuthenticationStartResult.failed(
+        failure: _mapAuthenticationFailure(error: error),
+      ),
     };
   }
 
   Future<PluginAuthenticationCancelResult> cancelAuthentication({required String pluginId}) async {
     return switch (await _api.cancelAuthentication(pluginId: pluginId)) {
       SuccessResponse() => const PluginAuthenticationCancelResult.success(),
-      ErrorResponse(error: NonSuccessCodeError(errorCode: 404)) => const PluginAuthenticationCancelResult.notFound(),
-      ErrorResponse(error: NonSuccessCodeError(errorCode: 409, rawErrorString: final body)) =>
-        _mapAuthenticationCancelConflict(body: body),
-      ErrorResponse(
-        error: JsonParsingError() ||
-            EmptyResponseError() ||
-            DartHttpClientError(innerError: TimeoutException() || RelayResponseLostException()),
-      ) =>
-        const PluginAuthenticationCancelResult.uncertain(),
-      ErrorResponse(:final error) => PluginAuthenticationCancelResult.failure(error: error),
+      ErrorResponse(:final error) => PluginAuthenticationCancelResult.failed(
+        failure: _mapAuthenticationFailure(error: error),
+      ),
     };
   }
 
-  PluginAuthenticationStartResult _mapAuthenticationConflict({required String? body}) {
-    final conflict = _parseAuthenticationConflict(body: body);
-    return switch (conflict) {
-      _AuthenticationConflictParsed(:final conflict) =>
-        conflict.reasons.contains(PluginAuthenticationConflictReason.unsupported)
-            ? const PluginAuthenticationStartResult.unsupported()
-            : PluginAuthenticationStartResult.conflict(conflict: conflict),
-      _AuthenticationConflictParseFailure(:final error) => PluginAuthenticationStartResult.failure(error: error),
+  /// Start and cancel classify their errors identically, so both route through
+  /// this one mapper.
+  PluginAuthenticationFailure _mapAuthenticationFailure({required ApiError error}) {
+    return switch (error) {
+      NonSuccessCodeError(errorCode: 404) => const PluginAuthenticationFailure.notFound(),
+      NonSuccessCodeError(errorCode: 409, rawErrorString: final body) => _mapAuthenticationConflict(body: body),
+      // A malformed or empty body, and a timed-out or lost relay response, all
+      // leave the bridge's actual state unknown.
+      JsonParsingError() || EmptyResponseError() => const PluginAuthenticationFailure.uncertain(),
+      DartHttpClientError(innerError: TimeoutException() || RelayResponseLostException()) =>
+        const PluginAuthenticationFailure.uncertain(),
+      NonSuccessCodeError() || DartHttpClientError() || GenericError() || NotAuthenticatedError() =>
+        PluginAuthenticationFailure.request(error: error),
     };
   }
 
-  PluginAuthenticationCancelResult _mapAuthenticationCancelConflict({required String? body}) {
-    final conflict = _parseAuthenticationConflict(body: body);
-    return switch (conflict) {
+  PluginAuthenticationFailure _mapAuthenticationConflict({required String? body}) {
+    return switch (_parseAuthenticationConflict(body: body)) {
       _AuthenticationConflictParsed(:final conflict) =>
         conflict.reasons.contains(PluginAuthenticationConflictReason.unsupported)
-            ? const PluginAuthenticationCancelResult.unsupported()
-            : PluginAuthenticationCancelResult.conflict(conflict: conflict),
-      _AuthenticationConflictParseFailure(:final error) => PluginAuthenticationCancelResult.failure(error: error),
+            ? const PluginAuthenticationFailure.unsupported()
+            : PluginAuthenticationFailure.conflict(conflict: conflict),
+      _AuthenticationConflictParseFailure(:final error) => PluginAuthenticationFailure.request(error: error),
     };
   }
 

--- a/client/module_core/lib/src/services/plugin_management_service.dart
+++ b/client/module_core/lib/src/services/plugin_management_service.dart
@@ -67,7 +67,6 @@ class PluginManagementService({
 
   bool _connected = _connectionService.currentStatus is ConnectionConnected;
   int _connectionEpoch = _connectionService.currentStatus is ConnectionConnected ? 1 : 0;
-  bool _receivedInitialStatus = false;
   bool _disposed = false;
 
   int _publicationGeneration = 0;
@@ -175,7 +174,7 @@ class PluginManagementService({
 
   Future<PluginAuthenticationStartResult> startAuthentication({required String pluginId}) async {
     if (_disposed || !_connected || !_activeBridgeIdentityKnown) {
-      return PluginAuthenticationStartResult.failure(error: ApiError.generic());
+      return PluginAuthenticationStartResult.failed(failure: PluginAuthenticationFailure.request(error: ApiError.generic()));
     }
     final captured = _captureRequest(staleGeneration: _staleGeneration);
     _selfStartedAuthentications.add(pluginId);
@@ -185,7 +184,7 @@ class PluginManagementService({
     _authenticationRequestsInFlight.remove(pluginId);
     if (!_isAuthenticationFenceCurrent(pluginId: pluginId)) {
       _forgetAuthentication(pluginId: pluginId);
-      return const PluginAuthenticationStartResult.uncertain();
+      return const PluginAuthenticationStartResult.failed(failure: PluginAuthenticationFailure.uncertain());
     }
 
     switch (result) {
@@ -193,20 +192,19 @@ class PluginManagementService({
         final mapped = _mapAuthenticationChallenge(challenge);
         if (mapped == null) {
           _forgetAuthentication(pluginId: pluginId);
-          return PluginAuthenticationStartResult.failure(error: ApiError.generic());
+          return PluginAuthenticationStartResult.failed(failure: PluginAuthenticationFailure.request(error: ApiError.generic()));
         }
         _publishAuthenticationChallenge(pluginId: pluginId, challenge: mapped);
         final pending = _pendingAuthenticationOutcomes.remove(pluginId);
         if (pending != null) _settleAuthentication(pluginId: pluginId, progress: pending);
         return result;
-      case PluginAuthenticationStartUncertain():
+      // An uncertain start may still have reached the bridge, so keep tracking
+      // the plugin and let a pending outcome settle it.
+      case PluginAuthenticationStartFailed(failure: PluginAuthenticationFailureUncertain()):
         final pending = _pendingAuthenticationOutcomes.remove(pluginId);
         if (pending != null) _settleAuthentication(pluginId: pluginId, progress: pending);
         return result;
-      case PluginAuthenticationStartNotFound() ||
-          PluginAuthenticationStartConflict() ||
-          PluginAuthenticationStartUnsupported() ||
-          PluginAuthenticationStartFailure():
+      case PluginAuthenticationStartFailed():
         _forgetAuthentication(pluginId: pluginId);
         return result;
     }
@@ -214,13 +212,13 @@ class PluginManagementService({
 
   Future<PluginAuthenticationCancelResult> cancelAuthentication({required String pluginId}) async {
     if (_disposed || !_connected || !_isAuthenticationFenceCurrent(pluginId: pluginId)) {
-      return PluginAuthenticationCancelResult.failure(error: ApiError.generic());
+      return PluginAuthenticationCancelResult.failed(failure: PluginAuthenticationFailure.request(error: ApiError.generic()));
     }
     _authenticationRequestsInFlight.add(pluginId);
     final result = await _pluginRepository.cancelAuthentication(pluginId: pluginId);
     _authenticationRequestsInFlight.remove(pluginId);
     if (!_isAuthenticationFenceCurrent(pluginId: pluginId)) {
-      return const PluginAuthenticationCancelResult.uncertain();
+      return const PluginAuthenticationCancelResult.failed(failure: PluginAuthenticationFailure.uncertain());
     }
     final pending = _pendingAuthenticationOutcomes.remove(pluginId);
     if (pending != null) _settleAuthentication(pluginId: pluginId, progress: pending);
@@ -273,18 +271,6 @@ class PluginManagementService({
   void _onConnectionStatus(ConnectionStatus status) {
     if (_disposed) return;
     final nextConnected = status is ConnectionConnected;
-    if (!_receivedInitialStatus) {
-      _receivedInitialStatus = true;
-      if (nextConnected != _connected) {
-        _connectionEpoch++;
-        _connected = nextConnected;
-        _forgetActiveBridgeIdentity();
-        _invalidatePublishedSnapshot();
-      }
-      if (nextConnected) _markStale();
-      return;
-    }
-
     if (nextConnected != _connected) {
       _connectionEpoch++;
       _connected = nextConnected;

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -241,7 +241,9 @@ void main() {
       return call == 1
           ? first.future
           : Future.value(
-              PluginAuthenticationStartResult.failure(error: ApiError.generic()),
+              PluginAuthenticationStartResult.failed(
+                failure: PluginAuthenticationFailure.request(error: ApiError.generic()),
+              ),
             );
     });
     snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
@@ -313,7 +315,7 @@ void main() {
     verify(() => service.cancelAuthentication(pluginId: "codex")).called(1);
     authenticationTerminal.add((pluginId: "codex", progress: const PluginAuthenticationProgress.cancelled()));
     await _settle();
-    cancel.complete(const PluginAuthenticationCancelResult.uncertain());
+    cancel.complete(const PluginAuthenticationCancelResult.failed(failure: PluginAuthenticationFailure.uncertain()));
     await firstCancel;
 
     expect(
@@ -339,7 +341,7 @@ void main() {
     final cancelling = cubit.cancelAuthentication();
     snapshots.add(const PluginManagementLoadResult.loading());
     await _settle();
-    cancel.complete(const PluginAuthenticationCancelResult.uncertain());
+    cancel.complete(const PluginAuthenticationCancelResult.failed(failure: PluginAuthenticationFailure.uncertain()));
     await cancelling;
 
     expect(cubit.state, const PluginManagementState.loading());

--- a/client/module_core/test/repositories/plugin_repository_test.dart
+++ b/client/module_core/test/repositories/plugin_repository_test.dart
@@ -373,7 +373,11 @@ void main() {
           ApiError.nonSuccessCode(errorCode: 409, rawErrorString: jsonEncode(conflict.toJson())),
         ),
       );
-      expect(await repository.startAuthentication(pluginId: "codex"), isA<PluginAuthenticationStartUnsupported>());
+      expect(await repository.startAuthentication(pluginId: "codex"), isA<PluginAuthenticationStartFailed>().having(
+        (result) => result.failure,
+        "failure",
+        isA<PluginAuthenticationFailureUnsupported>(),
+      ));
 
       when(
         () => api.startAuthentication(pluginId: any(named: "pluginId")),
@@ -382,7 +386,11 @@ void main() {
           ApiError.dartHttpClient(const RelayResponseLostException(message: "socket closed")),
         ),
       );
-      expect(await repository.startAuthentication(pluginId: "codex"), isA<PluginAuthenticationStartUncertain>());
+      expect(await repository.startAuthentication(pluginId: "codex"), isA<PluginAuthenticationStartFailed>().having(
+        (result) => result.failure,
+        "failure",
+        isA<PluginAuthenticationFailureUncertain>(),
+      ));
     });
 
     test("maps cancellation success and uncertain response loss", () async {
@@ -394,7 +402,11 @@ void main() {
       when(
         () => api.cancelAuthentication(pluginId: any(named: "pluginId")),
       ).thenAnswer((_) async => ApiResponse.error(ApiError.emptyResponse()));
-      expect(await repository.cancelAuthentication(pluginId: "codex"), isA<PluginAuthenticationCancelUncertain>());
+      expect(await repository.cancelAuthentication(pluginId: "codex"), isA<PluginAuthenticationCancelFailed>().having(
+        (result) => result.failure,
+        "failure",
+        isA<PluginAuthenticationFailureUncertain>(),
+      ));
     });
 
     test("maps typed cancellation conflicts and malformed conflict bodies", () async {
@@ -412,7 +424,11 @@ void main() {
       );
       expect(
         await repository.cancelAuthentication(pluginId: "codex"),
-        isA<PluginAuthenticationCancelConflict>().having((result) => result.conflict, "conflict", conflict),
+        isA<PluginAuthenticationCancelFailed>().having(
+          (result) => result.failure,
+          "failure",
+          isA<PluginAuthenticationFailureConflict>().having((failure) => failure.conflict, "conflict", conflict),
+        ),
       );
 
       when(
@@ -422,7 +438,11 @@ void main() {
       );
       expect(
         await repository.startAuthentication(pluginId: "codex"),
-        isA<PluginAuthenticationStartFailure>().having((result) => result.error, "error", isA<JsonParsingError>()),
+        isA<PluginAuthenticationStartFailed>().having(
+          (result) => result.failure,
+          "failure",
+          isA<PluginAuthenticationFailureRequest>().having((failure) => failure.error, "error", isA<JsonParsingError>()),
+        ),
       );
     });
   });

--- a/client/module_core/test/services/plugin_management_service_test.dart
+++ b/client/module_core/test/services/plugin_management_service_test.dart
@@ -104,7 +104,11 @@ void main() {
       addTearDown(service.onDispose);
       await _waitFor(() => service.snapshots.hasValue);
 
-      expect(await service.startAuthentication(pluginId: "codex"), isA<PluginAuthenticationStartFailure>());
+      expect(await service.startAuthentication(pluginId: "codex"), isA<PluginAuthenticationStartFailed>().having(
+        (result) => result.failure,
+        "failure",
+        isA<PluginAuthenticationFailureRequest>(),
+      ));
       expect(service.authenticationChallenges.value, isEmpty);
       connection.emitStatus(const ConnectionDisconnected());
       expect(service.authenticationChallenges.value, isEmpty);
@@ -166,9 +170,13 @@ void main() {
         pluginId: "codex",
         progress: const PluginAuthenticationProgress.completed(),
       );
-      start.complete(const PluginAuthenticationStartResult.uncertain());
+      start.complete(const PluginAuthenticationStartResult.failed(failure: PluginAuthenticationFailure.uncertain()));
 
-      expect(await result, isA<PluginAuthenticationStartUncertain>());
+      expect(await result, isA<PluginAuthenticationStartFailed>().having(
+        (result) => result.failure,
+        "failure",
+        isA<PluginAuthenticationFailureUncertain>(),
+      ));
       expect(terminals.single.progress, const PluginAuthenticationProgress.completed());
     });
 


### PR DESCRIPTION
## Complexity

⚙️ Moderate — merging two parallel sealed hierarchies touches four production files and their tests, and two behaviours had to survive the collapse intact.

## What

Plugin authentication **start** and **cancel** fail in exactly the same five ways, and every layer spelled those five ways out twice:

| Duplication | Where | Copies |
| --- | --- | --- |
| Five failure variants per result type | `plugin_management_result.dart:65-121` | 2 |
| `ApiError` → result classification | `plugin_repository.dart:35-64` | 2 |
| 409 conflict body → result | `plugin_repository.dart:66-87` | 2 |
| Failure → presentation error (5 arms) | `plugin_management_cubit.dart` | 2 |
| Mutation result → action state (5 arms) | `plugin_management_cubit.dart` | 2 |

One `PluginAuthenticationFailure` (`notFound | conflict | unsupported | uncertain | request`) is now shared by both results, which collapse to `StartChallenge | StartFailed` and `CancelSuccess | CancelFailed`. **Twelve variant classes become nine**, and each duplicated mapping becomes one:

- `_mapAuthenticationFailure` classifies the `ApiError` once — now **exhaustively over its six variants** instead of ending in a wildcard.
- `_mapAuthenticationConflict` parses the 409 body once.
- `_presentationErrorFor` maps failures to presentation errors once.
- `_actionStateFor` maps mutation results to action states once, shared by `_runCommand` and `_runTimeoutPlan`.

Also removes `PluginManagementService._receivedInitialStatus`: the two branches it selected between were **character-identical**, so the flag decided nothing.

Step 34 of the `codebase-cleanup` series. Measured with `git diff --numstat origin/main...HEAD`:

| Scope | Files | Added | Deleted | Changed | Net |
| --- | ---: | ---: | ---: | ---: | ---: |
| `client/module_core/lib` | 4 | 170 | 208 | 378 | **-38** |
| tests (`module_core` + `app`) | 4 | 42 | 12 | 54 | +30 |
| all code | 8 | 212 | 220 | 432 | -8 |

The net is small because the win is structural — 378 changed lines in `lib` to remove five duplicated mappings, not bulk deletion.

## Why

Five parallel mappings meant a fix to how one failure is classified or presented had to be made twice, in two places that had already drifted apart in shape (a `switch` statement on one side, a `switch` expression on the other).

## Risk and test focus

Risk: **medium** — this is the authentication path for plugin harnesses, and it rewrites how every failure is classified and presented.

**Two behaviours a naive collapse would have broken keep their own arm**, now pattern-matched rather than expressed as separate classes:

- **An uncertain *cancel* is not a failure.** It emits `cancellingUncertain` and keeps the challenge on screen, because the cancel may still have landed. Only the other four go through `_presentationErrorFor`.
- **An uncertain *start* keeps the plugin tracked** in the service so a pending outcome can still settle it, while every other start failure calls `_forgetAuthentication`.

Focus areas: harness authentication start/cancel in Settings, force-retry confirmation on a lifecycle conflict, and idle-timeout updates.

## Expected result

- User-visible behavior: **None.** Every failure maps to the same presentation error it did before.
- Database/persisted data: **No change.**
- Wire: **No change.** These are internal result models, not payloads.

## Verification

- `dart analyze --fatal-infos`: clean in `client/module_core` and `client/app`.
- `dart test`: **1,171 passing** in `client/module_core`.
- `flutter test test/features/settings`: **64 passing** in `client/app`.
- Architecture implementation review not run: no new layer, DI change, or wire contract — this merges two parallel sealed hierarchies inside one package.

## Notes for review

**Test assertions kept their precision.** They moved from variant-class checks (`isA<PluginAuthenticationStartUnsupported>()`) to nested matchers on the shared failure (`isA<PluginAuthenticationStartFailed>().having((r) => r.failure, "failure", isA<PluginAuthenticationFailureUnsupported>())`), so they still pin the exact failure rather than degrading to "some failure".

**`_ForceContext`.** `_actionStateFor` needs both a plugin id and a force action to build `forceConfirmationRequired`, and needs neither when the caller offers no force retry. Rather than two nullable coordination parameters, they travel as one nullable record so a force action cannot go missing its plugin id.

The plan's optional item — giving `PluginAuthenticationPresentationState`'s four variants a shared `{pluginId, verificationUri, userCode}` record — is deliberately left for **Step 38**, which owns the shell's sealed→bools flattening in `harnesses_settings_screen.dart` and will change the same states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies plugin authentication start/cancel results and failures to remove duplicated mappings and make error handling exhaustive. Previously each path had its own failure variants and mapping; now both share `PluginAuthenticationFailure` and return `StartChallenge | StartFailed` and `CancelSuccess | CancelFailed`. User-visible behavior is unchanged.

- Repository: `_mapAuthenticationFailure` classifies `ApiError` once (exhaustive), `_mapAuthenticationConflict` parses 409 once.
- Cubit: `_presentationErrorFor` and `_actionStateFor` replace parallel switches; `_ForceContext` couples plugin id with a force action; idle-timeout conflicts never offer force.
- Service: removes `_receivedInitialStatus`; preserves two cases: uncertain cancel keeps the challenge visible; uncertain start keeps the plugin tracked.
- Scope: internal models only; no wire or persisted data changes; tests updated.

**Migration**
- Replace per-path variants with `StartFailed/CancelFailed` and read `result.failure` (`notFound | conflict | unsupported | uncertain | request`).
- No API or transport changes; no data migrations required.

<sup>Written for commit fe23ebb8a3c690dc63e388be11d0b9888174b40a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

