### PR TITLE
🌿 Fix OMP refresh for large model catalogs

### DIFF
--- a/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
+++ b/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
@@ -58,7 +58,6 @@ class OmpPlugin._({
       repository: catalogRepository,
       tracker: catalogTracker,
       totalTimeout: const Duration(seconds: 20),
-      maxModels: 24,
     );
     final ompSessionOptionsService = OmpSessionOptionsService(
       catalogService: catalogService,

--- a/bridge/sesori_plugin_omp/lib/src/services/omp_catalog_service.dart
+++ b/bridge/sesori_plugin_omp/lib/src/services/omp_catalog_service.dart
@@ -13,7 +13,6 @@ class OmpCatalogService({
   required final OmpCatalogRepository _repository,
   required final OmpCatalogTracker _tracker,
   required final Duration _totalTimeout,
-  required final int _maxModels,
 }) {
   final Map<String, Future<OmpCatalogDiscoveryResult>> _inFlight = {};
   Future<void> _leaseTail = Future.value();
@@ -73,7 +72,9 @@ class OmpCatalogService({
       }
 
       final thinkingByModel = <String, OmpThinkingOptions>{};
-      for (final model in initial.models.take(_maxModels)) {
+      // The total deadline bounds this sweep. A count cap would make every larger
+      // healthy catalog partial, so it could never replace an older complete cache.
+      for (final model in initial.models) {
         try {
           final snapshot = await _repository.selectModel(
             sessionId: sessionId,

--- a/bridge/sesori_plugin_omp/test/omp_catalog_service_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_catalog_service_test.dart
@@ -35,7 +35,6 @@ void main() {
       repository: repository,
       tracker: tracker,
       totalTimeout: const Duration(seconds: 2),
-      maxModels: 8,
     );
 
     final outcome = await service.ensureCatalog(projectId: "/project");
@@ -69,7 +68,6 @@ void main() {
       repository: repository,
       tracker: tracker,
       totalTimeout: const Duration(seconds: 2),
-      maxModels: 8,
     );
 
     repository.commandName = "alpha";
@@ -97,7 +95,6 @@ void main() {
       repository: repository,
       tracker: OmpCatalogTracker(),
       totalTimeout: const Duration(seconds: 2),
-      maxModels: 8,
     );
 
     final catalog = (await service.ensureCatalog(projectId: "/project") as OmpCatalogObserved).catalog;
@@ -119,7 +116,6 @@ void main() {
       repository: repository,
       tracker: tracker,
       totalTimeout: const Duration(seconds: 2),
-      maxModels: 8,
     );
     final good = (await service.ensureCatalog(projectId: "/project") as OmpCatalogObserved).catalog;
     repository.created = const AcpNewSessionResult(
@@ -146,7 +142,6 @@ void main() {
       repository: repository,
       tracker: OmpCatalogTracker(),
       totalTimeout: const Duration(seconds: 2),
-      maxModels: 8,
     );
 
     final outcome = await service.ensureCatalog(projectId: "/project");
@@ -156,6 +151,31 @@ void main() {
     expect(catalog.models, hasLength(3));
     expect(catalog.thinkingByModel, isNot(contains("custom/team/model-v2")));
     expect(catalog.thinkingByModel["other/model"]!.variants, ["high"]);
+  });
+
+  test("hydrates every model in large catalogs", () async {
+    final models = [for (var index = 0; index < 30; index++) "provider/model-$index"];
+    final created = _result(sessionId: "probe", model: models.first, thinking: const ["off"]);
+    created.configOptions.first["options"] = [
+      for (final model in models) {"value": model, "name": model},
+    ];
+    final repository = _FakeCatalogRepository(
+      created: created,
+      selections: const {},
+    );
+    final service = OmpCatalogService(
+      repository: repository,
+      tracker: OmpCatalogTracker(),
+      totalTimeout: const Duration(seconds: 2),
+    );
+
+    final outcome = await service.ensureCatalog(projectId: "/project");
+    final catalog = (outcome as OmpCatalogObserved).catalog;
+
+    expect(catalog.models, hasLength(models.length));
+    expect(catalog.thinkingByModel.keys, unorderedEquals(models));
+    expect(catalog.completeness, PluginSessionOptionsCompleteness.complete);
+    expect(repository.selectedModels, models);
   });
 }
 

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -109,10 +109,12 @@ variant, and worktree mode, and creating the session with its first input.
 - Graceful shutdown fences new create routes, aborts and drains accepted metadata
   work, drains session operations and local mutations, then closes normalized
   event delivery and its remaining tails.
-- OMP discovers modes, commands, providers/models, and model-specific thinking
-  levels in a project-scoped scratch session. Model values remain exact even
-  when the model ID contains slashes, and the configured pre-sweep model remains
-  the default. A rejected or partially applied selection fails before prompting.
+- OMP discovers modes, commands, every advertised provider/model, and model-specific
+  thinking levels in a project-scoped scratch session. Large catalogs from multiple
+  logged-in providers remain complete so they can replace an older complete cache.
+  Model values remain exact even when the model ID contains slashes, and the configured
+  pre-sweep model remains the default. A rejected or partially applied selection fails
+  before prompting.
 
 ## Regression Levels
 


### PR DESCRIPTION
## Complexity

🌿 Straightforward — this removes one OMP-only catalog count limit and adds focused regression coverage.

## What

- Hydrate thinking options for every model OMP advertises, while retaining the existing 20-second probe deadline.
- Add coverage for a catalog larger than the previous 24-model cap.
- Document that multi-provider OMP catalogs must remain complete enough to replace an older cache.

## Why

OMP currently advertises 44 models after multiple subscription logins. Sesori refreshed only the first 24, marked the otherwise healthy result partial, and correctly refused to replace the older complete cache. That left the original single test model visible even though fresh OMP discovery could see all providers.

## Risk and test focus

The OMP scratch probe now performs one config selection per advertised model instead of stopping at 24. The existing total deadline still bounds the work. Focus is on large catalogs, completeness classification, and preservation of partial status when a model hydration actually fails.

There is no database schema, migration, wire-contract, or unrelated plugin impact. The user-visible impact is that newly logged-in OMP providers and models appear after refresh.

## Expected result

Refreshing OMP models replaces an older complete cache with the full current catalog, so all logged-in subscriptions become selectable.

## Verification

- `cd bridge/sesori_plugin_omp && dart test`
- `cd bridge/sesori_plugin_omp && dart test test/omp_catalog_service_test.dart`
- `cd bridge/sesori_plugin_omp && dart analyze --fatal-infos`
- Local OMP ACP probe: 5 providers, 44 models, `complete`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the 24-model cap in OMP catalog refresh and hydrates thinking options for every advertised model. Large but healthy catalogs now become complete and replace older caches, so all logged-in provider models appear after refresh.

- Old vs new: previously hydrated only the first 24 models and often marked catalogs partial; now iterates all models under the existing 20s total timeout.
- Code: drops `maxModels` from `OmpCatalogService` and call site; sweeps `initial.models` fully; timeout still bounds work.
- Tests: adds a 30-model catalog test and updates existing tests; preserves partial status when a selection actually fails.
- Docs: clarifies that discovery covers every advertised provider/model and that large multi-provider catalogs can replace older complete caches.

<sup>Written for commit 17ad8b8593f750409710f2a8107612ee8db3c296. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

