### PR TITLE
🌿 [codebase-cleanup] bridge(plugins): add plugin-local test support for OpenCode, ACP, and Pi [step 11/45]

### DIFF
--- a/.plan/active/codebase-cleanup/steps/step-11.md
+++ b/.plan/active/codebase-cleanup/steps/step-11.md
@@ -1,0 +1,57 @@
+# Step 11/45 — Add plugin-local test support for OpenCode, ACP, and Pi
+
+## Re-verification against `main`
+
+OpenCode still had three `OpenCodeApi` fakes totaling 579 lines. They differed
+in scenario state but repeated the same API surface, so one configurable
+`FakeOpenCodeApi` now owns their combined behavior and call recording. The
+plan's raw fixture audit found 84 `Project` and 51 `Session` constructions, but
+many encode the behavior under test through timestamps, parentage, sandbox
+paths, metadata, or `GlobalSession`. The 21 default-shaped construction/helper
+sites use `openCodeProject` or `openCodeSession`; behavior-bearing variants stay
+explicit.
+
+ACP had 14 repeated `TestAcpPlugin` compositions across 11 tests. A single
+`composeTestAcpPlugin` now creates fresh command/configuration trackers and
+wires the event mapper and session-options service to those same instances.
+The custom redaction launch spec remains an override. Cursor, OMP, and Hermes
+composition stays local because those plugins own backend-specific catalogs,
+cleanup, and option services rather than repeating the neutral ACP bundle.
+
+Pi had four `PiSessionStorageApi` fakes, but not one common successful method
+surface. Shared catalog, extension, and service variants now inherit only their
+common state. The process repository's missing/exact-path fakes and both
+history-storage fakes remain local because their strict capabilities are
+scenario-specific.
+
+## Review corrections
+
+Review found two behavior regressions in the first consolidation. OpenCode's
+shared fake filtered child sessions before `OpenCodeRepository` could exercise
+its own filtering; root filtering is now opt-in only for the tracker profile.
+Pi's first shared fake returned successful defaults for methods that several
+former fakes deliberately left unsupported; capability-specific variants now
+preserve each former fake's exact supported and fail-loud surface. Review also
+caught legacy fake bodies left inside block comments, which were deleted rather
+than retained as an alternate implementation.
+
+Follow-up review reported no remaining OpenCode findings. Its final Pi note
+that the missing-session process fake had lost its no-op marker cleanup was
+also corrected.
+
+## Verification
+
+`dart analyze --fatal-infos` clean in `sesori_plugin_opencode`,
+`sesori_plugin_acp`, `sesori_plugin_pi`, `sesori_plugin_cursor`,
+`sesori_plugin_omp`, and `sesori_plugin_hermes`. `dart test`: OpenCode 434, ACP
+260, Pi 260, Cursor 136, OMP 52, Hermes 38 — **1,180 tests passed**.
+
+Size, excluding this evidence file, via
+`git diff --numstat "$(git merge-base HEAD origin/main)"...HEAD -- bridge/sesori_plugin_acp bridge/sesori_plugin_opencode bridge/sesori_plugin_pi`
+against merge-base `8f857ed22`: **`+582 / -1,351` = 1,933 changed lines**.
+This is 433 lines over the 1,500-line soft cap, but is deletion-heavy and ends
+at **769 fewer test/support lines** across the three packages.
+
+Architecture implementation review not run: the new ACP export is explicitly a
+test-only library; the change does not alter production behavior, dependency
+ownership, or contracts.

--- a/bridge/sesori_plugin_acp/lib/acp_testing.dart
+++ b/bridge/sesori_plugin_acp/lib/acp_testing.dart
@@ -1,4 +1,5 @@
 // Test utilities for ACP harness packages (FakeAcpProcess etc.). Import from
 // test code only: `package:acp_plugin/acp_testing.dart`.
+export "src/testing/compose_test_acp_plugin.dart";
 export "src/testing/fake_acp_process.dart";
 export "src/testing/test_acp_plugin.dart";

--- a/bridge/sesori_plugin_acp/lib/src/testing/compose_test_acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/testing/compose_test_acp_plugin.dart
@@ -1,0 +1,36 @@
+import "../acp_command_tracker.dart";
+import "../acp_event_mapper.dart";
+import "../acp_process_factory.dart";
+import "../acp_session_configuration_tracker.dart";
+import "../acp_session_options_service.dart";
+import "test_acp_plugin.dart";
+
+TestAcpPlugin composeTestAcpPlugin({
+  required AcpProcessFactory processFactory,
+  String id = "acp",
+  String agentDisplayName = "ACP",
+  AcpLaunchSpec launchSpec = const AcpLaunchSpec(command: "agent", args: ["acp"]),
+  String launchDirectory = "/repo",
+}) {
+  final configurationTracker = AcpSessionConfigurationTracker();
+  final commandTracker = AcpCommandTracker();
+  return TestAcpPlugin(
+    id: id,
+    agentDisplayName: agentDisplayName,
+    launchSpec: launchSpec,
+    launchDirectory: launchDirectory,
+    eventMapper: AcpEventMapper(
+      launchDirectory: launchDirectory,
+      pluginId: id,
+      configurationTracker: configurationTracker,
+    ),
+    commandTracker: commandTracker,
+    sessionOptionsService: AcpSessionOptionsService(
+      configurationTracker: configurationTracker,
+      commandTracker: commandTracker,
+      pluginId: id,
+      agentDisplayName: agentDisplayName,
+    ),
+    processFactory: processFactory,
+  );
+}

--- a/bridge/sesori_plugin_acp/test/acp_bridge_plugin_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_bridge_plugin_test.dart
@@ -10,25 +10,8 @@ void main() {
 
     setUp(() {
       fake = FakeAcpProcess();
-      final configurationTracker = AcpSessionConfigurationTracker();
-      final commandTracker = AcpCommandTracker();
-      plugin = TestAcpPlugin(
-        id: "acp",
-        agentDisplayName: "ACP",
+      plugin = composeTestAcpPlugin(
         launchSpec: const AcpLaunchSpec(command: "/opt/agent", args: ["-e", "https://user:secret@host/api", "acp"]),
-        launchDirectory: "/repo",
-        eventMapper: AcpEventMapper(
-          launchDirectory: "/repo",
-          pluginId: "acp",
-          configurationTracker: configurationTracker,
-        ),
-        commandTracker: commandTracker,
-        sessionOptionsService: AcpSessionOptionsService(
-          configurationTracker: configurationTracker,
-          commandTracker: commandTracker,
-          pluginId: "acp",
-          agentDisplayName: "ACP",
-        ),
         processFactory: (_) async => fake,
       );
     });

--- a/bridge/sesori_plugin_acp/test/acp_commands_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_commands_test.dart
@@ -92,27 +92,7 @@ void main() {
     setUp(() {
       fake = FakeAcpProcess();
       emitted = <BridgeSseEvent>[];
-      final configurationTracker = AcpSessionConfigurationTracker();
-      final commandTracker = AcpCommandTracker();
-      plugin = TestAcpPlugin(
-        id: "acp",
-        agentDisplayName: "ACP",
-        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
-        launchDirectory: cwd,
-        eventMapper: AcpEventMapper(
-          launchDirectory: cwd,
-          pluginId: "acp",
-          configurationTracker: configurationTracker,
-        ),
-        commandTracker: commandTracker,
-        sessionOptionsService: AcpSessionOptionsService(
-          configurationTracker: configurationTracker,
-          commandTracker: commandTracker,
-          pluginId: "acp",
-          agentDisplayName: "ACP",
-        ),
-        processFactory: (_) async => fake,
-      );
+      plugin = composeTestAcpPlugin(processFactory: (_) async => fake, launchDirectory: cwd);
       plugin.events.listen(emitted.add);
     });
 
@@ -227,25 +207,7 @@ void main() {
     final replay = FakeAcpProcess();
     final processes = [live, replay];
     final emitted = <BridgeSseEvent>[];
-    final configurationTracker = AcpSessionConfigurationTracker();
-    final commandTracker = AcpCommandTracker();
-    final plugin = TestAcpPlugin(
-      id: "acp",
-      agentDisplayName: "ACP",
-      launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
-      launchDirectory: "/repo",
-      eventMapper: AcpEventMapper(
-        launchDirectory: "/repo",
-        pluginId: "acp",
-        configurationTracker: configurationTracker,
-      ),
-      commandTracker: commandTracker,
-      sessionOptionsService: AcpSessionOptionsService(
-        configurationTracker: configurationTracker,
-        commandTracker: commandTracker,
-        pluginId: "acp",
-        agentDisplayName: "ACP",
-      ),
+    final plugin = composeTestAcpPlugin(
       processFactory: (_) async => processes.removeAt(0),
     );
     plugin.events.listen(emitted.add);

--- a/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
@@ -18,27 +18,7 @@ void main() {
 
     setUp(() {
       fake = FakeAcpProcess();
-      final configurationTracker = AcpSessionConfigurationTracker();
-      final commandTracker = AcpCommandTracker();
-      plugin = TestAcpPlugin(
-        id: "acp",
-        agentDisplayName: "ACP",
-        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
-        launchDirectory: cwd,
-        eventMapper: AcpEventMapper(
-          launchDirectory: cwd,
-          pluginId: "acp",
-          configurationTracker: configurationTracker,
-        ),
-        commandTracker: commandTracker,
-        sessionOptionsService: AcpSessionOptionsService(
-          configurationTracker: configurationTracker,
-          commandTracker: commandTracker,
-          pluginId: "acp",
-          agentDisplayName: "ACP",
-        ),
-        processFactory: (_) async => fake,
-      );
+      plugin = composeTestAcpPlugin(processFactory: (_) async => fake, launchDirectory: cwd);
       // Prime the session's directory so the replay skips the live warm-up
       // enumeration and the only client it spins up is the replay client.
       plugin.primeSessionDirectory(sessionId: sessionId, directory: cwd);
@@ -330,26 +310,9 @@ void main() {
       final liveFake = FakeAcpProcess();
       final replayFake = FakeAcpProcess();
       final availableFakes = [liveFake, replayFake];
-      final configurationTracker = AcpSessionConfigurationTracker();
-      final commandTracker = AcpCommandTracker();
-      final createdPlugin = TestAcpPlugin(
-        id: "acp",
-        agentDisplayName: "ACP",
-        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
-        launchDirectory: cwd,
-        eventMapper: AcpEventMapper(
-          launchDirectory: cwd,
-          pluginId: "acp",
-          configurationTracker: configurationTracker,
-        ),
-        commandTracker: commandTracker,
-        sessionOptionsService: AcpSessionOptionsService(
-          configurationTracker: configurationTracker,
-          commandTracker: commandTracker,
-          pluginId: "acp",
-          agentDisplayName: "ACP",
-        ),
+      final createdPlugin = composeTestAcpPlugin(
         processFactory: (_) async => availableFakes.removeAt(0),
+        launchDirectory: cwd,
       );
       final emitted = <BridgeSseEvent>[];
       final eventSubscription = createdPlugin.events.listen(emitted.add);

--- a/bridge/sesori_plugin_acp/test/acp_initialize_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_initialize_test.dart
@@ -15,25 +15,8 @@ void main() {
 
     setUp(() {
       fakes.clear();
-      final configurationTracker = AcpSessionConfigurationTracker();
-      final commandTracker = AcpCommandTracker();
-      plugin = TestAcpPlugin(
-        id: "acp",
-        agentDisplayName: "ACP",
-        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+      plugin = composeTestAcpPlugin(
         launchDirectory: cwd,
-        eventMapper: AcpEventMapper(
-          launchDirectory: cwd,
-          pluginId: "acp",
-          configurationTracker: configurationTracker,
-        ),
-        commandTracker: commandTracker,
-        sessionOptionsService: AcpSessionOptionsService(
-          configurationTracker: configurationTracker,
-          commandTracker: commandTracker,
-          pluginId: "acp",
-          agentDisplayName: "ACP",
-        ),
         processFactory: (_) async {
           final fake = FakeAcpProcess();
           fakes.add(fake);

--- a/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
@@ -17,27 +17,7 @@ void main() {
     setUp(() {
       fake = FakeAcpProcess();
       emitted = [];
-      final configurationTracker = AcpSessionConfigurationTracker();
-      final commandTracker = AcpCommandTracker();
-      plugin = TestAcpPlugin(
-        id: "acp",
-        agentDisplayName: "ACP",
-        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
-        launchDirectory: cwd,
-        eventMapper: AcpEventMapper(
-          launchDirectory: cwd,
-          pluginId: "acp",
-          configurationTracker: configurationTracker,
-        ),
-        commandTracker: commandTracker,
-        sessionOptionsService: AcpSessionOptionsService(
-          configurationTracker: configurationTracker,
-          commandTracker: commandTracker,
-          pluginId: "acp",
-          agentDisplayName: "ACP",
-        ),
-        processFactory: (_) async => fake,
-      );
+      plugin = composeTestAcpPlugin(processFactory: (_) async => fake, launchDirectory: cwd);
       plugin.events.listen(emitted.add);
     });
 

--- a/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
@@ -739,25 +739,8 @@ void main() {
     });
 
     test("a broken history replay surfaces as a typed failure, not an empty thread", () async {
-      final configurationTracker = AcpSessionConfigurationTracker();
-      final commandTracker = AcpCommandTracker();
-      final failingPlugin = TestAcpPlugin(
-        id: "acp",
-        agentDisplayName: "ACP",
-        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+      final failingPlugin = composeTestAcpPlugin(
         launchDirectory: cwd,
-        eventMapper: AcpEventMapper(
-          launchDirectory: cwd,
-          pluginId: "acp",
-          configurationTracker: configurationTracker,
-        ),
-        commandTracker: commandTracker,
-        sessionOptionsService: AcpSessionOptionsService(
-          configurationTracker: configurationTracker,
-          commandTracker: commandTracker,
-          pluginId: "acp",
-          agentDisplayName: "ACP",
-        ),
         processFactory: _throwReplayProcess,
       );
       addTearDown(failingPlugin.dispose);

--- a/bridge/sesori_plugin_acp/test/acp_reconnect_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_reconnect_test.dart
@@ -14,25 +14,8 @@ void main() {
 
     setUp(() {
       fakes.clear();
-      final configurationTracker = AcpSessionConfigurationTracker();
-      final commandTracker = AcpCommandTracker();
-      plugin = TestAcpPlugin(
-        id: "acp",
-        agentDisplayName: "ACP",
-        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+      plugin = composeTestAcpPlugin(
         launchDirectory: cwd,
-        eventMapper: AcpEventMapper(
-          launchDirectory: cwd,
-          pluginId: "acp",
-          configurationTracker: configurationTracker,
-        ),
-        commandTracker: commandTracker,
-        sessionOptionsService: AcpSessionOptionsService(
-          configurationTracker: configurationTracker,
-          commandTracker: commandTracker,
-          pluginId: "acp",
-          agentDisplayName: "ACP",
-        ),
         processFactory: (_) async {
           final fake = FakeAcpProcess();
           fakes.add(fake);

--- a/bridge/sesori_plugin_acp/test/acp_resume_only_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_only_test.dart
@@ -17,27 +17,7 @@ void main() {
 
     setUp(() {
       fake = FakeAcpProcess();
-      final configurationTracker = AcpSessionConfigurationTracker();
-      final commandTracker = AcpCommandTracker();
-      plugin = TestAcpPlugin(
-        id: "acp",
-        agentDisplayName: "ACP",
-        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
-        launchDirectory: cwd,
-        eventMapper: AcpEventMapper(
-          launchDirectory: cwd,
-          pluginId: "acp",
-          configurationTracker: configurationTracker,
-        ),
-        commandTracker: commandTracker,
-        sessionOptionsService: AcpSessionOptionsService(
-          configurationTracker: configurationTracker,
-          commandTracker: commandTracker,
-          pluginId: "acp",
-          agentDisplayName: "ACP",
-        ),
-        processFactory: (_) async => fake,
-      );
+      plugin = composeTestAcpPlugin(processFactory: (_) async => fake, launchDirectory: cwd);
       emitted.clear();
       plugin.events.listen(emitted.add);
     });

--- a/bridge/sesori_plugin_acp/test/acp_resume_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_test.dart
@@ -16,27 +16,7 @@ void main() {
 
     setUp(() {
       fake = FakeAcpProcess();
-      final configurationTracker = AcpSessionConfigurationTracker();
-      final commandTracker = AcpCommandTracker();
-      plugin = TestAcpPlugin(
-        id: "acp",
-        agentDisplayName: "ACP",
-        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
-        launchDirectory: cwd,
-        eventMapper: AcpEventMapper(
-          launchDirectory: cwd,
-          pluginId: "acp",
-          configurationTracker: configurationTracker,
-        ),
-        commandTracker: commandTracker,
-        sessionOptionsService: AcpSessionOptionsService(
-          configurationTracker: configurationTracker,
-          commandTracker: commandTracker,
-          pluginId: "acp",
-          agentDisplayName: "ACP",
-        ),
-        processFactory: (_) async => fake,
-      );
+      plugin = composeTestAcpPlugin(processFactory: (_) async => fake, launchDirectory: cwd);
       emitted.clear();
       plugin.events.listen(emitted.add);
     });

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -84,27 +84,7 @@ void main() {
 
     setUp(() {
       fake = _FlushControlledAcpProcess();
-      final configurationTracker = AcpSessionConfigurationTracker();
-      final commandTracker = AcpCommandTracker();
-      plugin = TestAcpPlugin(
-        id: "acp",
-        agentDisplayName: "ACP",
-        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
-        launchDirectory: cwd,
-        eventMapper: AcpEventMapper(
-          launchDirectory: cwd,
-          pluginId: "acp",
-          configurationTracker: configurationTracker,
-        ),
-        commandTracker: commandTracker,
-        sessionOptionsService: AcpSessionOptionsService(
-          configurationTracker: configurationTracker,
-          commandTracker: commandTracker,
-          pluginId: "acp",
-          agentDisplayName: "ACP",
-        ),
-        processFactory: (_) async => fake,
-      );
+      plugin = composeTestAcpPlugin(processFactory: (_) async => fake, launchDirectory: cwd);
       emitted.clear();
       streamErrors.clear();
       promptSequence = 0;
@@ -599,25 +579,8 @@ void main() {
     test("queued reconnect authentication failure surfaces on the event stream", () async {
       var processStarts = 0;
       await plugin.dispose();
-      final configurationTracker = AcpSessionConfigurationTracker();
-      final commandTracker = AcpCommandTracker();
-      plugin = TestAcpPlugin(
-        id: "acp",
-        agentDisplayName: "ACP",
-        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+      plugin = composeTestAcpPlugin(
         launchDirectory: cwd,
-        eventMapper: AcpEventMapper(
-          launchDirectory: cwd,
-          pluginId: "acp",
-          configurationTracker: configurationTracker,
-        ),
-        commandTracker: commandTracker,
-        sessionOptionsService: AcpSessionOptionsService(
-          configurationTracker: configurationTracker,
-          commandTracker: commandTracker,
-          pluginId: "acp",
-          agentDisplayName: "ACP",
-        ),
         processFactory: (_) async {
           processStarts++;
           if (processStarts == 1) return fake;
@@ -962,25 +925,8 @@ void main() {
       // dead client.
       final fakes = [FakeAcpProcess(), FakeAcpProcess()];
       final spawned = <FakeAcpProcess>[];
-      final configurationTracker = AcpSessionConfigurationTracker();
-      final commandTracker = AcpCommandTracker();
-      final respawning = TestAcpPlugin(
-        id: "acp",
-        agentDisplayName: "ACP",
-        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+      final respawning = composeTestAcpPlugin(
         launchDirectory: cwd,
-        eventMapper: AcpEventMapper(
-          launchDirectory: cwd,
-          pluginId: "acp",
-          configurationTracker: configurationTracker,
-        ),
-        commandTracker: commandTracker,
-        sessionOptionsService: AcpSessionOptionsService(
-          configurationTracker: configurationTracker,
-          commandTracker: commandTracker,
-          pluginId: "acp",
-          agentDisplayName: "ACP",
-        ),
         processFactory: (_) async {
           final next = fakes.removeAt(0);
           spawned.add(next);

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -4,6 +4,9 @@ import "package:opencode_plugin/opencode_plugin.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
+import "support/fake_open_code_api.dart";
+import "support/open_code_fixtures.dart";
+
 void main() {
   group("ActiveSessionTracker", () {
     test("empty tracker has empty activeSessions", () {
@@ -49,16 +52,7 @@ void main() {
       test("SSE session.created populates getSessionDirectory", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/projects/foo",
-            ),
+            openCodeProject(id: "p1", worktree: "/projects/foo"),
           ],
         );
 
@@ -76,16 +70,7 @@ void main() {
       test("SSE session.updated preserves raw directory", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/projects/foo",
-            ),
+            openCodeProject(id: "p1", worktree: "/projects/foo"),
           ],
         );
 
@@ -107,16 +92,7 @@ void main() {
       test("SSE session.deleted removes from getSessionDirectory", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/projects/foo",
-            ),
+            openCodeProject(id: "p1", worktree: "/projects/foo"),
           ],
         );
 
@@ -131,16 +107,7 @@ void main() {
       test("coldStart populates getSessionDirectory for all fetched sessions", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/projects/foo",
-            ),
+            openCodeProject(id: "p1", worktree: "/projects/foo"),
           ],
           sessions: [
             _session("s1", "/projects/foo"),
@@ -329,16 +296,7 @@ void main() {
       test("coldStart populates active statuses from busy/retry sessions", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/projects/foo",
-            ),
+            openCodeProject(id: "p1", worktree: "/projects/foo"),
           ],
           sessions: [
             _session("s1", "/projects/foo"),
@@ -363,16 +321,7 @@ void main() {
       test("SSE busy event adds to active statuses", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/projects/foo",
-            ),
+            openCodeProject(id: "p1", worktree: "/projects/foo"),
           ],
         );
 
@@ -388,16 +337,7 @@ void main() {
       test("SSE idle event removes from active statuses", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/projects/foo",
-            ),
+            openCodeProject(id: "p1", worktree: "/projects/foo"),
           ],
           sessions: [_session("s1", "/projects/foo")],
           statuses: {"s1": const SessionStatusBusy()},
@@ -420,16 +360,7 @@ void main() {
       test("reset clears active statuses", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/projects/foo",
-            ),
+            openCodeProject(id: "p1", worktree: "/projects/foo"),
           ],
           sessions: [_session("s1", "/projects/foo")],
           statuses: {"s1": const SessionStatusBusy()},
@@ -2610,79 +2541,17 @@ SseEventData _childSessionCreated(String id, String parentId, String directory) 
 
 SseEventData _sessionUpdated(String id, String directory) {
   return SseEventData.sessionUpdated(
-    info: Session(
-      slug: "slug",
-      title: "title",
-      version: "v",
-      workspaceID: null,
-      path: null,
-      summary: null,
-      cost: null,
-      tokens: null,
-      share: null,
-      agent: null,
-      model: null,
-      metadata: null,
-      permission: null,
-      revert: null,
-      parentID: null,
-      time: const SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-      id: id,
-      projectID: "project",
-      directory: directory,
-    ),
+    info: openCodeSession(id: id, directory: directory, projectID: "project"),
   );
 }
 
 SseEventData _sessionDeleted(String id, [String directory = ""]) {
   return SseEventData.sessionDeleted(
-    info: Session(
-      slug: "slug",
-      title: "title",
-      version: "v",
-      workspaceID: null,
-      path: null,
-      summary: null,
-      cost: null,
-      tokens: null,
-      share: null,
-      agent: null,
-      model: null,
-      metadata: null,
-      permission: null,
-      revert: null,
-      parentID: null,
-      time: const SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-      id: id,
-      projectID: "project",
-      directory: directory,
-    ),
+    info: openCodeSession(id: id, directory: directory, projectID: "project"),
   );
 }
 
-Session _session(String id, String directory) {
-  return Session(
-    slug: "slug",
-    title: "title",
-    version: "v",
-    workspaceID: null,
-    path: null,
-    parentID: null,
-    summary: null,
-    cost: null,
-    tokens: null,
-    share: null,
-    agent: null,
-    model: null,
-    metadata: null,
-    permission: null,
-    revert: null,
-    time: const SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-    id: id,
-    projectID: "project",
-    directory: directory,
-  );
-}
+Session _session(String id, String directory) => openCodeSession(id: id, directory: directory, projectID: "project");
 
 SseEventData _sessionBusy(String id) {
   return SseEventData.sessionStatus(
@@ -2750,10 +2619,11 @@ OpenCodeRepository _fakeRepository({
   Map<String, SessionStatus>? statuses,
 }) {
   return OpenCodeRepository(
-    _FakeApi(
-      projects: projects,
-      sessions: sessions,
-      statuses: statuses,
+    FakeOpenCodeApi(
+      projects: projects ?? const [],
+      sessions: sessions ?? const [],
+      statuses: statuses ?? const {},
+      filterRootSessions: true,
     ),
   );
 }
@@ -2776,173 +2646,7 @@ Future<ActiveSessionTracker> _coldStartedTracker({
   return tracker;
 }
 
-class _FakeApi({
-  List<Project>? projects,
-  List<Session>? sessions,
-  Map<String, SessionStatus>? statuses,
-}) implements OpenCodeApi {
-  final List<Project> _projects = projects ?? [];
-  final List<Session> _sessions = sessions ?? [];
-  final Map<String, SessionStatus> _statuses = statuses ?? {};
-
-  @override
-  Future<bool> healthCheck() async => true;
-
-  @override
-  Future<List<Project>> listProjects() async => _projects;
-
-  @override
-  Future<List<Session>> listRootSessions() async => _sessions;
-
-  @override
-  Future<List<Session>> listSessions({String? directory, required bool roots}) async =>
-      roots ? _sessions.where((s) => s.parentID == null).toList() : _sessions;
-
-  @override
-  Future<List<Command>> listCommands({required String? directory}) async => const [];
-
-  @override
-  Future<Session> createSession({required String directory, String? parentSessionId}) async =>
-      throw UnimplementedError();
-
-  @override
-  Future<Session> getSession({required String sessionId, required String? directory}) async =>
-      throw UnimplementedError();
-
-  @override
-  Future<Session> updateSession({
-    required String sessionId,
-    required Map<String, dynamic> body,
-    required String? directory,
-  }) async => throw UnimplementedError();
-
-  @override
-  Future<void> deleteSession({required String sessionId, required String? directory}) async {}
-
-  @override
-  Future<void> removeWorktree({
-    required String directory,
-    required String worktreePath,
-  }) async {}
-
-  @override
-  Future<SessionMessagesResponseItem?> sendPrompt({
-    required String sessionId,
-    required SendPromptBody body,
-    required String? directory,
-  }) async => null;
-
-  @override
-  Future<void> updateMessagePart({
-    required String sessionId,
-    required String messageId,
-    required String partId,
-    required Part part,
-    required String? directory,
-  }) async {}
-
-  @override
-  Future<void> deleteMessage({
-    required String sessionId,
-    required String messageId,
-    required String? directory,
-  }) async {}
-
-  @override
-  Future<void> sendCommand({
-    required String sessionId,
-    required SendCommandBody body,
-    required String? directory,
-  }) async {}
-
-  @override
-  Future<void> abortSession({required String sessionId, required String? directory}) async {}
-
-  @override
-  Future<List<Agent>> listAgents({required String directory}) async => [];
-
-  @override
-  Future<List<QuestionRequest>> getPendingQuestions({required String? directory}) async => [];
-
-  @override
-  Future<List<PermissionRequest>> getPendingPermissions({required String? directory}) async => [];
-
-  @override
-  Future<void> replyToQuestion({
-    required String questionId,
-    required String? directory,
-    required QuestionReplyBody body,
-  }) async {}
-
-  @override
-  Future<void> replyToPermission({
-    required String requestId,
-    required String? directory,
-    required PluginPermissionReply reply,
-  }) async {}
-
-  @override
-  Future<void> rejectQuestion({
-    required String questionId,
-    required String? directory,
-  }) async {}
-
-  @override
-  Future<Project> getProject({required String directory}) async => throw UnimplementedError();
-
-  @override
-  Future<List<Session>> getChildren({
-    required String sessionId,
-    required String? directory,
-  }) async => [];
-
-  @override
-  Future<List<SessionMessagesResponseItem>> getMessages({
-    required String sessionId,
-    required String? directory,
-  }) async => [];
-
-  @override
-  Future<List<GlobalSession>> listAllSessions({
-    required String? directory,
-    required bool roots,
-  }) async => [];
-
-  @override
-  Future<Map<String, SessionStatus>> getSessionStatuses({required String? directory}) async {
-    if (directory == null) return _statuses;
-    final sessionIdsInDirectory = _sessions
-        .where((s) => s.directory == directory || s.directory.startsWith("$directory/"))
-        .map((s) => s.id)
-        .toSet();
-    return Map.fromEntries(
-      _statuses.entries.where((e) => sessionIdsInDirectory.contains(e.key)),
-    );
-  }
-
-  @override
-  Future<ProviderListResponse> listProviders() async =>
-      const ProviderListResponse(all: [], defaultValue: {}, connected: []);
-
-  @override
-  Future<ConfigProvidersResponse> listConfigProviders({required String? directory}) async =>
-      const ConfigProvidersResponse(providers: [], defaultValue: {});
-
-  @override
-  Future<Project> updateProject({
-    required String projectId,
-    required String directory,
-    required UpdateProjectBody body,
-  }) async => throw UnimplementedError();
-
-  @override
-  Future<Session> forkSession({
-    required String sessionId,
-    required String directory,
-  }) async => throw UnimplementedError();
-}
-
-class _GatedStatusApi() extends _FakeApi {
+class _GatedStatusApi() extends FakeOpenCodeApi {
   this : super(statuses: {"session": const SessionStatusIdle()});
 
   final Completer<void> statusRequested = Completer<void>();

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -3,11 +3,14 @@ import "package:opencode_plugin/src/models/openapi/compaction_part.g.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
+import "support/fake_open_code_api.dart";
+import "support/open_code_fixtures.dart";
+
 void main() {
   group("OpenCodeRepository.getProject", () {
     test("maps OpenCode's global project to a folder-specific virtual project", () async {
-      final api = _FakeApi(
-        currentProject: _backendProject(
+      final api = FakeOpenCodeApi(
+        currentProject: openCodeProject(
           id: "global",
           worktree: "/",
           name: "Global",
@@ -24,8 +27,8 @@ void main() {
     });
 
     test("keeps a Git project's canonical worktree identity", () async {
-      final api = _FakeApi(
-        currentProject: _backendProject(
+      final api = FakeOpenCodeApi(
+        currentProject: openCodeProject(
           id: "project-1",
           worktree: "/projects/original",
           name: "Repository",
@@ -43,8 +46,8 @@ void main() {
 
   group("OpenCodeRepository.renameProject", () {
     test("renames a virtual folder without updating the shared global project", () async {
-      final api = _FakeApi(
-        currentProject: _backendProject(
+      final api = FakeOpenCodeApi(
+        currentProject: openCodeProject(
           id: "global",
           worktree: "/",
           name: "Global",
@@ -66,50 +69,10 @@ void main() {
 
   group("OpenCodeRepository.getSessions", () {
     test("excludes child sessions (non-null parentID)", () async {
-      final api = _FakeApi(
+      final api = FakeOpenCodeApi(
         sessions: [
-          const Session(
-            slug: "slug",
-            title: "title",
-            version: "v",
-            time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-            id: "parent-1",
-            projectID: "p1",
-            directory: "/repo",
-            workspaceID: null,
-            path: null,
-            parentID: null,
-            summary: null,
-            cost: null,
-            tokens: null,
-            share: null,
-            agent: null,
-            model: null,
-            metadata: null,
-            permission: null,
-            revert: null,
-          ),
-          const Session(
-            slug: "slug",
-            title: "title",
-            version: "v",
-            time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-            id: "child-1",
-            projectID: "p1",
-            directory: "/repo",
-            parentID: "parent-1",
-            workspaceID: null,
-            path: null,
-            summary: null,
-            cost: null,
-            tokens: null,
-            share: null,
-            agent: null,
-            model: null,
-            metadata: null,
-            permission: null,
-            revert: null,
-          ),
+          openCodeSession(id: "parent-1", directory: "/repo"),
+          openCodeSession(id: "child-1", directory: "/repo", parentID: "parent-1"),
           const Session(
             slug: "slug",
             title: "title",
@@ -165,7 +128,7 @@ void main() {
     });
 
     test("includes sessions with null parentID", () async {
-      final api = _FakeApi(
+      final api = FakeOpenCodeApi(
         sessions: [
           const Session(
             slug: "slug",
@@ -219,7 +182,7 @@ void main() {
     });
 
     test("excludes child sessions from global sessions too", () async {
-      final api = _FakeApi(
+      final api = FakeOpenCodeApi(
         globalSessions: [
           const GlobalSession(
             slug: "slug",
@@ -277,7 +240,7 @@ void main() {
     });
 
     test("filters by worktree directory", () async {
-      final api = _FakeApi(
+      final api = FakeOpenCodeApi(
         sessions: [
           const Session(
             slug: "slug",
@@ -331,7 +294,7 @@ void main() {
     });
 
     test("sorts by updated time descending", () async {
-      final api = _FakeApi(
+      final api = FakeOpenCodeApi(
         sessions: [
           const Session(
             slug: "slug",
@@ -385,7 +348,7 @@ void main() {
     });
 
     test("deduplicates standard and global sessions", () async {
-      final api = _FakeApi(
+      final api = FakeOpenCodeApi(
         sessions: [
           const Session(
             slug: "slug",
@@ -470,7 +433,7 @@ void main() {
     test("ignores the raw project startup timestamp and derives activity from root sessions", () async {
       // OpenCode stamps the raw project update time at server startup, making
       // it newer than actual work. It must not influence project activity.
-      final api = _FakeApi(
+      final api = FakeOpenCodeApi(
         projects: [
           const Project(
             sandboxes: <String>[],
@@ -542,7 +505,7 @@ void main() {
 
     test("derives activity from global sessions into matching real project", () async {
       // Orphaned global sessions under a directory that also has a real project.
-      final api = _FakeApi(
+      final api = FakeOpenCodeApi(
         projects: [
           const Project(
             sandboxes: <String>[],
@@ -591,7 +554,7 @@ void main() {
     });
 
     test("activity is null when no sessions exist", () async {
-      final api = _FakeApi(
+      final api = FakeOpenCodeApi(
         projects: [
           const Project(
             sandboxes: <String>[],
@@ -626,7 +589,7 @@ void main() {
       // Project has sessions from both the real project ID and the global
       // project ID (pre-git-init orphans). Both should contribute to the
       // session-derived activity.
-      final api = _FakeApi(
+      final api = FakeOpenCodeApi(
         projects: [
           const Project(
             sandboxes: <String>[],
@@ -699,7 +662,7 @@ void main() {
     test("creates virtual projects only from global sessions", () async {
       // A directory with only global sessions (no real project entry) should
       // produce a virtual project.
-      final api = _FakeApi(
+      final api = FakeOpenCodeApi(
         projects: [
           const Project(
             sandboxes: <String>[],
@@ -754,7 +717,7 @@ void main() {
       // Sessions belonging to a non-global project ID should not produce
       // virtual projects — they already belong to a real project even if the
       // project entry wasn't returned by the API (edge case).
-      final api = _FakeApi(
+      final api = FakeOpenCodeApi(
         projects: [],
         globalSessions: [
           const GlobalSession(
@@ -794,7 +757,7 @@ void main() {
       // ran OpenCode from /repo/packages/foo). The project worktree is /repo.
       // The session's timestamp should still contribute to the project's
       // session-derived activity.
-      final api = _FakeApi(
+      final api = FakeOpenCodeApi(
         projects: [
           const Project(
             sandboxes: <String>[],
@@ -843,7 +806,7 @@ void main() {
     });
 
     test("attributes sandbox session activity to the canonical project", () async {
-      final api = _FakeApi(
+      final api = FakeOpenCodeApi(
         projects: [
           const Project(
             sandboxes: <String>["/moved/repo", "/second/repo", ""],
@@ -960,7 +923,7 @@ void main() {
     });
 
     test("excludes global meta-project from results", () async {
-      final api = _FakeApi(
+      final api = FakeOpenCodeApi(
         projects: [
           const Project(
             sandboxes: <String>[],
@@ -995,7 +958,7 @@ void main() {
 
   group("OpenCodeRepository.getCommands", () {
     test("maps OpenCode commands to plugin commands in Layer 2", () async {
-      final api = _FakeApi(
+      final api = FakeOpenCodeApi(
         commands: const [
           Command(
             name: "/review-work",
@@ -1034,7 +997,7 @@ void main() {
 
   group("OpenCodeRepository.createSession", () {
     test("trims directory before calling api and mapping projectID", () async {
-      final api = _FakeApi(
+      final api = FakeOpenCodeApi(
         createdSession: const Session(
           slug: "slug",
           version: "v",
@@ -1072,7 +1035,7 @@ void main() {
 
   group("OpenCodeRepository message reservation", () {
     test("lets OpenCode name an empty non-renderable message", () async {
-      final api = _FakeApi();
+      final api = FakeOpenCodeApi();
       final repository = OpenCodeRepository(api);
 
       final messageId = await repository.reserveMessage(
@@ -1098,7 +1061,7 @@ void main() {
     });
 
     test("reserves and converts the exact placeholder part for compaction", () async {
-      final api = _FakeApi();
+      final api = FakeOpenCodeApi();
       final repository = OpenCodeRepository(api);
 
       final reservation = await repository.reserveCompactionMessage(
@@ -1140,7 +1103,7 @@ void main() {
     });
 
     test("deletes a rejected reservation by exact message id", () async {
-      final api = _FakeApi();
+      final api = FakeOpenCodeApi();
       final repository = OpenCodeRepository(api);
 
       await repository.deleteMessage(
@@ -1155,7 +1118,7 @@ void main() {
 
   group("OpenCodeRepository variant passthrough", () {
     test("sendPrompt forwards raw variant", () async {
-      final api = _FakeApi();
+      final api = FakeOpenCodeApi();
       final repository = OpenCodeRepository(api);
 
       await repository.sendPrompt(
@@ -1174,7 +1137,7 @@ void main() {
     });
 
     test("sendPrompt omits variant when null", () async {
-      final api = _FakeApi();
+      final api = FakeOpenCodeApi();
       final repository = OpenCodeRepository(api);
 
       await repository.sendPrompt(
@@ -1192,7 +1155,7 @@ void main() {
     });
 
     test("sendCommand forwards raw variant", () async {
-      final api = _FakeApi();
+      final api = FakeOpenCodeApi();
       final repository = OpenCodeRepository(api);
 
       await repository.sendCommand(
@@ -1214,7 +1177,7 @@ void main() {
 
   group("OpenCodeRepository.addCompactionInstructions", () {
     test("persists instructions as a no-reply prompt", () async {
-      final api = _FakeApi();
+      final api = FakeOpenCodeApi();
       final repository = OpenCodeRepository(api);
 
       await repository.addCompactionInstructions(
@@ -1291,258 +1254,4 @@ void main() {
       expect(withoutVariant.containsKey("variant"), isFalse);
     });
   });
-}
-
-class _FakeApi({
-  List<Session>? sessions,
-  List<GlobalSession>? globalSessions,
-  List<Project>? projects,
-  List<Command>? commands,
-  final Session? _createdSession,
-  final Project? _currentProject,
-}) implements OpenCodeApi {
-  final List<Session> _sessions = sessions ?? [];
-  final List<GlobalSession> _globalSessions = globalSessions ?? [];
-  final List<Project> _projects = projects ?? [];
-  final List<Command> _commands = commands ?? [];
-  String? lastCreateDirectory;
-  String? lastCreateParentSessionId;
-  String? lastPromptSessionId;
-  String? lastPromptDirectory;
-  SendPromptBody? lastPromptBody;
-  final List<SendPromptBody> promptBodies = [];
-  Part? lastUpdatedPart;
-  String? lastUpdatedMessageId;
-  String? lastUpdatedPartId;
-  String? lastDeletedMessageId;
-  String? lastCommandSessionId;
-  String? lastCommandDirectory;
-  SendCommandBody? lastCommandBody;
-  String? lastGetProjectDirectory;
-  int updateProjectCalls = 0;
-
-  @override
-  Future<bool> healthCheck() async => true;
-
-  @override
-  Future<List<Project>> listProjects() async => _projects;
-
-  @override
-  Future<List<Session>> listRootSessions() async => _sessions;
-
-  @override
-  Future<List<Session>> listSessions({String? directory, required bool roots}) async => _sessions;
-
-  @override
-  Future<List<Command>> listCommands({required String? directory}) async => _commands;
-
-  @override
-  Future<Session> createSession({required String directory, String? parentSessionId}) async {
-    lastCreateDirectory = directory;
-    lastCreateParentSessionId = parentSessionId;
-    return _createdSession ??
-        const Session(
-          slug: "slug",
-          version: "v",
-          id: "created",
-          projectID: "global",
-          directory: "/repo",
-          parentID: null,
-          title: "",
-          time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-          summary: null,
-          workspaceID: null,
-          path: null,
-          cost: null,
-          tokens: null,
-          share: null,
-          agent: null,
-          model: null,
-          metadata: null,
-          permission: null,
-          revert: null,
-        );
-  }
-
-  @override
-  Future<Session> getSession({required String sessionId, required String? directory}) async =>
-      throw UnimplementedError();
-
-  @override
-  Future<Session> updateSession({
-    required String sessionId,
-    required Map<String, dynamic> body,
-    required String? directory,
-  }) async => throw UnimplementedError();
-
-  @override
-  Future<void> deleteSession({required String sessionId, required String? directory}) async {}
-
-  @override
-  Future<void> removeWorktree({
-    required String directory,
-    required String worktreePath,
-  }) async {}
-
-  @override
-  Future<SessionMessagesResponseItem?> sendPrompt({
-    required String sessionId,
-    required SendPromptBody body,
-    required String? directory,
-  }) async {
-    lastPromptSessionId = sessionId;
-    lastPromptDirectory = directory;
-    lastPromptBody = body;
-    promptBodies.add(body);
-    if (!body.noReply) return null;
-    return SessionMessagesResponseItem.fromJson({
-      "info": {
-        "id": "msg-reserved",
-        "sessionID": sessionId,
-        "role": "user",
-        "time": const {"created": 1},
-        "agent": body.agent ?? "build",
-        "model": const {"providerID": "openai", "modelID": "gpt-4.1"},
-      },
-      "parts": [
-        if (body.parts.isNotEmpty)
-          {
-            "id": "prt-reserved",
-            "sessionID": sessionId,
-            "messageID": "msg-reserved",
-            "type": "text",
-            "text": "",
-          },
-      ],
-    });
-  }
-
-  @override
-  Future<void> updateMessagePart({
-    required String sessionId,
-    required String messageId,
-    required String partId,
-    required Part part,
-    required String? directory,
-  }) async {
-    lastUpdatedMessageId = messageId;
-    lastUpdatedPartId = partId;
-    lastUpdatedPart = part;
-  }
-
-  @override
-  Future<void> deleteMessage({
-    required String sessionId,
-    required String messageId,
-    required String? directory,
-  }) async {
-    lastDeletedMessageId = messageId;
-  }
-
-  @override
-  Future<void> sendCommand({
-    required String sessionId,
-    required SendCommandBody body,
-    required String? directory,
-  }) async {
-    lastCommandSessionId = sessionId;
-    lastCommandDirectory = directory;
-    lastCommandBody = body;
-  }
-
-  @override
-  Future<void> abortSession({required String sessionId, required String? directory}) async {}
-
-  @override
-  Future<List<Agent>> listAgents({required String directory}) async => [];
-
-  @override
-  Future<List<QuestionRequest>> getPendingQuestions({required String? directory}) async => [];
-
-  @override
-  Future<List<PermissionRequest>> getPendingPermissions({required String? directory}) async => [];
-
-  @override
-  Future<void> replyToQuestion({
-    required String questionId,
-    required String? directory,
-    required QuestionReplyBody body,
-  }) async {}
-
-  @override
-  Future<void> replyToPermission({
-    required String requestId,
-    required String? directory,
-    required PluginPermissionReply reply,
-  }) async {}
-
-  @override
-  Future<void> rejectQuestion({
-    required String questionId,
-    required String? directory,
-  }) async {}
-
-  @override
-  Future<Project> getProject({required String directory}) async {
-    lastGetProjectDirectory = directory;
-    return _currentProject ?? (throw UnimplementedError());
-  }
-
-  @override
-  Future<List<Session>> getChildren({
-    required String sessionId,
-    required String? directory,
-  }) async => [];
-
-  @override
-  Future<List<SessionMessagesResponseItem>> getMessages({
-    required String sessionId,
-    required String? directory,
-  }) async => [];
-
-  @override
-  Future<List<GlobalSession>> listAllSessions({
-    required String? directory,
-    required bool roots,
-  }) async => _globalSessions;
-
-  @override
-  Future<Map<String, SessionStatus>> getSessionStatuses({required String? directory}) async => {};
-
-  @override
-  Future<ProviderListResponse> listProviders() async =>
-      const ProviderListResponse(all: [], defaultValue: {}, connected: []);
-
-  @override
-  Future<ConfigProvidersResponse> listConfigProviders({required String? directory}) async =>
-      const ConfigProvidersResponse(providers: [], defaultValue: {});
-
-  @override
-  Future<Project> updateProject({
-    required String projectId,
-    required String directory,
-    required UpdateProjectBody body,
-  }) async {
-    updateProjectCalls += 1;
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<Session> forkSession({
-    required String sessionId,
-    required String directory,
-  }) async => throw UnimplementedError();
-}
-
-Project _backendProject({required String id, required String worktree, required String? name}) {
-  return Project(
-    time: const ProjectTime(created: 0, updated: 0, initialized: null),
-    sandboxes: const [],
-    id: id,
-    worktree: worktree,
-    vcs: null,
-    name: name,
-    icon: null,
-    commands: null,
-  );
 }

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -9,6 +9,9 @@ import "package:sesori_shared/sesori_shared.dart"
     show ActiveSession, ProjectActivitySummary, maxInlineMessageAttachmentBytes;
 import "package:test/test.dart";
 
+import "support/fake_open_code_api.dart";
+import "support/open_code_fixtures.dart";
+
 void main() {
   group("OpenCodeService.getProjects", () {
     test("returns projects and owns tracker alias bookkeeping", () async {
@@ -216,48 +219,8 @@ void main() {
 
   group("OpenCodeService.getSessions", () {
     final sessions = [
-      const Session(
-        slug: "slug",
-        title: "title",
-        version: "v",
-        time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-        id: "s1",
-        projectID: "p1",
-        directory: "/repo",
-        workspaceID: null,
-        path: null,
-        parentID: null,
-        summary: null,
-        cost: null,
-        tokens: null,
-        share: null,
-        agent: null,
-        model: null,
-        metadata: null,
-        permission: null,
-        revert: null,
-      ),
-      const Session(
-        slug: "slug",
-        title: "title",
-        version: "v",
-        time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-        id: "s2",
-        projectID: "p1",
-        directory: "/repo",
-        workspaceID: null,
-        path: null,
-        parentID: null,
-        summary: null,
-        cost: null,
-        tokens: null,
-        share: null,
-        agent: null,
-        model: null,
-        metadata: null,
-        permission: null,
-        revert: null,
-      ),
+      openCodeSession(id: "s1", directory: "/repo"),
+      openCodeSession(id: "s2", directory: "/repo"),
       const Session(
         slug: "slug",
         title: "title",
@@ -1917,181 +1880,6 @@ SseEventData _questionAsked(String id, String sessionId) {
     sessionID: sessionId,
     questions: const [],
   );
-}
-
-class FakeOpenCodeApi({var List<SessionMessagesResponseItem> messages = const [], var Object? messagesError})
-    implements OpenCodeApi {
-  String? lastRequestedSessionId;
-  String? lastRequestedDirectory;
-
-  @override
-  Future<bool> healthCheck() async => true;
-
-  @override
-  Future<List<SessionMessagesResponseItem>> getMessages({required String sessionId, required String? directory}) async {
-    lastRequestedSessionId = sessionId;
-    lastRequestedDirectory = directory;
-    if (messagesError != null) throw messagesError!;
-    return messages;
-  }
-
-  @override
-  Future<List<Command>> listCommands({required String? directory}) async => const [];
-
-  @override
-  Future<Session> createSession({required String directory, String? parentSessionId}) async =>
-      throw UnimplementedError();
-
-  @override
-  Future<Session> getSession({required String sessionId, required String? directory}) async =>
-      throw UnimplementedError();
-
-  @override
-  Future<Session> updateSession({
-    required String sessionId,
-    required Map<String, dynamic> body,
-    required String? directory,
-  }) async => throw UnimplementedError();
-
-  @override
-  Future<List<Session>> getChildren({
-    required String sessionId,
-    required String? directory,
-  }) async => [];
-
-  @override
-  Future<Map<String, SessionStatus>> getSessionStatuses({required String? directory}) async => {};
-
-  @override
-  Future<void> deleteSession({required String sessionId, required String? directory}) async {}
-
-  @override
-  Future<void> removeWorktree({
-    required String directory,
-    required String worktreePath,
-  }) async {}
-
-  @override
-  Future<SessionMessagesResponseItem?> sendPrompt({
-    required String sessionId,
-    required SendPromptBody body,
-    required String? directory,
-  }) async => body.noReply
-      ? SessionMessagesResponseItem.fromJson({
-          "info": {
-            "id": "msg-reserved",
-            "sessionID": sessionId,
-            "role": "user",
-            "time": const {"created": 1},
-            "agent": body.agent ?? "build",
-            "model": const {"providerID": "openai", "modelID": "gpt-4.1"},
-          },
-          "parts": [
-            if (body.parts.isNotEmpty)
-              {
-                "id": "prt-reserved",
-                "sessionID": sessionId,
-                "messageID": "msg-reserved",
-                "type": "text",
-                "text": "",
-              },
-          ],
-        })
-      : null;
-
-  @override
-  Future<void> updateMessagePart({
-    required String sessionId,
-    required String messageId,
-    required String partId,
-    required Part part,
-    required String? directory,
-  }) async {}
-
-  @override
-  Future<void> deleteMessage({
-    required String sessionId,
-    required String messageId,
-    required String? directory,
-  }) async {}
-
-  @override
-  Future<void> sendCommand({
-    required String sessionId,
-    required SendCommandBody body,
-    required String? directory,
-  }) async {}
-
-  @override
-  Future<void> abortSession({required String sessionId, required String? directory}) async {}
-
-  @override
-  Future<List<Agent>> listAgents({required String directory}) async => [];
-
-  @override
-  Future<List<QuestionRequest>> getPendingQuestions({required String? directory}) async => [];
-
-  @override
-  Future<List<PermissionRequest>> getPendingPermissions({required String? directory}) async => [];
-
-  @override
-  Future<void> replyToQuestion({
-    required String questionId,
-    required String? directory,
-    required QuestionReplyBody body,
-  }) async {}
-
-  @override
-  Future<void> replyToPermission({
-    required String requestId,
-    required String? directory,
-    required PluginPermissionReply reply,
-  }) async {}
-
-  @override
-  Future<void> rejectQuestion({
-    required String questionId,
-    required String? directory,
-  }) async {}
-
-  @override
-  Future<Project> getProject({required String directory}) async => throw UnimplementedError();
-
-  @override
-  Future<Project> updateProject({
-    required String projectId,
-    required String directory,
-    required UpdateProjectBody body,
-  }) async => throw UnimplementedError();
-
-  @override
-  Future<List<GlobalSession>> listAllSessions({
-    required String? directory,
-    required bool roots,
-  }) async => [];
-
-  @override
-  Future<List<Project>> listProjects() async => [];
-
-  @override
-  Future<List<Session>> listRootSessions() async => [];
-
-  @override
-  Future<List<Session>> listSessions({String? directory, required bool roots}) async => [];
-
-  @override
-  Future<ProviderListResponse> listProviders() async =>
-      const ProviderListResponse(all: [], defaultValue: {}, connected: []);
-
-  @override
-  Future<ConfigProvidersResponse> listConfigProviders({required String? directory}) async =>
-      const ConfigProvidersResponse(providers: [], defaultValue: {});
-
-  @override
-  Future<Session> forkSession({
-    required String sessionId,
-    required String directory,
-  }) async => throw UnimplementedError();
 }
 
 class FakeOpenCodeRepository._({

--- a/bridge/sesori_plugin_opencode/test/sse_event_mapper_test.dart
+++ b/bridge/sesori_plugin_opencode/test/sse_event_mapper_test.dart
@@ -1,11 +1,12 @@
 import "package:opencode_plugin/src/models/openapi/assistant_message.g.dart";
-import "package:opencode_plugin/src/models/openapi/session.g.dart";
 import "package:opencode_plugin/src/models/openapi/user_message.g.dart";
 import "package:opencode_plugin/src/models/sse_event_data.g.dart";
 import "package:opencode_plugin/src/sse_event_mapper.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" as shared;
 import "package:test/test.dart";
+
+import "support/open_code_fixtures.dart";
 
 AssistantMessage _assistantMessage({required Object? error}) {
   return AssistantMessage(
@@ -84,29 +85,13 @@ void main() {
     });
 
     test("maps session.created using provided canonical projectID", () {
-      const session = Session(
-        slug: "slug",
-        title: "title",
-        version: "v",
-        time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
+      final session = openCodeSession(
         id: "session-1",
         projectID: "/repo",
         directory: "/repo/packages/foo",
-        workspaceID: null,
-        path: null,
-        parentID: null,
-        summary: null,
-        cost: null,
-        tokens: null,
-        share: null,
-        agent: null,
-        model: null,
-        metadata: null,
-        permission: null,
-        revert: null,
       );
 
-      final result = mapper.map(const SseEventData.sessionCreated(info: session));
+      final result = mapper.map(SseEventData.sessionCreated(info: session));
 
       expect(result, isNotNull);
       final event = result! as BridgeSseSessionCreated;
@@ -116,29 +101,13 @@ void main() {
     });
 
     test("maps session.updated using provided canonical projectID", () {
-      const session = Session(
-        slug: "slug",
-        title: "title",
-        version: "v",
-        time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
+      final session = openCodeSession(
         id: "session-2",
         projectID: "/repo",
         directory: "/repo/packages/foo",
-        workspaceID: null,
-        path: null,
-        parentID: null,
-        summary: null,
-        cost: null,
-        tokens: null,
-        share: null,
-        agent: null,
-        model: null,
-        metadata: null,
-        permission: null,
-        revert: null,
       );
 
-      final result = mapper.map(const SseEventData.sessionUpdated(info: session));
+      final result = mapper.map(SseEventData.sessionUpdated(info: session));
 
       expect(result, isNotNull);
       final event = result! as BridgeSseSessionUpdated;
@@ -147,29 +116,13 @@ void main() {
     });
 
     test("maps session.deleted using provided canonical projectID", () {
-      const session = Session(
-        slug: "slug",
-        title: "title",
-        version: "v",
-        time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
+      final session = openCodeSession(
         id: "session-3",
         projectID: "/repo",
         directory: "/repo/packages/foo",
-        workspaceID: null,
-        path: null,
-        parentID: null,
-        summary: null,
-        cost: null,
-        tokens: null,
-        share: null,
-        agent: null,
-        model: null,
-        metadata: null,
-        permission: null,
-        revert: null,
       );
 
-      final result = mapper.map(const SseEventData.sessionDeleted(info: session));
+      final result = mapper.map(SseEventData.sessionDeleted(info: session));
 
       expect(result, isNotNull);
       final event = result! as BridgeSseSessionDeleted;

--- a/bridge/sesori_plugin_opencode/test/support/fake_open_code_api.dart
+++ b/bridge/sesori_plugin_opencode/test/support/fake_open_code_api.dart
@@ -1,0 +1,186 @@
+// ignore_for_file: annotate_overrides
+
+import "package:opencode_plugin/opencode_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+class FakeOpenCodeApi({
+  final List<Session> sessions = const [],
+  final List<GlobalSession> globalSessions = const [],
+  final List<Project> projects = const [],
+  final List<Command> commands = const [],
+  final Map<String, SessionStatus> statuses = const {},
+  final List<SessionMessagesResponseItem> messages = const [],
+  final Object? messagesError,
+  final Session? createdSession,
+  final Project? currentProject,
+  final bool filterRootSessions = false,
+}) implements OpenCodeApi {
+  String? lastCreateDirectory;
+  String? lastCreateParentSessionId;
+  String? lastPromptSessionId;
+  String? lastPromptDirectory;
+  SendPromptBody? lastPromptBody;
+  final List<SendPromptBody> promptBodies = [];
+  Part? lastUpdatedPart;
+  String? lastUpdatedMessageId;
+  String? lastUpdatedPartId;
+  String? lastDeletedMessageId;
+  String? lastCommandSessionId;
+  String? lastCommandDirectory;
+  SendCommandBody? lastCommandBody;
+  String? lastGetProjectDirectory;
+  String? lastRequestedSessionId;
+  String? lastRequestedDirectory;
+  int updateProjectCalls = 0;
+
+  Future<bool> healthCheck() async => true;
+  Future<List<Project>> listProjects() async => projects;
+  Future<List<Session>> listRootSessions() async => sessions;
+  Future<List<Session>> listSessions({String? directory, required bool roots}) async =>
+      roots && filterRootSessions ? sessions.where((session) => session.parentID == null).toList() : sessions;
+  Future<List<Command>> listCommands({required String? directory}) async => commands;
+  Future<Session> createSession({required String directory, String? parentSessionId}) async {
+    lastCreateDirectory = directory;
+    lastCreateParentSessionId = parentSessionId;
+    return createdSession ?? _defaultCreatedSession;
+  }
+
+  Future<Session> getSession({required String sessionId, required String? directory}) async =>
+      throw UnimplementedError();
+  Future<Session> updateSession({
+    required String sessionId,
+    required Map<String, dynamic> body,
+    required String? directory,
+  }) async => throw UnimplementedError();
+  Future<void> deleteSession({required String sessionId, required String? directory}) async {}
+  Future<void> removeWorktree({required String directory, required String worktreePath}) async {}
+  Future<SessionMessagesResponseItem?> sendPrompt({
+    required String sessionId,
+    required SendPromptBody body,
+    required String? directory,
+  }) async {
+    lastPromptSessionId = sessionId;
+    lastPromptDirectory = directory;
+    lastPromptBody = body;
+    promptBodies.add(body);
+    if (!body.noReply) return null;
+    return SessionMessagesResponseItem.fromJson({
+      "info": {
+        "id": "msg-reserved",
+        "sessionID": sessionId,
+        "role": "user",
+        "time": const {"created": 1},
+        "agent": body.agent ?? "build",
+        "model": const {"providerID": "openai", "modelID": "gpt-4.1"},
+      },
+      "parts": [
+        if (body.parts.isNotEmpty)
+          {"id": "prt-reserved", "sessionID": sessionId, "messageID": "msg-reserved", "type": "text", "text": ""},
+      ],
+    });
+  }
+
+  Future<void> updateMessagePart({
+    required String sessionId,
+    required String messageId,
+    required String partId,
+    required Part part,
+    required String? directory,
+  }) async {
+    lastUpdatedMessageId = messageId;
+    lastUpdatedPartId = partId;
+    lastUpdatedPart = part;
+  }
+
+  Future<void> deleteMessage({
+    required String sessionId,
+    required String messageId,
+    required String? directory,
+  }) async => lastDeletedMessageId = messageId;
+  Future<void> sendCommand({
+    required String sessionId,
+    required SendCommandBody body,
+    required String? directory,
+  }) async {
+    lastCommandSessionId = sessionId;
+    lastCommandDirectory = directory;
+    lastCommandBody = body;
+  }
+
+  Future<void> abortSession({required String sessionId, required String? directory}) async {}
+  Future<List<Agent>> listAgents({required String directory}) async => [];
+  Future<List<QuestionRequest>> getPendingQuestions({required String? directory}) async => [];
+  Future<List<PermissionRequest>> getPendingPermissions({required String? directory}) async => [];
+  Future<void> replyToQuestion({
+    required String questionId,
+    required String? directory,
+    required QuestionReplyBody body,
+  }) async {}
+  Future<void> replyToPermission({
+    required String requestId,
+    required String? directory,
+    required PluginPermissionReply reply,
+  }) async {}
+  Future<void> rejectQuestion({required String questionId, required String? directory}) async {}
+  Future<Project> getProject({required String directory}) async {
+    lastGetProjectDirectory = directory;
+    return currentProject ?? (throw UnimplementedError());
+  }
+
+  Future<List<Session>> getChildren({required String sessionId, required String? directory}) async => [];
+  Future<List<SessionMessagesResponseItem>> getMessages({required String sessionId, required String? directory}) async {
+    lastRequestedSessionId = sessionId;
+    lastRequestedDirectory = directory;
+    if (messagesError case final error?) throw error;
+    return messages;
+  }
+
+  Future<List<GlobalSession>> listAllSessions({required String? directory, required bool roots}) async =>
+      globalSessions;
+  Future<Map<String, SessionStatus>> getSessionStatuses({required String? directory}) async {
+    if (directory == null) return statuses;
+    final ids = sessions
+        .where((session) => session.directory == directory || session.directory.startsWith("$directory/"))
+        .map((session) => session.id)
+        .toSet();
+    return Map.fromEntries(statuses.entries.where((entry) => ids.contains(entry.key)));
+  }
+
+  Future<ProviderListResponse> listProviders() async =>
+      const ProviderListResponse(all: [], defaultValue: {}, connected: []);
+  Future<ConfigProvidersResponse> listConfigProviders({required String? directory}) async =>
+      const ConfigProvidersResponse(providers: [], defaultValue: {});
+  Future<Project> updateProject({
+    required String projectId,
+    required String directory,
+    required UpdateProjectBody body,
+  }) async {
+    updateProjectCalls += 1;
+    throw UnimplementedError();
+  }
+
+  Future<Session> forkSession({required String sessionId, required String directory}) async =>
+      throw UnimplementedError();
+}
+
+const _defaultCreatedSession = Session(
+  slug: "slug",
+  version: "v",
+  id: "created",
+  projectID: "global",
+  directory: "/repo",
+  parentID: null,
+  title: "",
+  time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
+  summary: null,
+  workspaceID: null,
+  path: null,
+  cost: null,
+  tokens: null,
+  share: null,
+  agent: null,
+  model: null,
+  metadata: null,
+  permission: null,
+  revert: null,
+);

--- a/bridge/sesori_plugin_opencode/test/support/open_code_fixtures.dart
+++ b/bridge/sesori_plugin_opencode/test/support/open_code_fixtures.dart
@@ -1,0 +1,48 @@
+import "package:opencode_plugin/opencode_plugin.dart";
+
+Project openCodeProject({
+  required String id,
+  required String worktree,
+  String? name,
+  List<String> sandboxes = const [],
+  ProjectTime time = const ProjectTime(created: 0, updated: 0, initialized: null),
+}) => Project(
+  time: time,
+  sandboxes: sandboxes,
+  vcs: null,
+  name: name,
+  icon: null,
+  commands: null,
+  id: id,
+  worktree: worktree,
+);
+
+Session openCodeSession({
+  required String id,
+  required String directory,
+  String projectID = "p1",
+  String? parentID,
+  String slug = "slug",
+  String title = "title",
+  SessionTime time = const SessionTime(created: 0, updated: 0, compacting: null, archived: null),
+}) => Session(
+  slug: slug,
+  title: title,
+  version: "v",
+  time: time,
+  id: id,
+  projectID: projectID,
+  directory: directory,
+  workspaceID: null,
+  path: null,
+  parentID: parentID,
+  summary: null,
+  cost: null,
+  tokens: null,
+  share: null,
+  agent: null,
+  model: null,
+  metadata: null,
+  permission: null,
+  revert: null,
+);

--- a/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
@@ -12,6 +12,8 @@ import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show nor
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
+import "support/fake_pi_session_storage_api.dart";
+
 void main() {
   late List<PiExtensionUiEvent> events;
   late PiExtensionUiService service;
@@ -21,8 +23,8 @@ void main() {
   setUp(() async {
     events = [];
     projectId = normalizeProjectDirectory(directory: "/repo/worktree");
-    final storage = _FakeStorageApi(
-      sessions: [
+    final storage = FakePiExtensionSessionStorageApi(
+      initialSessions: [
         _metadata(id: "root", cwd: "/repo", updated: 3),
         _metadata(id: "child", cwd: "/repo/worktree", updated: 2, parentId: "root"),
       ],
@@ -258,9 +260,9 @@ void main() {
     final gate = Completer<void>();
     final delayed = PiExtensionUiService(
       catalogRepository: PiSessionCatalogRepository(
-        storageApi: _FakeStorageApi(
-          sessions: [_metadata(id: "child", cwd: "/repo", updated: 1)],
-          gate: gate,
+        storageApi: FakePiExtensionSessionStorageApi(
+          initialSessions: [_metadata(id: "child", cwd: "/repo", updated: 1)],
+          listGate: gate,
         ),
       ),
       processRepository: processes.repository,
@@ -288,9 +290,9 @@ void main() {
     final gate = Completer<void>();
     final delayed = PiExtensionUiService(
       catalogRepository: PiSessionCatalogRepository(
-        storageApi: _FakeStorageApi(
-          sessions: [_metadata(id: "child", cwd: "/repo", updated: 1)],
-          gate: gate,
+        storageApi: FakePiExtensionSessionStorageApi(
+          initialSessions: [_metadata(id: "child", cwd: "/repo", updated: 1)],
+          listGate: gate,
         ),
       ),
       processRepository: processes.repository,
@@ -343,7 +345,10 @@ void main() {
   test("catalog failures cancel the unresolved Pi dialog", () async {
     final failing = PiExtensionUiService(
       catalogRepository: PiSessionCatalogRepository(
-        storageApi: _FakeStorageApi(sessions: const [], error: StateError("catalog unavailable")),
+        storageApi: FakePiExtensionSessionStorageApi(
+          initialSessions: const [],
+          listError: StateError("catalog unavailable"),
+        ),
       ),
       processRepository: processes.repository,
       tracker: PiExtensionUiTracker(),
@@ -374,9 +379,9 @@ void main() {
     final gate = Completer<void>();
     final delayed = PiExtensionUiService(
       catalogRepository: PiSessionCatalogRepository(
-        storageApi: _FakeStorageApi(
-          sessions: [_metadata(id: "child", cwd: "/repo", updated: 1)],
-          gate: gate,
+        storageApi: FakePiExtensionSessionStorageApi(
+          initialSessions: [_metadata(id: "child", cwd: "/repo", updated: 1)],
+          listGate: gate,
         ),
       ),
       processRepository: processes.repository,
@@ -407,8 +412,8 @@ void main() {
     await processes.repository.teardown(sessionId: "child");
     final unavailable = PiExtensionUiService(
       catalogRepository: PiSessionCatalogRepository(
-        storageApi: _FakeStorageApi(
-          sessions: [_metadata(id: "child", cwd: "/repo", updated: 1)],
+        storageApi: FakePiExtensionSessionStorageApi(
+          initialSessions: [_metadata(id: "child", cwd: "/repo", updated: 1)],
         ),
       ),
       processRepository: processes.repository,
@@ -452,7 +457,7 @@ final class const _SentReply({
   required final PiExtensionUiReply reply,
 });
 
-final class _ProcessFixture({required final _FakeStorageApi storage}) {
+final class _ProcessFixture({required final FakePiExtensionSessionStorageApi storage}) {
   final List<FakePiProcess> processes = [FakePiProcess()];
   late int generation;
   late final PiSessionProcessRepository repository = PiSessionProcessRepository(
@@ -531,51 +536,5 @@ PiSessionMetadata _metadata({required String id, required String cwd, required i
       createdAt: null,
       updatedAt: DateTime.fromMillisecondsSinceEpoch(updated, isUtc: true),
     );
-
-final class _FakeStorageApi({
-  required final List<PiSessionMetadata> sessions,
-  final Completer<void>? gate,
-  final Object? error,
-}) implements PiSessionStorageApi {
-  @override
-  Future<List<PiSessionMetadata>> listSessionMetadata({required Set<String> knownDirectories}) async {
-    await gate?.future;
-    if (error case final error?) throw error;
-    return sessions;
-  }
-
-  @override
-  Future<String?> resolveEffectiveSessionDirectory({required String directory}) async => null;
-
-  @override
-  Future<void> clearPendingNewSession({required String sessionId, required Set<String> knownDirectories}) async {}
-
-  @override
-  Future<PiPendingNewSession?> readPendingNewSession({
-    required String sessionId,
-    required Set<String> knownDirectories,
-  }) async => null;
-
-  @override
-  Future<void> writePendingNewSession({
-    required String sessionId,
-    required String cwd,
-    required String? parentSessionPath,
-  }) async {}
-
-  @override
-  Future<PiResolvedSession?> resolveSession({required String sessionId, required Set<String> knownDirectories}) async {
-    for (final metadata in sessions) {
-      if (metadata.id == sessionId) return PiResolvedSession(metadata: metadata, path: "/sessions/$sessionId.jsonl");
-    }
-    return null;
-  }
-
-  @override
-  Future<String?> resolveSessionPath({required String sessionId, required Set<String> knownDirectories}) async => null;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
 
 String _repeat(String value, int count) => List.filled(count, value).join();

--- a/bridge/sesori_plugin_pi/test/pi_session_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_catalog_repository_test.dart
@@ -2,11 +2,13 @@ import "package:pi_plugin/pi_plugin.dart";
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show normalizeProjectDirectory;
 import "package:test/test.dart";
 
+import "support/fake_pi_session_storage_api.dart";
+
 void main() {
   group("PiSessionCatalogRepository", () {
     test("maps metadata, normalizes projects, and sorts newest first", () async {
-      final api = _FakeStorageApi(
-        sessions: [
+      final api = FakePiCatalogSessionStorageApi(
+        initialSessions: [
           _metadata(id: "older", cwd: "/repo/./app", updated: 10, created: 5),
           _metadata(id: "newer", cwd: "/repo/app/", updated: 20, created: null, title: "Named"),
         ],
@@ -25,8 +27,8 @@ void main() {
 
     test("filters by normalized project before applying pagination", () async {
       final repository = PiSessionCatalogRepository(
-        storageApi: _FakeStorageApi(
-          sessions: [
+        storageApi: FakePiCatalogSessionStorageApi(
+          initialSessions: [
             _metadata(id: "other", cwd: "/repo/other", updated: 40),
             _metadata(id: "third", cwd: "/repo/app", updated: 30),
             _metadata(id: "second", cwd: "/repo/app", updated: 20),
@@ -45,8 +47,8 @@ void main() {
 
     test("lists direct children using resolved parent ids", () async {
       final repository = PiSessionCatalogRepository(
-        storageApi: _FakeStorageApi(
-          sessions: [
+        storageApi: FakePiCatalogSessionStorageApi(
+          initialSessions: [
             _metadata(id: "root", cwd: "/repo", updated: 30),
             _metadata(id: "child", cwd: "/repo", updated: 20, parentId: "root"),
             _metadata(id: "grandchild", cwd: "/repo", updated: 10, parentId: "child"),
@@ -59,8 +61,8 @@ void main() {
 
     test("resolves the top imported parent and owning worktree project", () async {
       final repository = PiSessionCatalogRepository(
-        storageApi: _FakeStorageApi(
-          sessions: [
+        storageApi: FakePiCatalogSessionStorageApi(
+          initialSessions: [
             _metadata(id: "root", cwd: "/repo", updated: 30),
             _metadata(id: "child", cwd: "/repo/worktree", updated: 20, parentId: "root"),
             _metadata(id: "leaf", cwd: "/repo/worktree", updated: 10, parentId: "child"),
@@ -76,7 +78,7 @@ void main() {
     });
 
     test("retains primed attribution as a scan root after metadata appears", () async {
-      final api = _FakeStorageApi(sessions: const []);
+      final api = FakePiCatalogSessionStorageApi(initialSessions: const []);
       final repository = PiSessionCatalogRepository(storageApi: api);
       repository.primeSessionDirectory(sessionId: "pending", directory: "/repo/new/.");
 
@@ -91,12 +93,12 @@ void main() {
 
       api.sessions = const [];
       await repository.listAllSessions(knownDirectories: const {});
-      expect(api.knownDirectories.last, contains(normalizeProjectDirectory(directory: "/repo/new")));
+      expect(api.listedKnownDirectories.last, contains(normalizeProjectDirectory(directory: "/repo/new")));
     });
 
     test("directory priming preserves pending parent lineage", () async {
       final repository = PiSessionCatalogRepository(
-        storageApi: _FakeStorageApi(sessions: const []),
+        storageApi: FakePiCatalogSessionStorageApi(initialSessions: const []),
       );
       repository.recordPendingSession(
         sessionId: "child",
@@ -113,7 +115,7 @@ void main() {
 
     test("propagates storage failures instead of returning an empty catalog", () async {
       final repository = PiSessionCatalogRepository(
-        storageApi: _FakeStorageApi(sessions: const [], failure: StateError("scan failed")),
+        storageApi: FakePiCatalogSessionStorageApi(initialSessions: const [], listError: StateError("scan failed")),
       );
 
       await expectLater(
@@ -139,29 +141,3 @@ PiSessionMetadata _metadata({
   createdAt: created == null ? null : DateTime.fromMillisecondsSinceEpoch(created, isUtc: true),
   updatedAt: DateTime.fromMillisecondsSinceEpoch(updated, isUtc: true),
 );
-
-final class _FakeStorageApi({required List<PiSessionMetadata> sessions, final Object? failure})
-    implements PiSessionStorageApi {
-  List<PiSessionMetadata> sessions = sessions;
-  final List<Set<String>> knownDirectories = [];
-
-  @override
-  Future<List<PiSessionMetadata>> listSessionMetadata({required Set<String> knownDirectories}) async {
-    this.knownDirectories.add(Set.unmodifiable(knownDirectories));
-    if (failure case final error?) throw error;
-    return sessions;
-  }
-
-  @override
-  Future<String?> resolveEffectiveSessionDirectory({required String directory}) async => null;
-
-  @override
-  Future<PiResolvedSession?> resolveSession({required String sessionId, required Set<String> knownDirectories}) async =>
-      null;
-
-  @override
-  Future<String?> resolveSessionPath({required String sessionId, required Set<String> knownDirectories}) async => null;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}

--- a/bridge/sesori_plugin_pi/test/pi_session_process_repository_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_process_repository_test.dart
@@ -59,7 +59,11 @@ void main() {
       addTearDown(repository.dispose);
       final connecting = repository.ensureResident(sessionId: "session", knownDirectories: const {});
       final initial = await waitForCommand(process: process, type: "get_entries");
-      process.emitResponse(id: initial["id"]! as String, command: "get_entries", data: _historyJson(text: "first"));
+      process.emitResponse(
+        id: initial["id"]! as String,
+        command: "get_entries",
+        data: _historyJson(text: "first"),
+      );
       await connecting;
 
       final pending = repository.loadHistory(sessionId: "session", knownDirectories: const {});
@@ -68,7 +72,11 @@ void main() {
         identities.forSession(sessionId: "session").next(role: PiMessageIdentityRole.user, timestamp: 1),
         "pi:session:user:1:2",
       );
-      process.emitResponse(id: replay["id"]! as String, command: "get_entries", data: _historyJson(text: "first"));
+      process.emitResponse(
+        id: replay["id"]! as String,
+        command: "get_entries",
+        data: _historyJson(text: "first"),
+      );
       await pending;
 
       expect(
@@ -137,7 +145,7 @@ void main() {
     test("missing session throws cause-preserving not found without starting a process", () async {
       var starts = 0;
       final repository = _repository(
-        storageApi: _FakeStorageApi(missing: true),
+        storageApi: _MissingProcessStorage(),
         processFactory: ({required spec}) async {
           starts++;
           return FakePiProcess();
@@ -173,7 +181,7 @@ void main() {
         ].map(jsonEncode).join("\n"),
       );
       final process = FakePiProcess();
-      final storage = _FakeStorageApi(path: path);
+      final storage = _ProcessStorage(path: path);
       final repository = _repository(
         storageApi: storage,
         processFactory: ({required spec}) async {
@@ -204,7 +212,7 @@ void main() {
 
     test("does not fall back for arbitrary send failure", () async {
       final process = FakePiProcess(stdinWritesFail: true);
-      final storage = _FakeStorageApi();
+      final storage = _ProcessStorage();
       final repository = _repository(
         storageApi: storage,
         processFactory: ({required spec}) async => process,
@@ -229,7 +237,7 @@ void main() {
     });
 
     test("falls back when exact no-model startup surfaces as stdin failure", () async {
-      final storage = _FakeStorageApi(
+      final storage = _ProcessStorage(
         history: PiSessionFileHistoryDto(
           header: const PiSessionFileHeaderDto(version: 3, id: "session"),
           entries: [_fileUserEntry(id: "entry", parentId: null, text: "from file", timestamp: 1)],
@@ -329,7 +337,7 @@ void main() {
     });
 
     test("migrates v1 file entries into a linear active branch", () async {
-      final storage = _FakeStorageApi(
+      final storage = _ProcessStorage(
         history: PiSessionFileHistoryDto(
           header: const PiSessionFileHeaderDto(version: null, id: "session"),
           entries: [
@@ -345,7 +353,7 @@ void main() {
     });
 
     test("migrates v2 hookMessage role to visible custom content", () async {
-      final storage = _FakeStorageApi(
+      final storage = _ProcessStorage(
         history: PiSessionFileHistoryDto(
           header: const PiSessionFileHeaderDto(version: 2, id: "session"),
           entries: [
@@ -417,7 +425,7 @@ PiSessionProcessRepository _repository({
   Duration startupExitTimeout = const Duration(seconds: 5),
   Duration historyRpcTimeout = const Duration(minutes: 2),
 }) {
-  final storage = storageApi ?? _FakeStorageApi();
+  final storage = storageApi ?? _ProcessStorage();
   return PiSessionProcessRepository(
     storageApi: storage,
     historyStorageApi: _FakeHistoryStorageApi(storageApi: storage),
@@ -478,7 +486,7 @@ PiSessionFileEntryDto _fileUserEntry({
   ),
 );
 
-Future<List<PluginMessageWithParts>> _loadFileFallback({required _FakeStorageApi storage}) {
+Future<List<PluginMessageWithParts>> _loadFileFallback({required _ProcessStorage storage}) {
   final process = FakePiProcess();
   return _repository(
     storageApi: storage,
@@ -490,19 +498,27 @@ Future<List<PluginMessageWithParts>> _loadFileFallback({required _FakeStorageApi
   ).loadHistory(sessionId: "session", knownDirectories: const {});
 }
 
-final class _FakeStorageApi({
-  bool missing = false,
+final class _MissingProcessStorage() implements PiSessionStorageApi {
+  @override
+  Future<void> clearPendingNewSession({required String sessionId, required Set<String> knownDirectories}) async {}
+
+  @override
+  Future<PiResolvedSession?> resolveSession({required String sessionId, required Set<String> knownDirectories}) async =>
+      null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+final class _ProcessStorage({
   final String path = "/exact/session.jsonl",
   final PiSessionFileHistoryDto? history,
 }) implements PiSessionStorageApi {
-  final bool _missing = missing;
-
   @override
   Future<void> clearPendingNewSession({required String sessionId, required Set<String> knownDirectories}) async {}
 
   @override
   Future<PiResolvedSession?> resolveSession({required String sessionId, required Set<String> knownDirectories}) async {
-    if (_missing) return null;
     return PiResolvedSession(
       metadata: PiSessionMetadata(
         id: sessionId,
@@ -523,7 +539,7 @@ final class _FakeStorageApi({
 final class _FakeHistoryStorageApi({required super.storageApi}) extends PiSessionHistoryStorageApi {
   @override
   Future<PiSessionFileHistoryDto> readSessionHistory({required String path}) {
-    if (storageApi case _FakeStorageApi(:final history?)) return Future.value(history);
+    if (storageApi case _ProcessStorage(:final history?)) return Future.value(history);
     return PiSessionHistoryStorageApi(
       storageApi: PiSessionStorageApi(environment: const {}),
     ).readSessionHistory(path: path);

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -17,11 +17,12 @@ import "package:pi_plugin/src/trackers/pi_tool_tracker.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
+import "support/fake_pi_session_storage_api.dart";
 import "support/pi_rpc_client_test_factory.dart";
 
 void main() {
   test("new session preparation generates a valid secure id and persists its marker", () async {
-    final storage = _Storage(initialResolved: null);
+    final storage = _Storage(initialResolvedSession: null);
     final fixture = _Fixture(processes: const [], storageOverride: storage);
     addTearDown(fixture.dispose);
     final service = fixture.service();
@@ -37,7 +38,7 @@ void main() {
   });
 
   test("prepared sessions retain their marker directory until deletion", () async {
-    final storage = _Storage(initialResolved: null);
+    final storage = _Storage(initialResolvedSession: null);
     final fixture = _Fixture(processes: const [], storageOverride: storage);
     addTearDown(fixture.dispose);
     final service = fixture.service();
@@ -51,7 +52,7 @@ void main() {
 
   test("persisted turns do not rescan pending marker storage", () async {
     final process = FakePiProcess();
-    final storage = _Storage(initialResolved: _resolved());
+    final storage = _Storage(initialResolvedSession: _resolved());
     final fixture = _Fixture(processes: [process], storageOverride: storage);
     addTearDown(fixture.dispose);
     final service = fixture.service();
@@ -98,8 +99,8 @@ void main() {
   test("resolved session clears stale marker before startup and cleanup failure remains best-effort", () async {
     final process = FakePiProcess();
     final storage = _Storage(
-      initialResolved: _resolved(),
-      initialPending: const PiPendingNewSession(id: "session", cwd: "/pending", parentSessionPath: null),
+      initialResolvedSession: _resolved(),
+      initialPendingNewSession: const PiPendingNewSession(id: "session", cwd: "/pending", parentSessionPath: null),
     );
     final fixture = _Fixture(processes: [process], storageOverride: storage);
     addTearDown(fixture.dispose);
@@ -113,7 +114,7 @@ void main() {
 
     final failedCleanupProcess = FakePiProcess();
     final failedCleanupStorage = _Storage(
-      initialResolved: _resolved(id: "other"),
+      initialResolvedSession: _resolved(id: "other"),
       clearError: StateError("marker cleanup failed"),
     );
     final failedCleanupFixture = _Fixture(
@@ -138,8 +139,8 @@ void main() {
     final resumed = FakePiProcess();
     final created = FakePiProcess();
     final storage = _Storage(
-      initialResolved: _resolved(),
-      initialPending: const PiPendingNewSession(id: "session", cwd: "/pending", parentSessionPath: null),
+      initialResolvedSession: _resolved(),
+      initialPendingNewSession: const PiPendingNewSession(id: "session", cwd: "/pending", parentSessionPath: null),
     );
     final fixture = _Fixture(processes: [resumed, created], storageOverride: storage);
     addTearDown(fixture.dispose);
@@ -161,7 +162,7 @@ void main() {
 
   test("new session clears its pending marker once persistence becomes observable", () async {
     final process = FakePiProcess();
-    final storage = _Storage(initialResolved: null);
+    final storage = _Storage(initialResolvedSession: null);
     final fixture = _Fixture(processes: [process], storageOverride: storage);
     addTearDown(fixture.dispose);
     final service = fixture.service();
@@ -191,7 +192,7 @@ void main() {
 
   test("fork preparation resolves a parent from its own project directory", () async {
     final storage = _Storage(
-      initialResolved: PiResolvedSession(
+      initialResolvedSession: PiResolvedSession(
         metadata: PiSessionMetadata(
           id: "parent",
           cwd: "/parent-project",
@@ -233,7 +234,7 @@ void main() {
   test("teardown fences and reaps a process whose spawn completes late", () async {
     final process = FakePiProcess();
     final spawn = Completer<PiProcessHandle>();
-    final storage = _Storage(initialResolved: _resolved());
+    final storage = _Storage(initialResolvedSession: _resolved());
     final identities = PiMessageIdentityTracker(pluginId: "pi");
     final repository = PiSessionProcessRepository(
       storageApi: storage,
@@ -321,7 +322,7 @@ void main() {
       final transient = FakePiProcess();
       final resident = FakePiProcess();
       final gate = Completer<void>();
-      final storage = _Storage(initialResolved: _resolved(), resolveGate: gate);
+      final storage = _Storage(initialResolvedSession: _resolved(), resolveGate: gate);
       final fixture = _Fixture(processes: [transient, resident], storageOverride: storage);
       addTearDown(fixture.dispose);
 
@@ -1517,7 +1518,7 @@ void main() {
 
   test("idle reap preserves pending marker location for later deletion", () async {
     final process = FakePiProcess();
-    final storage = _Storage(initialResolved: null);
+    final storage = _Storage(initialResolvedSession: null);
     final fixture = _Fixture(processes: [process], storageOverride: storage);
     final clock = _ManualClock();
     final service = fixture.service(clock: clock);
@@ -1681,7 +1682,7 @@ final class _Fixture({
   final Duration historyRpcTimeout = const Duration(seconds: 2),
 }) {
   final List<FakePiProcess> _processes = List.of(processes);
-  late final _Storage storage = storageOverride ?? _Storage(initialResolved: _resolved());
+  late final _Storage storage = storageOverride ?? _Storage(initialResolvedSession: _resolved());
   final List<PiLaunchSpec> spawned = [];
   late final PiMessageIdentityTracker identities = PiMessageIdentityTracker(pluginId: "pi");
   late final PiHistoryMapper historyMapper = PiHistoryMapper(pluginId: "pi");
@@ -1740,16 +1741,24 @@ final class _Fixture({
 }
 
 final class _Storage({
-  required final PiResolvedSession? initialResolved,
-  final PiPendingNewSession? initialPending,
+  required super.initialResolvedSession,
+  super.initialPendingNewSession,
   final Completer<void>? resolveGate,
-  final Object? clearError,
+  super.clearError,
   final String? requiredKnownDirectory,
-}) implements PiSessionStorageApi {
-  PiResolvedSession? resolved = initialResolved;
-  PiPendingNewSession? pending = initialPending;
-  Set<String>? clearedDirectories;
-  int resolveCalls = 0;
+}) extends FakePiServiceSessionStorageApi {
+  PiResolvedSession? get resolved => resolvedSession;
+  set resolved(PiResolvedSession? value) => resolvedSession = value;
+  PiPendingNewSession? get pending => pendingNewSession;
+  set pending(PiPendingNewSession? value) => pendingNewSession = value;
+  Set<String>? get clearedDirectories => clearedKnownDirectories;
+
+  @override
+  Future<void> clearPendingNewSession({required String sessionId, required Set<String> knownDirectories}) async {
+    if (clearError case final error?) throw error;
+    await super.clearPendingNewSession(sessionId: sessionId, knownDirectories: knownDirectories);
+  }
+
   @override
   Future<PiResolvedSession?> resolveSession({required String sessionId, required Set<String> knownDirectories}) async {
     resolveCalls++;
@@ -1759,38 +1768,9 @@ final class _Storage({
   }
 
   @override
-  Future<String?> resolveSessionPath({required String sessionId, required Set<String> knownDirectories}) async =>
-      (await resolveSession(sessionId: sessionId, knownDirectories: knownDirectories))?.path;
-
-  @override
-  Future<PiPendingNewSession?> readPendingNewSession({
-    required String sessionId,
-    required Set<String> knownDirectories,
-  }) async => pending;
-
-  @override
-  Future<void> clearPendingNewSession({required String sessionId, required Set<String> knownDirectories}) async {
-    if (clearError case final error?) throw error;
-    clearedDirectories = Set.of(knownDirectories);
-    pending = null;
-  }
-
-  @override
-  Future<void> writePendingNewSession({
-    required String sessionId,
-    required String cwd,
-    required String? parentSessionPath,
-  }) async {
-    pending = PiPendingNewSession(id: sessionId, cwd: cwd, parentSessionPath: parentSessionPath);
-  }
-
-  @override
   Future<List<PiSessionMetadata>> listSessionMetadata({required Set<String> knownDirectories}) async => [
     if (resolved case PiResolvedSession(:final metadata)) metadata,
   ];
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 final class _HistoryStorage({required super.storageApi}) extends PiSessionHistoryStorageApi {

--- a/bridge/sesori_plugin_pi/test/support/fake_pi_session_storage_api.dart
+++ b/bridge/sesori_plugin_pi/test/support/fake_pi_session_storage_api.dart
@@ -1,0 +1,132 @@
+import "dart:async";
+
+import "package:pi_plugin/pi_plugin.dart";
+
+class FakePiSessionStorageApi({
+  final List<PiSessionMetadata> initialSessions = const [],
+  final PiResolvedSession? initialResolvedSession,
+  final PiPendingNewSession? initialPendingNewSession,
+  final Completer<void>? listGate,
+  final Object? listError,
+  final Object? clearError,
+}) implements PiSessionStorageApi {
+  late List<PiSessionMetadata> sessions = initialSessions;
+  late PiResolvedSession? resolvedSession = initialResolvedSession;
+  late PiPendingNewSession? pendingNewSession = initialPendingNewSession;
+  final List<Set<String>> listedKnownDirectories = [];
+  Set<String>? clearedKnownDirectories;
+  int resolveCalls = 0;
+
+  Future<List<PiSessionMetadata>> list() async {
+    await listGate?.future;
+    if (listError case final error?) throw error;
+    return sessions;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+final class FakePiCatalogSessionStorageApi({
+  super.initialSessions,
+  super.listGate,
+  super.listError,
+}) extends FakePiSessionStorageApi {
+  @override
+  Future<List<PiSessionMetadata>> listSessionMetadata({required Set<String> knownDirectories}) {
+    listedKnownDirectories.add(Set.unmodifiable(knownDirectories));
+    return list();
+  }
+
+  @override
+  Future<String?> resolveEffectiveSessionDirectory({required String directory}) async => null;
+
+  @override
+  Future<PiResolvedSession?> resolveSession({required String sessionId, required Set<String> knownDirectories}) async =>
+      null;
+
+  @override
+  Future<String?> resolveSessionPath({required String sessionId, required Set<String> knownDirectories}) async => null;
+}
+
+final class FakePiExtensionSessionStorageApi({
+  super.initialSessions,
+  super.listGate,
+  super.listError,
+}) extends FakePiSessionStorageApi {
+  @override
+  Future<List<PiSessionMetadata>> listSessionMetadata({required Set<String> knownDirectories}) => list();
+
+  @override
+  Future<String?> resolveEffectiveSessionDirectory({required String directory}) async => null;
+
+  @override
+  Future<PiResolvedSession?> resolveSession({required String sessionId, required Set<String> knownDirectories}) async {
+    for (final metadata in sessions) {
+      if (metadata.id == sessionId) {
+        return PiResolvedSession(metadata: metadata, path: "/sessions/$sessionId.jsonl");
+      }
+    }
+    return null;
+  }
+
+  @override
+  Future<String?> resolveSessionPath({required String sessionId, required Set<String> knownDirectories}) async => null;
+
+  @override
+  Future<PiPendingNewSession?> readPendingNewSession({
+    required String sessionId,
+    required Set<String> knownDirectories,
+  }) async => null;
+
+  @override
+  Future<void> clearPendingNewSession({required String sessionId, required Set<String> knownDirectories}) async {}
+
+  @override
+  Future<void> writePendingNewSession({
+    required String sessionId,
+    required String cwd,
+    required String? parentSessionPath,
+  }) async {}
+}
+
+class FakePiServiceSessionStorageApi({
+  required super.initialResolvedSession,
+  super.initialPendingNewSession,
+  super.clearError,
+}) extends FakePiSessionStorageApi {
+  @override
+  Future<PiResolvedSession?> resolveSession({required String sessionId, required Set<String> knownDirectories}) async {
+    resolveCalls++;
+    return resolvedSession;
+  }
+
+  @override
+  Future<String?> resolveSessionPath({required String sessionId, required Set<String> knownDirectories}) async =>
+      (await resolveSession(sessionId: sessionId, knownDirectories: knownDirectories))?.path;
+
+  @override
+  Future<PiPendingNewSession?> readPendingNewSession({
+    required String sessionId,
+    required Set<String> knownDirectories,
+  }) async => pendingNewSession;
+
+  @override
+  Future<void> clearPendingNewSession({required String sessionId, required Set<String> knownDirectories}) async {
+    if (clearError case final error?) throw error;
+    clearedKnownDirectories = Set.of(knownDirectories);
+    pendingNewSession = null;
+  }
+
+  @override
+  Future<void> writePendingNewSession({
+    required String sessionId,
+    required String cwd,
+    required String? parentSessionPath,
+  }) async {
+    pendingNewSession = PiPendingNewSession(id: sessionId, cwd: cwd, parentSessionPath: parentSessionPath);
+  }
+
+  @override
+  Future<List<PiSessionMetadata>> listSessionMetadata({required Set<String> knownDirectories}) async => sessions;
+}


### PR DESCRIPTION
## Complexity

Straightforward. This is test-only consolidation across three plugin packages, with strict fake capability differences preserved explicitly.

## What

- Consolidate three OpenCode API fakes into `FakeOpenCodeApi` and share default-shaped `Project`/`Session` fixtures.
- Add `composeTestAcpPlugin` and replace 14 repeated neutral ACP plugin compositions across 11 tests.
- Add capability-specific Pi catalog, extension, and service storage fakes while retaining strict process/history variants locally.
- Record current-main scope, review corrections, verification, and the deletion-heavy size overage in `steps/step-11.md`.

## Why

Plugin tests repeated large API surfaces and collaborator wiring. Package-local support removes that duplication without moving backend-specific behavior into shared production code or weakening fail-loud test paths.

## Risk and test focus

There is no user-visible or database impact. The main risk is changing fake behavior so a production call is filtered early or unexpectedly succeeds; review corrected OpenCode root filtering and Pi capability defaults, and follow-up review found no remaining OpenCode issue. ACP consumers were verified to receive fresh, consistently shared trackers per plugin composition.

## Expected result

OpenCode, ACP, and Pi tests use smaller package-local fixtures and builders, specialized backend behavior remains local, and the three package trees end with 769 fewer test/support lines.

## Verification

- `dart analyze --fatal-infos` in OpenCode, ACP, Pi, Cursor, OMP, and Hermes
- `dart test` in OpenCode (434), ACP (260), Pi (260), Cursor (136), OMP (52), and Hermes (38)
- 1,180 tests passed total

Architecture implementation review was not run because the ACP export is explicitly test-only and this PR changes no production architecture or contract.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates test fakes and composition helpers for `opencode_plugin`, `sesori_plugin_acp`, and `pi_plugin` to remove duplication while preserving strict, backend-specific behavior. Old tests hand-wired large surfaces per file; new tests use package-local fakes and a single ACP composition helper, yielding smaller, clearer tests with no production impact.

- OpenCode: Replace three fakes with a single configurable `FakeOpenCodeApi`; share `openCodeProject` and `openCodeSession` fixtures. Root-session filtering is now explicit via `filterRootSessions`. Verify global-project mapping and root filtering in updated tests.
- ACP: Add `composeTestAcpPlugin` that creates fresh `AcpCommandTracker` and `AcpSessionConfigurationTracker` and wires them consistently to the event mapper and session options service. `launchSpec` remains overridable.
- Pi: Add capability-specific session storage fakes for catalog, extension UI, and service while keeping strict process/history variants local. Tests cover pagination and project normalization paths.
- Size and scope: Net −769 test/support lines across the three packages; no database or user-visible changes; no production contracts changed.
- Verification: dart analyze with fatal infos across packages; 1,180 tests pass.

<sup>Written for commit 93d76ddf074351c339ef62f39cc3c8b7a3cfe41e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

