### PR TITLE
🌿 Keep retained history ordered during re-import

### DIFF
--- a/bridge/app/lib/src/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/repositories/chat_history_repository.dart
@@ -346,9 +346,10 @@ class ChatHistoryRepository({
   /// Replaces the session's transcript with [messages], numbering them in
   /// transcript order.
   ///
-  /// Rows the transcript does not contain — live events newer than the fetch —
-  /// are kept above the imported maximum, preserving their relative order, so
-  /// no captured message is lost to a backfill that raced it.
+  /// Rows the transcript does not contain are retained. Their recorded message
+  /// time determines where they rejoin the imported transcript while their
+  /// relative order stays stable. Thus an older backend-only row cannot jump to
+  /// the newest edge on re-import, while a genuinely newer live row stays there.
   Future<void> replaceSessionMessages({
     required String sessionId,
     required AttachmentStorageScope storageScope,
@@ -364,12 +365,12 @@ class ChatHistoryRepository({
         if (!importedIds.contains(row.messageId)) row,
     ];
 
-    final messageRows = <HistoryMessagesTableData>[];
+    final importedMessageRows = <HistoryMessagesTableData>[];
     final partRows = <HistoryPartsTableData>[];
     var seq = 0;
     for (final message in messages) {
       seq++;
-      messageRows.add(
+      importedMessageRows.add(
         HistoryMessagesTableData(
           sessionId: sessionId,
           messageId: message.info.id,
@@ -392,9 +393,38 @@ class ChatHistoryRepository({
         );
       }
     }
-    for (final row in retained..sort((left, right) => left.seq.compareTo(right.seq))) {
-      seq++;
-      messageRows.add(row.copyWith(seq: seq));
+    final retainedCreatedAt = [
+      for (final row in retained) Message.fromJson(jsonDecodeMap(row.infoJson)).time?.created,
+    ];
+    int? nextRetainedCreatedAt;
+    for (var index = retainedCreatedAt.length - 1; index >= 0; index--) {
+      nextRetainedCreatedAt = retainedCreatedAt[index] ?? nextRetainedCreatedAt;
+      retainedCreatedAt[index] = nextRetainedCreatedAt;
+    }
+    int? previousRetainedCreatedAt;
+    for (var index = 0; index < retainedCreatedAt.length; index++) {
+      final createdAt = retainedCreatedAt[index] ?? previousRetainedCreatedAt;
+      if (createdAt == null) continue;
+      final orderedCreatedAt = previousRetainedCreatedAt == null || createdAt >= previousRetainedCreatedAt
+          ? createdAt
+          : previousRetainedCreatedAt;
+      retainedCreatedAt[index] = orderedCreatedAt;
+      previousRetainedCreatedAt = orderedCreatedAt;
+    }
+
+    final messageRows = <HistoryMessagesTableData>[];
+    var importedIndex = 0;
+    var retainedIndex = 0;
+    while (importedIndex < importedMessageRows.length || retainedIndex < retained.length) {
+      final useRetained =
+          importedIndex == importedMessageRows.length ||
+          (retainedIndex < retained.length &&
+              retainedCreatedAt[retainedIndex] != null &&
+              messages[importedIndex].info.time?.created != null &&
+              retainedCreatedAt[retainedIndex]! < messages[importedIndex].info.time!.created);
+      final row = useRetained ? retained[retainedIndex++] : importedMessageRows[importedIndex++];
+      final orderedSeq = messageRows.length + 1;
+      messageRows.add(row.seq == orderedSeq ? row : row.copyWith(seq: orderedSeq));
     }
 
     await _chatHistoryDao.replaceSessionRows(

--- a/bridge/app/test/bridge/services/chat_history_capture_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_capture_test.dart
@@ -340,11 +340,11 @@ void main() {
     });
 
     test("keeps live messages the fetched transcript does not contain", () async {
-      final repository = _FakeSessionRepository(transcript: [_messageWithParts(id: "m1")]);
+      final repository = _FakeSessionRepository(transcript: [_messageWithPartsAt(id: "m1", createdAt: 100)]);
       final history = createTestChatHistory(sessionRepository: repository);
       await history.service.captureMessage(
         sessionId: "ses_a",
-        message: _message(id: "live"),
+        message: _messageAt(id: "live", createdAt: 200),
       );
 
       await history.service.backfillSession(sessionId: "ses_a");
@@ -354,6 +354,41 @@ void main() {
         stored.map((message) => message.info.id),
         const ["m1", "live"],
         reason: "a message captured after the fetch must survive above the imported maximum",
+      );
+    });
+
+    test("a re-import restores retained messages to timestamp order", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [
+          _messageWithPartsAt(id: "before", createdAt: 100),
+          _messageWithPartsAt(id: "after", createdAt: 300),
+        ],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.backfillSession(sessionId: "ses_a");
+      await history.service.captureMessage(
+        sessionId: "ses_a",
+        message: _messageAt(id: "retained", createdAt: 200),
+      );
+      await history.service.captureMessage(
+        sessionId: "ses_a",
+        message: const Message.error(
+          id: "retained-error",
+          sessionID: "ses_a",
+          agent: null,
+          modelID: null,
+          providerID: null,
+          errorName: "Error",
+          errorMessage: "failed",
+          time: null,
+        ),
+      );
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      expect(
+        (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
+        const ["before", "retained", "retained-error", "after"],
       );
     });
 
@@ -523,12 +558,14 @@ Future<List<MessageWithParts>> _storedMessages({
   storageScope: testAttachmentStorageScope(sessionId: sessionId),
 )).messages;
 
-Message _message({required String id}) => Message.user(
+Message _message({required String id}) => _messageAt(id: id, createdAt: 1);
+
+Message _messageAt({required String id, required int createdAt}) => Message.user(
   promptId: null,
   id: id,
   sessionID: "ses_a",
   agent: null,
-  time: const MessageTime(created: 1, completed: null),
+  time: MessageTime(created: createdAt, completed: null),
 );
 
 MessagePart _part({
@@ -553,8 +590,10 @@ MessagePart _part({
   attachment: attachment,
 );
 
-MessageWithParts _messageWithParts({required String id}) => MessageWithParts(
-  info: _message(id: id),
+MessageWithParts _messageWithParts({required String id}) => _messageWithPartsAt(id: id, createdAt: 1);
+
+MessageWithParts _messageWithPartsAt({required String id, required int createdAt}) => MessageWithParts(
+  info: _messageAt(id: id, createdAt: createdAt),
   parts: [_part(id: "$id-p1", messageId: id, text: "text of $id")],
 );
 

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -12,6 +12,10 @@ and rejoined after a client reconnect, plugin restart, or bridge restart.
   never starts a stopped backend. Only a first backfill or a re-read after the
   backend advanced may reach it; backfill is lazy and per session, and a session
   advanced outside Sesori is detected as stale, re-read, and re-cached.
+- Messages visible live but absent from the backend's replay remain visible
+  after a stale re-read. They rejoin at their recorded creation time while
+  preserving relative order, so a catalog re-import cannot move old rows to the
+  newest edge.
 - Live streamed messages and parts become queryable immediately after they
   finalize, with the same visibility filtering and tool-output bound a backend
   fetch returns. Reasoning finalizes when the stream advances to assistant or
@@ -58,7 +62,7 @@ and rejoined after a client reconnect, plugin restart, or bridge restart.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Headless bridge, one representative plugin: a previously synced session's transcript is served with every backend stopped. |
-| L2 Routine | Live plugin, representative: first backfill, live capture that becomes immediately queryable, and paging older messages on a transcript longer than one page. Automated Pi coverage: active branches, v1-v3 fallback migration, compaction visibility, hidden-context decoding, bounded tool/image mapping, content-index streaming, cumulative tool updates, and live/replay final parity. |
+| L2 Routine | Live plugin, representative: first backfill, live capture that becomes immediately queryable, stale re-read ordering for retained live-only rows, and paging older messages on a transcript longer than one page. Automated Pi coverage: active branches, v1-v3 fallback migration, compaction visibility, hidden-context decoding, bounded tool/image mapping, content-index streaming, cumulative tool updates, and live/replay final parity. |
 | L3 Release | Client end to end on the release-target client platform, every supporting production plugin: open a long session, page back, continue a live turn, reopen cold, and confirm live and replayed content converge including tool and image parts. |
 | L4 Extended | Relay integration plus owning client automated coverage, every supporting production plugin: session advanced through the backend's own CLI, plugin restart and event-stream-gap invalidation, bridge restart, client reconnect inside and outside the replay window without refresh losing concurrently finalized content, two clients on one session, a slow request beside unrelated traffic. |
 | L5 Full | Automated and headless bridge for unreadable or partial store artifacts, interrupted backfill, and startup reconciliation; packaged or external for pagination's released-client shape; live plugin for very large transcripts. Every supporting production plugin. |
@@ -82,6 +86,7 @@ image parts converge by their own rules.
   reattachment, or triggers repeated requests while one page is in flight.
 - A session advanced outside Sesori keeps serving the old transcript, or stored
   transcripts are marked complete after a gap without a full re-sync.
+- A stale re-read moves an older retained message to the newest edge.
 - Pi falls back after an arbitrary RPC failure, shows an abandoned branch or
   summary payload, or exposes a private path, raw backend error, or hidden prompt
   prefix in mapped history.


### PR DESCRIPTION
## Complexity

🌿 Straightforward: one plugin-neutral history merge rule, regression coverage, and the matching regression contract.

## What

- Merge replay-omitted retained rows back into a refreshed transcript by their recorded creation time.
- Preserve retained-row relative order, including rows without their own timestamp.
- Cover a stale re-import repairing an already-appended older row while keeping genuinely newer live rows at the newest edge.

## Why

A stale history re-read previously appended every row omitted by backend replay after the imported transcript. Claude Code emits some visible live user rows that its persisted replay intentionally omits, so catalog re-import could move old rows to the newest edge even though their timestamps were old. The storage merge was plugin-neutral, so the same failure was possible for other backends with replay-omitted live rows.

## Risk and test focus

The change affects only ordering during full history replacement. Imported replay order remains authoritative, retained rows keep their own relative order, and timestamp ties or missing ordering information preserve the existing imported-before-retained fallback. No schema or migration impact; a later stale re-read repairs affected stored sequence values.

## Expected result

Re-importing or otherwise refreshing a stale session keeps older retained user messages at their chronological position instead of presenting them as recent messages.

## Verification

- `dart test test/bridge/services/chat_history_capture_test.dart`
- `dart analyze --fatal-infos lib/src/repositories/chat_history_repository.dart test/bridge/services/chat_history_capture_test.dart`
- `dart format lib/src/repositories/chat_history_repository.dart test/bridge/services/chat_history_capture_test.dart`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps retained live-only messages in chronological position during session re-import. Previously, re-import appended all retained rows after the imported transcript; now retained rows rejoin by recorded creation time while preserving their relative order, so older rows no longer jump to the newest edge and genuinely newer live rows stay newest.

- Applies only during full history replacement; imported replay order remains authoritative.
- For retained rows without timestamps, inherit neighboring timestamps to maintain relative order; ties still resolve as imported-before-retained.
- Renumbers sequences stably; no schema changes or migrations. A stale re-import repairs any previously misordered sequences.
- Adds a regression test for retained-row ordering and updates recovery docs.

<sup>Written for commit 2aea4d5a0ae50a049b580963ca0b30f7e89e0800. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

