### PR TITLE
🌱 Restore macOS pull-to-refresh feedback

### DIFF
--- a/client/app/lib/features/session_list/session_list_panel.dart
+++ b/client/app/lib/features/session_list/session_list_panel.dart
@@ -136,7 +136,10 @@ class const SessionListPanel({
       ],
     );
     if (state is SessionListLoaded) {
-      scrollView = RefreshIndicator.noSpinner(
+      // This control owns drag progress and the held in-flight presentation;
+      // PregoActivityIndicator cannot replace either interaction state.
+      // ignore: no_slop_linter/avoid_flutter_spinners
+      scrollView = RefreshIndicator(
         onRefresh: () => refreshSessionList(context),
         child: scrollView,
       );

--- a/client/app/test/features/session_list/session_list_panel_test.dart
+++ b/client/app/test/features/session_list/session_list_panel_test.dart
@@ -30,10 +30,11 @@ void main() {
 
   // Renders the real panel at a fixed width; the header sits inside the panel's
   // own 16pt horizontal padding, so the header content width is [width] - 32.
-  Future<void> pumpPanel(WidgetTester tester, {required double width}) async {
+  Future<void> pumpPanel(WidgetTester tester, {required double width, required TargetPlatform platform}) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(
+          platform: platform,
           colorScheme: PregoColors.light.toFlutterColorScheme(),
           textTheme: PregoTextTheme.light.asFlutterTextTheme(),
           extensions: [PregoDesignSystem.light],
@@ -71,7 +72,7 @@ void main() {
   testWidgets("narrow landscape pane lays out the header without overflow", (tester) async {
     // 258 - 32pt padding = 226pt header — the narrowest real split pane, where
     // the labelled layout used to overflow by 25px across and 310px down.
-    await pumpPanel(tester, width: 258);
+    await pumpPanel(tester, width: 258, platform: TargetPlatform.android);
 
     expect(tester.takeException(), isNull);
     // The action collapses to an icon-only button so the title keeps its width;
@@ -87,10 +88,18 @@ void main() {
     // can't be asserted here: the fixed-width test font renders "New session"
     // far wider than the real font, which would overflow a snug header only in
     // tests — the real-font fit is verified on-device.)
-    await pumpPanel(tester, width: 600);
+    await pumpPanel(tester, width: 600, platform: TargetPlatform.android);
 
     expect(tester.takeException(), isNull);
     expect(find.byIcon(Icons.add), findsOneWidget);
     expect(find.text(newSessionLabel(tester)), findsOneWidget);
+  });
+
+  testWidgets("wide macOS pane keeps pull-to-refresh feedback enabled", (tester) async {
+    await pumpPanel(tester, width: 600, platform: TargetPlatform.macOS);
+
+    final refreshIndicator = tester.widget<RefreshIndicator>(find.byType(RefreshIndicator));
+    expect(refreshIndicator.displacement, greaterThan(0));
+    expect(refreshIndicator.strokeWidth, greaterThan(0));
   });
 }

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -31,6 +31,9 @@ child sessions with titles, activity, statuses, and unseen state.
   are reserved for back; on Android gesture navigation, both 10% edges are
   reserved. Android button navigation and other platforms retain the full row
   as a swipe target.
+- Pull-to-refresh provides visible drag and in-flight feedback in both the
+  full-screen lists and the wide split-view session pane. Releasing a trackpad
+  pull while the refresh is pending keeps the pane's indicator visible.
 - A session created in a dedicated worktree receives a system prompt identifying
   that worktree, its initial branch, and base branch. The prompt requires all
   work to remain in that worktree, while permitting use of the initial branch,
@@ -123,6 +126,8 @@ navigation, and a non-mobile platform; begin drags inside and just outside each
 - Hiding destroys sessions, or a cancelled import destroys the committed catalog.
 - A project or session row animates under a system back gesture, or an edge that
   has no active system back gesture stops accepting row actions.
+- A wide session pane starts a refresh without showing or holding its pull
+  indicator until the operation completes.
 - A generated title/branch update fails to reach list/detail, changes unseen,
   moves the worktree, or rewrites the backend's creation-time system context.
 
@@ -160,7 +165,8 @@ navigation, and a non-mobile platform; begin drags inside and just outside each
   `client/module_core/test/services/session_list_service_test.dart`,
   `client/module_core/test/services/session_unseen_tracker_test.dart`,
   `client/module_core/test/cubits/session_list/session_list_cubit_test.dart`,
-  `client/module_prego/test/interactions/prego_swipe_actions_test.dart`
+  `client/module_prego/test/interactions/prego_swipe_actions_test.dart`,
+  `client/app/test/features/session_list/session_list_panel_test.dart`
 - Client row swipe behavior:
   `client/module_prego/lib/interactions/prego_swipe_actions.dart`
 - Plans (discovery only): `.plan/completed/multi-plugin-release-prep`,


### PR DESCRIPTION
## Complexity

Trivial (`🌱`). This restores one refresh-control constructor and adds focused regression coverage.

## What

- Restore the feedback-bearing `RefreshIndicator` in the wide session-list pane.
- Keep the spinner lint exception local and document why `noSpinner` cannot preserve this interaction.
- Add macOS pane coverage that rejects zero-displacement, zero-stroke refresh controls.
- Record visible trackpad refresh feedback in the projects-and-sessions regression contract.

## Why

PR #1001 changed the wide pane to `RefreshIndicator.noSpinner`. That constructor hard-codes zero displacement and stroke width, so a trackpad pull still triggered the refresh but no longer showed or held the refresh indicator. The gesture work in #1037 and #1039 was not the cause.

## Risk and test focus

User-visible impact is limited to restoring pull-to-refresh feedback in the wide session pane. There is no database, persisted-state, transport, authentication, encryption, or analytics impact.

Review should focus on the intentional spinner-lint exception and preserving visible drag/in-flight feedback on macOS without changing the refresh action itself.

## Expected result

Pulling the wide session pane with a macOS trackpad shows the refresh indicator, which remains visible until the refresh completes. Android and full-screen list behavior is unchanged.

## Verification

- `flutter test test/features/session_list/session_list_panel_test.dart` in `client/app`
- `dart analyze` in `client/app`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores visible pull-to-refresh feedback on macOS in the wide session pane by using the standard RefreshIndicator. Previously, noSpinner triggered refresh without showing or holding the indicator; now the indicator appears during drag and remains until refresh completes. Android and full-screen lists are unchanged.

**Review notes**
- Replace RefreshIndicator.noSpinner with RefreshIndicator; keep a local spinner-lint suppression with rationale.
- Add a macOS widget test that asserts non-zero displacement and stroke width.
- Update the projects-and-sessions regression contract to require visible drag and in-flight feedback and to reject zero-displacement/zero-stroke controls.

<sup>Written for commit 9482208687cd84adadb4484a2a81b0a58b92a2e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

