### PR TITLE
🌿 Prevent row swipe animations during back gestures

### DIFF
--- a/client/module_prego/lib/interactions/prego_swipe_actions.dart
+++ b/client/module_prego/lib/interactions/prego_swipe_actions.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
 import 'package:material_ui/material_ui.dart';
 
@@ -51,6 +52,11 @@ typedef PregoSwipeActionBuilder = Widget Function(BuildContext context, VoidCall
 /// an alternative path to the same actions (the project row's long-press
 /// menu). While a side is closed its actions are excluded from semantics and
 /// focus traversal entirely, so the row still reads as one button.
+///
+/// Touch drags beginning at a system-back edge stay out of this row's gesture
+/// arena: the leading 10% on iOS, and both 10% edges on Android when the view
+/// reports gesture-navigation insets. Button-navigation Android and all other
+/// platforms retain the full row as a swipe target.
 class const PregoSwipeActions({
   super.key,
 
@@ -115,6 +121,9 @@ const double _commitClearance = 64;
 /// fling settles the row open from any distance, a closing fling settles it
 /// shut and cancels a pending commit.
 const double _flingVelocity = 700;
+
+/// The row-width fraction reserved for a system back gesture where one exists.
+const double _systemBackGestureExclusionFraction = 0.1;
 
 /// One build's strip children, captured as a unit when a close settle begins.
 typedef _StripChildren = ({List<Widget> actions, Widget primary, Widget? leadingPrimary});
@@ -186,6 +195,8 @@ class _PregoSwipeActionsState() extends State<PregoSwipeActions> with SingleTick
 
   @override
   Widget build(BuildContext context) {
+    final gestureSettings = MediaQuery.maybeGestureSettingsOf(context);
+    final scrollBehavior = ScrollConfiguration.of(context);
     final strips =
         _frozenStrips ??
         (
@@ -200,11 +211,23 @@ class _PregoSwipeActionsState() extends State<PregoSwipeActions> with SingleTick
 
     final row = TapRegion(
       onTapOutside: (_) => _handleTapOutside(),
-      child: GestureDetector(
-        onHorizontalDragStart: _handleDragStart,
-        onHorizontalDragUpdate: _handleDragUpdate,
-        onHorizontalDragEnd: _handleDragEnd,
-        onHorizontalDragCancel: _handleDragCancel,
+      child: RawGestureDetector(
+        gestures: <Type, GestureRecognizerFactory>{
+          _EdgeSafeHorizontalDragGestureRecognizer:
+              GestureRecognizerFactoryWithHandlers<_EdgeSafeHorizontalDragGestureRecognizer>(
+                () => _EdgeSafeHorizontalDragGestureRecognizer(debugOwner: this),
+                (recognizer) {
+                  recognizer
+                    ..onStart = _handleDragStart
+                    ..onUpdate = _handleDragUpdate
+                    ..onEnd = _handleDragEnd
+                    ..onCancel = _handleDragCancel
+                    ..multitouchDragStrategy = scrollBehavior.getMultitouchDragStrategy(context)
+                    ..gestureSettings = gestureSettings
+                    ..isStartAllowed = (event) => _allowsDragStart(context: context, event: event);
+                },
+              ),
+        },
         child: LayoutBuilder(
           builder: (context, constraints) {
             _rowWidth = constraints.maxWidth;
@@ -305,6 +328,28 @@ class _PregoSwipeActionsState() extends State<PregoSwipeActions> with SingleTick
   }
 
   // ── Gesture handling ───────────────────────────────────────────────────────
+
+  bool _allowsDragStart({required BuildContext context, required PointerEvent event}) {
+    if (event.kind != PointerDeviceKind.touch || _rowWidth <= 0) return true;
+
+    final platform = Theme.of(context).platform;
+    final usesAndroidGestureNavigation =
+        platform == TargetPlatform.android && _usesAndroidGestureNavigation(context: context);
+    final excludeStart = platform == TargetPlatform.iOS || usesAndroidGestureNavigation;
+    final excludeEnd = usesAndroidGestureNavigation;
+    if (!excludeStart && !excludeEnd) return true;
+
+    final fromStart = Directionality.of(context) == TextDirection.ltr
+        ? event.localPosition.dx
+        : _rowWidth - event.localPosition.dx;
+    final exclusion = _rowWidth * _systemBackGestureExclusionFraction;
+    return (!excludeStart || fromStart > exclusion) && (!excludeEnd || fromStart < _rowWidth - exclusion);
+  }
+
+  bool _usesAndroidGestureNavigation({required BuildContext context}) {
+    final insets = MediaQuery.maybeSystemGestureInsetsOf(context);
+    return insets != null && (insets.left > 0 || insets.right > 0);
+  }
 
   void _handleDragStart(DragStartDetails details) {
     _dragging = true;
@@ -467,6 +512,13 @@ class _PregoSwipeActionsState() extends State<PregoSwipeActions> with SingleTick
     _watchedScroll?.removeListener(_handleScroll);
     _watchedScroll = null;
   }
+}
+
+class _EdgeSafeHorizontalDragGestureRecognizer({required super.debugOwner}) extends HorizontalDragGestureRecognizer {
+  late bool Function(PointerEvent event) isStartAllowed;
+
+  @override
+  bool isPointerAllowed(PointerEvent event) => super.isPointerAllowed(event) && isStartAllowed(event);
 }
 
 /// One side of a [PregoSwipeActions] row — the trailing strip or the leading

--- a/client/module_prego/test/interactions/prego_swipe_actions_test.dart
+++ b/client/module_prego/test/interactions/prego_swipe_actions_test.dart
@@ -92,9 +92,15 @@ Widget _harness({
   required List<Widget> rows,
   ScrollController? scrollController,
   TextDirection textDirection = TextDirection.ltr,
+  TargetPlatform? platform,
+  EdgeInsets systemGestureInsets = EdgeInsets.zero,
 }) {
   return MaterialApp(
-    theme: ThemeData(extensions: [PregoDesignSystem.light]),
+    theme: ThemeData(platform: platform, extensions: [PregoDesignSystem.light]),
+    builder: (context, child) => MediaQuery(
+      data: MediaQuery.of(context).copyWith(systemGestureInsets: systemGestureInsets),
+      child: child!,
+    ),
     home: Directionality(
       textDirection: textDirection,
       child: Scaffold(
@@ -113,6 +119,11 @@ Widget _harness({
 /// Drags [label]'s row horizontally by [dx] and lets it settle.
 Future<void> _swipe(WidgetTester tester, {required String label, required double dx}) async {
   await tester.drag(find.text('$label content'), Offset(dx, 0));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _swipeFrom(WidgetTester tester, {required Offset origin, required double dx}) async {
+  await tester.dragFrom(origin, Offset(dx, 0));
   await tester.pumpAndSettle();
 }
 
@@ -457,6 +468,85 @@ void main() {
 
     expect(counters.fullSwipes, 0);
     // ~190px extent at release — past half the reveal, so it settles open.
+    expect(_primaryRect(tester, 'A').left, lessThan(_surfaceWidth));
+  });
+
+  testWidgets('Android gesture navigation leaves both row edges to system back gestures', (tester) async {
+    final counters = _Counters();
+    await tester.pumpWidget(
+      _harness(
+        rows: [_row(label: 'A', counters: counters, leadingWidth: _leadingWidth)],
+        platform: TargetPlatform.android,
+        systemGestureInsets: const EdgeInsets.symmetric(horizontal: 24),
+      ),
+    );
+
+    await _swipeFrom(tester, origin: const Offset(40, 48), dx: 120);
+    expect(_leadingRect(tester, 'A').right, lessThanOrEqualTo(0));
+
+    await _swipeFrom(tester, origin: const Offset(760, 48), dx: -150);
+    expect(_primaryRect(tester, 'A').left, greaterThanOrEqualTo(_surfaceWidth));
+    expect(counters.leadingFullSwipes, 0);
+    expect(counters.fullSwipes, 0);
+
+    await _swipeFrom(tester, origin: const Offset(100, 48), dx: 120);
+    expect(_leadingRect(tester, 'A').left, moreOrLessEquals(16, epsilon: 1));
+  });
+
+  testWidgets('Android button navigation keeps swipe actions active at both row edges', (tester) async {
+    final counters = _Counters();
+    await tester.pumpWidget(
+      _harness(
+        rows: [_row(label: 'A', counters: counters, leadingWidth: _leadingWidth)],
+        platform: TargetPlatform.android,
+      ),
+    );
+
+    await _swipeFrom(tester, origin: const Offset(40, 48), dx: 120);
+    expect(_leadingRect(tester, 'A').left, moreOrLessEquals(16, epsilon: 1));
+
+    await tester.tap(find.text('A content'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+    await _swipeFrom(tester, origin: const Offset(760, 48), dx: -150);
+    expect(_primaryRect(tester, 'A').left, lessThan(_surfaceWidth));
+  });
+
+  testWidgets('iOS leaves only the directional start edge to back navigation', (tester) async {
+    final counters = _Counters();
+    await tester.pumpWidget(
+      _harness(
+        rows: [_row(label: 'A', counters: counters, leadingWidth: _leadingWidth)],
+        platform: TargetPlatform.iOS,
+      ),
+    );
+
+    await _swipeFrom(tester, origin: const Offset(40, 48), dx: 120);
+    expect(_leadingRect(tester, 'A').right, lessThanOrEqualTo(0));
+
+    await _swipeFrom(tester, origin: const Offset(100, 48), dx: 120);
+    expect(_leadingRect(tester, 'A').left, moreOrLessEquals(16, epsilon: 1));
+
+    await tester.tap(find.text('A content'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+    await _swipeFrom(tester, origin: const Offset(760, 48), dx: -150);
+    expect(_primaryRect(tester, 'A').left, lessThan(_surfaceWidth));
+  });
+
+  testWidgets('other platforms keep swipe actions active at both row edges', (tester) async {
+    final counters = _Counters();
+    await tester.pumpWidget(
+      _harness(
+        rows: [_row(label: 'A', counters: counters, leadingWidth: _leadingWidth)],
+        platform: TargetPlatform.macOS,
+      ),
+    );
+
+    await _swipeFrom(tester, origin: const Offset(40, 48), dx: 120);
+    expect(_leadingRect(tester, 'A').left, moreOrLessEquals(16, epsilon: 1));
+
+    await tester.tap(find.text('A content'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+    await _swipeFrom(tester, origin: const Offset(760, 48), dx: -150);
     expect(_primaryRect(tester, 'A').left, lessThan(_surfaceWidth));
   });
 

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -26,6 +26,11 @@ child sessions with titles, activity, statuses, and unseen state.
 - Opening validates the path and surfaces the git-initialization choice. Hiding
   delists without destroying sessions or history. Import is explicit, per
   plugin, atomic, non-destructive, cancellable, and attributes progress.
+- Project and session row actions remain swipeable without competing visually
+  with system back navigation. On iOS, drags beginning in the row's leading 10%
+  are reserved for back; on Android gesture navigation, both 10% edges are
+  reserved. Android button navigation and other platforms retain the full row
+  as a swipe target.
 - A session created in a dedicated worktree receives a system prompt identifying
   that worktree, its initial branch, and base branch. The prompt requires all
   work to remain in that worktree, while permitting use of the initial branch,
@@ -81,7 +86,7 @@ child sessions with titles, activity, statuses, and unseen state.
 |---|---|
 | L1 Smoke | Headless bridge, representative plugin: project list and one project's session list return committed data with plugin attribution. |
 | L2 Routine | Headless bridge, representative plugin: open, rename, hide; create a session and see it listed before metadata, then observe generated title and eligible branch refinement through the existing session update without unseen change; unseen otherwise advances and clears; the existing activity marker appears in REST and live list-state projections; statuses report idle/busy. |
-| L3 Release | Client end to end (phone): every supporting production plugin still covers native/derived ownership, import, and child resolution; Pi imports configured/default/known roots with explicit names and resolvable lineage; one representative plugin proves two running roots and two projects with running roots reorder after committed user-side activity, inactive session/project order is unchanged, a live patch reorders without another status event or project summary, and omitted ordering facts use updated-time fallbacks. Focused ACP protocol and client ordering tests prove the exact awaiting-only state is not promoted because normal production root prompts remain running while awaiting input. Lists and unseen badges render. |
+| L3 Release | Client end to end (phone): every supporting production plugin still covers native/derived ownership, import, and child resolution; Pi imports configured/default/known roots with explicit names and resolvable lineage; one representative plugin proves two running roots and two projects with running roots reorder after committed user-side activity, inactive session/project order is unchanged, a live patch reorders without another status event or project summary, and omitted ordering facts use updated-time fallbacks. Focused ACP protocol and client ordering tests prove the exact awaiting-only state is not promoted because normal production root prompts remain running while awaiting input. Lists and unseen badges render; project and session row swipes stay inert from the iOS back edge and both Android gesture-navigation edges while remaining active at unreserved edges and under Android button navigation. |
 | L4 Extended | Relay integration, every supporting production plugin: bridge and plugin restart preserve identity and overrides; a moved backend-native project keeps them while a moved bridge-derived project is discovered as new without mutating the old catalog; a cancelled or failed import leaves the prior catalog intact; reads during import stay consistent; an unavailable plugin is reported while others keep listing. |
 | L5 Full | Client end to end, every supporting production plugin: multiple clients observe consistent listings and unseen transitions; large catalogs and paged listings behave; unattributed payloads resolve to the historical identity. |
 
@@ -94,6 +99,9 @@ disposable sessions and projects and restore hidden-state changes afterwards.
 For activity order, vary REST versus live delivery, null versus populated
 markers, ties, awaiting-only versus running state, and assistant/tool updates
 after a marker has been established.
+For list-row swipes, alternate iOS, Android gesture navigation, Android button
+navigation, and a non-mobile platform; begin drags inside and just outside each
+10% edge buffer.
 
 ## Failure Signals
 
@@ -113,6 +121,8 @@ after a marker has been established.
   the top of its list while still displaying that stale time.
 - Unseen never clears, clears without viewing, or an unavailable plugin is idle.
 - Hiding destroys sessions, or a cancelled import destroys the committed catalog.
+- A project or session row animates under a system back gesture, or an edge that
+  has no active system back gesture stops accepting row actions.
 - A generated title/branch update fails to reach list/detail, changes unseen,
   moves the worktree, or rewrites the backend's creation-time system context.
 
@@ -149,7 +159,10 @@ after a marker has been established.
   `bridge/sesori_plugin_pi/test/pi_session_catalog_repository_test.dart`,
   `client/module_core/test/services/session_list_service_test.dart`,
   `client/module_core/test/services/session_unseen_tracker_test.dart`,
-  `client/module_core/test/cubits/session_list/session_list_cubit_test.dart`
+  `client/module_core/test/cubits/session_list/session_list_cubit_test.dart`,
+  `client/module_prego/test/interactions/prego_swipe_actions_test.dart`
+- Client row swipe behavior:
+  `client/module_prego/lib/interactions/prego_swipe_actions.dart`
 - Plans (discovery only): `.plan/completed/multi-plugin-release-prep`,
   `setup-aware-plugin-management`, `relay-request-concurrency`;
   `.plan/active/session-user-interaction-order`


### PR DESCRIPTION
## Complexity

Straightforward. The change stays inside the existing shared swipe primitive and adds a focused gesture recognizer plus platform-matrix coverage.

## What

- Reject touch drags that begin in the leading 10% of a swipe row on iOS.
- Reject touch drags that begin in either 10% edge on Android only when horizontal `MediaQuery.systemGestureInsets` indicate gesture navigation.
- Preserve full-width row swipes for Android button navigation, non-mobile platforms, and non-touch input.
- Add focused widget coverage and update the projects-and-sessions regression contract.

## Why

Android back gestures could animate a project or session row at the same time as the system back transition. Reserving the active system-back edges prevents the competing row animation without changing the action behavior away from those edges.

## Risk and test focus

User-visible impact is limited to where project and session row swipes may begin. There is no database, persisted-state, transport, authentication, or analytics impact.

Review should focus on gesture-arena rejection, directional iOS behavior, Android gesture-navigation detection, and preserving edge swipes under Android button navigation and other platforms.

## Expected result

System back gestures no longer move project or session rows. Swipe actions still work immediately outside the 10% buffer and everywhere no conflicting system gesture exists.

## Verification

- `flutter test test/interactions/prego_swipe_actions_test.dart` in `client/module_prego`
- `flutter test test/features/project_list/project_tile_swipe_test.dart test/features/session_list/session_tile_swipe_test.dart` in `client/app`
- `dart analyze` in `client/module_prego`
- `dart analyze` in `client/app`
- `flutter build ios --simulator --debug --no-codesign` in `client/app`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents project and session rows from animating during system back gestures. Previously, a back swipe could drag a row; now drags that start within a 10% edge buffer are rejected, while swipe actions remain available outside the buffer and on platforms without conflicting back gestures.

- Review notes:
  - iOS: reserves the leading 10% of the row; Android gesture navigation: reserves both 10% edges using `MediaQuery.systemGestureInsets`; Android button navigation and other platforms keep full-width swipes.
  - Uses a custom horizontal drag recognizer to block drag starts in reserved edges; preserves gesture arena behavior, `ScrollConfiguration` multitouch strategy, and RTL awareness.
  - Non-touch input paths are unchanged; semantics and focus traversal remain intact.

- Verification:
  - Run tests in `client/module_prego` and `client/app`: `flutter test test/interactions/prego_swipe_actions_test.dart`, `test/features/project_list/project_tile_swipe_test.dart`, `test/features/session_list/session_tile_swipe_test.dart`.
  - Analyze and build: `dart analyze` in both apps and `flutter build ios --simulator --debug --no-codesign`.

<sup>Written for commit 5f6e52fab463481035b73047f0fee39c1e1262f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

