### PR TITLE
🌿 Let Pi finish preflight compaction before follow-ups time out

### DIFF
--- a/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
+++ b/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
@@ -65,6 +65,9 @@ final class PiPlugin._({
       identityTracker: identities,
       startupExitTimeout: startupExitTimeout,
       historyRpcTimeout: historyRpcTimeout,
+      // Pi can run model-backed automatic compaction before acknowledging a
+      // prompt, so prompt preflight needs the same generous bound as a turn.
+      promptRpcTimeout: const Duration(minutes: 30),
     );
     final extensionUiService = PiExtensionUiService(
       catalogRepository: catalogRepository,

--- a/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
@@ -110,6 +110,7 @@ final class PiSessionProcessRepository({
   required final PiMessageIdentityTracker _identityTracker,
   required final Duration _startupExitTimeout,
   required final Duration _historyRpcTimeout,
+  required final Duration _promptRpcTimeout,
 }) {
   final Map<String, String> _environment = Map.unmodifiable(environment);
   final Map<String, _ResidentClient> _residents = {};
@@ -378,7 +379,7 @@ final class PiSessionProcessRepository({
         "images": payload.images,
         "streamingBehavior": _PiPromptStreamingBehavior.steer.wireValue,
       },
-      timeout: _historyRpcTimeout,
+      timeout: _promptRpcTimeout,
     );
   }
 

--- a/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
@@ -470,6 +470,7 @@ final class _ProcessFixture({required final FakePiExtensionSessionStorageApi sto
     identityTracker: PiMessageIdentityTracker(pluginId: "pi"),
     startupExitTimeout: const Duration(milliseconds: 50),
     historyRpcTimeout: const Duration(seconds: 2),
+    promptRpcTimeout: const Duration(minutes: 30),
   );
 
   List<_SentReply> get replies => [

--- a/bridge/sesori_plugin_pi/test/pi_session_process_repository_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_process_repository_test.dart
@@ -436,6 +436,7 @@ PiSessionProcessRepository _repository({
     identityTracker: identityTracker ?? PiMessageIdentityTracker(pluginId: "pi"),
     startupExitTimeout: startupExitTimeout,
     historyRpcTimeout: historyRpcTimeout,
+    promptRpcTimeout: const Duration(minutes: 30),
   );
 }
 

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -246,6 +246,7 @@ void main() {
       identityTracker: identities,
       startupExitTimeout: const Duration(milliseconds: 50),
       historyRpcTimeout: const Duration(seconds: 2),
+      promptRpcTimeout: const Duration(minutes: 30),
     );
     addTearDown(repository.dispose);
 
@@ -1354,13 +1355,44 @@ void main() {
     expect(events.whereType<BridgeSseSessionError>(), hasLength(1));
   });
 
+  test("pre-prompt compaction can outlive ordinary RPC timeout", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process])
+      ..historyRpcTimeout = const Duration(milliseconds: 20)
+      ..promptRpcTimeout = const Duration(seconds: 1);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "compacting-prompt",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "after compaction")],
+      userVisibleText: "after compaction",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    final prompt = await waitForCommand(process: process, type: "prompt");
+    process.emit(frame: {"type": "compaction_start", "reason": "threshold"});
+
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    expect(process.killed, isFalse);
+    expect(service.queuedPrompts(sessionId: "session").single.id, "compacting-prompt");
+    expect(service.sessionStatuses["session"], const PluginSessionStatus.busy());
+
+    process.emit(frame: {"type": "agent_start"});
+    process.emitResponse(id: prompt["id"]! as String, command: "prompt");
+    await pump();
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: "session");
+  });
+
   test("ambiguous prompt timeout tears down generation before queued work reconnects", () async {
     final timedOut = FakePiProcess();
     final replacement = FakePiProcess();
-    final fixture = _Fixture(
-      processes: [timedOut, replacement],
-      historyRpcTimeout: const Duration(milliseconds: 20),
-    );
+    final fixture = _Fixture(processes: [timedOut, replacement])..promptRpcTimeout = const Duration(milliseconds: 20);
     addTearDown(fixture.dispose);
     final service = fixture.service();
 
@@ -2022,10 +2054,11 @@ PiResolvedSession _resolved({String id = "session"}) => PiResolvedSession(
 final class _Fixture({
   required List<FakePiProcess> processes,
   final _Storage? storageOverride,
-  final Duration historyRpcTimeout = const Duration(seconds: 2),
 }) {
   final List<FakePiProcess> _processes = List.of(processes);
   Duration? idleTimeout = const Duration(minutes: 5);
+  Duration historyRpcTimeout = const Duration(seconds: 2);
+  Duration promptRpcTimeout = const Duration(seconds: 2);
   late final _Storage storage = storageOverride ?? _Storage(initialResolvedSession: _resolved());
   final List<PiLaunchSpec> spawned = [];
   late final PiMessageIdentityTracker identities = PiMessageIdentityTracker(pluginId: "pi");
@@ -2046,6 +2079,7 @@ final class _Fixture({
     identityTracker: identities,
     startupExitTimeout: const Duration(milliseconds: 50),
     historyRpcTimeout: historyRpcTimeout,
+    promptRpcTimeout: promptRpcTimeout,
   );
 
   PiSessionService service({ServerClock clock = const ServerClock()}) {

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -64,9 +64,12 @@ defaults and queued client sends coherent.
   `steer` streaming behavior as soon as the preceding prompt is accepted, so Pi
   injects them at the next tool boundary instead of waiting for the run to
   settle. A model or thinking-level change remains bridge-queued until the
-  current run settles. An accepted prompt remains bridge-queued through startup
-  and selection until Pi echoes
-  its correlated user message, including an attachment-only echo; it can be
+  current run settles. Pi may run model-backed automatic compaction before it
+  acknowledges a prompt, so that preflight uses a turn-scale deadline instead
+  of the shorter history/control RPC deadline and the prompt remains visibly
+  queued while compaction runs. An accepted prompt remains bridge-queued
+  through startup and selection until Pi echoes its correlated user message,
+  including an attachment-only echo; it can be
   cancelled before dispatch, and its undispatched prompt id remains immediately
   retryable while cancellation settles. If a successful run omits an echo, Pi
   maps each stored payload through the same user-message path before clearing
@@ -249,6 +252,8 @@ replay, and abort after output has started.
   staged prompt, changes FIFO order or prompt identity, refreshes and retries
   without a bound, or leaves a corrected selection on a variant the picker does
   not display.
+- A cold Pi follow-up wakes the process but times out in pre-prompt automatic
+  compaction before reaching the agent.
 - An abort, permission reply, or question reply stalls behind a send to a
   busy session on the same session lane, or a Cursor/Hermes follow-up waits for
   the active turn to finish naturally instead of cancelling it before dispatch.


### PR DESCRIPTION
## Complexity

Straightforward — the fix separates one backend-specific prompt-preflight deadline from Pi's shorter control/history RPC deadline.

## What

- Give Pi prompt acknowledgement a 30-minute turn-scale deadline while keeping history, selection, state, and control RPCs at their existing two-minute bound.
- Add a regression where pre-prompt automatic compaction outlives the ordinary RPC timeout without killing the process or dropping the queued prompt.
- Record the supported behavior and failure signal in the session-turn regression contract.

## Why

Pi can run model-backed automatic compaction before acknowledging a `prompt` RPC. A large resumed session therefore woke correctly and emitted its extension startup notification, but the bridge reused the two-minute history timeout for prompt preflight. The bridge killed Pi while compaction was still running, leaving the follow-up queued until that timeout and then returning the session to idle without reaching the agent.

## Risk and test focus

Risk is limited to Pi prompt timeout handling. Review should focus on keeping ambiguous prompt timeout recovery intact while allowing legitimate compaction preflight to run longer. There is no database, persisted-format, wire-contract, analytics, or client-UI impact.

## Expected result

A cold Pi follow-up remains visibly queued while automatic compaction runs, then reaches the agent when Pi acknowledges it instead of being killed by the shorter history/control deadline.

## Verification

- `cd bridge && dart pub get`
- `cd bridge/sesori_plugin_pi && dart analyze --fatal-infos`
- `cd bridge/sesori_plugin_pi && dart test` — 269 tests passed
- Real-session copy probe with tools disabled: Pi emitted the startup UI request, immediately entered threshold compaction, crossed the old 120-second deadline, completed compaction after 187.9 seconds, and acknowledged the prompt successfully at 187.9 seconds. The original session was untouched and the temporary copy was removed.
- `git diff --check`
