### PR TITLE
⚙️ [catalog-rescan] Route scan state through the list cubits [step 6a/8]

### DIFF
--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -948,6 +948,16 @@ non-destructive: `_mergeProjectRow` and `_mergeSessionRow` preserve `hidden`,
 
 ## Step 6/8 - Surface Catalog Rescan In The App
 
+Delivered as 6a, 6b, and 6c. The scope and verification below are the
+**aggregate** of all three; the sub-step that owns each part is marked, so a
+reviewer of one PR can see what belongs to it.
+
+- **6a** owns the cubit bullet and its module_core verification.
+- **6b** owns the row widget, the three list hosts, and their `app_en.arb`
+  resources, plus the widget tests for the row states.
+- **6c** owns the Settings action, its enablement and rejection, and its
+  resources.
+
 ### Scope
 
 - `ProjectListCubit`, `SessionListCubit`, and `PluginManagementCubit` each

--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -757,12 +757,26 @@ before the plan is retired.
 | 3/8 | `⚙️ [catalog-rescan] Report new items from a catalog import [step 3/8]` | 350-600 |
 | 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 |
 | 5/8 | `⚙️ [catalog-rescan] Add a second stage to pull-to-refresh [step 5/8]` | 350-600 |
-| 6/8 | `⚙️ [catalog-rescan] Surface catalog rescan in the app [step 6/8]` | 950-1,400 |
+| 6a/8 | `⚙️ [catalog-rescan] Route scan state through the list cubits [step 6a/8]` | 450-750 |
+| 6b/8 | `⚙️ [catalog-rescan] Show the catalog scan in the lists [step 6b/8]` | 500-800 |
+| 6c/8 | `🌿 [catalog-rescan] Scan one harness from Settings [step 6c/8]` | 350-600 |
 | 7/8 | `🌱 [catalog-rescan] Reconcile catalog rescan regression docs [step 7/8]` | 80-160 |
 | 8/8 | `🌱 [catalog-rescan] Verify and retire the catalog rescan plan [step 8/8]` | 60-140 |
 
 Step 5 is `⚙️` rather than `🌿` because it extracts a new shared component and
 moves the split-view pane onto it, rather than adding a parameter to one widget.
+
+Step 6 is delivered as three sub-steps rather than one PR, split by layer and
+surface so none exceeds the size cap. The denominator stays 8: these are one
+step's worth of scope, not three new steps.
+
+- **6a** is `module_core` only — the two list cubits gain the scan state, the
+  intent methods, and the refresh on leaving a live operation. Nothing renders,
+  so it is reviewable as pure state.
+- **6b** is the row widget and the three list hosts, which is where the feature
+  first becomes visible.
+- **6c** is the Settings action, whose per-harness result and enablement rules
+  are independent of the aggregate row.
 
 Step 1's target is measured against `PLAN.md` alone. Both files are new, so the
 combined numstat counts every line of `TRACKER.md` too — including its review

--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -373,8 +373,8 @@ rejection on the card instead of skipping it.
 No widget subscribes to `CatalogRescanService`. Each surface's existing cubit
 gains one subscription to its `ValueStream`, surfaces the rescan state through
 its own state, and exposes the intent methods the screen dispatches
-(`startRescan()`, `startRescanFor(pluginId)`, `cancelRescan()`,
-`dismissRescan()`). This keeps the shell's Layer-4 boundary intact and puts the
+(`startCatalogScan()`, `cancelCatalogScan()`, `dismissCatalogScan()` on the two
+list cubits; `startCatalogScanFor(pluginId)` on `PluginManagementCubit`). This keeps the shell's Layer-4 boundary intact and puts the
 post-success list refresh in the object that already owns refreshing.
 
 A dedicated `CatalogRescanCubit` was considered and rejected: the two list
@@ -651,6 +651,7 @@ Deliberately **not** added:
 | An older bridge omits `newItems` | Success row shows totals instead of a delta | Accepted. Honest degradation, and the absent group makes the difference explicit rather than silently wrong |
 | A rescan in flight when the connection drops | The row disappears and does not return | Accepted. The bridge continues and commits the import; the next connect seeds only non-terminal statuses, so a rescan that finished meanwhile is simply not announced |
 | Two surfaces trigger a rescan for the same harness at once | The bridge coalesces it: `CatalogImportService.start` finds the active control and applies the trigger to it | No client-side guard needed; existing bridge behavior is correct |
+| A concurrent list read overwrites what a scan imported, or the post-scan read fails | The imported rows stay unseen until the next refresh | Accepted. The list cubits' read path has no ordering or retry guarantee today, independent of this feature — eight call sites, only the silent one coalescing. The post-scan read waits for the newest in-flight read and then starts fresh, which covers the ordinary cases; making it airtight needs a monotonic read guard across both cubits' core paths, which is a separate refactor. Recovery already exists: the project list re-reads on a 30s throttle while visible, both cubits re-read on `dataMayBeStale` and on reconnect, and a pull re-reads on demand. Owner decision 2026-08-24 |
 | A cancel `DELETE` races a harness that just completed | The bridge answers on the already-settled plugin and the SSE terminal event wins | Accepted; no client-side ordering guard |
 | A failure row names no cause | The user must open the bridge log to learn why a harness failed | Accepted. `CatalogImportFailed.message` is unbounded `error.toString()`; a vaguer row is the honest trade until a producer-side sanitization boundary exists |
 | A lost response for a start that never arrived | That harness stays in `pluginIds` with no progress until the connection resets | Accepted. Bounded and self-clearing; a third result type across two layers is not worth it |
@@ -952,18 +953,22 @@ Delivered as 6a, 6b, and 6c. The scope and verification below are the
 **aggregate** of all three; the sub-step that owns each part is marked, so a
 reviewer of one PR can see what belongs to it.
 
-- **6a** owns the cubit bullet and its module_core verification.
+- **6a** owns the two list cubits' subscription, intents, and post-scan
+  refresh, plus its module_core verification.
 - **6b** owns the row widget, the three list hosts, and their `app_en.arb`
   resources, plus the widget tests for the row states.
-- **6c** owns the Settings action, its enablement and rejection, and its
-  resources.
+- **6c** owns `PluginManagementCubit`'s subscription and
+  `startCatalogScanFor(pluginId)`, the Settings action, its enablement and
+  rejection, and its resources.
 
 ### Scope
 
 - `ProjectListCubit`, `SessionListCubit`, and `PluginManagementCubit` each
   subscribe to `CatalogRescanService`, surface the rescan state through their
-  own state, and expose `startRescan()`, `startRescanFor(pluginId)`,
-  `cancelRescan()`, and `dismissRescan()`. The two list cubits additionally run
+  own state. The two list cubits expose `startCatalogScan()`,
+  `cancelCatalogScan()` and `dismissCatalogScan()`; `PluginManagementCubit`
+  exposes `startCatalogScanFor(pluginId)`, which is 6c's, because only a
+  targeted start needs a per-harness result. The two list cubits additionally run
   their existing silent refresh whenever the service **leaves a live operation**
   — settled with a summary, settled as observed, or cancelled — because a
   committed import raises no list invalidation of its own. Keying the refresh on
@@ -974,11 +979,11 @@ reviewer of one PR can see what belongs to it.
   shell's other cross-feature widgets, with its seven presentations. It renders
   the state it is given, owns no timer, and renders no bridge-supplied text.
 - Project list, full-screen session list, and split-view pane: supply
-  `deepRefresh` from the cubit's `startRescan()`, and render the row as the
+  `deepRefresh` from the cubit's `startCatalogScan()`, and render the row as the
   sliver at index 0 in place of the soft-refresh indicator while a rescan is
   running.
 - Settings to Harnesses: the per-harness `Rescan` action in
-  `_HarnessControlCard`, calling `startRescanFor(pluginId)`, enabled only for a
+  `_HarnessControlCard`, calling `startCatalogScanFor(pluginId)`, enabled only for a
   harness whose `runtimeState.isRoutable` is true and disabled while that
   harness is itself a member of the live operation; a targeted start joins that
   operation rather than replacing it, so no cross-harness disabling is needed.

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -494,6 +494,18 @@ duplicate-emission nicety.
 - **Step 6a verification:** `dart analyze --fatal-infos` clean on
   `client/module_core` and `client/app`; module_core 1,349 tests passed
   (6 new cubit cases); app 854 tests passed
-- **Step 6a review:** pending
+- **Step 6a review:** `architecture-implementation-review` **rejected** the first
+  pass with three findings, all applied. Two were one real bug: both cubits
+  rebuilt their loaded state without `catalogScan`, so it reverted to idle —
+  and on the project list the erasing rebuild was the very refresh the scan's
+  own `settled` listener fires, which would have wiped the terminal row it was
+  fired for. On the session list any session event during a scan reset the
+  running row. Fixed by re-deriving from the owner in both paths, the way the
+  sibling activity and unseen fields already do. The third: the shared
+  `FakeCatalogRescanService` declared the interface without implementing
+  `start(pluginId:)` and hid the gap behind `noSuchMethod`, which would have
+  turned any future interface addition into a runtime throw in every consumer
+  instead of a compile error. Both regression tests were confirmed to fail
+  without the fix
 - **Step 6a PR:** pending
 - **Final disposition:** pending

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -5,9 +5,9 @@
 - **Plan slug:** `catalog-rescan`
 - **Implementation base:** `main` at
   `7b1ebe9bc629d05b5d104e76cd5dbaa1514d65a2`
-- **Series state:** Steps 1/8 to 4/8 merged; Step 5/8 open
-- **Current step:** add a second stage to pull-to-refresh
-- **Next action:** land Step 5, then Step 6's app surfaces
+- **Series state:** Steps 1/8 to 5/8 merged; Step 6a/8 open
+- **Current step:** route scan state through the list cubits
+- **Next action:** land 6a, then 6b's row and hosts, then 6c's Settings action
 - **Origin issue:** [#961](https://github.com/sesori-ai/sesori_apps_monorepo/issues/961)
 - **External overlap:** [#1008](https://github.com/sesori-ai/sesori_apps_monorepo/issues/1008)
   owns Codex live updates; do not address it here
@@ -132,8 +132,10 @@
 | [x] | 2/8 | `🌱 [catalog-rescan] Re-hydrate stale plugin catalogs [step 2/8]` | 20-60 | [PR #1071](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1071) merged |
 | [x] | 3/8 | `⚙️ [catalog-rescan] Report new items from a catalog import [step 3/8]` | 350-600 | [PR #1074](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1074) merged |
 | [x] | 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 | [PR #1085](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1085) merged |
-| [ ] | 5/8 | `⚙️ [catalog-rescan] Add a second stage to pull-to-refresh [step 5/8]` | 350-600 | Open |
-| [ ] | 6/8 | `⚙️ [catalog-rescan] Surface catalog rescan in the app [step 6/8]` | 950-1,400 | Not started |
+| [x] | 5/8 | `⚙️ [catalog-rescan] Add a second stage to pull-to-refresh [step 5/8]` | 350-600 | [PR #1093](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1093) merged |
+| [ ] | 6a/8 | `⚙️ [catalog-rescan] Route scan state through the list cubits [step 6a/8]` | 450-750 | Open |
+| [ ] | 6b/8 | `⚙️ [catalog-rescan] Show the catalog scan in the lists [step 6b/8]` | 500-800 | Not started |
+| [ ] | 6c/8 | `🌿 [catalog-rescan] Scan one harness from Settings [step 6c/8]` | 350-600 | Not started |
 | [ ] | 7/8 | `🌱 [catalog-rescan] Reconcile catalog rescan regression docs [step 7/8]` | 80-160 | Not started |
 | [ ] | 8/8 | `🌱 [catalog-rescan] Verify and retire the catalog rescan plan [step 8/8]` | 60-140 | Not started |
 
@@ -486,4 +488,12 @@ duplicate-emission nicety.
   unbuildable release semantics and would have misdirected step 6, and the new
   design-system file's doc comments carried product vocabulary
 - **Step 5 PR:** pending
+- **Step 6a base:** `main` at `0969f00d6`
+- **Step 6a changed lines:** 346 of delivered code, under the 450-750 estimate
+  because the cubits reuse their existing refresh rather than adding one
+- **Step 6a verification:** `dart analyze --fatal-infos` clean on
+  `client/module_core` and `client/app`; module_core 1,349 tests passed
+  (6 new cubit cases); app 854 tests passed
+- **Step 6a review:** pending
+- **Step 6a PR:** pending
 - **Final disposition:** pending

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -472,7 +472,8 @@ duplicate-emission nicety.
 - **Step 4 review:** `architecture-implementation-review` **rejected** the first
   pass with two blocking A2 findings, both divergences from the approved
   operation model, both applied with regression coverage
-- **Step 4 PR:** pending
+- **Step 4 PR:** [#1085](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1085)
+  merged
 - **Step 5 base:** `main` at `bafa7cd02`
 - **Step 5 changed lines:** 427 of delivered code, inside the 350-600 target;
   `.plan/` excluded so the figure cannot count itself
@@ -487,7 +488,8 @@ duplicate-emission nicety.
   observations were applied: `PLAN.md`'s Step 5 scope section still described the
   unbuildable release semantics and would have misdirected step 6, and the new
   design-system file's doc comments carried product vocabulary
-- **Step 5 PR:** pending
+- **Step 5 PR:** [#1093](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1093)
+  merged
 - **Step 6a base:** `main` at `0969f00d6`
 - **Step 6a changed lines:** 346 of delivered code, under the 450-750 estimate
   because the cubits reuse their existing refresh rather than adding one

--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -49,6 +49,7 @@ class const ProjectListScreen({super.key}) extends StatelessWidget {
               productAnalyticsService: getIt<ProductAnalyticsService>(),
             ),
             failureReporter: getIt<FailureReporter>(),
+            catalogRescanService: getIt<CatalogRescanService>(),
           ),
         ),
         // The machine this account is paired with, resolved independently of the

--- a/client/app/lib/features/session_list/session_list_cubit_provider.dart
+++ b/client/app/lib/features/session_list/session_list_cubit_provider.dart
@@ -24,6 +24,7 @@ class const SessionListCubitProvider({
         routeSource: getIt<RouteSource>(),
         projectId: projectId,
         failureReporter: getIt<FailureReporter>(),
+        catalogRescanService: getIt<CatalogRescanService>(),
       ),
       child: child,
     );

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -444,6 +444,7 @@ void main() {
       ),
     );
     GetIt.instance.registerSingleton<ConnectionService>(connectionService);
+    GetIt.instance.registerSingleton<CatalogRescanService>(FakeCatalogRescanService());
     GetIt.instance.registerSingleton<ProjectRepository>(projectRepository);
     GetIt.instance.registerSingleton<VoiceTranscriptionService>(voiceTranscriptionService);
     GetIt.instance.registerSingleton<ComposerImagePicker>(imagePicker);

--- a/client/app/test/features/session_detail/session_detail_title_hydration_test.dart
+++ b/client/app/test/features/session_detail/session_detail_title_hydration_test.dart
@@ -138,6 +138,8 @@ void _registerDependencies({
   final getIt = GetIt.instance;
 
   getIt.registerSingleton<ConnectionService>(connectionService);
+
+  getIt.registerSingleton<CatalogRescanService>(FakeCatalogRescanService());
   getIt.registerSingleton<SessionDetailLoadService>(loadService);
   getIt.registerSingleton<SessionRepository>(promptDispatcher);
   getIt.registerSingleton<PermissionRepository>(permissionRepository);

--- a/client/app/test/features/session_diffs/session_diffs_collapse_scroll_test.dart
+++ b/client/app/test/features/session_diffs/session_diffs_collapse_scroll_test.dart
@@ -7,7 +7,7 @@ import "package:mocktail/mocktail.dart";
 import "package:sesori_auth/sesori_auth.dart" show ApiResponse;
 import "package:sesori_dart_core/sesori_dart_core.dart" show ConnectionOverlayCubit, DiffCubit, DiffState;
 import "package:sesori_dart_core/sesori_dart_core.dart"
-    show ConnectionService, ProductAnalyticsService, SessionRepository;
+    show CatalogRescanService, ConnectionService, ProductAnalyticsService, SessionRepository;
 import "package:sesori_mobile/features/session_diffs/session_diffs_body.dart";
 import "package:sesori_mobile/features/session_diffs/session_diffs_screen.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
@@ -88,6 +88,7 @@ void main() {
     stubProductAnalyticsService(service: analyticsService);
     getIt.registerSingleton<SessionRepository>(mockRepo);
     getIt.registerSingleton<ConnectionService>(mockConnectionService);
+    getIt.registerSingleton<CatalogRescanService>(FakeCatalogRescanService());
     getIt.registerSingleton<ProductAnalyticsService>(analyticsService);
   });
 

--- a/client/app/test/features/settings/settings_screen_test.dart
+++ b/client/app/test/features/settings/settings_screen_test.dart
@@ -133,6 +133,7 @@ void main() {
     when(() => connectionService.currentStatus).thenAnswer((_) => connectionStatuses.value);
     when(() => connectionService.status).thenAnswer((_) => connectionStatuses.stream);
     GetIt.instance.registerSingleton<ConnectionService>(connectionService);
+    GetIt.instance.registerSingleton<CatalogRescanService>(FakeCatalogRescanService());
 
     authSession = _StubAuthSession();
     when(authSession.logoutCurrentDevice).thenAnswer((_) async {});

--- a/client/app/test/helpers/test_helpers.dart
+++ b/client/app/test/helpers/test_helpers.dart
@@ -121,6 +121,13 @@ void _registerListServices({
     ),
   );
   getIt.registerSingleton<ProductAnalyticsService>(analyticsService);
+  // The list cubits project the catalog scan onto their state, so every test
+  // that renders a list needs one. Registered here rather than per test file
+  // because it is a dependency of the lists themselves, not of any one screen.
+  if (getIt.isRegistered<CatalogRescanService>()) {
+    getIt.unregister<CatalogRescanService>();
+  }
+  getIt.registerSingleton<CatalogRescanService>(FakeCatalogRescanService());
 }
 
 class MockFirebaseCrashlytics() extends Mock implements FirebaseCrashlytics;

--- a/client/module_core/lib/sesori_dart_core.dart
+++ b/client/module_core/lib/sesori_dart_core.dart
@@ -49,11 +49,8 @@ export "src/capabilities/relay/room_key_storage.dart";
 export "src/capabilities/server_connection/connection_service.dart";
 export "src/capabilities/server_connection/models/connection_status.dart";
 export "src/capabilities/server_connection/server_connection_config.dart";
-// Capabilities
 export "src/capabilities/voice/voice_api.dart";
-// Consumers
 export "src/consumers/analytics/session_activity_analytics_listener.dart";
-// Cubits
 export "src/cubits/appearance/appearance_cubit.dart";
 export "src/cubits/bridge_identity/bridge_identity_cubit.dart";
 export "src/cubits/bridge_identity/bridge_identity_state.dart";
@@ -98,11 +95,8 @@ export "src/cubits/splash/splash_cubit.dart";
 export "src/cubits/splash/splash_state.dart";
 export "src/cubits/sse_toast/sse_toast_cubit.dart";
 export "src/cubits/sse_toast/sse_toast_state.dart";
-// DI
 export "src/di/injection.dart";
-// Errors
 export "src/errors/remote_failure_reason.dart";
-// Analytics foundation
 export "src/foundation/models/composer/composer_attachment.dart";
 export "src/foundation/models/composer/composer_draft.dart";
 export "src/foundation/models/product_analytics/analytics_runtime_capability.dart";
@@ -114,9 +108,7 @@ export "src/foundation/platform/attachment_thumbnail_storage.dart";
 export "src/foundation/platform/image_clipboard.dart";
 export "src/foundation/platform/image_saver.dart";
 export "src/foundation/platform/image_sharer.dart";
-// Logging
 export "src/logging/logging.dart";
-// Platform interfaces
 export "src/platform/deep_link_source.dart";
 export "src/platform/lifecycle_source.dart";
 export "src/platform/local_notification_client.dart";
@@ -146,16 +138,16 @@ export "src/repositories/product_analytics_preference_repository.dart";
 export "src/repositories/project_repository.dart";
 export "src/repositories/registered_bridges_store.dart";
 export "src/repositories/session_repository.dart";
-// Routing
 export "src/routing/analytics_route_listener.dart";
 export "src/routing/app_routes.dart";
 export "src/routing/notification_open_dispatcher.dart";
-// Services
+export "src/services/catalog_rescan_service.dart";
 export "src/services/composer_draft_calculator.dart";
 export "src/services/foreground_notification_dispatcher.dart";
 export "src/services/installation_analytics_service.dart";
 export "src/services/loaded_state_analytics_reporter.dart";
 export "src/services/message_thumbnail_cache_service.dart";
+export "src/services/models/catalog_rescan_state.dart";
 export "src/services/models/new_session_backend_scope.dart";
 export "src/services/models/new_session_options_source.dart";
 export "src/services/models/new_session_selection_intent.dart";
@@ -176,7 +168,6 @@ export "src/services/session_list_service.dart";
 export "src/services/session_unseen_tracker.dart";
 export "src/services/session_viewing_service.dart";
 export "src/services/sse_event_tracker.dart";
-// Utils
 export "src/utils/command_filter/command_picker_entry_builder.dart";
 export "src/utils/diff/diff_engine.dart";
 export "src/utils/diff/language_detector.dart";

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -15,7 +15,9 @@ import "../../platform/route_source.dart";
 import "../../repositories/models/analytics_delivery_result.dart";
 import "../../repositories/project_repository.dart";
 import "../../routing/app_routes.dart";
+import "../../services/catalog_rescan_service.dart";
 import "../../services/loaded_state_analytics_reporter.dart";
+import "../../services/models/catalog_rescan_state.dart";
 import "../../services/models/session_activity_info.dart";
 import "../../services/product_analytics_service.dart";
 import "../../services/project_list_service.dart";
@@ -44,6 +46,7 @@ class ProjectListCubit(
   required final ProductAnalyticsService _productAnalyticsService,
   required final LoadedStateAnalyticsReporter _loadedStateAnalyticsReporter,
   required final FailureReporter _failureReporter,
+  required final CatalogRescanService _catalogRescanService,
 }) extends Cubit<ProjectListState> {
   final CompositeSubscription _subscriptions = CompositeSubscription();
 
@@ -63,6 +66,14 @@ class ProjectListCubit(
     _subscriptions.add(
       _sseEventTracker.projectTimestampUpdates.listen(_onProjectTimestampUpdated),
     );
+
+    // 1a2. The catalog scan, which any surface can start. Its state is only
+    //     projected onto the list; the operation itself is the service's.
+    _subscriptions.add(_catalogRescanService.state.listen(_onCatalogScanState));
+    // A committed import raises no list invalidation of its own, so the list
+    // refreshes when the scan leaves a live operation — however it ended,
+    // because a run this client only observed publishes no terminal state.
+    _subscriptions.add(_catalogRescanService.settled.listen((_) => unawaited(refreshProjects())));
 
     // 1b. Immediate unseen (bold) updates (no API call).
     _subscriptions.add(
@@ -703,6 +714,22 @@ class ProjectListCubit(
           emit(ProjectListState.failed(reason: error.remoteFailureReason));
         }
         return false;
+    }
+  }
+
+  /// Starts a catalog scan across every harness this bridge can import from.
+  void startCatalogScan() => unawaited(_catalogRescanService.startAll());
+
+  /// Stops the scan in flight.
+  void cancelCatalogScan() => unawaited(_catalogRescanService.cancel());
+
+  /// Clears a finished scan the user has read.
+  void dismissCatalogScan() => _catalogRescanService.dismiss();
+
+  void _onCatalogScanState(CatalogRescanState scan) {
+    if (isClosed) return;
+    if (state case final ProjectListLoaded loaded) {
+      emit(loaded.copyWith(catalogScan: scan));
     }
   }
 

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -486,6 +486,9 @@ class ProjectListCubit(
   /// In-flight silent refresh, used for coalescing.
   Future<bool>? _activeRefresh;
 
+  /// The most recent list read of any kind.
+  Future<bool>? _activeFetch;
+
   /// Re-fetches projects without showing the full-screen loading indicator.
   /// Concurrent calls are coalesced: if a refresh is already in-flight, the
   /// existing Future is returned instead of starting a second network request.
@@ -661,7 +664,21 @@ class ProjectListCubit(
     return error is NonSuccessCodeError && error.errorCode == 403;
   }
 
-  Future<bool> _fetchProjects({bool silent = false}) async {
+  /// Registers every list read, silent or not, so an ordering-sensitive caller
+  /// can wait for whatever is already in flight. [_activeRefresh] tracks only
+  /// the coalescing silent path, so an initial or retry load is invisible to it.
+  Future<bool> _fetchProjects({bool silent = false}) {
+    final fetch = _runFetchProjects(silent: silent);
+    _activeFetch = fetch;
+    unawaited(
+      fetch.whenComplete(() {
+        if (identical(_activeFetch, fetch)) _activeFetch = null;
+      }).catchError((Object _) => false),
+    );
+    return fetch;
+  }
+
+  Future<bool> _runFetchProjects({bool silent = false}) async {
     // Captured BEFORE the fetch so the seed can't overwrite a live update that
     // arrives while the request is in flight.
     final unseenTick = _sessionUnseenTracker.tick;
@@ -728,7 +745,15 @@ class ProjectListCubit(
   /// the read that follows is guaranteed to see the imported rows, which is the
   /// whole point of refreshing here — the import raises no other invalidation.
   Future<void> _refreshAfterScan() async {
-    await _activeRefresh;
+    // Every read, not just the coalescing silent one: a full load in flight
+    // would otherwise race this fetch and, landing last, overwrite what the
+    // scan just imported. A failing read reports itself, so it is not
+    // re-reported here.
+    try {
+      await _activeFetch;
+    } on Object catch (_) {
+      // Ignored: the read that failed owns its own reporting.
+    }
     if (isClosed) return;
     await refreshProjects();
   }

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -693,6 +693,10 @@ class ProjectListCubit(
             projects: sortedProjects,
             activityById: _sseEventTracker.currentProjectActivity,
             unseenByProjectId: _unseenByProjectId(sortedProjects),
+            // Re-derived from its owner, like the two fields above it. This
+            // emit is what the scan's own settled listener triggers, so
+            // omitting it would erase the terminal row it was fired for.
+            catalogScan: _catalogRescanService.state.value,
           ),
         );
         _loadedStateAnalyticsReporter.reportLoaded(

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -73,7 +73,7 @@ class ProjectListCubit(
     // A committed import raises no list invalidation of its own, so the list
     // refreshes when the scan leaves a live operation — however it ended,
     // because a run this client only observed publishes no terminal state.
-    _subscriptions.add(_catalogRescanService.settled.listen((_) => unawaited(refreshProjects())));
+    _subscriptions.add(_catalogRescanService.settled.listen((_) => unawaited(_refreshAfterScan())));
 
     // 1b. Immediate unseen (bold) updates (no API call).
     _subscriptions.add(
@@ -719,6 +719,18 @@ class ProjectListCubit(
         }
         return false;
     }
+  }
+
+  /// Reads the catalog strictly after the scan committed.
+  ///
+  /// [refreshProjects] coalesces onto a refresh already in flight, and that one
+  /// may have started before the import committed. Waiting it out first means
+  /// the read that follows is guaranteed to see the imported rows, which is the
+  /// whole point of refreshing here — the import raises no other invalidation.
+  Future<void> _refreshAfterScan() async {
+    await _activeRefresh;
+    if (isClosed) return;
+    await refreshProjects();
   }
 
   /// Starts a catalog scan across every harness this bridge can import from.

--- a/client/module_core/lib/src/cubits/project_list/project_list_state.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_state.dart
@@ -2,6 +2,7 @@ import "package:freezed_annotation/freezed_annotation.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../../errors/remote_failure_reason.dart";
+import "../../services/models/catalog_rescan_state.dart";
 
 part "project_list_state.freezed.dart";
 
@@ -18,6 +19,14 @@ sealed class ProjectListState with _$ProjectListState {
     /// `SesoriSessionUnseenChanged` updates, the latter taking precedence.
     @Default({}) Map<String, bool> unseenByProjectId,
     @Default(false) bool isRefreshing,
+
+    /// The catalog scan shown above the list, if any is worth showing.
+    ///
+    /// Carried here beside [isRefreshing] because it is the same kind of thing:
+    /// transient operation status the list renders over its content. The scan
+    /// itself is owned by `CatalogRescanService`; this is only the projection
+    /// the screen watches.
+    @Default(CatalogRescanState.idle()) CatalogRescanState catalogScan,
   }) = ProjectListLoaded;
 
   const factory failed({required RemoteFailureReason reason}) = ProjectListFailed;

--- a/client/module_core/lib/src/cubits/project_list/project_list_state.freezed.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_state.freezed.dart
@@ -79,7 +79,7 @@ String toString() {
 
 
 class ProjectListLoaded implements ProjectListState {
-  const ProjectListLoaded({required  List<ProjectSummary> projects, required  Map<String, int> activityById,  Map<String, bool> unseenByProjectId = const {}, this.isRefreshing = false}): _projects = projects,_activityById = activityById,_unseenByProjectId = unseenByProjectId;
+  const ProjectListLoaded({required  List<ProjectSummary> projects, required  Map<String, int> activityById,  Map<String, bool> unseenByProjectId = const {}, this.isRefreshing = false, this.catalogScan = const CatalogRescanState.idle()}): _projects = projects,_activityById = activityById,_unseenByProjectId = unseenByProjectId;
   
 
  final  List<ProjectSummary> _projects;
@@ -110,6 +110,13 @@ class ProjectListLoaded implements ProjectListState {
 }
 
 @JsonKey() final  bool isRefreshing;
+/// The catalog scan shown above the list, if any is worth showing.
+///
+/// Carried here beside [isRefreshing] because it is the same kind of thing:
+/// transient operation status the list renders over its content. The scan
+/// itself is owned by `CatalogRescanService`; this is only the projection
+/// the screen watches.
+@JsonKey() final  CatalogRescanState catalogScan;
 
 /// Create a copy of ProjectListState
 /// with the given fields replaced by the non-null parameter values.
@@ -121,16 +128,16 @@ $ProjectListLoadedCopyWith<ProjectListLoaded> get copyWith => _$ProjectListLoade
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectListLoaded&&const DeepCollectionEquality().equals(other._projects, _projects)&&const DeepCollectionEquality().equals(other._activityById, _activityById)&&const DeepCollectionEquality().equals(other._unseenByProjectId, _unseenByProjectId)&&(identical(other.isRefreshing, isRefreshing) || other.isRefreshing == isRefreshing));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectListLoaded&&const DeepCollectionEquality().equals(other._projects, _projects)&&const DeepCollectionEquality().equals(other._activityById, _activityById)&&const DeepCollectionEquality().equals(other._unseenByProjectId, _unseenByProjectId)&&(identical(other.isRefreshing, isRefreshing) || other.isRefreshing == isRefreshing)&&(identical(other.catalogScan, catalogScan) || other.catalogScan == catalogScan));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_projects),const DeepCollectionEquality().hash(_activityById),const DeepCollectionEquality().hash(_unseenByProjectId),isRefreshing);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_projects),const DeepCollectionEquality().hash(_activityById),const DeepCollectionEquality().hash(_unseenByProjectId),isRefreshing,catalogScan);
 
 @override
 String toString() {
-  return 'ProjectListState.loaded(projects: $projects, activityById: $activityById, unseenByProjectId: $unseenByProjectId, isRefreshing: $isRefreshing)';
+  return 'ProjectListState.loaded(projects: $projects, activityById: $activityById, unseenByProjectId: $unseenByProjectId, isRefreshing: $isRefreshing, catalogScan: $catalogScan)';
 }
 
 
@@ -141,7 +148,7 @@ abstract mixin class $ProjectListLoadedCopyWith<$Res> implements $ProjectListSta
   factory $ProjectListLoadedCopyWith(ProjectListLoaded value, $Res Function(ProjectListLoaded) _then) = _$ProjectListLoadedCopyWithImpl;
 @useResult
 $Res call({
- List<ProjectSummary> projects, Map<String, int> activityById, Map<String, bool> unseenByProjectId, bool isRefreshing
+ List<ProjectSummary> projects, Map<String, int> activityById, Map<String, bool> unseenByProjectId, bool isRefreshing, CatalogRescanState catalogScan
 });
 
 
@@ -158,13 +165,14 @@ class _$ProjectListLoadedCopyWithImpl<$Res>
 
 /// Create a copy of ProjectListState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? projects = null,Object? activityById = null,Object? unseenByProjectId = null,Object? isRefreshing = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? projects = null,Object? activityById = null,Object? unseenByProjectId = null,Object? isRefreshing = null,Object? catalogScan = null,}) {
   return _then(ProjectListLoaded(
 projects: null == projects ? _self._projects : projects // ignore: cast_nullable_to_non_nullable
 as List<ProjectSummary>,activityById: null == activityById ? _self._activityById : activityById // ignore: cast_nullable_to_non_nullable
 as Map<String, int>,unseenByProjectId: null == unseenByProjectId ? _self._unseenByProjectId : unseenByProjectId // ignore: cast_nullable_to_non_nullable
 as Map<String, bool>,isRefreshing: null == isRefreshing ? _self.isRefreshing : isRefreshing // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,catalogScan: null == catalogScan ? _self.catalogScan : catalogScan // ignore: cast_nullable_to_non_nullable
+as CatalogRescanState,
   ));
 }
 

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -58,7 +58,7 @@ class SessionListCubit({
     // refreshes when the scan leaves a live operation — however it ended,
     // because a run this client only observed publishes no terminal state.
     _subscriptions.add(
-      _catalogRescanService.settled.listen((_) => unawaited(refreshSessions())),
+      _catalogRescanService.settled.listen((_) => unawaited(_refreshAfterScan())),
     );
     _subscriptions.add(_connectionService.events.listen(_handleEvent));
     // 1. Navigate-back refresh: one immediate fetch when the user returns to
@@ -611,6 +611,18 @@ class SessionListCubit({
         }
         return false;
     }
+  }
+
+  /// Reads the catalog strictly after the scan committed.
+  ///
+  /// [refreshSessions] coalesces onto a refresh already in flight, and that one
+  /// may have started before the import committed. Waiting it out first means
+  /// the read that follows is guaranteed to see the imported rows, which is the
+  /// whole point of refreshing here — the import raises no other invalidation.
+  Future<void> _refreshAfterScan() async {
+    await _activeRefresh;
+    if (isClosed) return;
+    await refreshSessions();
   }
 
   /// Starts a catalog scan across every harness this bridge can import from.

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -546,6 +546,9 @@ class SessionListCubit({
   /// In-flight silent refresh, used for coalescing.
   Future<bool>? _activeRefresh;
 
+  /// The most recent list read of any kind.
+  Future<bool>? _activeFetch;
+
   /// Re-fetches sessions without showing the full-screen loading indicator.
   /// Concurrent calls are coalesced: if a refresh is already in-flight, the
   /// existing Future is returned instead of starting a second network request.
@@ -561,7 +564,21 @@ class SessionListCubit({
     ).whenComplete(() => _activeRefresh = null);
   }
 
-  Future<bool> _fetchSessions({bool silent = false, bool waitForPrData = false}) async {
+  /// Registers every list read, silent or not, so an ordering-sensitive caller
+  /// can wait for whatever is already in flight. [_activeRefresh] tracks only
+  /// the coalescing silent path, so an initial or retry load is invisible to it.
+  Future<bool> _fetchSessions({bool silent = false, bool waitForPrData = false}) {
+    final fetch = _runFetchSessions(silent: silent, waitForPrData: waitForPrData);
+    _activeFetch = fetch;
+    unawaited(
+      fetch.whenComplete(() {
+        if (identical(_activeFetch, fetch)) _activeFetch = null;
+      }).catchError((Object _) => false),
+    );
+    return fetch;
+  }
+
+  Future<bool> _runFetchSessions({bool silent = false, bool waitForPrData = false}) async {
     // Captured BEFORE the fetch so the seed can't overwrite a live update that
     // arrives while the (possibly PR-data-delayed) request is in flight.
     final unseenTick = _sessionUnseenTracker.tick;
@@ -620,7 +637,15 @@ class SessionListCubit({
   /// the read that follows is guaranteed to see the imported rows, which is the
   /// whole point of refreshing here — the import raises no other invalidation.
   Future<void> _refreshAfterScan() async {
-    await _activeRefresh;
+    // Every read, not just the coalescing silent one: a full load in flight
+    // would otherwise race this fetch and, landing last, overwrite what the
+    // scan just imported. A failing read reports itself, so it is not
+    // re-reported here.
+    try {
+      await _activeFetch;
+    } on Object catch (_) {
+      // Ignored: the read that failed owns its own reporting.
+    }
     if (isClosed) return;
     await refreshSessions();
   }

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -16,6 +16,8 @@ import "../../repositories/models/session_cleanup_rejection.dart";
 import "../../repositories/project_repository.dart";
 import "../../repositories/session_repository.dart";
 import "../../routing/app_routes.dart";
+import "../../services/catalog_rescan_service.dart";
+import "../../services/models/catalog_rescan_state.dart";
 import "../../services/models/session_activity_info.dart";
 import "../../services/models/session_list_item_state.dart";
 import "../../services/project_viewing_service.dart";
@@ -35,6 +37,7 @@ class SessionListCubit({
   required final RouteSource _routeSource,
   required final String _projectId,
   required final FailureReporter _failureReporter,
+  required final CatalogRescanService _catalogRescanService,
 }) extends Cubit<SessionListState> {
   final CompositeSubscription _subscriptions = CompositeSubscription();
 
@@ -48,6 +51,15 @@ class SessionListCubit({
 
   this : super(const SessionListState.loading()) {
     loadSessions();
+    // The catalog scan, which any surface can start. Its state is only
+    // projected onto this list; the operation itself is the service's.
+    _subscriptions.add(_catalogRescanService.state.listen(_onCatalogScanState));
+    // A committed import raises no list invalidation of its own, so the list
+    // refreshes when the scan leaves a live operation — however it ended,
+    // because a run this client only observed publishes no terminal state.
+    _subscriptions.add(
+      _catalogRescanService.settled.listen((_) => unawaited(refreshSessions())),
+    );
     _subscriptions.add(_connectionService.events.listen(_handleEvent));
     // 1. Navigate-back refresh: one immediate fetch when the user returns to
     //    the sessions page. pairwise() ensures this doesn't fire on the
@@ -593,6 +605,22 @@ class SessionListCubit({
           emit(SessionListState.failed(reason: error.remoteFailureReason));
         }
         return false;
+    }
+  }
+
+  /// Starts a catalog scan across every harness this bridge can import from.
+  void startCatalogScan() => unawaited(_catalogRescanService.startAll());
+
+  /// Stops the scan in flight.
+  void cancelCatalogScan() => unawaited(_catalogRescanService.cancel());
+
+  /// Clears a finished scan the user has read.
+  void dismissCatalogScan() => _catalogRescanService.dismiss();
+
+  void _onCatalogScanState(CatalogRescanState scan) {
+    if (isClosed) return;
+    if (state case final SessionListLoaded loaded) {
+      emit(loaded.copyWith(catalogScan: scan));
     }
   }
 

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -511,6 +511,11 @@ class SessionListCubit({
         activeSessionIds: projectActivity,
         unseenBySessionId: _unseenBySessionId(visible),
         isRefreshing: isRefreshing,
+        // Re-derived from its owner, like the two fields above it. Threading
+        // the previous loaded state forward would not do: the refresh this
+        // scan itself triggers rebuilds from a state that may not exist yet,
+        // and the terminal row it was fired for would be erased.
+        catalogScan: _catalogRescanService.state.value,
         baseBranch: _gitContext?.baseBranch,
         repoSlug: _gitContext?.repoSlug,
         repoProvider: _gitContext?.repoProvider ?? RepoProvider.other,

--- a/client/module_core/lib/src/cubits/session_list/session_list_state.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_state.dart
@@ -3,6 +3,7 @@ import "package:sesori_shared/sesori_shared.dart";
 
 import "../../errors/remote_failure_reason.dart";
 import "../../repositories/models/repo_provider.dart";
+import "../../services/models/catalog_rescan_state.dart";
 import "../../services/models/session_activity_info.dart";
 
 part "session_list_state.freezed.dart";
@@ -21,6 +22,14 @@ sealed class SessionListState with _$SessionListState {
     /// child tasks are running.
     @Default({}) Map<String, SessionActivityInfo> activeSessionIds,
     @Default(false) bool isRefreshing,
+
+    /// The catalog scan shown above the list, if any is worth showing.
+    ///
+    /// Carried here beside [isRefreshing] because it is the same kind of thing:
+    /// transient operation status the list renders over its content. The scan
+    /// itself is owned by `CatalogRescanService`; this is only the projection
+    /// the screen watches.
+    @Default(CatalogRescanState.idle()) CatalogRescanState catalogScan,
 
     /// Map of session ID -> whether it has unseen changes (bold title). Merges
     /// the REST-seeded `Session.unseen` with live `SesoriSessionUnseenChanged`

--- a/client/module_core/lib/src/cubits/session_list/session_list_state.freezed.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_state.freezed.dart
@@ -79,7 +79,7 @@ String toString() {
 
 
 class SessionListLoaded implements SessionListState {
-  const SessionListLoaded({required  List<Session> sessions, this.showArchived = false,  Map<String, SessionActivityInfo> activeSessionIds = const {}, this.isRefreshing = false,  Map<String, bool> unseenBySessionId = const {}, required this.baseBranch, required this.repoSlug, this.repoProvider = RepoProvider.other}): _sessions = sessions,_activeSessionIds = activeSessionIds,_unseenBySessionId = unseenBySessionId;
+  const SessionListLoaded({required  List<Session> sessions, this.showArchived = false,  Map<String, SessionActivityInfo> activeSessionIds = const {}, this.isRefreshing = false, this.catalogScan = const CatalogRescanState.idle(),  Map<String, bool> unseenBySessionId = const {}, required this.baseBranch, required this.repoSlug, this.repoProvider = RepoProvider.other}): _sessions = sessions,_activeSessionIds = activeSessionIds,_unseenBySessionId = unseenBySessionId;
   
 
  final  List<Session> _sessions;
@@ -106,6 +106,13 @@ class SessionListLoaded implements SessionListState {
 }
 
 @JsonKey() final  bool isRefreshing;
+/// The catalog scan shown above the list, if any is worth showing.
+///
+/// Carried here beside [isRefreshing] because it is the same kind of thing:
+/// transient operation status the list renders over its content. The scan
+/// itself is owned by `CatalogRescanService`; this is only the projection
+/// the screen watches.
+@JsonKey() final  CatalogRescanState catalogScan;
 /// Map of session ID -> whether it has unseen changes (bold title). Merges
 /// the REST-seeded `Session.unseen` with live `SesoriSessionUnseenChanged`
 /// updates, the latter taking precedence.
@@ -139,16 +146,16 @@ $SessionListLoadedCopyWith<SessionListLoaded> get copyWith => _$SessionListLoade
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionListLoaded&&const DeepCollectionEquality().equals(other._sessions, _sessions)&&(identical(other.showArchived, showArchived) || other.showArchived == showArchived)&&const DeepCollectionEquality().equals(other._activeSessionIds, _activeSessionIds)&&(identical(other.isRefreshing, isRefreshing) || other.isRefreshing == isRefreshing)&&const DeepCollectionEquality().equals(other._unseenBySessionId, _unseenBySessionId)&&(identical(other.baseBranch, baseBranch) || other.baseBranch == baseBranch)&&(identical(other.repoSlug, repoSlug) || other.repoSlug == repoSlug)&&(identical(other.repoProvider, repoProvider) || other.repoProvider == repoProvider));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionListLoaded&&const DeepCollectionEquality().equals(other._sessions, _sessions)&&(identical(other.showArchived, showArchived) || other.showArchived == showArchived)&&const DeepCollectionEquality().equals(other._activeSessionIds, _activeSessionIds)&&(identical(other.isRefreshing, isRefreshing) || other.isRefreshing == isRefreshing)&&(identical(other.catalogScan, catalogScan) || other.catalogScan == catalogScan)&&const DeepCollectionEquality().equals(other._unseenBySessionId, _unseenBySessionId)&&(identical(other.baseBranch, baseBranch) || other.baseBranch == baseBranch)&&(identical(other.repoSlug, repoSlug) || other.repoSlug == repoSlug)&&(identical(other.repoProvider, repoProvider) || other.repoProvider == repoProvider));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_sessions),showArchived,const DeepCollectionEquality().hash(_activeSessionIds),isRefreshing,const DeepCollectionEquality().hash(_unseenBySessionId),baseBranch,repoSlug,repoProvider);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_sessions),showArchived,const DeepCollectionEquality().hash(_activeSessionIds),isRefreshing,catalogScan,const DeepCollectionEquality().hash(_unseenBySessionId),baseBranch,repoSlug,repoProvider);
 
 @override
 String toString() {
-  return 'SessionListState.loaded(sessions: $sessions, showArchived: $showArchived, activeSessionIds: $activeSessionIds, isRefreshing: $isRefreshing, unseenBySessionId: $unseenBySessionId, baseBranch: $baseBranch, repoSlug: $repoSlug, repoProvider: $repoProvider)';
+  return 'SessionListState.loaded(sessions: $sessions, showArchived: $showArchived, activeSessionIds: $activeSessionIds, isRefreshing: $isRefreshing, catalogScan: $catalogScan, unseenBySessionId: $unseenBySessionId, baseBranch: $baseBranch, repoSlug: $repoSlug, repoProvider: $repoProvider)';
 }
 
 
@@ -159,7 +166,7 @@ abstract mixin class $SessionListLoadedCopyWith<$Res> implements $SessionListSta
   factory $SessionListLoadedCopyWith(SessionListLoaded value, $Res Function(SessionListLoaded) _then) = _$SessionListLoadedCopyWithImpl;
 @useResult
 $Res call({
- List<Session> sessions, bool showArchived, Map<String, SessionActivityInfo> activeSessionIds, bool isRefreshing, Map<String, bool> unseenBySessionId, String? baseBranch, String? repoSlug, RepoProvider repoProvider
+ List<Session> sessions, bool showArchived, Map<String, SessionActivityInfo> activeSessionIds, bool isRefreshing, CatalogRescanState catalogScan, Map<String, bool> unseenBySessionId, String? baseBranch, String? repoSlug, RepoProvider repoProvider
 });
 
 
@@ -176,13 +183,14 @@ class _$SessionListLoadedCopyWithImpl<$Res>
 
 /// Create a copy of SessionListState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? sessions = null,Object? showArchived = null,Object? activeSessionIds = null,Object? isRefreshing = null,Object? unseenBySessionId = null,Object? baseBranch = freezed,Object? repoSlug = freezed,Object? repoProvider = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? sessions = null,Object? showArchived = null,Object? activeSessionIds = null,Object? isRefreshing = null,Object? catalogScan = null,Object? unseenBySessionId = null,Object? baseBranch = freezed,Object? repoSlug = freezed,Object? repoProvider = null,}) {
   return _then(SessionListLoaded(
 sessions: null == sessions ? _self._sessions : sessions // ignore: cast_nullable_to_non_nullable
 as List<Session>,showArchived: null == showArchived ? _self.showArchived : showArchived // ignore: cast_nullable_to_non_nullable
 as bool,activeSessionIds: null == activeSessionIds ? _self._activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
 as Map<String, SessionActivityInfo>,isRefreshing: null == isRefreshing ? _self.isRefreshing : isRefreshing // ignore: cast_nullable_to_non_nullable
-as bool,unseenBySessionId: null == unseenBySessionId ? _self._unseenBySessionId : unseenBySessionId // ignore: cast_nullable_to_non_nullable
+as bool,catalogScan: null == catalogScan ? _self.catalogScan : catalogScan // ignore: cast_nullable_to_non_nullable
+as CatalogRescanState,unseenBySessionId: null == unseenBySessionId ? _self._unseenBySessionId : unseenBySessionId // ignore: cast_nullable_to_non_nullable
 as Map<String, bool>,baseBranch: freezed == baseBranch ? _self.baseBranch : baseBranch // ignore: cast_nullable_to_non_nullable
 as String?,repoSlug: freezed == repoSlug ? _self.repoSlug : repoSlug // ignore: cast_nullable_to_non_nullable
 as String?,repoProvider: null == repoProvider ? _self.repoProvider : repoProvider // ignore: cast_nullable_to_non_nullable

--- a/client/module_core/lib/src/testing/test_helpers.dart
+++ b/client/module_core/lib/src/testing/test_helpers.dart
@@ -871,8 +871,22 @@ class FakeCatalogRescanService() implements CatalogRescanService {
   @override
   Stream<void> get settled => _settled.stream;
 
+  /// Plugin ids passed to [start], in call order.
+  final List<String> startedPluginIds = [];
+
+  CatalogRescanStartResult _startResult = const CatalogRescanStartResult.accepted();
+
+  /// Sets what [start] answers, so a test can drive a rejection.
+  void stubStartResult(CatalogRescanStartResult result) => _startResult = result;
+
   @override
   Future<void> startAll() async => _startAlls.add(null);
+
+  @override
+  Future<CatalogRescanStartResult> start({required String pluginId}) async {
+    startedPluginIds.add(pluginId);
+    return _startResult;
+  }
 
   @override
   Future<void> cancel() async => _cancels.add(null);
@@ -896,7 +910,4 @@ class FakeCatalogRescanService() implements CatalogRescanService {
     await _settled.close();
   }
 
-  @override
-  // ignore: no_slop_linter/avoid_dynamic_return_type, mocktail's fallback signature
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/client/module_core/lib/src/testing/test_helpers.dart
+++ b/client/module_core/lib/src/testing/test_helpers.dart
@@ -34,6 +34,8 @@ import "../repositories/project_repository.dart";
 import "../repositories/registered_bridges_store.dart";
 import "../repositories/session_repository.dart";
 import "../routing/app_routes.dart";
+import "../services/catalog_rescan_service.dart";
+import "../services/models/catalog_rescan_state.dart";
 import "../services/models/session_activity_info.dart";
 import "../services/models/session_list_item_state.dart";
 import "../services/product_analytics_service.dart";
@@ -842,4 +844,59 @@ class FakeAuthSession({required AuthState initialState}) implements AuthSession 
   Future<AuthUser> loginWithApple({required String idToken, required String nonce}) async {
     throw UnimplementedError();
   }
+}
+
+/// A [CatalogRescanService] a test drives directly.
+///
+/// The real service owns a whole operation lifecycle; a consumer only cares
+/// that it publishes state, announces when a run closes, and accepts intents,
+/// so this exposes exactly those.
+class FakeCatalogRescanService() implements CatalogRescanService {
+  final BehaviorSubject<CatalogRescanState> _state = BehaviorSubject.seeded(
+    const CatalogRescanState.idle(),
+  );
+  final StreamController<void> _settled = StreamController<void>.broadcast(sync: true);
+
+  final List<void> _startAlls = [];
+  final List<void> _cancels = [];
+  final List<void> _dismisses = [];
+
+  int get startAllCalls => _startAlls.length;
+  int get cancelCalls => _cancels.length;
+  int get dismissCalls => _dismisses.length;
+
+  @override
+  ValueStream<CatalogRescanState> get state => _state.stream;
+
+  @override
+  Stream<void> get settled => _settled.stream;
+
+  @override
+  Future<void> startAll() async => _startAlls.add(null);
+
+  @override
+  Future<void> cancel() async => _cancels.add(null);
+
+  @override
+  void dismiss() => _dismisses.add(null);
+
+  /// Publishes [next] as the current scan state.
+  void emit(CatalogRescanState next) => _state.add(next);
+
+  /// Announces that a live operation closed, whatever it settled as.
+  void emitSettled() => _settled.add(null);
+
+  /// Closes both streams. Named to match `Disposable`, because `get_it` calls
+  /// it on reset and every widget test that registers this fake goes through
+  /// that path.
+  @override
+  Future<void> onDispose() async {
+    if (_state.isClosed) return;
+    await _state.close();
+    await _settled.close();
+  }
+
+  @override
+  // ignore: no_slop_linter/avoid_dynamic_return_type, mocktail's fallback signature
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -2447,6 +2447,33 @@ void main() {
         expect((cubit.state as ProjectListLoaded).catalogScan, isA<CatalogRescanSucceeded>());
       });
 
+      test("reads again after an in-flight refresh rather than coalescing onto it", () async {
+        stubProjects();
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await Future<void>.delayed(Duration.zero);
+
+        // A refresh that started before the import committed.
+        final inFlight = Completer<ApiResponse<Projects>>();
+        when(() => mockProjectRepository.listProjects()).thenAnswer((_) => inFlight.future);
+        unawaited(cubit.refreshProjects());
+        await Future<void>.delayed(Duration.zero);
+        clearInteractions(mockProjectRepository);
+
+        fakeCatalogRescanService.emitSettled();
+        await Future<void>.delayed(Duration.zero);
+        verifyNever(() => mockProjectRepository.listProjects());
+
+        // Releasing the old request must be followed by a fresh read, or the
+        // imported rows are never seen: the import raises no other signal.
+        stubProjects();
+        inFlight.complete(ApiResponse.success(const Projects(data: <ProjectSummary>[])));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        verify(() => mockProjectRepository.listProjects()).called(1);
+      });
+
       test("forwards the scan intents to the service", () async {
         stubProjects();
         final cubit = buildCubit();

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -2425,6 +2425,28 @@ void main() {
         verify(() => mockProjectRepository.listProjects()).called(1);
       });
 
+      test("keeps a terminal scan through the refresh it triggers", () async {
+        stubProjects();
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await Future<void>.delayed(Duration.zero);
+        stubProjects();
+
+        // The service publishes its terminal state and then announces the
+        // close, which starts the refresh. That refresh must not erase the row
+        // it was fired for.
+        fakeCatalogRescanService.emit(
+          const CatalogRescanState.succeeded(
+            harnessCount: 1,
+            counts: CatalogRescanCounts.delta(newProjects: 2, newSessions: 5),
+          ),
+        );
+        fakeCatalogRescanService.emitSettled();
+        await Future<void>.delayed(Duration.zero);
+
+        expect((cubit.state as ProjectListLoaded).catalogScan, isA<CatalogRescanSucceeded>());
+      });
+
       test("forwards the scan intents to the service", () async {
         stubProjects();
         final cubit = buildCubit();

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -2474,6 +2474,29 @@ void main() {
         verify(() => mockProjectRepository.listProjects()).called(1);
       });
 
+      test("waits for a full load too, not only a silent refresh", () async {
+        // Only the silent path is coalesced, so an initial or retry load is
+        // invisible to it. Landing last, it would overwrite what the scan
+        // imported.
+        final initial = Completer<ApiResponse<Projects>>();
+        when(() => mockProjectRepository.listProjects()).thenAnswer((_) => initial.future);
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await Future<void>.delayed(Duration.zero);
+        clearInteractions(mockProjectRepository);
+
+        fakeCatalogRescanService.emitSettled();
+        await Future<void>.delayed(Duration.zero);
+        verifyNever(() => mockProjectRepository.listProjects());
+
+        stubProjects();
+        initial.complete(ApiResponse.success(const Projects(data: <ProjectSummary>[])));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        verify(() => mockProjectRepository.listProjects()).called(1);
+      });
+
       test("forwards the scan intents to the service", () async {
         stubProjects();
         final cubit = buildCubit();

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -15,6 +15,7 @@ import "package:sesori_dart_core/src/foundation/models/product_analytics/product
 import "package:sesori_dart_core/src/foundation/models/product_analytics/product_analytics_preference.dart";
 import "package:sesori_dart_core/src/repositories/models/analytics_delivery_result.dart";
 import "package:sesori_dart_core/src/services/loaded_state_analytics_reporter.dart";
+import "package:sesori_dart_core/src/services/models/catalog_rescan_state.dart";
 import "package:sesori_dart_core/src/services/models/product_analytics_state.dart";
 import "package:sesori_dart_core/src/services/models/session_activity_info.dart";
 import "package:sesori_dart_core/src/services/product_analytics_service.dart";
@@ -61,6 +62,7 @@ void main() {
 
   group("ProjectListCubit", () {
     late MockProjectRepository mockProjectRepository;
+    late FakeCatalogRescanService fakeCatalogRescanService;
     late ProjectListService projectListService;
     late MockConnectionService mockConnectionService;
     late MockSseEventTracker mockSseEventTracker;
@@ -74,6 +76,7 @@ void main() {
     late Completer<ApiResponse<Projects>> projectFetchCompleter;
 
     setUp(() {
+      fakeCatalogRescanService = FakeCatalogRescanService();
       mockProjectRepository = MockProjectRepository();
       projectListService = ProjectListService(
         repository: mockProjectRepository,
@@ -141,6 +144,7 @@ void main() {
         productAnalyticsService: mockProductAnalyticsService,
       ),
       failureReporter: mockFailureReporter,
+      catalogRescanService: fakeCatalogRescanService,
     );
 
     test("onboarding outcome intents report the seven bounded events", () async {
@@ -2376,5 +2380,68 @@ void main() {
         },
       );
     });
+
+    group("catalog scan", () {
+      void stubProjects() {
+        when(
+          () => mockProjectRepository.listProjects(),
+        ).thenAnswer((_) async => ApiResponse.success(const Projects(data: <ProjectSummary>[])));
+      }
+
+      test("projects the scan onto the loaded state", () async {
+        stubProjects();
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await Future<void>.delayed(Duration.zero);
+
+        fakeCatalogRescanService.emit(
+          const CatalogRescanState.running(
+            activePluginName: "Codex",
+            sessionsSeen: 148,
+            pluginIds: {"codex"},
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          (cubit.state as ProjectListLoaded).catalogScan,
+          isA<CatalogRescanRunning>().having((s) => s.sessionsSeen, "sessionsSeen", 148),
+        );
+      });
+
+      test("refreshes when a scan leaves a live operation", () async {
+        stubProjects();
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await Future<void>.delayed(Duration.zero);
+        clearInteractions(mockProjectRepository);
+        stubProjects();
+
+        // A committed import raises no list invalidation of its own, so this
+        // refresh is the only thing that surfaces what the scan imported.
+        fakeCatalogRescanService.emitSettled();
+        await Future<void>.delayed(Duration.zero);
+
+        verify(() => mockProjectRepository.listProjects()).called(1);
+      });
+
+      test("forwards the scan intents to the service", () async {
+        stubProjects();
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await Future<void>.delayed(Duration.zero);
+
+        cubit
+          ..startCatalogScan()
+          ..cancelCatalogScan()
+          ..dismissCatalogScan();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(fakeCatalogRescanService.startAllCalls, 1);
+        expect(fakeCatalogRescanService.cancelCalls, 1);
+        expect(fakeCatalogRescanService.dismissCalls, 1);
+      });
+    });
+
   });
 }

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -14,6 +14,7 @@ import "package:sesori_dart_core/src/cubits/session_list/session_list_state.dart
 import "package:sesori_dart_core/src/repositories/models/repo_provider.dart";
 import "package:sesori_dart_core/src/repositories/models/session_cleanup_rejection.dart" as domain;
 import "package:sesori_dart_core/src/repositories/project_repository.dart";
+import "package:sesori_dart_core/src/services/models/catalog_rescan_state.dart";
 import "package:sesori_dart_core/src/services/models/session_activity_info.dart";
 import "package:sesori_dart_core/src/services/session_activity_calculator.dart";
 import "package:sesori_dart_core/src/services/session_list_service.dart";
@@ -27,6 +28,7 @@ void main() {
 
   group("SessionListCubit", () {
     late MockSessionRepository mockSessionService;
+    late FakeCatalogRescanService fakeCatalogRescanService;
     late MockProjectRepository mockProjectRepository;
     late SessionListService sessionListService;
     late MockConnectionService mockConnectionService;
@@ -41,6 +43,7 @@ void main() {
     const projectId = "project-1";
 
     setUp(() {
+      fakeCatalogRescanService = FakeCatalogRescanService();
       mockSessionService = MockSessionRepository();
       mockProjectRepository = MockProjectRepository();
       sessionListService = SessionListService(
@@ -95,6 +98,7 @@ void main() {
       routeSource: mockRouteSource,
       projectId: projectId,
       failureReporter: mockFailureReporter,
+      catalogRescanService: fakeCatalogRescanService,
     );
 
     test("successful list render readies its project claim and close releases it", () async {
@@ -1538,6 +1542,7 @@ void main() {
           routeSource: mockRouteSource,
           projectId: "global",
           failureReporter: mockFailureReporter,
+          catalogRescanService: fakeCatalogRescanService,
         );
       },
       expect: () => [
@@ -2185,6 +2190,77 @@ void main() {
       expect(fakeSessionUnseenTracker.currentSessionUnseen[projectId]?["s1"]?.unseen, isTrue);
       expect((cubit.state as SessionListLoaded).unseenBySessionId["s1"], isTrue);
     });
+
+    group("catalog scan", () {
+      void stubSessions() {
+        when(
+          () => mockProjectRepository.listSessions(
+            projectId: projectId,
+            waitForPrData: any(named: "waitForPrData"),
+          ),
+        ).thenAnswer((_) async => ApiResponse.success(const SessionListResponse(items: [])));
+      }
+
+      test("projects the scan onto the loaded state", () async {
+        stubSessions();
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await cubit.stream.firstWhere((state) => state is SessionListLoaded);
+
+        fakeCatalogRescanService.emit(
+          const CatalogRescanState.running(
+            activePluginName: "Codex",
+            sessionsSeen: 148,
+            pluginIds: {"codex"},
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          (cubit.state as SessionListLoaded).catalogScan,
+          isA<CatalogRescanRunning>().having((s) => s.activePluginName, "activePluginName", "Codex"),
+        );
+      });
+
+      test("refreshes when a scan leaves a live operation", () async {
+        stubSessions();
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await cubit.stream.firstWhere((state) => state is SessionListLoaded);
+        clearInteractions(mockProjectRepository);
+        stubSessions();
+
+        // A committed import raises no list invalidation of its own, so this
+        // refresh is the only thing that surfaces what the scan imported.
+        fakeCatalogRescanService.emitSettled();
+        await Future<void>.delayed(Duration.zero);
+
+        verify(
+          () => mockProjectRepository.listSessions(
+            projectId: projectId,
+            waitForPrData: any(named: "waitForPrData"),
+          ),
+        ).called(1);
+      });
+
+      test("forwards the scan intents to the service", () async {
+        stubSessions();
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await cubit.stream.firstWhere((state) => state is SessionListLoaded);
+
+        cubit
+          ..startCatalogScan()
+          ..cancelCatalogScan()
+          ..dismissCatalogScan();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(fakeCatalogRescanService.startAllCalls, 1);
+        expect(fakeCatalogRescanService.cancelCalls, 1);
+        expect(fakeCatalogRescanService.dismissCalls, 1);
+      });
+    });
+
   });
 }
 

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -2243,6 +2243,30 @@ void main() {
         ).called(1);
       });
 
+      test("keeps a terminal scan through an unrelated list rebuild", () async {
+        stubSessions();
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await cubit.stream.firstWhere((state) => state is SessionListLoaded);
+
+        fakeCatalogRescanService.emit(
+          const CatalogRescanState.failed(harnessCount: 2),
+        );
+        await Future<void>.delayed(Duration.zero);
+        expect((cubit.state as SessionListLoaded).catalogScan, isA<CatalogRescanFailed>());
+
+        // Any list rebuild — a session event, a toggle, the refresh the scan
+        // itself triggers — must not reset a row that persists until dismissed.
+        cubit.toggleArchived();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          (cubit.state as SessionListLoaded).catalogScan,
+          isA<CatalogRescanFailed>(),
+          reason: "a failure the user has not read must survive a rebuild",
+        );
+      });
+
       test("forwards the scan intents to the service", () async {
         stubSessions();
         final cubit = buildCubit();


### PR DESCRIPTION
## Complexity

Moderate. Small per-cubit change, but it touches two generated states and every
app test harness that renders a list.

## What

The first of three sub-steps for step 6, split by layer so none exceeds the size
cap. This one is `module_core` plus wiring; nothing renders yet.

- `ProjectListLoaded` and `SessionListLoaded` gain a `catalogScan` projection,
  beside the `isRefreshing` they already carry — it is the same kind of thing,
  transient operation status the list renders over its content.
- Both cubits subscribe to `CatalogRescanService`, expose `startCatalogScan()`,
  `cancelCatalogScan()` and `dismissCatalogScan()`, and run their **existing**
  silent refresh when a scan leaves a live operation.
- `FakeCatalogRescanService` joins the shared `sesori_dart_core/testing.dart`
  barrel, so `module_core` and `client/app` drive the same fake.

## Why

A committed catalog import raises no list invalidation of its own —
`catalogImportRepository.backendActivity` feeds only `ChatHistoryActivityListener`,
and the `sessionsUpdated` producers are PR sync and the unseen service. Without
this refresh the scan would announce new sessions over a list that still lacks
them, which is the feature failing at its whole purpose.

The refresh is keyed on **leaving a live operation** rather than on the terminal
success variants, because a run this client only observed settles without
publishing one and would otherwise never refresh.

## Risk and test focus

Low behaviourally, wider than it looks by blast radius.

Nothing user-visible changes: no widget reads `catalogScan` until 6b, and no
surface calls the intents. The risk is the wiring — two generated states
regenerated, two `BlocProvider` sites given a new dependency, and the shared app
test helper now registering the service.

That last part is worth a reviewer's eye: the fake is registered in
`_registerListServices` rather than per test file, because it is a dependency of
the lists themselves rather than of any one screen. Registering it per file
instead caused duplicate-registration failures in harnesses that also call the
shared helper.

`FakeCatalogRescanService.onDispose()` matches `Disposable` deliberately —
`get_it` calls it on reset, which every widget test goes through.

## Expected result

**User-visible:** none.

**Database:** no change.

**Internal:** `ProjectListLoaded.catalogScan` and `SessionListLoaded.catalogScan`
default to `CatalogRescanState.idle()`, so existing consumers are unaffected.

## Verification

- `dart analyze --fatal-infos` clean on `client/module_core` and `client/app`
- `client/module_core`: 1,349 tests passing, 6 new — each cubit proves it
  projects the scan, refreshes on a settled scan, and forwards all three intents
- `client/app`: 854 tests passing
- `dart run build_runner build` for the two regenerated states
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes catalog rescan state through the project and session list cubits and orders the post-scan refresh behind any in-flight read. Previously lists didn’t track scans and a refresh could race or miss imported sessions; now they project scan status, keep it through rebuilds, and refresh strictly after the scan commits.

- Adds `catalogScan: CatalogRescanState` to `ProjectListLoaded` and `SessionListLoaded` (default `idle()`; no UI yet).
- `ProjectListCubit` and `SessionListCubit` subscribe to `CatalogRescanService.state` and `settled`, and expose `startCatalogScan()`, `cancelCatalogScan()`, and `dismissCatalogScan()`.
- Re-derives `catalogScan` from `CatalogRescanService` on any loaded-state rebuild to avoid erasing terminal scan rows (including the refresh triggered by `settled`).
- Orders the post-scan refresh: waits for any active list read (initial, retry, or coalesced silent) via `_activeFetch`, then refreshes to prevent overwriting imported rows.
- DI: both cubits now require `CatalogRescanService`. App providers inject it; tests must register `FakeCatalogRescanService`. `@sesori_dart_core` re-exports `services/catalog_rescan_service.dart` and `services/models/catalog_rescan_state.dart`.
- Docs: plan splits step 6 into 6a/6b/6c and records the read-ordering rationale; tracker updated with steps 4–5 merged.

<sup>Written for commit 24fc856f9f621495b45daef78ca93534e61f6e72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

