### PR TITLE
⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]

### DIFF
--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -357,6 +357,25 @@ refresh gap as consequences of one definition.
 | Regenerate injectable registration for the new service | Verified `client/module_core/lib/src/di/injection.config.dart` exists. Step 4 now runs the build runner and commits its output |
 | Add pane callback plumbing before testing the deep pull | Step 5 introduces the pane's optional `onDeepRefresh` parameter so its own test is implementable; step 6 wires it to the cubit |
 
+### Step 4 implementation review on `catalog-rescan-service`
+
+`architecture-implementation-review` rejected the first pass. Both findings were
+A2 state-ownership violations where the code diverged from the operation model
+the plan had already approved, not disagreements with the model itself. Layering,
+the three declared collaborators, the Layer-3 composition with
+`PluginManagementService`, and the regenerated DI were all cleared.
+
+| Finding | Correction applied |
+|---|---|
+| The all-`404` close acted on dispatch-scoped results and could tear down members it never dispatched | Both terminal branches now require `_members.isEmpty`. A `404` or `503` already removes its own harness, so an empty member set is exactly "nothing else is live"; a joining start that is rejected returns its result and leaves the run alone |
+| Both unsupported-snapshot paths published over a live operation, leaving a non-live state while members were still tracked — so `dismiss()` cleared them without announcing the close and the lists never refreshed | Those publishes are gated on an empty operation, and liveness now reads `_members`, not the published state. Reachable on a v1.6.x bridge, which has `/plugin/import` but not `/plugin/management` |
+
+The reviewer also noted two quality points outside its verdict. The row keeping
+the name of a harness that had just finished was a real wrong label and is
+fixed. The missing value equality on state variants is left alone: `Set<String>`
+has no value equality either, so honest `==` would mean a set comparator for a
+duplicate-emission nicety.
+
 ## Verification Log
 
 - **Step 1 documentation validation:** `git diff --check` passed; step tokens
@@ -414,4 +433,19 @@ refresh gap as consequences of one definition.
   totals-versus-delta contract and its absent-delta fallback in that document
   and in its L2 Routine entry. Step 7 builds on that rather than restating it
 - **Step 3 PR:** pending
+- **Step 4 base:** `main` at `669fd0cd0`
+- **Step 4 changed lines:** 1,271 of delivered code against merge-base
+  `669fd0cd045e5ea8a6740e4f944d0634b0d11939`, over the 700-1,050 target. The
+  overage is test weight: 620 of it is `catalog_rescan_service_test.dart`, which
+  the operation model needs because every rule it encodes — join, dispatch-time
+  membership, observed settlement, the success-only timer — is only observable
+  through a scenario. Production is 653 across six files, inside the estimate.
+  `.plan/` is excluded so the figure cannot count itself
+- **Step 4 verification:** `dart analyze --fatal-infos` clean on
+  `client/module_core`; full module suite 1,333 tests passed, including 28 new
+  `catalog_rescan_service_test.dart` cases
+- **Step 4 review:** `architecture-implementation-review` **rejected** the first
+  pass with two blocking A2 findings, both divergences from the approved
+  operation model, both applied with regression coverage
+- **Step 4 PR:** pending
 - **Final disposition:** pending

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -5,9 +5,9 @@
 - **Plan slug:** `catalog-rescan`
 - **Implementation base:** `main` at
   `7b1ebe9bc629d05b5d104e76cd5dbaa1514d65a2`
-- **Series state:** Steps 1/8 and 2/8 merged; Step 3/8 open
-- **Current step:** report new items from a catalog import
-- **Next action:** land Step 3, then Step 4's client rescan service
+- **Series state:** Steps 1/8 to 3/8 merged; Step 4/8 open
+- **Current step:** add the client catalog rescan service
+- **Next action:** land Step 4, then Step 5's two-stage pull control
 - **Origin issue:** [#961](https://github.com/sesori-ai/sesori_apps_monorepo/issues/961)
 - **External overlap:** [#1008](https://github.com/sesori-ai/sesori_apps_monorepo/issues/1008)
   owns Codex live updates; do not address it here
@@ -122,8 +122,8 @@
 |---|---|---|---:|---|
 | [x] | 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 950-1,100 (`PLAN.md`) | [PR #1064](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1064) merged |
 | [x] | 2/8 | `🌱 [catalog-rescan] Re-hydrate stale plugin catalogs [step 2/8]` | 20-60 | [PR #1071](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1071) merged |
-| [ ] | 3/8 | `⚙️ [catalog-rescan] Report new items from a catalog import [step 3/8]` | 350-600 | Open |
-| [ ] | 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 | Not started |
+| [x] | 3/8 | `⚙️ [catalog-rescan] Report new items from a catalog import [step 3/8]` | 350-600 | [PR #1074](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1074) merged |
+| [ ] | 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 | Open |
 | [ ] | 5/8 | `⚙️ [catalog-rescan] Add a second stage to pull-to-refresh [step 5/8]` | 350-600 | Not started |
 | [ ] | 6/8 | `⚙️ [catalog-rescan] Surface catalog rescan in the app [step 6/8]` | 950-1,400 | Not started |
 | [ ] | 7/8 | `🌱 [catalog-rescan] Reconcile catalog rescan regression docs [step 7/8]` | 80-160 | Not started |
@@ -168,30 +168,30 @@
 
 ## Step 4 Checklist
 
-- [ ] Add the three API methods; give cancel a `pluginId`.
-- [ ] Classify `404` and `503` as "cannot import", not as failures.
-- [ ] Declare exactly three collaborators: `PluginRepository`,
+- [x] Add the three API methods; give cancel a `pluginId`.
+- [x] Classify `404` and `503` as "cannot import", not as failures.
+- [x] Declare exactly three collaborators: `PluginRepository`,
   `PluginManagementService`, `ConnectionService`.
-- [ ] Put `CatalogRescanState` in `services/models/catalog_rescan_state.dart`.
-- [ ] Pattern-match `SesoriCatalogImportProgress` in the service; leave
+- [x] Put `CatalogRescanState` in `services/models/catalog_rescan_state.dart`.
+- [x] Pattern-match `SesoriCatalogImportProgress` in the service; leave
   `sse_event.dart` and `sse_event_tracker.dart` untouched.
-- [ ] Filter the recovery read to non-terminal statuses only.
-- [ ] Reset to idle on disconnect and on active-bridge change; add no
+- [x] Filter the recovery read to non-terminal statuses only.
+- [x] Reset to idle on disconnect and on active-bridge change; add no
   generation or fence state.
-- [ ] Implement the `owned`/`observed` operation model: a second start joins the
+- [x] Implement the `owned`/`observed` operation model: a second start joins the
   live operation, unsolicited progress opens an observed one, cancel fans out
   over live members whether `Starting` or `Running`, and the map is cleared only
   when leaving idle or terminal.
-- [ ] Arm the 4s clear for `CatalogRescanSucceeded` only, and cancel it on every
+- [x] Arm the 4s clear for `CatalogRescanSucceeded` only, and cancel it on every
   start and reset.
-- [ ] Publish `CatalogRescanUnsupported` from an unsupported management snapshot
+- [x] Publish `CatalogRescanUnsupported` from an unsupported management snapshot
   without issuing any request.
-- [ ] Retain the `ApiError` in `CatalogRescanStartFailed` and log it locally.
-- [ ] Run the `module_core` build runner and commit `injection.config.dart`.
-- [ ] Record membership on dispatch; keep a harness on timeout or lost response.
-- [ ] Select harnesses by `runtimeState.isRoutable`.
-- [ ] Never lift `CatalogImportFailed.message` into client state.
-- [ ] Prove aggregation across two harnesses, all seven states including a mixed
+- [x] Retain the `ApiError` in `CatalogRescanStartFailed` and log it locally.
+- [x] Run the `module_core` build runner and commit `injection.config.dart`.
+- [x] Record membership on dispatch; keep a harness on timeout or lost response.
+- [x] Select harnesses by `runtimeState.isRoutable`.
+- [x] Never lift `CatalogImportFailed.message` into client state.
+- [x] Prove aggregation across two harnesses, all seven states including a mixed
   outcome, the older-bridge payload, both reconnect cases, a disconnect, a
   `503` in the fan-out, cancel fanning out one `DELETE` per running id, a
   second sequential rescan not inheriting the previous aggregate, a failure

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -370,7 +370,22 @@ the three declared collaborators, the Layer-3 composition with
 | The all-`404` close acted on dispatch-scoped results and could tear down members it never dispatched | Both terminal branches now require `_members.isEmpty`. A `404` or `503` already removes its own harness, so an empty member set is exactly "nothing else is live"; a joining start that is rejected returns its result and leaves the run alone |
 | Both unsupported-snapshot paths published over a live operation, leaving a non-live state while members were still tracked — so `dismiss()` cleared them without announcing the close and the lists never refreshed | Those publishes are gated on an empty operation, and liveness now reads `_members`, not the published state. Reachable on a v1.6.x bridge, which has `/plugin/import` but not `/plugin/management` |
 
-The reviewer also noted two quality points outside its verdict. The row keeping
+A second pass also rejected, with two further A2 findings — both in `_start`'s
+post-`await` continuation, both applied with regression coverage:
+
+| Finding | Correction applied |
+|---|---|
+| `_members.isEmpty` alone is also true when the operation closed *during* the await, so a start whose response resolved late could erase a failure row that must persist and fire a duplicate refresh. Reachable by a relay timeout, or by tapping cancel before the POST returns | The guard is now `_members.isEmpty && _state.value.isLive`; `_openOrJoin` always publishes a live state before dispatch and an unsupported answer is never published over a live operation, so this is true exactly when the dispatch's own operation is still open |
+| The bridge-wide `CatalogRescanUnsupported` claim was inferred from a dispatch that need not cover every harness, so one targeted `404` — which the bridge also returns for a *deselected* plugin — told every surface the bridge cannot rescan at all | `_start` takes `coversEveryHarness`, true only from `startAll()`. A targeted rejection is reported solely through its returned result, per `PLAN.md` |
+
+Both of its non-blocking observations were applied too: an active-bridge change
+now announces its close like a disconnect does, and the `NonSuccessCodeError`
+sniff moved out of the service into a `CatalogImportMutationUncertain` variant,
+matching the two sibling mappers that already own transport classification in
+the repository. The exhaustive-switch error that fix produced is what proved the
+service had been reasoning about transport shapes at all.
+
+The first reviewer also noted two quality points outside its verdict. The row keeping
 the name of a harness that had just finished was a real wrong label and is
 fixed. The missing value equality on state variants is left alone: `Set<String>`
 has no value equality either, so honest `==` would mean a set comparator for a

--- a/client/module_core/lib/src/api/plugin_api.dart
+++ b/client/module_core/lib/src/api/plugin_api.dart
@@ -49,4 +49,26 @@ class PluginApi({required final RelayHttpApiClient _client}) {
       fromJson: SuccessEmptyResponse.fromJson,
     );
   }
+
+  Future<ApiResponse<SuccessEmptyResponse>> startCatalogImport({required String pluginId}) {
+    return _client.post(
+      "/plugin/import",
+      body: CatalogImportRequest(pluginId: pluginId).toJson(),
+      fromJson: SuccessEmptyResponse.fromJson,
+    );
+  }
+
+  /// Cancels the import for one plugin. The route cancels exactly one plugin
+  /// per call, so a caller cancelling several issues one request each.
+  Future<ApiResponse<SuccessEmptyResponse>> cancelCatalogImport({required String pluginId}) {
+    return _client.delete(
+      "/plugin/import",
+      body: CatalogImportRequest(pluginId: pluginId).toJson(),
+      fromJson: SuccessEmptyResponse.fromJson,
+    );
+  }
+
+  Future<ApiResponse<CatalogImportStatusesResponse>> getCatalogImportStatuses() {
+    return _client.get("/plugin/import", fromJson: CatalogImportStatusesResponse.fromJson);
+  }
 }

--- a/client/module_core/lib/src/di/injection.config.dart
+++ b/client/module_core/lib/src/di/injection.config.dart
@@ -97,6 +97,8 @@ import 'package:sesori_dart_core/src/routing/analytics_route_listener.dart'
     as _i888;
 import 'package:sesori_dart_core/src/routing/notification_open_dispatcher.dart'
     as _i516;
+import 'package:sesori_dart_core/src/services/catalog_rescan_service.dart'
+    as _i572;
 import 'package:sesori_dart_core/src/services/foreground_notification_dispatcher.dart'
     as _i101;
 import 'package:sesori_dart_core/src/services/installation_analytics_service.dart'
@@ -462,6 +464,13 @@ extension GetItInjectableX on _i174.GetIt {
         authSession: gh<_i442.AuthSession>(),
       ),
       dispose: (i) => i.dispose(),
+    );
+    gh.lazySingleton<_i572.CatalogRescanService>(
+      () => _i572.CatalogRescanService(
+        pluginRepository: gh<_i337.PluginRepository>(),
+        managementService: gh<_i110.PluginManagementService>(),
+        connectionService: gh<_i369.ConnectionService>(),
+      ),
     );
     return this;
   }

--- a/client/module_core/lib/src/repositories/models/catalog_import_result.dart
+++ b/client/module_core/lib/src/repositories/models/catalog_import_result.dart
@@ -35,8 +35,8 @@ final class const CatalogImportMutationUnavailable() extends CatalogImportMutati
 final class const CatalogImportMutationUncertain({required final ApiError error})
     extends CatalogImportMutationResult;
 
-/// The bridge answered and refused, or the answer was unusable for a reason
-/// that is not a lost response. [error] is retained so the caller can log it.
+/// Any error not classified as a `404`, a `503`, or an uncertain outcome.
+/// [error] is retained so the caller can log it.
 final class const CatalogImportMutationFailure({required final ApiError error})
     extends CatalogImportMutationResult;
 

--- a/client/module_core/lib/src/repositories/models/catalog_import_result.dart
+++ b/client/module_core/lib/src/repositories/models/catalog_import_result.dart
@@ -15,6 +15,8 @@ sealed class const CatalogImportMutationResult() {
 
   const factory unavailable() = CatalogImportMutationUnavailable;
 
+  const factory uncertain({required ApiError error}) = CatalogImportMutationUncertain;
+
   const factory failure({required ApiError error}) = CatalogImportMutationFailure;
 }
 
@@ -27,9 +29,14 @@ final class const CatalogImportMutationNotFound() extends CatalogImportMutationR
 /// The bridge answered `503`: it knows the plugin but cannot import from it.
 final class const CatalogImportMutationUnavailable() extends CatalogImportMutationResult;
 
-/// Anything else, including a request that may never have reached the bridge.
-/// [error] is retained so the caller can log it; a transport or decoding
-/// failure cannot be explained by the bridge's own log.
+/// The request may or may not have reached the bridge: a timed-out or lost
+/// relay response fires after delivery as readily as before it. A caller must
+/// not write the harness off.
+final class const CatalogImportMutationUncertain({required final ApiError error})
+    extends CatalogImportMutationResult;
+
+/// The bridge answered and refused, or the answer was unusable for a reason
+/// that is not a lost response. [error] is retained so the caller can log it.
 final class const CatalogImportMutationFailure({required final ApiError error})
     extends CatalogImportMutationResult;
 

--- a/client/module_core/lib/src/repositories/models/catalog_import_result.dart
+++ b/client/module_core/lib/src/repositories/models/catalog_import_result.dart
@@ -1,0 +1,54 @@
+import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+/// Outcome of asking the bridge to start or cancel one plugin's catalog import.
+///
+/// `404` and `503` are separated rather than folded into one "cannot import"
+/// case, because they mean different things to a caller fanning out: `503` is a
+/// harness the bridge knows but cannot start right now, while `404` from every
+/// harness at once is how a bridge with no `/plugin/import` route at all
+/// presents itself.
+sealed class const CatalogImportMutationResult() {
+  const factory accepted() = CatalogImportMutationAccepted;
+
+  const factory notFound() = CatalogImportMutationNotFound;
+
+  const factory unavailable() = CatalogImportMutationUnavailable;
+
+  const factory failure({required ApiError error}) = CatalogImportMutationFailure;
+}
+
+final class const CatalogImportMutationAccepted() extends CatalogImportMutationResult;
+
+/// The bridge answered `404`: it does not know this plugin, or it has no
+/// catalog import route.
+final class const CatalogImportMutationNotFound() extends CatalogImportMutationResult;
+
+/// The bridge answered `503`: it knows the plugin but cannot import from it.
+final class const CatalogImportMutationUnavailable() extends CatalogImportMutationResult;
+
+/// Anything else, including a request that may never have reached the bridge.
+/// [error] is retained so the caller can log it; a transport or decoding
+/// failure cannot be explained by the bridge's own log.
+final class const CatalogImportMutationFailure({required final ApiError error})
+    extends CatalogImportMutationResult;
+
+/// Outcome of reading the bridge's latest per-plugin import statuses.
+sealed class const CatalogImportStatusesResult() {
+  const factory supported({required List<CatalogImportProgress> statuses}) =
+      CatalogImportStatusesSupported;
+
+  const factory unsupported() = CatalogImportStatusesUnsupported;
+
+  const factory failure({required ApiError error}) = CatalogImportStatusesFailure;
+}
+
+final class const CatalogImportStatusesSupported({
+  required final List<CatalogImportProgress> statuses,
+}) extends CatalogImportStatusesResult;
+
+/// The bridge has no catalog import route.
+final class const CatalogImportStatusesUnsupported() extends CatalogImportStatusesResult;
+
+final class const CatalogImportStatusesFailure({required final ApiError error})
+    extends CatalogImportStatusesResult;

--- a/client/module_core/lib/src/repositories/plugin_repository.dart
+++ b/client/module_core/lib/src/repositories/plugin_repository.dart
@@ -6,6 +6,7 @@ import "package:sesori_shared/sesori_shared.dart";
 
 import "../api/plugin_api.dart";
 import "../capabilities/relay/relay_client.dart";
+import "models/catalog_import_result.dart";
 import "models/plugin_discovery_snapshot.dart";
 import "models/plugin_management_result.dart";
 
@@ -38,6 +39,31 @@ class PluginRepository({required final PluginApi _api}) {
       ErrorResponse(:final error) => PluginAuthenticationStartResult.failed(
         failure: _mapAuthenticationFailure(error: error),
       ),
+    };
+  }
+
+  Future<CatalogImportMutationResult> startCatalogImport({required String pluginId}) async {
+    return _mapCatalogImportMutation(await _api.startCatalogImport(pluginId: pluginId));
+  }
+
+  Future<CatalogImportMutationResult> cancelCatalogImport({required String pluginId}) async {
+    return _mapCatalogImportMutation(await _api.cancelCatalogImport(pluginId: pluginId));
+  }
+
+  Future<CatalogImportStatusesResult> getCatalogImportStatuses() async {
+    return switch (await _api.getCatalogImportStatuses()) {
+      SuccessResponse(:final data) => CatalogImportStatusesResult.supported(statuses: data.statuses),
+      ErrorResponse(error: NonSuccessCodeError(errorCode: 404)) => const CatalogImportStatusesResult.unsupported(),
+      ErrorResponse(:final error) => CatalogImportStatusesResult.failure(error: error),
+    };
+  }
+
+  CatalogImportMutationResult _mapCatalogImportMutation(ApiResponse<SuccessEmptyResponse> response) {
+    return switch (response) {
+      SuccessResponse() => const CatalogImportMutationResult.accepted(),
+      ErrorResponse(error: NonSuccessCodeError(errorCode: 404)) => const CatalogImportMutationResult.notFound(),
+      ErrorResponse(error: NonSuccessCodeError(errorCode: 503)) => const CatalogImportMutationResult.unavailable(),
+      ErrorResponse(:final error) => CatalogImportMutationResult.failure(error: error),
     };
   }
 

--- a/client/module_core/lib/src/repositories/plugin_repository.dart
+++ b/client/module_core/lib/src/repositories/plugin_repository.dart
@@ -63,6 +63,14 @@ class PluginRepository({required final PluginApi _api}) {
       SuccessResponse() => const CatalogImportMutationResult.accepted(),
       ErrorResponse(error: NonSuccessCodeError(errorCode: 404)) => const CatalogImportMutationResult.notFound(),
       ErrorResponse(error: NonSuccessCodeError(errorCode: 503)) => const CatalogImportMutationResult.unavailable(),
+      // A dispatched request whose outcome cannot be proven may well have
+      // landed, so it is never reported as an ordinary failure.
+      ErrorResponse(
+        error: final error && (JsonParsingError() ||
+            EmptyResponseError() ||
+            DartHttpClientError(innerError: TimeoutException() || RelayResponseLostException())),
+      ) =>
+        CatalogImportMutationResult.uncertain(error: error),
       ErrorResponse(:final error) => CatalogImportMutationResult.failure(error: error),
     };
   }

--- a/client/module_core/lib/src/services/catalog_rescan_service.dart
+++ b/client/module_core/lib/src/services/catalog_rescan_service.dart
@@ -81,10 +81,13 @@ class CatalogRescanService({
   Future<void> startAll() async {
     if (_disposed) return;
     switch (_managementService.snapshots.valueOrNull) {
-      // No management route means a bridge older than the import route too, so
-      // there is nothing to fan out to and no `404` would ever be requested.
+      // Without a management snapshot there are no harness ids to fan out to,
+      // so no request is made and no `404` would ever come back to reveal the
+      // missing route. `/plugin/management` is *younger* than `/plugin/import`
+      // (v1.7.0 against v1.6.0), so such a bridge may well be importing right
+      // now — which is why a live operation is left alone.
       case PluginManagementLoadResultUnsupported():
-        _publish(const CatalogRescanState.unsupported());
+        if (_members.isEmpty) _publish(const CatalogRescanState.unsupported());
       case PluginManagementLoadResultSupported(:final response):
         final pluginIds = [
           for (final plugin in response.plugins)
@@ -104,7 +107,9 @@ class CatalogRescanService({
   Future<CatalogRescanStartResult> start({required String pluginId}) async {
     if (_disposed) return const CatalogRescanStartResult.notImportable();
     if (_managementService.snapshots.valueOrNull is PluginManagementLoadResultUnsupported) {
-      _publish(const CatalogRescanState.unsupported());
+      // Tell the caller either way, but never overwrite a run in flight with a
+      // state that reads as terminal.
+      if (_members.isEmpty) _publish(const CatalogRescanState.unsupported());
       return const CatalogRescanStartResult.unsupported();
     }
     final results = await _start(pluginIds: [pluginId]);
@@ -124,7 +129,9 @@ class CatalogRescanService({
 
   /// Clears a terminal row the user has read.
   void dismiss() {
-    if (_disposed || _state.value.isLive) return;
+    // Membership, not the published state, decides whether a run is open: an
+    // unsupported answer can be published over a live operation.
+    if (_disposed || _members.isNotEmpty) return;
     _reset();
   }
 
@@ -148,17 +155,19 @@ class CatalogRescanService({
         }),
     ]);
     if (_disposed) return results;
-    // Every harness answering 404 at once is how a bridge with no import route
-    // presents itself. One harness answering 404 only means that harness is
-    // unknown, so this deliberately requires all of them.
-    if (results.isNotEmpty && results.values.every((r) => r is CatalogRescanStartUnsupported)) {
-      _closeOperation(const CatalogRescanState.unsupported());
-      return results;
-    }
-    // Every harness was skipped as not importable, so nothing is running and
-    // there is nothing to report.
+    // Both branches below require an empty operation. A `404` or `503` already
+    // removed its harness in _applyStartOutcome, so a non-empty _members means
+    // something is still running — including a harness this dispatch never
+    // sent, which a joining start must not tear down.
     if (_members.isEmpty) {
-      _closeOperation(const CatalogRescanState.idle());
+      // Every harness answering 404 at once is how a bridge with no import
+      // route presents itself. One harness answering 404 only means that
+      // harness is unknown, so this deliberately requires all of them.
+      final unsupported =
+          results.isNotEmpty && results.values.every((r) => r is CatalogRescanStartUnsupported);
+      _closeOperation(
+        unsupported ? const CatalogRescanState.unsupported() : const CatalogRescanState.idle(),
+      );
       return results;
     }
     _publishLive();
@@ -233,6 +242,9 @@ class CatalogRescanService({
     _progressByPluginId[pluginId] = progress;
     if (_isTerminal(progress)) {
       _settleIfComplete();
+      // Still running: re-point the row at a harness that is actually working,
+      // rather than leaving it naming the one that just finished.
+      if (_members.isNotEmpty) _publishLive();
       return;
     }
     _publishLive();
@@ -359,7 +371,7 @@ class CatalogRescanService({
     final nextConnected = status is ConnectionConnected;
     if (nextConnected == _connected) return;
     _connected = nextConnected;
-    final wasLive = _state.value.isLive;
+    final wasLive = _members.isNotEmpty;
     _reset();
     // A run interrupted by a drop still committed whatever it had published, so
     // announce the close even though no summary is claimed for it.

--- a/client/module_core/lib/src/services/catalog_rescan_service.dart
+++ b/client/module_core/lib/src/services/catalog_rescan_service.dart
@@ -80,6 +80,12 @@ class CatalogRescanService({
   /// start waits for the cancel to finish owning its plugin ids first.
   Future<void>? _cancelling;
 
+  /// The harness ids a cancellation currently owns. Progress for these is not
+  /// adopted: a delayed event from the run being cancelled would otherwise
+  /// reopen it as an observed operation, and the next rescan would join that
+  /// stale member and lose its own summary.
+  final Set<String> _cancellingPluginIds = {};
+
   Timer? _clearTimer;
   bool _connected = _connectionService.currentStatus is ConnectionConnected;
   String? _activeBridgeId;
@@ -135,7 +141,9 @@ class CatalogRescanService({
   /// begun. The route cancels one plugin per call, so this fans out.
   Future<void> cancel() {
     if (_disposed || _members.isEmpty) return Future<void>.value();
-    return _cancelling = _cancel(pluginIds: Set<String>.of(_members));
+    final pluginIds = Set<String>.of(_members);
+    _cancellingPluginIds.addAll(pluginIds);
+    return _cancelling = _cancel(pluginIds: pluginIds);
   }
 
   Future<void> _cancel({required Set<String> pluginIds}) async {
@@ -158,6 +166,7 @@ class CatalogRescanService({
           }),
       ]);
     } finally {
+      _cancellingPluginIds.removeAll(pluginIds);
       _cancelling = null;
     }
   }
@@ -299,7 +308,7 @@ class CatalogRescanService({
       // A rescan someone else started, seen live. Adopt it so its imported
       // sessions still reach the lists, but as an observed operation, which
       // claims no summary.
-      if (_isTerminal(progress)) return;
+      if (_isTerminal(progress) || _cancellingPluginIds.contains(pluginId)) return;
       _openOrJoin(pluginIds: [pluginId], observed: true);
     }
     // Someone else cancelled a member of this run. That is intervention, not

--- a/client/module_core/lib/src/services/catalog_rescan_service.dart
+++ b/client/module_core/lib/src/services/catalog_rescan_service.dart
@@ -42,6 +42,10 @@ class CatalogRescanService({
       ..add(_connectionService.status.listen(_onConnectionStatus))
       ..add(_connectionService.events.listen(_onSseEvent))
       ..add(_managementService.snapshots.listen(_onManagementSnapshot));
+    // Resolved lazily, so the connection is often already up by the time this
+    // exists and no false-to-true transition will ever arrive to trigger the
+    // recovery read.
+    if (_connected) unawaited(_recoverInFlight());
   }
 
   final BehaviorSubject<CatalogRescanState> _state = BehaviorSubject.seeded(
@@ -63,6 +67,10 @@ class CatalogRescanService({
 
   /// True when the live operation was discovered rather than started here.
   bool _observed = false;
+
+  /// Start requests still awaiting a response, so a cancel can order itself
+  /// after them rather than racing its own POST.
+  final Set<Future<void>> _pendingStarts = {};
 
   Timer? _clearTimer;
   bool _connected = _connectionService.currentStatus is ConnectionConnected;
@@ -120,10 +128,22 @@ class CatalogRescanService({
   Future<void> cancel() async {
     if (_disposed || _members.isEmpty) return;
     final pluginIds = Set<String>.of(_members);
+    // Close first so the row goes at once, then wait for any start still in
+    // flight: a DELETE that overtakes its POST finds no import to cancel, and
+    // the import the user just cancelled would run anyway.
     _closeOperation(const CatalogRescanState.idle());
-    await Future.wait([
+    await Future.wait(_pendingStarts);
+    final outcomes = await Future.wait([
       for (final pluginId in pluginIds) _pluginRepository.cancelCatalogImport(pluginId: pluginId),
     ]);
+    for (final outcome in outcomes) {
+      // A refused or unprovable cancel means the import may still be running,
+      // and nothing else records that.
+      if (outcome case CatalogImportMutationFailure(:final error) ||
+          CatalogImportMutationUncertain(:final error)) {
+        logw("Catalog rescan cancellation was not confirmed for a harness", error);
+      }
+    }
   }
 
   /// Clears a terminal row the user has read.
@@ -150,12 +170,18 @@ class CatalogRescanService({
   }) async {
     _openOrJoin(pluginIds: pluginIds, observed: false);
     final results = <String, CatalogRescanStartResult>{};
-    await Future.wait([
+    final dispatched = [
       for (final pluginId in pluginIds)
         _pluginRepository.startCatalogImport(pluginId: pluginId).then((outcome) {
           results[pluginId] = _applyStartOutcome(pluginId: pluginId, outcome: outcome);
         }),
-    ]);
+    ];
+    _pendingStarts.addAll(dispatched);
+    try {
+      await Future.wait(dispatched);
+    } finally {
+      _pendingStarts.removeAll(dispatched);
+    }
     if (_disposed) return results;
     // Two conditions, not one. `_members.isEmpty` alone is also true when the
     // operation closed while this dispatch was awaiting — settled from SSE,
@@ -225,6 +251,11 @@ class CatalogRescanService({
       _clearTimer = null;
       _progressByPluginId.clear();
       _observed = observed;
+    } else if (observed) {
+      // A harness someone else started joined a run this client owned. The
+      // operation can no longer claim it saw every member, so it stops being
+      // able to summarise itself.
+      _observed = true;
     }
     _members.addAll(pluginIds);
     _publishLive();
@@ -425,7 +456,11 @@ class CatalogRescanService({
         }
         _publishLive();
       case CatalogImportStatusesUnsupported():
-      case CatalogImportStatusesFailure():
+        return;
+      case CatalogImportStatusesFailure(:final error):
+        // Nothing else logs this, and there is no retry until the next
+        // reconnect, so an import already running stays invisible.
+        logw("Catalog rescan could not read in-flight imports after connecting", error);
         return;
     }
   }

--- a/client/module_core/lib/src/services/catalog_rescan_service.dart
+++ b/client/module_core/lib/src/services/catalog_rescan_service.dart
@@ -3,7 +3,6 @@ import "dart:async";
 import "package:get_it/get_it.dart";
 import "package:injectable/injectable.dart";
 import "package:rxdart/rxdart.dart";
-import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../capabilities/server_connection/connection_service.dart";
@@ -94,7 +93,7 @@ class CatalogRescanService({
             if (plugin.runtimeState.isRoutable) plugin.setup.id,
         ];
         if (pluginIds.isEmpty) return;
-        await _start(pluginIds: pluginIds);
+        await _start(pluginIds: pluginIds, coversEveryHarness: true);
       case PluginManagementLoadResultLoading() || PluginManagementLoadResultFailure() || null:
         return;
     }
@@ -112,7 +111,7 @@ class CatalogRescanService({
       if (_members.isEmpty) _publish(const CatalogRescanState.unsupported());
       return const CatalogRescanStartResult.unsupported();
     }
-    final results = await _start(pluginIds: [pluginId]);
+    final results = await _start(pluginIds: [pluginId], coversEveryHarness: false);
     return results[pluginId] ?? const CatalogRescanStartResult.notImportable();
   }
 
@@ -145,7 +144,10 @@ class CatalogRescanService({
     await _settled.close();
   }
 
-  Future<Map<String, CatalogRescanStartResult>> _start({required List<String> pluginIds}) async {
+  Future<Map<String, CatalogRescanStartResult>> _start({
+    required List<String> pluginIds,
+    required bool coversEveryHarness,
+  }) async {
     _openOrJoin(pluginIds: pluginIds, observed: false);
     final results = <String, CatalogRescanStartResult>{};
     await Future.wait([
@@ -155,16 +157,22 @@ class CatalogRescanService({
         }),
     ]);
     if (_disposed) return results;
-    // Both branches below require an empty operation. A `404` or `503` already
-    // removed its harness in _applyStartOutcome, so a non-empty _members means
-    // something is still running — including a harness this dispatch never
-    // sent, which a joining start must not tear down.
-    if (_members.isEmpty) {
-      // Every harness answering 404 at once is how a bridge with no import
-      // route presents itself. One harness answering 404 only means that
-      // harness is unknown, so this deliberately requires all of them.
-      final unsupported =
-          results.isNotEmpty && results.values.every((r) => r is CatalogRescanStartUnsupported);
+    // Two conditions, not one. `_members.isEmpty` alone is also true when the
+    // operation closed while this dispatch was awaiting — settled from SSE,
+    // cancelled, or reset by a disconnect — and closing it again would erase a
+    // failure row that must persist and fire a second refresh. `isLive` is the
+    // cheap way to tell those apart, because _openOrJoin always publishes a
+    // live state before dispatch and an unsupported answer is never published
+    // over a live operation.
+    if (_members.isEmpty && _state.value.isLive) {
+      // "No import route" is a claim about the whole bridge, so only a fan-out
+      // that covered every harness may make it. A targeted start reports its
+      // own rejection through the returned result instead; the bridge answers
+      // 404 for an unknown *and* for a deselected plugin, so one 404 says
+      // nothing about the route.
+      final unsupported = coversEveryHarness &&
+          results.isNotEmpty &&
+          results.values.every((r) => r is CatalogRescanStartUnsupported);
       _closeOperation(
         unsupported ? const CatalogRescanState.unsupported() : const CatalogRescanState.idle(),
       );
@@ -193,21 +201,20 @@ class CatalogRescanService({
       case CatalogImportMutationUnavailable():
         _members.remove(pluginId);
         return const CatalogRescanStartResult.notImportable();
+      case CatalogImportMutationUncertain(:final error):
+        // The request may well have landed, so the harness stays a member and
+        // settles from its own progress event rather than being written off.
+        logw("Catalog rescan start could not be confirmed for a harness", error);
+        return CatalogRescanStartResult.failed(cause: error);
       case CatalogImportMutationFailure(:final error):
-        // Retained locally because a transport or decoding failure may never
-        // have reached the bridge, so the bridge log cannot explain it.
+        // The bridge answered and refused, so this harness is settled and
+        // counts against the run. Retained locally because the failure may
+        // never have reached the bridge's own log.
         logw("Catalog rescan could not be started for a harness", error);
-        if (error is NonSuccessCodeError) {
-          // The bridge answered and refused, so this harness is settled and
-          // counts against the run.
-          _progressByPluginId[pluginId] = CatalogImportProgress.failed(
-            pluginId: pluginId,
-            message: "start rejected",
-          );
-        }
-        // Otherwise the request may well have landed — a relay timeout or lost
-        // response fires after delivery just as readily as before it — so the
-        // harness stays a member and settles from its own progress event.
+        _progressByPluginId[pluginId] = CatalogImportProgress.failed(
+          pluginId: pluginId,
+          message: "start rejected",
+        );
         return CatalogRescanStartResult.failed(cause: error);
     }
   }
@@ -386,7 +393,13 @@ class CatalogRescanService({
       for (final plugin in snapshot.response.plugins) plugin.setup.id: plugin.setup.displayName,
     };
     final bridgeId = snapshot.response.bridgeId;
-    if (_activeBridgeId != null && _activeBridgeId != bridgeId) _reset();
+    if (_activeBridgeId != null && _activeBridgeId != bridgeId) {
+      // Same rule as a disconnect: every close of a live operation announces
+      // itself, so the two triggers the plan lists together behave alike.
+      final wasLive = _members.isNotEmpty;
+      _reset();
+      if (wasLive && !_settled.isClosed) _settled.add(null);
+    }
     _activeBridgeId = bridgeId;
   }
 

--- a/client/module_core/lib/src/services/catalog_rescan_service.dart
+++ b/client/module_core/lib/src/services/catalog_rescan_service.dart
@@ -1,0 +1,417 @@
+import "dart:async";
+
+import "package:get_it/get_it.dart";
+import "package:injectable/injectable.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../capabilities/server_connection/connection_service.dart";
+import "../capabilities/server_connection/models/connection_status.dart";
+import "../capabilities/server_connection/models/sse_event.dart";
+import "../logging/logging.dart";
+import "../repositories/models/catalog_import_result.dart";
+import "../repositories/models/plugin_management_result.dart";
+import "../repositories/plugin_repository.dart";
+import "models/catalog_rescan_state.dart";
+import "plugin_management_service.dart";
+
+/// How long a successful rescan row stays before clearing itself.
+const _successVisibleFor = Duration(seconds: 4);
+
+/// Drives catalog rescans and publishes them as one aggregate row.
+///
+/// The service owns a single *operation*: the set of harness ids it is
+/// currently tracking, plus whether this client saw the whole thing. An
+/// operation is `owned` when this client dispatched every member's start, and
+/// `observed` when it learned of the run from the recovery read or from an
+/// unsolicited progress event. Only an owned operation reports a terminal
+/// summary; an observed one settles quietly, because the client cannot know
+/// what happened to members it never saw.
+///
+/// Naming the operation is what keeps membership, settlement, cancellation and
+/// the post-run refresh consistent with one another instead of being four
+/// independent rules.
+@lazySingleton
+class CatalogRescanService({
+  required final PluginRepository _pluginRepository,
+  required final PluginManagementService _managementService,
+  required final ConnectionService _connectionService,
+}) with Disposable {
+  this {
+    _subscriptions
+      ..add(_connectionService.status.listen(_onConnectionStatus))
+      ..add(_connectionService.events.listen(_onSseEvent))
+      ..add(_managementService.snapshots.listen(_onManagementSnapshot));
+  }
+
+  final BehaviorSubject<CatalogRescanState> _state = BehaviorSubject.seeded(
+    const CatalogRescanState.idle(),
+  );
+  final StreamController<void> _settled = StreamController<void>.broadcast(sync: true);
+  final CompositeSubscription _subscriptions = CompositeSubscription();
+
+  /// Latest progress per harness in the live operation. Cleared whenever an
+  /// operation opens or the state resets, never on a join.
+  final Map<String, CatalogImportProgress> _progressByPluginId = {};
+
+  /// The live operation's members, or empty when none is live.
+  final Set<String> _members = {};
+
+  /// Display names for the current bridge's harnesses, so a running row can
+  /// name the harness rather than echo its id.
+  Map<String, String> _displayNames = const {};
+
+  /// True when the live operation was discovered rather than started here.
+  bool _observed = false;
+
+  Timer? _clearTimer;
+  bool _connected = _connectionService.currentStatus is ConnectionConnected;
+  String? _activeBridgeId;
+  bool _disposed = false;
+
+  ValueStream<CatalogRescanState> get state => _state.stream;
+
+  /// Fires whenever a live operation closes, however it ended. Consumers
+  /// refresh their lists from this rather than from the terminal variants,
+  /// because an observed run publishes no terminal variant at all.
+  Stream<void> get settled => _settled.stream;
+
+  /// Rescans every harness this bridge can import from.
+  Future<void> startAll() async {
+    if (_disposed) return;
+    switch (_managementService.snapshots.valueOrNull) {
+      // No management route means a bridge older than the import route too, so
+      // there is nothing to fan out to and no `404` would ever be requested.
+      case PluginManagementLoadResultUnsupported():
+        _publish(const CatalogRescanState.unsupported());
+      case PluginManagementLoadResultSupported(:final response):
+        final pluginIds = [
+          for (final plugin in response.plugins)
+            if (plugin.runtimeState.isRoutable) plugin.setup.id,
+        ];
+        if (pluginIds.isEmpty) return;
+        await _start(pluginIds: pluginIds);
+      case PluginManagementLoadResultLoading() || PluginManagementLoadResultFailure() || null:
+        return;
+    }
+  }
+
+  /// Rescans one named harness, joining the live operation when there is one.
+  ///
+  /// Unlike [startAll], the outcome is returned so the surface that named the
+  /// harness can report a rejection instead of silently skipping it.
+  Future<CatalogRescanStartResult> start({required String pluginId}) async {
+    if (_disposed) return const CatalogRescanStartResult.notImportable();
+    if (_managementService.snapshots.valueOrNull is PluginManagementLoadResultUnsupported) {
+      _publish(const CatalogRescanState.unsupported());
+      return const CatalogRescanStartResult.unsupported();
+    }
+    final results = await _start(pluginIds: [pluginId]);
+    return results[pluginId] ?? const CatalogRescanStartResult.notImportable();
+  }
+
+  /// Cancels every member of the live operation, whether or not progress has
+  /// begun. The route cancels one plugin per call, so this fans out.
+  Future<void> cancel() async {
+    if (_disposed || _members.isEmpty) return;
+    final pluginIds = Set<String>.of(_members);
+    _closeOperation(const CatalogRescanState.idle());
+    await Future.wait([
+      for (final pluginId in pluginIds) _pluginRepository.cancelCatalogImport(pluginId: pluginId),
+    ]);
+  }
+
+  /// Clears a terminal row the user has read.
+  void dismiss() {
+    if (_disposed || _state.value.isLive) return;
+    _reset();
+  }
+
+  @override
+  Future<void> onDispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    _clearTimer?.cancel();
+    await _subscriptions.dispose();
+    await _state.close();
+    await _settled.close();
+  }
+
+  Future<Map<String, CatalogRescanStartResult>> _start({required List<String> pluginIds}) async {
+    _openOrJoin(pluginIds: pluginIds, observed: false);
+    final results = <String, CatalogRescanStartResult>{};
+    await Future.wait([
+      for (final pluginId in pluginIds)
+        _pluginRepository.startCatalogImport(pluginId: pluginId).then((outcome) {
+          results[pluginId] = _applyStartOutcome(pluginId: pluginId, outcome: outcome);
+        }),
+    ]);
+    if (_disposed) return results;
+    // Every harness answering 404 at once is how a bridge with no import route
+    // presents itself. One harness answering 404 only means that harness is
+    // unknown, so this deliberately requires all of them.
+    if (results.isNotEmpty && results.values.every((r) => r is CatalogRescanStartUnsupported)) {
+      _closeOperation(const CatalogRescanState.unsupported());
+      return results;
+    }
+    // Every harness was skipped as not importable, so nothing is running and
+    // there is nothing to report.
+    if (_members.isEmpty) {
+      _closeOperation(const CatalogRescanState.idle());
+      return results;
+    }
+    _publishLive();
+    _settleIfComplete();
+    return results;
+  }
+
+  /// Applies one dispatch outcome to membership.
+  ///
+  /// A harness joins on dispatch rather than on acknowledgement, so a timeout
+  /// or lost response — which the relay can raise *after* the request landed —
+  /// keeps it in the operation. Only an answer from the bridge removes it.
+  CatalogRescanStartResult _applyStartOutcome({
+    required String pluginId,
+    required CatalogImportMutationResult outcome,
+  }) {
+    switch (outcome) {
+      case CatalogImportMutationAccepted():
+        return const CatalogRescanStartResult.accepted();
+      case CatalogImportMutationNotFound():
+        _members.remove(pluginId);
+        return const CatalogRescanStartResult.unsupported();
+      case CatalogImportMutationUnavailable():
+        _members.remove(pluginId);
+        return const CatalogRescanStartResult.notImportable();
+      case CatalogImportMutationFailure(:final error):
+        // Retained locally because a transport or decoding failure may never
+        // have reached the bridge, so the bridge log cannot explain it.
+        logw("Catalog rescan could not be started for a harness", error);
+        if (error is NonSuccessCodeError) {
+          // The bridge answered and refused, so this harness is settled and
+          // counts against the run.
+          _progressByPluginId[pluginId] = CatalogImportProgress.failed(
+            pluginId: pluginId,
+            message: "start rejected",
+          );
+        }
+        // Otherwise the request may well have landed — a relay timeout or lost
+        // response fires after delivery just as readily as before it — so the
+        // harness stays a member and settles from its own progress event.
+        return CatalogRescanStartResult.failed(cause: error);
+    }
+  }
+
+  void _openOrJoin({required List<String> pluginIds, required bool observed}) {
+    if (_members.isEmpty) {
+      _clearTimer?.cancel();
+      _clearTimer = null;
+      _progressByPluginId.clear();
+      _observed = observed;
+    }
+    _members.addAll(pluginIds);
+    _publishLive();
+  }
+
+  void _onSseEvent(SseEvent event) {
+    if (_disposed) return;
+    if (event.data case SesoriCatalogImportProgress(:final progress)) {
+      _applyProgress(progress);
+    }
+  }
+
+  void _applyProgress(CatalogImportProgress progress) {
+    final pluginId = progress.pluginId;
+    if (!_members.contains(pluginId)) {
+      // A rescan someone else started, seen live. Adopt it so its imported
+      // sessions still reach the lists, but as an observed operation, which
+      // claims no summary.
+      if (_isTerminal(progress)) return;
+      _openOrJoin(pluginIds: [pluginId], observed: true);
+    }
+    _progressByPluginId[pluginId] = progress;
+    if (_isTerminal(progress)) {
+      _settleIfComplete();
+      return;
+    }
+    _publishLive();
+  }
+
+  void _publishLive() {
+    if (_members.isEmpty) return;
+    final active = _activeProgress();
+    _publish(
+      active == null
+          ? CatalogRescanState.starting(pluginIds: Set<String>.unmodifiable(_members))
+          : CatalogRescanState.running(
+              activePluginName: _displayNames[active.pluginId] ?? active.pluginId,
+              sessionsSeen: switch (active) {
+                CatalogImportEnumerating(:final sessionsSeen) => sessionsSeen,
+                CatalogImportCommitting(:final sessionsSeen) => sessionsSeen,
+                // Unreachable: _activeProgress only returns a non-terminal
+                // status, and the switch stays exhaustive so a new phase is a
+                // compile error rather than a silent zero.
+                CatalogImportCompleted() ||
+                CatalogImportCancelled() ||
+                CatalogImportFailed() => 0,
+              },
+              pluginIds: Set<String>.unmodifiable(_members),
+            ),
+    );
+  }
+
+  /// The harness whose progress the row names, preferring whichever is still
+  /// working over one that already settled.
+  CatalogImportProgress? _activeProgress() {
+    for (final pluginId in _members) {
+      final progress = _progressByPluginId[pluginId];
+      if (progress != null && !_isTerminal(progress)) return progress;
+    }
+    return null;
+  }
+
+  void _settleIfComplete() {
+    if (_members.isEmpty) return;
+    final settledMembers = [
+      for (final pluginId in _members)
+        if (_progressByPluginId[pluginId] case final progress? when _isTerminal(progress)) progress,
+    ];
+    if (settledMembers.length < _members.length) return;
+
+    // An operation this client did not see from the start cannot honestly
+    // summarise itself: members that finished while it was away were dropped
+    // by the recovery filter and cannot be recovered, because the bridge's
+    // status read carries no operation identity.
+    if (_observed) {
+      _closeOperation(const CatalogRescanState.idle());
+      return;
+    }
+
+    final succeeded = settledMembers.whereType<CatalogImportCompleted>().toList(growable: false);
+    final failedCount = settledMembers.length - succeeded.length;
+    if (succeeded.isEmpty) {
+      _closeOperation(CatalogRescanState.failed(harnessCount: settledMembers.length));
+      return;
+    }
+    if (failedCount > 0) {
+      _closeOperation(
+        CatalogRescanState.partlyFailed(succeededCount: succeeded.length, failedCount: failedCount),
+      );
+      return;
+    }
+    _closeOperation(
+      CatalogRescanState.succeeded(harnessCount: succeeded.length, counts: _sumCounts(succeeded)),
+    );
+  }
+
+  /// Sums across every succeeded harness rather than reporting whichever
+  /// finished last. Falls back to totals when any harness omitted its delta,
+  /// because a delta missing one contribution would understate the result while
+  /// still reading as authoritative.
+  CatalogRescanCounts _sumCounts(List<CatalogImportCompleted> completions) {
+    if (completions.every((c) => c.newItems != null)) {
+      var projects = 0;
+      var sessions = 0;
+      for (final completion in completions) {
+        if (completion.newItems case final newItems?) {
+          projects += newItems.projects;
+          sessions += newItems.sessions;
+        }
+      }
+      return CatalogRescanCounts.delta(newProjects: projects, newSessions: sessions);
+    }
+    var projects = 0;
+    var sessions = 0;
+    for (final completion in completions) {
+      projects += completion.projectsImported;
+      sessions += completion.sessionsImported;
+    }
+    return CatalogRescanCounts.totals(projects: projects, sessions: sessions);
+  }
+
+  /// Ends the live operation and publishes [next]. Always announces the close,
+  /// so a consumer refreshes whether the run summarised itself or not.
+  void _closeOperation(CatalogRescanState next) {
+    _members.clear();
+    _progressByPluginId.clear();
+    _observed = false;
+    _publish(next);
+    if (!_settled.isClosed) _settled.add(null);
+    if (next is CatalogRescanSucceeded) {
+      _clearTimer?.cancel();
+      _clearTimer = Timer(_successVisibleFor, _reset);
+    }
+  }
+
+  void _reset() {
+    if (_disposed) return;
+    _clearTimer?.cancel();
+    _clearTimer = null;
+    _members.clear();
+    _progressByPluginId.clear();
+    _observed = false;
+    _publish(const CatalogRescanState.idle());
+  }
+
+  void _onConnectionStatus(ConnectionStatus status) {
+    if (_disposed) return;
+    final nextConnected = status is ConnectionConnected;
+    if (nextConnected == _connected) return;
+    _connected = nextConnected;
+    final wasLive = _state.value.isLive;
+    _reset();
+    // A run interrupted by a drop still committed whatever it had published, so
+    // announce the close even though no summary is claimed for it.
+    if (wasLive && !_settled.isClosed) _settled.add(null);
+    if (nextConnected) unawaited(_recoverInFlight());
+  }
+
+  void _onManagementSnapshot(PluginManagementLoadResult snapshot) {
+    if (_disposed) return;
+    if (snapshot is! PluginManagementLoadResultSupported) return;
+    _displayNames = {
+      for (final plugin in snapshot.response.plugins) plugin.setup.id: plugin.setup.displayName,
+    };
+    final bridgeId = snapshot.response.bridgeId;
+    if (_activeBridgeId != null && _activeBridgeId != bridgeId) _reset();
+    _activeBridgeId = bridgeId;
+  }
+
+  /// Adopts a rescan that was already running when this client connected.
+  ///
+  /// Terminal statuses are discarded rather than adopted: the bridge keeps the
+  /// last status per plugin forever, and its hydration short-circuit publishes
+  /// a completion for every enabled plugin at every start, so seeding from them
+  /// would announce a stale "rescan complete" on every connect.
+  Future<void> _recoverInFlight() async {
+    final result = await _pluginRepository.getCatalogImportStatuses();
+    if (_disposed || !_connected) return;
+    switch (result) {
+      case CatalogImportStatusesSupported(:final statuses):
+        final inFlight = statuses.where((status) => !_isTerminal(status)).toList(growable: false);
+        if (inFlight.isEmpty || _members.isNotEmpty) return;
+        _openOrJoin(
+          pluginIds: [for (final status in inFlight) status.pluginId],
+          observed: true,
+        );
+        for (final status in inFlight) {
+          _progressByPluginId[status.pluginId] = status;
+        }
+        _publishLive();
+      case CatalogImportStatusesUnsupported():
+      case CatalogImportStatusesFailure():
+        return;
+    }
+  }
+
+  bool _isTerminal(CatalogImportProgress progress) => switch (progress) {
+    CatalogImportCompleted() || CatalogImportCancelled() || CatalogImportFailed() => true,
+    CatalogImportEnumerating() || CatalogImportCommitting() => false,
+  };
+
+  void _publish(CatalogRescanState next) {
+    if (_disposed || _state.isClosed || _state.value == next) return;
+    _state.add(next);
+  }
+}

--- a/client/module_core/lib/src/services/catalog_rescan_service.dart
+++ b/client/module_core/lib/src/services/catalog_rescan_service.dart
@@ -264,13 +264,13 @@ class CatalogRescanService({
       case CatalogImportMutationUncertain(:final error):
         // The request may well have landed, so the harness stays a member and
         // settles from its own progress event rather than being written off.
-        logw("Catalog rescan start could not be confirmed for a harness", error);
+        logw("Catalog rescan start could not be confirmed for $pluginId", error);
         return CatalogRescanStartResult.failed(cause: error);
       case CatalogImportMutationFailure(:final error):
         // The bridge answered and refused, so this harness is settled and
         // counts against the run. Retained locally because the failure may
         // never have reached the bridge's own log.
-        logw("Catalog rescan could not be started for a harness", error);
+        logw("Catalog rescan could not be started for $pluginId", error);
         _progressByPluginId[pluginId] = CatalogImportProgress.failed(
           pluginId: pluginId,
           message: "start rejected",
@@ -315,6 +315,14 @@ class CatalogRescanService({
     // failure, and it means this client no longer saw the whole operation, so
     // it settles quietly instead of publishing a persistent failure row.
     if (progress is CatalogImportCancelled) _observed = true;
+    // A member that already settled and is reporting progress again was
+    // restarted by someone else. Its second run is not this operation's to
+    // summarise, so the aggregate stops claiming one — the same rule as a
+    // harness joining from outside, which this path bypasses.
+    final previous = _progressByPluginId[pluginId];
+    if (previous != null && _isTerminal(previous) && !_isTerminal(progress)) {
+      _observed = true;
+    }
     _progressByPluginId[pluginId] = progress;
     if (_isTerminal(progress)) {
       _settleIfComplete();
@@ -468,6 +476,13 @@ class CatalogRescanService({
       final wasLive = _members.isNotEmpty;
       _reset();
       if (wasLive && !_settled.isClosed) _settled.add(null);
+      // The recovery read fired on reconnect may have adopted the new bridge's
+      // run before this identity arrived, and the reset above just discarded
+      // it. Read again now that the identity is settled, or an import already
+      // running here stays invisible until it ends.
+      _activeBridgeId = bridgeId;
+      unawaited(_recoverInFlight());
+      return;
     }
     _activeBridgeId = bridgeId;
   }

--- a/client/module_core/lib/src/services/catalog_rescan_service.dart
+++ b/client/module_core/lib/src/services/catalog_rescan_service.dart
@@ -72,6 +72,14 @@ class CatalogRescanService({
   /// after them rather than racing its own POST.
   final Set<Future<void>> _pendingStarts = {};
 
+  /// A cancellation that has not finished dispatching its DELETEs.
+  ///
+  /// A cancel has to wait for any start still in flight, or its DELETE can
+  /// overtake the POST and cancel nothing. That wait would otherwise leave a
+  /// window where a new rescan could begin and inherit those DELETEs, so a
+  /// start waits for the cancel to finish owning its plugin ids first.
+  Future<void>? _cancelling;
+
   Timer? _clearTimer;
   bool _connected = _connectionService.currentStatus is ConnectionConnected;
   String? _activeBridgeId;
@@ -125,24 +133,32 @@ class CatalogRescanService({
 
   /// Cancels every member of the live operation, whether or not progress has
   /// begun. The route cancels one plugin per call, so this fans out.
-  Future<void> cancel() async {
-    if (_disposed || _members.isEmpty) return;
-    final pluginIds = Set<String>.of(_members);
+  Future<void> cancel() {
+    if (_disposed || _members.isEmpty) return Future<void>.value();
+    return _cancelling = _cancel(pluginIds: Set<String>.of(_members));
+  }
+
+  Future<void> _cancel({required Set<String> pluginIds}) async {
     // Close first so the row goes at once, then wait for any start still in
     // flight: a DELETE that overtakes its POST finds no import to cancel, and
     // the import the user just cancelled would run anyway.
     _closeOperation(const CatalogRescanState.idle());
-    await Future.wait(_pendingStarts);
-    final outcomes = await Future.wait([
-      for (final pluginId in pluginIds) _pluginRepository.cancelCatalogImport(pluginId: pluginId),
-    ]);
-    for (final outcome in outcomes) {
-      // A refused or unprovable cancel means the import may still be running,
-      // and nothing else records that.
-      if (outcome case CatalogImportMutationFailure(:final error) ||
-          CatalogImportMutationUncertain(:final error)) {
-        logw("Catalog rescan cancellation was not confirmed for a harness", error);
-      }
+    try {
+      await Future.wait(_pendingStarts);
+      await Future.wait([
+        for (final pluginId in pluginIds)
+          _pluginRepository.cancelCatalogImport(pluginId: pluginId).then((outcome) {
+            // A refused or unprovable cancel means that import may still be
+            // running, and nothing else records it. The harness id is the only
+            // thing that identifies which one, since every call shares a route.
+            if (outcome case CatalogImportMutationFailure(:final error) ||
+                CatalogImportMutationUncertain(:final error)) {
+              logw("Catalog rescan cancellation was not confirmed for $pluginId", error);
+            }
+          }),
+      ]);
+    } finally {
+      _cancelling = null;
     }
   }
 
@@ -168,6 +184,15 @@ class CatalogRescanService({
     required List<String> pluginIds,
     required bool coversEveryHarness,
   }) async {
+    // Never begin inside a cancellation's window: its DELETEs are already
+    // aimed at these plugin ids and would cancel this run instead. Guarded
+    // rather than awaited unconditionally, because `await null` still yields,
+    // and the operation must open before this call returns to its caller so an
+    // immediate cancel can see it.
+    if (_cancelling case final cancelling?) {
+      await cancelling;
+      if (_disposed) return {};
+    }
     _openOrJoin(pluginIds: pluginIds, observed: false);
     final results = <String, CatalogRescanStartResult>{};
     final dispatched = [
@@ -277,6 +302,10 @@ class CatalogRescanService({
       if (_isTerminal(progress)) return;
       _openOrJoin(pluginIds: [pluginId], observed: true);
     }
+    // Someone else cancelled a member of this run. That is intervention, not
+    // failure, and it means this client no longer saw the whole operation, so
+    // it settles quietly instead of publishing a persistent failure row.
+    if (progress is CatalogImportCancelled) _observed = true;
     _progressByPluginId[pluginId] = progress;
     if (_isTerminal(progress)) {
       _settleIfComplete();

--- a/client/module_core/lib/src/services/models/catalog_rescan_state.dart
+++ b/client/module_core/lib/src/services/models/catalog_rescan_state.dart
@@ -1,0 +1,129 @@
+import "package:sesori_auth/sesori_auth.dart";
+
+/// What a completed rescan found, as one aggregate across every harness that
+/// took part.
+///
+/// Two variants rather than nullable counts, because "the bridge reported a
+/// delta" and "the bridge reports no delta" need different wording and a
+/// consumer must not be able to confuse them.
+sealed class const CatalogRescanCounts() {
+  const factory delta({required int newProjects, required int newSessions}) = CatalogRescanDelta;
+
+  const factory totals({required int projects, required int sessions}) = CatalogRescanTotals;
+}
+
+/// Summed new-item counts, reported when every succeeded harness supplied one.
+final class const CatalogRescanDelta({
+  required final int newProjects,
+  required final int newSessions,
+}) extends CatalogRescanCounts {
+  bool get isEmpty => newProjects == 0 && newSessions == 0;
+}
+
+/// Summed published totals, used when at least one harness omitted its delta.
+///
+/// A delta missing one harness's contribution would understate the result while
+/// still reading as authoritative, so the whole row falls back rather than
+/// mixing the two.
+final class const CatalogRescanTotals({
+  required final int projects,
+  required final int sessions,
+}) extends CatalogRescanCounts;
+
+/// The aggregate rescan shown as a single row, whatever the harness count.
+sealed class const CatalogRescanState() {
+  const factory idle() = CatalogRescanIdle;
+
+  const factory starting({required Set<String> pluginIds}) = CatalogRescanStarting;
+
+  const factory running({
+    required String activePluginName,
+    required int sessionsSeen,
+    required Set<String> pluginIds,
+  }) = CatalogRescanRunning;
+
+  const factory succeeded({
+    required int harnessCount,
+    required CatalogRescanCounts counts,
+  }) = CatalogRescanSucceeded;
+
+  const factory partlyFailed({
+    required int succeededCount,
+    required int failedCount,
+  }) = CatalogRescanPartlyFailed;
+
+  const factory failed({required int harnessCount}) = CatalogRescanFailed;
+
+  const factory unsupported() = CatalogRescanUnsupported;
+
+  /// Whether a rescan is in flight. Leaving this is what tells a list to
+  /// refresh, since a committed import raises no invalidation of its own.
+  bool get isLive => this is CatalogRescanStarting || this is CatalogRescanRunning;
+}
+
+final class const CatalogRescanIdle() extends CatalogRescanState;
+
+/// Requests are dispatched but no progress has arrived yet.
+///
+/// Separate from [CatalogRescanRunning] because between dispatch and the first
+/// progress event there is no active harness and no session count, and a single
+/// running state carrying both would have to invent them.
+final class const CatalogRescanStarting({required final Set<String> pluginIds})
+    extends CatalogRescanState;
+
+final class const CatalogRescanRunning({
+  required final String activePluginName,
+  required final int sessionsSeen,
+  required final Set<String> pluginIds,
+}) extends CatalogRescanState;
+
+final class const CatalogRescanSucceeded({
+  required final int harnessCount,
+  required final CatalogRescanCounts counts,
+}) extends CatalogRescanState;
+
+/// Some harnesses succeeded and some did not.
+///
+/// Deliberately carries no counts: a partial total would invite the reader to
+/// trust it as the whole result.
+final class const CatalogRescanPartlyFailed({
+  required final int succeededCount,
+  required final int failedCount,
+}) extends CatalogRescanState;
+
+/// Every harness failed. Carries no message: `CatalogImportFailed.message` is
+/// the bridge's raw `error.toString()` and is never lifted into client state.
+final class const CatalogRescanFailed({required final int harnessCount})
+    extends CatalogRescanState;
+
+/// This bridge cannot rescan at all, because it predates the import route.
+final class const CatalogRescanUnsupported() extends CatalogRescanState;
+
+/// Outcome of a rescan aimed at one named harness.
+///
+/// A targeted request reports back to the card that asked for it, unlike the
+/// fan-out, which silently skips a harness that cannot import.
+sealed class const CatalogRescanStartResult() {
+  const factory accepted() = CatalogRescanStartAccepted;
+
+  const factory notImportable() = CatalogRescanStartNotImportable;
+
+  const factory unsupported() = CatalogRescanStartUnsupported;
+
+  const factory failed({required ApiError cause}) = CatalogRescanStartFailed;
+}
+
+final class const CatalogRescanStartAccepted() extends CatalogRescanStartResult;
+
+/// The bridge knows this harness but will not import from it right now.
+final class const CatalogRescanStartNotImportable() extends CatalogRescanStartResult;
+
+/// The bridge has no catalog import route.
+final class const CatalogRescanStartUnsupported() extends CatalogRescanStartResult;
+
+/// The request failed. [cause] is retained for the local log, because a
+/// transport or decoding failure may never have reached the bridge and so
+/// cannot be explained by the bridge's own log. It is not for display: the card
+/// renders bounded text only.
+final class const CatalogRescanStartFailed({required final ApiError cause})
+    extends CatalogRescanStartResult;

--- a/client/module_core/test/services/catalog_rescan_service_test.dart
+++ b/client/module_core/test/services/catalog_rescan_service_test.dart
@@ -1,0 +1,538 @@
+import "dart:async";
+
+import "package:fake_async/fake_async.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/connection_service.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/models/connection_status.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/models/sse_event.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/server_connection_config.dart";
+import "package:sesori_dart_core/src/repositories/models/catalog_import_result.dart";
+import "package:sesori_dart_core/src/repositories/models/plugin_management_result.dart";
+import "package:sesori_dart_core/src/repositories/plugin_repository.dart";
+import "package:sesori_dart_core/src/services/catalog_rescan_service.dart";
+import "package:sesori_dart_core/src/services/models/catalog_rescan_state.dart";
+import "package:sesori_dart_core/src/services/plugin_management_service.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("CatalogRescanService", () {
+    late _FakePluginRepository repository;
+    late _FakeConnectionService connection;
+    late _FakeManagementService management;
+    late CatalogRescanService service;
+
+    void build({
+      PluginManagementLoadResult? snapshot,
+      ConnectionStatus initialStatus = _connected,
+    }) {
+      repository = _FakePluginRepository();
+      connection = _FakeConnectionService(initialStatus: initialStatus);
+      management = _FakeManagementService(
+        snapshot ?? _snapshot(routable: const {"codex": "Codex", "claude": "Claude"}),
+      );
+      service = CatalogRescanService(
+        pluginRepository: repository,
+        managementService: management,
+        connectionService: connection,
+      );
+    }
+
+    setUp(build);
+
+    tearDown(() async {
+      await service.onDispose();
+      await connection.dispose();
+      await management.dispose();
+    });
+
+    test("starts idle and fans out one request per routable harness", () async {
+      expect(service.state.value, isA<CatalogRescanIdle>());
+
+      await service.startAll();
+
+      expect(repository.startedPluginIds, unorderedEquals(["codex", "claude"]));
+      expect(
+        service.state.value,
+        isA<CatalogRescanStarting>().having((s) => s.pluginIds, "pluginIds", {"codex", "claude"}),
+      );
+    });
+
+    test("names the enumerating harness once progress arrives", () async {
+      await service.startAll();
+
+      connection.emitProgress(const CatalogImportProgress.enumerating(
+        pluginId: "codex",
+        projectsSeen: 3,
+        sessionsSeen: 42,
+      ));
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanRunning>()
+            .having((s) => s.activePluginName, "activePluginName", "Codex")
+            .having((s) => s.sessionsSeen, "sessionsSeen", 42),
+      );
+    });
+
+    test("sums deltas across every harness rather than reporting the last one", () async {
+      await service.startAll();
+
+      connection.emitProgress(_completed("codex", newProjects: 2, newSessions: 5));
+      connection.emitProgress(_completed("claude", newProjects: 1, newSessions: 3));
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanSucceeded>()
+            .having((s) => s.harnessCount, "harnessCount", 2)
+            .having(
+              (s) => s.counts,
+              "counts",
+              isA<CatalogRescanDelta>()
+                  .having((c) => c.newProjects, "newProjects", 3)
+                  .having((c) => c.newSessions, "newSessions", 8),
+            ),
+      );
+    });
+
+    test("falls back to summed totals when any harness omits its delta", () async {
+      await service.startAll();
+
+      connection.emitProgress(_completed("codex", newProjects: 2, newSessions: 5, totals: 10));
+      // An older bridge omits newItems entirely.
+      connection.emitProgress(_completed("claude", totals: 7));
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanSucceeded>().having(
+          (s) => s.counts,
+          "counts",
+          isA<CatalogRescanTotals>()
+              .having((c) => c.projects, "projects", 17)
+              .having((c) => c.sessions, "sessions", 17),
+        ),
+      );
+    });
+
+    test("reports a mixed outcome when one harness fails", () async {
+      await service.startAll();
+
+      connection.emitProgress(_completed("codex", newProjects: 1, newSessions: 1));
+      connection.emitProgress(const CatalogImportProgress.failed(
+        pluginId: "claude",
+        message: "boom: /Users/someone/secret/path",
+      ));
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanPartlyFailed>()
+            .having((s) => s.succeededCount, "succeededCount", 1)
+            .having((s) => s.failedCount, "failedCount", 1),
+      );
+    });
+
+    test("reports total failure when every harness fails, carrying no bridge text", () async {
+      await service.startAll();
+
+      connection.emitProgress(const CatalogImportProgress.failed(pluginId: "codex", message: "a"));
+      connection.emitProgress(const CatalogImportProgress.failed(pluginId: "claude", message: "b"));
+
+      final state = service.state.value;
+      expect(state, isA<CatalogRescanFailed>().having((s) => s.harnessCount, "harnessCount", 2));
+      expect(state.toString(), isNot(contains("boom")));
+    });
+
+    test("clears a success after its window but keeps a failure until dismissed", () async {
+      fakeAsync((async) {
+        // Rebuilt inside the zone: a stream listener runs in the zone that
+        // called listen, so a service built in setUp would schedule real
+        // timers that elapse cannot advance.
+        build();
+        unawaited(service.startAll());
+        async.flushMicrotasks();
+        connection.emitProgress(_completed("codex", newProjects: 1, newSessions: 1));
+        connection.emitProgress(_completed("claude", newProjects: 0, newSessions: 0));
+        expect(service.state.value, isA<CatalogRescanSucceeded>());
+
+        async.elapse(const Duration(seconds: 5));
+        expect(service.state.value, isA<CatalogRescanIdle>());
+
+        unawaited(service.startAll());
+        async.flushMicrotasks();
+        connection.emitProgress(const CatalogImportProgress.failed(pluginId: "codex", message: "x"));
+        connection.emitProgress(const CatalogImportProgress.failed(pluginId: "claude", message: "y"));
+        expect(service.state.value, isA<CatalogRescanFailed>());
+
+        async.elapse(const Duration(seconds: 30));
+        expect(service.state.value, isA<CatalogRescanFailed>(), reason: "a failure must be read");
+
+        service.dismiss();
+        expect(service.state.value, isA<CatalogRescanIdle>());
+      });
+    });
+
+    test("a second rescan inside the success window is not reset by the stale timer", () async {
+      fakeAsync((async) {
+        build();
+        unawaited(service.startAll());
+        async.flushMicrotasks();
+        connection.emitProgress(_completed("codex", newProjects: 1, newSessions: 1));
+        connection.emitProgress(_completed("claude", newProjects: 1, newSessions: 1));
+        expect(service.state.value, isA<CatalogRescanSucceeded>());
+
+        async.elapse(const Duration(seconds: 1));
+        unawaited(service.startAll());
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 5));
+
+        expect(
+          service.state.value,
+          isA<CatalogRescanStarting>(),
+          reason: "the previous success timer must not reset the new run",
+        );
+      });
+    });
+
+    test("a second sequential rescan does not inherit the previous aggregate", () async {
+      await service.startAll();
+      connection.emitProgress(_completed("codex", newProjects: 9, newSessions: 9));
+      connection.emitProgress(_completed("claude", newProjects: 9, newSessions: 9));
+      expect(service.state.value, isA<CatalogRescanSucceeded>());
+      service.dismiss();
+
+      await service.startAll();
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanStarting>(),
+        reason: "retained progress from the previous run must be cleared",
+      );
+      connection.emitProgress(_completed("codex", newProjects: 0, newSessions: 0));
+      expect(service.state.value, isA<CatalogRescanStarting>(), reason: "claude has not settled");
+    });
+
+    test("a targeted start joins the live operation instead of replacing it", () async {
+      build(snapshot: _snapshot(routable: const {"codex": "Codex"}));
+      await service.startAll();
+      expect((service.state.value as CatalogRescanStarting).pluginIds, {"codex"});
+
+      final result = await service.start(pluginId: "claude");
+
+      expect(result, isA<CatalogRescanStartAccepted>());
+      expect(
+        (service.state.value as CatalogRescanStarting).pluginIds,
+        {"codex", "claude"},
+        reason: "codex must stay in aggregation and cancellation",
+      );
+    });
+
+    test("skips a harness the bridge reports unavailable, without failing the run", () async {
+      repository.resultFor["claude"] = const CatalogImportMutationResult.unavailable();
+
+      await service.startAll();
+
+      expect((service.state.value as CatalogRescanStarting).pluginIds, {"codex"});
+      connection.emitProgress(_completed("codex", newProjects: 1, newSessions: 0));
+      expect(
+        service.state.value,
+        isA<CatalogRescanSucceeded>().having((s) => s.harnessCount, "harnessCount", 1),
+      );
+    });
+
+    test("keeps a harness whose response was lost, so SSE still settles it", () async {
+      repository.resultFor["claude"] = CatalogImportMutationResult.failure(
+        error: ApiError.dartHttpClient(TimeoutException("relay response lost")),
+      );
+
+      await service.startAll();
+      connection.emitProgress(_completed("codex", newProjects: 1, newSessions: 1));
+
+      expect(
+        service.state.value.isLive,
+        isTrue,
+        reason: "the request may have landed, so the harness is not written off",
+      );
+
+      connection.emitProgress(_completed("claude", newProjects: 2, newSessions: 2));
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanSucceeded>().having((s) => s.harnessCount, "harnessCount", 2),
+      );
+    });
+
+    test("counts a start the bridge explicitly refused as a failed harness", () async {
+      repository.resultFor["claude"] = CatalogImportMutationResult.failure(
+        error: ApiError.nonSuccessCode(errorCode: 500, rawErrorString: null),
+      );
+
+      await service.startAll();
+      connection.emitProgress(_completed("codex", newProjects: 1, newSessions: 1));
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanPartlyFailed>()
+            .having((s) => s.succeededCount, "succeededCount", 1)
+            .having((s) => s.failedCount, "failedCount", 1),
+      );
+    });
+
+    test("reports an unsupported bridge when every harness answers 404", () async {
+      repository.resultFor["codex"] = const CatalogImportMutationResult.notFound();
+      repository.resultFor["claude"] = const CatalogImportMutationResult.notFound();
+
+      await service.startAll();
+
+      expect(service.state.value, isA<CatalogRescanUnsupported>());
+    });
+
+    test("reports an unsupported bridge from an unsupported snapshot, issuing no request", () async {
+      build(snapshot: const PluginManagementLoadResult.unsupported());
+
+      await service.startAll();
+
+      expect(service.state.value, isA<CatalogRescanUnsupported>());
+      expect(repository.startedPluginIds, isEmpty);
+    });
+
+    test("a targeted start on an unsupported bridge tells the caller", () async {
+      build(snapshot: const PluginManagementLoadResult.unsupported());
+
+      expect(await service.start(pluginId: "codex"), isA<CatalogRescanStartUnsupported>());
+    });
+
+    test("a targeted start reports a rejection instead of skipping it", () async {
+      repository.resultFor["codex"] = const CatalogImportMutationResult.unavailable();
+
+      expect(await service.start(pluginId: "codex"), isA<CatalogRescanStartNotImportable>());
+    });
+
+    test("a failed targeted start retains its cause for the log", () async {
+      final cause = ApiError.nonSuccessCode(errorCode: 500, rawErrorString: null);
+      repository.resultFor["codex"] = CatalogImportMutationResult.failure(error: cause);
+
+      final result = await service.start(pluginId: "codex");
+
+      expect(result, isA<CatalogRescanStartFailed>().having((r) => r.cause, "cause", cause));
+    });
+
+    test("cancel fans out one request per member, including while starting", () async {
+      await service.startAll();
+      expect(service.state.value, isA<CatalogRescanStarting>());
+
+      await service.cancel();
+
+      expect(repository.cancelledPluginIds, unorderedEquals(["codex", "claude"]));
+      expect(service.state.value, isA<CatalogRescanIdle>());
+    });
+
+    test("adopts an unsolicited rescan and settles it without claiming a summary", () async {
+      final settled = <void>[];
+      service.settled.listen(settled.add);
+
+      connection.emitProgress(const CatalogImportProgress.enumerating(
+        pluginId: "codex",
+        projectsSeen: 1,
+        sessionsSeen: 4,
+      ));
+      expect(service.state.value, isA<CatalogRescanRunning>());
+
+      connection.emitProgress(_completed("codex", newProjects: 5, newSessions: 5));
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanIdle>(),
+        reason: "a run this client did not start cannot honestly summarise itself",
+      );
+      expect(settled, hasLength(1), reason: "the lists still have to refresh");
+    });
+
+    test("ignores an unsolicited terminal event for a run it never saw", () async {
+      connection.emitProgress(_completed("codex", newProjects: 3, newSessions: 3));
+
+      expect(service.state.value, isA<CatalogRescanIdle>());
+    });
+
+    test("announces the close whenever a live operation ends", () async {
+      final settled = <void>[];
+      service.settled.listen(settled.add);
+
+      await service.startAll();
+      connection.emitProgress(_completed("codex", newProjects: 1, newSessions: 1));
+      connection.emitProgress(_completed("claude", newProjects: 1, newSessions: 1));
+
+      expect(settled, hasLength(1));
+    });
+
+    test("a reconnect adopts an in-flight import from the status read", () async {
+      build(initialStatus: const ConnectionStatus.disconnected());
+      repository.statuses = const CatalogImportStatusesResult.supported(
+        statuses: [
+          CatalogImportProgress.enumerating(pluginId: "codex", projectsSeen: 1, sessionsSeen: 7),
+        ],
+      );
+
+      connection.emitStatus(_connected);
+      await pumpEventQueue();
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanRunning>().having((s) => s.sessionsSeen, "sessionsSeen", 7),
+      );
+    });
+
+    test("a reconnect discards terminal statuses instead of announcing a stale success", () async {
+      build(initialStatus: const ConnectionStatus.disconnected());
+      repository.statuses = CatalogImportStatusesResult.supported(
+        statuses: [
+          _completed("codex", newProjects: 0, newSessions: 0),
+          _completed("claude", newProjects: 40, newSessions: 40),
+        ],
+      );
+
+      connection.emitStatus(_connected);
+      await pumpEventQueue();
+
+      expect(service.state.value, isA<CatalogRescanIdle>());
+    });
+
+    test("a disconnect clears an active rescan and announces the close", () async {
+      final settled = <void>[];
+      service.settled.listen(settled.add);
+      await service.startAll();
+      expect(service.state.value, isA<CatalogRescanStarting>());
+
+      connection.emitStatus(const ConnectionStatus.disconnected());
+      await pumpEventQueue();
+
+      expect(service.state.value, isA<CatalogRescanIdle>());
+      expect(settled, hasLength(1));
+    });
+  });
+}
+
+const _config = ServerConnectionConfig(relayHost: "relay.example.com", authToken: null);
+const _health = HealthResponse(healthy: true, version: "test", filesystemAccessDegraded: false);
+const _connected = ConnectionStatus.connected(config: _config, health: _health);
+
+CatalogImportCompleted _completed(
+  String pluginId, {
+  int? newProjects,
+  int? newSessions,
+  int totals = 1,
+}) {
+  return CatalogImportProgress.completed(
+    pluginId: pluginId,
+    projectsImported: totals,
+    sessionsImported: totals,
+    newItems: newProjects == null || newSessions == null
+        ? null
+        : CatalogImportNewItems(projects: newProjects, sessions: newSessions),
+    completedAt: 1,
+  ) as CatalogImportCompleted;
+}
+
+PluginManagementLoadResult _snapshot({
+  required Map<String, String> routable,
+  String bridgeId = "bridge-1",
+}) {
+  return PluginManagementLoadResult.supported(
+    response: PluginManagementResponse(
+      snapshotToken: "token",
+      bridgeId: bridgeId,
+      defaultPluginId: null,
+      defaultIdleTimeoutMins: 10,
+      plugins: [
+        for (final MapEntry(key: id, value: name) in routable.entries)
+          PluginManagementMetadata(
+            setup: PluginSetupMetadata(
+              id: id,
+              displayName: name,
+              state: PluginSetupState.ready,
+              runtimeVersion: null,
+              actionHint: null,
+            ),
+            runtimeState: PluginRuntimeState.dormant,
+            workState: PluginManagementWorkState.idle,
+            idleTimeoutMins: 10,
+            hasIdleTimeoutOverride: false,
+            managementCapabilities: const {PluginManagementCapability.lifecycle},
+            actionHint: null,
+          ),
+      ],
+    ),
+    refreshError: null,
+  );
+}
+
+class _FakePluginRepository() implements PluginRepository {
+  final Map<String, CatalogImportMutationResult> resultFor = {};
+  final List<String> startedPluginIds = [];
+  final List<String> cancelledPluginIds = [];
+  CatalogImportStatusesResult statuses = const CatalogImportStatusesResult.supported(statuses: []);
+
+  @override
+  Future<CatalogImportMutationResult> startCatalogImport({required String pluginId}) async {
+    startedPluginIds.add(pluginId);
+    return resultFor[pluginId] ?? const CatalogImportMutationResult.accepted();
+  }
+
+  @override
+  Future<CatalogImportMutationResult> cancelCatalogImport({required String pluginId}) async {
+    cancelledPluginIds.add(pluginId);
+    return const CatalogImportMutationResult.accepted();
+  }
+
+  @override
+  Future<CatalogImportStatusesResult> getCatalogImportStatuses() async => statuses;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeManagementService(PluginManagementLoadResult initial) implements PluginManagementService {
+  final BehaviorSubject<PluginManagementLoadResult> _snapshots = BehaviorSubject.seeded(initial);
+
+  @override
+  ValueStream<PluginManagementLoadResult> get snapshots => _snapshots.stream;
+
+  void emit(PluginManagementLoadResult snapshot) => _snapshots.add(snapshot);
+
+  Future<void> dispose() => _snapshots.close();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeConnectionService({required ConnectionStatus initialStatus}) implements ConnectionService {
+  final BehaviorSubject<ConnectionStatus> _statuses = BehaviorSubject.seeded(initialStatus);
+  final StreamController<SseEvent> _events = StreamController.broadcast(sync: true);
+  final StreamController<void> _stale = StreamController.broadcast(sync: true);
+
+  @override
+  ConnectionStatus get currentStatus => _statuses.value;
+
+  @override
+  ValueStream<ConnectionStatus> get status => _statuses.stream;
+
+  @override
+  Stream<SseEvent> get events => _events.stream;
+
+  @override
+  Stream<void> get dataMayBeStale => _stale.stream;
+
+  void emitStatus(ConnectionStatus status) => _statuses.add(status);
+
+  void emitProgress(CatalogImportProgress progress) {
+    _events.add(SseEvent(data: SesoriSseEvent.catalogImportProgress(progress: progress)));
+  }
+
+  @override
+  Future<void> dispose() async {
+    await Future.wait([_statuses.close(), _events.close(), _stale.close()]);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/client/module_core/test/services/catalog_rescan_service_test.dart
+++ b/client/module_core/test/services/catalog_rescan_service_test.dart
@@ -538,6 +538,38 @@ void main() {
       );
     });
 
+    test("a stale event from a cancelled run cannot reopen it", () async {
+      build(snapshot: _snapshot(routable: const {"codex": "Codex"}));
+      final release = Completer<CatalogImportMutationResult>();
+      repository.pendingFor["codex"] = release.future;
+      final firstRun = service.startAll();
+      final cancelling = service.cancel();
+
+      // A progress event from the run being cancelled arrives before the
+      // DELETE has gone out.
+      connection.emitProgress(const CatalogImportProgress.enumerating(
+        pluginId: "codex",
+        projectsSeen: 1,
+        sessionsSeen: 3,
+      ));
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanIdle>(),
+        reason: "a cancelled run must not reopen itself as an observed operation",
+      );
+
+      release.complete(const CatalogImportMutationResult.accepted());
+      await firstRun;
+      await cancelling;
+
+      // The next rescan must still be able to claim its own summary.
+      await service.startAll();
+      connection.emitProgress(_completed("codex", newProjects: 2, newSessions: 2));
+
+      expect(service.state.value, isA<CatalogRescanSucceeded>());
+    });
+
     test("an outside cancellation settles quietly instead of showing a failure", () async {
       build(snapshot: _snapshot(routable: const {"codex": "Codex"}));
       final settled = <void>[];

--- a/client/module_core/test/services/catalog_rescan_service_test.dart
+++ b/client/module_core/test/services/catalog_rescan_service_test.dart
@@ -287,6 +287,70 @@ void main() {
       expect(service.state.value, isA<CatalogRescanUnsupported>());
     });
 
+    test("a joining start that answers 404 leaves the live run untouched", () async {
+      build(snapshot: _snapshot(routable: const {"codex": "Codex"}));
+      await service.startAll();
+      repository.resultFor["ghost"] = const CatalogImportMutationResult.notFound();
+
+      final result = await service.start(pluginId: "ghost");
+
+      expect(result, isA<CatalogRescanStartUnsupported>());
+      expect(
+        (service.state.value as CatalogRescanStarting).pluginIds,
+        {"codex"},
+        reason: "one unknown harness must not be read as a bridge without the route",
+      );
+
+      connection.emitProgress(_completed("codex", newProjects: 1, newSessions: 1));
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanSucceeded>(),
+        reason: "the surviving harness must still settle and refresh",
+      );
+    });
+
+    test("an unsupported snapshot does not overwrite a run already in flight", () async {
+      final settled = <void>[];
+      service.settled.listen(settled.add);
+      // A v1.6.x bridge has the import route but no management route, so a run
+      // can be live while the snapshot reports unsupported.
+      connection.emitProgress(const CatalogImportProgress.enumerating(
+        pluginId: "codex",
+        projectsSeen: 1,
+        sessionsSeen: 2,
+      ));
+      management.emit(const PluginManagementLoadResult.unsupported());
+
+      await service.startAll();
+
+      expect(service.state.value.isLive, isTrue, reason: "the live run must survive");
+      service.dismiss();
+      expect(service.state.value.isLive, isTrue, reason: "a live run is not dismissible");
+
+      connection.emitProgress(_completed("codex", newProjects: 3, newSessions: 3));
+
+      expect(settled, hasLength(1), reason: "its close must still refresh the lists");
+    });
+
+    test("re-points the row at a harness still working when another settles", () async {
+      await service.startAll();
+      connection.emitProgress(const CatalogImportProgress.enumerating(
+        pluginId: "claude",
+        projectsSeen: 1,
+        sessionsSeen: 9,
+      ));
+      expect((service.state.value as CatalogRescanRunning).activePluginName, "Claude");
+
+      connection.emitProgress(_completed("claude", newProjects: 1, newSessions: 1));
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanStarting>(),
+        reason: "codex has reported nothing yet, so no harness can be named",
+      );
+    });
+
     test("reports an unsupported bridge from an unsupported snapshot, issuing no request", () async {
       build(snapshot: const PluginManagementLoadResult.unsupported());
 

--- a/client/module_core/test/services/catalog_rescan_service_test.dart
+++ b/client/module_core/test/services/catalog_rescan_service_test.dart
@@ -538,6 +538,49 @@ void main() {
       );
     });
 
+    test("a member restarted from outside stops the run claiming a summary", () async {
+      await service.startAll();
+      connection.emitProgress(_completed("codex", newProjects: 1, newSessions: 1));
+
+      // Another surface restarts codex while claude is still running.
+      connection.emitProgress(const CatalogImportProgress.enumerating(
+        pluginId: "codex",
+        projectsSeen: 1,
+        sessionsSeen: 1,
+      ));
+      connection.emitProgress(_completed("codex", newProjects: 50, newSessions: 50));
+      connection.emitProgress(_completed("claude", newProjects: 1, newSessions: 1));
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanIdle>(),
+        reason: "the second codex run's counts are not this operation's to report",
+      );
+    });
+
+    test("reads in-flight imports again once a new bridge identity lands", () async {
+      build(initialStatus: const ConnectionStatus.disconnected());
+      repository.statuses = const CatalogImportStatusesResult.supported(
+        statuses: [
+          CatalogImportProgress.enumerating(pluginId: "codex", projectsSeen: 1, sessionsSeen: 6),
+        ],
+      );
+      connection.emitStatus(_connected);
+      await pumpEventQueue();
+      expect(service.state.value, isA<CatalogRescanRunning>());
+
+      // The management snapshot for the newly connected bridge arrives after
+      // the recovery read and reports a different identity.
+      management.emit(_snapshot(routable: const {"codex": "Codex"}, bridgeId: "bridge-2"));
+      await pumpEventQueue();
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanRunning>().having((s) => s.sessionsSeen, "sessionsSeen", 6),
+        reason: "the reset for the new identity must be followed by another read",
+      );
+    });
+
     test("a stale event from a cancelled run cannot reopen it", () async {
       build(snapshot: _snapshot(routable: const {"codex": "Codex"}));
       final release = Completer<CatalogImportMutationResult>();

--- a/client/module_core/test/services/catalog_rescan_service_test.dart
+++ b/client/module_core/test/services/catalog_rescan_service_test.dart
@@ -508,6 +508,53 @@ void main() {
       expect(repository.cancelledPluginIds, contains("codex"));
     });
 
+    test("a rescan started during a cancellation does not inherit its DELETEs", () async {
+      final release = Completer<CatalogImportMutationResult>();
+      repository.pendingFor["codex"] = release.future;
+      final firstRun = service.startAll();
+
+      final cancelling = service.cancel();
+      // The user taps rescan again while the cancellation is still waiting for
+      // the first start to come back.
+      final secondRun = service.startAll();
+      await pumpEventQueue();
+
+      expect(
+        repository.startedPluginIds.where((id) => id == "codex"),
+        hasLength(1),
+        reason: "the second start must not begin inside the cancellation window",
+      );
+
+      release.complete(const CatalogImportMutationResult.accepted());
+      await firstRun;
+      await cancelling;
+      await secondRun;
+
+      expect(repository.cancelledPluginIds, contains("codex"));
+      expect(
+        repository.startedPluginIds.where((id) => id == "codex"),
+        hasLength(2),
+        reason: "and must run once the cancellation has dispatched",
+      );
+    });
+
+    test("an outside cancellation settles quietly instead of showing a failure", () async {
+      build(snapshot: _snapshot(routable: const {"codex": "Codex"}));
+      final settled = <void>[];
+      service.settled.listen(settled.add);
+      await service.startAll();
+
+      // Another connected surface cancelled this harness.
+      connection.emitProgress(const CatalogImportProgress.cancelled(pluginId: "codex"));
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanIdle>(),
+        reason: "a deliberate cancellation elsewhere is not this run's failure",
+      );
+      expect(settled, hasLength(1));
+    });
+
     test("recovers an in-flight import when resolved onto a live connection", () async {
       repository = _FakePluginRepository();
       connection = _FakeConnectionService(initialStatus: _connected);

--- a/client/module_core/test/services/catalog_rescan_service_test.dart
+++ b/client/module_core/test/services/catalog_rescan_service_test.dart
@@ -241,7 +241,7 @@ void main() {
     });
 
     test("keeps a harness whose response was lost, so SSE still settles it", () async {
-      repository.resultFor["claude"] = CatalogImportMutationResult.failure(
+      repository.resultFor["claude"] = CatalogImportMutationResult.uncertain(
         error: ApiError.dartHttpClient(TimeoutException("relay response lost")),
       );
 
@@ -349,6 +349,44 @@ void main() {
         isA<CatalogRescanStarting>(),
         reason: "codex has reported nothing yet, so no harness can be named",
       );
+    });
+
+    test("a targeted 404 does not claim the whole bridge cannot rescan", () async {
+      // The bridge answers 404 for an unknown plugin and for a deselected one
+      // alike, so one 404 says nothing about whether the route exists.
+      repository.resultFor["codex"] = const CatalogImportMutationResult.notFound();
+
+      final result = await service.start(pluginId: "codex");
+
+      expect(result, isA<CatalogRescanStartUnsupported>(), reason: "the caller is told");
+      expect(
+        service.state.value,
+        isA<CatalogRescanIdle>(),
+        reason: "but no bridge-wide claim reaches the other surfaces",
+      );
+    });
+
+    test("a start resolving after its run already settled leaves the row alone", () async {
+      final settled = <void>[];
+      service.settled.listen(settled.add);
+      final release = Completer<CatalogImportMutationResult>();
+      repository.pendingFor["claude"] = release.future;
+
+      final pending = service.startAll();
+      // Both harnesses fail over SSE while claude's response is still in flight.
+      connection.emitProgress(const CatalogImportProgress.failed(pluginId: "codex", message: "x"));
+      connection.emitProgress(const CatalogImportProgress.failed(pluginId: "claude", message: "y"));
+      expect(service.state.value, isA<CatalogRescanFailed>());
+
+      release.complete(const CatalogImportMutationResult.accepted());
+      await pending;
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanFailed>(),
+        reason: "a diagnostic the user has not read must not erase itself",
+      );
+      expect(settled, hasLength(1), reason: "and the lists must not refresh twice");
     });
 
     test("reports an unsupported bridge from an unsupported snapshot, issuing no request", () async {
@@ -532,6 +570,7 @@ PluginManagementLoadResult _snapshot({
 
 class _FakePluginRepository() implements PluginRepository {
   final Map<String, CatalogImportMutationResult> resultFor = {};
+  final Map<String, Future<CatalogImportMutationResult>> pendingFor = {};
   final List<String> startedPluginIds = [];
   final List<String> cancelledPluginIds = [];
   CatalogImportStatusesResult statuses = const CatalogImportStatusesResult.supported(statuses: []);
@@ -539,6 +578,7 @@ class _FakePluginRepository() implements PluginRepository {
   @override
   Future<CatalogImportMutationResult> startCatalogImport({required String pluginId}) async {
     startedPluginIds.add(pluginId);
+    if (pendingFor.remove(pluginId) case final pending?) return await pending;
     return resultFor[pluginId] ?? const CatalogImportMutationResult.accepted();
   }
 

--- a/client/module_core/test/services/catalog_rescan_service_test.dart
+++ b/client/module_core/test/services/catalog_rescan_service_test.dart
@@ -467,6 +467,72 @@ void main() {
       expect(settled, hasLength(1));
     });
 
+    test("an operation stops claiming a summary once an outside harness joins", () async {
+      await service.startAll();
+
+      // A third harness this client never dispatched appears from elsewhere.
+      connection.emitProgress(const CatalogImportProgress.enumerating(
+        pluginId: "outsider",
+        projectsSeen: 1,
+        sessionsSeen: 1,
+      ));
+      connection.emitProgress(_completed("codex", newProjects: 1, newSessions: 1));
+      connection.emitProgress(_completed("claude", newProjects: 1, newSessions: 1));
+      connection.emitProgress(_completed("outsider", newProjects: 1, newSessions: 1));
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanIdle>(),
+        reason: "it can no longer vouch for every member, so it claims nothing",
+      );
+    });
+
+    test("cancel waits for a start still in flight before sending its DELETE", () async {
+      final release = Completer<CatalogImportMutationResult>();
+      repository.pendingFor["codex"] = release.future;
+      final pending = service.startAll();
+
+      final cancelling = service.cancel();
+      await pumpEventQueue();
+
+      expect(
+        repository.cancelledPluginIds,
+        isEmpty,
+        reason: "a DELETE that overtakes its POST cancels nothing",
+      );
+
+      release.complete(const CatalogImportMutationResult.accepted());
+      await pending;
+      await cancelling;
+
+      expect(repository.cancelledPluginIds, contains("codex"));
+    });
+
+    test("recovers an in-flight import when resolved onto a live connection", () async {
+      repository = _FakePluginRepository();
+      connection = _FakeConnectionService(initialStatus: _connected);
+      management = _FakeManagementService(_snapshot(routable: const {"codex": "Codex"}));
+      repository.statuses = const CatalogImportStatusesResult.supported(
+        statuses: [
+          CatalogImportProgress.enumerating(pluginId: "codex", projectsSeen: 1, sessionsSeen: 5),
+        ],
+      );
+
+      // No false-to-true transition ever arrives for a service built while the
+      // connection is already up.
+      service = CatalogRescanService(
+        pluginRepository: repository,
+        managementService: management,
+        connectionService: connection,
+      );
+      await pumpEventQueue();
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanRunning>().having((s) => s.sessionsSeen, "sessionsSeen", 5),
+      );
+    });
+
     test("a reconnect adopts an in-flight import from the status read", () async {
       build(initialStatus: const ConnectionStatus.disconnected());
       repository.statuses = const CatalogImportStatusesResult.supported(


### PR DESCRIPTION
## Complexity

Moderate. Three thin API/repository methods plus one service that owns a small
state machine. The machine is where the difficulty is: it has to stay coherent
across joins, lost responses, reconnects and cancellation.

## What

Wires the three already-existing `/plugin/import` routes into the client and
adds `CatalogRescanService`.

- `PluginApi` gains `startCatalogImport`, `cancelCatalogImport` and
  `getCatalogImportStatuses`. Cancel takes a `pluginId` because the route
  cancels exactly one plugin per call.
- `PluginRepository` maps them to typed results. `404` and `503` stay distinct:
  `503` is a harness the bridge knows but will not start, while `404` from
  *every* harness is how a bridge with no import route presents itself.
- `CatalogRescanService`, a `@lazySingleton` over `PluginRepository`,
  `PluginManagementService` and `ConnectionService`.

The service owns one **operation**: the set of harness ids it is tracking plus
whether this client saw the whole thing. It is `owned` when this client
dispatched every member's start, `observed` when it learned of the run from the
recovery read or an unsolicited progress event. That single definition is what
makes membership, settlement, cancellation and the post-run refresh consistent
instead of four rules that drift apart.

Consequences that fall out of it:

- A second start **joins** the live operation rather than replacing it, so a
  harness already importing stays in aggregation and cancellation.
- Membership is recorded on **dispatch**. A relay timeout or lost response fires
  after delivery just as readily as before it, so only an explicit answer from
  the bridge settles or removes a harness.
- Only an `owned` operation reports a terminal summary. An `observed` one
  settles to idle, because members that finished during the outage were dropped
  by the recovery filter and `latestStatuses` carries no operation identity to
  recover them by.
- The list refresh is keyed on **leaving a live operation** (`settled`), not on
  the terminal variants — otherwise an observed run would never refresh.

`sse_event.dart` and `sse_event_tracker.dart` are deliberately untouched: the
service pattern-matches the event itself, exactly as `PluginManagementService`
already does for install progress.

## Why

Issue #961. The bridge routes have worked since v1.6.0 with zero client callers,
so `sesori-bridge --import-plugin` run by hand is the only thing that ever
refreshes a catalog. This is the layer the gesture (step 5) and the row (step 6)
sit on.

## Risk and test focus

Moderate, all client-side. Nothing renders yet, so no user-visible surface
changes in this PR.

The risk is state-machine coherence, and that is where the tests are. Worth a
reviewer's attention:

- a joining start that is rejected must not tear down harnesses it never
  dispatched;
- an unsupported management snapshot must not overwrite a run in flight — a
  `v1.6.x` bridge has `/plugin/import` but *not* `/plugin/management`, so that
  combination is reachable inside the supported baseline;
- a lost response keeps its harness, while an explicit rejection settles it;
- the recovery read discards terminal statuses, or every connect would announce
  a stale "rescan complete" — the bridge keeps the last status per plugin
  forever and its hydration short-circuit publishes a completion for every
  enabled plugin at startup.

`architecture-implementation-review` **rejected** the first pass with two
blocking findings, both divergences from the approved operation model. Both are
fixed with regression coverage; the detail is in `TRACKER.md`.

## Expected result

**User-visible:** none. No widget consumes the service yet.

**Database:** no change.

**Internal:** `getIt<CatalogRescanService>()` resolves; `injection.config.dart`
is regenerated, not hand-edited.

## Verification

- `dart analyze --fatal-infos` clean on `client/module_core`
- full `client/module_core` suite: 1,333 tests passing, including 28 new
  `catalog_rescan_service_test.dart` cases covering every state, the join, the
  lost response, both reconnect cases, the disconnect, cancel-while-starting,
  the sequential rescan, the success timer window, and the summed/fallback
  counts
- `dart run build_runner build` for the DI registration
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a client-side catalog rescan service and wires `/plugin/import` start/cancel/status so the app can initiate, observe, and cancel multi‑harness imports and refresh lists when runs settle. Previously the client could not trigger or follow catalog imports.

- API/Repository: add `startCatalogImport`, `cancelCatalogImport`, `getCatalogImportStatuses`; keep `404` (not found) vs `503` (unavailable); classify transport/timeout/decoding as `uncertain`; a targeted `404` informs only its caller; only a fan‑out that covers every harness may claim bridge‑wide unsupported.
- Operation model: single owned/observed operation; second start joins; record membership on dispatch; only owned runs publish terminal summaries; a late‑resolving start cannot erase a settled row; if a member restarts from outside, switch to observed and suppress the summary; auto‑clear success after 4s.
- Cancellation: fan out one DELETE per member; wait for in‑flight POSTs; new starts serialize behind an in‑flight cancel; ignore progress for harnesses a cancel still owns; treat outside cancellations as intervention; log unconfirmed cancels with the harness id.
- SSE/Recovery: adopt unsolicited/in‑flight runs as observed; filter terminal statuses during recovery; recover in‑flight imports when resolved on a live connection; reset and announce close on disconnect and on active‑bridge change, then re‑read statuses for the new identity; keep an operation observed once an outside harness joins.
- Aggregation/UI: sum deltas across harnesses when all provide them, else fall back to summed totals; the running row names the active harness; never lift bridge error text into client state.
- DI: register `CatalogRescanService` in `injection.config.dart`.

<sup>Written for commit ffbde2a488b3336f30ce358dc1420f5a8409256d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

