### PR TITLE
🌿 client(app): prefetch the older transcript page before the oldest edge

### DIFF
--- a/.plan/active/codebase-cleanup/steps/step-41.md
+++ b/.plan/active/codebase-cleanup/steps/step-41.md
@@ -24,3 +24,12 @@
 - `dart analyze --fatal-infos` from `client/app`: passed, no issues.
 - `git diff --check`: passed.
 - `flutter test test/features/session_detail`: passed, 245 tests. Expected fixture error logs and one existing non-fatal hit-test warning remained observable.
+
+## Post-merge follow-up
+
+The replaced package prefetched the older page at 20% from the visual top,
+while the landed trigger waited for a scroll to end exactly at the oldest
+edge — reported as history scrolling feeling less smooth. A follow-up PR
+restores prefetch: older pages now load from scroll updates within ~600px
+(about one viewport) of the oldest edge, keeping the scroll-end fallback for
+transcripts too short to scroll and all existing request gates.

--- a/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -105,6 +105,11 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
   static const _kRetryErrorRowId = "session-detail-retry-error-row";
   static const _kPromptRowPrefix = "session-detail-prompt-";
 
+  /// Distance from the oldest edge at which the next older page starts
+  /// loading — about one phone viewport, so scrolling back through history
+  /// has its page ready instead of stopping dead at the edge.
+  static const double _kOlderPagePrefetchExtent = 600;
+
   late final ScrollFollowTracker _follow;
 
   /// Shared 0..1 progress for the horizontal timestamp-reveal "peek".
@@ -588,9 +593,17 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
 
   bool _onScrollNotification(ScrollNotification notification) {
     final loadOlderMessages = widget.onLoadOlderMessages;
-    if (notification is ScrollEndNotification &&
+    // Prefetch on scroll updates nearing the oldest edge, so paging back
+    // through history feels continuous. The scroll-end check is the fallback
+    // for a transcript too short to scroll: clamping physics emits no update
+    // at zero extent, only the end notification.
+    final nearingOldestEdge = switch (notification) {
+      ScrollUpdateNotification(:final metrics) => metrics.extentAfter < _kOlderPagePrefetchExtent,
+      ScrollEndNotification(:final metrics) => metrics.extentAfter == 0,
+      _ => false,
+    };
+    if (nearingOldestEdge &&
         notification.metrics.axis == Axis.vertical &&
-        notification.metrics.extentAfter == 0 &&
         !_loadOlderCallbackInFlight &&
         !widget.isLoadingOlderMessages &&
         loadOlderMessages != null) {

--- a/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -516,6 +516,32 @@ void main() {
     expect(requested, greaterThan(0), reason: "reaching the oldest message must load the next page");
   });
 
+  testWidgets("nearing the oldest edge prefetches the older page before reaching it", (tester) async {
+    var requested = 0;
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        initialMessages: _userMessages(count: 12),
+        initialStreamingText: const {},
+        onLoadOlderMessages: () async => requested++,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Small increments so the scroll never lands exactly on the edge: the
+    // request must come from a mid-scroll update inside the prefetch band.
+    for (var attempt = 0; attempt < 60 && requested == 0; attempt++) {
+      await tester.drag(find.byType(SessionDetailMessageList), const Offset(0, 200));
+      await tester.pump();
+    }
+
+    expect(requested, 1);
+    expect(
+      _position(tester).extentAfter,
+      greaterThan(0),
+      reason: "the older page must be requested before the scroll reaches the oldest edge",
+    );
+  });
+
   testWidgets("older-page requests do not overlap and retry after completion", (tester) async {
     final completions = <Completer<void>>[];
     var requested = 0;

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -21,8 +21,9 @@ and rejoined after a client reconnect, plugin restart, or bridge restart.
   before or after its stream block-stop event. Clients request the latest page
   and page older messages on demand; a client predating pagination gets the full
   transcript.
-- Client history uses a reversed list. Reaching its oldest edge requests one
-  page at a time; prepended rows become visible without shifting the detached
+- Client history uses a reversed list. Nearing its oldest edge prefetches the
+  next page, one request at a time, so paging back through history rarely stops
+  dead at the edge; prepended rows become visible without shifting the detached
   reading position or admitting messages and streaming changes that arrived at
   the newest edge while detached.
 - After a reconnect inside the replay window, buffered events are delivered;


### PR DESCRIPTION
## Complexity

🌿 Straightforward: one scroll-notification predicate, plus focused coverage and documentation.

## What

- Request the next older transcript page from scroll updates within ~600px (about one viewport) of the oldest edge, instead of only when a scroll ends exactly at that edge.
- Keep the scroll-end-at-edge check as the fallback for transcripts too short to scroll.
- Leave every existing request gate unchanged: one request at a time, suppressed while the parent reports loading, released on completion or error.

## Why

Step 41 (#1076) replaced `flutter_chat_ui` with a plain reversed `ListView`. The package prefetched older history at 20% from the visual top, so scrolling back felt continuous. The landed replacement only triggered on `ScrollEndNotification` with `extentAfter == 0`, which made every page boundary a stop: hit the edge, wait for the page, scroll again. This was reported as history scrolling feeling less smooth than before the removal, and it is the one behavior the package genuinely provided.

Frame-level rendering was not the cause — the removed widget wrapped the same lazy sliver list with no `cacheExtent` override, and did strictly more per-frame work.

## Risk and test focus

Risk is concentrated in request frequency: the wider trigger must not fan out into repeated or overlapping page loads. The in-flight gate, `isLoadingOlderMessages` suppression, and completion/error release are unchanged and still covered. Prepending an older page grows `maxScrollExtent`, so a completed page moves the viewport out of the prefetch band rather than re-triggering. No database or wire-contract impact.

## Expected result

Paging back through a long transcript loads the next page before the scroll reaches the oldest edge, so history scrolling regains its pre-removal continuity. Short transcripts, detached-reader positioning, and prepend behavior are unchanged.

## Verification

- `flutter test test/features/session_detail/widgets/session_detail_message_list_test.dart` — 38 passed, including a new test asserting the request fires while `extentAfter > 0`.
- `flutter test test/features/session_detail` — 246 passed.
- `dart analyze --fatal-infos` from `client/app` — no issues.
- `dart format --set-exit-if-changed` on both changed Dart files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefetches the next older transcript page when a scroll update nears the oldest edge (~600px), restoring smooth back-scroll. Previously, loading only occurred when a scroll ended exactly at the edge; now it preloads earlier while keeping the scroll-end fallback for short transcripts.

**Review notes**
- Adds `_kOlderPagePrefetchExtent = 600` and triggers on `ScrollUpdateNotification` when `extentAfter` < 600; retains the `ScrollEndNotification` check at `extentAfter == 0`.
- Preserves existing gating: one request at a time, suppressed while `isLoadingOlderMessages`, released on completion/error; no API or data changes.
- Adds a widget test that asserts the request fires before the edge; updates docs to reflect prefetch and restores the behavior previously provided by `flutter_chat_ui`.

<sup>Written for commit 7ad8ff299e46513fbe531396fd95048ce709b55f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

