### PR TITLE
⚙️ [codebase-cleanup] bridge(app): simplify Orchestrator fencing and PluginLifecycleService initialization [step 17/45]

### DIFF
--- a/.plan/active/codebase-cleanup/steps/step-17.md
+++ b/.plan/active/codebase-cleanup/steps/step-17.md
@@ -1,0 +1,55 @@
+# Step 17/45 - Simplify Orchestrator and plugin lifecycle initialization
+
+## Re-verification against `main`
+
+`OrchestratorSession` still owned three `CompositeSubscription`s that were
+cancelled together, a one-element plugin-listener list, and a `PushDispatcher`
+reference used only to call a no-op disposal chain. The session now owns one
+composite and one listener directly. The shared HTTP transport remains owned by
+the composition root, so the no-op `PushDispatcher.dispose` and
+`PushNotificationClient.dispose` methods and their tests are gone.
+
+Plugin-event generation checks now consistently use `_isCurrentSource`. The
+second same-stack check was removed because no await separates it from the
+outer ordered check; every fence after an await or queued boundary remains.
+Sourced event paths now require their already-non-null plugin ID. Initial relay
+connection failures also retain their original error type and stack instead of
+being replaced by an untyped exception that mislabeled later startup failures.
+
+`PluginLifecycleService` now receives immutable plugin metadata in its
+constructor. Registration-derived fields are non-null and final, and every
+production and test caller supplies plugins at construction. The repository no
+longer maps `PluginRuntimeSnapshot` into a field-for-field lifecycle copy; the
+service consumes the runtime snapshot directly, including the typed transition.
+The duplicated stop-intent and lifecycle-state mappings and ready-ID equality
+loop are consolidated.
+
+The three bridge-ID reads around idle-timeout mutation remain deliberate: they
+fence immediate dispatch, acquisition of the queued mutation turn, and the
+settings callback before persistence. Removing any of them would weaken the
+existing identity-revocation behavior covered by the lifecycle tests.
+
+No wire contract, persisted data, database schema, or intended user-visible
+behavior changed.
+
+## Verification
+
+- `dart analyze --fatal-infos` in `bridge/app`: clean.
+- `dart test -j1 test/bridge/orchestrator_*_test.dart test/push
+  test/services/plugin_lifecycle_service_test.dart
+  test/bridge/routing/get_plugin_setup_handler_test.dart`: 231 tests passed.
+- After adding constructor-time duplicate-ID coverage,
+  `dart test -j1 test/services/plugin_lifecycle_service_test.dart`: 50 tests
+  passed.
+- `git diff --check`: clean.
+- `dart format` formatted all supported touched files. The pinned formatter
+  crashes while building existing enhanced enum bodies in `orchestrator.dart`,
+  `bridge_runtime_runner.dart`, and `plugin_lifecycle_test_support.dart`
+  (`dart_style` null-check failure); analyzer parsing is clean and their edited
+  sections retain the existing formatting.
+
+The production diff excluding this evidence file is `+184 / -284`.
+
+## Architecture implementation review
+
+Approved with no actionable findings.

--- a/.plan/active/codebase-cleanup/steps/step-17.md
+++ b/.plan/active/codebase-cleanup/steps/step-17.md
@@ -48,7 +48,12 @@ behavior changed.
   (`dart_style` null-check failure); analyzer parsing is clean and their edited
   sections retain the existing formatting.
 
-The production diff excluding this evidence file is `+184 / -284`.
+The merge base used for the final scope measurement is
+`5ffd05c5e7c29c8e901c81f2e0b8e0dea00a100e`. Running
+`BASE=$(git merge-base origin/main HEAD)` followed by
+`git diff --numstat "$BASE" -- bridge/app/lib` gives a production-only total
+of `+188 / -286`; `git diff --numstat "$BASE" -- bridge/app/test` gives a test
+total of `+429 / -473`. The evidence file itself is excluded from both totals.
 
 ## Architecture implementation review
 

--- a/bridge/app/lib/src/orchestrator.dart
+++ b/bridge/app/lib/src/orchestrator.dart
@@ -499,9 +499,10 @@ class Orchestrator({
       bridgeSettingsRepository: _bridgeSettingsRepository,
       permissionAutoApprovalService: permissionAutoApprovalService,
     );
-    final pluginEventListeners = [
-      PluginEventListener(source: _pluginRuntime.backendEvents, dispatcher: sessionEventDispatcher),
-    ];
+    final pluginEventListener = PluginEventListener(
+      source: _pluginRuntime.backendEvents,
+      dispatcher: sessionEventDispatcher,
+    );
     final sessionBindingCommitListener = SessionBindingCommitListener(
       source: sessionRepository.bindingCommits,
       dispatcher: sessionEventDispatcher,
@@ -606,7 +607,7 @@ class Orchestrator({
       config: config,
       client: _client,
       pluginEvents: normalizedPluginEvents,
-      pluginEventListeners: pluginEventListeners,
+      pluginEventListener: pluginEventListener,
       sessionBindingCommitListener: sessionBindingCommitListener,
       sessionMutationListener: sessionMutationListener,
       chatHistoryListener: chatHistoryListener,
@@ -616,7 +617,6 @@ class Orchestrator({
       sessionOptionsChangedRefreshListener: sessionOptionsChangedRefreshListener,
       sessionEventDispatcher: sessionEventDispatcher,
       pluginRuntime: _pluginRuntime,
-      pushDispatcher: pushDispatcher,
       completionListener: completionListener,
       maintenanceListener: maintenanceListener,
       accessTokenProvider: _accessTokenProvider,
@@ -704,7 +704,7 @@ class OrchestratorSession._({
     required final BridgeConfig config,
     required final RelayClient _client,
     required final Stream<NormalizedSourcedBridgeEvent> _pluginEvents,
-    required final List<PluginEventListener> _pluginEventListeners,
+    required final PluginEventListener _pluginEventListener,
     required final SessionBindingCommitListener _sessionBindingCommitListener,
     required final SessionMutationListener _sessionMutationListener,
     required final ChatHistoryListener _chatHistoryListener,
@@ -714,7 +714,6 @@ class OrchestratorSession._({
     required final SessionOptionsChangedRefreshListener _sessionOptionsChangedRefreshListener,
     required final SessionEventDispatcher _sessionEventDispatcher,
     required final PluginRuntime _pluginRuntime,
-    required final PushDispatcher _pushDispatcher,
     required final CompletionPushListener _completionListener,
     required final MaintenancePushListener _maintenanceListener,
     required final AccessTokenProvider _accessTokenProvider,
@@ -750,10 +749,6 @@ class OrchestratorSession._({
     required final ControlStatusNotifier? _statusNotifier,
     required final ReconnectBackoffPolicy _reconnectBackoff,
   }) {
-  // ignore: cancel_subscriptions - cancelled by the failure-isolated session drain.
-  final CompositeSubscription _promptDefaultsSubscriptions = CompositeSubscription();
-  // ignore: cancel_subscriptions - cancelled by the failure-isolated session drain.
-  final CompositeSubscription _catalogImportSubscriptions = CompositeSubscription();
   // ignore: cancel_subscriptions - cancelled by the failure-isolated session drain.
   final CompositeSubscription _subscriptions = CompositeSubscription();
   StreamSubscription<NormalizedSourcedBridgeEvent>? _normalizedEventSubscription;
@@ -797,7 +792,7 @@ class OrchestratorSession._({
         .listen((progress) {
           _enqueueWireEvent(SesoriSseEvent.catalogImportProgress(progress: progress));
         })
-        .addTo(_catalogImportSubscriptions);
+        .addTo(_subscriptions);
     pluginManagementSnapshotTokens
         .listen((snapshotToken) {
           _enqueueWireEvent(SesoriSseEvent.pluginManagementChanged(snapshotToken: snapshotToken));
@@ -834,7 +829,7 @@ class OrchestratorSession._({
             ),
           );
         })
-        .addTo(_promptDefaultsSubscriptions);
+        .addTo(_subscriptions);
   }
 
   /// Broadcast stream of byte counts emitted each time data is sent to a phone.
@@ -887,9 +882,7 @@ class OrchestratorSession._({
     _sessionMutationListener.start();
     _chatHistoryListener.start();
     _sessionBindingCommitListener.start();
-    for (final listener in _pluginEventListeners) {
-      listener.start();
-    }
+    _pluginEventListener.start();
     _sessionOptionsCreationRefreshListener.start();
     _sessionOptionsChangedRefreshListener.start();
     _viewedProjectPrRefreshListener.start();
@@ -961,80 +954,75 @@ class OrchestratorSession._({
     Log.d("bridge registered");
     if (_cancelled) return;
 
-    final RelayConnection relayConnection;
-    try {
-      Log.d("connecting to relay...");
-      relayConnection = await _client.connect();
-      _relayConnection = relayConnection;
-      Log.d("relay connected");
-      if (_cancelled) {
-        final closeFuture = _client.closeIfCurrent(connection: relayConnection);
-        if (identical(_relayConnection, relayConnection)) {
-          _relayConnection = null;
-        }
-        await closeFuture;
-        return;
+    Log.d("connecting to relay...");
+    final relayConnection = await _client.connect();
+    _relayConnection = relayConnection;
+    Log.d("relay connected");
+    if (_cancelled) {
+      final closeFuture = _client.closeIfCurrent(connection: relayConnection);
+      if (identical(_relayConnection, relayConnection)) {
+        _relayConnection = null;
       }
-
-      _maintenanceListener.start();
-      _projectActivityService.changes
-          .listen((change) {
-            final event = SesoriSseEvent.projectUpdated(
-              projectID: change.projectId,
-              updatedAt: change.updatedAt,
-            );
-            _enqueueWireEvent(event);
-            _completionListener.handleSseEvent(event);
-          })
-          .addTo(_subscriptions);
-
-      if (_yoloSettingsService.currentSettings.enabled) await _permissionAutoApprovalService.approvePending();
-      final startupSummary = await _buildProjectsSummary();
-      if (startupSummary != null) {
-        _completionListener.handleSseEvent(startupSummary);
-        if (startupSummary is SesoriProjectsSummary) {
-          _statusNotifier?.handleProjectsSummary(summary: startupSummary);
-        }
-      }
-      _prSyncService.renderedChanges
-          .listen((change) {
-            _enqueueWireEvent(SesoriSseEvent.sessionsUpdated(projectID: change.projectId));
-          })
-          .addTo(_subscriptions);
-      _sessionUnseenService.unseenChanges
-          .listen((change) {
-            _enqueueWireEvent(
-              SesoriSseEvent.sessionUnseenChanged(
-                projectID: change.projectId,
-                sessionId: change.sessionId,
-                unseen: change.unseen,
-                projectHasUnseenChanges: change.projectHasUnseenChanges,
-                lastUserActivityAt: change.lastUserActivityAt,
-              ),
-            );
-          })
-          .addTo(_subscriptions);
-      // Live re-auth: when the token provider emits a token whose auth IDENTITY
-      // differs from the one the relay socket is actually authenticated with
-      // (supervised mode: the GUI pushed a token_update after an account switch;
-      // standalone: a re-login as another user picked up by the next refresh),
-      // drop the relay so the reconnect loop below re-authenticates on the fresh
-      // token — the same path a relay-side disconnect drives, so both triggers
-      // stay symmetric.
-      //
-      // Identity-gated on purpose: the relay validates the JWT once at connect
-      // and never re-checks it for the lifetime of the socket, so a routine
-      // same-user token rotation (TokenManager refreshing near expiry during
-      // metadata generation or push sends, or the GUI pushing a routine refresh)
-      // keeps the open socket fully valid. Dropping it would disconnect every
-      // phone mid-flight for nothing — see [_requiresRelayReauth].
-      _accessTokenProvider.tokenStream
-          .where(_requiresRelayReauth)
-          .listen((token) => unawaited(_reauthenticateRelay()))
-          .addTo(_subscriptions);
-    } catch (e) {
-      throw Exception("failed to connect to relay: $e");
+      await closeFuture;
+      return;
     }
+
+    _maintenanceListener.start();
+    _projectActivityService.changes
+        .listen((change) {
+          final event = SesoriSseEvent.projectUpdated(
+            projectID: change.projectId,
+            updatedAt: change.updatedAt,
+          );
+          _enqueueWireEvent(event);
+          _completionListener.handleSseEvent(event);
+        })
+        .addTo(_subscriptions);
+
+    if (_yoloSettingsService.currentSettings.enabled) await _permissionAutoApprovalService.approvePending();
+    final startupSummary = await _buildProjectsSummary();
+    if (startupSummary != null) {
+      _completionListener.handleSseEvent(startupSummary);
+      if (startupSummary is SesoriProjectsSummary) {
+        _statusNotifier?.handleProjectsSummary(summary: startupSummary);
+      }
+    }
+    _prSyncService.renderedChanges
+        .listen((change) {
+          _enqueueWireEvent(SesoriSseEvent.sessionsUpdated(projectID: change.projectId));
+        })
+        .addTo(_subscriptions);
+    _sessionUnseenService.unseenChanges
+        .listen((change) {
+          _enqueueWireEvent(
+            SesoriSseEvent.sessionUnseenChanged(
+              projectID: change.projectId,
+              sessionId: change.sessionId,
+              unseen: change.unseen,
+              projectHasUnseenChanges: change.projectHasUnseenChanges,
+              lastUserActivityAt: change.lastUserActivityAt,
+            ),
+          );
+        })
+        .addTo(_subscriptions);
+    // Live re-auth: when the token provider emits a token whose auth IDENTITY
+    // differs from the one the relay socket is actually authenticated with
+    // (supervised mode: the GUI pushed a token_update after an account switch;
+    // standalone: a re-login as another user picked up by the next refresh),
+    // drop the relay so the reconnect loop below re-authenticates on the fresh
+    // token — the same path a relay-side disconnect drives, so both triggers
+    // stay symmetric.
+    //
+    // Identity-gated on purpose: the relay validates the JWT once at connect
+    // and never re-checks it for the lifetime of the socket, so a routine
+    // same-user token rotation (TokenManager refreshing near expiry during
+    // metadata generation or push sends, or the GUI pushing a routine refresh)
+    // keeps the open socket fully valid. Dropping it would disconnect every
+    // phone mid-flight for nothing — see [_requiresRelayReauth].
+    _accessTokenProvider.tokenStream
+        .where(_requiresRelayReauth)
+        .listen((token) => unawaited(_reauthenticateRelay()))
+        .addTo(_subscriptions);
 
     Console.message("Relay:  ${config.relayURL}");
     Console.message("Waiting for relay events...");
@@ -1074,9 +1062,7 @@ class OrchestratorSession._({
     );
     await Future.wait([
       attempt(_subscriptions.cancel),
-      attempt(_promptDefaultsSubscriptions.cancel),
-      attempt(_catalogImportSubscriptions.cancel),
-      for (final listener in _pluginEventListeners) attempt(listener.dispose),
+      attempt(_pluginEventListener.dispose),
       attempt(_sessionBindingCommitListener.dispose),
       attempt(_chatHistoryListener.dispose),
       attempt(_chatHistoryActivityListener.dispose),
@@ -1126,9 +1112,6 @@ class OrchestratorSession._({
     Log.v("stopping sse manager...");
     await attempt(_sseManager.stop);
     Log.v("sse manager stopped (+${teardownSw.elapsedMilliseconds}ms)");
-    Log.v("disposing push notification service...");
-    await attempt(_pushDispatcher.dispose);
-    Log.v("push notification service disposed (+${teardownSw.elapsedMilliseconds}ms)");
     await Future.wait([
       attempt(_localWireEventsController.close),
       attempt(_bytesSentController.close),
@@ -1363,13 +1346,11 @@ class OrchestratorSession._({
     return () async {
       await previous;
       try {
-        final generation = source.generation;
-        if (generation != null &&
-            !_pluginRuntime.isCurrentEvent(
-              pluginId: source.pluginId,
-              generation: generation,
-              allowDuringStop: source.allowDuringStop,
-            )) {
+        if (!_isCurrentSource(
+          pluginId: source.pluginId,
+          generation: source.generation,
+          allowDuringStop: source.allowDuringStop,
+        )) {
           return;
         }
         await _processPluginEvent(source);
@@ -1392,14 +1373,6 @@ class OrchestratorSession._({
       _ => sourcedEvent,
     };
     try {
-      if (generation != null &&
-          !_pluginRuntime.isCurrentEvent(
-            pluginId: pluginId,
-            generation: generation,
-            allowDuringStop: allowDuringStop,
-          )) {
-        return;
-      }
       Log.v("[sse] plugin event arrived: ${event.runtimeType}");
 
       if (event is BridgeSsePermissionReplied) {
@@ -1478,12 +1451,11 @@ class OrchestratorSession._({
         final sesoriEvent = event is BridgeSseProjectUpdated ? null : _mapper.map(event: event, pluginId: pluginId);
         delivery = sesoriEvent == null ? null : SseEventDelivery.uniform(event: sesoriEvent);
       }
-      if (generation != null &&
-          !_pluginRuntime.isCurrentEvent(
-            pluginId: pluginId,
-            generation: generation,
-            allowDuringStop: allowDuringStop,
-          )) {
+      if (!_isCurrentSource(
+        pluginId: pluginId,
+        generation: generation,
+        allowDuringStop: allowDuringStop,
+      )) {
         return;
       }
       if (delivery != null) {
@@ -1500,12 +1472,11 @@ class OrchestratorSession._({
       // Both trigger types mean activity changed. Rebuild from repository data
       // after delivering session.deleted so clients observe deletion first.
       if (refreshProjectsSummary) {
-        if (generation != null &&
-            !_pluginRuntime.isCurrentEvent(
-              pluginId: pluginId,
-              generation: generation,
-              allowDuringStop: allowDuringStop,
-            )) {
+        if (!_isCurrentSource(
+          pluginId: pluginId,
+          generation: generation,
+          allowDuringStop: allowDuringStop,
+        )) {
           return;
         }
         await _buildAndDeliverProjectsSummaryInOrder(
@@ -1535,7 +1506,7 @@ class OrchestratorSession._({
   /// rewritten part to subscribers as an ordinary part update.
   Future<void> _finalizeOpenToolParts({
     required String sessionId,
-    required String? pluginId,
+    required String pluginId,
     required int? generation,
     required bool allowDuringStop,
   }) async {
@@ -1603,7 +1574,7 @@ class OrchestratorSession._({
 
   Future<void> _deliverSseEvent({
     required SseEventDelivery delivery,
-    required String? pluginId,
+    required String pluginId,
     required int? generation,
     required bool allowDuringStop,
   }) async {
@@ -1653,7 +1624,7 @@ class OrchestratorSession._({
   }
 
   Future<void> _buildAndDeliverProjectsSummaryInOrder({
-    required String? pluginId,
+    required String pluginId,
     required int? generation,
     required bool allowDuringStop,
   }) {
@@ -1688,12 +1659,11 @@ class OrchestratorSession._({
   }
 
   bool _isCurrentSource({
-    required String? pluginId,
+    required String pluginId,
     required int? generation,
     required bool allowDuringStop,
   }) {
     if (generation == null) return true;
-    if (pluginId == null) return false;
     return _pluginRuntime.isCurrentEvent(
       pluginId: pluginId,
       generation: generation,

--- a/bridge/app/lib/src/push/push_dispatcher.dart
+++ b/bridge/app/lib/src/push/push_dispatcher.dart
@@ -36,10 +36,6 @@ class PushDispatcher({
     );
   }
 
-  Future<void> dispose() async {
-    await _client.dispose();
-  }
-
   void _sendImmediateNotificationIfApplicable(SesoriSseEvent event) {
     final notificationData = _contentBuilder.extractNotificationData(event);
     if (notificationData == null) {

--- a/bridge/app/lib/src/push/push_notification_client.dart
+++ b/bridge/app/lib/src/push/push_notification_client.dart
@@ -41,8 +41,4 @@ class PushNotificationClient({
       body: jsonEncode(payload.toJson()),
     );
   }
-
-  Future<void> dispose() async {
-    // Shared http client lifetime is owned by the composition root.
-  }
 }

--- a/bridge/app/lib/src/repositories/plugin_lifecycle_repository.dart
+++ b/bridge/app/lib/src/repositories/plugin_lifecycle_repository.dart
@@ -2,18 +2,6 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "../runtime/plugin_runtime.dart";
 
-class const PluginLifecycleSnapshot({
-  required final String pluginId,
-  required final PluginProjectOwnership projectOwnership,
-  required final PluginSetupStatus setup,
-  required final PluginRuntimeAccessGate accessGate,
-  required final bool startAllowed,
-  required final PluginRuntimeState state,
-  required final PluginWorkState workState,
-  required final int leaseCount,
-  required final bool transitionSettled,
-});
-
 class PluginLifecycleRepository({required final PluginRuntime _runtime}) {
   Future<Map<String, PluginSetupStatus>> inspect({
     required Set<String> pluginIds,
@@ -69,23 +57,6 @@ class PluginLifecycleRepository({required final PluginRuntime _runtime}) {
     required PluginStopIntent intent,
   }) => _runtime.restart(pluginId: pluginId, intent: intent);
 
-  Stream<List<PluginLifecycleSnapshot>> get snapshots => _runtime.snapshots.map(_mapSnapshots);
-  List<PluginLifecycleSnapshot> get snapshot => _mapSnapshots(_runtime.snapshot);
-
-  List<PluginLifecycleSnapshot> _mapSnapshots(List<PluginRuntimeSnapshot> snapshots) {
-    return List<PluginLifecycleSnapshot>.unmodifiable([
-      for (final snapshot in snapshots)
-        PluginLifecycleSnapshot(
-          pluginId: snapshot.pluginId,
-          projectOwnership: snapshot.projectOwnership,
-          setup: snapshot.setup,
-          accessGate: snapshot.accessGate,
-          startAllowed: snapshot.startAllowed,
-          state: snapshot.state,
-          workState: snapshot.workState,
-          leaseCount: snapshot.leaseCount,
-          transitionSettled: snapshot.transition == PluginRuntimeTransition.none,
-        ),
-    ]);
-  }
+  Stream<List<PluginRuntimeSnapshot>> get snapshots => _runtime.snapshots;
+  List<PluginRuntimeSnapshot> get snapshot => _runtime.snapshot;
 }

--- a/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
@@ -655,7 +655,6 @@ class const BridgeRuntimeRunner._() {
             bridgeSettingsRepository: bridgeSettingsRepository,
             idleTimerScheduler: const PluginIdleTimerScheduler(),
             bridgeIdProvider: bridgeRegistrationService,
-          )..registerPlugins(
             plugins: [
               for (final descriptor in knownPlugins)
                 (

--- a/bridge/app/lib/src/runtime/plugin_runtime.dart
+++ b/bridge/app/lib/src/runtime/plugin_runtime.dart
@@ -88,7 +88,7 @@ class PluginRuntime({
   final Set<StartAbortController> _authenticationAbortControllers = <StartAbortController>{};
 
   Stream<List<PluginRuntimeSnapshot>> get snapshots => _snapshotsSubject.stream;
-  List<PluginRuntimeSnapshot> get snapshot => List<PluginRuntimeSnapshot>.unmodifiable(_buildSnapshots());
+  List<PluginRuntimeSnapshot> get snapshot => _buildSnapshots();
   Stream<SourcedPluginRuntimeEvent> get backendEvents => _backendEventsSubject.stream;
   Stream<SourcedPluginProvisionProgress> get provisionProgress => _provisionProgressSubject.stream;
 
@@ -1658,7 +1658,9 @@ class PluginRuntime({
     return slot;
   }
 
-  List<PluginRuntimeSnapshot> _buildSnapshots() => [for (final slot in _slots.values) _snapshotFor(slot)];
+  List<PluginRuntimeSnapshot> _buildSnapshots() => List<PluginRuntimeSnapshot>.unmodifiable([
+    for (final slot in _slots.values) _snapshotFor(slot),
+  ]);
 
   PluginRuntimeSnapshot _snapshotFor(_PluginRuntimeSlot slot) {
     final state = switch (slot.accessGate) {

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -50,6 +50,19 @@ typedef PluginInstallProgressUpdate = ({
 
 typedef PluginAuthenticationProgressUpdate = ({String pluginId, PluginAuthenticationProgress progress});
 
+List<RegisteredPluginMetadata> _validateAndSortPlugins(List<RegisteredPluginMetadata> plugins) {
+  final ids = plugins.map((plugin) => plugin.id).toList(growable: false);
+  if (ids.toSet().length != ids.length) {
+    throw ArgumentError.value(plugins, "plugins", "must not contain duplicate ids");
+  }
+  final sorted = [...plugins]
+    ..sort((left, right) {
+      final byName = left.displayName.toLowerCase().compareTo(right.displayName.toLowerCase());
+      return byName != 0 ? byName : left.id.compareTo(right.id);
+    });
+  return List<RegisteredPluginMetadata>.unmodifiable(sorted);
+}
+
 class const PluginIdleTimerScheduler() {
   Timer schedule({required Duration duration, required void Function() onElapsed}) {
     return Timer(duration, onElapsed);
@@ -62,12 +75,22 @@ class PluginLifecycleService({
   required final BridgeSettingsRepository _bridgeSettingsRepository,
   required final PluginIdleTimerScheduler _idleTimerScheduler,
   required final BridgeIdProvider _bridgeIdProvider,
+  required List<RegisteredPluginMetadata> plugins,
 }) {
-  List<RegisteredPluginMetadata>? _registeredPlugins;
-  Set<String>? _knownPluginIds;
-  Map<String, PluginResidencyPolicy>? _residencyPolicyById;
-  late Map<String, PluginSessionOptionsScope> _sessionOptionsScopeById;
-  Map<String, Set<PluginControlCapability>>? _managementCapabilitiesById;
+  final List<RegisteredPluginMetadata> _registeredPlugins = _validateAndSortPlugins(plugins);
+  final Set<String> _knownPluginIds = Set<String>.unmodifiable(plugins.map((plugin) => plugin.id));
+  final Map<String, PluginResidencyPolicy> _residencyPolicyById = Map<String, PluginResidencyPolicy>.unmodifiable({
+    for (final plugin in plugins) plugin.id: plugin.residencyPolicy,
+  });
+  final Map<String, PluginSessionOptionsScope> _sessionOptionsScopeById =
+      Map<String, PluginSessionOptionsScope>.unmodifiable({
+        for (final plugin in plugins) plugin.id: plugin.sessionOptionsScope,
+      });
+  final Map<String, Set<PluginControlCapability>> _managementCapabilitiesById =
+      Map<String, Set<PluginControlCapability>>.unmodifiable({
+        for (final plugin in plugins)
+          plugin.id: Set<PluginControlCapability>.unmodifiable(plugin.managementCapabilities),
+      });
   List<String>? _eligiblePluginIds;
   Set<String> _startAllowedPluginIds = {};
   Map<String, PluginMetadata> _metadataById = <String, PluginMetadata>{};
@@ -80,7 +103,7 @@ class PluginLifecycleService({
   final StreamController<PluginAuthenticationProgressUpdate> _authenticationProgressController =
       StreamController<PluginAuthenticationProgressUpdate>.broadcast(sync: true);
   final Map<String, DateTime> _lastInstallDownloadEmit = {};
-  StreamSubscription<List<PluginLifecycleSnapshot>>? _runtimeSubscription;
+  StreamSubscription<List<PluginRuntimeSnapshot>>? _runtimeSubscription;
   Future<void>? _disposeFuture;
   Future<void> _settingsMutationTail = Future<void>.value();
   final Map<String, _ActivePluginCommand> _activePluginCommands = {};
@@ -90,30 +113,6 @@ class PluginLifecycleService({
   _PluginManagementSnapshot? _lastPublishedManagementSnapshot;
   final Random _random = Random.secure();
   bool _disposing = false;
-
-  void registerPlugins({required List<RegisteredPluginMetadata> plugins}) {
-    if (_registeredPlugins != null) throw StateError("Plugins are already registered.");
-    final ids = plugins.map((plugin) => plugin.id).toList(growable: false);
-    if (ids.toSet().length != ids.length) {
-      throw ArgumentError.value(plugins, "plugins", "must not contain duplicate ids");
-    }
-    final sorted = [...plugins]
-      ..sort((left, right) {
-        final byName = left.displayName.toLowerCase().compareTo(right.displayName.toLowerCase());
-        return byName != 0 ? byName : left.id.compareTo(right.id);
-      });
-    _registeredPlugins = List<RegisteredPluginMetadata>.unmodifiable(sorted);
-    _knownPluginIds = Set<String>.unmodifiable(ids);
-    _residencyPolicyById = Map<String, PluginResidencyPolicy>.unmodifiable({
-      for (final plugin in plugins) plugin.id: plugin.residencyPolicy,
-    });
-    _sessionOptionsScopeById = Map<String, PluginSessionOptionsScope>.unmodifiable({
-      for (final plugin in plugins) plugin.id: plugin.sessionOptionsScope,
-    });
-    _managementCapabilitiesById = Map<String, Set<PluginControlCapability>>.unmodifiable({
-      for (final plugin in plugins) plugin.id: Set<PluginControlCapability>.unmodifiable(plugin.managementCapabilities),
-    });
-  }
 
   Set<String> uncontrollableDisabledPluginIds({required Set<String> disabledPluginIds}) {
     if (_eligiblePluginIds != null) throw StateError("Plugin lifecycle is already initialized.");
@@ -129,19 +128,14 @@ class PluginLifecycleService({
     required Map<String, PluginSetupStatus> setupById,
   }) {
     if (_eligiblePluginIds != null) throw StateError("Plugin lifecycle is already initialized.");
-    final registeredPlugins = _registeredPlugins;
-    final knownPluginIds = _knownPluginIds;
-    if (registeredPlugins == null || knownPluginIds == null) {
-      throw StateError("Plugins have not been registered.");
-    }
-    if (setupById.keys.toSet().difference(knownPluginIds).isNotEmpty ||
-        knownPluginIds.difference(setupById.keys.toSet()).isNotEmpty) {
+    if (setupById.keys.toSet().difference(_knownPluginIds).isNotEmpty ||
+        _knownPluginIds.difference(setupById.keys.toSet()).isNotEmpty) {
       throw ArgumentError.value(setupById, "setupById", "must contain exactly every registered plugin id");
     }
 
     _setupById = Map<String, PluginSetupStatus>.unmodifiable(setupById);
     final eligiblePluginIds = List<String>.unmodifiable([
-      for (final plugin in registeredPlugins)
+      for (final plugin in _registeredPlugins)
         if (!disabledPluginIds.contains(plugin.id)) plugin.id,
     ]);
     final setupReadyPluginIds = <String>{
@@ -154,7 +148,7 @@ class PluginLifecycleService({
     _rebuildMetadata();
     final defaultPluginId = _selectableDefaultPluginId();
     final eagerPluginIds = List<String>.unmodifiable([
-      for (final plugin in registeredPlugins)
+      for (final plugin in _registeredPlugins)
         if (eligiblePluginIds.contains(plugin.id) &&
             setupReadyPluginIds.contains(plugin.id) &&
             plugin.activationPolicy == PluginActivationPolicy.eager)
@@ -176,12 +170,10 @@ class PluginLifecycleService({
   }
 
   PluginCompositionView get compositionView {
-    final knownPluginIds = _knownPluginIds;
     final eligiblePluginIds = _requireEligiblePluginIds();
-    if (knownPluginIds == null) throw StateError("Plugin lifecycle has not been initialized.");
     return (
-      knownPluginIds: knownPluginIds,
-      orderedPluginIds: List<String>.unmodifiable(_registeredPlugins!.map((plugin) => plugin.id)),
+      knownPluginIds: _knownPluginIds,
+      orderedPluginIds: List<String>.unmodifiable(_registeredPlugins.map((plugin) => plugin.id)),
       eligiblePluginIds: eligiblePluginIds,
       defaultPluginId: _selectableDefaultPluginId(),
       projectOwnershipById: Map<String, PluginProjectOwnership>.unmodifiable({
@@ -206,14 +198,13 @@ class PluginLifecycleService({
   }
 
   PluginSetupResponse get setupSnapshot {
-    final registeredPlugins = _registeredPlugins;
     final setupById = _setupById;
-    if (registeredPlugins == null || setupById == null) {
+    if (setupById == null) {
       throw StateError("Plugin lifecycle has not been initialized.");
     }
     return PluginSetupResponse(
       plugins: [
-        for (final plugin in registeredPlugins) _mapSetupMetadata(plugin: plugin, setup: setupById[plugin.id]!),
+        for (final plugin in _registeredPlugins) _mapSetupMetadata(plugin: plugin, setup: setupById[plugin.id]!),
       ],
     );
   }
@@ -224,7 +215,7 @@ class PluginLifecycleService({
   }
 
   _PluginManagementSnapshot _requireManagementSnapshot() {
-    if (_registeredPlugins == null || _setupById == null) {
+    if (_setupById == null) {
       throw StateError("Plugin lifecycle has not been initialized.");
     }
     final snapshot = _lastPublishedManagementSnapshot;
@@ -270,11 +261,10 @@ class PluginLifecycleService({
     required String pluginId,
     required PluginLifecycleCommandRequest request,
   }) {
-    final knownPluginIds = _knownPluginIds;
-    if (knownPluginIds == null || _setupById == null) {
+    if (_setupById == null) {
       throw StateError("Plugin lifecycle has not been initialized.");
     }
-    if (!knownPluginIds.contains(pluginId)) {
+    if (!_knownPluginIds.contains(pluginId)) {
       throw PluginManagementPluginNotFoundException(pluginId);
     }
     if (_lastPublishedManagementSnapshot == null) {
@@ -337,11 +327,10 @@ class PluginLifecycleService({
   Stream<PluginAuthenticationProgressUpdate> get authenticationProgress => _authenticationProgressController.stream;
 
   Future<PluginAuthenticationChallengeResponse> authenticate({required String pluginId}) {
-    final knownPluginIds = _knownPluginIds;
-    if (knownPluginIds == null || _setupById == null) {
+    if (_setupById == null) {
       throw StateError("Plugin lifecycle has not been initialized.");
     }
-    if (!knownPluginIds.contains(pluginId)) {
+    if (!_knownPluginIds.contains(pluginId)) {
       throw PluginManagementPluginNotFoundException(pluginId);
     }
     _requireBridgeId();
@@ -387,11 +376,10 @@ class PluginLifecycleService({
   }
 
   Future<SuccessEmptyResponse> cancelAuthentication({required String pluginId}) async {
-    final knownPluginIds = _knownPluginIds;
-    if (knownPluginIds == null || _setupById == null) {
+    if (_setupById == null) {
       throw StateError("Plugin lifecycle has not been initialized.");
     }
-    if (!knownPluginIds.contains(pluginId)) {
+    if (!_knownPluginIds.contains(pluginId)) {
       throw PluginManagementPluginNotFoundException(pluginId);
     }
     _requireBridgeId();
@@ -627,8 +615,7 @@ class PluginLifecycleService({
   }
 
   Future<PluginManagementResponse> updateIdleTimeout({required PluginIdleTimeoutUpdateRequest request}) {
-    final knownPluginIds = _knownPluginIds;
-    if (knownPluginIds == null || _setupById == null) {
+    if (_setupById == null) {
       throw StateError("Plugin lifecycle has not been initialized.");
     }
     if (_lastPublishedManagementSnapshot == null) {
@@ -639,7 +626,7 @@ class PluginLifecycleService({
         break;
       case PluginIdleTimeoutSetOverrideRequest(:final pluginId) ||
           PluginIdleTimeoutClearOverrideRequest(:final pluginId):
-        if (!knownPluginIds.contains(pluginId)) {
+        if (!_knownPluginIds.contains(pluginId)) {
           throw PluginManagementPluginNotFoundException(pluginId);
         }
     }
@@ -759,10 +746,7 @@ class PluginLifecycleService({
     if (!_requireEligiblePluginIds().contains(pluginId)) return;
     final result = await _lifecycleRepository.prepareDisable(
       pluginId: pluginId,
-      intent: switch (mode) {
-        PluginStopMode.safe => PluginStopIntent.safe,
-        PluginStopMode.force => PluginStopIntent.force,
-      },
+      intent: _mapStopIntent(mode: mode),
     );
     switch (result) {
       case PluginRuntimeCommandConflict(:final reasons):
@@ -912,7 +896,7 @@ class PluginLifecycleService({
       _startAllowedPluginIds.remove(pluginId);
     }
     _eligiblePluginIds = List<String>.unmodifiable([
-      for (final plugin in _registeredPlugins!)
+      for (final plugin in _registeredPlugins)
         if (eligibleIds.contains(plugin.id)) plugin.id,
     ]);
     _rebuildMetadata();
@@ -935,7 +919,7 @@ class PluginLifecycleService({
     PluginRuntimeConflictReason.notEligible => PluginLifecycleConflictReason.notEnabled,
   };
 
-  void _applyRuntimeSnapshots(List<PluginLifecycleSnapshot> snapshots) {
+  void _applyRuntimeSnapshots(List<PluginRuntimeSnapshot> snapshots) {
     final setupById = _setupById;
     if (setupById != null) {
       _setupById = Map<String, PluginSetupStatus>.unmodifiable({
@@ -950,14 +934,10 @@ class PluginLifecycleService({
     for (final snapshot in snapshots) {
       final current = _metadataById[snapshot.pluginId];
       if (current == null) continue;
-      final state = switch (snapshot.state) {
-        PluginRuntimeState.dormant ||
-        PluginRuntimeState.active ||
-        PluginRuntimeState.starting => PluginLifecycleState.ready,
-        PluginRuntimeState.degraded || PluginRuntimeState.stopping => PluginLifecycleState.degraded,
-        PluginRuntimeState.failed => PluginLifecycleState.failed,
-        PluginRuntimeState.disabled || PluginRuntimeState.blocked => PluginLifecycleState.unavailable,
-      };
+      final state = _lifecycleState(
+        runtimeState: snapshot.state,
+        unavailableState: PluginLifecycleState.unavailable,
+      );
       _metadataById[snapshot.pluginId] = current.copyWith(state: state, actionHint: _actionHint(state));
     }
     final subject = _metadataSubject;
@@ -971,21 +951,16 @@ class PluginLifecycleService({
     final snapshots = {for (final snapshot in _lifecycleRepository.snapshot) snapshot.pluginId: snapshot};
     final setupById = _requireSetupById();
     _metadataById = <String, PluginMetadata>{
-      for (final plugin in _registeredPlugins!)
+      for (final plugin in _registeredPlugins)
         if (_requireEligiblePluginIds().contains(plugin.id))
           plugin.id: () {
             final runtimeState = snapshots[plugin.id]?.state;
-            final state = switch (runtimeState) {
-              PluginRuntimeState.dormant ||
-              PluginRuntimeState.starting ||
-              PluginRuntimeState.active => PluginLifecycleState.ready,
-              PluginRuntimeState.degraded || PluginRuntimeState.stopping => PluginLifecycleState.degraded,
-              PluginRuntimeState.failed => PluginLifecycleState.failed,
-              PluginRuntimeState.disabled || PluginRuntimeState.blocked || null =>
-                setupById[plugin.id] is PluginSetupReady
-                    ? PluginLifecycleState.ready
-                    : PluginLifecycleState.unavailable,
-            };
+            final state = _lifecycleState(
+              runtimeState: runtimeState,
+              unavailableState: setupById[plugin.id] is PluginSetupReady
+                  ? PluginLifecycleState.ready
+                  : PluginLifecycleState.unavailable,
+            );
             return PluginMetadata(
               id: plugin.id,
               displayName: plugin.displayName,
@@ -1024,7 +999,19 @@ class PluginLifecycleService({
     return null;
   }
 
-  bool _isSelectable(PluginLifecycleSnapshot snapshot) {
+  PluginLifecycleState _lifecycleState({
+    required PluginRuntimeState? runtimeState,
+    required PluginLifecycleState unavailableState,
+  }) => switch (runtimeState) {
+    PluginRuntimeState.dormant ||
+    PluginRuntimeState.active ||
+    PluginRuntimeState.starting => PluginLifecycleState.ready,
+    PluginRuntimeState.degraded || PluginRuntimeState.stopping => PluginLifecycleState.degraded,
+    PluginRuntimeState.failed => PluginLifecycleState.failed,
+    PluginRuntimeState.disabled || PluginRuntimeState.blocked || null => unavailableState,
+  };
+
+  bool _isSelectable(PluginRuntimeSnapshot snapshot) {
     if (snapshot.accessGate != PluginRuntimeAccessGate.enabled) return false;
     return switch (snapshot.state) {
       PluginRuntimeState.dormant ||
@@ -1101,27 +1088,21 @@ class PluginLifecycleService({
       };
 
   Set<String> _pluginIdsSupporting({required PluginControlCapability capability}) {
-    final capabilitiesById = _managementCapabilitiesById;
-    if (capabilitiesById == null) throw StateError("Plugins have not been registered.");
     return {
-      for (final MapEntry(key: pluginId, value: capabilities) in capabilitiesById.entries)
+      for (final MapEntry(key: pluginId, value: capabilities) in _managementCapabilitiesById.entries)
         if (capabilities.contains(capability)) pluginId,
     };
   }
 
   Set<String> _pluginIdsWithout({required PluginControlCapability capability}) {
-    final capabilitiesById = _managementCapabilitiesById;
-    if (capabilitiesById == null) throw StateError("Plugins have not been registered.");
     return {
-      for (final MapEntry(key: pluginId, value: capabilities) in capabilitiesById.entries)
+      for (final MapEntry(key: pluginId, value: capabilities) in _managementCapabilitiesById.entries)
         if (!capabilities.contains(capability)) pluginId,
     };
   }
 
   Set<PluginControlCapability> _managementCapabilitiesForPluginId({required String pluginId}) {
-    final capabilitiesById = _managementCapabilitiesById;
-    if (capabilitiesById == null) throw StateError("Plugins have not been registered.");
-    return capabilitiesById[pluginId] ?? (throw StateError('Plugin "$pluginId" is not registered.'));
+    return _managementCapabilitiesById[pluginId] ?? (throw StateError('Plugin "$pluginId" is not registered.'));
   }
 
   void _requireManagementCapability({required String pluginId, required PluginControlCapability capability}) {
@@ -1151,13 +1132,12 @@ class PluginLifecycleService({
   }
 
   PluginManagementMetadata _managementRowForPluginId(String pluginId) {
-    final plugin = _registeredPlugins!.singleWhere((candidate) => candidate.id == pluginId);
+    final plugin = _registeredPlugins.singleWhere((candidate) => candidate.id == pluginId);
     return _managementRow(plugin: plugin);
   }
 
   _PluginManagementSnapshot _buildManagementSnapshot({required String snapshotToken}) {
-    final registeredPlugins = _registeredPlugins;
-    if (registeredPlugins == null || _setupById == null) {
+    if (_setupById == null) {
       throw StateError("Plugin lifecycle has not been initialized.");
     }
     final settings = _bridgeSettingsRepository.currentSettings;
@@ -1165,7 +1145,7 @@ class PluginLifecycleService({
       snapshotToken: snapshotToken,
       defaultPluginId: _selectableDefaultPluginId(),
       defaultIdleTimeoutMins: settings.plugins.defaults.idleTimeoutMins ?? defaultPluginIdleTimeoutMins,
-      plugins: [for (final plugin in registeredPlugins) _managementRow(plugin: plugin)],
+      plugins: [for (final plugin in _registeredPlugins) _managementRow(plugin: plugin)],
     );
   }
 
@@ -1189,10 +1169,8 @@ class PluginLifecycleService({
   }
 
   bool get _hasCompleteManagementRuntimeSnapshot {
-    final registeredPlugins = _registeredPlugins;
-    if (registeredPlugins == null) return false;
     final runtimePluginIds = _lifecycleRepository.snapshot.map((snapshot) => snapshot.pluginId).toSet();
-    return registeredPlugins.every((plugin) => runtimePluginIds.contains(plugin.id));
+    return _registeredPlugins.every((plugin) => runtimePluginIds.contains(plugin.id));
   }
 
   shared.PluginRuntimeState _mapRuntimeState(PluginRuntimeState state) => switch (state) {
@@ -1283,8 +1261,8 @@ class PluginLifecycleService({
     if (firstError != null) Error.throwWithStackTrace(firstError, firstStackTrace!);
   }
 
-  List<String> _buildReadyPluginIds(List<PluginLifecycleSnapshot> snapshots) {
-    final byId = <String, PluginLifecycleSnapshot>{
+  List<String> _buildReadyPluginIds(List<PluginRuntimeSnapshot> snapshots) {
+    final byId = <String, PluginRuntimeSnapshot>{
       for (final snapshot in snapshots) snapshot.pluginId: snapshot,
     };
     return List<String>.unmodifiable([
@@ -1298,21 +1276,11 @@ class PluginLifecycleService({
     ]);
   }
 
-  void _publishReadyPluginIds(List<PluginLifecycleSnapshot> snapshots) {
+  void _publishReadyPluginIds(List<PluginRuntimeSnapshot> snapshots) {
     final subject = _readyPluginIdsSubject;
     if (subject == null || subject.isClosed) return;
     final next = _buildReadyPluginIds(snapshots);
-    final current = subject.value;
-    if (current.length == next.length) {
-      var equal = true;
-      for (var index = 0; index < current.length; index++) {
-        if (current[index] != next[index]) {
-          equal = false;
-          break;
-        }
-      }
-      if (equal) return;
-    }
+    if (const ListEquality<String>().equals(subject.value, next)) return;
     subject.add(next);
   }
 
@@ -1323,7 +1291,7 @@ class PluginLifecycleService({
     _publishReadyPluginIds(_lifecycleRepository.snapshot);
   }
 
-  void _syncIdleTimers(List<PluginLifecycleSnapshot> snapshots) {
+  void _syncIdleTimers(List<PluginRuntimeSnapshot> snapshots) {
     if (_disposing) return;
     final currentIds = snapshots.map((snapshot) => snapshot.pluginId).toSet();
     _idleTimers.keys.where((pluginId) => !currentIds.contains(pluginId)).toList().forEach(_cancelIdleTimer);
@@ -1355,11 +1323,11 @@ class PluginLifecycleService({
     _idleTimers.remove(pluginId)?.timer.cancel();
   }
 
-  bool _isIdleCandidate(PluginLifecycleSnapshot snapshot) {
+  bool _isIdleCandidate(PluginRuntimeSnapshot snapshot) {
     return snapshot.accessGate == PluginRuntimeAccessGate.enabled &&
         snapshot.workState == PluginWorkState.idle &&
         snapshot.leaseCount == 0 &&
-        snapshot.transitionSettled &&
+        snapshot.transition == PluginRuntimeTransition.none &&
         (snapshot.state == PluginRuntimeState.active || snapshot.state == PluginRuntimeState.degraded);
   }
 
@@ -1379,7 +1347,7 @@ class PluginLifecycleService({
   /// backend the bridge does not own (OpenCode attach mode) or own idle
   /// reclamation internally (Claude's per-session process reap).
   int _suspensionIdleTimeoutMins(String pluginId) {
-    final residencyPolicy = _residencyPolicyById?[pluginId];
+    final residencyPolicy = _residencyPolicyById[pluginId];
     if (residencyPolicy == null) throw StateError("Plugin lifecycle has not been registered.");
     if (residencyPolicy == PluginResidencyPolicy.resident) return 0;
     return _effectiveIdleTimeoutMins(pluginId);

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -30,31 +30,28 @@ void main() {
     final bridgeSettingsRepository = createTestBridgeSettingsRepository();
     final lifecycleService =
         PluginLifecycleService(
-            lifecycleRepository: PluginLifecycleRepository(runtime: pluginRuntime),
-            preferredDefaultPluginId: legacyMissingPluginId,
-            bridgeSettingsRepository: bridgeSettingsRepository,
-            idleTimerScheduler: const PluginIdleTimerScheduler(),
-            bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
-          )
-          ..registerPlugins(
-            plugins: const [
-              (
-                id: "opencode",
-                displayName: "OpenCode",
-                activationPolicy: PluginActivationPolicy.onDemand,
-                residencyPolicy: PluginResidencyPolicy.transient,
-                sessionOptionsScope: PluginSessionOptionsScope.project,
-                managementCapabilities: defaultManagementCapabilities,
-                supportsPromptAttachments: false,
-              ),
-            ],
-          )
-          ..initialize(
-            disabledPluginIds: const {"opencode"},
-            setupById: const {
-              "opencode": PluginSetupNotInspected(),
-            },
-          );
+          lifecycleRepository: PluginLifecycleRepository(runtime: pluginRuntime),
+          preferredDefaultPluginId: legacyMissingPluginId,
+          bridgeSettingsRepository: bridgeSettingsRepository,
+          idleTimerScheduler: const PluginIdleTimerScheduler(),
+          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
+          plugins: const [
+            (
+              id: "opencode",
+              displayName: "OpenCode",
+              activationPolicy: PluginActivationPolicy.onDemand,
+              residencyPolicy: PluginResidencyPolicy.transient,
+              sessionOptionsScope: PluginSessionOptionsScope.project,
+              managementCapabilities: defaultManagementCapabilities,
+              supportsPromptAttachments: false,
+            ),
+          ],
+        )..initialize(
+          disabledPluginIds: const {"opencode"},
+          setupById: const {
+            "opencode": PluginSetupNotInspected(),
+          },
+        );
     final httpClient = http.Client();
     final relayClient = RelayClient(
       relayURL: "ws://127.0.0.1:${relayServer.port}",
@@ -242,8 +239,14 @@ void main() {
       expect(await localPluginEvent.timeout(const Duration(seconds: 2)), isA<SesoriVcsBranchUpdated>());
       connectGate.complete();
 
-      await expectLater(startFuture, throwsA(isA<Exception>()));
-      await expectLater(stopped, throwsA(isA<Exception>()));
+      await expectLater(
+        startFuture,
+        throwsA(isA<StateError>().having((error) => error.message, "message", "connect failed")),
+      );
+      await expectLater(
+        stopped,
+        throwsA(isA<StateError>().having((error) => error.message, "message", "connect failed")),
+      );
       await expectLater(localWireEventsDone, completes);
       await expectLater(session.start(), throwsA(isA<StateError>()));
 

--- a/bridge/app/test/bridge/routing/get_plugin_setup_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_plugin_setup_handler_test.dart
@@ -23,43 +23,40 @@ void main() {
       pluginRuntime = createTestPluginRuntime(plugins: [_ReadyPluginApi()]);
       lifecycleService =
           PluginLifecycleService(
-              lifecycleRepository: PluginLifecycleRepository(runtime: pluginRuntime),
-              preferredDefaultPluginId: legacyMissingPluginId,
-              bridgeSettingsRepository: createTestBridgeSettingsRepository(),
-              idleTimerScheduler: const PluginIdleTimerScheduler(),
-              bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
-            )
-            ..registerPlugins(
-              plugins: const [
-                (
-                  id: "ready",
-                  displayName: "Ready",
-                  activationPolicy: PluginActivationPolicy.onDemand,
-                  residencyPolicy: PluginResidencyPolicy.transient,
-                  sessionOptionsScope: PluginSessionOptionsScope.project,
-                  managementCapabilities: defaultManagementCapabilities,
-                  supportsPromptAttachments: false,
-                ),
-                (
-                  id: "blocked",
-                  displayName: "Blocked",
-                  activationPolicy: PluginActivationPolicy.onDemand,
-                  residencyPolicy: PluginResidencyPolicy.transient,
-                  sessionOptionsScope: PluginSessionOptionsScope.project,
-                  managementCapabilities: defaultManagementCapabilities,
-                  supportsPromptAttachments: false,
-                ),
-              ],
-            )
-            ..initialize(
-              disabledPluginIds: const {},
-              setupById: const {
-                "ready": PluginSetupReady(),
-                "blocked": PluginSetupAuthenticationRequired(
-                  actionHint: "Authenticate the backend locally, then retry.",
-                ),
-              },
-            );
+            lifecycleRepository: PluginLifecycleRepository(runtime: pluginRuntime),
+            preferredDefaultPluginId: legacyMissingPluginId,
+            bridgeSettingsRepository: createTestBridgeSettingsRepository(),
+            idleTimerScheduler: const PluginIdleTimerScheduler(),
+            bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
+            plugins: const [
+              (
+                id: "ready",
+                displayName: "Ready",
+                activationPolicy: PluginActivationPolicy.onDemand,
+                residencyPolicy: PluginResidencyPolicy.transient,
+                sessionOptionsScope: PluginSessionOptionsScope.project,
+                managementCapabilities: defaultManagementCapabilities,
+                supportsPromptAttachments: false,
+              ),
+              (
+                id: "blocked",
+                displayName: "Blocked",
+                activationPolicy: PluginActivationPolicy.onDemand,
+                residencyPolicy: PluginResidencyPolicy.transient,
+                sessionOptionsScope: PluginSessionOptionsScope.project,
+                managementCapabilities: defaultManagementCapabilities,
+                supportsPromptAttachments: false,
+              ),
+            ],
+          )..initialize(
+            disabledPluginIds: const {},
+            setupById: const {
+              "ready": PluginSetupReady(),
+              "blocked": PluginSetupAuthenticationRequired(
+                actionHint: "Authenticate the backend locally, then retry.",
+              ),
+            },
+          );
       await Future<void>.delayed(Duration.zero);
       handler = GetPluginSetupHandler(lifecycleService: lifecycleService);
       selectableHandler = GetPluginsHandler(

--- a/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
@@ -8,6 +8,16 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
 void main() {
+  test("snapshot emissions cannot be mutated by subscribers", () async {
+    final runtime = _runtime(factory: _FakeGenerationFactory(startGate: Future<void>.value()));
+    addTearDown(runtime.dispose);
+
+    final snapshots = await runtime.snapshots.first;
+
+    expect(snapshots.clear, throwsUnsupportedError);
+    expect((await runtime.snapshots.first).single.pluginId, "one");
+  });
+
   test("only the latest setup inspection can update a slot", () async {
     final firstGate = Completer<PluginSetupStatus>();
     final secondGate = Completer<PluginSetupStatus>();

--- a/bridge/app/test/helpers/plugin_lifecycle_test_support.dart
+++ b/bridge/app/test/helpers/plugin_lifecycle_test_support.dart
@@ -36,8 +36,6 @@ Future<PluginLifecycleService> createPluginLifecycleService({
           bridgeSettingsRepository: settingsRepository,
           idleTimerScheduler: const PluginIdleTimerScheduler(),
           bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
-        )
-        ..registerPlugins(
           plugins: [
             for (final plugin in plugins)
               (

--- a/bridge/app/test/push/completion_push_listener_test.dart
+++ b/bridge/app/test/push/completion_push_listener_test.dart
@@ -253,9 +253,6 @@ class _FakePushDispatcher() implements PushDispatcher {
   void dispatchImmediateIfApplicable(SesoriSseEvent event) {
     immediateEvents.add(event);
   }
-
-  @override
-  Future<void> dispose() async {}
 }
 
 Session _session({

--- a/bridge/app/test/push/push_dispatcher_test.dart
+++ b/bridge/app/test/push/push_dispatcher_test.dart
@@ -497,14 +497,6 @@ void main() {
         expect(harness.notifier.abortedRootCount, equals(0));
       });
     });
-
-    test("dispose closes the push notification client transport", () async {
-      final harness = _newHarness();
-
-      await harness.dispatcher.dispose();
-
-      expect(harness.client.disposeCallCount, equals(1));
-    });
   });
 }
 
@@ -582,7 +574,6 @@ class ThrowingPushSessionStateTracker({required super.now, final bool throwFindP
 
 class FakePushNotificationClient() extends PushNotificationClient {
   final List<SendNotificationPayload> sentPayloads = [];
-  int disposeCallCount = 0;
 
   this
     : super(
@@ -594,11 +585,6 @@ class FakePushNotificationClient() extends PushNotificationClient {
   @override
   Future<void> sendNotification(SendNotificationPayload payload) async {
     sentPayloads.add(payload);
-  }
-
-  @override
-  Future<void> dispose() async {
-    disposeCallCount += 1;
   }
 }
 

--- a/bridge/app/test/push/push_notification_client_test.dart
+++ b/bridge/app/test/push/push_notification_client_test.dart
@@ -328,32 +328,5 @@ void main() {
       expect(requestCount, equals(1));
       expect(fakeManager.forceRefreshCalled, isFalse);
     });
-
-    test("dispose does not close the shared http transport", () async {
-      final httpClient = _FakeHttpClient();
-      final client = PushNotificationClient(
-        authBackendURL: "https://api.sesori.test",
-        tokenRefreshManager: _FakeTokenRefreshManager("token"),
-        client: httpClient,
-      );
-
-      await client.dispose();
-
-      expect(httpClient.closeCallCount, equals(0));
-    });
   });
-}
-
-class _FakeHttpClient() extends http.BaseClient {
-  int closeCallCount = 0;
-
-  @override
-  Future<http.StreamedResponse> send(http.BaseRequest request) {
-    throw UnimplementedError();
-  }
-
-  @override
-  void close() {
-    closeCallCount += 1;
-  }
 }

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -272,6 +272,25 @@ void main() {
     commandRepository.inspectionGate!.complete();
   });
 
+  test("rejects duplicate plugin ids during construction", () {
+    final runtime = createRegisteredTestPluginRuntime(pluginIds: const ["one"]);
+    addTearDown(runtime.dispose);
+    const plugin = (
+      id: "one",
+      displayName: "One",
+      activationPolicy: PluginActivationPolicy.onDemand,
+      residencyPolicy: PluginResidencyPolicy.transient,
+      sessionOptionsScope: PluginSessionOptionsScope.project,
+      managementCapabilities: defaultManagementCapabilities,
+      supportsPromptAttachments: false,
+    );
+
+    expect(
+      () => _service(runtime: runtime, plugins: const [plugin, plugin]),
+      throwsArgumentError,
+    );
+  });
+
   test("derives alphabetical eligibility and default from setup", () {
     final runtime = createRegisteredTestPluginRuntime(pluginIds: const ["zeta", "alpha", "beta"]);
     addTearDown(runtime.dispose);
@@ -557,51 +576,48 @@ void main() {
     final bridgeIdProvider = FakeBridgeIdProvider();
     final service =
         PluginLifecycleService(
-            lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
-            preferredDefaultPluginId: legacyMissingPluginId,
-            bridgeSettingsRepository: settingsRepository,
-            idleTimerScheduler: const PluginIdleTimerScheduler(),
-            bridgeIdProvider: bridgeIdProvider,
-          )
-          ..registerPlugins(
-            plugins: const [
-              (
-                id: "opencode",
-                displayName: "OpenCode",
-                activationPolicy: PluginActivationPolicy.onDemand,
-                residencyPolicy: PluginResidencyPolicy.resident,
-                sessionOptionsScope: PluginSessionOptionsScope.project,
-                managementCapabilities: defaultManagementCapabilities,
-                supportsPromptAttachments: false,
-              ),
-              (
-                id: "alpha",
-                displayName: "Alpha",
-                activationPolicy: PluginActivationPolicy.onDemand,
-                residencyPolicy: PluginResidencyPolicy.transient,
-                sessionOptionsScope: PluginSessionOptionsScope.project,
-                managementCapabilities: defaultManagementCapabilities,
-                supportsPromptAttachments: false,
-              ),
-              (
-                id: "beta",
-                displayName: "Beta",
-                activationPolicy: PluginActivationPolicy.onDemand,
-                residencyPolicy: PluginResidencyPolicy.transient,
-                sessionOptionsScope: PluginSessionOptionsScope.plugin,
-                managementCapabilities: defaultManagementCapabilities,
-                supportsPromptAttachments: false,
-              ),
-            ],
-          )
-          ..initialize(
-            disabledPluginIds: const {"beta"},
-            setupById: const {
-              "opencode": PluginSetupReady(),
-              "alpha": PluginSetupRuntimeMissing(actionHint: "Install Alpha."),
-              "beta": PluginSetupNotInspected(),
-            },
-          );
+          lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
+          preferredDefaultPluginId: legacyMissingPluginId,
+          bridgeSettingsRepository: settingsRepository,
+          idleTimerScheduler: const PluginIdleTimerScheduler(),
+          bridgeIdProvider: bridgeIdProvider,
+          plugins: const [
+            (
+              id: "opencode",
+              displayName: "OpenCode",
+              activationPolicy: PluginActivationPolicy.onDemand,
+              residencyPolicy: PluginResidencyPolicy.resident,
+              sessionOptionsScope: PluginSessionOptionsScope.project,
+              managementCapabilities: defaultManagementCapabilities,
+              supportsPromptAttachments: false,
+            ),
+            (
+              id: "alpha",
+              displayName: "Alpha",
+              activationPolicy: PluginActivationPolicy.onDemand,
+              residencyPolicy: PluginResidencyPolicy.transient,
+              sessionOptionsScope: PluginSessionOptionsScope.project,
+              managementCapabilities: defaultManagementCapabilities,
+              supportsPromptAttachments: false,
+            ),
+            (
+              id: "beta",
+              displayName: "Beta",
+              activationPolicy: PluginActivationPolicy.onDemand,
+              residencyPolicy: PluginResidencyPolicy.transient,
+              sessionOptionsScope: PluginSessionOptionsScope.plugin,
+              managementCapabilities: defaultManagementCapabilities,
+              supportsPromptAttachments: false,
+            ),
+          ],
+        )..initialize(
+          disabledPluginIds: const {"beta"},
+          setupById: const {
+            "opencode": PluginSetupReady(),
+            "alpha": PluginSetupRuntimeMissing(actionHint: "Install Alpha."),
+            "beta": PluginSetupNotInspected(),
+          },
+        );
     addTearDown(service.dispose);
 
     // Lifecycle initialization precedes bridge registration in the runtime;
@@ -709,35 +725,33 @@ void main() {
         plugins: BridgePluginSettings(disabledPluginIds: {"external", "managed", "future-plugin"}),
       ),
     );
-    final service =
-        PluginLifecycleService(
-          lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
-          preferredDefaultPluginId: legacyMissingPluginId,
-          bridgeSettingsRepository: settingsRepository,
-          idleTimerScheduler: const PluginIdleTimerScheduler(),
-          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
-        )..registerPlugins(
-          plugins: const [
-            (
-              id: "external",
-              displayName: "External",
-              activationPolicy: PluginActivationPolicy.onDemand,
-              residencyPolicy: PluginResidencyPolicy.resident,
-              sessionOptionsScope: PluginSessionOptionsScope.plugin,
-              managementCapabilities: {PluginControlCapability.setupRefresh},
-              supportsPromptAttachments: false,
-            ),
-            (
-              id: "managed",
-              displayName: "Managed",
-              activationPolicy: PluginActivationPolicy.onDemand,
-              residencyPolicy: PluginResidencyPolicy.transient,
-              sessionOptionsScope: PluginSessionOptionsScope.project,
-              managementCapabilities: defaultManagementCapabilities,
-              supportsPromptAttachments: false,
-            ),
-          ],
-        );
+    final service = PluginLifecycleService(
+      lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
+      preferredDefaultPluginId: legacyMissingPluginId,
+      bridgeSettingsRepository: settingsRepository,
+      idleTimerScheduler: const PluginIdleTimerScheduler(),
+      bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
+      plugins: const [
+        (
+          id: "external",
+          displayName: "External",
+          activationPolicy: PluginActivationPolicy.onDemand,
+          residencyPolicy: PluginResidencyPolicy.resident,
+          sessionOptionsScope: PluginSessionOptionsScope.plugin,
+          managementCapabilities: {PluginControlCapability.setupRefresh},
+          supportsPromptAttachments: false,
+        ),
+        (
+          id: "managed",
+          displayName: "Managed",
+          activationPolicy: PluginActivationPolicy.onDemand,
+          residencyPolicy: PluginResidencyPolicy.transient,
+          sessionOptionsScope: PluginSessionOptionsScope.project,
+          managementCapabilities: defaultManagementCapabilities,
+          supportsPromptAttachments: false,
+        ),
+      ],
+    );
     addTearDown(service.dispose);
 
     final disabledPluginIds = service.uncontrollableDisabledPluginIds(
@@ -942,41 +956,38 @@ void main() {
     );
     final service =
         PluginLifecycleService(
-            lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
-            preferredDefaultPluginId: legacyMissingPluginId,
-            bridgeSettingsRepository: settingsRepository,
-            idleTimerScheduler: const PluginIdleTimerScheduler(),
-            bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
-          )
-          ..registerPlugins(
-            plugins: const [
-              (
-                id: "managed",
-                displayName: "Managed",
-                activationPolicy: PluginActivationPolicy.onDemand,
-                residencyPolicy: PluginResidencyPolicy.transient,
-                sessionOptionsScope: PluginSessionOptionsScope.project,
-                managementCapabilities: {PluginControlCapability.idleTimeout},
-                supportsPromptAttachments: false,
-              ),
-              (
-                id: "external",
-                displayName: "External",
-                activationPolicy: PluginActivationPolicy.onDemand,
-                residencyPolicy: PluginResidencyPolicy.transient,
-                sessionOptionsScope: PluginSessionOptionsScope.plugin,
-                managementCapabilities: {PluginControlCapability.setupRefresh},
-                supportsPromptAttachments: false,
-              ),
-            ],
-          )
-          ..initialize(
-            disabledPluginIds: const {},
-            setupById: const {
-              "managed": PluginSetupReady(),
-              "external": PluginSetupReady(),
-            },
-          );
+          lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
+          preferredDefaultPluginId: legacyMissingPluginId,
+          bridgeSettingsRepository: settingsRepository,
+          idleTimerScheduler: const PluginIdleTimerScheduler(),
+          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
+          plugins: const [
+            (
+              id: "managed",
+              displayName: "Managed",
+              activationPolicy: PluginActivationPolicy.onDemand,
+              residencyPolicy: PluginResidencyPolicy.transient,
+              sessionOptionsScope: PluginSessionOptionsScope.project,
+              managementCapabilities: {PluginControlCapability.idleTimeout},
+              supportsPromptAttachments: false,
+            ),
+            (
+              id: "external",
+              displayName: "External",
+              activationPolicy: PluginActivationPolicy.onDemand,
+              residencyPolicy: PluginResidencyPolicy.transient,
+              sessionOptionsScope: PluginSessionOptionsScope.plugin,
+              managementCapabilities: {PluginControlCapability.setupRefresh},
+              supportsPromptAttachments: false,
+            ),
+          ],
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {
+            "managed": PluginSetupReady(),
+            "external": PluginSetupReady(),
+          },
+        );
     addTearDown(() async {
       await service.dispose();
       await runtime.dispose();
@@ -1068,29 +1079,26 @@ void main() {
     final bridgeIdProvider = FakeBridgeIdProvider("br_test1234");
     final service =
         PluginLifecycleService(
-            lifecycleRepository: repository,
-            preferredDefaultPluginId: legacyMissingPluginId,
-            bridgeSettingsRepository: settingsRepository,
-            idleTimerScheduler: const PluginIdleTimerScheduler(),
-            bridgeIdProvider: bridgeIdProvider,
-          )
-          ..registerPlugins(
-            plugins: const [
-              (
-                id: "one",
-                displayName: "One",
-                activationPolicy: PluginActivationPolicy.onDemand,
-                residencyPolicy: PluginResidencyPolicy.transient,
-                sessionOptionsScope: PluginSessionOptionsScope.project,
-                managementCapabilities: defaultManagementCapabilities,
-                supportsPromptAttachments: false,
-              ),
-            ],
-          )
-          ..initialize(
-            disabledPluginIds: const {},
-            setupById: const {"one": PluginSetupReady()},
-          );
+          lifecycleRepository: repository,
+          preferredDefaultPluginId: legacyMissingPluginId,
+          bridgeSettingsRepository: settingsRepository,
+          idleTimerScheduler: const PluginIdleTimerScheduler(),
+          bridgeIdProvider: bridgeIdProvider,
+          plugins: const [
+            (
+              id: "one",
+              displayName: "One",
+              activationPolicy: PluginActivationPolicy.onDemand,
+              residencyPolicy: PluginResidencyPolicy.transient,
+              sessionOptionsScope: PluginSessionOptionsScope.project,
+              managementCapabilities: defaultManagementCapabilities,
+              supportsPromptAttachments: false,
+            ),
+          ],
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"one": PluginSetupReady()},
+        );
     addTearDown(service.dispose);
 
     final active = service.updateIdleTimeout(
@@ -1326,29 +1334,26 @@ void main() {
       ..saveGate = Completer<void>();
     final service =
         PluginLifecycleService(
-            lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
-            preferredDefaultPluginId: legacyMissingPluginId,
-            bridgeSettingsRepository: settingsRepository,
-            idleTimerScheduler: const PluginIdleTimerScheduler(),
-            bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
-          )
-          ..registerPlugins(
-            plugins: const [
-              (
-                id: "one",
-                displayName: "One",
-                activationPolicy: PluginActivationPolicy.onDemand,
-                residencyPolicy: PluginResidencyPolicy.transient,
-                sessionOptionsScope: PluginSessionOptionsScope.project,
-                managementCapabilities: defaultManagementCapabilities,
-                supportsPromptAttachments: false,
-              ),
-            ],
-          )
-          ..initialize(
-            disabledPluginIds: const {},
-            setupById: const {"one": PluginSetupReady()},
-          );
+          lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
+          preferredDefaultPluginId: legacyMissingPluginId,
+          bridgeSettingsRepository: settingsRepository,
+          idleTimerScheduler: const PluginIdleTimerScheduler(),
+          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
+          plugins: const [
+            (
+              id: "one",
+              displayName: "One",
+              activationPolicy: PluginActivationPolicy.onDemand,
+              residencyPolicy: PluginResidencyPolicy.transient,
+              sessionOptionsScope: PluginSessionOptionsScope.project,
+              managementCapabilities: defaultManagementCapabilities,
+              supportsPromptAttachments: false,
+            ),
+          ],
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"one": PluginSetupReady()},
+        );
     addTearDown(() async {
       await service.dispose();
       await runtime.dispose();
@@ -1382,29 +1387,26 @@ void main() {
       ..saveGate = Completer<void>();
     final service =
         PluginLifecycleService(
-            lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
-            preferredDefaultPluginId: legacyMissingPluginId,
-            bridgeSettingsRepository: settingsRepository,
-            idleTimerScheduler: const PluginIdleTimerScheduler(),
-            bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
-          )
-          ..registerPlugins(
-            plugins: const [
-              (
-                id: "one",
-                displayName: "One",
-                activationPolicy: PluginActivationPolicy.onDemand,
-                residencyPolicy: PluginResidencyPolicy.transient,
-                sessionOptionsScope: PluginSessionOptionsScope.project,
-                managementCapabilities: defaultManagementCapabilities,
-                supportsPromptAttachments: false,
-              ),
-            ],
-          )
-          ..initialize(
-            disabledPluginIds: const {},
-            setupById: const {"one": PluginSetupReady()},
-          );
+          lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
+          preferredDefaultPluginId: legacyMissingPluginId,
+          bridgeSettingsRepository: settingsRepository,
+          idleTimerScheduler: const PluginIdleTimerScheduler(),
+          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
+          plugins: const [
+            (
+              id: "one",
+              displayName: "One",
+              activationPolicy: PluginActivationPolicy.onDemand,
+              residencyPolicy: PluginResidencyPolicy.transient,
+              sessionOptionsScope: PluginSessionOptionsScope.project,
+              managementCapabilities: defaultManagementCapabilities,
+              supportsPromptAttachments: false,
+            ),
+          ],
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"one": PluginSetupReady()},
+        );
     addTearDown(() async {
       await service.dispose();
       await runtime.dispose();
@@ -1440,29 +1442,26 @@ void main() {
     final bridgeIdProvider = FakeBridgeIdProvider("br_test1234");
     final service =
         PluginLifecycleService(
-            lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
-            preferredDefaultPluginId: legacyMissingPluginId,
-            bridgeSettingsRepository: settingsRepository,
-            idleTimerScheduler: const PluginIdleTimerScheduler(),
-            bridgeIdProvider: bridgeIdProvider,
-          )
-          ..registerPlugins(
-            plugins: const [
-              (
-                id: "one",
-                displayName: "One",
-                activationPolicy: PluginActivationPolicy.onDemand,
-                residencyPolicy: PluginResidencyPolicy.transient,
-                sessionOptionsScope: PluginSessionOptionsScope.project,
-                managementCapabilities: defaultManagementCapabilities,
-                supportsPromptAttachments: false,
-              ),
-            ],
-          )
-          ..initialize(
-            disabledPluginIds: const {},
-            setupById: const {"one": PluginSetupReady()},
-          );
+          lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
+          preferredDefaultPluginId: legacyMissingPluginId,
+          bridgeSettingsRepository: settingsRepository,
+          idleTimerScheduler: const PluginIdleTimerScheduler(),
+          bridgeIdProvider: bridgeIdProvider,
+          plugins: const [
+            (
+              id: "one",
+              displayName: "One",
+              activationPolicy: PluginActivationPolicy.onDemand,
+              residencyPolicy: PluginResidencyPolicy.transient,
+              sessionOptionsScope: PluginSessionOptionsScope.project,
+              managementCapabilities: defaultManagementCapabilities,
+              supportsPromptAttachments: false,
+            ),
+          ],
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"one": PluginSetupReady()},
+        );
     addTearDown(() async {
       await service.dispose();
       await runtime.dispose();
@@ -1485,29 +1484,26 @@ void main() {
       ..saveError = StateError("disk full");
     final service =
         PluginLifecycleService(
-            lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
-            preferredDefaultPluginId: legacyMissingPluginId,
-            bridgeSettingsRepository: settingsRepository,
-            idleTimerScheduler: const PluginIdleTimerScheduler(),
-            bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
-          )
-          ..registerPlugins(
-            plugins: const [
-              (
-                id: "one",
-                displayName: "One",
-                activationPolicy: PluginActivationPolicy.onDemand,
-                residencyPolicy: PluginResidencyPolicy.transient,
-                sessionOptionsScope: PluginSessionOptionsScope.project,
-                managementCapabilities: defaultManagementCapabilities,
-                supportsPromptAttachments: false,
-              ),
-            ],
-          )
-          ..initialize(
-            disabledPluginIds: const {},
-            setupById: const {"one": PluginSetupReady()},
-          );
+          lifecycleRepository: PluginLifecycleRepository(runtime: runtime),
+          preferredDefaultPluginId: legacyMissingPluginId,
+          bridgeSettingsRepository: settingsRepository,
+          idleTimerScheduler: const PluginIdleTimerScheduler(),
+          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
+          plugins: const [
+            (
+              id: "one",
+              displayName: "One",
+              activationPolicy: PluginActivationPolicy.onDemand,
+              residencyPolicy: PluginResidencyPolicy.transient,
+              sessionOptionsScope: PluginSessionOptionsScope.project,
+              managementCapabilities: defaultManagementCapabilities,
+              supportsPromptAttachments: false,
+            ),
+          ],
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"one": PluginSetupReady()},
+        );
     addTearDown(() async {
       await service.dispose();
       await runtime.dispose();
@@ -1555,7 +1551,7 @@ void main() {
     expect(settingsRepository.settings.plugins.isDisabled(pluginId: "one"), isTrue);
     expect(repository.rollbackCalls, isZero);
     expect(repository.snapshot.single.accessGate, PluginRuntimeAccessGate.disabled);
-    expect(repository.snapshot.single.transitionSettled, isTrue);
+    expect(repository.snapshot.single.transition, PluginRuntimeTransition.none);
     expect(service.compositionView.eligiblePluginIds, isEmpty);
 
     final retry = await service.command(
@@ -2072,26 +2068,24 @@ void main() {
   test("ready plugin ids replay setup-ready dormant plugins", () async {
     final repository = _IdleLifecycleRepository(initialState: PluginRuntimeState.dormant);
     addTearDown(repository.dispose);
-    final service =
-        PluginLifecycleService(
-          lifecycleRepository: repository,
-          preferredDefaultPluginId: legacyMissingPluginId,
-          bridgeSettingsRepository: createTestBridgeSettingsRepository(),
-          idleTimerScheduler: const PluginIdleTimerScheduler(),
-          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
-        )..registerPlugins(
-          plugins: const [
-            (
-              id: "one",
-              displayName: "One",
-              activationPolicy: PluginActivationPolicy.onDemand,
-              residencyPolicy: PluginResidencyPolicy.transient,
-              sessionOptionsScope: PluginSessionOptionsScope.project,
-              managementCapabilities: defaultManagementCapabilities,
-              supportsPromptAttachments: false,
-            ),
-          ],
-        );
+    final service = PluginLifecycleService(
+      lifecycleRepository: repository,
+      preferredDefaultPluginId: legacyMissingPluginId,
+      bridgeSettingsRepository: createTestBridgeSettingsRepository(),
+      idleTimerScheduler: const PluginIdleTimerScheduler(),
+      bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
+      plugins: const [
+        (
+          id: "one",
+          displayName: "One",
+          activationPolicy: PluginActivationPolicy.onDemand,
+          residencyPolicy: PluginResidencyPolicy.transient,
+          sessionOptionsScope: PluginSessionOptionsScope.project,
+          managementCapabilities: defaultManagementCapabilities,
+          supportsPromptAttachments: false,
+        ),
+      ],
+    );
     addTearDown(service.dispose);
     service.initialize(
       disabledPluginIds: const {},
@@ -2106,26 +2100,24 @@ void main() {
     final repository = _IdleLifecycleRepository();
     addTearDown(repository.dispose);
     final timerScheduler = _ControllablePluginIdleTimerScheduler();
-    final service =
-        PluginLifecycleService(
-          lifecycleRepository: repository,
-          preferredDefaultPluginId: legacyMissingPluginId,
-          bridgeSettingsRepository: createTestBridgeSettingsRepository(),
-          idleTimerScheduler: timerScheduler,
-          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
-        )..registerPlugins(
-          plugins: const [
-            (
-              id: "one",
-              displayName: "One",
-              activationPolicy: PluginActivationPolicy.onDemand,
-              residencyPolicy: PluginResidencyPolicy.transient,
-              sessionOptionsScope: PluginSessionOptionsScope.project,
-              managementCapabilities: defaultManagementCapabilities,
-              supportsPromptAttachments: false,
-            ),
-          ],
-        );
+    final service = PluginLifecycleService(
+      lifecycleRepository: repository,
+      preferredDefaultPluginId: legacyMissingPluginId,
+      bridgeSettingsRepository: createTestBridgeSettingsRepository(),
+      idleTimerScheduler: timerScheduler,
+      bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
+      plugins: const [
+        (
+          id: "one",
+          displayName: "One",
+          activationPolicy: PluginActivationPolicy.onDemand,
+          residencyPolicy: PluginResidencyPolicy.transient,
+          sessionOptionsScope: PluginSessionOptionsScope.project,
+          managementCapabilities: defaultManagementCapabilities,
+          supportsPromptAttachments: false,
+        ),
+      ],
+    );
     addTearDown(service.dispose);
     service.initialize(
       disabledPluginIds: const {},
@@ -2134,7 +2126,11 @@ void main() {
 
     repository.publish(workState: PluginWorkState.busy, leaseCount: 0);
     repository.publish(workState: PluginWorkState.idle, leaseCount: 1);
-    repository.publish(workState: PluginWorkState.idle, leaseCount: 0, transitionSettled: false);
+    repository.publish(
+      workState: PluginWorkState.idle,
+      leaseCount: 0,
+      transition: PluginRuntimeTransition.stopping,
+    );
     await Future<void>.delayed(Duration.zero);
     expect(timerScheduler.timers, isEmpty);
 
@@ -2149,34 +2145,32 @@ void main() {
     final repository = _IdleLifecycleRepository();
     addTearDown(repository.dispose);
     final timerScheduler = _ControllablePluginIdleTimerScheduler();
-    final service =
-        PluginLifecycleService(
-          lifecycleRepository: repository,
-          preferredDefaultPluginId: legacyMissingPluginId,
-          bridgeSettingsRepository: createTestBridgeSettingsRepository(
-            settings: const BridgeSettings(
-              plugins: BridgePluginSettings(
-                settingsByPluginId: {
-                  "one": PluginLifecycleSettings(idleTimeoutMins: 0),
-                },
-              ),
-            ),
+    final service = PluginLifecycleService(
+      lifecycleRepository: repository,
+      preferredDefaultPluginId: legacyMissingPluginId,
+      bridgeSettingsRepository: createTestBridgeSettingsRepository(
+        settings: const BridgeSettings(
+          plugins: BridgePluginSettings(
+            settingsByPluginId: {
+              "one": PluginLifecycleSettings(idleTimeoutMins: 0),
+            },
           ),
-          idleTimerScheduler: timerScheduler,
-          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
-        )..registerPlugins(
-          plugins: const [
-            (
-              id: "one",
-              displayName: "One",
-              activationPolicy: PluginActivationPolicy.onDemand,
-              residencyPolicy: PluginResidencyPolicy.transient,
-              sessionOptionsScope: PluginSessionOptionsScope.project,
-              managementCapabilities: defaultManagementCapabilities,
-              supportsPromptAttachments: false,
-            ),
-          ],
-        );
+        ),
+      ),
+      idleTimerScheduler: timerScheduler,
+      bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
+      plugins: const [
+        (
+          id: "one",
+          displayName: "One",
+          activationPolicy: PluginActivationPolicy.onDemand,
+          residencyPolicy: PluginResidencyPolicy.transient,
+          sessionOptionsScope: PluginSessionOptionsScope.project,
+          managementCapabilities: defaultManagementCapabilities,
+          supportsPromptAttachments: false,
+        ),
+      ],
+    );
     addTearDown(service.dispose);
     service.initialize(
       disabledPluginIds: const {},
@@ -2203,26 +2197,24 @@ void main() {
         ),
       ),
     );
-    final service =
-        PluginLifecycleService(
-          lifecycleRepository: repository,
-          preferredDefaultPluginId: legacyMissingPluginId,
-          bridgeSettingsRepository: settingsRepository,
-          idleTimerScheduler: timerScheduler,
-          bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
-        )..registerPlugins(
-          plugins: const [
-            (
-              id: "one",
-              displayName: "One",
-              activationPolicy: PluginActivationPolicy.onDemand,
-              residencyPolicy: PluginResidencyPolicy.resident,
-              sessionOptionsScope: PluginSessionOptionsScope.project,
-              managementCapabilities: defaultManagementCapabilities,
-              supportsPromptAttachments: false,
-            ),
-          ],
-        );
+    final service = PluginLifecycleService(
+      lifecycleRepository: repository,
+      preferredDefaultPluginId: legacyMissingPluginId,
+      bridgeSettingsRepository: settingsRepository,
+      idleTimerScheduler: timerScheduler,
+      bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
+      plugins: const [
+        (
+          id: "one",
+          displayName: "One",
+          activationPolicy: PluginActivationPolicy.onDemand,
+          residencyPolicy: PluginResidencyPolicy.resident,
+          sessionOptionsScope: PluginSessionOptionsScope.project,
+          managementCapabilities: defaultManagementCapabilities,
+          supportsPromptAttachments: false,
+        ),
+      ],
+    );
     addTearDown(service.dispose);
     service.initialize(
       disabledPluginIds: const {},
@@ -2265,7 +2257,8 @@ PluginLifecycleService _service({
     bridgeSettingsRepository: createTestBridgeSettingsRepository(),
     idleTimerScheduler: const PluginIdleTimerScheduler(),
     bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
-  )..registerPlugins(plugins: plugins);
+    plugins: plugins,
+  );
 }
 
 PluginLifecycleService _singleIdleService({
@@ -2276,29 +2269,26 @@ PluginLifecycleService _singleIdleService({
   Set<PluginControlCapability> managementCapabilities = defaultManagementCapabilities,
 }) {
   return PluginLifecycleService(
-      lifecycleRepository: lifecycleRepository,
-      preferredDefaultPluginId: legacyMissingPluginId,
-      bridgeSettingsRepository: settingsRepository,
-      idleTimerScheduler: timerScheduler,
-      bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
-    )
-    ..registerPlugins(
-      plugins: [
-        (
-          id: "one",
-          displayName: "One",
-          activationPolicy: PluginActivationPolicy.onDemand,
-          residencyPolicy: residencyPolicy,
-          sessionOptionsScope: PluginSessionOptionsScope.project,
-          managementCapabilities: managementCapabilities,
-          supportsPromptAttachments: false,
-        ),
-      ],
-    )
-    ..initialize(
-      disabledPluginIds: const {},
-      setupById: const {"one": PluginSetupReady()},
-    );
+    lifecycleRepository: lifecycleRepository,
+    preferredDefaultPluginId: legacyMissingPluginId,
+    bridgeSettingsRepository: settingsRepository,
+    idleTimerScheduler: timerScheduler,
+    bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
+    plugins: [
+      (
+        id: "one",
+        displayName: "One",
+        activationPolicy: PluginActivationPolicy.onDemand,
+        residencyPolicy: residencyPolicy,
+        sessionOptionsScope: PluginSessionOptionsScope.project,
+        managementCapabilities: managementCapabilities,
+        supportsPromptAttachments: false,
+      ),
+    ],
+  )..initialize(
+    disabledPluginIds: const {},
+    setupById: const {"one": PluginSetupReady()},
+  );
 }
 
 PluginLifecycleService _commandService({
@@ -2312,7 +2302,6 @@ PluginLifecycleService _commandService({
     bridgeSettingsRepository: settingsRepository ?? createTestBridgeSettingsRepository(),
     idleTimerScheduler: const PluginIdleTimerScheduler(),
     bridgeIdProvider: FakeBridgeIdProvider("br_test1234"),
-  )..registerPlugins(
     plugins: [
       (
         id: "one",
@@ -2346,17 +2335,17 @@ class _FakePluginApi({@override required final String id}) extends BridgeDerived
 
 class _IdleLifecycleRepository({PluginRuntimeState initialState = PluginRuntimeState.active})
     implements PluginLifecycleRepository {
-  final StreamController<List<PluginLifecycleSnapshot>> _snapshots = StreamController.broadcast(sync: true);
-  List<PluginLifecycleSnapshot> _current = [
+  final StreamController<List<PluginRuntimeSnapshot>> _snapshots = StreamController.broadcast(sync: true);
+  List<PluginRuntimeSnapshot> _current = [
     _snapshot(state: initialState, workState: PluginWorkState.unknown, leaseCount: 0),
   ];
   int stopCalls = 0;
 
   @override
-  Stream<List<PluginLifecycleSnapshot>> get snapshots => _snapshots.stream;
+  Stream<List<PluginRuntimeSnapshot>> get snapshots => _snapshots.stream;
 
   @override
-  List<PluginLifecycleSnapshot> get snapshot => List.unmodifiable(_current);
+  List<PluginRuntimeSnapshot> get snapshot => List.unmodifiable(_current);
 
   @override
   void applyAccess({required Set<String> eligiblePluginIds, required Set<String> startAllowedPluginIds}) {}
@@ -2365,14 +2354,14 @@ class _IdleLifecycleRepository({PluginRuntimeState initialState = PluginRuntimeS
     PluginRuntimeState state = PluginRuntimeState.active,
     required PluginWorkState workState,
     required int leaseCount,
-    bool transitionSettled = true,
+    PluginRuntimeTransition transition = PluginRuntimeTransition.none,
   }) {
     _current = [
       _snapshot(
         state: state,
         workState: workState,
         leaseCount: leaseCount,
-        transitionSettled: transitionSettled,
+        transition: transition,
       ),
     ];
     _snapshots.add(snapshot);
@@ -2406,24 +2395,25 @@ class _IdleLifecycleRepository({PluginRuntimeState initialState = PluginRuntimeS
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 
-  static PluginLifecycleSnapshot _snapshot({
+  static PluginRuntimeSnapshot _snapshot({
     PluginRuntimeState state = PluginRuntimeState.active,
     required PluginWorkState workState,
     required int leaseCount,
-    bool transitionSettled = true,
+    PluginRuntimeTransition transition = PluginRuntimeTransition.none,
     PluginRuntimeAccessGate accessGate = PluginRuntimeAccessGate.enabled,
     bool startAllowed = true,
   }) {
-    return PluginLifecycleSnapshot(
+    return PluginRuntimeSnapshot(
       pluginId: "one",
       projectOwnership: PluginProjectOwnership.native,
       setup: const PluginSetupReady(),
       accessGate: accessGate,
       startAllowed: startAllowed,
+      generation: 1,
       state: state,
       workState: workState,
       leaseCount: leaseCount,
-      transitionSettled: transitionSettled,
+      transition: transition,
     );
   }
 }
@@ -2502,17 +2492,18 @@ class _CommandLifecycleRepository({
   required final Completer<void>? inspectionGate,
   required var String? startFailureMessage,
 }) implements PluginLifecycleRepository {
-  final StreamController<List<PluginLifecycleSnapshot>> _snapshots = StreamController.broadcast(sync: true);
-  PluginLifecycleSnapshot _current = const PluginLifecycleSnapshot(
+  final StreamController<List<PluginRuntimeSnapshot>> _snapshots = StreamController.broadcast(sync: true);
+  PluginRuntimeSnapshot _current = const PluginRuntimeSnapshot(
     pluginId: "one",
     projectOwnership: PluginProjectOwnership.native,
     setup: PluginSetupNotInspected(),
     accessGate: PluginRuntimeAccessGate.disabled,
     startAllowed: false,
+    generation: null,
     state: PluginRuntimeState.disabled,
     workState: PluginWorkState.unknown,
     leaseCount: 0,
-    transitionSettled: true,
+    transition: PluginRuntimeTransition.none,
   );
   int inspectCalls = 0;
   int startCalls = 0;
@@ -2549,10 +2540,10 @@ class _CommandLifecycleRepository({
   }
 
   @override
-  List<PluginLifecycleSnapshot> get snapshot => [_current];
+  List<PluginRuntimeSnapshot> get snapshot => [_current];
 
   @override
-  Stream<List<PluginLifecycleSnapshot>> get snapshots => _snapshots.stream;
+  Stream<List<PluginRuntimeSnapshot>> get snapshots => _snapshots.stream;
 
   @override
   void applyAccess({required Set<String> eligiblePluginIds, required Set<String> startAllowedPluginIds}) {
@@ -2569,7 +2560,7 @@ class _CommandLifecycleRepository({
           : _current.state == PluginRuntimeState.active
           ? PluginRuntimeState.active
           : PluginRuntimeState.dormant,
-      transitionSettled: true,
+      transition: PluginRuntimeTransition.none,
     );
     _publish();
   }
@@ -2588,7 +2579,7 @@ class _CommandLifecycleRepository({
       accessGate: _current.accessGate,
       startAllowed: _current.startAllowed,
       state: _current.state,
-      transitionSettled: true,
+      transition: PluginRuntimeTransition.none,
     );
     _publish();
     return {"one": inspectionResult};
@@ -2606,7 +2597,7 @@ class _CommandLifecycleRepository({
       accessGate: _current.accessGate,
       startAllowed: _current.startAllowed,
       state: PluginRuntimeState.active,
-      transitionSettled: true,
+      transition: PluginRuntimeTransition.none,
     );
     _publish();
     return PluginRuntimeCommandApplied(snapshot: _runtimeSnapshot());
@@ -2632,7 +2623,7 @@ class _CommandLifecycleRepository({
       accessGate: PluginRuntimeAccessGate.draining,
       startAllowed: _current.startAllowed,
       state: PluginRuntimeState.stopping,
-      transitionSettled: false,
+      transition: PluginRuntimeTransition.stopping,
     );
     _publish();
     return PluginRuntimeCommandApplied(snapshot: _runtimeSnapshot());
@@ -2645,7 +2636,7 @@ class _CommandLifecycleRepository({
       accessGate: PluginRuntimeAccessGate.disabled,
       startAllowed: false,
       state: PluginRuntimeState.disabled,
-      transitionSettled: true,
+      transition: PluginRuntimeTransition.none,
     );
     _publish();
   }
@@ -2653,23 +2644,24 @@ class _CommandLifecycleRepository({
   @override
   void rollbackDisable({required String pluginId}) => throw UnsupportedError("unused");
 
-  PluginLifecycleSnapshot _copySnapshot({
+  PluginRuntimeSnapshot _copySnapshot({
     required PluginSetupStatus setup,
     required PluginRuntimeAccessGate accessGate,
     required bool startAllowed,
     required PluginRuntimeState state,
-    required bool transitionSettled,
+    required PluginRuntimeTransition transition,
   }) {
-    return PluginLifecycleSnapshot(
+    return PluginRuntimeSnapshot(
       pluginId: "one",
       projectOwnership: PluginProjectOwnership.native,
       setup: setup,
       accessGate: accessGate,
       startAllowed: startAllowed,
+      generation: _current.generation,
       state: state,
       workState: PluginWorkState.unknown,
       leaseCount: 0,
-      transitionSettled: transitionSettled,
+      transition: transition,
     );
   }
 
@@ -2683,7 +2675,7 @@ class _CommandLifecycleRepository({
     state: _current.state,
     workState: _current.workState,
     leaseCount: _current.leaseCount,
-    transition: _current.transitionSettled ? PluginRuntimeTransition.none : PluginRuntimeTransition.stopping,
+    transition: _current.transition,
   );
 
   void _publish() => _snapshots.add(snapshot);


### PR DESCRIPTION
## Complexity

⚙️ Moderate. This refactor updates lifecycle initialization and ownership across the bridge composition root, Orchestrator session, lifecycle repository, service, and test seams.

## What

- Make registered plugin metadata a required `PluginLifecycleService` constructor input and remove two-phase registration state.
- Let `PluginLifecycleRepository` expose `PluginRuntimeSnapshot` directly instead of maintaining a field-for-field copy.
- Consolidate lifecycle-state, stop-intent, and ready-list comparisons.
- Use one Orchestrator subscription composite and one plugin event listener.
- Centralize plugin-event source fencing while preserving every post-await and queued-boundary check.
- Preserve initial relay connection error type and stack.
- Remove the session-owned no-op push disposal chain.

## Why

The existing code represented impossible pre-registration states, duplicated runtime models and event fences, and retained lifecycle objects solely to call no-op disposal methods. Removing those paths makes ownership and initialization explicit without changing bridge behavior.

## Risk and test focus

The main risk is lifecycle ordering: stale plugin events, session teardown, plugin eligibility, idle suspension, and relay startup errors. Tests focus on all Orchestrator suites, push behavior, lifecycle commands and snapshots, constructor validation, and plugin setup routing.

The three bridge-identity checks around idle-timeout persistence remain intact because they fence immediate dispatch, queued mutation acquisition, and the persistence callback separately.

## Expected result

No user-visible or database/persisted-data change. Internally, Orchestrator and plugin lifecycle initialization have fewer duplicated states and clearer ownership boundaries.

## Verification

- `dart analyze --fatal-infos` in `bridge/app`
- `dart test -j1 test/bridge/orchestrator_*_test.dart test/push test/services/plugin_lifecycle_service_test.dart test/bridge/routing/get_plugin_setup_handler_test.dart` (231 tests)
- `dart test -j1 test/services/plugin_lifecycle_service_test.dart` after adding constructor validation coverage (50 tests)
- `git diff --check`
- Architecture implementation review: approved with no findings
- Correctness review: no findings

The pinned formatter crashes while building existing enhanced enum bodies in `orchestrator.dart`, `bridge_runtime_runner.dart`, and `plugin_lifecycle_test_support.dart`; analyzer parsing is clean and the other touched files were formatted successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies orchestrator session wiring and plugin lifecycle initialization, removes redundant fences and disposal paths, and makes runtime snapshot emissions immutable. Old behavior allowed duplicate event fences and mutable snapshot lists; new behavior centralizes a single `_isCurrentSource` fence and emits unmodifiable `PluginRuntimeSnapshot` lists. Relay connect errors now propagate their original type and stack.

- `PluginLifecycleService` now takes `plugins: [...]` in its constructor; delete `registerPlugins(...)`.
- Replace `PluginLifecycleSnapshot` with `PluginRuntimeSnapshot`; read `snapshot`/`snapshots` directly from the repository. Replace `transitionSettled` with `transition`.
- Orchestrator: pass a single `pluginEventListener` (not a list); stop passing `pushDispatcher`. Ensure SSE paths provide a non-null `pluginId`.
- Remove calls to `PushDispatcher.dispose()` and `PushNotificationClient.dispose()`.
- Tests that matched a generic relay connect error must now assert the original error (for example, `StateError("connect failed")`).
- If any code mutated runtime snapshot lists from `PluginRuntime.snapshots`/`snapshot`, stop doing so. These lists are now unmodifiable.

<sup>Written for commit e360fd2dcd6d44706e1af2fe0721408661f3226e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

