### PR TITLE
🚧 [codebase-cleanup] Consolidate list cubits and relay plumbing [step 32/45]

### DIFF
--- a/.plan/active/codebase-cleanup/steps/step-32.md
+++ b/.plan/active/codebase-cleanup/steps/step-32.md
@@ -76,6 +76,7 @@ cd shared/sesori_shared && dart test test/protocol/framing_test.dart            
 cd shared/sesori_shared && dart analyze --fatal-infos                               # clean
 cd client/app && flutter test test/capabilities test/core/api                       # 77 passing
 cd client/app && flutter test test/features/session_list                            # 87 passing
+cd client/app && flutter test test/features/project_list                            # 89 passing (post-CI fix)
 cd client/app && flutter analyze --fatal-infos                                      # clean
 cd client/module_desktop_core && dart analyze --fatal-infos                         # clean
 cd client/desktop && flutter analyze --fatal-infos                                  # clean
@@ -84,6 +85,12 @@ git diff --check                                                                
 
 The pinned formatter formatted compatible files and hit its known Dart 3.13
 enhanced-enum crash in `relay_client.dart`; all analyzers remain clean.
+
+Mobile CI initially failed on `client/app`
+`project_list_nav_bar_test.dart` ("pulling the disconnected page down
+re-attempts the bridge connection"): that app-level test still stubbed and
+verified the removed direct `reconnect()` call. It now stubs and verifies
+`reconnectAndAwaitOutcome(timeout: 15s)`.
 
 Architecture implementation review approved the new service contract, request
 ID ownership, DI construction, shared framing boundary, and cubit integration

--- a/.plan/active/codebase-cleanup/steps/step-32.md
+++ b/.plan/active/codebase-cleanup/steps/step-32.md
@@ -1,0 +1,89 @@
+# Step 32 — List cubits and relay plumbing
+
+The list cubits and relay stack retained several exact implementation copies.
+This step consolidates the shared seams while leaving typed state and reconnect
+lifecycle differences explicit.
+
+## Re-verification against `main`
+
+- The session/project `_reconnectIfNeeded` methods remained equivalent,
+  including their silent timeout handling.
+- Four project loaded-state paths repeated order, unseen projection, and emit.
+- Stale refresh, active refresh, route-listener, and retry wrappers remain
+  intentionally local because they own typed cubit state or distinct request
+  parameters.
+- Session archive and delete are not equivalent optimistic removals: archive
+  mutates a returned session before filtering, while delete removes an item and
+  has different response and cleanup-rejection handling.
+- Relay HTTP verbs still repeated the same connection, send, and auth mapping,
+  but their public body, query, header, timeout, and sensitivity contracts differ.
+- Relay request IDs had two exact per-owner implementations.
+- Reconnect-delay cancellation was the one exact repeated ConnectionService
+  cleanup. The planned stale-attempt, teardown, and backoff helpers would combine
+  call sites with different close codes, state publication, or timing, so they
+  were not introduced.
+- Relay framing, view sends, and controller close mechanics remained duplicated.
+- `ClockProvider` and `RelayClientFactory` still had unnecessary DI registrations
+  despite constructor defaults supporting production and direct test overrides.
+
+## What changed
+
+- Added `ConnectionService.reconnectAndAwaitOutcome` and migrated both list
+  cubits to it, making reconnect timeout failures locally observable.
+- Added project-only `_emitOrdered` for the four equivalent loaded-state updates.
+- Consolidated RelayHttpApiClient verbs behind one private request path while
+  preserving every public signature and sensitivity flag.
+- Added one request-ID generator instance per relay HTTP client and connection
+  service, preserving independent counters.
+- Consolidated reconnect-delay cancellation without moving reconnect gates or
+  teardown/state timing.
+- Reused shared `frame`/`unframe` in RelayClient while retaining plaintext size
+  checks, encryptor/channel race checks, and exact handshake replay frames.
+- Consolidated best-effort view sends and controller close mechanics while
+  preserving SSE detachment and diagnostic contexts.
+- Corrected the stale bridge-offline handshake documentation.
+- Removed DI registrations for the two constructor-default test seams and
+  regenerated Injectable output.
+
+Change-budget totals exclude this evidence file and use the merge base with
+`origin/main`:
+
+```bash
+BASE=$(git merge-base HEAD origin/main)
+git diff --numstat "$BASE"...HEAD -- client/module_core/lib
+git diff --numstat "$BASE"...HEAD -- client/module_core/test
+```
+
+| Scope | Additions | Deletions |
+| --- | ---: | ---: |
+| Production/lib, including generated DI output | 221 | 319 |
+| Tests | 131 | 20 |
+
+## Behavior
+
+No user-visible or database behavior changes. HTTP request shapes, auth error
+mapping, sensitive-response redaction, request-ID format, reconnect outcomes,
+encrypted wire bytes, handshake replay, list ordering, and optimistic list
+actions retain their prior semantics. No wire or persisted contract changed.
+
+## Verification
+
+```bash
+cd client/module_core && dart run build_runner build --delete-conflicting-outputs
+cd client/module_core && dart analyze --fatal-infos
+cd client/module_core && dart test test/cubits/session_list test/cubits/project_list test/capabilities test/api/client/relay_http_client_test.dart  # 245 passing
+cd shared/sesori_shared && dart test test/protocol/framing_test.dart                 # 5 passing
+cd shared/sesori_shared && dart analyze --fatal-infos                               # clean
+cd client/app && flutter test test/capabilities test/core/api                       # 77 passing
+cd client/app && flutter analyze --fatal-infos                                      # clean
+cd client/module_desktop_core && dart analyze --fatal-infos                         # clean
+cd client/desktop && flutter analyze --fatal-infos                                  # clean
+git diff --check                                                                    # clean
+```
+
+The pinned formatter formatted compatible files and hit its known Dart 3.13
+enhanced-enum crash in `relay_client.dart`; all analyzers remain clean.
+
+Architecture implementation review approved the new service contract, request
+ID ownership, DI construction, shared framing boundary, and cubit integration
+with no findings. A separate correctness review found no plausible regressions.

--- a/.plan/active/codebase-cleanup/steps/step-32.md
+++ b/.plan/active/codebase-cleanup/steps/step-32.md
@@ -75,6 +75,7 @@ cd client/module_core && dart test test/cubits/session_list test/cubits/project_
 cd shared/sesori_shared && dart test test/protocol/framing_test.dart                 # 5 passing
 cd shared/sesori_shared && dart analyze --fatal-infos                               # clean
 cd client/app && flutter test test/capabilities test/core/api                       # 77 passing
+cd client/app && flutter test test/features/session_list                            # 87 passing
 cd client/app && flutter analyze --fatal-infos                                      # clean
 cd client/module_desktop_core && dart analyze --fatal-infos                         # clean
 cd client/desktop && flutter analyze --fatal-infos                                  # clean

--- a/client/app/test/features/project_list/project_list_nav_bar_test.dart
+++ b/client/app/test/features/project_list/project_list_nav_bar_test.dart
@@ -169,15 +169,18 @@ void main() {
   });
 
   testWidgets("pulling the disconnected page down re-attempts the bridge connection", (tester) async {
+    when(
+      () => mockConnectionService.reconnectAndAwaitOutcome(timeout: any(named: "timeout")),
+    ).thenAnswer((_) async {});
     await pumpScreen(tester, hasRegisteredBridges: false);
-    verifyNever(() => mockConnectionService.reconnect());
+    verifyNever(() => mockConnectionService.reconnectAndAwaitOutcome(timeout: any(named: "timeout")));
 
     // The scaffold's sliver refresh control drives the reconnect that the
     // body's own pull-to-refresh used to.
     await tester.fling(find.byType(CustomScrollView), const Offset(0, 300), 1000);
     await tester.pumpAndSettle();
 
-    verify(() => mockConnectionService.reconnect()).called(1);
+    verify(() => mockConnectionService.reconnectAndAwaitOutcome(timeout: const Duration(seconds: 15))).called(1);
   });
 
   // -------------------------------------------------------------------------

--- a/client/module_core/lib/src/api/client/relay_http_client.dart
+++ b/client/module_core/lib/src/api/client/relay_http_client.dart
@@ -1,12 +1,12 @@
 import "dart:async";
 import "dart:convert";
-import "dart:math";
 
 import "package:injectable/injectable.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../../capabilities/relay/relay_client.dart";
+import "../../capabilities/relay/relay_request_id_generator.dart";
 import "../../capabilities/server_connection/connection_service.dart";
 import "../../logging/logging.dart";
 
@@ -15,8 +15,7 @@ class RelayHttpApiClient(final ConnectionService _connectionService) {
   static const Duration _defaultRequestTimeout = Duration(seconds: 30);
   static const String _sensitiveParsingErrorMarker = "Sensitive response omitted";
 
-  int _requestCounter = 0;
-  final Random _requestIdRandom = Random();
+  final RelayRequestIdGenerator _requestIdGenerator = RelayRequestIdGenerator();
 
   // ignore: no_slop_linter/prefer_required_named_parameters, optional HTTP parameters
   Future<ApiResponse<T>> get<T>(
@@ -25,24 +24,16 @@ class RelayHttpApiClient(final ConnectionService _connectionService) {
     required T Function(Map<String, dynamic> json) fromJson,
     Map<String, String>? queryParameters,
     Map<String, String>? headers,
-  }) async {
-    final relayClient = _connectionService.relayClient;
-    if (relayClient != null && relayClient.isConnected) {
-      return _mapAuthErrors(
-        await _sendViaRelay(
-          relayClient: relayClient,
-          method: HttpMethod.get,
-          path: path,
-          fromJson: fromJson,
-          queryParameters: queryParameters,
-          extraHeaders: headers,
-          timeout: _defaultRequestTimeout,
-          sensitiveResponse: false,
-        ),
-      );
-    }
-    return _relayDisconnectedResponse();
-  }
+  }) => _request(
+    method: HttpMethod.get,
+    path: path,
+    fromJson: fromJson,
+    queryParameters: queryParameters,
+    body: null,
+    extraHeaders: headers,
+    timeout: _defaultRequestTimeout,
+    sensitiveResponse: false,
+  );
 
   // ignore: no_slop_linter/prefer_required_named_parameters, optional HTTP parameters
   Future<ApiResponse<T>> post<T>(
@@ -53,25 +44,16 @@ class RelayHttpApiClient(final ConnectionService _connectionService) {
     required Object? body,
     Map<String, String>? queryParameters,
     Map<String, String>? headers,
-  }) async {
-    final relayClient = _connectionService.relayClient;
-    if (relayClient != null && relayClient.isConnected) {
-      return _mapAuthErrors(
-        await _sendViaRelay(
-          relayClient: relayClient,
-          method: HttpMethod.post,
-          path: path,
-          fromJson: fromJson,
-          queryParameters: queryParameters,
-          body: body,
-          extraHeaders: headers,
-          timeout: _defaultRequestTimeout,
-          sensitiveResponse: false,
-        ),
-      );
-    }
-    return _relayDisconnectedResponse();
-  }
+  }) => _request(
+    method: HttpMethod.post,
+    path: path,
+    fromJson: fromJson,
+    queryParameters: queryParameters,
+    body: body,
+    extraHeaders: headers,
+    timeout: _defaultRequestTimeout,
+    sensitiveResponse: false,
+  );
 
   Future<ApiResponse<T>> postWithTimeout<T>(
     String path, {
@@ -80,25 +62,16 @@ class RelayHttpApiClient(final ConnectionService _connectionService) {
     // ignore: no_slop_linter/prefer_specific_type
     required Object body,
     required Duration timeout,
-  }) async {
-    final relayClient = _connectionService.relayClient;
-    if (relayClient != null && relayClient.isConnected) {
-      return _mapAuthErrors(
-        await _sendViaRelay(
-          relayClient: relayClient,
-          method: HttpMethod.post,
-          path: path,
-          fromJson: fromJson,
-          queryParameters: null,
-          body: body,
-          extraHeaders: null,
-          timeout: timeout,
-          sensitiveResponse: true,
-        ),
-      );
-    }
-    return _relayDisconnectedResponse();
-  }
+  }) => _request(
+    method: HttpMethod.post,
+    path: path,
+    fromJson: fromJson,
+    queryParameters: null,
+    body: body,
+    extraHeaders: null,
+    timeout: timeout,
+    sensitiveResponse: true,
+  );
 
   // ignore: no_slop_linter/prefer_required_named_parameters, optional HTTP parameters
   Future<ApiResponse<T>> patch<T>(
@@ -109,25 +82,16 @@ class RelayHttpApiClient(final ConnectionService _connectionService) {
     required Object? body,
     Map<String, String>? queryParameters,
     Map<String, String>? headers,
-  }) async {
-    final relayClient = _connectionService.relayClient;
-    if (relayClient != null && relayClient.isConnected) {
-      return _mapAuthErrors(
-        await _sendViaRelay(
-          relayClient: relayClient,
-          method: HttpMethod.patch,
-          path: path,
-          fromJson: fromJson,
-          queryParameters: queryParameters,
-          body: body,
-          extraHeaders: headers,
-          timeout: _defaultRequestTimeout,
-          sensitiveResponse: false,
-        ),
-      );
-    }
-    return _relayDisconnectedResponse();
-  }
+  }) => _request(
+    method: HttpMethod.patch,
+    path: path,
+    fromJson: fromJson,
+    queryParameters: queryParameters,
+    body: body,
+    extraHeaders: headers,
+    timeout: _defaultRequestTimeout,
+    sensitiveResponse: false,
+  );
 
   // ignore: no_slop_linter/prefer_required_named_parameters, optional HTTP parameters
   Future<ApiResponse<T>> delete<T>(
@@ -138,24 +102,46 @@ class RelayHttpApiClient(final ConnectionService _connectionService) {
     Object? body,
     Map<String, String>? queryParameters,
     Map<String, String>? headers,
+  }) => _request(
+    method: HttpMethod.delete,
+    path: path,
+    fromJson: fromJson,
+    queryParameters: queryParameters,
+    body: body,
+    extraHeaders: headers,
+    timeout: _defaultRequestTimeout,
+    sensitiveResponse: false,
+  );
+
+  Future<ApiResponse<T>> _request<T>({
+    required HttpMethod method,
+    required String path,
+    // ignore: no_slop_linter/prefer_specific_type, JSON parsing callback requires dynamic payload
+    required T Function(Map<String, dynamic> json) fromJson,
+    required Map<String, String>? queryParameters,
+    // ignore: no_slop_linter/prefer_specific_type
+    required Object? body,
+    required Map<String, String>? extraHeaders,
+    required Duration timeout,
+    required bool sensitiveResponse,
   }) async {
     final relayClient = _connectionService.relayClient;
-    if (relayClient != null && relayClient.isConnected) {
-      return _mapAuthErrors(
-        await _sendViaRelay(
-          relayClient: relayClient,
-          method: HttpMethod.delete,
-          path: path,
-          fromJson: fromJson,
-          queryParameters: queryParameters,
-          body: body,
-          extraHeaders: headers,
-          timeout: _defaultRequestTimeout,
-          sensitiveResponse: false,
-        ),
-      );
+    if (relayClient == null || !relayClient.isConnected) {
+      return _relayDisconnectedResponse();
     }
-    return _relayDisconnectedResponse();
+    return _mapAuthErrors(
+      await _sendViaRelay(
+        relayClient: relayClient,
+        method: method,
+        path: path,
+        fromJson: fromJson,
+        queryParameters: queryParameters,
+        body: body,
+        extraHeaders: extraHeaders,
+        timeout: timeout,
+        sensitiveResponse: sensitiveResponse,
+      ),
+    );
   }
 
   ApiResponse<T> _mapAuthErrors<T>(ApiResponse<T> response) {
@@ -179,7 +165,7 @@ class RelayHttpApiClient(final ConnectionService _connectionService) {
     required Duration timeout,
     required bool sensitiveResponse,
   }) async {
-    final requestId = _nextRelayRequestId();
+    final requestId = _requestIdGenerator();
     final fullPath = Uri(path: path, queryParameters: queryParameters).toString();
     final bodyString = body == null
         ? null
@@ -255,13 +241,5 @@ class RelayHttpApiClient(final ConnectionService _connectionService) {
       return "Invalid JSON syntax or shape; offset=${offset?.toString() ?? 'unknown'}";
     }
     return "Response DTO conversion failed";
-  }
-
-  String _nextRelayRequestId() {
-    _requestCounter = (_requestCounter + 1) & 0xFFFF;
-    final timestamp = DateTime.now().microsecondsSinceEpoch.toRadixString(16);
-    final counter = _requestCounter.toRadixString(16).padLeft(4, "0");
-    final random = _requestIdRandom.nextInt(0x10000).toRadixString(16).padLeft(4, "0");
-    return "$timestamp-$counter$random";
   }
 }

--- a/client/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/client/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -800,9 +800,9 @@ class RelayClient._({
 
 /// Internal signal that the relay reported the bridge offline during the
 /// initial handshake (no bridge in the account group yet). Distinct from a
-/// fatal connection error so [RelayClient.connect] resolves into
-/// [RelayClient.connect] returning with [RelayClient.isConnected] false and
-/// keeps the socket open instead of tearing it down.
+/// fatal connection error so [RelayClient.connect] returns with
+/// [RelayClient.isConnected] false and keeps the socket open instead of
+/// tearing it down.
 class const _BridgeOfflineDuringHandshake() implements Exception;
 
 /// A request frame was sent (or may have been sent) but its response can no

--- a/client/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/client/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -447,30 +447,24 @@ class RelayClient._({
   /// Declares to the bridge which session this phone is currently viewing
   /// ([sessionId] == null when viewing nothing). Fire-and-forget control
   /// message; no-op when not connected.
-  Future<void> sendSessionView({required String? sessionId}) async {
-    if (!isConnected || _sessionEncryptor == null) {
-      return;
-    }
-    try {
-      await _sendEncryptedMessage(RelayMessage.sessionView(sessionId: sessionId));
-    } catch (error, stackTrace) {
-      // Best-effort control message: a disconnect can race the connected check
-      // above. Swallow so callers' fire-and-forget `unawaited` paths never see
-      // an unhandled async error; the phone re-asserts its view on reconnect.
-      logw("sendSessionView failed (likely a disconnect race)", error, stackTrace);
-    }
-  }
+  Future<void> sendSessionView({required String? sessionId}) => _sendViewMessage(
+    message: RelayMessage.sessionView(sessionId: sessionId),
+    operation: "sendSessionView",
+  );
 
   /// Declares to the bridge which project this client is currently viewing.
   /// Best-effort control message; no-op when not connected.
-  Future<void> sendProjectView({required String? projectId}) async {
-    if (!isConnected || _sessionEncryptor == null) {
-      return;
-    }
+  Future<void> sendProjectView({required String? projectId}) => _sendViewMessage(
+    message: RelayMessage.projectView(projectId: projectId),
+    operation: "sendProjectView",
+  );
+
+  Future<void> _sendViewMessage({required RelayMessage message, required String operation}) async {
+    if (!isConnected || _sessionEncryptor == null) return;
     try {
-      await _sendEncryptedMessage(RelayMessage.projectView(projectId: projectId));
+      await _sendEncryptedMessage(message);
     } on Object catch (error, stackTrace) {
-      logw("sendProjectView failed: disconnect race", error, stackTrace);
+      logw("$operation failed: disconnect race", error, stackTrace);
     }
   }
 
@@ -619,16 +613,10 @@ class RelayClient._({
         maxPlaintextBytes: _maxPlaintextMessageBytes,
       );
     }
-    final encryptedBytes = await encryptor.encrypt(jsonBytes);
+    final payload = await frame(jsonBytes, encryptor: encryptor);
     if (_disposed || !identical(_channel, channel) || !identical(_sessionEncryptor, encryptor)) {
       throw StateError("RelayClient disconnected during message encryption");
     }
-    // Preallocate instead of spreading the ciphertext into a boxed List<int>:
-    // a max-size attachment would otherwise materialize tens of millions of
-    // boxed integers and exhaust mobile memory before the frame is sent.
-    final payload = Uint8List(encryptedBytes.length + 1);
-    payload[0] = _messageVersion;
-    payload.setRange(1, payload.length, encryptedBytes);
     return (channel: channel, encryptor: encryptor, payload: payload);
   }
 
@@ -669,10 +657,7 @@ class RelayClient._({
     }
 
     final jsonBytes = utf8.encode(jsonEncode(message.toJson()));
-    final encryptedBytes = await encryptor.encrypt(jsonBytes);
-    final payload = Uint8List(encryptedBytes.length + 1);
-    payload[0] = _messageVersion;
-    payload.setRange(1, payload.length, encryptedBytes);
+    final payload = await frame(jsonBytes, encryptor: encryptor);
     _pendingHandshakeFrame = payload;
     channel.sink.add(payload);
   }
@@ -683,14 +668,7 @@ class RelayClient._({
       throw const FormatException("Relay message is empty");
     }
 
-    final version = message.first;
-    if (version != _messageVersion) {
-      throw FormatException("Unsupported relay message version: $version");
-    }
-
-    final encryptedPayload = message.sublist(1);
-    final decryptedBytes = await encryptor.decrypt(encryptedPayload);
-
+    final decryptedBytes = await unframe(message, encryptor: encryptor);
     final decoded = jsonDecodeMap(utf8.decode(decryptedBytes));
     return RelayMessage.fromJson(decoded);
   }
@@ -742,28 +720,21 @@ class RelayClient._({
       return;
     }
 
+    await _closeController(controller: controller, context: "relay SSE stream");
+  }
+
+  Future<void> _closeBridgeStatusController() =>
+      _closeController(controller: _bridgeStatusController, context: "relay bridge status");
+
+  Future<void> _closeSocketClosedController() =>
+      _closeController(controller: _socketClosedController, context: "relay socket-closed");
+
+  Future<void> _closeController<T>({required StreamController<T> controller, required String context}) async {
+    if (controller.isClosed) return;
     try {
       await controller.close();
     } catch (error, stackTrace) {
-      loge("Failed to close relay SSE stream controller", error, stackTrace);
-    }
-  }
-
-  Future<void> _closeBridgeStatusController() async {
-    if (_bridgeStatusController.isClosed) return;
-    try {
-      await _bridgeStatusController.close();
-    } catch (error, stackTrace) {
-      loge("Failed to close relay bridge status controller", error, stackTrace);
-    }
-  }
-
-  Future<void> _closeSocketClosedController() async {
-    if (_socketClosedController.isClosed) return;
-    try {
-      await _socketClosedController.close();
-    } catch (error, stackTrace) {
-      loge("Failed to close relay socket-closed controller", error, stackTrace);
+      loge("Failed to close $context controller", error, stackTrace);
     }
   }
 
@@ -830,8 +801,8 @@ class RelayClient._({
 /// Internal signal that the relay reported the bridge offline during the
 /// initial handshake (no bridge in the account group yet). Distinct from a
 /// fatal connection error so [RelayClient.connect] resolves into
-/// [RelayConnectOutcome.bridgeAbsent] and keeps the socket open instead of
-/// tearing it down.
+/// [RelayClient.connect] returning with [RelayClient.isConnected] false and
+/// keeps the socket open instead of tearing it down.
 class const _BridgeOfflineDuringHandshake() implements Exception;
 
 /// A request frame was sent (or may have been sent) but its response can no

--- a/client/module_core/lib/src/capabilities/relay/relay_request_id_generator.dart
+++ b/client/module_core/lib/src/capabilities/relay/relay_request_id_generator.dart
@@ -1,0 +1,14 @@
+import "dart:math";
+
+final class RelayRequestIdGenerator() {
+  final Random _random = Random();
+  int _counter = 0;
+
+  String call() {
+    _counter = (_counter + 1) & 0xFFFF;
+    final timestamp = DateTime.now().microsecondsSinceEpoch.toRadixString(16);
+    final counter = _counter.toRadixString(16).padLeft(4, "0");
+    final random = _random.nextInt(0x10000).toRadixString(16).padLeft(4, "0");
+    return "$timestamp-$counter$random";
+  }
+}

--- a/client/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/client/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -13,18 +13,17 @@ import "../../logging/logging.dart";
 import "../../platform/lifecycle_source.dart";
 import "../relay/relay_client.dart";
 import "../relay/relay_config.dart";
+import "../relay/relay_request_id_generator.dart";
 import "../relay/room_key_storage.dart";
 import "api_paths.dart";
 import "models/connection_status.dart";
 import "models/sse_event.dart";
 import "server_connection_config.dart";
 
-@lazySingleton
 class const ClockProvider() {
   DateTime call() => DateTime.now();
 }
 
-@lazySingleton
 class const RelayClientFactory() {
   RelayClient call({
     required String relayHost,
@@ -47,8 +46,8 @@ class ConnectionService(
   final AuthSession _authSession,
   final LifecycleSource _lifecycleSource,
   final FailureReporter _failureReporter, {
-  @visibleForTesting final ClockProvider _clock = const ClockProvider(),
-  @visibleForTesting final RelayClientFactory _relayClientFactory = const RelayClientFactory(),
+  @ignoreParam @visibleForTesting final ClockProvider _clock = const ClockProvider(),
+  @ignoreParam @visibleForTesting final RelayClientFactory _relayClientFactory = const RelayClientFactory(),
 }) {
   final BehaviorSubject<ConnectionStatus> _status = BehaviorSubject.seeded(const ConnectionStatus.disconnected());
   final StreamController<SseEvent> _events = StreamController<SseEvent>.broadcast();
@@ -65,8 +64,7 @@ class ConnectionService(
   Completer<void>? _reconnectDelayCompleter;
   Future<bool>? _activeAuthConnect;
   Future<void>? _activeDisconnect;
-  int _requestCounter = 0;
-  final Random _requestIdRandom = Random();
+  final RelayRequestIdGenerator _requestIdGenerator = RelayRequestIdGenerator();
   int _authRetryCount = 0;
   Duration _relayReconnectBackoff = const Duration(seconds: 1);
   // Last health metadata fetched on a fresh-DH connect. Resumed reconnects skip
@@ -167,10 +165,7 @@ class ConnectionService(
     _isInBackground = true;
     _backgroundedAt = _clock();
     logd("App backgrounded — pausing reconnect attempts");
-    _reconnectTimer?.cancel();
-    if (_reconnectDelayCompleter case final completer? when !completer.isCompleted) {
-      completer.complete();
-    }
+    _cancelReconnectDelay();
   }
 
   /// Push-based connection status stream.
@@ -327,7 +322,7 @@ class ConnectionService(
       } else {
         final response = await relayClient.sendRequest(
           request: RelayRequest(
-            id: _nextRelayRequestId(),
+            id: _requestIdGenerator(),
             method: "GET",
             path: ApiPaths.health,
             headers: {},
@@ -427,12 +422,23 @@ class ConnectionService(
 
   /// Manually disconnect. Clears config, closes SSE, cancels timers.
   void disconnect() {
-    _reconnectTimer?.cancel();
-    if (_reconnectDelayCompleter case final completer? when !completer.isCompleted) {
-      completer.complete();
-    }
+    _cancelReconnectDelay();
     unawaited(_disconnectRelayClient());
     _status.add(const ConnectionStatus.disconnected());
+  }
+
+  Future<void> reconnectAndAwaitOutcome({required Duration timeout}) async {
+    if (_status.value is ConnectionConnected) return;
+    if (_status.value is! ConnectionReconnecting) {
+      reconnect();
+    }
+    if (_status.value is! ConnectionReconnecting) return;
+
+    try {
+      await status.where((status) => status is! ConnectionReconnecting).first.timeout(timeout);
+    } on TimeoutException catch (error, stackTrace) {
+      logw("Timed out waiting for relay reconnect outcome", error, stackTrace);
+    }
   }
 
   /// Manually trigger reconnect attempt (e.g. from the overlay).
@@ -440,10 +446,7 @@ class ConnectionService(
     final config = activeConfig;
     if (config == null) return;
 
-    _reconnectTimer?.cancel();
-    if (_reconnectDelayCompleter case final completer? when !completer.isCompleted) {
-      completer.complete();
-    }
+    _cancelReconnectDelay();
     _relayReconnectBackoff = const Duration(seconds: 1);
     _status.add(ConnectionStatus.reconnecting(config: config));
     unawaited(_reconnectRelayWithRefresh(config, immediate: true));
@@ -878,12 +881,11 @@ class ConnectionService(
     }
   }
 
-  String _nextRelayRequestId() {
-    _requestCounter = (_requestCounter + 1) & 0xFFFF;
-    final timestamp = DateTime.now().microsecondsSinceEpoch.toRadixString(16);
-    final counter = _requestCounter.toRadixString(16).padLeft(4, "0");
-    final random = _requestIdRandom.nextInt(0x10000).toRadixString(16).padLeft(4, "0");
-    return "$timestamp-$counter$random";
+  void _cancelReconnectDelay() {
+    _reconnectTimer?.cancel();
+    if (_reconnectDelayCompleter case final completer? when !completer.isCompleted) {
+      completer.complete();
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -891,10 +893,7 @@ class ConnectionService(
   // ---------------------------------------------------------------------------
 
   void dispose() {
-    _reconnectTimer?.cancel();
-    if (_reconnectDelayCompleter case final completer? when !completer.isCompleted) {
-      completer.complete();
-    }
+    _cancelReconnectDelay();
     _status.add(const ConnectionStatus.disconnected());
     unawaited(_disconnectRelayClient());
     _compositeSubscription.dispose();

--- a/client/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/client/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -427,6 +427,10 @@ class ConnectionService(
     _status.add(const ConnectionStatus.disconnected());
   }
 
+  /// Triggers [reconnect] when not already connected or reconnecting, then
+  /// waits until the status settles (connected, lost, bridge offline) or
+  /// [timeout] elapses. A timeout is logged and absorbed so callers can fall
+  /// through to their own fetch, which fails with a user-visible error.
   Future<void> reconnectAndAwaitOutcome({required Duration timeout}) async {
     if (_status.value is ConnectionConnected) return;
     if (_status.value is! ConnectionReconnecting) {

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -214,33 +214,17 @@ class ProjectListCubit(
   void _onSessionActivityUpdated(Map<String, Map<String, SessionActivityInfo>> activityByProjectId) {
     if (isClosed) return;
     if (state case final ProjectListLoaded loaded) {
-      final ordered = _projectListService.orderProjects(
-        projects: loaded.projects,
-        activityByProjectId: activityByProjectId,
-        listStateByProjectId: _sessionUnseenTracker.currentSessionUnseen,
-      );
-      emit(
-        loaded.copyWith(
-          projects: ordered,
-          unseenByProjectId: _unseenByProjectId(ordered),
-        ),
-      );
+      _emitOrdered(loaded: loaded, projects: loaded.projects, activityByProjectId: activityByProjectId);
     }
   }
 
   void _onSessionListStateUpdated() {
     if (isClosed) return;
     if (state case final ProjectListLoaded loaded) {
-      final ordered = _projectListService.orderProjects(
+      _emitOrdered(
+        loaded: loaded,
         projects: loaded.projects,
         activityByProjectId: _sseEventTracker.currentSessionActivity,
-        listStateByProjectId: _sessionUnseenTracker.currentSessionUnseen,
-      );
-      emit(
-        loaded.copyWith(
-          projects: ordered,
-          unseenByProjectId: _unseenByProjectId(ordered),
-        ),
       );
     }
   }
@@ -255,17 +239,10 @@ class ProjectListCubit(
         );
         if (!merged.changed) return;
 
-        final ordered = _projectListService.orderProjects(
+        _emitOrdered(
+          loaded: loaded,
           projects: merged.projects,
           activityByProjectId: _sseEventTracker.currentSessionActivity,
-          listStateByProjectId: _sessionUnseenTracker.currentSessionUnseen,
-        );
-
-        emit(
-          loaded.copyWith(
-            projects: ordered,
-            unseenByProjectId: _unseenByProjectId(ordered),
-          ),
         );
       }
     } catch (e, st) {
@@ -439,31 +416,9 @@ class ProjectListCubit(
     // when the relay is disconnected).
     await Future<void>.delayed(Duration.zero);
     if (isClosed) return;
-    await _reconnectIfNeeded();
+    await _connectionService.reconnectAndAwaitOutcome(timeout: const Duration(seconds: 15));
     if (isClosed) return;
     await _fetchProjects();
-  }
-
-  /// Attempts to reconnect the relay when it is not in the
-  /// [ConnectionConnected] state. Returns once the connection resolves
-  /// (connected, lost, or timed out).
-  Future<void> _reconnectIfNeeded() async {
-    if (_connectionService.currentStatus is ConnectionConnected) return;
-
-    if (_connectionService.currentStatus is! ConnectionReconnecting) {
-      _connectionService.reconnect();
-    }
-    // If reconnect is now in progress, wait for the outcome.
-    if (_connectionService.currentStatus is! ConnectionReconnecting) return;
-
-    try {
-      await _connectionService.status
-          .where((s) => s is! ConnectionReconnecting)
-          .first
-          .timeout(const Duration(seconds: 15));
-    } on TimeoutException catch (_) {
-      // Fall through — fetch will fail gracefully with a user-visible error.
-    }
   }
 
   /// True while [reconnectBridge] is re-establishing the connection. The
@@ -504,7 +459,7 @@ class ProjectListCubit(
         await _connectionService.connectWithFreshAuthToken();
       } else {
         // An existing config dropped (e.g. bridge offline) — reconnect it.
-        await _reconnectIfNeeded();
+        await _connectionService.reconnectAndAwaitOutcome(timeout: const Duration(seconds: 15));
       }
       if (isClosed) return;
       if (_isBridgeUnavailable) {
@@ -538,22 +493,34 @@ class ProjectListCubit(
       return false;
     }
     if (state case final ProjectListLoaded loaded) {
-      final remaining = _projectListService.orderProjects(
+      _emitOrdered(
+        loaded: loaded,
         projects: _projectListService.removeProject(
           projects: loaded.projects,
           projectId: projectId,
         ),
         activityByProjectId: _sseEventTracker.currentSessionActivity,
-        listStateByProjectId: _sessionUnseenTracker.currentSessionUnseen,
-      );
-      emit(
-        loaded.copyWith(
-          projects: remaining,
-          unseenByProjectId: _unseenByProjectId(remaining),
-        ),
       );
     }
     return true;
+  }
+
+  void _emitOrdered({
+    required ProjectListLoaded loaded,
+    required List<ProjectSummary> projects,
+    required Map<String, Map<String, SessionActivityInfo>> activityByProjectId,
+  }) {
+    final ordered = _projectListService.orderProjects(
+      projects: projects,
+      activityByProjectId: activityByProjectId,
+      listStateByProjectId: _sessionUnseenTracker.currentSessionUnseen,
+    );
+    emit(
+      loaded.copyWith(
+        projects: ordered,
+        unseenByProjectId: _unseenByProjectId(ordered),
+      ),
+    );
   }
 
   /// Creates a new project named [name] below [parentPath].

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -521,30 +521,9 @@ class SessionListCubit({
     emit(const SessionListState.loading());
     await Future<void>.delayed(Duration.zero);
     if (isClosed) return;
-    await _reconnectIfNeeded();
+    await _connectionService.reconnectAndAwaitOutcome(timeout: const Duration(seconds: 15));
     if (isClosed) return;
     await _fetchSessions();
-  }
-
-  /// Attempts to reconnect the relay when it is not in the
-  /// [ConnectionConnected] state. Returns once the connection resolves
-  /// (connected, lost, or timed out).
-  Future<void> _reconnectIfNeeded() async {
-    if (_connectionService.currentStatus is ConnectionConnected) return;
-
-    if (_connectionService.currentStatus is! ConnectionReconnecting) {
-      _connectionService.reconnect();
-    }
-    if (_connectionService.currentStatus is! ConnectionReconnecting) return;
-
-    try {
-      await _connectionService.status
-          .where((s) => s is! ConnectionReconnecting)
-          .first
-          .timeout(const Duration(seconds: 15));
-    } on TimeoutException catch (_) {
-      // Fall through — fetch will fail gracefully with a user-visible error.
-    }
   }
 
   /// In-flight silent refresh, used for coalescing.

--- a/client/module_core/lib/src/di/injection.config.dart
+++ b/client/module_core/lib/src/di/injection.config.dart
@@ -150,10 +150,6 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i64.ComposerDraftStorage>(
       () => _i64.ComposerDraftStorage(),
     );
-    gh.lazySingleton<_i369.ClockProvider>(() => const _i369.ClockProvider());
-    gh.lazySingleton<_i369.RelayClientFactory>(
-      () => const _i369.RelayClientFactory(),
-    );
     gh.lazySingleton<_i913.NewSessionSelectionTracker>(
       () => _i913.NewSessionSelectionTracker(),
     );
@@ -241,6 +237,16 @@ extension GetItInjectableX on _i174.GetIt {
       ),
       dispose: (i) => i.dispose(),
     );
+    gh.lazySingleton<_i369.ConnectionService>(
+      () => _i369.ConnectionService(
+        gh<_i553.RelayCryptoService>(),
+        gh<_i896.RoomKeyStorage>(),
+        gh<_i442.AuthTokenProvider>(),
+        gh<_i442.AuthSession>(),
+        gh<_i903.LifecycleSource>(),
+        gh<_i553.FailureReporter>(),
+      ),
+    );
     gh.lazySingleton<_i933.LegalRepository>(
       () => _i933.LegalRepository(api: gh<_i835.LegalApi>()),
     );
@@ -259,6 +265,11 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i804.ProductAnalyticsPreferenceRepository(
         api: gh<_i560.ProductAnalyticsPreferenceApi>(),
         storage: gh<_i197.ProductAnalyticsPreferenceStorage>(),
+      ),
+    );
+    gh.lazySingleton<_i37.ViewDeclarationApi>(
+      () => _i37.ViewDeclarationApi(
+        connectionService: gh<_i369.ConnectionService>(),
       ),
     );
     gh.lazySingleton<_i555.ProductAnalyticsPreferenceService>(
@@ -304,17 +315,14 @@ extension GetItInjectableX on _i174.GetIt {
       ),
       dispose: (i) => i.dispose(),
     );
-    gh.lazySingleton<_i369.ConnectionService>(
-      () => _i369.ConnectionService(
-        gh<_i553.RelayCryptoService>(),
-        gh<_i896.RoomKeyStorage>(),
-        gh<_i442.AuthTokenProvider>(),
-        gh<_i442.AuthSession>(),
-        gh<_i903.LifecycleSource>(),
-        gh<_i553.FailureReporter>(),
-        clock: gh<_i369.ClockProvider>(),
-        relayClientFactory: gh<_i369.RelayClientFactory>(),
+    gh.lazySingleton<_i28.SessionUnseenTracker>(
+      () => _i28.SessionUnseenTracker(
+        gh<_i369.ConnectionService>(),
+        failureReporter: gh<_i553.FailureReporter>(),
       ),
+    );
+    gh.lazySingleton<_i857.RelayHttpApiClient>(
+      () => _i857.RelayHttpApiClient(gh<_i369.ConnectionService>()),
     );
     gh.lazySingleton<_i204.ProductAnalyticsService>(
       () => _i204.ProductAnalyticsService(
@@ -322,6 +330,27 @@ extension GetItInjectableX on _i174.GetIt {
         preferenceService: gh<_i555.ProductAnalyticsPreferenceService>(),
       ),
       dispose: (i) => i.dispose(),
+    );
+    gh.lazySingleton<_i415.BridgeSettingsApi>(
+      () => _i415.BridgeSettingsApi(client: gh<_i857.RelayHttpApiClient>()),
+    );
+    gh.lazySingleton<_i1068.FilesystemApi>(
+      () => _i1068.FilesystemApi(client: gh<_i857.RelayHttpApiClient>()),
+    );
+    gh.lazySingleton<_i231.PermissionApi>(
+      () => _i231.PermissionApi(client: gh<_i857.RelayHttpApiClient>()),
+    );
+    gh.lazySingleton<_i546.PluginApi>(
+      () => _i546.PluginApi(client: gh<_i857.RelayHttpApiClient>()),
+    );
+    gh.lazySingleton<_i733.ProjectApi>(
+      () => _i733.ProjectApi(client: gh<_i857.RelayHttpApiClient>()),
+    );
+    gh.lazySingleton<_i603.SessionApi>(
+      () => _i603.SessionApi(client: gh<_i857.RelayHttpApiClient>()),
+    );
+    gh.lazySingleton<_i143.ViewDeclarationRepository>(
+      () => _i143.ViewDeclarationRepository(api: gh<_i37.ViewDeclarationApi>()),
     );
     gh.lazySingleton<_i508.SseEventTracker>(
       () => _i508.SseEventTracker(
@@ -344,41 +373,6 @@ extension GetItInjectableX on _i174.GetIt {
         analyticsService: gh<_i204.ProductAnalyticsService>(),
       ),
       dispose: (i) => i.dispose(),
-    );
-    gh.lazySingleton<_i37.ViewDeclarationApi>(
-      () => _i37.ViewDeclarationApi(
-        connectionService: gh<_i369.ConnectionService>(),
-      ),
-    );
-    gh.lazySingleton<_i28.SessionUnseenTracker>(
-      () => _i28.SessionUnseenTracker(
-        gh<_i369.ConnectionService>(),
-        failureReporter: gh<_i553.FailureReporter>(),
-      ),
-    );
-    gh.lazySingleton<_i857.RelayHttpApiClient>(
-      () => _i857.RelayHttpApiClient(gh<_i369.ConnectionService>()),
-    );
-    gh.lazySingleton<_i415.BridgeSettingsApi>(
-      () => _i415.BridgeSettingsApi(client: gh<_i857.RelayHttpApiClient>()),
-    );
-    gh.lazySingleton<_i1068.FilesystemApi>(
-      () => _i1068.FilesystemApi(client: gh<_i857.RelayHttpApiClient>()),
-    );
-    gh.lazySingleton<_i231.PermissionApi>(
-      () => _i231.PermissionApi(client: gh<_i857.RelayHttpApiClient>()),
-    );
-    gh.lazySingleton<_i546.PluginApi>(
-      () => _i546.PluginApi(client: gh<_i857.RelayHttpApiClient>()),
-    );
-    gh.lazySingleton<_i733.ProjectApi>(
-      () => _i733.ProjectApi(client: gh<_i857.RelayHttpApiClient>()),
-    );
-    gh.lazySingleton<_i603.SessionApi>(
-      () => _i603.SessionApi(client: gh<_i857.RelayHttpApiClient>()),
-    );
-    gh.lazySingleton<_i143.ViewDeclarationRepository>(
-      () => _i143.ViewDeclarationRepository(api: gh<_i37.ViewDeclarationApi>()),
     );
     gh.lazySingleton<_i7.SessionRepository>(
       () => _i7.SessionRepository(api: gh<_i603.SessionApi>()),

--- a/client/module_core/test/capabilities/relay/relay_request_id_generator_test.dart
+++ b/client/module_core/test/capabilities/relay/relay_request_id_generator_test.dart
@@ -1,0 +1,13 @@
+import "package:sesori_dart_core/src/capabilities/relay/relay_request_id_generator.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("generates independent timestamp-counter-random request IDs", () {
+    final first = RelayRequestIdGenerator();
+    final second = RelayRequestIdGenerator();
+
+    expect(first(), matches(RegExp(r"^[0-9a-f]+-0001[0-9a-f]{4}$")));
+    expect(first(), matches(RegExp(r"^[0-9a-f]+-0002[0-9a-f]{4}$")));
+    expect(second(), matches(RegExp(r"^[0-9a-f]+-0001[0-9a-f]{4}$")));
+  });
+}

--- a/client/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
+++ b/client/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
@@ -12,6 +12,7 @@ import "package:sesori_dart_core/src/capabilities/server_connection/server_conne
 import "package:sesori_dart_core/src/platform/lifecycle_source.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
+
 import "../../helpers/test_helpers.dart";
 
 class MockRelayCryptoService() extends Mock implements RelayCryptoService;
@@ -108,6 +109,64 @@ void main() {
     tearDown(() async {
       await lifecycleController.close();
       await authStateController.close();
+    });
+
+    test("reconnectAndAwaitOutcome returns immediately when connected", () async {
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+      );
+      addTearDown(service.dispose);
+      service.emitStatusForTesting(
+        const ConnectionStatus.connected(
+          config: config,
+          health: health,
+        ),
+      );
+
+      await service.reconnectAndAwaitOutcome(timeout: const Duration(milliseconds: 10));
+
+      expect(service.currentStatus, isA<ConnectionConnected>());
+    });
+
+    test("reconnectAndAwaitOutcome waits for first resolved status", () async {
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+      );
+      addTearDown(service.dispose);
+      service.emitStatusForTesting(const ConnectionStatus.reconnecting(config: config));
+
+      final waiting = service.reconnectAndAwaitOutcome(timeout: const Duration(seconds: 1));
+      await Future<void>.delayed(Duration.zero);
+      service.emitStatusForTesting(const ConnectionStatus.connectionLost(config: config));
+
+      await waiting;
+    });
+
+    test("reconnectAndAwaitOutcome absorbs timeout", () async {
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+      );
+      addTearDown(service.dispose);
+      service.emitStatusForTesting(const ConnectionStatus.reconnecting(config: config));
+
+      await service.reconnectAndAwaitOutcome(timeout: const Duration(milliseconds: 1));
+
+      expect(service.currentStatus, isA<ConnectionReconnecting>());
     });
 
     test("disconnect during token refresh prevents reconnect", () async {

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -93,6 +93,9 @@ void main() {
       // Must be stubbed before any cubit is built — constructor subscribes immediately.
       when(() => mockConnectionService.status).thenAnswer((_) => statusController.stream);
       when(() => mockConnectionService.currentStatus).thenAnswer((_) => statusController.value);
+      when(
+        () => mockConnectionService.reconnectAndAwaitOutcome(timeout: any(named: "timeout")),
+      ).thenAnswer((_) async {});
       when(() => mockConnectionService.connectWithFreshAuthToken()).thenAnswer((_) async => true);
       // Default: a fresh account with no registered bridge (setup onboarding).
       when(() => mockRegisteredBridgesService.hasRegisteredBridges()).thenAnswer((_) async => false);
@@ -2196,24 +2199,12 @@ void main() {
         when(() => mockProjectRepository.listProjects()).thenAnswer(
           (_) async => ApiResponse.success(Projects(data: [testProjectSummary()])),
         );
-        const config = ServerConnectionConfig(
-          relayHost: "relay.example.com",
-          authToken: "test-token",
-        );
-        when(() => mockConnectionService.reconnect()).thenAnswer((_) {
-          when(() => mockConnectionService.currentStatus).thenReturn(
-            const ConnectionStatus.reconnecting(config: config),
-          );
-          statusController.add(const ConnectionStatus.reconnecting(config: config));
-        });
-        final retryFuture = cubit.retryLoadProjects();
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        const health = HealthResponse(healthy: true, version: "0.1.200", filesystemAccessDegraded: null);
-        statusController.add(
-          const ConnectionStatus.connected(config: config, health: health),
-        );
-        await retryFuture;
+        when(
+          () => mockConnectionService.reconnectAndAwaitOutcome(
+            timeout: any(named: "timeout"),
+          ),
+        ).thenAnswer((_) async {});
+        await cubit.retryLoadProjects();
       },
       skip: 1,
       expect: () => [
@@ -2225,7 +2216,11 @@ void main() {
         ),
       ],
       verify: (_) {
-        verify(() => mockConnectionService.reconnect()).called(1);
+        verify(
+          () => mockConnectionService.reconnectAndAwaitOutcome(
+            timeout: const Duration(seconds: 15),
+          ),
+        ).called(1);
       },
     );
 
@@ -2262,7 +2257,11 @@ void main() {
         ),
       ],
       verify: (_) {
-        verifyNever(() => mockConnectionService.reconnect());
+        verify(
+          () => mockConnectionService.reconnectAndAwaitOutcome(
+            timeout: const Duration(seconds: 15),
+          ),
+        ).called(1);
       },
     );
 

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -1123,6 +1123,46 @@ void main() {
     );
 
     blocTest<SessionListCubit, SessionListState>(
+      "retryLoadSessions reconnects before loading",
+      build: () {
+        when(
+          () => mockProjectRepository.listSessions(
+            projectId: projectId,
+            waitForPrData: any(named: "waitForPrData"),
+          ),
+        ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
+        when(
+          () => mockConnectionService.reconnectAndAwaitOutcome(
+            timeout: any(named: "timeout"),
+          ),
+        ).thenAnswer((_) async {});
+        return buildCubit();
+      },
+      act: (cubit) async {
+        await Future<void>.delayed(Duration.zero);
+        when(
+          () => mockProjectRepository.listSessions(
+            projectId: projectId,
+            waitForPrData: any(named: "waitForPrData"),
+          ),
+        ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [testSession(id: "s1")])));
+        await cubit.retryLoadSessions();
+      },
+      skip: 1,
+      expect: () => [
+        isA<SessionListLoading>(),
+        isA<SessionListLoaded>().having((state) => state.sessions.length, "sessions count after retry", 1),
+      ],
+      verify: (_) {
+        verify(
+          () => mockConnectionService.reconnectAndAwaitOutcome(
+            timeout: const Duration(seconds: 15),
+          ),
+        ).called(1);
+      },
+    );
+
+    blocTest<SessionListCubit, SessionListState>(
       "connection reconnect triggers silent refresh",
       build: () {
         when(


### PR DESCRIPTION
## Complexity

🚧 Complex. This is a mechanical consolidation across list-cubit retry orchestration, relay HTTP dispatch, reconnect lifecycle ownership, generated DI, and encrypted framing paths.

## What

- Move duplicated list-cubit reconnect waiting into `ConnectionService` and consolidate repeated project ordering emissions.
- Route RelayHttpApiClient verbs through one private request path while retaining their public contracts.
- Share request-ID generation with one generator instance per owning relay component.
- Consolidate exact reconnect-delay cleanup, view sends, controller closes, and relay frame/unframe mechanics.
- Remove unnecessary DI registrations for constructor-default test seams and regenerate Injectable output.
- Correct stale relay handshake documentation.

## Why

These paths repeated the same mechanics in multiple owners, increasing drift risk around timeout observability, HTTP option forwarding, request IDs, and encrypted framing. The consolidation keeps typed state and lifecycle differences local where they are not actually equivalent.

## Risk and test focus

Review risk is concentrated in HTTP body/query/header/timeout forwarding, sensitive-response redaction, reconnect completion timing, per-owner request-ID counters, plaintext size and disconnect race checks, and exact encrypted handshake replay bytes. There is no user-visible or database impact, and no wire or persisted contract changes.

## Expected result

Project and session retry behavior, relay requests, reconnect outcomes, list ordering, and encrypted transport remain unchanged while exact duplicate implementations are removed and reconnect timeouts become locally observable.

## Verification

- `client/module_core`: build_runner completed and regenerated DI.
- `client/module_core`: analyzer passed.
- `client/module_core`: 245 focused cubit, capability, and relay HTTP tests passed.
- `shared/sesori_shared`: 5 framing tests and analyzer passed.
- `client/app`: 77 capability/API tests and 87 session-list tests passed; analyzer passed.
- `client/module_desktop_core` and `client/desktop`: analyzers passed.
- Architecture implementation review: approved with no findings.
- Focused correctness review: no plausible regressions.
- `git diff --check`: passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates duplicated reconnect and relay plumbing across list cubits and clients. Previously each owner reimplemented reconnect waits, request‑ID generation, HTTP dispatch, framing, and controller closing; now these are centralized in `ConnectionService`, `RelayHttpApiClient`, and `RelayClient` without changing public contracts. List cubits can now observe reconnect timeouts locally.

- List cubits call `ConnectionService.reconnectAndAwaitOutcome(timeout: 15s)` before reload; removed local reconnect helpers and deduplicated project ordering via `_emitOrdered`.
- `RelayHttpApiClient` routes all verbs through a single `_request`, preserving body/query/header/timeout/sensitivity behavior; adds per‑owner `RelayRequestIdGenerator`; auth error mapping unchanged.
- `RelayClient` reuses shared `frame`/`unframe`, consolidates best‑effort view sends and controller closing with consistent logging; preserves plaintext‑size checks and handshake replay; handshake docs corrected.
- `ConnectionService` consolidates reconnect‑delay cancellation, shares request‑ID generation, and exposes `reconnectAndAwaitOutcome` for local timeout observability.
- DI cleanup removes unnecessary defaults for `ClockProvider` and `RelayClientFactory`; regenerated injection. Updated app nav bar test to stub `reconnectAndAwaitOutcome`. Added step evidence documenting the CI follow‑up.

**Behavior and risks**

- No wire, API, or database contract changes; list ordering, request IDs, reconnect outcomes, and encrypted payloads unchanged.
- Review focus: HTTP option and sensitive‑response forwarding, reconnect completion timing, per‑owner request‑ID counters, and exact encrypted handshake/frame bytes. No migration actions required.

<sup>Written for commit bb8e5a22350bab524497a8e321c26b5546a05470. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

