### PR TITLE
🚧 [codebase-cleanup] bridge(app): remove the triplicated PluginRuntime command preamble [step 16/45]

### DIFF
--- a/.plan/active/codebase-cleanup/steps/step-16.md
+++ b/.plan/active/codebase-cleanup/steps/step-16.md
@@ -1,0 +1,49 @@
+# Step 16/45 - Consolidate PluginRuntime command transitions
+
+## Re-verification against `main`
+
+`stop`, `prepareDisable`, and `restart` still repeated the same command guard,
+ownership, completer, transition, and settlement machinery. Their private
+single-caller implementations have been folded into the public methods, while
+the common behavior now lives in `_stopPreconditionConflict`,
+`_beginCommandTransition`, and `_settleCommandTransition`.
+
+The separate nullable transition owner and completer are now one nullable
+`_CommandTransition` record whose members are both non-null. This makes partial
+command ownership state unrepresentable and lets all ownership checks compare
+the record's unique owner. Prepared disables continue retaining the transition
+until `commitDisable` or `rollbackDisable`; stop and restart continue settling
+their transitions in `finally`; disposal continues waiting for settlement.
+
+`use` now delegates to `useWithGeneration` and discards only the returned
+generation. Rejected disable preparation now runs the synchronous guard ladder
+before publishing the draining gate, so a command that never starts no longer
+publishes a transient draining snapshot or invalidates an in-flight setup
+inspection. There is no await in that precondition sequence, so acquisition
+fencing is unchanged.
+
+No wire contract, persisted data, database schema, or user-visible behavior
+changed.
+
+## Verification
+
+- `dart analyze --fatal-infos` in `bridge/app`: clean.
+- `dart test -j1 test/bridge/runtime/plugin_runtime_test.dart
+  test/services/plugin_lifecycle_service_test.dart`: 109 tests passed.
+- `test/helpers/plugin_runtime_test_support.dart` is a helper library, not a
+  runnable test suite; it is compiled by the runtime tests above.
+- `git diff --check`: clean.
+- `dart format lib/src/runtime/plugin_runtime.dart` could not run because the
+  pinned formatter crashes while building this file's existing enhanced enum
+  body (`dart_style` null-check failure); analyzer parsing is clean and the
+  edited sections retain the file's existing formatting.
+
+The production diff excluding this evidence file is `+230 / -364`.
+
+## Architecture implementation review
+
+Approved. The reviewer confirmed the transition record makes partial ownership
+impossible, the helpers remain private on the lifecycle invariant owner, force
+takeover and restart failure precedence are preserved, prepared-disable and
+disposal settlement remain serialized, and `useWithGeneration` preserves lease,
+generation, authentication, and release behavior.

--- a/bridge/app/lib/src/runtime/plugin_runtime.dart
+++ b/bridge/app/lib/src/runtime/plugin_runtime.dart
@@ -249,19 +249,7 @@ class PluginRuntime({
     required String pluginId,
     required Enum operation,
     required Future<T> Function(BridgePluginApi api) body,
-  }) async {
-    final lease = await _acquire(pluginId: pluginId, operation: operation, startIfNeeded: true);
-    try {
-      final result = await body(lease.api);
-      _requireCurrentGeneration(lease: lease, operation: operation);
-      return result;
-    } on PluginAuthenticationRequiredException catch (error) {
-      _handleAuthenticationRequired(lease: lease, failure: error);
-      rethrow;
-    } finally {
-      _release(lease);
-    }
-  }
+  }) async => (await useWithGeneration(pluginId: pluginId, operation: operation, body: body)).value;
 
   Future<({T value, int generation})> useWithGeneration<T>({
     required String pluginId,
@@ -546,12 +534,84 @@ class PluginRuntime({
   Future<PluginRuntimeCommandResult> stop({
     required String pluginId,
     required PluginStopIntent intent,
-  }) => _stop(pluginId: pluginId, intent: intent);
+  }) async {
+    final slot = _requireSlot(pluginId);
+    if (_stopPreconditionConflict(slot: slot, intent: intent) case final conflict?) return conflict;
+    final hadPlugin = slot.plugin != null || slot.startFuture != null;
+    if (!hadPlugin) return PluginRuntimeCommandCurrent(snapshot: _snapshotFor(slot));
+
+    final generationLabel = slot.generation?.toString() ?? "pending";
+    Log.d('Stopping plugin "$pluginId" generation $generationLabel (${intent.name})');
+    final commandTransition = _beginCommandTransition(
+      slot: slot,
+      transition: PluginRuntimeTransition.stopping,
+    );
+    String? failureMessage;
+    try {
+      await _stopCurrentGeneration(slot: slot, intent: intent);
+      if (!_ownsCommandTransition(slot: slot, commandTransition: commandTransition)) {
+        return PluginRuntimeCommandConflict(
+          snapshot: _snapshotFor(slot),
+          reasons: const [PluginRuntimeConflictReason.transitioning],
+        );
+      }
+      slot.state = PluginRuntimeState.dormant;
+    } on Object catch (error) {
+      if (!_ownsCommandTransition(slot: slot, commandTransition: commandTransition)) {
+        return PluginRuntimeCommandConflict(
+          snapshot: _snapshotFor(slot),
+          reasons: const [PluginRuntimeConflictReason.transitioning],
+        );
+      }
+      slot.state = PluginRuntimeState.failed;
+      failureMessage = "$error";
+    } finally {
+      _settleCommandTransition(slot: slot, commandTransition: commandTransition);
+    }
+    if (failureMessage != null) {
+      return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: failureMessage);
+    }
+    Log.d('Plugin "$pluginId" generation $generationLabel stopped');
+    return PluginRuntimeCommandApplied(snapshot: _snapshotFor(slot));
+  }
 
   Future<PluginRuntimeCommandResult> prepareDisable({
     required String pluginId,
     required PluginStopIntent intent,
-  }) => _prepareDisable(pluginId: pluginId, intent: intent);
+  }) async {
+    final slot = _requireSlot(pluginId);
+    if (_stopPreconditionConflict(slot: slot, intent: intent) case final conflict?) return conflict;
+    final hadPlugin = slot.plugin != null || slot.startFuture != null;
+    slot.accessGate = PluginRuntimeAccessGate.draining;
+    slot.setupInspectionRevision++;
+    _publishSnapshots();
+
+    final commandTransition = _beginCommandTransition(
+      slot: slot,
+      transition: PluginRuntimeTransition.stopping,
+    );
+    if (!hadPlugin) return PluginRuntimeCommandCurrent(snapshot: _snapshotFor(slot));
+
+    final generationLabel = slot.generation?.toString() ?? "pending";
+    Log.d('Preparing plugin "$pluginId" generation $generationLabel for disable (${intent.name})');
+    try {
+      await _stopCurrentGeneration(slot: slot, intent: intent);
+      if (!_ownsCommandTransition(slot: slot, commandTransition: commandTransition)) {
+        throw StateError('Plugin "$pluginId" disable preparation lost transition ownership.');
+      }
+      slot.state = PluginRuntimeState.dormant;
+      _publishSnapshots();
+      return PluginRuntimeCommandApplied(snapshot: _snapshotFor(slot));
+    } on Object catch (error) {
+      if (_ownsCommandTransition(slot: slot, commandTransition: commandTransition)) {
+        slot
+          ..state = PluginRuntimeState.failed
+          ..accessGate = PluginRuntimeAccessGate.enabled;
+        _settleCommandTransition(slot: slot, commandTransition: commandTransition);
+      }
+      return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: "$error");
+    }
+  }
 
   void commitDisable({required String pluginId}) {
     final slot = _requireSlot(pluginId);
@@ -581,7 +641,148 @@ class PluginRuntime({
   Future<PluginRuntimeCommandResult> restart({
     required String pluginId,
     required PluginStopIntent intent,
-  }) => _restart(pluginId: pluginId, intent: intent);
+  }) async {
+    final slot = _requireSlot(pluginId);
+    if (!_shuttingDown && slot.accessGate == PluginRuntimeAccessGate.enabled && !slot.startAllowed) {
+      return PluginRuntimeCommandFailed(
+        snapshot: _snapshotFor(slot),
+        message: "plugin $pluginId is unavailable",
+      );
+    }
+    if (_stopPreconditionConflict(slot: slot, intent: intent) case final conflict?) return conflict;
+
+    final commandTransition = _beginCommandTransition(
+      slot: slot,
+      transition: PluginRuntimeTransition.restarting,
+    );
+    String? failureMessage;
+    try {
+      await _stopCurrentGeneration(slot: slot, intent: intent);
+      if (!_ownsCommandTransition(slot: slot, commandTransition: commandTransition)) {
+        return PluginRuntimeCommandConflict(
+          snapshot: _snapshotFor(slot),
+          reasons: const [PluginRuntimeConflictReason.transitioning],
+        );
+      }
+      slot.state = PluginRuntimeState.dormant;
+      if (_shuttingDown) {
+        failureMessage = "bridge is shutting down";
+      } else {
+        final plugin = await _beginStart(
+          slot: slot,
+          transition: PluginRuntimeTransition.restarting,
+          clearTransitionOnSettle: false,
+        );
+        if (!_ownsCommandTransition(slot: slot, commandTransition: commandTransition)) {
+          return PluginRuntimeCommandConflict(
+            snapshot: _snapshotFor(slot),
+            reasons: const [PluginRuntimeConflictReason.transitioning],
+          );
+        }
+        if (plugin == null || !_hasOperationalGeneration(slot)) failureMessage = "plugin failed to restart";
+      }
+    } on Object catch (error) {
+      if (!_ownsCommandTransition(slot: slot, commandTransition: commandTransition)) {
+        return PluginRuntimeCommandConflict(
+          snapshot: _snapshotFor(slot),
+          reasons: const [PluginRuntimeConflictReason.transitioning],
+        );
+      }
+      slot.state = PluginRuntimeState.failed;
+      failureMessage = "$error";
+    } finally {
+      _settleCommandTransition(slot: slot, commandTransition: commandTransition);
+    }
+    if (failureMessage != null) {
+      return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: failureMessage);
+    }
+    return PluginRuntimeCommandApplied(snapshot: _snapshotFor(slot));
+  }
+
+  PluginRuntimeCommandResult? _stopPreconditionConflict({
+    required _PluginRuntimeSlot slot,
+    required PluginStopIntent intent,
+  }) {
+    if (_shuttingDown) {
+      return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: "bridge is shutting down");
+    }
+    if (slot.accessGate == PluginRuntimeAccessGate.disabled) {
+      return PluginRuntimeCommandConflict(
+        snapshot: _snapshotFor(slot),
+        reasons: const [PluginRuntimeConflictReason.notEligible],
+      );
+    }
+    if (slot.accessGate == PluginRuntimeAccessGate.draining) {
+      return PluginRuntimeCommandConflict(
+        snapshot: _snapshotFor(slot),
+        reasons: const [PluginRuntimeConflictReason.transitioning],
+      );
+    }
+    final forceCanTakeOverTransition =
+        intent == PluginStopIntent.force &&
+        slot.commandTransition == null &&
+        slot.cleanupFuture == null &&
+        (slot.transition == PluginRuntimeTransition.starting ||
+            (slot.transition == PluginRuntimeTransition.stopping && slot.plugin != null));
+    if (slot.commandTransition != null ||
+        (slot.transition != PluginRuntimeTransition.none && !forceCanTakeOverTransition)) {
+      return PluginRuntimeCommandConflict(
+        snapshot: _snapshotFor(slot),
+        reasons: const [PluginRuntimeConflictReason.transitioning],
+      );
+    }
+    final hadPlugin = slot.plugin != null || slot.startFuture != null;
+    final hasLiveGeneration = slot.plugin != null;
+    if (intent == PluginStopIntent.safe && hadPlugin && slot.leaseCount > 0) {
+      return PluginRuntimeCommandConflict(
+        snapshot: _snapshotFor(slot),
+        reasons: const [PluginRuntimeConflictReason.inFlight],
+      );
+    }
+    if (intent == PluginStopIntent.safe && hasLiveGeneration && slot.workState == PluginWorkState.busy) {
+      return PluginRuntimeCommandConflict(
+        snapshot: _snapshotFor(slot),
+        reasons: const [PluginRuntimeConflictReason.busy],
+      );
+    }
+    if (intent == PluginStopIntent.safe && hasLiveGeneration && slot.workState == PluginWorkState.unknown) {
+      return PluginRuntimeCommandConflict(
+        snapshot: _snapshotFor(slot),
+        reasons: const [PluginRuntimeConflictReason.workStateUnknown],
+      );
+    }
+    return null;
+  }
+
+  _CommandTransition _beginCommandTransition({
+    required _PluginRuntimeSlot slot,
+    required PluginRuntimeTransition transition,
+  }) {
+    final commandTransition = (owner: Object(), completer: Completer<void>());
+    slot
+      ..commandTransition = commandTransition
+      ..transition = transition;
+    _publishSnapshots();
+    return commandTransition;
+  }
+
+  bool _ownsCommandTransition({
+    required _PluginRuntimeSlot slot,
+    required _CommandTransition commandTransition,
+  }) => identical(slot.commandTransition?.owner, commandTransition.owner);
+
+  void _settleCommandTransition({
+    required _PluginRuntimeSlot slot,
+    required _CommandTransition commandTransition,
+  }) {
+    if (_ownsCommandTransition(slot: slot, commandTransition: commandTransition)) {
+      slot
+        ..commandTransition = null
+        ..transition = PluginRuntimeTransition.none;
+    }
+    _publishSnapshots();
+    if (!commandTransition.completer.isCompleted) commandTransition.completer.complete();
+  }
 
   void beginShutdown() {
     if (_shuttingDown) return;
@@ -696,7 +897,7 @@ class PluginRuntime({
           }
           try {
             await slot.cleanupFuture;
-            await slot.commandTransitionCompleter?.future;
+            await slot.commandTransition?.completer.future;
             await _waitForDurableCommits(slot);
             await _cancelAndShutdownGeneration(slot: slot, plugin: slot.plugin);
           } on Object catch (error, stackTrace) {
@@ -712,362 +913,26 @@ class PluginRuntime({
     }
   }
 
-  Future<PluginRuntimeCommandResult> _stop({
-    required String pluginId,
-    required PluginStopIntent intent,
-  }) async {
-    final slot = _requireSlot(pluginId);
-    if (_shuttingDown) {
-      return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: "bridge is shutting down");
-    }
-    if (slot.accessGate == PluginRuntimeAccessGate.disabled) {
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.notEligible],
-      );
-    }
-    if (slot.accessGate == PluginRuntimeAccessGate.draining) {
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.transitioning],
-      );
-    }
-    final forceCanTakeOverTransition =
-        intent == PluginStopIntent.force &&
-        slot.commandTransitionOwner == null &&
-        slot.cleanupFuture == null &&
-        (slot.transition == PluginRuntimeTransition.starting ||
-            (slot.transition == PluginRuntimeTransition.stopping && slot.plugin != null));
-    if (slot.commandTransitionOwner != null ||
-        (slot.transition != PluginRuntimeTransition.none && !forceCanTakeOverTransition)) {
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.transitioning],
-      );
-    }
-    final hadPlugin = slot.plugin != null || slot.startFuture != null;
-    final hasLiveGeneration = slot.plugin != null;
-    if (intent == PluginStopIntent.safe && hadPlugin && slot.leaseCount > 0) {
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.inFlight],
-      );
-    }
-    if (intent == PluginStopIntent.safe && hasLiveGeneration && slot.workState == PluginWorkState.busy) {
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.busy],
-      );
-    }
-    if (intent == PluginStopIntent.safe && hasLiveGeneration && slot.workState == PluginWorkState.unknown) {
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.workStateUnknown],
-      );
-    }
-    if (!hadPlugin) return PluginRuntimeCommandCurrent(snapshot: _snapshotFor(slot));
-    final generationLabel = slot.generation?.toString() ?? "pending";
-    Log.d('Stopping plugin "$pluginId" generation $generationLabel (${intent.name})');
-    final transitionOwner = Object();
-    final transitionCompleter = Completer<void>();
-    slot
-      ..commandTransitionOwner = transitionOwner
-      ..commandTransitionCompleter = transitionCompleter
-      ..transition = PluginRuntimeTransition.stopping;
-    _publishSnapshots();
-    String? failureMessage;
-    try {
-      await _stopCurrentGeneration(slot: slot, intent: intent);
-      if (!identical(slot.commandTransitionOwner, transitionOwner)) {
-        return PluginRuntimeCommandConflict(
-          snapshot: _snapshotFor(slot),
-          reasons: const [PluginRuntimeConflictReason.transitioning],
-        );
-      }
-      slot.state = PluginRuntimeState.dormant;
-    } on Object catch (error) {
-      if (!identical(slot.commandTransitionOwner, transitionOwner)) {
-        return PluginRuntimeCommandConflict(
-          snapshot: _snapshotFor(slot),
-          reasons: const [PluginRuntimeConflictReason.transitioning],
-        );
-      }
-      slot.state = PluginRuntimeState.failed;
-      failureMessage = "$error";
-    } finally {
-      if (identical(slot.commandTransitionOwner, transitionOwner)) {
-        slot
-          ..commandTransitionOwner = null
-          ..commandTransitionCompleter = null
-          ..transition = PluginRuntimeTransition.none;
-      }
-      _publishSnapshots();
-      if (!transitionCompleter.isCompleted) transitionCompleter.complete();
-    }
-    if (failureMessage != null) {
-      return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: failureMessage);
-    }
-    Log.d('Plugin "$pluginId" generation $generationLabel stopped');
-    return hadPlugin
-        ? PluginRuntimeCommandApplied(snapshot: _snapshotFor(slot))
-        : PluginRuntimeCommandCurrent(snapshot: _snapshotFor(slot));
-  }
-
-  Future<PluginRuntimeCommandResult> _prepareDisable({
-    required String pluginId,
-    required PluginStopIntent intent,
-  }) async {
-    final slot = _requireSlot(pluginId);
-    if (_shuttingDown) {
-      return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: "bridge is shutting down");
-    }
-    if (slot.accessGate == PluginRuntimeAccessGate.disabled) {
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.notEligible],
-      );
-    }
-    if (slot.accessGate == PluginRuntimeAccessGate.draining) {
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.transitioning],
-      );
-    }
-    slot.accessGate = PluginRuntimeAccessGate.draining;
-    slot.setupInspectionRevision++;
-    _publishSnapshots();
-
-    final forceCanTakeOverTransition =
-        intent == PluginStopIntent.force &&
-        slot.commandTransitionOwner == null &&
-        slot.cleanupFuture == null &&
-        (slot.transition == PluginRuntimeTransition.starting ||
-            (slot.transition == PluginRuntimeTransition.stopping && slot.plugin != null));
-    if (slot.commandTransitionOwner != null ||
-        (slot.transition != PluginRuntimeTransition.none && !forceCanTakeOverTransition)) {
-      _restoreDisableAccess(slot);
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.transitioning],
-      );
-    }
-    final hadPlugin = slot.plugin != null || slot.startFuture != null;
-    final hasLiveGeneration = slot.plugin != null;
-    if (intent == PluginStopIntent.safe && hadPlugin && slot.leaseCount > 0) {
-      _restoreDisableAccess(slot);
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.inFlight],
-      );
-    }
-    if (intent == PluginStopIntent.safe && hasLiveGeneration && slot.workState == PluginWorkState.busy) {
-      _restoreDisableAccess(slot);
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.busy],
-      );
-    }
-    if (intent == PluginStopIntent.safe && hasLiveGeneration && slot.workState == PluginWorkState.unknown) {
-      _restoreDisableAccess(slot);
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.workStateUnknown],
-      );
-    }
-
-    final transitionOwner = Object();
-    final transitionCompleter = Completer<void>();
-    slot
-      ..commandTransitionOwner = transitionOwner
-      ..commandTransitionCompleter = transitionCompleter
-      ..transition = PluginRuntimeTransition.stopping;
-    _publishSnapshots();
-    if (!hadPlugin) return PluginRuntimeCommandCurrent(snapshot: _snapshotFor(slot));
-
-    final generationLabel = slot.generation?.toString() ?? "pending";
-    Log.d('Preparing plugin "$pluginId" generation $generationLabel for disable (${intent.name})');
-    try {
-      await _stopCurrentGeneration(slot: slot, intent: intent);
-      if (!identical(slot.commandTransitionOwner, transitionOwner)) {
-        throw StateError('Plugin "$pluginId" disable preparation lost transition ownership.');
-      }
-      slot.state = PluginRuntimeState.dormant;
-      _publishSnapshots();
-      return PluginRuntimeCommandApplied(snapshot: _snapshotFor(slot));
-    } on Object catch (error) {
-      if (identical(slot.commandTransitionOwner, transitionOwner)) {
-        slot.state = PluginRuntimeState.failed;
-        _restoreOwnedDisablePreparation(
-          slot: slot,
-          transitionOwner: transitionOwner,
-          transitionCompleter: transitionCompleter,
-        );
-      }
-      return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: "$error");
-    }
-  }
-
-  void _restoreDisableAccess(_PluginRuntimeSlot slot) {
-    slot.accessGate = PluginRuntimeAccessGate.enabled;
-    _publishSnapshots();
-  }
-
-  void _restoreOwnedDisablePreparation({
-    required _PluginRuntimeSlot slot,
-    required Object transitionOwner,
-    required Completer<void> transitionCompleter,
-  }) {
-    if (!identical(slot.commandTransitionOwner, transitionOwner) ||
-        !identical(slot.commandTransitionCompleter, transitionCompleter)) {
-      return;
-    }
-    slot
-      ..accessGate = PluginRuntimeAccessGate.enabled
-      ..commandTransitionOwner = null
-      ..commandTransitionCompleter = null
-      ..transition = PluginRuntimeTransition.none;
-    if (!transitionCompleter.isCompleted) transitionCompleter.complete();
-    _publishSnapshots();
-  }
-
   bool _isPreparedDisableSlot(_PluginRuntimeSlot slot) {
     return slot.accessGate == PluginRuntimeAccessGate.draining &&
-        slot.commandTransitionOwner != null &&
-        slot.commandTransitionCompleter != null &&
+        slot.commandTransition != null &&
         slot.transition == PluginRuntimeTransition.stopping &&
         slot.plugin == null &&
         slot.startFuture == null;
   }
 
   void _settlePreparedDisable(_PluginRuntimeSlot slot) {
-    final transitionCompleter = slot.commandTransitionCompleter;
+    final commandTransition = slot.commandTransition;
     slot
-      ..commandTransitionOwner = null
-      ..commandTransitionCompleter = null
+      ..commandTransition = null
       ..transition = PluginRuntimeTransition.none;
     try {
       _publishSnapshots();
     } finally {
-      if (transitionCompleter != null && !transitionCompleter.isCompleted) transitionCompleter.complete();
-    }
-  }
-
-  Future<PluginRuntimeCommandResult> _restart({
-    required String pluginId,
-    required PluginStopIntent intent,
-  }) async {
-    final slot = _requireSlot(pluginId);
-    if (_shuttingDown) {
-      return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: "bridge is shutting down");
-    }
-    if (slot.accessGate == PluginRuntimeAccessGate.disabled) {
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.notEligible],
-      );
-    }
-    if (slot.accessGate == PluginRuntimeAccessGate.draining) {
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.transitioning],
-      );
-    }
-    if (!slot.startAllowed) {
-      return PluginRuntimeCommandFailed(
-        snapshot: _snapshotFor(slot),
-        message: "plugin $pluginId is unavailable",
-      );
-    }
-    final forceCanTakeOverTransition =
-        intent == PluginStopIntent.force &&
-        slot.commandTransitionOwner == null &&
-        slot.cleanupFuture == null &&
-        (slot.transition == PluginRuntimeTransition.starting ||
-            (slot.transition == PluginRuntimeTransition.stopping && slot.plugin != null));
-    if (slot.commandTransitionOwner != null ||
-        (slot.transition != PluginRuntimeTransition.none && !forceCanTakeOverTransition)) {
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.transitioning],
-      );
-    }
-    final hadPlugin = slot.plugin != null || slot.startFuture != null;
-    final hasLiveGeneration = slot.plugin != null;
-    if (intent == PluginStopIntent.safe && hadPlugin && slot.leaseCount > 0) {
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.inFlight],
-      );
-    }
-    if (intent == PluginStopIntent.safe && hasLiveGeneration && slot.workState == PluginWorkState.busy) {
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.busy],
-      );
-    }
-    if (intent == PluginStopIntent.safe && hasLiveGeneration && slot.workState == PluginWorkState.unknown) {
-      return PluginRuntimeCommandConflict(
-        snapshot: _snapshotFor(slot),
-        reasons: const [PluginRuntimeConflictReason.workStateUnknown],
-      );
-    }
-
-    final transitionOwner = Object();
-    final transitionCompleter = Completer<void>();
-    slot
-      ..commandTransitionOwner = transitionOwner
-      ..commandTransitionCompleter = transitionCompleter
-      ..transition = PluginRuntimeTransition.restarting;
-    _publishSnapshots();
-    String? failureMessage;
-    try {
-      await _stopCurrentGeneration(slot: slot, intent: intent);
-      if (!identical(slot.commandTransitionOwner, transitionOwner)) {
-        return PluginRuntimeCommandConflict(
-          snapshot: _snapshotFor(slot),
-          reasons: const [PluginRuntimeConflictReason.transitioning],
-        );
+      if (commandTransition != null && !commandTransition.completer.isCompleted) {
+        commandTransition.completer.complete();
       }
-      slot.state = PluginRuntimeState.dormant;
-      if (_shuttingDown) {
-        failureMessage = "bridge is shutting down";
-      } else {
-        final plugin = await _beginStart(
-          slot: slot,
-          transition: PluginRuntimeTransition.restarting,
-          clearTransitionOnSettle: false,
-        );
-        if (!identical(slot.commandTransitionOwner, transitionOwner)) {
-          return PluginRuntimeCommandConflict(
-            snapshot: _snapshotFor(slot),
-            reasons: const [PluginRuntimeConflictReason.transitioning],
-          );
-        }
-        if (plugin == null || !_hasOperationalGeneration(slot)) failureMessage = "plugin failed to restart";
-      }
-    } on Object catch (error) {
-      if (!identical(slot.commandTransitionOwner, transitionOwner)) {
-        return PluginRuntimeCommandConflict(
-          snapshot: _snapshotFor(slot),
-          reasons: const [PluginRuntimeConflictReason.transitioning],
-        );
-      }
-      slot.state = PluginRuntimeState.failed;
-      failureMessage = "$error";
-    } finally {
-      if (identical(slot.commandTransitionOwner, transitionOwner)) {
-        slot
-          ..commandTransitionOwner = null
-          ..commandTransitionCompleter = null
-          ..transition = PluginRuntimeTransition.none;
-      }
-      _publishSnapshots();
-      if (!transitionCompleter.isCompleted) transitionCompleter.complete();
     }
-    if (failureMessage != null) {
-      return PluginRuntimeCommandFailed(snapshot: _snapshotFor(slot), message: failureMessage);
-    }
-    return PluginRuntimeCommandApplied(snapshot: _snapshotFor(slot));
   }
 
   Future<void> _stopCurrentGeneration({
@@ -1574,7 +1439,7 @@ class PluginRuntime({
     }
     if (status is PluginStopping) {
       slot.state = PluginRuntimeState.stopping;
-      if (slot.commandTransitionOwner == null) {
+      if (slot.commandTransition == null) {
         slot.transition = PluginRuntimeTransition.stopping;
       }
       _publishSnapshots();
@@ -1600,7 +1465,7 @@ class PluginRuntime({
     slot
       ..state = PluginRuntimeState.stopping
       ..workState = PluginWorkState.unknown;
-    if (slot.commandTransitionOwner == null) {
+    if (slot.commandTransition == null) {
       slot.transition = PluginRuntimeTransition.stopping;
     }
     _publishSnapshots();
@@ -1629,7 +1494,7 @@ class PluginRuntime({
           // The initiating start failure is already surfaced by its owner.
         }
         if (identical(slot.cleanupFuture, cleanup)) slot.cleanupFuture = null;
-        if (slot.commandTransitionOwner == null &&
+        if (slot.commandTransition == null &&
             slot.generation == generation &&
             slot.transition == PluginRuntimeTransition.stopping) {
           slot.transition = PluginRuntimeTransition.none;
@@ -1699,7 +1564,7 @@ class PluginRuntime({
           slot
             ..state = PluginRuntimeState.blocked
             ..workState = PluginWorkState.unknown;
-          if (slot.commandTransitionOwner == null) {
+          if (slot.commandTransition == null) {
             slot.transition = PluginRuntimeTransition.none;
           }
         }
@@ -1824,6 +1689,8 @@ class PluginRuntime({
   }
 }
 
+typedef _CommandTransition = ({Object owner, Completer<void> completer});
+
 class _PluginRuntimeSlot({required final PluginRuntimeRegistration registration}) {
   PluginSetupStatus setup = const PluginSetupUnknown(actionHint: null);
   PluginRuntimeAccessGate accessGate = PluginRuntimeAccessGate.disabled;
@@ -1833,8 +1700,7 @@ class _PluginRuntimeSlot({required final PluginRuntimeRegistration registration}
   PluginRuntimeState state = PluginRuntimeState.disabled;
   PluginWorkState workState = PluginWorkState.unknown;
   PluginRuntimeTransition transition = PluginRuntimeTransition.none;
-  Object? commandTransitionOwner;
-  Completer<void>? commandTransitionCompleter;
+  _CommandTransition? commandTransition;
   int leaseCount = 0;
   int durableCommitCount = 0;
   Completer<void>? durableCommitsDrained;


### PR DESCRIPTION
## Complexity

Moderate. This is a localized runtime refactor, but it consolidates serialized command-transition ownership across stop, disable, restart, disposal, and authentication-loss paths.

## What

- Inline the duplicated stop, prepare-disable, and restart command preambles into their public entry points.
- Represent command transition ownership and completion as one nullable record.
- Centralize transition acquisition, ownership checks, and settlement.
- Reuse `useWithGeneration` from `use` instead of maintaining duplicate acquisition logic.
- Record implementation, behavior-preservation, review, and verification evidence for Step 16.

## Why

`PluginRuntime` repeated the same transition protocol across several commands, making ownership and settlement behavior harder to audit and easier to evolve inconsistently. Consolidating that protocol reduces duplication while retaining the existing lifecycle and concurrency contracts.

## Risk and test focus

The main risk is changing command serialization or settlement ordering. Review and tests focus on force takeover, busy conflicts, restart failure precedence, prepared-disable retention, acquisition fencing, disposal, authentication loss, and ownership-loss paths.

There is no intended user-visible behavior change and no database impact.

## Expected result

Plugin runtime commands preserve their current external behavior while sharing one explicit transition protocol and substantially less duplicated implementation.

## Verification

- `dart analyze --fatal-infos` in `bridge/app`
- `dart test -j1 test/bridge/runtime/plugin_runtime_test.dart test/services/plugin_lifecycle_service_test.dart` (109 tests)
- `git diff --check origin/main...HEAD`
- Architecture implementation review: approved

`dart format lib/src/runtime/plugin_runtime.dart` cannot complete because the pinned `dart_style` crashes while building this file's existing enhanced enum body (`Null check operator used on a null value`). Analyzer parsing remains clean; the limitation and affected lines are recorded in the Step 16 evidence file.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates PluginRuntime command transitions and ownership into one protocol shared by `stop`, `prepareDisable`, and `restart`, reducing duplication while preserving lifecycle and concurrency guarantees. `prepareDisable` now runs synchronous guards before publishing the draining gate, avoiding transient draining snapshots on rejected requests.

- Inlines preambles into `stop`, `prepareDisable`, and `restart`; centralizes logic in `_stopPreconditionConflict`, `_beginCommandTransition`, `_ownsCommandTransition`, and `_settleCommandTransition`.
- Replaces `commandTransitionOwner`/`commandTransitionCompleter` with a single `_CommandTransition` record, making partial ownership state unrepresentable.
- `use` now delegates to `useWithGeneration`, discarding only the generation; external behavior is unchanged.
- Disposal waits on `slot.commandTransition?.completer` and durable commits, preserving settlement ordering.
- No wire, storage, or user-visible behavior changes; review focus: force takeover, in-flight/busy conflicts, restart failure precedence, prepared-disable retention/settlement, disposal, and authentication-loss paths.

<sup>Written for commit eb114aa61365e7e928d476e0feafd40b1bf479cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

