### PR TITLE
🌿 Keep session list displaced during refresh

### DIFF
--- a/client/app/lib/features/session_list/session_list_panel.dart
+++ b/client/app/lib/features/session_list/session_list_panel.dart
@@ -1,3 +1,4 @@
+import "package:cupertino_ui/cupertino_ui.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:material_ui/material_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
@@ -123,9 +124,22 @@ class const SessionListPanel({
   /// pull-to-refresh (only once the list has loaded).
   Widget _buildScrollableContent(BuildContext context, {required SessionListState state}) {
     final isRefreshing = state is SessionListLoaded && state.isRefreshing;
+    final canRefresh = state is SessionListLoaded;
+    final usesCupertinoRefresh =
+        canRefresh &&
+        switch (Theme.of(context).platform) {
+          TargetPlatform.iOS || TargetPlatform.macOS => true,
+          TargetPlatform.android || TargetPlatform.fuchsia || TargetPlatform.linux || TargetPlatform.windows => false,
+        };
     Widget scrollView = CustomScrollView(
-      physics: const AlwaysScrollableScrollPhysics(),
+      physics: usesCupertinoRefresh
+          ? const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics())
+          : const AlwaysScrollableScrollPhysics(),
       slivers: [
+        if (usesCupertinoRefresh)
+          CupertinoSliverRefreshControl(
+            onRefresh: () => refreshSessionList(context),
+          ),
         if (isRefreshing) const SliverToBoxAdapter(child: LinearProgressIndicator()),
         SessionListContent(
           projectName: projectName,
@@ -135,11 +149,11 @@ class const SessionListPanel({
         ),
       ],
     );
-    if (state is SessionListLoaded) {
-      // This adaptive control owns drag progress and the held in-flight
-      // presentation; PregoActivityIndicator cannot replace either state.
+    if (canRefresh && !usesCupertinoRefresh) {
+      // Material platforms use the overlay control; Apple platforms need the
+      // sliver above so the list remains displaced while refresh is pending.
       // ignore: no_slop_linter/avoid_flutter_spinners
-      scrollView = RefreshIndicator.adaptive(
+      scrollView = RefreshIndicator(
         onRefresh: () => refreshSessionList(context),
         child: scrollView,
       );

--- a/client/app/lib/features/session_list/session_list_panel.dart
+++ b/client/app/lib/features/session_list/session_list_panel.dart
@@ -125,18 +125,12 @@ class const SessionListPanel({
   Widget _buildScrollableContent(BuildContext context, {required SessionListState state}) {
     final isRefreshing = state is SessionListLoaded && state.isRefreshing;
     final canRefresh = state is SessionListLoaded;
-    final usesCupertinoRefresh =
-        canRefresh &&
-        switch (Theme.of(context).platform) {
-          TargetPlatform.iOS || TargetPlatform.macOS => true,
-          TargetPlatform.android || TargetPlatform.fuchsia || TargetPlatform.linux || TargetPlatform.windows => false,
-        };
-    Widget scrollView = CustomScrollView(
-      physics: usesCupertinoRefresh
+    return CustomScrollView(
+      physics: canRefresh
           ? const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics())
           : const AlwaysScrollableScrollPhysics(),
       slivers: [
-        if (usesCupertinoRefresh)
+        if (canRefresh)
           CupertinoSliverRefreshControl(
             onRefresh: () => refreshSessionList(context),
           ),
@@ -149,16 +143,6 @@ class const SessionListPanel({
         ),
       ],
     );
-    if (canRefresh && !usesCupertinoRefresh) {
-      // Material platforms use the overlay control; Apple platforms need the
-      // sliver above so the list remains displaced while refresh is pending.
-      // ignore: no_slop_linter/avoid_flutter_spinners
-      scrollView = RefreshIndicator(
-        onRefresh: () => refreshSessionList(context),
-        child: scrollView,
-      );
-    }
-    return scrollView;
   }
 
   String _title({required AppLocalizations loc}) => switch (projectName) {

--- a/client/app/test/features/session_list/session_list_panel_test.dart
+++ b/client/app/test/features/session_list/session_list_panel_test.dart
@@ -98,23 +98,36 @@ void main() {
     expect(find.text(newSessionLabel(tester)), findsOneWidget);
   });
 
-  testWidgets("wide macOS pane keeps pull-to-refresh feedback enabled", (tester) async {
+  testWidgets("wide macOS pane stays displaced while refresh is pending", (tester) async {
     final refreshCompleter = Completer<bool>();
+    var refreshStarted = false;
     when(
       () => cubit.refreshSessions(waitForPrData: true),
-    ).thenAnswer((_) => refreshCompleter.future);
+    ).thenAnswer((_) {
+      refreshStarted = true;
+      return refreshCompleter.future;
+    });
     await pumpPanel(tester, width: 600, platform: TargetPlatform.macOS);
 
-    final refreshIndicator = tester.widget<RefreshIndicator>(find.byType(RefreshIndicator));
-    expect(refreshIndicator.displacement, greaterThan(0));
-    expect(refreshIndicator.strokeWidth, greaterThan(0));
+    expect(tester.widget<CustomScrollView>(find.byType(CustomScrollView)).physics, isA<BouncingScrollPhysics>());
+    expect(find.byType(CupertinoSliverRefreshControl, skipOffstage: false), findsOneWidget);
+    expect(find.byType(RefreshIndicator), findsNothing);
+    final content = find.byKey(const Key("session-empty-terminal"));
+    final initialContentTop = tester.getTopLeft(content).dy;
 
-    unawaited(tester.state<RefreshIndicatorState>(find.byType(RefreshIndicator)).show());
+    final gesture = await tester.startGesture(tester.getCenter(content));
+    for (var step = 0; step < 30 && !refreshStarted; step++) {
+      await gesture.moveBy(const Offset(0, 10));
+      await tester.pump();
+    }
+    expect(refreshStarted, isTrue);
+    await gesture.up();
     await tester.pump();
-    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pump(const Duration(milliseconds: 500));
 
     expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
     expect(find.byType(RefreshProgressIndicator), findsNothing);
+    expect(tester.getTopLeft(content).dy, greaterThan(initialContentTop));
 
     await tester.pumpWidget(const SizedBox.shrink());
     refreshCompleter.complete(true);

--- a/client/app/test/features/session_list/session_list_panel_test.dart
+++ b/client/app/test/features/session_list/session_list_panel_test.dart
@@ -98,6 +98,13 @@ void main() {
     expect(find.text(newSessionLabel(tester)), findsOneWidget);
   });
 
+  testWidgets("wide Android pane uses the Cupertino refresh control", (tester) async {
+    await pumpPanel(tester, width: 600, platform: TargetPlatform.android);
+
+    expect(find.byType(CupertinoSliverRefreshControl, skipOffstage: false), findsOneWidget);
+    expect(find.byType(RefreshIndicator), findsNothing);
+  });
+
   testWidgets("wide macOS pane stays displaced while refresh is pending", (tester) async {
     final refreshCompleter = Completer<bool>();
     var refreshStarted = false;

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -32,7 +32,7 @@ child sessions with titles, activity, statuses, and unseen state.
   reserved. Android button navigation and other platforms retain the full row
   as a swipe target.
 - Pull-to-refresh provides visible drag and in-flight feedback in both the
-  full-screen lists and the wide split-view session pane. On iOS and macOS,
+  full-screen lists and the wide split-view session pane. On every platform,
   releasing a pull while the refresh is pending keeps the pane content
   displaced and its Cupertino indicator visible.
 - A session created in a dedicated worktree receives a system prompt identifying

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -33,8 +33,8 @@ child sessions with titles, activity, statuses, and unseen state.
   as a swipe target.
 - Pull-to-refresh provides visible drag and in-flight feedback in both the
   full-screen lists and the wide split-view session pane. Releasing a trackpad
-  pull while the refresh is pending keeps the pane's indicator visible, using
-  the Cupertino indicator style on iOS and macOS.
+  pull while the refresh is pending keeps the pane content displaced and its
+  indicator visible, using the Cupertino indicator style on iOS and macOS.
 - A session created in a dedicated worktree receives a system prompt identifying
   that worktree, its initial branch, and base branch. The prompt requires all
   work to remain in that worktree, while permitting use of the initial branch,

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -32,9 +32,9 @@ child sessions with titles, activity, statuses, and unseen state.
   reserved. Android button navigation and other platforms retain the full row
   as a swipe target.
 - Pull-to-refresh provides visible drag and in-flight feedback in both the
-  full-screen lists and the wide split-view session pane. Releasing a trackpad
-  pull while the refresh is pending keeps the pane content displaced and its
-  indicator visible, using the Cupertino indicator style on iOS and macOS.
+  full-screen lists and the wide split-view session pane. On iOS and macOS,
+  releasing a pull while the refresh is pending keeps the pane content
+  displaced and its Cupertino indicator visible.
 - A session created in a dedicated worktree receives a system prompt identifying
   that worktree, its initial branch, and base branch. The prompt requires all
   work to remain in that worktree, while permitting use of the initial branch,


### PR DESCRIPTION
## Complexity

Straightforward (`🌿`). This replaces the pane's overlay refresh control with the same in-scroll Cupertino control already used by the full-screen lists and exercises the loading geometry with a real pull gesture.

## What

- Use `CupertinoSliverRefreshControl` with bouncing physics in the wide session-list pane on every platform.
- Remove the platform switch and Material `RefreshIndicator` path.
- Verify Android also receives the Cupertino refresh control.
- Verify that releasing a macOS pull leaves both the spinner and displaced list content visible while refresh remains pending.
- Tighten the projects-and-sessions regression contract to require the held content displacement on every platform.

## Why

#1052 changed the macOS spinner to Cupertino styling through `RefreshIndicator.adaptive`, but that widget remains an overlay. It can keep the indicator alive while loading, but it cannot hold scrollable layout space, so the list immediately snaps back after the pull is released.

`CupertinoSliverRefreshControl` is part of the scroll view and retains a layout extent until the refresh future completes. Using it everywhere is simpler and matches the existing full-screen project and session list behavior across platforms.

## Risk and test focus

User-visible impact is limited to pull-to-refresh presentation in the wide session-list pane. Android, Windows, Linux, and Fuchsia now use the Cupertino refresh style and held displacement instead of the Material overlay. There is no database, persisted-state, transport, authentication, encryption, or analytics impact.

Review should focus on preserving refresh availability for short and empty lists and holding the list displacement only for the refresh lifetime.

## Expected result

After a pull triggers refresh on any platform, the pane stays overscrolled with a live Cupertino spinner until loading finishes.

## Verification

- `flutter test test/features/session_list/session_list_panel_test.dart` in `client/app`
- `dart analyze` in `client/app`
- `git diff --check`
