### PR TITLE
⚙️ Forward Pi extension-initiated turns through Sesori

### DIFF
--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -42,6 +42,9 @@ final class _PiSessionTurnState({required final String initialDirectory}) {
   _PiTurn? active;
   Future<void>? idleReap;
   PluginSessionStatus status = const PluginSessionStatus.idle();
+
+  /// The current resident whose frames may outlive a bridge-admitted prompt.
+  int? residentGeneration;
   bool agentRunning = false;
   int generation = 0;
   int idleGeneration = 0;
@@ -60,7 +63,8 @@ final class _PiSessionTurnState({required final String initialDirectory}) {
     return result;
   }
 
-  bool get hasWork => active != null || inFlight.isNotEmpty || queue.isNotEmpty;
+  bool get hasAdmittedWork => active != null || inFlight.isNotEmpty || queue.isNotEmpty;
+  bool get hasWork => agentRunning || hasAdmittedWork;
 
   bool isAdmitted({required String promptId}) =>
       turns.any(
@@ -449,6 +453,7 @@ final class PiSessionService({
       if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) {
         throw PiTurnCancelledException(sessionId: sessionId);
       }
+      state.residentGeneration = connection.generation;
       turn.connection = connection;
       await _processes.applySelection(
         sessionId: sessionId,
@@ -570,7 +575,13 @@ final class PiSessionService({
 
   void _handleFrame(PiSessionProcessFrame processFrame) {
     final state = _sessions[processFrame.sessionId];
-    if (state == null || !state.hasWork) return;
+    if (state == null) return;
+    final residentGeneration = state.residentGeneration;
+    if (residentGeneration != null && residentGeneration != processFrame.generation) return;
+    if (residentGeneration == null) {
+      if (!state.hasAdmittedWork) return;
+      state.residentGeneration = processFrame.generation;
+    }
     state.active?.connection ??= PiSessionConnection(
       sessionId: processFrame.sessionId,
       generation: processFrame.generation,
@@ -579,9 +590,9 @@ final class PiSessionService({
       for (final turn in state.turns)
         if (turn.connection?.generation == processFrame.generation) turn,
     ];
-    if (generationTurns.isEmpty) return;
     switch (processFrame.frame) {
       case PiEventFrame(:final event):
+        final wasAgentRunning = state.agentRunning;
         if (event is PiAgentStartEvent) {
           state.agentRunning = true;
           for (final turn in generationTurns) {
@@ -590,6 +601,10 @@ final class PiSessionService({
               ..agentStarted = true
               ..agentSettled = false
               ..settlementObservedBeforeAcceptance = false;
+          }
+          final belongsToPrompt = generationTurns.any((turn) => turn.promptDispatched);
+          if (!wasAgentRunning && !belongsToPrompt) {
+            _beginAgentInitiatedTurn(sessionId: processFrame.sessionId, state: state);
           }
         } else if (event is PiAgentSettledEvent) {
           state.agentRunning = false;
@@ -628,8 +643,10 @@ final class PiSessionService({
         }
         if (statusChanged) _emit(const BridgeSseProjectUpdated());
         if (event is PiAgentSettledEvent) {
+          var finishedPromptTurn = false;
           for (final turn in List<_PiTurn>.of(generationTurns)) {
             if (turn.promptDispatched && turn.responseSucceeded) {
+              finishedPromptTurn = true;
               _finish(
                 sessionId: processFrame.sessionId,
                 state: state,
@@ -638,6 +655,9 @@ final class PiSessionService({
                 failure: null,
               );
             }
+          }
+          if (!finishedPromptTurn && wasAgentRunning && !state.hasWork) {
+            _finishAgentInitiatedTurn(sessionId: processFrame.sessionId, state: state);
           }
         }
       case PiExtensionUiFrame(:final request):
@@ -663,6 +683,33 @@ final class PiSessionService({
     }
   }
 
+  void _beginAgentInitiatedTurn({required String sessionId, required _PiSessionTurnState state}) {
+    state.idleGeneration++;
+    state.status = const PluginSessionStatus.busy();
+    _emit(
+      BridgeSseSessionStatus(
+        sessionID: sessionId,
+        status: const shared.SessionStatus.busy().toJson(),
+      ),
+    );
+    _emit(const BridgeSseProjectUpdated());
+    _syncWorkState();
+  }
+
+  void _finishAgentInitiatedTurn({required String sessionId, required _PiSessionTurnState state}) {
+    state.status = const PluginSessionStatus.idle();
+    _emit(
+      BridgeSseSessionStatus(
+        sessionID: sessionId,
+        status: const shared.SessionStatus.idle().toJson(),
+      ),
+    );
+    _emit(BridgeSseSessionIdle(sessionID: sessionId));
+    _emit(const BridgeSseProjectUpdated());
+    _syncWorkState();
+    _scheduleIdleReap(sessionId: sessionId, state: state);
+  }
+
   _PiTurn? _turnForPrompt({required _PiSessionTurnState state, required String promptId}) {
     for (final turn in state.turns) {
       if (turn.promptId == promptId) return turn;
@@ -684,14 +731,31 @@ final class PiSessionService({
   void _handleExit(PiSessionProcessExit exit) {
     _extensionUi.cancelForOwner(sessionId: exit.sessionId, processGeneration: exit.generation);
     final state = _sessions[exit.sessionId];
-    if (state == null) return;
+    if (state == null || state.residentGeneration != exit.generation) return;
+    state.residentGeneration = null;
     final affected = [
       for (final turn in state.turns)
         if (turn.connection?.generation == exit.generation) turn,
     ];
-    if (affected.isEmpty) return;
+    final agentInitiatedTurnFailed = affected.isEmpty && state.agentRunning;
+    if (affected.isEmpty && !agentInitiatedTurnFailed) return;
     _clearCompaction(sessionId: exit.sessionId);
     state.agentRunning = false;
+    if (agentInitiatedTurnFailed) {
+      state.status = const PluginSessionStatus.idle();
+      _emit(
+        BridgeSseSessionStatus(
+          sessionID: exit.sessionId,
+          status: const shared.SessionStatus.idle().toJson(),
+        ),
+      );
+      _emit(BridgeSseSessionError(sessionID: exit.sessionId));
+      _emit(BridgeSseSessionIdle(sessionID: exit.sessionId));
+      _emit(const BridgeSseProjectUpdated());
+      _syncWorkState();
+      _scheduleIdleReap(sessionId: exit.sessionId, state: state);
+      return;
+    }
     final hasUncancelled = affected.any(
       (turn) => turn is! _PiQueuedPromptTurn || turn.queueState != _PiQueueState.cancelled,
     );
@@ -727,6 +791,7 @@ final class PiSessionService({
     required Object failure,
   }) {
     _clearCompaction(sessionId: sessionId);
+    if (state.residentGeneration == processGeneration) state.residentGeneration = null;
     state.agentRunning = false;
     final affected = [
       for (final turn in state.turns)
@@ -864,6 +929,7 @@ final class PiSessionService({
     }
     state
       ..active = null
+      ..residentGeneration = null
       ..agentRunning = false
       ..inFlight.clear()
       ..queue.clear()
@@ -990,6 +1056,7 @@ final class PiSessionService({
         return;
       }
       _extensionUi.cancelForOwner(sessionId: sessionId, processGeneration: null);
+      state.residentGeneration = null;
       final teardown = _processes.teardown(sessionId: sessionId);
       state.idleReap = teardown;
       _activeIdleReaps.add(teardown);

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -739,9 +739,14 @@ final class PiSessionService({
     ];
     final agentInitiatedTurnFailed = affected.isEmpty && state.agentRunning;
     if (affected.isEmpty && !agentInitiatedTurnFailed) return;
+    final failure = PiRpcProcessExitException(exitCode: exit.exitCode);
     _clearCompaction(sessionId: exit.sessionId);
     state.agentRunning = false;
     if (agentInitiatedTurnFailed) {
+      Log.w(
+        "[pi] resident process exited during an extension-initiated turn for session id=${exit.sessionId}",
+        failure,
+      );
       state.status = const PluginSessionStatus.idle();
       _emit(
         BridgeSseSessionStatus(
@@ -768,7 +773,6 @@ final class PiSessionService({
         ),
       );
     }
-    final failure = PiRpcProcessExitException(exitCode: exit.exitCode);
     if (hasUncancelled) {
       Log.w("[pi] resident process exited during active turns for session id=${exit.sessionId}", failure);
     }

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -1684,6 +1684,127 @@ void main() {
     expect(fixture.repository.residentSessionIds, isEmpty);
   });
 
+  test("extension-initiated idle turns remain visible and reset resident idleness", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process]);
+    addTearDown(fixture.dispose);
+    final clock = _ManualClock();
+    final service = fixture.service(clock: clock);
+    final events = <BridgeSseEvent>[];
+    service.events.listen(events.add);
+
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "prompt-extension",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "start")],
+      userVisibleText: "start",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    final prompt = await waitForCommand(process: process, type: "prompt");
+    process.emit(frame: {"type": "agent_start"});
+    process.emitResponse(id: prompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: "session");
+    await pump();
+    expect(clock.delays, [const Duration(minutes: 5)]);
+    events.clear();
+
+    process.emit(frame: {"type": "agent_start"});
+    await _waitForEvent<BridgeSseSessionStatus>(events: events);
+    expect(service.sessionStatuses["session"], const PluginSessionStatus.busy());
+    expect(service.currentWorkState, PluginWorkState.busy);
+
+    clock.elapse();
+    await pump();
+    expect(process.killed, isFalse);
+
+    process.emit(
+      frame: {
+        "type": "message_end",
+        "message": {
+          "role": "custom",
+          "content": "[PR Monitor] report",
+          "display": true,
+          "timestamp": 100,
+        },
+      },
+    );
+    process.emit(
+      frame: {
+        "type": "message_end",
+        "message": {
+          "role": "assistant",
+          "content": [
+            {"type": "text", "text": "Handled report"},
+          ],
+          "provider": "provider",
+          "model": "model",
+          "stopReason": "stop",
+          "errorMessage": null,
+          "timestamp": 101,
+        },
+      },
+    );
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: "session");
+    await _waitForEventCount<BridgeSseMessageUpdated>(events: events, count: 2);
+
+    expect(
+      events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part.text),
+      containsAllInOrder(["[PR Monitor] report", "Handled report"]),
+    );
+    expect(
+      events.whereType<BridgeSseSessionStatus>().map((event) => event.status["type"]),
+      ["busy", "idle"],
+    );
+    expect(events.whereType<BridgeSseSessionIdle>(), hasLength(1));
+    expect(service.currentWorkState, PluginWorkState.idle);
+    expect(clock.delays, [const Duration(minutes: 5), const Duration(minutes: 5)]);
+
+    clock.elapse();
+    await pump();
+    expect(process.killed, isTrue);
+  });
+
+  test("extension-initiated process exit reports failure and returns idle", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process])..idleTimeout = null;
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+    final events = <BridgeSseEvent>[];
+    service.events.listen(events.add);
+
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "prompt-before-extension-exit",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "start")],
+      userVisibleText: "start",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    final prompt = await waitForCommand(process: process, type: "prompt");
+    process.emit(frame: {"type": "agent_start"});
+    process.emitResponse(id: prompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_settled"});
+    await _waitForIdle(service: service, sessionId: "session");
+    events.clear();
+
+    process.emit(frame: {"type": "agent_start"});
+    await _waitForEvent<BridgeSseSessionStatus>(events: events);
+    process.exit(code: 9);
+    await _waitForEvent<BridgeSseSessionError>(events: events);
+
+    expect(service.sessionStatuses["session"], const PluginSessionStatus.idle());
+    expect(service.currentWorkState, PluginWorkState.idle);
+    expect(events.whereType<BridgeSseSessionIdle>(), hasLength(1));
+    expect(fixture.repository.residentSessionIds, isEmpty);
+  });
+
   test("idle reap and disposal terminate residents", () async {
     final first = FakePiProcess();
     final second = FakePiProcess();

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -1773,32 +1773,37 @@ void main() {
     final process = FakePiProcess();
     final fixture = _Fixture(processes: [process])..idleTimeout = null;
     addTearDown(fixture.dispose);
-    final service = fixture.service();
+    late PiSessionService service;
     final events = <BridgeSseEvent>[];
-    service.events.listen(events.add);
+    final warnings = await _captureWarnings(() async {
+      service = fixture.service();
+      service.events.listen(events.add);
 
-    await service.sendPrompt(
-      sessionId: "session",
-      promptId: "prompt-before-extension-exit",
-      directory: "/project",
-      parts: [const PluginPromptPart.text(text: "start")],
-      userVisibleText: "start",
-      variant: null,
-      model: null,
-    );
-    await _answerEntries(process);
-    final prompt = await waitForCommand(process: process, type: "prompt");
-    process.emit(frame: {"type": "agent_start"});
-    process.emitResponse(id: prompt["id"]! as String, command: "prompt");
-    process.emit(frame: {"type": "agent_settled"});
-    await _waitForIdle(service: service, sessionId: "session");
-    events.clear();
+      await service.sendPrompt(
+        sessionId: "session",
+        promptId: "prompt-before-extension-exit",
+        directory: "/project",
+        parts: [const PluginPromptPart.text(text: "start")],
+        userVisibleText: "start",
+        variant: null,
+        model: null,
+      );
+      await _answerEntries(process);
+      final prompt = await waitForCommand(process: process, type: "prompt");
+      process.emit(frame: {"type": "agent_start"});
+      process.emitResponse(id: prompt["id"]! as String, command: "prompt");
+      process.emit(frame: {"type": "agent_settled"});
+      await _waitForIdle(service: service, sessionId: "session");
+      events.clear();
 
-    process.emit(frame: {"type": "agent_start"});
-    await _waitForEvent<BridgeSseSessionStatus>(events: events);
-    process.exit(code: 9);
-    await _waitForEvent<BridgeSseSessionError>(events: events);
+      process.emit(frame: {"type": "agent_start"});
+      await _waitForEvent<BridgeSseSessionStatus>(events: events);
+      process.exit(code: 9);
+      await _waitForEvent<BridgeSseSessionError>(events: events);
+    });
 
+    expect(warnings, contains("extension-initiated turn for session id=session"));
+    expect(warnings, contains("PiRpcProcessExitException(exitCode: 9)"));
     expect(service.sessionStatuses["session"], const PluginSessionStatus.idle());
     expect(service.currentWorkState, PluginWorkState.idle);
     expect(events.whereType<BridgeSseSessionIdle>(), hasLength(1));

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -77,6 +77,10 @@ defaults and queued client sends coherent.
   retryable while cancellation settles. If a successful run omits an echo, Pi
   maps each stored payload through the same user-message path before clearing
   the queue. Process exit settles dispatched work before queued work reconnects.
+  A resident Pi extension may initiate a turn after the bridge queue becomes
+  idle. Its visible custom message, assistant/tool output, and busy-to-idle
+  lifecycle still reach clients, and its activity restarts the resident idle
+  window instead of being discarded or reaped mid-turn.
 - Pi slash commands are accepted by their correlated response or a matching
   extension dialog and remain in the request's sending state until then rather
   than exposing a cancellable bridge-queue entry. Commands reject while that


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this changes Pi session lifecycle and resident-generation ownership so extension-initiated work is routed without weakening abort, reconnect, or idle-reap fencing.

## What

- Forward frames from the current resident Pi RPC process even when no Sesori-admitted prompt remains.
- Surface extension-initiated custom messages, assistant/tool output, and busy-to-idle lifecycle events.
- Treat autonomous Pi work as plugin work, invalidate the old idle deadline when it starts, and re-arm residency when it settles.
- Fence late frames by resident generation and return failed autonomous turns to visible idle/error state.
- Add regression coverage for PR-monitor-shaped messages, agent wake-up, idle reset, process failure, and existing shutdown races.

## Why

Pi itself was working: persisted session evidence showed visible `pr-monitor` custom messages followed by autonomous assistant/tool turns. Sesori accepted the first report only while its initiating client turn was still active, then discarded later reports and their complete agent turns because `PiSessionService._handleFrame` returned whenever its bridge-owned turn queue was empty.

That made an idle Pi agent wake and work invisibly while Sesori showed neither the `[PR Monitor]` report nor the resulting activity.

## Risk and test focus

The main risk is lifecycle ordering across client prompts, extension-initiated turns, process replacement, abort, shutdown, and idle teardown. Tests focus on current-generation fencing, exact busy/idle transitions, visible custom and assistant messages, work-state ownership, idle-window renewal, autonomous process failure, and the existing abort race.

There is no database or wire-schema change. OMP's separate ACP limitation is unchanged.

## Expected result

A resident Pi extension can push a visible report into an idle Sesori session and wake the agent. Sesori forwards the report and resulting turn, reflects busy/idle state for completion handling, and does not reap the process mid-turn.

The configured Pi idle timeout still applies after the autonomous turn settles; users who need indefinite quiet monitoring can disable that timeout.

## Verification

- `dart pub get` from `bridge/`
- `dart test` in `bridge/sesori_plugin_pi`: 276 passed
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_pi`: no issues
- `git diff --check`
- Architecture implementation review: approved with no findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward extension-initiated Pi turns through Sesori so they reach clients even when the bridge queue is idle. Previously, Sesori dropped resident frames after the last admitted prompt, hiding PR-monitor reports and autonomous assistant/tool turns.

**Bug Fixes**
- Fence frames by resident generation to ignore late frames from replaced processes.
- Start a bridge-visible agent-initiated turn on agent_start and finish it on agent_settled, emitting busy→idle status events.
- Reset the resident idle window when agent-initiated work begins and avoid mid-turn reap; reap only after settle.
- On resident process exit during agent-initiated work, emit an error and return the session to idle.
- Log autonomous process exits with the exit code.
- Add regression tests and docs for PR-monitor messages, wake-ups, idle resets, failures, and shutdown races; no schema or wire changes.

<sup>Written for commit 724361f4cd3fe07103473d2da7ddeec58b446035. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

