### PR TITLE
🌿 Fix OpenCode prompt reservation failures

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -427,9 +427,6 @@ class OpenCodePlugin._({
     final messageId = await _call(
       () => _service.reserveMessage(
         sessionId: sessionId,
-        agent: agent,
-        variant: variant,
-        model: model,
       ),
     );
     _promptMessages.record(messageId: messageId, promptId: promptId);
@@ -497,9 +494,6 @@ class OpenCodePlugin._({
     final messageId = await _call(
       () => _service.reserveMessage(
         sessionId: sessionId,
-        agent: agent,
-        variant: variant,
-        model: model,
       ),
     );
     _promptMessages.record(messageId: messageId, promptId: promptId);

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
@@ -167,18 +167,15 @@ class OpenCodeRepository(final OpenCodeApi _api) {
   Future<String> reserveMessage({
     required String sessionId,
     required String? directory,
-    required String? agent,
-    required PluginSessionVariant? variant,
-    required ({String providerID, String modelID})? model,
   }) async {
     final response = await _sendPrompt(
       sessionId: sessionId,
       directory: directory,
       messageId: null,
       parts: const [],
-      agent: agent,
-      variant: variant,
-      model: model,
+      agent: null,
+      variant: null,
+      model: null,
       noReply: true,
       syntheticText: false,
     );

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -341,17 +341,11 @@ class OpenCodeService(
 
   Future<String> reserveMessage({
     required String sessionId,
-    required String? agent,
-    required PluginSessionVariant? variant,
-    required ({String providerID, String modelID})? model,
   }) {
     final directory = _getTrackedDirectory(sessionId: sessionId);
     return repository.reserveMessage(
       sessionId: sessionId,
       directory: directory,
-      agent: agent,
-      variant: variant,
-      model: model,
     );
   }
 

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -1034,16 +1034,13 @@ void main() {
   });
 
   group("OpenCodeRepository message reservation", () {
-    test("lets OpenCode name an empty non-renderable message", () async {
+    test("lets OpenCode name an option-free empty non-renderable message", () async {
       final api = FakeOpenCodeApi();
       final repository = OpenCodeRepository(api);
 
       final messageId = await repository.reserveMessage(
         sessionId: "ses-1",
         directory: " /repo ",
-        agent: "build",
-        variant: const PluginSessionVariant(id: "low"),
-        model: (providerID: "openai", modelID: "gpt-4.1"),
       );
 
       expect(messageId, equals("msg-reserved"));
@@ -1052,9 +1049,6 @@ void main() {
         api.lastPromptBody?.toJson(),
         equals({
           "parts": <dynamic>[],
-          "agent": "build",
-          "variant": "low",
-          "model": {"providerID": "openai", "modelID": "gpt-4.1"},
           "noReply": true,
         }),
       );

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -704,9 +704,6 @@ void main() {
 
       final messageId = await service.reserveMessage(
         sessionId: "ses-1",
-        agent: "build",
-        variant: null,
-        model: null,
       );
 
       expect(messageId, equals("msg-reserved"));
@@ -2111,9 +2108,6 @@ class FakeOpenCodeRepository._({
   Future<String> reserveMessage({
     required String sessionId,
     required String? directory,
-    required String? agent,
-    required PluginSessionVariant? variant,
-    required ({String providerID, String modelID})? model,
   }) async {
     lastReservedDirectory = directory;
     return "msg-reserved";

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -147,7 +147,9 @@ defaults and queued client sends coherent.
   dispatch, using the link its backend exposes — Claude's queue entry, ACP's
   accepted send, Pi's dispatcher, Codex's client-supplied identifier, and
   OpenCode's server-reserved ordered message identifier that the bridge reuses
-  for the real dispatch. OpenCode applies the same correlation to prompts,
+  for the real dispatch. Reservation does not apply or validate the requested
+  agent, model, or variant; the real dispatch owns those selections. OpenCode
+  applies the same correlation to prompts,
   slash commands, and manual compaction. Compaction renders only the user-entered
   command arguments; bridge-authored guidance remains backend-only. A message
   authored in the backend's own UI carries no prompt id and renders as an


### PR DESCRIPTION
## Complexity

🌿 Straightforward: narrow OpenCode plugin request-shaping fix.

## What

- Reserve normal OpenCode message IDs without agent, model, or variant fields.
- Keep those selections on the real prompt or slash-command dispatch.
- Add regression coverage and document the reservation boundary.

## Why

The synchronous reservation request unnecessarily resolves and applies supplied session options before the real dispatch. OpenCode can report failures from that preparatory request as a generic 500, preventing the actual asynchronous prompt request from owning option selection and reporting its outcome.

## Risk and test focus

Low risk. The reservation remains an empty, no-reply message and still obtains OpenCode's ordered server ID. Test focus is request serialization and prompt/command correlation. There is no database impact.

## Expected result

OpenCode prompt and slash-command reservations no longer fail while applying options intended for the real dispatch. User-visible behavior is otherwise unchanged.

## Verification

- `dart pub get` from `bridge/`
- `dart test test/opencode_repository_test.dart test/opencode_service_test.dart test/opencode_plugin_impl_test.dart`
- `dart analyze --fatal-infos` from `bridge/sesori_plugin_opencode/`
