### PR TITLE
🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]

### DIFF
--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -791,7 +791,7 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
   harness in a fan-out answers `404`; and let a recovery-seeded rescan resolve
   to `CatalogRescanIdle` rather than to a terminal summary.
 - Leave `sse_event.dart` and `sse_event_tracker.dart` untouched.
-- Tests: aggregation across two concurrent harnesses; all five states including
+- Tests: aggregation across two concurrent harnesses; all seven states including
   a mixed success/failure fan-out; the older-bridge payload with `newItems`
   omitted; a two-harness success summing both deltas rather than reporting one;
   a two-harness success where one omitted `newItems` falling back to summed
@@ -866,7 +866,7 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
   per plugin id by `PluginManagementCubit` and rendered on that card, so a
   targeted `503`, `404`, or unsupported-bridge answer lands on the harness the
   user selected instead of the shared row.
-- New `app_en.arb` resources for both captions, the five row states, the delta
+- New `app_en.arb` resources for both captions, the seven row states, the delta
   and totals wordings, the `Nothing new` case, the partly-failed wording, the
   bounded failure line naming the bridge log, and the Settings action with its
   semantics label and its rejection message.

--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -262,6 +262,15 @@ The success summary is worded from the counts carrier:
 - totals only, which is what an older bridge sends:
   `43 projects, 193 sessions`.
 
+Across an N-harness fan-out the counts are **summed**, not taken from whichever
+harness finished last. The carrier is `CatalogRescanDelta` only when every
+succeeded harness reported `newItems`; if any one omitted it, the whole row
+falls back to `CatalogRescanTotals` summed the same way, because a delta missing
+one harness's contribution would understate the result and read as authoritative.
+Every harness in a fan-out answers from the same bridge, so in practice the
+mixed case arises only if a bridge reports inconsistently; the rule exists so
+that case degrades honestly rather than silently.
+
 Cancel issues one `DELETE /plugin/import` per harness still running.
 
 ### Non-gesture twin on Settings to Harnesses
@@ -731,7 +740,9 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
 - Leave `sse_event.dart` and `sse_event_tracker.dart` untouched.
 - Tests: aggregation across two concurrent harnesses; all five states including
   a mixed success/failure fan-out; the older-bridge payload with `newItems`
-  omitted; a reconnect whose `GET` holds only terminal statuses producing no
+  omitted; a two-harness success summing both deltas rather than reporting one;
+  a two-harness success where one omitted `newItems` falling back to summed
+  totals; a reconnect whose `GET` holds only terminal statuses producing no
   row; a reconnect whose `GET` holds an in-flight status producing a running
   row; a disconnect clearing an active rescan; a fan-out where one harness
   answers `503`; cancel issuing one `DELETE` per running harness; a **second

--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -417,7 +417,7 @@ sealed CatalogRescanStartResult          // returned by start(pluginId)
   CatalogRescanStartAccepted()
   CatalogRescanStartNotImportable()
   CatalogRescanStartUnsupported()
-  CatalogRescanStartFailed()
+  CatalogRescanStartFailed({ ApiError cause })
 ```
 
 Separate variants rather than a single state with nullable fields, so a mixed
@@ -437,52 +437,78 @@ for installs, so the rejection lands on the harness the user selected rather tha
 in the shared aggregate row. The fan-out ignores the result and keeps its silent
 skip.
 
-### Lifetimes owned by the service
+`CatalogRescanStartFailed` retains the repository's `ApiError` as a typed cause,
+and the service logs it locally with the original error and stack trace. A
+transport, authentication, or decoding failure may never have reached the bridge
+at all, so pointing the user at the bridge log would diagnose nothing. Only
+bounded presentation text is rendered; the cause exists for the local log, not
+for the card.
 
-The service owns every transition out of a terminal state. The row widget
-renders whatever it is given and owns no timer.
+### The rescan operation
 
-| Trigger | Transition |
+Four review rounds produced rules that composed badly because the service had no
+explicit notion of *which run* it was tracking. Everything below follows from one
+definition instead.
+
+An **operation** is the set of harness ids the service is currently tracking,
+plus whether this client saw the whole thing. It is `owned` when this client
+dispatched every member's start, and `observed` when the service learned about it
+from `GET /plugin/import` on connect or from an unsolicited progress event.
+
+| Event | Effect on the operation |
 |---|---|
-| 4s after `CatalogRescanSucceeded` | to `CatalogRescanIdle` |
-| Dismiss tapped on either failure state | to `CatalogRescanIdle` |
-| Cancel confirmed | to `CatalogRescanIdle` |
-| A new rescan starts | to `CatalogRescanRunning`, clearing the retained progress map first |
-| Connection lost, or the active bridge changes | to `CatalogRescanIdle`, clearing the retained progress map |
-| Connection established or restored | seed from `GET /plugin/import`, keeping only `CatalogImportEnumerating` and `CatalogImportCommitting`; discard every terminal status |
+| A start is dispatched while idle or terminal | Cancel any pending clear timer, clear the retained progress map, open an `owned` operation containing that harness |
+| A start is dispatched while an operation is live | **Join** it: add the harness to the members. The map is not cleared and the run in flight is not disturbed |
+| A start joins an `observed` operation | The operation stays `observed`; this client still did not see the rest of it |
+| Non-terminal progress arrives for a harness that is not a member, while idle | Open an `observed` operation containing that harness |
+| Non-terminal progress arrives for a member | Update the map; publish `CatalogRescanRunning` |
+| A terminal event arrives for a member | Record it; the member is settled |
+| Every member has settled | See the settlement table below |
+| Cancel | `DELETE` for every member id, whether the state is `Starting` or `Running`; close the operation |
+| Connection lost, or the active bridge changes | Close the operation, clear the map, cancel the timer |
+| Connection established or restored | Seed an `observed` operation from `GET /plugin/import`, keeping only `CatalogImportEnumerating` and `CatalogImportCommitting` and discarding every terminal status |
 
-The 4s clear applies to **success only**. `CatalogRescanPartlyFailed` and
-`CatalogRescanFailed` persist until the user dismisses them, a new rescan
-starts, or the connection resets: a diagnostic the user did not get to read is
-worse than a row that outstays its welcome.
+Settlement:
 
-The retained progress map is cleared whenever a rescan starts and whenever the
-state resets to idle. Without that, a second rescan would aggregate the previous
-run's terminal entries before the harnesses reported anything, and could publish
-a terminal state before the new run had begun.
+| Operation | Published state | Then |
+|---|---|---|
+| `owned`, all members succeeded | `CatalogRescanSucceeded` | cleared to idle after 4s |
+| `owned`, some members failed | `CatalogRescanPartlyFailed` | held until dismissed |
+| `owned`, all members failed | `CatalogRescanFailed` | held until dismissed |
+| `observed` | `CatalogRescanIdle` immediately | no summary is claimed |
 
-A rescan **seeded from recovery resolves to `CatalogRescanIdle`, never to a
-terminal summary.** After a reconnect the service knows only which harnesses
-were still enumerating; a harness that completed or failed while the connection
-was down appears in `latestStatuses` as a terminal status that is discarded, and
-the client cannot tell whether it belonged to this rescan, the previous one, or
-bridge-startup hydration, because `latestStatuses` carries no operation identity
-and no grouping. Publishing a success from that partial membership would
-understate the counts and could hide a failed harness behind an authoritative
-"Rescan complete". Recovery therefore shows progress and refreshes the lists when
-it settles, and claims no summary. Only a rescan this client observed from its
-start reports a terminal result.
+**Every** close of a live operation refreshes the two lists, whether it settled
+with a summary, settled as `observed`, or was cancelled. The refresh is tied to
+leaving a live operation, not to the terminal variants, so a run this client
+merely observed still makes its imported sessions appear.
 
-Terminal outcomes are adopted only from the SSE stream, and only for a rescan
-this service already knows is running. This is deliberately the whole lifetime
-rule: no generation counters, no request fences, and no stale-generation
-tracking. `PluginManagementService` needs that machinery because it reconciles
-mutations against a versioned snapshot token; a progress stream that resets to
-idle on disconnect does not.
+Why `observed` claims nothing: after a reconnect the service knows only which
+harnesses were still enumerating. A harness that completed or failed while the
+connection was down appears in `latestStatuses` as a terminal status that is
+discarded, and the client cannot tell whether it belonged to this run, the
+previous one, or bridge-startup hydration, because `latestStatuses` carries no
+operation identity and no grouping. Publishing a success from that partial
+membership would understate the counts and could hide a failed harness behind an
+authoritative "Rescan complete".
 
-Because the service owns the terminal lifetime, two mounted hosts always render
-the same row for the same duration, and revisiting a list after a rescan
-finished shows nothing rather than replaying a stale success.
+The 4s clear applies to success only, and is cancelled by any new start or reset.
+`CatalogRescanPartlyFailed` and `CatalogRescanFailed` persist until dismissed: a
+diagnostic the user did not get to read is worse than a row that outstays its
+welcome.
+
+Since a targeted start joins rather than replaces, the Settings cards need no
+cross-harness disabling. Each card is disabled only while that harness is itself
+a member, and starting a second harness while a first is importing simply widens
+the same operation.
+
+This is deliberately the whole model: no generation counters, no request fences,
+no stale-generation tracking. `PluginManagementService` needs that machinery
+because it reconciles mutations against a versioned snapshot token; an operation
+that closes on disconnect does not.
+
+Because the service owns the operation, two mounted hosts always render the same
+row for the same duration, and revisiting a list after a rescan finished shows
+nothing rather than replaying a stale success.
 
 ## Compatibility
 
@@ -505,8 +531,17 @@ finished shows nothing rather than replaying a stale success.
   route at all, so the deep pull would otherwise perform its soft refresh and
   silently do nothing.
 
-  When **every** harness in a fan-out answers `404`, the service publishes
-  `CatalogRescanUnsupported` and the row says the bridge needs updating. A
+  `/plugin/management` is **younger still**: its first public tag is `v1.7.0`.
+  `PluginRepository.getManagement()` maps a `404` there to
+  `PluginManagementLoadResultUnsupported` (`plugin_repository.dart:14-20`), so on
+  a `v1.4`-`v1.6` bridge the harness source yields no ids at all and a fan-out
+  would send zero requests. `CatalogRescanUnsupported` is therefore published
+  directly whenever the management snapshot is unsupported, without waiting for a
+  `404` that would never be requested.
+
+  When a snapshot **is** available but **every** harness in a fan-out answers
+  `404`, the service publishes `CatalogRescanUnsupported` too and the row says the
+  bridge needs updating. A
   targeted start on such a bridge returns `CatalogRescanStartUnsupported` and the
   card says the same. Sniffing the error body to tell a missing route from an
   unknown plugin is deliberately avoided: both mean "this bridge cannot rescan",
@@ -683,7 +718,7 @@ before the plan is retired.
 
 | Step | Exact PR title | Changed-line target |
 |---|---|---:|
-| 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 1,050-1,250 |
+| 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 1,300-1,450 |
 | 2/8 | `🌱 [catalog-rescan] Re-hydrate stale plugin catalogs [step 2/8]` | 20-60 |
 | 3/8 | `⚙️ [catalog-rescan] Report new items from a catalog import [step 3/8]` | 350-600 |
 | 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 |
@@ -791,6 +826,11 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
   harness in a fan-out answers `404`; and let a recovery-seeded rescan resolve
   to `CatalogRescanIdle` rather than to a terminal summary.
 - Leave `sse_event.dart` and `sse_event_tracker.dart` untouched.
+- Run `module_core`'s build runner and commit the regenerated
+  `lib/src/di/injection.config.dart`. `@lazySingleton` alone registers nothing:
+  analysis still passes because `getIt<CatalogRescanService>()` resolves
+  dynamically, so a missing factory would not surface until step 6 fails at
+  runtime.
 - Tests: aggregation across two concurrent harnesses; all seven states including
   a mixed success/failure fan-out; the older-bridge payload with `newItems`
   omitted; a two-harness success summing both deltas rather than reporting one;
@@ -805,7 +845,14 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
   state from SSE; a fan-out where every harness answers `404` publishing
   `CatalogRescanUnsupported`; a dispatched start publishing `CatalogRescanStarting`
   before any progress arrives; and a recovery-seeded rescan settling to idle with
-  no summary while still refreshing.
+  no summary while still refreshing; an unsolicited progress event opening an
+  observed operation from idle and refreshing the lists when it closes; a
+  targeted start joining a live operation instead of clearing it; a cancel while
+  `Starting` issuing a `DELETE` per dispatched harness; a second rescan begun
+  inside the previous success's 4s window not being reset by the stale timer;
+  an unsupported management snapshot publishing `CatalogRescanUnsupported`
+  without issuing any request; and a `CatalogRescanStartFailed` retaining its
+  `ApiError` cause and logging it locally.
 
 ### Verification
 
@@ -823,9 +870,13 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
 - `PregoGlassScaffold` composes it behind a new optional `onDeepRefresh`, and
   asserts that `onDeepRefresh` requires `onRefresh`, matching the existing
   `scrollable`/`onRefresh` assertion.
-- `SessionListPanel._buildScrollableContent` replaces its bare
-  `CupertinoSliverRefreshControl` with `PregoSliverRefreshControl`, so the pane
-  gets stage 2 without any threshold logic in `client/app`.
+- `SessionListPanel` replaces its bare `CupertinoSliverRefreshControl` with
+  `PregoSliverRefreshControl` **and** takes an optional `onDeepRefresh` callback
+  parameter, so the pane gets stage 2 without any threshold logic in
+  `client/app`. The parameter is introduced here, defaulting to null, and step 6
+  wires it to the cubit's `startRescan()`. Without it step 5's pane test would
+  have no deep callback to invoke, because the pane currently hardcodes
+  `refreshSessionList(context)` and the cubit intent does not exist until step 6.
 - Render the caption under the existing indicator only once the pull passes the
   soft trigger, so an ordinary pull is visually unchanged.
 - Add a design catalog scenario if the scaffold has one; otherwise widget tests
@@ -849,9 +900,12 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
   subscribe to `CatalogRescanService`, surface the rescan state through their
   own state, and expose `startRescan()`, `startRescanFor(pluginId)`,
   `cancelRescan()`, and `dismissRescan()`. The two list cubits additionally run
-  their existing silent refresh on `CatalogRescanSucceeded` and
-  `CatalogRescanPartlyFailed`, because a committed import raises no list
-  invalidation of its own.
+  their existing silent refresh whenever the service **leaves a live operation**
+  — settled with a summary, settled as observed, or cancelled — because a
+  committed import raises no list invalidation of its own. Keying the refresh on
+  leaving a live operation rather than on the terminal variants is what makes an
+  observed run, which never publishes a summary, still surface its imported
+  sessions.
 - The aggregate rescan row widget in `client/app/lib/core/widgets/`, beside the
   shell's other cross-feature widgets, with its seven presentations. It renders
   the state it is given, owns no timer, and renders no bridge-supplied text.
@@ -862,7 +916,9 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
 - Settings to Harnesses: the per-harness `Rescan` action in
   `_HarnessControlCard`, calling `startRescanFor(pluginId)`, enabled only for a
   harness whose `runtimeState.isRoutable` is true and disabled while that
-  harness is already rescanning. The typed `CatalogRescanStartResult` is held
+  harness is itself a member of the live operation; a targeted start joins that
+  operation rather than replacing it, so no cross-harness disabling is needed.
+  The typed `CatalogRescanStartResult` is held
   per plugin id by `PluginManagementCubit` and rendered on that card, so a
   targeted `503`, `404`, or unsupported-bridge answer lands on the harness the
   user selected instead of the shared row.

--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -1,0 +1,722 @@
+# Client-Triggered Catalog Rescan
+
+## Status
+
+- **Plan slug:** `catalog-rescan`
+- **Status:** Active - Step 1/8 plan publication
+- **Plan date:** 2026-08-23
+- **Repository:** `sesori-ai/sesori_apps_monorepo`
+- **Current implementation base:** `main` at
+  `7b1ebe9bc629d05b5d104e76cd5dbaa1514d65a2`
+- **Current branch:** `fix-missing-imports-logs`
+- **Origin issue:** [#961](https://github.com/sesori-ai/sesori_apps_monorepo/issues/961)
+- **Related:** [#1008](https://github.com/sesori-ai/sesori_apps_monorepo/issues/1008)
+  owns Codex live updates and is not addressed here
+- **Delivery:** eight PRs, slug `catalog-rescan`
+
+## Goal
+
+Give the user a way to re-import harness catalogs from the app, so projects and
+sessions created while the bridge was down become visible without running a CLI
+flag by hand.
+
+## User Report And Root Cause
+
+Issue #961 reports Codex projects and sessions missing from the app. Fresh logs
+from bridge v1.8.0 show the exact mechanism.
+
+A normal start prints:
+
+```text
+Imported codex catalog: 0 project(s), 0 session(s).
+Imported opencode catalog: 0 project(s), 0 session(s).
+```
+
+There is no preceding `Importing codex catalog...` line and no
+`Starting plugin "codex"` line. That is the short-circuit in
+`CatalogImportService._run`
+(`bridge/app/lib/src/services/catalog_import_service.dart:101-118`): an
+automatic import whose durable hydration marker already exists publishes
+`completed(0, 0)` and returns without enumerating anything or starting the
+plugin.
+
+The marker is keyed on `(pluginId, projectionVersion)`
+(`bridge/app/lib/src/api/database/tables/catalog_hydrations_table.dart`).
+`CatalogImportRepository.projectionVersion`
+(`bridge/app/lib/src/repositories/catalog_import_repository.dart:34`) is still
+`1` and has never been bumped since it was introduced in
+[#488](https://github.com/sesori-ai/sesori_apps_monorepo/pull/488).
+
+Consequences:
+
+1. An install that hydrated a partial catalog under an older bridge keeps that
+   partial catalog across every subsequent release.
+2. Nothing re-imports afterwards except `sesori-bridge --import-plugin <id>`,
+   whose headless trigger sets `explicitImportRequested` and bypasses the marker
+   check.
+
+The reporter's explicit run does produce a correct catalog, so the Codex scan
+itself is healthy on v1.8.0:
+
+```text
+[CodexCatalogRepository][codex] rollout catalog scan: files=193,
+  recognizedRollouts=193, indexEntries=45, unreadableOrMissingMetadata=0,
+  mismatchedMetadata=0, records=193
+[CodexCatalogRepository][codex] catalog discovery: records=193,
+  knownDirectories=49, noiseExcluded=0, missingCwd=0,
+  projectDirectories=43, sessions=193
+```
+
+The gap is the absence of any in-app path to that same import.
+
+## Confirmed Findings
+
+### The bridge side is already complete and entirely unused
+
+| Capability | Location | Shape | State |
+|---|---|---|---|
+| Start an import | `POST /plugin/import` in `routing/start_catalog_import_handler.dart` | `BodyRequestHandler<CatalogImportRequest, …>`; body carries `pluginId` | Works; zero client callers |
+| Cancel an import | `DELETE /plugin/import` in `routing/cancel_catalog_import_handler.dart` | `BodyRequestHandler<CatalogImportRequest, …>`; **also requires `pluginId`** and cancels exactly one plugin | Works; unused |
+| Read latest status per plugin | `GET /plugin/import` in `routing/get_catalog_import_statuses_handler.dart` | Returns `CatalogImportService.latestStatuses` | Works; unused |
+| Stream progress | SSE `catalog.import.progress` (`sesori_sse_event.dart:51`) | Global, not session-scoped | Emitted; unused |
+
+A repository-wide search for `plugin/import` under `client/` and `shared/`
+returns nothing.
+
+### `latestStatuses` retains terminal statuses forever
+
+`CatalogImportService.latestStatuses` returns the last published status per
+eligible plugin, with no recency or terminality filter. Because the hydration
+short-circuit publishes `completed(0, 0)` for every already-hydrated plugin at
+every bridge start, a naive recovery read of `GET /plugin/import` would render
+a "Rescan complete / Nothing new" row on every connect. The recovery read must
+therefore seed only from non-terminal statuses.
+
+### The two "ignore arms" are not an event dispatch registry
+
+`SesoriCatalogImportProgress` appears in two switch arms today, and **both must
+be left exactly as they are**:
+
+- `sse_event.dart:36` is inside `SseEvent._extractSessionId`, which answers
+  "which session does this event belong to". A catalog import has no session, so
+  removing the arm would either make the switch non-exhaustive or fabricate a
+  session binding.
+- `sse_event_tracker.dart:103` is the no-op arm of `SseEventTracker._handleEvent`,
+  a service that owns project and session activity derivation only.
+
+`SesoriPluginInstallProgress` sits in both arms today and is nonetheless fully
+consumed, because `PluginManagementService._onSseEvent` subscribes to
+`ConnectionService.events` and pattern-matches it directly. That is the exact
+precedent this work copies.
+
+### An import starts the harness backend
+
+`CatalogImportRepository.importCatalog` reaches the plugin through
+`PluginRuntime.useStream`, which acquires its lease with `startIfNeeded: true`
+(`bridge/app/lib/src/runtime/plugin_runtime.dart:406`). The reporter's log
+confirms it:
+
+```text
+[CodexPluginDescriptor][codex] app-server started on ws://127.0.0.1:61625
+```
+
+A rescan therefore costs a backend start per harness. That is the reason the
+deep rescan is a deliberate second-stage action rather than the default refresh.
+
+### Completion counts are totals, not deltas
+
+`CatalogImportCompleted.projectsImported` and `sessionsImported`
+(`shared/sesori_shared/lib/src/models/sesori/catalog_import_progress.dart:22-28`)
+are the number of rows published, not the number that were new. Reporting them
+verbatim after a rescan that changed nothing would tell the user that 193
+sessions just arrived.
+
+Both delta facts are already computed inside
+`CatalogImportRepository._publishCatalog`:
+
+- a session is new when `currentBindings[session.id]` is `null`
+  (`catalog_import_repository.dart:431`);
+- a project is new when `_projectCatalogIdentityCalculator.calculate` returns
+  `null` for it (`catalog_import_repository.dart:395`).
+
+No new enumeration, query, or persisted state is required to count them.
+
+### The three refresh hosts do not share one scaffold
+
+Two hosts drive `PregoGlassScaffold.onRefresh`: the project list
+(`project_list_screen.dart:179`) and the full-screen session list
+(`session_list_scaffold.dart`). The third does not.
+`SessionListPanel._buildScrollableContent`
+(`client/app/lib/features/session_list/session_list_panel.dart:127-145`) builds
+its own `CustomScrollView` with a bare `CupertinoSliverRefreshControl` and never
+touches the scaffold.
+
+The deep-pull behavior therefore cannot live in `PregoGlassScaffold`, or the
+split-view pane would have to re-implement the threshold and caption logic in
+`client/app`. It lives in one `module_prego` refresh-control widget that the
+scaffold composes and the pane uses directly.
+
+### The client already has every other pattern this needs
+
+- `PluginManagementService`
+  (`client/module_core/lib/src/services/plugin_management_service.dart`) folds
+  `SesoriPluginInstallProgress` into a
+  `BehaviorSubject<Map<String, PluginInstallProgress>>` that
+  `PluginManagementCubit` renders. The rescan service mirrors it.
+- The existing refresh builder already receives `refreshState`, `pulledExtent`,
+  and `triggerDistance`
+  (`client/module_prego/lib/components/navigation/prego_glass_scaffold.dart:356`).
+- The top-of-list slot the progress row occupies already exists: a
+  `LinearProgressIndicator` sliver at `project_list_screen.dart:302` and at
+  `session_list_panel.dart:137`.
+- Harness enablement is already known to the client through
+  `PluginManagementMetadata.runtimeState.isEnabled`
+  (`shared/sesori_shared/lib/src/models/sesori/plugin_management.dart:20`).
+- `client/app/lib/core/widgets/` already holds the shell's cross-feature widgets
+  (`connection_banner.dart`, `session_split/`), which is where a widget consumed
+  by two features belongs.
+
+## Approved Design
+
+These were decided by the user during planning. Do not reopen them.
+
+### Two-stage pull-to-refresh
+
+**Stage 1 (soft) is unchanged.** Pull to the normal trigger distance. Refetches
+projects or sessions from the bridge's committed catalog. Awaited, spinner in
+the refresh control, near-instant. This remains the default and the only
+behavior most pulls produce.
+
+**Stage 2 (deep rescan)** arms when the pull passes `1.6 x triggerDistance`.
+The refresh control's caption follows the pull:
+
+| Pull distance | Caption |
+|---|---|
+| below `triggerDistance` | none (today's indicator) |
+| `triggerDistance` to `1.6 x` | `Keep pulling to rescan harnesses` |
+| past `1.6 x` | `Release to rescan harnesses` |
+
+Release runs the soft refresh exactly as today **and** additionally triggers the
+catalog import. The import is never awaited: the refresh control settles on the
+soft refresh alone.
+
+All three arming, caption, and release-dispatch behavior lives in a single
+`module_prego` widget, `PregoSliverRefreshControl`, which wraps
+`CupertinoSliverRefreshControl` and owns the one mutable `bool` recording
+whether the deep threshold was crossed at the moment of release.
+`PregoGlassScaffold` composes it behind a new optional `onDeepRefresh`
+parameter; `SessionListPanel` uses it directly in place of its bare
+`CupertinoSliverRefreshControl`. No pull-threshold logic is written in
+`client/app`.
+
+All three hosts get stage 2: the project list, the full-screen session list,
+and the wide split-view session pane.
+
+### One aggregate progress row
+
+A single sliver at index 0 of the list, taking over the slot the soft-refresh
+`LinearProgressIndicator` uses today. It scrolls with the list as an ordinary
+entry. It is not pinned, not a banner, not a toast, not a dialog.
+
+| State | Leading | Title | Subtitle | Trailing |
+|---|---|---|---|---|
+| Running | indeterminate ring | `Rescanning harnesses` | harness currently enumerating plus its running session count | cancel |
+| Succeeded | check | `Rescan complete` | new-item summary | none; the service clears it after 4s |
+| Partly failed | warning | `Rescan finished` | `1 of 3 harnesses failed` plus the sanitized message | dismiss |
+| Failed | warning | `Rescan failed` | sanitized `CatalogImportFailed.message` | dismiss |
+| Cancelled | — | — | — | row removed immediately |
+
+With several harnesses enabled the row stays a single row. Its subtitle names
+whichever harness is currently enumerating; it does not grow one row per
+harness, so the top of the list never reflows as harnesses finish at different
+times. The terminal states summarise the whole fan-out rather than reporting
+whichever harness happened to finish last.
+
+The success summary is worded from the counts carrier:
+
+- delta known, one or more new: `5 new sessions in 2 new projects`;
+- delta known, nothing new: `Nothing new`;
+- totals only, which is what an older bridge sends:
+  `43 projects, 193 sessions`.
+
+Cancel issues one `DELETE /plugin/import` per harness still running.
+
+### Non-gesture twin on Settings to Harnesses
+
+Each `_HarnessControlCard`
+(`client/app/lib/features/settings/harnesses_settings_screen.dart:384`) gains a
+`Rescan` action that imports that one harness. This is required, not optional:
+the pull gesture is invisible to screen readers and awkward with a mouse, and
+the reporter runs the bridge on a desktop. The user chose this placement over an
+app-bar menu item.
+
+The action is offered only for a harness whose `runtimeState.isEnabled` is true,
+and it is disabled while that harness already has a rescan in flight.
+
+## Ownership And Data Flow
+
+```text
+pull past 1.6x   ->  ProjectListCubit / SessionListCubit
+Settings Rescan  ->  PluginManagementCubit
+                          |
+                          v
+                  CatalogRescanService          (client/module_core/lib/src/services)
+                    |  startAll() / start(pluginId) / cancel()
+                    |
+                    +-- PluginManagementService.snapshots   (enabled set + display names)
+                    |
+                    +-- PluginRepository                    (client/module_core/lib/src/repositories)
+                    |        v
+                    |     PluginApi                         (client/module_core/lib/src/api)
+                    |        v
+                    |     POST / DELETE / GET /plugin/import
+                    |
+                    +-- ConnectionService.events            (SSE + connection status)
+                          |
+                          v
+                  ValueStream<CatalogRescanState>
+                          v
+        rescan row in client/app/lib/core/widgets/, hosted by
+        the project list, the session list, and the split-view pane
+```
+
+`CatalogRescanService` is a `@lazySingleton` in `module_core`, resolved with
+`getIt<CatalogRescanService>()` per the app shell's DI convention. Its declared
+collaborators are exactly `PluginRepository`, `PluginManagementService`, and
+`ConnectionService`.
+
+`PluginManagementService.snapshots` is the source for both the enabled-harness
+set and the display names the row shows. It is a Layer-3 to Layer-3 composition,
+which the module permits, and it is preferred over a second
+`PluginRepository.getManagement()` read because the snapshot is already
+maintained, already refreshed on reconnect, and already invalidated by
+`plugin.management.changed`. A second read would duplicate that lifecycle.
+
+`CatalogRescanState` and its counts carrier live in
+`client/module_core/lib/src/services/models/catalog_rescan_state.dart`.
+
+`startAll()` reads the current management snapshot, keeps every harness whose
+`runtimeState.isEnabled` is true, and issues one `POST /plugin/import` per
+harness. A harness the bridge reports as unavailable answers `503` and a harness
+it does not know answers `404`; both are skipped silently, because a harness
+that cannot import is not an error the user asked about. Any other failure
+surfaces on the row.
+
+`cancel()` issues one `DELETE /plugin/import` per id in
+`CatalogRescanRunning.pluginIds`, because the route cancels exactly one plugin
+per call.
+
+### State
+
+```text
+sealed CatalogRescanState
+  CatalogRescanIdle()
+  CatalogRescanRunning({ String activePluginName, int sessionsSeen,
+                         Set<String> pluginIds })
+  CatalogRescanSucceeded({ int harnessCount, CatalogRescanCounts counts })
+  CatalogRescanPartlyFailed({ int succeededCount, int failedCount,
+                              String message })
+  CatalogRescanFailed({ int harnessCount, String message })
+
+sealed CatalogRescanCounts
+  CatalogRescanDelta({ int newProjects, int newSessions })
+  CatalogRescanTotals({ int projects, int sessions })
+```
+
+Five variants rather than a single terminal state with nullable fields, so a
+mixed outcome across N harnesses is representable and a half-populated one is
+not. `CatalogRescanPartlyFailed` deliberately carries no counts: the row reports
+the failure, and a partial count would invite the reader to trust it as the
+whole result.
+
+### Lifetimes owned by the service
+
+The service owns every transition out of a terminal state. The row widget
+renders whatever it is given and owns no timer.
+
+| Trigger | Transition |
+|---|---|
+| 4s after a terminal state | to `CatalogRescanIdle` |
+| Dismiss tapped on a failure | to `CatalogRescanIdle` |
+| Cancel confirmed | to `CatalogRescanIdle` |
+| Connection lost, or the active bridge changes | to `CatalogRescanIdle` |
+| Connection established or restored | seed from `GET /plugin/import`, keeping only `CatalogImportEnumerating` and `CatalogImportCommitting`; discard every terminal status |
+
+Terminal outcomes are adopted only from the SSE stream, and only for a rescan
+this service already knows is running. This is deliberately the whole lifetime
+rule: no generation counters, no request fences, and no stale-generation
+tracking. `PluginManagementService` needs that machinery because it reconciles
+mutations against a versioned snapshot token; a progress stream that resets to
+idle on disconnect does not.
+
+Because the service owns the terminal lifetime, two mounted hosts always render
+the same row for the same duration, and revisiting a list after a rescan
+finished shows nothing rather than replaying a stale success.
+
+## Compatibility
+
+- `CatalogImportCompleted` gains a single **nullable** `newItems` object:
+  `CatalogImportNewItems({required int projects, required int sessions})`.
+  One optional group rather than two independently nullable ints, so
+  "delta known" and "delta absent" are the only two representable cases.
+- Every package using `json_serializable` in this repository configures
+  `include_if_null: false`, so an older bridge simply omits the key and a newer
+  client decodes it as `null`. Nullable is required rather than a zero-valued
+  default: defaulting would make an older bridge report `Nothing new` after a
+  rescan that in fact imported a hundred sessions.
+- A newer bridge talking to an older client is unaffected: the added key is
+  ignored by the older decoder.
+- No new route, no route signature change, and no change to either existing
+  request body. Fanning out one request per harness keeps the client working
+  against every published bridge.
+- The `projectionVersion` bump writes new marker rows and leaves the
+  `projectionVersion = 1` rows in place. No migration, no backfill, no schema
+  change.
+
+## Complexity Budget
+
+New persisted state: **none**.
+
+New wire fields: **one nullable object** on one existing event.
+
+New in-memory mutable parts:
+
+| Part | Owner | Why it must exist |
+|---|---|---|
+| `Map<String, CatalogImportProgress>` | `CatalogRescanService` | Aggregating several concurrent harness imports into one row requires the latest progress per harness |
+| `BehaviorSubject<CatalogRescanState>` | `CatalogRescanService` | The published stream, seeded so a late subscriber renders correctly |
+| `CompositeSubscription` | `CatalogRescanService` | SSE plus connection-status subscriptions, matching `PluginManagementService` |
+| `Timer?` | `CatalogRescanService` | The 4s terminal-state clear. Owned here, not by the row, so two mounted hosts cannot run disagreeing timers |
+| `bool _disposed` | `CatalogRescanService` | Module convention for `Disposable` services |
+| `bool _deepArmed` | `PregoSliverRefreshControl` | The refresh control reports pull distance continuously but fires `onRefresh` once; the threshold state at release must survive that one frame |
+
+Two fan-outs are recorded rather than hidden: `startAll()` issues one `POST` per
+enabled harness, and `cancel()` issues one `DELETE` per running harness. Both
+are required by routes that address exactly one plugin per call, and neither
+adds retained state beyond `CatalogRescanRunning.pluginIds`.
+
+Deliberately **not** added:
+
+- **No authorship tracking.** `catalog.import.progress` is a global SSE event by
+  design. A rescan started from the CLI or another surface showing on this phone
+  is correct behavior, not a leak, so the service does not record which surface
+  started what.
+- **No `catalogImport` management capability.** Adding a declared capability
+  would be a wire change bought only to avoid skipping two status codes.
+- **No bulk `import all` route.** It would need a capability flag or a fallback
+  path for older bridges to buy one fewer round trip.
+- **No polling.** `GET /plugin/import` is read once when the service connects or
+  reconnects. There is no timer and no repeated read.
+- **No generation or fence machinery.** Resetting to idle on disconnect makes it
+  unnecessary at this scale.
+- **No changes to the two SSE switch arms.** Both are correct as they stand;
+  the service pattern-matches the event itself.
+- **No persisted last-rescan timestamp.** A `Last scanned 6 days ago - Rescan`
+  nudge is a plausible follow-up and is explicitly out of scope.
+- **No change to the once-per-install automatic hydration.** Importing on every
+  bridge start would boot every enabled harness backend at every launch, which is
+  the exact cost the durable marker was built to avoid.
+
+## Accepted Risks
+
+| Risk | Impact | Decision |
+|---|---|---|
+| `projectionVersion = 1` rows stay in `catalog_hydrations_table` after the bump | Three dead rows, invisible to the user | Accepted. No cleanup migration; cosmetic residue does not justify schema work |
+| A deep rescan boots every enabled harness backend | CPU and fan cost on the user's machine | Accepted and intended. It is gated behind a deliberate extra pull and an explicit Settings action, never a plain refresh |
+| An older bridge omits `newItems` | Success row shows totals instead of a delta | Accepted. Honest degradation, and the absent group makes the difference explicit rather than silently wrong |
+| A rescan in flight when the connection drops | The row disappears and does not return | Accepted. The bridge continues and commits the import; the next connect seeds only non-terminal statuses, so a rescan that finished meanwhile is simply not announced |
+| Two surfaces trigger a rescan for the same harness at once | The bridge coalesces it: `CatalogImportService.start` finds the active control and applies the trigger to it | No client-side guard needed; existing bridge behavior is correct |
+| A cancel `DELETE` races a harness that just completed | The bridge answers on the already-settled plugin and the SSE terminal event wins | Accepted; no client-side ordering guard |
+
+## Cleanup Assessment
+
+Inspected for obsolescence: the soft-refresh `LinearProgressIndicator` sliver in
+both hosts, the totals fields on `CatalogImportCompleted`, the hydration marker
+table, the `--import-plugin` CLI flag, the two SSE switch arms, and
+`SessionListPanel`'s bare `CupertinoSliverRefreshControl`.
+
+Outcome: **one small removal is directly caused, the rest are retained.**
+
+- `SessionListPanel`'s bare `CupertinoSliverRefreshControl` is replaced by
+  `PregoSliverRefreshControl` in Step 5. That is a direct, in-PR replacement.
+- The soft-refresh indicator still serves stage 1 and is only superseded while a
+  rescan is running.
+- The totals fields remain the honest fallback for an older bridge.
+- The hydration marker still governs first-install hydration, which this plan
+  deliberately does not change.
+- `--import-plugin` remains the headless and support path.
+- Both SSE switch arms are correct and stay.
+
+One item is deferred rather than found-and-skipped: if a future plan does move
+automatic import off the durable marker, the marker table, its DAO,
+`CatalogEmptyHydrationPolicy`, and `projectionVersion` all become dead together
+and should be removed in one coherent PR at that time.
+
+## Regression Coverage
+
+Affected feature documents:
+
+- `docs/regression/projects-and-sessions.md` - owns the import contract. Its
+  existing line, "Import is explicit, per plugin, atomic, non-destructive,
+  cancellable, and attributes progress", stays true and gains the
+  client-triggered rescan and the new-item reporting.
+- `docs/regression/plugin-setup-and-lifecycle.md` - owns the harness management
+  surface, which gains the per-harness `Rescan` action.
+
+Highest level needed: **L3 Release**. The delivered behavior ends at rendering
+in the client, so the authoritative boundary is client end to end; no lower
+boundary observes the gesture, the row, or the wording.
+
+Required matrix:
+
+| Dimension | Scope | Reason |
+|---|---|---|
+| Boundary | Client end to end, plus automated for the delta counting | The count itself is deterministic repository behavior with an owning suite; the gesture, row, and wording are not |
+| Plugin | Representative for the gesture, row, cancel, and fan-out | The bridge owns import after a normalized plugin boundary |
+| Plugin | One native-ownership and one bridge-derived harness for the new-item counts | `_publishCatalog` counts projects differently per `PluginProjectOwnership` branch, so one branch cannot prove the other |
+| Plugin | Two enabled harnesses at once for the aggregate terminal states | A single-harness run cannot prove `CatalogRescanPartlyFailed` |
+| Platform | One mobile platform plus the wide split-view layout | The pane hosts stage 2 through a different scroll owner than the two scaffold hosts |
+| Compatibility | One run against a bridge that omits `newItems` | Proves the totals fallback rather than a false `Nothing new` |
+| Recovery | One reconnect against a bridge holding terminal statuses | Proves the recovery read discards them instead of announcing a stale success |
+
+Any reduction to this matrix requires explicit user acceptance recorded here
+before the plan is retired.
+
+## Non-Goals
+
+- Codex live updates for sessions advancing in an external CLI process; that is
+  [#1008](https://github.com/sesori-ai/sesori_apps_monorepo/issues/1008).
+- Changing when automatic hydration runs, or removing the durable marker.
+- A bulk import route, an import capability flag, or any other new wire route.
+- A persisted last-rescan timestamp or a staleness nudge in the list.
+- Per-harness progress rows.
+- Analytics. This is a reliability repair for a reported defect, not a product
+  adoption question.
+- Any change to `client/desktop`, which hosts no project or session list.
+
+## Delivery Rules
+
+- The series has exactly eight steps.
+- Every step updates `TRACKER.md` with its base, actual changed-line count,
+  verification, review outcome, and PR link.
+- Tests and analysis run only for the packages a step touches. CI owns the full
+  matrix.
+- `architecture-plan-review` reviewed this plan and rejected the first revision;
+  all ten findings were applied directly and are recorded in `TRACKER.md`.
+- Run `architecture-implementation-review` on steps 3, 4, and 6, which are the
+  architecture-bearing ones. Steps 2, 7, and 8 do not qualify. Step 5 qualifies
+  only because it introduces a new shared `module_prego` component and changes
+  which owner drives the pane's scroll; review it if that component's API is not
+  a straight extraction.
+- Step 8 moves `.plan/active/catalog-rescan/` to
+  `.plan/completed/catalog-rescan/` only after the recorded L3 matrix passes.
+
+## Fixed PR Series
+
+| Step | Exact PR title | Changed-line target |
+|---|---|---:|
+| 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 850-1,000 |
+| 2/8 | `🌱 [catalog-rescan] Re-hydrate stale plugin catalogs [step 2/8]` | 20-60 |
+| 3/8 | `⚙️ [catalog-rescan] Report new items from a catalog import [step 3/8]` | 350-600 |
+| 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 |
+| 5/8 | `⚙️ [catalog-rescan] Add a second stage to pull-to-refresh [step 5/8]` | 350-600 |
+| 6/8 | `⚙️ [catalog-rescan] Surface catalog rescan in the app [step 6/8]` | 700-1,100 |
+| 7/8 | `🌱 [catalog-rescan] Reconcile catalog rescan regression docs [step 7/8]` | 80-160 |
+| 8/8 | `🌱 [catalog-rescan] Verify and retire the catalog rescan plan [step 8/8]` | 60-140 |
+
+Step 5 is `⚙️` rather than `🌿` because it extracts a new shared component and
+moves the split-view pane onto it, rather than adding a parameter to one widget.
+
+## Step 1/8 - Publish The Plan
+
+### Scope
+
+- Add this `PLAN.md` and `TRACKER.md`.
+- Record the root cause, the approved design, the complexity budget, the
+  accepted risks, and the fixed series.
+- Run architecture plan review and apply valid findings directly.
+
+### Verification
+
+- `git diff --check`
+- plan files only in the diff
+- plan and tracker agree on titles and step total
+
+## Step 2/8 - Re-Hydrate Stale Plugin Catalogs
+
+Ships first and independently because it repairs the reported cohort
+immediately, ahead of any UI work.
+
+### Scope
+
+- Bump `CatalogImportRepository.projectionVersion` from `1` to `2` with a
+  comment recording why: every marker written before v1.8.0 can describe a
+  catalog produced by superseded discovery, and the marker is the only thing
+  preventing a correction.
+- Leave `projectionVersion = 1` rows in place. No migration, no cleanup.
+- Adjust only the tests that assert the constant.
+
+### Expected result
+
+Each enabled harness re-hydrates once on the next bridge start. Re-import is
+non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
+`displayName`, `title`, overrides, and archive state, and
+`getTombstonedSessionIds` keeps deleted sessions deleted.
+
+### Verification
+
+- targeted `catalog_import_repository` and `catalog_import_service` tests
+- `dart analyze --fatal-infos` from `bridge/app`
+
+## Step 3/8 - Report New Items From A Catalog Import
+
+### Scope
+
+- Add `CatalogImportNewItems({required int projects, required int sessions})`
+  to `shared/sesori_shared`, add it as a nullable field on
+  `CatalogImportCompleted`, and regenerate
+  `catalog_import_progress.freezed.dart` and `.g.dart`.
+- Count both in `CatalogImportRepository._publishCatalog` from facts already in
+  hand: `currentBindings[session.id] == null` for a session, and a `null`
+  result from `_projectCatalogIdentityCalculator.calculate` for a project.
+  Count correctly in both `PluginProjectOwnership` branches.
+- Carry the value through `CatalogImportService` untouched.
+- Extend `listeners/catalog_import_console_listener.dart` so a headless import
+  prints the delta when it is present.
+- Add repository tests covering: a first import where everything is new; a
+  re-import where nothing is new; a re-import where some are new; both
+  ownership branches; and a decode of a payload with the key omitted.
+
+### Verification
+
+- targeted `catalog_import_repository` tests
+- `dart analyze --fatal-infos` from `bridge/app` and `shared/sesori_shared`
+- shared model round-trip tests
+- architecture implementation review
+
+## Step 4/8 - Add The Client Catalog Rescan Service
+
+### Scope
+
+- `PluginApi`: `startCatalogImport({required String pluginId})`,
+  `cancelCatalogImport({required String pluginId})`, and
+  `getCatalogImportStatuses()`. Cancel takes a plugin id because
+  `DELETE /plugin/import` is a body handler that cancels exactly one plugin.
+- `PluginRepository`: map those to typed results, classifying `404` and `503`
+  as "this harness cannot import" rather than as failures.
+- `CatalogRescanState` and `CatalogRescanCounts` in
+  `client/module_core/lib/src/services/models/catalog_rescan_state.dart`.
+- `CatalogRescanService` as a `@lazySingleton`, collaborators
+  `PluginRepository`, `PluginManagementService`, and `ConnectionService`:
+  pattern-match `SesoriCatalogImportProgress` off `ConnectionService.events`
+  exactly as `PluginManagementService._onSseEvent` does; read
+  `GET /plugin/import` once on connect and reconnect, keeping only
+  `CatalogImportEnumerating` and `CatalogImportCommitting`; reset to
+  `CatalogRescanIdle` on disconnect and on an active-bridge change; own the 4s
+  terminal clear; and expose `ValueStream<CatalogRescanState>`, `startAll()`,
+  `start(pluginId)`, `cancel()`, and `dismiss()`.
+- Leave `sse_event.dart` and `sse_event_tracker.dart` untouched.
+- Tests: aggregation across two concurrent harnesses; all five states including
+  a mixed success/failure fan-out; the older-bridge payload with `newItems`
+  omitted; a reconnect whose `GET` holds only terminal statuses producing no
+  row; a reconnect whose `GET` holds an in-flight status producing a running
+  row; a disconnect clearing an active rescan; a fan-out where one harness
+  answers `503`; and cancel issuing one `DELETE` per running harness.
+
+### Verification
+
+- targeted `module_core` service and repository tests
+- `dart analyze --fatal-infos` from `client/module_core`
+- architecture implementation review
+
+## Step 5/8 - Add A Second Stage To Pull-To-Refresh
+
+### Scope
+
+- Add `PregoSliverRefreshControl` to `module_prego`: wraps
+  `CupertinoSliverRefreshControl`, owns the `1.6 x triggerDistance` arming, the
+  caption selection, and the release dispatch of both callbacks.
+- `PregoGlassScaffold` composes it behind a new optional `onDeepRefresh`, and
+  asserts that `onDeepRefresh` requires `onRefresh`, matching the existing
+  `scrollable`/`onRefresh` assertion.
+- `SessionListPanel._buildScrollableContent` replaces its bare
+  `CupertinoSliverRefreshControl` with `PregoSliverRefreshControl`, so the pane
+  gets stage 2 without any threshold logic in `client/app`.
+- Render the caption under the existing indicator only once the pull passes the
+  soft trigger, so an ordinary pull is visually unchanged.
+- Add a design catalog scenario if the scaffold has one; otherwise widget tests
+  covering: a short pull fires only the soft refresh, a long pull fires both,
+  and a long pull abandoned before release fires neither. Prove all three in
+  the pane as well as in the scaffold.
+
+### Verification
+
+- targeted `module_prego` and `client/app` session-pane widget tests
+- `dart analyze --fatal-infos` from `client/module_prego` and `client/app`
+- `dart run tool/generate_manifest.dart --check` from `client/design_catalog`
+  if a scenario was added
+
+## Step 6/8 - Surface Catalog Rescan In The App
+
+### Scope
+
+- The aggregate rescan row widget in `client/app/lib/core/widgets/`, beside the
+  shell's other cross-feature widgets, with its five presentations. It renders
+  the state it is given and owns no timer.
+- Project list, full-screen session list, and split-view pane: wire
+  `onDeepRefresh` to `CatalogRescanService.startAll()`, and render the row as
+  the sliver at index 0 in place of the soft-refresh indicator while a rescan is
+  running.
+- Settings to Harnesses: the per-harness `Rescan` action in
+  `_HarnessControlCard`, calling `start(pluginId)`, enabled only for an enabled
+  harness and disabled while that harness is already rescanning.
+- New `app_en.arb` resources for both captions, the five row states, the delta
+  and totals wordings, the `Nothing new` case, the partly-failed wording, and
+  the Settings action with its semantics label.
+- Widget tests: all five row states; the totals fallback; cancel; dismiss; and
+  the Settings action's enablement rules.
+
+### Verification
+
+- targeted `client/app` widget tests
+- `dart analyze --fatal-infos` from `client/app`
+- `flutter gen-l10n` output committed
+- architecture implementation review
+
+## Step 7/8 - Reconcile Regression Docs
+
+### Scope
+
+- `docs/regression/projects-and-sessions.md`: record the client-triggered
+  rescan, the two-stage pull across all three hosts, the aggregate progress row
+  and its terminal states, cancellation, new-item reporting with its
+  older-bridge fallback, and the recovery read discarding terminal statuses.
+- `docs/regression/plugin-setup-and-lifecycle.md`: record the per-harness
+  `Rescan` action and its enablement rules.
+- Record the required plugin, platform, compatibility, and recovery matrix in
+  both.
+
+### Verification
+
+- `git diff --check`
+- documentation only in the diff
+- levels and matrix match this plan
+
+## Step 8/8 - Verify And Retire
+
+### Scope
+
+- Run the recorded L3 matrix, including both ownership branches, the two-harness
+  mixed-outcome run, the older-bridge compatibility run, and the reconnect
+  recovery run.
+- Record the result, and any explicitly accepted reduction, in `TRACKER.md`.
+- Move `.plan/active/catalog-rescan/` to `.plan/completed/catalog-rescan/` once
+  that coverage passes.
+- Close or update issue #961 with the outcome.
+
+### Verification
+
+- every recorded matrix entry has a pass, a blocked reason, or an accepted
+  reduction
+- plan and tracker agree
+- `git diff --check`

--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -220,11 +220,18 @@ entry. It is not pinned, not a banner, not a toast, not a dialog.
 
 | State | Leading | Title | Subtitle | Trailing |
 |---|---|---|---|---|
+| Starting | indeterminate ring | `Rescanning harnesses` | none | cancel |
 | Running | indeterminate ring | `Rescanning harnesses` | harness currently enumerating plus its running session count | cancel |
 | Succeeded | check | `Rescan complete` | new-item summary | none; the service clears it after 4s |
 | Partly failed | warning | `Rescan finished` | `1 of 3 harnesses could not be rescanned` | dismiss |
 | Failed | warning | `Rescan failed` | `Check the bridge log for details` | dismiss |
+| Unsupported | warning | `Rescan needs a newer bridge` | `Update the bridge to rescan from here` | dismiss |
 | Cancelled | — | — | — | row removed immediately |
+
+`Starting` exists because a dispatched request is not yet an enumerating
+harness. Between dispatch and the first progress event there is no active
+harness name and no session count, so a single running state carrying both
+would have to invent them and claim enumeration the client cannot observe.
 
 **No failure text from the bridge is rendered.** `CatalogImportService._run`
 catches `Object` and sends `error.toString()` as `CatalogImportFailed.message`,
@@ -394,26 +401,41 @@ outcome and not worth a new result variant across two layers.
 ```text
 sealed CatalogRescanState
   CatalogRescanIdle()
+  CatalogRescanStarting({ Set<String> pluginIds })
   CatalogRescanRunning({ String activePluginName, int sessionsSeen,
                          Set<String> pluginIds })
   CatalogRescanSucceeded({ int harnessCount, CatalogRescanCounts counts })
   CatalogRescanPartlyFailed({ int succeededCount, int failedCount })
   CatalogRescanFailed({ int harnessCount })
+  CatalogRescanUnsupported()
 
 sealed CatalogRescanCounts
   CatalogRescanDelta({ int newProjects, int newSessions })
   CatalogRescanTotals({ int projects, int sessions })
+
+sealed CatalogRescanStartResult          // returned by start(pluginId)
+  CatalogRescanStartAccepted()
+  CatalogRescanStartNotImportable()
+  CatalogRescanStartUnsupported()
+  CatalogRescanStartFailed()
 ```
 
-Five variants rather than a single terminal state with nullable fields, so a
-mixed outcome across N harnesses is representable and a half-populated one is
-not. `CatalogRescanPartlyFailed` deliberately carries no counts: the row reports
-the failure, and a partial count would invite the reader to trust it as the
-whole result.
+Separate variants rather than a single state with nullable fields, so a mixed
+outcome across N harnesses is representable and a half-populated one is not.
+`CatalogRescanPartlyFailed` deliberately carries no counts: the row reports the
+failure, and a partial count would invite the reader to trust it as the whole
+result.
 
 Neither failure variant carries free text. `CatalogImportFailed.message` is the
 bridge's `error.toString()` and is not privacy-bounded, so it is never lifted
 into client state where a widget could render it.
+
+`CatalogRescanStartResult` exists so a **targeted** rescan can report back to the
+card that asked for it. `PluginManagementCubit` holds the latest result per
+plugin id, mirroring the `Map<String, PluginInstallProgress>` it already keeps
+for installs, so the rejection lands on the harness the user selected rather than
+in the shared aggregate row. The fan-out ignores the result and keeps its silent
+skip.
 
 ### Lifetimes owned by the service
 
@@ -438,6 +460,18 @@ The retained progress map is cleared whenever a rescan starts and whenever the
 state resets to idle. Without that, a second rescan would aggregate the previous
 run's terminal entries before the harnesses reported anything, and could publish
 a terminal state before the new run had begun.
+
+A rescan **seeded from recovery resolves to `CatalogRescanIdle`, never to a
+terminal summary.** After a reconnect the service knows only which harnesses
+were still enumerating; a harness that completed or failed while the connection
+was down appears in `latestStatuses` as a terminal status that is discarded, and
+the client cannot tell whether it belonged to this rescan, the previous one, or
+bridge-startup hydration, because `latestStatuses` carries no operation identity
+and no grouping. Publishing a success from that partial membership would
+understate the counts and could hide a failed harness behind an authoritative
+"Rescan complete". Recovery therefore shows progress and refreshes the lists when
+it settles, and claims no summary. Only a rescan this client observed from its
+start reports a terminal result.
 
 Terminal outcomes are adopted only from the SSE stream, and only for a rescan
 this service already knows is running. This is deliberately the whole lifetime
@@ -464,8 +498,19 @@ finished shows nothing rather than replaying a stale success.
 - A newer bridge talking to an older client is unaffected: the added key is
   ignored by the older decoder.
 - No new route, no route signature change, and no change to either existing
-  request body. Fanning out one request per harness keeps the client working
-  against every published bridge.
+  request body.
+- **`/plugin/import` does not exist on every supported bridge.** It shipped in
+  `v1.6.0` (PR #488), while the owner-approved compatibility baseline is
+  `>= v1.4.0`. A `v1.4.x` or `v1.5.x` bridge is a supported peer with no import
+  route at all, so the deep pull would otherwise perform its soft refresh and
+  silently do nothing.
+
+  When **every** harness in a fan-out answers `404`, the service publishes
+  `CatalogRescanUnsupported` and the row says the bridge needs updating. A
+  targeted start on such a bridge returns `CatalogRescanStartUnsupported` and the
+  card says the same. Sniffing the error body to tell a missing route from an
+  unknown plugin is deliberately avoided: both mean "this bridge cannot rescan",
+  and an all-`404` fan-out is the honest signal for it.
 - The `projectionVersion` bump writes new marker rows and leaves the
   `projectionVersion = 1` rows in place. No migration, no backfill, no schema
   change.
@@ -487,6 +532,8 @@ New in-memory mutable parts:
 | `bool _disposed` | `CatalogRescanService` | Module convention for `Disposable` services |
 | `bool _deepArmed` | `PregoSliverRefreshControl` | The refresh control reports pull distance continuously but fires `onRefresh` once; the threshold state at release must survive that one frame |
 | One subscription and one state field each | `ProjectListCubit`, `SessionListCubit`, `PluginManagementCubit` | The shell's Layer-4 boundary: widgets render cubit state rather than holding a service stream, and the two list cubits own their own post-success refresh |
+| `bool _recoverySeeded` | `CatalogRescanService` | Distinguishes a rescan this client started from one discovered already running, so only the former reports a terminal summary. Cleared on every start and every reset |
+| `Map<String, CatalogRescanStartResult>` | `PluginManagementCubit` | Per-card targeted-start results, mirroring the `Map<String, PluginInstallProgress>` the cubit already keeps |
 
 Two fan-outs are recorded rather than hidden: `startAll()` issues one `POST` per
 enabled harness, and `cancel()` issues one `DELETE` per running harness. Both
@@ -538,6 +585,7 @@ Deliberately **not** added:
 | A cancel `DELETE` races a harness that just completed | The bridge answers on the already-settled plugin and the SSE terminal event wins | Accepted; no client-side ordering guard |
 | A failure row names no cause | The user must open the bridge log to learn why a harness failed | Accepted. `CatalogImportFailed.message` is unbounded `error.toString()`; a vaguer row is the honest trade until a producer-side sanitization boundary exists |
 | A lost response for a start that never arrived | That harness stays in `pluginIds` with no progress until the connection resets | Accepted. Bounded and self-clearing; a third result type across two layers is not worth it |
+| A rescan interrupted by a disconnect reports no summary | The user sees progress resume and the lists refresh, but no "Rescan complete" line for that run | Accepted deliberately. The alternative is claiming a total the client cannot vouch for; the lists, which are what the user actually came for, are still correct |
 
 ## Cleanup Assessment
 
@@ -590,6 +638,8 @@ Required matrix:
 | Compatibility | One run against a bridge that omits `newItems` | Proves the totals fallback rather than a false `Nothing new` |
 | Recovery | One reconnect against a bridge holding terminal statuses | Proves the recovery read discards them instead of announcing a stale success |
 | Freshness | One rescan that genuinely imports a new session, observed in the list without a second manual refresh | The whole point of the feature; a committed import raises no list invalidation, so the post-success refresh is the only thing making the new row appear |
+| Compatibility | One run against a supported bridge older than `v1.6.0`, which has no `/plugin/import` at all | Proves the gesture reports an unsupported bridge instead of silently doing nothing |
+| Recovery | One disconnect mid-rescan, reconnect, and settle | Proves the recovered run refreshes the lists and claims no summary |
 | Setup state | One setup-blocked harness on Settings to Harnesses | Proves `Rescan` is not offered as a tappable no-op for a harness the bridge will reject |
 
 Any reduction to this matrix requires explicit user acceptance recorded here
@@ -736,7 +786,10 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
   table above; select harnesses by `runtimeState.isRoutable`; never lift
   `CatalogImportFailed.message` into state; and expose
   `ValueStream<CatalogRescanState>`, `startAll()`, `start(pluginId)`,
-  `cancel()`, and `dismiss()`.
+  `cancel()`, and `dismiss()`. `start(pluginId)` returns a typed
+  `CatalogRescanStartResult`; publish `CatalogRescanUnsupported` when every
+  harness in a fan-out answers `404`; and let a recovery-seeded rescan resolve
+  to `CatalogRescanIdle` rather than to a terminal summary.
 - Leave `sse_event.dart` and `sse_event_tracker.dart` untouched.
 - Tests: aggregation across two concurrent harnesses; all five states including
   a mixed success/failure fan-out; the older-bridge payload with `newItems`
@@ -749,7 +802,10 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
   sequential rescan** proving the previous run's terminal entries do not leak
   into the new aggregate; a failure state surviving well past 4s while a
   success clears; and a start whose response is lost still reaching a terminal
-  state from SSE.
+  state from SSE; a fan-out where every harness answers `404` publishing
+  `CatalogRescanUnsupported`; a dispatched start publishing `CatalogRescanStarting`
+  before any progress arrives; and a recovery-seeded rescan settling to idle with
+  no summary while still refreshing.
 
 ### Verification
 
@@ -797,7 +853,7 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
   `CatalogRescanPartlyFailed`, because a committed import raises no list
   invalidation of its own.
 - The aggregate rescan row widget in `client/app/lib/core/widgets/`, beside the
-  shell's other cross-feature widgets, with its five presentations. It renders
+  shell's other cross-feature widgets, with its seven presentations. It renders
   the state it is given, owns no timer, and renders no bridge-supplied text.
 - Project list, full-screen session list, and split-view pane: wire
   `onDeepRefresh` to the cubit's `startRescan()`, and render the row as the
@@ -806,13 +862,15 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
 - Settings to Harnesses: the per-harness `Rescan` action in
   `_HarnessControlCard`, calling `startRescanFor(pluginId)`, enabled only for a
   harness whose `runtimeState.isRoutable` is true and disabled while that
-  harness is already rescanning. A targeted `503` or `404` is surfaced on the
-  card rather than silently skipped.
+  harness is already rescanning. The typed `CatalogRescanStartResult` is held
+  per plugin id by `PluginManagementCubit` and rendered on that card, so a
+  targeted `503`, `404`, or unsupported-bridge answer lands on the harness the
+  user selected instead of the shared row.
 - New `app_en.arb` resources for both captions, the five row states, the delta
   and totals wordings, the `Nothing new` case, the partly-failed wording, the
   bounded failure line naming the bridge log, and the Settings action with its
   semantics label and its rejection message.
-- Widget and cubit tests: all five row states; the totals fallback; cancel;
+- Widget and cubit tests: all seven row states; the totals fallback; cancel;
   dismiss; the Settings action's enablement rules and its targeted rejection;
   that a terminal success triggers exactly one list refresh per list cubit; and
   that no test fixture's `CatalogImportFailed.message` reaches a rendered

--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -222,9 +222,32 @@ entry. It is not pinned, not a banner, not a toast, not a dialog.
 |---|---|---|---|---|
 | Running | indeterminate ring | `Rescanning harnesses` | harness currently enumerating plus its running session count | cancel |
 | Succeeded | check | `Rescan complete` | new-item summary | none; the service clears it after 4s |
-| Partly failed | warning | `Rescan finished` | `1 of 3 harnesses failed` plus the sanitized message | dismiss |
-| Failed | warning | `Rescan failed` | sanitized `CatalogImportFailed.message` | dismiss |
+| Partly failed | warning | `Rescan finished` | `1 of 3 harnesses could not be rescanned` | dismiss |
+| Failed | warning | `Rescan failed` | `Check the bridge log for details` | dismiss |
 | Cancelled | — | — | — | row removed immediately |
+
+**No failure text from the bridge is rendered.** `CatalogImportService._run`
+catches `Object` and sends `error.toString()` as `CatalogImportFailed.message`,
+so that field can carry paths, identifiers, and other local context. It is a
+useful bridge log line and an unsafe phone string. The row therefore reports a
+bounded failure and points at the log, and `CatalogRescanFailed` carries no free
+text at all. Adding a sanitization boundary at the producer would let the row say
+more; that is recorded as a follow-up rather than smuggled into this series.
+
+### Refreshing the list after a rescan commits
+
+A committed import does **not** invalidate the client's lists today.
+`CatalogImportRepository.backendActivity` feeds only `ChatHistoryActivityListener`
+(`orchestrator.dart:524-527`); the `sessionsUpdated` producers are PR sync and
+the unseen service, neither of which the import touches. The stage-1 soft refresh
+runs on release, before the import commits, so without an explicit refresh the
+row would announce new sessions over a list that still lacks them.
+
+`ProjectListCubit` and `SessionListCubit` therefore refresh themselves when the
+rescan reaches `CatalogRescanSucceeded` or `CatalogRescanPartlyFailed`, reusing
+the existing silent refresh each already owns. This is a client-side refresh, not
+a new bridge event: the progress stream is global, so a rescan started from the
+CLI or from another surface refreshes these lists just the same.
 
 With several harnesses enabled the row stays a single row. Its subtitle names
 whichever harness is currently enumerating; it does not grow one row per
@@ -250,20 +273,26 @@ the pull gesture is invisible to screen readers and awkward with a mouse, and
 the reporter runs the bridge on a desktop. The user chose this placement over an
 app-bar menu item.
 
-The action is offered only for a harness whose `runtimeState.isEnabled` is true,
+The action is offered only for a harness whose `runtimeState.isRoutable` is true,
 and it is disabled while that harness already has a rescan in flight.
+`isEnabled` is deliberately **not** the predicate: it is true for
+`PluginRuntimeState.blocked` and `failed`, neither of which the bridge admits to
+`startAllowedPluginIds` (`plugin_runtime.dart:105-108`, which requires
+`accessGate == enabled && slot.startAllowed`). Offering a tappable `Rescan` on a
+setup-blocked harness would produce a `503` and, under the fan-out's silent-skip
+rule, no visible result at all.
+
+The silent `503` skip belongs to `startAll()` only. A **targeted** rescan — the
+Settings action, where the user named exactly one harness — surfaces the
+rejection on the card instead of skipping it.
 
 ## Ownership And Data Flow
 
 ```text
-pull past 1.6x   ->  ProjectListCubit / SessionListCubit
-Settings Rescan  ->  PluginManagementCubit
-                          |
-                          v
                   CatalogRescanService          (client/module_core/lib/src/services)
-                    |  startAll() / start(pluginId) / cancel()
+                    |  startAll() / start(pluginId) / cancel() / dismiss()
                     |
-                    +-- PluginManagementService.snapshots   (enabled set + display names)
+                    +-- PluginManagementService.snapshots   (routable set + display names)
                     |
                     +-- PluginRepository                    (client/module_core/lib/src/repositories)
                     |        v
@@ -275,10 +304,32 @@ Settings Rescan  ->  PluginManagementCubit
                           |
                           v
                   ValueStream<CatalogRescanState>
-                          v
-        rescan row in client/app/lib/core/widgets/, hosted by
-        the project list, the session list, and the split-view pane
+                          |
+        +-----------------+------------------+
+        v                 v                  v
+  ProjectListCubit  SessionListCubit  PluginManagementCubit
+        |                 |                  |
+        |  each exposes the rescan state in  |
+        |  its own state and refreshes its   |
+        |  list on a terminal success        |
+        v                 v                  v
+  project list      session list +      Settings > Harnesses
+                    split-view pane
+
+  Widgets watch their cubit and dispatch intents to it. No widget holds
+  the service stream, and no widget calls the service directly.
 ```
+
+No widget subscribes to `CatalogRescanService`. Each surface's existing cubit
+gains one subscription to its `ValueStream`, surfaces the rescan state through
+its own state, and exposes the intent methods the screen dispatches
+(`startRescan()`, `startRescanFor(pluginId)`, `cancelRescan()`,
+`dismissRescan()`). This keeps the shell's Layer-4 boundary intact and puts the
+post-success list refresh in the object that already owns refreshing.
+
+A dedicated `CatalogRescanCubit` was considered and rejected: the two list
+surfaces must refresh themselves on success, which only their own cubits can do,
+so a fourth cubit would add an object without removing any wiring.
 
 `CatalogRescanService` is a `@lazySingleton` in `module_core`, resolved with
 `getIt<CatalogRescanService>()` per the app shell's DI convention. Its declared
@@ -296,15 +347,38 @@ maintained, already refreshed on reconnect, and already invalidated by
 `client/module_core/lib/src/services/models/catalog_rescan_state.dart`.
 
 `startAll()` reads the current management snapshot, keeps every harness whose
-`runtimeState.isEnabled` is true, and issues one `POST /plugin/import` per
+`runtimeState.isRoutable` is true, and issues one `POST /plugin/import` per
 harness. A harness the bridge reports as unavailable answers `503` and a harness
-it does not know answers `404`; both are skipped silently, because a harness
-that cannot import is not an error the user asked about. Any other failure
-surfaces on the row.
+it does not know answers `404`; in the fan-out both are skipped silently, because
+a harness that cannot import is not an error the user asked about.
 
 `cancel()` issues one `DELETE /plugin/import` per id in
 `CatalogRescanRunning.pluginIds`, because the route cancels exactly one plugin
 per call.
+
+### A harness joins the rescan on dispatch, not on acknowledgement
+
+`RelayHttpApiClient` can complete a request with `TimeoutException` or
+`RelayResponseLostException` (`relay_client.dart:172, 491, 570`) **after** the
+POST or DELETE was already delivered. Membership is therefore recorded when the
+request is dispatched, not when it is acknowledged:
+
+| Outcome of the start request | Effect on `pluginIds` |
+|---|---|
+| Accepted | stays |
+| `404` or `503` | removed; the harness cannot import |
+| Any other explicit rejection | removed and counted as failed |
+| Timeout or lost response | **stays**; the import may well be running |
+
+A harness leaves the set on its own terminal SSE event. A start whose response
+was lost therefore still renders progress and still reaches a terminal state,
+instead of being written off as failed while the bridge imports.
+
+This is deliberately a membership rule rather than a third "uncertain" result
+type. The only case the rule does not settle is a lost response for a request
+that genuinely never arrived: that harness stays in `pluginIds` with no progress
+until the connection resets the state to idle, which is a bounded, self-clearing
+outcome and not worth a new result variant across two layers.
 
 ### State
 
@@ -314,9 +388,8 @@ sealed CatalogRescanState
   CatalogRescanRunning({ String activePluginName, int sessionsSeen,
                          Set<String> pluginIds })
   CatalogRescanSucceeded({ int harnessCount, CatalogRescanCounts counts })
-  CatalogRescanPartlyFailed({ int succeededCount, int failedCount,
-                              String message })
-  CatalogRescanFailed({ int harnessCount, String message })
+  CatalogRescanPartlyFailed({ int succeededCount, int failedCount })
+  CatalogRescanFailed({ int harnessCount })
 
 sealed CatalogRescanCounts
   CatalogRescanDelta({ int newProjects, int newSessions })
@@ -329,6 +402,10 @@ not. `CatalogRescanPartlyFailed` deliberately carries no counts: the row reports
 the failure, and a partial count would invite the reader to trust it as the
 whole result.
 
+Neither failure variant carries free text. `CatalogImportFailed.message` is the
+bridge's `error.toString()` and is not privacy-bounded, so it is never lifted
+into client state where a widget could render it.
+
 ### Lifetimes owned by the service
 
 The service owns every transition out of a terminal state. The row widget
@@ -336,11 +413,22 @@ renders whatever it is given and owns no timer.
 
 | Trigger | Transition |
 |---|---|
-| 4s after a terminal state | to `CatalogRescanIdle` |
-| Dismiss tapped on a failure | to `CatalogRescanIdle` |
+| 4s after `CatalogRescanSucceeded` | to `CatalogRescanIdle` |
+| Dismiss tapped on either failure state | to `CatalogRescanIdle` |
 | Cancel confirmed | to `CatalogRescanIdle` |
-| Connection lost, or the active bridge changes | to `CatalogRescanIdle` |
+| A new rescan starts | to `CatalogRescanRunning`, clearing the retained progress map first |
+| Connection lost, or the active bridge changes | to `CatalogRescanIdle`, clearing the retained progress map |
 | Connection established or restored | seed from `GET /plugin/import`, keeping only `CatalogImportEnumerating` and `CatalogImportCommitting`; discard every terminal status |
+
+The 4s clear applies to **success only**. `CatalogRescanPartlyFailed` and
+`CatalogRescanFailed` persist until the user dismisses them, a new rescan
+starts, or the connection resets: a diagnostic the user did not get to read is
+worse than a row that outstays its welcome.
+
+The retained progress map is cleared whenever a rescan starts and whenever the
+state resets to idle. Without that, a second rescan would aggregate the previous
+run's terminal entries before the harnesses reported anything, and could publish
+a terminal state before the new run had begun.
 
 Terminal outcomes are adopted only from the SSE stream, and only for a rescan
 this service already knows is running. This is deliberately the whole lifetime
@@ -383,12 +471,13 @@ New in-memory mutable parts:
 
 | Part | Owner | Why it must exist |
 |---|---|---|
-| `Map<String, CatalogImportProgress>` | `CatalogRescanService` | Aggregating several concurrent harness imports into one row requires the latest progress per harness |
+| `Map<String, CatalogImportProgress>` | `CatalogRescanService` | Aggregating several concurrent harness imports into one row requires the latest progress per harness. Cleared on every rescan start and on every reset to idle |
 | `BehaviorSubject<CatalogRescanState>` | `CatalogRescanService` | The published stream, seeded so a late subscriber renders correctly |
 | `CompositeSubscription` | `CatalogRescanService` | SSE plus connection-status subscriptions, matching `PluginManagementService` |
-| `Timer?` | `CatalogRescanService` | The 4s terminal-state clear. Owned here, not by the row, so two mounted hosts cannot run disagreeing timers |
+| `Timer?` | `CatalogRescanService` | The 4s success clear. Owned here, not by the row, so two mounted hosts cannot run disagreeing timers. Never armed for a failure state |
 | `bool _disposed` | `CatalogRescanService` | Module convention for `Disposable` services |
 | `bool _deepArmed` | `PregoSliverRefreshControl` | The refresh control reports pull distance continuously but fires `onRefresh` once; the threshold state at release must survive that one frame |
+| One subscription and one state field each | `ProjectListCubit`, `SessionListCubit`, `PluginManagementCubit` | The shell's Layer-4 boundary: widgets render cubit state rather than holding a service stream, and the two list cubits own their own post-success refresh |
 
 Two fan-outs are recorded rather than hidden: `startAll()` issues one `POST` per
 enabled harness, and `cancel()` issues one `DELETE` per running harness. Both
@@ -409,6 +498,17 @@ Deliberately **not** added:
   reconnects. There is no timer and no repeated read.
 - **No generation or fence machinery.** Resetting to idle on disconnect makes it
   unnecessary at this scale.
+- **No third "uncertain" mutation result.** A dispatch-based membership rule
+  closes the lost-response hole without a new result variant threaded through
+  the API and repository layers.
+- **No fourth `CatalogRescanCubit`.** The two list cubits must refresh
+  themselves on success, so a dedicated cubit would add an object without
+  removing any wiring.
+- **No client-side sanitizer for `CatalogImportFailed.message`.** The field is
+  simply never lifted into client state. Sanitizing at the consumer would still
+  have carried the raw string over the wire.
+- **No new bridge event for post-import list invalidation.** The two list cubits
+  already own a silent refresh and already see the global progress stream.
 - **No changes to the two SSE switch arms.** Both are correct as they stand;
   the service pattern-matches the event itself.
 - **No persisted last-rescan timestamp.** A `Last scanned 6 days ago - Rescan`
@@ -427,6 +527,8 @@ Deliberately **not** added:
 | A rescan in flight when the connection drops | The row disappears and does not return | Accepted. The bridge continues and commits the import; the next connect seeds only non-terminal statuses, so a rescan that finished meanwhile is simply not announced |
 | Two surfaces trigger a rescan for the same harness at once | The bridge coalesces it: `CatalogImportService.start` finds the active control and applies the trigger to it | No client-side guard needed; existing bridge behavior is correct |
 | A cancel `DELETE` races a harness that just completed | The bridge answers on the already-settled plugin and the SSE terminal event wins | Accepted; no client-side ordering guard |
+| A failure row names no cause | The user must open the bridge log to learn why a harness failed | Accepted. `CatalogImportFailed.message` is unbounded `error.toString()`; a vaguer row is the honest trade until a producer-side sanitization boundary exists |
+| A lost response for a start that never arrived | That harness stays in `pluginIds` with no progress until the connection resets | Accepted. Bounded and self-clearing; a third result type across two layers is not worth it |
 
 ## Cleanup Assessment
 
@@ -478,6 +580,8 @@ Required matrix:
 | Platform | One mobile platform plus the wide split-view layout | The pane hosts stage 2 through a different scroll owner than the two scaffold hosts |
 | Compatibility | One run against a bridge that omits `newItems` | Proves the totals fallback rather than a false `Nothing new` |
 | Recovery | One reconnect against a bridge holding terminal statuses | Proves the recovery read discards them instead of announcing a stale success |
+| Freshness | One rescan that genuinely imports a new session, observed in the list without a second manual refresh | The whole point of the feature; a committed import raises no list invalidation, so the post-success refresh is the only thing making the new row appear |
+| Setup state | One setup-blocked harness on Settings to Harnesses | Proves `Rescan` is not offered as a tappable no-op for a harness the bridge will reject |
 
 Any reduction to this matrix requires explicit user acceptance recorded here
 before the plan is retired.
@@ -493,6 +597,11 @@ before the plan is retired.
 - Analytics. This is a reliability repair for a reported defect, not a product
   adoption question.
 - Any change to `client/desktop`, which hosts no project or session list.
+- A privacy-safe mapping for `CatalogImportFailed.message`. The right fix is a
+  bounded failure reason at the producer in `CatalogImportService._run`, keeping
+  the original error and stack trace in the local bridge log. Until that exists
+  the row reports a bounded failure and names the log; this series does not
+  change the producer, and no client code renders the field.
 
 ## Delivery Rules
 
@@ -503,11 +612,11 @@ before the plan is retired.
   matrix.
 - `architecture-plan-review` reviewed this plan and rejected the first revision;
   all ten findings were applied directly and are recorded in `TRACKER.md`.
-- Run `architecture-implementation-review` on steps 3, 4, and 6, which are the
-  architecture-bearing ones. Steps 2, 7, and 8 do not qualify. Step 5 qualifies
-  only because it introduces a new shared `module_prego` component and changes
-  which owner drives the pane's scroll; review it if that component's API is not
-  a straight extraction.
+- Run `architecture-implementation-review` on steps 3, 4, 5, and 6. Step 5 is
+  included unconditionally: it adds a new shared production component and moves
+  which owner drives the split-view pane's scroll, which is an architecture
+  boundary regardless of how much of its API is a straight extraction. Steps 2,
+  7, and 8 do not qualify.
 - Step 8 moves `.plan/active/catalog-rescan/` to
   `.plan/completed/catalog-rescan/` only after the recorded L3 matrix passes.
 
@@ -515,12 +624,12 @@ before the plan is retired.
 
 | Step | Exact PR title | Changed-line target |
 |---|---|---:|
-| 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 850-1,000 |
+| 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 1,050-1,250 |
 | 2/8 | `🌱 [catalog-rescan] Re-hydrate stale plugin catalogs [step 2/8]` | 20-60 |
 | 3/8 | `⚙️ [catalog-rescan] Report new items from a catalog import [step 3/8]` | 350-600 |
 | 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 |
 | 5/8 | `⚙️ [catalog-rescan] Add a second stage to pull-to-refresh [step 5/8]` | 350-600 |
-| 6/8 | `⚙️ [catalog-rescan] Surface catalog rescan in the app [step 6/8]` | 700-1,100 |
+| 6/8 | `⚙️ [catalog-rescan] Surface catalog rescan in the app [step 6/8]` | 950-1,400 |
 | 7/8 | `🌱 [catalog-rescan] Reconcile catalog rescan regression docs [step 7/8]` | 80-160 |
 | 8/8 | `🌱 [catalog-rescan] Verify and retire the catalog rescan plan [step 8/8]` | 60-140 |
 
@@ -612,16 +721,24 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
   exactly as `PluginManagementService._onSseEvent` does; read
   `GET /plugin/import` once on connect and reconnect, keeping only
   `CatalogImportEnumerating` and `CatalogImportCommitting`; reset to
-  `CatalogRescanIdle` on disconnect and on an active-bridge change; own the 4s
-  terminal clear; and expose `ValueStream<CatalogRescanState>`, `startAll()`,
-  `start(pluginId)`, `cancel()`, and `dismiss()`.
+  `CatalogRescanIdle` on disconnect and on an active-bridge change; clear the
+  retained progress map on every rescan start and every reset; arm the 4s clear
+  for `CatalogRescanSucceeded` only; record membership on dispatch per the
+  table above; select harnesses by `runtimeState.isRoutable`; never lift
+  `CatalogImportFailed.message` into state; and expose
+  `ValueStream<CatalogRescanState>`, `startAll()`, `start(pluginId)`,
+  `cancel()`, and `dismiss()`.
 - Leave `sse_event.dart` and `sse_event_tracker.dart` untouched.
 - Tests: aggregation across two concurrent harnesses; all five states including
   a mixed success/failure fan-out; the older-bridge payload with `newItems`
   omitted; a reconnect whose `GET` holds only terminal statuses producing no
   row; a reconnect whose `GET` holds an in-flight status producing a running
   row; a disconnect clearing an active rescan; a fan-out where one harness
-  answers `503`; and cancel issuing one `DELETE` per running harness.
+  answers `503`; cancel issuing one `DELETE` per running harness; a **second
+  sequential rescan** proving the previous run's terminal entries do not leak
+  into the new aggregate; a failure state surviving well past 4s while a
+  success clears; and a start whose response is lost still reaching a terminal
+  state from SSE.
 
 ### Verification
 
@@ -655,26 +772,40 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
 - `dart analyze --fatal-infos` from `client/module_prego` and `client/app`
 - `dart run tool/generate_manifest.dart --check` from `client/design_catalog`
   if a scenario was added
+- architecture implementation review
 
 ## Step 6/8 - Surface Catalog Rescan In The App
 
 ### Scope
 
+- `ProjectListCubit`, `SessionListCubit`, and `PluginManagementCubit` each
+  subscribe to `CatalogRescanService`, surface the rescan state through their
+  own state, and expose `startRescan()`, `startRescanFor(pluginId)`,
+  `cancelRescan()`, and `dismissRescan()`. The two list cubits additionally run
+  their existing silent refresh on `CatalogRescanSucceeded` and
+  `CatalogRescanPartlyFailed`, because a committed import raises no list
+  invalidation of its own.
 - The aggregate rescan row widget in `client/app/lib/core/widgets/`, beside the
   shell's other cross-feature widgets, with its five presentations. It renders
-  the state it is given and owns no timer.
+  the state it is given, owns no timer, and renders no bridge-supplied text.
 - Project list, full-screen session list, and split-view pane: wire
-  `onDeepRefresh` to `CatalogRescanService.startAll()`, and render the row as
-  the sliver at index 0 in place of the soft-refresh indicator while a rescan is
+  `onDeepRefresh` to the cubit's `startRescan()`, and render the row as the
+  sliver at index 0 in place of the soft-refresh indicator while a rescan is
   running.
 - Settings to Harnesses: the per-harness `Rescan` action in
-  `_HarnessControlCard`, calling `start(pluginId)`, enabled only for an enabled
-  harness and disabled while that harness is already rescanning.
+  `_HarnessControlCard`, calling `startRescanFor(pluginId)`, enabled only for a
+  harness whose `runtimeState.isRoutable` is true and disabled while that
+  harness is already rescanning. A targeted `503` or `404` is surfaced on the
+  card rather than silently skipped.
 - New `app_en.arb` resources for both captions, the five row states, the delta
-  and totals wordings, the `Nothing new` case, the partly-failed wording, and
-  the Settings action with its semantics label.
-- Widget tests: all five row states; the totals fallback; cancel; dismiss; and
-  the Settings action's enablement rules.
+  and totals wordings, the `Nothing new` case, the partly-failed wording, the
+  bounded failure line naming the bridge log, and the Settings action with its
+  semantics label and its rejection message.
+- Widget and cubit tests: all five row states; the totals fallback; cancel;
+  dismiss; the Settings action's enablement rules and its targeted rejection;
+  that a terminal success triggers exactly one list refresh per list cubit; and
+  that no test fixture's `CatalogImportFailed.message` reaches a rendered
+  string.
 
 ### Verification
 
@@ -689,12 +820,13 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
 
 - `docs/regression/projects-and-sessions.md`: record the client-triggered
   rescan, the two-stage pull across all three hosts, the aggregate progress row
-  and its terminal states, cancellation, new-item reporting with its
+  and its terminal states, the post-success list refresh, failure rows
+  persisting until dismissal, cancellation, new-item reporting with its
   older-bridge fallback, and the recovery read discarding terminal statuses.
 - `docs/regression/plugin-setup-and-lifecycle.md`: record the per-harness
-  `Rescan` action and its enablement rules.
-- Record the required plugin, platform, compatibility, and recovery matrix in
-  both.
+  `Rescan` action, its `isRoutable` enablement rule, and its targeted rejection.
+- Record the required plugin, platform, compatibility, recovery, freshness, and
+  setup-state matrix in both.
 
 ### Verification
 
@@ -707,8 +839,8 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
 ### Scope
 
 - Run the recorded L3 matrix, including both ownership branches, the two-harness
-  mixed-outcome run, the older-bridge compatibility run, and the reconnect
-  recovery run.
+  mixed-outcome run, the older-bridge compatibility run, the reconnect recovery
+  run, the freshness run, and the setup-blocked harness run.
 - Record the result, and any explicitly accepted reduction, in `TRACKER.md`.
 - Move `.plan/active/catalog-rescan/` to `.plan/completed/catalog-rescan/` once
   that coverage passes.

--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -560,14 +560,14 @@ New in-memory mutable parts:
 
 | Part | Owner | Why it must exist |
 |---|---|---|
-| `Map<String, CatalogImportProgress>` | `CatalogRescanService` | Aggregating several concurrent harness imports into one row requires the latest progress per harness. Cleared on every rescan start and on every reset to idle |
+| `Map<String, CatalogImportProgress>` | `CatalogRescanService` | Aggregating several concurrent harness imports into one row requires the latest progress per harness. Cleared only when a start **opens** an operation from idle or terminal, and on every reset to idle. A start that joins a live operation must not clear it |
 | `BehaviorSubject<CatalogRescanState>` | `CatalogRescanService` | The published stream, seeded so a late subscriber renders correctly |
 | `CompositeSubscription` | `CatalogRescanService` | SSE plus connection-status subscriptions, matching `PluginManagementService` |
 | `Timer?` | `CatalogRescanService` | The 4s success clear. Owned here, not by the row, so two mounted hosts cannot run disagreeing timers. Never armed for a failure state |
 | `bool _disposed` | `CatalogRescanService` | Module convention for `Disposable` services |
 | `bool _deepArmed` | `PregoSliverRefreshControl` | The refresh control reports pull distance continuously but fires `onRefresh` once; the threshold state at release must survive that one frame |
 | One subscription and one state field each | `ProjectListCubit`, `SessionListCubit`, `PluginManagementCubit` | The shell's Layer-4 boundary: widgets render cubit state rather than holding a service stream, and the two list cubits own their own post-success refresh |
-| `bool _recoverySeeded` | `CatalogRescanService` | Distinguishes a rescan this client started from one discovered already running, so only the former reports a terminal summary. Cleared on every start and every reset |
+| `bool _recoverySeeded` | `CatalogRescanService` | Marks the live operation `observed` rather than `owned`, so only a fully-seen run reports a terminal summary. Set when an operation opens from the recovery `GET` or from unsolicited progress; cleared when a start opens a new operation and on every reset. A join leaves it untouched, because joining an `observed` run does not make this client the observer of its earlier members |
 | `Map<String, CatalogRescanStartResult>` | `PluginManagementCubit` | Per-card targeted-start results, mirroring the `Map<String, PluginInstallProgress>` the cubit already keeps |
 
 Two fan-outs are recorded rather than hidden: `startAll()` issues one `POST` per
@@ -718,7 +718,7 @@ before the plan is retired.
 
 | Step | Exact PR title | Changed-line target |
 |---|---|---:|
-| 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 1,300-1,450 |
+| 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 950-1,100 (`PLAN.md`) |
 | 2/8 | `🌱 [catalog-rescan] Re-hydrate stale plugin catalogs [step 2/8]` | 20-60 |
 | 3/8 | `⚙️ [catalog-rescan] Report new items from a catalog import [step 3/8]` | 350-600 |
 | 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 |
@@ -729,6 +729,14 @@ before the plan is retired.
 
 Step 5 is `⚙️` rather than `🌿` because it extracts a new shared component and
 moves the split-view pane onto it, rather than adding a parameter to one widget.
+
+Step 1's target is measured against `PLAN.md` alone. Both files are new, so the
+combined numstat counts every line of `TRACKER.md` too — including its review
+records and verification log, which grow with each review round rather than with
+scope. Budgeting the combined figure would mean widening the target whenever
+review documentation grew, which measures nothing. The delivered scope of step 1
+is the plan document; the combined total is recorded in `TRACKER.md` as
+information only.
 
 ## Step 1/8 - Publish The Plan
 
@@ -816,7 +824,8 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
   `GET /plugin/import` once on connect and reconnect, keeping only
   `CatalogImportEnumerating` and `CatalogImportCommitting`; reset to
   `CatalogRescanIdle` on disconnect and on an active-bridge change; clear the
-  retained progress map on every rescan start and every reset; arm the 4s clear
+  retained progress map only when a start opens an operation and on every reset,
+  never on a join; arm the 4s clear
   for `CatalogRescanSucceeded` only; record membership on dispatch per the
   table above; select harnesses by `runtimeState.isRoutable`; never lift
   `CatalogImportFailed.message` into state; and expose

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -225,7 +225,9 @@ independently verified in the tree before the correction was applied.
 - **Step 1 documentation validation:** `git diff --check` passed; step tokens
   and exact PR titles diffed clean between `PLAN.md` and `TRACKER.md`; plan
   files only in the diff
-- **Step 1 changed lines:** 950 documentation-only insertions, 0 deletions
+- **Step 1 changed lines:** 957 documentation-only insertions, 0 deletions, from
+  `git diff --numstat <merge-base>...HEAD` (informational only; the figure counts
+  these verification-log lines, so it cannot independently validate the target)
 - **Step 1 review:** `architecture-plan-review` rejected the first revision;
   all ten findings applied directly, recorded above
 - **Step 1 PR:** [#1064](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1064)

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -276,12 +276,26 @@ committed import raises no list invalidation.
 | Route rescan actions and state through cubits | All three cubits gain a subscription, state, and intent methods; no widget holds the service stream. A dedicated fourth cubit was considered and rejected in the plan |
 | Do not enable Rescan for blocked harnesses | Enablement moved to `runtimeState.isRoutable`, and a targeted rejection is surfaced on the card. The silent `503` skip is now scoped to the fan-out only |
 
+### Second round on #1064
+
+`cubic-dev-ai` raised two more findings, both applied.
+
+| Finding | Correction applied |
+|---|---|
+| The N-harness counts reduction was never defined | Counts are summed across every succeeded harness; the carrier is a delta only when every succeeded harness reported one, otherwise summed totals. Applied in `8ed1dce81` with two step-4 tests |
+| The PR description still quoted the superseded changed-line total | Description updated to the recomputed figure with its per-file split |
+
+Two replies in the first codex round were posted to each other's threads. Both
+underlying fixes had landed correctly in the plan; only the routing was wrong.
+Corrected replies were posted on both threads, the fully-addressed one was
+resolved, and the partially-addressed one was re-opened.
+
 ## Verification Log
 
 - **Step 1 documentation validation:** `git diff --check` passed; step tokens
   and exact PR titles diffed clean between `PLAN.md` and `TRACKER.md`; plan
   files only in the diff
-- **Step 1 changed lines:** 1,156 documentation-only insertions, 0 deletions, from
+- **Step 1 changed lines:** 1,170 documentation-only insertions, 0 deletions, from
   `git diff --numstat <merge-base>...HEAD` (informational only; the figure counts
   these verification-log lines, so it cannot independently validate the target)
 - **Step 1 review:** `architecture-plan-review` rejected the first revision;

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -175,7 +175,7 @@
 - [ ] Record membership on dispatch; keep a harness on timeout or lost response.
 - [ ] Select harnesses by `runtimeState.isRoutable`.
 - [ ] Never lift `CatalogImportFailed.message` into client state.
-- [ ] Prove aggregation across two harnesses, all five states including a mixed
+- [ ] Prove aggregation across two harnesses, all seven states including a mixed
   outcome, the older-bridge payload, both reconnect cases, a disconnect, a
   `503` in the fan-out, cancel fanning out one `DELETE` per running id, a
   second sequential rescan not inheriting the previous aggregate, a failure
@@ -199,13 +199,13 @@
 - [ ] Give all three cubits a rescan subscription, state, and intent methods.
 - [ ] Refresh both lists on `CatalogRescanSucceeded` and
   `CatalogRescanPartlyFailed`.
-- [ ] Build the rescan row in `client/app/lib/core/widgets/` with all five
+- [ ] Build the rescan row in `client/app/lib/core/widgets/` with all seven
   presentations, no timer, and no bridge-supplied text.
 - [ ] Wire all three hosts through their cubits; no widget touches the service.
 - [ ] Add the per-harness Settings action with `isRoutable` enablement and a
   surfaced targeted rejection.
 - [ ] Add every `app_en.arb` resource and commit the generated l10n.
-- [ ] Prove the five row states, the totals fallback, cancel, dismiss, the
+- [ ] Prove the seven row states, the totals fallback, cancel, dismiss, the
   Settings action's enablement and rejection, exactly one list refresh per
   cubit on terminal success, and that no fixture message reaches a rendered
   string.
@@ -244,7 +244,7 @@
 | 4 | `cancelCatalogImport()` had no `pluginId` and could not be implemented | Signature corrected; `cancel()` now fans out one `DELETE` per running harness, recorded in the complexity budget |
 | 5 | The management-snapshot collaborator and the state's location were undeclared | Both declared: `PluginManagementService.snapshots`, and `services/models/catalog_rescan_state.dart` |
 | 6 | The 4s auto-dismiss timer was owned by the row, not the state owner | Moved to `CatalogRescanService`; the row owns no timer |
-| 7 | The terminal state could not represent an N-harness outcome | Replaced with five sealed variants including `CatalogRescanPartlyFailed` |
+| 7 | The terminal state could not represent an N-harness outcome | Replaced with sealed variants including `CatalogRescanPartlyFailed`; round three extended the set to seven |
 | 8 | Nothing stated the rescan state's lifetime across disconnect or bridge change | Lifetime table added; resets to idle, no generation or fence machinery |
 | 9 | The rescan row widget's home was unnamed while two features consume it | Named `client/app/lib/core/widgets/` |
 | 10 | The delta counts were two independently nullable ints on wire and client | Grouped into one nullable `CatalogImportNewItems` and a sealed `CatalogRescanCounts` |

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -59,7 +59,7 @@
 | Progress presentation | One aggregate row | Fixed height; the top of the list never reflows as harnesses finish at different times |
 | Row placement | Ordinary sliver at index 0, scrolls with the list | Non-intrusive; a refresh already scrolls to the top, so it is visible when it matters |
 | Row home | `client/app/lib/core/widgets/` | Consumed by two features; must not live inside either |
-| Terminal state | Five sealed variants summarising the whole fan-out | One `pluginName` could not describe two harnesses finishing differently |
+| Terminal state | Sealed variants summarising the whole fan-out | One `pluginName` could not describe two harnesses finishing differently |
 | Terminal lifetime | Owned by `CatalogRescanService`, not the row | Two mounted hosts would otherwise run disagreeing 4s timers, and a revisit would replay a stale success |
 | Auto-clear scope | Success only; failures persist until dismissed | A diagnostic the user did not get to read is worse than a row that outstays its welcome |
 | Post-success refresh | Both list cubits run their existing silent refresh | A committed import raises no list invalidation, so the row would otherwise announce new sessions over a stale list |
@@ -68,6 +68,10 @@
 | Fan-out membership | Recorded on dispatch, not acknowledgement | `RelayResponseLostException` and timeouts can fire after the request landed |
 | Harness predicate | `runtimeState.isRoutable` | `isEnabled` is true for `blocked` and `failed`, which the bridge rejects with `503` |
 | Counts reduction | Summed across harnesses; delta only if every harness reported one | A delta missing a harness's contribution would understate the result while reading as authoritative |
+| Dispatched-but-silent phase | Its own `CatalogRescanStarting` variant | A single running state carrying `activePluginName` and `sessionsSeen` would have to invent both before the first progress event |
+| Older bridges | `CatalogRescanUnsupported` when every harness answers `404` | `/plugin/import` shipped in v1.6.0 but the baseline is `>= v1.4.0`, so supported peers exist with no route |
+| Recovered rescans | Resolve to idle, never to a terminal summary | `latestStatuses` has no operation identity, so a recovered run cannot honestly claim a total |
+| Targeted rejections | Typed `CatalogRescanStartResult` held per plugin id by `PluginManagementCubit` | The aggregate row cannot say which card was rejected |
 | Completion wording | New items, with a totals fallback | Reporting 193 totals after a no-op rescan would be actively misleading |
 | New-count transport | One nullable `CatalogImportNewItems` object | Two independent `int?` fields make `{5, null}` representable and meaningless |
 | Recovery read | Seed only from non-terminal statuses | `latestStatuses` retains terminal statuses forever |
@@ -86,7 +90,7 @@
 | Changing either SSE switch arm | Rejected | Both are correct; the service pattern-matches the event itself, as `PluginManagementService` already does |
 | Per-harness progress rows | Rejected | User chose the aggregate row |
 | Pinned progress row | Rejected | User chose the scrolling row |
-| Authorship tracking of who started a rescan | Rejected | The SSE event is global by design; cross-surface visibility is correct |
+| Authorship tracking of who started a rescan | Rejected | The SSE event is global by design; cross-surface visibility is correct. `_recoverySeeded` is not authorship: it records whether *this* client observed the run from its start, which is what licenses claiming a total |
 | Client polling of `GET /plugin/import` | Rejected | One filtered read on connect and reconnect is sufficient |
 | Generation or request-fence machinery | Rejected | Resetting to idle on disconnect removes the need |
 | A second `PluginRepository.getManagement()` read | Rejected | `PluginManagementService.snapshots` already maintains, refreshes, and invalidates that data |
@@ -97,6 +101,8 @@
 | A new bridge event for post-import list invalidation | Rejected | The list cubits already own a silent refresh and already see the global progress stream |
 | A client-side sanitizer for `CatalogImportFailed.message` | Rejected | Sanitizing at the consumer still carries the raw string over the wire; the field is simply not lifted into state |
 | A privacy-safe failure reason at the producer | Deferred | The right fix is a bounded reason in `CatalogImportService._run` with the original error kept in the bridge log; out of scope for this series |
+| Preserving discarded terminal statuses across a reconnect | Rejected | `latestStatuses` carries no operation identity or grouping, so "belonging to the recovered operation" is not determinable; recovered runs claim no summary instead |
+| Sniffing the error body to tell a missing route from an unknown plugin | Rejected | Both mean "this bridge cannot rescan"; an all-`404` fan-out is the honest signal |
 | Analytics for rescans | Rejected | Reliability repair for a reported defect, not a product adoption question |
 
 ## Open Questions
@@ -290,12 +296,26 @@ underlying fixes had landed correctly in the plan; only the routing was wrong.
 Corrected replies were posted on both threads, the fully-addressed one was
 resolved, and the partially-addressed one was re-opened.
 
+### Third round on #1064
+
+`chatgpt-codex-connector` raised four more findings; three applied in full, one
+in part. The one repeat on the still-open lost-response thread was the original
+comment resurfacing on an unresolved thread, not a follow-up, so it was not
+answered twice.
+
+| Finding | Correction applied |
+|---|---|
+| Represent the dispatched-before-progress phase | Added `CatalogRescanStarting({pluginIds})`. A single running state would have had to invent `activePluginName` and `sessionsSeen` before any progress arrived, and claim enumeration the client cannot observe |
+| Surface unsupported catalog-import routes | Verified: `/plugin/import` shipped in `v1.6.0` while the approved baseline is `>= v1.4.0`, so supported peers genuinely lack it. Added `CatalogRescanUnsupported`, published when every harness in a fan-out answers `404`, plus `CatalogRescanStartUnsupported` for a targeted start. Corrected the false "works against every published bridge" claim |
+| Model targeted rejections per harness | Added the typed `CatalogRescanStartResult`, held per plugin id by `PluginManagementCubit` exactly as it already holds `PluginInstallProgress`, so a rejection renders on the card the user selected |
+| Preserve missed terminal outcomes during recovery | **Partially applied.** Fixed the harmful half: a recovery-seeded rescan resolves to idle and never publishes a summary, so it can no longer report an authoritative success that hides a failed harness. Declined the proposed fix itself as not implementable — `latestStatuses` carries no operation identity or grouping, so a discarded terminal status cannot be attributed to the recovered run rather than the previous one or bridge-startup hydration. The residue, a run interrupted by a disconnect reporting no summary while its lists still refresh correctly, is recorded as an accepted risk |
+
 ## Verification Log
 
 - **Step 1 documentation validation:** `git diff --check` passed; step tokens
   and exact PR titles diffed clean between `PLAN.md` and `TRACKER.md`; plan
   files only in the diff
-- **Step 1 changed lines:** 1,170 documentation-only insertions, 0 deletions, from
+- **Step 1 changed lines:** 1,248 documentation-only insertions, 0 deletions, from
   `git diff --numstat <merge-base>...HEAD` (informational only; the figure counts
   these verification-log lines, so it cannot independently validate the target)
 - **Step 1 review:** `architecture-plan-review` rejected the first revision;

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -71,6 +71,11 @@
 | Dispatched-but-silent phase | Its own `CatalogRescanStarting` variant | A single running state carrying `activePluginName` and `sessionsSeen` would have to invent both before the first progress event |
 | Older bridges | `CatalogRescanUnsupported` when every harness answers `404` | `/plugin/import` shipped in v1.6.0 but the baseline is `>= v1.4.0`, so supported peers exist with no route |
 | Recovered rescans | Resolve to idle, never to a terminal summary | `latestStatuses` has no operation identity, so a recovered run cannot honestly claim a total |
+| Operation model | One explicit `owned`/`observed` operation owns membership, settlement, and the refresh | Four rounds of separately-correct lifetime rules composed badly; the seam was that no run was ever named |
+| Second start while running | Joins the live operation | Replacing it dropped the first harness from aggregation and cancellation |
+| List refresh trigger | Leaving a live operation, not the terminal variants | An observed run publishes no summary and would otherwise never refresh |
+| Pre-v1.7.0 bridges | `CatalogRescanUnsupported` straight from an unsupported management snapshot | `/plugin/management` is v1.7.0; without a snapshot the fan-out sends zero requests, so the all-`404` branch never fires |
+| Start failures | `CatalogRescanStartFailed` retains the `ApiError` and is logged locally | A transport or decode failure may never reach the bridge, so its log cannot explain it |
 | Targeted rejections | Typed `CatalogRescanStartResult` held per plugin id by `PluginManagementCubit` | The aggregate row cannot say which card was rejected |
 | Completion wording | New items, with a totals fallback | Reporting 193 totals after a no-op rescan would be actively misleading |
 | New-count transport | One nullable `CatalogImportNewItems` object | Two independent `int?` fields make `{5, null}` representable and meaningless |
@@ -103,6 +108,7 @@
 | A privacy-safe failure reason at the producer | Deferred | The right fix is a bounded reason in `CatalogImportService._run` with the original error kept in the bridge log; out of scope for this series |
 | Preserving discarded terminal statuses across a reconnect | Rejected | `latestStatuses` carries no operation identity or grouping, so "belonging to the recovered operation" is not determinable; recovered runs claim no summary instead |
 | Sniffing the error body to tell a missing route from an unknown plugin | Rejected | Both mean "this bridge cannot rescan"; an all-`404` fan-out is the honest signal |
+| Deriving a legacy harness set from `/plugin` discovery | Rejected | Would add a second harness source and a second routability predicate for the single public release (v1.6.0) that has import but not management, on an auto-updating bridge |
 | Analytics for rescans | Rejected | Reliability repair for a reported defect, not a product adoption question |
 
 ## Open Questions
@@ -114,7 +120,7 @@
 
 | Done | Step | Exact PR title | Changed-line target | State |
 |---|---|---|---:|---|
-| [ ] | 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 1,050-1,250 | In preparation |
+| [ ] | 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 1,300-1,450 | In preparation |
 | [ ] | 2/8 | `🌱 [catalog-rescan] Re-hydrate stale plugin catalogs [step 2/8]` | 20-60 | Not started |
 | [ ] | 3/8 | `⚙️ [catalog-rescan] Report new items from a catalog import [step 3/8]` | 350-600 | Not started |
 | [ ] | 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 | Not started |
@@ -170,8 +176,16 @@
 - [ ] Filter the recovery read to non-terminal statuses only.
 - [ ] Reset to idle on disconnect and on active-bridge change; add no
   generation or fence state.
-- [ ] Clear the retained progress map on every rescan start and every reset.
-- [ ] Arm the 4s clear for `CatalogRescanSucceeded` only.
+- [ ] Implement the `owned`/`observed` operation model: a second start joins the
+  live operation, unsolicited progress opens an observed one, cancel fans out
+  over live members whether `Starting` or `Running`, and the map is cleared only
+  when leaving idle or terminal.
+- [ ] Arm the 4s clear for `CatalogRescanSucceeded` only, and cancel it on every
+  start and reset.
+- [ ] Publish `CatalogRescanUnsupported` from an unsupported management snapshot
+  without issuing any request.
+- [ ] Retain the `ApiError` in `CatalogRescanStartFailed` and log it locally.
+- [ ] Run the `module_core` build runner and commit `injection.config.dart`.
 - [ ] Record membership on dispatch; keep a harness on timeout or lost response.
 - [ ] Select harnesses by `runtimeState.isRoutable`.
 - [ ] Never lift `CatalogImportFailed.message` into client state.
@@ -179,8 +193,11 @@
   outcome, the older-bridge payload, both reconnect cases, a disconnect, a
   `503` in the fan-out, cancel fanning out one `DELETE` per running id, a
   second sequential rescan not inheriting the previous aggregate, a failure
-  surviving past 4s while a success clears, and a lost start response still
-  reaching a terminal state from SSE.
+  surviving past 4s while a success clears, a lost start response still reaching
+  a terminal state from SSE, an unsolicited progress event opening an observed
+  operation and refreshing on close, a targeted start joining a live operation,
+  a cancel while `Starting`, a second rescan begun inside the previous success's
+  4s window, an unsupported management snapshot, and a retained `ApiError`.
 - [ ] Run `architecture-implementation-review`.
 
 ## Step 5 Checklist
@@ -188,7 +205,9 @@
 - [ ] Add `PregoSliverRefreshControl` owning arming, captions, and dispatch.
 - [ ] Compose it in `PregoGlassScaffold` behind `onDeepRefresh` and assert it
   requires `onRefresh`.
-- [ ] Replace `SessionListPanel`'s bare `CupertinoSliverRefreshControl` with it.
+- [ ] Replace `SessionListPanel`'s bare `CupertinoSliverRefreshControl` with it
+  and give the pane an optional `onDeepRefresh` parameter, so the pane test has a
+  callback before the cubit intent exists.
 - [ ] Leave an ordinary pull visually unchanged.
 - [ ] Prove short pull, long pull, and abandoned long pull, in both the scaffold
   and the pane.
@@ -197,8 +216,9 @@
 ## Step 6 Checklist
 
 - [ ] Give all three cubits a rescan subscription, state, and intent methods.
-- [ ] Refresh both lists on `CatalogRescanSucceeded` and
-  `CatalogRescanPartlyFailed`.
+- [ ] Refresh both lists whenever the service leaves a live operation, not only
+  on the terminal summary variants.
+- [ ] Wire the pane's `onDeepRefresh` parameter to the cubit.
 - [ ] Build the rescan row in `client/app/lib/core/widgets/` with all seven
   presentations, no timer, and no bridge-supplied text.
 - [ ] Wire all three hosts through their cubits; no widget touches the service.
@@ -310,12 +330,35 @@ answered twice.
 | Model targeted rejections per harness | Added the typed `CatalogRescanStartResult`, held per plugin id by `PluginManagementCubit` exactly as it already holds `PluginInstallProgress`, so a rejection renders on the card the user selected |
 | Preserve missed terminal outcomes during recovery | **Partially applied.** Fixed the harmful half: a recovery-seeded rescan resolves to idle and never publishes a summary, so it can no longer report an authoritative success that hides a failed harness. Declined the proposed fix itself as not implementable — `latestStatuses` carries no operation identity or grouping, so a discarded terminal status cannot be attributed to the recovered run rather than the previous one or bridge-startup hydration. The residue, a run interrupted by a disconnect reporting no summary while its lists still refresh correctly, is recorded as an accepted risk |
 
+### Fourth round on #1064
+
+`chatgpt-codex-connector` raised nine findings; all nine applied. Four of them —
+adopting cross-surface rescans, cancelling while `Starting`, a second start
+clearing the live run, and a stale success timer resetting a new run — all landed
+on the same seam: the service had accumulated lifetime rules across three rounds
+without ever naming *which run* it tracked. Rather than add four more rules, the
+`Lifetimes owned by the service` section was replaced with an explicit
+`owned`/`observed` operation model, which resolves all four plus the recovered-run
+refresh gap as consequences of one definition.
+
+| Finding | Correction applied |
+|---|---|
+| Adopt rescans started by other connected surfaces | Unsolicited non-terminal progress opens an `observed` operation from idle. The plan had already promised cross-surface refresh while the rules made it impossible |
+| Cancel harnesses while the rescan is still starting | Cancel fans out over the members of the live operation, whether the published state is `Starting` or `Running` |
+| Preserve an active run when another harness starts | A targeted start **joins** the live operation instead of opening a new one; the map is cleared only when leaving idle or terminal |
+| Refresh lists when a recovered rescan settles | The refresh is keyed on leaving a live operation, not on the terminal variants, so an `observed` run still surfaces its sessions |
+| Cancel the prior success timer before a new rescan | Every start and reset cancels the pending clear timer |
+| Handle older bridges without management snapshots | Verified: `/plugin/management` first shipped in `v1.7.0` and a `404` maps to `PluginManagementLoadResultUnsupported`, so the fan-out would have sent zero requests and the all-`404` branch never fired. `CatalogRescanUnsupported` is now published directly from an unsupported snapshot |
+| Retain client request failures in the typed result | `CatalogRescanStartFailed` carries the `ApiError` cause and the service logs it locally; rendering stays bounded |
+| Regenerate injectable registration for the new service | Verified `client/module_core/lib/src/di/injection.config.dart` exists. Step 4 now runs the build runner and commits its output |
+| Add pane callback plumbing before testing the deep pull | Step 5 introduces the pane's optional `onDeepRefresh` parameter so its own test is implementable; step 6 wires it to the cubit |
+
 ## Verification Log
 
 - **Step 1 documentation validation:** `git diff --check` passed; step tokens
   and exact PR titles diffed clean between `PLAN.md` and `TRACKER.md`; plan
   files only in the diff
-- **Step 1 changed lines:** 1,248 documentation-only insertions, 0 deletions, from
+- **Step 1 changed lines:** 1,347 documentation-only insertions, 0 deletions, from
   `git diff --numstat <merge-base>...HEAD` (informational only; the figure counts
   these verification-log lines, so it cannot independently validate the target)
 - **Step 1 review:** `architecture-plan-review` rejected the first revision;

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -120,7 +120,7 @@
 
 | Done | Step | Exact PR title | Changed-line target | State |
 |---|---|---|---:|---|
-| [ ] | 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 1,300-1,450 | In preparation |
+| [ ] | 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 950-1,100 (`PLAN.md`) | In preparation |
 | [ ] | 2/8 | `🌱 [catalog-rescan] Re-hydrate stale plugin catalogs [step 2/8]` | 20-60 | Not started |
 | [ ] | 3/8 | `⚙️ [catalog-rescan] Report new items from a catalog import [step 3/8]` | 350-600 | Not started |
 | [ ] | 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 | Not started |
@@ -296,7 +296,7 @@ committed import raises no list invalidation.
 | Refresh catalogs after a rescan commits | Both list cubits run their existing silent refresh on a terminal success. Without it the row announced new sessions over a stale list — the feature's whole purpose |
 | Sanitize import failures before rendering them | Neither failure variant carries free text; the row reports a bounded failure and names the bridge log. A producer-side sanitization boundary is recorded as a named follow-up |
 | Keep failure states visible until dismissal | The 4s clear now applies to `CatalogRescanSucceeded` only; this also removed a contradiction between the plan's own presentation and lifetime tables |
-| Clear retained progress between rescans | The progress map is cleared on every rescan start and every reset to idle; sequential-rescan coverage added |
+| Clear retained progress between rescans | The progress map is cleared when a start opens an operation and on every reset to idle; round four scoped this to opening starts only, since a join must not clear it. Sequential-rescan coverage added |
 | Require architecture review for Step 5 | Step 5 now listed unconditionally alongside 3, 4, and 6 |
 | Model lost mutation responses as uncertain | **Partially applied.** Membership is recorded on dispatch and a harness survives a timeout or lost response, which closes the hole. The proposed third "uncertain" result type was declined as machinery across two layers for a bounded, self-clearing case; the residue is recorded as an accepted risk |
 | Route rescan actions and state through cubits | All three cubits gain a subscription, state, and intent methods; no widget holds the service stream. A dedicated fourth cubit was considered and rejected in the plan |
@@ -358,11 +358,12 @@ refresh gap as consequences of one definition.
 - **Step 1 documentation validation:** `git diff --check` passed; step tokens
   and exact PR titles diffed clean between `PLAN.md` and `TRACKER.md`; plan
   files only in the diff
-- **Step 1 changed lines:** 1,347 documentation-only insertions, 0 deletions, from
-  `git diff --numstat <merge-base>...HEAD` (informational only; the figure counts
-  these verification-log lines, so it cannot independently validate the target)
+- **Step 1 changed lines:** `PLAN.md` is the budgeted scope and is measured
+  against the 950-1,100 target. The combined numstat for both new files is
+  recorded below as information only and is deliberately not a budget check
 - **Step 1 review:** `architecture-plan-review` rejected the first revision;
   all ten findings applied directly, recorded above
+- **Step 1 combined numstat (information only):** `PLAN.md` 988 + `TRACKER.md` 369 = 1,357 insertions, 0 deletions
 - **Step 1 PR:** [#1064](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1064)
   open
 - **Final disposition:** pending

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -117,8 +117,8 @@
 - [x] Fix the eight-step series with exact titles and complexity emoji.
 - [x] Run `architecture-plan-review` through a sub-agent and apply valid
   findings directly.
-- [ ] Run `git diff --check` and plan/tracker consistency validation.
-- [ ] Commit, push, open the Step 1 PR, and record its URL and change count.
+- [x] Run `git diff --check` and plan/tracker consistency validation.
+- [x] Commit, push, open the Step 1 PR, and record its URL and change count.
 
 ## Step 2 Checklist
 
@@ -222,7 +222,12 @@ independently verified in the tree before the correction was applied.
 
 ## Verification Log
 
-- **Step 1 documentation validation:** pending
-- **Step 1 changed lines:** pending
-- **Step 1 PR:** pending
+- **Step 1 documentation validation:** `git diff --check` passed; step tokens
+  and exact PR titles diffed clean between `PLAN.md` and `TRACKER.md`; plan
+  files only in the diff
+- **Step 1 changed lines:** 950 documentation-only insertions, 0 deletions
+- **Step 1 review:** `architecture-plan-review` rejected the first revision;
+  all ten findings applied directly, recorded above
+- **Step 1 PR:** [#1064](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1064)
+  open
 - **Final disposition:** pending

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -61,12 +61,18 @@
 | Row home | `client/app/lib/core/widgets/` | Consumed by two features; must not live inside either |
 | Terminal state | Five sealed variants summarising the whole fan-out | One `pluginName` could not describe two harnesses finishing differently |
 | Terminal lifetime | Owned by `CatalogRescanService`, not the row | Two mounted hosts would otherwise run disagreeing 4s timers, and a revisit would replay a stale success |
+| Auto-clear scope | Success only; failures persist until dismissed | A diagnostic the user did not get to read is worse than a row that outstays its welcome |
+| Post-success refresh | Both list cubits run their existing silent refresh | A committed import raises no list invalidation, so the row would otherwise announce new sessions over a stale list |
+| Failure text | Never lifted into client state | `CatalogImportFailed.message` is the bridge's unbounded `error.toString()` |
+| State routing | Through `ProjectListCubit`, `SessionListCubit`, `PluginManagementCubit` | Keeps the shell's Layer-4 boundary and puts the refresh in the object that already owns refreshing |
+| Fan-out membership | Recorded on dispatch, not acknowledgement | `RelayResponseLostException` and timeouts can fire after the request landed |
+| Harness predicate | `runtimeState.isRoutable` | `isEnabled` is true for `blocked` and `failed`, which the bridge rejects with `503` |
 | Completion wording | New items, with a totals fallback | Reporting 193 totals after a no-op rescan would be actively misleading |
 | New-count transport | One nullable `CatalogImportNewItems` object | Two independent `int?` fields make `{5, null}` representable and meaningless |
 | Recovery read | Seed only from non-terminal statuses | `latestStatuses` retains terminal statuses forever |
 | Connection lifetime | Reset to idle on disconnect and bridge change | Makes generation and fence machinery unnecessary at this scale |
 | Non-gesture twin | Per-harness action on Settings to Harnesses | Required for screen readers and desktop; user chose it over an app-bar item |
-| Fan-out | One `POST` per enabled harness, one `DELETE` per running harness | Both routes address exactly one plugin per call; no wire change |
+| Fan-out | One `POST` per routable harness, one `DELETE` per running harness | Both routes address exactly one plugin per call; no wire change |
 | Stale markers | Bump `projectionVersion` to `2` | The mechanism already exists for exactly this; ships first, independently |
 
 ## Rejected And Deferred
@@ -85,6 +91,11 @@
 | A second `PluginRepository.getManagement()` read | Rejected | `PluginManagementService.snapshots` already maintains, refreshes, and invalidates that data |
 | Persisted last-rescan timestamp and a staleness nudge | Deferred | Plausible follow-up; needs a new persisted field and list affordance to serve a problem the deliberate rescan already solves |
 | Removing the hydration marker table, DAO, `CatalogEmptyHydrationPolicy`, and `projectionVersion` | Deferred | They all die together only if a future plan moves automatic import off the marker; removing them now would break first-install hydration |
+| A third "uncertain" mutation result | Rejected | A dispatch-based membership rule closes the lost-response hole without threading a variant through two layers |
+| A dedicated `CatalogRescanCubit` | Rejected | The two list cubits must refresh themselves on success, so a fourth cubit adds an object without removing wiring |
+| A new bridge event for post-import list invalidation | Rejected | The list cubits already own a silent refresh and already see the global progress stream |
+| A client-side sanitizer for `CatalogImportFailed.message` | Rejected | Sanitizing at the consumer still carries the raw string over the wire; the field is simply not lifted into state |
+| A privacy-safe failure reason at the producer | Deferred | The right fix is a bounded reason in `CatalogImportService._run` with the original error kept in the bridge log; out of scope for this series |
 | Analytics for rescans | Rejected | Reliability repair for a reported defect, not a product adoption question |
 
 ## Open Questions
@@ -96,12 +107,12 @@
 
 | Done | Step | Exact PR title | Changed-line target | State |
 |---|---|---|---:|---|
-| [ ] | 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 850-1,000 | In preparation |
+| [ ] | 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 1,050-1,250 | In preparation |
 | [ ] | 2/8 | `🌱 [catalog-rescan] Re-hydrate stale plugin catalogs [step 2/8]` | 20-60 | Not started |
 | [ ] | 3/8 | `⚙️ [catalog-rescan] Report new items from a catalog import [step 3/8]` | 350-600 | Not started |
 | [ ] | 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 | Not started |
 | [ ] | 5/8 | `⚙️ [catalog-rescan] Add a second stage to pull-to-refresh [step 5/8]` | 350-600 | Not started |
-| [ ] | 6/8 | `⚙️ [catalog-rescan] Surface catalog rescan in the app [step 6/8]` | 700-1,100 | Not started |
+| [ ] | 6/8 | `⚙️ [catalog-rescan] Surface catalog rescan in the app [step 6/8]` | 950-1,400 | Not started |
 | [ ] | 7/8 | `🌱 [catalog-rescan] Reconcile catalog rescan regression docs [step 7/8]` | 80-160 | Not started |
 | [ ] | 8/8 | `🌱 [catalog-rescan] Verify and retire the catalog rescan plan [step 8/8]` | 60-140 | Not started |
 
@@ -152,10 +163,17 @@
 - [ ] Filter the recovery read to non-terminal statuses only.
 - [ ] Reset to idle on disconnect and on active-bridge change; add no
   generation or fence state.
-- [ ] Own the 4s terminal clear in the service.
+- [ ] Clear the retained progress map on every rescan start and every reset.
+- [ ] Arm the 4s clear for `CatalogRescanSucceeded` only.
+- [ ] Record membership on dispatch; keep a harness on timeout or lost response.
+- [ ] Select harnesses by `runtimeState.isRoutable`.
+- [ ] Never lift `CatalogImportFailed.message` into client state.
 - [ ] Prove aggregation across two harnesses, all five states including a mixed
   outcome, the older-bridge payload, both reconnect cases, a disconnect, a
-  `503` in the fan-out, and cancel fanning out one `DELETE` per running id.
+  `503` in the fan-out, cancel fanning out one `DELETE` per running id, a
+  second sequential rescan not inheriting the previous aggregate, a failure
+  surviving past 4s while a success clears, and a lost start response still
+  reaching a terminal state from SSE.
 - [ ] Run `architecture-implementation-review`.
 
 ## Step 5 Checklist
@@ -167,16 +185,23 @@
 - [ ] Leave an ordinary pull visually unchanged.
 - [ ] Prove short pull, long pull, and abandoned long pull, in both the scaffold
   and the pane.
+- [ ] Run `architecture-implementation-review`.
 
 ## Step 6 Checklist
 
+- [ ] Give all three cubits a rescan subscription, state, and intent methods.
+- [ ] Refresh both lists on `CatalogRescanSucceeded` and
+  `CatalogRescanPartlyFailed`.
 - [ ] Build the rescan row in `client/app/lib/core/widgets/` with all five
-  presentations and no timer.
-- [ ] Wire all three hosts.
-- [ ] Add the per-harness Settings action with its enablement rules.
+  presentations, no timer, and no bridge-supplied text.
+- [ ] Wire all three hosts through their cubits; no widget touches the service.
+- [ ] Add the per-harness Settings action with `isRoutable` enablement and a
+  surfaced targeted rejection.
 - [ ] Add every `app_en.arb` resource and commit the generated l10n.
-- [ ] Prove the five row states, the totals fallback, cancel, dismiss, and the
-  Settings action's enablement.
+- [ ] Prove the five row states, the totals fallback, cancel, dismiss, the
+  Settings action's enablement and rejection, exactly one list refresh per
+  cubit on terminal success, and that no fixture message reaches a rendered
+  string.
 - [ ] Run `architecture-implementation-review`.
 
 ## Step 7 Checklist
@@ -220,12 +245,42 @@
 Three findings rested on facts that contradicted the plan's text; each was
 independently verified in the tree before the correction was applied.
 
+## PR Review
+
+### cubic-dev-ai on #1064
+
+One P3 finding on the recorded step-1 changed-line count. Valid: the figure was
+captured before the verification-log commit added its own lines. Recomputed from
+the merge-base and marked informational, since it counts itself. Applied in
+`006ae510a`; thread resolved.
+
+### chatgpt-codex-connector on #1064
+
+Eight findings, all assessed valid and applied. Three rested on facts verified
+in the tree first: `startAllowedPluginIds` requires
+`accessGate == enabled && slot.startAllowed` (`plugin_runtime.dart:105-108`);
+`RelayResponseLostException` is real and fires after dispatch
+(`relay_client.dart:172, 491, 570`); and `catalogImportRepository.backendActivity`
+feeds only `ChatHistoryActivityListener` (`orchestrator.dart:524-527`), so a
+committed import raises no list invalidation.
+
+| Finding | Correction applied |
+|---|---|
+| Refresh catalogs after a rescan commits | Both list cubits run their existing silent refresh on a terminal success. Without it the row announced new sessions over a stale list — the feature's whole purpose |
+| Sanitize import failures before rendering them | Neither failure variant carries free text; the row reports a bounded failure and names the bridge log. A producer-side sanitization boundary is recorded as a named follow-up |
+| Keep failure states visible until dismissal | The 4s clear now applies to `CatalogRescanSucceeded` only; this also removed a contradiction between the plan's own presentation and lifetime tables |
+| Clear retained progress between rescans | The progress map is cleared on every rescan start and every reset to idle; sequential-rescan coverage added |
+| Require architecture review for Step 5 | Step 5 now listed unconditionally alongside 3, 4, and 6 |
+| Model lost mutation responses as uncertain | **Partially applied.** Membership is recorded on dispatch and a harness survives a timeout or lost response, which closes the hole. The proposed third "uncertain" result type was declined as machinery across two layers for a bounded, self-clearing case; the residue is recorded as an accepted risk |
+| Route rescan actions and state through cubits | All three cubits gain a subscription, state, and intent methods; no widget holds the service stream. A dedicated fourth cubit was considered and rejected in the plan |
+| Do not enable Rescan for blocked harnesses | Enablement moved to `runtimeState.isRoutable`, and a targeted rejection is surfaced on the card. The silent `503` skip is now scoped to the fan-out only |
+
 ## Verification Log
 
 - **Step 1 documentation validation:** `git diff --check` passed; step tokens
   and exact PR titles diffed clean between `PLAN.md` and `TRACKER.md`; plan
   files only in the diff
-- **Step 1 changed lines:** 957 documentation-only insertions, 0 deletions, from
+- **Step 1 changed lines:** 1,144 documentation-only insertions, 0 deletions, from
   `git diff --numstat <merge-base>...HEAD` (informational only; the figure counts
   these verification-log lines, so it cannot independently validate the target)
 - **Step 1 review:** `architecture-plan-review` rejected the first revision;

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -67,6 +67,7 @@
 | State routing | Through `ProjectListCubit`, `SessionListCubit`, `PluginManagementCubit` | Keeps the shell's Layer-4 boundary and puts the refresh in the object that already owns refreshing |
 | Fan-out membership | Recorded on dispatch, not acknowledgement | `RelayResponseLostException` and timeouts can fire after the request landed |
 | Harness predicate | `runtimeState.isRoutable` | `isEnabled` is true for `blocked` and `failed`, which the bridge rejects with `503` |
+| Counts reduction | Summed across harnesses; delta only if every harness reported one | A delta missing a harness's contribution would understate the result while reading as authoritative |
 | Completion wording | New items, with a totals fallback | Reporting 193 totals after a no-op rescan would be actively misleading |
 | New-count transport | One nullable `CatalogImportNewItems` object | Two independent `int?` fields make `{5, null}` representable and meaningless |
 | Recovery read | Seed only from non-terminal statuses | `latestStatuses` retains terminal statuses forever |
@@ -280,7 +281,7 @@ committed import raises no list invalidation.
 - **Step 1 documentation validation:** `git diff --check` passed; step tokens
   and exact PR titles diffed clean between `PLAN.md` and `TRACKER.md`; plan
   files only in the diff
-- **Step 1 changed lines:** 1,144 documentation-only insertions, 0 deletions, from
+- **Step 1 changed lines:** 1,156 documentation-only insertions, 0 deletions, from
   `git diff --numstat <merge-base>...HEAD` (informational only; the figure counts
   these verification-log lines, so it cannot independently validate the target)
 - **Step 1 review:** `architecture-plan-review` rejected the first revision;

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -1,0 +1,228 @@
+# Client-Triggered Catalog Rescan: Tracker
+
+## Current State
+
+- **Plan slug:** `catalog-rescan`
+- **Implementation base:** `main` at
+  `7b1ebe9bc629d05b5d104e76cd5dbaa1514d65a2`
+- **Series state:** Step 1/8 in preparation, plan review applied
+- **Current step:** publish the plan
+- **Next action:** open the Step 1 PR, then Step 2's `projectionVersion` bump
+- **Origin issue:** [#961](https://github.com/sesori-ai/sesori_apps_monorepo/issues/961)
+- **External overlap:** [#1008](https://github.com/sesori-ai/sesori_apps_monorepo/issues/1008)
+  owns Codex live updates; do not address it here
+
+## Confirmed Evidence
+
+- [x] An automatic import with an existing hydration marker publishes
+  `completed(0, 0)` and returns without enumerating or starting the plugin
+  (`catalog_import_service.dart:101-118`).
+- [x] `CatalogImportRepository.projectionVersion` is still `1` and has never
+  been bumped since PR #488, so no release has ever invalidated a marker.
+- [x] `--import-plugin` uses the headless trigger, sets
+  `explicitImportRequested`, and is the only path that bypasses the marker.
+- [x] `POST`, `DELETE`, and `GET /plugin/import` and SSE
+  `catalog.import.progress` all exist and work; a search for `plugin/import`
+  under `client/` and `shared/` returns nothing.
+- [x] `DELETE /plugin/import` is a `BodyRequestHandler<CatalogImportRequest, …>`
+  and cancels exactly one plugin per call, so cancel needs a plugin id.
+- [x] `GET /plugin/import` returns `CatalogImportService.latestStatuses`, which
+  retains terminal statuses indefinitely; combined with the hydration
+  short-circuit publishing `completed(0, 0)` at every bridge start, an
+  unfiltered recovery read would render a stale success row on every connect.
+- [x] The two switch arms holding `SesoriCatalogImportProgress` are a
+  `sessionId` extractor (`sse_event.dart:36`) and `SseEventTracker`'s no-op arm
+  (`sse_event_tracker.dart:103`). Neither is an event dispatch registry.
+  `SesoriPluginInstallProgress` sits in both and is still fully consumed by
+  `PluginManagementService._onSseEvent`, which is the precedent to copy.
+- [x] `SessionListPanel._buildScrollableContent`
+  (`session_list_panel.dart:127-145`) builds its own `CustomScrollView` with a
+  bare `CupertinoSliverRefreshControl` and does not use `PregoGlassScaffold`.
+- [x] An import acquires its plugin lease with `startIfNeeded: true`
+  (`plugin_runtime.dart:406`), so a rescan starts the harness backend.
+- [x] `CatalogImportCompleted` carries totals, not deltas; both delta facts are
+  already available inside `_publishCatalog`.
+- [x] The reporter's v1.8.0 explicit import produces a complete catalog
+  (`files=193 ... sessions=193`, `noiseExcluded=0`, `missingCwd=0`), so the
+  Codex scan itself is healthy.
+- [x] `client/app/lib/core/widgets/` already holds the shell's cross-feature
+  widgets, so a widget consumed by two features belongs there.
+- [x] `client/desktop` hosts no project or session list, so no desktop shell
+  work is required.
+
+## Design Decisions
+
+| Decision | Chosen | Rationale |
+|---|---|---|
+| Refresh model | Two-stage pull: soft unchanged, deep armed past `1.6 x triggerDistance` | A rescan boots every enabled harness backend, so it must be deliberate |
+| Gesture owner | One `module_prego` `PregoSliverRefreshControl` | Three hosts, only two of which use `PregoGlassScaffold`; the pane must not re-implement thresholds in `client/app` |
+| Progress presentation | One aggregate row | Fixed height; the top of the list never reflows as harnesses finish at different times |
+| Row placement | Ordinary sliver at index 0, scrolls with the list | Non-intrusive; a refresh already scrolls to the top, so it is visible when it matters |
+| Row home | `client/app/lib/core/widgets/` | Consumed by two features; must not live inside either |
+| Terminal state | Five sealed variants summarising the whole fan-out | One `pluginName` could not describe two harnesses finishing differently |
+| Terminal lifetime | Owned by `CatalogRescanService`, not the row | Two mounted hosts would otherwise run disagreeing 4s timers, and a revisit would replay a stale success |
+| Completion wording | New items, with a totals fallback | Reporting 193 totals after a no-op rescan would be actively misleading |
+| New-count transport | One nullable `CatalogImportNewItems` object | Two independent `int?` fields make `{5, null}` representable and meaningless |
+| Recovery read | Seed only from non-terminal statuses | `latestStatuses` retains terminal statuses forever |
+| Connection lifetime | Reset to idle on disconnect and bridge change | Makes generation and fence machinery unnecessary at this scale |
+| Non-gesture twin | Per-harness action on Settings to Harnesses | Required for screen readers and desktop; user chose it over an app-bar item |
+| Fan-out | One `POST` per enabled harness, one `DELETE` per running harness | Both routes address exactly one plugin per call; no wire change |
+| Stale markers | Bump `projectionVersion` to `2` | The mechanism already exists for exactly this; ships first, independently |
+
+## Rejected And Deferred
+
+| Option | Status | Reason |
+|---|---|---|
+| Import on every bridge start | Rejected | Boots every enabled harness backend at every launch, the exact cost the durable marker exists to avoid |
+| Bulk `import all` route | Rejected | Needs a capability flag or an older-bridge fallback to buy one fewer round trip |
+| `catalogImport` management capability | Rejected | A wire change bought only to avoid skipping two status codes |
+| Changing either SSE switch arm | Rejected | Both are correct; the service pattern-matches the event itself, as `PluginManagementService` already does |
+| Per-harness progress rows | Rejected | User chose the aggregate row |
+| Pinned progress row | Rejected | User chose the scrolling row |
+| Authorship tracking of who started a rescan | Rejected | The SSE event is global by design; cross-surface visibility is correct |
+| Client polling of `GET /plugin/import` | Rejected | One filtered read on connect and reconnect is sufficient |
+| Generation or request-fence machinery | Rejected | Resetting to idle on disconnect removes the need |
+| A second `PluginRepository.getManagement()` read | Rejected | `PluginManagementService.snapshots` already maintains, refreshes, and invalidates that data |
+| Persisted last-rescan timestamp and a staleness nudge | Deferred | Plausible follow-up; needs a new persisted field and list affordance to serve a problem the deliberate rescan already solves |
+| Removing the hydration marker table, DAO, `CatalogEmptyHydrationPolicy`, and `projectionVersion` | Deferred | They all die together only if a future plan moves automatic import off the marker; removing them now would break first-install hydration |
+| Analytics for rescans | Rejected | Reliability repair for a reported defect, not a product adoption question |
+
+## Open Questions
+
+- [ ] Does `PregoGlassScaffold` have an existing design catalog scenario, or do
+  widget tests alone cover the second stage?
+
+## Delivery Steps
+
+| Done | Step | Exact PR title | Changed-line target | State |
+|---|---|---|---:|---|
+| [ ] | 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 850-1,000 | In preparation |
+| [ ] | 2/8 | `🌱 [catalog-rescan] Re-hydrate stale plugin catalogs [step 2/8]` | 20-60 | Not started |
+| [ ] | 3/8 | `⚙️ [catalog-rescan] Report new items from a catalog import [step 3/8]` | 350-600 | Not started |
+| [ ] | 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 | Not started |
+| [ ] | 5/8 | `⚙️ [catalog-rescan] Add a second stage to pull-to-refresh [step 5/8]` | 350-600 | Not started |
+| [ ] | 6/8 | `⚙️ [catalog-rescan] Surface catalog rescan in the app [step 6/8]` | 700-1,100 | Not started |
+| [ ] | 7/8 | `🌱 [catalog-rescan] Reconcile catalog rescan regression docs [step 7/8]` | 80-160 | Not started |
+| [ ] | 8/8 | `🌱 [catalog-rescan] Verify and retire the catalog rescan plan [step 8/8]` | 60-140 | Not started |
+
+## Step 1 Checklist
+
+- [x] Record the root cause with exact file and line evidence.
+- [x] Record the approved design and mark it closed to reopening.
+- [x] Record the complexity budget, naming every new mutable part and every
+  deliberately omitted one.
+- [x] Record accepted risks with their impact.
+- [x] Record the cleanup assessment outcome.
+- [x] Record affected regression documents, the required level, and the matrix.
+- [x] Fix the eight-step series with exact titles and complexity emoji.
+- [x] Run `architecture-plan-review` through a sub-agent and apply valid
+  findings directly.
+- [ ] Run `git diff --check` and plan/tracker consistency validation.
+- [ ] Commit, push, open the Step 1 PR, and record its URL and change count.
+
+## Step 2 Checklist
+
+- [ ] Bump `projectionVersion` to `2` with a comment recording why.
+- [ ] Leave `projectionVersion = 1` rows in place; add no migration.
+- [ ] Update only the tests that assert the constant.
+- [ ] Confirm re-import stays non-destructive: `hidden`, `displayName`,
+  `title`, overrides, archive state, and tombstones survive.
+- [ ] Run targeted bridge tests and `dart analyze --fatal-infos`.
+
+## Step 3 Checklist
+
+- [ ] Add `CatalogImportNewItems` and hang it off `CatalogImportCompleted` as
+  one nullable field; regenerate.
+- [ ] Count both from facts already in `_publishCatalog`; add no query or scan.
+- [ ] Count correctly in both `PluginProjectOwnership` branches.
+- [ ] Print the delta in `catalog_import_console_listener.dart` when present.
+- [ ] Prove a first import, a no-op re-import, a partial re-import, both
+  ownership branches, and a decode with the key omitted.
+- [ ] Run `architecture-implementation-review`.
+
+## Step 4 Checklist
+
+- [ ] Add the three API methods; give cancel a `pluginId`.
+- [ ] Classify `404` and `503` as "cannot import", not as failures.
+- [ ] Declare exactly three collaborators: `PluginRepository`,
+  `PluginManagementService`, `ConnectionService`.
+- [ ] Put `CatalogRescanState` in `services/models/catalog_rescan_state.dart`.
+- [ ] Pattern-match `SesoriCatalogImportProgress` in the service; leave
+  `sse_event.dart` and `sse_event_tracker.dart` untouched.
+- [ ] Filter the recovery read to non-terminal statuses only.
+- [ ] Reset to idle on disconnect and on active-bridge change; add no
+  generation or fence state.
+- [ ] Own the 4s terminal clear in the service.
+- [ ] Prove aggregation across two harnesses, all five states including a mixed
+  outcome, the older-bridge payload, both reconnect cases, a disconnect, a
+  `503` in the fan-out, and cancel fanning out one `DELETE` per running id.
+- [ ] Run `architecture-implementation-review`.
+
+## Step 5 Checklist
+
+- [ ] Add `PregoSliverRefreshControl` owning arming, captions, and dispatch.
+- [ ] Compose it in `PregoGlassScaffold` behind `onDeepRefresh` and assert it
+  requires `onRefresh`.
+- [ ] Replace `SessionListPanel`'s bare `CupertinoSliverRefreshControl` with it.
+- [ ] Leave an ordinary pull visually unchanged.
+- [ ] Prove short pull, long pull, and abandoned long pull, in both the scaffold
+  and the pane.
+
+## Step 6 Checklist
+
+- [ ] Build the rescan row in `client/app/lib/core/widgets/` with all five
+  presentations and no timer.
+- [ ] Wire all three hosts.
+- [ ] Add the per-harness Settings action with its enablement rules.
+- [ ] Add every `app_en.arb` resource and commit the generated l10n.
+- [ ] Prove the five row states, the totals fallback, cancel, dismiss, and the
+  Settings action's enablement.
+- [ ] Run `architecture-implementation-review`.
+
+## Step 7 Checklist
+
+- [ ] Update `docs/regression/projects-and-sessions.md`.
+- [ ] Update `docs/regression/plugin-setup-and-lifecycle.md`.
+- [ ] Record the level and the full matrix in both.
+
+## Step 8 Checklist
+
+- [ ] Run the recorded L3 matrix including both ownership branches, the
+  two-harness mixed outcome, the older-bridge compatibility run, and the
+  reconnect recovery run.
+- [ ] Record every entry as passed, blocked, or an explicitly accepted
+  reduction.
+- [ ] Move the plan directory to `.plan/completed/catalog-rescan/`.
+- [ ] Close or update issue #961 with the outcome.
+
+## Plan Review
+
+- **Reviewer:** `architecture-plan-review`
+- **Date:** 2026-08-23
+- **Reviewed scope:** complete `.plan/active/catalog-rescan/`
+- **Verdict:** pre-review gate passed; plan **rejected on substance** with ten
+  findings. None challenged a user-locked decision.
+- **Findings applied:** all ten, directly, without re-review.
+
+| # | Finding | Correction applied |
+|---|---|---|
+| 1 | Step 4's "stop routing into the ignore arms" bullet was wrong at both targets | Bullet deleted. Both arms stay; the service pattern-matches the event itself, as `PluginManagementService` already does |
+| 2 | The claim that the split-view pane hosts `PregoGlassScaffold` was false | Corrected. Gesture moved into a new `module_prego` `PregoSliverRefreshControl`; the pane is now named in Step 5, not only Step 6 |
+| 3 | The recovery read would announce stale terminal statuses on every connect | Recovery read filtered to `CatalogImportEnumerating` and `CatalogImportCommitting` only |
+| 4 | `cancelCatalogImport()` had no `pluginId` and could not be implemented | Signature corrected; `cancel()` now fans out one `DELETE` per running harness, recorded in the complexity budget |
+| 5 | The management-snapshot collaborator and the state's location were undeclared | Both declared: `PluginManagementService.snapshots`, and `services/models/catalog_rescan_state.dart` |
+| 6 | The 4s auto-dismiss timer was owned by the row, not the state owner | Moved to `CatalogRescanService`; the row owns no timer |
+| 7 | The terminal state could not represent an N-harness outcome | Replaced with five sealed variants including `CatalogRescanPartlyFailed` |
+| 8 | Nothing stated the rescan state's lifetime across disconnect or bridge change | Lifetime table added; resets to idle, no generation or fence machinery |
+| 9 | The rescan row widget's home was unnamed while two features consume it | Named `client/app/lib/core/widgets/` |
+| 10 | The delta counts were two independently nullable ints on wire and client | Grouped into one nullable `CatalogImportNewItems` and a sealed `CatalogRescanCounts` |
+
+Three findings rested on facts that contradicted the plan's text; each was
+independently verified in the tree before the correction was applied.
+
+## Verification Log
+
+- **Step 1 documentation validation:** pending
+- **Step 1 changed lines:** pending
+- **Step 1 PR:** pending
+- **Final disposition:** pending


### PR DESCRIPTION
## Complexity

Trivial. Documentation only: one plan and one tracker, no production code.

## What

Raises `.plan/active/catalog-rescan/` with `PLAN.md` and `TRACKER.md` for an
eight-step series that gives the app a way to re-import harness catalogs.

The plan records:

- the root cause of #961 with exact file and line evidence;
- the user-approved UX (two-stage pull-to-refresh, one aggregate progress row
  that scrolls with the list, new-item rather than total counts, and a
  per-harness `Rescan` action on Settings → Harnesses);
- ownership and data flow, the sealed rescan state, and every lifetime rule;
- a complexity budget naming each new mutable part and each deliberately
  omitted one;
- accepted risks, the cleanup assessment, and the L3 regression matrix; and
- the fixed eight-step PR series.

## Why

Fresh v1.8.0 logs on #961 show that a normal bridge start prints
`Imported codex catalog: 0 project(s), 0 session(s).` with no preceding
`Importing codex catalog...` line and no `Starting plugin "codex"` line. That is
the hydration short-circuit at `catalog_import_service.dart:101-118`: an
automatic import whose durable marker already exists returns without
enumerating anything.

`CatalogImportRepository.projectionVersion` is still `1` and has never been
bumped since #488, so no release has ever invalidated a marker. `POST`,
`DELETE`, and `GET /plugin/import` and the `catalog.import.progress` SSE event
all exist and work, but have zero client callers. The only thing that ever
re-imports is `sesori-bridge --import-plugin <id>`, run by hand.

Consequence: Codex projects and sessions created while the bridge was down stay
invisible. That is the recurring report on #961.

## Risk and test focus

Risk is documentation-only. Nothing executes.

The material risk this plan carries forward is that steps 3–6 change a wire
model and add a production service, which is why steps 3, 4, and 6 are marked
for `architecture-implementation-review`.

`architecture-plan-review` rejected the first revision with ten findings. All
ten were applied directly and are recorded in `TRACKER.md` with their
corrections. Three rested on facts that contradicted the plan's text; each was
independently verified in the tree before correcting:

- `SessionListPanel` does **not** use `PregoGlassScaffold` — it builds a raw
  `CustomScrollView` with a bare `CupertinoSliverRefreshControl`, so the deep
  pull now lives in a new shared `module_prego` control rather than in the
  scaffold;
- the two switch arms holding `SesoriCatalogImportProgress` are a `sessionId`
  extractor and `SseEventTracker`'s no-op arm, not an event dispatch registry —
  both stay untouched, and the service pattern-matches the event itself as
  `PluginManagementService` already does; and
- `GET /plugin/import` retains terminal statuses forever, so the recovery read
  is now filtered to non-terminal statuses to avoid announcing a stale
  "Rescan complete" on every connect.

## Expected result

No user-visible change. No database change. No production code change.

A reviewer should see two new Markdown files under `.plan/active/catalog-rescan/`
whose step totals, exact PR titles, and complexity emoji agree, and whose
recorded matrix matches `docs/regression/README.md`.

Step 2 — the one-line `projectionVersion` bump that unsticks every install still
frozen on a partial pre-1.8.0 catalog — follows immediately.

## Verification

- `git diff --check` passed
- plan files only in the diff. `PLAN.md` is the budgeted scope at 988 lines, inside the recorded 950-1,100 target; the combined numstat for both new files is 1,357 insertions, 0 deletions, recorded as information only because it counts the tracker's own review notes
- step tokens and exact PR titles diffed clean between `PLAN.md` and `TRACKER.md`
- no Dart or Flutter suites run: documentation-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes the updated plan and tracker for a client‑triggered catalog rescan. Documentation only; clarifies state lifetimes to avoid stale progress and miscounted summaries.

- Adds `.plan/active/catalog-rescan/PLAN.md` and `TRACKER.md`; verify the diff is docs‑only.
- Defines an explicit owned/observed operation: a new start joins a live run, unsolicited in‑flight progress is adopted, cancel covers the Starting phase, the success timer cancels on every new start, and the retained progress map clears only when a new operation opens (a join does not clear it). Both lists refresh when a live operation closes (success, observed, or cancelled).
- Compatibility and errors: publish `CatalogRescanUnsupported` from an unsupported management snapshot or an all‑`404` fan‑out; recovery‑seeded runs resolve to idle with no summary; targeted starts return a typed result; Rescan is gated on `runtimeState.isRoutable`; start failures retain a typed `ApiError` (not rendered).
- Counts and UI: sum new‑item deltas across all succeeded harnesses; fall back to summed totals if any delta is missing; one aggregate row; the split‑view session pane gets a deep‑refresh callback in step 5.
- State model updates: adds `CatalogRescanStarting`; documents recovery, cancellation, and timer lifetimes.
- Review metric note: measure step‑1 line target against `PLAN.md` only; record the combined numstat in `TRACKER.md` for information.

**Rollout**
- Step 2 bumps `CatalogImportRepository.projectionVersion` to re‑hydrate stale catalogs (no migration).
- Steps 3–6: add new‑item reporting, the rescan service (commit regenerated DI), the second‑stage pull‑to‑refresh via `module_prego`, and app surfaces; `architecture-implementation-review` required on 3, 4, 5, and 6.

<sup>Written for commit c5a42beab615c4461f833d53efaa8c5b51d950be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

