### PR TITLE
⚙️ [codebase-cleanup] tooling: align installers, assert codegen freshness, and enable no_slop_linter for small bridge packages [step 43/45]

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -50,6 +50,10 @@ jobs:
         run: dart pub get
         working-directory: bridge
 
+      - name: Get analyzer plugin dependencies
+        run: dart pub get
+        working-directory: shared/no_slop_linter
+
       - name: Analyze bridge packages
         shell: bash
         working-directory: bridge
@@ -93,6 +97,33 @@ jobs:
             fi
             echo "::endgroup::"
           done
+
+  codegen-freshness:
+    needs: toolchain
+    runs-on: ubuntu-latest
+    env:
+      PUB_CACHE: ${{ github.workspace }}/.pub-cache
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ needs.toolchain.outputs.dart-version }}
+
+      - uses: actions/cache@v5
+        with:
+          path: ${{ env.PUB_CACHE }}
+          key: ${{ runner.os }}-${{ runner.arch }}-pub-${{ hashFiles('bridge/pubspec.lock') }}
+
+      - name: Get dependencies (workspace)
+        run: dart pub get
+        working-directory: bridge
+
+      - name: Verify offline OpenCode SSE generation is fresh
+        working-directory: bridge/sesori_plugin_opencode
+        run: |
+          dart run tool/generate_sse_events.dart
+          git diff --exit-code -- lib/src/models/sse_event_data.g.dart
 
   build-smoke:
     needs: toolchain

--- a/.plan/active/codebase-cleanup/PLAN.md
+++ b/.plan/active/codebase-cleanup/PLAN.md
@@ -1370,17 +1370,17 @@ All verified with whole-word grep over lib, bin, and test across the repo.
 
 ### Step 43 — installer parity, codegen freshness, `no_slop_linter` (D6)
 
-- Installer parity (PR #1017 finding F16): `install.sh` supports
-  `GITHUB`/`GITHUB_API` overrides that `install.ps1` hardcodes past, and
-  stable-version validation differs (regex vs `[version]::TryParse`, which
-  accepts four-component versions), so the two installers can select different
-  releases from identical metadata. `install.ps1` gains the env-override
-  handling and exact three-component validation; fixture-driven parity tests
+- Installer parity (PR #1017 finding F16): stable-version validation differs
+  (regex vs `[version]::TryParse`, which accepts four-component versions), so
+  the two installers can select different releases from identical metadata.
+  Both installers pin the canonical GitHub hosts so environment variables cannot
+  redirect executable downloads, and `install.ps1` gains exact three-component
+  validation; fixture-driven parity tests
   extending `bridge/app/test/tool/installers_test.dart` cover release selection
   and order, partial releases, checksum parsing, archive/checksum URL
-  construction including overrides, and manifest writing for both scripts. The
-  PowerShell rejection of non-three-component versions is a recorded behavior
-  delta (matches `install.sh`).
+  construction including hostile host variables, and manifest writing for both
+  scripts. The PowerShell rejection of non-three-component versions is a
+  recorded behavior delta (matches `install.sh`).
 - Codegen freshness: a CI job regenerates the OpenCode outputs that are fully
   reproducible from committed inputs (SSE events from the committed manifest)
   and fails on diff; the OpenAPI-derived client requires an uncommitted spec and
@@ -1391,7 +1391,7 @@ All verified with whole-word grep over lib, bin, and test across the repo.
   (validating whether a per-package `analysis_options.yaml` under the pub
   workspace accepts `plugins:` or the workspace root must carry it), fix what
   it reports there, and record per-package warning counts for `bridge/app` and
-  the plugins in `TRACKER.md` for the owner's later decision.
+  the plugins in `steps/step-43.md` for the owner's later decision.
 - Verify: installer parity suite; the freshness job fails when an offline-
   reproducible output is dirtied locally; `dart analyze --fatal-infos` in the
   three packages; CI green.

--- a/.plan/active/codebase-cleanup/TRACKER.md
+++ b/.plan/active/codebase-cleanup/TRACKER.md
@@ -39,7 +39,7 @@ five open PRs). Steps sharing a package stay serialized: 4 after 3 (both
 - [ ] **D5** Material→Prego dialog breadth — default only what the footer and
   confirm-sheet consolidation naturally covers
 - [x] **D6** `no_slop_linter` in bridge — default applied: enabled in the three
-  small packages, with counts recorded for the rest
+  small packages, with deferred-package counts recorded in Step 43 evidence
 
 ## Locked Principles
 
@@ -208,27 +208,6 @@ Fixed titles and order. Status is GitHub's; evidence is in `steps/step-NN.md`.
   `GET /settings` first and fall back to `GET /settings/pull-request-refresh`
   for supported older bridges. Keep the client fallback and bridge route until
   the minimum supported public client and bridge are both greater than v1.8.0.
-
-## Step 43 `no_slop_linter` Counts
-
-Only the three approved small packages include the workspace-root plugin
-configuration. Larger-package counts were measured by temporarily including
-that configuration, then restoring their existing analyzer options.
-
-| Package | Findings | Step 43 enforcement |
-| --- | ---: | --- |
-| `app` | 567 | Deferred |
-| `sesori_bridge_foundation` | 15 before fixes, 0 after | Enabled |
-| `sesori_plugin_interface` | 37 before fixes, 0 after | Enabled |
-| `sesori_plugin_runtime` | 41 before fixes, 0 after | Enabled |
-| `sesori_plugin_opencode` | 403 | Deferred |
-| `sesori_plugin_codex` | 250 | Deferred |
-| `sesori_plugin_acp` | 217 | Deferred |
-| `sesori_plugin_cursor` | 42 | Deferred |
-| `sesori_plugin_omp` | 27 | Deferred |
-| `sesori_plugin_claude` | 161 | Deferred |
-| `sesori_plugin_pi` | 163 | Deferred |
-| `sesori_plugin_hermes` | 5 | Deferred |
 
 ## Plan Review
 

--- a/.plan/active/codebase-cleanup/TRACKER.md
+++ b/.plan/active/codebase-cleanup/TRACKER.md
@@ -38,8 +38,8 @@ five open PRs). Steps sharing a package stay serialized: 4 after 3 (both
 - [ ] **D4** `cryptography_flutter` — default remove as unused (never enabled)
 - [ ] **D5** Material→Prego dialog breadth — default only what the footer and
   confirm-sheet consolidation naturally covers
-- [ ] **D6** `no_slop_linter` in bridge — default small packages only, record
-  counts for the rest
+- [x] **D6** `no_slop_linter` in bridge — default applied: enabled in the three
+  small packages, with counts recorded for the rest
 
 ## Locked Principles
 
@@ -57,7 +57,7 @@ five open PRs). Steps sharing a package stay serialized: 4 after 3 (both
 - [x] Session-detail refresh coordination, dispatcher merging, orchestrator
   splitting, and `ConnectionService`/`RelayClient` lifecycle redesign are out.
 - [x] Architecture-implementation review only for Steps 4, 7, 15, 17, 18, 20,
-  21, 22, 23, 25, 26, 27, 28, 29, 30, 31, 32, 33, 36, 37, 42.
+  21, 22, 23, 25, 26, 27, 28, 29, 30, 31, 32, 33, 36, 37, 42, 43.
 - [x] 1,500 changed-line soft cap; deletion- or generated-heavy overages are
   recorded with the reason.
 
@@ -208,6 +208,27 @@ Fixed titles and order. Status is GitHub's; evidence is in `steps/step-NN.md`.
   `GET /settings` first and fall back to `GET /settings/pull-request-refresh`
   for supported older bridges. Keep the client fallback and bridge route until
   the minimum supported public client and bridge are both greater than v1.8.0.
+
+## Step 43 `no_slop_linter` Counts
+
+Only the three approved small packages include the workspace-root plugin
+configuration. Larger-package counts were measured by temporarily including
+that configuration, then restoring their existing analyzer options.
+
+| Package | Findings | Step 43 enforcement |
+| --- | ---: | --- |
+| `app` | 567 | Deferred |
+| `sesori_bridge_foundation` | 15 before fixes, 0 after | Enabled |
+| `sesori_plugin_interface` | 37 before fixes, 0 after | Enabled |
+| `sesori_plugin_runtime` | 41 before fixes, 0 after | Enabled |
+| `sesori_plugin_opencode` | 403 | Deferred |
+| `sesori_plugin_codex` | 250 | Deferred |
+| `sesori_plugin_acp` | 217 | Deferred |
+| `sesori_plugin_cursor` | 42 | Deferred |
+| `sesori_plugin_omp` | 27 | Deferred |
+| `sesori_plugin_claude` | 161 | Deferred |
+| `sesori_plugin_pi` | 163 | Deferred |
+| `sesori_plugin_hermes` | 5 | Deferred |
 
 ## Plan Review
 

--- a/.plan/active/codebase-cleanup/steps/step-43.md
+++ b/.plan/active/codebase-cleanup/steps/step-43.md
@@ -1,0 +1,52 @@
+# Step 43 — Installer Parity, Codegen Freshness, And Bridge Linting
+
+## Re-verified evidence
+
+- `install.sh` already honored `GITHUB`/`GITHUB_API` overrides and accepted only
+  exact three-component stable tags, while `install.ps1` hardcoded GitHub hosts
+  and `[version]::TryParse` also accepted four-component versions.
+- OpenCode SSE output is fully reproducible from its committed event manifest;
+  the OpenAPI client still depends on an uncommitted upstream specification and
+  remains outside the offline freshness check.
+- Analyzer plugins must be declared at the pub-workspace root. Packages that
+  include `bridge/analysis_options.yaml` receive `no_slop_linter`; packages that
+  continue including `bridge/app/analysis_options.yaml` do not.
+
+## Change
+
+- Aligned `install.ps1` release selection and host overrides with `install.sh`,
+  and added a non-installing library mode so the real PowerShell resolvers can
+  run against shared release fixtures.
+- Added fixture coverage for incomplete releases, prereleases, invalid tag
+  prefixes, four-component versions, release ordering, and overridden archive,
+  checksum, and API URLs.
+- Added a Bridge CI freshness job that regenerates committed OpenCode SSE output
+  offline and fails on a diff. Bridge analysis now resolves the analyzer
+  plugin's own dependencies before loading it.
+- Enabled `no_slop_linter` in `sesori_bridge_foundation`,
+  `sesori_plugin_interface`, and `sesori_plugin_runtime`; fixed their 15, 37,
+  and 41 findings respectively. Intentional public, callback, JSON, and opaque
+  error boundaries use narrow documented suppressions.
+- Made managed-process start-abort signals required and non-null across the
+  internal runtime contract, and let debug logging retain an original error and
+  stack trace without escalating expected probe misses to warnings.
+- Recorded the deferred larger-package counts in `TRACKER.md` and updated the
+  positive installer regression contract.
+
+## Verification
+
+- `dart test test/tool/installers_test.dart`: passed, 28 tests; 2 executable
+  PowerShell cases skipped because PowerShell is not installed locally.
+- `bash -n install.sh`: passed.
+- `dart run tool/generate_sse_events.dart`: reproduced 44 variants and 6 refs;
+  the generated-file diff check passed.
+- Full package suites passed for `sesori_plugin_interface` (152),
+  `sesori_bridge_foundation`, and `sesori_plugin_runtime` (123).
+- `make analyze`: passed all 12 bridge packages with `--fatal-infos`; the three
+  opted-in packages reported no `no_slop_linter` findings.
+- `git diff --check`: passed.
+- Architecture implementation review approved the complete Step 43 diff with
+  no findings; independent correctness review also found no issues.
+- The pinned formatter formatted the files it could parse but still crashes on
+  existing enhanced enums with `Null check operator used on a null value`;
+  analyzer and diff checks remain the formatting authority for those files.

--- a/.plan/active/codebase-cleanup/steps/step-43.md
+++ b/.plan/active/codebase-cleanup/steps/step-43.md
@@ -2,9 +2,10 @@
 
 ## Re-verified evidence
 
-- `install.sh` already honored `GITHUB`/`GITHUB_API` overrides and accepted only
-  exact three-component stable tags, while `install.ps1` hardcoded GitHub hosts
-  and `[version]::TryParse` also accepted four-component versions.
+- `install.sh` accepted only exact three-component stable tags, while
+  `install.ps1` used `[version]::TryParse`, which also accepted four-component
+  versions. Review confirmed that both installers must pin canonical GitHub hosts
+  so environment variables cannot redirect executable downloads.
 - OpenCode SSE output is fully reproducible from its committed event manifest;
   the OpenAPI client still depends on an uncommitted upstream specification and
   remains outside the offline freshness check.
@@ -14,12 +15,12 @@
 
 ## Change
 
-- Aligned `install.ps1` release selection and host overrides with `install.sh`,
-  and added a non-installing library mode so the real PowerShell resolvers can
-  run against shared release fixtures.
+- Aligned `install.ps1` release selection with `install.sh`, pinned both scripts
+  to canonical GitHub hosts, and added a non-installing library mode so the real
+  PowerShell resolvers can run against shared release fixtures.
 - Added fixture coverage for incomplete releases, prereleases, invalid tag
-  prefixes, four-component versions, release ordering, and overridden archive,
-  checksum, and API URLs.
+  prefixes, four-component versions, release ordering, canonical archive,
+  checksum, and API URLs, and hostile host environment variables.
 - Added a Bridge CI freshness job that regenerates committed OpenCode SSE output
   offline and fails on a diff. Bridge analysis now resolves the analyzer
   plugin's own dependencies before loading it.
@@ -28,10 +29,31 @@
   and 41 findings respectively. Intentional public, callback, JSON, and opaque
   error boundaries use narrow documented suppressions.
 - Made managed-process start-abort signals required and non-null across the
-  internal runtime contract, and let debug logging retain an original error and
-  stack trace without escalating expected probe misses to warnings.
-- Recorded the deferred larger-package counts in `TRACKER.md` and updated the
+  internal runtime contract. Debug logging remains message-only; a caught probe
+  launch error uses warning logging to retain its original error and stack trace.
+- Recorded the deferred larger-package counts below and updated the
   positive installer regression contract.
+
+## `no_slop_linter` counts
+
+Only the three approved small packages include the workspace-root plugin
+configuration. Larger-package counts were measured by temporarily including
+that configuration, then restoring their existing analyzer options.
+
+| Package | Findings | Step 43 enforcement |
+| --- | ---: | --- |
+| `app` | 567 | Deferred |
+| `sesori_bridge_foundation` | 15 before fixes, 0 after | Enabled |
+| `sesori_plugin_interface` | 37 before fixes, 0 after | Enabled |
+| `sesori_plugin_runtime` | 41 before fixes, 0 after | Enabled |
+| `sesori_plugin_opencode` | 403 | Deferred |
+| `sesori_plugin_codex` | 250 | Deferred |
+| `sesori_plugin_acp` | 217 | Deferred |
+| `sesori_plugin_cursor` | 42 | Deferred |
+| `sesori_plugin_omp` | 27 | Deferred |
+| `sesori_plugin_claude` | 161 | Deferred |
+| `sesori_plugin_pi` | 163 | Deferred |
+| `sesori_plugin_hermes` | 5 | Deferred |
 
 ## Verification
 
@@ -42,11 +64,15 @@
   the generated-file diff check passed.
 - Full package suites passed for `sesori_plugin_interface` (152),
   `sesori_bridge_foundation`, and `sesori_plugin_runtime` (123).
+- Focused app repository suites passed 73 tests after the plugin-session API
+  moved to required named parameters.
 - `make analyze`: passed all 12 bridge packages with `--fatal-infos`; the three
   opted-in packages reported no `no_slop_linter` findings.
 - `git diff --check`: passed.
-- Architecture implementation review approved the complete Step 43 diff with
-  no findings; independent correctness review also found no issues.
+- Architecture implementation review approved the initial Step 43 diff with no
+  findings. The follow-up review skill was unavailable after two attempts; an
+  independent correctness and security review of the feedback diff found no
+  issues.
 - The pinned formatter formatted the files it could parse but still crashes on
   existing enhanced enums with `Null check operator used on a null value`;
   analyzer and diff checks remain the formatting authority for those files.

--- a/bridge/analysis_options.yaml
+++ b/bridge/analysis_options.yaml
@@ -1,3 +1,5 @@
-# plugins:
-#   no_slop_linter:
-#     path: ../shared/no_slop_linter
+include: app/analysis_options.yaml
+
+plugins:
+  no_slop_linter:
+    path: ../shared/no_slop_linter

--- a/bridge/app/lib/src/repositories/catalog_import_repository.dart
+++ b/bridge/app/lib/src/repositories/catalog_import_repository.dart
@@ -180,7 +180,7 @@ class CatalogImportRepository({
             return;
           }
           final projectPath = _normalizeRequiredPath(project.directory);
-          final roots = await plugin.getSessions(projectPath);
+          final roots = await plugin.getSessions(projectId: projectPath, start: null, limit: null);
           if (control.cancellationRequested) {
             yield CatalogImportProgress.cancelled(pluginId: pluginId);
             return;

--- a/bridge/app/lib/src/repositories/session_repository.dart
+++ b/bridge/app/lib/src/repositories/session_repository.dart
@@ -765,7 +765,7 @@ class SessionRepository({
             existing ??
             _hiddenProjectPlaceholder(projectId: project.id, path: project.directory);
         if (hydratedProjectIds.contains(hydratedProject.projectId)) continue;
-        final sessions = await plugin.getSessions(project.directory, start: null, limit: null);
+        final sessions = await plugin.getSessions(projectId: project.directory, start: null, limit: null);
         hydratedProjectIds.add(hydratedProject.projectId);
         hydrations.add(
           _ActiveRootHydration(

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -1106,10 +1106,10 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi, _SubscriptionAware
   }
 
   @override
-  Future<List<PluginSession>> getSessions(
-    String worktree, {
-    int? start,
-    int? limit,
+  Future<List<PluginSession>> getSessions({
+    required String projectId,
+    required int? start,
+    required int? limit,
   }) async => sessionsResult;
 
   @override
@@ -1359,10 +1359,10 @@ class _TrackingBridgePlugin() implements NativeProjectsPluginApi, _SubscriptionA
   Future<List<PluginProject>> getProjects() async => [];
 
   @override
-  Future<List<PluginSession>> getSessions(
-    String worktree, {
-    int? start,
-    int? limit,
+  Future<List<PluginSession>> getSessions({
+    required String projectId,
+    required int? start,
+    required int? limit,
   }) async => [];
 
   @override

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -417,10 +417,10 @@ class _ThrowingSummaryPlugin() implements NativeProjectsPluginApi {
   Future<List<PluginProject>> getProjects() async => [];
 
   @override
-  Future<List<PluginSession>> getSessions(
-    String worktree, {
-    int? start,
-    int? limit,
+  Future<List<PluginSession>> getSessions({
+    required String projectId,
+    required int? start,
+    required int? limit,
   }) async => [];
 
   @override

--- a/bridge/app/test/bridge/repositories/session_repository_persistence_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_persistence_test.dart
@@ -273,7 +273,7 @@ class _NeverCompletingPlugin() extends _ThrowingPlugin {
   }
 
   @override
-  Future<List<PluginSession>> getSessions(String projectId, {int? start, int? limit}) {
+  Future<List<PluginSession>> getSessions({required String projectId, required int? start, required int? limit}) {
     calls++;
     return Completer<List<PluginSession>>().future;
   }

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -2776,14 +2776,14 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi {
   }
 
   @override
-  Future<List<PluginSession>> getSessions(String worktree, {int? start, int? limit}) async {
+  Future<List<PluginSession>> getSessions({required String projectId, required int? start, required int? limit}) async {
     getSessionsCalls++;
-    lastGetSessionsWorktree = worktree;
+    lastGetSessionsWorktree = projectId;
     if (getSessionsFailuresRemaining > 0) {
       getSessionsFailuresRemaining--;
       throw StateError("session collection unavailable");
     }
-    return sessionsByWorktree[worktree] ?? sessionsResult;
+    return sessionsByWorktree[projectId] ?? sessionsResult;
   }
 
   @override

--- a/bridge/app/test/bridge/routing/catalog_read_handlers_test.dart
+++ b/bridge/app/test/bridge/routing/catalog_read_handlers_test.dart
@@ -266,7 +266,7 @@ class _NeverCompletingPlugin() implements NativeProjectsPluginApi {
   }
 
   @override
-  Future<List<PluginSession>> getSessions(String projectId, {int? start, int? limit}) {
+  Future<List<PluginSession>> getSessions({required String projectId, required int? start, required int? limit}) {
     calls++;
     return Completer<List<PluginSession>>().future;
   }

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -799,7 +799,7 @@ class FakeSessionRepository({
     lastVerifiedGithubLogin = verifiedGithubLogin;
     lastGetSessionsArgs = (projectId: projectId, start: start, limit: limit);
     final pluginSessions = await _plugin.getSessions(
-      projectId,
+      projectId: projectId,
       start: start,
       limit: limit,
     );

--- a/bridge/app/test/helpers/fakes/fake_bridge_plugin.dart
+++ b/bridge/app/test/helpers/fakes/fake_bridge_plugin.dart
@@ -130,13 +130,13 @@ class FakeBridgePlugin() implements NativeProjectsPluginApi {
   }
 
   @override
-  Future<List<PluginSession>> getSessions(
-    String worktree, {
-    int? start,
-    int? limit,
+  Future<List<PluginSession>> getSessions({
+    required String projectId,
+    required int? start,
+    required int? limit,
   }) async {
     if (throwOnGetSessions) throw Exception("getSessions error");
-    lastGetSessionsWorktree = worktree;
+    lastGetSessionsWorktree = projectId;
     lastGetSessionsStart = start;
     lastGetSessionsLimit = limit;
     return sessionsResult;

--- a/bridge/app/test/integration/pr_sync_fk_regression_test.dart
+++ b/bridge/app/test/integration/pr_sync_fk_regression_test.dart
@@ -309,7 +309,7 @@ class _FakeBridgePlugin({required final List<PluginProject> _projects, required 
   Stream<BridgeSseEvent> get events => throw UnimplementedError();
 
   @override
-  Future<List<PluginSession>> getSessions(String projectId, {int? start, int? limit}) async => _sessions;
+  Future<List<PluginSession>> getSessions({required String projectId, required int? start, required int? limit}) async => _sessions;
 
   @override
   Future<List<PluginCommand>> getCommands({required String? projectId}) async => const [];

--- a/bridge/app/test/repositories/catalog_import_repository_test.dart
+++ b/bridge/app/test/repositories/catalog_import_repository_test.dart
@@ -1135,7 +1135,7 @@ class _NativeImportPlugin({
   }
 
   @override
-  Future<List<PluginSession>> getSessions(String projectId, {int? start, int? limit}) async {
+  Future<List<PluginSession>> getSessions({required String projectId, required int? start, required int? limit}) async {
     await onGetSessions?.call(projectId);
     return rootsByProject[projectId] ?? const [];
   }

--- a/bridge/app/test/tool/fixtures/installer_releases.json
+++ b/bridge/app/test/tool/fixtures/installer_releases.json
@@ -1,0 +1,51 @@
+[
+  {
+    "tag_name": "v2.10.0",
+    "draft": false,
+    "prerelease": false,
+    "assets": [
+      {"name": "sesori-bridge-linux-x64.tar.gz", "browser_download_url": "https://downloads.example/v2.10.0/archive"},
+      {"name": "sesori-bridge-windows-x64.zip", "browser_download_url": "https://downloads.example/v2.10.0/archive.zip"},
+      {"name": "checksums.txt", "browser_download_url": "https://downloads.example/v2.10.0/checksums"}
+    ]
+  },
+  {
+    "tag_name": "v3.0.0",
+    "draft": false,
+    "prerelease": false,
+    "assets": [
+      {"name": "sesori-bridge-linux-x64.tar.gz", "browser_download_url": "https://downloads.example/v3.0.0/archive"},
+      {"name": "sesori-bridge-windows-x64.zip", "browser_download_url": "https://downloads.example/v3.0.0/archive.zip"}
+    ]
+  },
+  {
+    "tag_name": "v20.0.0.1",
+    "draft": false,
+    "prerelease": false,
+    "assets": [
+      {"name": "sesori-bridge-linux-x64.tar.gz", "browser_download_url": "https://downloads.example/v20.0.0.1/archive"},
+      {"name": "sesori-bridge-windows-x64.zip", "browser_download_url": "https://downloads.example/v20.0.0.1/archive.zip"},
+      {"name": "checksums.txt", "browser_download_url": "https://downloads.example/v20.0.0.1/checksums"}
+    ]
+  },
+  {
+    "tag_name": "v99.0.0",
+    "draft": false,
+    "prerelease": true,
+    "assets": [
+      {"name": "sesori-bridge-linux-x64.tar.gz"},
+      {"name": "sesori-bridge-windows-x64.zip"},
+      {"name": "checksums.txt"}
+    ]
+  },
+  {
+    "tag_name": "repo-v50.0.0",
+    "draft": false,
+    "prerelease": false,
+    "assets": [
+      {"name": "sesori-bridge-linux-x64.tar.gz"},
+      {"name": "sesori-bridge-windows-x64.zip"},
+      {"name": "checksums.txt"}
+    ]
+  }
+]

--- a/bridge/app/test/tool/installers_test.dart
+++ b/bridge/app/test/tool/installers_test.dart
@@ -727,6 +727,7 @@ Write-Output \$release.TagName
           environment: {
             ...Platform.environment,
             'SESORI_INSTALLER_LIBRARY_MODE': '1',
+            'LOCALAPPDATA': Directory.systemTemp.path,
           },
         );
 
@@ -755,6 +756,7 @@ Write-Output \$ReleasesApiUrl
           environment: {
             ...Platform.environment,
             'SESORI_INSTALLER_LIBRARY_MODE': '1',
+            'LOCALAPPDATA': Directory.systemTemp.path,
             'GITHUB': 'https://github.enterprise.example',
             'GITHUB_API': 'https://api.github.enterprise.example',
           },

--- a/bridge/app/test/tool/installers_test.dart
+++ b/bridge/app/test/tool/installers_test.dart
@@ -128,7 +128,7 @@ printf '%s\n' 'HTTP/2 302' 'location: https://github.com/sesori-ai/sesori_apps_m
       expect((result.stdout as String).trim(), equals('1.2.3'));
     });
 
-    test('resolves the latest release via the static latest/download redirect (no API, no Python)', () async {
+    test('resolves latest/download from canonical GitHub despite hostile host variables', () async {
       final libraryPath = await _createInstallShLibrary();
       final tempDir = await Directory.systemTemp.createTemp('install-sh-latest-');
       addTearDown(() => tempDir.delete(recursive: true));
@@ -155,6 +155,8 @@ printf '%s\n%s\n%s\n' "\$RESOLVED_VERSION" "\$RESOLVED_ARCHIVE_URL" "\$RESOLVED_
         environment: {
           'PATH': '${binDir.path}:${Platform.environment['PATH'] ?? ''}',
           'HOME': tempDir.path,
+          'GITHUB': 'https://github.enterprise.example',
+          'GITHUB_API': 'https://api.github.enterprise.example',
         },
       );
 
@@ -735,12 +737,12 @@ Write-Output \$release.TagName
     );
 
     test(
-      'install.ps1 constructs archive and checksum URLs from GitHub host overrides',
+      'install.ps1 ignores GitHub host environment variables',
       () async {
         final script =
             '''
 . ${_powerShellQuote(_installPs1Path())}
-function Get-RedirectLocation { return "\$env:GITHUB/sesori-ai/sesori_apps_monorepo/releases/download/v4.5.6/sesori-bridge-windows-x64.zip" }
+function Get-RedirectLocation { return "https://github.com/sesori-ai/sesori_apps_monorepo/releases/download/v4.5.6/sesori-bridge-windows-x64.zip" }
 function Test-RemoteAssetExists { return \$true }
 \$release = Resolve-BridgeReleaseViaLatest -ArchiveName 'sesori-bridge-windows-x64.zip'
 Write-Output \$release.AssetUrl
@@ -762,9 +764,9 @@ Write-Output \$ReleasesApiUrl
         expect(
           (result.stdout as String).trim().split(RegExp(r'\r?\n')),
           equals([
-            'https://github.enterprise.example/sesori-ai/sesori_apps_monorepo/releases/download/v4.5.6/sesori-bridge-windows-x64.zip',
-            'https://github.enterprise.example/sesori-ai/sesori_apps_monorepo/releases/download/v4.5.6/checksums.txt',
-            'https://api.github.enterprise.example/repos/sesori-ai/sesori_apps_monorepo/releases',
+            'https://github.com/sesori-ai/sesori_apps_monorepo/releases/download/v4.5.6/sesori-bridge-windows-x64.zip',
+            'https://github.com/sesori-ai/sesori_apps_monorepo/releases/download/v4.5.6/checksums.txt',
+            'https://api.github.com/repos/sesori-ai/sesori_apps_monorepo/releases',
           ]),
         );
       },
@@ -886,11 +888,10 @@ Write-Output \$ReleasesApiUrl
       expect(script, isNot(contains('bridge-v')));
     });
 
-    test('uses GitHub host overrides and exposes a non-installing library mode', () {
-      expect(script, contains(r'$env:GITHUB.TrimEnd'));
-      expect(script, contains(r'$env:GITHUB_API.TrimEnd'));
-      expect(script, contains(r'$RepoBase   = "$GitHubBase/$RepoOwner/$RepoName"'));
-      expect(script, contains(r'$ReleasesApiUrl = "$GitHubApiBase/repos/$RepoOwner/$RepoName/releases"'));
+    test('pins GitHub hosts and exposes a non-installing library mode', () {
+      expect(script, isNot(contains(r'$env:GITHUB')));
+      expect(script, contains(r'$RepoBase   = "https://github.com/$RepoOwner/$RepoName"'));
+      expect(script, contains(r'$ReleasesApiUrl = "https://api.github.com/repos/$RepoOwner/$RepoName/releases"'));
       expect(script, contains(r"if ($env:SESORI_INSTALLER_LIBRARY_MODE -eq '1')"));
     });
   });

--- a/bridge/app/test/tool/installers_test.dart
+++ b/bridge/app/test/tool/installers_test.dart
@@ -10,6 +10,22 @@ String _installShPath() => p.join(_repoRoot(), 'install.sh');
 
 String _installPs1Path() => p.join(_repoRoot(), 'install.ps1');
 
+String _installerFixturePath() => p.join(Directory.current.path, 'test', 'tool', 'fixtures', 'installer_releases.json');
+
+String _powerShellQuote(String value) => "'${value.replaceAll("'", "''")}'";
+
+String? _powerShellExecutable() {
+  for (final candidate in ['pwsh', 'powershell']) {
+    try {
+      final result = Process.runSync(candidate, const ['-NoProfile', '-NonInteractive', '-Command', r'$null']);
+      if (result.exitCode == 0) return candidate;
+    } on ProcessException {
+      // PowerShell is optional locally; the Ubuntu CI runner provides pwsh.
+    }
+  }
+  return null;
+}
+
 Future<String> _createInstallShLibrary() async {
   final tempDir = await Directory.systemTemp.createTemp('install-sh-lib-');
   addTearDown(() => tempDir.delete(recursive: true));
@@ -667,6 +683,95 @@ cat "\$HOME/.zprofile"
     });
   });
 
+  group('installer release parity', () {
+    test('install.sh selects the newest complete three-component stable release fixture', () async {
+      final libraryPath = await _createInstallShLibrary();
+      final result = await _runBashSnippet(
+        script:
+            '''
+source ${jsonEncode(libraryPath)}
+fetch_redirect_headers() { printf '%s\n' 'HTTP/2 404'; }
+fetch_text() { cat ${jsonEncode(_installerFixturePath())}; }
+resolve_release sesori-bridge-linux-x64.tar.gz
+printf '%s' "\$RESOLVED_VERSION"
+''',
+        environment: {
+          'PATH': Platform.environment['PATH'] ?? '',
+          'HOME': Directory.systemTemp.path,
+        },
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      expect((result.stdout as String).trim(), equals('2.10.0'));
+    });
+
+    final powerShell = _powerShellExecutable();
+    test(
+      'install.ps1 selects the newest complete three-component stable release fixture',
+      () async {
+        final script =
+            '''
+. ${_powerShellQuote(_installPs1Path())}
+function Invoke-RestMethod {
+    param([string]\$Uri, [hashtable]\$Headers)
+    return Get-Content -Raw ${_powerShellQuote(_installerFixturePath())} | ConvertFrom-Json
+}
+\$release = Resolve-BridgeReleaseViaScan -ArchiveName 'sesori-bridge-windows-x64.zip'
+Write-Output \$release.TagName
+''';
+        final result = await Process.run(
+          powerShell!,
+          ['-NoProfile', '-NonInteractive', '-Command', script],
+          environment: {
+            ...Platform.environment,
+            'SESORI_INSTALLER_LIBRARY_MODE': '1',
+          },
+        );
+
+        expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+        expect((result.stdout as String).trim(), equals('v2.10.0'));
+      },
+      skip: powerShell == null ? 'PowerShell is not installed on this host' : false,
+    );
+
+    test(
+      'install.ps1 constructs archive and checksum URLs from GitHub host overrides',
+      () async {
+        final script =
+            '''
+. ${_powerShellQuote(_installPs1Path())}
+function Get-RedirectLocation { return "\$env:GITHUB/sesori-ai/sesori_apps_monorepo/releases/download/v4.5.6/sesori-bridge-windows-x64.zip" }
+function Test-RemoteAssetExists { return \$true }
+\$release = Resolve-BridgeReleaseViaLatest -ArchiveName 'sesori-bridge-windows-x64.zip'
+Write-Output \$release.AssetUrl
+Write-Output \$release.ChecksumsUrl
+Write-Output \$ReleasesApiUrl
+''';
+        final result = await Process.run(
+          powerShell!,
+          ['-NoProfile', '-NonInteractive', '-Command', script],
+          environment: {
+            ...Platform.environment,
+            'SESORI_INSTALLER_LIBRARY_MODE': '1',
+            'GITHUB': 'https://github.enterprise.example',
+            'GITHUB_API': 'https://api.github.enterprise.example',
+          },
+        );
+
+        expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+        expect(
+          (result.stdout as String).trim().split(RegExp(r'\r?\n')),
+          equals([
+            'https://github.enterprise.example/sesori-ai/sesori_apps_monorepo/releases/download/v4.5.6/sesori-bridge-windows-x64.zip',
+            'https://github.enterprise.example/sesori-ai/sesori_apps_monorepo/releases/download/v4.5.6/checksums.txt',
+            'https://api.github.enterprise.example/repos/sesori-ai/sesori_apps_monorepo/releases',
+          ]),
+        );
+      },
+      skip: powerShell == null ? 'PowerShell is not installed on this host' : false,
+    );
+  });
+
   group('install.ps1 contract', () {
     late String script;
 
@@ -705,6 +810,7 @@ cat "\$HOME/.zprofile"
       // Fallback scan retained: pagination + client-side filtering + version sort.
       expect(script, contains(r"$tagName.StartsWith('v')"));
       expect(script, contains(r'''$release.draft -or $release.prerelease'''));
+      expect(script, contains(r"$versionText -notmatch '^\d+\.\d+\.\d+$'"));
       expect(script, contains(r'[version]::TryParse($versionText, [ref]$parsedVersion)'));
       expect(script, contains(r'$page -le $ReleasesMaxPages'));
       expect(script, contains(r'"${ReleasesApiUrl}?per_page=$ReleasesPerPage&page=$page"'));
@@ -776,7 +882,16 @@ cat "\$HOME/.zprofile"
     test('accepts only v release tags', () {
       expect(script, contains(r"if ($tagName.StartsWith('v')) {"));
       expect(script, contains(r'$versionText = $tagName.Substring(1)'));
+      expect(script, contains(r"$versionText -notmatch '^\d+\.\d+\.\d+$'"));
       expect(script, isNot(contains('bridge-v')));
+    });
+
+    test('uses GitHub host overrides and exposes a non-installing library mode', () {
+      expect(script, contains(r'$env:GITHUB.TrimEnd'));
+      expect(script, contains(r'$env:GITHUB_API.TrimEnd'));
+      expect(script, contains(r'$RepoBase   = "$GitHubBase/$RepoOwner/$RepoName"'));
+      expect(script, contains(r'$ReleasesApiUrl = "$GitHubApiBase/repos/$RepoOwner/$RepoName/releases"'));
+      expect(script, contains(r"if ($env:SESORI_INSTALLER_LIBRARY_MODE -eq '1')"));
     });
   });
 }

--- a/bridge/app/test/updater/release_contract_test.dart
+++ b/bridge/app/test/updater/release_contract_test.dart
@@ -152,7 +152,7 @@ void main() {
       // Primary path: GitHub-native always-latest static download; the version is
       // read from the versioned download redirect, and both the archive and
       // checksums.txt are required before the latest release is accepted.
-      expect(script, contains(r'GITHUB="${GITHUB:-https://github.com}"'));
+      expect(script, contains('GITHUB_BASE_URL="https://github.com"'));
       expect(script, contains('releases/latest/download'));
       expect(script, contains(r'${latest_base}/${filename}'));
       expect(script, contains(r'${latest_base}/checksums.txt'));
@@ -161,7 +161,10 @@ void main() {
 
       // Fallback scan: still the REST API, but small and reading pages from
       // files (paths-as-args only), never env vars.
-      expect(script, contains(r'GITHUB_API="${GITHUB_API:-https://api.github.com}"'));
+      expect(
+        script,
+        contains(r'GITHUB_RELEASES_API_URL="https://api.github.com/repos/${GITHUB_REPO}/releases"'),
+      );
       expect(script, contains('GITHUB_RELEASES_PER_PAGE=30'));
       expect(script, contains('GITHUB_RELEASES_MAX_PAGES=3'));
       expect(script, contains(r'?per_page=${GITHUB_RELEASES_PER_PAGE}&page=${page}'));

--- a/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
+++ b/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
@@ -836,7 +836,7 @@ class _BenchmarkPlugin({
   }
 
   @override
-  Future<List<PluginSession>> getSessions(String projectId, {int? start, int? limit}) {
+  Future<List<PluginSession>> getSessions({required String projectId, required int? start, required int? limit}) {
     listReadCalls++;
     return Future<List<PluginSession>>.error(StateError("catalog read unexpectedly called plugin.getSessions"));
   }

--- a/bridge/app/tool/benchmarks/live_list_baseline.dart
+++ b/bridge/app/tool/benchmarks/live_list_baseline.dart
@@ -741,7 +741,7 @@ class _ThrowingBenchmarkPlugin({@override required final String id})
   Future<PluginProject> getProject(String projectId) => _throwListRead(read: "project detail");
 
   @override
-  Future<List<PluginSession>> getSessions(String projectId, {int? start, int? limit}) =>
+  Future<List<PluginSession>> getSessions({required String projectId, required int? start, required int? limit}) =>
       _throwListRead(read: "root sessions");
 
   @override

--- a/bridge/sesori_bridge_foundation/analysis_options.yaml
+++ b/bridge/sesori_bridge_foundation/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: ../app/analysis_options.yaml
+include: ../analysis_options.yaml

--- a/bridge/sesori_bridge_foundation/lib/src/archive_extractor.dart
+++ b/bridge/sesori_bridge_foundation/lib/src/archive_extractor.dart
@@ -76,7 +76,7 @@ class ArchiveExtractor({required final CommandExecutor _commandExecutor}) {
             : _extractZipPosix(archivePath: archivePath, stagingPath: stagingPath),
       };
     } on Object catch (error, stackTrace) {
-      final String reason = "extraction command failed to run: $error";
+      final String reason = "extraction command failed to run: ${error.toString()}";
       Log.w("Archive extraction command threw", error, stackTrace);
       _deleteQuietly(stagingDir);
       return ArchiveExtractionResult.failure(reason: reason);

--- a/bridge/sesori_bridge_foundation/lib/src/binary_download_client.dart
+++ b/bridge/sesori_bridge_foundation/lib/src/binary_download_client.dart
@@ -70,15 +70,15 @@ class BinaryDownloadClient({
     try {
       response = await _httpClient.send(request).timeout(_requestTimeout);
     } on TimeoutException catch (error) {
-      throw DownloadException(kind: DownloadFailureKind.network, message: "Download connection timed out: $error");
+      throw DownloadException(kind: DownloadFailureKind.network, message: "Download connection timed out: ${error.toString()}");
     } on SocketException catch (error) {
-      throw DownloadException(kind: DownloadFailureKind.network, message: "Download connection failed: $error");
+      throw DownloadException(kind: DownloadFailureKind.network, message: "Download connection failed: ${error.toString()}");
     } on HttpException catch (error) {
-      throw DownloadException(kind: DownloadFailureKind.network, message: "Download HTTP error: $error");
+      throw DownloadException(kind: DownloadFailureKind.network, message: "Download HTTP error: ${error.toString()}");
     } on http.ClientException catch (error) {
-      throw DownloadException(kind: DownloadFailureKind.network, message: "Download client error: $error");
+      throw DownloadException(kind: DownloadFailureKind.network, message: "Download client error: ${error.toString()}");
     } on Object catch (error) {
-      throw DownloadException(kind: DownloadFailureKind.failed, message: "Download failed to start: $error");
+      throw DownloadException(kind: DownloadFailureKind.failed, message: "Download failed to start: ${error.toString()}");
     }
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
@@ -96,7 +96,7 @@ class BinaryDownloadClient({
     try {
       sink = File(destinationPath).openWrite();
     } on Object catch (error) {
-      throw DownloadException(kind: DownloadFailureKind.failed, message: "Could not open download destination: $error");
+      throw DownloadException(kind: DownloadFailureKind.failed, message: "Could not open download destination: ${error.toString()}");
     }
 
     var receivedBytes = 0;
@@ -109,17 +109,17 @@ class BinaryDownloadClient({
       }
       bodyCompleted = true;
     } on TimeoutException catch (error) {
-      throw DownloadException(kind: DownloadFailureKind.network, message: "Download stream stalled: $error");
+      throw DownloadException(kind: DownloadFailureKind.network, message: "Download stream stalled: ${error.toString()}");
     } on SocketException catch (error) {
-      throw DownloadException(kind: DownloadFailureKind.network, message: "Download connection failed: $error");
+      throw DownloadException(kind: DownloadFailureKind.network, message: "Download connection failed: ${error.toString()}");
     } on HttpException catch (error) {
-      throw DownloadException(kind: DownloadFailureKind.network, message: "Download HTTP error: $error");
+      throw DownloadException(kind: DownloadFailureKind.network, message: "Download HTTP error: ${error.toString()}");
     } on http.ClientException catch (error) {
       // A connection reset/drop while reading the body (after a 2xx) is the same
       // transient outage class as a pre-response failure — keep it retryable.
-      throw DownloadException(kind: DownloadFailureKind.network, message: "Download connection dropped: $error");
+      throw DownloadException(kind: DownloadFailureKind.network, message: "Download connection dropped: ${error.toString()}");
     } on Object catch (error) {
-      throw DownloadException(kind: DownloadFailureKind.failed, message: "Download failed: $error");
+      throw DownloadException(kind: DownloadFailureKind.failed, message: "Download failed: ${error.toString()}");
     } finally {
       // The finally also runs when the consumer cancels the subscription
       // mid-stream, so the sink is always closed — no leaked handle or locked
@@ -132,7 +132,7 @@ class BinaryDownloadClient({
         try {
           await sink.close();
         } on Object catch (error) {
-          throw DownloadException(kind: DownloadFailureKind.failed, message: "Could not finalize download: $error");
+          throw DownloadException(kind: DownloadFailureKind.failed, message: "Could not finalize download: ${error.toString()}");
         }
       } else {
         // Error or cancellation: close quietly so a teardown failure never masks

--- a/bridge/sesori_bridge_foundation/lib/src/command_executor.dart
+++ b/bridge/sesori_bridge_foundation/lib/src/command_executor.dart
@@ -12,6 +12,7 @@ abstract class CommandExecutor() {
   /// captured result. Implementations must enforce a timeout (killing the child
   /// and throwing) so a hung command can never stall the caller; [timeout],
   /// when provided, overrides the implementation default.
+  // ignore: no_slop_linter/prefer_required_named_parameters, public command-execution API has established positional call sites
   Future<CommandResult> run(
     String executable,
     List<String> arguments, {

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -567,10 +567,10 @@ abstract class AcpPlugin({
   }
 
   @override
-  Future<List<PluginSession>> getSessions(
-    String projectId, {
-    int? start,
-    int? limit,
+  Future<List<PluginSession>> getSessions({
+    required String projectId,
+    required int? start,
+    required int? limit,
   }) async {
     final AcpStdioClient client;
     try {

--- a/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
@@ -520,7 +520,7 @@ void main() {
       // enumeration would (the app lists a project's sessions before opening
       // one), then prompt a session this process never created so a
       // resume-load is forced.
-      final listing = plugin.getSessions(opened);
+      final listing = plugin.getSessions(projectId: opened, start: null, limit: null);
       await respond("session/list", {
         "sessions": [
           {"sessionId": "old-s", "cwd": opened, "title": "Prior"},
@@ -708,7 +708,7 @@ void main() {
       const opened = "/Users/x/kustos";
 
       // The agent itself reported the session's cwd via enumeration…
-      final listing = plugin.getSessions(opened);
+      final listing = plugin.getSessions(projectId: opened, start: null, limit: null);
       await respond("session/list", {
         "sessions": [
           {"sessionId": "old-s", "cwd": opened, "title": "Prior"},

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -59,7 +59,7 @@ final class ClaudePlugin({
   String get launchDirectory => _launchDirectory;
 
   @override
-  Future<List<PluginSession>> getSessions(String projectId, {int? start, int? limit}) async {
+  Future<List<PluginSession>> getSessions({required String projectId, required int? start, required int? limit}) async {
     final persisted = await _transcripts.getSessions(projectId: projectId, start: null, limit: null);
     final target = normalizeProjectDirectory(directory: projectId);
     final combined = _mergeSessions(persisted, [
@@ -307,7 +307,7 @@ final class ClaudePlugin({
 
   @override
   Future<List<PluginPendingQuestion>> getProjectQuestions({required String projectId}) async {
-    final sessions = await getSessions(projectId);
+    final sessions = await getSessions(projectId: projectId, start: null, limit: null);
     return [
       for (final session in sessions) ..._approvals.pendingQuestionsForSession(sessionId: session.id),
     ];

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -541,7 +541,7 @@ void main() {
       await harness.plugin.deleteSession(session.id);
 
       expect(process.killed, isTrue);
-      expect(await harness.plugin.getSessions("/tmp/project"), isEmpty);
+      expect(await harness.plugin.getSessions(projectId: "/tmp/project", start: null, limit: null), isEmpty);
       expect(await harness.plugin.getSessionStatuses(), isEmpty);
       await expectLater(
         harness.plugin.deleteSession(session.id),
@@ -563,7 +563,7 @@ void main() {
         ),
       );
 
-      expect(await harness.plugin.getSessions("/tmp/project"), isEmpty);
+      expect(await harness.plugin.getSessions(projectId: "/tmp/project", start: null, limit: null), isEmpty);
       expect(await harness.plugin.getSessionStatuses(), isEmpty);
     });
 

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -629,10 +629,10 @@ class CodexPlugin._({
   void primeSessionDirectory({required String sessionId, required String directory}) {}
 
   @override
-  Future<List<PluginSession>> getSessions(
-    String projectId, {
-    int? start,
-    int? limit,
+  Future<List<PluginSession>> getSessions({
+    required String projectId,
+    required int? start,
+    required int? limit,
   }) async => await _sessionService.getSessions(
     projectId: projectId,
     start: start,

--- a/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
@@ -60,7 +60,7 @@ void main() {
           clientFactory: () => CodexAppServerClient(serverUrl: serverUrl),
           keepaliveInterval: const Duration(seconds: 30),
         );
-        expect(await plugin.getSessions("/repo/example"), isEmpty);
+        expect(await plugin.getSessions(projectId: "/repo/example", start: null, limit: null), isEmpty);
         expect(await plugin.getSessionMessages("s-1"), isEmpty);
         expect(await plugin.getSessionStatuses(), isEmpty);
         expect(plugin.getActiveSessionsSummary(), isEmpty);

--- a/bridge/sesori_plugin_codex/test/codex_plugin_phase6_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_phase6_test.dart
@@ -99,7 +99,7 @@ void main() {
       expect(indexLines, hasLength(1));
       expect(indexLines.single, contains("Survivor"));
       // Listing sessions reflects the delete.
-      final remaining = await plugin.getSessions(projectCwd.path);
+      final remaining = await plugin.getSessions(projectId: projectCwd.path, start: null, limit: null);
       expect(
         remaining.map((s) => s.id).toList(),
         equals([

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -2318,13 +2318,13 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
         keepaliveInterval: const Duration(seconds: 30),
       );
 
-      final sessions = await plugin.getSessions("/work/sample-app");
+      final sessions = await plugin.getSessions(projectId: "/work/sample-app", start: null, limit: null);
       expect(sessions, hasLength(1));
       expect(sessions.single.id, equals("019a0000-1111-2222-3333-aaaaaaaaaaaa"));
       expect(sessions.single.directory, equals("/work/sample-app"));
 
       // Filtering by a different CWD returns empty.
-      final none = await plugin.getSessions("/somewhere/else");
+      final none = await plugin.getSessions(projectId: "/somewhere/else", start: null, limit: null);
       expect(none, isEmpty);
       await plugin.dispose();
     });

--- a/bridge/sesori_plugin_interface/analysis_options.yaml
+++ b/bridge/sesori_plugin_interface/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: ../app/analysis_options.yaml
+include: ../analysis_options.yaml

--- a/bridge/sesori_plugin_interface/lib/src/ansi_color.dart
+++ b/bridge/sesori_plugin_interface/lib/src/ansi_color.dart
@@ -28,6 +28,7 @@ class AnsiColorFormatter._() {
   ///
   /// [environment] defaults to the process environment and exists to make the
   /// color opt-in/opt-out deterministically testable.
+  // ignore: no_slop_linter/prefer_required_named_parameters, environment is optional public configuration
   static String colorize({
     required String text,
     required AnsiColor color,

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -34,8 +34,7 @@ sealed class BridgePluginApi() {
   Stream<BridgeSseEvent> get events;
 
   /// Get sessions for a project directory.
-  // ignore: no_slop_linter/prefer_required_named_parameters, established plugin API signature
-  Future<List<PluginSession>> getSessions(String projectId, {int? start, int? limit});
+  Future<List<PluginSession>> getSessions({required String projectId, required int? start, required int? limit});
 
   /// Get the slash commands available to the current project.
   Future<List<PluginCommand>> getCommands({required String? projectId});

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -34,6 +34,7 @@ sealed class BridgePluginApi() {
   Stream<BridgeSseEvent> get events;
 
   /// Get sessions for a project directory.
+  // ignore: no_slop_linter/prefer_required_named_parameters, established plugin API signature
   Future<List<PluginSession>> getSessions(String projectId, {int? start, int? limit});
 
   /// Get the slash commands available to the current project.

--- a/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
@@ -23,8 +23,10 @@ class const BridgeSseGlobalDisposed() extends BridgeSseEvent;
 /// Signals that the emitting plugin's process-wide command catalog changed.
 class const BridgeSseCommandCatalogUpdated() extends BridgeSseEvent;
 
+// ignore: no_slop_linter/prefer_specific_type, SSE payload values are heterogeneous
 class const BridgeSseSessionCreated({required final Map<String, dynamic> info}) extends BridgeSseEvent;
 
+// ignore: no_slop_linter/prefer_specific_type, SSE payload values are heterogeneous
 class const BridgeSseSessionUpdated({required final Map<String, dynamic> info, required final bool titleChanged})
     extends BridgeSseEvent;
 
@@ -41,6 +43,7 @@ class const BridgeSseSessionPromptDefaultsChanged({
   required final PluginAgentModel? model,
 }) extends BridgeSseEvent;
 
+// ignore: no_slop_linter/prefer_specific_type, SSE payload values are heterogeneous
 class const BridgeSseSessionDeleted({required final Map<String, dynamic> info}) extends BridgeSseEvent;
 
 class const BridgeSseSessionDiff({required final String sessionID}) extends BridgeSseEvent;
@@ -49,6 +52,7 @@ class const BridgeSseSessionError({required final String? sessionID}) extends Br
 
 class const BridgeSseSessionCompacted({required final String sessionID}) extends BridgeSseEvent;
 
+// ignore: no_slop_linter/prefer_specific_type, SSE payload values are heterogeneous
 class const BridgeSseSessionStatus({required final String sessionID, required final Map<String, dynamic> status})
     extends BridgeSseEvent;
 
@@ -72,6 +76,7 @@ class const BridgeSseQueuedPromptsUpdated({
   required final List<PluginQueuedPrompt> prompts,
 }) extends BridgeSseEvent;
 
+// ignore: no_slop_linter/prefer_specific_type, SSE payload values are heterogeneous
 class const BridgeSseMessageUpdated({required final Map<String, dynamic> info}) extends BridgeSseEvent;
 
 class const BridgeSseMessageRemoved({required final String sessionID, required final String messageID})

--- a/bridge/sesori_plugin_interface/lib/src/buffered_stream.dart
+++ b/bridge/sesori_plugin_interface/lib/src/buffered_stream.dart
@@ -32,6 +32,7 @@ class BufferedUntilFirstListener<T>() {
     }
   }
 
+  // ignore: no_slop_linter/prefer_required_named_parameters, mirrors StreamController.addError
   void addError(Object error, [StackTrace? stackTrace]) {
     _ensureOpen();
     if (_hasListener) {

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_config.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_config.dart
@@ -29,11 +29,13 @@ class const PluginConfigException(
 class PluginConfig {
   /// [values] is held by reference (the constructor is const, so a defensive
   /// copy is impossible) and must not be mutated after construction.
+  // ignore: no_slop_linter/prefer_specific_type, option values have declared heterogeneous types
   const new({required Map<String, Object?> values}) : _values = values;
 
   /// A config with no options, for plugins that declare none.
   const new empty() : _values = const {};
 
+  // ignore: no_slop_linter/prefer_specific_type, option values have declared heterogeneous types
   final Map<String, Object?> _values;
 
   /// Parses [raw] as the integer value of option [name] — the single source
@@ -42,6 +44,7 @@ class PluginConfig {
   /// `null` or empty [raw] returns `null` (absent). A non-numeric value
   /// throws [PluginConfigException] with a usage-style message naming the
   /// flag.
+  // ignore: no_slop_linter/prefer_required_named_parameters, public parsing API
   static int? parseIntegerOption(String name, String? raw) {
     if (raw == null || raw.isEmpty) {
       return null;
@@ -85,6 +88,7 @@ class PluginConfig {
   /// throws for them.
   int? intValue(String name) => parseIntegerOption(name, value(name));
 
+  // ignore: no_slop_linter/prefer_specific_type, option values have declared heterogeneous types
   Object? _require(String name) {
     if (!_values.containsKey(name)) {
       throw ArgumentError.value(name, "name", "Plugin option was never declared");

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_option.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_option.dart
@@ -80,6 +80,7 @@ final class const PluginValueOption({
   /// Built-in [validate] hook requiring an integer value. Delegates to
   /// [PluginConfig.parseIntegerOption] so the parse rule and error message
   /// have a single source of truth.
+  // ignore: no_slop_linter/prefer_required_named_parameters, validator callback signature
   static void validateInteger(String name, String value) {
     PluginConfig.parseIntegerOption(name, value);
   }

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_start_exception.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_start_exception.dart
@@ -10,11 +10,12 @@ class const PluginStartException(
   final String message, {
 
   /// The underlying error, when one exists.
+  // ignore: no_slop_linter/prefer_specific_type, caught errors are opaque
   required final Object? cause,
 }) implements Exception {
   @override
   String toString() {
-    final causeDetail = cause == null ? "" : " (cause: $cause)";
+    final causeDetail = cause == null ? "" : " (cause: ${cause.toString()})";
     return "PluginStartException: $message$causeDetail";
   }
 }

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_status.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_status.dart
@@ -33,7 +33,6 @@ sealed class const PluginStatus() {
   ///
   /// Transitioning to a status equal to the current one is handled by the
   /// publisher as a no-op and is not part of this relation.
-  // ignore: no_slop_linter/prefer_required_named_parameters, public state-machine API
   bool canTransitionTo(PluginStatus next) {
     return switch (this) {
       PluginStarting() =>

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_status.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_status.dart
@@ -33,6 +33,7 @@ sealed class const PluginStatus() {
   ///
   /// Transitioning to a status equal to the current one is handled by the
   /// publisher as a no-op and is not part of this relation.
+  // ignore: no_slop_linter/prefer_required_named_parameters, public state-machine API
   bool canTransitionTo(PluginStatus next) {
     return switch (this) {
       PluginStarting() =>
@@ -120,7 +121,7 @@ final class const PluginDegraded({
   @override
   String toString() {
     final action = requiresUserAction ? ", requiresUserAction: $userActionHint" : "";
-    return "PluginDegraded(since: $since, recoverable: $recoverable$action)";
+    return "PluginDegraded(since: ${since.toString()}, recoverable: $recoverable$action)";
   }
 }
 
@@ -157,6 +158,7 @@ final class const PluginFailed({
   required final String reason,
 
   /// The underlying error, when one exists.
+  // ignore: no_slop_linter/prefer_specific_type, caught errors are opaque
   required final Object? cause,
 }) extends PluginStatus {
   @override
@@ -168,7 +170,7 @@ final class const PluginFailed({
   int get hashCode => Object.hash(reason, cause);
 
   @override
-  String toString() => "PluginFailed(reason: $reason${cause == null ? "" : ", cause: $cause"})";
+  String toString() => "PluginFailed(reason: $reason${cause == null ? "" : ", cause: ${cause.toString()}"})";
 }
 
 /// The plugin's `shutdown()` is in progress.

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_status_controller.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_status_controller.dart
@@ -53,9 +53,10 @@ class PluginStatusController({required PluginStatus initial}) {
   ///
   /// Throws [StateError] when the transition is illegal. A no-op when [next]
   /// equals the current status.
+  // ignore: no_slop_linter/prefer_required_named_parameters, public controller API
   void set(PluginStatus next) {
     if (!trySet(next)) {
-      throw StateError("Illegal plugin status transition: $_current -> $next.");
+      throw StateError("Illegal plugin status transition: ${_current.toString()} -> ${next.toString()}.");
     }
   }
 
@@ -64,6 +65,7 @@ class PluginStatusController({required PluginStatus initial}) {
   ///
   /// Use this from racy status sources — an exit monitor firing during a
   /// clean shutdown must not surface `PluginFailed` after `PluginStopping`.
+  // ignore: no_slop_linter/prefer_required_named_parameters, public controller API
   bool trySet(PluginStatus next) {
     if (next == _current) {
       return true;

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_status_controller.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_status_controller.dart
@@ -53,7 +53,6 @@ class PluginStatusController({required PluginStatus initial}) {
   ///
   /// Throws [StateError] when the transition is illegal. A no-op when [next]
   /// equals the current status.
-  // ignore: no_slop_linter/prefer_required_named_parameters, public controller API
   void set(PluginStatus next) {
     if (!trySet(next)) {
       throw StateError("Illegal plugin status transition: ${_current.toString()} -> ${next.toString()}.");
@@ -65,7 +64,6 @@ class PluginStatusController({required PluginStatus initial}) {
   ///
   /// Use this from racy status sources — an exit monitor firing during a
   /// clean shutdown must not surface `PluginFailed` after `PluginStopping`.
-  // ignore: no_slop_linter/prefer_required_named_parameters, public controller API
   bool trySet(PluginStatus next) {
     if (next == _current) {
       return true;

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/steady_plugin_lifecycle.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/steady_plugin_lifecycle.dart
@@ -146,7 +146,7 @@ mixin SteadyPluginLifecycle implements BridgePlugin {
           // An unhandled async error here would take down the whole isolate
           // over a status report; log it instead.
           .catchError((Object error, StackTrace stackTrace) {
-            Log.w("SteadyPluginLifecycle: degraded debounce failed: $error\n$stackTrace");
+            Log.w("SteadyPluginLifecycle: degraded debounce failed", error, stackTrace);
           }),
     );
   }
@@ -154,6 +154,7 @@ mixin SteadyPluginLifecycle implements BridgePlugin {
   /// Reports a terminal failure. Dropped silently once [shutdown] has
   /// started (no `Failed` after `Stopping`).
   @protected
+  // ignore: no_slop_linter/prefer_specific_type, caught failure causes are opaque
   void markFailed(String reason, {required Object? cause}) {
     _cancelPendingDegraded();
     _statusMachine.trySet(PluginFailed(reason: reason, cause: cause));

--- a/bridge/sesori_plugin_interface/lib/src/log.dart
+++ b/bridge/sesori_plugin_interface/lib/src/log.dart
@@ -30,8 +30,7 @@ class Log._() {
   static void v(String message) => _write(LogLevel.verbose, message, null, null);
 
   /// Log a debug-level message.
-  // ignore: no_slop_linter/prefer_required_named_parameters, logging APIs keep the primary message positional
-  static void d(String message, [Object? error, StackTrace? st]) => _write(LogLevel.debug, message, error, st);
+  static void d(String message) => _write(LogLevel.debug, message, null, null);
 
   /// Log an info-level message.
   static void i(String message) => _write(LogLevel.info, message, null, null);

--- a/bridge/sesori_plugin_interface/lib/src/log.dart
+++ b/bridge/sesori_plugin_interface/lib/src/log.dart
@@ -30,17 +30,21 @@ class Log._() {
   static void v(String message) => _write(LogLevel.verbose, message, null, null);
 
   /// Log a debug-level message.
-  static void d(String message) => _write(LogLevel.debug, message, null, null);
+  // ignore: no_slop_linter/prefer_required_named_parameters, logging APIs keep the primary message positional
+  static void d(String message, [Object? error, StackTrace? st]) => _write(LogLevel.debug, message, error, st);
 
   /// Log an info-level message.
   static void i(String message) => _write(LogLevel.info, message, null, null);
 
   /// Log a warning-level message.
+  // ignore: no_slop_linter/prefer_required_named_parameters, logging APIs keep the primary message positional
   static void w(String message, [Object? error, StackTrace? st]) => _write(LogLevel.warning, message, error, st);
 
   /// Log an error-level message.
+  // ignore: no_slop_linter/prefer_required_named_parameters, logging APIs keep the primary message positional
   static void e(String message, [Object? error, StackTrace? st]) => _write(LogLevel.error, message, error, st);
 
+  // ignore: no_slop_linter/prefer_required_named_parameters, private logging sink mirrors the public logging APIs
   static void _write(
     LogLevel msgLevel,
     String rawMessage,
@@ -72,13 +76,13 @@ class Log._() {
     // All diagnostic logs go to stderr so the log stream stays separate from
     // user-facing output (which [Console] writes to stdout) and can be
     // silenced without making the bridge unoperable.
-    stderr.writeln(_colorizeForLevel(msgLevel, buffer.toString()));
+    stderr.writeln(_colorizeForLevel(msgLevel: msgLevel, text: buffer.toString()));
   }
 
   /// Colorizes log lines by severity when stderr is an interactive terminal:
   /// verbose is gray, debug is light blue, warning is yellow, and error is red.
   /// Info lines are written without color.
-  static String _colorizeForLevel(LogLevel msgLevel, String text) {
+  static String _colorizeForLevel({required LogLevel msgLevel, required String text}) {
     switch (msgLevel) {
       case LogLevel.verbose:
         return AnsiColorFormatter.colorize(text: text, color: AnsiColor.gray, out: stderr);

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_command.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_command.dart
@@ -12,6 +12,7 @@ enum PluginCommandSource() {
 
 @Freezed(fromJson: true, toJson: true)
 sealed class PluginCommand with _$PluginCommand {
+  // ignore: no_slop_linter/prefer_required_named_parameters, generated public model signature
   const factory({
     required String name,
     String? template,

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_project.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_project.dart
@@ -13,6 +13,7 @@ part "plugin_project.g.dart";
 /// populated from upstream project metadata.
 @freezed
 sealed class PluginProject with _$PluginProject {
+  // ignore: no_slop_linter/prefer_required_named_parameters, generated public model signature
   const factory({
     required String id,
     required String directory,
@@ -28,6 +29,7 @@ sealed class PluginProject with _$PluginProject {
 /// the activity is null.
 @freezed
 sealed class PluginProjectActivity with _$PluginProjectActivity {
+  // ignore: no_slop_linter/prefer_required_named_parameters, generated public model signature
   const factory({
     required int createdAt,
     required int updatedAt,

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_project.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_project.dart
@@ -29,7 +29,6 @@ sealed class PluginProject with _$PluginProject {
 /// the activity is null.
 @freezed
 sealed class PluginProjectActivity with _$PluginProjectActivity {
-  // ignore: no_slop_linter/prefer_required_named_parameters, generated public model signature
   const factory({
     required int createdAt,
     required int updatedAt,

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_provider.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_provider.dart
@@ -14,6 +14,7 @@ enum PluginProviderAuthType() {
 /// A model available from a provider.
 @freezed
 sealed class PluginModel with _$PluginModel {
+  // ignore: no_slop_linter/prefer_required_named_parameters, generated public model signature
   const factory({
     required String id,
     required String name,

--- a/bridge/sesori_plugin_interface/lib/src/plugin_api_exception.dart
+++ b/bridge/sesori_plugin_interface/lib/src/plugin_api_exception.dart
@@ -4,19 +4,25 @@ import "plugin_operation_exception.dart";
 ///
 /// Handlers and routers can catch this to forward the real HTTP status
 /// instead of collapsing every failure to 502.
-class PluginApiException(super.endpoint, int statusCode, {super.message, super.cause}) extends PluginOperationException {
+// ignore: no_slop_linter/prefer_required_named_parameters, public exception constructor
+class PluginApiException(super.endpoint, int statusCode, {super.message, super.cause})
+    extends PluginOperationException {
   this : super(statusCode: statusCode);
 
   /// The endpoint that failed; alias of [operation] for HTTP-backed plugins.
   String get endpoint => operation;
 
   @override
+  // ignore: no_slop_linter/avoid_bang_operator, this constructor always supplies the base status code
   int get statusCode => super.statusCode!;
 
   @override
   String toString() {
-    final detail = message == null || message!.isEmpty ? "" : ": $message";
-    final causeDetail = cause == null ? "" : " (cause: $cause)";
+    final detail = switch (message) {
+      final message? when message.isNotEmpty => ": $message",
+      _ => "",
+    };
+    final causeDetail = cause == null ? "" : " (cause: ${cause.toString()})";
     return "PluginApiException: $endpoint failed with status $statusCode$detail$causeDetail";
   }
 }

--- a/bridge/sesori_plugin_interface/lib/src/plugin_api_exception.dart
+++ b/bridge/sesori_plugin_interface/lib/src/plugin_api_exception.dart
@@ -4,7 +4,6 @@ import "plugin_operation_exception.dart";
 ///
 /// Handlers and routers can catch this to forward the real HTTP status
 /// instead of collapsing every failure to 502.
-// ignore: no_slop_linter/prefer_required_named_parameters, public exception constructor
 class PluginApiException(super.endpoint, int statusCode, {super.message, super.cause})
     extends PluginOperationException {
   this : super(statusCode: statusCode);

--- a/bridge/sesori_plugin_interface/lib/src/plugin_operation_exception.dart
+++ b/bridge/sesori_plugin_interface/lib/src/plugin_operation_exception.dart
@@ -12,8 +12,10 @@ class PluginOperationException implements Exception {
   final int? statusCode;
 
   final String? message;
+  // ignore: no_slop_linter/prefer_specific_type, caught errors are opaque
   final Object? cause;
 
+  // ignore: no_slop_linter/prefer_required_named_parameters, public exception constructor
   const new(
     this.operation, {
     this.statusCode,
@@ -26,6 +28,7 @@ class PluginOperationException implements Exception {
   /// Handlers use [isNotFound] for idempotent deletes, so non-HTTP plugins
   /// should signal missing entities through this constructor rather than a
   /// hand-rolled status code.
+  // ignore: no_slop_linter/prefer_required_named_parameters, public exception constructor
   const new notFound(this.operation, {this.message, this.cause}) : statusCode = 404;
 
   /// `true` when this failure means the target entity does not exist.
@@ -35,7 +38,7 @@ class PluginOperationException implements Exception {
   String toString() {
     final status = statusCode == null ? "" : " with status $statusCode";
     final detail = message == null ? "" : ": $message";
-    final causeDetail = cause == null ? "" : " (cause: $cause)";
+    final causeDetail = cause == null ? "" : " (cause: ${cause.toString()})";
     return "PluginOperationException: $operation failed$status$detail$causeDetail";
   }
 }

--- a/bridge/sesori_plugin_interface/lib/src/plugin_operation_exception.dart
+++ b/bridge/sesori_plugin_interface/lib/src/plugin_operation_exception.dart
@@ -15,7 +15,6 @@ class PluginOperationException implements Exception {
   // ignore: no_slop_linter/prefer_specific_type, caught errors are opaque
   final Object? cause;
 
-  // ignore: no_slop_linter/prefer_required_named_parameters, public exception constructor
   const new(
     this.operation, {
     this.statusCode,
@@ -28,7 +27,6 @@ class PluginOperationException implements Exception {
   /// Handlers use [isNotFound] for idempotent deletes, so non-HTTP plugins
   /// should signal missing entities through this constructor rather than a
   /// hand-rolled status code.
-  // ignore: no_slop_linter/prefer_required_named_parameters, public exception constructor
   const new notFound(this.operation, {this.message, this.cause}) : statusCode = 404;
 
   /// `true` when this failure means the target entity does not exist.

--- a/bridge/sesori_plugin_interface/lib/src/testing/fake_stdout.dart
+++ b/bridge/sesori_plugin_interface/lib/src/testing/fake_stdout.dart
@@ -18,7 +18,7 @@ class BufferingStdout() implements Stdout {
   void writeln([Object? object = ""]) => _buffer.writeln(object);
 
   @override
-  // ignore: no_slop_linter/prefer_specific_type, Stdout's own signature
+  // ignore: no_slop_linter/prefer_specific_type, no_slop_linter/avoid_dynamic_return_type, Stdout's own signature
   dynamic noSuchMethod(Invocation invocation) => null;
 }
 
@@ -38,6 +38,6 @@ class CapturingStdout({required final List<String> lines}) implements Stdout {
   void writeln([Object? object = ""]) => lines.add(object.toString());
 
   @override
-  // ignore: no_slop_linter/prefer_specific_type, Stdout's own signature
+  // ignore: no_slop_linter/prefer_specific_type, no_slop_linter/avoid_dynamic_return_type, Stdout's own signature
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
@@ -201,7 +201,7 @@ void main() {
       respond(launchDirectoryFrame, {"sessions": <Object?>[]});
       expect(await global, isEmpty);
 
-      final project = plugin.getSessions("/repo");
+      final project = plugin.getSessions(projectId: "/repo", start: null, limit: null);
       final cwdFrame = await waitForFrame(AcpMethods.sessionList, count: 3);
       expect(cwdFrame["params"], {"cwd": "/repo"});
       respond(cwdFrame, {"sessions": <Object?>[]});

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -374,10 +374,10 @@ class OpenCodePlugin._({
   Future<List<PluginProject>> getProjects() => _call(_service.getProjects);
 
   @override
-  Future<List<PluginSession>> getSessions(
-    String projectId, {
-    int? start,
-    int? limit,
+  Future<List<PluginSession>> getSessions({
+    required String projectId,
+    required int? start,
+    required int? limit,
   }) async {
     final sessions = await _call(
       () => _service.getSessions(

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -134,7 +134,7 @@ void main() {
     test("getSessions maps internal sessions to plugin sessions", () async {
       final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
 
-      final sessions = await plugin.getSessions("/repo");
+      final sessions = await plugin.getSessions(projectId: "/repo", start: null, limit: null);
 
       expect(sessions, hasLength(2));
 
@@ -168,7 +168,7 @@ void main() {
 
       await plugin.getProjects();
 
-      final sessions = await plugin.getSessions("/moved/repo");
+      final sessions = await plugin.getSessions(projectId: "/moved/repo", start: null, limit: null);
       final moved = sessions.firstWhere((session) => session.id == "s-moved");
       expect(moved.projectID, equals("/repo"));
     });
@@ -196,7 +196,7 @@ void main() {
       expect(project.directory, equals("/moved/repo"));
       expect(project.activity, isNull);
 
-      final sessions = await plugin.getSessions("/moved/repo");
+      final sessions = await plugin.getSessions(projectId: "/moved/repo", start: null, limit: null);
       final moved = sessions.firstWhere((session) => session.id == "s-moved");
       // Without the alias this would fall back to the requested directory.
       expect(moved.projectID, equals("/repo"));

--- a/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
+++ b/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
@@ -130,7 +130,7 @@ final class PiPlugin._({
       _catalogRepository.primeSessionDirectory(sessionId: sessionId, directory: directory);
 
   @override
-  Future<List<PluginSession>> getSessions(String projectId, {int? start, int? limit}) =>
+  Future<List<PluginSession>> getSessions({required String projectId, required int? start, required int? limit}) =>
       _catalogRepository.getSessions(projectId: projectId, start: start, limit: limit);
 
   @override

--- a/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
@@ -29,7 +29,7 @@ void main() {
       );
 
       expect(harness.processes, isEmpty);
-      expect((await harness.plugin.getSessions(harness.project.path)).single.id, session.id);
+      expect((await harness.plugin.getSessions(projectId: harness.project.path, start: null, limit: null)).single.id, session.id);
       expect(await harness.plugin.getSessionMessages(session.id), isEmpty);
 
       final events = <BridgeSseEvent>[];

--- a/bridge/sesori_plugin_runtime/analysis_options.yaml
+++ b/bridge/sesori_plugin_runtime/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: ../app/analysis_options.yaml
+include: ../analysis_options.yaml

--- a/bridge/sesori_plugin_runtime/lib/src/host_json_runtime_ownership_repository.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/host_json_runtime_ownership_repository.dart
@@ -29,8 +29,8 @@ class HostJsonRuntimeOwnershipRepository<R>({
       name: _fileName,
       transform: (current) async {
         final parsed = _parseRecords(contents: current);
-        if (parsed.invalidError != null) {
-          await _handleInvalidRuntimeFile(reason: "invalid runtime ownership file", error: parsed.invalidError!);
+        if (parsed.invalidError case final invalidError?) {
+          await _handleInvalidRuntimeFile(reason: "invalid runtime ownership file", error: invalidError);
         }
         parsed.records[_mapper.ownerSessionIdOf(record: record)] = record;
         return jsonEncode(_recordsToJson(records: parsed.records));
@@ -44,8 +44,8 @@ class HostJsonRuntimeOwnershipRepository<R>({
       name: _fileName,
       transform: (current) async {
         final parsed = _parseRecords(contents: current);
-        if (parsed.invalidError != null) {
-          await _handleInvalidRuntimeFile(reason: "invalid runtime ownership file", error: parsed.invalidError!);
+        if (parsed.invalidError case final invalidError?) {
+          await _handleInvalidRuntimeFile(reason: "invalid runtime ownership file", error: invalidError);
         }
         final removedRecord = parsed.records.remove(ownerSessionId);
         if (removedRecord == null) {
@@ -72,31 +72,36 @@ class HostJsonRuntimeOwnershipRepository<R>({
       return <String, R>{};
     }
     final parsed = _parseRecords(contents: contents);
-    if (parsed.invalidError != null) {
-      await _quarantineIfStillInvalid(reason: "invalid runtime ownership file", error: parsed.invalidError!);
+    if (parsed.invalidError case final invalidError?) {
+      await _quarantineIfStillInvalid(reason: "invalid runtime ownership file", error: invalidError);
       return <String, R>{};
     }
     return parsed.records;
   }
 
+  // ignore: no_slop_linter/prefer_specific_type, parse failures retain their opaque original error
   ({Map<String, R> records, Object? invalidError}) _parseRecords({required String? contents}) {
     if (contents == null || contents.trim().isEmpty) {
       return (records: <String, R>{}, invalidError: null);
     }
 
     try {
-      final decoded = jsonDecode(contents);
-      if (decoded is! Map) {
+      // ignore: no_slop_linter/prefer_specific_type, JSON decoding produces dynamic values at this boundary.
+      final dynamic decoded = jsonDecode(contents);
+      // ignore: no_slop_linter/prefer_specific_type, JSON objects contain heterogeneous values
+      if (decoded is! Map<String, dynamic>) {
         throw const FormatException("Runtime ownership root must be an object");
       }
-      final rootJson = Map<String, dynamic>.from(decoded);
-      return (
-        records: <String, R>{
-          for (final MapEntry<String, dynamic> entry in rootJson.entries)
-            entry.key: _mapper.fromJson(json: Map<String, dynamic>.from(entry.value as Map)),
-        },
-        invalidError: null,
-      );
+      final records = <String, R>{};
+      for (final entry in decoded.entries) {
+        final value = entry.value;
+        // ignore: no_slop_linter/prefer_specific_type, JSON objects contain heterogeneous values
+        if (value is! Map<String, dynamic>) {
+          throw const FormatException("Runtime ownership record must be an object");
+        }
+        records[entry.key] = _mapper.fromJson(json: value);
+      }
+      return (records: records, invalidError: null);
     } on Object catch (error) {
       return (records: <String, R>{}, invalidError: error);
     }
@@ -116,38 +121,44 @@ class HostJsonRuntimeOwnershipRepository<R>({
             return current;
           }
           final recheck = _parseRecords(contents: current);
-          if (recheck.invalidError == null) {
-            return current;
+          if (recheck.invalidError case final invalidError?) {
+            await _handleInvalidRuntimeFile(reason: reason, error: invalidError);
+            return null;
           }
-          await _handleInvalidRuntimeFile(reason: reason, error: recheck.invalidError!);
-          return null;
+          return current;
         },
       );
-    } on Object catch (updateError) {
+    } on Object catch (updateError, stackTrace) {
       Log.w(
         "Could not revalidate runtime ownership file at $_fileName before quarantine; "
-        "continuing fresh without persisted ownership state. Error: $updateError (original: $error)",
+        "continuing fresh without persisted ownership state. Original error: ${error.toString()}",
+        updateError,
+        stackTrace,
       );
     }
   }
 
+  // ignore: no_slop_linter/prefer_specific_type, JSON encoding requires dynamic values at this boundary.
   Map<String, dynamic> _recordsToJson({required Map<String, R> records}) {
+    // ignore: no_slop_linter/prefer_specific_type, JSON encoding requires dynamic values at this boundary.
     return <String, dynamic>{
       for (final MapEntry<String, R> entry in records.entries) entry.key: _mapper.toJson(record: entry.value),
     };
   }
 
   Future<void> _handleInvalidRuntimeFile({required String reason, required Object error}) async {
-    Log.w("$reason at $_fileName; ignoring persisted ownership state and continuing fresh. Error: $error");
+    Log.w("$reason at $_fileName; ignoring persisted ownership state and continuing fresh", error);
 
     final timestamp = _clock.now().toUtc().toIso8601String().replaceAll(":", "-").replaceAll(".", "-");
     final quarantinedName = "${_fileNameBase()}.invalid.$timestamp.json";
 
     try {
       await _store.quarantine(name: _fileName, quarantinedName: quarantinedName);
-    } on Object catch (renameError) {
+    } on Object catch (renameError, stackTrace) {
       Log.w(
-        "Failed to rename invalid runtime ownership file at $_fileName; continuing fresh without persisted ownership state. Error: $renameError",
+        "Failed to rename invalid runtime ownership file at $_fileName; continuing fresh without persisted ownership state",
+        renameError,
+        stackTrace,
       );
     }
   }

--- a/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
@@ -29,9 +29,9 @@ class ManagedProcessService<R>({
   Future<ManagedRuntimeHandle<R>> start({
     required ManagedRuntimeSpec<R> spec,
     required List<ProcessIdentity> terminatedBridgeIdentities,
-    StartAbortSignal? startAborted,
+    required StartAbortSignal startAborted,
   }) async {
-    final abort = startAborted ?? StartAbortSignal.never;
+    final abort = startAborted;
 
     await cleanupStaleOwnedRuntimes(terminatedBridgeIdentities: terminatedBridgeIdentities);
     _throwIfAborted(abort);
@@ -52,9 +52,9 @@ class ManagedProcessService<R>({
   Future<ManagedRuntimeHandle<R>> attach({
     required ManagedRuntimeSpec<R> spec,
     required int port,
-    StartAbortSignal? startAborted,
+    required StartAbortSignal startAborted,
   }) async {
-    final abort = startAborted ?? StartAbortSignal.never;
+    final abort = startAborted;
     _throwIfAborted(abort);
 
     final probe = await _probeTolerant(spec: spec, port: port);
@@ -92,9 +92,9 @@ class ManagedProcessService<R>({
     required int port,
     required Duration portReleaseTimeout,
     required Duration portReleasePollInterval,
-    StartAbortSignal? startAborted,
+    required StartAbortSignal startAborted,
   }) async {
-    final abort = startAborted ?? StartAbortSignal.never;
+    final abort = startAborted;
     _throwIfAborted(abort);
     await _waitForPortRelease(
       spec: spec,
@@ -562,8 +562,8 @@ class ManagedProcessService<R>({
         (_runtimeStartMarkerOf(record: record) == null ||
             process.identity.startMarker == _runtimeStartMarkerOf(record: record)) &&
         _samePath(
-          process.identity.executablePath,
-          _runtimeExecutablePathOf(record: record),
+          actual: process.identity.executablePath,
+          expected: _runtimeExecutablePathOf(record: record),
           platform: process.identity.platform,
         ) &&
         _matchesRuntimeCommandLine(identity: process.identity, record: record);
@@ -613,10 +613,18 @@ class ManagedProcessService<R>({
     }
     if (_runtimeStartMarkerOf(record: record) != null || identity.startMarker != null) {
       return identity.startMarker == _runtimeStartMarkerOf(record: record) &&
-          _samePath(identity.executablePath, _runtimeExecutablePathOf(record: record), platform: identity.platform) &&
+          _samePath(
+            actual: identity.executablePath,
+            expected: _runtimeExecutablePathOf(record: record),
+            platform: identity.platform,
+          ) &&
           _matchesRuntimeCommandLine(identity: identity, record: record);
     }
-    return _samePath(identity.executablePath, _runtimeExecutablePathOf(record: record), platform: identity.platform);
+    return _samePath(
+      actual: identity.executablePath,
+      expected: _runtimeExecutablePathOf(record: record),
+      platform: identity.platform,
+    );
   }
 
   bool _matchesBridgeRecord({required ProcessIdentity identity, required R record}) {
@@ -629,7 +637,7 @@ class ManagedProcessService<R>({
     return true;
   }
 
-  bool _samePath(String? actual, String? expected, {required String platform}) {
+  bool _samePath({required String? actual, required String? expected, required String platform}) {
     if (actual == null || expected == null) {
       return false;
     }

--- a/bridge/sesori_plugin_runtime/lib/src/managed_runtime_monitor.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_runtime_monitor.dart
@@ -132,10 +132,12 @@ class ManagedRuntimeMonitor<R>({
 
     // exitCode is a bare Future with no cancel; _onUnexpectedExit re-checks the
     // current-child identity and the disarm flag, so a stale completion is inert.
-    unawaited(process.exitCode.then((code) => _onUnexpectedExit(process, code)).catchError((Object _) {}));
+    unawaited(
+      process.exitCode.then((code) => _onUnexpectedExit(process: process, exitCode: code)).catchError((Object _) {}),
+    );
   }
 
-  Future<void> _onUnexpectedExit(SpawnedProcess process, int exitCode) async {
+  Future<void> _onUnexpectedExit({required SpawnedProcess process, required int exitCode}) async {
     if (_disarmed || !identical(process, _currentHandle?.process)) {
       return;
     }

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_install_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_install_service.dart
@@ -54,7 +54,7 @@ class ManagedRuntimeInstallService({
     } on Object catch (error) {
       // Surfaced (and rendered) via ProvisionFailed — no separate upfront log.
       yield ProvisionFailed(
-        message: "Could not determine this machine's platform for the $name runtime ($error).",
+        message: "Could not determine this machine's platform for the $name runtime (${error.toString()}).",
       );
       return;
     }
@@ -96,7 +96,7 @@ class ManagedRuntimeInstallService({
       );
       _throwIfAborted(startAborted: startAborted);
       if (cachedVersion != null && cachedVersion.compareTo(bundled) == 0) {
-        Log.i("[$id] managed $name $bundled already installed");
+        Log.i("[$id] managed $name ${bundled.toString()} already installed");
         // Sweep before the terminal event: consumers may stop listening as
         // soon as ProvisionReady arrives, which would cancel this stream and
         // leave superseded version directories behind.
@@ -106,7 +106,7 @@ class ManagedRuntimeInstallService({
       }
       Log.w(
         "[$id] cached managed runtime at '$binaryPath' is version "
-        "'${cachedVersion ?? "unrunnable"}' (expected '$bundled'); reinstalling",
+        "'${cachedVersion?.toString() ?? "unrunnable"}' (expected '${bundled.toString()}'); reinstalling",
       );
     }
 
@@ -147,12 +147,12 @@ class ManagedRuntimeInstallService({
       yield ProvisionFailed(
         message:
             "The downloaded $name runtime is not runnable on this machine "
-            "(reported '${installedVersion ?? "no version"}', expected '$bundled').",
+            "(reported '${installedVersion?.toString() ?? "no version"}', expected '${bundled.toString()}').",
       );
       return;
     }
 
-    Log.i("[$id] installed managed $name $bundled");
+    Log.i("[$id] installed managed $name ${bundled.toString()}");
     // Sweep before the terminal event: consumers may stop listening as soon as
     // ProvisionReady arrives, which would cancel this stream mid-sweep.
     await _cleaner.sweep(managedDir: managedDir, keepVersion: bundled.raw);

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_provision_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_provision_service.dart
@@ -42,7 +42,7 @@ class ManagedRuntimeProvisionService({
     );
     _throwIfAborted(host);
     if (pathVersion != null && pathVersion.compareTo(minimum) >= 0) {
-      Log.i("[$id] using PATH $name $pathVersion (>= minimum $minimum)");
+      Log.i("[$id] using PATH $name ${pathVersion.toString()} (>= minimum ${minimum.toString()})");
       yield ProvisionReady(binaryPath: _manifest.pathExecutableName);
       return;
     }
@@ -54,7 +54,7 @@ class ManagedRuntimeProvisionService({
       );
       _throwIfAborted(host);
       if (candidateVersion != null && candidateVersion.compareTo(minimum) >= 0) {
-        Log.i("[$id] using $name $candidateVersion at $candidate (>= minimum $minimum)");
+        Log.i("[$id] using $name ${candidateVersion.toString()} at $candidate (>= minimum ${minimum.toString()})");
         yield ProvisionReady(binaryPath: candidate);
         return;
       }
@@ -70,11 +70,11 @@ class ManagedRuntimeProvisionService({
       if (pathVersion != null) {
         yield ProvisionNotice(
           message:
-              "Installed $name $pathVersion is older than the minimum supported $minimum; "
-              "using the existing managed $name $bundled instead.",
+              "Installed $name ${pathVersion.toString()} is older than the minimum supported ${minimum.toString()}; "
+              "using the existing managed $name ${bundled.toString()} instead.",
         );
       }
-      Log.i("[$id] using existing managed $name $bundled");
+      Log.i("[$id] using existing managed $name ${bundled.toString()}");
       yield ProvisionReady(binaryPath: managedBinaryPath);
       return;
     }

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_version.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_version.dart
@@ -25,8 +25,9 @@ sealed class const RuntimeVersion() implements Comparable<RuntimeVersion> {
 
 /// A semver-ordered runtime version (OpenCode, codex).
 final class const SemanticRuntimeVersion._({
-  @override
-  required final String raw, required final SemanticVersion version}) extends RuntimeVersion {
+  @override required final String raw,
+  required final SemanticVersion version,
+}) extends RuntimeVersion {
   factory parse({required String value}) {
     return SemanticRuntimeVersion._(
       raw: value.trim(),
@@ -42,7 +43,11 @@ final class const SemanticRuntimeVersion._({
   @override
   int compareTo(RuntimeVersion other) {
     if (other is! SemanticRuntimeVersion) {
-      throw ArgumentError.value(other, "other", "cannot compare a semantic version with ${other.runtimeType}");
+      throw ArgumentError.value(
+        other,
+        "other",
+        "cannot compare a semantic version with ${other.runtimeType.toString()}",
+      );
     }
     return version.compareTo(other.version);
   }
@@ -70,12 +75,11 @@ final class const SemanticRuntimeVersion._({
 /// day and carries no order, so a dated build is never ranked below the same
 /// day's bare version — the mistake semver ordering makes.
 final class const CalendarRuntimeVersion._({
-    @override
-  required final String raw,
-    required final int year,
-    required final int month,
-    required final int day,
-  }) extends RuntimeVersion {
+  @override required final String raw,
+  required final int year,
+  required final int month,
+  required final int day,
+}) extends RuntimeVersion {
   static final RegExp _pattern = RegExp(r"^(\d{4})\.(\d{1,2})\.(\d{1,2})(?:[-.].*)?$");
 
   factory parse({required String value}) {
@@ -90,8 +94,11 @@ final class const CalendarRuntimeVersion._({
     final trimmed = value.trim();
     final match = _pattern.firstMatch(trimmed);
     if (match == null) return null;
+    // ignore: no_slop_linter/avoid_bang_operator, the matching pattern requires this date group
     final year = int.parse(match.group(1)!);
+    // ignore: no_slop_linter/avoid_bang_operator, the matching pattern requires this date group
     final month = int.parse(match.group(2)!);
+    // ignore: no_slop_linter/avoid_bang_operator, the matching pattern requires this date group
     final day = int.parse(match.group(3)!);
     final date = DateTime.utc(year, month, day);
     if (date.year != year || date.month != month || date.day != day) return null;
@@ -106,7 +113,11 @@ final class const CalendarRuntimeVersion._({
   @override
   int compareTo(RuntimeVersion other) {
     if (other is! CalendarRuntimeVersion) {
-      throw ArgumentError.value(other, "other", "cannot compare a calendar version with ${other.runtimeType}");
+      throw ArgumentError.value(
+        other,
+        "other",
+        "cannot compare a calendar version with ${other.runtimeType.toString()}",
+      );
     }
     final byYear = year.compareTo(other.year);
     if (byYear != 0) return byYear;

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_version_validator.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_version_validator.dart
@@ -32,7 +32,7 @@ class RuntimeVersionValidator({
       );
     } on Object catch (error, stackTrace) {
       // Almost always ENOENT (not installed / not on PATH) or a probe timeout.
-      Log.d("[${_manifest.runtimeId}] version probe could not run '$executable --version'", error, stackTrace);
+      Log.w("[${_manifest.runtimeId}] version probe could not run '$executable --version'", error, stackTrace);
       return null;
     }
 

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_version_validator.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_version_validator.dart
@@ -30,9 +30,9 @@ class RuntimeVersionValidator({
         environment: environment,
         timeout: _probeTimeout,
       );
-    } on Object catch (error) {
+    } on Object catch (error, stackTrace) {
       // Almost always ENOENT (not installed / not on PATH) or a probe timeout.
-      Log.d("[${_manifest.runtimeId}] version probe could not run '$executable --version': $error");
+      Log.d("[${_manifest.runtimeId}] version probe could not run '$executable --version'", error, stackTrace);
       return null;
     }
 

--- a/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
@@ -31,6 +31,7 @@ void main() {
       final handle = await fakes.service().start(
         spec: fakes.spec(portPolicy: _dynamic(<int>[4096, 49152, 49153])),
         terminatedBridgeIdentities: const <ProcessIdentity>[],
+        startAborted: StartAbortSignal.never,
       );
 
       expect(handle.port, equals(49153));
@@ -54,6 +55,7 @@ void main() {
       final handle = await fakes.service().start(
         spec: fakes.spec(portPolicy: _dynamic(<int>[49152])),
         terminatedBridgeIdentities: const <ProcessIdentity>[],
+        startAborted: StartAbortSignal.never,
       );
 
       expect(handle.port, equals(49152));
@@ -88,6 +90,7 @@ void main() {
       final handle = await fakes.service().start(
         spec: fakes.spec(portPolicy: _dynamic(<int>[49152, 49153])),
         terminatedBridgeIdentities: const <ProcessIdentity>[],
+        startAborted: StartAbortSignal.never,
       );
 
       expect(handle.port, equals(49153));
@@ -122,6 +125,7 @@ void main() {
             portPolicy: _dynamic(List<int>.generate(10, (index) => 49152 + index)),
           ),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
+          startAborted: StartAbortSignal.never,
         ),
         throwsA(isA<PluginStartException>()),
       );
@@ -146,6 +150,7 @@ void main() {
             ),
           ),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
+          startAborted: StartAbortSignal.never,
         ),
         throwsA(isA<PluginStartException>()),
       );
@@ -164,6 +169,7 @@ void main() {
             portPolicy: _dynamic(<int>[49152, 49153]),
           ),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
+          startAborted: StartAbortSignal.never,
         ),
         throwsA(isA<ProcessException>()),
       );
@@ -198,6 +204,7 @@ void main() {
         fakes.service().start(
           spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 4096)),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
+          startAborted: StartAbortSignal.never,
         ),
         throwsA(isA<PluginStartException>()),
       );
@@ -217,6 +224,7 @@ void main() {
         fakes.service().start(
           spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 50128)),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
+          startAborted: StartAbortSignal.never,
         ),
         throwsA(isA<StateError>()),
       );
@@ -237,6 +245,7 @@ void main() {
       final handle = await fakes.service().start(
         spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 50123)),
         terminatedBridgeIdentities: const <ProcessIdentity>[],
+        startAborted: StartAbortSignal.never,
       );
 
       expect(
@@ -261,6 +270,7 @@ void main() {
         fakes.service().start(
           spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 50130)),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
+          startAborted: StartAbortSignal.never,
         ),
         throwsA(isA<PluginStartException>()),
       );
@@ -290,6 +300,7 @@ void main() {
         fakes.service().start(
           spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 50133)),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
+          startAborted: StartAbortSignal.never,
         ),
         throwsA(isA<PluginStartException>()),
       );
@@ -304,6 +315,7 @@ void main() {
             portPolicy: const ExplicitPortPolicy(port: 4096),
           ),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
+          startAborted: StartAbortSignal.never,
         ),
         throwsA(isA<PluginStartException>()),
       );
@@ -323,6 +335,7 @@ void main() {
           portPolicy: const ExplicitPortPolicy(port: 4096),
         ),
         terminatedBridgeIdentities: const <ProcessIdentity>[],
+        startAborted: StartAbortSignal.never,
       );
 
       expect(fakes.bindable.probedPorts, equals(<int>[4096]));
@@ -351,6 +364,7 @@ void main() {
             portPolicy: const ExplicitPortPolicy(port: 50140),
           ),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
+          startAborted: StartAbortSignal.never,
         ),
         throwsA(isA<PluginStartException>()),
       );
@@ -371,6 +385,7 @@ void main() {
             buildRecord: (draft) => throw StateError("malformed record"),
           ),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
+          startAborted: StartAbortSignal.never,
         ),
         throwsA(isA<StateError>()),
       );
@@ -406,6 +421,7 @@ void main() {
           ),
         ),
         terminatedBridgeIdentities: const <ProcessIdentity>[],
+        startAborted: StartAbortSignal.never,
       );
 
       expect(handle.port, equals(50150));
@@ -434,6 +450,7 @@ void main() {
             ),
           ),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
+          startAborted: StartAbortSignal.never,
         ),
         throwsA(isA<PluginStartException>()),
       );
@@ -477,6 +494,7 @@ void main() {
             ),
           ),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
+          startAborted: StartAbortSignal.never,
         ),
         throwsA(isA<PluginStartException>()),
       );
@@ -600,6 +618,7 @@ void main() {
       final handle = await fakes.service().attach(
         spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 50125)),
         port: 50125,
+        startAborted: StartAbortSignal.never,
       );
 
       expect(handle.port, equals(50125));
@@ -621,6 +640,7 @@ void main() {
         fakes.service().attach(
           spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 50126)),
           port: 50126,
+          startAborted: StartAbortSignal.never,
         ),
         throwsA(isA<PluginStartException>()),
       );
@@ -656,6 +676,7 @@ void main() {
         fakes.service().attach(
           spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 50127)),
           port: 50127,
+          startAborted: StartAbortSignal.never,
         ),
         throwsA(isA<PluginStartException>()),
       );

--- a/docs/regression/bridge-installation-and-updates.md
+++ b/docs/regression/bridge-installation-and-updates.md
@@ -11,7 +11,9 @@ reconciliation, periodic check, in-place apply, and explicit update command.
 - Installers and the npm bootstrap produce the same managed install, expose the
   `sesori-bridge` launcher, and report the version; installers take the newest
   non-prerelease release carrying the platform archive and its basename-keyed checksum
-  manifest, and verify artifacts before installing them.
+  manifest, and verify artifacts before installing them. Both installer scripts honor
+  `GITHUB`/`GITHUB_API` host overrides and accept only exact `vX.Y.Z` stable tags when
+  scanning releases.
 - An interactive standalone `run` on a sufficiently wide terminal identifies the bridge
   with the installer wordmark and current version. It uses the shared color and Unicode
   capability rules plus a compact ASCII fallback, while supervised starts, redirected
@@ -76,4 +78,5 @@ after apply. Use a throwaway machine when mutating an install root.
 - `bridge/app/lib/src/foundation/bridge_startup_banner_formatter.dart`
 - `bridge/app/lib/src/updater/` policy, track, lock, repositories, services;
   `bridge/app/bin/bridge.dart` (`update`, `config track`)
-- Tests: `bridge/app/test/updater/`, notably policy and release-contract suites
+- Tests: `bridge/app/test/updater/`, notably policy and release-contract suites;
+  `bridge/app/test/tool/installers_test.dart`

--- a/docs/regression/bridge-installation-and-updates.md
+++ b/docs/regression/bridge-installation-and-updates.md
@@ -11,9 +11,9 @@ reconciliation, periodic check, in-place apply, and explicit update command.
 - Installers and the npm bootstrap produce the same managed install, expose the
   `sesori-bridge` launcher, and report the version; installers take the newest
   non-prerelease release carrying the platform archive and its basename-keyed checksum
-  manifest, and verify artifacts before installing them. Both installer scripts honor
-  `GITHUB`/`GITHUB_API` host overrides and accept only exact `vX.Y.Z` stable tags when
-  scanning releases.
+  manifest, and verify artifacts before installing them. Both installer scripts use the
+  canonical GitHub and GitHub API hosts and accept only exact `vX.Y.Z` stable tags when
+  scanning releases; environment variables cannot redirect artifact downloads.
 - An interactive standalone `run` on a sufficiently wide terminal identifies the bridge
   with the installer wordmark and current version. It uses the shared color and Unicode
   capability rules plus a compact ASCII fallback, while supervised starts, redirected

--- a/install.ps1
+++ b/install.ps1
@@ -303,10 +303,8 @@ function Write-PanelEmphasisRow {
 
 $RepoOwner  = 'sesori-ai'
 $RepoName   = 'sesori_apps_monorepo'
-$GitHubBase = if ($env:GITHUB) { $env:GITHUB.TrimEnd('/') } else { 'https://github.com' }
-$GitHubApiBase = if ($env:GITHUB_API) { $env:GITHUB_API.TrimEnd('/') } else { 'https://api.github.com' }
-$RepoBase   = "$GitHubBase/$RepoOwner/$RepoName"
-$ReleasesApiUrl = "$GitHubApiBase/repos/$RepoOwner/$RepoName/releases"
+$RepoBase   = "https://github.com/$RepoOwner/$RepoName"
+$ReleasesApiUrl = "https://api.github.com/repos/$RepoOwner/$RepoName/releases"
 # Fallback-only knobs: scanning recent releases is a cold path used only when the
 # latest release lacks this platform's asset. Kept small because the release
 # pipeline prunes internal pre-releases to a single rolling object.

--- a/install.ps1
+++ b/install.ps1
@@ -301,12 +301,12 @@ function Write-PanelEmphasisRow {
     Write-Line ('  ' + $Border + $bar + $Script:C_RESET + ' ' + $painted + $spaces + ' ' + $Border + $bar + $Script:C_RESET)
 }
 
-Init-Style
-
 $RepoOwner  = 'sesori-ai'
 $RepoName   = 'sesori_apps_monorepo'
-$RepoBase   = "https://github.com/$RepoOwner/$RepoName"
-$ReleasesApiUrl = "https://api.github.com/repos/$RepoOwner/$RepoName/releases"
+$GitHubBase = if ($env:GITHUB) { $env:GITHUB.TrimEnd('/') } else { 'https://github.com' }
+$GitHubApiBase = if ($env:GITHUB_API) { $env:GITHUB_API.TrimEnd('/') } else { 'https://api.github.com' }
+$RepoBase   = "$GitHubBase/$RepoOwner/$RepoName"
+$ReleasesApiUrl = "$GitHubApiBase/repos/$RepoOwner/$RepoName/releases"
 # Fallback-only knobs: scanning recent releases is a cold path used only when the
 # latest release lacks this platform's asset. Kept small because the release
 # pipeline prunes internal pre-releases to a single rolling object.
@@ -344,23 +344,6 @@ function Resolve-OsArchitecture {
     return $null
 }
 
-$detectedOsArchitecture = Resolve-OsArchitecture
-switch ($detectedOsArchitecture) {
-    '64-bit' { $arch = 'x64' }
-    'AMD64'  { $arch = 'x64' }
-    'X64'    { $arch = 'x64' }
-    'ARM64'  { $arch = 'arm64' }
-    'ARM 64-bit Processor' { $arch = 'arm64' }
-    default  { $arch = $null }
-}
-
-if ($arch -notin @('x64', 'arm64')) {
-    Write-Err "Unsupported architecture '$detectedOsArchitecture'."
-    Write-Hint "Only x64 (AMD64) and arm64 are supported on Windows."
-    exit 1
-}
-
-$ArchiveName   = "sesori-bridge-windows-$arch.zip"
 # Returns the Location header of the first (non-followed) redirect for $Url, or
 # $null. Used to learn the version from GitHub's latest -> versioned-download
 # redirect without downloading the asset body.
@@ -476,6 +459,9 @@ function Resolve-BridgeReleaseViaScan {
         if ($release.draft -or $release.prerelease) {
             continue
         }
+        if ($versionText -notmatch '^\d+\.\d+\.\d+$') {
+            continue
+        }
         $parsedVersion = $null
         if (-not [version]::TryParse($versionText, [ref]$parsedVersion)) {
             continue
@@ -516,6 +502,29 @@ function Resolve-BridgeRelease {
     return $release
 }
 
+if ($env:SESORI_INSTALLER_LIBRARY_MODE -eq '1') {
+    return
+}
+
+Init-Style
+
+$detectedOsArchitecture = Resolve-OsArchitecture
+switch ($detectedOsArchitecture) {
+    '64-bit' { $arch = 'x64' }
+    'AMD64'  { $arch = 'x64' }
+    'X64'    { $arch = 'x64' }
+    'ARM64'  { $arch = 'arm64' }
+    'ARM 64-bit Processor' { $arch = 'arm64' }
+    default  { $arch = $null }
+}
+
+if ($arch -notin @('x64', 'arm64')) {
+    Write-Err "Unsupported architecture '$detectedOsArchitecture'."
+    Write-Hint "Only x64 (AMD64) and arm64 are supported on Windows."
+    exit 1
+}
+
+$ArchiveName = "sesori-bridge-windows-$arch.zip"
 $Release = Resolve-BridgeRelease -ArchiveName $ArchiveName
 if (-not $Release -and $arch -eq 'arm64') {
     Write-Warn "No native arm64 bridge release found yet; falling back to the x64 build (runs under emulation on Windows arm64). Re-run this installer after a native arm64 release to switch to the native build."

--- a/install.sh
+++ b/install.sh
@@ -10,13 +10,11 @@ SYMLINK_DIR="${HOME}/.local/bin"
 SYMLINK="${SYMLINK_DIR}/sesori-bridge"
 MANAGED_MANIFEST="${INSTALL_DIR}/.managed-runtime.json"
 GITHUB_REPO="sesori-ai/sesori_apps_monorepo"
-# Base hosts are overridable for GitHub Enterprise or testing (see Bun/uv installers).
-GITHUB="${GITHUB:-https://github.com}"
-GITHUB_API="${GITHUB_API:-https://api.github.com}"
+GITHUB_BASE_URL="https://github.com"
 # Fallback-only knobs: scanning recent releases is a cold path used only when the
 # latest release is missing this platform's asset. Kept small because the release
 # pipeline prunes internal pre-releases to a single rolling object.
-GITHUB_RELEASES_API_URL="${GITHUB_API}/repos/${GITHUB_REPO}/releases"
+GITHUB_RELEASES_API_URL="https://api.github.com/repos/${GITHUB_REPO}/releases"
 GITHUB_RELEASES_PER_PAGE=30
 GITHUB_RELEASES_MAX_PAGES=3
 
@@ -558,7 +556,7 @@ remote_asset_exists() {
 # caller can fall back to a scan of older releases.
 resolve_release_via_latest() {
     local filename="${1}"
-    local latest_base="${GITHUB}/${GITHUB_REPO}/releases/latest/download"
+    local latest_base="${GITHUB_BASE_URL}/${GITHUB_REPO}/releases/latest/download"
 
     local headers
     headers="$(fetch_redirect_headers "${latest_base}/${filename}")" || return 1
@@ -575,8 +573,8 @@ resolve_release_via_latest() {
 
     if [ -n "${version}" ]; then
         RESOLVED_VERSION="${version}"
-        RESOLVED_ARCHIVE_URL="${GITHUB}/${GITHUB_REPO}/releases/download/v${version}/${filename}"
-        RESOLVED_CHECKSUMS_URL="${GITHUB}/${GITHUB_REPO}/releases/download/v${version}/checksums.txt"
+        RESOLVED_ARCHIVE_URL="${GITHUB_BASE_URL}/${GITHUB_REPO}/releases/download/v${version}/${filename}"
+        RESOLVED_CHECKSUMS_URL="${GITHUB_BASE_URL}/${GITHUB_REPO}/releases/download/v${version}/checksums.txt"
     else
         # The asset exists but the version was not parseable from the redirect;
         # download via the always-latest URLs and resolve the version from the
@@ -680,8 +678,8 @@ sys.exit(1)
     }
 
     RESOLVED_VERSION="${tag#v}"
-    RESOLVED_ARCHIVE_URL="${GITHUB}/${GITHUB_REPO}/releases/download/${tag}/${filename}"
-    RESOLVED_CHECKSUMS_URL="${GITHUB}/${GITHUB_REPO}/releases/download/${tag}/checksums.txt"
+    RESOLVED_ARCHIVE_URL="${GITHUB_BASE_URL}/${GITHUB_REPO}/releases/download/${tag}/${filename}"
+    RESOLVED_CHECKSUMS_URL="${GITHUB_BASE_URL}/${GITHUB_REPO}/releases/download/${tag}/checksums.txt"
     return 0
 }
 


### PR DESCRIPTION
## Complexity

⚙️ Moderate. This combines cross-platform installer behavior, CI freshness enforcement, selective analyzer-plugin rollout, and internal bridge contract tightening.

## What

- Aligned PowerShell release selection with the shell installer and pinned both installers to canonical GitHub hosts so environment variables cannot redirect executable downloads.
- Added shared installer fixtures, hostile-host coverage, and a non-installing PowerShell library mode.
- Added offline OpenCode SSE codegen freshness enforcement to Bridge CI.
- Enabled `no_slop_linter` for bridge foundation, plugin interface, and plugin runtime; fixed all findings there and recorded deferred-package counts in Step 43 evidence.
- Made managed-process abort signals non-null and converted the internal plugin session-list API to required named parameters.
- Restored message-only debug logging while retaining caught runtime probe errors and stack traces at warning level.

## Why

The installers could select different releases from identical metadata, environment host overrides weakened the installer trust boundary, committed generated output had no freshness guard, and no bridge package enforced the repository's custom lint rules.

## Risk and test focus

Risk is moderate. Review should focus on PowerShell 5.1-compatible release resolution, canonical installer hosts, analyzer-plugin scope, internal plugin-interface callers, runtime abort propagation, and logging severity/privacy. There is no database or persisted-data impact.

## Expected result

Both installer scripts select the same complete stable release from canonical GitHub, CI catches stale offline-reproducible SSE output, and the three small bridge packages enforce `no_slop_linter`. User-visible impact is limited to corrected and hardened installer release selection.

## Verification

- `make analyze`: all 12 bridge packages passed with `--fatal-infos`.
- Full tests passed for plugin interface (152) and plugin runtime (123); focused app repository suites passed 73 tests.
- Installer suite passed 28 tests; 2 executable PowerShell cases skipped because PowerShell is unavailable locally. The release-contract suite also passed.
- OpenCode SSE generation reproduced 44 variants and 6 refs with no generated diff.
- `bash -n install.sh`, app analysis, and `git diff --check` passed.
- Initial architecture implementation review approved with no findings. The follow-up review skill was unavailable after two attempts; an independent correctness and security review of the feedback diff found no issues.

The pinned Dart formatter still crashes on existing enhanced enums; analyzer and diff checks were used as formatting authority for those files.
