### PR TITLE
🌿 Stop and send Cursor and Hermes follow-ups

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -199,10 +199,9 @@ abstract class AcpPlugin({
 
   /// Whether accepting another input should cancel this session's active turn.
   ///
-  /// OMP gives another prompt for the same session this replacement behavior
-  /// itself. The shared adapter queues same-session requests, so its concrete
-  /// adapter declares the same policy here and the bridge sends the equivalent
-  /// standard cancel before dispatching the queued input.
+  /// Harnesses use this for stop-and-send behavior when they cannot steer an
+  /// active turn. The shared adapter queues the new input, sends the standard
+  /// ACP cancel, and dispatches the input only after cancellation settles.
   bool get cancelsActiveTurnForQueuedInput => false;
 
   /// Whether a turn must stop when its requested selection cannot be applied.

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
@@ -18,9 +18,10 @@ import "trackers/cursor_catalog_tracker.dart";
 
 /// Cursor backend over ACP plus Cursor's config-option model picker.
 ///
-/// Cursor keeps every stock ACP turn policy. Its selection writes are
-/// best-effort (`_setConfig` never throws), so `failsTurnOnSelectionError` is
-/// moot and left at the base default.
+/// Cursor uses standard ACP cancellation to stop an active turn before a
+/// same-session follow-up dispatches. Its selection writes are best-effort
+/// (`_setConfig` never throws), so `failsTurnOnSelectionError` is moot and left
+/// at the base default.
 class CursorPlugin._({
   required super.launchSpec,
   required super.launchDirectory,
@@ -134,6 +135,9 @@ class CursorPlugin._({
 
   @override
   Map<String, dynamic>? get initializeCapabilityMeta => CursorBinary.acpCapabilityMeta;
+
+  @override
+  bool get cancelsActiveTurnForQueuedInput => true;
 
   @override
   AcpApprovalRegistry buildApprovalRegistry(AcpStdioClient client) {

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
@@ -227,6 +227,78 @@ void main() {
       });
     });
 
+    test("a busy follow-up cancels the active turn before replacement dispatch", () async {
+      final events = <BridgeSseEvent>[];
+      final subscription = plugin.events.listen(events.add);
+      addTearDown(subscription.cancel);
+
+      final connecting = plugin.ensureConnected();
+      await respond("initialize", const {
+        "protocolVersion": 1,
+        "agentCapabilities": <String, dynamic>{},
+        "authMethods": <Object?>[],
+      });
+      expect(await connecting, isTrue);
+
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond("session/new", const {"sessionId": "s-follow-up"});
+      final session = await creating;
+
+      await plugin.sendPrompt(
+        promptId: "prompt-1",
+        sessionId: session.id,
+        parts: const [PluginPromptPart.text(text: "first")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final firstPrompt = await waitForFrame("session/prompt");
+
+      await plugin.sendPrompt(
+        promptId: "prompt-2",
+        sessionId: session.id,
+        parts: const [PluginPromptPart.text(text: "replace it")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final cancel = await waitForFrame("session/cancel");
+      expect(cancel["params"], {"sessionId": session.id});
+      expect(fake.written.where((frame) => frame["method"] == "session/prompt"), hasLength(1));
+      expect((await plugin.getQueuedPrompts(sessionId: session.id)).single.id, "prompt-2");
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": firstPrompt["id"],
+        "result": {"stopReason": "cancelled"},
+      });
+      final replacement = await waitForFrame("session/prompt");
+      final replacementParams = (replacement["params"] as Map).cast<String, dynamic>();
+      expect(replacementParams["sessionId"], session.id);
+      expect(((replacementParams["prompt"] as List).single as Map)["text"], "replace it");
+      expect(await plugin.getQueuedPrompts(sessionId: session.id), isEmpty);
+      expect(events.whereType<BridgeSseSessionIdle>(), isEmpty);
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": replacement["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+      for (var i = 0; i < 10 && events.whereType<BridgeSseSessionIdle>().isEmpty; i++) {
+        await pump();
+      }
+      expect(events.whereType<BridgeSseSessionIdle>(), hasLength(1));
+      expect(events.whereType<BridgeSseSessionError>(), isEmpty);
+    });
+
     test("captureSessionConfig populates providers, effort variants, and mode agents", () async {
       capture(catalogResult(), fromNewSession: true);
 

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
@@ -6,12 +6,12 @@ import "services/hermes_session_options_service.dart";
 
 /// Hermes Agent backend over ACP.
 ///
-/// Hermes is a stock ACP v1 server: `hermes acp` advertises load/list/resume/
+/// Hermes is an ACP v1 server: `hermes acp` advertises load/list/resume/
 /// fork/prompt capabilities and streams turns via `session/update`
-/// notifications, so the base [AcpPlugin] machinery — including every stock
-/// protocol policy (per-session turn serialization, no form elicitation, no
-/// capability meta, first non-terminal auth method, fail-closed selection) —
-/// applies unchanged. Only Hermes model discovery and its unstable
+/// notifications. It uses standard ACP cancellation for stop-and-send
+/// follow-ups; the remaining stock policies include per-session serialization,
+/// no form elicitation or capability meta, first non-terminal authentication,
+/// and fail-closed selection. Only Hermes model discovery and its unstable
 /// `session/set_model` extension are layered on here, isolated in this package.
 /// It has no managed runtime (Hermes installs itself; the bridge resolves it on
 /// PATH).
@@ -29,6 +29,9 @@ class HermesPlugin({
         id: HermesPluginIdentity.id,
         agentDisplayName: HermesPluginIdentity.displayName,
       );
+
+  @override
+  bool get cancelsActiveTurnForQueuedInput => true;
 
   @override
   void captureSessionConfig(

--- a/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
+++ b/bridge/sesori_plugin_hermes/test/hermes_plugin_test.dart
@@ -116,12 +116,12 @@ void main() {
       expect(spec.args, ["acp"]);
     });
 
-    test("keeps the stock ACP policies of a v1 server", () {
+    test("uses the stock ACP policies plus stop-and-send follow-ups", () {
       expect(plugin.authMethodId, isNull, reason: "Hermes provider ids are dynamic");
       expect(plugin.initializeCapabilityMeta, isNull);
       expect(plugin.supportsFormElicitation, isFalse, reason: "no elicitation/create on Hermes");
       expect(plugin.serializesPromptsProcessWide, isFalse);
-      expect(plugin.cancelsActiveTurnForQueuedInput, isFalse);
+      expect(plugin.cancelsActiveTurnForQueuedInput, isTrue);
       expect(plugin.failsTurnOnSelectionError, isTrue);
       expect(plugin.sessionCloseSettlementTimeout, const Duration(seconds: 5));
     });
@@ -206,6 +206,71 @@ void main() {
       await pump();
 
       expect(events.whereType<BridgeSseMessagePartDelta>().single.delta, "Hello");
+    });
+
+    test("a busy follow-up cancels the active turn before replacement dispatch", () async {
+      await connect();
+      final events = <BridgeSseEvent>[];
+      final subscription = plugin.events.listen(events.add);
+      addTearDown(subscription.cancel);
+
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond(method: "session/new", result: const {"sessionId": "s-follow-up"});
+      final session = await creating;
+
+      await plugin.sendPrompt(
+        promptId: "prompt-1",
+        sessionId: session.id,
+        parts: const [PluginPromptPart.text(text: "first")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final firstPrompt = await waitForFrame(method: "session/prompt");
+
+      await plugin.sendPrompt(
+        promptId: "prompt-2",
+        sessionId: session.id,
+        parts: const [PluginPromptPart.text(text: "replace it")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final cancel = await waitForFrame(method: "session/cancel");
+      expect(cancel["params"], {"sessionId": session.id});
+      expect(fake.written.where((frame) => frame["method"] == "session/prompt"), hasLength(1));
+      expect((await plugin.getQueuedPrompts(sessionId: session.id)).single.id, "prompt-2");
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": firstPrompt["id"],
+        "result": {"stopReason": "cancelled"},
+      });
+      final replacement = await waitForFrame(method: "session/prompt");
+      final replacementParams = (replacement["params"] as Map).cast<String, dynamic>();
+      expect(replacementParams["sessionId"], session.id);
+      expect(((replacementParams["prompt"] as List).single as Map)["text"], "replace it");
+      expect(await plugin.getQueuedPrompts(sessionId: session.id), isEmpty);
+      expect(events.whereType<BridgeSseSessionIdle>(), isEmpty);
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": replacement["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+      for (var i = 0; i < 10 && events.whereType<BridgeSseSessionIdle>().isEmpty; i++) {
+        await pump();
+      }
+      expect(events.whereType<BridgeSseSessionIdle>(), hasLength(1));
+      expect(events.whereType<BridgeSseSessionError>(), isEmpty);
     });
 
     test("deleteSession never calls session/close when closeSession is not advertised", () async {

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -93,28 +93,30 @@ defaults and queued client sends coherent.
 - Hermes runs turns through ACP v1 over `hermes acp`: initialization uses the
   first non-terminal provider authentication method, image prompt parts remain
   available, streamed updates use the shared ACP normalization, and abort uses
-  session cancellation. Available models come from Hermes's ACP session model
-  state, and the selected exact model ID is applied through Hermes's
-  `session/set_model` extension before each changed-model turn. A rejected model
-  fails before prompting. Completed assistant text is finalized at each tool
-  boundary, so earlier prose in a multi-tool turn does not depend on the final
-  turn snapshot. Sesori does not call form-elicitation or unadvertised
-  session-close methods to complete an ordinary turn.
+  session cancellation. A follow-up accepted during an active turn uses that
+  same cancellation path, then dispatches after the interrupted turn settles.
+  Available models come from Hermes's ACP session model state, and the selected
+  exact model ID is applied through Hermes's `session/set_model` extension before
+  each changed-model turn. A rejected model fails before prompting. Completed
+  assistant text is finalized at each tool boundary, so earlier prose in a
+  multi-tool turn does not depend on the final turn snapshot. Sesori does not
+  call form-elicitation or unadvertised session-close methods to complete an
+  ordinary turn.
 - Existing-session ACP prompts remain bridge-queued while an earlier same-session
   turn, declared process-wide lane, resume, or selection blocks their
-  `session/prompt` frame. ACP v1 has no standard steering or queued-input
-  operation and permits the next prompt after the current prompt turn completes,
-  so Cursor and Hermes intentionally retain FIFO turn boundaries rather than
-  sending overlapping prompt requests. Their synthetic user transcript message
-  is published only after that frame flushes successfully to the agent's stdin.
-  Follow-up and replayed user messages preserve ordered text and bounded
-  data-backed image parts, including attachment-only prompts. Initial projection
-  contains only normalized user-visible text plus those images; injected
-  context, local paths, and URLs remain absent. OMP runs different sessions
-  concurrently because its permission and form requests carry explicit session
-  IDs. OMP's ACP server defines a busy follow-up as replacement rather than
-  steering: Sesori immediately cancels the active turn, then dispatches the new
-  input after cancellation settles.
+  `session/prompt` frame. ACP v1 has no standard steering operation, so Sesori
+  never sends overlapping prompt requests. It does define `session/cancel`:
+  Cursor and Hermes therefore implement active-turn follow-ups as stop-and-send,
+  immediately cancelling the active turn and dispatching the queued input after
+  cancellation settles. Further already-queued inputs retain FIFO order. Their
+  synthetic user transcript message is published only after its frame flushes
+  successfully to the agent's stdin. Follow-up and replayed user messages
+  preserve ordered text and bounded data-backed image parts, including
+  attachment-only prompts. Initial projection contains only normalized
+  user-visible text plus those images; injected context, local paths, and URLs
+  remain absent. OMP runs different sessions concurrently because its permission
+  and form requests carry explicit session IDs. OMP uses the same stop-and-send
+  sequence for its ACP server's replacement semantics.
 - Normalized user-message events feed the durable user-side activity marker used
   to order running roots. Known event times are applied monotonically. Backend
   input represented as a user message, including automatic compaction or other
@@ -207,11 +209,11 @@ defaults and queued client sends coherent.
 
 Vary prompt shape, prompt versus slash command, explicit versus default
 agent/model, aborting early versus late, sending while busy to steer at a tool
-boundary, sending a command or selection change that must wait, cancelling before
-dispatch, leaving and reopening while an entry is visible, turn length, and
-client count. For Hermes, include text and image prompts,
-tool updates, a permission decision, cold history replay, and abort after output
-has started.
+boundary where supported or stop-and-send over ACP, sending a command or
+selection change that must wait, cancelling before dispatch, leaving and
+reopening while an entry is visible, turn length, and client count. For Hermes,
+include text and image prompts, tool updates, a permission decision, cold history
+replay, and abort after output has started.
 
 ## Failure Signals
 
@@ -248,7 +250,8 @@ has started.
   without a bound, or leaves a corrected selection on a variant the picker does
   not display.
 - An abort, permission reply, or question reply stalls behind a send to a
-  busy session on the same session lane.
+  busy session on the same session lane, or a Cursor/Hermes follow-up waits for
+  the active turn to finish naturally instead of cancelling it before dispatch.
 - Recovery or interruption artifacts from an aborted turn appear in the next
   user turn.
 - A normalized user message fails to advance the existing activity marker, or


### PR DESCRIPTION
## Complexity

🌿 Straightforward — Cursor and Hermes opt into an existing, tested ACP turn policy; no new queue or lifecycle mechanism is introduced.

## What

- Make Cursor and Hermes treat a same-session input during an active ACP prompt as stop-and-send.
- Keep the new input bridge-queued, send standard `session/cancel`, and dispatch it only after the interrupted prompt settles.
- Preserve FIFO order for any further already-queued inputs and avoid an intermediate idle/error transition.
- Add harness-specific cancellation/replacement regressions and update the session-turn behavior document.

There is no client UI, database, persisted-data, or client/bridge wire-contract impact.

## Why

ACP v1 has no standard steering operation, but it does define prompt cancellation. Cursor and Hermes already implement that cancellation contract, and Sesori already uses it for explicit Stop. Reusing the shared ACP stop-and-send policy makes a busy follow-up take effect promptly instead of waiting for the active turn to finish naturally, without sending overlapping prompt requests.

## Risk and test focus

The main risk is turn-lifecycle ordering: the replacement must remain queued until cancellation settles, the interrupted turn must not emit an error or idle state, and the replacement must preserve its prompt content and correlation. The new Cursor and Hermes regressions pin those boundaries.

Source inspection also confirmed that the current Cursor ACP handler returns `stopReason: cancelled` after cancelling its pending prompt and that supported Hermes 0.20.x hard-interrupts the active run and returns the same stop reason.

## Expected result

Sending a prompt or command to an actively running Cursor or Hermes session stops the current ACP turn and starts the accepted input as soon as cancellation completes. Partial output from the interrupted turn remains visible, and the session stays continuously busy until the replacement finishes.

## Verification

- `cd bridge/sesori_plugin_cursor && dart test` — 137 passed
- `cd bridge/sesori_plugin_hermes && dart test` — 39 passed
- `cd bridge/sesori_plugin_acp && dart test test/acp_turn_serialization_test.dart` — 24 passed
- `dart analyze --fatal-infos` in `sesori_plugin_acp`, `sesori_plugin_cursor`, and `sesori_plugin_hermes` — passed
- Focused Cursor and Hermes plugin suites rerun after final assertions — 32 and 10 passed
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the active ACP turn and immediately queues-and-sends follow-ups for Cursor and Hermes. Previously, same-session follow-ups waited for the active turn to finish; now the bridge queues the new input, sends `session/cancel`, then dispatches it after cancellation, preserving FIFO and avoiding idle/error transitions.

- **Review notes**
  - `sesori_plugin_cursor` and `sesori_plugin_hermes`: enable stop-and-send via `cancelsActiveTurnForQueuedInput = true`; shared `AcpPlugin` queues the input, issues `session/cancel`, and dispatches after settlement.
  - Adds targeted regressions to ensure only one `session/prompt` pre-cancel, the queued replacement preserves content/correlation, and the session stays busy (no idle/error) until the replacement completes.
  - Updates `docs/regression/session-turns.md` and clarifies the `AcpPlugin` cancellation comment in `sesori_plugin_acp`.
  - No client UI, database, or wire-contract changes; no migration required.

<sup>Written for commit c0036d604cdbb55cb0ddbb3740ba425e8ae91884. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

