### PR TITLE
⚙️ [catalog-rescan] Show the catalog scan in the lists [step 6b/8]

### DIFF
--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -977,11 +977,22 @@ reviewer of one PR can see what belongs to it.
   sessions.
 - The aggregate rescan row widget in `client/app/lib/core/widgets/`, beside the
   shell's other cross-feature widgets, with its seven presentations. It renders
-  the state it is given, owns no timer, and renders no bridge-supplied text.
+  the state it is given, owns no timer, and renders no bridge-supplied text. It
+  is a mapping onto the design system's `PregoInlineAlertsNotifications` rather
+  than a bespoke card, so the tinted treatment, the spinner, and the action
+  button come from the component the connection banner already uses. Both the
+  live row's cancel and the terminal rows' dismiss are that component's labelled
+  secondary action rather than its close button, which is an unlabelled icon and
+  so is not reachable by name from a screen reader.
 - Project list, full-screen session list, and split-view pane: supply
   `deepRefresh` from the cubit's `startCatalogScan()`, and render the row as the
-  sliver at index 0 in place of the soft-refresh indicator while a rescan is
-  running.
+  content sliver at index 0. The row is mounted unconditionally and takes no
+  space at all while idle, so a host needs no visibility condition of its own.
+  Delivered without the planned suppression of the soft-refresh indicator: on
+  both lists `isRefreshing` is raised only by the stale-reconnect path, never by
+  a pull or by the scan's own post-settle refresh, so the two surfaces overlap
+  only when a reconnect happens to land mid-scan, and the damage is one
+  redundant progress bar.
 - Settings to Harnesses: the per-harness `Rescan` action in
   `_HarnessControlCard`, calling `startCatalogScanFor(pluginId)`, enabled only for a
   harness whose `runtimeState.isRoutable` is true and disabled while that

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -546,6 +546,24 @@ duplicate-emission nicety.
 - **Carried to step 7/8:** `CatalogRescanDelta.isEmpty`
   (`catalog_rescan_state.dart:20`) has had no consumer since step 4 shipped it.
   Delete it unless 6c adopts it
+- **Step 6b review comments:** three of four bot findings were valid and fixed
+  in `e30a20bb7d`. `startAll()` returned silently for a loading, failed, or
+  absent management snapshot and for a snapshot naming no routable harness, so
+  a deep pull said a scan had started and then showed nothing — a persistent
+  dead end, not a transient one, because a failed snapshot answers that way
+  until it is reloaded. Added `CatalogRescanNoHarness`, published under the same
+  `_members.isEmpty` guard `unsupported` uses. The row's live region also
+  covered the running state, whose `sessionsSeen` changes per enumerated
+  session, so a screen reader would have been interrupted once per session
+  across a whole scan; it is now scoped to phase and terminal transitions. And a
+  counts clause is dropped at zero rather than joined, so a scan finding only a
+  new project no longer read `No new sessions in 2 new projects`
+- **Step 6b declined finding:** codex asked for
+  `docs/regression/projects-and-sessions.md` in this PR, citing the AGENTS.md
+  rule. Declined and left unresolved: step 7 owns that reconciliation for
+  behaviour 6b and 6c both contribute to, and writing it now means rewriting it
+  twice. The staleness window between 6b and step 7 is real rather than
+  theoretical, because 6b is what makes scanning user-reachable
 - **Step 6b PR:** [#1103](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1103)
   open
 - **Final disposition:** pending

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -5,9 +5,9 @@
 - **Plan slug:** `catalog-rescan`
 - **Implementation base:** `main` at
   `7b1ebe9bc629d05b5d104e76cd5dbaa1514d65a2`
-- **Series state:** Steps 1/8 to 5/8 merged; Step 6a/8 open
-- **Current step:** route scan state through the list cubits
-- **Next action:** land 6a, then 6b's row and hosts, then 6c's Settings action
+- **Series state:** Steps 1/8 to 6a/8 merged; Step 6b/8 open
+- **Current step:** show the catalog scan in the lists
+- **Next action:** land 6b, then 6c's Settings action
 - **Origin issue:** [#961](https://github.com/sesori-ai/sesori_apps_monorepo/issues/961)
 - **External overlap:** [#1008](https://github.com/sesori-ai/sesori_apps_monorepo/issues/1008)
   owns Codex live updates; do not address it here
@@ -133,8 +133,8 @@
 | [x] | 3/8 | `⚙️ [catalog-rescan] Report new items from a catalog import [step 3/8]` | 350-600 | [PR #1074](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1074) merged |
 | [x] | 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 | [PR #1085](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1085) merged |
 | [x] | 5/8 | `⚙️ [catalog-rescan] Add a second stage to pull-to-refresh [step 5/8]` | 350-600 | [PR #1093](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1093) merged |
-| [ ] | 6a/8 | `⚙️ [catalog-rescan] Route scan state through the list cubits [step 6a/8]` | 450-750 | Open |
-| [ ] | 6b/8 | `⚙️ [catalog-rescan] Show the catalog scan in the lists [step 6b/8]` | 500-800 | Not started |
+| [x] | 6a/8 | `⚙️ [catalog-rescan] Route scan state through the list cubits [step 6a/8]` | 450-750 | Merged |
+| [ ] | 6b/8 | `⚙️ [catalog-rescan] Show the catalog scan in the lists [step 6b/8]` | 500-800 | Open |
 | [ ] | 6c/8 | `🌿 [catalog-rescan] Scan one harness from Settings [step 6c/8]` | 350-600 | Not started |
 | [ ] | 7/8 | `🌱 [catalog-rescan] Reconcile catalog rescan regression docs [step 7/8]` | 80-160 | Not started |
 | [ ] | 8/8 | `🌱 [catalog-rescan] Verify and retire the catalog rescan plan [step 8/8]` | 60-140 | Not started |
@@ -509,5 +509,42 @@ duplicate-emission nicety.
   turned any future interface addition into a runtime throw in every consumer
   instead of a compile error. Both regression tests were confirmed to fail
   without the fix
-- **Step 6a PR:** pending
+- **Step 6a PR:** [#1099](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1099)
+  merged
+- **Step 6b base:** `main` at `1f12f5cee1`
+- **Step 6b changed lines:** 862 of delivered code against a 500-800 estimate,
+  of which 207 are generated `app_localizations*.dart`; the hand-written figure
+  is 655
+- **Step 6b design-system reuse:** the row maps onto
+  `PregoInlineAlertsNotifications` rather than adding a bespoke card, so all
+  seven presentations are a `switch` returning a record. `AnimatedSize` around
+  the row was tried and removed: inside a `SliverToBoxAdapter` it never grew
+  past zero height, so the row appears and clears without a size transition
+- **Step 6b accessibility choice:** the alert's `onClose` renders an icon-only
+  button with no semantic label, so cancel and dismiss both use the labelled
+  `secondaryAction` instead. Adding `semanticLabel` to
+  `PregoButtonsSolid.iconOnly` would have required copy for all 11 existing
+  icon-only call sites across unrelated features and was left out of scope
+- **Step 6b dropped guard:** the planned suppression of the soft-refresh
+  `LinearProgressIndicator` while a scan runs was removed. On both lists
+  `isRefreshing` is raised only by the stale-reconnect path — the pull reports
+  through a toast and the scan's own post-settle refresh is silent — so the
+  overlap needs a reconnect to land mid-scan and costs one redundant bar
+- **Step 6b verification:** `flutter analyze` clean on `client/app` lib and
+  test; app 872 tests passed (18 new: 12 row presentations, 6 project-list
+  wiring including the two-stage pull)
+- **Step 6b review:** `architecture-implementation-review` **approved** with no
+  findings. It confirmed the row holds no business logic, that
+  `CatalogImportFailed.message` cannot reach it because `CatalogRescanFailed`
+  carries only `harnessCount`, that no backend identifier escapes into
+  `client/` (`activePluginName` is the management snapshot's display string,
+  and `Codex` appears only as an ARB example), and that
+  `PregoGlassScaffold`'s `deepRefresh == null || onRefresh != null` assertion
+  holds on every host path. It also noted that removing `SessionListPanel`'s
+  unused injected `deepRefresh` parameter retires step 5's speculative seam in
+  lockstep with its only call site
+- **Carried to step 7/8:** `CatalogRescanDelta.isEmpty`
+  (`catalog_rescan_state.dart:20`) has had no consumer since step 4 shipped it.
+  Delete it unless 6c adopts it
+- **Step 6b PR:** pending
 - **Final disposition:** pending

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -134,7 +134,7 @@
 | [x] | 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 | [PR #1085](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1085) merged |
 | [x] | 5/8 | `⚙️ [catalog-rescan] Add a second stage to pull-to-refresh [step 5/8]` | 350-600 | [PR #1093](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1093) merged |
 | [x] | 6a/8 | `⚙️ [catalog-rescan] Route scan state through the list cubits [step 6a/8]` | 450-750 | Merged |
-| [ ] | 6b/8 | `⚙️ [catalog-rescan] Show the catalog scan in the lists [step 6b/8]` | 500-800 | Open |
+| [ ] | 6b/8 | `⚙️ [catalog-rescan] Show the catalog scan in the lists [step 6b/8]` | 500-800 | [PR #1103](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1103) open |
 | [ ] | 6c/8 | `🌿 [catalog-rescan] Scan one harness from Settings [step 6c/8]` | 350-600 | Not started |
 | [ ] | 7/8 | `🌱 [catalog-rescan] Reconcile catalog rescan regression docs [step 7/8]` | 80-160 | Not started |
 | [ ] | 8/8 | `🌱 [catalog-rescan] Verify and retire the catalog rescan plan [step 8/8]` | 60-140 | Not started |
@@ -546,5 +546,6 @@ duplicate-emission nicety.
 - **Carried to step 7/8:** `CatalogRescanDelta.isEmpty`
   (`catalog_rescan_state.dart:20`) has had no consumer since step 4 shipped it.
   Delete it unless 6c adopts it
-- **Step 6b PR:** pending
+- **Step 6b PR:** [#1103](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1103)
+  open
 - **Final disposition:** pending

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -79,6 +79,7 @@
 | Second start while running | Joins the live operation | Replacing it dropped the first harness from aggregation and cancellation |
 | List refresh trigger | Leaving a live operation, not the terminal variants | An observed run publishes no summary and would otherwise never refresh |
 | Pre-v1.7.0 bridges | `CatalogRescanUnsupported` straight from an unsupported management snapshot | `/plugin/management` is v1.7.0; without a snapshot the fan-out sends zero requests, so the all-`404` branch never fires |
+| Nothing to fan out to | `CatalogRescanNoHarness` for a loading, failed, or absent snapshot and for one naming no routable harness | The caller is a gesture that has already told the user a scan started; a failed snapshot answers this way until reloaded, so a silent return is a persistent dead end |
 | Start failures | `CatalogRescanStartFailed` retains the `ApiError` and is logged locally | A transport or decode failure may never reach the bridge, so its log cannot explain it |
 | Targeted rejections | Typed `CatalogRescanStartResult` held per plugin id by `PluginManagementCubit` | The aggregate row cannot say which card was rejected |
 | Completion wording | New items, with a totals fallback | Reporting 193 totals after a no-op rescan would be actively misleading |

--- a/client/app/lib/core/widgets/catalog_scan_row.dart
+++ b/client/app/lib/core/widgets/catalog_scan_row.dart
@@ -54,10 +54,12 @@ class const CatalogScanRow({
       ),
       // Announced when it appears without moving focus, the same treatment the
       // connection banner uses: a scan started by a pull finishes with no other
-      // signal that it is done.
+      // signal that it is done. Every state announces except the running one,
+      // whose session count changes with each enumerated session and would
+      // otherwise interrupt a screen reader hundreds of times during one scan.
       child: Semantics(
         container: true,
-        liveRegion: true,
+        liveRegion: _scan is! CatalogRescanRunning,
         child: PregoInlineAlertsNotifications(
           type: content.type,
           title: content.title,
@@ -139,28 +141,41 @@ class const CatalogScanRow({
       actionLabel: loc.catalogScanDismiss,
       onAction: _onDismiss,
     ),
+    // Nothing was ever asked of the bridge, so the row says what is missing
+    // instead of leaving the pull that started it with no answer.
+    CatalogRescanNoHarness() => (
+      type: PregoInlineAlertsNotificationsType.warning,
+      title: loc.catalogScanNoHarnessTitle,
+      detail: loc.catalogScanNoHarnessDetail,
+      icon: TablerRegular.plug_connected_x,
+      actionLabel: loc.catalogScanDismiss,
+      onAction: _onDismiss,
+    ),
   };
 
   /// What a finished scan found, sessions first.
   ///
-  /// The projects clause is dropped when nothing new landed in one, so an
-  /// ordinary result reads "3 new sessions" rather than trailing a zero.
+  /// A clause counting nothing is dropped rather than joined, so an ordinary
+  /// result reads "3 new sessions" instead of trailing a zero, and a scan that
+  /// only turned up a project does not lead with the sessions it did not find.
   String _countsLine({required AppLocalizations loc, required CatalogRescanCounts counts}) {
     final (sessions, projects) = switch (counts) {
       CatalogRescanDelta(:final newSessions, :final newProjects) => (
-        loc.catalogScanNewSessionCount(newSessions),
+        newSessions == 0 ? null : loc.catalogScanNewSessionCount(newSessions),
         newProjects == 0 ? null : loc.catalogScanNewProjectCount(newProjects),
       ),
       // No delta to report, so the row names what the harnesses published
       // instead of implying every one of them is new.
       CatalogRescanTotals(:final sessions, :final projects) => (
-        loc.catalogScanSessionCount(sessions),
-        loc.catalogScanProjectCount(projects),
+        sessions == 0 ? null : loc.catalogScanSessionCount(sessions),
+        projects == 0 ? null : loc.catalogScanProjectCount(projects),
       ),
     };
-    return switch (projects) {
-      final projects? => loc.catalogScanCountsJoined(sessions, projects),
-      null => sessions,
+    return switch ((sessions, projects)) {
+      (final sessions?, final projects?) => loc.catalogScanCountsJoined(sessions, projects),
+      (final sessions?, null) => sessions,
+      (null, final projects?) => projects,
+      (null, null) => loc.catalogScanNothingNew,
     };
   }
 }

--- a/client/app/lib/core/widgets/catalog_scan_row.dart
+++ b/client/app/lib/core/widgets/catalog_scan_row.dart
@@ -1,0 +1,166 @@
+import "package:material_ui/material_ui.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:theme_prego/module_prego.dart";
+
+import "../../l10n/app_localizations.dart";
+import "../extensions/build_context_x.dart";
+
+/// The catalog scan reported as one row above a list.
+///
+/// Every scan state renders through the shared inline alert, so the row picks
+/// up the design system's tinted card, spinner, and action buttons rather than
+/// owning a bespoke treatment. The scan is one aggregate however many harnesses
+/// take part, so this is one row rather than one per harness.
+///
+/// Sized by its state: [CatalogRescanIdle] takes no space at all, so a host can
+/// mount the row unconditionally and let the scan decide whether it shows.
+class const CatalogScanRow({
+  super.key,
+
+  /// The scan to report, read from the hosting list's own state so the row
+  /// re-renders with the list rather than subscribing separately.
+  required final CatalogRescanState _scan,
+
+  /// Stops a scan in flight. Offered while the scan is live, because the pull
+  /// gesture commits mid-drag and has no release to cancel on.
+  required final VoidCallback _onCancel,
+
+  /// Clears a finished scan the user has read.
+  required final VoidCallback _onDismiss,
+}) extends StatelessWidget {
+  /// The pull-to-refresh second stage that starts a scan, carrying the captions
+  /// that say what crossing the deeper threshold will do.
+  ///
+  /// Lives beside the row so the gesture that starts a scan and the row that
+  /// reports it stay worded together, and every list gets the same invitation.
+  static PregoDeepRefresh deepRefresh({required BuildContext context, required VoidCallback onStart}) {
+    return PregoDeepRefresh(
+      onDeepRefresh: onStart,
+      pullCaption: context.loc.catalogScanPullCaption,
+      deepCaption: context.loc.catalogScanDeepCaption,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final content = _contentFor(loc: context.loc);
+    if (content == null) return const SizedBox.shrink();
+    return Padding(
+      padding: EdgeInsetsDirectional.fromSTEB(
+        context.prego.spacing.lg,
+        context.prego.spacing.md,
+        context.prego.spacing.lg,
+        context.prego.spacing.sm,
+      ),
+      // Announced when it appears without moving focus, the same treatment the
+      // connection banner uses: a scan started by a pull finishes with no other
+      // signal that it is done.
+      child: Semantics(
+        container: true,
+        liveRegion: true,
+        child: PregoInlineAlertsNotifications(
+          type: content.type,
+          title: content.title,
+          supportingText: content.detail,
+          icon: content.icon,
+          secondaryAction: PregoInlineAlertsNotificationsAction(
+            label: content.actionLabel,
+            onPressed: content.onAction,
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// The one place the scan state decides how the row reads.
+  ///
+  /// `null` is the idle row, which renders nothing.
+  ({
+    PregoInlineAlertsNotificationsType type,
+    String title,
+    String? detail,
+    IconData? icon,
+    String actionLabel,
+    VoidCallback onAction,
+  })?
+  _contentFor({required AppLocalizations loc}) => switch (_scan) {
+    CatalogRescanIdle() => null,
+    // The spinner the loading type brings is the progress report: a scan has
+    // no total to count towards, so there is nothing to fill a bar with.
+    CatalogRescanStarting() => (
+      type: PregoInlineAlertsNotificationsType.loading,
+      title: loc.catalogScanRunningTitle,
+      detail: null,
+      icon: null,
+      actionLabel: loc.catalogScanCancel,
+      onAction: _onCancel,
+    ),
+    CatalogRescanRunning(:final activePluginName, :final sessionsSeen) => (
+      type: PregoInlineAlertsNotificationsType.loading,
+      title: loc.catalogScanRunningTitle,
+      detail: loc.catalogScanRunningDetail(activePluginName, sessionsSeen),
+      icon: null,
+      actionLabel: loc.catalogScanCancel,
+      onAction: _onCancel,
+    ),
+    CatalogRescanSucceeded(:final counts) => (
+      type: PregoInlineAlertsNotificationsType.success,
+      title: loc.catalogScanCompleteTitle,
+      detail: _countsLine(loc: loc, counts: counts),
+      icon: null,
+      actionLabel: loc.catalogScanDismiss,
+      onAction: _onDismiss,
+    ),
+    CatalogRescanPartlyFailed(:final succeededCount, :final failedCount) => (
+      type: PregoInlineAlertsNotificationsType.warning,
+      title: loc.catalogScanPartlyFailedTitle,
+      detail: loc.catalogScanPartlyFailedDetail(failedCount, succeededCount + failedCount),
+      icon: null,
+      actionLabel: loc.catalogScanDismiss,
+      onAction: _onDismiss,
+    ),
+    // The bridge's own error text never reaches the client, so the row names
+    // the log that has it rather than guessing at a cause.
+    CatalogRescanFailed() => (
+      type: PregoInlineAlertsNotificationsType.error,
+      title: loc.catalogScanFailedTitle,
+      detail: loc.catalogScanFailedDetail,
+      icon: null,
+      actionLabel: loc.catalogScanDismiss,
+      onAction: _onDismiss,
+    ),
+    // Not a failure of this scan but of the pairing, so it reads as something
+    // to fix rather than something to retry.
+    CatalogRescanUnsupported() => (
+      type: PregoInlineAlertsNotificationsType.warning,
+      title: loc.catalogScanUnsupportedTitle,
+      detail: loc.catalogScanUnsupportedDetail,
+      icon: TablerRegular.arrow_up_circle,
+      actionLabel: loc.catalogScanDismiss,
+      onAction: _onDismiss,
+    ),
+  };
+
+  /// What a finished scan found, sessions first.
+  ///
+  /// The projects clause is dropped when nothing new landed in one, so an
+  /// ordinary result reads "3 new sessions" rather than trailing a zero.
+  String _countsLine({required AppLocalizations loc, required CatalogRescanCounts counts}) {
+    final (sessions, projects) = switch (counts) {
+      CatalogRescanDelta(:final newSessions, :final newProjects) => (
+        loc.catalogScanNewSessionCount(newSessions),
+        newProjects == 0 ? null : loc.catalogScanNewProjectCount(newProjects),
+      ),
+      // No delta to report, so the row names what the harnesses published
+      // instead of implying every one of them is new.
+      CatalogRescanTotals(:final sessions, :final projects) => (
+        loc.catalogScanSessionCount(sessions),
+        loc.catalogScanProjectCount(projects),
+      ),
+    };
+    return switch (projects) {
+      final projects? => loc.catalogScanCountsJoined(sessions, projects),
+      null => sessions,
+    };
+  }
+}

--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -17,6 +17,7 @@ import "../../core/external_link.dart";
 import "../../core/routing/app_router.dart";
 import "../../core/support_links.dart";
 import "../../core/utils/copy_text_to_clipboard.dart";
+import "../../core/widgets/catalog_scan_row.dart";
 import "../../core/widgets/connection_banner.dart";
 import "../../core/widgets/connection_graphic.dart";
 import "../../core/widgets/remote_failure_view.dart";
@@ -177,6 +178,14 @@ class _ProjectListBodyState() extends State<_ProjectListBody> {
       floatingActionButton: floatingAction.action,
       floatingActionAlignment: floatingAction.alignment,
       onRefresh: _refreshFor(context: context, state: state),
+      // Only the loaded list can scan: the disconnected states pull to
+      // reconnect, and there is nothing to scan into until the list is there.
+      deepRefresh: state is ProjectListLoaded
+          ? CatalogScanRow.deepRefresh(
+              context: context,
+              onStart: () => context.read<ProjectListCubit>().startCatalogScan(),
+            )
+          : null,
       slivers: _buildContentSlivers(
         context: context,
         state: state,
@@ -298,8 +307,15 @@ class _ProjectListBodyState() extends State<_ProjectListBody> {
           ),
         ),
       ],
-      ProjectListLoaded(:final projects, :final activityById, :final unseenByProjectId) => [
+      ProjectListLoaded(:final projects, :final activityById, :final unseenByProjectId, :final catalogScan) => [
         if (isRefreshing) const SliverToBoxAdapter(child: LinearProgressIndicator()),
+        SliverToBoxAdapter(
+          child: CatalogScanRow(
+            scan: catalogScan,
+            onCancel: () => context.read<ProjectListCubit>().cancelCatalogScan(),
+            onDismiss: () => context.read<ProjectListCubit>().dismissCatalogScan(),
+          ),
+        ),
         // Keep the list mounted at zero items so its final row can finish the
         // closing transition before the connected-empty view takes over.
         PregoAnimatedSliverList<ProjectSummary>(

--- a/client/app/lib/features/session_list/session_list_panel.dart
+++ b/client/app/lib/features/session_list/session_list_panel.dart
@@ -5,6 +5,7 @@ import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
 
 import "../../core/extensions/build_context_x.dart";
+import "../../core/widgets/catalog_scan_row.dart";
 import "../../l10n/app_localizations.dart";
 import "session_list_content.dart";
 import "session_tile.dart";
@@ -17,10 +18,6 @@ class const SessionListPanel({
   required final SessionMenuEntriesBuilder sessionMenuEntries,
   required final VoidCallback onNewSession,
   final VoidCallback? onBack,
-    /// The optional second stage of this pane's pull-to-refresh. Introduced
-  /// here rather than with its consumer so the pane's own gesture is testable
-  /// before anything wires it up.
-  final PregoDeepRefresh? deepRefresh,
 }) extends StatelessWidget {
   /// Header width below which the labelled "New session" button collapses to an
   /// icon-only button so the title keeps a usable width.
@@ -128,6 +125,7 @@ class const SessionListPanel({
   Widget _buildScrollableContent(BuildContext context, {required SessionListState state}) {
     final isRefreshing = state is SessionListLoaded && state.isRefreshing;
     final canRefresh = state is SessionListLoaded;
+    final catalogScan = state is SessionListLoaded ? state.catalogScan : const CatalogRescanState.idle();
     return CustomScrollView(
       physics: canRefresh
           ? const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics())
@@ -136,11 +134,21 @@ class const SessionListPanel({
         if (canRefresh)
           PregoSliverRefreshControl(
             onRefresh: () => refreshSessionList(context),
-            deepRefresh: deepRefresh,
+            deepRefresh: CatalogScanRow.deepRefresh(
+              context: context,
+              onStart: () => context.read<SessionListCubit>().startCatalogScan(),
+            ),
             decorate: null,
             onPulledExtentChanged: null,
           ),
         if (isRefreshing) const SliverToBoxAdapter(child: LinearProgressIndicator()),
+        SliverToBoxAdapter(
+          child: CatalogScanRow(
+            scan: catalogScan,
+            onCancel: () => context.read<SessionListCubit>().cancelCatalogScan(),
+            onDismiss: () => context.read<SessionListCubit>().dismissCatalogScan(),
+          ),
+        ),
         SessionListContent(
           projectName: projectName,
           selectedSessionId: selectedSessionId,

--- a/client/app/lib/features/session_list/session_list_scaffold.dart
+++ b/client/app/lib/features/session_list/session_list_scaffold.dart
@@ -6,6 +6,7 @@ import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
 import "package:theme_prego/module_prego.dart";
 
 import "../../core/extensions/build_context_x.dart";
+import "../../core/widgets/catalog_scan_row.dart";
 import "../../core/widgets/connection_banner.dart";
 import "../../core/widgets/project_nav_subtitle.dart";
 import "session_list_content.dart";
@@ -26,6 +27,7 @@ class const SessionListScaffold({
     final state = context.watch<SessionListCubit>().state;
     final showArchived = state is SessionListLoaded && state.showArchived;
     final isRefreshing = state is SessionListLoaded && state.isRefreshing;
+    final catalogScan = state is SessionListLoaded ? state.catalogScan : const CatalogRescanState.idle();
 
     return PregoGlassScaffold(
       // The sessions route sits at the base of the nested pane navigator, so
@@ -62,8 +64,21 @@ class const SessionListScaffold({
       ),
       // Pull-to-refresh only makes sense once the list has loaded.
       onRefresh: state is SessionListLoaded ? () => refreshSessionList(context) : null,
+      deepRefresh: state is SessionListLoaded
+          ? CatalogScanRow.deepRefresh(
+              context: context,
+              onStart: () => context.read<SessionListCubit>().startCatalogScan(),
+            )
+          : null,
       slivers: [
         if (isRefreshing) const SliverToBoxAdapter(child: LinearProgressIndicator()),
+        SliverToBoxAdapter(
+          child: CatalogScanRow(
+            scan: catalogScan,
+            onCancel: () => context.read<SessionListCubit>().cancelCatalogScan(),
+            onDismiss: () => context.read<SessionListCubit>().dismissCatalogScan(),
+          ),
+        ),
         SessionListContent(
           projectName: projectName,
           selectedSessionId: selectedSessionId,

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -1030,5 +1030,124 @@
   "projectsOnboardingWhyFaqReadAnswer": "No. Everything between your phone and computer is end-to-end encrypted — the relay only passes along sealed data it can't read.",
   "@projectsOnboardingWhyFaqReadAnswer": {
     "description": "DRAFT copy pending final wording. Answer to the 'can Sesori read my sessions' FAQ question."
+  },
+  "catalogScanPullCaption": "Keep pulling to scan all harnesses",
+  "@catalogScanPullCaption": {
+    "description": "Caption under the pull-to-refresh spinner once the pull has passed the ordinary trigger, inviting the user to keep pulling to start a full catalog scan."
+  },
+  "catalogScanDeepCaption": "Scanning for new sessions",
+  "@catalogScanDeepCaption": {
+    "description": "Caption under the pull-to-refresh spinner once the deep pull has fired and the catalog scan has already started."
+  },
+  "catalogScanRunningTitle": "Scanning all harnesses",
+  "@catalogScanRunningTitle": {
+    "description": "Title of the row above a list while a catalog scan is in flight across every enabled harness."
+  },
+  "catalogScanRunningDetail": "{harness} — {sessions, plural, =1{1 session} other{{sessions} sessions}}",
+  "@catalogScanRunningDetail": {
+    "description": "Supporting line on the running scan row: the harness currently being scanned and how many sessions it has reported so far.",
+    "placeholders": {
+      "harness": {
+        "type": "String",
+        "example": "Codex"
+      },
+      "sessions": {
+        "type": "int"
+      }
+    }
+  },
+  "catalogScanCancel": "Cancel",
+  "@catalogScanCancel": {
+    "description": "Action on the running scan row that stops the catalog scan in flight."
+  },
+  "catalogScanCompleteTitle": "Scan complete",
+  "@catalogScanCompleteTitle": {
+    "description": "Title of the scan row once every harness finished scanning successfully."
+  },
+  "catalogScanNewSessionCount": "{count, plural, =0{No new sessions} =1{1 new session} other{{count} new sessions}}",
+  "@catalogScanNewSessionCount": {
+    "description": "Sessions clause of a finished scan's result, counting only sessions the scan had not imported before.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "catalogScanNewProjectCount": "{count, plural, =1{1 new project} other{{count} new projects}}",
+  "@catalogScanNewProjectCount": {
+    "description": "Projects clause of a finished scan's result, counting only projects the scan had not imported before.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "catalogScanSessionCount": "{count, plural, =1{1 session} other{{count} sessions}}",
+  "@catalogScanSessionCount": {
+    "description": "Sessions clause used when a harness did not report what was new, so the row can only name the totals it published.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "catalogScanProjectCount": "{count, plural, =1{1 project} other{{count} projects}}",
+  "@catalogScanProjectCount": {
+    "description": "Projects clause used when a harness did not report what was new, so the row can only name the totals it published.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "catalogScanCountsJoined": "{sessions} in {projects}",
+  "@catalogScanCountsJoined": {
+    "description": "Joins the sessions and projects clauses of a finished scan's result into one line.",
+    "placeholders": {
+      "sessions": {
+        "type": "String",
+        "example": "5 new sessions"
+      },
+      "projects": {
+        "type": "String",
+        "example": "2 new projects"
+      }
+    }
+  },
+  "catalogScanPartlyFailedTitle": "Scan finished",
+  "@catalogScanPartlyFailedTitle": {
+    "description": "Title of the scan row when some harnesses scanned successfully and others did not."
+  },
+  "catalogScanPartlyFailedDetail": "{failed} of {total} harnesses could not be scanned",
+  "@catalogScanPartlyFailedDetail": {
+    "description": "Supporting line on a partly failed scan row. Both harnesses counts are at least one, so the total is always plural.",
+    "placeholders": {
+      "failed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "catalogScanFailedTitle": "Scan failed",
+  "@catalogScanFailedTitle": {
+    "description": "Title of the scan row when no harness could be scanned."
+  },
+  "catalogScanFailedDetail": "Check the bridge log for details",
+  "@catalogScanFailedDetail": {
+    "description": "Supporting line on a failed scan row. The bridge's own error text is never shown here, so the row points at the log that has it."
+  },
+  "catalogScanUnsupportedTitle": "Scanning needs a newer bridge",
+  "@catalogScanUnsupportedTitle": {
+    "description": "Title of the scan row when the connected bridge is too old to scan harness catalogs on request."
+  },
+  "catalogScanUnsupportedDetail": "Update the bridge to scan from here",
+  "@catalogScanUnsupportedDetail": {
+    "description": "Supporting line on the unsupported scan row, naming what would make scanning available."
+  },
+  "catalogScanDismiss": "Dismiss",
+  "@catalogScanDismiss": {
+    "description": "Action on a finished scan row that clears it once the user has read the result."
   }
 }

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -1064,9 +1064,13 @@
   "@catalogScanCompleteTitle": {
     "description": "Title of the scan row once every harness finished scanning successfully."
   },
-  "catalogScanNewSessionCount": "{count, plural, =0{No new sessions} =1{1 new session} other{{count} new sessions}}",
+  "catalogScanNothingNew": "No new sessions",
+  "@catalogScanNothingNew": {
+    "description": "Whole result line of a finished scan that turned up neither a new session nor a new project. A standalone sentence, unlike the count clauses, which are noun phrases meant to be joined."
+  },
+  "catalogScanNewSessionCount": "{count, plural, =1{1 new session} other{{count} new sessions}}",
   "@catalogScanNewSessionCount": {
-    "description": "Sessions clause of a finished scan's result, counting only sessions the scan had not imported before.",
+    "description": "Sessions clause of a finished scan's result, counting only sessions the scan had not imported before. Never rendered for a count of zero; that clause is dropped so the line reads as a noun phrase either way.",
     "placeholders": {
       "count": {
         "type": "int"
@@ -1145,6 +1149,14 @@
   "catalogScanUnsupportedDetail": "Update the bridge to scan from here",
   "@catalogScanUnsupportedDetail": {
     "description": "Supporting line on the unsupported scan row, naming what would make scanning available."
+  },
+  "catalogScanNoHarnessTitle": "No harness to scan",
+  "@catalogScanNoHarnessTitle": {
+    "description": "Title of the scan row when no harness could be scanned: none is connected and ready, or the bridge has not reported its harnesses yet."
+  },
+  "catalogScanNoHarnessDetail": "Check your harnesses in Settings",
+  "@catalogScanNoHarnessDetail": {
+    "description": "Supporting line on the no-harness scan row, naming where the user can see and fix their harness setup."
   },
   "catalogScanDismiss": "Dismiss",
   "@catalogScanDismiss": {

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -3270,6 +3270,114 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No. Everything between your phone and computer is end-to-end encrypted — the relay only passes along sealed data it can\'t read.'**
   String get projectsOnboardingWhyFaqReadAnswer;
+
+  /// Caption under the pull-to-refresh spinner once the pull has passed the ordinary trigger, inviting the user to keep pulling to start a full catalog scan.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep pulling to scan all harnesses'**
+  String get catalogScanPullCaption;
+
+  /// Caption under the pull-to-refresh spinner once the deep pull has fired and the catalog scan has already started.
+  ///
+  /// In en, this message translates to:
+  /// **'Scanning for new sessions'**
+  String get catalogScanDeepCaption;
+
+  /// Title of the row above a list while a catalog scan is in flight across every enabled harness.
+  ///
+  /// In en, this message translates to:
+  /// **'Scanning all harnesses'**
+  String get catalogScanRunningTitle;
+
+  /// Supporting line on the running scan row: the harness currently being scanned and how many sessions it has reported so far.
+  ///
+  /// In en, this message translates to:
+  /// **'{harness} — {sessions, plural, =1{1 session} other{{sessions} sessions}}'**
+  String catalogScanRunningDetail(String harness, int sessions);
+
+  /// Action on the running scan row that stops the catalog scan in flight.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get catalogScanCancel;
+
+  /// Title of the scan row once every harness finished scanning successfully.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan complete'**
+  String get catalogScanCompleteTitle;
+
+  /// Sessions clause of a finished scan's result, counting only sessions the scan had not imported before.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =0{No new sessions} =1{1 new session} other{{count} new sessions}}'**
+  String catalogScanNewSessionCount(int count);
+
+  /// Projects clause of a finished scan's result, counting only projects the scan had not imported before.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 new project} other{{count} new projects}}'**
+  String catalogScanNewProjectCount(int count);
+
+  /// Sessions clause used when a harness did not report what was new, so the row can only name the totals it published.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 session} other{{count} sessions}}'**
+  String catalogScanSessionCount(int count);
+
+  /// Projects clause used when a harness did not report what was new, so the row can only name the totals it published.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 project} other{{count} projects}}'**
+  String catalogScanProjectCount(int count);
+
+  /// Joins the sessions and projects clauses of a finished scan's result into one line.
+  ///
+  /// In en, this message translates to:
+  /// **'{sessions} in {projects}'**
+  String catalogScanCountsJoined(String sessions, String projects);
+
+  /// Title of the scan row when some harnesses scanned successfully and others did not.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan finished'**
+  String get catalogScanPartlyFailedTitle;
+
+  /// Supporting line on a partly failed scan row. Both harnesses counts are at least one, so the total is always plural.
+  ///
+  /// In en, this message translates to:
+  /// **'{failed} of {total} harnesses could not be scanned'**
+  String catalogScanPartlyFailedDetail(int failed, int total);
+
+  /// Title of the scan row when no harness could be scanned.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan failed'**
+  String get catalogScanFailedTitle;
+
+  /// Supporting line on a failed scan row. The bridge's own error text is never shown here, so the row points at the log that has it.
+  ///
+  /// In en, this message translates to:
+  /// **'Check the bridge log for details'**
+  String get catalogScanFailedDetail;
+
+  /// Title of the scan row when the connected bridge is too old to scan harness catalogs on request.
+  ///
+  /// In en, this message translates to:
+  /// **'Scanning needs a newer bridge'**
+  String get catalogScanUnsupportedTitle;
+
+  /// Supporting line on the unsupported scan row, naming what would make scanning available.
+  ///
+  /// In en, this message translates to:
+  /// **'Update the bridge to scan from here'**
+  String get catalogScanUnsupportedDetail;
+
+  /// Action on a finished scan row that clears it once the user has read the result.
+  ///
+  /// In en, this message translates to:
+  /// **'Dismiss'**
+  String get catalogScanDismiss;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -3307,10 +3307,16 @@ abstract class AppLocalizations {
   /// **'Scan complete'**
   String get catalogScanCompleteTitle;
 
-  /// Sessions clause of a finished scan's result, counting only sessions the scan had not imported before.
+  /// Whole result line of a finished scan that turned up neither a new session nor a new project. A standalone sentence, unlike the count clauses, which are noun phrases meant to be joined.
   ///
   /// In en, this message translates to:
-  /// **'{count, plural, =0{No new sessions} =1{1 new session} other{{count} new sessions}}'**
+  /// **'No new sessions'**
+  String get catalogScanNothingNew;
+
+  /// Sessions clause of a finished scan's result, counting only sessions the scan had not imported before. Never rendered for a count of zero; that clause is dropped so the line reads as a noun phrase either way.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 new session} other{{count} new sessions}}'**
   String catalogScanNewSessionCount(int count);
 
   /// Projects clause of a finished scan's result, counting only projects the scan had not imported before.
@@ -3372,6 +3378,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Update the bridge to scan from here'**
   String get catalogScanUnsupportedDetail;
+
+  /// Title of the scan row when no harness could be scanned: none is connected and ready, or the bridge has not reported its harnesses yet.
+  ///
+  /// In en, this message translates to:
+  /// **'No harness to scan'**
+  String get catalogScanNoHarnessTitle;
+
+  /// Supporting line on the no-harness scan row, naming where the user can see and fix their harness setup.
+  ///
+  /// In en, this message translates to:
+  /// **'Check your harnesses in Settings'**
+  String get catalogScanNoHarnessDetail;
 
   /// Action on a finished scan row that clears it once the user has read the result.
   ///

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -1742,4 +1742,103 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get projectsOnboardingWhyFaqReadAnswer =>
       'No. Everything between your phone and computer is end-to-end encrypted — the relay only passes along sealed data it can\'t read.';
+
+  @override
+  String get catalogScanPullCaption => 'Keep pulling to scan all harnesses';
+
+  @override
+  String get catalogScanDeepCaption => 'Scanning for new sessions';
+
+  @override
+  String get catalogScanRunningTitle => 'Scanning all harnesses';
+
+  @override
+  String catalogScanRunningDetail(String harness, int sessions) {
+    String _temp0 = intl.Intl.pluralLogic(
+      sessions,
+      locale: localeName,
+      other: '$sessions sessions',
+      one: '1 session',
+    );
+    return '$harness — $_temp0';
+  }
+
+  @override
+  String get catalogScanCancel => 'Cancel';
+
+  @override
+  String get catalogScanCompleteTitle => 'Scan complete';
+
+  @override
+  String catalogScanNewSessionCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count new sessions',
+      one: '1 new session',
+      zero: 'No new sessions',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String catalogScanNewProjectCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count new projects',
+      one: '1 new project',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String catalogScanSessionCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count sessions',
+      one: '1 session',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String catalogScanProjectCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count projects',
+      one: '1 project',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String catalogScanCountsJoined(String sessions, String projects) {
+    return '$sessions in $projects';
+  }
+
+  @override
+  String get catalogScanPartlyFailedTitle => 'Scan finished';
+
+  @override
+  String catalogScanPartlyFailedDetail(int failed, int total) {
+    return '$failed of $total harnesses could not be scanned';
+  }
+
+  @override
+  String get catalogScanFailedTitle => 'Scan failed';
+
+  @override
+  String get catalogScanFailedDetail => 'Check the bridge log for details';
+
+  @override
+  String get catalogScanUnsupportedTitle => 'Scanning needs a newer bridge';
+
+  @override
+  String get catalogScanUnsupportedDetail => 'Update the bridge to scan from here';
+
+  @override
+  String get catalogScanDismiss => 'Dismiss';
 }

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -1770,13 +1770,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get catalogScanCompleteTitle => 'Scan complete';
 
   @override
+  String get catalogScanNothingNew => 'No new sessions';
+
+  @override
   String catalogScanNewSessionCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
       other: '$count new sessions',
       one: '1 new session',
-      zero: 'No new sessions',
     );
     return '$_temp0';
   }
@@ -1838,6 +1840,12 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get catalogScanUnsupportedDetail => 'Update the bridge to scan from here';
+
+  @override
+  String get catalogScanNoHarnessTitle => 'No harness to scan';
+
+  @override
+  String get catalogScanNoHarnessDetail => 'Check your harnesses in Settings';
 
   @override
   String get catalogScanDismiss => 'Dismiss';

--- a/client/app/test/core/widgets/catalog_scan_row_test.dart
+++ b/client/app/test/core/widgets/catalog_scan_row_test.dart
@@ -109,6 +109,20 @@ void main() {
       expect(find.text("No new sessions"), findsOneWidget);
     });
 
+    // The sessions clause is dropped rather than joined at zero, so the line
+    // stays a noun phrase instead of reading "No new sessions in 2 new projects".
+    testWidgets("leads with projects when a scan turned up no new session", (tester) async {
+      await pumpRow(
+        tester,
+        const CatalogRescanState.succeeded(
+          harnessCount: 1,
+          counts: CatalogRescanCounts.delta(newProjects: 2, newSessions: 0),
+        ),
+      );
+
+      expect(find.text("2 new projects"), findsOneWidget);
+    });
+
     // A harness that omitted its delta makes the whole row fall back, so the
     // wording must not imply any of the counted items is new.
     testWidgets("reports published totals as totals when no delta is available", (tester) async {
@@ -146,6 +160,37 @@ void main() {
       final loc = await AppLocalizations.delegate.load(const Locale("en"));
       expect(find.text(loc.catalogScanUnsupportedTitle), findsOneWidget);
       expect(find.text(loc.catalogScanUnsupportedDetail), findsOneWidget);
+    });
+
+    testWidgets("says there is nothing to scan when no harness is ready", (tester) async {
+      await pumpRow(tester, const CatalogRescanState.noHarness());
+
+      final loc = await AppLocalizations.delegate.load(const Locale("en"));
+      expect(find.text(loc.catalogScanNoHarnessTitle), findsOneWidget);
+      expect(find.text(loc.catalogScanNoHarnessDetail), findsOneWidget);
+    });
+
+    // The running row's session count changes with every enumerated session, so
+    // announcing it would interrupt a screen reader throughout a long scan.
+    testWidgets("announces every state except the one whose count keeps moving", (tester) async {
+      Future<bool?> announcesFor(CatalogRescanState scan) async {
+        await pumpRow(tester, scan);
+        return tester
+            .widget<Semantics>(
+              find.descendant(of: find.byType(CatalogScanRow), matching: find.byType(Semantics)).first,
+            )
+            .properties
+            .liveRegion;
+      }
+
+      expect(await announcesFor(const CatalogRescanState.starting(pluginIds: {"codex"})), isTrue);
+      expect(await announcesFor(const CatalogRescanState.failed(harnessCount: 1)), isTrue);
+      expect(
+        await announcesFor(
+          const CatalogRescanState.running(activePluginName: "Codex", sessionsSeen: 9, pluginIds: {"codex"}),
+        ),
+        isFalse,
+      );
     });
 
     testWidgets("dismisses a finished scan without cancelling anything", (tester) async {

--- a/client/app/test/core/widgets/catalog_scan_row_test.dart
+++ b/client/app/test/core/widgets/catalog_scan_row_test.dart
@@ -1,0 +1,161 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:material_ui/material_ui.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_mobile/core/widgets/catalog_scan_row.dart";
+import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:theme_prego/module_prego.dart";
+
+void main() {
+  late int cancelCount;
+  late int dismissCount;
+
+  setUp(() {
+    cancelCount = 0;
+    dismissCount = 0;
+  });
+
+  Future<void> pumpRow(WidgetTester tester, CatalogRescanState scan) {
+    return tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(extensions: [PregoDesignSystem.light]),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: CatalogScanRow(
+            scan: scan,
+            onCancel: () => cancelCount++,
+            onDismiss: () => dismissCount++,
+          ),
+        ),
+      ),
+    );
+  }
+
+  group("CatalogScanRow", () {
+    testWidgets("renders nothing at all while idle", (tester) async {
+      await pumpRow(tester, const CatalogRescanState.idle());
+
+      expect(find.byType(PregoInlineAlertsNotifications), findsNothing);
+      expect(tester.getSize(find.byType(CatalogScanRow)).height, 0);
+    });
+
+    testWidgets("reports the scan before any harness has reported progress", (tester) async {
+      await pumpRow(tester, const CatalogRescanState.starting(pluginIds: {"codex"}));
+
+      final loc = await AppLocalizations.delegate.load(const Locale("en"));
+      expect(find.text(loc.catalogScanRunningTitle), findsOneWidget);
+      expect(find.text(loc.catalogScanCancel), findsOneWidget);
+    });
+
+    testWidgets("names the harness being scanned and what it has seen", (tester) async {
+      await pumpRow(
+        tester,
+        const CatalogRescanState.running(
+          activePluginName: "Codex",
+          sessionsSeen: 148,
+          pluginIds: {"codex"},
+        ),
+      );
+
+      expect(find.text("Codex — 148 sessions"), findsOneWidget);
+    });
+
+    testWidgets("cancels the scan in flight from the running row", (tester) async {
+      await pumpRow(
+        tester,
+        const CatalogRescanState.running(activePluginName: "Codex", sessionsSeen: 1, pluginIds: {"codex"}),
+      );
+
+      final loc = await AppLocalizations.delegate.load(const Locale("en"));
+      await tester.tap(find.text(loc.catalogScanCancel));
+
+      expect(cancelCount, 1);
+      expect(dismissCount, 0);
+    });
+
+    testWidgets("drops the projects clause when nothing new landed in one", (tester) async {
+      await pumpRow(
+        tester,
+        const CatalogRescanState.succeeded(
+          harnessCount: 2,
+          counts: CatalogRescanCounts.delta(newProjects: 0, newSessions: 3),
+        ),
+      );
+
+      expect(find.text("3 new sessions"), findsOneWidget);
+    });
+
+    testWidgets("joins both clauses when new items landed in a new project", (tester) async {
+      await pumpRow(
+        tester,
+        const CatalogRescanState.succeeded(
+          harnessCount: 2,
+          counts: CatalogRescanCounts.delta(newProjects: 2, newSessions: 5),
+        ),
+      );
+
+      expect(find.text("5 new sessions in 2 new projects"), findsOneWidget);
+    });
+
+    testWidgets("says nothing was new rather than reporting a zero", (tester) async {
+      await pumpRow(
+        tester,
+        const CatalogRescanState.succeeded(
+          harnessCount: 1,
+          counts: CatalogRescanCounts.delta(newProjects: 0, newSessions: 0),
+        ),
+      );
+
+      expect(find.text("No new sessions"), findsOneWidget);
+    });
+
+    // A harness that omitted its delta makes the whole row fall back, so the
+    // wording must not imply any of the counted items is new.
+    testWidgets("reports published totals as totals when no delta is available", (tester) async {
+      await pumpRow(
+        tester,
+        const CatalogRescanState.succeeded(
+          harnessCount: 2,
+          counts: CatalogRescanCounts.totals(projects: 12, sessions: 148),
+        ),
+      );
+
+      expect(find.text("148 sessions in 12 projects"), findsOneWidget);
+      expect(find.textContaining("new"), findsNothing);
+    });
+
+    testWidgets("names how many harnesses failed out of the whole scan", (tester) async {
+      await pumpRow(tester, const CatalogRescanState.partlyFailed(succeededCount: 2, failedCount: 1));
+
+      expect(find.text("1 of 3 harnesses could not be scanned"), findsOneWidget);
+    });
+
+    // The bridge's raw error text is never lifted into client state, so the row
+    // points at the log that has it.
+    testWidgets("points at the bridge log when every harness failed", (tester) async {
+      await pumpRow(tester, const CatalogRescanState.failed(harnessCount: 2));
+
+      final loc = await AppLocalizations.delegate.load(const Locale("en"));
+      expect(find.text(loc.catalogScanFailedTitle), findsOneWidget);
+      expect(find.text(loc.catalogScanFailedDetail), findsOneWidget);
+    });
+
+    testWidgets("explains an older bridge instead of reporting a failure", (tester) async {
+      await pumpRow(tester, const CatalogRescanState.unsupported());
+
+      final loc = await AppLocalizations.delegate.load(const Locale("en"));
+      expect(find.text(loc.catalogScanUnsupportedTitle), findsOneWidget);
+      expect(find.text(loc.catalogScanUnsupportedDetail), findsOneWidget);
+    });
+
+    testWidgets("dismisses a finished scan without cancelling anything", (tester) async {
+      await pumpRow(tester, const CatalogRescanState.failed(harnessCount: 1));
+
+      final loc = await AppLocalizations.delegate.load(const Locale("en"));
+      await tester.tap(find.text(loc.catalogScanDismiss));
+
+      expect(dismissCount, 1);
+      expect(cancelCount, 0);
+    });
+  });
+}

--- a/client/app/test/features/project_list/project_list_catalog_scan_test.dart
+++ b/client/app/test/features/project_list/project_list_catalog_scan_test.dart
@@ -1,0 +1,194 @@
+import "package:flutter_bloc/flutter_bloc.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:material_ui/material_ui.dart";
+import "package:mocktail/mocktail.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_mobile/core/di/injection.dart";
+import "package:sesori_mobile/core/widgets/catalog_scan_row.dart";
+import "package:sesori_mobile/features/project_list/project_list_screen.dart";
+import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/module_prego.dart";
+
+import "../../helpers/test_helpers.dart";
+
+/// The project list is one of the three surfaces that host a catalog scan: it
+/// starts one from the second stage of its pull and reports it in a row above
+/// the list.
+///
+/// A live scan row spins forever, so these pump a fixed duration rather than
+/// settling.
+const Duration _rowSettled = Duration(milliseconds: 400);
+
+void main() {
+  const config = ServerConnectionConfig(relayHost: "relay.example.com", authToken: "test-token");
+  const health = HealthResponse(healthy: true, version: "0.1.200", filesystemAccessDegraded: false);
+  const connected = ConnectionStatus.connected(config: config, health: health);
+
+  late BehaviorSubject<ConnectionStatus> statusController;
+  late MockConnectionService mockConnectionService;
+  late MockProjectRepository mockProjectRepository;
+  late MockRegisteredBridgesService mockRegisteredBridgesService;
+  late FakeCatalogRescanService rescanService;
+  late StubConnectionOverlayCubit overlayCubit;
+
+  setUpAll(registerAllFallbackValues);
+
+  setUp(() {
+    statusController = BehaviorSubject<ConnectionStatus>.seeded(connected);
+    mockConnectionService = MockConnectionService();
+    mockProjectRepository = MockProjectRepository();
+    mockRegisteredBridgesService = MockRegisteredBridgesService();
+    overlayCubit = StubConnectionOverlayCubit();
+
+    when(() => mockConnectionService.status).thenAnswer((_) => statusController.stream);
+    when(() => mockConnectionService.currentStatus).thenAnswer((_) => statusController.value);
+    when(() => mockRegisteredBridgesService.hasRegisteredBridges()).thenAnswer((_) async => true);
+    when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer((_) async => const []);
+    when(() => mockProjectRepository.listProjects()).thenAnswer(
+      (_) async => ApiResponse.success(Projects(data: [testProjectSummary(name: "My Project")])),
+    );
+
+    getIt.registerLazySingleton<ProjectRepository>(() => mockProjectRepository);
+    registerListServices(projectRepository: mockProjectRepository);
+    getIt.registerLazySingleton<ConnectionService>(() => mockConnectionService);
+    getIt.registerLazySingleton<SseEventTracker>(MockSseEventTracker.new);
+    getIt.registerLazySingleton<RouteSource>(MockRouteSource.new);
+    getIt.registerLazySingleton<SessionUnseenTracker>(FakeSessionUnseenTracker.new);
+    getIt.registerLazySingleton<RegisteredBridgesService>(() => mockRegisteredBridgesService);
+    getIt.registerLazySingleton<FailureReporter>(MockFailureReporter.new);
+
+    rescanService = getIt<CatalogRescanService>() as FakeCatalogRescanService;
+  });
+
+  tearDown(() async {
+    await overlayCubit.close();
+    await statusController.close();
+    await getIt.reset();
+  });
+
+  Widget app() {
+    return BlocProvider<ConnectionOverlayCubit>.value(
+      value: overlayCubit,
+      child: MaterialApp(
+        theme: ThemeData(extensions: [PregoDesignSystem.light]),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const ProjectListScreen(),
+      ),
+    );
+  }
+
+  Future<AppLocalizations> pumpLoadedList(WidgetTester tester) async {
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+    return await AppLocalizations.delegate.load(const Locale("en"));
+  }
+
+  /// Publishes [scan] and lets the list rebuild around it.
+  Future<void> emitScan(WidgetTester tester, CatalogRescanState scan) async {
+    rescanService.emit(scan);
+    await tester.pump();
+    await tester.pump(_rowSettled);
+  }
+
+  /// Keeps pulling the list down in small steps until [until] holds, so these
+  /// tests describe how far the user pulls rather than how much overscroll a
+  /// given drag distance happens to produce under bouncing physics.
+  Future<void> pullFurtherUntil(WidgetTester tester, TestGesture gesture, bool Function() until) async {
+    for (var step = 0; step < 20 && !until(); step++) {
+      await gesture.moveBy(const Offset(0, 40));
+      await tester.pump();
+      // The deep stage fires from a post-frame callback, because the refresh
+      // control calls its builder from inside the sliver's layout.
+      await tester.pump();
+    }
+  }
+
+  testWidgets("pulling past the second threshold starts a scan across every harness", (tester) async {
+    final loc = await pumpLoadedList(tester);
+    final gesture = await tester.startGesture(tester.getCenter(find.text("My Project")));
+
+    // Past the ordinary trigger, the pull invites the deeper one …
+    await pullFurtherUntil(tester, gesture, () => find.text(loc.catalogScanPullCaption).evaluate().isNotEmpty);
+    expect(find.text(loc.catalogScanPullCaption), findsOneWidget);
+    expect(rescanService.startAllCalls, 0, reason: "the deeper threshold has not been crossed yet");
+
+    // … and crossing it starts the scan while the finger is still down, which
+    // is why the row that reports it has to offer its own cancel.
+    await pullFurtherUntil(tester, gesture, () => rescanService.startAllCalls > 0);
+    expect(rescanService.startAllCalls, 1);
+    expect(find.text(loc.catalogScanDeepCaption), findsOneWidget);
+
+    // Still one scan however much further the same pull travels.
+    await pullFurtherUntil(tester, gesture, () => false);
+    expect(rescanService.startAllCalls, 1);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets("reports a running scan above the list without displacing it", (tester) async {
+    final loc = await pumpLoadedList(tester);
+    expect(find.byType(PregoInlineAlertsNotifications), findsNothing);
+
+    await emitScan(
+      tester,
+      const CatalogRescanState.running(activePluginName: "Codex", sessionsSeen: 148, pluginIds: {"codex"}),
+    );
+
+    expect(find.text(loc.catalogScanRunningTitle), findsOneWidget);
+    expect(find.text("Codex — 148 sessions"), findsOneWidget);
+    expect(find.text("My Project"), findsOneWidget);
+  });
+
+  testWidgets("clears the row once the scan is dismissed", (tester) async {
+    await pumpLoadedList(tester);
+
+    await emitScan(tester, const CatalogRescanState.starting(pluginIds: {"codex"}));
+    expect(find.byType(PregoInlineAlertsNotifications), findsOneWidget);
+
+    await emitScan(tester, const CatalogRescanState.idle());
+    expect(find.byType(PregoInlineAlertsNotifications), findsNothing);
+    expect(find.text("My Project"), findsOneWidget);
+  });
+
+  testWidgets("cancels the scan from the row it is reported in", (tester) async {
+    final loc = await pumpLoadedList(tester);
+
+    await emitScan(tester, const CatalogRescanState.starting(pluginIds: {"codex"}));
+    await tester.tap(find.text(loc.catalogScanCancel));
+
+    expect(rescanService.cancelCalls, 1);
+  });
+
+  testWidgets("clears a finished scan the user has read", (tester) async {
+    final loc = await pumpLoadedList(tester);
+
+    await emitScan(
+      tester,
+      const CatalogRescanState.succeeded(
+        harnessCount: 1,
+        counts: CatalogRescanCounts.delta(newProjects: 1, newSessions: 4),
+      ),
+    );
+    expect(find.text("4 new sessions in 1 new project"), findsOneWidget);
+
+    await tester.tap(find.text(loc.catalogScanDismiss));
+    expect(rescanService.dismissCalls, 1);
+  });
+
+  // Nothing to scan into yet, and the pull there already means "reconnect".
+  testWidgets("offers no scan while the bridge is disconnected", (tester) async {
+    when(() => mockProjectRepository.listProjects()).thenAnswer(
+      (_) async => ApiResponse.error(ApiError.generic()),
+    );
+    statusController.add(const ConnectionStatus.bridgeOffline(config: config, health: health));
+
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CatalogScanRow), findsNothing);
+  });
+}

--- a/client/module_core/lib/src/services/catalog_rescan_service.dart
+++ b/client/module_core/lib/src/services/catalog_rescan_service.dart
@@ -114,10 +114,17 @@ class CatalogRescanService({
           for (final plugin in response.plugins)
             if (plugin.runtimeState.isRoutable) plugin.setup.id,
         ];
-        if (pluginIds.isEmpty) return;
+        if (pluginIds.isEmpty) {
+          if (_members.isEmpty) _publish(const CatalogRescanState.noHarness());
+          return;
+        }
         await _start(pluginIds: pluginIds, coversEveryHarness: true);
+      // No snapshot to fan out over. Reported rather than returned silently,
+      // because the caller is a gesture that has already told the user a scan
+      // started, and a failed snapshot keeps answering this way until it is
+      // reloaded.
       case PluginManagementLoadResultLoading() || PluginManagementLoadResultFailure() || null:
-        return;
+        if (_members.isEmpty) _publish(const CatalogRescanState.noHarness());
     }
   }
 

--- a/client/module_core/lib/src/services/models/catalog_rescan_state.dart
+++ b/client/module_core/lib/src/services/models/catalog_rescan_state.dart
@@ -56,6 +56,8 @@ sealed class const CatalogRescanState() {
 
   const factory unsupported() = CatalogRescanUnsupported;
 
+  const factory noHarness() = CatalogRescanNoHarness;
+
   /// Whether a rescan is in flight. Leaving this is what tells a list to
   /// refresh, since a committed import raises no invalidation of its own.
   bool get isLive => this is CatalogRescanStarting || this is CatalogRescanRunning;
@@ -98,6 +100,15 @@ final class const CatalogRescanFailed({required final int harnessCount})
 
 /// This bridge cannot rescan at all, because it predates the import route.
 final class const CatalogRescanUnsupported() extends CatalogRescanState;
+
+/// There is no harness to rescan: either no management snapshot has arrived
+/// yet, the one that arrived failed, or none of its harnesses is routable.
+///
+/// One variant for all three, because a rescan cannot start in any of them and
+/// the user's next move is the same. Without it a fan-out over an empty set
+/// would return silently, leaving the pull that asked for it with nothing to
+/// show for itself.
+final class const CatalogRescanNoHarness() extends CatalogRescanState;
 
 /// Outcome of a rescan aimed at one named harness.
 ///

--- a/client/module_core/test/services/catalog_rescan_service_test.dart
+++ b/client/module_core/test/services/catalog_rescan_service_test.dart
@@ -398,6 +398,40 @@ void main() {
       expect(repository.startedPluginIds, isEmpty);
     });
 
+    // The gesture that calls this has already told the user a scan started, so
+    // a fan-out with nothing to fan out to has to say so rather than return.
+    test("reports that there is no harness when the snapshot names none that is routable", () async {
+      build(snapshot: _snapshot(routable: const {}));
+
+      await service.startAll();
+
+      expect(service.state.value, isA<CatalogRescanNoHarness>());
+      expect(repository.startedPluginIds, isEmpty);
+    });
+
+    test("reports that there is no harness while no snapshot has arrived", () async {
+      build(snapshot: const PluginManagementLoadResult.loading());
+
+      await service.startAll();
+
+      expect(service.state.value, isA<CatalogRescanNoHarness>());
+      expect(repository.startedPluginIds, isEmpty);
+    });
+
+    test("a live run outlasts a fan-out that finds no harness", () async {
+      build(snapshot: _snapshot(routable: const {"codex": "Codex"}));
+      await service.startAll();
+      management.emit(const PluginManagementLoadResult.loading());
+
+      await service.startAll();
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanStarting>(),
+        reason: "the run in flight is still the truth about what is happening",
+      );
+    });
+
     test("a targeted start on an unsupported bridge tells the caller", () async {
       build(snapshot: const PluginManagementLoadResult.unsupported());
 


### PR DESCRIPTION
## Complexity

⚙️ Moderate. One new widget that is mostly a `switch` onto an existing
design-system component, plus three small host wirings and their resources.

## What

Adds the row that reports a catalog scan above the project list, the
full-screen session list, and the split-view session pane, and wires each of
the three to the second stage of its pull-to-refresh.

- `CatalogScanRow` (`client/app/lib/core/widgets/`) maps all seven
  `CatalogRescanState` cases onto `PregoInlineAlertsNotifications` — the same
  inline alert `ConnectionBanner` uses — so the tinted card, the spinner, and
  the action button come from the design system rather than a bespoke widget.
  Idle renders `SizedBox.shrink()`, so a host mounts the row unconditionally.
- `CatalogScanRow.deepRefresh(context:onStart:)` supplies the pull's second
  stage with its two captions, keeping the gesture that starts a scan worded
  beside the row that reports it.
- Both list cubits' `startCatalogScan()`, `cancelCatalogScan()`, and
  `dismissCatalogScan()` (shipped in 6a) gain their first callers.
- `SessionListPanel`'s injected `deepRefresh` parameter, added in step 5 before
  anything wired it up, is replaced by the real wiring and removed.
- New `app_en.arb` resources for the captions, the seven row states, and the
  delta / totals / nothing-new count wordings.

| State | Title | Detail | Action |
|---|---|---|---|
| Starting | Scanning all harnesses | — | Cancel |
| Running | Scanning all harnesses | `Codex — 148 sessions` | Cancel |
| Succeeded | Scan complete | `5 new sessions in 2 new projects`, `No new sessions`, or the totals fallback | Dismiss |
| Partly failed | Scan finished | `1 of 3 harnesses could not be scanned` | Dismiss |
| Failed | Scan failed | Check the bridge log for details | Dismiss |
| Unsupported | Scanning needs a newer bridge | Update the bridge to scan from here | Dismiss |

## Why

Step 6a routed the scan through the two list cubits but nothing rendered it and
nothing started it. This is the step that makes the feature reachable: without
it, `sesori-bridge --import-plugin <id>` by hand is still the only way to pick
up sessions a stale hydration marker skipped (issue #961).

## Risk and test focus

No database impact. No wire-contract change — this step is client-only and adds
no request the bridge has not already answered since step 4.

User-visible impact is the point of the step: three list surfaces gain a second
pull stage and a status row above the list.

Three deliberate departures from the plan, all recorded in `TRACKER.md`:

- **The soft-refresh bar is no longer suppressed while a scan runs.** On both
  lists `isRefreshing` is raised only by the stale-reconnect path — the pull
  reports through a toast and the scan's own post-settle refresh is silent — so
  the two progress surfaces overlap only when a reconnect lands mid-scan, and
  the cost is one redundant 4px bar.
- **Cancel and dismiss are the alert's labelled `secondaryAction`, not its
  close button.** `PregoButtonsSolid.iconOnly` takes no `semanticLabel`, so the
  ✕ is not reachable by name from a screen reader. Adding one would mean
  writing copy for 11 existing icon-only call sites across unrelated features.
- **No appearance animation.** `AnimatedSize` around the row never grew past
  zero height inside a `SliverToBoxAdapter` — the alert built, the box stayed
  at 0 — so it was removed rather than worked around.

Worth a look in review: the count wordings, which compose two plural resources
through a join so `5 new sessions in 2 new projects`, `3 new sessions`, and
`No new sessions` are each correct at every count; and the totals fallback,
which must not imply anything it names is new.

`CatalogImportFailed.message` still cannot reach the UI: `CatalogRescanFailed`
carries only `harnessCount`, and the failed row renders a static line pointing
at the bridge log.

## Expected result

Pulling a list past roughly 1.6× the ordinary trigger starts a scan across every
supported, enabled harness while the finger is still down, with the caption
changing to say so. A row appears at the top of the list naming the harness
being scanned and its live session count, with a Cancel action. When the scan
settles the row reports what was new, the list refreshes behind it, and the
success row clears itself after four seconds; failure rows stay until dismissed.

## Verification

- `flutter analyze lib test` in `client/app` — clean
- `client/app` suite — 872 passed, 18 new (12 row presentations covering all
  seven states and the count wordings, 6 project-list wiring cases including
  the two-stage pull driven as a real gesture)
- `flutter gen-l10n` output committed
- `architecture-implementation-review` — **approved, no findings**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows catalog scan progress above the project list and both session lists, and starts scans from the deep pull-to-refresh stage so rescans are reachable from the UI. Previously scans were routed but not user-triggerable or visible; now a row reports state and a deeper pull starts the scan.

- Adds `CatalogScanRow`, mapping all `CatalogRescanState` cases (including `noHarness`) to `PregoInlineAlertsNotifications`; idle renders zero height so hosts mount it unconditionally.
- Wires `PregoDeepRefresh` to start scans on the project list, full-screen session list, and split-view pane; removes the unused `SessionListPanel` `deepRefresh` parameter.
- Shows “No harness to scan” when the deep pull fires but no routable harness is available or the management snapshot hasn’t loaded; does not override an in-flight run.
- Limits live-region announcements to phase and terminal transitions so the running row doesn’t spam screen readers.
- Keeps the soft-refresh bar visible during scans; it may overlap if a reconnect lands mid-scan.
- Drops zero-count clauses in success text (e.g., show “2 new projects” without “No new sessions”); adds l10n for captions and pluralized result text; client-only with no wire-contract or database impact.

<sup>Written for commit f6a61d2fd82c6b1c59bc28dc2a62880099ac9984. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

