### PR TITLE
🌿 Fix duplicated Claude text parts when thinking precedes the answer

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -17,6 +17,15 @@ final class ClaudeEventDispatcher({
   final Map<String, Map<int, PluginMessagePart>> _completedStreamedParts = {};
   final Map<String, Set<String>> _streamedMessageIds = {};
 
+  /// Content blocks already carried by `assistant` frames, per message id.
+  ///
+  /// Claude Code emits one `assistant` frame per content block under the same
+  /// `message.id`, so every frame's own content restarts at offset 0. Blocks
+  /// are numbered across the whole message instead, matching the stream's
+  /// block index and the transcript history; otherwise a block streamed at
+  /// index >= 1 is finalized under a second part id and renders twice.
+  final Map<String, int> _assistantBlockCounts = {};
+
   void beginTurn({required String sessionId}) => _resetTurn(sessionId: sessionId);
 
   /// Clears completed-turn stream state.
@@ -43,6 +52,7 @@ final class ClaudeEventDispatcher({
     for (final messageId in messageIds) {
       _streamedBlocks.remove(messageId);
       _completedStreamedParts.remove(messageId);
+      _assistantBlockCounts.remove(messageId);
     }
   }
 
@@ -247,10 +257,23 @@ final class ClaudeEventDispatcher({
     final messageId = _nonEmptyString(message.messageId);
     if (messageId == null) return const [];
     _messageIds[sessionId] = messageId;
+    _streamedMessageIds.putIfAbsent(sessionId, () => <String>{}).add(messageId);
     if (_realModel(model: message.model) case final model?) _models[sessionId] = model;
     final mapped = _content.map(content: message.message["content"]);
+    // Counted before any filtering so a skipped block still occupies its
+    // ordinal, exactly as it does in the stream and the transcript.
+    final firstBlockIndex = _assistantBlockCounts[messageId] ?? 0;
+    _assistantBlockCounts[messageId] = firstBlockIndex + mapped.length;
     if (_content.containsInternalCommandOutput(blocks: mapped)) return const [];
-    final parts = _content.mapParts(content: message.message["content"], sessionId: sessionId, messageId: messageId);
+    final parts = [
+      for (var offset = 0; offset < mapped.length; offset++)
+        _content.mapPart(
+          block: mapped[offset],
+          index: firstBlockIndex + offset,
+          sessionId: sessionId,
+          messageId: messageId,
+        ),
+    ];
     if (!parts.any((part) => part.type.isVisible)) return const [];
     _announcedMessageIds[sessionId] = messageId;
     final events = <BridgeSseEvent>[
@@ -262,8 +285,9 @@ final class ClaudeEventDispatcher({
         ).toJson(),
       ),
     ];
-    for (var index = 0; index < mapped.length; index++) {
-      final part = switch (mapped[index]) {
+    for (var offset = 0; offset < mapped.length; offset++) {
+      final index = firstBlockIndex + offset;
+      final part = switch (mapped[offset]) {
         ClaudeMappedToolUseContentBlock(:final id, :final name, :final input) => _toolPart(
           sessionId: sessionId,
           tool: _tools.upsertCompleteBlock(
@@ -275,7 +299,7 @@ final class ClaudeEventDispatcher({
             input: input,
           ),
         ),
-        _ => parts[index],
+        _ => parts[offset],
       };
       if (_streamedBlocks[messageId]?.contains(index) ?? false) {
         _completedStreamedParts.putIfAbsent(messageId, () => <int, PluginMessagePart>{})[index] = part;

--- a/bridge/sesori_plugin_claude/lib/src/repositories/mappers/claude_content_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/mappers/claude_content_mapper.dart
@@ -118,7 +118,7 @@ final class const ClaudeContentMapper() {
     final blocks = map(content: content);
     return [
       for (var index = 0; index < blocks.length; index++)
-        _toPart(block: blocks[index], index: index, sessionId: sessionId, messageId: messageId),
+        mapPart(block: blocks[index], index: index, sessionId: sessionId, messageId: messageId),
     ];
   }
 
@@ -250,7 +250,9 @@ final class const ClaudeContentMapper() {
     return PluginMessageAttachment.inlineImage(mime: mime, base64: normalized, filename: null);
   }
 
-  PluginMessagePart _toPart({
+  /// Maps one block that sits at message-level ordinal [index], which names
+  /// parts without a backend identity of their own (text, thinking, images).
+  PluginMessagePart mapPart({
     required ClaudeMappedContentBlock block,
     required int index,
     required String sessionId,

--- a/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
@@ -197,6 +197,120 @@ void main() {
       expect(complete.whereType<BridgeSseMessagePartUpdated>().single.part.text, "persisted answer");
     });
 
+    test("numbers per-block assistant frames across the whole message", () {
+      // Claude Code emits one `assistant` frame per content block under the
+      // same message id, before that block stops, with the block alone at
+      // content offset 0 (verified against CLI 2.1.237).
+      _startMessage(mapper, messageId: "msg-split");
+      _map(
+        mapper,
+        _stream(
+          "content_block_start",
+          event: {
+            "index": 0,
+            "content_block": {"type": "thinking", "thinking": ""},
+          },
+        ),
+      );
+      _map(
+        mapper,
+        _stream(
+          "content_block_delta",
+          event: {
+            "index": 0,
+            "delta": {"type": "thinking_delta", "thinking": "reason"},
+          },
+        ),
+      );
+      _map(
+        mapper,
+        _assistant(
+          id: "msg-split",
+          content: const [
+            {"type": "thinking", "thinking": "reason", "signature": "opaque"},
+          ],
+        ),
+      );
+      final thinkingStopped = _map(mapper, _stream("content_block_stop", event: const {"index": 0}));
+      _map(
+        mapper,
+        _stream(
+          "content_block_start",
+          event: {
+            "index": 1,
+            "content_block": {"type": "text", "text": ""},
+          },
+        ),
+      );
+      final textDelta = _map(
+        mapper,
+        _stream(
+          "content_block_delta",
+          event: {
+            "index": 1,
+            "delta": {"type": "text_delta", "text": "answer"},
+          },
+        ),
+      );
+      final textComplete = _map(
+        mapper,
+        _assistant(
+          id: "msg-split",
+          content: const [
+            {"type": "text", "text": "answer"},
+          ],
+        ),
+      );
+      final textStopped = _map(mapper, _stream("content_block_stop", event: const {"index": 1}));
+      _map(
+        mapper,
+        _stream(
+          "content_block_start",
+          event: {
+            "index": 2,
+            "content_block": {
+              "type": "tool_use",
+              "id": "toolu-split",
+              "name": "Read",
+              "input": <String, Object?>{},
+            },
+          },
+        ),
+      );
+      final toolComplete = _map(
+        mapper,
+        _assistant(
+          id: "msg-split",
+          content: const [
+            {
+              "type": "tool_use",
+              "id": "toolu-split",
+              "name": "Read",
+              "input": {"file_path": "a.dart"},
+            },
+          ],
+        ),
+      );
+      final toolStopped = _map(mapper, _stream("content_block_stop", event: const {"index": 2}));
+
+      final thinking = thinkingStopped.whereType<BridgeSseMessagePartUpdated>().single.part;
+      expect(thinking.id, "msg-split-block-0");
+      expect(thinking.type, PluginMessagePartType.reasoning);
+      expect(thinking.text, "reason");
+      expect((textDelta.single as BridgeSseMessagePartDelta).partID, "msg-split-block-1");
+      // The complete text must finalize the streamed block-1 part, never land
+      // on block-0 as a second text copy over the thinking part.
+      expect(textComplete.whereType<BridgeSseMessagePartUpdated>(), isEmpty);
+      final text = textStopped.whereType<BridgeSseMessagePartUpdated>().single.part;
+      expect(text.id, "msg-split-block-1");
+      expect(text.type, PluginMessagePartType.text);
+      expect(text.text, "answer");
+      expect(toolComplete.whereType<BridgeSseMessagePartUpdated>(), isEmpty);
+      final tool = toolStopped.whereType<BridgeSseMessagePartUpdated>().single.part;
+      expect(tool.id, "toolu-split");
+      expect(tool.state?.status, PluginToolStatus.running);
+    });
+
     test("hides local command records and keeps the last real model", () {
       _startMessage(mapper, messageId: "msg-real", model: "claude-opus-5");
       _startMessage(mapper, messageId: "msg-command", model: "<synthetic>");
@@ -219,17 +333,19 @@ void main() {
           ],
         ),
       );
-      final error = _map(
-        mapper,
-        {
-          "type": "result",
-          "subtype": "success",
-          "session_id": "session-1",
-          "uuid": "result-error",
-          "is_error": true,
-          "terminal_reason": "api_error",
-        },
-      ).single as BridgeSseMessageUpdated;
+      final error =
+          _map(
+                mapper,
+                {
+                  "type": "result",
+                  "subtype": "success",
+                  "session_id": "session-1",
+                  "uuid": "result-error",
+                  "is_error": true,
+                  "terminal_reason": "api_error",
+                },
+              ).single
+              as BridgeSseMessageUpdated;
 
       expect(assistant, isEmpty);
       expect(user, isEmpty);
@@ -428,8 +544,7 @@ void main() {
     });
 
     test("strips the bridge worktree envelope from a replayed user frame", () {
-      const envelope =
-          "[SYSTEM CONTEXT \u2014 IMPORTANT]\nWorktree path: /private/worktree\n---\n";
+      const envelope = "[SYSTEM CONTEXT \u2014 IMPORTANT]\nWorktree path: /private/worktree\n---\n";
       final replayed = _map(
         mapper,
         _user(


### PR DESCRIPTION
## Complexity

🌿 Straightforward. Two production files in `sesori_plugin_claude` plus one dispatcher regression test; no contract, schema, or client changes.

## What

The Claude event dispatcher now numbers the content blocks carried by `assistant` frames across the whole message (per `message.id`) instead of by each frame's own content offset. `ClaudeContentMapper.mapPart` is exposed so the dispatcher can stamp a single block at its message-level ordinal; `mapParts` and all other callers are unchanged.

## Why

Claude Code emits **one `assistant` frame per content block** under the same `message.id` (verified live against CLI 2.1.237), so each frame's `content` array restarts at index 0. Streamed text/thinking parts are identified as `"$messageId-block-$streamIndex"`, but the complete frame was mapped to `"$messageId-block-0"` regardless of where the block sat in the stream.

Whenever the model thinks before answering, the stream is `0 = thinking`, `1 = text`: the text frame landed on `block-0`, overwriting the reasoning part with a text copy, while the streamed `block-1` text stayed → the same paragraph rendered twice. Tool parts were immune because they are keyed by `toolu_…` id, and leaving/reopening the session fixed it because transcript history groups records per `message.id` and numbers blocks correctly. This is the intermittent "messages duplicated but not tools" report.

## Risk and test focus

- Live Claude turns where the model thinks first (high/max effort): text must appear once, reasoning part must survive, tool cards unchanged.
- Turns without thinking and single-block messages behave exactly as before (ordinal 0).
- Counter is reset with the existing per-turn / per-session cleanup (`beginTurn`, `completeTurn`, `forgetSession`), and the message id is registered for cleanup even when a frame arrives without preceding stream events.
- No user-visible change beyond removing the duplicate; no database impact; no wire-contract change (part ids now match what history already produced).

## Expected result

A live Claude Code turn renders each text block once, with the thinking part intact, matching what the session shows after reopening. The existing history-parity test still passes, and the new dispatcher test reproduces the real per-block frame sequence (thinking → text → tool_use) and asserts the ids `block-0` (reasoning), `block-1` (text), `toolu-…` (tool).

## Verification

- `dart analyze` on `bridge/sesori_plugin_claude`: no errors or warnings.
- `dart test` for `claude_event_dispatcher`, `claude_content_mapper`, `claude_history_mapper`, `claude_tool_tracker`, `claude_plugin_impl`: all pass (70 tests).
- Real CLI probe (`claude -p --output-format stream-json --include-partial-messages --effort max`): confirmed `assistant` frames carry a single block each (`['thinking']`, then `['text']`) and arrive before that block's `content_block_stop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicated Claude text when the model thinks before answering by numbering assistant content blocks across the whole message. Previously each assistant frame reset its content offset to 0, so the completed text frame finalized as block-0 and overwrote the reasoning part; now parts use message‑level ordinals that match the stream and transcript history.

- Dispatcher tracks a per‑message block counter and uses ClaudeContentMapper.mapPart to stamp IDs like "$messageId-block-n"; mapParts and other callers are unchanged.
- Counter increments before filtering and resets on beginTurn/completeTurn/forgetSession; tools remain keyed by their own IDs.
- Adds a regression test for thinking → text → tool_use; asserts block-0 (reasoning), block-1 (text), and toolu-* IDs.
- No schema or wire‑contract changes; only removes the duplicate text rendering.

<sup>Written for commit 3e6e9cca4e945385b6d7264ed53e415b8aa7fe0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

