### PR TITLE
⚙️ [catalog-rescan] Add a second stage to pull-to-refresh [step 5/8]

### DIFF
--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -89,7 +89,7 @@ returns nothing.
 eligible plugin, with no recency or terminality filter. Because the hydration
 short-circuit publishes `completed(0, 0)` for every already-hydrated plugin at
 every bridge start, a naive recovery read of `GET /plugin/import` would render
-a "Rescan complete / Nothing new" row on every connect. The recovery read must
+a "Scan complete / No new sessions" row on every connect. The recovery read must
 therefore seed only from non-terminal statuses.
 
 ### The two "ignore arms" are not an event dispatch registry
@@ -299,7 +299,7 @@ whichever harness happened to finish last.
 The success summary is worded from the counts carrier:
 
 - delta known, one or more new: `5 new sessions in 2 new projects`;
-- delta known, nothing new: `Nothing new`;
+- delta known, nothing new: `No new sessions`;
 - totals only, which is what an older bridge sends:
   `43 projects, 193 sessions`.
 
@@ -553,7 +553,7 @@ nothing rather than replaying a stale success.
 - Every package using `json_serializable` in this repository configures
   `include_if_null: false`, so an older bridge simply omits the key and a newer
   client decodes it as `null`. Nullable is required rather than a zero-valued
-  default: defaulting would make an older bridge report `Nothing new` after a
+  default: defaulting would make an older bridge report `No new sessions` after a
   rescan that in fact imported a hundred sessions.
 - A newer bridge talking to an older client is unaffected: the added key is
   ignored by the older decoder.
@@ -704,7 +704,7 @@ Required matrix:
 | Plugin | One native-ownership and one bridge-derived harness for the new-item counts | `_publishCatalog` counts projects differently per `PluginProjectOwnership` branch, so one branch cannot prove the other |
 | Plugin | Two enabled harnesses at once for the aggregate terminal states | A single-harness run cannot prove `CatalogRescanPartlyFailed` |
 | Platform | One mobile platform plus the wide split-view layout | The pane hosts stage 2 through a different scroll owner than the two scaffold hosts |
-| Compatibility | One run against a bridge that omits `newItems` | Proves the totals fallback rather than a false `Nothing new` |
+| Compatibility | One run against a bridge that omits `newItems` | Proves the totals fallback rather than a false `No new sessions` |
 | Recovery | One reconnect against a bridge holding terminal statuses | Proves the recovery read discards them instead of announcing a stale success |
 | Freshness | One rescan that genuinely imports a new session, observed in the list without a second manual refresh | The whole point of the feature; a committed import raises no list invalidation, so the post-success refresh is the only thing making the new row appear |
 | Compatibility | One run against a supported bridge older than `v1.6.0`, which has no `/plugin/import` at all | Proves the gesture reports an unsupported bridge instead of silently doing nothing |
@@ -963,7 +963,7 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
   targeted `503`, `404`, or unsupported-bridge answer lands on the harness the
   user selected instead of the shared row.
 - New `app_en.arb` resources for both captions, the seven row states, the delta
-  and totals wordings, the `Nothing new` case, the partly-failed wording, the
+  and totals wordings, the `No new sessions` case, the partly-failed wording, the
   bounded failure line naming the bridge log, and the Settings action with its
   semantics label and its rejection message.
 - Widget and cubit tests: all seven row states; the totals fallback; cancel;

--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -201,8 +201,8 @@ crossing.
 | Pull distance | Caption |
 |---|---|
 | below `triggerDistance` | none (today's indicator) |
-| `triggerDistance` to `1.6 x` | the invitation, quiet and text-only |
-| past `1.6 x` | the fired label, in brand colour with a rotate icon |
+| `triggerDistance` to `1.6 x` | `Keep pulling to scan all harnesses`, quiet and text-only |
+| past `1.6 x` | `Scanning for new sessions`, in brand colour with a rotate icon |
 
 The caption cross-fades between the two, keyed on the phase rather than the
 text, so passing the threshold reads as one label becoming another and a host
@@ -236,13 +236,31 @@ entry. It is not pinned, not a banner, not a toast, not a dialog.
 
 | State | Leading | Title | Subtitle | Trailing |
 |---|---|---|---|---|
-| Starting | indeterminate ring | `Rescanning harnesses` | none | cancel |
-| Running | indeterminate ring | `Rescanning harnesses` | harness currently enumerating plus its running session count | cancel |
-| Succeeded | check | `Rescan complete` | new-item summary | none; the service clears it after 4s |
-| Partly failed | warning | `Rescan finished` | `1 of 3 harnesses could not be rescanned` | dismiss |
-| Failed | warning | `Rescan failed` | `Check the bridge log for details` | dismiss |
-| Unsupported | warning | `Rescan needs a newer bridge` | `Update the bridge to rescan from here` | dismiss |
+| Starting | indeterminate ring | `Scanning all harnesses` | none | cancel |
+| Running | indeterminate ring | `Scanning all harnesses` | the harness currently enumerating and its live session count, e.g. `Codex — 148 sessions` | cancel |
+| Succeeded | check | `Scan complete` | `5 new sessions in 2 new projects`, or `No new sessions` | none; the service clears it after 4s |
+| Partly failed | warning | `Scan finished` | `1 of 3 harnesses could not be scanned` | dismiss |
+| Failed | warning | `Scan failed` | `Check the bridge log for details` | dismiss |
+| Unsupported | warning | `Scanning needs a newer bridge` | `Update the bridge to scan from here` | dismiss |
 | Cancelled | — | — | — | row removed immediately |
+
+The row is a **tinted card**, not a plain tile: a rounded surface in a subtle
+brand tint, visually distinct from the session and project tiles around it. It
+reads as status rather than content, so it is never mistaken for a row that can
+be opened.
+
+The running subtitle names the harness and its **live** session count rather
+than progress across harnesses. A long single-harness scan is exactly when the
+user needs reassurance, and a "2 of 3" line goes completely still there while a
+climbing count keeps showing movement.
+
+Copy leads with sessions throughout and mentions projects only in the completion
+line, and only when there are any. Sessions are what a user notices missing —
+#961 was reported as missing sessions — and it keeps the captions short enough
+for a 226pt split pane.
+
+The Settings action is labelled `Scan for new sessions`, matching the same
+vocabulary.
 
 `Starting` exists because a dispatched request is not yet an enumerating
 harness. Between dispatch and the first progress event there is no active

--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -187,24 +187,40 @@ projects or sessions from the bridge's committed catalog. Awaited, spinner in
 the refresh control, near-instant. This remains the default and the only
 behavior most pulls produce.
 
-**Stage 2 (deep rescan)** arms when the pull passes `1.6 x triggerDistance`.
-The refresh control's caption follows the pull:
+**Stage 2 (deep rescan)** fires when the pull passes `1.6 x triggerDistance`.
+
+Both stages commit **on crossing their threshold, while the finger is still
+down**, not on release. That is not a choice: `CupertinoSliverRefreshControl`
+invokes `onRefresh` the moment the pull reaches `refreshTriggerPullDistance`,
+from a post-frame callback, and returns `armed` (`cupertino_ui`
+`refresh.dart:504-530`). There is no release-gated commit to hang a second stage
+on, so an earlier draft of this plan describing "release to rescan" was
+unbuildable. Owner decision 2026-08-24: keep the two-depth gesture and fire on
+crossing.
 
 | Pull distance | Caption |
 |---|---|
 | below `triggerDistance` | none (today's indicator) |
-| `triggerDistance` to `1.6 x` | `Keep pulling to rescan harnesses` |
-| past `1.6 x` | `Release to rescan harnesses` |
+| `triggerDistance` to `1.6 x` | the invitation, quiet and text-only |
+| past `1.6 x` | the fired label, in brand colour with a rotate icon |
 
-Release runs the soft refresh exactly as today **and** additionally triggers the
-catalog import. The import is never awaited: the refresh control settles on the
-soft refresh alone.
+The caption cross-fades between the two, keyed on the phase rather than the
+text, so passing the threshold reads as one label becoming another and a host
+rewording mid-pull cannot look like the stage changed. The fired phase is
+visually distinct rather than only differently worded, so the moment of
+commitment is legible at a glance.
 
-All three arming, caption, and release-dispatch behavior lives in a single
-`module_prego` widget, `PregoSliverRefreshControl`, which wraps
-`CupertinoSliverRefreshControl` and owns the one mutable `bool` recording
-whether the deep threshold was crossed at the moment of release.
-`PregoGlassScaffold` composes it behind a new optional `onDeepRefresh`
+The catalog import is never awaited: the refresh control settles on the soft
+refresh alone. One pull rescans at most once, however far it travels.
+
+Because there is no commit point, a pull past `1.6 x` cannot be taken back by
+dragging up. Cancelling is the progress row's job, which is the affordance that
+exists for it anyway.
+
+All threshold, caption, and dispatch behavior lives in a single `module_prego`
+widget, `PregoSliverRefreshControl`, which wraps `CupertinoSliverRefreshControl`
+and tracks the furthest extent this gesture reached plus whether it has already
+fired. `PregoGlassScaffold` composes it behind a new optional `deepRefresh`
 parameter; `SessionListPanel` uses it directly in place of its bare
 `CupertinoSliverRefreshControl`. No pull-threshold logic is written in
 `client/app`.

--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -890,31 +890,28 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
 ### Scope
 
 - Add `PregoSliverRefreshControl` to `module_prego`: wraps
-  `CupertinoSliverRefreshControl`, owns the `1.6 x triggerDistance` arming, the
-  caption selection, and the release dispatch of both callbacks.
-- `PregoGlassScaffold` composes it behind a new optional `onDeepRefresh`, and
-  asserts that `onDeepRefresh` requires `onRefresh`, matching the existing
+  `CupertinoSliverRefreshControl`, owns the `1.6 x triggerDistance` threshold,
+  the caption selection, and the dispatch of both callbacks.
+- `PregoGlassScaffold` composes it behind a new optional `deepRefresh`, and
+  asserts that `deepRefresh` requires `onRefresh`, matching the existing
   `scrollable`/`onRefresh` assertion.
 - `SessionListPanel` replaces its bare `CupertinoSliverRefreshControl` with
-  `PregoSliverRefreshControl` **and** takes an optional `onDeepRefresh` callback
-  parameter, so the pane gets stage 2 without any threshold logic in
-  `client/app`. The parameter is introduced here, defaulting to null, and step 6
-  wires it to the cubit's `startRescan()`. Without it step 5's pane test would
-  have no deep callback to invoke, because the pane currently hardcodes
-  `refreshSessionList(context)` and the cubit intent does not exist until step 6.
+  `PregoSliverRefreshControl` **and** takes an optional `deepRefresh` parameter,
+  so the pane gets stage 2 without any threshold logic in `client/app`. The
+  parameter is introduced here, defaulting to null, and step 6 supplies it.
 - Render the caption under the existing indicator only once the pull passes the
   soft trigger, so an ordinary pull is visually unchanged.
-- Add a design catalog scenario if the scaffold has one; otherwise widget tests
-  covering: a short pull fires only the soft refresh, a long pull fires both,
-  and a long pull abandoned before release fires neither. Prove all three in
-  the pane as well as in the scaffold.
+- Widget tests covering: an ordinary pull fires only the soft refresh, a pull
+  past the deep threshold fires both, a pull abandoned before the trigger fires
+  neither, one pull rescans at most once however far it travels, arming does not
+  leak between pulls, the control behaves as the bare Cupertino one with no
+  second stage supplied, and the fired caption is visually distinct from the
+  invitation.
 
 ### Verification
 
-- targeted `module_prego` and `client/app` session-pane widget tests
+- targeted `module_prego` widget tests
 - `dart analyze --fatal-infos` from `client/module_prego` and `client/app`
-- `dart run tool/generate_manifest.dart --check` from `client/design_catalog`
-  if a scenario was added
 - architecture implementation review
 
 ## Step 6/8 - Surface Catalog Rescan In The App
@@ -934,8 +931,8 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
 - The aggregate rescan row widget in `client/app/lib/core/widgets/`, beside the
   shell's other cross-feature widgets, with its seven presentations. It renders
   the state it is given, owns no timer, and renders no bridge-supplied text.
-- Project list, full-screen session list, and split-view pane: wire
-  `onDeepRefresh` to the cubit's `startRescan()`, and render the row as the
+- Project list, full-screen session list, and split-view pane: supply
+  `deepRefresh` from the cubit's `startRescan()`, and render the row as the
   sliver at index 0 in place of the soft-refresh indicator while a rescan is
   running.
 - Settings to Harnesses: the per-harness `Rescan` action in

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -117,8 +117,12 @@
 
 ## Open Questions
 
-- [ ] Does `PregoGlassScaffold` have an existing design catalog scenario, or do
-  widget tests alone cover the second stage?
+- [x] Does `PregoGlassScaffold` have an existing design catalog scenario, or do
+  widget tests alone cover the second stage? **Answered in step 5:** the design
+  catalog has no scaffold scenario, so `PLAN.md`'s "otherwise widget tests" path
+  applies. Eight `prego_sliver_refresh_control_test.dart` cases cover the stage,
+  including its two caption phases and the fired label's visual distinction. No
+  catalog scenario was added, so no manifest regeneration was needed.
 
 ## Delivery Steps
 

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -57,6 +57,9 @@
 | Refresh model | Two-stage pull: soft unchanged, deep fires past `1.6 x triggerDistance` | A rescan boots every enabled harness backend, so it must be deliberate |
 | Deep-pull commit | On crossing the threshold, not on release | `CupertinoSliverRefreshControl` fires `onRefresh` on crossing and never on release, so release semantics were unbuildable. Owner decision 2026-08-24 |
 | Gesture owner | One `module_prego` `PregoSliverRefreshControl` | Three hosts, only two of which use `PregoGlassScaffold`; the pane must not re-implement thresholds in `client/app` |
+| Row weight | Tinted card, distinct from the surrounding tiles | Reads as status rather than content, so it is never mistaken for an openable row |
+| Running detail | The harness and its live session count | A "2 of 3" line goes still during a long single-harness scan, which is when reassurance matters most |
+| Copy | "Scan" led, sessions first, projects only in the result | Owner decision 2026-08-24: "rescan" named the mechanism, not the outcome |
 | Progress presentation | One aggregate row | Fixed height; the top of the list never reflows as harnesses finish at different times |
 | Row placement | Ordinary sliver at index 0, scrolls with the list | Non-intrusive; a refresh already scrolls to the top, so it is visible when it matters |
 | Row home | `client/app/lib/core/widgets/` | Consumed by two features; must not live inside either |

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -5,9 +5,9 @@
 - **Plan slug:** `catalog-rescan`
 - **Implementation base:** `main` at
   `7b1ebe9bc629d05b5d104e76cd5dbaa1514d65a2`
-- **Series state:** Steps 1/8 to 3/8 merged; Step 4/8 open
-- **Current step:** add the client catalog rescan service
-- **Next action:** land Step 4, then Step 5's two-stage pull control
+- **Series state:** Steps 1/8 to 4/8 merged; Step 5/8 open
+- **Current step:** add a second stage to pull-to-refresh
+- **Next action:** land Step 5, then Step 6's app surfaces
 - **Origin issue:** [#961](https://github.com/sesori-ai/sesori_apps_monorepo/issues/961)
 - **External overlap:** [#1008](https://github.com/sesori-ai/sesori_apps_monorepo/issues/1008)
   owns Codex live updates; do not address it here
@@ -54,7 +54,8 @@
 
 | Decision | Chosen | Rationale |
 |---|---|---|
-| Refresh model | Two-stage pull: soft unchanged, deep armed past `1.6 x triggerDistance` | A rescan boots every enabled harness backend, so it must be deliberate |
+| Refresh model | Two-stage pull: soft unchanged, deep fires past `1.6 x triggerDistance` | A rescan boots every enabled harness backend, so it must be deliberate |
+| Deep-pull commit | On crossing the threshold, not on release | `CupertinoSliverRefreshControl` fires `onRefresh` on crossing and never on release, so release semantics were unbuildable. Owner decision 2026-08-24 |
 | Gesture owner | One `module_prego` `PregoSliverRefreshControl` | Three hosts, only two of which use `PregoGlassScaffold`; the pane must not re-implement thresholds in `client/app` |
 | Progress presentation | One aggregate row | Fixed height; the top of the list never reflows as harnesses finish at different times |
 | Row placement | Ordinary sliver at index 0, scrolls with the list | Non-intrusive; a refresh already scrolls to the top, so it is visible when it matters |
@@ -123,8 +124,8 @@
 | [x] | 1/8 | `🌱 [catalog-rescan] Plan client-triggered catalog rescan [step 1/8]` | 950-1,100 (`PLAN.md`) | [PR #1064](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1064) merged |
 | [x] | 2/8 | `🌱 [catalog-rescan] Re-hydrate stale plugin catalogs [step 2/8]` | 20-60 | [PR #1071](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1071) merged |
 | [x] | 3/8 | `⚙️ [catalog-rescan] Report new items from a catalog import [step 3/8]` | 350-600 | [PR #1074](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1074) merged |
-| [ ] | 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 | Open |
-| [ ] | 5/8 | `⚙️ [catalog-rescan] Add a second stage to pull-to-refresh [step 5/8]` | 350-600 | Not started |
+| [x] | 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 | [PR #1085](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1085) merged |
+| [ ] | 5/8 | `⚙️ [catalog-rescan] Add a second stage to pull-to-refresh [step 5/8]` | 350-600 | Open |
 | [ ] | 6/8 | `⚙️ [catalog-rescan] Surface catalog rescan in the app [step 6/8]` | 950-1,400 | Not started |
 | [ ] | 7/8 | `🌱 [catalog-rescan] Reconcile catalog rescan regression docs [step 7/8]` | 80-160 | Not started |
 | [ ] | 8/8 | `🌱 [catalog-rescan] Verify and retire the catalog rescan plan [step 8/8]` | 60-140 | Not started |
@@ -204,15 +205,15 @@
 
 ## Step 5 Checklist
 
-- [ ] Add `PregoSliverRefreshControl` owning arming, captions, and dispatch.
-- [ ] Compose it in `PregoGlassScaffold` behind `onDeepRefresh` and assert it
+- [x] Add `PregoSliverRefreshControl` owning thresholds, captions, and dispatch.
+- [x] Compose it in `PregoGlassScaffold` behind `deepRefresh` and assert it
   requires `onRefresh`.
-- [ ] Replace `SessionListPanel`'s bare `CupertinoSliverRefreshControl` with it
-  and give the pane an optional `onDeepRefresh` parameter, so the pane test has a
-  callback before the cubit intent exists.
-- [ ] Leave an ordinary pull visually unchanged.
-- [ ] Prove short pull, long pull, and abandoned long pull, in both the scaffold
-  and the pane.
+- [x] Replace `SessionListPanel`'s bare `CupertinoSliverRefreshControl` with it
+  and give the pane an optional `deepRefresh` parameter, so step 6 has somewhere
+  to wire the cubit intent.
+- [x] Leave an ordinary pull visually unchanged.
+- [x] Prove short pull, long pull, abandoned pull, once-per-pull, no-second-stage,
+  caption order, and the fired label's visual distinction.
 - [ ] Run `architecture-implementation-review`.
 
 ## Step 6 Checklist
@@ -463,4 +464,12 @@ duplicate-emission nicety.
   pass with two blocking A2 findings, both divergences from the approved
   operation model, both applied with regression coverage
 - **Step 4 PR:** pending
+- **Step 5 base:** `main` at `bafa7cd02`
+- **Step 5 changed lines:** 427 of delivered code, inside the 350-600 target;
+  `.plan/` excluded so the figure cannot count itself
+- **Step 5 verification:** `dart analyze --fatal-infos` clean on
+  `client/module_prego` and `client/app`; full `module_prego` suite 227 tests
+  passed, including 8 new `prego_sliver_refresh_control_test.dart` cases
+- **Step 5 review:** pending
+- **Step 5 PR:** pending
 - **Final disposition:** pending

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -221,7 +221,7 @@
 - [ ] Give all three cubits a rescan subscription, state, and intent methods.
 - [ ] Refresh both lists whenever the service leaves a live operation, not only
   on the terminal summary variants.
-- [ ] Wire the pane's `onDeepRefresh` parameter to the cubit.
+- [ ] Wire the pane's `deepRefresh` parameter to the cubit.
 - [ ] Build the rescan row in `client/app/lib/core/widgets/` with all seven
   presentations, no timer, and no bridge-supplied text.
 - [ ] Wire all three hosts through their cubits; no widget touches the service.
@@ -470,6 +470,13 @@ duplicate-emission nicety.
 - **Step 5 verification:** `dart analyze --fatal-infos` clean on
   `client/module_prego` and `client/app`; full `module_prego` suite 227 tests
   passed, including 8 new `prego_sliver_refresh_control_test.dart` cases
-- **Step 5 review:** pending
+- **Step 5 review:** `architecture-implementation-review` **approved** with zero
+  findings. It confirmed the boundary tightened rather than widened — both hosts
+  lost their `cupertino_ui` imports, and `decorate` hands back only the built
+  indicator so no host can re-derive gesture state — and that the fire-on-
+  crossing correction is architecturally sound. Both of its non-blocking
+  observations were applied: `PLAN.md`'s Step 5 scope section still described the
+  unbuildable release semantics and would have misdirected step 6, and the new
+  design-system file's doc comments carried product vocabulary
 - **Step 5 PR:** pending
 - **Final disposition:** pending

--- a/client/app/lib/features/session_list/session_list_panel.dart
+++ b/client/app/lib/features/session_list/session_list_panel.dart
@@ -1,4 +1,3 @@
-import "package:cupertino_ui/cupertino_ui.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:material_ui/material_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
@@ -18,6 +17,10 @@ class const SessionListPanel({
   required final SessionMenuEntriesBuilder sessionMenuEntries,
   required final VoidCallback onNewSession,
   final VoidCallback? onBack,
+    /// The optional second stage of this pane's pull-to-refresh. Introduced
+  /// here rather than with its consumer so the pane's own gesture is testable
+  /// before anything wires it up.
+  final PregoDeepRefresh? deepRefresh,
 }) extends StatelessWidget {
   /// Header width below which the labelled "New session" button collapses to an
   /// icon-only button so the title keeps a usable width.
@@ -131,8 +134,9 @@ class const SessionListPanel({
           : const AlwaysScrollableScrollPhysics(),
       slivers: [
         if (canRefresh)
-          CupertinoSliverRefreshControl(
+          PregoSliverRefreshControl(
             onRefresh: () => refreshSessionList(context),
+            deepRefresh: deepRefresh,
           ),
         if (isRefreshing) const SliverToBoxAdapter(child: LinearProgressIndicator()),
         SessionListContent(

--- a/client/app/lib/features/session_list/session_list_panel.dart
+++ b/client/app/lib/features/session_list/session_list_panel.dart
@@ -137,6 +137,8 @@ class const SessionListPanel({
           PregoSliverRefreshControl(
             onRefresh: () => refreshSessionList(context),
             deepRefresh: deepRefresh,
+            decorate: null,
+            onPulledExtentChanged: null,
           ),
         if (isRefreshing) const SliverToBoxAdapter(child: LinearProgressIndicator()),
         SessionListContent(

--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -1,4 +1,3 @@
-import "package:cupertino_ui/cupertino_ui.dart" show CupertinoSliverRefreshControl, RefreshIndicatorMode;
 import "package:flutter/rendering.dart";
 import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:material_ui/material_ui.dart";
@@ -139,6 +138,9 @@ class const PregoGlassScaffold({
     /// When set, an in-scroll refresh control opens below the top bar and pushes
   /// the caller-provided content down while it is pulled.
   final Future<void> Function()? onRefresh,
+    /// An optional second stage for [onRefresh]: pulling past the ordinary
+  /// trigger arms it, and the caption tells the user what releasing will do.
+  final PregoDeepRefresh? deepRefresh,
     /// Page background painted behind the glass. Defaults to `bgSurface1`.
   final Color? backgroundColor,
     /// Whether the body scrolls behind the bar. Defaults to `true`. Set `false`
@@ -161,6 +163,10 @@ class const PregoGlassScaffold({
   this : assert(
          scrollable || onRefresh == null,
          "onRefresh requires scrollable to be true (the refresh control needs a draggable page)",
+       ),
+       assert(
+         deepRefresh == null || onRefresh != null,
+         "deepRefresh is a second stage of onRefresh, so it needs one to extend",
        );
 
   @override
@@ -350,17 +356,11 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
         // the live bar and large-title insets; the sliver itself opens at the
         // scroll origin and pushes the caller-provided content down.
         if (onRefresh != null)
-          CupertinoSliverRefreshControl(
+          PregoSliverRefreshControl(
             onRefresh: onRefresh,
-            builder: (context, refreshState, pulledExtent, triggerDistance, indicatorExtent) {
-              _refreshPulledExtent = refreshState == RefreshIndicatorMode.inactive ? 0 : pulledExtent;
-              final indicator = CupertinoSliverRefreshControl.buildRefreshIndicator(
-                context,
-                refreshState,
-                pulledExtent,
-                triggerDistance,
-                indicatorExtent,
-              );
+            deepRefresh: widget.deepRefresh,
+            onPulledExtentChanged: (extent) => _refreshPulledExtent = extent,
+            decorate: (context, indicator) {
               // A non-extended body already begins below the bar, but its
               // collapsing title still precedes the caller-provided content.
               if (!extendBehind) {

--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -138,8 +138,10 @@ class const PregoGlassScaffold({
     /// When set, an in-scroll refresh control opens below the top bar and pushes
   /// the caller-provided content down while it is pulled.
   final Future<void> Function()? onRefresh,
-    /// An optional second stage for [onRefresh]: pulling past the ordinary
-  /// trigger arms it, and the caption tells the user what releasing will do.
+    /// An optional second stage for [onRefresh]. Pulling past a deeper
+  /// threshold runs it **immediately**, not on release: the underlying refresh
+  /// control has no release-gated commit, so a crossed pull cannot be taken
+  /// back and the surface must offer its own cancel.
   final PregoDeepRefresh? deepRefresh,
     /// Page background painted behind the glass. Defaults to `bgSurface1`.
   final Color? backgroundColor,

--- a/client/module_prego/lib/components/navigation/prego_sliver_refresh_control.dart
+++ b/client/module_prego/lib/components/navigation/prego_sliver_refresh_control.dart
@@ -15,8 +15,8 @@ const double _deepPullFactor = 1.6;
 /// arm the deep pull without telling the user what releasing will do.
 class const PregoDeepRefresh({
   /// Runs in addition to the ordinary refresh, the moment the pull passes the
-  /// deep threshold. Never awaited: the refresh control settles on the soft
-  /// refresh alone.
+  /// deep threshold. Never awaited: the refresh control settles on the ordinary
+  /// refresh alone, so a long-running second stage cannot hold the spinner.
   required final void Function() onDeepRefresh,
 
   /// Shown once the pull passes the ordinary trigger, inviting the user to
@@ -37,8 +37,8 @@ class const PregoDeepRefresh({
 /// control invokes `onRefresh` the moment the pull crosses its trigger rather
 /// than on release (`refresh.dart` transitions `drag` straight to `armed` and
 /// schedules the task there). The second stage follows the same rule at its own
-/// deeper threshold, so a pull refreshes at one depth and additionally rescans
-/// at another.
+/// deeper threshold, so a pull refreshes at one depth and additionally runs the
+/// host's second action at another.
 ///
 /// Hosts differ in where the indicator sits, not in how the pull behaves, so
 /// they supply [decorate] and get identical gesture semantics for free — which
@@ -176,9 +176,9 @@ class const _CaptionedIndicator({
 
 /// One phase of the caption.
 ///
-/// The invitation is quiet and text-only. Once the rescan has fired the label
-/// takes the brand colour and gains its icon, so the moment of commitment is
-/// visible at a glance rather than needing the wording to be read.
+/// The invitation is quiet and text-only. Once the second stage has fired the
+/// label takes the brand colour and gains its icon, so the moment of commitment
+/// is visible at a glance rather than needing the wording to be read.
 class const _CaptionLabel({
   super.key,
   required final String caption,

--- a/client/module_prego/lib/components/navigation/prego_sliver_refresh_control.dart
+++ b/client/module_prego/lib/components/navigation/prego_sliver_refresh_control.dart
@@ -12,19 +12,23 @@ const double _deepPullFactor = 1.6;
 /// A second stage for a pull-to-refresh, opted into with its captions.
 ///
 /// One value rather than a callback plus two loose strings, so a host cannot
-/// arm the deep pull without telling the user what releasing will do.
+/// open the deep pull without telling the user what crossing it will do.
 class const PregoDeepRefresh({
-  /// Runs in addition to the ordinary refresh, the moment the pull passes the
-  /// deep threshold. Never awaited: the refresh control settles on the ordinary
-  /// refresh alone, so a long-running second stage cannot hold the spinner.
+  /// Runs in addition to the ordinary refresh, **the moment the pull passes
+  /// the deep threshold** — not on release. There is no release-gated commit to
+  /// hang it on, so once the threshold is crossed the action has started and the
+  /// host must offer its own way to cancel. Never awaited: the refresh control
+  /// settles on the ordinary refresh alone, so a long-running second stage
+  /// cannot hold the spinner.
   required final void Function() onDeepRefresh,
 
   /// Shown once the pull passes the ordinary trigger, inviting the user to
   /// keep going.
   required final String pullCaption,
 
-  /// Shown once [onDeepRefresh] has fired, so the caption reports what
-  /// happened rather than what releasing would do.
+  /// Shown once [onDeepRefresh] has fired, so the caption reports what has
+  /// already started rather than what releasing would do. It gives way to the
+  /// host's own progress surface as the pull retracts.
   required final String deepCaption,
 });
 
@@ -47,17 +51,17 @@ class const PregoSliverRefreshControl({
   super.key,
   required final Future<void> Function() _onRefresh,
 
-  /// The optional second stage. Absent leaves the control behaving exactly as
-  /// a bare [CupertinoSliverRefreshControl].
-  final PregoDeepRefresh? _deepRefresh,
+  /// The second stage. `null` leaves the control behaving exactly as a bare
+  /// [CupertinoSliverRefreshControl].
+  required final PregoDeepRefresh? _deepRefresh,
 
   /// Wraps the built indicator so a host can position it without owning any
-  /// gesture logic.
-  final Widget Function(BuildContext context, Widget indicator)? _decorate,
+  /// gesture logic. `null` paints it where the control puts it.
+  required final Widget Function(BuildContext context, Widget indicator)? _decorate,
 
   /// Reports the space the control currently holds open, for hosts that lay
   /// out against it. Zero whenever the control is inactive.
-  final void Function(double extent)? _onPulledExtentChanged,
+  required final void Function(double extent)? _onPulledExtentChanged,
 }) extends StatefulWidget {
   @override
   State<PregoSliverRefreshControl> createState() => _PregoSliverRefreshControlState();
@@ -112,13 +116,13 @@ class _PregoSliverRefreshControlState() extends State<PregoSliverRefreshControl>
           triggerDistance,
           indicatorExtent,
         );
-        // An unfired invitation follows the *live* extent, not the furthest
-        // reached: once the finger lifts, the control holds a shorter indicator
-        // extent while the refresh runs, and a caption keyed on the maximum
-        // would sit under the spinner for the whole of an ordinary refresh.
-        // A fired label ignores the extent entirely — the second stage has
-        // already run, so the report stays until the gesture ends.
-        final caption = deepRefresh == null || (!_deepFired && pulledExtent <= triggerDistance)
+        // Both phases follow the *live* extent, because the extent is what
+        // decides whether there is room. Once the finger lifts the control
+        // collapses to a held indicator extent far shorter than the trigger,
+        // and a caption pinned inside it would sit on top of the spinner.
+        // Retracting loses nothing: the host's progress surface takes over as
+        // the pull collapses, which is where the rest of the run is reported.
+        final caption = deepRefresh == null || pulledExtent <= triggerDistance
             ? null
             : _deepFired
             ? deepRefresh.deepCaption

--- a/client/module_prego/lib/components/navigation/prego_sliver_refresh_control.dart
+++ b/client/module_prego/lib/components/navigation/prego_sliver_refresh_control.dart
@@ -112,7 +112,12 @@ class _PregoSliverRefreshControlState() extends State<PregoSliverRefreshControl>
           triggerDistance,
           indicatorExtent,
         );
-        final caption = deepRefresh == null || _maxPulledExtent <= triggerDistance
+        // Visibility follows the *live* extent, not the furthest reached: once
+        // the finger lifts, the control holds a shorter indicator extent while
+        // the refresh runs, and a caption keyed on the maximum would sit under
+        // the spinner for the whole of an ordinary refresh. The phase still
+        // comes from the latch, so the fired label cannot revert mid-gesture.
+        final caption = deepRefresh == null || pulledExtent <= triggerDistance
             ? null
             : _deepFired
             ? deepRefresh.deepCaption
@@ -130,8 +135,10 @@ class _PregoSliverRefreshControlState() extends State<PregoSliverRefreshControl>
 
 /// The stock indicator with the stage-two caption beneath it.
 ///
-/// Painted in an unclipped stack so adding the caption cannot change the extent
-/// the refresh control reserves, which would shift the content under the pull.
+/// Both sit inside the extent the refresh control already reserved, so the
+/// caption never paints over the first row of the list below. The control
+/// constrains this builder to the whole pulled extent, which is at least the
+/// trigger distance whenever a caption is shown, so there is always room.
 class const _CaptionedIndicator({
   required final Widget indicator,
   required final String caption,
@@ -142,11 +149,10 @@ class const _CaptionedIndicator({
     final prego = context.prego;
     return Stack(
       alignment: Alignment.center,
-      clipBehavior: Clip.none,
       children: [
         indicator,
         Positioned(
-          bottom: -prego.spacing.xl,
+          bottom: prego.spacing.md,
           // Cross-faded and keyed on the phase, so passing the threshold reads
           // as one label becoming another rather than a flicker.
           child: AnimatedSwitcher(

--- a/client/module_prego/lib/components/navigation/prego_sliver_refresh_control.dart
+++ b/client/module_prego/lib/components/navigation/prego_sliver_refresh_control.dart
@@ -112,12 +112,13 @@ class _PregoSliverRefreshControlState() extends State<PregoSliverRefreshControl>
           triggerDistance,
           indicatorExtent,
         );
-        // Visibility follows the *live* extent, not the furthest reached: once
-        // the finger lifts, the control holds a shorter indicator extent while
-        // the refresh runs, and a caption keyed on the maximum would sit under
-        // the spinner for the whole of an ordinary refresh. The phase still
-        // comes from the latch, so the fired label cannot revert mid-gesture.
-        final caption = deepRefresh == null || pulledExtent <= triggerDistance
+        // An unfired invitation follows the *live* extent, not the furthest
+        // reached: once the finger lifts, the control holds a shorter indicator
+        // extent while the refresh runs, and a caption keyed on the maximum
+        // would sit under the spinner for the whole of an ordinary refresh.
+        // A fired label ignores the extent entirely — the second stage has
+        // already run, so the report stays until the gesture ends.
+        final caption = deepRefresh == null || (!_deepFired && pulledExtent <= triggerDistance)
             ? null
             : _deepFired
             ? deepRefresh.deepCaption
@@ -201,13 +202,18 @@ class const _CaptionLabel({
           Icon(TablerRegular.rotate_clockwise, size: prego.spacing.lg, color: color),
           SizedBox(width: prego.spacing.sm),
         ],
-        Text(
-          caption,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: fired
-              ? prego.textTheme.textXs.medium.copyWith(color: color)
-              : prego.textTheme.textXs.regular.copyWith(color: color),
+        // Flexible so the ellipsis can actually engage: a Row measures a plain
+        // Text against the space it asks for, so at large accessibility text
+        // scales an unconstrained label overflows instead of truncating.
+        Flexible(
+          child: Text(
+            caption,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: fired
+                ? prego.textTheme.textXs.medium.copyWith(color: color)
+                : prego.textTheme.textXs.regular.copyWith(color: color),
+          ),
         ),
       ],
     );

--- a/client/module_prego/lib/components/navigation/prego_sliver_refresh_control.dart
+++ b/client/module_prego/lib/components/navigation/prego_sliver_refresh_control.dart
@@ -1,0 +1,209 @@
+import "package:cupertino_ui/cupertino_ui.dart" show CupertinoSliverRefreshControl, RefreshIndicatorMode;
+import "package:flutter/scheduler.dart";
+import "package:material_ui/material_ui.dart";
+
+import "../../module_prego.dart";
+
+/// How much further than the normal trigger a pull must travel to arm the
+/// second stage. Far enough that an ordinary refresh never reaches it, close
+/// enough to be discoverable once the caption appears.
+const double _deepPullFactor = 1.6;
+
+/// A second stage for a pull-to-refresh, opted into with its captions.
+///
+/// One value rather than a callback plus two loose strings, so a host cannot
+/// arm the deep pull without telling the user what releasing will do.
+class const PregoDeepRefresh({
+  /// Runs in addition to the ordinary refresh, the moment the pull passes the
+  /// deep threshold. Never awaited: the refresh control settles on the soft
+  /// refresh alone.
+  required final void Function() onDeepRefresh,
+
+  /// Shown once the pull passes the ordinary trigger, inviting the user to
+  /// keep going.
+  required final String pullCaption,
+
+  /// Shown once [onDeepRefresh] has fired, so the caption reports what
+  /// happened rather than what releasing would do.
+  required final String deepCaption,
+});
+
+/// The pull-to-refresh control every Prego surface uses.
+///
+/// Wraps [CupertinoSliverRefreshControl] and owns the whole two-stage gesture:
+/// the threshold, the captions, and dispatching both callbacks.
+///
+/// Both stages commit while the finger is still down, because the underlying
+/// control invokes `onRefresh` the moment the pull crosses its trigger rather
+/// than on release (`refresh.dart` transitions `drag` straight to `armed` and
+/// schedules the task there). The second stage follows the same rule at its own
+/// deeper threshold, so a pull refreshes at one depth and additionally rescans
+/// at another.
+///
+/// Hosts differ in where the indicator sits, not in how the pull behaves, so
+/// they supply [decorate] and get identical gesture semantics for free — which
+/// is why this exists rather than a parameter on one scaffold.
+class const PregoSliverRefreshControl({
+  super.key,
+  required final Future<void> Function() _onRefresh,
+
+  /// The optional second stage. Absent leaves the control behaving exactly as
+  /// a bare [CupertinoSliverRefreshControl].
+  final PregoDeepRefresh? _deepRefresh,
+
+  /// Wraps the built indicator so a host can position it without owning any
+  /// gesture logic.
+  final Widget Function(BuildContext context, Widget indicator)? _decorate,
+
+  /// Reports the space the control currently holds open, for hosts that lay
+  /// out against it. Zero whenever the control is inactive.
+  final void Function(double extent)? _onPulledExtentChanged,
+}) extends StatefulWidget {
+  @override
+  State<PregoSliverRefreshControl> createState() => _PregoSliverRefreshControlState();
+}
+
+class _PregoSliverRefreshControlState() extends State<PregoSliverRefreshControl> {
+  /// The furthest this gesture has pulled, reset between gestures.
+  ///
+  /// The control reports the pull distance continuously but fires `onRefresh`
+  /// once, so the decision has to survive that frame. Tracking the furthest
+  /// point rather than the mode is deliberate: this refresh control reports
+  /// `RefreshIndicatorMode.done` while the finger is still down and still
+  /// pulling, so no mode reliably means "dragging". Backing off after passing
+  /// the threshold therefore keeps the second stage armed, which matches what
+  /// the caption promised at the moment it was passed.
+  double _maxPulledExtent = 0;
+
+  /// Whether this gesture has already run its second stage, so one pull can
+  /// only rescan once however far it travels.
+  bool _deepFired = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoSliverRefreshControl(
+      onRefresh: widget._onRefresh,
+      builder: (context, refreshState, pulledExtent, triggerDistance, indicatorExtent) {
+        widget._onPulledExtentChanged?.call(
+          refreshState == RefreshIndicatorMode.inactive ? 0 : pulledExtent,
+        );
+        final deepRefresh = widget._deepRefresh;
+        final deepThreshold = triggerDistance * _deepPullFactor;
+        if (refreshState == RefreshIndicatorMode.inactive) {
+          _maxPulledExtent = 0;
+          _deepFired = false;
+        } else if (pulledExtent > _maxPulledExtent) {
+          _maxPulledExtent = pulledExtent;
+        }
+        if (deepRefresh != null && !_deepFired && _maxPulledExtent >= deepThreshold) {
+          _deepFired = true;
+          // After this frame, because the refresh control calls its builder
+          // from inside the sliver's layout and the callback is user code.
+          SchedulerBinding.instance.addPostFrameCallback(
+            (_) => deepRefresh.onDeepRefresh(),
+            debugLabel: "PregoSliverRefreshControl.deepRefresh",
+          );
+        }
+
+        final indicator = CupertinoSliverRefreshControl.buildRefreshIndicator(
+          context,
+          refreshState,
+          pulledExtent,
+          triggerDistance,
+          indicatorExtent,
+        );
+        final caption = deepRefresh == null || _maxPulledExtent <= triggerDistance
+            ? null
+            : _deepFired
+            ? deepRefresh.deepCaption
+            : deepRefresh.pullCaption;
+        final content = caption == null
+            ? indicator
+            : _CaptionedIndicator(indicator: indicator, caption: caption, fired: _deepFired);
+        return widget._decorate?.call(context, content) ?? content;
+      },
+    );
+  }
+
+
+}
+
+/// The stock indicator with the stage-two caption beneath it.
+///
+/// Painted in an unclipped stack so adding the caption cannot change the extent
+/// the refresh control reserves, which would shift the content under the pull.
+class const _CaptionedIndicator({
+  required final Widget indicator,
+  required final String caption,
+  required final bool fired,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    return Stack(
+      alignment: Alignment.center,
+      clipBehavior: Clip.none,
+      children: [
+        indicator,
+        Positioned(
+          bottom: -prego.spacing.xl,
+          // Cross-faded and keyed on the phase, so passing the threshold reads
+          // as one label becoming another rather than a flicker.
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 160),
+            switchInCurve: Curves.easeOut,
+            switchOutCurve: Curves.easeIn,
+            transitionBuilder: (child, animation) => FadeTransition(
+              opacity: animation,
+              child: ScaleTransition(
+                scale: Tween<double>(begin: 0.94, end: 1).animate(animation),
+                child: child,
+              ),
+            ),
+            child: _CaptionLabel(
+              // The phase, not the text: a host changing wording mid-pull must
+              // not look like the stage changed.
+              key: ValueKey(fired),
+              caption: caption,
+              fired: fired,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// One phase of the caption.
+///
+/// The invitation is quiet and text-only. Once the rescan has fired the label
+/// takes the brand colour and gains its icon, so the moment of commitment is
+/// visible at a glance rather than needing the wording to be read.
+class const _CaptionLabel({
+  super.key,
+  required final String caption,
+  required final bool fired,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    final color = fired ? prego.colors.textBrandSecondary : prego.colors.textTertiary;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (fired) ...[
+          Icon(TablerRegular.rotate_clockwise, size: prego.spacing.lg, color: color),
+          SizedBox(width: prego.spacing.sm),
+        ],
+        Text(
+          caption,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: fired
+              ? prego.textTheme.textXs.medium.copyWith(color: color)
+              : prego.textTheme.textXs.regular.copyWith(color: color),
+        ),
+      ],
+    );
+  }
+}

--- a/client/module_prego/lib/module_prego.dart
+++ b/client/module_prego/lib/module_prego.dart
@@ -23,6 +23,7 @@ export 'components/navigation/prego_glass_scaffold.dart';
 export 'components/navigation/prego_nav_leading_title.dart';
 export 'components/navigation/prego_nav_subtitle.dart';
 export 'components/navigation/prego_nav_title.dart';
+export 'components/navigation/prego_sliver_refresh_control.dart';
 export 'components/navigation/prego_top_bar_inset.dart'
     show PregoTopBarInsetBuilder, PregoTopBarInsetScope, pregoTopBarInsetOf;
 export 'components/navigation/prego_top_navigation.dart';

--- a/client/module_prego/test/components/prego_sliver_refresh_control_test.dart
+++ b/client/module_prego/test/components/prego_sliver_refresh_control_test.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:flutter_test/flutter_test.dart";
 import "package:material_ui/material_ui.dart";
 import "package:theme_prego/module_prego.dart";
@@ -153,6 +155,78 @@ void main() {
       await tester.pump(const Duration(milliseconds: 300));
       expect(find.text("Scanning for new sessions"), findsOneWidget);
       expect(find.byIcon(TablerRegular.rotate_clockwise), findsOneWidget);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets("no caption survives an ordinary refresh once the finger lifts", (tester) async {
+      // The control holds a shorter indicator extent while the refresh runs, so
+      // a caption keyed on the furthest point reached would sit under the
+      // spinner for the whole of an ordinary refresh.
+      final completer = Completer<void>();
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(extensions: [PregoDesignSystem.light]),
+          home: Scaffold(
+            body: CustomScrollView(
+              physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
+              slivers: [
+                PregoSliverRefreshControl(
+                  onRefresh: () => completer.future,
+                  deepRefresh: PregoDeepRefresh(
+                    onDeepRefresh: () => deepRefreshes++,
+                    pullCaption: "Keep pulling to scan all harnesses",
+                    deepCaption: "Scanning for new sessions",
+                  ),
+                ),
+                SliverList.list(
+                  children: [for (var i = 0; i < 20; i++) SizedBox(height: 80, child: Text("row $i"))],
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final gesture = await tester.startGesture(const Offset(200, 100));
+      for (var step = 0; step < 5; step++) {
+        await gesture.moveBy(const Offset(0, 40));
+        await tester.pump();
+      }
+      expect(find.text("Keep pulling to scan all harnesses"), findsOneWidget);
+
+      await gesture.up();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(
+        find.text("Keep pulling to scan all harnesses"),
+        findsNothing,
+        reason: "an ordinary refresh must look exactly as it did before",
+      );
+
+      completer.complete();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets("the caption stays inside the extent the control reserved", (tester) async {
+      await tester.pumpWidget(harness(withDeepRefresh: true));
+      final gesture = await tester.startGesture(const Offset(200, 100));
+      for (var step = 0; step < 5; step++) {
+        await gesture.moveBy(const Offset(0, 40));
+        await tester.pump();
+      }
+
+      // The first list row must start below the caption, or the caption paints
+      // over the list.
+      final captionBottom = tester.getRect(find.text("Keep pulling to scan all harnesses")).bottom;
+      final firstRowTop = tester.getRect(find.text("row 0")).top;
+      expect(
+        captionBottom,
+        lessThanOrEqualTo(firstRowTop),
+        reason: "the caption must not overlap the first row",
+      );
 
       await gesture.up();
       await tester.pumpAndSettle();

--- a/client/module_prego/test/components/prego_sliver_refresh_control_test.dart
+++ b/client/module_prego/test/components/prego_sliver_refresh_control_test.dart
@@ -29,6 +29,8 @@ void main() {
             slivers: [
               PregoSliverRefreshControl(
                 onRefresh: () async => softRefreshes++,
+                decorate: null,
+                onPulledExtentChanged: null,
                 deepRefresh: withDeepRefresh
                     ? PregoDeepRefresh(
                         onDeepRefresh: () => deepRefreshes++,
@@ -174,6 +176,8 @@ void main() {
               slivers: [
                 PregoSliverRefreshControl(
                   onRefresh: () => completer.future,
+                  decorate: null,
+                  onPulledExtentChanged: null,
                   deepRefresh: PregoDeepRefresh(
                     onDeepRefresh: () => deepRefreshes++,
                     pullCaption: "Keep pulling to scan all harnesses",
@@ -232,9 +236,10 @@ void main() {
       await tester.pumpAndSettle();
     });
 
-    testWidgets("the fired report survives the finger lifting", (tester) async {
-      // The second stage has already run by this point, so the report is not
-      // an invitation that should retract with the pull.
+    testWidgets("the fired report gives way as the pull collapses", (tester) async {
+      // Once the finger lifts, the control holds an extent far shorter than the
+      // trigger; a caption pinned inside it would sit on top of the spinner.
+      // The host's progress surface reports the rest of the run.
       final completer = Completer<void>();
       await tester.pumpWidget(
         MaterialApp(
@@ -245,6 +250,8 @@ void main() {
               slivers: [
                 PregoSliverRefreshControl(
                   onRefresh: () => completer.future,
+                  decorate: null,
+                  onPulledExtentChanged: null,
                   deepRefresh: PregoDeepRefresh(
                     onDeepRefresh: () => deepRefreshes++,
                     pullCaption: "Keep pulling to scan all harnesses",
@@ -267,12 +274,17 @@ void main() {
       }
       await tester.pump(const Duration(milliseconds: 300));
       expect(find.text("Scanning for new sessions"), findsOneWidget);
+      expect(deepRefreshes, 1);
 
       await gesture.up();
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
-      expect(find.text("Scanning for new sessions"), findsOneWidget);
+      expect(
+        find.text("Scanning for new sessions"),
+        findsNothing,
+        reason: "the held extent cannot hold a caption without covering the spinner",
+      );
 
       completer.complete();
       await tester.pumpAndSettle();
@@ -292,6 +304,8 @@ void main() {
                 slivers: [
                   PregoSliverRefreshControl(
                     onRefresh: () async => softRefreshes++,
+                    decorate: null,
+                    onPulledExtentChanged: null,
                     deepRefresh: PregoDeepRefresh(
                       onDeepRefresh: () => deepRefreshes++,
                       pullCaption: "Keep pulling to scan every harness for sessions you have not seen",

--- a/client/module_prego/test/components/prego_sliver_refresh_control_test.dart
+++ b/client/module_prego/test/components/prego_sliver_refresh_control_test.dart
@@ -30,8 +30,8 @@ void main() {
                 deepRefresh: withDeepRefresh
                     ? PregoDeepRefresh(
                         onDeepRefresh: () => deepRefreshes++,
-                        pullCaption: "Keep pulling to rescan",
-                        deepCaption: "Rescanning harnesses",
+                        pullCaption: "Keep pulling to scan all harnesses",
+                        deepCaption: "Scanning for new sessions",
                       )
                     : null,
               ),
@@ -105,14 +105,14 @@ void main() {
       // gradual pull and asserted on their order rather than on a distance.
       final order = <String>[];
       void record() {
-        if (find.text("Keep pulling to rescan").evaluate().isNotEmpty) order.add("pull");
-        if (find.text("Rescanning harnesses").evaluate().isNotEmpty) order.add("deep");
+        if (find.text("Keep pulling to scan all harnesses").evaluate().isNotEmpty) order.add("pull");
+        if (find.text("Scanning for new sessions").evaluate().isNotEmpty) order.add("deep");
       }
 
       await gesture.moveBy(const Offset(0, 20));
       await tester.pump();
-      expect(find.text("Keep pulling to rescan"), findsNothing);
-      expect(find.text("Rescanning harnesses"), findsNothing);
+      expect(find.text("Keep pulling to scan all harnesses"), findsNothing);
+      expect(find.text("Scanning for new sessions"), findsNothing);
 
       for (var step = 0; step < 16; step++) {
         await gesture.moveBy(const Offset(0, 40));
@@ -142,7 +142,7 @@ void main() {
         await gesture.moveBy(const Offset(0, 40));
         await tester.pump();
       }
-      expect(find.text("Keep pulling to rescan"), findsOneWidget);
+      expect(find.text("Keep pulling to scan all harnesses"), findsOneWidget);
       expect(find.byIcon(TablerRegular.rotate_clockwise), findsNothing);
 
       // Past the deep threshold: the label gains its icon.
@@ -151,7 +151,7 @@ void main() {
         await tester.pump();
       }
       await tester.pump(const Duration(milliseconds: 300));
-      expect(find.text("Rescanning harnesses"), findsOneWidget);
+      expect(find.text("Scanning for new sessions"), findsOneWidget);
       expect(find.byIcon(TablerRegular.rotate_clockwise), findsOneWidget);
 
       await gesture.up();

--- a/client/module_prego/test/components/prego_sliver_refresh_control_test.dart
+++ b/client/module_prego/test/components/prego_sliver_refresh_control_test.dart
@@ -1,0 +1,187 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:material_ui/material_ui.dart";
+import "package:theme_prego/module_prego.dart";
+
+/// `CupertinoSliverRefreshControl` triggers at 100 logical px by default, so
+/// the deep stage arms at 160. Drags keep a margin on their side of each
+/// threshold, since a drag loses some distance to touch slop.
+const double _softTrigger = 100;
+const double _deepTrigger = _softTrigger * 1.6;
+
+void main() {
+  group("PregoSliverRefreshControl", () {
+    late int softRefreshes;
+    late int deepRefreshes;
+
+    setUp(() {
+      softRefreshes = 0;
+      deepRefreshes = 0;
+    });
+
+    Widget harness({required bool withDeepRefresh}) {
+      return MaterialApp(
+        theme: ThemeData(extensions: [PregoDesignSystem.light]),
+        home: Scaffold(
+          body: CustomScrollView(
+            physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
+            slivers: [
+              PregoSliverRefreshControl(
+                onRefresh: () async => softRefreshes++,
+                deepRefresh: withDeepRefresh
+                    ? PregoDeepRefresh(
+                        onDeepRefresh: () => deepRefreshes++,
+                        pullCaption: "Keep pulling to rescan",
+                        deepCaption: "Rescanning harnesses",
+                      )
+                    : null,
+              ),
+              SliverList.list(
+                children: [for (var i = 0; i < 20; i++) SizedBox(height: 80, child: Text("row $i"))],
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    Future<void> pullBy(WidgetTester tester, double distance) async {
+      final gesture = await tester.startGesture(const Offset(200, 100));
+      await gesture.moveBy(Offset(0, distance));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets("a pull to the ordinary trigger runs only the soft refresh", (tester) async {
+      await tester.pumpWidget(harness(withDeepRefresh: true));
+
+      await pullBy(tester, _softTrigger + 40);
+
+      expect(softRefreshes, 1);
+      expect(deepRefreshes, 0, reason: "the deep threshold was never reached");
+    });
+
+    testWidgets("a pull past the deep threshold runs both", (tester) async {
+      await tester.pumpWidget(harness(withDeepRefresh: true));
+
+      await pullBy(tester, _deepTrigger + 80);
+
+      expect(softRefreshes, 1);
+      expect(deepRefreshes, 1);
+    });
+
+    testWidgets("a pull abandoned before the trigger runs neither", (tester) async {
+      await tester.pumpWidget(harness(withDeepRefresh: true));
+
+      final gesture = await tester.startGesture(const Offset(200, 100));
+      // Short of the trigger, then back to rest.
+      await gesture.moveBy(const Offset(0, 40));
+      await tester.pump();
+      await gesture.moveBy(const Offset(0, -60));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(softRefreshes, 0);
+      expect(deepRefreshes, 0);
+    });
+
+    testWidgets("the deep stage cannot fire when no second stage is supplied", (tester) async {
+      await tester.pumpWidget(harness(withDeepRefresh: false));
+
+      await pullBy(tester, _deepTrigger + 80);
+
+      expect(softRefreshes, 1);
+      expect(deepRefreshes, 0);
+    });
+
+    testWidgets("captions appear only past the ordinary trigger and switch at the deep one", (
+      tester,
+    ) async {
+      await tester.pumpWidget(harness(withDeepRefresh: true));
+      final gesture = await tester.startGesture(const Offset(200, 100));
+
+      // Bouncing physics damps overscroll, so the captions are driven by a
+      // gradual pull and asserted on their order rather than on a distance.
+      final order = <String>[];
+      void record() {
+        if (find.text("Keep pulling to rescan").evaluate().isNotEmpty) order.add("pull");
+        if (find.text("Rescanning harnesses").evaluate().isNotEmpty) order.add("deep");
+      }
+
+      await gesture.moveBy(const Offset(0, 20));
+      await tester.pump();
+      expect(find.text("Keep pulling to rescan"), findsNothing);
+      expect(find.text("Rescanning harnesses"), findsNothing);
+
+      for (var step = 0; step < 16; step++) {
+        await gesture.moveBy(const Offset(0, 40));
+        await tester.pump();
+        record();
+      }
+
+      expect(order, contains("pull"), reason: "a pull past the trigger must invite the second stage");
+      expect(order, contains("deep"), reason: "and report once the rescan has fired");
+      expect(
+        order.indexOf("pull"),
+        lessThan(order.indexOf("deep")),
+        reason: "the invitation comes before the rescan",
+      );
+      expect(order.last, "deep");
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets("the fired caption is visually distinct from the invitation", (tester) async {
+      await tester.pumpWidget(harness(withDeepRefresh: true));
+      final gesture = await tester.startGesture(const Offset(200, 100));
+
+      // Past the ordinary trigger: a quiet, icon-less invitation.
+      for (var step = 0; step < 5; step++) {
+        await gesture.moveBy(const Offset(0, 40));
+        await tester.pump();
+      }
+      expect(find.text("Keep pulling to rescan"), findsOneWidget);
+      expect(find.byIcon(TablerRegular.rotate_clockwise), findsNothing);
+
+      // Past the deep threshold: the label gains its icon.
+      for (var step = 0; step < 6; step++) {
+        await gesture.moveBy(const Offset(0, 40));
+        await tester.pump();
+      }
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.text("Rescanning harnesses"), findsOneWidget);
+      expect(find.byIcon(TablerRegular.rotate_clockwise), findsOneWidget);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets("one pull rescans once however far it travels", (tester) async {
+      await tester.pumpWidget(harness(withDeepRefresh: true));
+
+      final gesture = await tester.startGesture(const Offset(200, 100));
+      for (var step = 0; step < 16; step++) {
+        await gesture.moveBy(const Offset(0, 40));
+        await tester.pump();
+      }
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(deepRefreshes, 1, reason: "crossing the threshold once must not fire per frame");
+    });
+
+    testWidgets("a second pull does not inherit the previous pull's arming", (tester) async {
+      await tester.pumpWidget(harness(withDeepRefresh: true));
+
+      await pullBy(tester, _deepTrigger + 80);
+      expect(deepRefreshes, 1);
+
+      await pullBy(tester, _softTrigger + 40);
+
+      expect(softRefreshes, 2);
+      expect(deepRefreshes, 1, reason: "the arming must reset after each release");
+    });
+  });
+}

--- a/client/module_prego/test/components/prego_sliver_refresh_control_test.dart
+++ b/client/module_prego/test/components/prego_sliver_refresh_control_test.dart
@@ -232,6 +232,94 @@ void main() {
       await tester.pumpAndSettle();
     });
 
+    testWidgets("the fired report survives the finger lifting", (tester) async {
+      // The second stage has already run by this point, so the report is not
+      // an invitation that should retract with the pull.
+      final completer = Completer<void>();
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(extensions: [PregoDesignSystem.light]),
+          home: Scaffold(
+            body: CustomScrollView(
+              physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
+              slivers: [
+                PregoSliverRefreshControl(
+                  onRefresh: () => completer.future,
+                  deepRefresh: PregoDeepRefresh(
+                    onDeepRefresh: () => deepRefreshes++,
+                    pullCaption: "Keep pulling to scan all harnesses",
+                    deepCaption: "Scanning for new sessions",
+                  ),
+                ),
+                SliverList.list(
+                  children: [for (var i = 0; i < 20; i++) SizedBox(height: 80, child: Text("row $i"))],
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final gesture = await tester.startGesture(const Offset(200, 100));
+      for (var step = 0; step < 11; step++) {
+        await gesture.moveBy(const Offset(0, 40));
+        await tester.pump();
+      }
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.text("Scanning for new sessions"), findsOneWidget);
+
+      await gesture.up();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text("Scanning for new sessions"), findsOneWidget);
+
+      completer.complete();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets("a long caption truncates rather than overflowing", (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(extensions: [PregoDesignSystem.light]),
+          home: MediaQuery(
+            // A large accessibility text scale, which is where an
+            // unconstrained label overflows instead of truncating.
+            data: const MediaQueryData(textScaler: TextScaler.linear(2.5)),
+            child: Scaffold(
+              body: CustomScrollView(
+                physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
+                slivers: [
+                  PregoSliverRefreshControl(
+                    onRefresh: () async => softRefreshes++,
+                    deepRefresh: PregoDeepRefresh(
+                      onDeepRefresh: () => deepRefreshes++,
+                      pullCaption: "Keep pulling to scan every harness for sessions you have not seen",
+                      deepCaption: "Scanning for new sessions",
+                    ),
+                  ),
+                  SliverList.list(
+                    children: [for (var i = 0; i < 20; i++) SizedBox(height: 80, child: Text("row $i"))],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final gesture = await tester.startGesture(const Offset(200, 100));
+      for (var step = 0; step < 5; step++) {
+        await gesture.moveBy(const Offset(0, 40));
+        await tester.pump();
+      }
+
+      expect(tester.takeException(), isNull, reason: "the caption must not overflow its row");
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
     testWidgets("one pull rescans once however far it travels", (tester) async {
       await tester.pumpWidget(harness(withDeepRefresh: true));
 


### PR DESCRIPTION
## Complexity

Moderate. One new shared component plus moving two hosts onto it, and the
underlying control's semantics forced a design correction mid-step.

## What

Adds `PregoSliverRefreshControl`, which owns the entire two-stage pull: the
thresholds, the captions, and dispatching both callbacks. `PregoGlassScaffold`
composes it behind a new optional `deepRefresh`; `SessionListPanel` uses it
directly in place of its bare `CupertinoSliverRefreshControl` and gains its own
`deepRefresh` parameter for step 6 to wire.

A pull now refreshes at the ordinary trigger and additionally rescans at
`1.6 x` that distance.

## Why

The plan called for the deep stage to arm past `1.6 x` and fire **on release**.
That is not implementable. `CupertinoSliverRefreshControl` invokes `onRefresh`
the moment the pull reaches `refreshTriggerPullDistance`, from a post-frame
callback, and returns `armed` — there is no release-gated commit
(`cupertino_ui` `refresh.dart:504-530`). Verified twice: the source, and a probe
showing the soft refresh had already run while the finger was still down.

So by the time a user reaches `1.6 x`, stage 1 has committed and no release
event exists to hang stage 2 on. **Owner decision:** keep the two-depth gesture
and fire on crossing. `PLAN.md` is corrected in this PR, including why the
earlier wording was unbuildable, so a later reader does not try to restore it.

The component exists rather than a scaffold parameter because three hosts need
the gesture and only two of them use `PregoGlassScaffold`; without it, the
split-view pane would re-implement thresholds in `client/app`.

## Risk and test focus

Moderate, confined to the pull gesture on three surfaces.

The behaviour worth a reviewer's attention:

- an ordinary pull is unchanged — no caption, no second callback;
- crossing `1.6 x` fires exactly once however far the pull continues;
- arming never leaks between gestures;
- with no `deepRefresh` supplied the control behaves as the bare Cupertino one.

Because there is no commit point, a pull past `1.6 x` cannot be taken back by
dragging up. Cancelling is the progress row's job, which is the affordance that
exists for it anyway. That trade is recorded in `PLAN.md`.

The caption cross-fades between two phases keyed on the phase rather than the
text, so a host rewording mid-pull cannot look like the stage changed. The fired
phase is visually distinct — brand colour plus a rotate icon — rather than only
differently worded, so the moment of commitment is legible without reading.

## Expected result

**User-visible:** an ordinary pull-to-refresh is unchanged. Pulling further now
shows a caption inviting a rescan, and passing the deeper threshold fires it and
says so. Nothing is wired to it yet — `deepRefresh` is null on every host until
step 6 — so this PR changes no behaviour a user can reach.

**Database:** no change.

**Internal:** `SessionListPanel` no longer builds its own refresh control.

## Verification

- `dart analyze --fatal-infos` clean on `client/module_prego` and `client/app`
- full `client/module_prego` suite: 227 tests passing, 8 new, covering the
  ordinary pull, the deep pull, an abandoned pull, the no-second-stage case,
  caption order, once-per-pull, no arming leaking between pulls, and the fired
  label's visual distinction
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a two-stage pull-to-refresh via `PregoSliverRefreshControl`; the deep stage fires on crossing 1.6× the trigger while dragging. Captions now follow the live pull extent and retract after release to avoid covering the spinner.

- Adds `PregoSliverRefreshControl` owning thresholds, captions, and dispatch; deep stage fires once per pull; not awaited; with no `deepRefresh`, behavior matches `CupertinoSliverRefreshControl`.
- Introduces `PregoDeepRefresh` (`onDeepRefresh`, `pullCaption`, `deepCaption`); captions cross-fade by phase, render inside the control’s sliver, the fired phase is brand-tinted with a rotate icon, and long text truncates at large text scales.
- Moves `PregoGlassScaffold` and `SessionListPanel` onto the control; scaffold exposes `deepRefresh`, `decorate`, and `onPulledExtentChanged`, and asserts `deepRefresh` requires `onRefresh`.
- Plan/Tracker: copy switches to scan-led (“Scan complete”, “No new sessions”); progress row is a tinted card that names the running harness and its live session count.
- Tests: 8 new cases cover ordinary/abandoned/deep pulls, once-per-pull, no-second-stage behavior, caption order, truncation, and that captions retract after release.

<sup>Written for commit 00a615ee27456ef2d715bcd00b6252beeb9c1257. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

