### PR TITLE
🌱 [catalog-rescan] Re-hydrate stale plugin catalogs [step 2/8]

### DIFF
--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -5,9 +5,9 @@
 - **Plan slug:** `catalog-rescan`
 - **Implementation base:** `main` at
   `7b1ebe9bc629d05b5d104e76cd5dbaa1514d65a2`
-- **Series state:** Step 1/8 in preparation, plan review applied
-- **Current step:** publish the plan
-- **Next action:** open the Step 1 PR, then Step 2's `projectionVersion` bump
+- **Series state:** Step 1/8 merged; Step 2/8 open
+- **Current step:** re-hydrate stale plugin catalogs
+- **Next action:** land Step 2, then Step 3's new-item counts
 - **Origin issue:** [#961](https://github.com/sesori-ai/sesori_apps_monorepo/issues/961)
 - **External overlap:** [#1008](https://github.com/sesori-ai/sesori_apps_monorepo/issues/1008)
   owns Codex live updates; do not address it here
@@ -120,8 +120,8 @@
 
 | Done | Step | Exact PR title | Changed-line target | State |
 |---|---|---|---:|---|
-| [ ] | 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 950-1,100 (`PLAN.md`) | In preparation |
-| [ ] | 2/8 | `🌱 [catalog-rescan] Re-hydrate stale plugin catalogs [step 2/8]` | 20-60 | Not started |
+| [x] | 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 950-1,100 (`PLAN.md`) | [PR #1064](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1064) merged |
+| [ ] | 2/8 | `🌱 [catalog-rescan] Re-hydrate stale plugin catalogs [step 2/8]` | 20-60 | Open |
 | [ ] | 3/8 | `⚙️ [catalog-rescan] Report new items from a catalog import [step 3/8]` | 350-600 | Not started |
 | [ ] | 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 | Not started |
 | [ ] | 5/8 | `⚙️ [catalog-rescan] Add a second stage to pull-to-refresh [step 5/8]` | 350-600 | Not started |
@@ -146,12 +146,14 @@
 
 ## Step 2 Checklist
 
-- [ ] Bump `projectionVersion` to `2` with a comment recording why.
-- [ ] Leave `projectionVersion = 1` rows in place; add no migration.
-- [ ] Update only the tests that assert the constant.
-- [ ] Confirm re-import stays non-destructive: `hidden`, `displayName`,
+- [x] Bump `projectionVersion` to `2` with a comment recording why.
+- [x] Leave `projectionVersion = 1` rows in place; add no migration.
+- [x] Update only the tests that assert the constant. No test asserts it: the
+  literal `1` in `catalog_queries_test.dart` is an arbitrary DAO-level value
+  proving exact-match retrieval, not the production constant, so it stays.
+- [x] Confirm re-import stays non-destructive: `hidden`, `displayName`,
   `title`, overrides, archive state, and tombstones survive.
-- [ ] Run targeted bridge tests and `dart analyze --fatal-infos`.
+- [x] Run targeted bridge tests and `dart analyze --fatal-infos`.
 
 ## Step 3 Checklist
 
@@ -365,5 +367,15 @@ refresh gap as consequences of one definition.
   all ten findings applied directly, recorded above
 - **Step 1 combined numstat (information only):** `PLAN.md` 988 + `TRACKER.md` 369 = 1,357 insertions, 0 deletions
 - **Step 1 PR:** [#1064](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1064)
-  open
+  merged
+- **Step 2 base:** `main` at `116f8fb2c`
+- **Step 2 verification:** 33 targeted tests passed —
+  `catalog_import_repository_test.dart` (16),
+  `catalog_import_service_test.dart` (9),
+  `catalog_import_handlers_test.dart` (3),
+  `catalog_queries_test.dart` (3), `catalog_import_startup_test.dart` (2);
+  `dart analyze --fatal-infos` from `bridge/app` reported no issues
+- **Step 2 review:** not architecture-bearing; a constant's value changes no
+  boundary, contract, or ownership
+- **Step 2 PR:** pending
 - **Final disposition:** pending

--- a/bridge/app/lib/src/repositories/catalog_import_repository.dart
+++ b/bridge/app/lib/src/repositories/catalog_import_repository.dart
@@ -31,7 +31,16 @@ class CatalogImportRepository({
     required final CatalogHydrationsDao _catalogHydrationsDao,
     required final ProjectCatalogIdentityCalculator _projectCatalogIdentityCalculator,
   }) {
-  static const int projectionVersion = 1;
+  /// Invalidates every durable hydration marker written by an earlier version.
+  ///
+  /// The marker at a given version means "this plugin's catalog was fully
+  /// hydrated once", and an automatic import short-circuits whenever one
+  /// exists. Bumped to 2 for issue #961: markers written before v1.8.0 can
+  /// describe a catalog produced by superseded discovery, and the marker was
+  /// the only thing preventing a corrected import from ever running. Bumping
+  /// re-hydrates each plugin exactly once; the merge is non-destructive and
+  /// tombstoned sessions stay deleted.
+  static const int projectionVersion = 2;
   static const int _responsivenessBatchSize = 512;
   static final Random _secureRandom = Random.secure();
 


### PR DESCRIPTION
## Complexity

Trivial. One constant's value, plus a comment recording why and the tracker
entry. No new code path.

## What

Bumps `CatalogImportRepository.projectionVersion` from `1` to `2`.

Durable hydration markers are keyed on `(pluginId, projectionVersion)`, so
raising the version invalidates every marker written by an earlier bridge and
each enabled plugin re-hydrates exactly once on the next start.

`projectionVersion = 1` rows are left in place. No migration, no backfill, no
schema change.

## Why

Issue #961. `CatalogImportService._run` short-circuits an automatic import to
`completed(0, 0)` whenever a marker exists — without enumerating anything or
even starting the plugin, which is why the reporter's log prints the count with
no `Importing codex catalog...` line above it.

`projectionVersion` has been `1` since it was introduced in #488, so no release
has ever invalidated a marker. An install that hydrated a partial catalog under
an older bridge keeps that partial catalog across every subsequent release, and
the only thing that re-imports is `sesori-bridge --import-plugin <id>` run by
hand.

This is the mechanism that exists for exactly this situation. Steps 3-6 build
the in-app rescan; this one unsticks everyone already frozen, and ships first
because it does not depend on any of that work.

## Risk and test focus

Low. The re-import path is the one `--import-plugin` already exercises, and it
is non-destructive by construction: `_mergeProjectRow` and `_mergeSessionRow`
preserve `hidden`, `displayName`, `title`, overrides, and archive state, and
`getTombstonedSessionIds` keeps deleted sessions deleted.

The behaviour worth watching is the first start after upgrading: each enabled
plugin runs one full catalog import, which starts that plugin's backend. On a
large catalog that is the same cost as one `--import-plugin` run.

No test asserts the constant. The literal `1` in `catalog_queries_test.dart` is
an arbitrary DAO-level value proving exact-match retrieval and replaceability,
not the production constant, so it stays as-is.

## Expected result

**User-visible:** on the first start after upgrading, each enabled harness
re-imports its catalog once, and projects or sessions missing because of a
stale marker appear. Subsequent starts short-circuit again, now at version 2.

**Database:** one new `catalog_hydrations` row per plugin at
`projectionVersion = 2`. The old rows remain and are never read again. No
schema change.

**Internal:** none beyond the constant.

## Verification

- `dart test` from `bridge/app`, 33 targeted tests, all passing:
  `catalog_import_repository_test.dart` (16),
  `catalog_import_service_test.dart` (9),
  `catalog_import_handlers_test.dart` (3), `catalog_queries_test.dart` (3),
  `catalog_import_startup_test.dart` (2)
- `dart analyze --fatal-infos` from `bridge/app` — no issues found
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Invalidates stale catalog hydration markers so enabled plugins re-import their catalogs once. Bumps `CatalogImportRepository.projectionVersion` from 1 to 2 to unblock automatic imports that previously short-circuited whenever a marker existed, leaving partial catalogs from older discovery; now each enabled plugin imports once on next start, then short-circuits at version 2.

- No migration or schema change; `projectionVersion = 1` rows remain and are ignored.
- First start after upgrade: each enabled plugin runs one full catalog import (starts the plugin backend); subsequent starts short-circuit at version 2.
- Merge is non-destructive: preserves hidden/displayName/title/overrides/archive state; tombstoned sessions remain deleted.
- Scope is a constant change; no new code path.

<sup>Written for commit 00d3e9022b73f4b4ea5bcc6d476908e2b2983eb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

