### PR TITLE
⚙️ Prevent catalog drain from blocking bridge shutdown

### DIFF
--- a/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
@@ -242,16 +242,21 @@ class const BridgeRuntimeRunner._() {
       )
       ..addPhase(
         phase: BridgeShutdownPhase.drain,
-        action: () => runtime?.catalogImportService.drain() ?? Future<void>.value(),
-      )
-      ..addPhase(
-        phase: BridgeShutdownPhase.drain,
         action: () => sessionRun ?? Future<void>.value(),
       )
       ..addPhase(
         phase: BridgeShutdownPhase.pluginDispose,
         action: shutdownStartedPlugins,
         budget: _pluginShutdownBudget,
+      )
+      ..addPhase(
+        phase: BridgeShutdownPhase.pluginDispose,
+        // Imports were fenced and asked to cancel in the signal phase, but a
+        // backend call already in flight may only settle when its plugin
+        // transport closes. Start the drain beside plugin shutdown rather than
+        // waiting on it first; the coordinator starts every action in a phase
+        // before awaiting any of them.
+        action: () => runtime?.catalogImportService.drain() ?? Future<void>.value(),
       )
       ..addPhase(
         phase: BridgeShutdownPhase.lifecycle,

--- a/bridge/app/lib/src/runtime/bridge_shutdown_coordinator.dart
+++ b/bridge/app/lib/src/runtime/bridge_shutdown_coordinator.dart
@@ -60,8 +60,13 @@ class BridgeShutdownCoordinator({
       return total + phaseBudget;
     });
     final totalSw = Stopwatch()..start();
+    BridgeShutdownPhase? activePhase;
     final backstop = Timer(shutdownBudget + _backstopSlack, () {
-      Log.e("Failed to finish gracefully after ${totalSw.elapsedMilliseconds}ms - forcing exit");
+      final phase = activePhase;
+      Log.e(
+        "Failed to finish gracefully after ${totalSw.elapsedMilliseconds}ms"
+        "${phase == null ? "" : " during the ${phase.name} phase"} - forcing exit",
+      );
       unawaited(_emergencyDisposalThenExit());
     });
     Object? firstError;
@@ -69,6 +74,7 @@ class BridgeShutdownCoordinator({
 
     try {
       for (final phase in BridgeShutdownPhase.values) {
+        activePhase = phase;
         final actions = _actions[phase]!;
         final futures = <Future<void>>[];
         for (final action in actions) {
@@ -93,6 +99,7 @@ class BridgeShutdownCoordinator({
           }
         }
       }
+      activePhase = null;
     } finally {
       backstop.cancel();
       Log.d("[shutdown] coordinator complete (${totalSw.elapsedMilliseconds}ms total)");

--- a/bridge/app/test/bridge/runtime/bridge_shutdown_coordinator_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_shutdown_coordinator_test.dart
@@ -1,9 +1,11 @@
 import "dart:async";
+import "dart:io";
 
 import "package:fake_async/fake_async.dart";
 import "package:sesori_bridge/src/runtime/bridge_shutdown_coordinator.dart";
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
-    show PluginStartAbortedException, StartAbortController, StartAbortSignal;
+    show Log, LogLevel, PluginStartAbortedException, StartAbortController, StartAbortSignal;
 import "package:test/test.dart";
 
 void main() {
@@ -50,10 +52,14 @@ void main() {
       final operations = <String>[];
 
       coordinator.add(disposable: () => operations.add("parallel.a"));
-      coordinator.addPhase(phase: BridgeShutdownPhase.lifecycle, action: () async => operations.add("ordered.1"),
+      coordinator.addPhase(
+        phase: BridgeShutdownPhase.lifecycle,
+        action: () async => operations.add("ordered.1"),
         budget: const Duration(seconds: 5),
       );
-      coordinator.addPhase(phase: BridgeShutdownPhase.lifecycle, action: () async => operations.add("ordered.2"),
+      coordinator.addPhase(
+        phase: BridgeShutdownPhase.lifecycle,
+        action: () async => operations.add("ordered.2"),
         budget: const Duration(seconds: 5),
       );
       coordinator.add(disposable: () => operations.add("parallel.b"));
@@ -70,10 +76,14 @@ void main() {
       );
       final operations = <String>[];
 
-      coordinator.addPhase(phase: BridgeShutdownPhase.lifecycle, action: () async => throw StateError("plugin shutdown failed"),
+      coordinator.addPhase(
+        phase: BridgeShutdownPhase.lifecycle,
+        action: () async => throw StateError("plugin shutdown failed"),
         budget: const Duration(seconds: 5),
       );
-      coordinator.addPhase(phase: BridgeShutdownPhase.lifecycle, action: () async => operations.add("ordered.2"),
+      coordinator.addPhase(
+        phase: BridgeShutdownPhase.lifecycle,
+        action: () async => operations.add("ordered.2"),
         budget: const Duration(seconds: 5),
       );
       coordinator.add(disposable: () => operations.add("parallel"));
@@ -134,32 +144,35 @@ void main() {
       expect(operations, ["signal.interrupt", "drain"]);
     });
 
-    test("starts every action in a phase before awaiting a blocked peer", () async {
+    test("starts plugin shutdown and catalog drain together before awaiting either", () async {
       final coordinator = BridgeShutdownCoordinator(
         startAbortSignal: StartAbortSignal.never,
         exitProcess: (_) {},
       );
-      final blocked = Completer<void>();
+      final catalogDrainStarted = Completer<void>();
+      final pluginTransportClosed = Completer<void>();
       final operations = <String>[];
 
       coordinator.addPhase(
-        phase: BridgeShutdownPhase.drain,
-        action: () {
-          operations.add("blocked");
-          return blocked.future;
+        phase: BridgeShutdownPhase.pluginDispose,
+        action: () async {
+          operations.add("plugin.shutdown");
+          await catalogDrainStarted.future;
+          pluginTransportClosed.complete();
         },
       );
       coordinator.addPhase(
-        phase: BridgeShutdownPhase.drain,
-        action: () => operations.add("ready"),
+        phase: BridgeShutdownPhase.pluginDispose,
+        action: () async {
+          operations.add("catalog.drain");
+          catalogDrainStarted.complete();
+          await pluginTransportClosed.future;
+        },
       );
 
-      final shutdown = coordinator.shutdown();
-      await Future<void>.delayed(Duration.zero);
-      expect(operations, ["blocked", "ready"]);
+      await coordinator.shutdown().timeout(const Duration(seconds: 1));
 
-      blocked.complete();
-      await shutdown;
+      expect(operations, ["plugin.shutdown", "catalog.drain"]);
     });
 
     test("an aborted plugin start does not block phases after plugin disposal", () async {
@@ -221,7 +234,9 @@ void main() {
           backstopExitCode: () => 1,
           exitProcess: exitCalls.add,
         );
-        coordinator.addPhase(phase: BridgeShutdownPhase.lifecycle, action: () => Completer<void>().future,
+        coordinator.addPhase(
+          phase: BridgeShutdownPhase.lifecycle,
+          action: () => Completer<void>().future,
           budget: const Duration(seconds: 10),
         );
 
@@ -232,6 +247,36 @@ void main() {
         async.elapse(const Duration(seconds: 2));
         expect(exitCalls, [1]);
       });
+    });
+
+    test("backstop log identifies the phase that did not drain", () {
+      final stderr = BufferingStdout();
+      final previousLevel = Log.level;
+      try {
+        Log.level = LogLevel.debug;
+        IOOverrides.runZoned(
+          () {
+            fakeAsync((async) {
+              final coordinator = BridgeShutdownCoordinator(
+                startAbortSignal: StartAbortSignal.never,
+                exitProcess: (_) {},
+              );
+              coordinator.addPhase(
+                phase: BridgeShutdownPhase.drain,
+                action: () => Completer<void>().future,
+              );
+
+              unawaited(coordinator.shutdown());
+              async.elapse(const Duration(seconds: 11));
+            });
+          },
+          stderr: () => stderr,
+        );
+
+        expect(stderr.text, contains("during the drain phase"));
+      } finally {
+        Log.level = previousLevel;
+      }
     });
 
     test("backstop covers a hung parallel phase even with no ordered steps", () {
@@ -332,7 +377,11 @@ void main() {
           startAbortSignal: StartAbortSignal.never,
           exitProcess: exitCalls.add,
         );
-        coordinator.addPhase(phase: BridgeShutdownPhase.lifecycle, action: () async {}, budget: const Duration(seconds: 10));
+        coordinator.addPhase(
+          phase: BridgeShutdownPhase.lifecycle,
+          action: () async {},
+          budget: const Duration(seconds: 10),
+        );
         coordinator.add(disposable: () {});
 
         unawaited(coordinator.shutdown());


### PR DESCRIPTION
## Complexity

Moderate. This changes lifecycle ordering between catalog imports and plugin teardown; it does not change wire contracts, persisted schemas, or user-facing product behavior.

## What

- Start cancellation-draining catalog imports in the same shutdown phase as plugin transport disposal.
- Include the active shutdown phase in the forced-exit backstop diagnostic.
- Cover cooperative plugin/catalog teardown and phase-specific backstop logging.

## Why

A catalog import already waiting on a backend call was drained before plugin disposal. If that call only settled when the plugin transport closed, shutdown formed a circular wait and reached the 40-second forced-exit backstop.

## Risk and test focus

The risk is closing a plugin transport while a canceled catalog import is unwinding. Shutdown fences new plugin leases and asks catalog imports to cancel in the signal phase before both teardown actions start. Tests focus on concurrent phase startup, catalog/runtime disposal behavior, plugin interruption, and the backstop diagnostic.

## Expected result

Canceled catalog operations and plugin transports can release each other during shutdown, avoiding the observed forced exit. If another phase stalls, the fatal log identifies that phase.

## Verification

- `dart test test/bridge/runtime/bridge_shutdown_coordinator_test.dart`
- `dart test test/services/catalog_import_service_test.dart test/bridge/runtime/plugin_runtime_test.dart`
- `dart analyze lib/src/runtime/bridge_runtime_runner.dart lib/src/runtime/bridge_shutdown_coordinator.dart test/bridge/runtime/bridge_shutdown_coordinator_test.dart`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent shutdown deadlocks by starting catalog import draining in the same phase as plugin disposal and by identifying the active phase in the forced-exit log. Previously, draining ran before plugin disposal and could hang when a backend call only settled after the plugin transport closed; now both start together so canceled imports and plugin transports can release each other.

- Move catalog import draining to the `pluginDispose` phase; the coordinator starts all actions in a phase before awaiting any.
- Include the active shutdown phase in the backstop fatal log to identify stalls.
- No API, schema, or user-visible behavior changes; no migration required.

<sup>Written for commit 789629cd8a6a8401f94fd1128d3b803631885ea4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

