### PR TITLE
🌱 [codebase-cleanup] docs: reconcile regression coverage after the cleanup [step 44/45]

### DIFF
--- a/.plan/active/codebase-cleanup/steps/step-44.md
+++ b/.plan/active/codebase-cleanup/steps/step-44.md
@@ -1,0 +1,40 @@
+# Step 44 — Regression Coverage Reconciliation
+
+## Re-verified evidence
+
+- Reconciled the Step 44 regression-document matrix against `origin/main` at
+  `bafa7cd026`, including the behavior-changing steps and source moves from the
+  cleanup series.
+- Merge-base diff: 9 files, 61 insertions, 17 deletions.
+- The plugin, client, compatibility, installer, notification, analytics, and
+  design contracts still describe the merged implementation and retain their
+  existing regression levels and proof boundaries.
+- OMP starts `omp acp` without an approval-mode argument; the prior claim that
+  it inherited the user's `tools.approvalMode` was not supported by the launch
+  specification. Pi continues to launch every session mode with `--approve`.
+- Step 7 flattened bridge production code out of `lib/src/bridge/`; several
+  source lists still named the old layout even though their behavior contracts
+  remained current.
+
+## Change
+
+- Corrected the OMP approval ownership statement in plugin lifecycle coverage.
+- Updated bridge source references in plugin lifecycle, runtime installation,
+  session creation, session turns, projects and sessions, diffs, and tool/file
+  coverage to the current flattened layout.
+- Added the existing popup-alert regression document to the feature index.
+- Reviewed without changes: bridge connectivity, questions and permissions,
+  session history and recovery, voice input, session archiving and deletion,
+  account and onboarding, bridge installation and updates, notifications,
+  analytics, design catalog, and popup alerts.
+
+## Verification
+
+- Confirmed every updated source path exists in the current tree.
+- Confirmed OMP's launch arguments and Pi's `--approve` arguments directly from
+  their production launch specifications.
+- Searched regression documents for remaining references to the flattened
+  `bridge/app/lib/src/bridge/` production layout.
+- `git diff --check`: passed.
+- Architecture implementation review: not run; this step changes documentation
+  and plan evidence only.

--- a/docs/regression/README.md
+++ b/docs/regression/README.md
@@ -157,6 +157,7 @@ failed, or unexecuted required coverage keeps the plan active.
 - [Permission auto-approval](permission-auto-approval.md)
 - [Plugin runtime installation](plugin-runtime-installation.md)
 - [Plugin setup and lifecycle](plugin-setup-and-lifecycle.md)
+- [Popup alerts](popup-alerts.md)
 - [Projects and sessions](projects-and-sessions.md)
 - [Pull request monitoring](pull-request-monitoring.md)
 - [Questions and permissions](questions-and-permissions.md)

--- a/docs/regression/diffs-and-source-control.md
+++ b/docs/regression/diffs-and-source-control.md
@@ -77,9 +77,9 @@ and in-place sessions, and default versus explicit base branches.
 
 ## Sources
 
-- Bridge: `bridge/app/lib/src/bridge/` session-diff and worktree services,
-  `repositories/session_diff_repository.dart`, `api/git_cli_api.dart`, and the
-  diff and base-branch handlers
+- Bridge: `bridge/app/lib/src/services/` session-diff and worktree services,
+  `bridge/app/lib/src/repositories/session_diff_repository.dart`,
+  `bridge/app/lib/src/api/git_cli_api.dart`, and the diff and base-branch handlers
 - Contract: `shared/sesori_shared/lib/src/models/sesori/file_diff.dart`
 - Client: `client/module_core/lib/src/cubits/session_diffs/`,
   `client/app/lib/features/session_diffs/`

--- a/docs/regression/plugin-runtime-installation.md
+++ b/docs/regression/plugin-runtime-installation.md
@@ -69,7 +69,8 @@ download, verification, or placement. Use a disposable data directory.
 
 - `bridge/sesori_plugin_interface/.../bridge_plugin_descriptor.dart`,
   `bridge/sesori_plugin_runtime/lib/src/provisioning/`, OpenCode, Codex, Cursor, Pi, and OMP manifests
-- `bridge/app/lib/src/services/plugin_lifecycle_service.dart`, `.../plugin_registry.dart`
+- `bridge/app/lib/src/services/plugin_lifecycle_service.dart`,
+  `bridge/app/lib/src/runtime/plugin_registry.dart`
 - `client/module_core/.../plugin_management_service.dart`,
   `client/app/lib/features/settings/harnesses_settings_screen.dart`
 - Tests: `bridge/app/test/services/plugin_lifecycle_service_test.dart`, per-plugin

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -24,8 +24,9 @@ idle suspension, the management snapshot, and lifecycle commands.
 - Pi and Oh My Pi are registered harnesses with managed installs where a platform
   archive exists and explicit `--pi-bin`/`--omp-bin` paths stay authoritative. Pi
   sessions always launch with `--approve` (project-local Pi settings, extensions,
-  skills, and prompt templates are trusted without prompts); OMP inherits the user's
-  `tools.approvalMode`. Provider login for both happens locally, never from the phone.
+  skills, and prompt templates are trusted without prompts); OMP launches `omp acp`
+  without an approval-mode override, leaving approval behavior to OMP. Provider login
+  for both happens locally, never from the phone.
 - Backend `tui.toast.show` SSE events render app-wide through the backend-neutral
   toast surface, presented with the design-system popup alert on the root
   navigator's overlay: every accepted toast is a new effect (equal repeated guidance
@@ -152,10 +153,10 @@ timeouts, and sessions afterwards.
 
 ## Sources
 
-- `bridge/sesori_plugin_interface/lib/src/lifecycle/`; registered OpenCode, Codex,
-  Cursor, Claude Code, and Hermes Agent descriptors; plugin routing handlers
+- `bridge/sesori_plugin_interface/lib/src/lifecycle/`; registered production plugin
+  descriptors; plugin routing handlers
 - `bridge/app/lib/src/services/plugin_lifecycle_service.dart`,
-  `bridge/app/lib/src/bridge/runtime/plugin_registry.dart`
+  `bridge/app/lib/src/runtime/plugin_registry.dart`
 - `bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart` and its tests
 - `bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart` and `codex_plugin_write_path_test.dart`
 - `client/module_core/.../plugin_management_service.dart`, `PregoBrandLogo`, and the

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -165,9 +165,10 @@ navigation, and a non-mobile platform; begin drags inside and just outside each
 
 ## Sources
 
-- Bridge: `bridge/app/lib/src/bridge/repositories/` (project, session, derived
-  session), `bridge/services/project_*`, `services/catalog_import_service.dart`,
-  catalog and session handlers in `bridge/routing/`
+- Bridge: `bridge/app/lib/src/repositories/` (project, session, derived session),
+  `bridge/app/lib/src/services/project_*`,
+  `bridge/app/lib/src/services/catalog_import_service.dart`, and catalog and
+  session handlers in `bridge/app/lib/src/routing/`
 - Contract: `bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart`
 - Pi metadata catalog: `bridge/sesori_plugin_pi/lib/src/api/pi_session_storage_api.dart`,
   `bridge/sesori_plugin_pi/lib/src/repositories/pi_session_catalog_repository.dart`

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -179,7 +179,7 @@ reconnect or option refresh while restoration is pending.
 
 - Bridge: `bridge/app/lib/src/api/sesori_server_api.dart`,
   `bridge/app/lib/src/repositories/session_metadata_repository.dart`,
-  `bridge/app/lib/src/bridge/services/` (session creation, mutation, events,
+  `bridge/app/lib/src/services/` (session creation, mutation, events,
   options, worktree), the create-session and options handlers, and their tests
 - OMP: `bridge/sesori_plugin_omp/lib/src/services/` and package tests
 - Contract:

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -298,8 +298,8 @@ replay, and abort after output has started.
 
 ## Sources
 
-- Bridge: `bridge/app/lib/src/bridge/services/` (prompt, abort, dispatcher,
-  event, chat history), `lib/src/bridge/sse/`, and their tests
+- Bridge: `bridge/app/lib/src/services/` (prompt, abort, dispatcher, event,
+  chat history), `bridge/app/lib/src/sse/`, and their tests
 - Contract: `bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart`;
   `shared/sesori_shared/lib/src/models/sesori/send_prompt_error_response.dart`;
   `shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart`

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -66,8 +66,8 @@ multi-byte, and empty output; compare live with a later reload.
 
 - Contract: `bridge/sesori_plugin_interface/lib/src/models/plugin_message.dart`;
   `shared/sesori_shared/lib/src/models/sesori/message_part.dart`
-- Bridge: `bridge/app/lib/src/bridge/plugin_to_shared_mapping.dart`,
-  `bridge/sse/bridge_event_mapper.dart`; mappers and tests under
+- Bridge: `bridge/app/lib/src/repositories/mappers/plugin_to_shared_mapping.dart`,
+  `bridge/app/lib/src/sse/bridge_event_mapper.dart`; mappers and tests under
   `bridge/sesori_plugin_*/`; `client/app/lib/features/session_detail/widgets/`
 - Tests: `bridge/app/test/bridge/sse/bridge_event_mapper_test.dart`
 - Plans (discovery only): `.plan/completed/output-image-support`,


### PR DESCRIPTION
## Complexity

🌱 Trivial: this is a documentation-only consistency pass over existing regression contracts and source references.

## What

- Correct the OMP approval-ownership statement to match its production launch specification.
- Refresh stale bridge source references after the production tree flatten.
- Add the existing popup-alert capability to the regression feature index.
- Record the complete reviewed/no-change Step 44 matrix and verification evidence.

## Why

The cleanup series changed implementation ownership and source locations across bridge and client code. Its durable regression catalog must describe the merged behavior and point maintainers at the current authoritative implementation before final release verification.

## Risk and test focus

Low risk. Documentation and plan evidence only; no production code, runtime flow, wire contract, persistence, or database behavior changes. Review should focus on the accuracy of the OMP approval statement, the updated source paths, and completeness of the regression index.

## Expected result

No user-visible or database change. Regression documentation accurately reflects current supported behavior and current source ownership, enabling Step 45 to execute the recorded release matrix.

## Verification

- Confirmed every updated production source path exists.
- Confirmed OMP launches `omp acp` without an approval-mode override and Pi continues to launch with `--approve`.
- Confirmed no regression document still references the flattened `bridge/app/lib/src/bridge/` production layout.
- `git diff --check` passed.
- No Dart or Flutter suites run because this PR changes documentation and plan evidence only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles regression documentation after the cleanup to keep the catalog accurate and source pointers current. The docs now state: previously OMP was described as inheriting the user's approval mode; now OMP launches `omp acp` without an approval override, while Pi continues to launch all session modes with `--approve`.

- Corrects the OMP approval ownership statement in `plugin-setup-and-lifecycle.md`.
- Updates bridge source paths to the flattened layout across: diffs, plugin runtime installation, plugin lifecycle, session creation, session turns, projects and sessions, and tools/file changes.
- Adds the existing popup-alerts coverage to the regression index.
- Adds `.plan/active/codebase-cleanup/steps/step-44.md` with the reviewed/no-change matrix and verification evidence.
- Verification: confirmed all updated paths exist, confirmed OMP/Pi launch arguments from specs, removed old `bridge/app/lib/src/bridge/` references, and `git diff --check` passed.
- No production code, runtime flow, wire contract, persistence, or database changes.

<sup>Written for commit 2102f7965ed86f969805584d4f991825301ecae1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

