### PR TITLE
⚙️ Keep OMP async work visibly active

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -109,6 +109,10 @@ abstract class AcpPlugin({
 
   final Map<String, PluginSessionStatus> _sessionStatuses = {};
 
+  /// Sessions doing agent-initiated work that ACP did not bracket with a
+  /// `session/prompt` request. OMP async-job delivery is the concrete case.
+  final Set<String> _agentInitiatedTurnSessions = {};
+
   /// Sessions whose initial user message was synthesized by this bridge
   /// process. History replay reuses that message identity to avoid a load/SSE
   /// race rendering the same prompt twice.
@@ -274,6 +278,59 @@ abstract class AcpPlugin({
     required Object error,
   }) => const [];
 
+  /// Observes a live notification after resume-history suppression but before
+  /// ordinary event mapping. Harnesses can use this for backend-specific
+  /// lifecycle signals that standard ACP does not model.
+  void onLiveAgentNotification(AcpNotification notification) {}
+
+  /// Whether this bridge has an accepted prompt running or queued for
+  /// [sessionId]. Agent-initiated output must only be vouched when this is
+  /// false; an ordinary prompt already owns its lifecycle.
+  bool hasBridgePromptTurn({required String sessionId}) => (_turnStates[sessionId]?.pending ?? 0) > 0;
+
+  /// Starts an agent-initiated turn that ACP did not bracket with
+  /// `session/prompt`. Returns whether this call opened the turn.
+  bool markAgentInitiatedTurnActive({required String sessionId, required int observedAt}) {
+    if (!_agentInitiatedTurnSessions.add(sessionId)) return false;
+    recordSessionActivity(sessionId: sessionId, observedAt: observedAt);
+    _sessionStatuses[sessionId] = const PluginSessionStatus.busy();
+    _syncWorkState();
+    _eventBuffer.add(
+      BridgeSseSessionStatus(
+        sessionID: sessionId,
+        status: const shared.SessionStatus.busy().toJson(),
+      ),
+    );
+    _eventBuffer.add(const BridgeSseProjectUpdated());
+    return true;
+  }
+
+  /// Settles a previously vouched agent-initiated turn. Returns whether one was
+  /// open. A bridge-owned prompt that has since started remains authoritative.
+  bool markAgentInitiatedTurnIdle({required String sessionId, required int? lastObservedAt}) {
+    if (!_agentInitiatedTurnSessions.remove(sessionId)) return false;
+    if (lastObservedAt != null) {
+      recordSessionActivity(sessionId: sessionId, observedAt: lastObservedAt);
+    }
+    if (!hasBridgePromptTurn(sessionId: sessionId)) {
+      _sessionStatuses[sessionId] = const PluginSessionStatus.idle();
+      _eventBuffer.add(BridgeSseSessionIdle(sessionID: sessionId));
+      _eventBuffer.add(const BridgeSseProjectUpdated());
+    }
+    _syncWorkState();
+    return true;
+  }
+
+  /// Emits a monotonic session-recency update at an observed activity instant.
+  void recordSessionActivity({required String sessionId, required int observedAt}) {
+    _eventBuffer.add(
+      eventMapper.mapSessionActivity(
+        sessionId: sessionId,
+        updatedAtMs: observedAt,
+      ),
+    );
+  }
+
   /// Invoked when the agent subprocess is torn down for a respawn (see
   /// [resetConnectionAfterExit]). The replacement process starts with none of
   /// the prior process's applied state, so a subclass that caches process-global
@@ -309,6 +366,7 @@ abstract class AcpPlugin({
         return;
       }
     }
+    onLiveAgentNotification(notification);
     eventMapper.map(notification).forEach(_eventBuffer.add);
   }
 
@@ -405,6 +463,7 @@ abstract class AcpPlugin({
   /// is left intact — the plugin stays alive, only the connection is reset.
   /// Never throws.
   Future<void> resetConnectionAfterExit() async {
+    _clearAgentInitiatedTurns();
     _workState.set(PluginWorkState.unknown);
     _connectFuture = null;
     _authenticationFailure = null;
@@ -842,7 +901,10 @@ abstract class AcpPlugin({
     await _connectedClient();
     // Another matching send may have been admitted while connection awaited.
     if (_turnStates[sessionId]?.hasAcceptedPrompt(promptId: promptId) ?? false) return;
-    _recordSessionActivity(sessionId);
+    recordSessionActivity(
+      sessionId: sessionId,
+      observedAt: DateTime.now().millisecondsSinceEpoch,
+    );
     final text = parts
         .whereType<PluginPromptPartText>()
         .map((part) => part.text)
@@ -895,7 +957,10 @@ abstract class AcpPlugin({
     await _connectedClient();
     // Another matching send may have been admitted while connection awaited.
     if (_turnStates[sessionId]?.hasAcceptedPrompt(promptId: promptId) ?? false) return;
-    _recordSessionActivity(sessionId);
+    recordSessionActivity(
+      sessionId: sessionId,
+      observedAt: DateTime.now().millisecondsSinceEpoch,
+    );
     final blocks = _contentBlocks([PluginPromptPart.text(text: body)]);
     if (blocks.isEmpty) return;
     _enqueueTurn(
@@ -948,15 +1013,6 @@ abstract class AcpPlugin({
       params: {"sessionId": sessionId},
     );
     _approvalRegistry?.cancelForSession(sessionId);
-  }
-
-  void _recordSessionActivity(String sessionId) {
-    _eventBuffer.add(
-      eventMapper.mapSessionActivity(
-        sessionId: sessionId,
-        updatedAtMs: DateTime.now().millisecondsSinceEpoch,
-      ),
-    );
   }
 
   /// The directory a session should be loaded/operated in — its own canonical
@@ -1091,6 +1147,9 @@ abstract class AcpPlugin({
     required _AcpTurn turn,
   }) {
     final state = _turnStates.putIfAbsent(sessionId, _SessionTurnState.new);
+    // An explicit prompt supersedes any heuristically vouched autonomous turn;
+    // its request/response pair now owns the lifecycle exactly.
+    _agentInitiatedTurnSessions.remove(sessionId);
     if (turn case _QueuedAcpTurn(:final queuedPrompt)) {
       state.queue.add(queuedPrompt);
     }
@@ -1357,6 +1416,7 @@ abstract class AcpPlugin({
 
   @override
   Future<void> abortSession({required String sessionId}) async {
+    markAgentInitiatedTurnIdle(sessionId: sessionId, lastObservedAt: null);
     // Aborting means "stop this conversation now": drop the queued-but-
     // undispatched turns first so they don't dispatch after the cancel. The
     // in-flight turn (if any) ends via the agent's cancellation, which
@@ -1454,6 +1514,7 @@ abstract class AcpPlugin({
       }
     }
     _turnStates.remove(sessionId);
+    _agentInitiatedTurnSessions.remove(sessionId);
     _pendingSelections.remove(sessionId);
     _inFlightTurnSessions.remove(sessionId);
     if (_lastTurnSessionId == sessionId) _lastTurnSessionId = null;
@@ -1743,9 +1804,10 @@ abstract class AcpPlugin({
     // live in different opened directories, not just the launch CWD.
     final byProject = <String, List<PluginActiveSession>>{};
     for (final sessionId in _sessionStatuses.keys) {
-      // A session with any unfinished turn (running or queued behind one)
-      // counts as running, so it stays active until its last turn settles.
-      final running = (_turnStates[sessionId]?.pending ?? 0) > 0;
+      // A session with any unfinished bridge turn (running or queued behind
+      // one), or a harness-vouched agent-initiated turn, counts as running.
+      final running =
+          (_turnStates[sessionId]?.pending ?? 0) > 0 || _agentInitiatedTurnSessions.contains(sessionId);
       final awaiting = registry?.hasPendingInput(sessionId) ?? false;
       if (!running && !awaiting) continue;
       (byProject[directoryForSession(sessionId: sessionId)] ??= []).add(
@@ -1787,9 +1849,23 @@ abstract class AcpPlugin({
     }
   }
 
+  void _clearAgentInitiatedTurns() {
+    if (_agentInitiatedTurnSessions.isEmpty) return;
+    for (final sessionId in _agentInitiatedTurnSessions) {
+      if (!hasBridgePromptTurn(sessionId: sessionId)) {
+        _sessionStatuses[sessionId] = const PluginSessionStatus.idle();
+      }
+    }
+    _agentInitiatedTurnSessions.clear();
+    _syncWorkState();
+    _eventBuffer.add(const BridgeSseProjectUpdated());
+  }
+
   void _syncWorkState() {
     final busy =
-        _turnStates.values.any((state) => state.pending > 0) || (_approvalRegistry?.hasAnyPendingInput ?? false);
+        _turnStates.values.any((state) => state.pending > 0) ||
+        _agentInitiatedTurnSessions.isNotEmpty ||
+        (_approvalRegistry?.hasAnyPendingInput ?? false);
     _workState.set(busy ? PluginWorkState.busy : PluginWorkState.idle);
   }
 }

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -283,6 +283,10 @@ abstract class AcpPlugin({
   /// lifecycle signals that standard ACP does not model.
   void onLiveAgentNotification(AcpNotification notification) {}
 
+  /// Invoked when an explicit bridge prompt takes ownership of [sessionId].
+  /// Harnesses can retire backend-specific autonomous-turn bookkeeping here.
+  void onBridgePromptTurnStarted({required String sessionId}) {}
+
   /// Whether this bridge has an accepted prompt running or queued for
   /// [sessionId]. Agent-initiated output must only be vouched when this is
   /// false; an ordinary prompt already owns its lifecycle.
@@ -1149,6 +1153,7 @@ abstract class AcpPlugin({
     final state = _turnStates.putIfAbsent(sessionId, _SessionTurnState.new);
     // An explicit prompt supersedes any heuristically vouched autonomous turn;
     // its request/response pair now owns the lifecycle exactly.
+    onBridgePromptTurnStarted(sessionId: sessionId);
     _agentInitiatedTurnSessions.remove(sessionId);
     if (turn case _QueuedAcpTurn(:final queuedPrompt)) {
       state.queue.add(queuedPrompt);
@@ -1854,6 +1859,7 @@ abstract class AcpPlugin({
     for (final sessionId in _agentInitiatedTurnSessions) {
       if (!hasBridgePromptTurn(sessionId: sessionId)) {
         _sessionStatuses[sessionId] = const PluginSessionStatus.idle();
+        _eventBuffer.add(BridgeSseSessionIdle(sessionID: sessionId));
       }
     }
     _agentInitiatedTurnSessions.clear();

--- a/bridge/sesori_plugin_acp/lib/src/acp_protocol.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_protocol.dart
@@ -34,6 +34,55 @@ abstract final class AcpMethods() {
   static const String elicitationCreate = "elicitation/create";
 }
 
+/// Known `session/update.update.sessionUpdate` variants.
+enum AcpSessionUpdateKind() {
+  agentMessageChunk,
+  agentThoughtChunk,
+  userMessageChunk,
+  toolCall,
+  toolCallUpdate,
+  plan,
+  currentModeUpdate,
+  configOptionUpdate,
+  availableCommandsUpdate,
+  sessionInfoUpdate,
+  usageUpdate,
+  unknown;
+
+  static AcpSessionUpdateKind parse(Object? raw) {
+    return switch (raw) {
+      "agent_message_chunk" => AcpSessionUpdateKind.agentMessageChunk,
+      "agent_thought_chunk" => AcpSessionUpdateKind.agentThoughtChunk,
+      "user_message_chunk" => AcpSessionUpdateKind.userMessageChunk,
+      "tool_call" => AcpSessionUpdateKind.toolCall,
+      "tool_call_update" => AcpSessionUpdateKind.toolCallUpdate,
+      "plan" => AcpSessionUpdateKind.plan,
+      "current_mode_update" => AcpSessionUpdateKind.currentModeUpdate,
+      "config_option_update" => AcpSessionUpdateKind.configOptionUpdate,
+      "available_commands_update" => AcpSessionUpdateKind.availableCommandsUpdate,
+      "session_info_update" => AcpSessionUpdateKind.sessionInfoUpdate,
+      "usage_update" => AcpSessionUpdateKind.usageUpdate,
+      _ => AcpSessionUpdateKind.unknown,
+    };
+  }
+
+  /// Whether this update proves that the agent is doing user-visible work.
+  bool get carriesAgentWork => switch (this) {
+    AcpSessionUpdateKind.agentMessageChunk ||
+    AcpSessionUpdateKind.agentThoughtChunk ||
+    AcpSessionUpdateKind.toolCall ||
+    AcpSessionUpdateKind.toolCallUpdate ||
+    AcpSessionUpdateKind.plan => true,
+    AcpSessionUpdateKind.userMessageChunk ||
+    AcpSessionUpdateKind.currentModeUpdate ||
+    AcpSessionUpdateKind.configOptionUpdate ||
+    AcpSessionUpdateKind.availableCommandsUpdate ||
+    AcpSessionUpdateKind.sessionInfoUpdate ||
+    AcpSessionUpdateKind.usageUpdate ||
+    AcpSessionUpdateKind.unknown => false,
+  };
+}
+
 /// An auth method advertised by the agent in the `initialize` result.
 enum AcpAuthMethodType() {
   terminal,

--- a/bridge/sesori_plugin_acp/test/acp_protocol_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_protocol_test.dart
@@ -87,6 +87,15 @@ void main() {
     expect(AcpStopReason.parse("???"), AcpStopReason.unknown);
   });
 
+  test("AcpSessionUpdateKind distinguishes agent work from protocol noise", () {
+    expect(AcpSessionUpdateKind.parse("agent_message_chunk").carriesAgentWork, isTrue);
+    expect(AcpSessionUpdateKind.parse("tool_call_update").carriesAgentWork, isTrue);
+    expect(AcpSessionUpdateKind.parse("plan").carriesAgentWork, isTrue);
+    expect(AcpSessionUpdateKind.parse("user_message_chunk").carriesAgentWork, isFalse);
+    expect(AcpSessionUpdateKind.parse("usage_update").carriesAgentWork, isFalse);
+    expect(AcpSessionUpdateKind.parse("future_update"), AcpSessionUpdateKind.unknown);
+  });
+
   group("AcpSessionListResult", () {
     test("parses sessions with ISO-8601 and epoch-ms timestamps", () {
       final result = AcpSessionListResult.fromJson({

--- a/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
+++ b/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
@@ -201,11 +201,9 @@ class OmpPlugin._({
 
   @override
   Future<void> deleteSession(String sessionId) async {
-    _agentInitiatedTurnFences.remove(sessionId);
-    _forgetAgentInitiatedTurn(sessionId: sessionId);
+    _agentInitiatedTurnFences.add(sessionId);
+    _settleTrackedAgentInitiatedTurn(sessionId: sessionId);
     await super.deleteSession(sessionId);
-    // Active deletion calls the overridden abort path, which re-adds the
-    // fence while the session settles; a successful delete owns final cleanup.
     _agentInitiatedTurnFences.remove(sessionId);
     _ompSessionOptionsService.forgetSession(sessionId: sessionId);
   }
@@ -242,11 +240,15 @@ class OmpPlugin._({
 
   void _settleAgentInitiatedTurn({required String sessionId, required _OmpAgentInitiatedTurn expected}) {
     if (!identical(_agentInitiatedTurns[sessionId], expected)) return;
-    _agentInitiatedTurns.remove(sessionId);
-    expected.timer?.cancel();
+    _settleTrackedAgentInitiatedTurn(sessionId: sessionId);
+  }
+
+  void _settleTrackedAgentInitiatedTurn({required String sessionId}) {
+    final turn = _agentInitiatedTurns.remove(sessionId);
+    turn?.timer?.cancel();
     markAgentInitiatedTurnIdle(
       sessionId: sessionId,
-      lastObservedAt: expected.lastObservedAt > expected.firstObservedAt ? expected.lastObservedAt : null,
+      lastObservedAt: turn != null && turn.lastObservedAt > turn.firstObservedAt ? turn.lastObservedAt : null,
     );
   }
 
@@ -263,7 +265,7 @@ class OmpPlugin._({
   @override
   Future<void> abortSession({required String sessionId}) async {
     _agentInitiatedTurnFences.add(sessionId);
-    _forgetAgentInitiatedTurn(sessionId: sessionId);
+    _settleTrackedAgentInitiatedTurn(sessionId: sessionId);
     await super.abortSession(sessionId: sessionId);
   }
 

--- a/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
+++ b/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
@@ -204,7 +204,6 @@ class OmpPlugin._({
     _agentInitiatedTurnFences.add(sessionId);
     _settleTrackedAgentInitiatedTurn(sessionId: sessionId);
     await super.deleteSession(sessionId);
-    _agentInitiatedTurnFences.remove(sessionId);
     _ompSessionOptionsService.forgetSession(sessionId: sessionId);
   }
 
@@ -269,17 +268,17 @@ class OmpPlugin._({
     await super.abortSession(sessionId: sessionId);
   }
 
-  void _clearAgentInitiatedTurnTimers() {
-    for (final turn in _agentInitiatedTurns.values) {
-      turn.timer?.cancel();
+  void _fenceAndSettleAgentInitiatedTurns() {
+    final sessionIds = _agentInitiatedTurns.keys.toList(growable: false);
+    _agentInitiatedTurnFences.addAll(sessionIds);
+    for (final sessionId in sessionIds) {
+      _settleTrackedAgentInitiatedTurn(sessionId: sessionId);
     }
-    _agentInitiatedTurns.clear();
-    _agentInitiatedTurnFences.clear();
   }
 
   @override
   void onConnectionReset() {
-    _clearAgentInitiatedTurnTimers();
+    _fenceAndSettleAgentInitiatedTurns();
     _ompSessionOptionsService.resetConnection();
   }
 
@@ -294,7 +293,7 @@ class OmpPlugin._({
 
   @override
   Future<void> dispose() async {
-    _clearAgentInitiatedTurnTimers();
+    _fenceAndSettleAgentInitiatedTurns();
     try {
       await _catalogService.dispose();
     } on Object catch (error, stack) {

--- a/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
+++ b/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:io" show Directory;
 
 import "package:acp_plugin/acp_plugin.dart";
@@ -16,10 +17,12 @@ import "trackers/omp_catalog_tracker.dart";
 
 /// Oh My Pi backend over ACP.
 ///
-/// OMP diverges from stock ACP in three policies: it serializes every prompt
-/// process-wide, replaces an in-flight turn when another input arrives, and
-/// supports standard form elicitation. Its project-scoped model/mode/thinking
-/// catalog and persisted-session cleanup run over isolated scratch processes.
+/// OMP diverges from stock ACP in four policies: it serializes every prompt
+/// process-wide, replaces an in-flight turn when another input arrives,
+/// supports standard form elicitation, and can stream agent-initiated async-job
+/// turns after `session/prompt` has returned. Its project-scoped
+/// model/mode/thinking catalog and persisted-session cleanup run over isolated
+/// scratch processes.
 class OmpPlugin._({
   required super.launchSpec,
   required super.launchDirectory,
@@ -29,13 +32,20 @@ class OmpPlugin._({
   required final OmpCatalogService _catalogService,
   required final OmpSessionOptionsService _ompSessionOptionsService,
   required final OmpSessionCleanupService _cleanupService,
+  required final Duration _agentInitiatedTurnQuietPeriod,
   super.processFactory,
 }) extends AcpPlugin implements PersistedSessionCleanupApi {
+  /// ACP v1 has no completion marker for OMP's agent-initiated turns. Silence
+  /// is therefore the only available boundary; a later update starts another
+  /// turn if a slow provider exceeds this window.
+  static const Duration defaultAgentInitiatedTurnQuietPeriod = Duration(minutes: 2);
+
   factory({
     String binaryPath = OmpBinary.defaultBinary,
     String? launchDirectory,
     String? scratchDirectory,
     required AcpProcessFactory processFactory,
+    required Duration agentInitiatedTurnQuietPeriod,
   }) {
     final cwd = launchDirectory ?? Directory.current.path;
     final launchSpec = OmpBinary.launchSpec(
@@ -99,9 +109,12 @@ class OmpPlugin._({
       catalogService: catalogService,
       ompSessionOptionsService: ompSessionOptionsService,
       cleanupService: cleanupService,
+      agentInitiatedTurnQuietPeriod: agentInitiatedTurnQuietPeriod,
       processFactory: processFactory,
     );
   }
+
+  final Map<String, _OmpAgentInitiatedTurn> _agentInitiatedTurns = {};
 
   this
     : super(
@@ -187,12 +200,66 @@ class OmpPlugin._({
 
   @override
   Future<void> deleteSession(String sessionId) async {
+    _forgetAgentInitiatedTurn(sessionId: sessionId);
     await super.deleteSession(sessionId);
     _ompSessionOptionsService.forgetSession(sessionId: sessionId);
   }
 
   @override
-  void onConnectionReset() => _ompSessionOptionsService.resetConnection();
+  void onLiveAgentNotification(AcpNotification notification) {
+    if (notification.method != AcpMethods.sessionUpdate) return;
+    final sessionId = notification.params["sessionId"];
+    final update = notification.params["update"];
+    if (sessionId is! String || sessionId.isEmpty || update is! Map) return;
+    final kind = AcpSessionUpdateKind.parse(update["sessionUpdate"]);
+    if (!kind.carriesAgentWork || hasBridgePromptTurn(sessionId: sessionId)) return;
+
+    final observedAt = DateTime.now().millisecondsSinceEpoch;
+    final opened = markAgentInitiatedTurnActive(
+      sessionId: sessionId,
+      observedAt: observedAt,
+    );
+    var turn = _agentInitiatedTurns[sessionId];
+    if (opened || turn == null) {
+      turn?.timer?.cancel();
+      turn = _OmpAgentInitiatedTurn(firstObservedAt: observedAt);
+      _agentInitiatedTurns[sessionId] = turn;
+    }
+    turn.lastObservedAt = observedAt;
+    turn.timer?.cancel();
+    final trackedTurn = turn;
+    turn.timer = Timer(
+      _agentInitiatedTurnQuietPeriod,
+      () => _settleAgentInitiatedTurn(sessionId: sessionId, expected: trackedTurn),
+    );
+  }
+
+  void _settleAgentInitiatedTurn({required String sessionId, required _OmpAgentInitiatedTurn expected}) {
+    if (!identical(_agentInitiatedTurns[sessionId], expected)) return;
+    _agentInitiatedTurns.remove(sessionId);
+    expected.timer?.cancel();
+    markAgentInitiatedTurnIdle(
+      sessionId: sessionId,
+      lastObservedAt: expected.lastObservedAt > expected.firstObservedAt ? expected.lastObservedAt : null,
+    );
+  }
+
+  void _forgetAgentInitiatedTurn({required String sessionId}) {
+    _agentInitiatedTurns.remove(sessionId)?.timer?.cancel();
+  }
+
+  void _clearAgentInitiatedTurnTimers() {
+    for (final turn in _agentInitiatedTurns.values) {
+      turn.timer?.cancel();
+    }
+    _agentInitiatedTurns.clear();
+  }
+
+  @override
+  void onConnectionReset() {
+    _clearAgentInitiatedTurnTimers();
+    _ompSessionOptionsService.resetConnection();
+  }
 
   @override
   Iterable<BridgeSseEvent> mapPromptFailure({
@@ -205,6 +272,7 @@ class OmpPlugin._({
 
   @override
   Future<void> dispose() async {
+    _clearAgentInitiatedTurnTimers();
     try {
       await _catalogService.dispose();
     } on Object catch (error, stack) {
@@ -231,4 +299,9 @@ class OmpPlugin._({
     final details = data["details"];
     return details is String && details.startsWith("No model selected.");
   }
+}
+
+class _OmpAgentInitiatedTurn({required final int firstObservedAt}) {
+  int lastObservedAt = 0;
+  Timer? timer;
 }

--- a/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
+++ b/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
@@ -115,6 +115,7 @@ class OmpPlugin._({
   }
 
   final Map<String, _OmpAgentInitiatedTurn> _agentInitiatedTurns = {};
+  final Set<String> _agentInitiatedTurnFences = {};
 
   this
     : super(
@@ -200,8 +201,12 @@ class OmpPlugin._({
 
   @override
   Future<void> deleteSession(String sessionId) async {
+    _agentInitiatedTurnFences.remove(sessionId);
     _forgetAgentInitiatedTurn(sessionId: sessionId);
     await super.deleteSession(sessionId);
+    // Active deletion calls the overridden abort path, which re-adds the
+    // fence while the session settles; a successful delete owns final cleanup.
+    _agentInitiatedTurnFences.remove(sessionId);
     _ompSessionOptionsService.forgetSession(sessionId: sessionId);
   }
 
@@ -211,6 +216,7 @@ class OmpPlugin._({
     final sessionId = notification.params["sessionId"];
     final update = notification.params["update"];
     if (sessionId is! String || sessionId.isEmpty || update is! Map) return;
+    if (_agentInitiatedTurnFences.contains(sessionId)) return;
     final kind = AcpSessionUpdateKind.parse(update["sessionUpdate"]);
     if (!kind.carriesAgentWork || hasBridgePromptTurn(sessionId: sessionId)) return;
 
@@ -248,11 +254,25 @@ class OmpPlugin._({
     _agentInitiatedTurns.remove(sessionId)?.timer?.cancel();
   }
 
+  @override
+  void onBridgePromptTurnStarted({required String sessionId}) {
+    _agentInitiatedTurnFences.remove(sessionId);
+    _forgetAgentInitiatedTurn(sessionId: sessionId);
+  }
+
+  @override
+  Future<void> abortSession({required String sessionId}) async {
+    _agentInitiatedTurnFences.add(sessionId);
+    _forgetAgentInitiatedTurn(sessionId: sessionId);
+    await super.abortSession(sessionId: sessionId);
+  }
+
   void _clearAgentInitiatedTurnTimers() {
     for (final turn in _agentInitiatedTurns.values) {
       turn.timer?.cancel();
     }
     _agentInitiatedTurns.clear();
+    _agentInitiatedTurnFences.clear();
   }
 
   @override

--- a/bridge/sesori_plugin_omp/lib/src/runtime/omp_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_omp/lib/src/runtime/omp_plugin_descriptor.dart
@@ -55,6 +55,7 @@ OmpPlugin _buildOmpPlugin({
   launchDirectory: launchDirectory,
   scratchDirectory: scratchDirectory,
   processFactory: processFactory,
+  agentInitiatedTurnQuietPeriod: OmpPlugin.defaultAgentInitiatedTurnQuietPeriod,
 );
 
 final class const OmpPluginDescriptor({

--- a/bridge/sesori_plugin_omp/test/omp_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_plugin_descriptor_test.dart
@@ -192,6 +192,7 @@ void main() {
               launchDirectory: launchDirectory,
               scratchDirectory: scratchDirectory,
               processFactory: (_) async => throw StateError("connection failed"),
+              agentInitiatedTurnQuietPeriod: OmpPlugin.defaultAgentInitiatedTurnQuietPeriod,
             ),
         buildRuntimeAssetService: _runtimeAssets,
         connectBudget: const Duration(milliseconds: 20),
@@ -220,6 +221,7 @@ void main() {
               binaryPath: binaryPath,
               launchDirectory: launchDirectory,
               scratchDirectory: scratchDirectory,
+              agentInitiatedTurnQuietPeriod: OmpPlugin.defaultAgentInitiatedTurnQuietPeriod,
               processFactory: (_) async {
                 if (attempts++ == 0) throw StateError("connection failed");
                 return process;

--- a/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
@@ -263,6 +263,32 @@ void main() {
       expect(plugin.getActiveSessionsSummary(), isNotEmpty, reason: "an explicit prompt clears the stop fence");
     });
 
+    test("deletion settles vouched work state", () async {
+      await connect();
+      final session = await create("session-1");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": AcpMethods.sessionUpdate,
+        "params": {
+          "sessionId": session.id,
+          "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "Background work"},
+          },
+        },
+      });
+      await Future<void>.delayed(Duration.zero);
+      expect(plugin.currentWorkState, PluginWorkState.busy);
+      events.clear();
+
+      await plugin.deleteSession(session.id);
+
+      expect(plugin.currentWorkState, PluginWorkState.idle);
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+      expect(await plugin.getSessionStatuses(), isNot(contains(session.id)));
+      expect(events.whereType<BridgeSseSessionIdle>(), hasLength(1));
+    });
+
     test("process reset emits idle for a vouched turn", () async {
       await connect();
       final session = await create("session-1");

--- a/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
@@ -18,7 +18,7 @@ void main() {
       events = [];
       plugin = OmpPlugin(
         launchDirectory: "/repo",
-        agentInitiatedTurnQuietPeriod: const Duration(milliseconds: 100),
+        agentInitiatedTurnQuietPeriod: const Duration(milliseconds: 500),
         processFactory: (spec) async {
           launchSpec = spec;
           return fake;
@@ -147,7 +147,7 @@ void main() {
       expect(events.whereType<BridgeSseSessionUpdated>(), hasLength(1));
       expect(events.whereType<BridgeSseSessionStatus>(), hasLength(1));
 
-      await Future<void>.delayed(const Duration(milliseconds: 60));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
       fake.emit({
         "jsonrpc": "2.0",
         "method": AcpMethods.sessionUpdate,
@@ -159,9 +159,9 @@ void main() {
           },
         },
       });
-      await Future<void>.delayed(const Duration(milliseconds: 60));
+      await Future<void>.delayed(const Duration(milliseconds: 100));
       expect(plugin.getActiveSessionsSummary(), isNotEmpty, reason: "later work must re-arm the quiet window");
-      await Future<void>.delayed(const Duration(milliseconds: 70));
+      await Future<void>.delayed(const Duration(milliseconds: 450));
 
       expect(plugin.getActiveSessionsSummary(), isEmpty);
       expect((await plugin.getSessionStatuses())[session.id], isA<PluginSessionStatusIdle>());
@@ -287,6 +287,22 @@ void main() {
       expect(plugin.getActiveSessionsSummary(), isEmpty);
       expect(await plugin.getSessionStatuses(), isNot(contains(session.id)));
       expect(events.whereType<BridgeSseSessionIdle>(), hasLength(1));
+      events.clear();
+      plugin.handleAgentNotification(
+        AcpNotification(
+          method: AcpMethods.sessionUpdate,
+          params: {
+            "sessionId": session.id,
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": {"type": "text", "text": "Late deleted-session output"},
+            },
+          },
+        ),
+      );
+      expect(plugin.currentWorkState, PluginWorkState.idle);
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+      expect(events.whereType<BridgeSseSessionStatus>(), isEmpty);
     });
 
     test("process reset emits idle for a vouched turn", () async {
@@ -313,6 +329,22 @@ void main() {
       expect(plugin.getActiveSessionsSummary(), isEmpty);
       expect(plugin.currentWorkState, PluginWorkState.unknown);
       expect(events.whereType<BridgeSseSessionIdle>(), hasLength(1));
+      events.clear();
+      plugin.handleAgentNotification(
+        AcpNotification(
+          method: AcpMethods.sessionUpdate,
+          params: {
+            "sessionId": session.id,
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": {"type": "text", "text": "Late pre-reset output"},
+            },
+          },
+        ),
+      );
+      expect(plugin.currentWorkState, PluginWorkState.unknown);
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+      expect(events.whereType<BridgeSseSessionStatus>(), isEmpty);
     });
 
     test("does not prompt after a partially applied model selection", () async {
@@ -713,7 +745,7 @@ void main() {
       final specs = <AcpLaunchSpec>[];
       plugin = OmpPlugin(
         launchDirectory: "/repo",
-        agentInitiatedTurnQuietPeriod: const Duration(milliseconds: 100),
+        agentInitiatedTurnQuietPeriod: const Duration(milliseconds: 500),
         processFactory: (spec) async {
           specs.add(spec);
           final process = FakeAcpProcess();

--- a/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
@@ -223,6 +223,72 @@ void main() {
       expect(events.whereType<BridgeSseSessionStatus>(), isEmpty);
     });
 
+    test("stop fences late unbracketed output until the next prompt", () async {
+      await connect();
+      final session = await create("session-1");
+      void emitAgentWork(String text) {
+        fake.emit({
+          "jsonrpc": "2.0",
+          "method": AcpMethods.sessionUpdate,
+          "params": {
+            "sessionId": session.id,
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": {"type": "text", "text": text},
+            },
+          },
+        });
+      }
+
+      emitAgentWork("Background work");
+      await Future<void>.delayed(Duration.zero);
+      expect(plugin.getActiveSessionsSummary(), isNotEmpty);
+
+      await plugin.abortSession(sessionId: session.id);
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+      events.clear();
+      emitAgentWork("Late cancellation output");
+      await Future<void>.delayed(Duration.zero);
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+      expect(events.whereType<BridgeSseSessionStatus>(), isEmpty);
+
+      await send(session.id, "continue");
+      final prompt = await waitForFrame(AcpMethods.sessionPrompt);
+      respond(prompt, {"stopReason": "end_turn"});
+      for (var i = 0; i < 200 && plugin.getActiveSessionsSummary().isNotEmpty; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+      emitAgentWork("New background work");
+      await Future<void>.delayed(Duration.zero);
+      expect(plugin.getActiveSessionsSummary(), isNotEmpty, reason: "an explicit prompt clears the stop fence");
+    });
+
+    test("process reset emits idle for a vouched turn", () async {
+      await connect();
+      final session = await create("session-1");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": AcpMethods.sessionUpdate,
+        "params": {
+          "sessionId": session.id,
+          "update": {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "background-1",
+            "title": "Background work",
+          },
+        },
+      });
+      await Future<void>.delayed(Duration.zero);
+      expect(plugin.getActiveSessionsSummary(), isNotEmpty);
+      events.clear();
+
+      await plugin.resetConnectionAfterExit();
+
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+      expect(plugin.currentWorkState, PluginWorkState.unknown);
+      expect(events.whereType<BridgeSseSessionIdle>(), hasLength(1));
+    });
+
     test("does not prompt after a partially applied model selection", () async {
       await connect();
       final creating = plugin.createSession(

--- a/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
@@ -18,6 +18,7 @@ void main() {
       events = [];
       plugin = OmpPlugin(
         launchDirectory: "/repo",
+        agentInitiatedTurnQuietPeriod: const Duration(milliseconds: 100),
         processFactory: (spec) async {
           launchSpec = spec;
           return fake;
@@ -118,6 +119,108 @@ void main() {
       expect(plugin.cancelsActiveTurnForQueuedInput, isTrue);
       expect(plugin.failsTurnOnSelectionError, isTrue);
       expect(plugin.supportsFormElicitation, isTrue);
+    });
+
+    test("vouches unbracketed agent work as active until the quiet window", () async {
+      await connect();
+      final session = await create("session-1");
+      events.clear();
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": AcpMethods.sessionUpdate,
+        "params": {
+          "sessionId": session.id,
+          "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "Background work resumed"},
+          },
+        },
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      final active = plugin.getActiveSessionsSummary().single.activeSessions.single;
+      expect(active.id, session.id);
+      expect(active.mainAgentRunning, isTrue);
+      expect((await plugin.getSessionStatuses())[session.id], isA<PluginSessionStatusBusy>());
+      expect(plugin.currentWorkState, PluginWorkState.busy);
+      expect(events.whereType<BridgeSseSessionUpdated>(), hasLength(1));
+      expect(events.whereType<BridgeSseSessionStatus>(), hasLength(1));
+
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": AcpMethods.sessionUpdate,
+        "params": {
+          "sessionId": session.id,
+          "update": {
+            "sessionUpdate": "agent_thought_chunk",
+            "content": {"type": "text", "text": "Still working"},
+          },
+        },
+      });
+      await Future<void>.delayed(const Duration(milliseconds: 60));
+      expect(plugin.getActiveSessionsSummary(), isNotEmpty, reason: "later work must re-arm the quiet window");
+      await Future<void>.delayed(const Duration(milliseconds: 70));
+
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+      expect((await plugin.getSessionStatuses())[session.id], isA<PluginSessionStatusIdle>());
+      expect(plugin.currentWorkState, PluginWorkState.idle);
+      expect(events.whereType<BridgeSseSessionIdle>(), hasLength(1));
+      expect(events.whereType<BridgeSseSessionUpdated>(), hasLength(2));
+    });
+
+    test("does not vouch ordinary output already owned by a prompt", () async {
+      await connect();
+      final session = await create("session-1");
+      await send(session.id, "inspect it");
+      final prompt = await waitForFrame(AcpMethods.sessionPrompt);
+      events.clear();
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": AcpMethods.sessionUpdate,
+        "params": {
+          "sessionId": session.id,
+          "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "Done"},
+          },
+        },
+      });
+      respond(prompt, {"stopReason": "end_turn"});
+      for (var i = 0; i < 200 && events.whereType<BridgeSseSessionIdle>().isEmpty; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+      await Future<void>.delayed(const Duration(milliseconds: 150));
+      expect(events.whereType<BridgeSseSessionIdle>(), hasLength(1));
+      expect(events.whereType<BridgeSseSessionUpdated>(), isEmpty);
+    });
+
+    test("does not vouch unbracketed non-work updates", () async {
+      await connect();
+      final session = await create("session-1");
+      events.clear();
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": AcpMethods.sessionUpdate,
+        "params": {
+          "sessionId": session.id,
+          "update": {
+            "sessionUpdate": "available_commands_update",
+            "availableCommands": <Object?>[],
+          },
+        },
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+      expect((await plugin.getSessionStatuses())[session.id], isA<PluginSessionStatusIdle>());
+      expect(plugin.currentWorkState, PluginWorkState.idle);
+      expect(events.whereType<BridgeSseSessionStatus>(), isEmpty);
     });
 
     test("does not prompt after a partially applied model selection", () async {
@@ -518,6 +621,7 @@ void main() {
       final specs = <AcpLaunchSpec>[];
       plugin = OmpPlugin(
         launchDirectory: "/repo",
+        agentInitiatedTurnQuietPeriod: const Duration(milliseconds: 100),
         processFactory: (spec) async {
           specs.add(spec);
           final process = FakeAcpProcess();

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -50,8 +50,11 @@ child sessions with titles, activity, statuses, and unseen state.
   that is newer. A plugin that reports an updated time only at import or rename
   — Claude and Pi, unlike Codex, ACP, and OpenCode — therefore still shows a
   recently prompted session as recent, instead of the transcript time read at
-  the last import. Marking a session unread never moves that time, and
-  assistant-only work does not advance it past the prompt that started it.
+  the last import. Marking a session unread never moves that time, and ordinary
+  assistant-only work does not advance it past the prompt that started it. OMP
+  agent-initiated async-job turns are the exception: ACP supplies no prompt
+  lifecycle for them, so their first and last observed work updates advance the
+  backend-reported time that keeps the row honest.
 - A newly committed session can list before generated metadata. Later generated
   title and eligible dedicated-branch refinement reuse `session.updated`; lists
   and detail adopt the durable session facts without marking unseen or moving the

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -101,7 +101,13 @@ defaults and queued client sends coherent.
   remain absent. OMP preserves its active-prompt replacement semantics by
   cancelling the active turn immediately, then dispatching the newly queued
   input after cancellation settles; Cursor and Hermes retain ordinary FIFO turn
-  boundaries.
+  boundaries. OMP async-job auto-delivery can begin another agent turn after
+  `session/prompt` has already returned, with only unbracketed `session/update`
+  work notifications. The bridge treats the first such text, reasoning, tool,
+  or plan update as running work, refreshes session recency, and keeps the turn
+  active until 120 seconds of quiet. Protocol-noise updates never create a
+  running turn; stop, deletion, process reset, and a new explicit prompt clear
+  the heuristic state.
 - Normalized user-message events feed the durable user-side activity marker used
   to order running roots. Known event times are applied monotonically. Backend
   input represented as a user message, including automatic compaction or other
@@ -197,6 +203,9 @@ has started.
 
 - A slash command holds the client request open for the whole run, or a slow
   plugin blocks unrelated sessions, other plugins, or relay traffic.
+- OMP continues streaming an async-job follow-up while the session/project row
+  reports idle or keeps its pre-follow-up timestamp, non-work ACP traffic makes
+  an idle row look active, or heuristic activity survives stop/reset/deletion.
 - Streaming stalls, duplicates or loses parts, shows an empty user bubble, or
   orders a late envelope at the wrong transcript position; the session never
   returns to idle. A terminal provider failure returns to idle without showing


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this adds a bounded OMP-specific lifecycle heuristic while keeping status, work-state, recency, and project summaries coherent through the shared ACP base.

## What

- Recognize OMP agent-initiated text, reasoning, tool, and plan updates that arrive without a `session/prompt` in flight.
- Vouch those updates as running work, advance session recency, and settle after 120 seconds of quiet.
- Keep ordinary prompted output and protocol-noise updates out of the heuristic.
- Clear heuristic activity through prompt supersession, stop, deletion, process reset, and disposal paths.
- Document the behavior and add focused ACP/OMP regression coverage.

## Why

OMP can auto-resume after an async job completes even though its original ACP `session/prompt` has already returned. ACP v1 sends that follow-up as unbracketed `session/update` notifications. Sesori rendered the output, but had no active turn to report, so the session row showed a stale timestamp instead of running activity.

## Risk and test focus

The main risk is false or lingering activity because ACP provides no completion marker for these turns. Tests cover work-vs-noise classification, quiet-window rearming and settlement, ordinary prompt ownership, status/work-state convergence, and recency updates. There is no database schema or wire-contract change.

User-visible impact: OMP async-job follow-ups now keep session and project rows visibly running and leave an accurate recent timestamp.

## Expected result

While unbracketed OMP follow-up output is arriving, the bridge reports that session as active. After two minutes without another work update, it returns to idle and retains the latest observed activity time.

## Verification

- `cd bridge && dart pub get`
- `cd bridge/sesori_plugin_acp && dart test`
- `cd bridge/sesori_plugin_omp && dart test`
- Targeted `dart analyze --fatal-infos` for all changed ACP and OMP source/test files
- Architecture implementation review: approved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps OMP agent-initiated async follow-ups visibly running and ignores stale post-stop output. Previously, unbracketed `session/update` rendered while rows stayed idle and could reanimate after stop/reset/delete; now we vouch real agent work as running, fence late updates until the next prompt, and settle after 120 seconds of silence.

- Classifies `session/update` kinds; vouches agent text/thought/tool/plan updates and ignores protocol noise.
- Vouches only when no bridge-owned prompt is active; refreshes recency on first/last observed work; includes vouched sessions in active-session summaries and project work-state.
- Settles vouched turns after the quiet window; emits idle on stop, deletion (settles before delete), process reset, and when a new prompt starts; clears timers on reset/dispose.
- Fences late unbracketed output after stop/deletion/reset until a new prompt begins.
- Extends ACP with `AcpSessionUpdateKind`, a live-notification tap, and helpers to mark agent-initiated turns active/idle; no schema or wire-contract changes. Tests and docs updated.

**Migration**
- If you construct `OmpPlugin` directly, pass `agentInitiatedTurnQuietPeriod` (defaults to 2 minutes via the runtime descriptor).

<sup>Written for commit 9bb1c1236c4dc8591c9c243d988c13dd6e57f8dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

