### PR TITLE
🌱 Widen Firebase Test Lab detection across settings tables

### DIFF
--- a/client/app/android/app/src/main/kotlin/com/sesori/app/MainActivity.kt
+++ b/client/app/android/app/src/main/kotlin/com/sesori/app/MainActivity.kt
@@ -33,9 +33,7 @@ class MainActivity : FlutterActivity(), FlutterUiDisplayListener {
         ).also { channel ->
             channel.setMethodCallHandler { call, result ->
                 when (call.method) {
-                    "isRunning" -> result.success(
-                        Settings.System.getString(contentResolver, "firebase.test.lab") == "true",
-                    )
+                    "isRunning" -> result.success(isRunningInFirebaseTestLab())
                     else -> result.notImplemented()
                 }
             }
@@ -115,7 +113,20 @@ class MainActivity : FlutterActivity(), FlutterUiDisplayListener {
         return getNavigationMode() == 2
     }
 
+    // Firebase documents this flag as `Settings.System` holding the exact string
+    // "true", but that read returned false throughout a Play pre-launch report:
+    // GA4 recorded 154 single-session installs of an unreleased version, each
+    // reporting product events the runtime capability should have suppressed.
+    // Google's own guidance describes the flag under instrumented-test behavior,
+    // so a Robo crawl may set it elsewhere, differently, or not at all. Read every
+    // settings table and accept any value — no real device carries this setting.
+    private fun isRunningInFirebaseTestLab(): Boolean =
+        Settings.System.getString(contentResolver, FIREBASE_TEST_LAB_SETTING) != null ||
+            Settings.Global.getString(contentResolver, FIREBASE_TEST_LAB_SETTING) != null ||
+            Settings.Secure.getString(contentResolver, FIREBASE_TEST_LAB_SETTING) != null
+
     private companion object {
         const val FIREBASE_TEST_LAB_CHANNEL_NAME = "com.sesori.app/firebase-test-lab"
+        const val FIREBASE_TEST_LAB_SETTING = "firebase.test.lab"
     }
 }

--- a/client/app/test/core/platform/firebase_analytics_configuration_test.dart
+++ b/client/app/test/core/platform/firebase_analytics_configuration_test.dart
@@ -39,16 +39,20 @@ void main() {
     expectAppleKeyDisabled(key: "FIREBASE_ANALYTICS_COLLECTION_ENABLED");
   });
 
-  test("Android uses the official Firebase Test Lab environment signal", () {
+  test("Android reads the Firebase Test Lab signal from every settings table", () {
     expect(
       androidMainActivity,
       contains('const val FIREBASE_TEST_LAB_CHANNEL_NAME = "com.sesori.app/firebase-test-lab"'),
     );
-    expect(androidMainActivity, contains('"isRunning" ->'));
-    expect(
-      androidMainActivity,
-      contains('Settings.System.getString(contentResolver, "firebase.test.lab") == "true"'),
-    );
+    expect(androidMainActivity, contains('"isRunning" -> result.success(isRunningInFirebaseTestLab())'));
+    expect(androidMainActivity, contains('const val FIREBASE_TEST_LAB_SETTING = "firebase.test.lab"'));
+    for (final table in const ["System", "Global", "Secure"]) {
+      expect(
+        androidMainActivity,
+        contains("Settings.$table.getString(contentResolver, FIREBASE_TEST_LAB_SETTING) != null"),
+        reason: "Test Lab detection must accept any value present in Settings.$table",
+      );
+    }
   });
 
   test("automatic Firebase screen reporting is disabled on every Firebase-enabled target", () {

--- a/docs/regression/analytics.md
+++ b/docs/regression/analytics.md
@@ -26,8 +26,9 @@ excluded, and the warehouse is external.
   outcomes, not taps, capture occurrence time at their seam, and deferred candidates emit at most once, dropping on
   disable, logout, or account switch. Results state SDK acceptance, not delivery.
 - Firebase Analytics collection defaults off at native startup and is enabled only after consent in a release process
-  outside Firebase Test Lab. Debug/profile runs and Play pre-launch crawlers emit neither automatic nor Sesori-defined
-  analytics events.
+  that exposes no `firebase.test.lab` flag in any Android settings table. Debug/profile runs emit neither automatic nor
+  Sesori-defined analytics events. Play pre-launch crawls are suppressed only when their devices expose that flag; a
+  crawl that withholds it is indistinguishable from a real install and is counted as one.
 
 ## Regression Levels
 

--- a/docs/regression/analytics.md
+++ b/docs/regression/analytics.md
@@ -27,8 +27,8 @@ excluded, and the warehouse is external.
   disable, logout, or account switch. Results state SDK acceptance, not delivery.
 - Firebase Analytics collection defaults off at native startup and is enabled only after consent in a release process
   that exposes no `firebase.test.lab` flag in any Android settings table. Debug/profile runs emit neither automatic nor
-  Sesori-defined analytics events. Play pre-launch crawls are suppressed only when their devices expose that flag; a
-  crawl that withholds it is indistinguishable from a real install and is counted as one.
+  Sesori-defined analytics events. Suppressing a Play pre-launch crawl depends on its devices exposing that flag, which
+  the app cannot verify from inside; the L5 pre-launch check is what confirms the guard actually held.
 
 ## Regression Levels
 


### PR DESCRIPTION
## Complexity

Trivial. One Android settings read widened from a single table and exact-value
comparison to three tables and a presence check.

## What

`MainActivity` reported Firebase Test Lab only when `Settings.System` held the
exact string `"true"`. It now reports Test Lab when `firebase.test.lab` is
present in `Settings.System`, `Settings.Global`, or `Settings.Secure`, with any
value.

## Why

The existing read returned false throughout a Play pre-launch report. GA4 for
2026-08-22 recorded 154 single-session installs of unreleased 1.8.1 — roughly
seven per internal upload, one `first_open` each, no country — and every one of
them emitted `product_screen_viewed`. That is only reachable when
`_analyticsIneligibilityReason()` returned null, so `FirebaseTestLabEnvironment`
must have resolved to `notRunning` on those devices.

Google documents the flag under instrumented-test behavior, so a Robo crawl may
set it in a different table, with a different value, or not at all. Reading all
three tables and accepting any value costs nothing and cannot produce a false
positive: no real device carries this setting anywhere.

This is the cheap shot, not a guaranteed fix. If phantom 1.8.1 users do not
collapse within a day of the next internal build, the flag is absent entirely
and the remaining options are an install-source gate or a public-release gate,
both of which trade a real population for a bot one.

## Risk and test focus

No user-visible change. No database impact. No wire contract change.

The Dart contract is untouched — the channel still answers a single bool — so
`firebase_test_lab_environment_test.dart` and
`firebase_analytics_startup_test.dart` continue to cover the wiring. Kotlin has
no test coverage here and mobile CI does not compile Android, so this was
verified by building the app locally.

Risk if the widened read is wrong in the other direction: a device that somehow
exposes `firebase.test.lab` would silently stop reporting analytics. No such
device is known, and the failure is loss of telemetry, not loss of function.

## Expected result

Play pre-launch crawls stop registering as users. Real installs are unaffected.

## Verification

- `flutter build apk --debug --target-platform android-arm64` — succeeds.
- Post-merge: watch active users for 1.8.1 in GA4 after the next internal build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widen Firebase Test Lab detection from an exact-value read in `Settings.System` to a presence check across `Settings.System`, `Settings.Global`, and `Settings.Secure`, reducing false negatives from Play pre-launch crawls. Previously we flagged Test Lab only when `Settings.System["firebase.test.lab"] == "true"`; now any non-null value in any table flags it.

- Replaces the inline check with `isRunningInFirebaseTestLab()`; `com.sesori.app/firebase-test-lab` still returns a single bool. Adds `FIREBASE_TEST_LAB_SETTING`.
- Aligns tests to assert the helper and all three table reads, and updates the regression doc to state suppression depends on the flag; the L5 pre-launch check confirms the guard held.
- After merge, monitor GA4 for a drop in pre-release traffic after the next internal build.

<sup>Written for commit 1b21177f163e66750bcd689514a2a17ad66ff86b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

