### PR TITLE
⚙️ Steer Pi follow-up prompts during active turns

### DIFF
--- a/.plan/completed/pi-harness/PROTOCOL.md
+++ b/.plan/completed/pi-harness/PROTOCOL.md
@@ -154,11 +154,14 @@ Rules:
 ```
 
 When Pi itself is already streaming, `prompt` requires
-`streamingBehavior: "steer" | "followUp"`. The planned plugin serializes its
-own exact per-turn selection and normally dispatches only while idle.
+`streamingBehavior: "steer" | "followUp"`. Sesori sends ordinary prompts with
+`streamingBehavior: "steer"`; Pi ignores that option while idle and injects a
+same-selection busy-session follow-up at the next tool boundary. Selection
+changes retain a run boundary. Sesori still serializes prompt acceptance in FIFO
+order and rejects slash commands while the session is busy.
 
-Pi also exposes `steer` and `follow_up`, but Sesori has no separate steering UI
-in this series.
+Pi also exposes separate `steer` and `follow_up` commands, but Sesori uses the
+streaming-aware `prompt` path so extension commands retain their normal handling.
 
 `abort` aborts retry/current agent work and waits for idle. It does not call
 Pi's `clearQueue()`, so hidden steering/follow-up queues survive. Sesori tears

--- a/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
@@ -62,6 +62,10 @@ final class const PiSessionConnection({
 
 final class const PiPromptPayload({required final String message, required final List<Map<String, Object?>> images});
 
+enum _PiPromptStreamingBehavior(final String wireValue) {
+  steer("steer");
+}
+
 final class const PiAgentState({required final bool streaming, required final int pendingMessageCount});
 
 final class const PiUnsupportedPromptAttachmentException({required final String variant}) implements Exception {
@@ -360,7 +364,11 @@ final class PiSessionProcessRepository({
     final resident = _requiredResident(connection);
     await resident.client.send(
       command: PiRpcCommand.prompt,
-      arguments: {"message": payload.message, "images": payload.images},
+      arguments: {
+        "message": payload.message,
+        "images": payload.images,
+        "streamingBehavior": _PiPromptStreamingBehavior.steer.wireValue,
+      },
       timeout: _historyRpcTimeout,
     );
   }

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
@@ -19,19 +19,23 @@ final class PiEventDispatcher({
   final PiToolTracker _tools = toolTracker;
   final Map<String, _SessionState> _sessions = {};
 
-  void beginTurn({
+  void registerPrompt({
     required String sessionId,
     required String promptId,
     required String? executionText,
     required String? userVisibleText,
   }) {
-    final state = _session(sessionId);
-    state
-      ..clearMessage()
-      ..executionText = executionText
-      ..userVisibleText = userVisibleText
-      ..promptId = promptId;
-    _tools.beginTurn(sessionId: sessionId);
+    _session(sessionId).pendingPrompts.add(
+      _PendingPrompt(
+        promptId: promptId,
+        executionText: executionText,
+        userVisibleText: userVisibleText,
+      ),
+    );
+  }
+
+  void cancelPrompt({required String sessionId, required String promptId}) {
+    _sessions[sessionId]?.pendingPrompts.removeWhere((prompt) => prompt.promptId == promptId);
   }
 
   void forgetSession({required String sessionId}) {
@@ -110,8 +114,8 @@ final class PiEventDispatcher({
       error: error,
     ),
     PiEntryAppendedEvent(:final entry) => _entryAppended(sessionId: sessionId, raw: entry),
+    PiTurnStartEvent() => _turnStart(sessionId: sessionId),
     PiAgentEndEvent() ||
-    PiTurnStartEvent() ||
     PiTurnEndEvent() ||
     PiBashExecutionUpdateEvent() ||
     PiQueueUpdateEvent() ||
@@ -316,24 +320,21 @@ final class PiEventDispatcher({
     if (message == null) return const [];
     final state = _session(sessionId);
     final textContent = message.content.whereType<PiTextContentDto>().singleOrNull;
-    final visibleText = state.userVisibleText;
-    final isAttachmentOnlyEcho =
-        (state.executionText?.isEmpty ?? false) &&
-        message.content.isNotEmpty &&
-        message.content.every((content) => content is PiImageContentDto);
-    final isTurnEcho = textContent?.text == state.executionText || isAttachmentOnlyEcho;
-    final exactText = isTurnEcho ? visibleText : null;
-    // Consumed on the first echo so a later replay with identical text does
-    // not correlate to the same prompt again.
-    final promptId = isTurnEcho ? state.promptId : null;
-    if (isTurnEcho) state.promptId = null;
+    final isAttachmentOnlyMessage =
+        message.content.isNotEmpty && message.content.every((content) => content is PiImageContentDto);
+    final correlationIndex = state.pendingPrompts.indexWhere(
+      (prompt) =>
+          textContent?.text == prompt.executionText ||
+          ((prompt.executionText?.isEmpty ?? false) && isAttachmentOnlyMessage),
+    );
+    final correlation = correlationIndex == -1 ? null : state.pendingPrompts.removeAt(correlationIndex);
     final messageId = state.identities.next(role: PiMessageIdentityRole.user, timestamp: message.timestamp);
     final mapped = _historyMapper.mapUserMessage(
       sessionId: sessionId,
       messageId: messageId,
       message: message,
-      exactText: exactText,
-      promptId: promptId,
+      exactText: correlation?.userVisibleText,
+      promptId: correlation?.promptId,
     );
     if (mapped == null) return const [];
     return [
@@ -539,6 +540,11 @@ final class PiEventDispatcher({
     );
   }
 
+  List<BridgeSseEvent> _turnStart({required String sessionId}) {
+    _tools.beginTurn(sessionId: sessionId);
+    return const [];
+  }
+
   List<BridgeSseEvent> _status({required String sessionId, required PiEvent event, required DateTime? now}) {
     final status = sessionStatusFor(event: event, now: now);
     return status == null ? const [] : [BridgeSseSessionStatus(sessionID: sessionId, status: status.toJson())];
@@ -619,12 +625,16 @@ final class PiEventDispatcher({
   );
 }
 
+final class const _PendingPrompt({
+  required final String promptId,
+  required final String? executionText,
+  required final String? userVisibleText,
+});
+
 final class _SessionState({required final PiMessageIdentityBuilder identities}) {
   String? messageId;
   PiAssistantMessageDto? message;
-  String? executionText;
-  String? userVisibleText;
-  String? promptId;
+  final List<_PendingPrompt> pendingPrompts = [];
   bool announced = false;
   final Set<({int contentIndex, PluginMessagePartType type})> startedParts = {};
   final Set<String> emittedPartIds = {};

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -31,10 +31,18 @@ final class _PiSessionTurnState({required final String initialDirectory}) {
   static const int _recentPromptIdLimit = 64;
 
   String directory = initialDirectory;
+
+  /// Admitted turns waiting for their FIFO dispatch attempt.
   final List<_PiTurn> queue = [];
+
+  /// Prompt commands accepted by Pi and governed by its current agent run.
+  final List<_PiTurn> inFlight = [];
+
+  /// The one turn currently connecting, selecting, or awaiting prompt acceptance.
   _PiTurn? active;
   Future<void>? idleReap;
   PluginSessionStatus status = const PluginSessionStatus.idle();
+  bool agentRunning = false;
   int generation = 0;
   int idleGeneration = 0;
 
@@ -44,15 +52,23 @@ final class _PiSessionTurnState({required final String initialDirectory}) {
   /// settled ids need this bounded window.
   final Queue<String> recentPromptIds = Queue<String>();
 
-  bool isAdmitted({required String promptId}) {
+  List<_PiTurn> get turns {
+    final result = List<_PiTurn>.of(inFlight);
     final activeTurn = active;
-    final activeAccepted =
-        activeTurn?.promptId == promptId &&
-        (activeTurn is! _PiQueuedPromptTurn || activeTurn.queueState != _PiQueueState.cancelled);
-    return activeAccepted ||
-        queue.any((turn) => turn.promptId == promptId) ||
-        recentPromptIds.contains(promptId);
+    if (activeTurn != null) result.add(activeTurn);
+    result.addAll(queue);
+    return result;
   }
+
+  bool get hasWork => active != null || inFlight.isNotEmpty || queue.isNotEmpty;
+
+  bool isAdmitted({required String promptId}) =>
+      turns.any(
+        (turn) =>
+            turn.promptId == promptId &&
+            (turn is! _PiQueuedPromptTurn || turn.queueState != _PiQueueState.cancelled),
+      ) ||
+      recentPromptIds.contains(promptId);
 
   void recordSettledPromptId({required String promptId}) {
     recentPromptIds.addLast(promptId);
@@ -143,7 +159,7 @@ final class PiSessionService({
     final state = _sessions[sessionId];
     if (state == null) return const [];
     return [
-      for (final turn in [?state.active, ...state.queue])
+      for (final turn in state.turns)
         if (turn is _PiQueuedPromptTurn && turn.queueState == _PiQueueState.visible) turn.presentation,
     ];
   }
@@ -168,6 +184,7 @@ final class PiSessionService({
     if (index == -1) return false;
     final turn = state.queue.removeAt(index) as _PiQueuedPromptTurn;
     _cancelQueuedPresentation(sessionId: sessionId, state: state, turn: turn);
+    _startNext(sessionId: sessionId, state: state);
     return true;
   }
 
@@ -320,7 +337,7 @@ final class PiSessionService({
     if (_disposed) return Future.error(const PiRpcDisposedException());
     final state = _sessions[sessionId];
     if (state != null && state.isAdmitted(promptId: promptId)) return Future.value();
-    if (state?.active != null || (state?.queue.isNotEmpty ?? false)) {
+    if (state?.hasWork ?? false) {
       return Future.error(PiSessionBusyException(sessionId: sessionId));
     }
     final execution = arguments.isEmpty ? "/$command" : "/$command $arguments";
@@ -357,8 +374,9 @@ final class PiSessionService({
     }
     state.directory = directory;
     state.idleGeneration++;
+    final wasIdle = !state.hasWork;
     state.queue.add(turn);
-    if (state.active == null && state.queue.length == 1) {
+    if (wasIdle) {
       state.status = const PluginSessionStatus.busy();
       _emit(
         BridgeSseSessionStatus(
@@ -375,11 +393,16 @@ final class PiSessionService({
 
   void _startNext({required String sessionId, required _PiSessionTurnState state}) {
     if (_disposed || state.active != null || state.queue.isEmpty || !identical(_sessions[sessionId], state)) return;
+    final preceding = state.inFlight.isEmpty ? null : state.inFlight.last;
+    if (preceding != null && _changesSelection(previous: preceding, next: state.queue.first)) return;
     final turn = state.queue.removeAt(0);
     state.active = turn;
     final generation = state.generation;
     unawaited(_runTurn(sessionId: sessionId, state: state, turn: turn, generation: generation));
   }
+
+  bool _changesSelection({required _PiTurn previous, required _PiTurn next}) =>
+      previous.model != next.model || previous.variant?.id != next.variant?.id;
 
   Future<void> _runTurn({
     required String sessionId,
@@ -410,15 +433,16 @@ final class PiSessionService({
       if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) {
         throw PiTurnCancelledException(sessionId: sessionId);
       }
-      _dispatcher.beginTurn(
+      _dispatcher.registerPrompt(
         sessionId: sessionId,
         promptId: turn.promptId,
         executionText: turn.payload.message,
         userVisibleText: turn.userVisibleText,
       );
-      turn.promptDispatched = true;
-      final response = _processes.dispatchPrompt(connection: connection, payload: turn.payload);
-      await response;
+      turn
+        ..promptDispatched = true
+        ..agentStarted = state.agentRunning;
+      await _processes.dispatchPrompt(connection: connection, payload: turn.payload);
       if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
       turn.responseSucceeded = true;
       if (turn is _PiCommandTurn && !turn.acceptance.isCompleted) {
@@ -428,14 +452,24 @@ final class PiSessionService({
       if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
       if (turn.agentSettled) {
         _finish(sessionId: sessionId, state: state, turn: turn, failed: false, failure: null);
-      } else if (!turn.agentStarted) {
+        return;
+      }
+      if (!turn.agentStarted) {
         final agentState = await _processes.getState(connection: connection);
         await Future<void>.delayed(Duration.zero);
         if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
+        if (turn.agentSettled) {
+          _finish(sessionId: sessionId, state: state, turn: turn, failed: false, failure: null);
+          return;
+        }
         if (!turn.agentStarted && !agentState.streaming && agentState.pendingMessageCount == 0) {
           _finish(sessionId: sessionId, state: state, turn: turn, failed: false, failure: null);
+          return;
         }
+        turn.agentStarted = agentState.streaming || agentState.pendingMessageCount > 0;
+        state.agentRunning = state.agentRunning || agentState.streaming;
       }
+      _moveInFlight(sessionId: sessionId, state: state, turn: turn);
     } on PiTurnCancelledException catch (error, stack) {
       if (turn is _PiCommandTurn && !turn.acceptance.isCompleted) {
         turn.acceptance.completeError(error, stack);
@@ -452,49 +486,87 @@ final class PiSessionService({
         _finish(sessionId: sessionId, state: state, turn: turn, failed: false, failure: null);
         return;
       }
-      if (error is TimeoutException && turn.promptDispatched) {
-        final connection = turn.connection;
-        if (connection != null) {
-          _extensionUi.cancelForOwner(
-            sessionId: sessionId,
-            processGeneration: connection.generation,
-          );
+      final connection = turn.connection;
+      final connectionFailed =
+          turn.promptDispatched && (error is TimeoutException || error is PiRpcProcessExitException);
+      if (connectionFailed && connection != null) {
+        _extensionUi.cancelForOwner(
+          sessionId: sessionId,
+          processGeneration: connection.generation,
+        );
+        if (error is TimeoutException) {
           await _processes.teardownConnection(connection: connection);
-          if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
+          if (!_ownsTurn(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
         }
       }
       if (turn is _PiCommandTurn && !turn.acceptance.isCompleted) {
         turn.acceptance.completeError(error, stack);
       }
-      if (_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) {
-        final presented = _processes.presentTurnFailure(sessionId: sessionId, error: error);
-        Log.w("[pi] admitted turn failed for session id=$sessionId", presented.cause, stack);
-        if (presented.message?.contains("/login") ?? false) {
-          _emit(
-            BridgeSseTuiToastShow(
-              title: "Pi login required",
-              message: presented.message,
-              variant: "warning",
-            ),
-          );
-        }
+      if (!_ownsTurn(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
+      final presented = _processes.presentTurnFailure(sessionId: sessionId, error: error);
+      Log.w("[pi] admitted turn failed for session id=$sessionId", presented.cause, stack);
+      if (presented.message?.contains("/login") ?? false) {
+        _emit(
+          BridgeSseTuiToastShow(
+            title: "Pi login required",
+            message: presented.message,
+            variant: "warning",
+          ),
+        );
+      }
+      if (connectionFailed && connection != null) {
+        _finishConnectionTurns(
+          sessionId: sessionId,
+          state: state,
+          processGeneration: connection.generation,
+          failure: error,
+        );
+      } else {
         _finish(sessionId: sessionId, state: state, turn: turn, failed: true, failure: error);
       }
     }
   }
 
+  void _moveInFlight({
+    required String sessionId,
+    required _PiSessionTurnState state,
+    required _PiTurn turn,
+  }) {
+    if (!identical(state.active, turn)) return;
+    state
+      ..active = null
+      ..inFlight.add(turn);
+    _startNext(sessionId: sessionId, state: state);
+  }
+
   void _handleFrame(PiSessionProcessFrame processFrame) {
     final state = _sessions[processFrame.sessionId];
-    final turn = state?.active;
-    if (state == null || turn == null) return;
-    turn.connection ??= PiSessionConnection(
+    if (state == null || !state.hasWork) return;
+    state.active?.connection ??= PiSessionConnection(
       sessionId: processFrame.sessionId,
       generation: processFrame.generation,
     );
-    if (turn.connection?.generation != processFrame.generation) return;
+    final generationTurns = [
+      for (final turn in state.turns)
+        if (turn.connection?.generation == processFrame.generation) turn,
+    ];
+    if (generationTurns.isEmpty) return;
     switch (processFrame.frame) {
       case PiEventFrame(:final event):
-        if (turn.promptDispatched && event is PiAgentStartEvent) turn.agentStarted = true;
+        if (event is PiAgentStartEvent) {
+          state.agentRunning = true;
+          for (final turn in generationTurns) {
+            if (!turn.promptDispatched) continue;
+            turn
+              ..agentStarted = true
+              ..agentSettled = false;
+          }
+        } else if (event is PiAgentSettledEvent) {
+          state.agentRunning = false;
+          for (final turn in generationTurns) {
+            if (turn.promptDispatched) turn.agentSettled = true;
+          }
+        }
         final now = _clock.now();
         final mappedStatus = _dispatcher.sessionStatusFor(event: event, now: now);
         final statusChanged =
@@ -509,37 +581,34 @@ final class PiSessionService({
               (event is PiAgentStartEvent || event is PiAgentSettledEvent) &&
               (mapped is BridgeSseSessionStatus || mapped is BridgeSseSessionIdle);
           if (!serviceOwnsLifecycle) _emit(mapped);
-        }
-        final userMessageEmitted =
-            turn.promptDispatched &&
-            mappedEvents.any(
-              (mapped) => mapped is BridgeSseMessageUpdated && mapped.info["promptId"] == turn.promptId,
-            );
-        if (userMessageEmitted) {
-          turn.userMessageEmitted = true;
-          if (turn is _PiQueuedPromptTurn && turn.queueState == _PiQueueState.visible) {
-            _releaseQueuedPresentation(sessionId: processFrame.sessionId, state: state, turn: turn);
+          if (mapped is! BridgeSseMessageUpdated) continue;
+          final promptId = mapped.info["promptId"];
+          if (promptId is! String) continue;
+          final correlated = _turnForPrompt(state: state, promptId: promptId);
+          if (correlated == null) continue;
+          correlated.userMessageEmitted = true;
+          if (correlated is _PiQueuedPromptTurn && correlated.queueState == _PiQueueState.visible) {
+            _releaseQueuedPresentation(sessionId: processFrame.sessionId, state: state, turn: correlated);
           }
         }
         if (statusChanged) _emit(const BridgeSseProjectUpdated());
-        if (turn.promptDispatched && event is PiAgentSettledEvent) {
-          turn.agentSettled = true;
-          if (turn.responseSucceeded) {
-            _finish(
-              sessionId: processFrame.sessionId,
-              state: state,
-              turn: turn,
-              failed: false,
-              failure: null,
-            );
+        if (event is PiAgentSettledEvent) {
+          for (final turn in List<_PiTurn>.of(generationTurns)) {
+            if (turn.promptDispatched && turn.responseSucceeded) {
+              _finish(
+                sessionId: processFrame.sessionId,
+                state: state,
+                turn: turn,
+                failed: false,
+                failure: null,
+              );
+            }
           }
         }
       case PiExtensionUiFrame(:final request):
-        if (turn is _PiCommandTurn &&
-            turn.promptDispatched &&
-            request is PiExtensionDialogRequest &&
-            !turn.acceptance.isCompleted) {
-          turn.acceptance.complete();
+        final commandTurn = _pendingCommandTurn(state: state, processGeneration: processFrame.generation);
+        if (commandTurn != null && request is PiExtensionDialogRequest && !commandTurn.acceptance.isCompleted) {
+          commandTurn.acceptance.complete();
         }
         unawaited(
           _extensionUi
@@ -559,13 +628,34 @@ final class PiSessionService({
     }
   }
 
+  _PiTurn? _turnForPrompt({required _PiSessionTurnState state, required String promptId}) {
+    for (final turn in state.turns) {
+      if (turn.promptId == promptId) return turn;
+    }
+    return null;
+  }
+
+  _PiCommandTurn? _pendingCommandTurn({required _PiSessionTurnState state, required int processGeneration}) {
+    for (final turn in state.turns.whereType<_PiCommandTurn>()) {
+      if (turn.promptDispatched && turn.connection?.generation == processGeneration) return turn;
+    }
+    return null;
+  }
+
   void _handleExit(PiSessionProcessExit exit) {
     _extensionUi.cancelForOwner(sessionId: exit.sessionId, processGeneration: exit.generation);
     final state = _sessions[exit.sessionId];
-    final turn = state?.active;
-    if (state == null || turn == null || turn.connection?.generation != exit.generation) return;
-    final cancelled = turn is _PiQueuedPromptTurn && turn.queueState == _PiQueueState.cancelled;
-    if (!cancelled && exit.authUnavailable) {
+    if (state == null) return;
+    final affected = [
+      for (final turn in state.turns)
+        if (turn.connection?.generation == exit.generation) turn,
+    ];
+    if (affected.isEmpty) return;
+    state.agentRunning = false;
+    final hasUncancelled = affected.any(
+      (turn) => turn is! _PiQueuedPromptTurn || turn.queueState != _PiQueueState.cancelled,
+    );
+    if (hasUncancelled && exit.authUnavailable) {
       _emit(
         const BridgeSseTuiToastShow(
           title: "Pi login required",
@@ -575,16 +665,42 @@ final class PiSessionService({
       );
     }
     final failure = PiRpcProcessExitException(exitCode: exit.exitCode);
-    if (!cancelled) {
-      Log.w("[pi] resident process exited during active turn for session id=${exit.sessionId}", failure);
+    if (hasUncancelled) {
+      Log.w("[pi] resident process exited during active turns for session id=${exit.sessionId}", failure);
     }
-    _finish(
-      sessionId: exit.sessionId,
-      state: state,
-      turn: turn,
-      failed: !cancelled,
-      failure: cancelled ? null : failure,
-    );
+    for (final turn in affected) {
+      final cancelled = turn is _PiQueuedPromptTurn && turn.queueState == _PiQueueState.cancelled;
+      _finish(
+        sessionId: exit.sessionId,
+        state: state,
+        turn: turn,
+        failed: !cancelled,
+        failure: cancelled ? null : failure,
+      );
+    }
+  }
+
+  void _finishConnectionTurns({
+    required String sessionId,
+    required _PiSessionTurnState state,
+    required int processGeneration,
+    required Object failure,
+  }) {
+    state.agentRunning = false;
+    final affected = [
+      for (final turn in state.turns)
+        if (turn.connection?.generation == processGeneration) turn,
+    ];
+    for (final turn in affected) {
+      final cancelled = turn is _PiQueuedPromptTurn && turn.queueState == _PiQueueState.cancelled;
+      _finish(
+        sessionId: sessionId,
+        state: state,
+        turn: turn,
+        failed: !cancelled,
+        failure: cancelled ? null : failure,
+      );
+    }
   }
 
   void _finish({
@@ -594,7 +710,9 @@ final class PiSessionService({
     required bool failed,
     required Object? failure,
   }) {
-    if (turn.settled) return;
+    if (turn.settled || !identical(_sessions[sessionId], state)) return;
+    final owned = identical(state.active, turn) || state.inFlight.contains(turn) || state.queue.contains(turn);
+    if (!owned) return;
     turn.settled = true;
     if (turn.promptDispatched) {
       state.recordSettledPromptId(promptId: turn.promptId);
@@ -605,21 +723,26 @@ final class PiSessionService({
         StackTrace.current,
       );
     }
-    if (!identical(_sessions[sessionId], state) || !identical(state.active, turn)) return;
     if (!failed && turn.promptDispatched && !turn.userMessageEmitted) {
       _emitMissingUserMessage(sessionId: sessionId, turn: turn);
+    } else if (!turn.userMessageEmitted) {
+      _dispatcher.cancelPrompt(sessionId: sessionId, promptId: turn.promptId);
     }
-    state.active = null;
+    if (identical(state.active, turn)) state.active = null;
+    state
+      ..inFlight.remove(turn)
+      ..queue.remove(turn);
     if (turn is _PiQueuedPromptTurn) {
       _releaseQueuedPresentation(sessionId: sessionId, state: state, turn: turn);
     }
     if (failed) _emit(BridgeSseSessionError(sessionID: sessionId));
     unawaited(_clearPendingWhenPersisted(sessionId: sessionId, directory: state.directory));
-    if (state.queue.isNotEmpty) {
-      final statusChanged = state.status != const PluginSessionStatus.busy();
-      state.status = const PluginSessionStatus.busy();
-      if (statusChanged) _emit(const BridgeSseProjectUpdated());
-      _startNext(sessionId: sessionId, state: state);
+    _startNext(sessionId: sessionId, state: state);
+    if (state.hasWork) {
+      if (state.status == const PluginSessionStatus.idle()) {
+        state.status = const PluginSessionStatus.busy();
+        _emit(const BridgeSseProjectUpdated());
+      }
       return;
     }
     state.status = const PluginSessionStatus.idle();
@@ -678,17 +801,21 @@ final class PiSessionService({
     }
     state.generation++;
     state.idleGeneration++;
-    final cancelled = [?state.active, ...state.queue];
+    final cancelled = state.turns.toList(growable: false);
     final hadQueuedPresentations = cancelled.any(
       (turn) => turn is _PiQueuedPromptTurn && turn.queueState == _PiQueueState.visible,
     );
     for (final turn in cancelled) {
       if (turn is _PiQueuedPromptTurn) turn.queueState = _PiQueueState.cancelled;
     }
-    state.active = null;
-    state.queue.clear();
-    state.status = const PluginSessionStatus.idle();
+    state
+      ..active = null
+      ..agentRunning = false
+      ..inFlight.clear()
+      ..queue.clear()
+      ..status = const PluginSessionStatus.idle();
     for (final turn in cancelled) {
+      _dispatcher.cancelPrompt(sessionId: sessionId, promptId: turn.promptId);
       if (turn is _PiCommandTurn && !turn.acceptance.isCompleted) {
         turn.acceptance.completeError(PiTurnCancelledException(sessionId: sessionId), StackTrace.current);
       }
@@ -721,7 +848,7 @@ final class PiSessionService({
     return () async {
       final activeSessionIds = <String>{
         for (final entry in _sessions.entries)
-          if (entry.value.active != null || entry.value.queue.isNotEmpty) entry.key,
+          if (entry.value.hasWork) entry.key,
       };
       if (activeSessionIds.isEmpty) return const <String>{};
       await Future.wait([
@@ -739,13 +866,17 @@ final class PiSessionService({
     if (state != null) {
       state.generation++;
       state.idleGeneration++;
-      for (final turn in [?state.active, ...state.queue]) {
+      for (final turn in state.turns) {
+        _dispatcher.cancelPrompt(sessionId: sessionId, promptId: turn.promptId);
         if (turn is _PiCommandTurn && !turn.acceptance.isCompleted) {
           turn.acceptance.completeError(PiTurnCancelledException(sessionId: sessionId), StackTrace.current);
         }
       }
-      state.active = null;
-      state.queue.clear();
+      state
+        ..active = null
+        ..agentRunning = false
+        ..inFlight.clear()
+        ..queue.clear();
     }
     final idleReap = state?.idleReap;
     if (idleReap != null) {
@@ -787,8 +918,7 @@ final class PiSessionService({
       await _clock.delay(duration: _idleTimeout);
       if (_disposed ||
           !identical(_sessions[sessionId], state) ||
-          state.active != null ||
-          state.queue.isNotEmpty ||
+          state.hasWork ||
           state.idleGeneration != generation) {
         return;
       }
@@ -858,9 +988,7 @@ final class PiSessionService({
   }
 
   void _syncWorkState() => _workState.set(
-    _sessions.values.any((state) => state.active != null || state.queue.isNotEmpty)
-        ? PluginWorkState.busy
-        : PluginWorkState.idle,
+    _sessions.values.any((state) => state.hasWork) ? PluginWorkState.busy : PluginWorkState.idle,
   );
 
   void _emit(BridgeSseEvent event) {
@@ -873,10 +1001,12 @@ final class PiSessionService({
 
   Future<void> _dispose({required Duration? shutdownBudget}) async {
     _disposed = true;
-    for (final state in _sessions.values) {
+    for (final entry in _sessions.entries) {
+      final state = entry.value;
       state.generation++;
       state.idleGeneration++;
-      for (final turn in [?state.active, ...state.queue]) {
+      for (final turn in state.turns) {
+        _dispatcher.cancelPrompt(sessionId: entry.key, promptId: turn.promptId);
         if (turn is _PiCommandTurn && !turn.acceptance.isCompleted) {
           turn.acceptance.completeError(const PiRpcDisposedException(), StackTrace.current);
         }

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -91,6 +91,7 @@ sealed class _PiTurn({
   bool responseSucceeded = false;
   bool agentStarted = false;
   bool agentSettled = false;
+  bool settlementObservedBeforeAcceptance = false;
   bool settled = false;
 }
 
@@ -393,16 +394,30 @@ final class PiSessionService({
 
   void _startNext({required String sessionId, required _PiSessionTurnState state}) {
     if (_disposed || state.active != null || state.queue.isEmpty || !identical(_sessions[sessionId], state)) return;
-    final preceding = state.inFlight.isEmpty ? null : state.inFlight.last;
-    if (preceding != null && _changesSelection(previous: preceding, next: state.queue.first)) return;
+    if (state.inFlight.isNotEmpty && _changesSelection(inFlight: state.inFlight, next: state.queue.first)) return;
     final turn = state.queue.removeAt(0);
     state.active = turn;
     final generation = state.generation;
     unawaited(_runTurn(sessionId: sessionId, state: state, turn: turn, generation: generation));
   }
 
-  bool _changesSelection({required _PiTurn previous, required _PiTurn next}) =>
-      previous.model != next.model || previous.variant?.id != next.variant?.id;
+  bool _changesSelection({required List<_PiTurn> inFlight, required _PiTurn next}) {
+    ({String providerID, String modelID})? effectiveModel;
+    String? effectiveVariant;
+    for (final turn in inFlight) {
+      final requestedModel = turn.model;
+      if (requestedModel != null && requestedModel != effectiveModel) {
+        effectiveModel = requestedModel;
+        effectiveVariant = null;
+      }
+      final requestedVariant = turn.variant?.id;
+      if (requestedVariant != null) effectiveVariant = requestedVariant;
+    }
+    final nextModel = next.model;
+    if (nextModel != null && nextModel != effectiveModel) return true;
+    final nextVariant = next.variant?.id;
+    return nextVariant != null && nextVariant != effectiveVariant;
+  }
 
   Future<void> _runTurn({
     required String sessionId,
@@ -454,7 +469,7 @@ final class PiSessionService({
         _finish(sessionId: sessionId, state: state, turn: turn, failed: false, failure: null);
         return;
       }
-      if (!turn.agentStarted) {
+      if (turn.settlementObservedBeforeAcceptance || !turn.agentStarted) {
         final agentState = await _processes.getState(connection: connection);
         await Future<void>.delayed(Duration.zero);
         if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
@@ -462,11 +477,14 @@ final class PiSessionService({
           _finish(sessionId: sessionId, state: state, turn: turn, failed: false, failure: null);
           return;
         }
-        if (!turn.agentStarted && !agentState.streaming && agentState.pendingMessageCount == 0) {
+        final hasAgentWork = agentState.streaming || agentState.pendingMessageCount > 0;
+        if (!hasAgentWork) {
           _finish(sessionId: sessionId, state: state, turn: turn, failed: false, failure: null);
           return;
         }
-        turn.agentStarted = agentState.streaming || agentState.pendingMessageCount > 0;
+        turn
+          ..agentStarted = true
+          ..settlementObservedBeforeAcceptance = false;
         state.agentRunning = state.agentRunning || agentState.streaming;
       }
       _moveInFlight(sessionId: sessionId, state: state, turn: turn);
@@ -559,12 +577,18 @@ final class PiSessionService({
             if (!turn.promptDispatched) continue;
             turn
               ..agentStarted = true
-              ..agentSettled = false;
+              ..agentSettled = false
+              ..settlementObservedBeforeAcceptance = false;
           }
         } else if (event is PiAgentSettledEvent) {
           state.agentRunning = false;
           for (final turn in generationTurns) {
-            if (turn.promptDispatched) turn.agentSettled = true;
+            if (!turn.promptDispatched) continue;
+            if (turn.responseSucceeded) {
+              turn.agentSettled = true;
+            } else {
+              turn.settlementObservedBeforeAcceptance = true;
+            }
           }
         }
         final now = _clock.now();
@@ -739,8 +763,14 @@ final class PiSessionService({
     unawaited(_clearPendingWhenPersisted(sessionId: sessionId, directory: state.directory));
     _startNext(sessionId: sessionId, state: state);
     if (state.hasWork) {
-      if (state.status == const PluginSessionStatus.idle()) {
+      if (state.status != const PluginSessionStatus.busy()) {
         state.status = const PluginSessionStatus.busy();
+        _emit(
+          BridgeSseSessionStatus(
+            sessionID: sessionId,
+            status: const shared.SessionStatus.busy().toJson(),
+          ),
+        );
         _emit(const BridgeSseProjectUpdated());
       }
       return;

--- a/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
@@ -90,6 +90,81 @@ void main() {
     expect(finalEvents.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part), replay.parts);
   });
 
+  test("registering a steering prompt preserves the active assistant stream and prompt order", () {
+    dispatcher.registerPrompt(
+      sessionId: sessionId,
+      promptId: "prompt-1",
+      executionText: "private first",
+      userVisibleText: "first",
+    );
+    final firstUser = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("message_end", {
+        "message": {
+          "role": "user",
+          "content": [
+            {"type": "text", "text": "private first"},
+          ],
+          "timestamp": 90,
+        },
+      }),
+    );
+    dispatcher.map(
+      sessionId: sessionId,
+      event: _event("message_start", {"message": _assistant(content: const [], timestamp: 100)}),
+    );
+    final beforeSteer = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("message_update", {
+        "assistantMessageEvent": {"type": "text_delta", "contentIndex": 0, "delta": "before "},
+      }),
+    );
+
+    dispatcher.registerPrompt(
+      sessionId: sessionId,
+      promptId: "prompt-2",
+      executionText: "private second",
+      userVisibleText: "second",
+    );
+    final afterSteer = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("message_update", {
+        "assistantMessageEvent": {"type": "text_delta", "contentIndex": 0, "delta": "after"},
+      }),
+    );
+    dispatcher.map(
+      sessionId: sessionId,
+      event: _event("message_end", {
+        "message": _assistant(
+          content: [
+            {"type": "text", "text": "before after"},
+          ],
+          timestamp: 100,
+          stopReason: "stop",
+        ),
+      }),
+    );
+    final steeringUser = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("message_end", {
+        "message": {
+          "role": "user",
+          "content": [
+            {"type": "text", "text": "private second"},
+          ],
+          "timestamp": 110,
+        },
+      }),
+    );
+
+    expect((firstUser.first as BridgeSseMessageUpdated).info["promptId"], "prompt-1");
+    expect(firstUser.whereType<BridgeSseMessagePartUpdated>().single.part.text, "first");
+    expect(beforeSteer.whereType<BridgeSseMessagePartDelta>().single.messageID, "pi:session:assistant:100:1");
+    expect(afterSteer.whereType<BridgeSseMessagePartDelta>().single.messageID, "pi:session:assistant:100:1");
+    expect((steeringUser.first as BridgeSseMessageUpdated).info["promptId"], "prompt-2");
+    expect(steeringUser.whereType<BridgeSseMessagePartUpdated>().single.part.text, "second");
+  });
+
   test("user message finals equal cold replay", () {
     final raw = {
       "role": "user",

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -659,6 +659,12 @@ void main() {
     expect(completed, isFalse);
     process.emitResponse(id: firstPrompt["id"]! as String, command: "prompt");
     await accepted;
+    final settledState = await waitForCommand(process: process, type: "get_state");
+    process.emitResponse(
+      id: settledState["id"]! as String,
+      command: "get_state",
+      data: {"isStreaming": false, "pendingMessageCount": 0},
+    );
     await _waitForIdle(service: service, sessionId: "session");
 
     final failed = service.sendCommand(
@@ -778,6 +784,55 @@ void main() {
     );
   });
 
+  test("settlement before steering acceptance does not finish the new run", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "settling-first",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "first")],
+      userVisibleText: "first",
+      variant: null,
+      model: null,
+    );
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "settling-steer",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "steer")],
+      userVisibleText: "steer",
+      variant: null,
+      model: null,
+    );
+
+    await _answerEntries(process);
+    final firstPrompt = await waitForCommand(process: process, type: "prompt");
+    process.emit(frame: {"type": "agent_start"});
+    process.emitResponse(id: firstPrompt["id"]! as String, command: "prompt");
+    final steeringPrompt = await _waitForNthCommand(process: process, type: "prompt", count: 2);
+
+    process.emit(frame: {"type": "agent_settled"});
+    process.emitResponse(id: steeringPrompt["id"]! as String, command: "prompt");
+    final stateCommand = await waitForCommand(process: process, type: "get_state");
+    process.emitResponse(
+      id: stateCommand["id"]! as String,
+      command: "get_state",
+      data: {"isStreaming": true, "pendingMessageCount": 0},
+    );
+    await pump();
+
+    expect(service.sessionStatuses["session"], const PluginSessionStatus.busy());
+    expect(service.currentWorkState, PluginWorkState.busy);
+
+    process.emit(frame: {"type": "agent_start"});
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: "session");
+  });
+
   test("a selection-changing follow-up waits for the active Pi run boundary", () async {
     final process = FakePiProcess();
     final fixture = _Fixture(processes: [process]);
@@ -820,6 +875,113 @@ void main() {
     process.emitResponse(id: secondModel["id"]! as String, command: "set_model");
     final secondPrompt = await _waitForNthCommand(process: process, type: "prompt", count: 2);
     process.emitResponse(id: secondPrompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: "session");
+  });
+
+  test("omitted selections inherit the active run and keep steering", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+    const model = (providerID: "provider", modelID: "model");
+    const variant = PluginSessionVariant(id: "high");
+
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "effective-first",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "first")],
+      userVisibleText: "first",
+      variant: variant,
+      model: model,
+    );
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "effective-inherited",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "inherit")],
+      userVisibleText: "inherit",
+      variant: null,
+      model: null,
+    );
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "effective-explicit",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "explicit")],
+      userVisibleText: "explicit",
+      variant: variant,
+      model: model,
+    );
+
+    await _answerEntries(process);
+    final setModel = await waitForCommand(process: process, type: "set_model");
+    process.emitResponse(id: setModel["id"]! as String, command: "set_model");
+    final setThinking = await waitForCommand(process: process, type: "set_thinking_level");
+    process.emitResponse(id: setThinking["id"]! as String, command: "set_thinking_level");
+    final firstPrompt = await waitForCommand(process: process, type: "prompt");
+    process.emit(frame: {"type": "agent_start"});
+    process.emitResponse(id: firstPrompt["id"]! as String, command: "prompt");
+
+    final inheritedPrompt = await _waitForNthCommand(process: process, type: "prompt", count: 2);
+    process.emitResponse(id: inheritedPrompt["id"]! as String, command: "prompt");
+    final explicitPrompt = await _waitForNthCommand(process: process, type: "prompt", count: 3);
+    expect(explicitPrompt["message"], "explicit");
+    expect(process.written.where((frame) => frame["type"] == "set_model"), hasLength(1));
+    expect(process.written.where((frame) => frame["type"] == "set_thinking_level"), hasLength(1));
+
+    process.emitResponse(id: explicitPrompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: "session");
+  });
+
+  test("queued work resets a terminal retry status before dispatch", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+    final events = <BridgeSseEvent>[];
+    service.events.listen(events.add);
+
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "retry-first",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "first")],
+      userVisibleText: "first",
+      variant: null,
+      model: (providerID: "provider", modelID: "first-model"),
+    );
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "retry-next",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "next")],
+      userVisibleText: "next",
+      variant: null,
+      model: (providerID: "provider", modelID: "next-model"),
+    );
+
+    await _answerEntries(process);
+    final firstModel = await waitForCommand(process: process, type: "set_model");
+    process.emitResponse(id: firstModel["id"]! as String, command: "set_model");
+    final firstPrompt = await waitForCommand(process: process, type: "prompt");
+    process.emit(frame: {"type": "agent_start"});
+    process.emitResponse(id: firstPrompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "auto_retry_start", "attempt": 2, "delayMs": 500});
+    process.emit(frame: {"type": "auto_retry_end", "success": false, "attempt": 2});
+    await pump();
+    expect(service.sessionStatuses["session"], isA<PluginSessionStatusRetry>());
+
+    process.emit(frame: {"type": "agent_settled"});
+    final nextModel = await _waitForNthCommand(process: process, type: "set_model", count: 2);
+    expect(service.sessionStatuses["session"], const PluginSessionStatus.busy());
+    expect(events.whereType<BridgeSseSessionStatus>().last.status["type"], "busy");
+
+    process.emitResponse(id: nextModel["id"]! as String, command: "set_model");
+    final nextPrompt = await _waitForNthCommand(process: process, type: "prompt", count: 2);
+    process.emitResponse(id: nextPrompt["id"]! as String, command: "prompt");
     process.emit(frame: {"type": "agent_settled"});
     await _waitForIdle(service: service, sessionId: "session");
   });

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -680,12 +680,14 @@ void main() {
     await _waitForIdle(service: service, sessionId: "session");
   });
 
-  test("prompt admission is immediate, same-session FIFO, and sessions run concurrently", () async {
+  test("prompt admission is immediate, busy follow-ups steer in FIFO, and sessions run concurrently", () async {
     final first = FakePiProcess();
     final other = FakePiProcess();
     final fixture = _Fixture(processes: [first, other]);
     addTearDown(fixture.dispose);
     final service = fixture.service();
+    final events = <BridgeSseEvent>[];
+    service.events.listen(events.add);
 
     await service.sendPrompt(
       sessionId: "one",
@@ -719,13 +721,107 @@ void main() {
     final firstPrompt = await waitForCommand(process: first, type: "prompt");
     final otherPrompt = await waitForCommand(process: other, type: "prompt");
     expect(firstPrompt["message"], "first");
+    expect(firstPrompt["streamingBehavior"], "steer");
     expect(otherPrompt["message"], "other");
+    expect(otherPrompt["streamingBehavior"], "steer");
     expect(first.written.where((frame) => frame["type"] == "prompt"), hasLength(1));
 
+    first.emit(frame: {"type": "agent_start"});
+    first.emit(
+      frame: {
+        "type": "message_end",
+        "message": {
+          "role": "user",
+          "content": [
+            {"type": "text", "text": "first"},
+          ],
+          "timestamp": 1,
+        },
+      },
+    );
     first.emitResponse(id: firstPrompt["id"]! as String, command: "prompt");
-    first.emit(frame: {"type": "agent_settled"});
     final secondPrompt = await _waitForNthCommand(process: first, type: "prompt", count: 2);
     expect(secondPrompt["message"], "second");
+    expect(secondPrompt["streamingBehavior"], "steer");
+    expect(
+      service.sessionStatuses["one"],
+      const PluginSessionStatus.busy(),
+      reason: "the follow-up must dispatch before the active run settles",
+    );
+
+    first.emitResponse(id: secondPrompt["id"]! as String, command: "prompt");
+    first.emit(
+      frame: {
+        "type": "message_end",
+        "message": {
+          "role": "user",
+          "content": [
+            {"type": "text", "text": "second"},
+          ],
+          "timestamp": 2,
+        },
+      },
+    );
+    first.emit(frame: {"type": "agent_settled"});
+    other.emitResponse(id: otherPrompt["id"]! as String, command: "prompt");
+    other.emit(frame: {"type": "agent_settled"});
+    await Future.wait([
+      _waitForIdle(service: service, sessionId: "one"),
+      _waitForIdle(service: service, sessionId: "two"),
+    ]);
+    expect(
+      events
+          .whereType<BridgeSseMessageUpdated>()
+          .map((event) => event.info["promptId"])
+          .where((promptId) => promptId == "prompt-8" || promptId == "prompt-9"),
+      ["prompt-8", "prompt-9"],
+    );
+  });
+
+  test("a selection-changing follow-up waits for the active Pi run boundary", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "selection-first",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "first")],
+      userVisibleText: "first",
+      variant: null,
+      model: (providerID: "provider", modelID: "first-model"),
+    );
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "selection-second",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "second")],
+      userVisibleText: "second",
+      variant: null,
+      model: (providerID: "provider", modelID: "second-model"),
+    );
+
+    await _answerEntries(process);
+    final firstModel = await waitForCommand(process: process, type: "set_model");
+    process.emitResponse(id: firstModel["id"]! as String, command: "set_model");
+    final firstPrompt = await waitForCommand(process: process, type: "prompt");
+    process.emit(frame: {"type": "agent_start"});
+    process.emitResponse(id: firstPrompt["id"]! as String, command: "prompt");
+    await pump();
+
+    expect(process.written.where((frame) => frame["type"] == "prompt"), hasLength(1));
+    expect(process.written.where((frame) => frame["type"] == "set_model"), hasLength(1));
+
+    process.emit(frame: {"type": "agent_settled"});
+    final secondModel = await _waitForNthCommand(process: process, type: "set_model", count: 2);
+    expect(secondModel["modelId"], "second-model");
+    process.emitResponse(id: secondModel["id"]! as String, command: "set_model");
+    final secondPrompt = await _waitForNthCommand(process: process, type: "prompt", count: 2);
+    process.emitResponse(id: secondPrompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: "session");
   });
 
   test("a retried prompt id is an idempotent no-op instead of a duplicate turn", () async {
@@ -1297,13 +1393,17 @@ void main() {
     final prompt = await waitForCommand(process: process, type: "prompt");
     process.emitResponse(id: prompt["id"]! as String, command: "prompt");
     process.emit(frame: {"type": "agent_start"});
+    final steeringPrompt = await _waitForNthCommand(process: process, type: "prompt", count: 2);
+    expect(steeringPrompt["message"], "queued");
+    expect(steeringPrompt["streamingBehavior"], "steer");
+    process.emitResponse(id: steeringPrompt["id"]! as String, command: "prompt");
     final abort = service.abort(sessionId: "session");
     final abortCommand = await waitForCommand(process: process, type: "abort");
     process.emitResponse(id: abortCommand["id"]! as String, command: "abort");
     await abort;
 
     expect(process.killed, isTrue);
-    expect(process.written.where((frame) => frame["type"] == "prompt"), hasLength(1));
+    expect(process.written.where((frame) => frame["type"] == "prompt"), hasLength(2));
     expect(fixture.repository.residentSessionIds, isEmpty);
   });
 

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -44,7 +44,12 @@ defaults and queued client sends coherent.
 - Codex user prompts use the same visible content live and after rollout replay:
   the bridge worktree context envelope is hidden, authored text remains, and
   bounded inline images render as file parts. An attachment-only initial prompt
-  therefore remains visible without exposing the generated context.
+  therefore remains visible without exposing the generated context. A plain
+  follow-up is sent immediately through `turn/start`; Codex's app server starts
+  a turn while idle and steers the active turn while busy, preserving the
+  client user-message id in either case. The bridge keeps the authoritative
+  active turn until its terminal event even when an older app server returns a
+  separate submission id for the steering request.
 - A plain Claude prompt sent while its resident process is working is written
   immediately with `priority: next`. Claude absorbs it at the next tool
   boundary when possible, within the active agent turn; otherwise Claude keeps
@@ -97,16 +102,19 @@ defaults and queued client sends coherent.
   session-close methods to complete an ordinary turn.
 - Existing-session ACP prompts remain bridge-queued while an earlier same-session
   turn, declared process-wide lane, resume, or selection blocks their
-  `session/prompt` frame. Their synthetic user transcript message is published
-  only after that frame flushes successfully to the agent's stdin. Follow-up and
-  replayed user messages preserve ordered text and bounded data-backed image
-  parts, including attachment-only prompts. Initial projection contains only
-  normalized user-visible text plus those images; injected context, local paths,
-  and URLs remain absent. OMP runs different sessions concurrently because its
-  permission and form requests carry explicit session IDs. Within one OMP
-  session, it preserves active-prompt replacement by cancelling the active turn
-  immediately, then dispatching the newly queued input after cancellation
-  settles; Cursor and Hermes retain ordinary FIFO turn boundaries.
+  `session/prompt` frame. ACP v1 has no standard steering or queued-input
+  operation and permits the next prompt after the current prompt turn completes,
+  so Cursor and Hermes intentionally retain FIFO turn boundaries rather than
+  sending overlapping prompt requests. Their synthetic user transcript message
+  is published only after that frame flushes successfully to the agent's stdin.
+  Follow-up and replayed user messages preserve ordered text and bounded
+  data-backed image parts, including attachment-only prompts. Initial projection
+  contains only normalized user-visible text plus those images; injected
+  context, local paths, and URLs remain absent. OMP runs different sessions
+  concurrently because its permission and form requests carry explicit session
+  IDs. OMP's ACP server defines a busy follow-up as replacement rather than
+  steering: Sesori immediately cancels the active turn, then dispatches the new
+  input after cancellation settles.
 - Normalized user-message events feed the durable user-side activity marker used
   to order running roots. Known event times are applied monotonically. Backend
   input represented as a user message, including automatic compaction or other

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -54,14 +54,18 @@ defaults and queued client sends coherent.
   instead of changing the active turn.
 - Pi keeps at most one lazy resident RPC process per active session and allows
   different sessions to run concurrently. Startup replays and hydrates message
-  identity before live frames attach or a turn dispatches; same-session prompts
-  remain FIFO. An accepted prompt remains bridge-queued through startup and
-  selection until Pi echoes its correlated user message, including an
-  attachment-only echo; it can be cancelled before dispatch, and its
-  undispatched prompt id remains immediately retryable while cancellation
-  settles. If a successful turn omits that echo, Pi maps the stored payload
-  through the same user-message path before clearing the queue. Process exit
-  settles current work before queued work reconnects.
+  identity before live frames attach or a turn dispatches. Same-session prompts
+  remain FIFO, and same-selection ordinary follow-ups dispatch with Pi's
+  `steer` streaming behavior as soon as the preceding prompt is accepted, so Pi
+  injects them at the next tool boundary instead of waiting for the run to
+  settle. A model or thinking-level change remains bridge-queued until the
+  current run settles. An accepted prompt remains bridge-queued through startup
+  and selection until Pi echoes
+  its correlated user message, including an attachment-only echo; it can be
+  cancelled before dispatch, and its undispatched prompt id remains immediately
+  retryable while cancellation settles. If a successful run omits an echo, Pi
+  maps each stored payload through the same user-message path before clearing
+  the queue. Process exit settles dispatched work before queued work reconnects.
 - Pi slash commands are accepted by their correlated response or a matching
   extension dialog and remain in the request's sending state until then rather
   than exposing a cancellable bridge-queue entry. Commands reject while that


### PR DESCRIPTION
## Complexity

Moderate — this changes Pi's per-session turn lifecycle so multiple accepted prompts can belong to one active agent run while preserving FIFO and selection boundaries.

## What

- Send Pi prompts with `streamingBehavior: "steer"`, which Pi ignores while idle and queues at the next tool boundary while busy.
- Dispatch same-selection follow-ups as soon as the preceding prompt is accepted; keep model/thinking changes queued until the active run settles.
- Track all prompts accepted into the active Pi run, correlate each user echo without resetting an active assistant stream, and settle them together across completion, abort, timeout, or process exit.
- Preserve a newly starting run when the prior settlement races steering acceptance, inherit omitted selections across a steering chain, and clear stale retry presentation before queued work starts.
- Update Pi protocol/regression documentation and focused queue, correlation, selection, and abort coverage.
- Audit every other production harness: Codex already steers an active turn immediately; Cursor and Hermes correctly retain ACP v1 FIFO boundaries; OMP intentionally cancels and replaces its active turn because that is its ACP server's defined behavior.

## Why

The bridge previously waited for `agent_settled` before sending the next Pi prompt. A follow-up submitted during an active turn therefore started only after the whole run completed instead of steering the running session as Pi supports.

## Risk and test focus

Risk is limited to Pi prompt lifecycle bookkeeping. Review should focus on FIFO dispatch, correlated queued-bubble replacement, selection-changing boundaries, multi-prompt settlement, cancellation, abort, timeout, and process-exit recovery. There is no database, persisted-data, client/bridge wire-contract, or client UI change.

## Expected result

A normal follow-up sent while Pi is working is accepted immediately and injected by Pi at the next tool boundary. Selection-changing prompts and slash commands retain their existing safe boundaries.

## Verification

- `cd bridge/sesori_plugin_pi && dart analyze --fatal-infos`
- `cd bridge/sesori_plugin_pi && dart test --reporter compact` — 267 tests passed
- Focused Codex active-turn steering test
- Focused ACP same-session FIFO boundary test
- Focused OMP active-turn replacement test
- Architecture implementation review — approved with no findings
- `git diff --check origin/main...HEAD`
