### PR TITLE
⚙️ Recover stale OpenCode prompt selections

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -12,6 +12,8 @@ import "prompt_message_tracker.dart";
 import "sse/sse_connection.dart";
 import "sse_event_mapper.dart";
 
+enum _StaleSessionOption() { agent, model, variant }
+
 String formatDroppedSseFrameLog({
   required String category,
   required String message,
@@ -39,6 +41,9 @@ class OpenCodePlugin._({
   void Function()? onConnected,
   void Function()? onDisconnected,
 }) implements OpenCodeManagedApi {
+  static const String _sendPromptOperation = "sendPrompt";
+  static const String _sendCommandOperation = "sendCommand";
+
   final SseEventParser _parser;
   final BufferedUntilFirstListener<BridgeSseEvent> _eventBuffer;
   final PluginWorkStateController _workState = PluginWorkStateController(initial: PluginWorkState.unknown);
@@ -174,6 +179,93 @@ class OpenCodePlugin._({
     final result = await _call(fn);
     _syncWorkState();
     return result;
+  }
+
+  /// Preserves OpenCode's synchronous reservation as the rejection boundary
+  /// while translating its generic 500 for a removed selection into the typed
+  /// stale-options contract. Discovery runs only after that ambiguous failure;
+  /// unrelated backend failures retain their original error and stack trace.
+  Future<T> _reserveWithStaleOptionsClassification<T>({
+    required String operation,
+    required String sessionId,
+    required String? agent,
+    required PluginSessionVariant? variant,
+    required ({String providerID, String modelID})? model,
+    required Future<T> Function() reserve,
+  }) async {
+    try {
+      return await _call(reserve);
+    } on PluginApiException catch (error, stackTrace) {
+      if (error.statusCode != io.HttpStatus.internalServerError ||
+          (agent == null && variant == null && model == null)) {
+        Error.throwWithStackTrace(error, stackTrace);
+      }
+
+      final _StaleSessionOption? staleOption;
+      try {
+        staleOption = await _findStaleSessionOption(
+          sessionId: sessionId,
+          agent: agent,
+          variant: variant,
+          model: model,
+        );
+      } on Object catch (validationError, validationStackTrace) {
+        Log.w(
+          "[opencode] failed to validate session options after reservation failure for $sessionId",
+          validationError,
+          validationStackTrace,
+        );
+        Error.throwWithStackTrace(error, stackTrace);
+      }
+
+      if (staleOption == null) Error.throwWithStackTrace(error, stackTrace);
+      Error.throwWithStackTrace(
+        PluginStaleOptionsException(
+          operation,
+          message: switch (staleOption) {
+            _StaleSessionOption.agent => "OpenCode no longer offers the selected agent.",
+            _StaleSessionOption.model => "OpenCode no longer offers the selected model.",
+            _StaleSessionOption.variant => "OpenCode no longer offers the selected variant.",
+          },
+          cause: error,
+        ),
+        stackTrace,
+      );
+    }
+  }
+
+  Future<_StaleSessionOption?> _findStaleSessionOption({
+    required String sessionId,
+    required String? agent,
+    required PluginSessionVariant? variant,
+    required ({String providerID, String modelID})? model,
+  }) async {
+    final projectId = _service.tracker.getSessionDirectory(sessionId: sessionId);
+    if (projectId == null) return null;
+
+    if (agent != null) {
+      final agents = await _call(() => _service.getAgents(projectId: projectId));
+      if (!agents.any((candidate) => candidate.name == agent)) return _StaleSessionOption.agent;
+    }
+
+    if (model case final requestedModel?) {
+      final providers = await _call(() => _service.getProviders(projectId: projectId));
+      PluginModel? offeredModel;
+      for (final provider in providers.providers) {
+        if (provider.id != requestedModel.providerID) continue;
+        for (final candidate in provider.models) {
+          if (candidate.id == requestedModel.modelID) {
+            offeredModel = candidate;
+            break;
+          }
+        }
+        break;
+      }
+      if (offeredModel == null || !offeredModel.isAvailable) return _StaleSessionOption.model;
+      if (variant != null && !offeredModel.variants.contains(variant.id)) return _StaleSessionOption.variant;
+    }
+
+    return null;
   }
 
   Future<void> _dispatchReservedMessage({
@@ -424,8 +516,13 @@ class OpenCodePlugin._({
     // OpenCode allocates the ordered id on its own host. Its reservation echo
     // is empty and cannot render; reusing the message below publishes the
     // stamped, renderable envelope after this correlation is recorded.
-    final messageId = await _call(
-      () => _service.reserveMessage(
+    final messageId = await _reserveWithStaleOptionsClassification(
+      operation: _sendPromptOperation,
+      sessionId: sessionId,
+      agent: agent,
+      variant: variant,
+      model: model,
+      reserve: () => _service.reserveMessage(
         sessionId: sessionId,
         agent: agent,
         variant: variant,
@@ -465,8 +562,13 @@ class OpenCodePlugin._({
     required ({String providerID, String modelID})? model,
   }) async {
     if (command == OpenCodeService.compactionCommandName) {
-      final reservation = await _call(
-        () => _service.reserveCompactionMessage(
+      final reservation = await _reserveWithStaleOptionsClassification(
+        operation: _sendCommandOperation,
+        sessionId: sessionId,
+        agent: agent,
+        variant: variant,
+        model: model,
+        reserve: () => _service.reserveCompactionMessage(
           sessionId: sessionId,
           arguments: arguments,
           userVisibleArguments: userVisibleArguments,
@@ -494,8 +596,13 @@ class OpenCodePlugin._({
       return;
     }
 
-    final messageId = await _call(
-      () => _service.reserveMessage(
+    final messageId = await _reserveWithStaleOptionsClassification(
+      operation: _sendCommandOperation,
+      sessionId: sessionId,
+      agent: agent,
+      variant: variant,
+      model: model,
+      reserve: () => _service.reserveMessage(
         sessionId: sessionId,
         agent: agent,
         variant: variant,

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -6,6 +6,7 @@ import "package:opencode_plugin/opencode_plugin.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
+enum _OptionDiscoveryRequest() { agents, providers }
 
 /// Waits until [count] events of type [T] have been delivered, or fails.
 ///
@@ -224,6 +225,8 @@ void main() {
       expect(options.completeness, PluginSessionOptionsCompleteness.complete);
       expect(options.agents, isNotEmpty);
       expect(options.providers.providers, isNotEmpty);
+      expect(server.lastAgentDirectoryHeader, "project-1");
+      expect(server.lastProvidersDirectoryHeader, "project-1");
       expect(
         options.commands.map((command) => command.name),
         contains(OpenCodeService.compactionCommandName),
@@ -443,6 +446,135 @@ void main() {
       );
 
       expect(plugin.currentWorkState, PluginWorkState.idle);
+    });
+
+    final staleSelectionCases =
+        <
+          ({
+            String name,
+            String? agent,
+            PluginSessionVariant? variant,
+            ({String providerID, String modelID})? model,
+            String expectedMessage,
+            _OptionDiscoveryRequest discoveryRequest,
+          })
+        >[
+          (
+            name: "agent",
+            agent: "removed-agent",
+            variant: null,
+            model: null,
+            expectedMessage: "OpenCode no longer offers the selected agent.",
+            discoveryRequest: _OptionDiscoveryRequest.agents,
+          ),
+          (
+            name: "model",
+            agent: null,
+            variant: null,
+            model: (providerID: "anthropic", modelID: "removed-model"),
+            expectedMessage: "OpenCode no longer offers the selected model.",
+            discoveryRequest: _OptionDiscoveryRequest.providers,
+          ),
+          (
+            name: "variant",
+            agent: null,
+            variant: const PluginSessionVariant(id: "medium"),
+            model: (providerID: "anthropic", modelID: "claude-3-opus"),
+            expectedMessage: "OpenCode no longer offers the selected variant.",
+            discoveryRequest: _OptionDiscoveryRequest.providers,
+          ),
+        ];
+
+    for (final testCase in staleSelectionCases) {
+      test("classifies a removed ${testCase.name} after a generic reservation failure", () async {
+        final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
+        addTearDown(plugin.dispose);
+        await server.waitForSseConnection();
+        server
+          ..failNoReplyMessageNumber = 1
+          ..noReplyMessageFailureStatusCode = HttpStatus.internalServerError;
+        server.requestLog.clear();
+
+        await expectLater(
+          plugin.sendPrompt(
+            promptId: "prompt-stale-${testCase.name}",
+            sessionId: "s-root",
+            parts: const [PluginPromptPart.text(text: "Continue")],
+            agent: testCase.agent,
+            variant: testCase.variant,
+            model: testCase.model,
+          ),
+          throwsA(
+            isA<PluginStaleOptionsException>()
+                .having((error) => error.operation, "operation", "sendPrompt")
+                .having((error) => error.message, "message", testCase.expectedMessage)
+                .having(
+                  (error) => error.cause,
+                  "cause",
+                  isA<PluginApiException>().having(
+                    (error) => error.statusCode,
+                    "statusCode",
+                    HttpStatus.internalServerError,
+                  ),
+                ),
+          ),
+        );
+
+        expect(
+          server.requestLog,
+          equals([
+            "POST /session/s-root/message",
+            switch (testCase.discoveryRequest) {
+              _OptionDiscoveryRequest.agents => "GET /agent",
+              _OptionDiscoveryRequest.providers => "GET /config/providers",
+            },
+          ]),
+        );
+        expect(server.requestLog, isNot(contains("POST /session/s-root/prompt_async")));
+        switch (testCase.discoveryRequest) {
+          case _OptionDiscoveryRequest.agents:
+            expect(server.lastAgentDirectoryHeader, "/repo");
+          case _OptionDiscoveryRequest.providers:
+            expect(server.lastProvidersDirectoryHeader, "/repo");
+        }
+      });
+    }
+
+    test("preserves a generic reservation failure when the selected agent remains available", () async {
+      final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
+      addTearDown(plugin.dispose);
+      await server.waitForSseConnection();
+      server
+        ..failNoReplyMessageNumber = 1
+        ..noReplyMessageFailureStatusCode = HttpStatus.internalServerError;
+      server.requestLog.clear();
+
+      await expectLater(
+        plugin.sendPrompt(
+          promptId: "prompt-backend-failure",
+          sessionId: "s-root",
+          parts: const [PluginPromptPart.text(text: "Continue")],
+          agent: "build",
+          variant: null,
+          model: null,
+        ),
+        throwsA(
+          isA<PluginApiException>().having(
+            (error) => error.statusCode,
+            "statusCode",
+            HttpStatus.internalServerError,
+          ),
+        ),
+      );
+
+      expect(
+        server.requestLog,
+        equals([
+          "POST /session/s-root/message",
+          "GET /agent",
+        ]),
+      );
+      expect(server.lastAgentDirectoryHeader, "/repo");
     });
 
     test("sendCommand detaches with the tracked directory and marks the turn busy", () async {
@@ -1334,12 +1466,15 @@ class _FakeOpenCodeServer() {
   final List<String> deletedMessageIds = [];
   Map<String, dynamic>? lastCommandBody;
   String? lastCommandDirectoryHeader;
+  String? lastAgentDirectoryHeader;
+  String? lastProvidersDirectoryHeader;
   String? lastCreatedSessionParentId;
   Completer<void>? holdCommand;
   int promptStatusCode = HttpStatus.ok;
   int commandStatusCode = HttpStatus.ok;
   int messagePartStatusCode = HttpStatus.ok;
   int? failNoReplyMessageNumber;
+  int noReplyMessageFailureStatusCode = HttpStatus.badRequest;
   int _nextMessageNumber = 1;
   bool acceptSseConnections = true;
   final List<String> abortedSessionIds = [];
@@ -1492,7 +1627,7 @@ class _FakeOpenCodeServer() {
       }
 
       if (request.method == "GET" && path == "/agent") {
-        expect(request.headers.value("x-opencode-directory"), equals("project-1"));
+        lastAgentDirectoryHeader = request.headers.value("x-opencode-directory");
         await _sendJson(request.response, [
           {
             "name": "build",
@@ -1560,7 +1695,7 @@ class _FakeOpenCodeServer() {
         final body = (jsonDecode(rawBody) as Map).cast<String, dynamic>();
         noReplyMessageBodies.add(body);
         if (noReplyMessageBodies.length == failNoReplyMessageNumber) {
-          request.response.statusCode = HttpStatus.badRequest;
+          request.response.statusCode = noReplyMessageFailureStatusCode;
           request.response.write("message failed");
           await request.response.close();
           return;
@@ -1703,7 +1838,7 @@ class _FakeOpenCodeServer() {
       }
 
       if (request.method == "GET" && path == "/config/providers") {
-        expect(request.headers.value("x-opencode-directory"), equals("project-1"));
+        lastProvidersDirectoryHeader = request.headers.value("x-opencode-directory");
         await _sendJson(request.response, {
           "providers": [
             {

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -138,11 +138,14 @@ defaults and queued client sends coherent.
   the same prompt id so retries stay idempotent.
 - When a plugin rejects a send before acceptance because its agent, model, or
   variant is no longer offered, the bridge deletes that options-cache row and
-  returns the typed `staleSessionOptions` rejection. The client force-refreshes
-  the options, replaces only unsupported queued selections without changing
-  FIFO order or prompt ids, warns the user, and retries once. A failed refresh
-  or second stale rejection leaves the prompt visible and queued instead of
-  disappearing or entering a retry loop.
+  returns the typed `staleSessionOptions` rejection. OpenCode keeps the requested
+  selection on its synchronous message reservation; when that endpoint collapses
+  a rejection into a generic 500, the plugin checks fresh project options and
+  classifies the failure as stale only when the requested selection is absent or unavailable.
+  The client force-refreshes the options, replaces only unsupported queued
+  selections without changing FIFO order or prompt ids, warns the user, and
+  retries once. A failed refresh or second stale rejection leaves the prompt
+  visible and queued instead of disappearing or entering a retry loop.
 - Each plugin stamps that prompt id onto the user-message echo of its own
   dispatch, using the link its backend exposes — Claude's queue entry, ACP's
   accepted send, Pi's dispatcher, Codex's client-supplied identifier, and


### PR DESCRIPTION
## Complexity

⚙️ Moderate: the code change is plugin-local, but it preserves the synchronous acceptance boundary while distinguishing a stale selection from an unrelated generic OpenCode failure.

## What

- Keep the requested agent, model, and variant on OpenCode's synchronous message reservation.
- When OpenCode collapses a reservation rejection into HTTP 500, query the live project catalog and classify the failure as `PluginStaleOptionsException` only when the requested selection is absent or unavailable.
- Preserve unrelated 500 responses and their original stack traces.
- Cover removed agents, models, and variants plus the non-stale 500 path, and document the OpenCode reservation boundary.

## Why

OpenCode 1.18.20 returned a generic 500 for a cached agent that no longer existed. Mapping the matching bundled stack location showed that the failure came from `SessionPrompt.createUserMessage`'s `Agent not found` branch.

Omitting options from the reservation, as proposed in #1069, only moves the same missing-agent failure into `prompt_async`. That endpoint returns 204 before background processing succeeds, so the bridge can no longer route the rejection through its existing stale-options refresh and bounded retry flow.

## Risk and test focus

Catalog verification runs only after an ambiguous reservation 500, not on successful sends. A 500 whose requested selection remains available is rethrown unchanged. Focus is the classification boundary, project-scoped discovery, and ensuring the real async dispatch never starts after a stale rejection.

There is no database or wire-contract impact. This reuses the existing structured stale-options rejection and client recovery behavior.

## Expected result

A prompt submitted with a removed OpenCode agent, model, or variant remains visible, receives the typed stale-options rejection, refreshes project options, and retries once with a supported selection. Unrelated OpenCode failures remain observable as their original failures.

## Verification

- `dart pub get` from `bridge/`
- `dart test test/opencode_plugin_impl_test.dart`
- `dart test test/opencode_plugin_impl_test.dart --name 'classifies a removed|preserves a generic reservation'`
- `dart analyze --fatal-infos` from `bridge/sesori_plugin_opencode/`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies OpenCode reservation 500s caused by removed agents/models/variants as typed stale-session-options, while preserving unrelated 500s. Keeps the selection on the synchronous reservation so the bridge can refresh options and retry once.

- Validates the requested agent/model/variant against the live project catalog only after a reservation 500; throws PluginStaleOptionsException when absent/unavailable, otherwise rethrows the original error and stack.
- Applies to both prompt and command reservations; prevents starting async dispatch after a stale rejection.
- Updates `sesori_plugin_opencode` tests to cover removed agent/model/variant and the non-stale 500 path; updates docs to document the reservation boundary.
- No API or database changes; no client migration required.

<sup>Written for commit 9935c91264dfae8c3adb042190c5d7c26bbefa7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

