### PR TITLE
🌿 Bound deterministic test waits

### DIFF
--- a/bridge/app/test/bridge/foundation/process_runner_test.dart
+++ b/bridge/app/test/bridge/foundation/process_runner_test.dart
@@ -87,6 +87,7 @@ Future<void> main(List<String> arguments) async {
       [parentScript.path, childScript.path, server.port.toString(), childPidFile.path],
       timeout: const Duration(seconds: 3),
     );
+    final timeoutObserved = expectLater(run, throwsA(isA<TimeoutException>()));
     var childConnected = false;
     var parentConnected = false;
     for (var connectionCount = 0; connectionCount < 2; connectionCount++) {
@@ -117,7 +118,7 @@ Future<void> main(List<String> arguments) async {
     expect(childConnected, isTrue);
     expect(parentConnected, isTrue);
     childPid = int.parse(await childPidFile.readAsString());
-    await expectLater(run, throwsA(isA<TimeoutException>()));
+    await timeoutObserved;
     stopwatch.stop();
 
     expect(stopwatch.elapsed, lessThan(const Duration(seconds: 4)));

--- a/client/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
@@ -149,7 +149,10 @@ void main() {
       addTearDown(sub.cancel);
 
       sessionEvents.add(permission);
-      await permissionSeen.future;
+      await permissionSeen.future.timeout(
+        const Duration(seconds: 5),
+        onTimeout: () => fail("Timed out waiting for permission stream delivery"),
+      );
 
       final loaded = cubit.state as SessionDetailLoaded;
       expect(loaded.pendingPermissions, [permission]);
@@ -572,7 +575,10 @@ void main() {
       addTearDown(sub.cancel);
 
       globalEvents.add(SseEvent(data: childPermission));
-      await permissionSeen.future;
+      await permissionSeen.future.timeout(
+        const Duration(seconds: 5),
+        onTimeout: () => fail("Timed out waiting for child permission stream delivery"),
+      );
 
       final loaded = cubit.state as SessionDetailLoaded;
       expect(loaded.pendingPermissions, [childPermission]);

--- a/client/module_core/test/cubits/session_detail/session_detail_cubit_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_cubit_test.dart
@@ -1297,6 +1297,11 @@ void main() {
             messageID: "refresh-message",
           ),
         );
+        await awaitState(
+          cubit: cubit,
+          predicate: (state) => state is SessionDetailLoaded && state.isRefreshing,
+          description: "silent refresh started",
+        );
         await _awaitNotRefreshing(cubit);
       },
       expect: () => [


### PR DESCRIPTION
## Complexity

🌿 Straightforward. Three localized test-harness races are corrected without changing production code.

## What

- attach the process timeout matcher before awaiting fixture handshakes
- add diagnostic bounds to permission-stream completer waits
- await silent-refresh start before awaiting its completion

## Why

Post-merge review of PR #1040 identified paths where a regression could surface as an unhandled asynchronous error, an unbounded test wait, or a false-positive fast-path state match.

## Risk and test focus

Low risk and test-only. Focus on process-timeout observation, permission stream delivery, and silent-refresh transition ordering. No user-visible, wire-contract, persisted-data, or database impact.

## Expected result

The deterministic timing tests fail promptly and accurately when the behavior under test regresses. No production behavior changes.

## Verification

- `dart analyze` clean in `bridge/app` and `client/module_core`
- `process_runner_test` passed three consecutive `dart test -j1` runs
- `session_detail_cubit_permission_test` and `session_detail_cubit_test` passed three consecutive `dart test -j1` runs
- `git diff --check` clean


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds deterministic test waits and fixes three localized test-harness races to improve reliability. Test-only; no production behavior changes.

**Key changes**
- Process runner: attach the process timeout expectation before fixture handshakes and await it later, ensuring the TimeoutException is captured and avoiding unhandled async errors.
- Permission stream tests: bound `permissionSeen.future` with a 5s timeout and a clear failure message to prevent unbounded hangs.
- Silent refresh tests: wait for the refresh to start (state isRefreshing) before awaiting completion to avoid false-positive fast-path matches.

<sup>Written for commit 5998f9b9ad5a00d5c4f5072846417e5f7d44ae49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

