### PR TITLE
🌿 Let OMP sessions run concurrently

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -199,10 +199,10 @@ abstract class AcpPlugin({
 
   /// Whether accepting another input should cancel this session's active turn.
   ///
-  /// OMP gives a concurrent ACP prompt this replacement behavior itself. The
-  /// shared adapter serializes requests, so its concrete adapter declares the
-  /// same policy here and the bridge sends the equivalent standard cancel
-  /// before dispatching the queued input.
+  /// OMP gives another prompt for the same session this replacement behavior
+  /// itself. The shared adapter queues same-session requests, so its concrete
+  /// adapter declares the same policy here and the bridge sends the equivalent
+  /// standard cancel before dispatching the queued input.
   bool get cancelsActiveTurnForQueuedInput => false;
 
   /// Whether a turn must stop when its requested selection cannot be applied.

--- a/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
+++ b/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
@@ -16,10 +16,10 @@ import "trackers/omp_catalog_tracker.dart";
 
 /// Oh My Pi backend over ACP.
 ///
-/// OMP diverges from stock ACP in three policies: it serializes every prompt
-/// process-wide, replaces an in-flight turn when another input arrives, and
-/// supports standard form elicitation. Its project-scoped model/mode/thinking
-/// catalog and persisted-session cleanup run over isolated scratch processes.
+/// OMP replaces an in-flight same-session turn when another input arrives and
+/// supports standard form elicitation. Independent sessions retain stock ACP's
+/// per-session turn lanes, while project-scoped model/mode/thinking catalog and
+/// persisted-session cleanup run over isolated scratch processes.
 class OmpPlugin._({
   required super.launchSpec,
   required super.launchDirectory,
@@ -113,9 +113,6 @@ class OmpPlugin._({
 
   @override
   bool get supportsFormElicitation => true;
-
-  @override
-  bool get serializesPromptsProcessWide => true;
 
   @override
   bool get cancelsActiveTurnForQueuedInput => true;

--- a/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
@@ -113,8 +113,8 @@ void main() {
       expect(await connecting, isTrue);
     });
 
-    test("uses OMP's process-wide and fail-closed policies", () {
-      expect(plugin.serializesPromptsProcessWide, isTrue);
+    test("uses OMP's per-session and fail-closed policies", () {
+      expect(plugin.serializesPromptsProcessWide, isFalse);
       expect(plugin.cancelsActiveTurnForQueuedInput, isTrue);
       expect(plugin.failsTurnOnSelectionError, isTrue);
       expect(plugin.supportsFormElicitation, isTrue);
@@ -208,7 +208,7 @@ void main() {
       expect(await project, isEmpty);
     });
 
-    test("serializes prompts and routes sessionless forms to the active turn", () async {
+    test("runs sessions concurrently and routes forms by explicit session id", () async {
       await connect();
       final first = await create("first");
       final second = await create("second");
@@ -216,14 +216,15 @@ void main() {
       await send(first.id, "one");
       final firstPrompt = await waitForFrame(AcpMethods.sessionPrompt);
       await send(second.id, "two");
-      await Future<void>.delayed(Duration.zero);
-      expect(frames(AcpMethods.sessionPrompt), hasLength(1));
+      final secondPrompt = await waitForFrame(AcpMethods.sessionPrompt, count: 2);
+      expect((secondPrompt["params"] as Map)["sessionId"], second.id);
 
       fake.emit({
         "jsonrpc": "2.0",
         "id": 41,
         "method": AcpMethods.elicitationCreate,
         "params": {
+          "sessionId": first.id,
           "mode": "form",
           "message": "Configure extension",
           "requestedSchema": {
@@ -251,8 +252,6 @@ void main() {
       });
 
       respond(firstPrompt, {"stopReason": "end_turn"});
-      final secondPrompt = await waitForFrame(AcpMethods.sessionPrompt, count: 2);
-      expect((secondPrompt["params"] as Map)["sessionId"], second.id);
       respond(secondPrompt, {"stopReason": "end_turn"});
     });
 

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -31,7 +31,9 @@ reaches the backend so the turn continues.
 - A sessionless backend request is attributed to the most recently dispatched
   active turn, falling back to the last dispatched turn at its settlement
   boundary. A backend requiring exact form correlation must serialize prompts
-  process-wide so another session cannot become the attribution target.
+  process-wide so another session cannot become the attribution target. OMP
+  supplies explicit session IDs on permissions and forms, so its independent
+  session turns remain attributable while running concurrently.
 - Resolving a request retires it in the pending list, on every open surface, and
   in completion-notification suppression. Raising and resolving a request also
   refreshes the activity summary, so the session's awaiting-input state appears

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -91,17 +91,18 @@ defaults and queued client sends coherent.
   boundary, so earlier prose in a multi-tool turn does not depend on the final
   turn snapshot. Sesori does not call form-elicitation or unadvertised
   session-close methods to complete an ordinary turn.
-- Existing-session ACP prompts remain bridge-queued while an earlier turn,
-  process-wide lane, resume, or selection blocks their `session/prompt` frame.
-  Their synthetic user transcript message is published only after that frame
-  flushes successfully to the agent's stdin. Follow-up and replayed user
-  messages preserve ordered text and bounded data-backed image parts, including
-  attachment-only prompts. Initial projection contains only normalized
-  user-visible text plus those images; injected context, local paths, and URLs
-  remain absent. OMP preserves its active-prompt replacement semantics by
-  cancelling the active turn immediately, then dispatching the newly queued
-  input after cancellation settles; Cursor and Hermes retain ordinary FIFO turn
-  boundaries.
+- Existing-session ACP prompts remain bridge-queued while an earlier same-session
+  turn, declared process-wide lane, resume, or selection blocks their
+  `session/prompt` frame. Their synthetic user transcript message is published
+  only after that frame flushes successfully to the agent's stdin. Follow-up and
+  replayed user messages preserve ordered text and bounded data-backed image
+  parts, including attachment-only prompts. Initial projection contains only
+  normalized user-visible text plus those images; injected context, local paths,
+  and URLs remain absent. OMP runs different sessions concurrently because its
+  permission and form requests carry explicit session IDs. Within one OMP
+  session, it preserves active-prompt replacement by cancelling the active turn
+  immediately, then dispatching the newly queued input after cancellation
+  settles; Cursor and Hermes retain ordinary FIFO turn boundaries.
 - Normalized user-message events feed the durable user-side activity marker used
   to order running roots. Known event times are applied monotonically. Backend
   input represented as a user message, including automatic compaction or other


### PR DESCRIPTION
## Complexity

🌿 Straightforward — removes one OMP-specific scheduling override and updates focused concurrency coverage.

## What

- Let OMP use the shared ACP adapter's normal per-session turn lanes, so different OMP sessions can run simultaneously.
- Preserve OMP's same-session cancel-and-replace behavior.
- Verify that an explicit OMP form `sessionId` wins even when another session was dispatched more recently.
- Update the session-turn and question/permission regression contracts.

## Why

OMP already supplies a session ID on permission and form requests. The process-wide lane was based on the stale assumption that those requests were sessionless, causing every active OMP session to head-of-line block every other one.

## Risk and test focus

The main risk is cross-session event or approval misattribution while turns overlap. The updated test leaves the first turn open, dispatches a second turn concurrently, then routes a form back to the first session by its explicit ID. Existing coverage continues to exercise same-session replacement.

There is no database or client/bridge wire-schema impact. The user-visible impact is that independent OMP sessions no longer wait for one another.

## Expected result

A prompt in one OMP session starts while another OMP session is still running. Forms and permissions remain attached to their declared session, while a follow-up in the same session retains OMP's replacement semantics.

## Verification

- `cd bridge && dart pub get`
- `cd bridge/sesori_plugin_omp && dart test` — 53 tests passed
- `cd bridge/sesori_plugin_omp && dart analyze --fatal-infos`
- `cd bridge/sesori_plugin_acp && dart test test/acp_step5_policy_test.dart` — 7 tests passed
- `cd bridge/sesori_plugin_acp && dart analyze --fatal-infos`
- Architecture implementation review — approved with no findings
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables concurrent OMP sessions by removing the process‑wide prompt serialization and using ACP’s per‑session turn lanes. Previously, all OMP prompts shared one lane and blocked each other; now independent sessions run in parallel while same‑session inputs still cancel and replace the active turn.

- Removes OMP’s `serializesPromptsProcessWide` override; keeps `cancelsActiveTurnForQueuedInput = true` and form elicitation support.
- Verifies that forms and permissions route by explicit `sessionId`, even if another session was dispatched more recently; updates tests and regression docs accordingly.
- Reviewer focus: ordering during overlapping turns, correct session attribution, and unchanged same‑session replacement behavior.
- No schema, database, or config changes. No migration required.

<sup>Written for commit c1b433048b50c76027d0cf58ba53caf7cc2ae119. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

