### PR TITLE
🌱 Use Cupertino refresh indicator on macOS

### DIFF
--- a/client/app/lib/features/session_list/session_list_panel.dart
+++ b/client/app/lib/features/session_list/session_list_panel.dart
@@ -136,10 +136,10 @@ class const SessionListPanel({
       ],
     );
     if (state is SessionListLoaded) {
-      // This control owns drag progress and the held in-flight presentation;
-      // PregoActivityIndicator cannot replace either interaction state.
+      // This adaptive control owns drag progress and the held in-flight
+      // presentation; PregoActivityIndicator cannot replace either state.
       // ignore: no_slop_linter/avoid_flutter_spinners
-      scrollView = RefreshIndicator(
+      scrollView = RefreshIndicator.adaptive(
         onRefresh: () => refreshSessionList(context),
         child: scrollView,
       );

--- a/client/app/test/features/session_list/session_list_panel_test.dart
+++ b/client/app/test/features/session_list/session_list_panel_test.dart
@@ -1,4 +1,7 @@
+import "dart:async";
+
 import "package:bloc_test/bloc_test.dart";
+import "package:cupertino_ui/cupertino_ui.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:material_ui/material_ui.dart";
@@ -96,10 +99,25 @@ void main() {
   });
 
   testWidgets("wide macOS pane keeps pull-to-refresh feedback enabled", (tester) async {
+    final refreshCompleter = Completer<bool>();
+    when(
+      () => cubit.refreshSessions(waitForPrData: true),
+    ).thenAnswer((_) => refreshCompleter.future);
     await pumpPanel(tester, width: 600, platform: TargetPlatform.macOS);
 
     final refreshIndicator = tester.widget<RefreshIndicator>(find.byType(RefreshIndicator));
     expect(refreshIndicator.displacement, greaterThan(0));
     expect(refreshIndicator.strokeWidth, greaterThan(0));
+
+    unawaited(tester.state<RefreshIndicatorState>(find.byType(RefreshIndicator)).show());
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+    expect(find.byType(RefreshProgressIndicator), findsNothing);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    refreshCompleter.complete(true);
+    await tester.pump();
   });
 }

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -33,7 +33,8 @@ child sessions with titles, activity, statuses, and unseen state.
   as a swipe target.
 - Pull-to-refresh provides visible drag and in-flight feedback in both the
   full-screen lists and the wide split-view session pane. Releasing a trackpad
-  pull while the refresh is pending keeps the pane's indicator visible.
+  pull while the refresh is pending keeps the pane's indicator visible, using
+  the Cupertino indicator style on iOS and macOS.
 - A session created in a dedicated worktree receives a system prompt identifying
   that worktree, its initial branch, and base branch. The prompt requires all
   work to remain in that worktree, while permitting use of the initial branch,


### PR DESCRIPTION
## Complexity

Trivial (`🌱`). This changes the restored refresh control to Flutter's adaptive constructor and extends one focused widget test.

## What

- Use `RefreshIndicator.adaptive` in the wide session-list pane.
- Verify the active macOS control renders `CupertinoActivityIndicator`, not `RefreshProgressIndicator`.
- Preserve the nonzero displacement and stroke checks added in #1048.
- Record the Apple-platform indicator style in the regression contract.

## Why

#1048 restored visible pull-to-refresh feedback on macOS, but used the Material indicator. The full-screen Apple-platform flow uses the Cupertino style, so the wide pane should match it.

## Risk and test focus

User-visible impact is limited to the refresh indicator style on iOS and macOS. Android continues to receive the Material indicator through Flutter's adaptive behavior. There is no database, persisted-state, transport, authentication, encryption, or analytics impact.

Review should focus on retaining the refresh displacement/lifecycle while selecting the Cupertino indicator on Apple platforms.

## Expected result

The macOS trackpad pull-to-refresh interaction keeps the restored visible feedback from #1048 but now displays the same Cupertino spinner style used on iOS.

## Verification

- `flutter test test/features/session_list/session_list_panel_test.dart` in `client/app`
- `dart analyze` in `client/app`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the wide session-list pane to `RefreshIndicator.adaptive` so macOS and iOS show the Cupertino pull-to-refresh indicator. Previously the pane showed the Material indicator on macOS; now Apple platforms match the full-screen flow, and Android remains Material via Flutter’s adaptive behavior.

- Review focus: confirm pull-to-refresh displacement and stroke width remain nonzero and the refresh lifecycle is unchanged.
- Tests: widget test asserts `CupertinoActivityIndicator` renders and `RefreshProgressIndicator` does not on macOS; preserves displacement/stroke checks.
- Docs: regression contract now specifies Cupertino indicator on Apple platforms.
- No migrations or config changes required.

<sup>Written for commit 3579cb175350d8b01984c9893bfbc93511758585. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

