### PR TITLE
🌿 Keep bridge logout clean after expired authentication

### DIFF
--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -16,6 +16,7 @@ import 'package:sesori_bridge/src/auth/bridge_id_storage.dart';
 import 'package:sesori_bridge/src/auth/bridge_registration_repository.dart';
 import 'package:sesori_bridge/src/auth/bridge_registration_service.dart';
 import 'package:sesori_bridge/src/auth/token.dart';
+import 'package:sesori_bridge/src/auth/token_refresh_exception.dart';
 import 'package:sesori_bridge/src/auth/token_service.dart';
 import 'package:sesori_bridge/src/foundation/abortable_request.dart';
 import 'package:sesori_bridge/src/foundation/bridge_startup_banner_formatter.dart';
@@ -360,11 +361,16 @@ Future<void> _unregisterBridgeRegistration({
   final TokenData tokens;
   try {
     tokens = await loadTokens(dataDirectory: dataDirectory);
-  } on Object catch (e) {
-    // A registered bridge with no usable token file — there is no credential
-    // left to authenticate the unregister call. Logout still proceeds, but
-    // leave a trace.
-    Log.w('Skipping bridge unregistration; could not load tokens: $e');
+  } on PathNotFoundException {
+    // Logout is idempotent. A persisted bridge id can outlive the token file
+    // after an earlier best-effort unregister failed, so no token is expected
+    // when the user runs logout again.
+    return;
+  } on Object catch (error, stackTrace) {
+    // A registered bridge with an unreadable token file has no credential for
+    // the unregister call. Logout still proceeds, but retain the unexpected
+    // local failure for diagnostics.
+    Log.w('Skipping bridge unregistration; could not load tokens', error, stackTrace);
     return;
   }
 
@@ -395,7 +401,18 @@ Future<void> _unregisterBridgeRegistration({
       hostName: Platform.localHostname,
       platform: BridgeRegistrationService.currentPlatformName(),
     );
-    await registrationService.unregister().timeout(const Duration(seconds: 10));
+    try {
+      await registrationService.unregister().timeout(const Duration(seconds: 10));
+    } on TokenRefreshException catch (error) {
+      if (error.statusCode != 401) {
+        rethrow;
+      }
+      // An expired or revoked saved session is a normal reason to log out. The
+      // server registration cannot be removed without valid credentials, but
+      // the local logout should remain clean and the persisted bridge id lets a
+      // later login reclaim the same registration.
+      Log.i('Skipping bridge unregistration because the saved authentication session is no longer valid.');
+    }
   } finally {
     tokenService.dispose();
     httpClient.close();

--- a/bridge/app/lib/src/auth/token_refresh_exception.dart
+++ b/bridge/app/lib/src/auth/token_refresh_exception.dart
@@ -1,5 +1,8 @@
 /// Thrown when token refresh fails.
-class const TokenRefreshException(final String reason) implements Exception {
+class const TokenRefreshException({
+  required final String reason,
+  final int? statusCode,
+}) implements Exception {
   @override
   String toString() => "TokenRefreshException: $reason";
 }

--- a/bridge/app/lib/src/auth/token_service.dart
+++ b/bridge/app/lib/src/auth/token_service.dart
@@ -71,19 +71,20 @@ class TokenService({
   Future<String> _doRefresh() async {
     final tokens = await _loadTokens();
     if (tokens == null) {
-      throw const TokenRefreshException("No tokens available for refresh");
+      throw const TokenRefreshException(reason: "No tokens available for refresh");
     }
 
     final refreshToken = tokens.refreshToken;
     if (refreshToken.isEmpty) {
-      throw const TokenRefreshException("Refresh token is empty");
+      throw const TokenRefreshException(reason: "Refresh token is empty");
     }
 
     final refresh = await _authRepository.refreshToken(refreshToken: refreshToken);
     final authResponse = switch (refresh) {
       AuthTokenRefreshed(:final response) => response,
       AuthTokenRefreshRejected(:final statusCode) => throw TokenRefreshException(
-        "Token refresh failed with status $statusCode",
+        reason: "Token refresh failed with status $statusCode",
+        statusCode: statusCode,
       ),
     };
 
@@ -99,7 +100,7 @@ class TokenService({
     try {
       final reloaded = await _loadTokens();
       if (reloaded == null) {
-        throw const TokenRefreshException("Token file cleared during refresh");
+        throw const TokenRefreshException(reason: "Token file cleared during refresh");
       }
       latestTokens = reloaded;
     } on FormatException {

--- a/bridge/app/test/auth/token_service_test.dart
+++ b/bridge/app/test/auth/token_service_test.dart
@@ -311,7 +311,10 @@ void main() {
         saveTokens: (_) async {},
       );
 
-      expect(manager.getAccessToken(), throwsA(isA<TokenRefreshException>()));
+      await expectLater(
+        manager.getAccessToken(),
+        throwsA(isA<TokenRefreshException>().having((error) => error.statusCode, "statusCode", 401)),
+      );
     });
 
     test("network error during refresh throws", () async {

--- a/bridge/app/test/push/push_notification_client_test.dart
+++ b/bridge/app/test/push/push_notification_client_test.dart
@@ -18,7 +18,7 @@ class _FakeTokenRefreshManager(final String _token, {final String? _forceRefresh
     if (forceRefresh) {
       forceRefreshCalled = true;
       if (_forceRefreshToken != null) return _forceRefreshToken;
-      throw const TokenRefreshException("Force refresh failed");
+      throw const TokenRefreshException(reason: "Force refresh failed");
     }
     return _token;
   }

--- a/docs/regression/account-and-onboarding.md
+++ b/docs/regression/account-and-onboarding.md
@@ -14,7 +14,9 @@ participates.
 - Startup routing uses local session state only, with no network work at splash.
 - Tokens live in secure storage with one writer, refresh before expiry, and are
   cleared on logout; the connection follows logout. Startup reads stored tokens
-  once before deciding whether validation or a fresh login is needed.
+  once before deciding whether validation or a fresh login is needed. Standalone
+  bridge logout remains clean and idempotent when tokens are already absent or
+  the saved authentication session has expired.
 - Auth-server URLs behave identically with or without trailing slashes, and
   deadline expiry actively aborts registration and token-refresh transport,
   including response-body consumption.


### PR DESCRIPTION
## Complexity

🌿 Straightforward. The logout path now distinguishes expected missing/expired authentication from unexpected unregister failures.

## What

- Treat an absent token file as an idempotent logout state, even when a retained bridge ID remains.
- Preserve refresh rejection status on `TokenRefreshException` and handle a 401 during best-effort unregistration without dumping an exception stack.
- Keep unexpected token-read and unregister failures fully logged.
- Document the idempotent standalone bridge logout behavior.

## Why

A successful `sesori-bridge logout` printed an alarming stack trace when the saved refresh token had expired. Running logout again then warned about the intentionally deleted `token.json` because the bridge ID is retained after a failed server unregister.

## Risk and test focus

Risk is limited to standalone bridge logout classification. A valid authenticated logout must still unregister first, unexpected failures must remain diagnosable, and local tokens must still be cleared when refresh returns 401.

User-visible impact: expired or already-cleared authentication no longer produces exception noise. There is no database, wire-contract, or server behavior impact.

## Expected result

Logout with a refresh-token 401 prints one concise informational line and clears local authentication without a stack trace. Repeating logout with no token file completes cleanly. The persisted bridge ID remains available for a later login to reclaim the registration.

## Verification

- `cd bridge/app && dart test test/auth/token_service_test.dart test/bridge/runtime/bridge_logout_runner_test.dart test/push/push_notification_client_test.dart`
- `cd bridge/app && dart analyze --fatal-infos`
- Manual CLI regression with a retained `bridge_id` and missing `token.json`
- Manual CLI regression against a fake auth endpoint returning 401 for refresh; verified no stack trace, token deletion, and bridge-ID retention


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `sesori-bridge logout` clean and idempotent when the saved session expired or tokens are already absent. Previously logout emitted a stack trace on refresh 401 and warned about a missing token on repeat runs; now it skips server unregister in these expected cases, logs one line, clears local auth, and leaves the persisted bridge ID for reclaim.

- Migration: Update `TokenRefreshException` call sites to the new constructor with named parameters: `TokenRefreshException(reason: ..., statusCode: ...)`.

<sup>Written for commit c31226f3d5929ecf49341b4406e47b32cab587d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

