### PR TITLE
⚙️ Honor bridge idle timeout for Pi sessions

### DIFF
--- a/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
+++ b/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
@@ -48,7 +48,7 @@ final class PiPlugin._({
     required Duration historyRpcTimeout,
     required Duration catalogTimeout,
     required Duration healthTimeout,
-    required Duration idleTimeout,
+    required Duration? Function() resolveIdleTimeout,
     required Duration editorTimeout,
   }) {
     final storage = PiSessionStorageApi(environment: storageEnvironment);
@@ -82,7 +82,7 @@ final class PiPlugin._({
       ),
       extensionUiService: extensionUiService,
       clock: clock,
-      idleTimeout: idleTimeout,
+      resolveIdleTimeout: resolveIdleTimeout,
     );
     final catalogService = PiCatalogService(
       repository: PiBackendCatalogRepository(

--- a/bridge/sesori_plugin_pi/lib/src/runtime/pi_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_pi/lib/src/runtime/pi_plugin_descriptor.dart
@@ -24,7 +24,7 @@ typedef PiPluginFactory = PiPlugin Function({
   required Duration historyRpcTimeout,
   required Duration catalogTimeout,
   required Duration healthTimeout,
-  required Duration idleTimeout,
+  required Duration? Function() resolveIdleTimeout,
   required Duration editorTimeout,
 });
 
@@ -40,7 +40,7 @@ PiPlugin _buildPiPlugin({
   required Duration historyRpcTimeout,
   required Duration catalogTimeout,
   required Duration healthTimeout,
-  required Duration idleTimeout,
+  required Duration? Function() resolveIdleTimeout,
   required Duration editorTimeout,
 }) => PiPlugin(
   binaryPath: binaryPath,
@@ -54,7 +54,7 @@ PiPlugin _buildPiPlugin({
   historyRpcTimeout: historyRpcTimeout,
   catalogTimeout: catalogTimeout,
   healthTimeout: healthTimeout,
-  idleTimeout: idleTimeout,
+  resolveIdleTimeout: resolveIdleTimeout,
   editorTimeout: editorTimeout,
 );
 
@@ -96,6 +96,13 @@ final class const PiPluginDescriptor({
 
   @override
   bool get supportsPromptAttachments => true;
+
+  /// Pi owns idle reclamation per session: each RPC child is reaped on the
+  /// user-configured timeout and resumed transparently on the next turn.
+  /// Whole-plugin suspension would duplicate that timer and can race the
+  /// per-session teardown, so the adapter remains resident like Claude Code.
+  @override
+  PluginResidencyPolicy residencyPolicy({required PluginConfig config}) => PluginResidencyPolicy.resident;
 
   @override
   List<PluginOption> get options => cliOptions;
@@ -293,7 +300,7 @@ final class const PiPluginDescriptor({
         historyRpcTimeout: const Duration(minutes: 2),
         catalogTimeout: const Duration(seconds: 30),
         healthTimeout: const Duration(seconds: 10),
-        idleTimeout: const Duration(minutes: 5),
+        resolveIdleTimeout: () => host.pluginIdleTimeout,
         editorTimeout: const Duration(minutes: 30),
       );
     } on Object {

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -112,7 +112,7 @@ final class PiSessionService({
   required final PiEventDispatcher eventDispatcher,
   required final PiExtensionUiService extensionUiService,
   required final ServerClock clock,
-  required final Duration idleTimeout,
+  required final Duration? Function() resolveIdleTimeout,
 }) {
   this {
     _frameSubscription = _processes.frames.listen(_handleFrame);
@@ -124,7 +124,7 @@ final class PiSessionService({
   final PiEventDispatcher _dispatcher = eventDispatcher;
   final PiExtensionUiService _extensionUi = extensionUiService;
   final ServerClock _clock = clock;
-  final Duration _idleTimeout = idleTimeout;
+  final Duration? Function() _resolveIdleTimeout = resolveIdleTimeout;
   final Map<String, _PiSessionTurnState> _sessions = {};
   final Map<String, String> _pendingNewDirectories = {};
   final Set<Future<void>> _activeIdleReaps = {};
@@ -800,8 +800,10 @@ final class PiSessionService({
 
   void _scheduleIdleReap({required String sessionId, required _PiSessionTurnState state}) {
     final generation = ++state.idleGeneration;
+    final idleTimeout = _resolveIdleTimeout();
+    if (idleTimeout == null) return;
     unawaited(() async {
-      await _clock.delay(duration: _idleTimeout);
+      await _clock.delay(duration: idleTimeout);
       if (_disposed ||
           !identical(_sessions[sessionId], state) ||
           state.active != null ||

--- a/bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart
@@ -11,12 +11,18 @@ void main() {
   group("PiPluginDescriptor setup", () {
     test("declares Pi capabilities without registering it", () {
       final descriptor = PiPluginDescriptor.production();
+      const config = PluginConfig(values: {PiPluginDescriptor.binOption: null});
 
       expect(descriptor.id, "pi");
       expect(descriptor.displayName, "Pi");
       expect(descriptor.projectOwnership, PluginProjectOwnership.bridgeDerived);
       expect(descriptor.sessionOptionsScope, PluginSessionOptionsScope.project);
       expect(descriptor.supportsPromptAttachments, isTrue);
+      expect(descriptor.residencyPolicy(config: config), PluginResidencyPolicy.resident);
+      expect(
+        descriptor.managementCapabilities(config: config),
+        contains(PluginControlCapability.idleTimeout),
+      );
       expect(descriptor.options.single.name, "bin");
       expect((descriptor.options.single as PluginValueOption).defaultsTo, isNull);
     });
@@ -100,7 +106,14 @@ void main() {
       final descriptor = PiPluginDescriptor.production();
 
       expect(descriptor.managementCapabilities(config: config), isNot(contains(PluginControlCapability.install)));
-      expect(await descriptor.ensureRuntime(host: _Host(processes: _Processes(), config: config)).toList(), isEmpty);
+      expect(
+        await descriptor
+            .ensureRuntime(
+              host: _Host(processes: _Processes(), config: config),
+            )
+            .toList(),
+        isEmpty,
+      );
     });
   });
 
@@ -109,6 +122,7 @@ void main() {
       String? capturedBinaryPath;
       Map<String, String>? capturedStorageEnvironment;
       Map<String, String>? capturedProcessEnvironment;
+      Duration? Function()? capturedIdleTimeoutResolver;
       final descriptor = _descriptor(
         buildPlugin:
             ({
@@ -123,12 +137,13 @@ void main() {
               required historyRpcTimeout,
               required catalogTimeout,
               required healthTimeout,
-              required idleTimeout,
+              required resolveIdleTimeout,
               required editorTimeout,
             }) {
               capturedBinaryPath = binaryPath;
               capturedStorageEnvironment = storageEnvironment;
               capturedProcessEnvironment = processEnvironment;
+              capturedIdleTimeoutResolver = resolveIdleTimeout;
               return _plugin(
                 binaryPath: binaryPath,
                 storageEnvironment: storageEnvironment,
@@ -141,18 +156,22 @@ void main() {
                 historyRpcTimeout: historyRpcTimeout,
                 catalogTimeout: catalogTimeout,
                 healthTimeout: healthTimeout,
-                idleTimeout: idleTimeout,
+                resolveIdleTimeout: resolveIdleTimeout,
                 editorTimeout: editorTimeout,
               );
             },
       );
-      final plugin = await descriptor.start(
-        _Host(processes: _Processes(), provisionedRuntimePath: "/managed/pi"),
+      final host = _Host(
+        processes: _Processes(),
+        provisionedRuntimePath: "/managed/pi",
+        pluginIdleTimeout: const Duration(minutes: 17),
       );
+      final plugin = await descriptor.start(host);
 
       expect(capturedBinaryPath, "/managed/pi");
       expect(capturedStorageEnvironment, containsPair("HOME", "/home/test"));
       expect(capturedProcessEnvironment, isEmpty);
+      expect(capturedIdleTimeoutResolver?.call(), const Duration(minutes: 17));
       expect(plugin.currentStatus, const PluginReady());
       expect(plugin.currentWorkState, PluginWorkState.idle);
 
@@ -178,7 +197,7 @@ void main() {
               required historyRpcTimeout,
               required catalogTimeout,
               required healthTimeout,
-              required idleTimeout,
+              required resolveIdleTimeout,
               required editorTimeout,
             }) {
               built = _plugin(
@@ -193,7 +212,7 @@ void main() {
                 historyRpcTimeout: historyRpcTimeout,
                 catalogTimeout: catalogTimeout,
                 healthTimeout: healthTimeout,
-                idleTimeout: idleTimeout,
+                resolveIdleTimeout: resolveIdleTimeout,
                 editorTimeout: editorTimeout,
               );
               abort.abort();
@@ -251,7 +270,7 @@ PiPlugin _plugin({
   required Duration historyRpcTimeout,
   required Duration catalogTimeout,
   required Duration healthTimeout,
-  required Duration idleTimeout,
+  required Duration? Function() resolveIdleTimeout,
   required Duration editorTimeout,
 }) => PiPlugin(
   binaryPath: binaryPath,
@@ -265,7 +284,7 @@ PiPlugin _plugin({
   historyRpcTimeout: historyRpcTimeout,
   catalogTimeout: catalogTimeout,
   healthTimeout: healthTimeout,
-  idleTimeout: idleTimeout,
+  resolveIdleTimeout: resolveIdleTimeout,
   editorTimeout: editorTimeout,
 );
 
@@ -273,6 +292,7 @@ class _Host({
   @override required final HostProcessService processes,
   @override final PluginConfig config = const PluginConfig(values: {PiPluginDescriptor.binOption: null}),
   @override final String? provisionedRuntimePath,
+  @override final Duration? pluginIdleTimeout = const Duration(minutes: 10),
   StartAbortSignal? startAborted,
 }) implements PluginHost {
   @override

--- a/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
@@ -390,7 +390,7 @@ final class _Harness({bool stdinCloseCompletes = true}) {
       historyRpcTimeout: const Duration(seconds: 2),
       catalogTimeout: const Duration(seconds: 2),
       healthTimeout: const Duration(seconds: 1),
-      idleTimeout: const Duration(minutes: 5),
+      resolveIdleTimeout: () => const Duration(minutes: 5),
       editorTimeout: const Duration(minutes: 1),
     );
   }

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -1371,6 +1371,55 @@ void main() {
     expect(second.killed, isTrue);
   });
 
+  test("reads the configured idle timeout live at each reap arm", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final clock = _ManualClock();
+    final service = fixture.service(clock: clock);
+    fixture.idleTimeout = null;
+
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "prompt-no-reap",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "first")],
+      userVisibleText: "first",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    final firstPrompt = await waitForCommand(process: process, type: "prompt");
+    process.emitResponse(id: firstPrompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: "session");
+
+    expect(clock.delays, isEmpty);
+    clock.elapse();
+    await pump();
+    expect(fixture.repository.residentSessionIds, contains("session"));
+
+    fixture.idleTimeout = const Duration(minutes: 1);
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "prompt-reap",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "second")],
+      userVisibleText: "second",
+      variant: null,
+      model: null,
+    );
+    final secondPrompt = await _waitForNthCommand(process: process, type: "prompt", count: 2);
+    process.emitResponse(id: secondPrompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: "session");
+
+    expect(clock.delays, [const Duration(minutes: 1)]);
+    clock.elapse();
+    await pump();
+    expect(process.killed, isTrue);
+  });
+
   test("dispose awaits an active idle-reap teardown", () async {
     final process = FakePiProcess(stdinCloseCompletes: false);
     final fixture = _Fixture(processes: [process]);
@@ -1714,6 +1763,7 @@ final class _Fixture({
   final Duration historyRpcTimeout = const Duration(seconds: 2),
 }) {
   final List<FakePiProcess> _processes = List.of(processes);
+  Duration? idleTimeout = const Duration(minutes: 5);
   late final _Storage storage = storageOverride ?? _Storage(initialResolvedSession: _resolved());
   final List<PiLaunchSpec> spawned = [];
   late final PiMessageIdentityTracker identities = PiMessageIdentityTracker(pluginId: "pi");
@@ -1754,7 +1804,7 @@ final class _Fixture({
       ),
       extensionUiService: extension,
       clock: clock,
-      idleTimeout: const Duration(minutes: 5),
+      resolveIdleTimeout: () => idleTimeout,
     );
     extensions.add(extension);
     _services.add(service);
@@ -1813,9 +1863,13 @@ final class _HistoryStorage({required super.storageApi}) extends PiSessionHistor
 
 final class _ManualClock() implements ServerClock {
   Completer<void>? _delay;
+  final List<Duration> delays = [];
 
   @override
-  Future<void> delay({required Duration duration}) => (_delay = Completer<void>()).future;
+  Future<void> delay({required Duration duration}) {
+    delays.add(duration);
+    return (_delay = Completer<void>()).future;
+  }
 
   void elapse() => _delay?.complete();
 

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -42,12 +42,13 @@ idle suspension, the management snapshot, and lifecycle commands.
   idle window and a resident one never does, and idle timeouts survive restart.
   Enable, disable, restart, and refresh are offered only where declared, with enable
   persisting eligibility, re-inspecting setup, then starting when ready.
-- A resident harness that keeps the idle-timeout capability (Claude Code) reports the
-  configured timeout instead of zero and consumes it internally through the host: the
-  Claude plugin reaps each idle session's CLI child process after that window and
+- A resident harness that keeps the idle-timeout capability (Claude Code or Pi) reports
+  the configured timeout instead of zero and consumes it internally through the host.
+  Each plugin reaps its idle per-session CLI/RPC child process after that window and
   transparently resumes it on the next prompt, so the settings knob stays effective
-  even though whole-plugin suspension never runs. A runtime timeout change applies at
-  each session's next idle transition without a plugin restart.
+  without a competing whole-plugin suspension timer. A runtime timeout change applies
+  at each session's next idle transition without a plugin restart; no timeout keeps the
+  child resident.
 - A Claude session whose CLI scheduled a `ScheduleWakeup` loop wakeup is not reaped
   before the wakeup fires (the in-process timer would die and `--resume` cannot rearm
   it); a wakeup that never fires stops deferring one idle window past its fire time.


### PR DESCRIPTION
## Complexity

Moderate — changes Pi's lifecycle ownership from competing whole-plugin and per-session timers to the established resident/per-session pattern used by Claude Code.

## What

- Audited every bundled plugin's idle-reclamation path; Pi was the only plugin with a hidden hardcoded idle timeout.
- Made the Pi adapter resident while its per-session RPC processes consume the live `PluginHost.pluginIdleTimeout` value.
- Made “No timeout” keep Pi session processes resident and runtime setting changes apply at the next idle transition.
- Added descriptor and session-service regression coverage and updated the lifecycle regression document.

## Why

Pi always reaped each session RPC process after five minutes, independently of the bridge default or Pi-specific override. A later follow-up resumed a new Pi process and could re-emit extension startup notifications even when the configured bridge timeout had not elapsed.

## Risk and test focus

The risk is limited to Pi process residency and teardown ordering. Tests focus on resident descriptor policy, host timeout wiring, disabled idle cleanup, live timeout changes, and existing teardown behavior. There is no wire-contract or database impact. The user-visible impact is that Pi now follows the configured idle-timeout setting instead of an undocumented five-minute limit.

## Expected result

Pi session processes remain resident until the effective bridge default or Pi override elapses. “No timeout” disables idle reaping, and Pi no longer races a separate whole-plugin suspension timer.

## Verification

- `cd bridge && dart pub get`
- `cd bridge/sesori_plugin_pi && dart analyze --fatal-infos`
- `cd bridge/sesori_plugin_pi && dart test` — 263 tests passed
- `cd bridge/app && dart test test/bridge/runtime/plugin_registry_test.dart` — 3 tests passed
- Architecture implementation review — approved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pi sessions now honor the bridge’s configured idle timeout. Previously, Pi always reaped each session after 5 minutes regardless of settings; now it uses the host timeout, and “No timeout” keeps sessions resident.

- The Pi adapter is resident; per-session RPC processes handle idle reclamation using the live `host.pluginIdleTimeout` value (read at each arm). Null disables reaping.
- Removes the hidden 5-minute timer and avoids a competing whole-plugin suspension timer; runtime timeout changes apply on the next idle transition without a restart.
- Adds tests for residency policy, live timeout resolution, and idle cleanup; updates lifecycle docs. No protocol or database changes.

<sup>Written for commit e16ca980816800276be38a99aea436ceec87a409. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

