### PR TITLE
⚙️ Resolve session timestamp gesture conflicts

### DIFF
--- a/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -6,6 +6,7 @@ import "package:flutter_chat_ui/flutter_chat_ui.dart" as chat_ui;
 import "package:material_ui/material_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/module_prego.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 import "assistant_message_card.dart";
@@ -123,10 +124,18 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
   /// rarer/longer labels ellipsize in [MessageTimestampReveal].
   static const double _kMaxReveal = 108;
 
-  /// Horizontal travel before a drag is treated as a timestamp peek
-  /// rather than a scroll. Kept below `kTouchSlop` so the peek engages
-  /// promptly, but only when horizontal travel clearly dominates.
-  static const double _kRevealEngageSlop = 8;
+  /// Vertical-dominant travel that releases the pending timestamp gesture to
+  /// the list. Kept below `kTouchSlop` so small vertical drags retain the
+  /// list's eager detach behavior.
+  static const double _kRevealCrossAxisRejectionSlop = 8;
+
+  static const Set<PointerDeviceKind> _kRevealPointerDevices = {
+    PointerDeviceKind.touch,
+    PointerDeviceKind.stylus,
+    PointerDeviceKind.invertedStylus,
+    PointerDeviceKind.trackpad,
+    PointerDeviceKind.unknown,
+  };
 
   /// Synthetic controller-entry id for the shimmering retry-error row
   /// pinned at the newest edge. Domain message ids come from the
@@ -158,24 +167,13 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
   /// drag moves the whole transcript in lockstep.
   late final AnimationController _revealController;
 
-  /// Pointer-tracking state for the reveal "peek" gesture (see
-  /// [_onRevealPointerMove]). `_revealPointer` is the active pointer id;
-  /// `_revealEngaged`/`_revealRejected` latch the horizontal-vs-vertical
-  /// decision for the duration of one gesture.
-  int? _revealPointer;
-  Offset _revealStart = Offset.zero;
-  bool _revealEngaged = false;
-  bool _revealRejected = false;
+  /// Captured on horizontal-drag down, before the outer trackpad listener can
+  /// detach. Once the horizontal recognizer wins, suppression restores this
+  /// state and keeps the timestamp peek from disturbing follow mode.
   bool _revealStartedFollowing = false;
 
-  /// True while a trackpad pan-zoom owns the reveal. The pointer-drag and
-  /// pan-zoom paths share the engage/reject latches above, so exactly one
-  /// may drive the peek at a time: whichever gesture starts first claims
-  /// ownership (`_revealPointer` for finger/stylus, this flag for
-  /// trackpad) and the other path no-ops until it releases. Guards against
-  /// a stray pan on a touchscreen-plus-trackpad device resetting the
-  /// latches — or springing the gutter shut — mid touch drag.
-  bool _revealPanActive = false;
+  bool _revealDragActive = false;
+  bool _revealDetachSuppressed = false;
 
   /// Snapshot taken at the moment of detach. `null` means "not frozen
   /// — use live `widget.*` props".
@@ -587,16 +585,11 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
         // Lift the pill clear of the floating composer overlaid below.
         bottomInset: widget.bottomInset,
       ),
-      // Horizontal "peek" gesture: slide the transcript left to reveal
-      // each message's timestamp on the right. Driven by a raw [Listener]
-      // rather than a drag GestureDetector on purpose — a competing
-      // horizontal drag recognizer would join the gesture arena and stop
-      // the list's vertical scroll recognizer from being the sole member,
-      // which would break small-drag detach. The Listener never joins the
-      // arena, so vertical scrolling is untouched; we disambiguate
-      // direction ourselves and only steer the reveal on horizontal-
-      // dominant gestures. `translucent` so the whole list area is tracked
-      // while taps and selection still reach the cards below.
+      // Horizontal "peek" gesture: slide the transcript left to reveal each
+      // message's timestamp on the right. This participates in the gesture
+      // arena so a nested horizontal scrollable, such as a fenced code block,
+      // wins exclusively. Early cross-axis rejection preserves the list's
+      // eager small-vertical-drag detach behavior.
       //
       // Input source is chosen by the pointer's *device kind*, not the
       // OS — so a desktop touchscreen still peeks by finger and an
@@ -608,17 +601,16 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
       //   path ignores the mouse kind) so it keeps selecting message
       //   text; hijacking it for the peek would make selection impossible.
       //
-      // Both handler sets are always bound; each only fires for its own
-      // device kind, so they never compete.
-      child: Listener(
+      child: PregoHorizontalDragGestureDetector(
         behavior: HitTestBehavior.translucent,
-        onPointerDown: _onRevealPointerDown,
-        onPointerMove: _onRevealPointerMove,
-        onPointerUp: _onRevealPointerUp,
-        onPointerCancel: _onRevealPointerCancel,
-        onPointerPanZoomStart: _onRevealPanZoomStart,
-        onPointerPanZoomUpdate: _onRevealPanZoomUpdate,
-        onPointerPanZoomEnd: _onRevealPanZoomEnd,
+        supportedDevices: _kRevealPointerDevices,
+        onHorizontalDragDown: _onRevealDragDown,
+        onHorizontalDragStart: _onRevealDragStart,
+        onHorizontalDragUpdate: _onRevealDragUpdate,
+        onHorizontalDragEnd: _onRevealDragEnd,
+        onHorizontalDragCancel: _onRevealDragCancel,
+        crossAxisRejectionSlop: _kRevealCrossAxisRejectionSlop,
+        dragStartBehavior: DragStartBehavior.down,
         child: chat_ui.Chat(
           key: _kListViewKey,
           currentUserId: _kUserAuthorId,
@@ -814,137 +806,41 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
     );
   }
 
-  void _onRevealPointerDown(PointerDownEvent event) {
-    // The first pointer owns the peek for its whole lifetime; ignore
-    // secondary touches so a stray second finger can't strand the
-    // gesture state (and the detach suppression) on the wrong pointer.
-    if (_revealPointer != null) return;
-    // A trackpad pan already owns the reveal — don't let a concurrent
-    // touch claim the shared latches out from under it.
-    if (_revealPanActive) return;
-    // A mouse press-and-drag is the text-selection gesture, so never
-    // hijack it for the peek — regardless of OS. (A trackpad click also
-    // reports as a mouse pointer; its two-finger swipe arrives separately
-    // via the pan-zoom path.) Finger and stylus drags drive the peek.
-    if (event.kind == PointerDeviceKind.mouse) return;
-    _revealPointer = event.pointer;
-    _revealStart = event.position;
-    _revealEngaged = false;
-    _revealRejected = false;
-    // Remember whether we were following when the gesture began: only
-    // then is a detach during this gesture "spurious" and worth undoing.
+  void _onRevealDragDown(DragDownDetails details) {
     _revealStartedFollowing = _follow.following;
   }
 
-  void _onRevealPointerMove(PointerMoveEvent event) {
-    if (event.pointer != _revealPointer || _revealRejected) return;
-
-    if (!_revealEngaged) {
-      // Disambiguate direction once the pointer clears the slop. Vertical,
-      // ambiguous, and rightward drags are left untouched: the scrollable
-      // keeps its eager small-drag detach, and a rightward drag stays free
-      // for the system back-swipe and any future gestures. The gutter is
-      // on the right, so only a clear leftward drag opens it.
-      final dx = event.position.dx - _revealStart.dx;
-      final dy = event.position.dy - _revealStart.dy;
-      if (dx.abs() < _kRevealEngageSlop && dy.abs() < _kRevealEngageSlop) return;
-      if (dy.abs() >= dx.abs() || dx > 0) {
-        _revealRejected = true;
-        return;
-      }
-      _revealEngaged = true;
-      // Take over any in-flight spring-back so the manual drag doesn't
-      // fight the closing animation. (Done here, not on pointer-down, so a
-      // vertical scroll that follows a release still springs shut.)
-      _revealController.stop();
-      // The scrollable fires a spurious drag-start as it claims the
-      // pointer. Only undo/suppress the resulting detach when we began
-      // the gesture following — otherwise the user was deliberately
-      // scrolled up reading history, and force-re-attaching here would
-      // discard their snapshot and teleport them to the newest edge.
-      if (_revealStartedFollowing) {
-        _follow.suppressDetach();
-      }
+  void _onRevealDragStart(DragStartDetails details) {
+    _revealDragActive = true;
+    _revealController.stop();
+    if (_revealStartedFollowing) {
+      _follow.suppressDetach();
+      _revealDetachSuppressed = true;
     }
+  }
 
-    // Dragging left (negative dx) opens the gutter further; dragging back
-    // right closes it. Normalise the per-move pixel delta by the gutter
-    // width and clamp to [0, 1].
-    final next = (_revealController.value - event.delta.dx / _kMaxReveal).clamp(0.0, 1.0);
+  void _onRevealDragUpdate(DragUpdateDetails details) {
+    final next = (_revealController.value - (details.primaryDelta ?? 0) / _kMaxReveal).clamp(0.0, 1.0);
     _revealController.value = next;
   }
 
-  void _onRevealPointerUp(PointerUpEvent event) {
-    if (event.pointer != _revealPointer) return;
-    _endReveal();
-  }
+  void _onRevealDragEnd(DragEndDetails details) => _endReveal();
 
-  void _onRevealPointerCancel(PointerCancelEvent event) {
-    if (event.pointer != _revealPointer) return;
-    _endReveal();
-  }
-
-  // ---------------------------------------------------------------------------
-  // Trackpad reveal: horizontal two-finger pan-zoom. Mirrors the touch
-  // pointer-drag path above (slop, horizontal-dominant gating, detach
-  // suppression, spring-back) but reads the cumulative `pan` and
-  // per-event `panDelta` from the pan-zoom stream instead of raw pointer
-  // positions. Reuses the same engage/reject/started-following latches as
-  // the pointer path, so a [_revealPanActive] / `_revealPointer`
-  // ownership handshake keeps the two from clobbering each other when a
-  // device has both a touchscreen and a trackpad.
-  // ---------------------------------------------------------------------------
-
-  void _onRevealPanZoomStart(PointerPanZoomStartEvent event) {
-    // A finger/stylus drag already owns the reveal — don't reset its
-    // latches from under it (see [_revealPanActive]).
-    if (_revealPointer != null) return;
-    _revealPanActive = true;
-    _revealEngaged = false;
-    _revealRejected = false;
-    _revealStartedFollowing = _follow.following;
-  }
-
-  void _onRevealPanZoomUpdate(PointerPanZoomUpdateEvent event) {
-    if (!_revealPanActive || _revealRejected) return;
-
-    if (!_revealEngaged) {
-      // Same direction disambiguation as the touch path: only a clear
-      // leftward pan opens the right-hand gutter; vertical, ambiguous and
-      // rightward pans are left for the list's own scroll handling.
-      final dx = event.pan.dx;
-      final dy = event.pan.dy;
-      if (dx.abs() < _kRevealEngageSlop && dy.abs() < _kRevealEngageSlop) return;
-      if (dy.abs() >= dx.abs() || dx > 0) {
-        _revealRejected = true;
-        return;
-      }
-      _revealEngaged = true;
-      _revealController.stop();
-      // The list's scroll plumbing detaches on pan-zoom start; undo that
-      // for a horizontal peek, but only when we began following (see the
-      // touch path for the rationale).
-      if (_revealStartedFollowing) {
-        _follow.suppressDetach();
-      }
+  void _onRevealDragCancel() {
+    if (!_revealDragActive) {
+      _revealStartedFollowing = false;
+      return;
     }
-
-    final next = (_revealController.value - event.panDelta.dx / _kMaxReveal).clamp(0.0, 1.0);
-    _revealController.value = next;
-  }
-
-  void _onRevealPanZoomEnd(PointerPanZoomEndEvent event) {
-    // Ignore a pan that never claimed the reveal (a finger drag owned it).
-    if (!_revealPanActive) return;
     _endReveal();
   }
 
   void _endReveal() {
-    _revealPointer = null;
-    _revealPanActive = false;
-    _revealEngaged = false;
-    _revealRejected = false;
-    _follow.releaseDetachSuppression();
+    _revealDragActive = false;
+    _revealStartedFollowing = false;
+    if (_revealDetachSuppressed) {
+      _revealDetachSuppressed = false;
+      _follow.releaseDetachSuppression();
+    }
     if (_revealController.value == 0) return;
     // Spring the gutter shut, honouring the OS reduce-motion preference
     // like the rest of the app's decorative animations.

--- a/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -124,10 +124,10 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
   /// rarer/longer labels ellipsize in [MessageTimestampReveal].
   static const double _kMaxReveal = 108;
 
-  /// Vertical-dominant travel that releases the pending timestamp gesture to
-  /// the list. Kept below `kTouchSlop` so small vertical drags retain the
-  /// list's eager detach behavior.
-  static const double _kRevealCrossAxisRejectionSlop = 8;
+  /// Disallowed-direction or vertical-dominant travel that releases the
+  /// pending timestamp gesture. Kept below `kTouchSlop` so small vertical and
+  /// rightward-first drags remain available to the transcript.
+  static const double _kRevealPendingRejectionSlop = 8;
 
   static const Set<PointerDeviceKind> _kRevealPointerDevices = {
     PointerDeviceKind.touch,
@@ -601,79 +601,83 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
       //   path ignores the mouse kind) so it keeps selecting message
       //   text; hijacking it for the peek would make selection impossible.
       //
-      child: PregoHorizontalDragGestureDetector(
-        behavior: HitTestBehavior.translucent,
-        supportedDevices: _kRevealPointerDevices,
-        onHorizontalDragDown: _onRevealDragDown,
-        onHorizontalDragStart: _onRevealDragStart,
-        onHorizontalDragUpdate: _onRevealDragUpdate,
-        onHorizontalDragEnd: _onRevealDragEnd,
-        onHorizontalDragCancel: _onRevealDragCancel,
-        crossAxisRejectionSlop: _kRevealCrossAxisRejectionSlop,
-        dragStartBehavior: DragStartBehavior.down,
-        child: chat_ui.Chat(
-          key: _kListViewKey,
-          currentUserId: _kUserAuthorId,
-          resolveUser: _resolveUser,
-          chatController: _chatController,
-          theme: _chatThemeFor(theme: Theme.of(context)),
-          backgroundColor: Colors.transparent,
-          builders: chat_core.Builders(
-            // Full-row control: drop the package's bubble/alignment/
-            // gesture wrapper and render our cards bare, exactly as the
-            // previous ListView did.
-            chatMessageBuilder: (
-              context,
-              message,
-              index,
-              animation,
-              child, {
-              bool? isRemoved,
-              required bool isSentByMe,
-              chat_core.MessageGroupStatus? groupStatus,
-            }) => child,
-            customMessageBuilder:
-                (
-                  context,
-                  message,
-                  index, {
-                  required bool isSentByMe,
-                  chat_core.MessageGroupStatus? groupStatus,
-                }) => _buildRow(
-                  entry: message,
-                  messages: messages,
-                  indexById: indexById,
-                  transientSubmissions: transientSubmissions,
-                  streamingText: streamingText,
-                  children: children,
-                  childStatuses: childStatuses,
-                  retryErrorMessage: retryErrorMessage,
-                ),
-            // The prompt input and tasks bar live outside this widget; reserve
-            // no composer space inside the list.
-            composerBuilder: (context) => const SizedBox.shrink(),
-            // Follow/detach owns the jump affordance via the overlay pill.
-            scrollToBottomBuilder: (context, animation, onPressed) => const SizedBox.shrink(),
-            // The loaded view renders its own empty state before this
-            // widget is ever mounted.
-            emptyChatListBuilder: (context) => const SizedBox.shrink(),
-            chatAnimatedListBuilder: (context, itemBuilder) => chat_ui.ChatAnimatedListReversed(
-              itemBuilder: itemBuilder,
-              scrollController: _follow.scrollController,
-              insertAnimationDuration: Duration.zero,
-              removeAnimationDuration: Duration.zero,
-              shouldScrollToEndWhenSendingMessage: false,
-              topPadding: 8 + widget.topInset,
-              bottomPadding: 8 + widget.bottomInset,
-              handleSafeArea: false,
-              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.manual,
-              // Always allow overscroll/bounce, even when the transcript is
-              // shorter than the viewport, so the list never feels locked.
-              physics: const AlwaysScrollableScrollPhysics(),
-              // The list is reversed, so "end" is the top: scrolling back
-              // through history is what asks for the older page. Null once
-              // the start is loaded, which stops the package asking again.
-              onEndReached: widget.onLoadOlderMessages,
+      child: NotificationListener<ScrollNotification>(
+        onNotification: _onNestedScrollNotification,
+        child: PregoHorizontalDragGestureDetector(
+          behavior: HitTestBehavior.translucent,
+          supportedDevices: _kRevealPointerDevices,
+          onHorizontalDragDown: _onRevealDragDown,
+          onHorizontalDragStart: _onRevealDragStart,
+          onHorizontalDragUpdate: _onRevealDragUpdate,
+          onHorizontalDragEnd: _onRevealDragEnd,
+          onHorizontalDragCancel: _onRevealDragCancel,
+          pendingRejectionSlop: _kRevealPendingRejectionSlop,
+          direction: PregoHorizontalDragDirection.left,
+          dragStartBehavior: DragStartBehavior.down,
+          child: chat_ui.Chat(
+            key: _kListViewKey,
+            currentUserId: _kUserAuthorId,
+            resolveUser: _resolveUser,
+            chatController: _chatController,
+            theme: _chatThemeFor(theme: Theme.of(context)),
+            backgroundColor: Colors.transparent,
+            builders: chat_core.Builders(
+              // Full-row control: drop the package's bubble/alignment/
+              // gesture wrapper and render our cards bare, exactly as the
+              // previous ListView did.
+              chatMessageBuilder: (
+                context,
+                message,
+                index,
+                animation,
+                child, {
+                bool? isRemoved,
+                required bool isSentByMe,
+                chat_core.MessageGroupStatus? groupStatus,
+              }) => child,
+              customMessageBuilder:
+                  (
+                    context,
+                    message,
+                    index, {
+                    required bool isSentByMe,
+                    chat_core.MessageGroupStatus? groupStatus,
+                  }) => _buildRow(
+                    entry: message,
+                    messages: messages,
+                    indexById: indexById,
+                    transientSubmissions: transientSubmissions,
+                    streamingText: streamingText,
+                    children: children,
+                    childStatuses: childStatuses,
+                    retryErrorMessage: retryErrorMessage,
+                  ),
+              // The prompt input and tasks bar live outside this widget; reserve
+              // no composer space inside the list.
+              composerBuilder: (context) => const SizedBox.shrink(),
+              // Follow/detach owns the jump affordance via the overlay pill.
+              scrollToBottomBuilder: (context, animation, onPressed) => const SizedBox.shrink(),
+              // The loaded view renders its own empty state before this
+              // widget is ever mounted.
+              emptyChatListBuilder: (context) => const SizedBox.shrink(),
+              chatAnimatedListBuilder: (context, itemBuilder) => chat_ui.ChatAnimatedListReversed(
+                itemBuilder: itemBuilder,
+                scrollController: _follow.scrollController,
+                insertAnimationDuration: Duration.zero,
+                removeAnimationDuration: Duration.zero,
+                shouldScrollToEndWhenSendingMessage: false,
+                topPadding: 8 + widget.topInset,
+                bottomPadding: 8 + widget.bottomInset,
+                handleSafeArea: false,
+                keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.manual,
+                // Always allow overscroll/bounce, even when the transcript is
+                // shorter than the viewport, so the list never feels locked.
+                physics: const AlwaysScrollableScrollPhysics(),
+                // The list is reversed, so "end" is the top: scrolling back
+                // through history is what asks for the older page. Null once
+                // the start is loaded, which stops the package asking again.
+                onEndReached: widget.onLoadOlderMessages,
+              ),
             ),
           ),
         ),
@@ -828,10 +832,29 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
 
   void _onRevealDragCancel() {
     if (!_revealDragActive) {
-      _revealStartedFollowing = false;
+      scheduleMicrotask(() {
+        if (mounted && !_revealDragActive) _revealStartedFollowing = false;
+      });
       return;
     }
     _endReveal();
+  }
+
+  bool _onNestedScrollNotification(ScrollNotification notification) {
+    if (notification is! ScrollStartNotification ||
+        notification.metrics.axis != Axis.horizontal ||
+        !_revealStartedFollowing ||
+        _revealDragActive) {
+      return false;
+    }
+
+    // A nested horizontal scrollable won after trackpad pan-start detached the
+    // transcript. Restore the follow state captured by drag-down; vertical
+    // scroll notifications deliberately leave that detach intact.
+    _follow.suppressDetach();
+    _follow.releaseDetachSuppression();
+    _revealStartedFollowing = false;
+    return false;
   }
 
   void _endReveal() {

--- a/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -1245,6 +1245,22 @@ void main() {
 
     await gesture.up();
     await tester.pumpAndSettle();
+
+    final touchScrollPixels = horizontalPosition.pixels;
+    final trackpad = await tester.createGesture(kind: PointerDeviceKind.trackpad);
+    final trackpadOrigin = tester.getCenter(find.byType(SingleChildScrollView));
+    await trackpad.panZoomStart(trackpadOrigin);
+    for (var i = 1; i <= 6; i++) {
+      await trackpad.panZoomUpdate(trackpadOrigin, pan: Offset(40.0 * i, 0));
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+
+    expect(horizontalPosition.pixels, lessThan(touchScrollPixels));
+    expect(tester.getTopLeft(codeBlockFinder).dx, closeTo(codeBlockRestX, 0.5));
+    expect(find.byKey(_jumpToLatestKey), findsNothing);
+
+    await trackpad.panZoomEnd();
+    await tester.pumpAndSettle();
   });
 
   testWidgets("peeking timestamps while detached does not snap back to the latest edge", (tester) async {
@@ -1388,7 +1404,7 @@ void main() {
     expect(tester.getTopLeft(textFinder).dx, closeTo(restX, 0.5));
   });
 
-  testWidgets("a rightward drag does not engage the peek (gutter is on the right)", (tester) async {
+  testWidgets("a rightward-first drag yields when it turns into a vertical scroll", (tester) async {
     await tester.binding.setSurfaceSize(const Size(900, 700));
     addTearDown(() => tester.binding.setSurfaceSize(null));
 
@@ -1419,6 +1435,12 @@ void main() {
     await tester.pump();
 
     expect(tester.getTopLeft(textFinder).dx, restX, reason: "rightward drag must not open the timestamp gutter");
+
+    await gesture.moveBy(const Offset(0, 300));
+    await tester.pump();
+
+    expect(_position(tester).pixels, greaterThan(20));
+    expect(find.byKey(_jumpToLatestKey), findsOneWidget);
 
     await gesture.up();
     await tester.pumpAndSettle();

--- a/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -2,6 +2,7 @@ import "package:flutter/gestures.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:material_ui/material_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_mobile/core/widgets/code_block.dart";
 import "package:sesori_mobile/features/session_detail/widgets/message_timestamp_reveal.dart";
 import "package:sesori_mobile/features/session_detail/widgets/queued_message_bubble.dart";
 import "package:sesori_mobile/features/session_detail/widgets/retry_error_message_card.dart";
@@ -19,6 +20,8 @@ class const _SessionDetailMessageListHarness({
   final List<QueuedSessionPrompt> initialBridgeQueuedPrompts = const [],
   final String? initialRetryErrorMessage,
   final Future<void> Function()? onLoadOlderMessages,
+  final TargetPlatform? platform,
+  final EdgeInsets systemGestureInsets = EdgeInsets.zero,
 }) extends StatefulWidget {
   @override
   State<_SessionDetailMessageListHarness> createState() => _SessionDetailMessageListHarnessState();
@@ -108,8 +111,12 @@ class _SessionDetailMessageListHarnessState() extends State<_SessionDetailMessag
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      theme: ThemeData(extensions: [PregoDesignSystem.light]),
-      darkTheme: ThemeData(extensions: [PregoDesignSystem.dark]),
+      theme: ThemeData(platform: widget.platform, extensions: [PregoDesignSystem.light]),
+      darkTheme: ThemeData(platform: widget.platform, extensions: [PregoDesignSystem.dark]),
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(systemGestureInsets: widget.systemGestureInsets),
+        child: child!,
+      ),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
@@ -877,7 +884,11 @@ void main() {
     // gesture to increasing scroll offset (i.e. scrolling toward older
     // content, away from the newest-at-bottom edge).
     final gesture = await tester.startGesture(tester.getCenter(find.byKey(_listViewKey)));
-    await gesture.moveBy(const Offset(0, 300));
+    // Establish vertical intent first so the timestamp recognizer leaves the
+    // arena, matching the stream of move events produced by a real drag.
+    await gesture.moveBy(const Offset(0, 12));
+    await tester.pump();
+    await gesture.moveBy(const Offset(0, 288));
     await tester.pump();
     expect(find.byKey(_jumpToLatestKey), findsOneWidget);
     expect(_position(tester).pixels, greaterThan(20));
@@ -1095,6 +1106,145 @@ void main() {
     await gesture.up();
     await tester.pumpAndSettle();
     expect(tester.getTopLeft(textFinder).dx, closeTo(restX, 0.5));
+  });
+
+  testWidgets("iOS system-back edge does not peek timestamps", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final created = DateTime.now().millisecondsSinceEpoch;
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        platform: TargetPlatform.iOS,
+        initialMessages: [
+          for (var i = 0; i < 12; i++)
+            _message(
+              messageId: "u$i",
+              role: "user",
+              text: _multilineText(label: "Message $i", lines: 6),
+              createdAtMs: created,
+            ),
+        ],
+        initialStreamingText: const {},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final textFinder = find.textContaining("Message 11").first;
+    final restX = tester.getTopLeft(textFinder).dx;
+    final y = tester.getCenter(find.byKey(_listViewKey)).dy;
+
+    final edgeGesture = await tester.startGesture(Offset(40, y));
+    await edgeGesture.moveBy(const Offset(-160, 0));
+    await tester.pump();
+    expect(tester.getTopLeft(textFinder).dx, restX);
+    await edgeGesture.up();
+
+    final contentGesture = await tester.startGesture(Offset(140, y));
+    await contentGesture.moveBy(const Offset(-160, 0));
+    await tester.pump();
+    expect(tester.getTopLeft(textFinder).dx, lessThan(restX));
+    await contentGesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets("Android gesture navigation keeps both system-back edges out of timestamp peeks", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final created = DateTime.now().millisecondsSinceEpoch;
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        platform: TargetPlatform.android,
+        systemGestureInsets: const EdgeInsets.symmetric(horizontal: 24),
+        initialMessages: [
+          for (var i = 0; i < 12; i++)
+            _message(
+              messageId: "u$i",
+              role: "user",
+              text: _multilineText(label: "Message $i", lines: 6),
+              createdAtMs: created,
+            ),
+        ],
+        initialStreamingText: const {},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final textFinder = find.textContaining("Message 11").first;
+    final restX = tester.getTopLeft(textFinder).dx;
+    final y = tester.getCenter(find.byKey(_listViewKey)).dy;
+
+    final startEdgeGesture = await tester.startGesture(Offset(40, y));
+    await startEdgeGesture.moveBy(const Offset(-160, 0));
+    await tester.pump();
+    expect(tester.getTopLeft(textFinder).dx, restX);
+    await startEdgeGesture.up();
+
+    final endEdgeGesture = await tester.startGesture(Offset(860, y));
+    await endEdgeGesture.moveBy(const Offset(-160, 0));
+    await tester.pump();
+    expect(tester.getTopLeft(textFinder).dx, restX);
+    await endEdgeGesture.up();
+
+    final contentGesture = await tester.startGesture(Offset(450, y));
+    await contentGesture.moveBy(const Offset(-160, 0));
+    await tester.pump();
+    expect(tester.getTopLeft(textFinder).dx, lessThan(restX));
+    await contentGesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets("a fenced code block scrolls horizontally without peeking timestamps", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final created = DateTime.now().millisecondsSinceEpoch;
+    final longCode = List.filled(16, "final horizontalOverflow = true; ").join();
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        initialMessages: [
+          ..._userMessages(count: 10),
+          _message(
+            messageId: "assistant-code",
+            role: "assistant",
+            text: "```dart\n$longCode\n```",
+            createdAtMs: created,
+          ),
+        ],
+        initialStreamingText: const {},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final codeBlockFinder = find.byType(CodeBlock);
+    expect(codeBlockFinder, findsOneWidget);
+    final horizontalScrollableFinder = find.descendant(
+      of: codeBlockFinder,
+      matching: find.byWidgetPredicate(
+        (widget) => widget is Scrollable && axisDirectionToAxis(widget.axisDirection) == Axis.horizontal,
+      ),
+    );
+    expect(horizontalScrollableFinder, findsOneWidget);
+
+    final codeBlockRestX = tester.getTopLeft(codeBlockFinder).dx;
+    final transcriptRestPixels = _position(tester).pixels;
+    final horizontalPosition = tester.state<ScrollableState>(horizontalScrollableFinder).position;
+    expect(horizontalPosition.pixels, 0);
+
+    final gesture = await tester.startGesture(tester.getCenter(find.byType(SingleChildScrollView)));
+    for (var i = 0; i < 6; i++) {
+      await gesture.moveBy(const Offset(-40, 0));
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+
+    expect(horizontalPosition.pixels, greaterThan(0));
+    expect(tester.getTopLeft(codeBlockFinder).dx, closeTo(codeBlockRestX, 0.5));
+    expect(_position(tester).pixels, transcriptRestPixels);
+    expect(find.byKey(_jumpToLatestKey), findsNothing);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
   });
 
   testWidgets("peeking timestamps while detached does not snap back to the latest edge", (tester) async {

--- a/client/module_prego/lib/interactions/prego_horizontal_drag_gesture_detector.dart
+++ b/client/module_prego/lib/interactions/prego_horizontal_drag_gesture_detector.dart
@@ -4,6 +4,13 @@ import 'package:material_ui/material_ui.dart';
 /// The fraction of a drag target reserved for a platform system-back gesture.
 const double _systemBackGestureExclusionFraction = 0.1;
 
+/// The physical directions a [PregoHorizontalDragGestureDetector] may accept.
+enum PregoHorizontalDragDirection() {
+  both,
+  left,
+  right;
+}
+
 /// A horizontal drag detector that stays out of platform system-back edges.
 ///
 /// Touch drags beginning in the directional start 10% are ignored on iOS. On
@@ -12,11 +19,11 @@ const double _systemBackGestureExclusionFraction = 0.1;
 /// platforms retain the full hit area.
 ///
 /// The detector participates in Flutter's gesture arena, so a horizontal
-/// recognizer in [child] can win instead. When [crossAxisRejectionSlop] is set,
-/// a still-pending claim is also rejected once vertical-dominant movement
-/// reaches that distance. This lets a competing vertical recognizer become the
-/// sole arena member before Flutter's normal touch slop when a host requires
-/// eager small-drag handling.
+/// recognizer in [child] can win instead. When [pendingRejectionSlop] is set, a
+/// still-pending claim is rejected once vertical-dominant movement or movement
+/// opposite [direction] reaches that distance. This lets another recognizer
+/// become the sole arena member before Flutter's normal touch slop when a host
+/// requires eager intent handling.
 class const PregoHorizontalDragGestureDetector({
   super.key,
   required final Widget child,
@@ -27,10 +34,11 @@ class const PregoHorizontalDragGestureDetector({
   required final GestureDragUpdateCallback onHorizontalDragUpdate,
   required final GestureDragEndCallback onHorizontalDragEnd,
   required final GestureDragCancelCallback onHorizontalDragCancel,
-  required final double? crossAxisRejectionSlop,
+  required final double? pendingRejectionSlop,
+  final PregoHorizontalDragDirection direction = PregoHorizontalDragDirection.both,
   final DragStartBehavior dragStartBehavior = DragStartBehavior.start,
 }) extends StatelessWidget {
-  this : assert(crossAxisRejectionSlop == null || crossAxisRejectionSlop > 0);
+  this : assert(pendingRejectionSlop == null || pendingRejectionSlop > 0);
 
   @override
   Widget build(BuildContext context) {
@@ -54,7 +62,8 @@ class const PregoHorizontalDragGestureDetector({
                   ..multitouchDragStrategy = scrollBehavior.getMultitouchDragStrategy(context)
                   ..gestureSettings = gestureSettings
                   ..supportedDevices = supportedDevices
-                  ..crossAxisRejectionSlop = crossAxisRejectionSlop
+                  ..pendingRejectionSlop = pendingRejectionSlop
+                  ..direction = direction
                   ..isStartAllowed = (event) => _allowsDragStart(context: context, event: event);
               },
             ),
@@ -94,7 +103,9 @@ class const PregoHorizontalDragGestureDetector({
 class _PregoHorizontalDragGestureRecognizer({required super.debugOwner}) extends HorizontalDragGestureRecognizer {
   late bool Function(PointerEvent event) isStartAllowed;
 
-  double? crossAxisRejectionSlop;
+  double? pendingRejectionSlop;
+
+  PregoHorizontalDragDirection direction = PregoHorizontalDragDirection.both;
 
   final Map<int, Offset> _pointerStarts = <int, Offset>{};
   final Set<int> _acceptedPointers = <int>{};
@@ -116,17 +127,25 @@ class _PregoHorizontalDragGestureRecognizer({required super.debugOwner}) extends
 
   @override
   void handleEvent(PointerEvent event) {
-    final rejectionSlop = crossAxisRejectionSlop;
+    final rejectionSlop = pendingRejectionSlop;
     final pendingDelta = switch (event) {
       PointerMoveEvent() => event.position - (_pointerStarts[event.pointer] ?? event.position),
       PointerPanZoomUpdateEvent() => event.pan,
       _ => null,
     };
-    if (rejectionSlop != null &&
-        !_acceptedPointers.contains(event.pointer) &&
+    final shouldRejectCrossAxis =
         pendingDelta != null &&
-        pendingDelta.dy.abs() >= rejectionSlop &&
-        pendingDelta.dy.abs() >= pendingDelta.dx.abs()) {
+        pendingDelta.dy.abs() >= (rejectionSlop ?? double.infinity) &&
+        pendingDelta.dy.abs() >= pendingDelta.dx.abs();
+    final shouldRejectDirection =
+        pendingDelta != null &&
+        pendingDelta.dx.abs() >= (rejectionSlop ?? double.infinity) &&
+        switch (direction) {
+          PregoHorizontalDragDirection.both => false,
+          PregoHorizontalDragDirection.left => pendingDelta.dx > 0,
+          PregoHorizontalDragDirection.right => pendingDelta.dx < 0,
+        };
+    if (!_acceptedPointers.contains(event.pointer) && (shouldRejectCrossAxis || shouldRejectDirection)) {
       resolvePointer(event.pointer, GestureDisposition.rejected);
       return;
     }

--- a/client/module_prego/lib/interactions/prego_horizontal_drag_gesture_detector.dart
+++ b/client/module_prego/lib/interactions/prego_horizontal_drag_gesture_detector.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/gestures.dart';
+import 'package:material_ui/material_ui.dart';
+
+/// The fraction of a drag target reserved for a platform system-back gesture.
+const double _systemBackGestureExclusionFraction = 0.1;
+
+/// A horizontal drag detector that stays out of platform system-back edges.
+///
+/// Touch drags beginning in the directional start 10% are ignored on iOS. On
+/// Android, both 10% edges are ignored when [MediaQuery.systemGestureInsets]
+/// reports horizontal gesture-navigation insets. Other pointer kinds and
+/// platforms retain the full hit area.
+///
+/// The detector participates in Flutter's gesture arena, so a horizontal
+/// recognizer in [child] can win instead. When [crossAxisRejectionSlop] is set,
+/// a still-pending claim is also rejected once vertical-dominant movement
+/// reaches that distance. This lets a competing vertical recognizer become the
+/// sole arena member before Flutter's normal touch slop when a host requires
+/// eager small-drag handling.
+class const PregoHorizontalDragGestureDetector({
+  super.key,
+  required final Widget child,
+  required final HitTestBehavior? behavior,
+  required final Set<PointerDeviceKind>? supportedDevices,
+  required final GestureDragDownCallback? onHorizontalDragDown,
+  required final GestureDragStartCallback onHorizontalDragStart,
+  required final GestureDragUpdateCallback onHorizontalDragUpdate,
+  required final GestureDragEndCallback onHorizontalDragEnd,
+  required final GestureDragCancelCallback onHorizontalDragCancel,
+  required final double? crossAxisRejectionSlop,
+  final DragStartBehavior dragStartBehavior = DragStartBehavior.start,
+}) extends StatelessWidget {
+  this : assert(crossAxisRejectionSlop == null || crossAxisRejectionSlop > 0);
+
+  @override
+  Widget build(BuildContext context) {
+    final gestureSettings = MediaQuery.maybeGestureSettingsOf(context);
+    final scrollBehavior = ScrollConfiguration.of(context);
+
+    return RawGestureDetector(
+      behavior: behavior,
+      gestures: <Type, GestureRecognizerFactory>{
+        _PregoHorizontalDragGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<_PregoHorizontalDragGestureRecognizer>(
+              () => _PregoHorizontalDragGestureRecognizer(debugOwner: this),
+              (recognizer) {
+                recognizer
+                  ..onDown = onHorizontalDragDown
+                  ..onStart = onHorizontalDragStart
+                  ..onUpdate = onHorizontalDragUpdate
+                  ..onEnd = onHorizontalDragEnd
+                  ..onCancel = onHorizontalDragCancel
+                  ..dragStartBehavior = dragStartBehavior
+                  ..multitouchDragStrategy = scrollBehavior.getMultitouchDragStrategy(context)
+                  ..gestureSettings = gestureSettings
+                  ..supportedDevices = supportedDevices
+                  ..crossAxisRejectionSlop = crossAxisRejectionSlop
+                  ..isStartAllowed = (event) => _allowsDragStart(context: context, event: event);
+              },
+            ),
+      },
+      child: child,
+    );
+  }
+
+  bool _allowsDragStart({required BuildContext context, required PointerEvent event}) {
+    if (event.kind != PointerDeviceKind.touch) return true;
+
+    final renderObject = context.findRenderObject();
+    if (renderObject is! RenderBox || !renderObject.hasSize) return true;
+    final width = renderObject.size.width;
+    if (width <= 0) return true;
+
+    final platform = Theme.of(context).platform;
+    final usesAndroidGestureNavigation =
+        platform == TargetPlatform.android && _usesAndroidGestureNavigation(context: context);
+    final excludeStart = platform == TargetPlatform.iOS || usesAndroidGestureNavigation;
+    final excludeEnd = usesAndroidGestureNavigation;
+    if (!excludeStart && !excludeEnd) return true;
+
+    final fromStart = Directionality.of(context) == TextDirection.ltr
+        ? event.localPosition.dx
+        : width - event.localPosition.dx;
+    final exclusion = width * _systemBackGestureExclusionFraction;
+    return (!excludeStart || fromStart > exclusion) && (!excludeEnd || fromStart < width - exclusion);
+  }
+
+  bool _usesAndroidGestureNavigation({required BuildContext context}) {
+    final insets = MediaQuery.maybeSystemGestureInsetsOf(context);
+    return insets != null && (insets.left > 0 || insets.right > 0);
+  }
+}
+
+class _PregoHorizontalDragGestureRecognizer({required super.debugOwner}) extends HorizontalDragGestureRecognizer {
+  late bool Function(PointerEvent event) isStartAllowed;
+
+  double? crossAxisRejectionSlop;
+
+  final Map<int, Offset> _pointerStarts = <int, Offset>{};
+  final Set<int> _acceptedPointers = <int>{};
+
+  @override
+  bool isPointerAllowed(PointerEvent event) => super.isPointerAllowed(event) && isStartAllowed(event);
+
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    _pointerStarts[event.pointer] = event.position;
+    super.addAllowedPointer(event);
+  }
+
+  @override
+  void addAllowedPointerPanZoom(PointerPanZoomStartEvent event) {
+    _pointerStarts[event.pointer] = Offset.zero;
+    super.addAllowedPointerPanZoom(event);
+  }
+
+  @override
+  void handleEvent(PointerEvent event) {
+    final rejectionSlop = crossAxisRejectionSlop;
+    final pendingDelta = switch (event) {
+      PointerMoveEvent() => event.position - (_pointerStarts[event.pointer] ?? event.position),
+      PointerPanZoomUpdateEvent() => event.pan,
+      _ => null,
+    };
+    if (rejectionSlop != null &&
+        !_acceptedPointers.contains(event.pointer) &&
+        pendingDelta != null &&
+        pendingDelta.dy.abs() >= rejectionSlop &&
+        pendingDelta.dy.abs() >= pendingDelta.dx.abs()) {
+      resolvePointer(event.pointer, GestureDisposition.rejected);
+      return;
+    }
+
+    super.handleEvent(event);
+    if (event is PointerUpEvent || event is PointerCancelEvent || event is PointerPanZoomEndEvent) {
+      _forgetPointer(event.pointer);
+    }
+  }
+
+  @override
+  void acceptGesture(int pointer) {
+    _acceptedPointers.add(pointer);
+    super.acceptGesture(pointer);
+  }
+
+  @override
+  void rejectGesture(int pointer) {
+    _forgetPointer(pointer);
+    super.rejectGesture(pointer);
+  }
+
+  void _forgetPointer(int pointer) {
+    _pointerStarts.remove(pointer);
+    _acceptedPointers.remove(pointer);
+  }
+}

--- a/client/module_prego/lib/interactions/prego_swipe_actions.dart
+++ b/client/module_prego/lib/interactions/prego_swipe_actions.dart
@@ -214,7 +214,7 @@ class _PregoSwipeActionsState() extends State<PregoSwipeActions> with SingleTick
         onHorizontalDragUpdate: _handleDragUpdate,
         onHorizontalDragEnd: _handleDragEnd,
         onHorizontalDragCancel: _handleDragCancel,
-        crossAxisRejectionSlop: null,
+        pendingRejectionSlop: null,
         child: LayoutBuilder(
           builder: (context, constraints) {
             _rowWidth = constraints.maxWidth;

--- a/client/module_prego/lib/interactions/prego_swipe_actions.dart
+++ b/client/module_prego/lib/interactions/prego_swipe_actions.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 import 'dart:math' as math;
 
-import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
 import 'package:material_ui/material_ui.dart';
 
 import '../motion/prego_reduced_motion.dart';
 import '../theme/prego_theme.dart';
+import 'prego_horizontal_drag_gesture_detector.dart';
 
 /// Builds the secondary actions revealed behind a [PregoSwipeActions] row.
 ///
@@ -122,9 +122,6 @@ const double _commitClearance = 64;
 /// shut and cancels a pending commit.
 const double _flingVelocity = 700;
 
-/// The row-width fraction reserved for a system back gesture where one exists.
-const double _systemBackGestureExclusionFraction = 0.1;
-
 /// One build's strip children, captured as a unit when a close settle begins.
 typedef _StripChildren = ({List<Widget> actions, Widget primary, Widget? leadingPrimary});
 
@@ -195,8 +192,6 @@ class _PregoSwipeActionsState() extends State<PregoSwipeActions> with SingleTick
 
   @override
   Widget build(BuildContext context) {
-    final gestureSettings = MediaQuery.maybeGestureSettingsOf(context);
-    final scrollBehavior = ScrollConfiguration.of(context);
     final strips =
         _frozenStrips ??
         (
@@ -211,23 +206,15 @@ class _PregoSwipeActionsState() extends State<PregoSwipeActions> with SingleTick
 
     final row = TapRegion(
       onTapOutside: (_) => _handleTapOutside(),
-      child: RawGestureDetector(
-        gestures: <Type, GestureRecognizerFactory>{
-          _EdgeSafeHorizontalDragGestureRecognizer:
-              GestureRecognizerFactoryWithHandlers<_EdgeSafeHorizontalDragGestureRecognizer>(
-                () => _EdgeSafeHorizontalDragGestureRecognizer(debugOwner: this),
-                (recognizer) {
-                  recognizer
-                    ..onStart = _handleDragStart
-                    ..onUpdate = _handleDragUpdate
-                    ..onEnd = _handleDragEnd
-                    ..onCancel = _handleDragCancel
-                    ..multitouchDragStrategy = scrollBehavior.getMultitouchDragStrategy(context)
-                    ..gestureSettings = gestureSettings
-                    ..isStartAllowed = (event) => _allowsDragStart(context: context, event: event);
-                },
-              ),
-        },
+      child: PregoHorizontalDragGestureDetector(
+        behavior: null,
+        supportedDevices: null,
+        onHorizontalDragDown: null,
+        onHorizontalDragStart: _handleDragStart,
+        onHorizontalDragUpdate: _handleDragUpdate,
+        onHorizontalDragEnd: _handleDragEnd,
+        onHorizontalDragCancel: _handleDragCancel,
+        crossAxisRejectionSlop: null,
         child: LayoutBuilder(
           builder: (context, constraints) {
             _rowWidth = constraints.maxWidth;
@@ -328,28 +315,6 @@ class _PregoSwipeActionsState() extends State<PregoSwipeActions> with SingleTick
   }
 
   // ── Gesture handling ───────────────────────────────────────────────────────
-
-  bool _allowsDragStart({required BuildContext context, required PointerEvent event}) {
-    if (event.kind != PointerDeviceKind.touch || _rowWidth <= 0) return true;
-
-    final platform = Theme.of(context).platform;
-    final usesAndroidGestureNavigation =
-        platform == TargetPlatform.android && _usesAndroidGestureNavigation(context: context);
-    final excludeStart = platform == TargetPlatform.iOS || usesAndroidGestureNavigation;
-    final excludeEnd = usesAndroidGestureNavigation;
-    if (!excludeStart && !excludeEnd) return true;
-
-    final fromStart = Directionality.of(context) == TextDirection.ltr
-        ? event.localPosition.dx
-        : _rowWidth - event.localPosition.dx;
-    final exclusion = _rowWidth * _systemBackGestureExclusionFraction;
-    return (!excludeStart || fromStart > exclusion) && (!excludeEnd || fromStart < _rowWidth - exclusion);
-  }
-
-  bool _usesAndroidGestureNavigation({required BuildContext context}) {
-    final insets = MediaQuery.maybeSystemGestureInsetsOf(context);
-    return insets != null && (insets.left > 0 || insets.right > 0);
-  }
 
   void _handleDragStart(DragStartDetails details) {
     _dragging = true;
@@ -512,13 +477,6 @@ class _PregoSwipeActionsState() extends State<PregoSwipeActions> with SingleTick
     _watchedScroll?.removeListener(_handleScroll);
     _watchedScroll = null;
   }
-}
-
-class _EdgeSafeHorizontalDragGestureRecognizer({required super.debugOwner}) extends HorizontalDragGestureRecognizer {
-  late bool Function(PointerEvent event) isStartAllowed;
-
-  @override
-  bool isPointerAllowed(PointerEvent event) => super.isPointerAllowed(event) && isStartAllowed(event);
 }
 
 /// One side of a [PregoSwipeActions] row — the trailing strip or the leading

--- a/client/module_prego/lib/module_prego.dart
+++ b/client/module_prego/lib/module_prego.dart
@@ -32,6 +32,7 @@ export 'components/surfaces/prego_grouped_rows.dart';
 export 'components/surfaces/prego_surfaces.dart';
 export 'icons/tabler_icons.g.dart';
 export 'icons/vespr_icons.g.dart';
+export 'interactions/prego_horizontal_drag_gesture_detector.dart';
 export 'interactions/prego_swipe_actions.dart';
 export 'motion/prego_reduced_motion.dart';
 export 'theme/prego_glass.dart';

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -166,6 +166,11 @@ defaults and queued client sends coherent.
 - Transcript content scrolling behind the top navigation or floating composer
   dissolves into a strong surface-colour fade, keeping the title and controls
   visually separate and screenshot-readable without text collisions.
+- A leftward touch, stylus, or trackpad drag across the transcript reveals all
+  message timestamps together without changing vertical scroll or follow state,
+  then settles closed on release. System-back edges remain reserved on iOS and
+  Android gesture navigation, mouse drags remain available for text selection,
+  and a horizontal drag inside a fenced code block scrolls only that block.
 
 ## Regression Levels
 
@@ -230,6 +235,9 @@ has started.
   running session as if they were user activity.
 - Scrolled transcript text remains clearly visible through the fade and collides
   with the navigation title or floating composer controls.
+- A timestamp peek responds from a reserved system-back edge, detaches or
+  vertically scrolls the transcript, captures a mouse selection drag, or moves
+  while a fenced code block is handling the horizontal drag.
 
 ## Known Limitations
 


### PR DESCRIPTION
## Complexity

Moderate. This extracts a shared gesture-arena recognizer and preserves the session list's eager small-drag and trackpad follow-state behavior.

## What

- Added an exported Prego horizontal drag detector that reserves platform system-back edges.
- Migrated Prego swipe actions and session timestamp reveal to the shared detector.
- Let nested fenced-code horizontal scrolling win the gesture arena without moving the transcript.
- Added iOS, Android gesture-navigation, code-block, and existing gesture-behavior regressions.
- Updated the session-turns regression contract.

## Why

The timestamp reveal used a raw pointer listener, so it reacted to drags intended for system back navigation and horizontally scrollable code blocks. The row-swipe edge policy also remained private to one component.

## Risk and test focus

This is a user-visible gesture behavior correction. Focus review on gesture-arena ownership, system-edge detection, trackpad detach suppression, and vertical small-drag preservation.

There is no database, wire-contract, authentication, encryption, or persisted-state impact.

## Expected result

Timestamp peeks remain available from ordinary transcript content, stay inactive at reserved system-back edges, and do not react while a fenced code block scrolls horizontally. Existing mouse selection, vertical scrolling, follow/detach, multitouch, and trackpad behavior remains intact.

## Verification

- `flutter test test/interactions/prego_swipe_actions_test.dart` in `client/module_prego`
- `flutter test test/features/session_detail/widgets/session_detail_message_list_test.dart` in `client/app`
- `dart analyze` in `client/module_prego`
- `dart analyze` in `client/app`
- `dart analyze` in `client/desktop`
- Architecture plan and implementation reviews approved with no remaining findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve conflicting horizontal gestures in session detail by replacing the raw listener with a shared `PregoHorizontalDragGestureDetector`. Old behavior: timestamp peeks captured system back-swipes and code-block drags; new behavior: reserves system-back edges, yields to nested horizontal scrollables, and preserves eager small-vertical-drag detach and trackpad follow-state.

- `PregoHorizontalDragGestureDetector` joins the gesture arena, reserves the start 10% on iOS and both 10% edges on Android when `MediaQuery.systemGestureInsets` signals gesture navigation, and adds early cross-axis and directional rejection via `pendingRejectionSlop`.
- Session list uses `dragStartBehavior.down`, supports only touch/stylus/trackpad (mouse remains text selection), suppresses detach only when the peek starts while following, and restores follow when a nested horizontal scrollable wins.
- Migrated `PregoSwipeActions` to the shared detector; removed duplicate edge-exclusion logic and exported the detector from `module_prego`.
- Added tests for iOS/Android system-back edges, fenced code-block horizontal scrolling, and directional handoffs; updated the session-turns regression contract.

<sup>Written for commit 715f85283b8b61e07914cdb3faea0c3ed4128fd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

