### PR TITLE
🌱 Return Claude sessions to busy once a retried request streams again

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -634,6 +634,7 @@ final class ClaudeSessionService({
         // turn and carries a new `ScheduleWakeup` must keep the new schedule.
         _trackSelfStartedTurn(sessionId: event.sessionId, message: event.message);
         _trackWakeupSchedule(sessionId: event.sessionId, message: event.message);
+        _settleRetry(sessionId: event.sessionId, message: event.message);
         final request = event.controlRequest;
         if (request != null) _approvals.handle(sessionId: event.sessionId, message: request);
       case ClaudeSessionProcessExited():
@@ -696,6 +697,15 @@ final class ClaudeSessionService({
       case ClaudeStreamMessage():
         break;
     }
+  }
+
+  /// Returns a retrying session to busy as soon as its retried request streams
+  /// output again. Only a new turn or the turn's end clears the status
+  /// otherwise, so a recovered retry would stay visible for the whole turn.
+  void _settleRetry({required String sessionId, required ClaudeStreamMessage message}) {
+    if (message is! ClaudeStreamEventMessage && message is! ClaudeAssistantMessage) return;
+    if (_retryStatuses.remove(sessionId) == null) return;
+    _emit(BridgeSseSessionStatus(sessionID: sessionId, status: const shared.SessionStatus.busy().toJson()));
   }
 
   void _endSelfStartedTurn({required String sessionId, required _SessionTurnState state}) {

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -590,6 +590,27 @@ void main() {
       expect(retry.next, DateTime.utc(2026, 8, 11, 12).millisecondsSinceEpoch + 1000);
       expect(events.whereType<BridgeSseSessionStatus>().last.status["next"], retry.next);
       expect(harness.plugin.getActiveSessionsSummary().single.activeSessions.single.isRetrying, isTrue);
+
+      // The retried request streaming again is the recovery signal; the turn
+      // is still running, so the session returns to busy rather than idle.
+      process.emit({
+        "type": "stream_event",
+        "session_id": testSessionId,
+        "uuid": "stream-1",
+        "parent_tool_use_id": null,
+        "event": {
+          "type": "message_start",
+          "message": {"id": "msg-recovered", "model": "claude-opus-5"},
+        },
+      });
+      await pump();
+
+      expect((await harness.plugin.getSessionStatuses())[testSessionId], isA<PluginSessionStatusBusy>());
+      expect(
+        shared.SessionStatus.fromJson(events.whereType<BridgeSseSessionStatus>().last.status),
+        isA<shared.SessionStatusBusy>(),
+      );
+      expect(harness.plugin.getActiveSessionsSummary().single.activeSessions.single.isRetrying, isFalse);
       await subscription.cancel();
     });
 

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -27,7 +27,8 @@ defaults and queued client sends coherent.
   concurrently on one plugin, and one slow session or plugin must not stall other
   sessions, other plugins, the relay read loop, or catalog reads.
 - Streaming produces incremental message and part events and a terminal status
-  transition back to idle; retry carries attempt, message, and timing, and
+  transition back to idle; retry carries attempt, message, and timing and
+  returns to busy as soon as the retried request streams output again, and
   finalized messages enter durable history matching a history read. A terminal
   provider failure appears as an inline error message and remains visible after
   refresh or reopen. Backend-provided message timestamps remain present through


### PR DESCRIPTION
## Complexity

🌱 Trivial. One new private method in `ClaudeSessionService`, one extended plugin test, one regression-doc sentence.

## What

When a Claude session is in `retry` status (after a `system/api_retry` frame) and the retried request starts streaming again (`stream_event` or `assistant` frame), the session service now drops the stored retry status and emits a `busy` session status.

## Why

`_retryStatuses` was only cleared at turn start, turn end, or session deletion. So after a network drop recovered, the live stream resumed (new messages visible) but the session stayed "Running (retrying)" with the inline retry message until the `result` frame ended the turn. `sessionStatuses` and `getActiveSessionsSummary` (`isRetrying`) projected the same stale retry for snapshots and the activity summary. The CLI never sends an explicit "retry succeeded" frame; the first turn-output frame after a retry is that signal.

## Risk and test focus

- Network drop / rate-limit retry mid-turn on a Claude session: status should flip retry → busy as soon as the next assistant output streams, and the inline retry message should disappear; the turn then ends to idle as before.
- A retry that is followed by another `api_retry` (still failing) keeps showing retry (nothing clears it until output arrives).
- A retry that exhausts into an error `result` still ends via `_finish` exactly as before.
- No wire-contract change (same `session.status` event with the existing `busy` payload), no database impact, no client change.

## Expected result

A Claude session that recovers from an API retry returns to plain "Running" (busy) the moment its output resumes, instead of staying "Running (retrying)" until the turn ends.

## Verification

- `dart analyze` on `bridge/sesori_plugin_claude`: no errors or warnings.
- `dart test` for `claude_plugin_impl` and `claude_session_service`: 56 tests pass, including the extended "preserves API retry status for snapshots and activity" test that now feeds a `message_start` after the retry and asserts busy via `getSessionStatuses`, the emitted `session.status` event, and `isRetrying == false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return Claude sessions to busy as soon as a retried request resumes streaming. Previously, sessions stayed "Running (retrying)" until the turn ended; now the first `stream_event` or `assistant` frame after `system/api_retry` clears retry and emits `busy`, removing the stale retry indicator immediately.

- Clears only the stored retry status on recovery; turn lifecycle and terminal statuses are unchanged.
- No wire or schema changes; emits the existing `session.status` with `busy`. No client or database changes.
- Tests cover recovery to busy, repeated retries that remain in retry, and error results that finish as before.

<sup>Written for commit 7fc790aa4000f5542ac742b65d5777e975773dfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

