### PR TITLE
⚙️ Fix catalog refresh ordering after imports

### DIFF
--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -519,16 +519,18 @@ Settlement:
 | `owned`, all members failed | `CatalogRescanFailed` | held until dismissed |
 | `observed` | `CatalogRescanIdle` immediately | no summary is claimed |
 
-Every observed `CatalogImportCompleted` announces `catalogChanged`, including a
-terminal event that arrives after this client already closed a cancelled row.
-Each list cubit records that commit as dirty and refreshes from a forced fresh
-snapshot; a second completion while that read is in flight produces one trailing
-snapshot. The dirty revision is consumed only when a snapshot applies, so an
-older overlapping read cannot overwrite imported rows. A failed snapshot stays
-pending until a later ordinary, reconnect, or staleness read applies; a stale
-superseded read cannot rearm it. A forced failure that preempts a full-screen
-load owns the terminal error, and an explicit pull follows the newer read's
-outcome.
+Every observed `CatalogImportCompleted` with one or more published project or
+session rows announces `catalogChanged`, including a terminal event that arrives
+after this client already closed a cancelled row. The automatic hydration
+shortcut reports zero rows without catalog publication, so it does not displace
+an ordinary list read. Each list cubit records a signalled commit as dirty and
+refreshes from a forced fresh snapshot; a second completion while that read is
+in flight produces one trailing snapshot. The dirty revision is consumed only
+when a snapshot applies, so an older overlapping read cannot overwrite imported
+rows. A failed snapshot stays pending until a later ordinary, reconnect, or
+staleness read applies; a stale superseded read cannot rearm it. A forced
+failure that preempts a full-screen load owns the terminal error, and an
+explicit pull follows the newer read's outcome.
 
 An observed run still surfaces imported sessions because it receives the same
 global completion event. A run that finishes while disconnected has no live
@@ -616,7 +618,7 @@ New in-memory mutable parts:
 |---|---|---|
 | `Map<String, CatalogImportProgress>` | `CatalogRescanService` | Aggregating several concurrent harness imports into one row requires the latest progress per harness. Cleared only when a start **opens** an operation from idle or terminal, and on every reset to idle. A start that joins a live operation must not clear it |
 | `BehaviorSubject<CatalogRescanState>` | `CatalogRescanService` | The published row state, seeded so a late subscriber renders correctly |
-| `StreamController<void>` | `CatalogRescanService` | Announces each `CatalogImportCompleted` as a durable catalog change, even if the progress row was already cancelled and closed |
+| `StreamController<void>` | `CatalogRescanService` | Announces each nonzero `CatalogImportCompleted` as a durable catalog change, even if the progress row was already cancelled and closed |
 | `CompositeSubscription` | `CatalogRescanService` | SSE plus connection-status subscriptions, matching `PluginManagementService` |
 | `Timer?` | `CatalogRescanService` | The 4s success clear. Owned here, not by the row, so two mounted hosts cannot run disagreeing timers. Never armed for a failure state |
 | `bool _disposed` | `CatalogRescanService` | Module convention for `Disposable` services |

--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -284,11 +284,18 @@ the unseen service, neither of which the import touches. The stage-1 soft refres
 runs on release, before the import commits, so without an explicit refresh the
 row would announce new sessions over a list that still lacks them.
 
-`ProjectListCubit` and `SessionListCubit` therefore refresh themselves when the
-rescan reaches `CatalogRescanSucceeded` or `CatalogRescanPartlyFailed`, reusing
-the existing silent refresh each already owns. This is a client-side refresh, not
-a new bridge event: the progress stream is global, so a rescan started from the
-CLI or from another surface refreshes these lists just the same.
+`CatalogRescanService` therefore emits `catalogChanged` for every observed
+`CatalogImportCompleted`, and `ProjectListCubit` and `SessionListCubit` refresh
+from that durable-data signal. This remains a client-side refresh, not a new
+bridge event: the service already receives the global progress stream, so a
+rescan started from the CLI or another surface refreshes these lists just the
+same.
+
+The signal is deliberately tied to `CatalogImportCompleted`, not to closing the
+progress row. A cancel closes that row immediately, but the bridge's `DELETE`
+only requests cancellation; an atomic publish that already began can still
+complete. The terminal completion is the first point at which a list read is
+known to see the durable catalog.
 
 With several harnesses enabled the row stays a single row. Its subtitle names
 whichever harness is currently enumerating; it does not grow one row per
@@ -353,15 +360,14 @@ rejection on the card instead of skipping it.
                     +-- ConnectionService.events            (SSE + connection status)
                           |
                           v
-                  ValueStream<CatalogRescanState>
+       ValueStream<CatalogRescanState> + catalogChanged Stream
                           |
         +-----------------+------------------+
         v                 v                  v
   ProjectListCubit  SessionListCubit  PluginManagementCubit
         |                 |                  |
-        |  each exposes the rescan state in  |
-        |  its own state and refreshes its   |
-        |  list on a terminal success        |
+        |  each exposes the rescan state; the|
+        |  lists refresh after durable commits|
         v                 v                  v
   project list      session list +      Settings > Harnesses
                     split-view pane
@@ -371,15 +377,17 @@ rejection on the card instead of skipping it.
 ```
 
 No widget subscribes to `CatalogRescanService`. Each surface's existing cubit
-gains one subscription to its `ValueStream`, surfaces the rescan state through
-its own state, and exposes the intent methods the screen dispatches
-(`startCatalogScan()`, `cancelCatalogScan()`, `dismissCatalogScan()` on the two
-list cubits; `startCatalogScanFor(pluginId)` on `PluginManagementCubit`). This keeps the shell's Layer-4 boundary intact and puts the
-post-success list refresh in the object that already owns refreshing.
+surfaces the rescan state through its own state and exposes the intent methods
+the screen dispatches (`startCatalogScan()`, `cancelCatalogScan()`,
+`dismissCatalogScan()` on the two list cubits; `startCatalogScanFor(pluginId)`
+on `PluginManagementCubit`). The list cubits additionally subscribe to
+`catalogChanged`, which is a durable catalog fact rather than row lifecycle.
+This keeps the shell's Layer-4 boundary intact and puts the list refresh in the
+object that already owns refreshing.
 
 A dedicated `CatalogRescanCubit` was considered and rejected: the two list
-surfaces must refresh themselves on success, which only their own cubits can do,
-so a fourth cubit would add an object without removing any wiring.
+surfaces must refresh themselves after a durable commit, which only their own
+cubits can do, so a fourth cubit would add an object without removing any wiring.
 
 `CatalogRescanService` is a `@lazySingleton` in `module_core`, resolved with
 `getIt<CatalogRescanService>()` per the app shell's DI convention. Its declared
@@ -511,10 +519,18 @@ Settlement:
 | `owned`, all members failed | `CatalogRescanFailed` | held until dismissed |
 | `observed` | `CatalogRescanIdle` immediately | no summary is claimed |
 
-**Every** close of a live operation refreshes the two lists, whether it settled
-with a summary, settled as `observed`, or was cancelled. The refresh is tied to
-leaving a live operation, not to the terminal variants, so a run this client
-merely observed still makes its imported sessions appear.
+Every observed `CatalogImportCompleted` announces `catalogChanged`, including a
+terminal event that arrives after this client already closed a cancelled row.
+Each list cubit records that commit as dirty and refreshes from a forced fresh
+snapshot; a second completion while that read is in flight produces one trailing
+snapshot. The dirty revision is consumed only when a snapshot applies, so an
+older overlapping read cannot overwrite imported rows and a failed snapshot is
+re-armed by the next ordinary, reconnect, or staleness refresh.
+
+An observed run still surfaces imported sessions because it receives the same
+global completion event. A run that finishes while disconnected has no live
+terminal event to consume; the existing reconnect refresh reads the durable
+catalog instead.
 
 Why `observed` claims nothing: after a reconnect the service knows only which
 harnesses were still enumerating. A harness that completed or failed while the
@@ -535,10 +551,11 @@ cross-harness disabling. Each card is disabled only while that harness is itself
 a member, and starting a second harness while a first is importing simply widens
 the same operation.
 
-This is deliberately the whole model: no generation counters, no request fences,
-no stale-generation tracking. `PluginManagementService` needs that machinery
-because it reconciles mutations against a versioned snapshot token; an operation
-that closes on disconnect does not.
+This is deliberately the whole **service** model: no generation counters, no
+request fences, and no stale-generation tracking inside
+`CatalogRescanService`. `PluginManagementService` needs that machinery because
+it reconciles mutations against a versioned snapshot token; the list cubits need
+small independent guards because they apply asynchronous catalog snapshots.
 
 Because the service owns the operation, two mounted hosts always render the same
 row for the same duration, and revisiting a list after a rescan finished shows
@@ -595,12 +612,14 @@ New in-memory mutable parts:
 | Part | Owner | Why it must exist |
 |---|---|---|
 | `Map<String, CatalogImportProgress>` | `CatalogRescanService` | Aggregating several concurrent harness imports into one row requires the latest progress per harness. Cleared only when a start **opens** an operation from idle or terminal, and on every reset to idle. A start that joins a live operation must not clear it |
-| `BehaviorSubject<CatalogRescanState>` | `CatalogRescanService` | The published stream, seeded so a late subscriber renders correctly |
+| `BehaviorSubject<CatalogRescanState>` | `CatalogRescanService` | The published row state, seeded so a late subscriber renders correctly |
+| `StreamController<void>` | `CatalogRescanService` | Announces each `CatalogImportCompleted` as a durable catalog change, even if the progress row was already cancelled and closed |
 | `CompositeSubscription` | `CatalogRescanService` | SSE plus connection-status subscriptions, matching `PluginManagementService` |
 | `Timer?` | `CatalogRescanService` | The 4s success clear. Owned here, not by the row, so two mounted hosts cannot run disagreeing timers. Never armed for a failure state |
 | `bool _disposed` | `CatalogRescanService` | Module convention for `Disposable` services |
 | `bool _deepArmed` | `PregoSliverRefreshControl` | The refresh control reports pull distance continuously but fires `onRefresh` once; the threshold state at release must survive that one frame |
-| One subscription and one state field each | `ProjectListCubit`, `SessionListCubit`, `PluginManagementCubit` | The shell's Layer-4 boundary: widgets render cubit state rather than holding a service stream, and the two list cubits own their own post-success refresh |
+| One state subscription and field each | `ProjectListCubit`, `SessionListCubit`, `PluginManagementCubit` | The shell's Layer-4 boundary: widgets render cubit state rather than holding a service stream |
+| Durable-change subscription plus request and dirty revisions | `ProjectListCubit`, `SessionListCubit` | Each list cubit owns its post-commit snapshot ordering |
 | `bool _recoverySeeded` | `CatalogRescanService` | Marks the live operation `observed` rather than `owned`, so only a fully-seen run reports a terminal summary. Set when an operation opens from the recovery `GET` or from unsolicited progress; cleared when a start opens a new operation and on every reset. A join leaves it untouched, because joining an `observed` run does not make this client the observer of its earlier members |
 | `Map<String, CatalogRescanStartResult>` | `PluginManagementCubit` | Per-card targeted-start results, mirroring the `Map<String, PluginInstallProgress>` the cubit already keeps |
 
@@ -621,8 +640,9 @@ Deliberately **not** added:
   path for older bridges to buy one fewer round trip.
 - **No polling.** `GET /plugin/import` is read once when the service connects or
   reconnects. There is no timer and no repeated read.
-- **No generation or fence machinery.** Resetting to idle on disconnect makes it
-  unnecessary at this scale.
+- **No generation or fence machinery in `CatalogRescanService`.** It only
+  publishes durable completion facts. The two list cubits keep their own small
+  request and dirty-revision guards because they alone own list snapshots.
 - **No third "uncertain" mutation result.** A dispatch-based membership rule
   closes the lost-response hole without a new result variant threaded through
   the API and repository layers.
@@ -632,8 +652,10 @@ Deliberately **not** added:
 - **No client-side sanitizer for `CatalogImportFailed.message`.** The field is
   simply never lifted into client state. Sanitizing at the consumer would still
   have carried the raw string over the wire.
-- **No new bridge event for post-import list invalidation.** The two list cubits
-  already own a silent refresh and already see the global progress stream.
+- **No new bridge event for post-import list invalidation.**
+  `CatalogRescanService` converts the existing global completion progress into
+  its client-local `catalogChanged` stream, and the list cubits already own their
+  silent snapshots.
 - **No changes to the two SSE switch arms.** Both are correct as they stand;
   the service pattern-matches the event itself.
 - **No persisted last-rescan timestamp.** A `Last scanned 6 days ago - Rescan`
@@ -651,8 +673,7 @@ Deliberately **not** added:
 | An older bridge omits `newItems` | Success row shows totals instead of a delta | Accepted. Honest degradation, and the absent group makes the difference explicit rather than silently wrong |
 | A rescan in flight when the connection drops | The row disappears and does not return | Accepted. The bridge continues and commits the import; the next connect seeds only non-terminal statuses, so a rescan that finished meanwhile is simply not announced |
 | Two surfaces trigger a rescan for the same harness at once | The bridge coalesces it: `CatalogImportService.start` finds the active control and applies the trigger to it | No client-side guard needed; existing bridge behavior is correct |
-| A concurrent list read overwrites what a scan imported, or the post-scan read fails | The imported rows stay unseen until the next refresh | Accepted. The list cubits' read path has no ordering or retry guarantee today, independent of this feature — eight call sites, only the silent one coalescing. The post-scan read waits for the newest in-flight read and then starts fresh, which covers the ordinary cases; making it airtight needs a monotonic read guard across both cubits' core paths, which is a separate refactor. Recovery already exists: the project list re-reads on a 30s throttle while visible, both cubits re-read on `dataMayBeStale` and on reconnect, and a pull re-reads on demand. Owner decision 2026-08-24 |
-| A cancel `DELETE` races a harness that just completed | The bridge answers on the already-settled plugin and the SSE terminal event wins | Accepted; no client-side ordering guard |
+| A post-commit list snapshot fails and no later list trigger arrives | Imported rows stay unseen until a later refresh | Accepted. The dirty completion revision is retained and the next ordinary, reconnect, or staleness refresh re-arms it; no autonomous retry loop is added for this low-frequency recovery path. |
 | A failure row names no cause | The user must open the bridge log to learn why a harness failed | Accepted. `CatalogImportFailed.message` is unbounded `error.toString()`; a vaguer row is the honest trade until a producer-side sanitization boundary exists |
 | A lost response for a start that never arrived | That harness stays in `pluginIds` with no progress until the connection resets | Accepted. Bounded and self-clearing; a third result type across two layers is not worth it |
 | A rescan interrupted by a disconnect reports no summary | The user sees progress resume and the lists refresh, but no "Rescan complete" line for that run | Accepted deliberately. The alternative is claiming a total the client cannot vouch for; the lists, which are what the user actually came for, are still correct |
@@ -968,13 +989,12 @@ reviewer of one PR can see what belongs to it.
   own state. The two list cubits expose `startCatalogScan()`,
   `cancelCatalogScan()` and `dismissCatalogScan()`; `PluginManagementCubit`
   exposes `startCatalogScanFor(pluginId)`, which is 6c's, because only a
-  targeted start needs a per-harness result. The two list cubits additionally run
-  their existing silent refresh whenever the service **leaves a live operation**
-  — settled with a summary, settled as observed, or cancelled — because a
-  committed import raises no list invalidation of its own. Keying the refresh on
-  leaving a live operation rather than on the terminal variants is what makes an
-  observed run, which never publishes a summary, still surface its imported
-  sessions.
+  targeted start needs a per-harness result. The two list cubits additionally
+  treat each `catalogChanged` emission as a dirty durable commit and force a
+  fresh silent snapshot. Their request generation prevents an older response
+  from overwriting that snapshot; a second commit in flight produces one
+  trailing read, and a failed read remains dirty for the next ordinary,
+  reconnect, or staleness refresh.
 - The aggregate rescan row widget in `client/app/lib/core/widgets/`, beside the
   shell's other cross-feature widgets, with its seven presentations. It renders
   the state it is given, owns no timer, and renders no bridge-supplied text.
@@ -997,9 +1017,10 @@ reviewer of one PR can see what belongs to it.
   semantics label and its rejection message.
 - Widget and cubit tests: all seven row states; the totals fallback; cancel;
   dismiss; the Settings action's enablement rules and its targeted rejection;
-  that a terminal success triggers exactly one list refresh per list cubit; and
-  that no test fixture's `CatalogImportFailed.message` reaches a rendered
-  string.
+  that committed imports produce a post-commit list snapshot without an older
+  read overwriting it, a second commit gets a trailing snapshot, a failed
+  snapshot remains dirty for a later refresh, and no test fixture's
+  `CatalogImportFailed.message` reaches a rendered string.
 
 ### Verification
 

--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -524,8 +524,11 @@ terminal event that arrives after this client already closed a cancelled row.
 Each list cubit records that commit as dirty and refreshes from a forced fresh
 snapshot; a second completion while that read is in flight produces one trailing
 snapshot. The dirty revision is consumed only when a snapshot applies, so an
-older overlapping read cannot overwrite imported rows and a failed snapshot is
-re-armed by the next ordinary, reconnect, or staleness refresh.
+older overlapping read cannot overwrite imported rows. A failed snapshot stays
+pending until a later ordinary, reconnect, or staleness read applies; a stale
+superseded read cannot rearm it. A forced failure that preempts a full-screen
+load owns the terminal error, and an explicit pull follows the newer read's
+outcome.
 
 An observed run still surfaces imported sessions because it receives the same
 global completion event. A run that finishes while disconnected has no live
@@ -673,7 +676,7 @@ Deliberately **not** added:
 | An older bridge omits `newItems` | Success row shows totals instead of a delta | Accepted. Honest degradation, and the absent group makes the difference explicit rather than silently wrong |
 | A rescan in flight when the connection drops | The row disappears and does not return | Accepted. The bridge continues and commits the import; the next connect seeds only non-terminal statuses, so a rescan that finished meanwhile is simply not announced |
 | Two surfaces trigger a rescan for the same harness at once | The bridge coalesces it: `CatalogImportService.start` finds the active control and applies the trigger to it | No client-side guard needed; existing bridge behavior is correct |
-| A post-commit list snapshot fails and no later list trigger arrives | Imported rows stay unseen until a later refresh | Accepted. The dirty completion revision is retained and the next ordinary, reconnect, or staleness refresh re-arms it; no autonomous retry loop is added for this low-frequency recovery path. |
+| A post-commit list snapshot fails and no later list trigger arrives | Imported rows stay unseen until a later refresh | Accepted. The dirty completion revision is retained and the next ordinary, reconnect, or staleness snapshot that applies re-arms it; no autonomous retry loop is added for this low-frequency recovery path. |
 | A failure row names no cause | The user must open the bridge log to learn why a harness failed | Accepted. `CatalogImportFailed.message` is unbounded `error.toString()`; a vaguer row is the honest trade until a producer-side sanitization boundary exists |
 | A lost response for a start that never arrived | That harness stays in `pluginIds` with no progress until the connection resets | Accepted. Bounded and self-clearing; a third result type across two layers is not worth it |
 | A rescan interrupted by a disconnect reports no summary | The user sees progress resume and the lists refresh, but no "Rescan complete" line for that run | Accepted deliberately. The alternative is claiming a total the client cannot vouch for; the lists, which are what the user actually came for, are still correct |

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -487,6 +487,10 @@ class ProjectListCubit(
   /// In-flight silent refresh, used for coalescing.
   Future<_ProjectFetchOutcome>? _activeRefresh;
 
+  /// Most recently started read. This is not a coalescing barrier: a refresh
+  /// whose response was superseded uses it only to observe the winning result.
+  Future<_ProjectFetchOutcome>? _latestFetch;
+
   /// Monotonically orders list reads so an older response cannot overwrite a
   /// snapshot requested after it.
   int _fetchGeneration = 0;
@@ -500,9 +504,26 @@ class ProjectListCubit(
 
   /// Re-fetches projects without showing the full-screen loading indicator.
   /// Concurrent ordinary calls coalesce onto the current silent refresh.
-  Future<bool> refreshProjects() async {
-    final outcome = await _refreshProjects(force: false, catalogRefresh: false);
-    return outcome != _ProjectFetchOutcome.failed;
+  Future<bool> refreshProjects() {
+    return _awaitRefreshResult(refresh: _refreshProjects(force: false, catalogRefresh: false));
+  }
+
+  /// A catalog refresh can supersede an explicit pull. Wait for the newer read
+  /// so the caller reports that read's outcome rather than premature success.
+  Future<bool> _awaitRefreshResult({required Future<_ProjectFetchOutcome> refresh}) async {
+    var latest = refresh;
+    while (true) {
+      switch (await latest) {
+        case _ProjectFetchOutcome.applied:
+          return true;
+        case _ProjectFetchOutcome.failed:
+          return false;
+        case _ProjectFetchOutcome.superseded:
+          final winningFetch = _latestFetch;
+          if (winningFetch == null || identical(winningFetch, latest)) return false;
+          latest = winningFetch;
+      }
+    }
   }
 
   Future<_ProjectFetchOutcome> _refreshProjects({
@@ -694,12 +715,14 @@ class ProjectListCubit(
   }) {
     final requestGeneration = ++_fetchGeneration;
     final catalogChangeGeneration = _catalogChangeGeneration;
-    return _runFetchProjects(
+    final fetch = _runFetchProjects(
       silent: silent,
       catalogRefresh: catalogRefresh,
       requestGeneration: requestGeneration,
       catalogChangeGeneration: catalogChangeGeneration,
     );
+    _latestFetch = fetch;
+    return fetch;
   }
 
   Future<_ProjectFetchOutcome> _runFetchProjects({
@@ -708,6 +731,7 @@ class ProjectListCubit(
     required int requestGeneration,
     required int catalogChangeGeneration,
   }) async {
+    var didApplySnapshot = false;
     try {
       // Captured BEFORE the fetch so the seed can't overwrite a live update
       // that arrives while the request is in flight.
@@ -750,10 +774,11 @@ class ProjectListCubit(
             occurredAtUtc: DateTime.now().toUtc(),
           );
           _consumeCatalogChangesThrough(generation: catalogChangeGeneration);
+          didApplySnapshot = true;
           return _ProjectFetchOutcome.applied;
 
         case ErrorResponse(:final error):
-          if (silent) {
+          if (silent && state is! ProjectListLoading) {
             logw("Failed to refresh projects: ${error.toString()}");
           } else if (_isBridgeUnavailable) {
             // The fetch failed because the bridge isn't connected — show the
@@ -770,7 +795,7 @@ class ProjectListCubit(
           return _ProjectFetchOutcome.failed;
       }
     } finally {
-      if (!catalogRefresh) _rearmCatalogRefreshAfterOrdinaryFetch();
+      if (!catalogRefresh && didApplySnapshot) _rearmCatalogRefreshAfterOrdinaryFetch();
     }
   }
 

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -737,7 +737,15 @@ class ProjectListCubit(
       // that arrives while the request is in flight.
       final unseenTick = _sessionUnseenTracker.tick;
       final projectResponse = await _projectListService.listProjects();
-      if (isClosed || requestGeneration != _fetchGeneration) {
+      if (isClosed) return _ProjectFetchOutcome.superseded;
+      if (requestGeneration != _fetchGeneration) {
+        if (projectResponse case ErrorResponse(:final error)) {
+          logw(
+            "Discarded superseded project list response "
+            "(request generation $requestGeneration, current $_fetchGeneration)",
+            error,
+          );
+        }
         return _ProjectFetchOutcome.superseded;
       }
 

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -35,6 +35,8 @@ const refreshThrottleDuration = Duration(seconds: 30);
 @visibleForTesting
 const initialProjectLoadConnectionWaitTimeout = Duration(seconds: 15);
 
+enum _ProjectFetchOutcome() { applied, failed, superseded }
+
 class ProjectListCubit(
   final ProjectRepository _projectRepository,
   final ConnectionService _connectionService,
@@ -70,10 +72,8 @@ class ProjectListCubit(
     // 1a2. The catalog scan, which any surface can start. Its state is only
     //     projected onto the list; the operation itself is the service's.
     _subscriptions.add(_catalogRescanService.state.listen(_onCatalogScanState));
-    // A committed import raises no list invalidation of its own, so the list
-    // refreshes when the scan leaves a live operation — however it ended,
-    // because a run this client only observed publishes no terminal state.
-    _subscriptions.add(_catalogRescanService.settled.listen((_) => unawaited(_refreshAfterScan())));
+    // A committed import raises no list invalidation of its own.
+    _subscriptions.add(_catalogRescanService.catalogChanged.listen((_) => _onCatalogChanged()));
 
     // 1b. Immediate unseen (bold) updates (no API call).
     _subscriptions.add(
@@ -308,7 +308,7 @@ class ProjectListCubit(
       // The relay connection is fully torn down — nothing is reachable and no
       // banner represents this state, so surface the bridge-disconnected flow.
       case ConnectionDisconnected():
-        unawaited(_emitBridgeDisconnected());
+        unawaited(_emitBridgeDisconnected(fetchGeneration: null));
       case ConnectionBridgeOffline():
         // A non-empty loaded list stays browsable while the bridge is offline —
         // the top-nav connection banner owns the messaging. The full-screen
@@ -316,7 +316,7 @@ class ProjectListCubit(
         // show (launch before the bridge starts, or an empty list whose
         // onboarding checklist would contradict an offline banner).
         if (state case ProjectListLoaded(:final projects) when projects.isNotEmpty) break;
-        unawaited(_emitBridgeDisconnected());
+        unawaited(_emitBridgeDisconnected(fetchGeneration: null));
       // Keep the current UI. A loaded list keeps hosting the inline connection
       // banner, which owns the ConnectionLost reconnect action;
       // ConnectionReconnecting is a brief transient.
@@ -337,9 +337,10 @@ class ProjectListCubit(
   ///
   /// Which machine the recovery view is trying to reach is resolved separately
   /// by `BridgeIdentityCubit`, so this state is never held back by that fetch.
-  Future<void> _emitBridgeDisconnected() async {
+  Future<void> _emitBridgeDisconnected({required int? fetchGeneration}) async {
     final hasRegisteredBridges = await _registeredBridgesService.hasRegisteredBridges();
     if (isClosed) return;
+    if (fetchGeneration != null && fetchGeneration != _fetchGeneration) return;
     if (!_isBridgeUnavailable) return;
     _loadedStateAnalyticsReporter.clearCurrentOccurrence();
     emit(ProjectListState.bridgeDisconnected(hasRegisteredBridges: hasRegisteredBridges));
@@ -364,17 +365,17 @@ class ProjectListCubit(
   Future<void> loadProjects() async {
     _loadedStateAnalyticsReporter.clearCurrentOccurrence();
     emit(const ProjectListState.loading());
-    await _fetchProjects();
+    await _fetchProjects(silent: false, catalogRefresh: false);
   }
 
   Future<void> _loadInitialProjects() async {
     await _prepareInitialConnection();
     if (isClosed) return;
     if (_isBridgeUnavailable) {
-      await _emitBridgeDisconnected();
+      await _emitBridgeDisconnected(fetchGeneration: null);
       return;
     }
-    await _fetchProjects();
+    await _fetchProjects(silent: false, catalogRefresh: false);
   }
 
   Future<void> _prepareInitialConnection() async {
@@ -429,7 +430,7 @@ class ProjectListCubit(
     if (isClosed) return;
     await _connectionService.reconnectAndAwaitOutcome(timeout: const Duration(seconds: 15));
     if (isClosed) return;
-    await _fetchProjects();
+    await _fetchProjects(silent: false, catalogRefresh: false);
   }
 
   /// True while [reconnectBridge] is re-establishing the connection. The
@@ -474,26 +475,49 @@ class ProjectListCubit(
       }
       if (isClosed) return;
       if (_isBridgeUnavailable) {
-        await _emitBridgeDisconnected();
+        await _emitBridgeDisconnected(fetchGeneration: null);
         return;
       }
-      await _fetchProjects();
+      await _fetchProjects(silent: false, catalogRefresh: false);
     } finally {
       _reconnectBridgeInFlight = false;
     }
   }
 
   /// In-flight silent refresh, used for coalescing.
-  Future<bool>? _activeRefresh;
+  Future<_ProjectFetchOutcome>? _activeRefresh;
 
-  /// The most recent list read of any kind.
-  Future<bool>? _activeFetch;
+  /// Monotonically orders list reads so an older response cannot overwrite a
+  /// snapshot requested after it.
+  int _fetchGeneration = 0;
+
+  /// Durable catalog commits observed by this cubit, and the newest commit a
+  /// successfully applied list snapshot has covered.
+  int _catalogChangeGeneration = 0;
+  int _catalogChangeConsumedGeneration = 0;
+  bool _catalogRefreshPausedAfterFailure = false;
+  Future<void>? _catalogRefresh;
 
   /// Re-fetches projects without showing the full-screen loading indicator.
-  /// Concurrent calls are coalesced: if a refresh is already in-flight, the
-  /// existing Future is returned instead of starting a second network request.
-  Future<bool> refreshProjects() {
-    return _activeRefresh ??= _fetchProjects(silent: true).whenComplete(() => _activeRefresh = null);
+  /// Concurrent ordinary calls coalesce onto the current silent refresh.
+  Future<bool> refreshProjects() async {
+    final outcome = await _refreshProjects(force: false, catalogRefresh: false);
+    return outcome != _ProjectFetchOutcome.failed;
+  }
+
+  Future<_ProjectFetchOutcome> _refreshProjects({
+    required bool force,
+    required bool catalogRefresh,
+  }) {
+    final active = _activeRefresh;
+    if (!force && active != null) return active;
+
+    late final Future<_ProjectFetchOutcome> refresh;
+    refresh = _fetchProjects(silent: true, catalogRefresh: catalogRefresh).whenComplete(() {
+      if (identical(_activeRefresh, refresh)) _activeRefresh = null;
+    });
+    _activeRefresh = refresh;
+    return refresh;
   }
 
   /// Calls the bridge API to hide the project, then removes it from the
@@ -664,98 +688,152 @@ class ProjectListCubit(
     return error is NonSuccessCodeError && error.errorCode == 403;
   }
 
-  /// Registers every list read, silent or not, so an ordering-sensitive caller
-  /// can wait for whatever is already in flight. [_activeRefresh] tracks only
-  /// the coalescing silent path, so an initial or retry load is invisible to it.
-  Future<bool> _fetchProjects({bool silent = false}) {
-    final fetch = _runFetchProjects(silent: silent);
-    _activeFetch = fetch;
-    unawaited(
-      fetch.whenComplete(() {
-        if (identical(_activeFetch, fetch)) _activeFetch = null;
-      }).catchError((Object _) => false),
+  Future<_ProjectFetchOutcome> _fetchProjects({
+    required bool silent,
+    required bool catalogRefresh,
+  }) {
+    final requestGeneration = ++_fetchGeneration;
+    final catalogChangeGeneration = _catalogChangeGeneration;
+    return _runFetchProjects(
+      silent: silent,
+      catalogRefresh: catalogRefresh,
+      requestGeneration: requestGeneration,
+      catalogChangeGeneration: catalogChangeGeneration,
     );
-    return fetch;
   }
 
-  Future<bool> _runFetchProjects({bool silent = false}) async {
-    // Captured BEFORE the fetch so the seed can't overwrite a live update that
-    // arrives while the request is in flight.
-    final unseenTick = _sessionUnseenTracker.tick;
-    final projectResponse = await _projectListService.listProjects();
-    if (isClosed) return false;
-
-    switch (projectResponse) {
-      case SuccessResponse(data: Projects(data: final projects)):
-        final mergedProjects = _projectListService
-            .mergeTimestampUpdates(
-              projects: projects,
-              timestampByProjectId: _sseEventTracker.currentProjectTimestampUpdates,
-            )
-            .projects;
-        final sortedProjects = _projectListService.orderProjects(
-          projects: mergedProjects,
-          activityByProjectId: _sseEventTracker.currentSessionActivity,
-          listStateByProjectId: _sessionUnseenTracker.currentSessionUnseen,
-        );
-        // The REST aggregate is authoritative at fetch time — seed the tracker
-        // so a stale live `true` can't keep a project bold after its last
-        // unseen session was archived/deleted while an echo was missed.
-        _sessionUnseenTracker.seedProjects(
-          {for (final p in sortedProjects) p.id: p.hasUnseenChanges},
-          sinceTick: unseenTick,
-        );
-        emit(
-          ProjectListState.loaded(
-            projects: sortedProjects,
-            activityById: _sseEventTracker.currentProjectActivity,
-            unseenByProjectId: _unseenByProjectId(sortedProjects),
-            // Re-derived from its owner, like the two fields above it. This
-            // emit is what the scan's own settled listener triggers, so
-            // omitting it would erase the terminal row it was fired for.
-            catalogScan: _catalogRescanService.state.value,
-          ),
-        );
-        _loadedStateAnalyticsReporter.reportLoaded(
-          isEmpty: sortedProjects.isEmpty,
-          occurredAtUtc: DateTime.now().toUtc(),
-        );
-        return true;
-
-      case ErrorResponse(:final error):
-        if (silent) {
-          logw("Failed to refresh projects: ${error.toString()}");
-        } else if (_isBridgeUnavailable) {
-          // The fetch failed because the bridge isn't connected — show the
-          // bridge-disconnected flow rather than a generic error.
-          await _emitBridgeDisconnected();
-        } else {
-          loge("Project list load failed", error);
-          _loadedStateAnalyticsReporter.clearCurrentOccurrence();
-          emit(ProjectListState.failed(reason: error.remoteFailureReason));
-        }
-        return false;
-    }
-  }
-
-  /// Reads the catalog strictly after the scan committed.
-  ///
-  /// [refreshProjects] coalesces onto a refresh already in flight, and that one
-  /// may have started before the import committed. Waiting it out first means
-  /// the read that follows is guaranteed to see the imported rows, which is the
-  /// whole point of refreshing here — the import raises no other invalidation.
-  Future<void> _refreshAfterScan() async {
-    // Every read, not just the coalescing silent one: a full load in flight
-    // would otherwise race this fetch and, landing last, overwrite what the
-    // scan just imported. A failing read reports itself, so it is not
-    // re-reported here.
+  Future<_ProjectFetchOutcome> _runFetchProjects({
+    required bool silent,
+    required bool catalogRefresh,
+    required int requestGeneration,
+    required int catalogChangeGeneration,
+  }) async {
     try {
-      await _activeFetch;
-    } on Object catch (_) {
-      // Ignored: the read that failed owns its own reporting.
+      // Captured BEFORE the fetch so the seed can't overwrite a live update
+      // that arrives while the request is in flight.
+      final unseenTick = _sessionUnseenTracker.tick;
+      final projectResponse = await _projectListService.listProjects();
+      if (isClosed || requestGeneration != _fetchGeneration) {
+        return _ProjectFetchOutcome.superseded;
+      }
+
+      switch (projectResponse) {
+        case SuccessResponse(data: Projects(data: final projects)):
+          final mergedProjects = _projectListService
+              .mergeTimestampUpdates(
+                projects: projects,
+                timestampByProjectId: _sseEventTracker.currentProjectTimestampUpdates,
+              )
+              .projects;
+          final sortedProjects = _projectListService.orderProjects(
+            projects: mergedProjects,
+            activityByProjectId: _sseEventTracker.currentSessionActivity,
+            listStateByProjectId: _sessionUnseenTracker.currentSessionUnseen,
+          );
+          // The REST aggregate is authoritative at fetch time — seed the tracker
+          // so a stale live `true` can't keep a project bold after its last
+          // unseen session was archived/deleted while an echo was missed.
+          _sessionUnseenTracker.seedProjects(
+            {for (final p in sortedProjects) p.id: p.hasUnseenChanges},
+            sinceTick: unseenTick,
+          );
+          emit(
+            ProjectListState.loaded(
+              projects: sortedProjects,
+              activityById: _sseEventTracker.currentProjectActivity,
+              unseenByProjectId: _unseenByProjectId(sortedProjects),
+              catalogScan: _catalogRescanService.state.value,
+            ),
+          );
+          _loadedStateAnalyticsReporter.reportLoaded(
+            isEmpty: sortedProjects.isEmpty,
+            occurredAtUtc: DateTime.now().toUtc(),
+          );
+          _consumeCatalogChangesThrough(generation: catalogChangeGeneration);
+          return _ProjectFetchOutcome.applied;
+
+        case ErrorResponse(:final error):
+          if (silent) {
+            logw("Failed to refresh projects: ${error.toString()}");
+          } else if (_isBridgeUnavailable) {
+            // The fetch failed because the bridge isn't connected — show the
+            // bridge-disconnected flow rather than a generic error.
+            await _emitBridgeDisconnected(fetchGeneration: requestGeneration);
+            if (isClosed || requestGeneration != _fetchGeneration) {
+              return _ProjectFetchOutcome.superseded;
+            }
+          } else {
+            loge("Project list load failed", error);
+            _loadedStateAnalyticsReporter.clearCurrentOccurrence();
+            emit(ProjectListState.failed(reason: error.remoteFailureReason));
+          }
+          return _ProjectFetchOutcome.failed;
+      }
+    } finally {
+      if (!catalogRefresh) _rearmCatalogRefreshAfterOrdinaryFetch();
     }
+  }
+
+  void _onCatalogChanged() {
     if (isClosed) return;
-    await refreshProjects();
+    _catalogChangeGeneration++;
+    _catalogRefreshPausedAfterFailure = false;
+    _ensureCatalogRefresh();
+  }
+
+  void _consumeCatalogChangesThrough({required int generation}) {
+    if (generation > _catalogChangeConsumedGeneration) {
+      _catalogChangeConsumedGeneration = generation;
+    }
+  }
+
+  void _ensureCatalogRefresh() {
+    if (isClosed ||
+        _catalogRefresh != null ||
+        _catalogRefreshPausedAfterFailure ||
+        _catalogChangeConsumedGeneration >= _catalogChangeGeneration) {
+      return;
+    }
+
+    late final Future<void> refresh;
+    refresh = _drainCatalogRefreshes().whenComplete(() {
+      if (!identical(_catalogRefresh, refresh)) return;
+      _catalogRefresh = null;
+      _ensureCatalogRefresh();
+    });
+    _catalogRefresh = refresh;
+    unawaited(refresh);
+  }
+
+  Future<void> _drainCatalogRefreshes() async {
+    while (!isClosed && _catalogChangeConsumedGeneration < _catalogChangeGeneration) {
+      final targetGeneration = _catalogChangeGeneration;
+      late final _ProjectFetchOutcome outcome;
+      try {
+        outcome = await _refreshProjects(force: true, catalogRefresh: true);
+      } on Object catch (error, stackTrace) {
+        loge("Catalog-change project refresh failed unexpectedly", error, stackTrace);
+        _catalogRefreshPausedAfterFailure = true;
+        return;
+      }
+
+      if (_catalogChangeConsumedGeneration >= _catalogChangeGeneration) return;
+      switch (outcome) {
+        case _ProjectFetchOutcome.applied:
+        case _ProjectFetchOutcome.superseded:
+          continue;
+        case _ProjectFetchOutcome.failed:
+          if (targetGeneration < _catalogChangeGeneration) continue;
+          _catalogRefreshPausedAfterFailure = true;
+          return;
+      }
+    }
+  }
+
+  void _rearmCatalogRefreshAfterOrdinaryFetch() {
+    if (isClosed || !_catalogRefreshPausedAfterFailure) return;
+    _catalogRefreshPausedAfterFailure = false;
+    _ensureCatalogRefresh();
   }
 
   /// Starts a catalog scan across every harness this bridge can import from.

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -548,6 +548,10 @@ class SessionListCubit({
   /// In-flight silent refresh, used for coalescing.
   Future<_SessionFetchOutcome>? _activeRefresh;
 
+  /// Most recently started read. This is not a coalescing barrier: a refresh
+  /// whose response was superseded uses it only to observe the winning result.
+  Future<_SessionFetchOutcome>? _latestFetch;
+
   /// Monotonically orders list reads so an older response cannot overwrite a
   /// snapshot requested after it.
   int _fetchGeneration = 0;
@@ -566,13 +570,32 @@ class SessionListCubit({
   /// GitHub PR metadata before returning. This is appropriate only for
   /// explicit user-initiated pull-to-refresh; background triggers such as
   /// reconnects, route navigation, or SSE events should leave it false.
-  Future<bool> refreshSessions({bool waitForPrData = false}) async {
-    final outcome = await _refreshSessions(
-      force: false,
-      catalogRefresh: false,
-      waitForPrData: waitForPrData,
+  Future<bool> refreshSessions({bool waitForPrData = false}) {
+    return _awaitRefreshResult(
+      refresh: _refreshSessions(
+        force: false,
+        catalogRefresh: false,
+        waitForPrData: waitForPrData,
+      ),
     );
-    return outcome != _SessionFetchOutcome.failed;
+  }
+
+  /// A catalog refresh can supersede an explicit pull. Wait for the newer read
+  /// so the caller reports that read's outcome rather than premature success.
+  Future<bool> _awaitRefreshResult({required Future<_SessionFetchOutcome> refresh}) async {
+    var latest = refresh;
+    while (true) {
+      switch (await latest) {
+        case _SessionFetchOutcome.applied:
+          return true;
+        case _SessionFetchOutcome.failed:
+          return false;
+        case _SessionFetchOutcome.superseded:
+          final winningFetch = _latestFetch;
+          if (winningFetch == null || identical(winningFetch, latest)) return false;
+          latest = winningFetch;
+      }
+    }
   }
 
   Future<_SessionFetchOutcome> _refreshSessions({
@@ -603,13 +626,15 @@ class SessionListCubit({
   }) {
     final requestGeneration = ++_fetchGeneration;
     final catalogChangeGeneration = _catalogChangeGeneration;
-    return _runFetchSessions(
+    final fetch = _runFetchSessions(
       silent: silent,
       catalogRefresh: catalogRefresh,
       waitForPrData: waitForPrData,
       requestGeneration: requestGeneration,
       catalogChangeGeneration: catalogChangeGeneration,
     );
+    _latestFetch = fetch;
+    return fetch;
   }
 
   Future<_SessionFetchOutcome> _runFetchSessions({
@@ -619,6 +644,7 @@ class SessionListCubit({
     required int requestGeneration,
     required int catalogChangeGeneration,
   }) async {
+    var didApplySnapshot = false;
     try {
       // Captured BEFORE the fetch so the seed can't overwrite a live update
       // that arrives while the (possibly PR-data-delayed) request is in flight.
@@ -660,10 +686,11 @@ class SessionListCubit({
           _emitFiltered();
           _projectViewingService.markClaimReady(claim: _projectViewClaim, projectId: _projectId);
           _consumeCatalogChangesThrough(generation: catalogChangeGeneration);
+          didApplySnapshot = true;
           return _SessionFetchOutcome.applied;
 
         case ErrorResponse(:final error):
-          if (silent) {
+          if (silent && state is! SessionListLoading) {
             logw("Failed to refresh sessions: ${error.toString()}");
           } else {
             _projectViewingService.markClaimFailed(claim: _projectViewClaim);
@@ -673,7 +700,7 @@ class SessionListCubit({
           return _SessionFetchOutcome.failed;
       }
     } finally {
-      if (!catalogRefresh) _rearmCatalogRefreshAfterOrdinaryFetch();
+      if (!catalogRefresh && didApplySnapshot) _rearmCatalogRefreshAfterOrdinaryFetch();
     }
   }
 

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -26,6 +26,8 @@ import "../../services/session_unseen_tracker.dart";
 import "../../services/sse_event_tracker.dart";
 import "session_list_state.dart";
 
+enum _SessionFetchOutcome() { applied, failed, superseded }
+
 class SessionListCubit({
   required final SessionRepository _sessionRepository,
   required final SessionListService _sessionListService,
@@ -54,12 +56,8 @@ class SessionListCubit({
     // The catalog scan, which any surface can start. Its state is only
     // projected onto this list; the operation itself is the service's.
     _subscriptions.add(_catalogRescanService.state.listen(_onCatalogScanState));
-    // A committed import raises no list invalidation of its own, so the list
-    // refreshes when the scan leaves a live operation — however it ended,
-    // because a run this client only observed publishes no terminal state.
-    _subscriptions.add(
-      _catalogRescanService.settled.listen((_) => unawaited(_refreshAfterScan())),
-    );
+    // A committed import raises no list invalidation of its own.
+    _subscriptions.add(_catalogRescanService.catalogChanged.listen((_) => _onCatalogChanged()));
     _subscriptions.add(_connectionService.events.listen(_handleEvent));
     // 1. Navigate-back refresh: one immediate fetch when the user returns to
     //    the sessions page. pairwise() ensures this doesn't fire on the
@@ -218,7 +216,9 @@ class SessionListCubit({
       final response = await _sessionRepository.markSessionSeen(sessionId: sessionId, read: read);
       if (response case ErrorResponse(:final error)) {
         loge("Failed to mark session ${read ? "read" : "unread"}", error);
-        if (!isClosed) await _fetchSessions(silent: true);
+        if (!isClosed) {
+          await _fetchSessions(silent: true, catalogRefresh: false, waitForPrData: false);
+        }
       }
     } catch (e, st) {
       unawaited(
@@ -235,7 +235,9 @@ class SessionListCubit({
               loge("Failed to report mark-seen error", error, stackTrace);
             }),
       );
-      if (!isClosed) await _fetchSessions(silent: true);
+      if (!isClosed) {
+        await _fetchSessions(silent: true, catalogRefresh: false, waitForPrData: false);
+      }
     }
   }
 
@@ -525,7 +527,7 @@ class SessionListCubit({
 
   Future<void> loadSessions() async {
     emit(const SessionListState.loading());
-    await _fetchSessions();
+    await _fetchSessions(silent: false, catalogRefresh: false, waitForPrData: false);
   }
 
   /// Retries loading sessions after a failure.
@@ -540,114 +542,205 @@ class SessionListCubit({
     if (isClosed) return;
     await _connectionService.reconnectAndAwaitOutcome(timeout: const Duration(seconds: 15));
     if (isClosed) return;
-    await _fetchSessions();
+    await _fetchSessions(silent: false, catalogRefresh: false, waitForPrData: false);
   }
 
   /// In-flight silent refresh, used for coalescing.
-  Future<bool>? _activeRefresh;
+  Future<_SessionFetchOutcome>? _activeRefresh;
 
-  /// The most recent list read of any kind.
-  Future<bool>? _activeFetch;
+  /// Monotonically orders list reads so an older response cannot overwrite a
+  /// snapshot requested after it.
+  int _fetchGeneration = 0;
+
+  /// Durable catalog commits observed by this cubit, and the newest commit a
+  /// successfully applied list snapshot has covered.
+  int _catalogChangeGeneration = 0;
+  int _catalogChangeConsumedGeneration = 0;
+  bool _catalogRefreshPausedAfterFailure = false;
+  Future<void>? _catalogRefresh;
 
   /// Re-fetches sessions without showing the full-screen loading indicator.
-  /// Concurrent calls are coalesced: if a refresh is already in-flight, the
-  /// existing Future is returned instead of starting a second network request.
+  /// Concurrent ordinary calls coalesce onto the current silent refresh.
   ///
   /// When [waitForPrData] is true the bridge will wait up to 5 s for
   /// GitHub PR metadata before returning. This is appropriate only for
   /// explicit user-initiated pull-to-refresh; background triggers such as
   /// reconnects, route navigation, or SSE events should leave it false.
-  Future<bool> refreshSessions({bool waitForPrData = false}) {
-    return _activeRefresh ??= _fetchSessions(
-      silent: true,
+  Future<bool> refreshSessions({bool waitForPrData = false}) async {
+    final outcome = await _refreshSessions(
+      force: false,
+      catalogRefresh: false,
       waitForPrData: waitForPrData,
-    ).whenComplete(() => _activeRefresh = null);
-  }
-
-  /// Registers every list read, silent or not, so an ordering-sensitive caller
-  /// can wait for whatever is already in flight. [_activeRefresh] tracks only
-  /// the coalescing silent path, so an initial or retry load is invisible to it.
-  Future<bool> _fetchSessions({bool silent = false, bool waitForPrData = false}) {
-    final fetch = _runFetchSessions(silent: silent, waitForPrData: waitForPrData);
-    _activeFetch = fetch;
-    unawaited(
-      fetch.whenComplete(() {
-        if (identical(_activeFetch, fetch)) _activeFetch = null;
-      }).catchError((Object _) => false),
     );
-    return fetch;
+    return outcome != _SessionFetchOutcome.failed;
   }
 
-  Future<bool> _runFetchSessions({bool silent = false, bool waitForPrData = false}) async {
-    // Captured BEFORE the fetch so the seed can't overwrite a live update that
-    // arrives while the (possibly PR-data-delayed) request is in flight.
-    final unseenTick = _sessionUnseenTracker.tick;
-    final (sessionsResponse, gitContextResponse) = await (
-      _sessionListService.listSessions(
-        projectId: _projectId,
-        waitForPrData: waitForPrData,
-      ),
-      _projectRepository.getGitContext(projectId: _projectId),
-    ).wait;
-    if (isClosed) return false;
+  Future<_SessionFetchOutcome> _refreshSessions({
+    required bool force,
+    required bool catalogRefresh,
+    required bool waitForPrData,
+  }) {
+    final active = _activeRefresh;
+    if (!force && active != null) return active;
 
-    // Update cached git context on success; silently ignore errors so
-    // the session list still loads even if the endpoint is unavailable.
-    if (gitContextResponse case SuccessResponse(:final data)) {
-      _gitContext = data;
-    }
-
-    switch (sessionsResponse) {
-      case SuccessResponse(:final data):
-        _allSessions = data.items;
-        // The REST flags are authoritative at fetch time — seed the tracker so
-        // a stale live `true` can't keep a row bold after a clear was missed
-        // (e.g. the session was read on another phone while reconnecting).
-        _sessionUnseenTracker.seedSessions(
-          projectId: _projectId,
-          stateBySessionId: {
-            for (final session in data.items)
-              session.id: (
-                unseen: session.unseen,
-                lastUserActivityAt: session.lastUserActivityAt,
-              ),
-          },
-          sinceTick: unseenTick,
-        );
-        _emitFiltered();
-        _projectViewingService.markClaimReady(claim: _projectViewClaim, projectId: _projectId);
-        return true;
-
-      case ErrorResponse(:final error):
-        if (silent) {
-          logw("Failed to refresh sessions: ${error.toString()}");
-        } else {
-          _projectViewingService.markClaimFailed(claim: _projectViewClaim);
-          loge("Session list load failed", error);
-          emit(SessionListState.failed(reason: error.remoteFailureReason));
-        }
-        return false;
-    }
+    late final Future<_SessionFetchOutcome> refresh;
+    refresh =
+        _fetchSessions(
+          silent: true,
+          catalogRefresh: catalogRefresh,
+          waitForPrData: waitForPrData,
+        ).whenComplete(() {
+          if (identical(_activeRefresh, refresh)) _activeRefresh = null;
+        });
+    _activeRefresh = refresh;
+    return refresh;
   }
 
-  /// Reads the catalog strictly after the scan committed.
-  ///
-  /// [refreshSessions] coalesces onto a refresh already in flight, and that one
-  /// may have started before the import committed. Waiting it out first means
-  /// the read that follows is guaranteed to see the imported rows, which is the
-  /// whole point of refreshing here — the import raises no other invalidation.
-  Future<void> _refreshAfterScan() async {
-    // Every read, not just the coalescing silent one: a full load in flight
-    // would otherwise race this fetch and, landing last, overwrite what the
-    // scan just imported. A failing read reports itself, so it is not
-    // re-reported here.
+  Future<_SessionFetchOutcome> _fetchSessions({
+    required bool silent,
+    required bool catalogRefresh,
+    required bool waitForPrData,
+  }) {
+    final requestGeneration = ++_fetchGeneration;
+    final catalogChangeGeneration = _catalogChangeGeneration;
+    return _runFetchSessions(
+      silent: silent,
+      catalogRefresh: catalogRefresh,
+      waitForPrData: waitForPrData,
+      requestGeneration: requestGeneration,
+      catalogChangeGeneration: catalogChangeGeneration,
+    );
+  }
+
+  Future<_SessionFetchOutcome> _runFetchSessions({
+    required bool silent,
+    required bool catalogRefresh,
+    required bool waitForPrData,
+    required int requestGeneration,
+    required int catalogChangeGeneration,
+  }) async {
     try {
-      await _activeFetch;
-    } on Object catch (_) {
-      // Ignored: the read that failed owns its own reporting.
+      // Captured BEFORE the fetch so the seed can't overwrite a live update
+      // that arrives while the (possibly PR-data-delayed) request is in flight.
+      final unseenTick = _sessionUnseenTracker.tick;
+      final (sessionsResponse, gitContextResponse) = await (
+        _sessionListService.listSessions(
+          projectId: _projectId,
+          waitForPrData: waitForPrData,
+        ),
+        _projectRepository.getGitContext(projectId: _projectId),
+      ).wait;
+      if (isClosed || requestGeneration != _fetchGeneration) {
+        return _SessionFetchOutcome.superseded;
+      }
+
+      // Update cached git context on success; silently ignore errors so
+      // the session list still loads even if the endpoint is unavailable.
+      if (gitContextResponse case SuccessResponse(:final data)) {
+        _gitContext = data;
+      }
+
+      switch (sessionsResponse) {
+        case SuccessResponse(:final data):
+          _allSessions = data.items;
+          // The REST flags are authoritative at fetch time — seed the tracker so
+          // a stale live `true` can't keep a row bold after a clear was missed
+          // (e.g. the session was read on another phone while reconnecting).
+          _sessionUnseenTracker.seedSessions(
+            projectId: _projectId,
+            stateBySessionId: {
+              for (final session in data.items)
+                session.id: (
+                  unseen: session.unseen,
+                  lastUserActivityAt: session.lastUserActivityAt,
+                ),
+            },
+            sinceTick: unseenTick,
+          );
+          _emitFiltered();
+          _projectViewingService.markClaimReady(claim: _projectViewClaim, projectId: _projectId);
+          _consumeCatalogChangesThrough(generation: catalogChangeGeneration);
+          return _SessionFetchOutcome.applied;
+
+        case ErrorResponse(:final error):
+          if (silent) {
+            logw("Failed to refresh sessions: ${error.toString()}");
+          } else {
+            _projectViewingService.markClaimFailed(claim: _projectViewClaim);
+            loge("Session list load failed", error);
+            emit(SessionListState.failed(reason: error.remoteFailureReason));
+          }
+          return _SessionFetchOutcome.failed;
+      }
+    } finally {
+      if (!catalogRefresh) _rearmCatalogRefreshAfterOrdinaryFetch();
     }
+  }
+
+  void _onCatalogChanged() {
     if (isClosed) return;
-    await refreshSessions();
+    _catalogChangeGeneration++;
+    _catalogRefreshPausedAfterFailure = false;
+    _ensureCatalogRefresh();
+  }
+
+  void _consumeCatalogChangesThrough({required int generation}) {
+    if (generation > _catalogChangeConsumedGeneration) {
+      _catalogChangeConsumedGeneration = generation;
+    }
+  }
+
+  void _ensureCatalogRefresh() {
+    if (isClosed ||
+        _catalogRefresh != null ||
+        _catalogRefreshPausedAfterFailure ||
+        _catalogChangeConsumedGeneration >= _catalogChangeGeneration) {
+      return;
+    }
+
+    late final Future<void> refresh;
+    refresh = _drainCatalogRefreshes().whenComplete(() {
+      if (!identical(_catalogRefresh, refresh)) return;
+      _catalogRefresh = null;
+      _ensureCatalogRefresh();
+    });
+    _catalogRefresh = refresh;
+    unawaited(refresh);
+  }
+
+  Future<void> _drainCatalogRefreshes() async {
+    while (!isClosed && _catalogChangeConsumedGeneration < _catalogChangeGeneration) {
+      final targetGeneration = _catalogChangeGeneration;
+      late final _SessionFetchOutcome outcome;
+      try {
+        outcome = await _refreshSessions(
+          force: true,
+          catalogRefresh: true,
+          waitForPrData: false,
+        );
+      } on Object catch (error, stackTrace) {
+        loge("Catalog-change session refresh failed unexpectedly", error, stackTrace);
+        _catalogRefreshPausedAfterFailure = true;
+        return;
+      }
+
+      if (_catalogChangeConsumedGeneration >= _catalogChangeGeneration) return;
+      switch (outcome) {
+        case _SessionFetchOutcome.applied:
+        case _SessionFetchOutcome.superseded:
+          continue;
+        case _SessionFetchOutcome.failed:
+          if (targetGeneration < _catalogChangeGeneration) continue;
+          _catalogRefreshPausedAfterFailure = true;
+          return;
+      }
+    }
+  }
+
+  void _rearmCatalogRefreshAfterOrdinaryFetch() {
+    if (isClosed || !_catalogRefreshPausedAfterFailure) return;
+    _catalogRefreshPausedAfterFailure = false;
+    _ensureCatalogRefresh();
   }
 
   /// Starts a catalog scan across every harness this bridge can import from.

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -548,6 +548,9 @@ class SessionListCubit({
   /// In-flight silent refresh, used for coalescing.
   Future<_SessionFetchOutcome>? _activeRefresh;
 
+  /// Whether the current silent refresh honors an explicit pull's PR-data wait.
+  bool _activeRefreshWaitsForPrData = false;
+
   /// Most recently started read. This is not a coalescing barrier: a refresh
   /// whose response was superseded uses it only to observe the winning result.
   Future<_SessionFetchOutcome>? _latestFetch;
@@ -613,9 +616,12 @@ class SessionListCubit({
           catalogRefresh: catalogRefresh,
           waitForPrData: waitForPrData,
         ).whenComplete(() {
-          if (identical(_activeRefresh, refresh)) _activeRefresh = null;
+          if (!identical(_activeRefresh, refresh)) return;
+          _activeRefresh = null;
+          _activeRefreshWaitsForPrData = false;
         });
     _activeRefresh = refresh;
+    _activeRefreshWaitsForPrData = waitForPrData;
     return refresh;
   }
 
@@ -656,7 +662,15 @@ class SessionListCubit({
         ),
         _projectRepository.getGitContext(projectId: _projectId),
       ).wait;
-      if (isClosed || requestGeneration != _fetchGeneration) {
+      if (isClosed) return _SessionFetchOutcome.superseded;
+      if (requestGeneration != _fetchGeneration) {
+        if (sessionsResponse case ErrorResponse(:final error)) {
+          logw(
+            "Discarded superseded session list response "
+            "(request generation $requestGeneration, current $_fetchGeneration)",
+            error,
+          );
+        }
         return _SessionFetchOutcome.superseded;
       }
 
@@ -738,12 +752,15 @@ class SessionListCubit({
   Future<void> _drainCatalogRefreshes() async {
     while (!isClosed && _catalogChangeConsumedGeneration < _catalogChangeGeneration) {
       final targetGeneration = _catalogChangeGeneration;
+      // A catalog snapshot superseding an explicit pull is still that pull's
+      // winning response, so preserve its bounded PR-data wait.
+      final waitForPrData = _activeRefresh == null ? false : _activeRefreshWaitsForPrData;
       late final _SessionFetchOutcome outcome;
       try {
         outcome = await _refreshSessions(
           force: true,
           catalogRefresh: true,
-          waitForPrData: false,
+          waitForPrData: waitForPrData,
         );
       } on Object catch (error, stackTrace) {
         loge("Catalog-change session refresh failed unexpectedly", error, stackTrace);

--- a/client/module_core/lib/src/services/catalog_rescan_service.dart
+++ b/client/module_core/lib/src/services/catalog_rescan_service.dart
@@ -51,7 +51,7 @@ class CatalogRescanService({
   final BehaviorSubject<CatalogRescanState> _state = BehaviorSubject.seeded(
     const CatalogRescanState.idle(),
   );
-  final StreamController<void> _settled = StreamController<void>.broadcast(sync: true);
+  final StreamController<void> _catalogChanged = StreamController<void>.broadcast(sync: true);
   final CompositeSubscription _subscriptions = CompositeSubscription();
 
   /// Latest progress per harness in the live operation. Cleared whenever an
@@ -93,10 +93,12 @@ class CatalogRescanService({
 
   ValueStream<CatalogRescanState> get state => _state.stream;
 
-  /// Fires whenever a live operation closes, however it ended. Consumers
-  /// refresh their lists from this rather than from the terminal variants,
-  /// because an observed run publishes no terminal variant at all.
-  Stream<void> get settled => _settled.stream;
+  /// Fires after any observed import commits its catalog transaction.
+  ///
+  /// List cubits use this durable-data signal rather than the progress row's
+  /// lifecycle, because cancelling a row does not prove an import that already
+  /// entered its atomic commit did not finish.
+  Stream<void> get catalogChanged => _catalogChanged.stream;
 
   /// Rescans every harness this bridge can import from.
   Future<void> startAll() async {
@@ -159,8 +161,8 @@ class CatalogRescanService({
             // A refused or unprovable cancel means that import may still be
             // running, and nothing else records it. The harness id is the only
             // thing that identifies which one, since every call shares a route.
-            if (outcome case CatalogImportMutationFailure(:final error) ||
-                CatalogImportMutationUncertain(:final error)) {
+            if (outcome
+                case CatalogImportMutationFailure(:final error) || CatalogImportMutationUncertain(:final error)) {
               logw("Catalog rescan cancellation was not confirmed for $pluginId", error);
             }
           }),
@@ -186,7 +188,7 @@ class CatalogRescanService({
     _clearTimer?.cancel();
     await _subscriptions.dispose();
     await _state.close();
-    await _settled.close();
+    await _catalogChanged.close();
   }
 
   Future<Map<String, CatalogRescanStartResult>> _start({
@@ -230,9 +232,8 @@ class CatalogRescanService({
       // own rejection through the returned result instead; the bridge answers
       // 404 for an unknown *and* for a deselected plugin, so one 404 says
       // nothing about the route.
-      final unsupported = coversEveryHarness &&
-          results.isNotEmpty &&
-          results.values.every((r) => r is CatalogRescanStartUnsupported);
+      final unsupported =
+          coversEveryHarness && results.isNotEmpty && results.values.every((r) => r is CatalogRescanStartUnsupported);
       _closeOperation(
         unsupported ? const CatalogRescanState.unsupported() : const CatalogRescanState.idle(),
       );
@@ -303,6 +304,14 @@ class CatalogRescanService({
   }
 
   void _applyProgress(CatalogImportProgress progress) {
+    // The bridge publishes this only after its atomic catalog transaction has
+    // returned. Announce it before the operation bookkeeping below: a commit
+    // that wins a user cancellation must still invalidate the lists even
+    // though the progress row remains closed.
+    if (progress is CatalogImportCompleted && !_catalogChanged.isClosed) {
+      _catalogChanged.add(null);
+    }
+
     final pluginId = progress.pluginId;
     if (!_members.contains(pluginId)) {
       // A rescan someone else started, seen live. Adopt it so its imported
@@ -348,9 +357,7 @@ class CatalogRescanService({
                 // Unreachable: _activeProgress only returns a non-terminal
                 // status, and the switch stays exhaustive so a new phase is a
                 // compile error rather than a silent zero.
-                CatalogImportCompleted() ||
-                CatalogImportCancelled() ||
-                CatalogImportFailed() => 0,
+                CatalogImportCompleted() || CatalogImportCancelled() || CatalogImportFailed() => 0,
               },
               pluginIds: Set<String>.unmodifiable(_members),
             ),
@@ -426,14 +433,12 @@ class CatalogRescanService({
     return CatalogRescanCounts.totals(projects: projects, sessions: sessions);
   }
 
-  /// Ends the live operation and publishes [next]. Always announces the close,
-  /// so a consumer refreshes whether the run summarised itself or not.
+  /// Ends the live operation and publishes [next].
   void _closeOperation(CatalogRescanState next) {
     _members.clear();
     _progressByPluginId.clear();
     _observed = false;
     _publish(next);
-    if (!_settled.isClosed) _settled.add(null);
     if (next is CatalogRescanSucceeded) {
       _clearTimer?.cancel();
       _clearTimer = Timer(_successVisibleFor, _reset);
@@ -455,11 +460,7 @@ class CatalogRescanService({
     final nextConnected = status is ConnectionConnected;
     if (nextConnected == _connected) return;
     _connected = nextConnected;
-    final wasLive = _members.isNotEmpty;
     _reset();
-    // A run interrupted by a drop still committed whatever it had published, so
-    // announce the close even though no summary is claimed for it.
-    if (wasLive && !_settled.isClosed) _settled.add(null);
     if (nextConnected) unawaited(_recoverInFlight());
   }
 
@@ -471,11 +472,7 @@ class CatalogRescanService({
     };
     final bridgeId = snapshot.response.bridgeId;
     if (_activeBridgeId != null && _activeBridgeId != bridgeId) {
-      // Same rule as a disconnect: every close of a live operation announces
-      // itself, so the two triggers the plan lists together behave alike.
-      final wasLive = _members.isNotEmpty;
       _reset();
-      if (wasLive && !_settled.isClosed) _settled.add(null);
       // The recovery read fired on reconnect may have adopted the new bridge's
       // run before this identity arrived, and the reset above just discarded
       // it. Read again now that the identity is settled, or an import already

--- a/client/module_core/lib/src/services/catalog_rescan_service.dart
+++ b/client/module_core/lib/src/services/catalog_rescan_service.dart
@@ -93,11 +93,12 @@ class CatalogRescanService({
 
   ValueStream<CatalogRescanState> get state => _state.stream;
 
-  /// Fires after any observed import commits its catalog transaction.
+  /// Fires after an observed import publishes list-visible catalog rows.
   ///
   /// List cubits use this durable-data signal rather than the progress row's
   /// lifecycle, because cancelling a row does not prove an import that already
-  /// entered its atomic commit did not finish.
+  /// entered its atomic commit did not finish. Automatic hydration markers
+  /// complete with zero published rows and do not invalidate the lists.
   Stream<void> get catalogChanged => _catalogChanged.stream;
 
   /// Rescans every harness this bridge can import from.
@@ -304,11 +305,14 @@ class CatalogRescanService({
   }
 
   void _applyProgress(CatalogImportProgress progress) {
-    // The bridge publishes this only after its atomic catalog transaction has
-    // returned. Announce it before the operation bookkeeping below: a commit
-    // that wins a user cancellation must still invalidate the lists even
-    // though the progress row remains closed.
-    if (progress is CatalogImportCompleted && !_catalogChanged.isClosed) {
+    // An automatic hydration marker completes without catalog publication and
+    // reports zero totals. Imports are non-destructive, so an actual empty
+    // publication also leaves every list row unchanged. Announce a committed
+    // snapshot before the operation bookkeeping below: a commit that wins a
+    // user cancellation must still invalidate the lists even though the
+    // progress row remains closed.
+    if (progress case CatalogImportCompleted(:final projectsImported, :final sessionsImported)
+        when (projectsImported > 0 || sessionsImported > 0) && !_catalogChanged.isClosed) {
       _catalogChanged.add(null);
     }
 

--- a/client/module_core/lib/src/testing/test_helpers.dart
+++ b/client/module_core/lib/src/testing/test_helpers.dart
@@ -849,13 +849,13 @@ class FakeAuthSession({required AuthState initialState}) implements AuthSession 
 /// A [CatalogRescanService] a test drives directly.
 ///
 /// The real service owns a whole operation lifecycle; a consumer only cares
-/// that it publishes state, announces when a run closes, and accepts intents,
-/// so this exposes exactly those.
+/// that it publishes state, announces committed catalog changes, and accepts
+/// intents, so this exposes exactly those.
 class FakeCatalogRescanService() implements CatalogRescanService {
   final BehaviorSubject<CatalogRescanState> _state = BehaviorSubject.seeded(
     const CatalogRescanState.idle(),
   );
-  final StreamController<void> _settled = StreamController<void>.broadcast(sync: true);
+  final StreamController<void> _catalogChanged = StreamController<void>.broadcast(sync: true);
 
   final List<void> _startAlls = [];
   final List<void> _cancels = [];
@@ -869,7 +869,7 @@ class FakeCatalogRescanService() implements CatalogRescanService {
   ValueStream<CatalogRescanState> get state => _state.stream;
 
   @override
-  Stream<void> get settled => _settled.stream;
+  Stream<void> get catalogChanged => _catalogChanged.stream;
 
   /// Plugin ids passed to [start], in call order.
   final List<String> startedPluginIds = [];
@@ -897,8 +897,8 @@ class FakeCatalogRescanService() implements CatalogRescanService {
   /// Publishes [next] as the current scan state.
   void emit(CatalogRescanState next) => _state.add(next);
 
-  /// Announces that a live operation closed, whatever it settled as.
-  void emitSettled() => _settled.add(null);
+  /// Announces that an import committed a durable catalog change.
+  void emitCatalogChanged() => _catalogChanged.add(null);
 
   /// Closes both streams. Named to match `Disposable`, because `get_it` calls
   /// it on reset and every widget test that registers this fake goes through
@@ -907,7 +907,6 @@ class FakeCatalogRescanService() implements CatalogRescanService {
   Future<void> onDispose() async {
     if (_state.isClosed) return;
     await _state.close();
-    await _settled.close();
+    await _catalogChanged.close();
   }
-
 }

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -2485,6 +2485,57 @@ void main() {
         expect((cubit.state as ProjectListLoaded).projects, [projectC]);
       });
 
+      test("a catalog failure that supersedes a full load exits loading", () async {
+        final fullLoad = Completer<ApiResponse<Projects>>();
+        var requestCount = 0;
+        Future<ApiResponse<Projects>> nextResponse() => switch (requestCount++) {
+          0 => successfulResponse(projects: const []),
+          1 => fullLoad.future,
+          2 => Future<ApiResponse<Projects>>.value(ApiResponse.error(ApiError.generic())),
+          _ => successfulResponse(projects: const []),
+        };
+        when(() => mockProjectRepository.listProjects()).thenAnswer((_) => nextResponse());
+
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await Future<void>.delayed(Duration.zero);
+
+        final load = cubit.loadProjects();
+        await Future<void>.delayed(Duration.zero);
+        final failure = cubit.stream.firstWhere((state) => state is ProjectListFailed);
+        fakeCatalogRescanService.emitCatalogChanged();
+
+        expect(await failure, isA<ProjectListFailed>());
+        fullLoad.complete(ApiResponse.success(const Projects(data: <ProjectSummary>[])));
+        await load;
+      });
+
+      test("a superseded explicit refresh reports the catalog refresh failure", () async {
+        final explicitRefresh = Completer<ApiResponse<Projects>>();
+        var requestCount = 0;
+        Future<ApiResponse<Projects>> nextResponse() => switch (requestCount++) {
+          0 => successfulResponse(projects: const []),
+          1 => explicitRefresh.future,
+          2 => Future<ApiResponse<Projects>>.value(ApiResponse.error(ApiError.generic())),
+          _ => successfulResponse(projects: const []),
+        };
+        when(() => mockProjectRepository.listProjects()).thenAnswer((_) => nextResponse());
+
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await Future<void>.delayed(Duration.zero);
+
+        final refresh = cubit.refreshProjects();
+        await Future<void>.delayed(Duration.zero);
+        fakeCatalogRescanService.emitCatalogChanged();
+        await Future<void>.delayed(Duration.zero);
+        expect(requestCount, 3);
+
+        explicitRefresh.complete(ApiResponse.success(const Projects(data: <ProjectSummary>[])));
+        expect(await refresh, isFalse);
+        expect(requestCount, 3, reason: "the stale explicit read must not rearm the failed catalog refresh");
+      });
+
       test("runs a trailing catalog refresh after another commit arrives in flight", () async {
         final firstPostCommit = Completer<ApiResponse<Projects>>();
         final secondPostCommit = Completer<ApiResponse<Projects>>();

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -2388,6 +2388,10 @@ void main() {
         ).thenAnswer((_) async => ApiResponse.success(const Projects(data: <ProjectSummary>[])));
       }
 
+      Future<ApiResponse<Projects>> successfulResponse({required List<ProjectSummary> projects}) {
+        return Future<ApiResponse<Projects>>.value(ApiResponse.success(Projects(data: projects)));
+      }
+
       test("projects the scan onto the loaded state", () async {
         stubProjects();
         final cubit = buildCubit();
@@ -2409,7 +2413,7 @@ void main() {
         );
       });
 
-      test("refreshes when a scan leaves a live operation", () async {
+      test("refreshes after a committed catalog change", () async {
         stubProjects();
         final cubit = buildCubit();
         addTearDown(cubit.close);
@@ -2417,84 +2421,125 @@ void main() {
         clearInteractions(mockProjectRepository);
         stubProjects();
 
-        // A committed import raises no list invalidation of its own, so this
-        // refresh is the only thing that surfaces what the scan imported.
-        fakeCatalogRescanService.emitSettled();
+        fakeCatalogRescanService.emitCatalogChanged();
         await Future<void>.delayed(Duration.zero);
 
         verify(() => mockProjectRepository.listProjects()).called(1);
       });
 
-      test("keeps a terminal scan through the refresh it triggers", () async {
+      test("keeps a terminal scan through the committed-change refresh", () async {
         stubProjects();
         final cubit = buildCubit();
         addTearDown(cubit.close);
         await Future<void>.delayed(Duration.zero);
         stubProjects();
 
-        // The service publishes its terminal state and then announces the
-        // close, which starts the refresh. That refresh must not erase the row
-        // it was fired for.
         fakeCatalogRescanService.emit(
           const CatalogRescanState.succeeded(
             harnessCount: 1,
             counts: CatalogRescanCounts.delta(newProjects: 2, newSessions: 5),
           ),
         );
-        fakeCatalogRescanService.emitSettled();
+        fakeCatalogRescanService.emitCatalogChanged();
         await Future<void>.delayed(Duration.zero);
 
         expect((cubit.state as ProjectListLoaded).catalogScan, isA<CatalogRescanSucceeded>());
       });
 
-      test("reads again after an in-flight refresh rather than coalescing onto it", () async {
-        stubProjects();
+      test("post-commit data wins over overlapping earlier reads", () async {
+        final olderRefresh = Completer<ApiResponse<Projects>>();
+        final olderFullLoad = Completer<ApiResponse<Projects>>();
+        final postCommit = Completer<ApiResponse<Projects>>();
+        var requestCount = 0;
+        Future<ApiResponse<Projects>> nextResponse() => switch (requestCount++) {
+          0 => successfulResponse(projects: const []),
+          1 => olderRefresh.future,
+          2 => olderFullLoad.future,
+          3 => postCommit.future,
+          _ => throw StateError("unexpected project list request"),
+        };
+        when(() => mockProjectRepository.listProjects()).thenAnswer((_) => nextResponse());
+
         final cubit = buildCubit();
         addTearDown(cubit.close);
         await Future<void>.delayed(Duration.zero);
 
-        // A refresh that started before the import committed.
-        final inFlight = Completer<ApiResponse<Projects>>();
-        when(() => mockProjectRepository.listProjects()).thenAnswer((_) => inFlight.future);
         unawaited(cubit.refreshProjects());
         await Future<void>.delayed(Duration.zero);
-        clearInteractions(mockProjectRepository);
-
-        fakeCatalogRescanService.emitSettled();
+        unawaited(cubit.loadProjects());
         await Future<void>.delayed(Duration.zero);
-        verifyNever(() => mockProjectRepository.listProjects());
+        fakeCatalogRescanService.emitCatalogChanged();
+        await Future<void>.delayed(Duration.zero);
+        expect(requestCount, 4, reason: "the catalog refresh must not coalesce onto the older refresh");
 
-        // Releasing the old request must be followed by a fresh read, or the
-        // imported rows are never seen: the import raises no other signal.
-        stubProjects();
-        inFlight.complete(ApiResponse.success(const Projects(data: <ProjectSummary>[])));
+        postCommit.complete(ApiResponse.success(Projects(data: [projectC])));
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
+        expect((cubit.state as ProjectListLoaded).projects, [projectC]);
 
-        verify(() => mockProjectRepository.listProjects()).called(1);
+        olderFullLoad.complete(ApiResponse.success(const Projects(data: <ProjectSummary>[])));
+        olderRefresh.complete(ApiResponse.success(const Projects(data: <ProjectSummary>[])));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect((cubit.state as ProjectListLoaded).projects, [projectC]);
       });
 
-      test("waits for a full load too, not only a silent refresh", () async {
-        // Only the silent path is coalesced, so an initial or retry load is
-        // invisible to it. Landing last, it would overwrite what the scan
-        // imported.
-        final initial = Completer<ApiResponse<Projects>>();
-        when(() => mockProjectRepository.listProjects()).thenAnswer((_) => initial.future);
+      test("runs a trailing catalog refresh after another commit arrives in flight", () async {
+        final firstPostCommit = Completer<ApiResponse<Projects>>();
+        final secondPostCommit = Completer<ApiResponse<Projects>>();
+        var requestCount = 0;
+        Future<ApiResponse<Projects>> nextResponse() => switch (requestCount++) {
+          0 => successfulResponse(projects: const []),
+          1 => firstPostCommit.future,
+          2 => secondPostCommit.future,
+          _ => throw StateError("unexpected project list request"),
+        };
+        when(() => mockProjectRepository.listProjects()).thenAnswer((_) => nextResponse());
+
         final cubit = buildCubit();
         addTearDown(cubit.close);
         await Future<void>.delayed(Duration.zero);
-        clearInteractions(mockProjectRepository);
 
-        fakeCatalogRescanService.emitSettled();
+        fakeCatalogRescanService
+          ..emitCatalogChanged()
+          ..emitCatalogChanged();
         await Future<void>.delayed(Duration.zero);
-        verifyNever(() => mockProjectRepository.listProjects());
+        expect(requestCount, 2);
 
-        stubProjects();
-        initial.complete(ApiResponse.success(const Projects(data: <ProjectSummary>[])));
+        firstPostCommit.complete(ApiResponse.success(Projects(data: [projectA])));
         await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        expect(requestCount, 3, reason: "the second commit needs a later snapshot");
+
+        secondPostCommit.complete(ApiResponse.success(Projects(data: [projectC])));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        expect((cubit.state as ProjectListLoaded).projects, [projectC]);
+      });
+
+      test("preserves a failed catalog refresh for the next ordinary refresh", () async {
+        var requestCount = 0;
+        Future<ApiResponse<Projects>> nextResponse() => switch (requestCount++) {
+          0 => successfulResponse(projects: const []),
+          1 => Future<ApiResponse<Projects>>.value(ApiResponse.error(ApiError.generic())),
+          2 => successfulResponse(projects: [projectC]),
+          _ => throw StateError("unexpected project list request"),
+        };
+        when(() => mockProjectRepository.listProjects()).thenAnswer((_) => nextResponse());
+
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
         await Future<void>.delayed(Duration.zero);
 
-        verify(() => mockProjectRepository.listProjects()).called(1);
+        fakeCatalogRescanService.emitCatalogChanged();
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        expect(requestCount, 2, reason: "a failed catalog refresh must not retry in a loop");
+
+        expect(await cubit.refreshProjects(), isTrue);
+        expect(requestCount, 3);
+        expect((cubit.state as ProjectListLoaded).projects, [projectC]);
       });
 
       test("forwards the scan intents to the service", () async {
@@ -2514,6 +2559,5 @@ void main() {
         expect(fakeCatalogRescanService.dismissCalls, 1);
       });
     });
-
   });
 }

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -2201,6 +2201,12 @@ void main() {
         ).thenAnswer((_) async => ApiResponse.success(const SessionListResponse(items: [])));
       }
 
+      Future<ApiResponse<SessionListResponse>> successfulResponse({required List<Session> sessions}) {
+        return Future<ApiResponse<SessionListResponse>>.value(
+          ApiResponse.success(SessionListResponse(items: sessions)),
+        );
+      }
+
       test("projects the scan onto the loaded state", () async {
         stubSessions();
         final cubit = buildCubit();
@@ -2222,7 +2228,7 @@ void main() {
         );
       });
 
-      test("refreshes when a scan leaves a live operation", () async {
+      test("refreshes after a committed catalog change", () async {
         stubSessions();
         final cubit = buildCubit();
         addTearDown(cubit.close);
@@ -2230,9 +2236,7 @@ void main() {
         clearInteractions(mockProjectRepository);
         stubSessions();
 
-        // A committed import raises no list invalidation of its own, so this
-        // refresh is the only thing that surfaces what the scan imported.
-        fakeCatalogRescanService.emitSettled();
+        fakeCatalogRescanService.emitCatalogChanged();
         await Future<void>.delayed(Duration.zero);
 
         verify(
@@ -2267,6 +2271,121 @@ void main() {
         );
       });
 
+      test("post-commit data wins over overlapping earlier reads", () async {
+        final olderRefresh = Completer<ApiResponse<SessionListResponse>>();
+        final olderFullLoad = Completer<ApiResponse<SessionListResponse>>();
+        final postCommit = Completer<ApiResponse<SessionListResponse>>();
+        final catalogSession = testSession(id: "catalog", title: "Imported after scan");
+        var requestCount = 0;
+        Future<ApiResponse<SessionListResponse>> nextResponse() => switch (requestCount++) {
+          0 => successfulResponse(sessions: const []),
+          1 => olderRefresh.future,
+          2 => olderFullLoad.future,
+          3 => postCommit.future,
+          _ => throw StateError("unexpected session list request"),
+        };
+        when(
+          () => mockProjectRepository.listSessions(
+            projectId: projectId,
+            waitForPrData: any(named: "waitForPrData"),
+          ),
+        ).thenAnswer((_) => nextResponse());
+
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await cubit.stream.firstWhere((state) => state is SessionListLoaded);
+
+        unawaited(cubit.refreshSessions());
+        await Future<void>.delayed(Duration.zero);
+        unawaited(cubit.loadSessions());
+        await Future<void>.delayed(Duration.zero);
+        fakeCatalogRescanService.emitCatalogChanged();
+        await Future<void>.delayed(Duration.zero);
+        expect(requestCount, 4, reason: "the catalog refresh must not coalesce onto the older refresh");
+
+        postCommit.complete(ApiResponse.success(SessionListResponse(items: [catalogSession])));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        expect((cubit.state as SessionListLoaded).sessions, [catalogSession]);
+
+        olderFullLoad.complete(ApiResponse.success(const SessionListResponse(items: [])));
+        olderRefresh.complete(ApiResponse.success(const SessionListResponse(items: [])));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect((cubit.state as SessionListLoaded).sessions, [catalogSession]);
+      });
+
+      test("runs a trailing catalog refresh after another commit arrives in flight", () async {
+        final firstPostCommit = Completer<ApiResponse<SessionListResponse>>();
+        final secondPostCommit = Completer<ApiResponse<SessionListResponse>>();
+        final firstSession = testSession(id: "first", title: "First import");
+        final secondSession = testSession(id: "second", title: "Second import");
+        var requestCount = 0;
+        Future<ApiResponse<SessionListResponse>> nextResponse() => switch (requestCount++) {
+          0 => successfulResponse(sessions: const []),
+          1 => firstPostCommit.future,
+          2 => secondPostCommit.future,
+          _ => throw StateError("unexpected session list request"),
+        };
+        when(
+          () => mockProjectRepository.listSessions(
+            projectId: projectId,
+            waitForPrData: any(named: "waitForPrData"),
+          ),
+        ).thenAnswer((_) => nextResponse());
+
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await cubit.stream.firstWhere((state) => state is SessionListLoaded);
+
+        fakeCatalogRescanService
+          ..emitCatalogChanged()
+          ..emitCatalogChanged();
+        await Future<void>.delayed(Duration.zero);
+        expect(requestCount, 2);
+
+        firstPostCommit.complete(ApiResponse.success(SessionListResponse(items: [firstSession])));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        expect(requestCount, 3, reason: "the second commit needs a later snapshot");
+
+        secondPostCommit.complete(ApiResponse.success(SessionListResponse(items: [secondSession])));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        expect((cubit.state as SessionListLoaded).sessions, [secondSession]);
+      });
+
+      test("preserves a failed catalog refresh for the next ordinary refresh", () async {
+        final catalogSession = testSession(id: "catalog", title: "Imported after retry");
+        var requestCount = 0;
+        Future<ApiResponse<SessionListResponse>> nextResponse() => switch (requestCount++) {
+          0 => successfulResponse(sessions: const []),
+          1 => Future<ApiResponse<SessionListResponse>>.value(ApiResponse.error(ApiError.generic())),
+          2 => successfulResponse(sessions: [catalogSession]),
+          _ => throw StateError("unexpected session list request"),
+        };
+        when(
+          () => mockProjectRepository.listSessions(
+            projectId: projectId,
+            waitForPrData: any(named: "waitForPrData"),
+          ),
+        ).thenAnswer((_) => nextResponse());
+
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await cubit.stream.firstWhere((state) => state is SessionListLoaded);
+
+        fakeCatalogRescanService.emitCatalogChanged();
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        expect(requestCount, 2, reason: "a failed catalog refresh must not retry in a loop");
+
+        expect(await cubit.refreshSessions(), isTrue);
+        expect(requestCount, 3);
+        expect((cubit.state as SessionListLoaded).sessions, [catalogSession]);
+      });
+
       test("forwards the scan intents to the service", () async {
         stubSessions();
         final cubit = buildCubit();
@@ -2284,7 +2403,6 @@ void main() {
         expect(fakeCatalogRescanService.dismissCalls, 1);
       });
     });
-
   });
 }
 

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -2316,6 +2316,67 @@ void main() {
         expect((cubit.state as SessionListLoaded).sessions, [catalogSession]);
       });
 
+      test("a catalog failure that supersedes a full load exits loading", () async {
+        final fullLoad = Completer<ApiResponse<SessionListResponse>>();
+        var requestCount = 0;
+        Future<ApiResponse<SessionListResponse>> nextResponse() => switch (requestCount++) {
+          0 => successfulResponse(sessions: const []),
+          1 => fullLoad.future,
+          2 => Future<ApiResponse<SessionListResponse>>.value(ApiResponse.error(ApiError.generic())),
+          _ => successfulResponse(sessions: const []),
+        };
+        when(
+          () => mockProjectRepository.listSessions(
+            projectId: projectId,
+            waitForPrData: any(named: "waitForPrData"),
+          ),
+        ).thenAnswer((_) => nextResponse());
+
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await cubit.stream.firstWhere((state) => state is SessionListLoaded);
+
+        final load = cubit.loadSessions();
+        await Future<void>.delayed(Duration.zero);
+        final failure = cubit.stream.firstWhere((state) => state is SessionListFailed);
+        fakeCatalogRescanService.emitCatalogChanged();
+
+        expect(await failure, isA<SessionListFailed>());
+        fullLoad.complete(ApiResponse.success(const SessionListResponse(items: [])));
+        await load;
+      });
+
+      test("a superseded explicit refresh reports the catalog refresh failure", () async {
+        final explicitRefresh = Completer<ApiResponse<SessionListResponse>>();
+        var requestCount = 0;
+        Future<ApiResponse<SessionListResponse>> nextResponse() => switch (requestCount++) {
+          0 => successfulResponse(sessions: const []),
+          1 => explicitRefresh.future,
+          2 => Future<ApiResponse<SessionListResponse>>.value(ApiResponse.error(ApiError.generic())),
+          _ => successfulResponse(sessions: const []),
+        };
+        when(
+          () => mockProjectRepository.listSessions(
+            projectId: projectId,
+            waitForPrData: any(named: "waitForPrData"),
+          ),
+        ).thenAnswer((_) => nextResponse());
+
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+        await cubit.stream.firstWhere((state) => state is SessionListLoaded);
+
+        final refresh = cubit.refreshSessions(waitForPrData: true);
+        await Future<void>.delayed(Duration.zero);
+        fakeCatalogRescanService.emitCatalogChanged();
+        await Future<void>.delayed(Duration.zero);
+        expect(requestCount, 3);
+
+        explicitRefresh.complete(ApiResponse.success(const SessionListResponse(items: [])));
+        expect(await refresh, isFalse);
+        expect(requestCount, 3, reason: "the stale explicit read must not rearm the failed catalog refresh");
+      });
+
       test("runs a trailing catalog refresh after another commit arrives in flight", () async {
         final firstPostCommit = Completer<ApiResponse<SessionListResponse>>();
         final secondPostCommit = Completer<ApiResponse<SessionListResponse>>();

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -2348,6 +2348,7 @@ void main() {
 
       test("a superseded explicit refresh reports the catalog refresh failure", () async {
         final explicitRefresh = Completer<ApiResponse<SessionListResponse>>();
+        final waitForPrDataCalls = <bool>[];
         var requestCount = 0;
         Future<ApiResponse<SessionListResponse>> nextResponse() => switch (requestCount++) {
           0 => successfulResponse(sessions: const []),
@@ -2360,7 +2361,10 @@ void main() {
             projectId: projectId,
             waitForPrData: any(named: "waitForPrData"),
           ),
-        ).thenAnswer((_) => nextResponse());
+        ).thenAnswer((invocation) {
+          waitForPrDataCalls.add(invocation.namedArguments[#waitForPrData] as bool);
+          return nextResponse();
+        });
 
         final cubit = buildCubit();
         addTearDown(cubit.close);
@@ -2371,6 +2375,7 @@ void main() {
         fakeCatalogRescanService.emitCatalogChanged();
         await Future<void>.delayed(Duration.zero);
         expect(requestCount, 3);
+        expect(waitForPrDataCalls, [false, true, true]);
 
         explicitRefresh.complete(ApiResponse.success(const SessionListResponse(items: [])));
         expect(await refresh, isFalse);

--- a/client/module_core/test/services/catalog_rescan_service_test.dart
+++ b/client/module_core/test/services/catalog_rescan_service_test.dart
@@ -470,6 +470,16 @@ void main() {
       expect(catalogChanges, hasLength(1));
     });
 
+    test("ignores a zero-count hydration completion", () async {
+      final catalogChanges = <void>[];
+      service.catalogChanged.listen(catalogChanges.add);
+
+      connection.emitProgress(_completed("codex", newProjects: 0, newSessions: 0, totals: 0));
+
+      expect(catalogChanges, isEmpty);
+      expect(service.state.value, isA<CatalogRescanIdle>());
+    });
+
     test("announces each durable catalog commit", () async {
       final catalogChanges = <void>[];
       service.catalogChanged.listen(catalogChanges.add);

--- a/client/module_core/test/services/catalog_rescan_service_test.dart
+++ b/client/module_core/test/services/catalog_rescan_service_test.dart
@@ -62,11 +62,13 @@ void main() {
     test("names the enumerating harness once progress arrives", () async {
       await service.startAll();
 
-      connection.emitProgress(const CatalogImportProgress.enumerating(
-        pluginId: "codex",
-        projectsSeen: 3,
-        sessionsSeen: 42,
-      ));
+      connection.emitProgress(
+        const CatalogImportProgress.enumerating(
+          pluginId: "codex",
+          projectsSeen: 3,
+          sessionsSeen: 42,
+        ),
+      );
 
       expect(
         service.state.value,
@@ -119,10 +121,12 @@ void main() {
       await service.startAll();
 
       connection.emitProgress(_completed("codex", newProjects: 1, newSessions: 1));
-      connection.emitProgress(const CatalogImportProgress.failed(
-        pluginId: "claude",
-        message: "boom: /Users/someone/secret/path",
-      ));
+      connection.emitProgress(
+        const CatalogImportProgress.failed(
+          pluginId: "claude",
+          message: "boom: /Users/someone/secret/path",
+        ),
+      );
 
       expect(
         service.state.value,
@@ -311,15 +315,17 @@ void main() {
     });
 
     test("an unsupported snapshot does not overwrite a run already in flight", () async {
-      final settled = <void>[];
-      service.settled.listen(settled.add);
+      final catalogChanges = <void>[];
+      service.catalogChanged.listen(catalogChanges.add);
       // A v1.6.x bridge has the import route but no management route, so a run
       // can be live while the snapshot reports unsupported.
-      connection.emitProgress(const CatalogImportProgress.enumerating(
-        pluginId: "codex",
-        projectsSeen: 1,
-        sessionsSeen: 2,
-      ));
+      connection.emitProgress(
+        const CatalogImportProgress.enumerating(
+          pluginId: "codex",
+          projectsSeen: 1,
+          sessionsSeen: 2,
+        ),
+      );
       management.emit(const PluginManagementLoadResult.unsupported());
 
       await service.startAll();
@@ -330,16 +336,18 @@ void main() {
 
       connection.emitProgress(_completed("codex", newProjects: 3, newSessions: 3));
 
-      expect(settled, hasLength(1), reason: "its close must still refresh the lists");
+      expect(catalogChanges, hasLength(1), reason: "its committed import must refresh the lists");
     });
 
     test("re-points the row at a harness still working when another settles", () async {
       await service.startAll();
-      connection.emitProgress(const CatalogImportProgress.enumerating(
-        pluginId: "claude",
-        projectsSeen: 1,
-        sessionsSeen: 9,
-      ));
+      connection.emitProgress(
+        const CatalogImportProgress.enumerating(
+          pluginId: "claude",
+          projectsSeen: 1,
+          sessionsSeen: 9,
+        ),
+      );
       expect((service.state.value as CatalogRescanRunning).activePluginName, "Claude");
 
       connection.emitProgress(_completed("claude", newProjects: 1, newSessions: 1));
@@ -366,9 +374,9 @@ void main() {
       );
     });
 
-    test("a start resolving after its run already settled leaves the row alone", () async {
-      final settled = <void>[];
-      service.settled.listen(settled.add);
+    test("a start resolving after its failed run settled leaves the row alone", () async {
+      final catalogChanges = <void>[];
+      service.catalogChanged.listen(catalogChanges.add);
       final release = Completer<CatalogImportMutationResult>();
       repository.pendingFor["claude"] = release.future;
 
@@ -386,7 +394,7 @@ void main() {
         isA<CatalogRescanFailed>(),
         reason: "a diagnostic the user has not read must not erase itself",
       );
-      expect(settled, hasLength(1), reason: "and the lists must not refresh twice");
+      expect(catalogChanges, isEmpty, reason: "a failed import did not change the catalog");
     });
 
     test("reports an unsupported bridge from an unsupported snapshot, issuing no request", () async {
@@ -429,15 +437,17 @@ void main() {
       expect(service.state.value, isA<CatalogRescanIdle>());
     });
 
-    test("adopts an unsolicited rescan and settles it without claiming a summary", () async {
-      final settled = <void>[];
-      service.settled.listen(settled.add);
+    test("adopts an unsolicited rescan and refreshes after its commit without claiming a summary", () async {
+      final catalogChanges = <void>[];
+      service.catalogChanged.listen(catalogChanges.add);
 
-      connection.emitProgress(const CatalogImportProgress.enumerating(
-        pluginId: "codex",
-        projectsSeen: 1,
-        sessionsSeen: 4,
-      ));
+      connection.emitProgress(
+        const CatalogImportProgress.enumerating(
+          pluginId: "codex",
+          projectsSeen: 1,
+          sessionsSeen: 4,
+        ),
+      );
       expect(service.state.value, isA<CatalogRescanRunning>());
 
       connection.emitProgress(_completed("codex", newProjects: 5, newSessions: 5));
@@ -447,35 +457,41 @@ void main() {
         isA<CatalogRescanIdle>(),
         reason: "a run this client did not start cannot honestly summarise itself",
       );
-      expect(settled, hasLength(1), reason: "the lists still have to refresh");
+      expect(catalogChanges, hasLength(1), reason: "the lists still have to refresh");
     });
 
-    test("ignores an unsolicited terminal event for a run it never saw", () async {
+    test("announces an unsolicited terminal commit without reopening a row", () async {
+      final catalogChanges = <void>[];
+      service.catalogChanged.listen(catalogChanges.add);
+
       connection.emitProgress(_completed("codex", newProjects: 3, newSessions: 3));
 
       expect(service.state.value, isA<CatalogRescanIdle>());
+      expect(catalogChanges, hasLength(1));
     });
 
-    test("announces the close whenever a live operation ends", () async {
-      final settled = <void>[];
-      service.settled.listen(settled.add);
+    test("announces each durable catalog commit", () async {
+      final catalogChanges = <void>[];
+      service.catalogChanged.listen(catalogChanges.add);
 
       await service.startAll();
       connection.emitProgress(_completed("codex", newProjects: 1, newSessions: 1));
       connection.emitProgress(_completed("claude", newProjects: 1, newSessions: 1));
 
-      expect(settled, hasLength(1));
+      expect(catalogChanges, hasLength(2));
     });
 
     test("an operation stops claiming a summary once an outside harness joins", () async {
       await service.startAll();
 
       // A third harness this client never dispatched appears from elsewhere.
-      connection.emitProgress(const CatalogImportProgress.enumerating(
-        pluginId: "outsider",
-        projectsSeen: 1,
-        sessionsSeen: 1,
-      ));
+      connection.emitProgress(
+        const CatalogImportProgress.enumerating(
+          pluginId: "outsider",
+          projectsSeen: 1,
+          sessionsSeen: 1,
+        ),
+      );
       connection.emitProgress(_completed("codex", newProjects: 1, newSessions: 1));
       connection.emitProgress(_completed("claude", newProjects: 1, newSessions: 1));
       connection.emitProgress(_completed("outsider", newProjects: 1, newSessions: 1));
@@ -485,6 +501,21 @@ void main() {
         isA<CatalogRescanIdle>(),
         reason: "it can no longer vouch for every member, so it claims nothing",
       );
+    });
+
+    test("announces a commit that arrives after an immediate cancel", () async {
+      build(snapshot: _snapshot(routable: const {"codex": "Codex"}));
+      final catalogChanges = <void>[];
+      service.catalogChanged.listen(catalogChanges.add);
+      await service.startAll();
+
+      await service.cancel();
+      expect(service.state.value, isA<CatalogRescanIdle>(), reason: "the row still closes immediately");
+
+      connection.emitProgress(_completed("codex", newProjects: 1, newSessions: 1));
+
+      expect(service.state.value, isA<CatalogRescanIdle>());
+      expect(catalogChanges, hasLength(1), reason: "the completed atomic commit still invalidates lists");
     });
 
     test("cancel waits for a start still in flight before sending its DELETE", () async {
@@ -543,11 +574,13 @@ void main() {
       connection.emitProgress(_completed("codex", newProjects: 1, newSessions: 1));
 
       // Another surface restarts codex while claude is still running.
-      connection.emitProgress(const CatalogImportProgress.enumerating(
-        pluginId: "codex",
-        projectsSeen: 1,
-        sessionsSeen: 1,
-      ));
+      connection.emitProgress(
+        const CatalogImportProgress.enumerating(
+          pluginId: "codex",
+          projectsSeen: 1,
+          sessionsSeen: 1,
+        ),
+      );
       connection.emitProgress(_completed("codex", newProjects: 50, newSessions: 50));
       connection.emitProgress(_completed("claude", newProjects: 1, newSessions: 1));
 
@@ -590,11 +623,13 @@ void main() {
 
       // A progress event from the run being cancelled arrives before the
       // DELETE has gone out.
-      connection.emitProgress(const CatalogImportProgress.enumerating(
-        pluginId: "codex",
-        projectsSeen: 1,
-        sessionsSeen: 3,
-      ));
+      connection.emitProgress(
+        const CatalogImportProgress.enumerating(
+          pluginId: "codex",
+          projectsSeen: 1,
+          sessionsSeen: 3,
+        ),
+      );
 
       expect(
         service.state.value,
@@ -613,10 +648,10 @@ void main() {
       expect(service.state.value, isA<CatalogRescanSucceeded>());
     });
 
-    test("an outside cancellation settles quietly instead of showing a failure", () async {
+    test("an outside cancellation closes quietly instead of showing a failure", () async {
       build(snapshot: _snapshot(routable: const {"codex": "Codex"}));
-      final settled = <void>[];
-      service.settled.listen(settled.add);
+      final catalogChanges = <void>[];
+      service.catalogChanged.listen(catalogChanges.add);
       await service.startAll();
 
       // Another connected surface cancelled this harness.
@@ -627,7 +662,7 @@ void main() {
         isA<CatalogRescanIdle>(),
         reason: "a deliberate cancellation elsewhere is not this run's failure",
       );
-      expect(settled, hasLength(1));
+      expect(catalogChanges, isEmpty);
     });
 
     test("recovers an in-flight import when resolved onto a live connection", () async {
@@ -687,9 +722,9 @@ void main() {
       expect(service.state.value, isA<CatalogRescanIdle>());
     });
 
-    test("a disconnect clears an active rescan and announces the close", () async {
-      final settled = <void>[];
-      service.settled.listen(settled.add);
+    test("a disconnect clears an active rescan without claiming a catalog change", () async {
+      final catalogChanges = <void>[];
+      service.catalogChanged.listen(catalogChanges.add);
       await service.startAll();
       expect(service.state.value, isA<CatalogRescanStarting>());
 
@@ -697,7 +732,7 @@ void main() {
       await pumpEventQueue();
 
       expect(service.state.value, isA<CatalogRescanIdle>());
-      expect(settled, hasLength(1));
+      expect(catalogChanges, isEmpty);
     });
   });
 }

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -35,6 +35,14 @@ child sessions with titles, activity, statuses, and unseen state.
   "nothing new" after an import that added everything. A headless completion
   line therefore states the delta, or `Nothing new.`, or the totals alone when
   the producer omits the delta.
+- Every observed `CatalogImportCompleted` invalidates mounted project and
+  session lists only after the bridge's atomic catalog transaction completed.
+  A pre-commit list response cannot overwrite that later snapshot; another
+  completion while it is loading produces one trailing read. If the snapshot
+  fails, the committed change remains pending for the next ordinary, reconnect,
+  or staleness refresh rather than being discarded. Cancelling hides the progress
+  row immediately, but a transaction already in progress that completes after
+  that cancellation still drives the same list refresh.
 - Project and session row actions remain swipeable without competing visually
   with system back navigation. On iOS, drags beginning in the row's leading 10%
   are reserved for back; on Android gesture navigation, both 10% edges are
@@ -101,7 +109,7 @@ child sessions with titles, activity, statuses, and unseen state.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Headless bridge, representative plugin: project list and one project's session list return committed data with plugin attribution. |
-| L2 Routine | Headless bridge, representative plugin: open, rename, hide; create a session and see it listed before metadata, then observe generated title and eligible branch refinement through the existing session update without unseen change; unseen otherwise advances and clears; the existing activity marker appears in REST and live list-state projections; statuses report idle/busy. A first import reports every published row as new, a re-import of an unchanged catalog reports the same totals with a zero delta, and a completion whose delta is absent reports its totals without claiming nothing changed. |
+| L2 Routine | Headless bridge, representative plugin: open, rename, hide; create a session and see it listed before metadata, then observe generated title and eligible branch refinement through the existing session update without unseen change; unseen otherwise advances and clears; the existing activity marker appears in REST and live list-state projections; statuses report idle/busy. A first import reports every published row as new, a re-import of an unchanged catalog reports the same totals with a zero delta, and a completion whose delta is absent reports its totals without claiming nothing changed. Focused client coverage holds pre-commit list reads through a completion, proves the post-commit snapshot wins and a second completion gets a trailing snapshot, retains a failed snapshot for the next refresh, and covers a completion after immediate cancellation. |
 | L3 Release | Client end to end (phone): every supporting production plugin still covers native/derived ownership, import, and child resolution; Pi imports configured/default/known roots with explicit names and resolvable lineage; one representative plugin proves two running roots and two projects with running roots reorder after committed user-side activity, inactive session/project order is unchanged, a live patch reorders without another status event or project summary, and omitted ordering facts use updated-time fallbacks. Focused ACP protocol and client ordering tests prove the exact awaiting-only state is not promoted because normal production root prompts remain running while awaiting input. Lists and unseen badges render; project and session row swipes stay inert from the iOS back edge and both Android gesture-navigation edges while remaining active at unreserved edges and under Android button navigation. |
 | L4 Extended | Relay integration, every supporting production plugin: bridge and plugin restart preserve identity and overrides; a moved backend-native project keeps them while a moved bridge-derived project is discovered as new without mutating the old catalog; a cancelled or failed import leaves the prior catalog intact; reads during import stay consistent; an unavailable plugin is reported while others keep listing. |
 | L5 Full | Client end to end, every supporting production plugin: multiple clients observe consistent listings and unseen transitions; large catalogs and paged listings behave; unattributed payloads resolve to the historical identity. |
@@ -121,7 +129,10 @@ navigation, and a non-mobile platform; begin drags inside and just outside each
 
 ## Failure Signals
 
-- A catalog read starts a backend, hangs on import, or returns a partial list.
+- A catalog read starts a backend, hangs on import, returns a partial list, or an
+  older response overwrites a post-commit snapshot.
+- A committed catalog change is lost after a failed list snapshot, or a commit
+  that finishes after cancellation leaves the mounted list stale.
 - A moved backend-native project appears new or empty, loses sessions, or resolves
   git in the old location; a moved bridge-derived project mutates the old catalog
   identity instead of being discovered as new.
@@ -178,6 +189,8 @@ navigation, and a non-mobile platform; begin drags inside and just outside each
   `bridge/sesori_plugin_pi/test/pi_session_catalog_repository_test.dart`,
   `client/module_core/test/services/session_list_service_test.dart`,
   `client/module_core/test/services/session_unseen_tracker_test.dart`,
+  `client/module_core/test/services/catalog_rescan_service_test.dart`,
+  `client/module_core/test/cubits/project_list/project_list_cubit_test.dart`,
   `client/module_core/test/cubits/session_list/session_list_cubit_test.dart`,
   `client/module_prego/test/interactions/prego_swipe_actions_test.dart`,
   `client/app/test/features/session_list/session_list_panel_test.dart`

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -35,17 +35,19 @@ child sessions with titles, activity, statuses, and unseen state.
   "nothing new" after an import that added everything. A headless completion
   line therefore states the delta, or `Nothing new.`, or the totals alone when
   the producer omits the delta.
-- Every observed `CatalogImportCompleted` invalidates mounted project and
-  session lists only after the bridge's atomic catalog transaction completed.
-  A pre-commit list response cannot overwrite that later snapshot; another
-  completion while it is loading produces one trailing read. If the snapshot
-  fails, the committed change remains pending for the next ordinary, reconnect,
-  or staleness refresh rather than being discarded. A failed forced snapshot
-  replaces a full-screen load it superseded instead of leaving a spinner, and a
-  superseded pull waits for the winning snapshot's result. A stale superseded
-  read cannot rearm a failed change. Cancelling hides the progress row
-  immediately, but a transaction already in progress that completes after that
-  cancellation still drives the same list refresh.
+- Every observed `CatalogImportCompleted` that publishes at least one project
+  or session invalidates mounted project and session lists only after the
+  bridge's atomic catalog transaction completed. An automatic hydration marker
+  publishes zero rows and never interrupts an ordinary list read. A pre-commit
+  list response cannot overwrite a later snapshot; another completion while it
+  is loading produces one trailing read. If the snapshot fails, the committed
+  change remains pending for the next ordinary, reconnect, or staleness refresh
+  rather than being discarded. A failed forced snapshot replaces a full-screen
+  load it superseded instead of leaving a spinner, and a superseded pull waits
+  for the winning snapshot's result; a session pull keeps its bounded PR-data
+  wait. A stale superseded read cannot rearm a failed change. Cancelling hides
+  the progress row immediately, but a transaction already in progress that
+  completes after that cancellation still drives the same list refresh.
 - Project and session row actions remain swipeable without competing visually
   with system back navigation. On iOS, drags beginning in the row's leading 10%
   are reserved for back; on Android gesture navigation, both 10% edges are
@@ -112,7 +114,7 @@ child sessions with titles, activity, statuses, and unseen state.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Headless bridge, representative plugin: project list and one project's session list return committed data with plugin attribution. |
-| L2 Routine | Headless bridge, representative plugin: open, rename, hide; create a session and see it listed before metadata, then observe generated title and eligible branch refinement through the existing session update without unseen change; unseen otherwise advances and clears; the existing activity marker appears in REST and live list-state projections; statuses report idle/busy. A first import reports every published row as new, a re-import of an unchanged catalog reports the same totals with a zero delta, and a completion whose delta is absent reports its totals without claiming nothing changed. Focused client coverage holds pre-commit list reads through a completion, proves the post-commit snapshot wins and a second completion gets a trailing snapshot, retains a failed snapshot for the next refresh, proves an interrupted full-screen load and pull surface the winning failure, and covers a completion after immediate cancellation. |
+| L2 Routine | Headless bridge, representative plugin: open, rename, hide; create a session and see it listed before metadata, then observe generated title and eligible branch refinement through the existing session update without unseen change; unseen otherwise advances and clears; the existing activity marker appears in REST and live list-state projections; statuses report idle/busy. A first import reports every published row as new, a re-import of an unchanged catalog reports the same totals with a zero delta, and a completion whose delta is absent reports its totals without claiming nothing changed. Focused client coverage holds pre-commit list reads through a completion, ignores a zero-count hydration completion, proves the post-commit snapshot wins and a second completion gets a trailing snapshot, retains a failed snapshot for the next refresh, proves an interrupted full-screen load and pull surface the winning failure while retaining session PR-data waiting, and covers a completion after immediate cancellation. |
 | L3 Release | Client end to end (phone): every supporting production plugin still covers native/derived ownership, import, and child resolution; Pi imports configured/default/known roots with explicit names and resolvable lineage; one representative plugin proves two running roots and two projects with running roots reorder after committed user-side activity, inactive session/project order is unchanged, a live patch reorders without another status event or project summary, and omitted ordering facts use updated-time fallbacks. Focused ACP protocol and client ordering tests prove the exact awaiting-only state is not promoted because normal production root prompts remain running while awaiting input. Lists and unseen badges render; project and session row swipes stay inert from the iOS back edge and both Android gesture-navigation edges while remaining active at unreserved edges and under Android button navigation. |
 | L4 Extended | Relay integration, every supporting production plugin: bridge and plugin restart preserve identity and overrides; a moved backend-native project keeps them while a moved bridge-derived project is discovered as new without mutating the old catalog; a cancelled or failed import leaves the prior catalog intact; reads during import stay consistent; an unavailable plugin is reported while others keep listing. |
 | L5 Full | Client end to end, every supporting production plugin: multiple clients observe consistent listings and unseen transitions; large catalogs and paged listings behave; unattributed payloads resolve to the historical identity. |
@@ -134,10 +136,11 @@ navigation, and a non-mobile platform; begin drags inside and just outside each
 
 - A catalog read starts a backend, hangs on import, returns a partial list, or an
   older response overwrites a post-commit snapshot.
-- A committed catalog change is lost after a failed list snapshot, a forced
+- A zero-count hydration completion interrupts an ordinary list read, a
+  committed catalog change is lost after a failed list snapshot, a forced
   catalog failure leaves a full-screen list loading or reports a superseded pull
-  as successful, or a commit that finishes after cancellation leaves the mounted
-  list stale.
+  as successful or without its requested PR data, or a commit that finishes
+  after cancellation leaves the mounted list stale.
 - A moved backend-native project appears new or empty, loses sessions, or resolves
   git in the old location; a moved bridge-derived project mutates the old catalog
   identity instead of being discovered as new.

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -40,9 +40,12 @@ child sessions with titles, activity, statuses, and unseen state.
   A pre-commit list response cannot overwrite that later snapshot; another
   completion while it is loading produces one trailing read. If the snapshot
   fails, the committed change remains pending for the next ordinary, reconnect,
-  or staleness refresh rather than being discarded. Cancelling hides the progress
-  row immediately, but a transaction already in progress that completes after
-  that cancellation still drives the same list refresh.
+  or staleness refresh rather than being discarded. A failed forced snapshot
+  replaces a full-screen load it superseded instead of leaving a spinner, and a
+  superseded pull waits for the winning snapshot's result. A stale superseded
+  read cannot rearm a failed change. Cancelling hides the progress row
+  immediately, but a transaction already in progress that completes after that
+  cancellation still drives the same list refresh.
 - Project and session row actions remain swipeable without competing visually
   with system back navigation. On iOS, drags beginning in the row's leading 10%
   are reserved for back; on Android gesture navigation, both 10% edges are
@@ -109,7 +112,7 @@ child sessions with titles, activity, statuses, and unseen state.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Headless bridge, representative plugin: project list and one project's session list return committed data with plugin attribution. |
-| L2 Routine | Headless bridge, representative plugin: open, rename, hide; create a session and see it listed before metadata, then observe generated title and eligible branch refinement through the existing session update without unseen change; unseen otherwise advances and clears; the existing activity marker appears in REST and live list-state projections; statuses report idle/busy. A first import reports every published row as new, a re-import of an unchanged catalog reports the same totals with a zero delta, and a completion whose delta is absent reports its totals without claiming nothing changed. Focused client coverage holds pre-commit list reads through a completion, proves the post-commit snapshot wins and a second completion gets a trailing snapshot, retains a failed snapshot for the next refresh, and covers a completion after immediate cancellation. |
+| L2 Routine | Headless bridge, representative plugin: open, rename, hide; create a session and see it listed before metadata, then observe generated title and eligible branch refinement through the existing session update without unseen change; unseen otherwise advances and clears; the existing activity marker appears in REST and live list-state projections; statuses report idle/busy. A first import reports every published row as new, a re-import of an unchanged catalog reports the same totals with a zero delta, and a completion whose delta is absent reports its totals without claiming nothing changed. Focused client coverage holds pre-commit list reads through a completion, proves the post-commit snapshot wins and a second completion gets a trailing snapshot, retains a failed snapshot for the next refresh, proves an interrupted full-screen load and pull surface the winning failure, and covers a completion after immediate cancellation. |
 | L3 Release | Client end to end (phone): every supporting production plugin still covers native/derived ownership, import, and child resolution; Pi imports configured/default/known roots with explicit names and resolvable lineage; one representative plugin proves two running roots and two projects with running roots reorder after committed user-side activity, inactive session/project order is unchanged, a live patch reorders without another status event or project summary, and omitted ordering facts use updated-time fallbacks. Focused ACP protocol and client ordering tests prove the exact awaiting-only state is not promoted because normal production root prompts remain running while awaiting input. Lists and unseen badges render; project and session row swipes stay inert from the iOS back edge and both Android gesture-navigation edges while remaining active at unreserved edges and under Android button navigation. |
 | L4 Extended | Relay integration, every supporting production plugin: bridge and plugin restart preserve identity and overrides; a moved backend-native project keeps them while a moved bridge-derived project is discovered as new without mutating the old catalog; a cancelled or failed import leaves the prior catalog intact; reads during import stay consistent; an unavailable plugin is reported while others keep listing. |
 | L5 Full | Client end to end, every supporting production plugin: multiple clients observe consistent listings and unseen transitions; large catalogs and paged listings behave; unattributed payloads resolve to the historical identity. |
@@ -131,8 +134,10 @@ navigation, and a non-mobile platform; begin drags inside and just outside each
 
 - A catalog read starts a backend, hangs on import, returns a partial list, or an
   older response overwrites a post-commit snapshot.
-- A committed catalog change is lost after a failed list snapshot, or a commit
-  that finishes after cancellation leaves the mounted list stale.
+- A committed catalog change is lost after a failed list snapshot, a forced
+  catalog failure leaves a full-screen list loading or reports a superseded pull
+  as successful, or a commit that finishes after cancellation leaves the mounted
+  list stale.
 - A moved backend-native project appears new or empty, loses sessions, or resolves
   git in the old location; a moved bridge-derived project mutates the old catalog
   identity instead of being discovered as new.


### PR DESCRIPTION
## Complexity

Moderate. This changes the ordering contract between catalog progress and two
independent list-read paths while retaining the existing immediate-cancel UI.

## What

- Replace the lifecycle-oriented `CatalogRescanService.settled` stream with a
  durable `catalogChanged` signal emitted for every `CatalogImportCompleted`.
- Fence project and session list reads by request generation so an older response
  cannot overwrite a newer post-commit snapshot.
- Coalesce multiple committed imports into a fresh read plus, when needed, one
  trailing read. Retain a failed catalog refresh for the next ordinary,
  reconnect, or staleness refresh.
- Let a forced failure replace a superseded full-screen load, and make an
  explicit pull await the winning read's outcome rather than report success
  early.
- Ignore zero-row automatic-hydration completions, retain a session pull's
  PR-data wait when a catalog read supersedes it, and log a discarded stale
  error response locally.
- Cover completion after immediate cancellation, overlapping reads, trailing
  reads, and failure recovery; update the catalog rescan plan and regression
  coverage.

## Why

PR #1099's `_activeFetch` stored only one future. Overlapping reads could still
coalesce a post-scan refresh onto an older pre-commit request, then apply stale
rows. Also, bridge DELETE acknowledges cancellation before an atomic catalog
commit already underway necessarily finishes. A completed progress event is the
reliable durable-data boundary.

## Risk and test focus

The main risk is changing coalescing behavior in both list cubits. Focused tests
hold earlier reads open, prove a post-commit response wins, prove a second commit
gets a trailing snapshot, and prove a failed snapshot is retained for a later
refresh. They also cover a catalog failure that interrupts a full-screen load or
an explicit pull, a zero-row hydration completion, and retention of the
session PR-data wait. Service coverage proves a completion after immediate
cancellation still invalidates lists while the progress row remains closed.

## Expected result

**User-visible:** No new UI. Imported projects and sessions reliably appear
without requiring a second manual refresh, including when an import completes
just after cancellation.

**Database:** No change.

**Internal:** List snapshots are latest-request-wins and catalog invalidation is
tied to durable import completion rather than progress-row lifecycle.

## Verification

- `dart analyze --fatal-infos` in `client/module_core`
- Focused module-core catalog rescan and project/session list cubit tests
- `flutter analyze --fatal-infos` in `client/app`
- Focused app tests using the shared catalog-rescan fake
- Architecture plan review: approved
- Architecture implementation review: approved
- `git diff --check`
