### PR TITLE
🌿 Remove Pi model catalog limit

### DIFF
--- a/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
+++ b/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
@@ -50,7 +50,6 @@ final class PiPlugin._({
     required Duration healthTimeout,
     required Duration idleTimeout,
     required Duration editorTimeout,
-    required int maxCatalogModels,
   }) {
     final storage = PiSessionStorageApi(environment: storageEnvironment);
     final catalogRepository = PiSessionCatalogRepository(storageApi: storage);
@@ -95,7 +94,6 @@ final class PiPlugin._({
       ),
       tracker: PiCatalogTracker(),
       totalTimeout: catalogTimeout,
-      maxModels: maxCatalogModels,
     );
     return PiPlugin._(
       catalogRepository: catalogRepository,

--- a/bridge/sesori_plugin_pi/lib/src/repositories/pi_backend_catalog_repository.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/pi_backend_catalog_repository.dart
@@ -45,7 +45,6 @@ class PiBackendCatalogRepository({
   Future<PiCatalogProbeSnapshot> probe({
     required String projectId,
     required Duration totalTimeout,
-    required int maxModels,
   }) async {
     final stopwatch = Stopwatch()..start();
     final normalizedProject = normalizeProjectDirectory(directory: projectId);
@@ -92,11 +91,12 @@ class PiBackendCatalogRepository({
       final initialIndex = deduped.indexWhere((model) => _sameModel(model, initialModel));
       if (initialIndex < 0) throw StateError("Pi selected model is absent from the catalog");
       if (initialIndex > 0) deduped.insert(0, deduped.removeAt(initialIndex));
-      final bounded = deduped.take(maxModels).toList();
 
-      var partial = deduped.length > bounded.length;
+      var partial = false;
       final thinkingByModel = <String, List<String>>{};
-      for (final model in bounded.where((model) => model.reasoning)) {
+      // The total deadline bounds this sweep. A count cap would make every larger
+      // healthy catalog partial, so it could never replace an older complete cache.
+      for (final model in deduped.where((model) => model.reasoning)) {
         try {
           await _send(
             client: client,
@@ -157,7 +157,7 @@ class PiBackendCatalogRepository({
         ],
         providers: PluginProvidersResult(
           providers: _providers(
-            models: bounded,
+            models: deduped,
             initial: initialModel,
             thinkingByModel: thinkingByModel,
           ),

--- a/bridge/sesori_plugin_pi/lib/src/runtime/pi_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_pi/lib/src/runtime/pi_plugin_descriptor.dart
@@ -26,7 +26,6 @@ typedef PiPluginFactory = PiPlugin Function({
   required Duration healthTimeout,
   required Duration idleTimeout,
   required Duration editorTimeout,
-  required int maxCatalogModels,
 });
 
 PiPlugin _buildPiPlugin({
@@ -43,7 +42,6 @@ PiPlugin _buildPiPlugin({
   required Duration healthTimeout,
   required Duration idleTimeout,
   required Duration editorTimeout,
-  required int maxCatalogModels,
 }) => PiPlugin(
   binaryPath: binaryPath,
   storageEnvironment: storageEnvironment,
@@ -58,7 +56,6 @@ PiPlugin _buildPiPlugin({
   healthTimeout: healthTimeout,
   idleTimeout: idleTimeout,
   editorTimeout: editorTimeout,
-  maxCatalogModels: maxCatalogModels,
 );
 
 /// Descriptor and lifecycle composition root for the local Pi CLI plugin.
@@ -298,7 +295,6 @@ final class const PiPluginDescriptor({
         healthTimeout: const Duration(seconds: 10),
         idleTimeout: const Duration(minutes: 5),
         editorTimeout: const Duration(minutes: 30),
-        maxCatalogModels: 100,
       );
     } on Object {
       await processFactory.dispose();

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_catalog_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_catalog_service.dart
@@ -8,11 +8,9 @@ class PiCatalogService({
   required final PiBackendCatalogRepository _repository,
   required final PiCatalogTracker _tracker,
   required final Duration _totalTimeout,
-  required final int _maxModels,
 }) {
   this {
     if (_totalTimeout <= Duration.zero) throw ArgumentError.value(_totalTimeout, "totalTimeout", "must be positive");
-    if (_maxModels <= 0) throw ArgumentError.value(_maxModels, "maxModels", "must be positive");
   }
 
   final Map<String, Future<_PiCatalogProbeOutcome>> _inFlight = {};
@@ -63,7 +61,6 @@ class PiCatalogService({
       final probe = await _repository.probe(
         projectId: projectId,
         totalTimeout: _totalTimeout,
-        maxModels: _maxModels,
       );
       final snapshot = PluginSessionOptions(
         agents: probe.agents,

--- a/bridge/sesori_plugin_pi/test/pi_backend_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_backend_catalog_repository_test.dart
@@ -74,21 +74,23 @@ void main() {
     expect(replies.every((frame) => frame["cancelled"] == true), isTrue);
   });
 
-  test("bounds model hydration and marks capped catalog partial", () async {
+  test("hydrates every advertised model and keeps large catalogs complete", () async {
+    final models = [
+      for (var index = 0; index < 101; index++) _model(provider: "google", id: "model-$index", reasoning: true),
+    ];
     final harness = _ProbeHarness(
-      stateModel: _model(provider: "google", id: "third", reasoning: true),
-      models: [
-        _model(provider: "google", id: "first", reasoning: true),
-        _model(provider: "google", id: "second", reasoning: true),
-        _model(provider: "google", id: "third", reasoning: true),
-      ],
+      stateModel: _model(provider: "google", id: "model-100", reasoning: true),
+      models: models,
     );
 
-    final options = await harness.probe(maxModels: 2);
+    final options = await harness.probe();
+    final discovered = options.providers.providers.single.models;
 
-    expect(options.completeness, PluginSessionOptionsCompleteness.partial);
-    expect(options.providers.providers.single.models.map((model) => model.id), ["third", "first"]);
-    expect(harness.selected, [("google", "third"), ("google", "first")]);
+    expect(options.completeness, PluginSessionOptionsCompleteness.complete);
+    expect(discovered, hasLength(models.length));
+    expect(discovered.first.id, "model-100");
+    expect(discovered.last.id, "model-99");
+    expect(harness.selected, hasLength(models.length));
   });
 
   test("optional thinking and command failures preserve partial catalogs", () async {
@@ -217,7 +219,6 @@ class _ProbeHarness({
 
   Future<PluginSessionOptions> probe({
     Duration timeout = const Duration(seconds: 2),
-    int maxModels = 8,
   }) async {
     final snapshot =
         await PiBackendCatalogRepository(
@@ -236,7 +237,6 @@ class _ProbeHarness({
         ).probe(
           projectId: path.normalize(path.absolute("project/./nested/..")),
           totalTimeout: timeout,
-          maxModels: maxModels,
         );
     return PluginSessionOptions(
       agents: snapshot.agents,

--- a/bridge/sesori_plugin_pi/test/pi_catalog_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_catalog_service_test.dart
@@ -116,7 +116,6 @@ PiCatalogService _service({required PiBackendCatalogRepository repository, requi
       repository: repository,
       tracker: tracker,
       totalTimeout: const Duration(seconds: 2),
-      maxModels: 4,
     );
 
 PluginSessionOptions _options({
@@ -141,7 +140,6 @@ class _FakeCatalogRepository({required final List<Object> results}) implements P
   Future<PiCatalogProbeSnapshot> probe({
     required String projectId,
     required Duration totalTimeout,
-    required int maxModels,
   }) async {
     projects.add(projectId);
     active++;

--- a/bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart
@@ -125,7 +125,6 @@ void main() {
               required healthTimeout,
               required idleTimeout,
               required editorTimeout,
-              required maxCatalogModels,
             }) {
               capturedBinaryPath = binaryPath;
               capturedStorageEnvironment = storageEnvironment;
@@ -144,7 +143,6 @@ void main() {
                 healthTimeout: healthTimeout,
                 idleTimeout: idleTimeout,
                 editorTimeout: editorTimeout,
-                maxCatalogModels: maxCatalogModels,
               );
             },
       );
@@ -182,7 +180,6 @@ void main() {
               required healthTimeout,
               required idleTimeout,
               required editorTimeout,
-              required maxCatalogModels,
             }) {
               built = _plugin(
                 binaryPath: binaryPath,
@@ -198,7 +195,6 @@ void main() {
                 healthTimeout: healthTimeout,
                 idleTimeout: idleTimeout,
                 editorTimeout: editorTimeout,
-                maxCatalogModels: maxCatalogModels,
               );
               abort.abort();
               return built!;
@@ -257,7 +253,6 @@ PiPlugin _plugin({
   required Duration healthTimeout,
   required Duration idleTimeout,
   required Duration editorTimeout,
-  required int maxCatalogModels,
 }) => PiPlugin(
   binaryPath: binaryPath,
   storageEnvironment: storageEnvironment,
@@ -272,7 +267,6 @@ PiPlugin _plugin({
   healthTimeout: healthTimeout,
   idleTimeout: idleTimeout,
   editorTimeout: editorTimeout,
-  maxCatalogModels: maxCatalogModels,
 );
 
 class _Host({

--- a/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
@@ -392,7 +392,6 @@ final class _Harness({bool stdinCloseCompletes = true}) {
       healthTimeout: const Duration(seconds: 1),
       idleTimeout: const Duration(minutes: 5),
       editorTimeout: const Duration(minutes: 1),
-      maxCatalogModels: 10,
     );
   }
 

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -115,6 +115,9 @@ variant, and worktree mode, and creating the session with its first input.
   Model values remain exact even when the model ID contains slashes, and the configured
   pre-sweep model remains the default. A rejected or partially applied selection fails
   before prompting.
+- Pi likewise discovers every advertised model and its available thinking levels within
+  the existing total probe deadline, so catalog size alone never makes a healthy refresh
+  partial or leaves an older complete cache in place.
 
 ## Regression Levels
 


### PR DESCRIPTION
## Complexity

🌿 Straightforward — removes the remaining Pi-only model-count limit and its internal plumbing.

## What

- Remove Pi's 100-model catalog cap from the descriptor, plugin, service, and repository.
- Discover and return every model Pi advertises while retaining the existing 30-second total probe deadline.
- Replace the capped-catalog test with coverage for a complete 101-model catalog.

## Why

Follow-up to #1065. Pi had the same structural risk as OMP: crossing the arbitrary count limit marked a healthy refresh partial, allowing an older complete cache to remain visible. The total probe deadline already provides the necessary bound.

## Risk and test focus

Large Pi catalogs perform more model/thinking RPCs, but the existing total deadline still bounds discovery. Test focus is full-catalog preservation, completeness classification, timeout behavior, and descriptor/plugin construction after removing the internal parameter.

There is no database, migration, wire-contract, or unrelated plugin impact. User-visible behavior changes only when Pi advertises more than 100 models.

## Expected result

Pi catalog size alone no longer truncates models or prevents a fresh catalog from replacing an older complete cache.

## Verification

- `cd bridge/sesori_plugin_pi && dart test test/pi_backend_catalog_repository_test.dart test/pi_catalog_service_test.dart test/pi_plugin_descriptor_test.dart test/pi_plugin_impl_test.dart`
- `cd bridge/sesori_plugin_pi && dart analyze --fatal-infos`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes Pi’s 100-model catalog cap so discovery returns every advertised model within the existing 30s total probe deadline. Previously catalogs over 100 were truncated and marked partial, leaving older complete caches visible; now large catalogs stay complete and can replace the cache.

- Removes the `maxCatalogModels` parameter and related plumbing from the descriptor, service, repository, and plugin impl; the repository now processes the full deduped catalog.
- The total probe deadline continues to bound RPCs; large catalogs may issue more reasoning checks but remain within the deadline.
- Replaces the capped-catalog test with a 101-model full-catalog test; updates descriptor/service tests accordingly and documents the behavior in regression notes.
- No DB, wire-contract, or migration changes; behavior differs only when Pi advertises more than 100 models.

<sup>Written for commit 555f981241af8848ba788951400da736aaa00efa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

