### PR TITLE
🌱 Fix architecture skill YAML frontmatter

### DIFF
--- a/.agents/skills/architecture-implementation-review/SKILL.md
+++ b/.agents/skills/architecture-implementation-review/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: architecture-implementation-review
-description: Reviews architecture-bearing production changes, not general implementation correctness. Must be invoked as a sub-agent: the main agent should ask a sub-agent to perform the review using this skill, rather than loading the skill directly in the main agent context. Run that sub-agent with a medium-intelligence model when one is available. Prefers Git scopes such as a branch, commit range, recent commits, or PR, but also accepts file-based scopes. Avoids legacy-cleanup scope creep; callers seek user guidance after two rejected passes.
+description: >-
+  Reviews architecture-bearing production changes, not general implementation correctness. Must be invoked as a
+  sub-agent: the main agent should ask a sub-agent to perform the review using this skill, rather than loading the skill
+  directly in the main agent context. Run that sub-agent with a medium-intelligence model when one is available. Prefers
+  Git scopes such as a branch, commit range, recent commits, or PR, but also accepts file-based scopes. Avoids
+  legacy-cleanup scope creep; callers seek user guidance after two rejected passes.
 ---
 
 # Architecture Implementation Review

--- a/.agents/skills/architecture-plan-review/SKILL.md
+++ b/.agents/skills/architecture-plan-review/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: architecture-plan-review
-description: Reviews an architecture-bearing development plan against strict Sesori architectural rules. Must be invoked as a sub-agent: the main agent should ask a sub-agent to perform the review using this skill, rather than loading the skill directly in the main agent context. Run that sub-agent with a medium-intelligence model when one is available. The caller fixes valid findings directly without re-reviewing those fixes. A plan may be reviewed again after a too-vague rejection or considerable changes caused by new findings or user requests.
+description: >-
+  Reviews an architecture-bearing development plan against strict Sesori architectural rules. Must be invoked as a
+  sub-agent: the main agent should ask a sub-agent to perform the review using this skill, rather than loading the skill
+  directly in the main agent context. Run that sub-agent with a medium-intelligence model when one is available. The
+  caller fixes valid findings directly without re-reviewing those fixes. A plan may be reviewed again after a too-vague
+  rejection or considerable changes caused by new findings or user requests.
 ---
 
 # Architecture Plan Review


### PR DESCRIPTION
## Complexity

🌱 Trivial — frontmatter-only YAML formatting correction.

## What

Convert both architecture review skill descriptions to folded YAML block scalars.

## Why

The descriptions contain `: `, which YAML interprets as a nested mapping when left unquoted. Pi therefore reports skill conflicts and skips both skills.

## Risk and test focus

No user-visible product or database impact. The only risk is malformed skill metadata, covered by parsing both updated files and checking the diff for whitespace errors.

## Expected result

Pi discovers `architecture-plan-review` and `architecture-implementation-review` without YAML conflict warnings.

## Verification

- Parsed both updated `SKILL.md` files successfully with Ruby Psych.
- `git diff --check` passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes YAML frontmatter in both architecture skills by converting description fields to folded block scalars. Previously, descriptions with ": " were parsed as nested mappings, causing Pi to report skill conflicts and skip loading; now Pi discovers both skills without warnings.

**Reviewer notes**
- Changes are limited to the frontmatter in `.agents/skills/architecture-implementation-review/SKILL.md` and `.agents/skills/architecture-plan-review/SKILL.md`; verify indentation and folded scalar formatting.
- No runtime or database impact; optionally parse the files or run Pi to confirm both skills load without conflict warnings.

<sup>Written for commit 8420dabfcaa14fb86fb603d9e34dc232e994cae1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

