### PR TITLE
⚙️ Stop noisy failures during active-session shutdown

### DIFF
--- a/bridge/app/lib/src/orchestrator.dart
+++ b/bridge/app/lib/src/orchestrator.dart
@@ -1040,6 +1040,7 @@ class OrchestratorSession._({
   Future<void> _teardown() async {
     _routedRequestDispatcher.beginShutdown();
     _sessionCreationService.beginShutdown();
+    _prSyncService.dispose();
     final teardownSw = Stopwatch()..start();
     Object? firstTeardownError;
     StackTrace? firstTeardownStackTrace;

--- a/bridge/app/lib/src/orchestrator.dart
+++ b/bridge/app/lib/src/orchestrator.dart
@@ -1106,8 +1106,7 @@ class OrchestratorSession._({
     Log.v("[shutdown] completion listener disposed (+${teardownSw.elapsedMilliseconds}ms)");
     await attempt(_maintenanceListener.dispose);
     await attempt(_viewedProjectPrRefreshListener.dispose);
-    await attempt(_prSyncService.dispose);
-    Log.v("[shutdown] maintenance + pr-sync listeners disposed (+${teardownSw.elapsedMilliseconds}ms)");
+    Log.v("[shutdown] maintenance listeners disposed (+${teardownSw.elapsedMilliseconds}ms)");
     // Plugin teardown is owned by BridgePlugin.shutdown(), run as the
     // shutdown coordinator's ordered step — the deprecated direct
     // api.dispose() call is gone since the descriptor flip.
@@ -1254,6 +1253,7 @@ class OrchestratorSession._({
   void beginShutdown() {
     _routedRequestDispatcher.beginShutdown();
     _sessionCreationService.beginShutdown();
+    _prSyncService.dispose();
     if (_cancelRequestedAt == null) {
       _cancelRequestedAt = DateTime.now();
       Log.d(

--- a/bridge/app/lib/src/orchestrator.dart
+++ b/bridge/app/lib/src/orchestrator.dart
@@ -1040,7 +1040,7 @@ class OrchestratorSession._({
   Future<void> _teardown() async {
     _routedRequestDispatcher.beginShutdown();
     _sessionCreationService.beginShutdown();
-    _prSyncService.dispose();
+    _prSyncService.beginShutdown();
     final teardownSw = Stopwatch()..start();
     Object? firstTeardownError;
     StackTrace? firstTeardownStackTrace;
@@ -1107,7 +1107,8 @@ class OrchestratorSession._({
     Log.v("[shutdown] completion listener disposed (+${teardownSw.elapsedMilliseconds}ms)");
     await attempt(_maintenanceListener.dispose);
     await attempt(_viewedProjectPrRefreshListener.dispose);
-    Log.v("[shutdown] maintenance listeners disposed (+${teardownSw.elapsedMilliseconds}ms)");
+    await attempt(_prSyncService.drain);
+    Log.v("[shutdown] maintenance + pr-sync listeners disposed (+${teardownSw.elapsedMilliseconds}ms)");
     // Plugin teardown is owned by BridgePlugin.shutdown(), run as the
     // shutdown coordinator's ordered step — the deprecated direct
     // api.dispose() call is gone since the descriptor flip.
@@ -1254,7 +1255,7 @@ class OrchestratorSession._({
   void beginShutdown() {
     _routedRequestDispatcher.beginShutdown();
     _sessionCreationService.beginShutdown();
-    _prSyncService.dispose();
+    _prSyncService.beginShutdown();
     if (_cancelRequestedAt == null) {
       _cancelRequestedAt = DateTime.now();
       Log.d(

--- a/bridge/app/lib/src/services/pr_sync_service.dart
+++ b/bridge/app/lib/src/services/pr_sync_service.dart
@@ -35,6 +35,8 @@ class PrSyncService({
   ({bool capable, DateTime checkedAt})? _githubCliCapabilityCache;
   Future<bool>? _githubCliCapabilityCheck;
   bool _identityVerificationFailureReported = false;
+  Future<void>? _activeDrain;
+  Future<void>? _disposeFuture;
   bool _isDraining = false;
   bool _disposed = false;
 
@@ -107,7 +109,9 @@ class PrSyncService({
   void _ensureDrainStarted() {
     if (_isDraining || _disposed) return;
     _isDraining = true;
-    unawaited(_drainRefreshCycles());
+    final drain = _drainRefreshCycles();
+    _activeDrain = drain;
+    unawaited(drain);
   }
 
   Future<void> _drainRefreshCycles() async {
@@ -352,7 +356,7 @@ class PrSyncService({
     }
   }
 
-  void dispose() {
+  void beginShutdown() {
     if (_disposed) return;
     _disposed = true;
     _pendingProjectGenerations.clear();
@@ -360,7 +364,19 @@ class PrSyncService({
       waiter.fail();
     }
     _refreshWaiters.clear();
-    _renderedChangesController.close();
+  }
+
+  Future<void> drain() => _disposeFuture ??= _drain();
+
+  Future<void> dispose() {
+    beginShutdown();
+    return drain();
+  }
+
+  Future<void> _drain() async {
+    final activeDrain = _activeDrain;
+    if (activeDrain != null) await activeDrain;
+    await _renderedChangesController.close();
   }
 }
 

--- a/bridge/app/lib/src/services/pr_sync_service.dart
+++ b/bridge/app/lib/src/services/pr_sync_service.dart
@@ -201,6 +201,7 @@ class PrSyncService({
         for (final session in sessions)
           if (session.parentSessionId == null) session,
     ];
+    if (_disposed) return outcomes;
     final targetsByDirectory = await _prSource.resolvePullRequestTargets(
       directories: rootSessions.map((session) => session.directory),
     );

--- a/bridge/app/lib/src/services/pr_sync_service.dart
+++ b/bridge/app/lib/src/services/pr_sync_service.dart
@@ -204,6 +204,7 @@ class PrSyncService({
     final targetsByDirectory = await _prSource.resolvePullRequestTargets(
       directories: rootSessions.map((session) => session.directory),
     );
+    if (_disposed) return outcomes;
     final failedProjectIds = <String>{};
     for (final entry in targetsByDirectory.entries) {
       switch (entry.value) {

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -627,6 +627,43 @@ void main() {
       expect(await first, PrRefreshOutcome.failed);
       expect(source.selectionCalls, hasLength(1));
     });
+
+    test("dispose abandons local resolution finishing during shutdown", () async {
+      final resolutionBlock = Completer<void>();
+      final resolutionError = PullRequestTargetResolutionException(
+        innerError: StateError("git exited during shutdown"),
+        innerStackTrace: StackTrace.current,
+      );
+      final source = _FakePrSource(
+        targetsByDirectory: {
+          "/one": PullRequestRepositoryResolutionFailed(
+            branchName: "feature/current",
+            error: resolutionError,
+          ),
+        },
+        resolutionBlock: resolutionBlock,
+      );
+      final pullRequests = _FakePullRequestRepository();
+      final service = _service(
+        source: source,
+        pullRequests: pullRequests,
+        sessionsByProject: {
+          "one": [_session(id: "one", projectId: "one", directory: "/one")],
+        },
+      );
+
+      final refresh = service.triggerRefresh(
+        projectIds: {"one"},
+        refreshPolicy: PrRefreshPolicy.background,
+      );
+      await _waitFor(() => source.resolveCalls.isNotEmpty);
+      service.dispose();
+      resolutionBlock.complete();
+      await _waitFor(() => source.completedResolutionCount == 1);
+      await refresh;
+
+      expect(pullRequests.applyCalls, isEmpty);
+    });
   });
 }
 
@@ -689,6 +726,7 @@ final class _FakePrSource({
   Map<String, PullRequestDirectoryTarget> targetsByDirectory = const {},
   final List<Map<String, PullRequestDirectoryTarget>> resolutionResults = const [],
   final List<Completer<void>> selectionBlocks = const [],
+  final Completer<void>? resolutionBlock,
 }) implements PrSourceRepository {
   final List<List<String>> resolveCalls = <List<String>>[];
   final List<List<PullRequestSelectionTarget>> selectionCalls = <List<PullRequestSelectionTarget>>[];
@@ -704,6 +742,7 @@ final class _FakePrSource({
   int identityCallCount = 0;
   int _activeSelections = 0;
   int maxConcurrentSelections = 0;
+  int completedResolutionCount = 0;
 
   @override
   Future<Map<String, PullRequestDirectoryTarget>> resolvePullRequestTargets({
@@ -711,6 +750,8 @@ final class _FakePrSource({
   }) async {
     final uniqueDirectories = directories.toSet().toList(growable: false)..sort();
     resolveCalls.add(uniqueDirectories);
+    if (resolutionBlock case final block?) await block.future;
+    completedResolutionCount++;
     final resultIndex = resolveCalls.length - 1;
     final configured = resultIndex < resolutionResults.length ? resolutionResults[resultIndex] : targetsByDirectory;
     return {

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -628,6 +628,38 @@ void main() {
       expect(source.selectionCalls, hasLength(1));
     });
 
+    test("dispose during session loading does not start local resolution", () async {
+      final sessionLoadBlock = Completer<void>();
+      final source = _FakePrSource();
+      final pullRequests = _FakePullRequestRepository();
+      final sessions = _FakeSessionRepository(
+        sessionsByProject: {
+          "one": [_session(id: "one", projectId: "one", directory: "/one")],
+        },
+        loadBlock: sessionLoadBlock,
+      );
+      final service = PrSyncService(
+        prSource: source,
+        pullRequestRepository: pullRequests,
+        sessionRepository: sessions,
+        clock: const Clock(),
+        debounceWindow: Duration.zero,
+      );
+
+      final refresh = service.triggerRefresh(
+        projectIds: {"one"},
+        refreshPolicy: PrRefreshPolicy.background,
+      );
+      await sessions.loadStarted.future;
+      service.dispose();
+      sessionLoadBlock.complete();
+      await _waitFor(() => sessions.completedLoadCount == 1);
+      await refresh;
+
+      expect(source.resolveCalls, isEmpty);
+      expect(pullRequests.applyCalls, isEmpty);
+    });
+
     test("dispose abandons local resolution finishing during shutdown", () async {
       final resolutionBlock = Completer<void>();
       final resolutionError = PullRequestTargetResolutionException(
@@ -862,10 +894,18 @@ final class _FakePullRequestRepository() implements PullRequestRepository {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-final class _FakeSessionRepository({required final Map<String, List<StoredSession>> sessionsByProject})
-    implements SessionRepository {
+final class _FakeSessionRepository({
+  required final Map<String, List<StoredSession>> sessionsByProject,
+  final Completer<void>? loadBlock,
+}) implements SessionRepository {
+  final Completer<void> loadStarted = Completer<void>();
+  int completedLoadCount = 0;
+
   @override
   Future<List<StoredSession>> getStoredSessionsByProjectId({required String projectId}) async {
+    if (!loadStarted.isCompleted) loadStarted.complete();
+    if (loadBlock case final block?) await block.future;
+    completedLoadCount++;
     return sessionsByProject[projectId] ?? const <StoredSession>[];
   }
 

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -620,10 +620,11 @@ void main() {
         projectIds: {"one"},
         refreshPolicy: PrRefreshPolicy.explicit,
       );
-      service.dispose();
+      final disposal = service.dispose();
 
       expect(await queued, PrRefreshOutcome.failed);
       selectionBlock.complete();
+      await disposal;
       expect(await first, PrRefreshOutcome.failed);
       expect(source.selectionCalls, hasLength(1));
     });
@@ -651,13 +652,48 @@ void main() {
         refreshPolicy: PrRefreshPolicy.background,
       );
       await sessions.loadStarted.future;
-      service.dispose();
+      final disposal = service.dispose();
       sessionLoadBlock.complete();
+      await disposal;
       await _waitFor(() => sessions.completedLoadCount == 1);
       await refresh;
 
       expect(source.resolveCalls, isEmpty);
       expect(pullRequests.applyCalls, isEmpty);
+    });
+
+    test("dispose waits for an active local refresh write", () async {
+      final applyBlock = Completer<void>();
+      final source = _FakePrSource(
+        targetsByDirectory: const {
+          "/one": PullRequestLocalBranchDirectoryTarget(branchName: "feature/current"),
+        },
+      );
+      final pullRequests = _FakePullRequestRepository(applyBlock: applyBlock);
+      final service = _service(
+        source: source,
+        pullRequests: pullRequests,
+        sessionsByProject: {
+          "one": [_session(id: "one", projectId: "one", directory: "/one")],
+        },
+      );
+
+      final refresh = service.triggerRefresh(
+        projectIds: {"one"},
+        refreshPolicy: PrRefreshPolicy.background,
+      );
+      await pullRequests.applyStarted.future;
+      final disposal = service.dispose();
+      var disposalCompleted = false;
+      unawaited(disposal.then((_) => disposalCompleted = true));
+      await Future<void>.delayed(Duration.zero);
+      expect(disposalCompleted, isFalse);
+
+      applyBlock.complete();
+      await disposal;
+
+      expect(disposalCompleted, isTrue);
+      expect(await refresh, PrRefreshOutcome.failed);
     });
 
     test("dispose abandons local resolution finishing during shutdown", () async {
@@ -689,8 +725,9 @@ void main() {
         refreshPolicy: PrRefreshPolicy.background,
       );
       await _waitFor(() => source.resolveCalls.isNotEmpty);
-      service.dispose();
+      final disposal = service.dispose();
       resolutionBlock.complete();
+      await disposal;
       await _waitFor(() => source.completedResolutionCount == 1);
       await refresh;
 
@@ -835,7 +872,7 @@ final class _FakePrSource({
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-final class _FakePullRequestRepository() implements PullRequestRepository {
+final class _FakePullRequestRepository({final Completer<void>? applyBlock}) implements PullRequestRepository {
   Set<String> localChangedProjectIds = const <String>{};
   Set<String> preparedChangedProjectIds = const <String>{};
   final Map<String, PullRequestReplacementOutcome> replacementOutcomes = <String, PullRequestReplacementOutcome>{};
@@ -851,6 +888,7 @@ final class _FakePullRequestRepository() implements PullRequestRepository {
     })
   >
   replaceCalls = [];
+  final Completer<void> applyStarted = Completer<void>();
 
   @override
   Future<Set<String>> applyResolvedTargets({
@@ -861,6 +899,8 @@ final class _FakePullRequestRepository() implements PullRequestRepository {
       sessionsByProject: Map<String, List<StoredSession>>.from(sessionsByProject),
       targets: Map<String, PullRequestDirectoryTarget>.from(targetsByDirectory),
     ));
+    if (!applyStarted.isCompleted) applyStarted.complete();
+    if (applyBlock case final block?) await block.future;
     return localChangedProjectIds;
   }
 

--- a/bridge/sesori_plugin_pi/lib/src/api/pi_rpc_client.dart
+++ b/bridge/sesori_plugin_pi/lib/src/api/pi_rpc_client.dart
@@ -182,7 +182,7 @@ class PiRpcClient({
 
     unawaited(
       process.stdin.done.catchError((Object error, StackTrace stack) {
-        if (generation != _generation) return;
+        if (generation != _generation || _exited.isCompleted) return;
         Log.w("[pi] stdin stream failed", error, stack);
         _failPending(PiRpcStdinException(cause: error), stack);
         try {

--- a/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
@@ -60,6 +60,15 @@ final class const PiSessionConnection({
   required final int generation,
 });
 
+sealed class const PiSessionAbortResult();
+
+final class const PiSessionAbortAcknowledged() extends PiSessionAbortResult;
+
+final class const PiSessionAbortProcessExited({
+  required final Object innerError,
+  required final StackTrace innerStackTrace,
+}) extends PiSessionAbortResult;
+
 final class const PiPromptPayload({required final String message, required final List<Map<String, Object?>> images});
 
 final class const PiAgentState({required final bool streaming, required final int pendingMessageCount});
@@ -380,12 +389,17 @@ final class PiSessionProcessRepository({
     );
   }
 
-  Future<void> abort({required PiSessionConnection connection}) async {
-    await _requiredResident(connection).client.send(
-      command: PiRpcCommand.abort,
-      arguments: const {},
-      timeout: _historyRpcTimeout,
-    );
+  Future<PiSessionAbortResult> abort({required PiSessionConnection connection}) async {
+    try {
+      await _requiredResident(connection).client.send(
+        command: PiRpcCommand.abort,
+        arguments: const {},
+        timeout: _historyRpcTimeout,
+      );
+      return const PiSessionAbortAcknowledged();
+    } on PiRpcProcessExitException catch (error, stackTrace) {
+      return PiSessionAbortProcessExited(innerError: error, innerStackTrace: stackTrace);
+    }
   }
 
   bool sendExtensionUiResponse({

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -670,7 +670,14 @@ final class PiSessionService({
     }
   }
 
-  Future<void> abort({required String sessionId}) async {
+  Future<void> abort({required String sessionId}) {
+    return _abort(sessionId: sessionId, processExitIsExpected: false);
+  }
+
+  Future<void> _abort({
+    required String sessionId,
+    required bool processExitIsExpected,
+  }) async {
     final state = _sessions[sessionId];
     if (state == null) {
       await _processes.teardown(sessionId: sessionId);
@@ -699,7 +706,16 @@ final class PiSessionService({
     try {
       final idleReap = state.idleReap;
       if (idleReap != null) await idleReap;
-      if (connection != null) await _processes.abort(connection: connection);
+      if (connection != null) {
+        switch (await _processes.abort(connection: connection)) {
+          case PiSessionAbortAcknowledged():
+            break;
+          case PiSessionAbortProcessExited(:final innerError, :final innerStackTrace):
+            if (!processExitIsExpected) {
+              Log.w("[pi] abort command failed for session id=$sessionId", innerError, innerStackTrace);
+            }
+        }
+      }
     } on Object catch (error, stack) {
       Log.w("[pi] abort command failed for session id=$sessionId", error, stack);
     } finally {
@@ -725,7 +741,8 @@ final class PiSessionService({
       };
       if (activeSessionIds.isEmpty) return const <String>{};
       await Future.wait([
-        for (final sessionId in activeSessionIds) abort(sessionId: sessionId),
+        for (final sessionId in activeSessionIds)
+          _abort(sessionId: sessionId, processExitIsExpected: true),
       ]);
       if (currentWorkState != PluginWorkState.idle) {
         await workState.firstWhere((state) => state == PluginWorkState.idle);

--- a/bridge/sesori_plugin_pi/test/pi_rpc_client_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_rpc_client_test.dart
@@ -345,6 +345,23 @@ void main() {
       expect(started.process.killed, isTrue);
     });
 
+    test("ignores an asynchronous stdin failure after process exit is confirmed", () async {
+      final started = await startTestClient();
+      addTearDown(started.client.dispose);
+      final pending = started.client.send(
+        command: PiRpcCommand.getState,
+        arguments: const {},
+        timeout: const Duration(seconds: 5),
+      );
+      await waitForCommand(process: started.process, type: "get_state");
+
+      started.process.exit(code: -2);
+      await expectLater(pending, throwsA(isA<PiRpcProcessExitException>()));
+      started.process.failStdin(error: const SocketException("broken pipe"));
+      await pump();
+      expect(started.process.killed, isFalse);
+    });
+
     test("fails fast once the process has exited", () async {
       final started = await startTestClient();
       addTearDown(started.client.dispose);

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -1307,6 +1307,38 @@ void main() {
     expect(fixture.repository.residentSessionIds, isEmpty);
   });
 
+  test("shutdown interruption accepts process exit before abort response", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "prompt-shutdown",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "active work")],
+      userVisibleText: "active work",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    final prompt = await waitForCommand(process: process, type: "prompt");
+    process.emitResponse(id: prompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_start"});
+
+    final warnings = await _captureWarnings(() async {
+      final interruption = service.interruptActiveWork(budget: const Duration(seconds: 1));
+      await waitForCommand(process: process, type: "abort");
+      process.exit(code: -2);
+      await interruption;
+    });
+
+    expect(warnings, isNot(contains("abort command failed")));
+    expect(service.sessionStatuses["session"], const PluginSessionStatus.idle());
+    expect(fixture.repository.residentSessionIds, isEmpty);
+  });
+
   test("idle reap and disposal terminate residents", () async {
     final first = FakePiProcess();
     final second = FakePiProcess();


### PR DESCRIPTION
## Complexity

⚙️ Moderate — coordinates bridge shutdown fencing with Pi transport, repository, and service boundaries.

## What

- Dispose PR synchronization when shutdown begins and abandon local target resolution that completes afterward.
- Treat a Pi process exit during active-work interruption as an already-completed shutdown outcome.
- Ignore a redundant asynchronous stdin failure after the Pi process exit has already been confirmed.
- Add regressions for all three shutdown races.

## Why

Stopping the bridge while a Pi session is active can terminate child processes before graceful interruption receives its acknowledgement. The bridge then reported expected process-exit, broken-pipe, and PR-resolution failures even though teardown completed successfully.

## Risk and test focus

The change is limited to shutdown/disposal paths. Existing direct abort failures and genuine pre-exit stdin failures remain observable. There is no wire, persisted-data, database-schema, or compatibility impact.

## Expected result

Stopping the bridge with active Pi work completes without the reported `PiRpcProcessExitException`, redundant broken-pipe warning, or shutdown-time local PR resolution warning.

## Verification

- `dart test test/pi_rpc_client_test.dart test/pi_session_service_test.dart` in `bridge/sesori_plugin_pi`
- `dart test test/bridge/services/pr_sync_service_test.dart` in `bridge/app`
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_pi`
- `dart analyze --fatal-infos` in `bridge/app`
- Architecture implementation review completed; its repository-boundary finding was applied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops noisy failures when shutting down with an active Pi session. Previously shutdown reported PiRpcProcessExitException, a redundant broken‑pipe warning, and PR target‑resolution failures; now process exit during interrupt is treated as expected, stdin failures after exit are ignored, and PR sync drains and abandons in‑flight work.

- Orchestrator: start PR sync shutdown early in both beginShutdown() and _teardown(); await _prSyncService.drain() instead of dispose.
- PR sync: add beginShutdown()/drain(); track an active drain and close after it; abandon resolution if disposed before/after session fetch; dispose calls beginShutdown+drain; tests cover disposal during session load, during resolution, and waiting for an active local apply write.
- RPC client: ignore asynchronous stdin failure once process exit is confirmed.
- Session process/service: abort() now returns PiSessionAbortResult (Acknowledged | ProcessExited); during shutdown, treat ProcessExited as success and suppress the warning; still warn on unexpected abort failures.
- No wire/data/schema changes or migration required; tests cover the three shutdown races.

<sup>Written for commit ef42452c8704c1a58b907fdb0d5dfe474d412f36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

