### PR TITLE
⚙️ [codebase-cleanup] tests: replace real-duration sleeps with fake time and state awaiting [step 14/45]

### DIFF
--- a/.plan/active/codebase-cleanup/steps/step-14.md
+++ b/.plan/active/codebase-cleanup/steps/step-14.md
@@ -1,0 +1,47 @@
+# Step 14/45 - Replace arbitrary test waits with deterministic synchronization
+
+## Re-verification against `main`
+
+The historical total of 187 sleeps included 141 Flutter fake-time animation
+pumps, which are deterministic and remain unchanged. This step removes 56
+positive-duration waits from the selected pure-Dart hotspots. Positive
+durations that define the timeout behavior under test remain; they are not used
+as synchronization sleeps.
+
+The session-detail and session-list suites now await observable cubit state or
+controlled completers. The staleness cooldown tests retain their existing 100
+ms behavior but advance it with `fakeAsync`. The Codex locator test overrides
+filesystem metadata with `IOOverrides`, and the process-runner fixture uses a
+bounded, newline-framed loopback control channel instead of sleeping before
+checking descendant cleanup.
+
+The shared `awaitState` helper centralizes state-stream waiting and includes a
+bounded diagnostic timeout. No production implementation, wire contract,
+persisted data, database schema, or user-visible behavior changed.
+
+## Verification
+
+- `dart analyze` in `client/module_core`: clean.
+- Seven touched module-core suites: 158 tests passed three consecutive times
+  with `dart test -j1`.
+- The three module-core suites changed during final review
+  (`session_detail_cubit_permission_test`, `session_detail_stale_test`, and
+  `session_list_cubit_test`): 84 tests passed three consecutive times from
+  their final contents with `dart test -j1`.
+- `dart analyze` in `bridge/sesori_plugin_codex`: clean.
+- `codex_desktop_app_locator_test`: 5 tests passed three consecutive times with
+  `dart test -j1`.
+- `dart analyze` in `bridge/app`: clean.
+- `process_runner_test`: 2 tests passed three consecutive times from its final
+  contents with `dart test -j1`.
+- Scoped scans found no remaining positive-duration `Future.delayed` calls or
+  `sleep` calls in the touched hotspots.
+- `git diff --check`: clean.
+
+The raw diff excluding this evidence file is `+942 / -702`. It exceeds the
+1,500 changed-line soft cap because wrapping nine cooldown tests in `fakeAsync`
+reindents their complete bodies; the change is test-only and contains no
+production logic.
+
+Architecture implementation review not run: Step 14 changes tests and a test
+helper only, which is outside the architecture-review scope.

--- a/bridge/app/test/bridge/foundation/process_runner_test.dart
+++ b/bridge/app/test/bridge/foundation/process_runner_test.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:convert";
 import "dart:io";
 
 import "package:sesori_bridge/src/foundation/process_runner.dart";
@@ -37,33 +38,100 @@ void main() {
     addTearDown(() => directory.delete(recursive: true));
     final childScript = File("${directory.path}/child.dart");
     await childScript.writeAsString('''
-Future<void> main() => Future<void>.delayed(const Duration(seconds: 3));
+import "dart:io";
+
+Future<void> main(List<String> arguments) async {
+  final socket = await Socket.connect(InternetAddress.loopbackIPv4, int.parse(arguments[0]));
+  socket.writeln("child");
+  await socket.flush();
+  await socket.first;
+  socket.writeln("cleaned");
+  await socket.flush();
+  await socket.close();
+}
 ''');
     final parentScript = File("${directory.path}/parent.dart");
     await parentScript.writeAsString('''
 import "dart:io";
 
 Future<void> main(List<String> arguments) async {
-  await Process.start(
+  final child = await Process.start(
     Platform.resolvedExecutable,
-    [arguments.single],
+    [arguments[0], arguments[1]],
     mode: ProcessStartMode.inheritStdio,
   );
+  await File(arguments[2]).writeAsString(child.pid.toString());
+  final socket = await Socket.connect(InternetAddress.loopbackIPv4, int.parse(arguments[1]));
+  socket.writeln("parent");
+  await socket.flush();
+  await socket.close();
 }
 ''');
 
+    final childPidFile = File("${directory.path}/child_pid");
+    final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    final connections = StreamIterator(server);
+    Socket? childSocket;
+    StreamIterator<String>? childMessages;
+    int? childPid;
+    addTearDown(() async {
+      childSocket?.destroy();
+      if (childPid case final pid?) Process.killPid(pid);
+      await childMessages?.cancel();
+      await connections.cancel();
+    });
     final stopwatch = Stopwatch()..start();
-    await expectLater(
-      ProcessRunner().run(
-        Platform.resolvedExecutable,
-        [parentScript.path, childScript.path],
-        timeout: const Duration(seconds: 1),
-      ),
-      throwsA(isA<TimeoutException>()),
+    final run = ProcessRunner().run(
+      Platform.resolvedExecutable,
+      [parentScript.path, childScript.path, server.port.toString(), childPidFile.path],
+      timeout: const Duration(seconds: 3),
     );
+    var childConnected = false;
+    var parentConnected = false;
+    for (var connectionCount = 0; connectionCount < 2; connectionCount++) {
+      expect(
+        await connections.moveNext().timeout(const Duration(seconds: 5)),
+        isTrue,
+        reason: "fixture should open both child and parent control connections",
+      );
+      final socket = connections.current;
+      final messages = StreamIterator(
+        socket.map<List<int>>((bytes) => bytes).transform(utf8.decoder).transform(const LineSplitter()),
+      );
+      expect(
+        await messages.moveNext().timeout(const Duration(seconds: 5)),
+        isTrue,
+        reason: "fixture should identify its control connection",
+      );
+      if (messages.current == "child") {
+        childSocket = socket;
+        childMessages = messages;
+        childConnected = true;
+      } else {
+        expect(messages.current, "parent");
+        parentConnected = true;
+        await messages.cancel();
+      }
+    }
+    expect(childConnected, isTrue);
+    expect(parentConnected, isTrue);
+    childPid = int.parse(await childPidFile.readAsString());
+    await expectLater(run, throwsA(isA<TimeoutException>()));
     stopwatch.stop();
 
-    expect(stopwatch.elapsed, lessThan(const Duration(seconds: 2)));
-    await Future<void>.delayed(const Duration(seconds: 3));
+    expect(stopwatch.elapsed, lessThan(const Duration(seconds: 4)));
+    expect(childPid, greaterThan(0));
+    final connectedChildSocket = childSocket!;
+    final connectedChildMessages = childMessages!;
+    connectedChildSocket.write("terminate");
+    await connectedChildSocket.flush();
+    expect(
+      await connectedChildMessages.moveNext().timeout(const Duration(seconds: 5)),
+      isTrue,
+      reason: "child should acknowledge cleanup",
+    );
+    expect(connectedChildMessages.current, "cleaned");
+    await connectedChildSocket.close();
   });
 }

--- a/bridge/sesori_plugin_codex/test/runtime/codex_desktop_app_locator_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_desktop_app_locator_test.dart
@@ -31,20 +31,25 @@ void main() {
       expect(candidates, everyElement(startsWith("/Applications")));
     });
 
-    test("windows probes the stable path and hash subdirectories newest first", () async {
+    test("windows probes the stable path and hash subdirectories newest first", () {
       final localAppData = Directory.systemTemp.createTempSync("codex-locator-test");
       addTearDown(() => localAppData.deleteSync(recursive: true));
-      final binDir = Directory(p.join(localAppData.path, "OpenAI", "Codex", "bin"))
-        ..createSync(recursive: true);
+      final binDir = Directory(p.join(localAppData.path, "OpenAI", "Codex", "bin"))..createSync(recursive: true);
       final older = Directory(p.join(binDir.path, "aaaa1111"))..createSync();
-      // Directory mtimes cannot be set directly from dart:io; a real delay
-      // between creations keeps newest-first ordering observable.
-      await Future<void>.delayed(const Duration(milliseconds: 1100));
       final newer = Directory(p.join(binDir.path, "bbbb2222"))..createSync();
+      final modificationTimes = {
+        older.path: DateTime.utc(2026, 8, 22, 12),
+        newer.path: DateTime.utc(2026, 8, 22, 13),
+      };
 
-      final candidates = codexDesktopAppCliCandidates(
-        environment: {"LOCALAPPDATA": localAppData.path},
-        os: PlatformOs.windows,
+      final candidates = IOOverrides.runZoned(
+        () => codexDesktopAppCliCandidates(
+          environment: {"LOCALAPPDATA": localAppData.path},
+          os: PlatformOs.windows,
+        ),
+        statSync: (path) => modificationTimes[path] == null
+            ? FileStat.statSync(path)
+            : _FakeFileStat(modified: modificationTimes[path]!),
       );
 
       expect(candidates, [
@@ -71,4 +76,12 @@ void main() {
       );
     });
   });
+}
+
+final class _FakeFileStat({@override required final DateTime modified}) implements FileStat {
+  @override
+  FileSystemEntityType get type => FileSystemEntityType.directory;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/client/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
@@ -140,12 +140,16 @@ void main() {
         description: "Allow writing file",
       );
 
+      final permissionSeen = Completer<void>();
       final seenPermissions = <SesoriPermissionAsked>[];
-      final sub = cubit.permissionStream.listen(seenPermissions.add);
+      final sub = cubit.permissionStream.listen((permission) {
+        seenPermissions.add(permission);
+        permissionSeen.complete();
+      });
       addTearDown(sub.cancel);
 
       sessionEvents.add(permission);
-      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await permissionSeen.future;
 
       final loaded = cubit.state as SessionDetailLoaded;
       expect(loaded.pendingPermissions, [permission]);
@@ -176,7 +180,11 @@ void main() {
 
       sessionEvents.add(permission);
       sessionEvents.add(permission);
-      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await awaitState(
+        cubit: cubit,
+        predicate: (state) => state is SessionDetailLoaded && state.pendingPermissions.isNotEmpty,
+        description: "permission added",
+      );
 
       final loaded = cubit.state as SessionDetailLoaded;
       expect(loaded.pendingPermissions, hasLength(1));
@@ -215,7 +223,11 @@ void main() {
           description: "Allow writing file",
         ),
       );
-      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await awaitState(
+        cubit: cubit,
+        predicate: (state) => state is SessionDetailLoaded && state.pendingPermissions.isNotEmpty,
+        description: "permission added",
+      );
 
       final resultFuture = cubit.replyToPermission(
         requestId: "perm-123",
@@ -272,7 +284,11 @@ void main() {
           description: "Allow writing file",
         ),
       );
-      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await awaitState(
+        cubit: cubit,
+        predicate: (state) => state is SessionDetailLoaded && state.pendingPermissions.isNotEmpty,
+        description: "permission added",
+      );
 
       final result = await cubit.replyToPermission(
         requestId: "perm-123",
@@ -475,7 +491,7 @@ void main() {
         description: "Allow writing file",
       );
       sessionEvents.add(permission);
-      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await pumpEventQueue();
 
       expect(cubit.state, const SessionDetailState.loading());
 
@@ -547,12 +563,16 @@ void main() {
         description: "Run ls",
       );
 
+      final permissionSeen = Completer<void>();
       final seen = <SesoriPermissionAsked>[];
-      final sub = cubit.permissionStream.listen(seen.add);
+      final sub = cubit.permissionStream.listen((permission) {
+        seen.add(permission);
+        permissionSeen.complete();
+      });
       addTearDown(sub.cancel);
 
       globalEvents.add(SseEvent(data: childPermission));
-      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await permissionSeen.future;
 
       final loaded = cubit.state as SessionDetailLoaded;
       expect(loaded.pendingPermissions, [childPermission]);
@@ -569,7 +589,11 @@ void main() {
           ),
         ),
       );
-      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await awaitState(
+        cubit: cubit,
+        predicate: (state) => state is SessionDetailLoaded && state.pendingPermissions.isEmpty,
+        description: "permission removed",
+      );
       expect((cubit.state as SessionDetailLoaded).pendingPermissions, isEmpty);
     });
 
@@ -598,9 +622,23 @@ void main() {
           ),
         ),
       );
-      await Future<void>.delayed(const Duration(milliseconds: 20));
+      const relevantPermission = SesoriPermissionAsked(
+        requestID: "perm-control",
+        sessionID: "child-1",
+        displaySessionId: sessionId,
+        tool: "bash",
+        description: "Run pwd",
+      );
+      globalEvents.add(SseEvent(data: relevantPermission));
+      await awaitState(
+        cubit: cubit,
+        predicate: (state) =>
+            state is SessionDetailLoaded &&
+            state.pendingPermissions.any((permission) => permission.requestID == relevantPermission.requestID),
+        description: "relevant permission processed after unrelated permission",
+      );
 
-      expect((cubit.state as SessionDetailLoaded).pendingPermissions, isEmpty);
+      expect((cubit.state as SessionDetailLoaded).pendingPermissions, [relevantPermission]);
     });
 
     test("rejecting a surfaced child question targets the child (owner) session", () async {
@@ -854,9 +892,9 @@ ProviderListResponse _providers() {
 }
 
 Future<void> _awaitLoaded(SessionDetailCubit cubit) async {
-  for (var i = 0; i < 100; i++) {
-    if (cubit.state is SessionDetailLoaded) return;
-    await Future<void>.delayed(const Duration(milliseconds: 1));
-  }
-  fail("Timed out waiting for SessionDetailLoaded; current state: ${cubit.state}");
+  await awaitState(
+    cubit: cubit,
+    predicate: (state) => state is SessionDetailLoaded,
+    description: "SessionDetailLoaded",
+  );
 }

--- a/client/module_core/test/cubits/session_detail/session_detail_cubit_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_cubit_test.dart
@@ -602,7 +602,11 @@ void main() {
         sessionEvents.add(
           const SesoriSessionStatus(sessionID: sessionId, status: SessionStatus.busy()),
         );
-        await Future<void>.delayed(const Duration(milliseconds: 10));
+        await awaitState(
+          cubit: cubit,
+          predicate: (state) => state is SessionDetailLoaded && state.sessionStatus == const SessionStatus.busy(),
+          description: "busy session",
+        );
 
         // Send message while busy — should send immediately (not queue).
         await cubit.sendMessage(
@@ -1216,7 +1220,11 @@ void main() {
         // A newer child session arrives via global SSE event.
         final newerChild = testSession(id: "child-2", parentID: sessionId, updatedAt: 5000);
         globalEvents.add(SseEvent(data: SesoriSessionCreated(info: newerChild)));
-        await Future<void>.delayed(const Duration(milliseconds: 10));
+        await awaitState(
+          cubit: cubit,
+          predicate: (state) => state is SessionDetailLoaded && state.children.first.id == "child-2",
+          description: "new child inserted first",
+        );
       },
       expect: () => [
         // Initial load with one child.
@@ -1289,7 +1297,7 @@ void main() {
             messageID: "refresh-message",
           ),
         );
-        await Future<void>.delayed(const Duration(milliseconds: 10));
+        await _awaitNotRefreshing(cubit);
       },
       expect: () => [
         // Initial load: newest first.
@@ -1421,7 +1429,11 @@ void main() {
         // Old child gets a newer updated timestamp.
         final updatedOldChild = testSession(id: "child-old", parentID: sessionId, updatedAt: 5000);
         globalEvents.add(SseEvent(data: SesoriSessionUpdated(info: updatedOldChild)));
-        await Future<void>.delayed(const Duration(milliseconds: 10));
+        await awaitState(
+          cubit: cubit,
+          predicate: (state) => state is SessionDetailLoaded && state.children.first.id == "child-old",
+          description: "updated child re-sorted first",
+        );
       },
       expect: () => [
         // Initial load: newest first.
@@ -1707,7 +1719,11 @@ void main() {
         sessionEvents.add(
           const SesoriSessionStatus(sessionID: sessionId, status: SessionStatus.idle()),
         );
-        await Future<void>.delayed(const Duration(milliseconds: 10));
+        await awaitState(
+          cubit: cubit,
+          predicate: (state) => state is SessionDetailLoaded && state.sessionStatus == const SessionStatus.idle(),
+          description: "idle session",
+        );
       },
       expect: () => [
         // Initial load.
@@ -1792,7 +1808,7 @@ void main() {
             health: testHealthResponse(),
           ),
         );
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await _awaitQueuedMessages(cubit, isEmpty);
       },
       expect: () => [
         // Initial load.
@@ -1880,7 +1896,7 @@ void main() {
           health: testHealthResponse(),
         ),
       );
-      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await _awaitQueuedMessages(cubit, isEmpty);
 
       verify(
         () => mockSessionService.sendMessage(
@@ -1945,7 +1961,7 @@ void main() {
         health: testHealthResponse(),
       );
       connectionStatus.add(connected);
-      await Future<void>.delayed(const Duration(milliseconds: 10));
+      await Future<void>.delayed(Duration.zero);
 
       when(() => mockConnectionService.currentStatus).thenReturn(
         const ConnectionStatus.connectionLost(
@@ -2081,7 +2097,7 @@ void main() {
       );
 
       allowFirstSendToComplete.complete();
-      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await _awaitQueuedMessages(cubit, isEmpty);
 
       expect(sentTexts, equals(["first", "second"]));
       expect((cubit.state as SessionDetailLoaded).queuedMessages, isEmpty);
@@ -2238,7 +2254,7 @@ void main() {
         );
 
         // Wait for both messages to drain via self-chaining.
-        await Future<void>.delayed(const Duration(milliseconds: 100));
+        await _awaitQueuedMessages(cubit, isEmpty);
       },
       verify: (_) {
         verify(
@@ -2336,7 +2352,14 @@ void main() {
             health: testHealthResponse(),
           ),
         );
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await awaitState(
+          cubit: cubit,
+          predicate: (state) =>
+              state is SessionDetailLoaded &&
+              state.queuedMessages.map((message) => message.displayText).contains("will fail") &&
+              state.sendingSubmission == null,
+          description: "failed queued message re-queued",
+        );
       },
       expect: () => [
         // Initial load.
@@ -2443,7 +2466,11 @@ void main() {
           failureReporter: mockFailureReporter,
         );
         addTearDown(cubit.close);
-        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await awaitState(
+          cubit: cubit,
+          predicate: (state) => state is SessionDetailFailed,
+          description: "failed session load",
+        );
 
         verifyNever(() => viewingService.setViewingSession(any()));
         verify(
@@ -2475,12 +2502,17 @@ void main() {
           failureReporter: mockFailureReporter,
         );
         addTearDown(cubit.close);
-        await _awaitLoaded(cubit);
+        await Future<void>.delayed(Duration.zero);
         clearInteractions(viewingService);
+        final viewReasserted = Completer<void>();
+        when(() => viewingService.setViewingSession(sessionId)).thenAnswer((_) {
+          viewReasserted.complete();
+        });
 
         // Stale signal arrives while disconnected — the refresh is deferred.
         mockConnectionService.emitDataMayBeStale();
-        await Future<void>.delayed(const Duration(milliseconds: 10));
+        final staleSignalDelivered = Future<void>.delayed(Duration.zero);
+        await staleSignalDelivered;
         verifyNever(() => viewingService.setViewingSession(any()));
 
         // Reconnect: the bridge released this connection's view on the drop,
@@ -2492,12 +2524,12 @@ void main() {
           ),
         );
         connectionStatus.add(
-          const ConnectionStatus.connected(
-            config: ServerConnectionConfig(relayHost: "fake.example.com"),
-            health: HealthResponse(healthy: true, version: "1", filesystemAccessDegraded: null),
+          ConnectionStatus.connected(
+            config: const ServerConnectionConfig(relayHost: "fake.example.com"),
+            health: testHealthResponse(),
           ),
         );
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await viewReasserted.future;
 
         verify(() => viewingService.setViewingSession(sessionId)).called(1);
       });
@@ -2532,7 +2564,12 @@ void main() {
 
         lifecycle.emitState(LifecycleState.paused);
         lifecycle.emitState(LifecycleState.resumed);
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await awaitState(
+          cubit: cubit,
+          predicate: (state) => state is SessionDetailLoaded && state.isRefreshing,
+          description: "resume refresh started",
+        );
+        await _awaitNotRefreshing(cubit);
 
         // The post-resume silent refresh completed and re-declared the view.
         verify(() => viewingService.setViewingSession(sessionId)).called(1);
@@ -2590,26 +2627,27 @@ void _stubPromptAttachmentCapability({
 }
 
 Future<void> _awaitLoaded(SessionDetailCubit cubit) async {
-  for (var i = 0; i < 50; i++) {
-    if (cubit.state is SessionDetailLoaded) return;
-    await Future<void>.delayed(const Duration(milliseconds: 1));
-  }
+  await awaitState(
+    cubit: cubit,
+    predicate: (state) => state is SessionDetailLoaded,
+    description: "SessionDetailLoaded",
+  );
 }
 
 Future<void> _awaitQueuedMessages(SessionDetailCubit cubit, Matcher matcher) async {
-  for (var i = 0; i < 50; i++) {
-    final state = cubit.state;
-    if (state is SessionDetailLoaded && matcher.matches(state.queuedMessages, <Object, Object>{})) return;
-    await Future<void>.delayed(const Duration(milliseconds: 1));
-  }
+  await awaitState(
+    cubit: cubit,
+    predicate: (state) => state is SessionDetailLoaded && matcher.matches(state.queuedMessages, <Object, Object>{}),
+    description: "queued messages matching $matcher",
+  );
 }
 
 Future<void> _awaitNotRefreshing(SessionDetailCubit cubit) async {
-  for (var i = 0; i < 50; i++) {
-    final state = cubit.state;
-    if (state is SessionDetailLoaded && !state.isRefreshing) return;
-    await Future<void>.delayed(const Duration(milliseconds: 1));
-  }
+  await awaitState(
+    cubit: cubit,
+    predicate: (state) => state is SessionDetailLoaded && !state.isRefreshing,
+    description: "non-refreshing SessionDetailLoaded",
+  );
 }
 
 void _stubAllDefaults(

--- a/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
@@ -498,11 +498,11 @@ void main() {
           projectId: any(named: "projectId"),
         ),
       );
-      for (var i = 0; i < 100; i++) {
-        final state = cubit.state;
-        if (state is SessionDetailLoaded && !state.isRefreshing) break;
-        await Future<void>.delayed(const Duration(milliseconds: 5));
-      }
+      await awaitState(
+        cubit: cubit,
+        predicate: (state) => state is SessionDetailLoaded && !state.isRefreshing,
+        description: "completed refresh",
+      );
 
       final refreshed = cubit.state as SessionDetailLoaded;
       expect(refreshed.isRefreshing, isFalse);
@@ -614,9 +614,7 @@ void main() {
           isBridgeConnected: true,
         ),
       );
-      for (var i = 0; i < 100 && sendCalls < 2; i++) {
-        await Future<void>.delayed(const Duration(milliseconds: 5));
-      }
+      await _awaitCondition(() => sendCalls == 2);
 
       expect(sendCalls, 2);
       expect((cubit.state as SessionDetailLoaded).queuedMessages, isEmpty);
@@ -1037,7 +1035,11 @@ void main() {
       );
 
       // Wait for the failure state to be emitted
-      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await awaitState(
+        cubit: cubit,
+        predicate: (state) => state is SessionDetailFailed,
+        description: "SessionDetailFailed",
+      );
       expect(cubit.state, isA<SessionDetailFailed>());
 
       // Now reload manually — the old buffered event should NOT be replayed
@@ -1100,7 +1102,11 @@ void main() {
       final cubit = createCubit(loadService: mockLoadService);
 
       // Wait for the failure state
-      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await awaitState(
+        cubit: cubit,
+        predicate: (state) => state is SessionDetailFailed,
+        description: "SessionDetailFailed",
+      );
       expect(cubit.state, isA<SessionDetailFailed>());
 
       // Emit an event while in failed state — should be dropped
@@ -1778,33 +1784,31 @@ void main() {
 }
 
 Future<void> _awaitLoaded(SessionDetailCubit cubit) async {
-  for (var i = 0; i < 100; i++) {
-    if (cubit.state is SessionDetailLoaded) return;
-    await Future<void>.delayed(const Duration(milliseconds: 5));
-  }
-  fail("Timed out waiting for SessionDetailLoaded; current state: ${cubit.state}");
+  await awaitState(
+    cubit: cubit,
+    predicate: (state) => state is SessionDetailLoaded,
+    description: "SessionDetailLoaded",
+  );
 }
 
 Future<void> _awaitLoadedWithCommand(
   SessionDetailCubit cubit, {
   required String command,
 }) async {
-  for (var i = 0; i < 100; i++) {
-    final state = cubit.state;
-    if (state is SessionDetailLoaded &&
+  await awaitState(
+    cubit: cubit,
+    predicate: (state) =>
+        state is SessionDetailLoaded &&
         !state.isRefreshing &&
-        state.availableCommands.any((item) => item.name == command)) {
-      return;
-    }
-    await Future<void>.delayed(const Duration(milliseconds: 5));
-  }
-  fail("Timed out waiting for '$command'; current state: ${cubit.state}");
+        state.availableCommands.any((item) => item.name == command),
+    description: "available command '$command'",
+  );
 }
 
 Future<void> _awaitCondition(bool Function() condition) async {
   for (var i = 0; i < 100; i++) {
     if (condition()) return;
-    await Future<void>.delayed(const Duration(milliseconds: 5));
+    await Future<void>.delayed(Duration.zero);
   }
   fail("Timed out waiting for condition");
 }

--- a/client/module_core/test/cubits/session_detail/session_detail_paging_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_paging_test.dart
@@ -217,13 +217,11 @@ void main() {
 }
 
 Future<void> _awaitLoaded(SessionDetailCubit cubit) async {
-  if (cubit.state is SessionDetailLoaded) return;
-  await cubit.stream
-      .firstWhere((state) => state is SessionDetailLoaded)
-      .timeout(
-        const Duration(seconds: 5),
-        onTimeout: () => throw StateError("cubit never reached loaded; last state: ${cubit.state}"),
-      );
+  await awaitState(
+    cubit: cubit,
+    predicate: (state) => state is SessionDetailLoaded,
+    description: "SessionDetailLoaded",
+  );
 }
 
 MessageWithParts _message({required String id}) => MessageWithParts(

--- a/client/module_core/test/cubits/session_detail/session_detail_reconnect_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_reconnect_test.dart
@@ -384,9 +384,9 @@ MessageWithParts _messageWithParts() {
 }
 
 Future<void> _awaitLoaded(SessionDetailCubit cubit) async {
-  for (var i = 0; i < 100; i++) {
-    if (cubit.state is SessionDetailLoaded) return;
-    await Future<void>.delayed(const Duration(milliseconds: 5));
-  }
-  fail("Timed out waiting for SessionDetailLoaded; current state: ${cubit.state}");
+  await awaitState(
+    cubit: cubit,
+    predicate: (state) => state is SessionDetailLoaded,
+    description: "SessionDetailLoaded",
+  );
 }

--- a/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:fake_async/fake_async.dart";
 import "package:mocktail/mocktail.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
@@ -18,6 +19,8 @@ import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
 import "../../helpers/test_helpers.dart";
+
+const _cooldown = Duration(milliseconds: 100);
 
 void main() {
   const sessionId = "session-1";
@@ -814,178 +817,193 @@ void main() {
       },
     );
 
-    test("a failed leading stale refresh retries until a snapshot succeeds", () async {
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-        eventRefreshMinInterval: const Duration(milliseconds: 100),
-      );
-      addTearDown(cubit.close);
+    test("a failed leading stale refresh retries until a snapshot succeeds", () {
+      fakeAsync((FakeAsync async) {
+        final cubit = SessionDetailCubit(
+          mockConnectionService,
+          loadService: loadService,
+          promptDispatcher: promptDispatcher,
+          permissionRepository: mockPermissionRepository,
+          sessionViewingService: stubbedSessionViewingService(),
+          projectViewingService: stubbedProjectViewingService(),
+          lifecycleSource: FakeLifecycleSource(),
+          composerDraftRepository: inMemoryComposerDraftRepository(),
+          productAnalyticsService: stubbedProductAnalyticsService(),
+          sessionId: sessionId,
+          projectId: "project-1",
+          notificationCanceller: mockNotificationCanceller,
+          failureReporter: MockFailureReporter(),
+          eventRefreshMinInterval: _cooldown,
+        );
 
-      await _awaitLoaded(cubit);
-      reset(mockSessionService);
-      _stubLoadApis(mockSessionService, sessionId: sessionId);
-      when(
-        () => mockSessionService.listCommands(
-          projectId: any(named: "projectId"),
-          pluginId: any(named: "pluginId"),
-        ),
-      ).thenAnswer(
-        (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
-      );
-      var messageLoads = 0;
-      when(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).thenAnswer((_) async {
-        messageLoads++;
-        if (messageLoads == 1) {
-          return ApiResponse.error(ApiError.generic());
-        }
-        return ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null));
+        _settleLoaded(async: async, cubit: cubit);
+        reset(mockSessionService);
+        _stubLoadApis(mockSessionService, sessionId: sessionId);
+        when(
+          () => mockSessionService.listCommands(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
+        );
+        var messageLoads = 0;
+        when(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).thenAnswer((_) async {
+          messageLoads++;
+          if (messageLoads == 1) {
+            return ApiResponse.error(ApiError.generic());
+          }
+          return ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null));
+        });
+
+        mockConnectionService.emitDataMayBeStale();
+        async.elapse(Duration.zero);
+        expect(messageLoads, 1);
+
+        // The cooldown elapses and the restored staleness produces the retry.
+        async.elapse(_cooldown);
+        expect(messageLoads, 2);
+
+        // The successful retry consumed the signal; later windows stay quiet.
+        async.elapse(_cooldown * 2);
+        expect(messageLoads, 2);
+
+        _completeCleanup(async: async, futures: [cubit.close()]);
       });
-
-      mockConnectionService.emitDataMayBeStale();
-      await pumpEventQueue();
-      expect(messageLoads, 1);
-
-      await Future<void>.delayed(const Duration(milliseconds: 120));
-      expect(messageLoads, 2);
-
-      await Future<void>.delayed(const Duration(milliseconds: 150));
-      expect(messageLoads, 2);
     });
 
-    test("an option load failure preserves catalogs and retries until options load", () async {
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-        eventRefreshMinInterval: const Duration(milliseconds: 100),
-      );
-      addTearDown(cubit.close);
+    test("an option load failure preserves catalogs and retries until options load", () {
+      fakeAsync((FakeAsync async) {
+        final cubit = SessionDetailCubit(
+          mockConnectionService,
+          loadService: loadService,
+          promptDispatcher: promptDispatcher,
+          permissionRepository: mockPermissionRepository,
+          sessionViewingService: stubbedSessionViewingService(),
+          projectViewingService: stubbedProjectViewingService(),
+          lifecycleSource: FakeLifecycleSource(),
+          composerDraftRepository: inMemoryComposerDraftRepository(),
+          productAnalyticsService: stubbedProductAnalyticsService(),
+          sessionId: sessionId,
+          projectId: "project-1",
+          notificationCanceller: mockNotificationCanceller,
+          failureReporter: MockFailureReporter(),
+          eventRefreshMinInterval: _cooldown,
+        );
 
-      await _awaitLoaded(cubit);
-      final before = cubit.state as SessionDetailLoaded;
-      var providerLoads = 0;
-      when(
-        () => mockSessionService.listProviders(
-          projectId: any(named: "projectId"),
-          pluginId: any(named: "pluginId"),
-        ),
-      ).thenAnswer((_) async {
-        providerLoads++;
-        return providerLoads == 1
-            ? ApiResponse<ProviderListResponse>.error(ApiError.generic())
-            : ApiResponse.success(_providers());
+        _settleLoaded(async: async, cubit: cubit);
+        final before = cubit.state as SessionDetailLoaded;
+        var providerLoads = 0;
+        when(
+          () => mockSessionService.listProviders(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer((_) async {
+          providerLoads++;
+          return providerLoads == 1
+              ? ApiResponse<ProviderListResponse>.error(ApiError.generic())
+              : ApiResponse.success(_providers());
+        });
+
+        mockConnectionService.emitDataMayBeStale();
+        async.elapse(Duration.zero);
+
+        expect(providerLoads, 1);
+        final afterFailure = cubit.state as SessionDetailLoaded;
+        expect(afterFailure.availableAgents, before.availableAgents);
+        expect(afterFailure.availableProviders, before.availableProviders);
+        expect(afterFailure.availableCommands, before.availableCommands);
+
+        // The cooldown elapses and the retained staleness retries the options.
+        async.elapse(_cooldown);
+        expect(providerLoads, 2);
+
+        // The successful retry consumed the signal; later windows stay quiet.
+        async.elapse(_cooldown * 2);
+        expect(providerLoads, 2);
+
+        _completeCleanup(async: async, futures: [cubit.close()]);
       });
-
-      mockConnectionService.emitDataMayBeStale();
-      await pumpEventQueue();
-
-      expect(providerLoads, 1);
-      final afterFailure = cubit.state as SessionDetailLoaded;
-      expect(afterFailure.availableAgents, before.availableAgents);
-      expect(afterFailure.availableProviders, before.availableProviders);
-      expect(afterFailure.availableCommands, before.availableCommands);
-
-      await Future<void>.delayed(const Duration(milliseconds: 120));
-      expect(providerLoads, 2);
-
-      await Future<void>.delayed(const Duration(milliseconds: 150));
-      expect(providerLoads, 2);
     });
 
     test("a disconnected failed refresh waits for reconnect instead of retrying each cooldown", () async {
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-        eventRefreshMinInterval: const Duration(milliseconds: 100),
-      );
-      addTearDown(cubit.close);
-
-      await _awaitLoaded(cubit);
-      reset(mockSessionService);
-      _stubLoadApis(mockSessionService, sessionId: sessionId);
-      when(
-        () => mockSessionService.listCommands(
-          projectId: any(named: "projectId"),
-          pluginId: any(named: "pluginId"),
-        ),
-      ).thenAnswer(
-        (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
-      );
-
-      final firstMessages = Completer<ApiResponse<MessageWithPartsResponse>>();
-      var messageLoads = 0;
-      when(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).thenAnswer((_) {
-        messageLoads++;
-        if (messageLoads == 1) return firstMessages.future;
-        return Future.value(
-          ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
+      late final SessionDetailCubit cubit;
+      late final StreamSubscription<SessionDetailState> sub;
+      fakeAsync((FakeAsync async) {
+        cubit = SessionDetailCubit(
+          mockConnectionService,
+          loadService: loadService,
+          promptDispatcher: promptDispatcher,
+          permissionRepository: mockPermissionRepository,
+          sessionViewingService: stubbedSessionViewingService(),
+          projectViewingService: stubbedProjectViewingService(),
+          lifecycleSource: FakeLifecycleSource(),
+          composerDraftRepository: inMemoryComposerDraftRepository(),
+          productAnalyticsService: stubbedProductAnalyticsService(),
+          sessionId: sessionId,
+          projectId: "project-1",
+          notificationCanceller: mockNotificationCanceller,
+          failureReporter: MockFailureReporter(),
+          eventRefreshMinInterval: _cooldown,
         );
+
+        _settleLoaded(async: async, cubit: cubit);
+        reset(mockSessionService);
+        _stubLoadApis(mockSessionService, sessionId: sessionId);
+        when(
+          () => mockSessionService.listCommands(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
+        );
+
+        final firstMessages = Completer<ApiResponse<MessageWithPartsResponse>>();
+        var messageLoads = 0;
+        when(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).thenAnswer((_) {
+          messageLoads++;
+          if (messageLoads == 1) return firstMessages.future;
+          return Future.value(
+            ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
+          );
+        });
+
+        final emitted = <SessionDetailState>[];
+        sub = cubit.stream.listen(emitted.add);
+
+        mockConnectionService.emitDataMayBeStale();
+        async.elapse(Duration.zero);
+        connectionStatus.add(connectionLostStatus);
+        firstMessages.complete(ApiResponse.error(ApiError.generic()));
+
+        // Several cooldown windows pass while disconnected: no retry fires.
+        async.elapse(_cooldown * 3);
+        expect(messageLoads, 1);
+        expect(
+          emitted.whereType<SessionDetailLoaded>().where((state) => state.isRefreshing),
+          hasLength(1),
+        );
+
+        connectionStatus.add(connectedStatus);
+        async.elapse(Duration.zero);
+        expect(messageLoads, 2);
       });
-
-      final emitted = <SessionDetailState>[];
-      final sub = cubit.stream.listen(emitted.add);
-      addTearDown(sub.cancel);
-
-      mockConnectionService.emitDataMayBeStale();
-      await pumpEventQueue();
-      connectionStatus.add(connectionLostStatus);
-      firstMessages.complete(ApiResponse.error(ApiError.generic()));
-
-      await Future<void>.delayed(const Duration(milliseconds: 250));
-      expect(messageLoads, 1);
-      expect(
-        emitted.whereType<SessionDetailLoaded>().where((state) => state.isRefreshing),
-        hasLength(1),
-      );
-
-      connectionStatus.add(connectedStatus);
-      await pumpEventQueue();
-      expect(messageLoads, 2);
+      await sub.cancel();
+      await cubit.close();
     });
 
     test("concurrent stale signals are coalesced (single API call)", () async {
@@ -1088,451 +1106,473 @@ void main() {
       ).called(1);
     });
 
-    test("staleness bursts inside the cooldown collapse into one immediate and one trailing refresh", () async {
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-        eventRefreshMinInterval: const Duration(milliseconds: 100),
-      );
-      addTearDown(cubit.close);
+    test("staleness bursts inside the cooldown collapse into one immediate and one trailing refresh", () {
+      fakeAsync((FakeAsync async) {
+        final cubit = SessionDetailCubit(
+          mockConnectionService,
+          loadService: loadService,
+          promptDispatcher: promptDispatcher,
+          permissionRepository: mockPermissionRepository,
+          sessionViewingService: stubbedSessionViewingService(),
+          projectViewingService: stubbedProjectViewingService(),
+          lifecycleSource: FakeLifecycleSource(),
+          composerDraftRepository: inMemoryComposerDraftRepository(),
+          productAnalyticsService: stubbedProductAnalyticsService(),
+          sessionId: sessionId,
+          projectId: "project-1",
+          notificationCanceller: mockNotificationCanceller,
+          failureReporter: MockFailureReporter(),
+          eventRefreshMinInterval: _cooldown,
+        );
 
-      await _awaitLoaded(cubit);
-      reset(mockSessionService);
-      _stubLoadApis(mockSessionService, sessionId: sessionId);
-      when(
-        () => mockSessionService.listCommands(
-          projectId: any(named: "projectId"),
-          pluginId: any(named: "pluginId"),
-        ),
-      ).thenAnswer(
-        (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
-      );
+        _settleLoaded(async: async, cubit: cubit);
+        reset(mockSessionService);
+        _stubLoadApis(mockSessionService, sessionId: sessionId);
+        when(
+          () => mockSessionService.listCommands(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
+        );
 
-      // A burst of staleness signals: the first refreshes immediately, the
-      // rest queue behind the cooldown.
-      mockConnectionService.emitDataMayBeStale();
-      mockConnectionService.emitDataMayBeStale();
-      mockConnectionService.emitDataMayBeStale();
-      await pumpEventQueue();
-      verify(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).called(1);
+        // A burst of staleness signals: the first refreshes immediately, the
+        // rest queue behind the cooldown.
+        mockConnectionService.emitDataMayBeStale();
+        mockConnectionService.emitDataMayBeStale();
+        mockConnectionService.emitDataMayBeStale();
+        async.elapse(Duration.zero);
+        verify(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).called(1);
 
-      // Once the cooldown elapses, the queued signals collapse into exactly
-      // one trailing refresh...
-      await Future<void>.delayed(const Duration(milliseconds: 120));
-      verify(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).called(1);
+        // Once the cooldown elapses, the queued signals collapse into exactly
+        // one trailing refresh...
+        async.elapse(_cooldown);
+        verify(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).called(1);
 
-      // ...and a drained queue schedules nothing further.
-      await Future<void>.delayed(const Duration(milliseconds: 150));
-      verifyNever(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      );
-    });
+        // ...and a drained queue schedules nothing further.
+        async.elapse(_cooldown * 2);
+        verifyNever(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        );
 
-    test("a queued signal survives a refresh that outlives the cooldown window", () async {
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-        eventRefreshMinInterval: const Duration(milliseconds: 100),
-      );
-      addTearDown(cubit.close);
-
-      await _awaitLoaded(cubit);
-      reset(mockSessionService);
-      _stubLoadApis(mockSessionService, sessionId: sessionId);
-      when(
-        () => mockSessionService.listCommands(
-          projectId: any(named: "projectId"),
-          pluginId: any(named: "pluginId"),
-        ),
-      ).thenAnswer(
-        (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
-      );
-
-      // Hold the first refresh's message fetch so the refresh itself spans
-      // the entire cooldown window.
-      final messagesCompleter = Completer<ApiResponse<MessageWithPartsResponse>>();
-      when(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).thenAnswer((_) => messagesCompleter.future);
-
-      mockConnectionService.emitDataMayBeStale();
-      mockConnectionService.emitDataMayBeStale();
-      await pumpEventQueue();
-      verify(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).called(1);
-
-      // The cooldown elapses while the first refresh is still in flight; the
-      // queued signal must be retained, not silently coalesced into the
-      // stale in-flight run.
-      await Future<void>.delayed(const Duration(milliseconds: 120));
-      when(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).thenAnswer(
-        (_) async => ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
-      );
-      messagesCompleter.complete(
-        ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
-      );
-
-      // Once the next window elapses, the retained signal produces the
-      // trailing refresh against fresh data.
-      await Future<void>.delayed(const Duration(milliseconds: 150));
-      verify(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).called(1);
-    });
-
-    test("the trailing refresh runs as soon as a slow refresh completes, not a window later", () async {
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-        eventRefreshMinInterval: const Duration(milliseconds: 100),
-      );
-      addTearDown(cubit.close);
-
-      await _awaitLoaded(cubit);
-      reset(mockSessionService);
-      _stubLoadApis(mockSessionService, sessionId: sessionId);
-      when(
-        () => mockSessionService.listCommands(
-          projectId: any(named: "projectId"),
-          pluginId: any(named: "pluginId"),
-        ),
-      ).thenAnswer(
-        (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
-      );
-
-      final messagesCompleter = Completer<ApiResponse<MessageWithPartsResponse>>();
-      when(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).thenAnswer((_) => messagesCompleter.future);
-
-      mockConnectionService.emitDataMayBeStale();
-      mockConnectionService.emitDataMayBeStale();
-      await Future<void>.delayed(const Duration(milliseconds: 120));
-      verify(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).called(1);
-
-      // The minimum interval elapsed mid-refresh; when the slow refresh
-      // finally completes, the queued trailing refresh must start right away
-      // rather than waiting out another full cooldown window.
-      when(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).thenAnswer(
-        (_) async => ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
-      );
-      messagesCompleter.complete(
-        ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
-      );
-      await pumpEventQueue();
-      verify(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).called(1);
-    });
-
-    test("the queue is held while hidden and consumed by the resume refresh", () async {
-      final lifecycle = FakeLifecycleSource();
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: lifecycle,
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-        eventRefreshMinInterval: const Duration(milliseconds: 100),
-      );
-      addTearDown(cubit.close);
-
-      await _awaitLoaded(cubit);
-      reset(mockSessionService);
-      _stubLoadApis(mockSessionService, sessionId: sessionId);
-      when(
-        () => mockSessionService.listCommands(
-          projectId: any(named: "projectId"),
-          pluginId: any(named: "pluginId"),
-        ),
-      ).thenAnswer(
-        (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
-      );
-
-      mockConnectionService.emitDataMayBeStale();
-      mockConnectionService.emitDataMayBeStale();
-      await pumpEventQueue();
-      verify(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).called(1);
-
-      // Backgrounding cancels the cooldown: the queued trailing refresh must
-      // not spend the radio while the app is hidden.
-      lifecycle.emitState(LifecycleState.paused);
-      await Future<void>.delayed(const Duration(milliseconds: 300));
-      verifyNever(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      );
-
-      // The resume bypass refresh consumes the held signal...
-      lifecycle.emitState(LifecycleState.resumed);
-      await pumpEventQueue();
-      verify(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).called(1);
-
-      // ...so nothing further fires afterwards.
-      await Future<void>.delayed(const Duration(milliseconds: 300));
-      verifyNever(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      );
-    });
-
-    test("a failed resume refresh preserves hidden staleness until a snapshot succeeds", () async {
-      final lifecycle = FakeLifecycleSource();
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: lifecycle,
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-        eventRefreshMinInterval: const Duration(milliseconds: 100),
-      );
-      addTearDown(cubit.close);
-
-      await _awaitLoaded(cubit);
-      reset(mockSessionService);
-      _stubLoadApis(mockSessionService, sessionId: sessionId);
-      when(
-        () => mockSessionService.listCommands(
-          projectId: any(named: "projectId"),
-          pluginId: any(named: "pluginId"),
-        ),
-      ).thenAnswer(
-        (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
-      );
-      var messageLoads = 0;
-      when(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).thenAnswer((_) async {
-        messageLoads++;
-        if (messageLoads == 1) {
-          return ApiResponse.error(ApiError.generic());
-        }
-        return ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null));
+        _completeCleanup(async: async, futures: [cubit.close()]);
       });
-
-      lifecycle.emitState(LifecycleState.paused);
-      mockConnectionService.emitDataMayBeStale();
-      await Future<void>.delayed(const Duration(milliseconds: 150));
-      expect(messageLoads, 0);
-
-      lifecycle.emitState(LifecycleState.resumed);
-      await pumpEventQueue();
-      expect(messageLoads, 1);
-
-      await Future<void>.delayed(const Duration(milliseconds: 120));
-      expect(messageLoads, 2);
-
-      await Future<void>.delayed(const Duration(milliseconds: 150));
-      expect(messageLoads, 2);
     });
 
-    test("a signal queued behind an in-flight refresh survives a pause/resume cycle", () async {
-      final lifecycle = FakeLifecycleSource();
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: lifecycle,
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-        eventRefreshMinInterval: const Duration(milliseconds: 100),
-      );
-      addTearDown(cubit.close);
+    test("a queued signal survives a refresh that outlives the cooldown window", () {
+      fakeAsync((FakeAsync async) {
+        final cubit = SessionDetailCubit(
+          mockConnectionService,
+          loadService: loadService,
+          promptDispatcher: promptDispatcher,
+          permissionRepository: mockPermissionRepository,
+          sessionViewingService: stubbedSessionViewingService(),
+          projectViewingService: stubbedProjectViewingService(),
+          lifecycleSource: FakeLifecycleSource(),
+          composerDraftRepository: inMemoryComposerDraftRepository(),
+          productAnalyticsService: stubbedProductAnalyticsService(),
+          sessionId: sessionId,
+          projectId: "project-1",
+          notificationCanceller: mockNotificationCanceller,
+          failureReporter: MockFailureReporter(),
+          eventRefreshMinInterval: _cooldown,
+        );
 
-      await _awaitLoaded(cubit);
-      reset(mockSessionService);
-      _stubLoadApis(mockSessionService, sessionId: sessionId);
-      when(
-        () => mockSessionService.listCommands(
-          projectId: any(named: "projectId"),
-          pluginId: any(named: "pluginId"),
-        ),
-      ).thenAnswer(
-        (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
-      );
+        _settleLoaded(async: async, cubit: cubit);
+        reset(mockSessionService);
+        _stubLoadApis(mockSessionService, sessionId: sessionId);
+        when(
+          () => mockSessionService.listCommands(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
+        );
 
-      final messagesCompleter = Completer<ApiResponse<MessageWithPartsResponse>>();
-      when(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).thenAnswer((_) => messagesCompleter.future);
+        // Hold the first refresh's message fetch so the refresh itself spans
+        // the entire cooldown window.
+        final messagesCompleter = Completer<ApiResponse<MessageWithPartsResponse>>();
+        when(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).thenAnswer((_) => messagesCompleter.future);
 
-      // Refresh A starts and stays in flight; a second signal queues.
-      mockConnectionService.emitDataMayBeStale();
-      mockConnectionService.emitDataMayBeStale();
-      await pumpEventQueue();
-      verify(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).called(1);
+        mockConnectionService.emitDataMayBeStale();
+        mockConnectionService.emitDataMayBeStale();
+        async.elapse(Duration.zero);
+        verify(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).called(1);
 
-      // Pause cancels the cooldown (the only armed trailing trigger); the
-      // resume bypass finds A still in flight and cannot start a refresh.
-      lifecycle.emitState(LifecycleState.paused);
-      lifecycle.emitState(LifecycleState.resumed);
-      await pumpEventQueue();
+        // The cooldown elapses while the first refresh is still in flight; the
+        // queued signal must be retained, not silently coalesced into the
+        // stale in-flight run.
+        async.elapse(_cooldown);
+        when(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
+        );
+        messagesCompleter.complete(
+          ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
+        );
 
-      // When A finally completes, the queued signal must still produce the
-      // trailing refresh instead of being stranded.
-      when(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).thenAnswer(
-        (_) async => ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
-      );
-      messagesCompleter.complete(
-        ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
-      );
-      await pumpEventQueue();
-      verify(
-        () => mockSessionService.getMessages(
-          sessionId: any(named: "sessionId"),
-          limit: any(named: "limit"),
-          before: any(named: "before"),
-        ),
-      ).called(1);
+        // Once the next window elapses, the retained signal produces the
+        // trailing refresh against fresh data.
+        async.elapse(_cooldown * 2);
+        verify(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).called(1);
+
+        _completeCleanup(async: async, futures: [cubit.close()]);
+      });
+    });
+
+    test("the trailing refresh runs as soon as a slow refresh completes, not a window later", () {
+      fakeAsync((FakeAsync async) {
+        final cubit = SessionDetailCubit(
+          mockConnectionService,
+          loadService: loadService,
+          promptDispatcher: promptDispatcher,
+          permissionRepository: mockPermissionRepository,
+          sessionViewingService: stubbedSessionViewingService(),
+          projectViewingService: stubbedProjectViewingService(),
+          lifecycleSource: FakeLifecycleSource(),
+          composerDraftRepository: inMemoryComposerDraftRepository(),
+          productAnalyticsService: stubbedProductAnalyticsService(),
+          sessionId: sessionId,
+          projectId: "project-1",
+          notificationCanceller: mockNotificationCanceller,
+          failureReporter: MockFailureReporter(),
+          eventRefreshMinInterval: _cooldown,
+        );
+
+        _settleLoaded(async: async, cubit: cubit);
+        reset(mockSessionService);
+        _stubLoadApis(mockSessionService, sessionId: sessionId);
+        when(
+          () => mockSessionService.listCommands(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
+        );
+
+        final messagesCompleter = Completer<ApiResponse<MessageWithPartsResponse>>();
+        when(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).thenAnswer((_) => messagesCompleter.future);
+
+        mockConnectionService.emitDataMayBeStale();
+        mockConnectionService.emitDataMayBeStale();
+        // The minimum interval elapses while the first refresh is still in
+        // flight.
+        async.elapse(_cooldown);
+        verify(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).called(1);
+
+        // When the slow refresh finally completes, the queued trailing refresh
+        // must start right away rather than waiting out another full cooldown
+        // window.
+        when(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
+        );
+        messagesCompleter.complete(
+          ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
+        );
+        async.elapse(Duration.zero);
+        verify(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).called(1);
+
+        _completeCleanup(async: async, futures: [cubit.close()]);
+      });
+    });
+
+    test("the queue is held while hidden and consumed by the resume refresh", () {
+      fakeAsync((FakeAsync async) {
+        final lifecycle = FakeLifecycleSource();
+        final cubit = SessionDetailCubit(
+          mockConnectionService,
+          loadService: loadService,
+          promptDispatcher: promptDispatcher,
+          permissionRepository: mockPermissionRepository,
+          sessionViewingService: stubbedSessionViewingService(),
+          projectViewingService: stubbedProjectViewingService(),
+          lifecycleSource: lifecycle,
+          composerDraftRepository: inMemoryComposerDraftRepository(),
+          productAnalyticsService: stubbedProductAnalyticsService(),
+          sessionId: sessionId,
+          projectId: "project-1",
+          notificationCanceller: mockNotificationCanceller,
+          failureReporter: MockFailureReporter(),
+          eventRefreshMinInterval: _cooldown,
+        );
+
+        _settleLoaded(async: async, cubit: cubit);
+        reset(mockSessionService);
+        _stubLoadApis(mockSessionService, sessionId: sessionId);
+        when(
+          () => mockSessionService.listCommands(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
+        );
+
+        mockConnectionService.emitDataMayBeStale();
+        mockConnectionService.emitDataMayBeStale();
+        async.elapse(Duration.zero);
+        verify(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).called(1);
+
+        // Backgrounding cancels the cooldown: the queued trailing refresh must
+        // not spend the radio while the app is hidden.
+        lifecycle.emitState(LifecycleState.paused);
+        async.elapse(_cooldown * 3);
+        verifyNever(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        );
+
+        // The resume bypass refresh consumes the held signal...
+        lifecycle.emitState(LifecycleState.resumed);
+        async.elapse(Duration.zero);
+        verify(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).called(1);
+
+        // ...so nothing further fires afterwards.
+        async.elapse(_cooldown * 3);
+        verifyNever(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        );
+
+        _completeCleanup(async: async, futures: [cubit.close()]);
+      });
+    });
+
+    test("a failed resume refresh preserves hidden staleness until a snapshot succeeds", () {
+      fakeAsync((FakeAsync async) {
+        final lifecycle = FakeLifecycleSource();
+        final cubit = SessionDetailCubit(
+          mockConnectionService,
+          loadService: loadService,
+          promptDispatcher: promptDispatcher,
+          permissionRepository: mockPermissionRepository,
+          sessionViewingService: stubbedSessionViewingService(),
+          projectViewingService: stubbedProjectViewingService(),
+          lifecycleSource: lifecycle,
+          composerDraftRepository: inMemoryComposerDraftRepository(),
+          productAnalyticsService: stubbedProductAnalyticsService(),
+          sessionId: sessionId,
+          projectId: "project-1",
+          notificationCanceller: mockNotificationCanceller,
+          failureReporter: MockFailureReporter(),
+          eventRefreshMinInterval: _cooldown,
+        );
+
+        _settleLoaded(async: async, cubit: cubit);
+        reset(mockSessionService);
+        _stubLoadApis(mockSessionService, sessionId: sessionId);
+        when(
+          () => mockSessionService.listCommands(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
+        );
+        var messageLoads = 0;
+        when(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).thenAnswer((_) async {
+          messageLoads++;
+          if (messageLoads == 1) {
+            return ApiResponse.error(ApiError.generic());
+          }
+          return ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null));
+        });
+
+        lifecycle.emitState(LifecycleState.paused);
+        mockConnectionService.emitDataMayBeStale();
+        async.elapse(_cooldown * 2);
+        expect(messageLoads, 0);
+
+        lifecycle.emitState(LifecycleState.resumed);
+        async.elapse(Duration.zero);
+        expect(messageLoads, 1);
+
+        // The cooldown elapses and the preserved staleness retries.
+        async.elapse(_cooldown);
+        expect(messageLoads, 2);
+
+        // The successful retry consumed the signal; later windows stay quiet.
+        async.elapse(_cooldown * 2);
+        expect(messageLoads, 2);
+
+        _completeCleanup(async: async, futures: [cubit.close()]);
+      });
+    });
+
+    test("a signal queued behind an in-flight refresh survives a pause/resume cycle", () {
+      fakeAsync((FakeAsync async) {
+        final lifecycle = FakeLifecycleSource();
+        final cubit = SessionDetailCubit(
+          mockConnectionService,
+          loadService: loadService,
+          promptDispatcher: promptDispatcher,
+          permissionRepository: mockPermissionRepository,
+          sessionViewingService: stubbedSessionViewingService(),
+          projectViewingService: stubbedProjectViewingService(),
+          lifecycleSource: lifecycle,
+          composerDraftRepository: inMemoryComposerDraftRepository(),
+          productAnalyticsService: stubbedProductAnalyticsService(),
+          sessionId: sessionId,
+          projectId: "project-1",
+          notificationCanceller: mockNotificationCanceller,
+          failureReporter: MockFailureReporter(),
+          eventRefreshMinInterval: _cooldown,
+        );
+
+        _settleLoaded(async: async, cubit: cubit);
+        reset(mockSessionService);
+        _stubLoadApis(mockSessionService, sessionId: sessionId);
+        when(
+          () => mockSessionService.listCommands(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
+        );
+
+        final messagesCompleter = Completer<ApiResponse<MessageWithPartsResponse>>();
+        when(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).thenAnswer((_) => messagesCompleter.future);
+
+        // Refresh A starts and stays in flight; a second signal queues.
+        mockConnectionService.emitDataMayBeStale();
+        mockConnectionService.emitDataMayBeStale();
+        async.elapse(Duration.zero);
+        verify(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).called(1);
+
+        // Pause cancels the cooldown (the only armed trailing trigger); the
+        // resume bypass finds A still in flight and cannot start a refresh.
+        lifecycle.emitState(LifecycleState.paused);
+        lifecycle.emitState(LifecycleState.resumed);
+        async.elapse(Duration.zero);
+
+        // When A finally completes, the queued signal must still produce the
+        // trailing refresh instead of being stranded.
+        when(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
+        );
+        messagesCompleter.complete(
+          ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()], nextCursor: null)),
+        );
+        async.elapse(Duration.zero);
+        verify(
+          () => mockSessionService.getMessages(
+            sessionId: any(named: "sessionId"),
+            limit: any(named: "limit"),
+            before: any(named: "before"),
+          ),
+        ).called(1);
+
+        _completeCleanup(async: async, futures: [cubit.close()]);
+      });
     });
   });
 }
@@ -1640,26 +1680,34 @@ ProviderListResponse _providers() {
   );
 }
 
+void _settleLoaded({required FakeAsync async, required SessionDetailCubit cubit}) {
+  async.elapse(Duration.zero);
+  expect(
+    cubit.state,
+    isA<SessionDetailLoaded>(),
+    reason: "initial load should settle synchronously under fake time",
+  );
+}
+
+void _completeCleanup({required FakeAsync async, required List<Future<void>> futures}) {
+  var completed = false;
+  unawaited(Future.wait(futures).then((_) => completed = true));
+  async.flushMicrotasks();
+  expect(completed, isTrue, reason: "fake-time cleanup should complete");
+}
+
 Future<void> _awaitLoaded(SessionDetailCubit cubit) async {
-  if (cubit.state is SessionDetailLoaded) return;
-  await cubit.stream
-      .firstWhere((state) => state is SessionDetailLoaded)
-      .timeout(
-        const Duration(seconds: 5),
-        onTimeout: () => fail(
-          "Timed out waiting for SessionDetailLoaded; current state: ${cubit.state}",
-        ),
-      );
+  await awaitState(
+    cubit: cubit,
+    predicate: (state) => state is SessionDetailLoaded,
+    description: "SessionDetailLoaded",
+  );
 }
 
 Future<void> _awaitFailed(SessionDetailCubit cubit) async {
-  if (cubit.state is SessionDetailFailed) return;
-  await cubit.stream
-      .firstWhere((state) => state is SessionDetailFailed)
-      .timeout(
-        const Duration(seconds: 5),
-        onTimeout: () => fail(
-          "Timed out waiting for SessionDetailFailed; current state: ${cubit.state}",
-        ),
-      );
+  await awaitState(
+    cubit: cubit,
+    predicate: (state) => state is SessionDetailFailed,
+    description: "SessionDetailFailed",
+  );
 }

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -1592,8 +1592,14 @@ void main() {
             "s1": const SessionActivityInfo(mainAgentRunning: true, lastUserActivityAt: null, updatedAt: null),
           },
         });
-        // Wait for the activity update to be processed
-        await Future<void>.delayed(const Duration(milliseconds: 10));
+        await awaitState(
+          cubit: cubit,
+          predicate: (state) =>
+              state is SessionListLoaded &&
+              state.activeSessionIds.length == 1 &&
+              state.activeSessionIds.containsKey("s1"),
+          description: "SessionListLoaded with s1 active",
+        );
         // Emit updated activity
         mockSseEventTracker.emitSessionActivity({
           projectId: {
@@ -1869,6 +1875,7 @@ void main() {
       ],
     );
 
+    final loadingResponse = Completer<ApiResponse<SessionListResponse>>();
     blocTest<SessionListCubit, SessionListState>(
       "stale signal is ignored when state is not SessionListLoaded",
       build: () {
@@ -1877,18 +1884,14 @@ void main() {
             projectId: projectId,
             waitForPrData: any(named: "waitForPrData"),
           ),
-        ).thenAnswer(
-          (_) async => await Future.delayed(
-            const Duration(milliseconds: 100),
-            () => ApiResponse.success(SessionListResponse(items: [testSession()])),
-          ),
-        );
+        ).thenAnswer((_) => loadingResponse.future);
         return buildCubit();
       },
       act: (cubit) async {
         // Emit stale while still loading
         mockConnectionService.emitDataMayBeStale();
         await Future<void>.delayed(Duration.zero);
+        loadingResponse.complete(ApiResponse.success(SessionListResponse(items: [testSession()])));
       },
       skip: 1, // Skip the initial loading state
       expect: () => <SessionListState>[
@@ -1896,6 +1899,7 @@ void main() {
       ],
     );
 
+    final reconnectResponses = <Completer<ApiResponse<SessionListResponse>>>[];
     blocTest<SessionListCubit, SessionListState>(
       "stale + ConnectionConnected refresh coalesced into single API call",
       build: () {
@@ -1904,16 +1908,20 @@ void main() {
             projectId: projectId,
             waitForPrData: any(named: "waitForPrData"),
           ),
-        ).thenAnswer(
-          (_) async => await Future.delayed(
-            const Duration(milliseconds: 50),
-            () => ApiResponse.success(SessionListResponse(items: [testSession()])),
-          ),
-        );
+        ).thenAnswer((_) {
+          final response = Completer<ApiResponse<SessionListResponse>>();
+          reconnectResponses.add(response);
+          return response.future;
+        });
         return buildCubit();
       },
       act: (cubit) async {
-        await Future<void>.delayed(Duration.zero); // let initial load complete
+        reconnectResponses.single.complete(ApiResponse.success(SessionListResponse(items: [testSession()])));
+        await awaitState(
+          cubit: cubit,
+          predicate: (state) => state is SessionListLoaded,
+          description: "initial SessionListLoaded",
+        );
         // Emit both stale and ConnectionConnected simultaneously
         mockConnectionService.emitDataMayBeStale();
         statusController.add(
@@ -1922,16 +1930,25 @@ void main() {
             health: HealthResponse(healthy: true, version: "0.1.0", filesystemAccessDegraded: null),
           ),
         );
-        await Future<void>.delayed(const Duration(milliseconds: 100));
+        await awaitState(
+          cubit: cubit,
+          predicate: (state) => state is SessionListLoaded && state.isRefreshing,
+          description: "refreshing SessionListLoaded",
+        );
+        reconnectResponses.last.complete(ApiResponse.success(SessionListResponse(items: [testSession()])));
+        await awaitState(
+          cubit: cubit,
+          predicate: (state) => state is SessionListLoaded && !state.isRefreshing,
+          description: "completed SessionListLoaded refresh",
+        );
       },
       verify: (cubit) {
-        // Verify listSessions was called at least once (initial load + refresh)
         verify(
           () => mockProjectRepository.listSessions(
             projectId: projectId,
             waitForPrData: any(named: "waitForPrData"),
           ),
-        ).called(greaterThanOrEqualTo(1));
+        ).called(2);
       },
     );
 

--- a/client/module_core/test/helpers/test_helpers.dart
+++ b/client/module_core/test/helpers/test_helpers.dart
@@ -1,3 +1,6 @@
+import "dart:async";
+
+import "package:bloc/bloc.dart";
 import "package:mocktail/mocktail.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
@@ -36,3 +39,16 @@ void stubProductAnalyticsService({required MockProductAnalyticsService service})
 }
 
 void registerAllFallbackValues() => registerCoreFallbackValues();
+
+Future<State> awaitState<State>({
+  required BlocBase<State> cubit,
+  required bool Function(State state) predicate,
+  required String description,
+}) async {
+  if (predicate(cubit.state)) return cubit.state;
+  try {
+    return await cubit.stream.firstWhere(predicate).timeout(const Duration(seconds: 5));
+  } on TimeoutException {
+    throw StateError("Timed out waiting for $description; current state: ${cubit.state}");
+  }
+}


### PR DESCRIPTION
## Complexity

Moderate. The change is test-only, but it replaces timing assumptions across three packages and preserves explicit cooldown and process-timeout behavior.

## What

- add one diagnostic `awaitState` helper for module-core cubit tests
- replace arbitrary session-detail and session-list sleeps with state predicates and controlled completers
- drive staleness cooldown tests with `fakeAsync`
- override Codex locator file metadata in the test instead of waiting for filesystem timestamp changes
- replace process-runner fixture sleeps with a bounded loopback control channel
- record Step 14 scope and repeated-run evidence

## Why

Wall-clock sleeps make tests slower and sensitive to scheduler and filesystem timing. Deterministic synchronization preserves the behavior being asserted while removing avoidable latency and flakes.

## Risk and test focus

Risk is limited to test behavior. Review should focus on whether replacement barriers observe the authoritative outcome, cooldown tests still exercise the original 100 ms windows, and the process fixture always cleans up its descendant. There is no user-visible, wire-contract, persisted-data, or database impact.

## Expected result

The selected suites retain their behavioral coverage without arbitrary positive-duration synchronization sleeps and pass consistently under serial execution.

## Verification

- `dart analyze` clean in `client/module_core`, `bridge/sesori_plugin_codex`, and `bridge/app`
- all touched suites passed three consecutive times with `dart test -j1`
- final review found no unresolved timing, cleanup, assertion, or scope findings
- scoped sleep scans and `git diff --check` clean


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces wall-clock sleeps in tests with deterministic state awaits and fake time across `client/module_core`, `bridge/sesori_plugin_codex`, and `bridge/app`. Old tests used `Future.delayed` and file timestamp waits; new tests await observable state, drive 100 ms cooldowns with `fakeAsync`, and use a control socket for process cleanup. No production behavior changes.

- Adds `awaitState` helper and replaces arbitrary sleeps in session-detail and session-list tests with state predicates and completers.
- Drives staleness cooldown tests with `fakeAsync` to preserve the original 100 ms windows while removing real-time waits.
- Overrides file metadata in the Codex desktop app locator test via `IOOverrides.runZoned(statSync: ...)` to control directory modified times deterministically.
- Reworks the process-runner fixture to use a bounded loopback control channel (newline-framed socket) instead of sleeping, and asserts explicit child cleanup.

**Review and migration**
- Scope is test-only; focus on whether replacement barriers assert the intended outcomes and staleness cooldown semantics remain intact under `fakeAsync`.
- Tests must use `awaitState` instead of positive-duration `Future.delayed` for synchronization; use `fakeAsync` for cooldown-driven paths; process-runner tests should use the control socket pattern to coordinate termination.

<sup>Written for commit 8b2f650706b67f979d134a6a00c2b94810736482. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

