### PR TITLE
🌿 [codebase-cleanup] bridge(app): consolidate process-runner and service test fakes [step 10/45]

### DIFF
--- a/.plan/active/codebase-cleanup/steps/step-10.md
+++ b/.plan/active/codebase-cleanup/steps/step-10.md
@@ -35,7 +35,7 @@ connection/close timing remained test-specific and fail loud locally.
   control client now registers an idempotent teardown, and its affected suites
   pass.
 - `git diff --check`: passed.
-- Size excluding this evidence file against merge-base `3c45717ce5`:
+- Size excluding this evidence file against merge-base `e9aa8faeaf`:
   **`+435 / -968` = 1,403 changed lines**, under the 1,500-line soft cap and 533
   fewer test lines overall.
 - Architecture implementation review not run: this change is test-only and

--- a/.plan/active/codebase-cleanup/steps/step-10.md
+++ b/.plan/active/codebase-cleanup/steps/step-10.md
@@ -1,0 +1,42 @@
+# Step 10/45 — Consolidate bridge/app process-runner and service test fakes
+
+## Re-verification against `main`
+
+The duplicate families remained on `main`, but several copies had acquired
+meaningful behavior since the plan estimate. Equivalent fixed-result process
+runners, token refreshers, control clients, settings APIs, deletion-oriented
+worktree services, and strict process repositories could still share helpers.
+Command queues, detached restart spawning, synchronous subscription counting,
+queued settings reads, session-creation and rollback behavior, and relay
+connection/close timing remained test-specific and fail loud locally.
+
+## Change
+
+- Added one fail-loud `NoopProcessRunner` and responder-style
+  `RecordingProcessRunner`, replacing the equivalent local process runners.
+- Expanded the existing `FakeTokenRefresher` and added a self-cleaning
+  `FakeControlChannelClient` for fixed-token and ordinary send/stream tests.
+- Added `InMemoryBridgeSettingsApi`, `DeletionWorktreeServiceFake`, and
+  `StrictFakeProcessRepository`, then migrated the compatible service, routing,
+  runtime, and server tests.
+- Retained specialized local fakes where adopting a successful shared default
+  or hiding timing and ordering state would weaken the existing assertions.
+- The three recording relay clients now exercise different transport,
+  connection-promotion, failure, and close-order behavior, so no shared relay
+  fake was added solely to satisfy the original estimate.
+
+## Verification
+
+- `dart analyze --fatal-infos` in `bridge/app`: passed.
+- Full `dart test` in `bridge/app`: 2,692 passed; 2 executable PowerShell cases
+  skipped because PowerShell is unavailable locally.
+- Focused suites passed after the final helper migrations and lifecycle fix.
+- Correctness review found one low-severity controller-cleanup gap; the shared
+  control client now registers an idempotent teardown, and its affected suites
+  pass.
+- `git diff --check`: passed.
+- Size excluding this evidence file against merge-base `3c45717ce5`:
+  **`+435 / -968` = 1,403 changed lines**, under the 1,500-line soft cap and 533
+  fewer test lines overall.
+- Architecture implementation review not run: this change is test-only and
+  changes no production class, dependency ownership, or contract.

--- a/bridge/app/test/api/sesori_server_api_test.dart
+++ b/bridge/app/test/api/sesori_server_api_test.dart
@@ -9,6 +9,8 @@ import "package:sesori_bridge/src/foundation/abortable_request.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../helpers/test_helpers.dart";
+
 void main() {
   group("SesoriServerApi app-client status", () {
     test("sends immediate request to exact endpoint with bearer token", () async {
@@ -20,7 +22,7 @@ void main() {
           return http.Response('{"registered":true}', 200);
         }),
         requestDeadline: const Duration(seconds: 1),
-        tokenRefresher: _FakeTokenRefresher(token: "unused"),
+        tokenRefresher: FakeTokenRefresher(token: "unused"),
       );
 
       final response = await api.getAppClientStatus(accessToken: "secret-token");
@@ -36,13 +38,13 @@ void main() {
         authBackendUrl: "https://auth.example.test",
         client: MockClient((_) async => http.Response("missing", 503)),
         requestDeadline: const Duration(seconds: 1),
-        tokenRefresher: _FakeTokenRefresher(token: "unused"),
+        tokenRefresher: FakeTokenRefresher(token: "unused"),
       );
       final malformedApi = SesoriServerApi(
         authBackendUrl: "https://auth.example.test",
         client: MockClient((_) async => http.Response('{"registered":"yes"}', 200)),
         requestDeadline: const Duration(seconds: 1),
-        tokenRefresher: _FakeTokenRefresher(token: "unused"),
+        tokenRefresher: FakeTokenRefresher(token: "unused"),
       );
 
       await expectLater(
@@ -62,7 +64,7 @@ void main() {
         authBackendUrl: "https://auth.example.test",
         client: client,
         requestDeadline: Duration.zero,
-        tokenRefresher: _FakeTokenRefresher(token: "unused"),
+        tokenRefresher: FakeTokenRefresher(token: "unused"),
       );
 
       await expectLater(api.getAppClientStatus(accessToken: "token"), throwsA(isA<http.RequestAbortedException>()));
@@ -75,7 +77,7 @@ void main() {
         authBackendUrl: "https://auth.example.test",
         client: client,
         requestDeadline: const Duration(milliseconds: 5),
-        tokenRefresher: _FakeTokenRefresher(token: "unused"),
+        tokenRefresher: FakeTokenRefresher(token: "unused"),
       );
 
       await api.getAppClientStatus(accessToken: "token");
@@ -88,7 +90,7 @@ void main() {
   group("SesoriServerApi session metadata", () {
     test("acquires token and posts typed request while decoding title and branch", () async {
       late http.Request request;
-      final tokenRefresher = _FakeTokenRefresher(token: "secret-token");
+      final tokenRefresher = FakeTokenRefresher(token: "secret-token");
       final api = SesoriServerApi(
         authBackendUrl: "https://auth.example.test/",
         client: MockClient((incoming) async {
@@ -119,7 +121,7 @@ void main() {
 
     test("force-refreshes once after 401 and retries with refreshed token", () async {
       final requests = <http.Request>[];
-      final tokenRefresher = _FakeTokenRefresher(token: "stale", refreshedToken: "fresh");
+      final tokenRefresher = FakeTokenRefresher(token: "stale", refreshedToken: "fresh");
       final api = SesoriServerApi(
         authBackendUrl: "https://auth.example.test",
         client: MockClient((request) async {
@@ -147,7 +149,7 @@ void main() {
     test("does not retry non-401 or second 401", () async {
       for (final statusCode in [500, 401]) {
         var requestCount = 0;
-        final tokenRefresher = _FakeTokenRefresher(token: "stale", refreshedToken: "fresh");
+        final tokenRefresher = FakeTokenRefresher(token: "stale", refreshedToken: "fresh");
         final api = SesoriServerApi(
           authBackendUrl: "https://auth.example.test",
           client: MockClient((_) async {
@@ -179,7 +181,7 @@ void main() {
         authBackendUrl: "https://auth.example.test",
         client: MockClient((_) async => http.Response('{"title":1}', 200)),
         requestDeadline: const Duration(seconds: 1),
-        tokenRefresher: _FakeTokenRefresher(token: "token"),
+        tokenRefresher: FakeTokenRefresher(token: "token"),
       );
 
       await expectLater(
@@ -202,7 +204,7 @@ void main() {
         authBackendUrl: "https://auth.example.test",
         client: client,
         requestDeadline: Duration.zero,
-        tokenRefresher: _FakeTokenRefresher(token: "token"),
+        tokenRefresher: FakeTokenRefresher(token: "token"),
       );
 
       await expectLater(
@@ -222,7 +224,7 @@ void main() {
         authBackendUrl: "https://auth.example.test",
         client: client,
         requestDeadline: const Duration(seconds: 1),
-        tokenRefresher: _FakeTokenRefresher(token: "token"),
+        tokenRefresher: FakeTokenRefresher(token: "token"),
       );
 
       final response = api.generateSessionMetadata(
@@ -303,7 +305,7 @@ void main() {
         authBackendUrl: "https://auth.example.test",
         client: client,
         requestDeadline: const Duration(seconds: 1),
-        tokenRefresher: _FakeTokenRefresher(token: "token"),
+        tokenRefresher: FakeTokenRefresher(token: "token"),
       );
 
       await api.generateSessionMetadata(
@@ -316,18 +318,6 @@ void main() {
       expect(client.abortObserved, isFalse);
     });
   });
-}
-
-class _FakeTokenRefresher({required final String token, final String? refreshedToken}) implements TokenRefresher {
-  final String _token = token;
-  final String _refreshedToken = refreshedToken ?? token;
-  final List<bool> forceRefreshValues = [];
-
-  @override
-  Future<String> getAccessToken({bool forceRefresh = false}) async {
-    forceRefreshValues.add(forceRefresh);
-    return forceRefresh ? _refreshedToken : _token;
-  }
 }
 
 class _PendingTokenRefresher() implements TokenRefresher {

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -7,7 +7,6 @@ import "package:http/http.dart" as http;
 import "package:path/path.dart" as p;
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/api/database/tables/pull_requests_table.dart";
-import "package:sesori_bridge/src/auth/token_refresher.dart";
 import "package:sesori_bridge/src/debug_server.dart";
 import "package:sesori_bridge/src/foundation/process_runner.dart";
 import "package:sesori_bridge/src/foundation/relay_client.dart";
@@ -73,7 +72,7 @@ Future<_DebugServerHarness> _createDebugServerHarness({
     httpClient: httpClient,
     processRunner: ProcessRunner(),
     accessTokenProvider: FakeAccessTokenProvider(),
-    tokenRefresher: _FakeTokenRefresher(),
+    tokenRefresher: FakeTokenRefresher(),
     bridgeRegistrationService: createFakeBridgeRegistrationService(),
     failureReporter: failureReporter,
     restartService: effectiveRestartService,
@@ -1055,11 +1054,6 @@ class const _DebugServerHarness({
     httpClient.close();
     await relayServer.close();
   }
-}
-
-class _FakeTokenRefresher() implements TokenRefresher {
-  @override
-  Future<String> getAccessToken({bool forceRefresh = false}) async => "test-token";
 }
 
 // ---------------------------------------------------------------------------

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -5,7 +5,6 @@ import "dart:io";
 import "package:cryptography/cryptography.dart";
 import "package:http/http.dart" as http;
 import "package:sesori_bridge/src/api/database/database.dart";
-import "package:sesori_bridge/src/auth/token_refresher.dart";
 import "package:sesori_bridge/src/foundation/relay_client.dart";
 import "package:sesori_bridge/src/models/bridge_config.dart";
 import "package:sesori_bridge/src/orchestrator.dart";
@@ -1112,7 +1111,7 @@ class const _OrchestratorHarness({
       httpClient: httpClient,
       processRunner: NoopProcessRunner(),
       accessTokenProvider: FakeAccessTokenProvider(),
-      tokenRefresher: _FakeTokenRefresher(),
+      tokenRefresher: FakeTokenRefresher(token: "token"),
       bridgeRegistrationService: createFakeBridgeRegistrationService(),
       failureReporter: failureReporter,
       restartService: restartService,
@@ -1205,9 +1204,4 @@ class _SourcedPlugin(final String pluginId) extends FakeBridgePlugin {
     activeSummaryReadStarted = null;
     return activitySummaries;
   }
-}
-
-class _FakeTokenRefresher() implements TokenRefresher {
-  @override
-  Future<String> getAccessToken({bool forceRefresh = false}) async => "token";
 }

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -3,7 +3,6 @@ import "dart:io";
 
 import "package:http/http.dart" as http;
 import "package:sesori_bridge/src/api/database/database.dart";
-import "package:sesori_bridge/src/auth/token_refresher.dart";
 import "package:sesori_bridge/src/foundation/process_runner.dart";
 import "package:sesori_bridge/src/foundation/relay_client.dart";
 import "package:sesori_bridge/src/models/bridge_config.dart";
@@ -78,7 +77,7 @@ void main() {
       httpClient: httpClient,
       processRunner: ProcessRunner(),
       accessTokenProvider: FakeAccessTokenProvider(""),
-      tokenRefresher: _FakeTokenRefresher(),
+      tokenRefresher: FakeTokenRefresher(token: "token"),
       bridgeRegistrationService: createFakeBridgeRegistrationService(),
       failureReporter: FakeFailureReporter(),
       restartService: buildTestRestartService(),
@@ -156,7 +155,7 @@ void main() {
       httpClient: httpClient,
       processRunner: ProcessRunner(),
       accessTokenProvider: FakeAccessTokenProvider(""),
-      tokenRefresher: _FakeTokenRefresher(),
+      tokenRefresher: FakeTokenRefresher(token: "token"),
       bridgeRegistrationService: createFakeBridgeRegistrationService(),
       failureReporter: FakeFailureReporter(),
       restartService: buildTestRestartService(),
@@ -213,7 +212,7 @@ void main() {
         httpClient: httpClient,
         processRunner: ProcessRunner(),
         accessTokenProvider: FakeAccessTokenProvider(""),
-        tokenRefresher: _FakeTokenRefresher(),
+        tokenRefresher: FakeTokenRefresher(token: "token"),
         bridgeRegistrationService: createFakeBridgeRegistrationService(),
         failureReporter: FakeFailureReporter(),
         restartService: buildTestRestartService(),
@@ -306,7 +305,7 @@ class _TestHarness._({
     final relayServer = await TestRelayServer.start();
     final database = createTestDatabase();
     final failureReporter = CapturingFailureReporter();
-    final tokenRefresher = _FakeTokenRefresher();
+    final tokenRefresher = FakeTokenRefresher(token: "token");
     final relayClient = RelayClient(
       relayURL: "ws://127.0.0.1:${relayServer.port}",
       accessTokenProvider: FakeAccessTokenProvider(""),
@@ -585,9 +584,4 @@ class _ThrowingConnectRelayClient({required final Future<void> _connectGate}) ex
     await _connectGate;
     throw StateError("connect failed");
   }
-}
-
-class _FakeTokenRefresher() implements TokenRefresher {
-  @override
-  Future<String> getAccessToken({bool forceRefresh = false}) async => "token";
 }

--- a/bridge/app/test/bridge/orchestrator_live_attachment_test.dart
+++ b/bridge/app/test/bridge/orchestrator_live_attachment_test.dart
@@ -4,7 +4,6 @@ import "dart:typed_data";
 
 import "package:http/http.dart" as http;
 import "package:sesori_bridge/src/api/database/database.dart";
-import "package:sesori_bridge/src/auth/token_refresher.dart";
 import "package:sesori_bridge/src/foundation/relay_client.dart";
 import "package:sesori_bridge/src/models/bridge_config.dart";
 import "package:sesori_bridge/src/orchestrator.dart";
@@ -326,7 +325,7 @@ class _LiveAttachmentHarness({
       httpClient: httpClient,
       processRunner: NoopProcessRunner(),
       accessTokenProvider: FakeAccessTokenProvider(),
-      tokenRefresher: _FakeTokenRefresher(),
+      tokenRefresher: FakeTokenRefresher(token: "token"),
       bridgeRegistrationService: createFakeBridgeRegistrationService(),
       failureReporter: failureReporter,
       restartService: buildTestRestartService(),
@@ -430,9 +429,4 @@ Future<void> _insertRootSession({required AppDatabase database}) async {
 class _SourcedPlugin(final String pluginId) extends FakeBridgePlugin {
   @override
   String get id => pluginId;
-}
-
-class _FakeTokenRefresher() implements TokenRefresher {
-  @override
-  Future<String> getAccessToken({bool forceRefresh = false}) async => "token";
 }

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -1,11 +1,9 @@
 import "dart:async";
 import "dart:convert";
-import "dart:io";
 
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/api/database/tables/session_table.dart" show SessionDto;
 import "package:sesori_bridge/src/api/git_cli_api.dart";
-import "package:sesori_bridge/src/foundation/process_runner.dart";
 import "package:sesori_bridge/src/repositories/models/project_not_found_exception.dart";
 import "package:sesori_bridge/src/repositories/session_repository.dart";
 import "package:sesori_bridge/src/repositories/session_unseen_calculator.dart";
@@ -18,6 +16,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fake_process_runner.dart";
 import "../../helpers/test_database.dart";
 import "routing_test_helpers.dart";
 
@@ -1211,7 +1210,7 @@ class _FakeWorktreeService({required AppDatabase database}) extends WorktreeServ
           projectsDao: database.projectsDao,
           sessionDao: database.sessionDao,
           gitApi: GitCliApi(
-            processRunner: _NoopProcessRunner(),
+            processRunner: NoopProcessRunner(),
             gitPathExists: ({required String gitPath}) => true,
           ),
           plugin: _FakeBridgePlugin(),
@@ -1244,28 +1243,6 @@ class _FakeWorktreeService({required AppDatabase database}) extends WorktreeServ
     required String initialBranchName,
     required String generatedBranchName,
   }) async => renameResult;
-}
-
-class _NoopProcessRunner() implements ProcessRunner {
-  @override
-  Future<int> startDetached({
-    required String executable,
-    required List<String> arguments,
-    Map<String, String>? environment,
-  }) async {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<ProcessResult> run(
-    String executable,
-    List<String> arguments, {
-    Map<String, String>? environment,
-    String? workingDirectory,
-    Duration timeout = const Duration(seconds: 15),
-  }) {
-    throw UnimplementedError("_NoopProcessRunner should never execute git commands");
-  }
 }
 
 class _OpenCodeFakeBridgePlugin() extends FakeBridgePlugin {

--- a/bridge/app/test/bridge/routing/delete_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/delete_session_handler_test.dart
@@ -3,9 +3,7 @@ import "dart:io";
 
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/api/filesystem_api.dart";
-import "package:sesori_bridge/src/api/git_cli_api.dart";
 import "package:sesori_bridge/src/foundation/filesystem_permission_validator.dart";
-import "package:sesori_bridge/src/foundation/process_runner.dart";
 import "package:sesori_bridge/src/repositories/filesystem_repository.dart";
 import "package:sesori_bridge/src/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/routing/delete_session_handler.dart";
@@ -19,6 +17,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fakes/deletion_worktree_service_fake.dart";
 import "../../helpers/test_chat_history.dart";
 import "../../helpers/test_database.dart";
 import "routing_test_helpers.dart";
@@ -27,7 +26,7 @@ void main() {
   group("DeleteSessionHandler", () {
     late AppDatabase db;
     late _TrackingFakeBridgePlugin plugin;
-    late _FakeWorktreeService worktreeService;
+    late DeletionWorktreeServiceFake worktreeService;
     late SessionOperationDispatcher sessionOperationDispatcher;
     late SessionMutationDispatcher sessionMutationDispatcher;
     late DeleteSessionHandler handler;
@@ -38,7 +37,7 @@ void main() {
       db = createTestDatabase();
       operationLog = [];
       plugin = _TrackingFakeBridgePlugin(operationLog: operationLog);
-      worktreeService = _FakeWorktreeService(database: db, operationLog: operationLog);
+      worktreeService = DeletionWorktreeServiceFake(operationLog: operationLog);
       final sessionRepository = singlePluginSessionRepository(
         plugin: plugin,
         sessionDao: db.sessionDao,
@@ -496,88 +495,6 @@ Future<void> _insertSession({
     lastAgent: null,
     lastAgentModel: null,
   );
-}
-
-class _FakeWorktreeService({required AppDatabase database, required final List<String> operationLog})
-    extends WorktreeService {
-  WorktreeSafetyResult safetyResult = WorktreeSafe();
-  bool removeResult = true;
-
-  int checkCallCount = 0;
-  int removeCallCount = 0;
-
-  String? lastCheckWorktreePath;
-  String? lastRemoveProjectId;
-  String? lastRemoveWorktreePath;
-  bool? lastRemoveForce;
-
-  this
-    : super(
-        worktreeRepository: singlePluginWorktreeRepository(
-          projectsDao: database.projectsDao,
-          sessionDao: database.sessionDao,
-          gitApi: GitCliApi(
-            processRunner: _NoopProcessRunner(),
-            gitPathExists: ({required String gitPath}) => true,
-          ),
-          plugin: _FakeBridgePlugin(),
-        ),
-      );
-
-  @override
-  Future<WorktreeSafetyResult> checkWorktreeSafety({
-    required String worktreePath,
-  }) async {
-    checkCallCount++;
-    operationLog.add("checkSafety");
-    lastCheckWorktreePath = worktreePath;
-    return safetyResult;
-  }
-
-  @override
-  Future<bool> removeWorktree({
-    required String pluginId,
-    required String projectId,
-    required String worktreePath,
-    required bool force,
-  }) async {
-    removeCallCount++;
-    operationLog.add("removeWorktree");
-    lastRemoveProjectId = projectId;
-    lastRemoveWorktreePath = worktreePath;
-    lastRemoveForce = force;
-    return removeResult;
-  }
-}
-
-class _FakeBridgePlugin() extends FakeBridgePlugin {
-  @override
-  Future<void> deleteWorkspace({
-    required String projectId,
-    required String worktreePath,
-  }) async {}
-}
-
-class _NoopProcessRunner() implements ProcessRunner {
-  @override
-  Future<int> startDetached({
-    required String executable,
-    required List<String> arguments,
-    Map<String, String>? environment,
-  }) async {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<ProcessResult> run(
-    String executable,
-    List<String> arguments, {
-    Map<String, String>? environment,
-    String? workingDirectory,
-    Duration timeout = const Duration(seconds: 15),
-  }) {
-    throw UnimplementedError("_NoopProcessRunner should never execute git commands");
-  }
 }
 
 class _TrackingFakeBridgePlugin({required final List<String> operationLog}) extends FakeBridgePlugin {

--- a/bridge/app/test/bridge/routing/restart_bridge_handler_test.dart
+++ b/bridge/app/test/bridge/routing/restart_bridge_handler_test.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
-import 'package:sesori_bridge/src/foundation/process_runner.dart';
 import 'package:sesori_bridge/src/routing/restart_bridge_handler.dart';
 import 'package:sesori_bridge/src/routing/routed_request.dart';
 import 'package:sesori_bridge/src/server/api/system_process_api.dart';
@@ -11,29 +10,8 @@ import 'package:sesori_bridge/src/server/services/bridge_restart_service.dart';
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show ServerClock;
 import 'package:test/test.dart';
 
+import '../../helpers/fake_process_runner.dart';
 import 'routing_test_helpers.dart';
-
-class _NoopProcessRunner() implements ProcessRunner {
-  @override
-  Future<ProcessResult> run(
-    String executable,
-    List<String> arguments, {
-    Map<String, String>? environment,
-    String? workingDirectory,
-    Duration timeout = const Duration(seconds: 15),
-  }) async {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<int> startDetached({
-    required String executable,
-    required List<String> arguments,
-    Map<String, String>? environment,
-  }) async {
-    throw UnimplementedError();
-  }
-}
 
 void main() {
   late Directory tempDir;
@@ -52,7 +30,7 @@ void main() {
     return BridgeRestartService(
       processRepository: ProcessRepository(
         api: SystemProcessApi(
-          processRunner: _NoopProcessRunner(),
+          processRunner: NoopProcessRunner(),
           clock: const ServerClock(),
           isWindows: false,
           platform: 'linux',

--- a/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
+++ b/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
@@ -1,13 +1,10 @@
 import "dart:async";
 import "dart:convert";
-import "dart:io";
 
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/api/database/tables/pull_requests_table.dart";
 import "package:sesori_bridge/src/api/filesystem_api.dart";
-import "package:sesori_bridge/src/api/git_cli_api.dart";
 import "package:sesori_bridge/src/foundation/filesystem_permission_validator.dart";
-import "package:sesori_bridge/src/foundation/process_runner.dart";
 import "package:sesori_bridge/src/repositories/filesystem_repository.dart";
 import "package:sesori_bridge/src/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/routing/update_session_archive_status_handler.dart";
@@ -20,6 +17,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fakes/deletion_worktree_service_fake.dart";
 import "../../helpers/test_chat_history.dart";
 import "../../helpers/test_database.dart";
 import "routing_test_helpers.dart";
@@ -28,7 +26,7 @@ void main() {
   group("UpdateSessionArchiveStatusHandler", () {
     late AppDatabase db;
     late FakeBridgePlugin plugin;
-    late _FakeWorktreeService worktreeService;
+    late DeletionWorktreeServiceFake worktreeService;
     late SessionOperationDispatcher operationDispatcher;
     late SessionUnseenService unseenService;
     late UpdateSessionArchiveStatusHandler handler;
@@ -36,7 +34,7 @@ void main() {
     setUp(() {
       db = createTestDatabase();
       plugin = FakeBridgePlugin();
-      worktreeService = _FakeWorktreeService(database: db);
+      worktreeService = DeletionWorktreeServiceFake();
       final sessionRepository = singlePluginSessionRepository(
         plugin: plugin,
         sessionDao: db.sessionDao,
@@ -796,107 +794,5 @@ Future<void> _insertSession({
       updatedAt: archivedAt,
       projectionUpdatedAt: archivedAt,
     );
-  }
-}
-
-class _FakeWorktreeService({required AppDatabase database}) extends WorktreeService {
-  WorktreeSafetyResult safetyResult = WorktreeSafe();
-  bool removeResult = true;
-  bool branchExistsResult = true;
-
-  int checkCallCount = 0;
-  int removeCallCount = 0;
-
-  String? lastCheckWorktreePath;
-  String? lastRemoveProjectId;
-  String? lastRemoveWorktreePath;
-  bool? lastRemoveForce;
-
-  this
-    : super(
-        worktreeRepository: singlePluginWorktreeRepository(
-          projectsDao: database.projectsDao,
-          sessionDao: database.sessionDao,
-          gitApi: GitCliApi(
-            processRunner: _NoopProcessRunner(),
-            gitPathExists: ({required String gitPath}) => true,
-          ),
-          plugin: _FakeBridgePlugin(),
-        ),
-      );
-
-  @override
-  Future<WorktreeSafetyResult> checkWorktreeSafety({
-    required String worktreePath,
-  }) async {
-    checkCallCount++;
-    lastCheckWorktreePath = worktreePath;
-    return safetyResult;
-  }
-
-  @override
-  Future<bool> removeWorktree({
-    required String pluginId,
-    required String projectId,
-    required String worktreePath,
-    required bool force,
-  }) async {
-    removeCallCount++;
-    lastRemoveProjectId = projectId;
-    lastRemoveWorktreePath = worktreePath;
-    lastRemoveForce = force;
-    return removeResult;
-  }
-
-  @override
-  Future<bool> branchExists({
-    required String projectId,
-    required String branchName,
-  }) async {
-    return branchExistsResult;
-  }
-}
-
-class _FakeBridgePlugin() extends FakeBridgePlugin {
-  @override
-  Future<PluginSession> createSession({
-    required String directory,
-    required String? parentSessionId,
-    required List<PluginPromptPart> parts,
-    required String? userVisibleText,
-    required PluginSessionVariant? variant,
-    required String? agent,
-    required ({String providerID, String modelID})? model,
-  }) => throw UnimplementedError();
-
-  @override
-  Future<PluginSession> renameSession({required String sessionId, required String title}) => throw UnimplementedError();
-
-  @override
-  Future<PluginProject> renameProject({required String projectId, required String name}) => throw UnimplementedError();
-
-  @override
-  Future<PluginProject> getProject(String projectId) => throw UnimplementedError();
-}
-
-class _NoopProcessRunner() implements ProcessRunner {
-  @override
-  Future<int> startDetached({
-    required String executable,
-    required List<String> arguments,
-    Map<String, String>? environment,
-  }) async {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<ProcessResult> run(
-    String executable,
-    List<String> arguments, {
-    Map<String, String>? environment,
-    String? workingDirectory,
-    Duration timeout = const Duration(seconds: 15),
-  }) {
-    throw UnimplementedError("_NoopProcessRunner should never execute git commands");
   }
 }

--- a/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
@@ -2,7 +2,6 @@ import "dart:convert";
 
 import "package:fake_async/fake_async.dart";
 import "package:http/http.dart" as http;
-import "package:sesori_bridge/src/auth/token_refresher.dart";
 import "package:sesori_bridge/src/foundation/process_runner.dart";
 import "package:sesori_bridge/src/foundation/relay_client.dart";
 import "package:sesori_bridge/src/models/bridge_config.dart";
@@ -77,7 +76,7 @@ void main() {
       httpClient: httpClient,
       processRunner: ProcessRunner(),
       accessTokenProvider: FakeAccessTokenProvider(),
-      tokenRefresher: _FakeTokenRefresher(),
+      tokenRefresher: FakeTokenRefresher(),
       bridgeRegistrationService: createFakeBridgeRegistrationService(),
       failureReporter: failureReporter,
       restartService: restartService,
@@ -124,11 +123,6 @@ void main() {
   });
 }
 
-class _FakeTokenRefresher() implements TokenRefresher {
-  @override
-  Future<String> getAccessToken({bool forceRefresh = false}) async => "test-token";
-}
-
 ({
   PushDispatcher dispatcher,
   CompletionPushListener completionListener,
@@ -144,7 +138,7 @@ _createPushSubsystemForTest() {
   final dispatcher = PushDispatcher(
     client: PushNotificationClient(
       authBackendURL: "https://api.sesori.test",
-      tokenRefreshManager: _FakeTokenRefresher(),
+      tokenRefreshManager: FakeTokenRefresher(),
       client: http.Client(),
     ),
     rateLimiter: rateLimiter,

--- a/bridge/app/test/bridge/runtime/bridge_runtime_runner_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_runner_test.dart
@@ -1,8 +1,9 @@
 import "dart:io";
 
-import "package:sesori_bridge/src/foundation/process_runner.dart";
 import "package:sesori_bridge/src/runtime/bridge_runtime_runner.dart";
 import "package:test/test.dart";
+
+import "../../helpers/fake_process_runner.dart";
 
 void main() {
   group("BridgeRuntimeRunner.isLoopbackControlUrl", () {
@@ -56,7 +57,7 @@ void main() {
 
   group("BridgeRuntimeRunner.resolveLocalMachineName", () {
     test("uses the stable macOS LocalHostName instead of a numeric hostname", () async {
-      final runner = _RecordingProcessRunner(
+      final runner = RecordingProcessRunner(
         result: ProcessResult(1, 0, "Alexs-MB-2025\n", ""),
       );
 
@@ -74,7 +75,7 @@ void main() {
     test("uses a non-numeric macOS hostname when LocalHostName is unavailable", () async {
       final name = await BridgeRuntimeRunner.resolveLocalMachineName(
         isMacOS: true,
-        processRunner: _RecordingProcessRunner(
+        processRunner: RecordingProcessRunner(
           result: ProcessResult(1, 1, "", "No such key"),
         ),
         localHostname: "dev-laptop.local",
@@ -86,7 +87,7 @@ void main() {
     test("replaces a numeric macOS fallback hostname with one canonical name", () async {
       final name = await BridgeRuntimeRunner.resolveLocalMachineName(
         isMacOS: true,
-        processRunner: _RecordingProcessRunner(
+        processRunner: RecordingProcessRunner(
           result: ProcessResult(1, 1, "", "No such key"),
         ),
         localHostname: "192.168.1.170",
@@ -96,7 +97,7 @@ void main() {
     });
 
     test("keeps the platform hostname without invoking scutil elsewhere", () async {
-      final runner = _RecordingProcessRunner(
+      final runner = RecordingProcessRunner(
         result: ProcessResult(1, 0, "unused", ""),
       );
 
@@ -110,31 +111,4 @@ void main() {
       expect(runner.executable, isNull);
     });
   });
-}
-
-class _RecordingProcessRunner({required final ProcessResult result}) implements ProcessRunner {
-  String? executable;
-  List<String>? arguments;
-
-  @override
-  Future<ProcessResult> run(
-    String executable,
-    List<String> arguments, {
-    String? workingDirectory,
-    Map<String, String>? environment,
-    Duration timeout = const Duration(seconds: 15),
-  }) async {
-    this.executable = executable;
-    this.arguments = arguments;
-    return result;
-  }
-
-  @override
-  Future<int> startDetached({
-    required String executable,
-    required List<String> arguments,
-    Map<String, String>? environment,
-  }) {
-    throw UnimplementedError();
-  }
 }

--- a/bridge/app/test/bridge/runtime/plugin_generation_factory_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_generation_factory_test.dart
@@ -6,12 +6,13 @@ import "package:sesori_bridge/src/server/api/runtime_file_api.dart";
 import "package:sesori_bridge/src/server/foundation/process_match.dart";
 import "package:sesori_bridge/src/server/host/plugin_state_directory.dart";
 import "package:sesori_bridge/src/server/models/bridge_startup_lock.dart";
-import "package:sesori_bridge/src/server/repositories/process_repository.dart";
 import "package:sesori_bridge/src/server/repositories/startup_mutex_repository.dart";
 import "package:sesori_bridge/src/server/services/bridge_instance_service.dart";
 import "package:sesori_bridge/src/updater/models/managed_runtime_paths.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
+
+import "../../helpers/fake_process_repository.dart";
 
 // The plugin-specific start flows (managed start, attach mode, ownership
 // records) live with OpenCodePluginDescriptor in sesori_plugin_opencode;
@@ -482,19 +483,7 @@ class _FakeBridgePluginApi() extends NativeProjectsPluginApi {
 
 /// Never invoked in these tests: the host's process service is constructed
 /// but the fake descriptor short-circuits before any process work.
-class _FakeProcessRepository() implements ProcessRepository {
-  @override
-  Future<int> startDetached({
-    required String executable,
-    required List<String> arguments,
-    Map<String, String>? environment,
-  }) async {
-    throw UnimplementedError();
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
+class _FakeProcessRepository() extends StrictFakeProcessRepository;
 
 class _FakeStartupMutexRepository() implements StartupMutexRepository {
   bool rejectLock = false;

--- a/bridge/app/test/bridge/services/pending_interaction_service_test.dart
+++ b/bridge/app/test/bridge/services/pending_interaction_service_test.dart
@@ -1,6 +1,5 @@
 import "dart:async";
 
-import "package:sesori_bridge/src/api/bridge_settings_api.dart";
 import "package:sesori_bridge/src/repositories/bridge_settings_repository.dart";
 import "package:sesori_bridge/src/repositories/models/session_operation.dart";
 import "package:sesori_bridge/src/repositories/models/stored_session.dart";
@@ -13,6 +12,8 @@ import "package:sesori_bridge/src/services/permission_auto_approval_service.dart
 import "package:sesori_bridge/src/services/session_operation_dispatcher.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
+
+import "../../helpers/in_memory_bridge_settings_api.dart";
 
 void main() {
   group("PendingInteractionService", () {
@@ -31,7 +32,9 @@ void main() {
       });
       permissionRepository = _PermissionRepository();
       questionRepository = _QuestionRepository();
-      settingsRepository = BridgeSettingsRepository(api: _BridgeSettingsApi());
+      settingsRepository = BridgeSettingsRepository(
+        api: InMemoryBridgeSettingsApi(config: '{"yolo":true,"pullRequestRefreshIntervalSeconds":30}'),
+      );
       await settingsRepository.loadSettings();
       dispatcher = SessionOperationDispatcher(sessionRepository: sessionRepository);
       service = PendingInteractionService(
@@ -307,19 +310,4 @@ class _QuestionRepository() implements QuestionRepository {
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-class _BridgeSettingsApi() implements BridgeSettingsApi {
-  String config = '{"yolo":true,"pullRequestRefreshIntervalSeconds":30}';
-
-  @override
-  String get configFilePath => "/tmp/config.json";
-
-  @override
-  Future<String?> readConfig() async => config;
-
-  @override
-  Future<void> writeConfig(String jsonContent) async {
-    config = jsonContent;
-  }
 }

--- a/bridge/app/test/bridge/services/session_creation_service_test.dart
+++ b/bridge/app/test/bridge/services/session_creation_service_test.dart
@@ -3,7 +3,6 @@ import "dart:io";
 
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/api/git_cli_api.dart";
-import "package:sesori_bridge/src/foundation/process_runner.dart";
 import "package:sesori_bridge/src/repositories/models/project_not_found_exception.dart";
 import "package:sesori_bridge/src/repositories/session_metadata_repository.dart";
 import "package:sesori_bridge/src/repositories/session_unseen_calculator.dart";
@@ -16,6 +15,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fake_process_runner.dart";
 import "../../helpers/plugin_runtime_test_support.dart";
 import "../../helpers/test_database.dart";
 
@@ -39,7 +39,7 @@ void main() {
           projectsDao: db.projectsDao,
           sessionDao: db.sessionDao,
           gitApi: GitCliApi(
-            processRunner: _NoopProcessRunner(),
+            processRunner: NoopProcessRunner(),
             gitPathExists: ({required String gitPath}) => true,
           ),
           plugin: plugin,
@@ -770,26 +770,4 @@ class _FakePlugin() implements NativeProjectsPluginApi {
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-class _NoopProcessRunner() implements ProcessRunner {
-  @override
-  Future<int> startDetached({
-    required String executable,
-    required List<String> arguments,
-    Map<String, String>? environment,
-  }) async {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<ProcessResult> run(
-    String executable,
-    List<String> arguments, {
-    Map<String, String>? environment,
-    String? workingDirectory,
-    Duration timeout = const Duration(seconds: 15),
-  }) {
-    throw UnimplementedError("_NoopProcessRunner should never execute git commands");
-  }
 }

--- a/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
+++ b/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
@@ -2,9 +2,7 @@ import "dart:io";
 
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/api/filesystem_api.dart";
-import "package:sesori_bridge/src/api/git_cli_api.dart";
 import "package:sesori_bridge/src/foundation/filesystem_permission_validator.dart";
-import "package:sesori_bridge/src/foundation/process_runner.dart";
 import "package:sesori_bridge/src/repositories/filesystem_repository.dart";
 import "package:sesori_bridge/src/repositories/models/session_operation.dart";
 import "package:sesori_bridge/src/repositories/models/stored_session.dart";
@@ -20,6 +18,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fakes/deletion_worktree_service_fake.dart";
 import "../../helpers/fakes/fake_bridge_plugin.dart";
 import "../../helpers/test_chat_history.dart";
 import "../../helpers/test_database.dart";
@@ -27,14 +26,14 @@ import "../../helpers/test_database.dart";
 void main() {
   group("SessionLifecycleService cleanup", () {
     late AppDatabase db;
-    late _FakeWorktreeService worktreeService;
+    late DeletionWorktreeServiceFake worktreeService;
     late _FakeSessionRepository sessionRepository;
     late SessionOperationDispatcher operationDispatcher;
     late SessionLifecycleService service;
 
     setUp(() {
       db = createTestDatabase();
-      worktreeService = _FakeWorktreeService(database: db);
+      worktreeService = DeletionWorktreeServiceFake();
       sessionRepository = _FakeSessionRepository();
       operationDispatcher = SessionOperationDispatcher(sessionRepository: sessionRepository);
       service = SessionLifecycleService(
@@ -313,7 +312,7 @@ void main() {
       );
       operationDispatcher = SessionOperationDispatcher(sessionRepository: repository);
       service = SessionLifecycleService(
-        worktreeService: _FakeWorktreeService(database: db),
+        worktreeService: DeletionWorktreeServiceFake(),
         sessionRepository: repository,
         filesystemRepository: FilesystemRepository(
           filesystemApi: const FilesystemApi(),
@@ -513,51 +512,6 @@ class _FakeSessionRepository() implements SessionRepository {
   Future<String> resolveProjectDirectory({required String projectId}) async => projectId;
 }
 
-class _FakeWorktreeService({required AppDatabase database}) extends WorktreeService {
-  WorktreeSafetyResult safetyResult = WorktreeSafe();
-  bool removeResult = true;
-
-  int checkCallCount = 0;
-  int removeCallCount = 0;
-
-  String? lastRemoveWorktreePath;
-  bool? lastRemoveForce;
-
-  this
-    : super(
-        worktreeRepository: singlePluginWorktreeRepository(
-          projectsDao: database.projectsDao,
-          sessionDao: database.sessionDao,
-          gitApi: GitCliApi(
-            processRunner: _NoopProcessRunner(),
-            gitPathExists: ({required String gitPath}) => true,
-          ),
-          plugin: _FakeBridgePlugin(),
-        ),
-      );
-
-  @override
-  Future<WorktreeSafetyResult> checkWorktreeSafety({
-    required String worktreePath,
-  }) async {
-    checkCallCount++;
-    return safetyResult;
-  }
-
-  @override
-  Future<bool> removeWorktree({
-    required String pluginId,
-    required String projectId,
-    required String worktreePath,
-    required bool force,
-  }) async {
-    removeCallCount++;
-    lastRemoveWorktreePath = worktreePath;
-    lastRemoveForce = force;
-    return removeResult;
-  }
-}
-
 class _FakeBridgePlugin() extends FakeBridgePlugin {
   String? get lastArchivedSessionId => lastArchiveSessionId;
 
@@ -580,26 +534,4 @@ class _FakeBridgePlugin() extends FakeBridgePlugin {
 
   @override
   Future<PluginProject> getProject(String projectId) => throw UnimplementedError();
-}
-
-class _NoopProcessRunner() implements ProcessRunner {
-  @override
-  Future<int> startDetached({
-    required String executable,
-    required List<String> arguments,
-    Map<String, String>? environment,
-  }) async {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<ProcessResult> run(
-    String executable,
-    List<String> arguments, {
-    Map<String, String>? environment,
-    String? workingDirectory,
-    Duration timeout = const Duration(seconds: 15),
-  }) {
-    throw UnimplementedError("_NoopProcessRunner should never execute git commands");
-  }
 }

--- a/bridge/app/test/control/control_provision_notifier_test.dart
+++ b/bridge/app/test/control/control_provision_notifier_test.dart
@@ -1,18 +1,17 @@
-import "dart:async";
-
 import "package:sesori_bridge/src/control/control_provision_notifier.dart";
-import "package:sesori_bridge/src/foundation/control_channel_client.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../helpers/fake_control_channel_client.dart";
+
 void main() {
   group("ControlProvisionNotifier", () {
-    late _FakeControlChannelClient client;
+    late FakeControlChannelClient client;
     late ControlProvisionNotifier notifier;
 
     setUp(() {
-      client = _FakeControlChannelClient();
+      client = FakeControlChannelClient();
       notifier = ControlProvisionNotifier(client: client);
     });
 
@@ -206,42 +205,5 @@ void main() {
   });
 }
 
-Iterable<ControlProvisionProgress> _sentProgress(_FakeControlChannelClient client) =>
+Iterable<ControlProvisionProgress> _sentProgress(FakeControlChannelClient client) =>
     client.sentMessages.map((message) => (message as ControlProvisionProgressMessage).progress);
-
-class _FakeControlChannelClient() implements ControlChannelClient {
-  final List<String> sentFrames = <String>[];
-
-  /// Mimics [ControlChannelClient.send] throwing when the channel is down.
-  bool throwOnSend = false;
-
-  /// An arbitrary send failure (exercises the catch-all path).
-  Object? sendError;
-
-  List<ControlMessage> get sentMessages =>
-      sentFrames.map((frame) => ControlMessage.fromJson(jsonDecodeMap(frame))).toList();
-
-  @override
-  Stream<String> get inbound => const Stream<String>.empty();
-
-  @override
-  Stream<ControlChannelConnectionState> get connectionState => const Stream<ControlChannelConnectionState>.empty();
-
-  @override
-  void send(String frame) {
-    if (throwOnSend) {
-      throw const ControlChannelNotConnectedException("Control channel is not connected");
-    }
-    final error = sendError;
-    if (error != null) {
-      throw error;
-    }
-    sentFrames.add(frame);
-  }
-
-  @override
-  Future<void> connect() async {}
-
-  @override
-  Future<void> dispose() async {}
-}

--- a/bridge/app/test/control/control_status_notifier_test.dart
+++ b/bridge/app/test/control/control_status_notifier_test.dart
@@ -1,20 +1,22 @@
 import "dart:async";
 
 import "package:sesori_bridge/src/control/control_status_notifier.dart";
-import "package:sesori_bridge/src/foundation/control_channel_client.dart";
+import "package:sesori_bridge/src/foundation/control_channel_client.dart" show ControlChannelConnectionState;
 import "package:sesori_bridge/src/foundation/relay_client.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../helpers/fake_control_channel_client.dart";
+
 void main() {
-  late _FakeControlChannelClient client;
+  late FakeControlChannelClient client;
   late StreamController<List<PluginMetadata>> pluginMetadata;
   late StreamController<RelayConnectionState> relayState;
   late StreamController<String> registrations;
   late ControlStatusNotifier notifier;
 
   setUp(() {
-    client = _FakeControlChannelClient();
+    client = FakeControlChannelClient();
     pluginMetadata = StreamController<List<PluginMetadata>>.broadcast();
     relayState = StreamController<RelayConnectionState>.broadcast();
     registrations = StreamController<String>.broadcast();
@@ -174,15 +176,13 @@ void main() {
 
     test("the count sums active sessions across projects", () async {
       notifier.handleProjectsSummary(
-        summary:
-            SesoriSseEvent.projectsSummary(
-                  projects: [
-                    ProjectActivitySummary(id: "p1", activeSessions: [_session("a"), _session("b")]),
-                    ProjectActivitySummary(id: "p2", activeSessions: [_session("c")]),
-                    const ProjectActivitySummary(id: "p3", activeSessions: []),
-                  ],
-                )
-                as SesoriProjectsSummary,
+        summary: SesoriSseEvent.projectsSummary(
+          projects: [
+            ProjectActivitySummary(id: "p1", activeSessions: [_session("a"), _session("b")]),
+            ProjectActivitySummary(id: "p2", activeSessions: [_session("c")]),
+            const ProjectActivitySummary(id: "p3", activeSessions: []),
+          ],
+        ) as SesoriProjectsSummary,
       );
       await pump();
 
@@ -285,48 +285,11 @@ ActiveSession _session(String id) => ActiveSession(id: id, lastUserActivityAt: n
 
 SesoriProjectsSummary _summaryWithSessionCount(int count) {
   return SesoriSseEvent.projectsSummary(
-        projects: [
-          ProjectActivitySummary(
-            id: "project-1",
-            activeSessions: List<ActiveSession>.generate(count, (i) => _session("session-$i")),
-          ),
-        ],
-      )
-      as SesoriProjectsSummary;
-}
-
-class _FakeControlChannelClient() implements ControlChannelClient {
-  final StreamController<ControlChannelConnectionState> _connectionState =
-      StreamController<ControlChannelConnectionState>.broadcast();
-  final List<String> sentFrames = <String>[];
-
-  /// Mimics [ControlChannelClient.send] throwing when the channel is down.
-  bool throwOnSend = false;
-
-  List<ControlMessage> get sentMessages =>
-      sentFrames.map((frame) => ControlMessage.fromJson(jsonDecodeMap(frame))).toList();
-
-  void emitConnectionState(ControlChannelConnectionState state) => _connectionState.add(state);
-
-  @override
-  Stream<String> get inbound => const Stream<String>.empty();
-
-  @override
-  Stream<ControlChannelConnectionState> get connectionState => _connectionState.stream;
-
-  @override
-  void send(String frame) {
-    if (throwOnSend) {
-      throw const ControlChannelNotConnectedException("Control channel is not connected");
-    }
-    sentFrames.add(frame);
-  }
-
-  @override
-  Future<void> connect() async {}
-
-  @override
-  Future<void> dispose() async {
-    await _connectionState.close();
-  }
+    projects: [
+      ProjectActivitySummary(
+        id: "project-1",
+        activeSessions: List<ActiveSession>.generate(count, (i) => _session("session-$i")),
+      ),
+    ],
+  ) as SesoriProjectsSummary;
 }

--- a/bridge/app/test/helpers/fake_control_channel_client.dart
+++ b/bridge/app/test/helpers/fake_control_channel_client.dart
@@ -1,0 +1,53 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/foundation/control_channel_client.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+class FakeControlChannelClient() implements ControlChannelClient {
+  this {
+    addTearDown(dispose);
+  }
+
+  final StreamController<String> _inbound = StreamController<String>.broadcast();
+  final StreamController<ControlChannelConnectionState> _connectionState =
+      StreamController<ControlChannelConnectionState>.broadcast();
+  final List<String> sentFrames = [];
+  bool throwOnSend = false;
+  Object? sendError;
+  bool _disposed = false;
+
+  List<ControlMessage> get sentMessages =>
+      sentFrames.map((frame) => ControlMessage.fromJson(jsonDecodeMap(frame))).toList();
+
+  void emit(String frame) => _inbound.add(frame);
+
+  void emitConnectionState(ControlChannelConnectionState state) => _connectionState.add(state);
+
+  @override
+  Stream<String> get inbound => _inbound.stream;
+
+  @override
+  Stream<ControlChannelConnectionState> get connectionState => _connectionState.stream;
+
+  @override
+  void send(String frame) {
+    if (throwOnSend) {
+      throw const ControlChannelNotConnectedException("Control channel is not connected");
+    }
+    final error = sendError;
+    if (error != null) throw error;
+    sentFrames.add(frame);
+  }
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await _inbound.close();
+    await _connectionState.close();
+  }
+}

--- a/bridge/app/test/helpers/fake_process_repository.dart
+++ b/bridge/app/test/helpers/fake_process_repository.dart
@@ -1,0 +1,34 @@
+import "package:sesori_bridge/src/server/foundation/process_match.dart";
+import "package:sesori_bridge/src/server/repositories/process_repository.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+class StrictFakeProcessRepository() implements ProcessRepository {
+  @override
+  Future<int> startDetached({
+    required String executable,
+    required List<String> arguments,
+    Map<String, String>? environment,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<ProcessIdentity?> inspectProcess({required int pid}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<ProcessMatch?> inspectProcessMatch({required int pid}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<SignalResult> sendGracefulSignal({required int pid}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<SignalResult> sendForceSignal({required int pid}) {
+    throw UnimplementedError();
+  }
+}

--- a/bridge/app/test/helpers/fake_process_runner.dart
+++ b/bridge/app/test/helpers/fake_process_runner.dart
@@ -1,0 +1,98 @@
+import "dart:async";
+import "dart:io";
+
+import "package:sesori_bridge/src/foundation/process_runner.dart";
+
+typedef ProcessResponder = FutureOr<ProcessResult> Function(
+  String executable,
+  List<String> arguments, {
+  Map<String, String>? environment,
+  String? workingDirectory,
+  Duration timeout,
+});
+
+class NoopProcessRunner() implements ProcessRunner {
+  @override
+  Future<ProcessResult> run(
+    String executable,
+    List<String> arguments, {
+    Map<String, String>? environment,
+    String? workingDirectory,
+    Duration timeout = const Duration(seconds: 15),
+  }) async {
+    throw UnimplementedError("NoopProcessRunner must not run processes");
+  }
+
+  @override
+  Future<int> startDetached({
+    required String executable,
+    required List<String> arguments,
+    Map<String, String>? environment,
+  }) async {
+    throw UnimplementedError("NoopProcessRunner must not start processes");
+  }
+}
+
+class const ProcessRunInvocation({
+  required final String executable,
+  required final List<String> arguments,
+  required final Map<String, String>? environment,
+  required final String? workingDirectory,
+  required final Duration timeout,
+});
+
+final class RecordingProcessRunner({
+  ProcessResponder? responder,
+  ProcessResult? result,
+  int exitCode = 0,
+  String stdout = "",
+  String stderr = "",
+}) implements ProcessRunner {
+  final ProcessResponder _responder =
+      responder ??
+      ((_, _, {environment, workingDirectory, timeout = const Duration(seconds: 15)}) {
+        return result ?? ProcessResult(1, exitCode, stdout, stderr);
+      });
+  final List<ProcessRunInvocation> invocations = <ProcessRunInvocation>[];
+
+  List<ProcessRunInvocation> get calls => invocations;
+  String? get executable => invocations.lastOrNull?.executable;
+  List<String>? get arguments => invocations.lastOrNull?.arguments;
+  Map<String, String>? get environment => invocations.lastOrNull?.environment;
+  String? get workingDirectory => invocations.lastOrNull?.workingDirectory;
+
+  @override
+  Future<ProcessResult> run(
+    String executable,
+    List<String> arguments, {
+    Map<String, String>? environment,
+    String? workingDirectory,
+    Duration timeout = const Duration(seconds: 15),
+  }) async {
+    invocations.add(
+      ProcessRunInvocation(
+        executable: executable,
+        arguments: List<String>.from(arguments),
+        environment: environment == null ? null : Map<String, String>.from(environment),
+        workingDirectory: workingDirectory,
+        timeout: timeout,
+      ),
+    );
+    return await _responder(
+      executable,
+      arguments,
+      environment: environment,
+      workingDirectory: workingDirectory,
+      timeout: timeout,
+    );
+  }
+
+  @override
+  Future<int> startDetached({
+    required String executable,
+    required List<String> arguments,
+    Map<String, String>? environment,
+  }) async {
+    throw UnimplementedError("RecordingProcessRunner only records run calls");
+  }
+}

--- a/bridge/app/test/helpers/fakes/deletion_worktree_service_fake.dart
+++ b/bridge/app/test/helpers/fakes/deletion_worktree_service_fake.dart
@@ -1,0 +1,44 @@
+import "package:sesori_bridge/src/services/worktree_service.dart";
+
+class DeletionWorktreeServiceFake({final List<String>? operationLog}) implements WorktreeService {
+  WorktreeSafetyResult safetyResult = WorktreeSafe();
+  bool removeResult = true;
+  bool branchExistsResult = true;
+
+  int checkCallCount = 0;
+  int removeCallCount = 0;
+
+  String? lastCheckWorktreePath;
+  String? lastRemoveProjectId;
+  String? lastRemoveWorktreePath;
+  bool? lastRemoveForce;
+
+  @override
+  Future<WorktreeSafetyResult> checkWorktreeSafety({required String worktreePath}) async {
+    checkCallCount++;
+    operationLog?.add("checkSafety");
+    lastCheckWorktreePath = worktreePath;
+    return safetyResult;
+  }
+
+  @override
+  Future<bool> removeWorktree({
+    required String pluginId,
+    required String projectId,
+    required String worktreePath,
+    required bool force,
+  }) async {
+    removeCallCount++;
+    operationLog?.add("removeWorktree");
+    lastRemoveProjectId = projectId;
+    lastRemoveWorktreePath = worktreePath;
+    lastRemoveForce = force;
+    return removeResult;
+  }
+
+  @override
+  Future<bool> branchExists({required String projectId, required String branchName}) async => branchExistsResult;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/helpers/in_memory_bridge_settings_api.dart
+++ b/bridge/app/test/helpers/in_memory_bridge_settings_api.dart
@@ -1,0 +1,26 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/api/bridge_settings_api.dart";
+
+class InMemoryBridgeSettingsApi({
+  required var String? config,
+  @override final String configFilePath = "/tmp/config.json",
+}) implements BridgeSettingsApi {
+  int writeCount = 0;
+  Completer<void>? writeStarted;
+  Completer<void>? releaseWrite;
+
+  String? get lastWrittenConfig => writeCount == 0 ? null : config;
+
+  @override
+  Future<String?> readConfig() async => config;
+
+  @override
+  Future<void> writeConfig(String jsonContent) async {
+    writeStarted?.complete();
+    final release = releaseWrite;
+    if (release != null) await release.future;
+    config = jsonContent;
+    writeCount++;
+  }
+}

--- a/bridge/app/test/helpers/restart_test_support.dart
+++ b/bridge/app/test/helpers/restart_test_support.dart
@@ -1,35 +1,12 @@
-import 'dart:io';
-
-import 'package:sesori_bridge/src/foundation/process_runner.dart';
 import 'package:sesori_bridge/src/server/api/system_process_api.dart';
 import 'package:sesori_bridge/src/server/foundation/bridge_restart_command_builder.dart';
 import 'package:sesori_bridge/src/server/repositories/process_repository.dart';
 import 'package:sesori_bridge/src/server/services/bridge_restart_service.dart';
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show ServerClock;
 
-/// A [ProcessRunner] that fails fast if used — restart is never actually
-/// triggered in these tests, so the runner must stay untouched.
-class NoopProcessRunner() implements ProcessRunner {
-  @override
-  Future<ProcessResult> run(
-    String executable,
-    List<String> arguments, {
-    Map<String, String>? environment,
-    String? workingDirectory,
-    Duration timeout = const Duration(seconds: 15),
-  }) async {
-    throw UnimplementedError();
-  }
+import 'fake_process_runner.dart';
 
-  @override
-  Future<int> startDetached({
-    required String executable,
-    required List<String> arguments,
-    Map<String, String>? environment,
-  }) async {
-    throw UnimplementedError();
-  }
-}
+export 'fake_process_runner.dart' show NoopProcessRunner;
 
 /// Builds an inert [BridgeRestartService] for wiring tests that construct an
 /// `Orchestrator`/`BridgeRuntime` but never exercise the restart path.

--- a/bridge/app/test/helpers/test_helpers.dart
+++ b/bridge/app/test/helpers/test_helpers.dart
@@ -29,9 +29,16 @@ class FakeBridgeIdProvider([var String? id]) implements BridgeIdProvider {
   String? get bridgeId => id;
 }
 
-class FakeTokenRefresher() implements TokenRefresher {
+class FakeTokenRefresher({String token = "test-token", String? refreshedToken}) implements TokenRefresher {
+  final String _token = token;
+  final String? _refreshedToken = refreshedToken;
+  final List<bool> forceRefreshValues = [];
+
   @override
-  Future<String> getAccessToken({bool forceRefresh = false}) async => "test-token";
+  Future<String> getAccessToken({bool forceRefresh = false}) async {
+    forceRefreshValues.add(forceRefresh);
+    return forceRefresh ? _refreshedToken ?? _token : _token;
+  }
 }
 
 /// In-memory [BridgeIdStorage] substitute for [BridgeRegistrationService] tests.

--- a/bridge/app/test/push/push_dispatcher_test.dart
+++ b/bridge/app/test/push/push_dispatcher_test.dart
@@ -2,7 +2,6 @@ import "dart:io";
 
 import "package:fake_async/fake_async.dart";
 import "package:http/http.dart" as http;
-import "package:sesori_bridge/src/auth/token_refresher.dart";
 import "package:sesori_bridge/src/push/completion_notifier.dart";
 import "package:sesori_bridge/src/push/completion_push_listener.dart";
 import "package:sesori_bridge/src/push/maintenance_push_listener.dart";
@@ -16,6 +15,8 @@ import "package:sesori_bridge/src/push/push_session_state_tracker_types.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, LogLevel;
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
+
+import "../helpers/test_helpers.dart";
 
 void main() {
   group("PushDispatcher", () {
@@ -578,7 +579,7 @@ class FakePushNotificationClient() extends PushNotificationClient {
   this
     : super(
         authBackendURL: "https://example.com",
-        tokenRefreshManager: _FakeTokenRefresher(),
+        tokenRefreshManager: FakeTokenRefresher(token: "token"),
         client: http.Client(),
       );
 
@@ -604,13 +605,6 @@ class FakePushRateLimiter({var bool shouldAllowSend = true, super.now}) extends 
       sessionId: sessionId,
       rateLimitKey: rateLimitKey,
     );
-  }
-}
-
-class _FakeTokenRefresher() implements TokenRefresher {
-  @override
-  Future<String> getAccessToken({bool forceRefresh = false}) async {
-    return "token";
   }
 }
 

--- a/bridge/app/test/routing/bridge_settings_handlers_test.dart
+++ b/bridge/app/test/routing/bridge_settings_handlers_test.dart
@@ -1,6 +1,5 @@
 import "dart:convert";
 
-import "package:sesori_bridge/src/api/bridge_settings_api.dart";
 import "package:sesori_bridge/src/repositories/bridge_settings_repository.dart";
 import "package:sesori_bridge/src/routing/get_bridge_settings_handler.dart";
 import "package:sesori_bridge/src/routing/patch_bridge_settings_handler.dart";
@@ -11,16 +10,17 @@ import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
 import "../bridge/routing/routing_test_helpers.dart";
+import "../helpers/in_memory_bridge_settings_api.dart";
 
 void main() {
   group("bridge settings handlers", () {
-    late _MemoryBridgeSettingsApi api;
+    late InMemoryBridgeSettingsApi api;
     late BridgeSettingsRepository repository;
     late YoloSettingsService service;
     late PatchBridgeSettingsHandler patchHandler;
 
     setUp(() async {
-      api = _MemoryBridgeSettingsApi();
+      api = InMemoryBridgeSettingsApi(config: '{"yolo":false,"pullRequestRefreshIntervalSeconds":30}');
       repository = BridgeSettingsRepository(api: api);
       await repository.loadSettings();
       service = YoloSettingsService(
@@ -73,17 +73,4 @@ class _FakePermissionAutoApprovalService() implements PermissionAutoApprovalServ
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-class _MemoryBridgeSettingsApi() implements BridgeSettingsApi {
-  String? config = '{"yolo":false,"pullRequestRefreshIntervalSeconds":30}';
-
-  @override
-  String get configFilePath => "/tmp/config.json";
-
-  @override
-  Future<String?> readConfig() async => config;
-
-  @override
-  Future<void> writeConfig(String jsonContent) async => config = jsonContent;
 }

--- a/bridge/app/test/routing/pull_request_refresh_settings_handlers_test.dart
+++ b/bridge/app/test/routing/pull_request_refresh_settings_handlers_test.dart
@@ -1,6 +1,5 @@
 import "dart:convert";
 
-import "package:sesori_bridge/src/api/bridge_settings_api.dart";
 import "package:sesori_bridge/src/repositories/bridge_settings_repository.dart";
 import "package:sesori_bridge/src/routing/get_pull_request_refresh_settings_handler.dart";
 import "package:sesori_bridge/src/routing/patch_bridge_settings_handler.dart";
@@ -12,16 +11,17 @@ import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
 import "../bridge/routing/routing_test_helpers.dart";
+import "../helpers/in_memory_bridge_settings_api.dart";
 
 void main() {
   group("pull request refresh settings handlers", () {
-    late _MemoryBridgeSettingsApi api;
+    late InMemoryBridgeSettingsApi api;
     late BridgeSettingsRepository repository;
     late PullRequestRefreshSettingsService service;
     late YoloSettingsService yoloService;
 
     setUp(() async {
-      api = _MemoryBridgeSettingsApi();
+      api = InMemoryBridgeSettingsApi(config: '{"pullRequestRefreshIntervalSeconds":30}');
       repository = BridgeSettingsRepository(api: api);
       await repository.loadSettings();
       service = PullRequestRefreshSettingsService(bridgeSettingsRepository: repository);
@@ -162,21 +162,4 @@ class _FakePermissionAutoApprovalService() implements PermissionAutoApprovalServ
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-class _MemoryBridgeSettingsApi() implements BridgeSettingsApi {
-  String? config = '{"pullRequestRefreshIntervalSeconds":30}';
-  int writeCount = 0;
-
-  @override
-  String get configFilePath => "/tmp/config.json";
-
-  @override
-  Future<String?> readConfig() async => config;
-
-  @override
-  Future<void> writeConfig(String jsonContent) async {
-    config = jsonContent;
-    writeCount++;
-  }
 }

--- a/bridge/app/test/server/api/process_id_lookup_api_test.dart
+++ b/bridge/app/test/server/api/process_id_lookup_api_test.dart
@@ -1,14 +1,14 @@
-import "dart:async";
 import "dart:io";
 
-import "package:sesori_bridge/src/foundation/process_runner.dart";
 import "package:sesori_bridge/src/server/api/process_id_lookup_api.dart";
 import "package:test/test.dart";
+
+import "../../helpers/fake_process_runner.dart";
 
 void main() {
   group("ProcessIdLookupApi (POSIX)", () {
     test("exact-matches the executable name and parses process ids", () async {
-      final runner = _RecordingProcessRunner(stdout: "123\n456\n");
+      final runner = RecordingProcessRunner(stdout: "123\n456\n");
       final api = ProcessIdLookupApi.forPlatform(
         isWindows: false,
         processRunner: runner,
@@ -27,7 +27,7 @@ void main() {
     test("returns an empty list when pgrep finds no matches", () async {
       final api = ProcessIdLookupApi.forPlatform(
         isWindows: false,
-        processRunner: _RecordingProcessRunner(exitCode: 1),
+        processRunner: RecordingProcessRunner(exitCode: 1),
       );
 
       expect(
@@ -39,7 +39,7 @@ void main() {
     test("throws when pgrep fails", () async {
       final api = ProcessIdLookupApi.forPlatform(
         isWindows: false,
-        processRunner: _RecordingProcessRunner(
+        processRunner: RecordingProcessRunner(
           exitCode: 2,
           stderr: "invalid pattern",
         ),
@@ -55,7 +55,7 @@ void main() {
       for (final stdout in <String>["not-a-pid\n", "0\n", "-1\n"]) {
         final api = ProcessIdLookupApi.forPlatform(
           isWindows: false,
-          processRunner: _RecordingProcessRunner(stdout: stdout),
+          processRunner: RecordingProcessRunner(stdout: stdout),
         );
 
         await expectLater(
@@ -68,7 +68,7 @@ void main() {
 
   group("ProcessIdLookupApi (Windows)", () {
     test("filters tasklist by image name and parses process ids", () async {
-      final runner = _RecordingProcessRunner(
+      final runner = RecordingProcessRunner(
         stdout:
             '"sesori-bridge.exe","321","Console","1","12,345 K"\r\n'
             '"sesori-bridge.exe","654","Console","1","98,765 K"\r\n',
@@ -100,7 +100,7 @@ void main() {
     test("returns an empty list when tasklist finds no matches", () async {
       final api = ProcessIdLookupApi.forPlatform(
         isWindows: true,
-        processRunner: _RecordingProcessRunner(
+        processRunner: RecordingProcessRunner(
           stdout: "INFO: No tasks are running which match the specified criteria.\r\n",
         ),
       );
@@ -114,7 +114,7 @@ void main() {
     test("ignores malformed tasklist rows", () async {
       final api = ProcessIdLookupApi.forPlatform(
         isWindows: true,
-        processRunner: _RecordingProcessRunner(
+        processRunner: RecordingProcessRunner(
           stdout:
               '"sesori-bridge.exe","not-a-pid"\r\n'
               '"sesori-bridge.exe","0"\r\n',
@@ -130,7 +130,7 @@ void main() {
     test("throws when tasklist fails", () async {
       final api = ProcessIdLookupApi.forPlatform(
         isWindows: true,
-        processRunner: _RecordingProcessRunner(exitCode: 1, stderr: "boom"),
+        processRunner: RecordingProcessRunner(exitCode: 1, stderr: "boom"),
       );
 
       await expectLater(
@@ -139,34 +139,4 @@ void main() {
       );
     });
   });
-}
-
-class _RecordingProcessRunner({final int exitCode = 0, final String stdout = "", final String stderr = ""})
-    implements ProcessRunner {
-  String? executable;
-  List<String>? arguments;
-  Map<String, String>? environment;
-
-  @override
-  Future<ProcessResult> run(
-    String executable,
-    List<String> arguments, {
-    String? workingDirectory,
-    Map<String, String>? environment,
-    Duration timeout = const Duration(seconds: 15),
-  }) async {
-    this.executable = executable;
-    this.arguments = arguments;
-    this.environment = environment;
-    return ProcessResult(1, exitCode, stdout, stderr);
-  }
-
-  @override
-  Future<int> startDetached({
-    required String executable,
-    required List<String> arguments,
-    Map<String, String>? environment,
-  }) {
-    throw UnimplementedError();
-  }
 }

--- a/bridge/app/test/server/api/system_process_api_test.dart
+++ b/bridge/app/test/server/api/system_process_api_test.dart
@@ -1,14 +1,15 @@
 import "dart:io";
 
-import "package:sesori_bridge/src/foundation/process_runner.dart";
 import "package:sesori_bridge/src/server/api/system_process_api.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fake_process_runner.dart";
+
 void main() {
   group("SystemProcessApi (Windows)", () {
     test("inspectProcess issues a PID-scoped tasklist filter", () async {
-      final runner = _RecordingProcessRunner(
+      final runner = RecordingProcessRunner(
         stdout: '"sesori-bridge.exe","321","Console","1","12,345 K","Running","HOST\\alex","0:00:01","N/A"\r\n',
       );
       final api = SystemProcessApi(
@@ -34,7 +35,7 @@ void main() {
     });
 
     test("inspectProcess returns null when tasklist reports no matching task", () async {
-      final runner = _RecordingProcessRunner(
+      final runner = RecordingProcessRunner(
         stdout: "INFO: No tasks are running which match the specified criteria.\r\n",
       );
       final api = SystemProcessApi(
@@ -51,7 +52,7 @@ void main() {
     });
 
     test("inspectProcess throws on non-zero tasklist exit", () async {
-      final runner = _RecordingProcessRunner(exitCode: 1, stderr: "boom");
+      final runner = RecordingProcessRunner(exitCode: 1, stderr: "boom");
       final api = SystemProcessApi(
         processRunner: runner,
         clock: const ServerClock(),
@@ -66,7 +67,7 @@ void main() {
     });
 
     test("inspectProcess returns null for a non-positive PID without shelling out", () async {
-      final runner = _RecordingProcessRunner();
+      final runner = RecordingProcessRunner();
       final api = SystemProcessApi(
         processRunner: runner,
         clock: const ServerClock(),
@@ -82,7 +83,7 @@ void main() {
 
   group("SystemProcessApi (POSIX)", () {
     test("inspectProcess issues a PID-scoped ps query and parses one identity", () async {
-      final runner = _RecordingProcessRunner(
+      final runner = RecordingProcessRunner(
         stdout: "  321 alex     Mon Jun 22 09:15:01 2026 /usr/local/bin/sesori-bridge --relay wss://relay\n",
       );
       final api = SystemProcessApi(
@@ -116,7 +117,7 @@ void main() {
     test("inspectProcess returns null (without throwing) when ps exits non-zero with no stderr", () async {
       // A vanished pid: `ps -p` exits non-zero with empty stdout AND empty
       // stderr. That is the legitimate "no such process" signal.
-      final runner = _RecordingProcessRunner(exitCode: 1, stdout: "", stderr: "");
+      final runner = RecordingProcessRunner(exitCode: 1, stdout: "", stderr: "");
       final api = SystemProcessApi(
         processRunner: runner,
         clock: const ServerClock(),
@@ -135,7 +136,7 @@ void main() {
       // collapsed to null — callers rely on POSIX self-inspection errors
       // staying fatal so the startup lock is never poisoned with a
       // marker-less fallback identity.
-      final runner = _RecordingProcessRunner(exitCode: 1, stdout: "", stderr: "ps: unknown option");
+      final runner = RecordingProcessRunner(exitCode: 1, stdout: "", stderr: "ps: unknown option");
       final api = SystemProcessApi(
         processRunner: runner,
         clock: const ServerClock(),
@@ -150,7 +151,7 @@ void main() {
     });
 
     test("inspectProcess returns null when ps yields no matching row", () async {
-      final runner = _RecordingProcessRunner(stdout: "\n");
+      final runner = RecordingProcessRunner(stdout: "\n");
       final api = SystemProcessApi(
         processRunner: runner,
         clock: const ServerClock(),
@@ -162,7 +163,7 @@ void main() {
     });
 
     test("inspectProcess returns null for a non-positive PID without shelling out", () async {
-      final runner = _RecordingProcessRunner();
+      final runner = RecordingProcessRunner();
       final api = SystemProcessApi(
         processRunner: runner,
         clock: const ServerClock(),
@@ -175,36 +176,4 @@ void main() {
       expect(runner.calls, isEmpty);
     });
   });
-}
-
-class _RecordedCall({
-  required final String executable,
-  required final List<String> arguments,
-  required final Map<String, String>? environment,
-});
-
-class _RecordingProcessRunner({final int exitCode = 0, final String stdout = "", final String stderr = ""})
-    implements ProcessRunner {
-  final List<_RecordedCall> calls = <_RecordedCall>[];
-
-  @override
-  Future<ProcessResult> run(
-    String executable,
-    List<String> arguments, {
-    String? workingDirectory,
-    Map<String, String>? environment,
-    Duration timeout = const Duration(seconds: 15),
-  }) async {
-    calls.add(_RecordedCall(executable: executable, arguments: arguments, environment: environment));
-    return ProcessResult(1, exitCode, stdout, stderr);
-  }
-
-  @override
-  Future<int> startDetached({
-    required String executable,
-    required List<String> arguments,
-    Map<String, String>? environment,
-  }) {
-    throw UnimplementedError();
-  }
 }

--- a/bridge/app/test/server/host/bridge_host_info_impl_test.dart
+++ b/bridge/app/test/server/host/bridge_host_info_impl_test.dart
@@ -1,8 +1,9 @@
 import 'package:sesori_bridge/src/server/foundation/process_match.dart';
 import 'package:sesori_bridge/src/server/host/bridge_host_info_impl.dart';
-import 'package:sesori_bridge/src/server/repositories/process_repository.dart';
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
 import 'package:test/test.dart';
+
+import '../../helpers/fake_process_repository.dart';
 
 void main() {
   group('BridgeHostInfoImpl', () {
@@ -136,35 +137,11 @@ ProcessIdentity _identity({
   );
 }
 
-class _FakeProcessRepository() implements ProcessRepository {
-  @override
-  Future<int> startDetached({
-    required String executable,
-    required List<String> arguments,
-    Map<String, String>? environment,
-  }) async {
-    throw UnimplementedError();
-  }
-
+class _FakeProcessRepository() extends StrictFakeProcessRepository {
   final Map<int, ProcessMatch?> matchResults = <int, ProcessMatch?>{};
 
   @override
   Future<ProcessMatch?> inspectProcessMatch({required int pid}) async {
     return matchResults[pid];
-  }
-
-  @override
-  Future<ProcessIdentity?> inspectProcess({required int pid}) {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<SignalResult> sendGracefulSignal({required int pid}) {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<SignalResult> sendForceSignal({required int pid}) {
-    throw UnimplementedError();
   }
 }

--- a/bridge/app/test/server/host/bridge_host_process_service_test.dart
+++ b/bridge/app/test/server/host/bridge_host_process_service_test.dart
@@ -4,11 +4,12 @@ import 'dart:io';
 
 import 'package:sesori_bridge/src/foundation/process_runner.dart';
 import 'package:sesori_bridge/src/server/api/system_process_api.dart';
-import 'package:sesori_bridge/src/server/foundation/process_match.dart';
 import 'package:sesori_bridge/src/server/host/bridge_host_process_service.dart';
 import 'package:sesori_bridge/src/server/repositories/process_repository.dart';
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
 import 'package:test/test.dart';
+
+import '../../helpers/fake_process_repository.dart';
 
 void main() {
   group('BridgeHostProcessService', () {
@@ -391,16 +392,7 @@ class _FakeServerClock() implements ServerClock {
   Future<void> delay({required Duration duration}) async {}
 }
 
-class _FakeProcessRepository() implements ProcessRepository {
-  @override
-  Future<int> startDetached({
-    required String executable,
-    required List<String> arguments,
-    Map<String, String>? environment,
-  }) async {
-    throw UnimplementedError();
-  }
-
+class _FakeProcessRepository() extends StrictFakeProcessRepository {
   final Map<int, List<ProcessIdentity?>> inspectResults = <int, List<ProcessIdentity?>>{};
   Object? inspectError;
   SignalResult? gracefulResult;
@@ -430,10 +422,5 @@ class _FakeProcessRepository() implements ProcessRepository {
   Future<SignalResult> sendForceSignal({required int pid}) async {
     signalRequests.add('force:$pid');
     return forceResult!;
-  }
-
-  @override
-  Future<ProcessMatch?> inspectProcessMatch({required int pid}) {
-    throw UnimplementedError();
   }
 }

--- a/bridge/app/test/server/services/bridge_instance_service_test.dart
+++ b/bridge/app/test/server/services/bridge_instance_service_test.dart
@@ -1,17 +1,19 @@
 import 'dart:io';
 
-import 'package:sesori_bridge/src/foundation/control_channel_client.dart';
 import 'package:sesori_bridge/src/server/foundation/process_match.dart';
 import 'package:sesori_bridge/src/server/foundation/terminal_prompt_decision.dart';
 import 'package:sesori_bridge/src/server/models/bridge_startup_lock.dart';
 import 'package:sesori_bridge/src/server/repositories/bridge_instance_repository.dart';
-import 'package:sesori_bridge/src/server/repositories/process_repository.dart';
 import 'package:sesori_bridge/src/server/repositories/terminal_prompt_repository.dart';
 import 'package:sesori_bridge/src/server/services/bridge_instance_service.dart';
 import 'package:sesori_bridge/src/services/control_prompt_service.dart';
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
-import 'package:sesori_shared/sesori_shared.dart' show ControlMessage, ControlPromptKind, ControlPromptRequest, jsonDecodeMap;
+import 'package:sesori_shared/sesori_shared.dart'
+    show ControlMessage, ControlPromptKind, ControlPromptRequest, jsonDecodeMap;
 import 'package:test/test.dart';
+
+import '../../helpers/fake_control_channel_client.dart';
+import '../../helpers/fake_process_repository.dart';
 
 void main() {
   group('BridgeInstanceService', () {
@@ -354,7 +356,7 @@ void main() {
     late _FakeBridgeInstanceRepository bridgeInstanceRepository;
     late _FakeProcessRepository processRepository;
     late _FakeServerClock clock;
-    late _FakeControlChannelClient client;
+    late FakeControlChannelClient client;
     late ControlPromptService promptService;
     late BridgeInstanceService service;
 
@@ -362,7 +364,7 @@ void main() {
       bridgeInstanceRepository = _FakeBridgeInstanceRepository();
       processRepository = _FakeProcessRepository();
       clock = _FakeServerClock();
-      client = _FakeControlChannelClient();
+      client = FakeControlChannelClient();
       // A short timeout keeps the unanswered-prompt tests fast; production
       // uses the generous human-scale default.
       promptService = ControlPromptService(
@@ -457,7 +459,8 @@ void main() {
   });
 }
 
-ControlPromptRequest _decodePromptRequest(String frame) => ControlMessage.fromJson(jsonDecodeMap(frame)) as ControlPromptRequest;
+ControlPromptRequest _decodePromptRequest(String frame) =>
+    ControlMessage.fromJson(jsonDecodeMap(frame)) as ControlPromptRequest;
 
 ProcessIdentity _candidate({
   required int pid,
@@ -539,16 +542,7 @@ class _FakeTerminalPromptRepository() implements TerminalPromptRepository {
   }
 }
 
-class _FakeProcessRepository() implements ProcessRepository {
-  @override
-  Future<int> startDetached({
-    required String executable,
-    required List<String> arguments,
-    Map<String, String>? environment,
-  }) async {
-    throw UnimplementedError();
-  }
-
+class _FakeProcessRepository() extends StrictFakeProcessRepository {
   final List<String> signalRequests = <String>[];
   final Map<int, List<ProcessMatch?>> matchSnapshots = <int, List<ProcessMatch?>>{};
   bool throwGraceful = false;
@@ -615,31 +609,4 @@ class _FakeServerClock() implements ServerClock {
   DateTime now() {
     return DateTime.utc(2026, 5, 15, 12);
   }
-}
-
-class _FakeControlChannelClient() implements ControlChannelClient {
-  final List<String> sentFrames = <String>[];
-
-  /// Mimics [ControlChannelClient.send] throwing when the channel is down.
-  bool throwOnSend = false;
-
-  @override
-  Stream<String> get inbound => const Stream<String>.empty();
-
-  @override
-  void send(String frame) {
-    if (throwOnSend) {
-      throw const ControlChannelNotConnectedException('Control channel is not connected');
-    }
-    sentFrames.add(frame);
-  }
-
-  @override
-  Stream<ControlChannelConnectionState> get connectionState => const Stream<ControlChannelConnectionState>.empty();
-
-  @override
-  Future<void> connect() async {}
-
-  @override
-  Future<void> dispose() async {}
 }

--- a/bridge/app/test/server/startup_mutex_repository_test.dart
+++ b/bridge/app/test/server/startup_mutex_repository_test.dart
@@ -5,10 +5,11 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:sesori_bridge/src/server/api/runtime_file_api.dart';
 import 'package:sesori_bridge/src/server/foundation/process_match.dart';
-import 'package:sesori_bridge/src/server/repositories/process_repository.dart';
 import 'package:sesori_bridge/src/server/repositories/startup_mutex_repository.dart';
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
 import 'package:test/test.dart';
+
+import '../helpers/fake_process_repository.dart';
 
 void main() {
   group('StartupMutexRepository', () {
@@ -312,16 +313,7 @@ void main() {
   });
 }
 
-class _FakeProcessRepository() implements ProcessRepository {
-  @override
-  Future<int> startDetached({
-    required String executable,
-    required List<String> arguments,
-    Map<String, String>? environment,
-  }) async {
-    throw UnimplementedError();
-  }
-
+class _FakeProcessRepository() extends StrictFakeProcessRepository {
   final Map<int, ProcessMatch?> matchResults = <int, ProcessMatch?>{};
 
   @override
@@ -332,16 +324,6 @@ class _FakeProcessRepository() implements ProcessRepository {
   @override
   Future<ProcessMatch?> inspectProcessMatch({required int pid}) async {
     return matchResults[pid];
-  }
-
-  @override
-  Future<SignalResult> sendGracefulSignal({required int pid}) {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<SignalResult> sendForceSignal({required int pid}) {
-    throw UnimplementedError();
   }
 }
 

--- a/bridge/app/test/services/control_channel_token_service_test.dart
+++ b/bridge/app/test/services/control_channel_token_service_test.dart
@@ -3,19 +3,20 @@ import "dart:convert";
 
 import "package:sesori_bridge/src/auth/token_refresher.dart";
 import "package:sesori_bridge/src/control/bridge_control_message_dispatcher.dart";
-import "package:sesori_bridge/src/foundation/control_channel_client.dart";
 import "package:sesori_bridge/src/services/control_channel_token_service.dart";
 import "package:sesori_bridge/src/services/control_prompt_service.dart";
 import "package:sesori_bridge/src/services/control_unregister_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../helpers/fake_control_channel_client.dart";
+
 void main() {
   // The service no longer subscribes to the client itself — the dispatcher is
   // the single inbound subscriber — so these behaviour tests wire one over the
   // same fake client to keep driving the service with raw emitted frames.
   ControlChannelTokenService buildService(
-    _FakeControlChannelClient client, {
+    FakeControlChannelClient client, {
     Duration? requestTimeout,
   }) {
     final service = requestTimeout == null
@@ -33,7 +34,7 @@ void main() {
 
   group("ControlChannelTokenService", () {
     test("sends a token_request and resolves with the matching token_response", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = buildService(client);
       addTearDown(service.dispose);
 
@@ -50,7 +51,7 @@ void main() {
     });
 
     test("forwards forceRefresh in the request and returns the fresh token", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = buildService(client);
       addTearDown(service.dispose);
 
@@ -65,7 +66,7 @@ void main() {
     });
 
     test("caches the latest pulled token for accessToken and tokenStream", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = buildService(client);
       addTearDown(service.dispose);
 
@@ -95,7 +96,7 @@ void main() {
     });
 
     test("accessToken throws before the first successful pull", () {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = buildService(client);
       addTearDown(service.dispose);
 
@@ -103,7 +104,7 @@ void main() {
     });
 
     test("a null access token surfaces a typed failure and leaves the cache empty", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = buildService(client);
       addTearDown(service.dispose);
 
@@ -118,7 +119,7 @@ void main() {
     });
 
     test("maps a disconnected-channel send failure to a typed token failure", () async {
-      final client = _FakeControlChannelClient()..throwOnSend = true;
+      final client = FakeControlChannelClient()..throwOnSend = true;
       final service = buildService(client);
       addTearDown(service.dispose);
 
@@ -129,7 +130,7 @@ void main() {
     });
 
     test("a pushed token_update is adopted into accessToken and tokenStream", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = buildService(client);
       addTearDown(service.dispose);
 
@@ -151,7 +152,7 @@ void main() {
     });
 
     test("a pushed token_update clears a prior sign-out invalidation", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = buildService(client);
       addTearDown(service.dispose);
 
@@ -177,7 +178,7 @@ void main() {
     });
 
     test("a null token_response invalidates a previously cached token", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = buildService(client);
       addTearDown(service.dispose);
 
@@ -207,7 +208,7 @@ void main() {
     });
 
     test("an older in-flight pull does not clear a newer sign-out invalidation", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = buildService(client);
       addTearDown(service.dispose);
 
@@ -244,7 +245,7 @@ void main() {
     });
 
     test("a pushed token_update wins over a slower older pull response", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = buildService(client);
       addTearDown(service.dispose);
 
@@ -267,7 +268,7 @@ void main() {
     });
 
     test("the newest-issued pull wins even when an older pull completes first", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = buildService(client);
       addTearDown(service.dispose);
 
@@ -296,7 +297,7 @@ void main() {
     });
 
     test("times out with a typed failure when no response arrives", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = buildService(client, requestTimeout: const Duration(milliseconds: 20));
       addTearDown(service.dispose);
 
@@ -307,7 +308,7 @@ void main() {
     });
 
     test("correlates by id — a mismatched response is ignored", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = buildService(client);
       addTearDown(service.dispose);
 
@@ -322,7 +323,7 @@ void main() {
     });
 
     test("ignores unrelated and undecodable frames", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = buildService(client);
       addTearDown(service.dispose);
 
@@ -345,7 +346,7 @@ void main() {
     });
 
     test("dispose fails any in-flight request", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = buildService(client);
 
       final future = service.getAccessToken();
@@ -357,7 +358,7 @@ void main() {
     });
 
     test("getAccessToken after dispose fails fast without waiting for the timeout", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       // A long timeout proves the failure is the disposed guard, not the timer.
       final service = buildService(client, requestTimeout: const Duration(seconds: 30));
       await service.dispose();
@@ -371,7 +372,7 @@ void main() {
     });
 
     test("dispose is idempotent", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = buildService(client);
 
       await service.dispose();
@@ -379,7 +380,7 @@ void main() {
     });
 
     test("concurrent dispose callers await the same teardown", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = buildService(client);
 
       final first = service.dispose();
@@ -396,38 +397,6 @@ void main() {
 ControlMessage _decode(String frame) => ControlMessage.fromJson(jsonDecodeMap(frame));
 
 String _encode(ControlMessage message) => jsonEncode(message.toJson());
-
-class _FakeControlChannelClient() implements ControlChannelClient {
-  final StreamController<String> _inbound = StreamController<String>.broadcast();
-  final List<String> sentFrames = <String>[];
-
-  /// Mimics [ControlChannelClient.send] throwing when the channel is down.
-  bool throwOnSend = false;
-
-  void emit(String frame) => _inbound.add(frame);
-
-  @override
-  Stream<String> get inbound => _inbound.stream;
-
-  @override
-  void send(String frame) {
-    if (throwOnSend) {
-      throw const ControlChannelNotConnectedException("Control channel is not connected");
-    }
-    sentFrames.add(frame);
-  }
-
-  @override
-  Stream<ControlChannelConnectionState> get connectionState => const Stream<ControlChannelConnectionState>.empty();
-
-  @override
-  Future<void> connect() async {}
-
-  @override
-  Future<void> dispose() async {
-    await _inbound.close();
-  }
-}
 
 /// The token-service tests wire a real dispatcher but never exercise the logout
 /// command, so its unregister delegate is a no-op stand-in.

--- a/bridge/app/test/services/control_prompt_service_test.dart
+++ b/bridge/app/test/services/control_prompt_service_test.dart
@@ -1,15 +1,14 @@
-import "dart:async";
-
-import "package:sesori_bridge/src/foundation/control_channel_client.dart";
 import "package:sesori_bridge/src/server/foundation/terminal_prompt_decision.dart";
 import "package:sesori_bridge/src/services/control_prompt_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../helpers/fake_control_channel_client.dart";
+
 void main() {
   group("ControlPromptService", () {
     test("askReplaceExistingBridge sends a replace_bridge prompt and maps accepted to replace", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = ControlPromptService(client: client);
       addTearDown(service.dispose);
 
@@ -25,7 +24,7 @@ void main() {
     });
 
     test("askReplaceStartingBridge maps a rejected answer to decline", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = ControlPromptService(client: client);
       addTearDown(service.dispose);
 
@@ -41,7 +40,7 @@ void main() {
     });
 
     test("correlates by id — a mismatched answer is ignored", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = ControlPromptService(client: client);
       addTearDown(service.dispose);
 
@@ -56,7 +55,7 @@ void main() {
     });
 
     test("no answer within the timeout degrades to nonInteractive", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = ControlPromptService(
         client: client,
         responseTimeout: const Duration(milliseconds: 20),
@@ -70,7 +69,7 @@ void main() {
     });
 
     test("a disconnected channel degrades to nonInteractive", () async {
-      final client = _FakeControlChannelClient()..throwOnSend = true;
+      final client = FakeControlChannelClient()..throwOnSend = true;
       final service = ControlPromptService(client: client);
       addTearDown(service.dispose);
 
@@ -81,7 +80,7 @@ void main() {
     });
 
     test("an unexpected transport failure degrades to nonInteractive instead of crashing", () async {
-      final client = _FakeControlChannelClient()..sendError = StateError("sink is closed");
+      final client = FakeControlChannelClient()..sendError = StateError("sink is closed");
       final service = ControlPromptService(client: client);
       addTearDown(service.dispose);
 
@@ -92,7 +91,7 @@ void main() {
     });
 
     test("dispose resolves an in-flight ask as nonInteractive", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = ControlPromptService(client: client);
 
       final future = service.askReplaceExistingBridge(bridgeCount: 1);
@@ -103,7 +102,7 @@ void main() {
     });
 
     test("an ask after dispose is nonInteractive without sending", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = ControlPromptService(client: client);
       await service.dispose();
 
@@ -115,7 +114,7 @@ void main() {
     });
 
     test("announceLoginNeeded sends a login_needed prompt without awaiting an answer", () async {
-      final client = _FakeControlChannelClient();
+      final client = FakeControlChannelClient();
       final service = ControlPromptService(client: client);
       addTearDown(service.dispose);
 
@@ -126,7 +125,7 @@ void main() {
     });
 
     test("announceLoginNeeded is best-effort — a disconnected channel does not throw", () {
-      final client = _FakeControlChannelClient()..throwOnSend = true;
+      final client = FakeControlChannelClient()..throwOnSend = true;
       final service = ControlPromptService(client: client);
       addTearDown(service.dispose);
 
@@ -135,7 +134,7 @@ void main() {
     });
 
     test("announceLoginNeeded is best-effort — an unexpected transport failure does not throw", () {
-      final client = _FakeControlChannelClient()..sendError = StateError("sink is closed");
+      final client = FakeControlChannelClient()..sendError = StateError("sink is closed");
       final service = ControlPromptService(client: client);
       addTearDown(service.dispose);
 
@@ -146,37 +145,3 @@ void main() {
 }
 
 ControlMessage _decode(String frame) => ControlMessage.fromJson(jsonDecodeMap(frame));
-
-class _FakeControlChannelClient() implements ControlChannelClient {
-  final List<String> sentFrames = <String>[];
-
-  /// Mimics [ControlChannelClient.send] throwing when the channel is down.
-  bool throwOnSend = false;
-
-  /// Mimics an unexpected transport failure (e.g. a mid-close sink).
-  Object? sendError;
-
-  @override
-  Stream<String> get inbound => const Stream<String>.empty();
-
-  @override
-  void send(String frame) {
-    if (throwOnSend) {
-      throw const ControlChannelNotConnectedException("Control channel is not connected");
-    }
-    final error = sendError;
-    if (error != null) {
-      throw error;
-    }
-    sentFrames.add(frame);
-  }
-
-  @override
-  Stream<ControlChannelConnectionState> get connectionState => const Stream<ControlChannelConnectionState>.empty();
-
-  @override
-  Future<void> connect() async {}
-
-  @override
-  Future<void> dispose() async {}
-}

--- a/bridge/app/test/services/pull_request_refresh_settings_service_test.dart
+++ b/bridge/app/test/services/pull_request_refresh_settings_service_test.dart
@@ -1,20 +1,21 @@
 import "dart:async";
 
-import "package:sesori_bridge/src/api/bridge_settings_api.dart";
 import "package:sesori_bridge/src/repositories/bridge_settings.dart";
 import "package:sesori_bridge/src/repositories/bridge_settings_repository.dart";
 import "package:sesori_bridge/src/services/pull_request_refresh_settings_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../helpers/in_memory_bridge_settings_api.dart";
+
 void main() {
   group("PullRequestRefreshSettingsService", () {
-    late _MemoryBridgeSettingsApi api;
+    late InMemoryBridgeSettingsApi api;
     late BridgeSettingsRepository repository;
     late PullRequestRefreshSettingsService service;
 
     setUp(() async {
-      api = _MemoryBridgeSettingsApi(
+      api = InMemoryBridgeSettingsApi(
         config: '{"pullRequestRefreshIntervalSeconds":30}',
       );
       repository = BridgeSettingsRepository(api: api);
@@ -132,25 +133,4 @@ void main() {
       await subscription.cancel();
     });
   });
-}
-
-class _MemoryBridgeSettingsApi({required var String? config}) implements BridgeSettingsApi {
-  int writeCount = 0;
-  Completer<void>? writeStarted;
-  Completer<void>? releaseWrite;
-
-  @override
-  String get configFilePath => "/tmp/config.json";
-
-  @override
-  Future<String?> readConfig() async => config;
-
-  @override
-  Future<void> writeConfig(String jsonContent) async {
-    writeStarted?.complete();
-    final release = releaseWrite;
-    if (release != null) await release.future;
-    config = jsonContent;
-    writeCount++;
-  }
 }

--- a/bridge/app/test/services/yolo_settings_service_test.dart
+++ b/bridge/app/test/services/yolo_settings_service_test.dart
@@ -1,21 +1,22 @@
 import "dart:async";
 
-import "package:sesori_bridge/src/api/bridge_settings_api.dart";
 import "package:sesori_bridge/src/repositories/bridge_settings_repository.dart";
 import "package:sesori_bridge/src/services/permission_auto_approval_service.dart";
 import "package:sesori_bridge/src/services/yolo_settings_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../helpers/in_memory_bridge_settings_api.dart";
+
 void main() {
   group("YoloSettingsService", () {
-    late _MemoryBridgeSettingsApi api;
+    late InMemoryBridgeSettingsApi api;
     late _FakePermissionAutoApprovalService permissionAutoApprovalService;
     late BridgeSettingsRepository repository;
     late YoloSettingsService service;
 
     setUp(() async {
-      api = _MemoryBridgeSettingsApi();
+      api = InMemoryBridgeSettingsApi(config: '{"yolo":false,"pullRequestRefreshIntervalSeconds":30}');
       repository = BridgeSettingsRepository(api: api);
       await repository.loadSettings();
       permissionAutoApprovalService = _FakePermissionAutoApprovalService();
@@ -67,21 +68,4 @@ class _FakePermissionAutoApprovalService() implements PermissionAutoApprovalServ
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
-
-class _MemoryBridgeSettingsApi() implements BridgeSettingsApi {
-  String? config = '{"yolo":false,"pullRequestRefreshIntervalSeconds":30}';
-  int writeCount = 0;
-
-  @override
-  String get configFilePath => "/tmp/config.json";
-
-  @override
-  Future<String?> readConfig() async => config;
-
-  @override
-  Future<void> writeConfig(String jsonContent) async {
-    config = jsonContent;
-    writeCount++;
-  }
 }


### PR DESCRIPTION
## Complexity

🌿 Straightforward — this is a broad but test-only helper consolidation with no production dependency or contract changes.

## What

- Add shared fail-loud process runner, control-channel, process-repository, settings, worktree, and token-refresher test fakes.
- Replace equivalent local copies across bridge app tests.
- Keep command queues, detached spawning, synchronous subscription tracking, rollback behavior, and relay lifecycle fakes local where their semantics are test-specific.
- Record Step 10 implementation and verification evidence.

## Why

Equivalent test doubles had drifted across many suites, increasing maintenance cost and making defaults inconsistent. The shared helpers centralize only genuinely interchangeable behavior without weakening specialized assertions.

## Risk and test focus

Low risk. Production code is unchanged; review should focus on whether migrated fakes preserve failure, ordering, lifecycle, and captured-argument behavior. Specialized timing and command-sequencing fakes remain local.

## Expected result

No user-visible or database/persisted-data impact. Bridge app tests use fewer duplicate helpers while preserving their existing behavior and coverage.

## Verification

- `dart analyze --fatal-infos` in `bridge/app`
- `dart test` in `bridge/app`: 2,692 passed; 2 PowerShell cases skipped because PowerShell is unavailable locally
- `git diff --check`
- Correctness review completed; one controller-cleanup finding was fixed and reverified


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates bridge/app test fakes into shared helpers and migrates suites to use them. This reduces drift and standardizes defaults; production code and behavior are unchanged.

- Added shared fakes: Noop/Recording process runners, a self-cleaning control-channel client, an in-memory bridge-settings API, a deletion-focused worktree service, a strict process repository, and a `FakeTokenRefresher` that records forceRefresh and supports a refreshed token.
- Replaced equivalent local fakes across tests; kept specialized fakes where timing, ordering, or command sequencing are test-specific.
- Review focus: confirm migrated fakes preserve failure modes, ordering, lifecycle, and captured arguments; note the control-channel client’s idempotent teardown.
- Verification: dart analyze passes; bridge/app tests pass (2,692); two PowerShell cases skipped on non-Windows environments.

<sup>Written for commit 70b736e89e8014ffb0ba69b4ef2d8d816fe23dda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

