### PR TITLE
🌿 Show Pi compaction while startup prompt is queued

### DIFF
--- a/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
+++ b/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
@@ -273,10 +273,11 @@ final class PiPlugin._({
     final session = await _requiredSession(sessionId: sessionId, operation: "getSessionMessages");
     if (session.time == null) return const [];
     try {
-      return await _processRepository.loadHistory(
+      final history = await _processRepository.loadHistory(
         sessionId: sessionId,
         knownDirectories: {session.directory},
       );
+      return _sessionService.withLiveMessages(sessionId: sessionId, history: history);
     } on PluginOperationException {
       rethrow;
     } on Object catch (error, stackTrace) {

--- a/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_history_mapper.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_history_mapper.dart
@@ -240,16 +240,35 @@ final class PiHistoryMapper({
     }
   }
 
-  PluginMessageWithParts mapCompaction({required String sessionId, required String messageId}) {
+  PluginMessageWithParts mapRunningCompaction({required String sessionId, required String messageId}) => _mapCompaction(
+    sessionId: sessionId,
+    messageId: messageId,
+    title: "Compacting context",
+    status: PluginToolStatus.running,
+  );
+
+  PluginMessageWithParts mapCompaction({required String sessionId, required String messageId}) => _mapCompaction(
+    sessionId: sessionId,
+    messageId: messageId,
+    title: "Context compacted",
+    status: PluginToolStatus.completed,
+  );
+
+  PluginMessageWithParts _mapCompaction({
+    required String sessionId,
+    required String messageId,
+    required String title,
+    required PluginToolStatus status,
+  }) {
     final draft = _toolMessage(
       sessionId: sessionId,
       messageId: messageId,
       timestamp: null,
       tool: "compact",
-      title: "Context compacted",
+      title: title,
       output: null,
       error: null,
-      status: PluginToolStatus.completed,
+      status: status,
     );
     return PluginMessageWithParts(info: draft.info, parts: draft.parts);
   }

--- a/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_message_identity_builder.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_message_identity_builder.dart
@@ -16,6 +16,7 @@ final class PiMessageIdentityBuilder({
 
   final Map<String, int> _ordinals = {};
   final Map<String, int> _allocations = {};
+  int? _reservedCompactionOrdinal;
 
   PiMessageIdentitySnapshot snapshot() => PiMessageIdentitySnapshot._(
     ordinals: Map.unmodifiable(_ordinals),
@@ -48,6 +49,29 @@ final class PiMessageIdentityBuilder({
     return _next(role: PiMessageIdentityRole.compaction, timestampPart: compactionTimestampSentinel);
   }
 
+  /// Reserves the next compaction ID without advancing the persisted-history
+  /// cursor. Hydration can therefore replace ordinals while the live
+  /// compaction keeps the ID it will receive when persisted.
+  String reserveCompaction() {
+    final key = _compactionKey;
+    final ordinal = _reservedCompactionOrdinal ??= (_ordinals[key] ?? 0) + 1;
+    return _compactionId(ordinal: ordinal);
+  }
+
+  String commitCompaction() {
+    final ordinal = _reservedCompactionOrdinal;
+    if (ordinal == null) return nextCompaction();
+    final key = _compactionKey;
+    if ((_ordinals[key] ?? 0) < ordinal) _ordinals[key] = ordinal;
+    _allocations[key] = (_allocations[key] ?? 0) + 1;
+    _reservedCompactionOrdinal = null;
+    return _compactionId(ordinal: ordinal);
+  }
+
+  void releaseCompaction() {
+    _reservedCompactionOrdinal = null;
+  }
+
   String nextTopLevelCustomMessage() {
     return _next(role: PiMessageIdentityRole.custom, timestampPart: customMessageTimestampSentinel);
   }
@@ -59,6 +83,11 @@ final class PiMessageIdentityBuilder({
     _allocations[key] = (_allocations[key] ?? 0) + 1;
     return "$pluginId:$sessionId:${role.segment}:$timestampPart:$ordinal";
   }
+
+  String get _compactionKey => "${PiMessageIdentityRole.compaction.segment}\u0000$compactionTimestampSentinel";
+
+  String _compactionId({required int ordinal}) =>
+      "$pluginId:$sessionId:${PiMessageIdentityRole.compaction.segment}:$compactionTimestampSentinel:$ordinal";
 }
 
 final class PiMessageIdentitySnapshot._({

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
@@ -38,6 +38,23 @@ final class PiEventDispatcher({
     _sessions[sessionId]?.pendingPrompts.removeWhere((prompt) => prompt.promptId == promptId);
   }
 
+  PluginMessageWithParts? activeCompactionMessage({required String sessionId}) {
+    final state = _sessions[sessionId];
+    final messageId = state?.compactionMessageId;
+    if (messageId == null) return null;
+    return _historyMapper.mapRunningCompaction(sessionId: sessionId, messageId: messageId);
+  }
+
+  List<BridgeSseEvent> clearCompaction({required String sessionId}) {
+    final state = _sessions[sessionId];
+    final messageId = state?.compactionMessageId;
+    if (state == null || messageId == null) return const [];
+    state
+      ..compactionMessageId = null
+      ..identities.releaseCompaction();
+    return [BridgeSseMessageRemoved(sessionID: sessionId, messageID: messageId)];
+  }
+
   void forgetSession({required String sessionId}) {
     _sessions.remove(sessionId);
     _identityTracker.forgetSession(sessionId: sessionId);
@@ -556,7 +573,7 @@ final class PiEventDispatcher({
     required DateTime? now,
   }) {
     final state = _session(sessionId);
-    final messageId = state.compactionMessageId ??= state.identities.nextCompaction();
+    final messageId = state.compactionMessageId ??= state.identities.reserveCompaction();
     final mapped = _historyMapper.mapRunningCompaction(sessionId: sessionId, messageId: messageId);
     return [
       ..._status(sessionId: sessionId, event: event, now: now),
@@ -594,14 +611,13 @@ final class PiEventDispatcher({
     }
     if (aborted || errorMessage != null) {
       if (willRetry) return const [];
-      final messageId = _sessions[sessionId]?.compactionMessageId;
       return [
-        if (messageId != null) BridgeSseMessageRemoved(sessionID: sessionId, messageID: messageId),
+        ...clearCompaction(sessionId: sessionId),
         BridgeSseSessionError(sessionID: sessionId),
       ];
     }
     final state = _session(sessionId);
-    final messageId = state.compactionMessageId ?? state.identities.nextCompaction();
+    final messageId = state.identities.commitCompaction();
     state.compactionMessageId = null;
     final mapped = _historyMapper.mapCompaction(sessionId: sessionId, messageId: messageId);
     return [

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
@@ -99,8 +99,8 @@ final class PiEventDispatcher({
       finalError: finalError,
     ),
     PiAutoRetryEndEvent() ||
-    PiSummarizationRetryAttemptStartEvent() ||
-    PiCompactionStartEvent() => _status(sessionId: sessionId, event: event, now: now),
+    PiSummarizationRetryAttemptStartEvent() => _status(sessionId: sessionId, event: event, now: now),
+    PiCompactionStartEvent() => _compactionStart(sessionId: sessionId, event: event, now: now),
     PiCompactionEndEvent(:final reason, :final aborted, :final willRetry, :final errorMessage) => _compactionEnd(
       sessionId: sessionId,
       reason: reason,
@@ -550,6 +550,21 @@ final class PiEventDispatcher({
     return status == null ? const [] : [BridgeSseSessionStatus(sessionID: sessionId, status: status.toJson())];
   }
 
+  List<BridgeSseEvent> _compactionStart({
+    required String sessionId,
+    required PiCompactionStartEvent event,
+    required DateTime? now,
+  }) {
+    final state = _session(sessionId);
+    final messageId = state.compactionMessageId ??= state.identities.nextCompaction();
+    final mapped = _historyMapper.mapRunningCompaction(sessionId: sessionId, messageId: messageId);
+    return [
+      ..._status(sessionId: sessionId, event: event, now: now),
+      BridgeSseMessageUpdated(info: mapped.info.toJson()),
+      for (final part in mapped.parts) BridgeSseMessagePartUpdated(part: part),
+    ];
+  }
+
   List<BridgeSseEvent> _retryEnd({
     required String sessionId,
     required int? attempt,
@@ -577,12 +592,17 @@ final class PiEventDispatcher({
         _PiCompactionFailureDiagnostic(reason: reason, detail: errorMessage),
       );
     }
-    if ((aborted || errorMessage != null) && !willRetry) {
-      return [BridgeSseSessionError(sessionID: sessionId)];
+    if (aborted || errorMessage != null) {
+      if (willRetry) return const [];
+      final messageId = _sessions[sessionId]?.compactionMessageId;
+      return [
+        if (messageId != null) BridgeSseMessageRemoved(sessionID: sessionId, messageID: messageId),
+        BridgeSseSessionError(sessionID: sessionId),
+      ];
     }
-    if (willRetry) return const [];
     final state = _session(sessionId);
-    final messageId = state.identities.nextCompaction();
+    final messageId = state.compactionMessageId ?? state.identities.nextCompaction();
+    state.compactionMessageId = null;
     final mapped = _historyMapper.mapCompaction(sessionId: sessionId, messageId: messageId);
     return [
       BridgeSseSessionCompacted(sessionID: sessionId),
@@ -638,6 +658,7 @@ final class _SessionState({required final PiMessageIdentityBuilder identities}) 
   bool announced = false;
   final Set<({int contentIndex, PluginMessagePartType type})> startedParts = {};
   final Set<String> emittedPartIds = {};
+  String? compactionMessageId;
 
   void clearMessage() {
     messageId = null;

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -165,6 +165,17 @@ final class PiSessionService({
     ];
   }
 
+  List<PluginMessageWithParts> withLiveMessages({
+    required String sessionId,
+    required List<PluginMessageWithParts> history,
+  }) {
+    final activeCompaction = _dispatcher.activeCompactionMessage(sessionId: sessionId);
+    if (activeCompaction == null || history.any((message) => message.info.id == activeCompaction.info.id)) {
+      return history;
+    }
+    return [...history, activeCompaction];
+  }
+
   bool cancelQueuedPrompt({required String sessionId, required String promptId}) {
     final state = _sessions[sessionId];
     if (state == null) return false;
@@ -666,6 +677,10 @@ final class PiSessionService({
     return null;
   }
 
+  void _clearCompaction({required String sessionId}) {
+    _dispatcher.clearCompaction(sessionId: sessionId).forEach(_emit);
+  }
+
   void _handleExit(PiSessionProcessExit exit) {
     _extensionUi.cancelForOwner(sessionId: exit.sessionId, processGeneration: exit.generation);
     final state = _sessions[exit.sessionId];
@@ -675,6 +690,7 @@ final class PiSessionService({
         if (turn.connection?.generation == exit.generation) turn,
     ];
     if (affected.isEmpty) return;
+    _clearCompaction(sessionId: exit.sessionId);
     state.agentRunning = false;
     final hasUncancelled = affected.any(
       (turn) => turn is! _PiQueuedPromptTurn || turn.queueState != _PiQueueState.cancelled,
@@ -710,6 +726,7 @@ final class PiSessionService({
     required int processGeneration,
     required Object failure,
   }) {
+    _clearCompaction(sessionId: sessionId);
     state.agentRunning = false;
     final affected = [
       for (final turn in state.turns)
@@ -857,6 +874,7 @@ final class PiSessionService({
         turn.acceptance.completeError(PiTurnCancelledException(sessionId: sessionId), StackTrace.current);
       }
     }
+    _clearCompaction(sessionId: sessionId);
     if (hadQueuedPresentations) _emitQueueUpdate(sessionId: sessionId, state: state);
     _extensionUi.cancelForOwner(sessionId: sessionId, processGeneration: null);
     final connection = cancelled.firstOrNull?.connection;

--- a/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
@@ -652,6 +652,31 @@ void main() {
     expect(events.whereType<BridgeSseSessionError>(), isEmpty);
   });
 
+  test("successful overflow compaction completes before Pi retries the agent", () {
+    final compacting = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("compaction_start", {"reason": "overflow"}),
+    );
+    final compacted = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("compaction_end", {
+        "reason": "overflow",
+        "aborted": false,
+        "willRetry": true,
+      }),
+    );
+
+    expect(compacted.whereType<BridgeSseSessionCompacted>(), hasLength(1));
+    expect(
+      compacted.whereType<BridgeSseMessageUpdated>().single.info["id"],
+      compacting.whereType<BridgeSseMessageUpdated>().single.info["id"],
+    );
+    expect(
+      compacted.whereType<BridgeSseMessagePartUpdated>().single.part.state?.status,
+      PluginToolStatus.completed,
+    );
+  });
+
   test("terminal compaction failures remove the running card and preserve its replay identity", () {
     final compacting = dispatcher.map(
       sessionId: sessionId,
@@ -676,6 +701,27 @@ void main() {
     expect(failed.whereType<BridgeSseMessageRemoved>().single.messageID, messageId);
     expect(failed.whereType<BridgeSseSessionError>(), hasLength(1));
     expect(restarted.whereType<BridgeSseMessageUpdated>().single.info["id"], messageId);
+  });
+
+  test("running compaction identity survives history hydration before completion", () {
+    final compacting = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("compaction_start", {"reason": "threshold"}),
+    );
+    final messageId = compacting.whereType<BridgeSseMessageUpdated>().single.info["id"];
+    identities.hydrate<void>(sessionId: sessionId, map: (_) {});
+
+    final compacted = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("compaction_end", {"aborted": false, "willRetry": false}),
+    );
+    final next = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("compaction_start", {"reason": "threshold"}),
+    );
+
+    expect(compacted.whereType<BridgeSseMessageUpdated>().single.info["id"], messageId);
+    expect(next.whereType<BridgeSseMessageUpdated>().single.info["id"], "pi:session:compaction:compaction:2");
   });
 
   test("interleaved sessions and unknown variants keep state isolated", () {

--- a/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
@@ -581,7 +581,7 @@ void main() {
     expect(events.whereType<BridgeSseMessagePartUpdated>().single.part.text, "Extension result");
   });
 
-  test("retry, compaction, and only agent_settled produce status lifecycle", () {
+  test("retry and compaction map lifecycle while only agent_settled emits idle", () {
     final retry = dispatcher.map(
       sessionId: sessionId,
       event: _event("auto_retry_start", {"attempt": 2, "delayMs": 500}),
@@ -599,6 +599,10 @@ void main() {
       sessionId: sessionId,
       event: _event("agent_end", {"willRetry": false}),
     );
+    final compacting = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("compaction_start", {"reason": "threshold"}),
+    );
     final compacted = dispatcher.map(
       sessionId: sessionId,
       event: _event("compaction_end", {"aborted": false, "willRetry": false}),
@@ -614,12 +618,26 @@ void main() {
     expect(agentEnd, isEmpty);
     expect((autoRetryResumed.single as BridgeSseSessionStatus).status, {"runtimeType": "busy"});
     expect((summarizationResumed.single as BridgeSseSessionStatus).status, {"runtimeType": "busy"});
+    expect(compacting.whereType<BridgeSseSessionStatus>().single.status, {"runtimeType": "busy"});
+    final runningMessage = compacting.whereType<BridgeSseMessageUpdated>().single;
+    expect(runningMessage.info["id"], "pi:session:compaction:compaction:1");
+    final runningPart = compacting.whereType<BridgeSseMessagePartUpdated>().single.part;
+    expect(runningPart.state?.status, PluginToolStatus.running);
+    expect(runningPart.state?.title, "Compacting context");
     expect(compacted.whereType<BridgeSseSessionCompacted>(), hasLength(1));
-    expect(compacted.whereType<BridgeSseMessagePartUpdated>().single.part.state?.title, "Context compacted");
+    expect(compacted.whereType<BridgeSseMessageUpdated>().single.info["id"], runningMessage.info["id"]);
+    final completedPart = compacted.whereType<BridgeSseMessagePartUpdated>().single.part;
+    expect(completedPart.id, runningPart.id);
+    expect(completedPart.state?.status, PluginToolStatus.completed);
+    expect(completedPart.state?.title, "Context compacted");
     expect(settled.whereType<BridgeSseSessionIdle>(), hasLength(1));
   });
 
-  test("recovering compaction failures stay local while Pi retries", () {
+  test("recovering compaction failures keep the running card while Pi retries", () {
+    dispatcher.map(
+      sessionId: sessionId,
+      event: _event("compaction_start", {"reason": "overflow"}),
+    );
     final events = dispatcher.map(
       sessionId: sessionId,
       event: _event("compaction_end", {
@@ -630,7 +648,34 @@ void main() {
       }),
     );
 
+    expect(events.whereType<BridgeSseMessageRemoved>(), isEmpty);
     expect(events.whereType<BridgeSseSessionError>(), isEmpty);
+  });
+
+  test("terminal compaction failures remove the running card and preserve its replay identity", () {
+    final compacting = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("compaction_start", {"reason": "threshold"}),
+    );
+    final messageId = compacting.whereType<BridgeSseMessageUpdated>().single.info["id"];
+
+    final failed = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("compaction_end", {
+        "reason": "threshold",
+        "errorMessage": "provider detail",
+        "aborted": false,
+        "willRetry": false,
+      }),
+    );
+    final restarted = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("compaction_start", {"reason": "threshold"}),
+    );
+
+    expect(failed.whereType<BridgeSseMessageRemoved>().single.messageID, messageId);
+    expect(failed.whereType<BridgeSseSessionError>(), hasLength(1));
+    expect(restarted.whereType<BridgeSseMessageUpdated>().single.info["id"], messageId);
   });
 
   test("interleaved sessions and unknown variants keep state isolated", () {

--- a/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
@@ -29,7 +29,10 @@ void main() {
       );
 
       expect(harness.processes, isEmpty);
-      expect((await harness.plugin.getSessions(projectId: harness.project.path, start: null, limit: null)).single.id, session.id);
+      expect(
+        (await harness.plugin.getSessions(projectId: harness.project.path, start: null, limit: null)).single.id,
+        session.id,
+      );
       expect(await harness.plugin.getSessionMessages(session.id), isEmpty);
 
       final events = <BridgeSseEvent>[];
@@ -39,6 +42,29 @@ void main() {
       }
       expect(events.single, isA<BridgeSseSessionCreated>());
       await subscription.cancel();
+    });
+
+    test("session snapshot includes an active compaction for late viewers", () async {
+      harness.writeSession(id: "session", parentPath: null);
+      await harness.plugin.getSessions(projectId: harness.project.path, start: null, limit: null);
+      await harness.plugin.sendPrompt(
+        sessionId: "session",
+        promptId: "prompt",
+        parts: const [PluginPromptPart.text(text: "continue")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final process = await harness.nextSessionProcess();
+      await waitForCommand(process: process, type: "prompt");
+      process.emit(frame: {"type": "compaction_start", "reason": "threshold"});
+      await pump();
+
+      final messages = await harness.plugin.getSessionMessages("session");
+
+      expect(messages, hasLength(1));
+      expect(messages.single.parts.single.state?.status, PluginToolStatus.running);
+      expect(messages.single.parts.single.state?.title, "Compacting context");
     });
 
     test("buffers created before busy when the first turn starts", () async {

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -1355,6 +1355,35 @@ void main() {
     expect(events.whereType<BridgeSseSessionError>(), hasLength(1));
   });
 
+  test("process exit removes an active compaction card", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+    final events = <BridgeSseEvent>[];
+    service.events.listen(events.add);
+
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "compacting-prompt",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "after compaction")],
+      userVisibleText: "after compaction",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    await waitForCommand(process: process, type: "prompt");
+    process.emit(frame: {"type": "compaction_start", "reason": "threshold"});
+    await _waitForEventCount<BridgeSseMessageUpdated>(events: events, count: 1);
+    final messageId = events.whereType<BridgeSseMessageUpdated>().single.info["id"];
+
+    process.exit(code: 9);
+
+    await _waitForIdle(service: service, sessionId: "session");
+    expect(events.whereType<BridgeSseMessageRemoved>().single.messageID, messageId);
+  });
+
   test("pre-prompt compaction stays visible beyond the ordinary RPC timeout", () async {
     final process = FakePiProcess();
     final fixture = _Fixture(processes: [process])
@@ -1575,11 +1604,13 @@ void main() {
     await _waitForIdle(service: service, sessionId: "child");
   });
 
-  test("abort invalidates queue, sends abort, and tears down process", () async {
+  test("abort invalidates queue, removes compaction, sends abort, and tears down process", () async {
     final process = FakePiProcess();
     final fixture = _Fixture(processes: [process]);
     addTearDown(fixture.dispose);
     final service = fixture.service();
+    final events = <BridgeSseEvent>[];
+    service.events.listen(events.add);
 
     await service.sendPrompt(
       sessionId: "session",
@@ -1603,6 +1634,9 @@ void main() {
     final prompt = await waitForCommand(process: process, type: "prompt");
     process.emitResponse(id: prompt["id"]! as String, command: "prompt");
     process.emit(frame: {"type": "agent_start"});
+    process.emit(frame: {"type": "compaction_start", "reason": "threshold"});
+    await _waitForEventCount<BridgeSseMessageUpdated>(events: events, count: 1);
+    final compactionMessageId = events.whereType<BridgeSseMessageUpdated>().single.info["id"];
     final steeringPrompt = await _waitForNthCommand(process: process, type: "prompt", count: 2);
     expect(steeringPrompt["message"], "queued");
     expect(steeringPrompt["streamingBehavior"], "steer");
@@ -1615,6 +1649,7 @@ void main() {
     expect(process.killed, isTrue);
     expect(process.written.where((frame) => frame["type"] == "prompt"), hasLength(2));
     expect(fixture.repository.residentSessionIds, isEmpty);
+    expect(events.whereType<BridgeSseMessageRemoved>().single.messageID, compactionMessageId);
   });
 
   test("shutdown interruption accepts process exit before abort response", () async {

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -1355,13 +1355,15 @@ void main() {
     expect(events.whereType<BridgeSseSessionError>(), hasLength(1));
   });
 
-  test("pre-prompt compaction can outlive ordinary RPC timeout", () async {
+  test("pre-prompt compaction stays visible beyond the ordinary RPC timeout", () async {
     final process = FakePiProcess();
     final fixture = _Fixture(processes: [process])
       ..historyRpcTimeout = const Duration(milliseconds: 20)
       ..promptRpcTimeout = const Duration(seconds: 1);
     addTearDown(fixture.dispose);
     final service = fixture.service();
+    final events = <BridgeSseEvent>[];
+    service.events.listen(events.add);
 
     await service.sendPrompt(
       sessionId: "session",
@@ -1381,6 +1383,20 @@ void main() {
     expect(process.killed, isFalse);
     expect(service.queuedPrompts(sessionId: "session").single.id, "compacting-prompt");
     expect(service.sessionStatuses["session"], const PluginSessionStatus.busy());
+    final runningMessage = events.whereType<BridgeSseMessageUpdated>().single;
+    final runningPart = events.whereType<BridgeSseMessagePartUpdated>().single.part;
+    expect(runningPart.messageID, runningMessage.info["id"]);
+    expect(runningPart.state?.status, PluginToolStatus.running);
+    expect(runningPart.state?.title, "Compacting context");
+
+    process.emit(frame: {"type": "compaction_end", "aborted": false, "willRetry": false});
+    await pump();
+
+    expect(events.whereType<BridgeSseMessageUpdated>().last.info["id"], runningMessage.info["id"]);
+    final completedPart = events.whereType<BridgeSseMessagePartUpdated>().last.part;
+    expect(completedPart.id, runningPart.id);
+    expect(completedPart.state?.status, PluginToolStatus.completed);
+    expect(completedPart.state?.title, "Context compacted");
 
     process.emit(frame: {"type": "agent_start"});
     process.emitResponse(id: prompt["id"]! as String, command: "prompt");

--- a/client/app/test/features/session_detail/widgets/assistant_message_card_test.dart
+++ b/client/app/test/features/session_detail/widgets/assistant_message_card_test.dart
@@ -119,6 +119,31 @@ MessagePart _toolPart({required String id, required String toolName}) {
   );
 }
 
+MessagePart _runningCompactionPart() {
+  return const MessagePart(
+    id: "compaction-tool",
+    sessionID: "session-1",
+    messageID: "assistant-1",
+    type: MessagePartType.tool,
+    text: null,
+    tool: "compact",
+    state: ToolState(
+      status: ToolStatus.running,
+      title: "Compacting context",
+      output: null,
+      error: null,
+      attachments: [],
+    ),
+    prompt: null,
+    description: null,
+    agent: null,
+    agentName: null,
+    attempt: null,
+    retryError: null,
+    attachment: null,
+  );
+}
+
 MessagePart _filePart({required String id, String filename = "report.pdf"}) {
   return MessagePart(
     id: id,
@@ -219,6 +244,18 @@ void main() {
 
     final markdownBodies = tester.widgetList<MarkdownBody>(find.byType(MarkdownBody)).toList();
     expect(markdownBodies.map((widget) => widget.data), ['Before tool', 'After tool']);
+  });
+
+  testWidgets("renders an active compaction tool as running", (tester) async {
+    await tester.pumpWidget(
+      _AssistantMessageCardHarness(
+        message: _assistantMessage(parts: [_runningCompactionPart()]),
+        streamingText: const {},
+      ),
+    );
+
+    expect(find.text("Compacting context"), findsOneWidget);
+    expect(find.text("Running"), findsOneWidget);
   });
 
   testWidgets("streaming text updates the rendered markdown without breaking the SelectionArea", (tester) async {

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -66,8 +66,10 @@ defaults and queued client sends coherent.
   settle. A model or thinking-level change remains bridge-queued until the
   current run settles. Pi may run model-backed automatic compaction before it
   acknowledges a prompt, so that preflight uses a turn-scale deadline instead
-  of the shorter history/control RPC deadline and the prompt remains visibly
-  queued while compaction runs. An accepted prompt remains bridge-queued
+  of the shorter history/control RPC deadline. The prompt remains visibly
+  queued alongside a running `Compacting context` tool card while compaction
+  runs; the card updates in place to `Context compacted` when Pi persists the
+  result. An accepted prompt remains bridge-queued
   through startup and selection until Pi echoes its correlated user message,
   including an attachment-only echo; it can be
   cancelled before dispatch, and its undispatched prompt id remains immediately
@@ -253,7 +255,9 @@ replay, and abort after output has started.
   without a bound, or leaves a corrected selection on a variant the picker does
   not display.
 - A cold Pi follow-up wakes the process but times out in pre-prompt automatic
-  compaction before reaching the agent.
+  compaction before reaching the agent, exposes only the queued prompt while
+  compaction is underway, or replaces the running compaction card instead of
+  updating it in place when compaction ends.
 - An abort, permission reply, or question reply stalls behind a send to a
   busy session on the same session lane, or a Cursor/Hermes follow-up waits for
   the active turn to finish naturally instead of cancelling it before dispatch.

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -68,8 +68,9 @@ defaults and queued client sends coherent.
   acknowledges a prompt, so that preflight uses a turn-scale deadline instead
   of the shorter history/control RPC deadline. The prompt remains visibly
   queued alongside a running `Compacting context` tool card while compaction
-  runs; the card updates in place to `Context compacted` when Pi persists the
-  result. An accepted prompt remains bridge-queued
+  runs, including in snapshots loaded by later viewers. The card updates in
+  place to `Context compacted` when Pi persists the result; aborting or losing
+  the Pi process removes it. An accepted prompt remains bridge-queued
   through startup and selection until Pi echoes its correlated user message,
   including an attachment-only echo; it can be
   cancelled before dispatch, and its undispatched prompt id remains immediately
@@ -255,9 +256,10 @@ replay, and abort after output has started.
   without a bound, or leaves a corrected selection on a variant the picker does
   not display.
 - A cold Pi follow-up wakes the process but times out in pre-prompt automatic
-  compaction before reaching the agent, exposes only the queued prompt while
-  compaction is underway, or replaces the running compaction card instead of
-  updating it in place when compaction ends.
+  compaction before reaching the agent; an initial or later viewer exposes only
+  the queued prompt while compaction is underway; the running card is replaced
+  instead of updated when compaction ends, or survives an abort or process
+  exit.
 - An abort, permission reply, or question reply stalls behind a send to a
   busy session on the same session lane, or a Cursor/Hermes follow-up waits for
   the active turn to finish naturally instead of cancelling it before dispatch.


### PR DESCRIPTION
## Complexity

Straightforward — reuses the existing normalized tool lifecycle and keeps one stable message identity from Pi's start event through completion.

## What

- Publish a running `Compacting context` tool card as soon as Pi emits `compaction_start`.
- Update that same message and part in place to `Context compacted` when Pi persists the compaction.
- Remove the live card on terminal failure while retaining its unpersisted replay identity for a later attempt.
- Cover the pre-prompt startup path, dispatcher lifecycle, history parity, rendered running state, and regression contract.

## Why

Pi can spend several minutes compacting before acknowledging a startup prompt. The prompt correctly remains queued during that preflight, but without a running tool card the session looks stalled until the completed compaction appears.

## Risk and test focus

Risk is limited to Pi compaction event presentation and synthetic message identity. Review should focus on the running-to-completed in-place transition, retry and terminal-failure cleanup, and parity with persisted compaction history. The user-visible impact is the new running tool card; there is no database, persisted-format, new wire-contract, or analytics impact.

## Expected result

A cold Pi follow-up remains queued while startup compaction runs, with an immediate `Compacting context` tool card that shows the existing running indicator and updates in place to `Context compacted` before the prompt reaches the agent.

## Verification

- `cd bridge && dart pub get`
- `cd bridge/sesori_plugin_pi && dart test test/pi_event_dispatcher_test.dart test/pi_session_service_test.dart` — 74 tests passed
- `cd bridge/sesori_plugin_pi && dart test test/pi_history_mapper_test.dart` — 18 tests passed
- `cd bridge/sesori_plugin_pi && dart analyze --fatal-infos`
- `cd client/app && flutter test test/features/session_detail/widgets/assistant_message_card_test.dart --plain-name "renders an active compaction tool as running"`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a running compaction tool card during Pi startup and keeps its identity stable until completion or removal. Previously no card appeared until completion; now queued prompts show progress, late viewers see the live card, and the card updates in place or is removed on terminal failure or teardown.

- Review focus
  - `PiEventDispatcher`: maps `compaction_start` to busy plus a running "Compacting context" tool; reserves a compaction message id; on `compaction_end` completes in place and emits `BridgeSseSessionCompacted` (even when the agent will retry), keeps the running card for recoverable failures, and removes the card and emits `BridgeSseSessionError` for terminal failures; adds `clearCompaction()` used on exit/failure/abort.
  - Stable identity: `PiMessageIdentityBuilder` adds `reserveCompaction/commitCompaction/releaseCompaction` so the running card’s id survives history hydration and retries; terminal failures preserve the id for replay.
  - Snapshot visibility: `PiSessionService.withLiveMessages` appends an active compaction to history; `PiPluginImpl.getSessionMessages` uses it so late viewers see the running card; teardown paths remove it.
  - Mapping/UI: `PiHistoryMapper` adds `mapRunningCompaction`; the client assistant card renders the running state; docs note snapshot visibility and teardown removal.
  - No database or wire contract changes. Tests cover lifecycle, retries, exit/abort cleanup, hydration stability, and pre-prompt visibility beyond the RPC timeout.

<sup>Written for commit 5c562db82db4369db8a1056ff3f93df7d3e5a83b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

