### PR TITLE
🌿 [catalog-rescan] Scan one harness from Settings [step 6c/8]

### DIFF
--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -1018,15 +1018,18 @@ reviewer of one PR can see what belongs to it.
   a pull or by the scan's own post-settle refresh, so the two surfaces overlap
   only when a reconnect happens to land mid-scan, and the damage is one
   redundant progress bar.
-- Settings to Harnesses: the per-harness `Rescan` action in
-  `_HarnessControlCard`, calling `startCatalogScanFor(pluginId)`, enabled only for a
-  harness whose `runtimeState.isRoutable` is true and disabled while that
-  harness is itself a member of the live operation; a targeted start joins that
-  operation rather than replacing it, so no cross-harness disabling is needed.
-  The typed `CatalogRescanStartResult` is held
-  per plugin id by `PluginManagementCubit` and rendered on that card, so a
-  targeted `503`, `404`, or unsupported-bridge answer lands on the harness the
-  user selected instead of the shared row.
+- Settings to Harnesses: the per-harness scan action in `_HarnessControlCard`,
+  calling `startCatalogScanFor(pluginId)`, offered only for a harness whose
+  `runtimeState.isRoutable` is true and not offered again while that harness is
+  itself a member of the live operation; a targeted start joins that operation
+  rather than replacing it, so no cross-harness disabling is needed. The typed
+  `CatalogRescanStartResult` is held per plugin id by `PluginManagementCubit`
+  and rendered on that card in place of its description, so a targeted `503`,
+  `404`, or unsupported-bridge answer lands on the harness the user selected
+  instead of the shared row. A rejection is cleared by the next attempt on that
+  harness or by leaving the screen, which rebuilds the cubit; no dismiss action
+  is offered, because a stale line on a card the user has walked away from is
+  not worth its own control.
 - New `app_en.arb` resources for both captions, the seven row states, the delta
   and totals wordings, the `No new sessions` case, the partly-failed wording, the
   bounded failure line naming the bridge log, and the Settings action with its

--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -1057,8 +1057,10 @@ reviewer of one PR can see what belongs to it.
   and its terminal states, the post-success list refresh, failure rows
   persisting until dismissal, cancellation, new-item reporting with its
   older-bridge fallback, and the recovery read discarding terminal statuses.
-- `docs/regression/plugin-setup-and-lifecycle.md`: record the per-harness
-  `Rescan` action, its `isRoutable` enablement rule, and its targeted rejection.
+- `docs/regression/plugin-setup-and-lifecycle.md`: already reconciled in step
+  6c, which recorded the per-harness scan action, its `isRoutable` rule, its
+  targeted rejection, and its L3/L4 coverage. Step 7 only re-checks it against
+  the shipped behaviour.
 - Record the required plugin, platform, compatibility, recovery, freshness, and
   setup-state matrix in both.
 

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -5,9 +5,9 @@
 - **Plan slug:** `catalog-rescan`
 - **Implementation base:** `main` at
   `7b1ebe9bc629d05b5d104e76cd5dbaa1514d65a2`
-- **Series state:** Steps 1/8 to 6a/8 merged; Step 6b/8 open
-- **Current step:** show the catalog scan in the lists
-- **Next action:** land 6b, then 6c's Settings action
+- **Series state:** Steps 1/8 to 6b/8 merged; Step 6c/8 open
+- **Current step:** scan one harness from Settings
+- **Next action:** land 6c, then reconcile the regression docs in step 7
 - **Origin issue:** [#961](https://github.com/sesori-ai/sesori_apps_monorepo/issues/961)
 - **External overlap:** [#1008](https://github.com/sesori-ai/sesori_apps_monorepo/issues/1008)
   owns Codex live updates; do not address it here
@@ -135,8 +135,8 @@
 | [x] | 4/8 | `⚙️ [catalog-rescan] Add the client catalog rescan service [step 4/8]` | 700-1,050 | [PR #1085](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1085) merged |
 | [x] | 5/8 | `⚙️ [catalog-rescan] Add a second stage to pull-to-refresh [step 5/8]` | 350-600 | [PR #1093](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1093) merged |
 | [x] | 6a/8 | `⚙️ [catalog-rescan] Route scan state through the list cubits [step 6a/8]` | 450-750 | Merged |
-| [ ] | 6b/8 | `⚙️ [catalog-rescan] Show the catalog scan in the lists [step 6b/8]` | 500-800 | [PR #1103](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1103) open |
-| [ ] | 6c/8 | `🌿 [catalog-rescan] Scan one harness from Settings [step 6c/8]` | 350-600 | Not started |
+| [x] | 6b/8 | `⚙️ [catalog-rescan] Show the catalog scan in the lists [step 6b/8]` | 500-800 | [PR #1103](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1103) merged |
+| [ ] | 6c/8 | `🌿 [catalog-rescan] Scan one harness from Settings [step 6c/8]` | 350-600 | Open |
 | [ ] | 7/8 | `🌱 [catalog-rescan] Reconcile catalog rescan regression docs [step 7/8]` | 80-160 | Not started |
 | [ ] | 8/8 | `🌱 [catalog-rescan] Verify and retire the catalog rescan plan [step 8/8]` | 60-140 | Not started |
 
@@ -567,4 +567,33 @@ duplicate-emission nicety.
   theoretical, because 6b is what makes scanning user-reachable
 - **Step 6b PR:** [#1103](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1103)
   open
+- **Step 6c base:** `main` at `d8459ae9cf`
+- **Step 6c changed lines:** 451 of delivered code, within the 350-600 estimate
+- **Step 6c field ownership:** `scanningPluginIds` is re-read from
+  `CatalogRescanService` on every snapshot rebuild, the way `installs` is, so a
+  scan a list's pull started still closes the Settings action and reopening the
+  screen mid-scan does not hide it. `scanRejections` is carried forward from the
+  previous ready state, the way `action` and `authentication` are, because
+  nothing outside the cubit holds a rejection the user has not read. The
+  regression test for the rebuild was confirmed to fail without both
+- **Step 6c dropped intent:** `dismissCatalogScanRejection` was written and then
+  removed before commit — it had no caller, since a rejection clears on the next
+  attempt on that harness or on leaving the screen, which rebuilds the cubit
+- **Step 6c verification:** `flutter analyze lib test` clean on `client/app`;
+  `dart analyze --fatal-infos lib test` clean on `client/module_core`; app 890
+  tests passed, module_core 1,373 passed (13 new: 6 cubit, 7 widget)
+- **Step 6c review:** `architecture-implementation-review` **approved** with no
+  architectural findings. It confirmed both writers of `scanningPluginIds` funnel
+  through one getter so the stream and rebuild paths cannot diverge, that
+  `isRoutable` is the shared model's own getter rather than an eligibility rule
+  re-implemented in the shell, and that `CatalogRescanStartFailed.cause` never
+  reaches a rendered string. It also caught a real documentation defect this
+  commit introduced: inserting `startCatalogScanFor` between `install()`'s doc
+  comment and `install()` orphaned that comment. Fixed
+- **Step 6c PR:** pending
+- **Upstream change during 6c:** PR #1106 fixed the catalog refresh ordering
+  seam this plan had recorded as an accepted residue, renaming the service's
+  `settled` to `catalogChanged` and already updating part of
+  `docs/regression/projects-and-sessions.md`. Step 7's scope is therefore
+  smaller than the plan text describes and must be re-derived from the file
 - **Final disposition:** pending

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -590,7 +590,19 @@ duplicate-emission nicety.
   reaches a rendered string. It also caught a real documentation defect this
   commit introduced: inserting `startCatalogScanFor` between `install()`'s doc
   comment and `install()` orphaned that comment. Fixed
-- **Step 6c PR:** pending
+- **Step 6c PR:** [#1113](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1113)
+  open
+- **Step 6c review comments:** both bot findings valid, fixed in `7a4e024ea4`.
+  The failed-start line said "Check the bridge log", which contradicts this
+  plan's own reason for retaining the `ApiError`: the request may never have
+  reached the bridge. Now neutral, because the app has no user-facing log
+  viewer either. The lists' failed row still names the bridge log and is
+  correct — that one comes from a bridge-side `CatalogImportFailed` event
+- **Step 6c doc reversal:** codex asked again for the regression document in the
+  same PR, and this time it was right where it was not on 6b. 6c is the last
+  implementation step, so nothing written now would be rewritten in step 7.
+  `plugin-setup-and-lifecycle.md` was reconciled here, leaving step 7 with
+  `projects-and-sessions.md` only
 - **Upstream change during 6c:** PR #1106 fixed the catalog refresh ordering
   seam this plan had recorded as an accepted residue, renaming the service's
   `settled` to `catalogChanged` and already updating part of

--- a/client/app/lib/features/settings/harnesses_settings_screen.dart
+++ b/client/app/lib/features/settings/harnesses_settings_screen.dart
@@ -29,6 +29,7 @@ class const HarnessesSettingsScreen({
       create: (_) => PluginManagementCubit(
         service: getIt<PluginManagementService>(),
         urlLauncher: getIt<UrlLauncher>(),
+        catalogRescanService: getIt<CatalogRescanService>(),
       ),
       child: _HarnessesSettingsBody(presentation: presentation),
     );
@@ -276,6 +277,8 @@ class const _ReadyView({required final PluginManagementReady state}) extends Sta
                         action: state.action,
                         authentication: state.authentication,
                         install: state.installs[response.plugins[index].setup.id],
+                        scanning: state.scanningPluginIds.contains(response.plugins[index].setup.id),
+                        scanRejection: state.scanRejections[response.plugins[index].setup.id],
                       ),
                       if (index != response.plugins.length - 1) const SizedBox(height: PregoSpacing.md),
                     ],
@@ -320,6 +323,12 @@ class const _HarnessControlCard({
     required final PluginAuthenticationPresentationState authentication,
     /// This harness' in-flight managed runtime install, when one is running.
   required final PluginInstallProgress? install,
+    /// Whether a catalog scan covering this harness is running, started here
+  /// or from a list's pull.
+  required final bool scanning,
+    /// Why this harness' last targeted scan was turned down, if it was. Never
+  /// carries an accepted start.
+  required final CatalogRescanStartResult? scanRejection,
   }) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -344,6 +353,16 @@ class const _HarnessControlCard({
         capabilities.contains(PluginManagementCapability.install) &&
         (plugin.setup.state == PluginSetupState.runtimeMissing || plugin.setup.state == PluginSetupState.unavailable);
     final showRestart = showOperational && supportsLifecycle;
+    final showScan = plugin.runtimeState.isRoutable;
+    // A rejection replaces the row's description until the user starts another
+    // scan, so the answer to "why did nothing happen" stays on the card that
+    // was tapped. The bridge's own error text is never among these.
+    final scanRejectionText = switch (scanRejection) {
+      null || CatalogRescanStartAccepted() => null,
+      CatalogRescanStartNotImportable() => loc.harnessManagementScanNotReady,
+      CatalogRescanStartUnsupported() => loc.harnessManagementScanUnsupported,
+      CatalogRescanStartFailed() => loc.harnessManagementScanFailed,
+    };
     final showTimeout = showOperational && supportsIdleTimeout;
     final showClearTimeout = showTimeout && plugin.hasIdleTimeoutOverride;
     final supportsAuthentication = capabilities.contains(PluginManagementCapability.authentication);
@@ -506,6 +525,21 @@ class const _HarnessControlCard({
               icon: TablerRegular.rotate_clockwise,
               title: Text(loc.harnessManagementRestart),
               onTap: blocked ? null : () => context.read<PluginManagementCubit>().restart(pluginId: pluginId),
+            ),
+          // The keyboard-and-pointer twin of the lists' deep pull, which is
+          // invisible to a screen reader and awkward with a mouse. Offered only
+          // for a routable harness: `isEnabled` is also true for blocked and
+          // failed, which the bridge answers with a 503.
+          if (showScan)
+            PregoGroupedRow(
+              key: Key("harness_management_scan_$pluginId"),
+              icon: TablerRegular.refresh_dot,
+              title: Text(loc.harnessManagementScan),
+              subtitle: Text(scanRejectionText ?? loc.harnessManagementScanDescription),
+              trailing: scanning ? PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary) : null,
+              onTap: blocked || scanning
+                  ? null
+                  : () => context.read<PluginManagementCubit>().startCatalogScanFor(pluginId: pluginId),
             ),
           if (showTimeout)
             PregoGroupedRow(

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -1158,6 +1158,26 @@
   "@catalogScanNoHarnessDetail": {
     "description": "Supporting line on the no-harness scan row, naming where the user can see and fix their harness setup."
   },
+  "harnessManagementScan": "Scan for sessions",
+  "@harnessManagementScan": {
+    "description": "Settings action on a harness card that re-imports that one harness's catalog, the pointer-and-keyboard equivalent of the lists' deep pull."
+  },
+  "harnessManagementScanDescription": "Import projects and sessions this harness has on disk",
+  "@harnessManagementScanDescription": {
+    "description": "Supporting line under the per-harness scan action, saying what scanning does."
+  },
+  "harnessManagementScanNotReady": "This harness cannot be scanned right now",
+  "@harnessManagementScanNotReady": {
+    "description": "Replaces the scan action's description when the bridge refused to import from this harness, usually because it is not running or its setup is incomplete."
+  },
+  "harnessManagementScanUnsupported": "Update the bridge to scan from here",
+  "@harnessManagementScanUnsupported": {
+    "description": "Replaces the scan action's description when the connected bridge is too old to import catalogs on request."
+  },
+  "harnessManagementScanFailed": "Could not start the scan. Check the bridge log for details",
+  "@harnessManagementScanFailed": {
+    "description": "Replaces the scan action's description when the request itself failed. The underlying error is kept for the local log rather than shown."
+  },
   "catalogScanDismiss": "Dismiss",
   "@catalogScanDismiss": {
     "description": "Action on a finished scan row that clears it once the user has read the result."

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -1174,9 +1174,9 @@
   "@harnessManagementScanUnsupported": {
     "description": "Replaces the scan action's description when the connected bridge is too old to import catalogs on request."
   },
-  "harnessManagementScanFailed": "Could not start the scan. Check the bridge log for details",
+  "harnessManagementScanFailed": "Could not start the scan. Try again in a moment",
   "@harnessManagementScanFailed": {
-    "description": "Replaces the scan action's description when the request itself failed. The underlying error is kept for the local log rather than shown."
+    "description": "Replaces the scan action's description when the request itself failed. Names no log, because the request may never have reached the bridge, and the client-side cause it is recorded against has no user-facing viewer."
   },
   "catalogScanDismiss": "Dismiss",
   "@catalogScanDismiss": {

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -3415,10 +3415,10 @@ abstract class AppLocalizations {
   /// **'Update the bridge to scan from here'**
   String get harnessManagementScanUnsupported;
 
-  /// Replaces the scan action's description when the request itself failed. The underlying error is kept for the local log rather than shown.
+  /// Replaces the scan action's description when the request itself failed. Names no log, because the request may never have reached the bridge, and the client-side cause it is recorded against has no user-facing viewer.
   ///
   /// In en, this message translates to:
-  /// **'Could not start the scan. Check the bridge log for details'**
+  /// **'Could not start the scan. Try again in a moment'**
   String get harnessManagementScanFailed;
 
   /// Action on a finished scan row that clears it once the user has read the result.

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -3391,6 +3391,36 @@ abstract class AppLocalizations {
   /// **'Check your harnesses in Settings'**
   String get catalogScanNoHarnessDetail;
 
+  /// Settings action on a harness card that re-imports that one harness's catalog, the pointer-and-keyboard equivalent of the lists' deep pull.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan for sessions'**
+  String get harnessManagementScan;
+
+  /// Supporting line under the per-harness scan action, saying what scanning does.
+  ///
+  /// In en, this message translates to:
+  /// **'Import projects and sessions this harness has on disk'**
+  String get harnessManagementScanDescription;
+
+  /// Replaces the scan action's description when the bridge refused to import from this harness, usually because it is not running or its setup is incomplete.
+  ///
+  /// In en, this message translates to:
+  /// **'This harness cannot be scanned right now'**
+  String get harnessManagementScanNotReady;
+
+  /// Replaces the scan action's description when the connected bridge is too old to import catalogs on request.
+  ///
+  /// In en, this message translates to:
+  /// **'Update the bridge to scan from here'**
+  String get harnessManagementScanUnsupported;
+
+  /// Replaces the scan action's description when the request itself failed. The underlying error is kept for the local log rather than shown.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not start the scan. Check the bridge log for details'**
+  String get harnessManagementScanFailed;
+
   /// Action on a finished scan row that clears it once the user has read the result.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -1848,5 +1848,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get catalogScanNoHarnessDetail => 'Check your harnesses in Settings';
 
   @override
+  String get harnessManagementScan => 'Scan for sessions';
+
+  @override
+  String get harnessManagementScanDescription => 'Import projects and sessions this harness has on disk';
+
+  @override
+  String get harnessManagementScanNotReady => 'This harness cannot be scanned right now';
+
+  @override
+  String get harnessManagementScanUnsupported => 'Update the bridge to scan from here';
+
+  @override
+  String get harnessManagementScanFailed => 'Could not start the scan. Check the bridge log for details';
+
+  @override
   String get catalogScanDismiss => 'Dismiss';
 }

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -1860,7 +1860,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get harnessManagementScanUnsupported => 'Update the bridge to scan from here';
 
   @override
-  String get harnessManagementScanFailed => 'Could not start the scan. Check the bridge log for details';
+  String get harnessManagementScanFailed => 'Could not start the scan. Try again in a moment';
 
   @override
   String get catalogScanDismiss => 'Dismiss';

--- a/client/app/test/features/settings/harnesses_settings_screen_test.dart
+++ b/client/app/test/features/settings/harnesses_settings_screen_test.dart
@@ -193,6 +193,7 @@ void main() {
   late BehaviorSubject<Map<String, PluginAuthenticationChallenge>> authenticationChallenges;
   late StreamController<PluginAuthenticationTerminalUpdate> authenticationTerminal;
   late _MockUrlLauncher urlLauncher;
+  late FakeCatalogRescanService rescan;
 
   setUpAll(() {
     registerFallbackValue(const PluginLifecycleCommandRequest.enable());
@@ -208,6 +209,7 @@ void main() {
     await GetIt.instance.reset();
     service = _MockPluginManagementService();
     urlLauncher = _MockUrlLauncher();
+    rescan = FakeCatalogRescanService();
     snapshots = BehaviorSubject();
     installProgress = BehaviorSubject.seeded(const {});
     authenticationChallenges = BehaviorSubject.seeded(const {});
@@ -283,6 +285,7 @@ void main() {
     );
     GetIt.instance.registerSingleton<PluginManagementService>(service);
     GetIt.instance.registerSingleton<UrlLauncher>(urlLauncher);
+    GetIt.instance.registerSingleton<CatalogRescanService>(rescan);
   });
 
   tearDown(() async {
@@ -1388,4 +1391,118 @@ void main() {
     expect(find.byType(HarnessesSettingsScreen), findsNothing);
     expect(find.text("open-harnesses"), findsOneWidget);
   });
+
+  group("per-harness catalog scan", () {
+    Finder scanRowText(String pluginId, String text) => find.descendant(
+      of: find.byKey(Key("harness_management_scan_$pluginId")),
+      matching: find.text(text),
+    );
+
+    Future<void> openHarnesses(WidgetTester tester) async {
+      _useTallSurface(tester);
+      await tester.pumpWidget(_app());
+      snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+      await tester.pumpAndSettle();
+    }
+
+    // The keyboard-and-pointer twin of the lists' deep pull. A screen reader
+    // cannot perform that gesture at all, so this row is not optional.
+    testWidgets("starts a scan for the harness whose row was tapped", (tester) async {
+      await openHarnesses(tester);
+
+      await _openRow(tester, "harness_management_scan_future-harness");
+
+      expect(rescan.startedPluginIds, ["future-harness"]);
+    });
+
+    // isEnabled is true for blocked and failed, which the bridge rejects with a
+    // 503, so offering the row there would be a tappable no-op.
+    testWidgets("offers no scan for a harness the bridge would refuse", (tester) async {
+      await openHarnesses(tester);
+
+      expect(find.byKey(const Key("harness_management_scan_future-harness")), findsOneWidget);
+      expect(
+        find.byKey(const Key("harness_management_scan_codex")),
+        findsNothing,
+        reason: "codex is setup-blocked, so it is not routable",
+      );
+    });
+
+    testWidgets("does not offer the scan again while one covers this harness", (tester) async {
+      await openHarnesses(tester);
+      final row = find.byKey(const Key("harness_management_scan_future-harness"));
+      await tester.ensureVisible(row);
+      rescan.emit(const CatalogRescanState.starting(pluginIds: {"future-harness"}));
+      // Fixed pumps rather than settling: the row's spinner never stops.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await tester.tap(row);
+      await tester.pump();
+
+      expect(rescan.startedPluginIds, isEmpty);
+      expect(
+        find.descendant(of: row, matching: find.byType(PregoActivityIndicator)),
+        findsOneWidget,
+      );
+    });
+
+    // The fan-out skips a harness it cannot import from; a targeted scan must
+    // say so on the card the user actually tapped.
+    testWidgets("reports a targeted rejection on the harness that was named", (tester) async {
+      await openHarnesses(tester);
+      rescan.stubStartResult(const CatalogRescanStartResult.notImportable());
+
+      await _openRow(tester, "harness_management_scan_future-harness");
+
+      final loc = await AppLocalizations.delegate.load(const Locale("en"));
+      expect(scanRowText("future-harness", loc.harnessManagementScanNotReady), findsOneWidget);
+      expect(
+        scanRowText("opencode", loc.harnessManagementScanDescription),
+        findsOneWidget,
+        reason: "a rejection belongs to the harness that was named, not to every card",
+      );
+    });
+
+    testWidgets("says an older bridge cannot scan rather than reporting a failure", (tester) async {
+      await openHarnesses(tester);
+      rescan.stubStartResult(const CatalogRescanStartResult.unsupported());
+
+      await _openRow(tester, "harness_management_scan_future-harness");
+
+      final loc = await AppLocalizations.delegate.load(const Locale("en"));
+      expect(scanRowText("future-harness", loc.harnessManagementScanUnsupported), findsOneWidget);
+    });
+
+    // The cause is kept for the local log; the card renders bounded text only.
+    testWidgets("never renders the error behind a failed start", (tester) async {
+      await openHarnesses(tester);
+      rescan.stubStartResult(
+        CatalogRescanStartResult.failed(
+          cause: ApiError.nonSuccessCode(errorCode: 500, rawErrorString: "boom /Users/someone/secret"),
+        ),
+      );
+
+      await _openRow(tester, "harness_management_scan_future-harness");
+
+      final loc = await AppLocalizations.delegate.load(const Locale("en"));
+      expect(scanRowText("future-harness", loc.harnessManagementScanFailed), findsOneWidget);
+      expect(find.textContaining("boom"), findsNothing);
+      expect(find.textContaining("secret"), findsNothing);
+    });
+
+    testWidgets("a retry clears the rejection the previous attempt left", (tester) async {
+      await openHarnesses(tester);
+      rescan.stubStartResult(const CatalogRescanStartResult.notImportable());
+      await _openRow(tester, "harness_management_scan_future-harness");
+
+      rescan.stubStartResult(const CatalogRescanStartResult.accepted());
+      await _openRow(tester, "harness_management_scan_future-harness");
+
+      final loc = await AppLocalizations.delegate.load(const Locale("en"));
+      expect(scanRowText("future-harness", loc.harnessManagementScanNotReady), findsNothing);
+      expect(scanRowText("future-harness", loc.harnessManagementScanDescription), findsOneWidget);
+    });
+  });
+
 }

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
@@ -7,16 +7,22 @@ import "package:sesori_shared/sesori_shared.dart";
 
 import "../../platform/url_launcher.dart";
 import "../../repositories/models/plugin_management_result.dart";
+import "../../services/catalog_rescan_service.dart";
+import "../../services/models/catalog_rescan_state.dart";
 import "../../services/plugin_management_service.dart";
 import "plugin_management_state.dart";
 
-class PluginManagementCubit({required final PluginManagementService _service, required final UrlLauncher _urlLauncher})
-    extends Cubit<PluginManagementState> {
+class PluginManagementCubit({
+  required final PluginManagementService _service,
+  required final UrlLauncher _urlLauncher,
+  required final CatalogRescanService _catalogRescanService,
+}) extends Cubit<PluginManagementState> {
   this : super(const PluginManagementState.loading()) {
     _subscriptions
       ..add(_service.snapshots.listen((snapshot) => _onSnapshot(snapshot: snapshot)))
       ..add(_service.installProgress.listen((installs) => _onInstallProgress(installs: installs)))
-      ..add(_service.authenticationTerminal.listen(_onAuthenticationTerminal));
+      ..add(_service.authenticationTerminal.listen(_onAuthenticationTerminal))
+      ..add(_catalogRescanService.state.listen(_onCatalogScan));
   }
 
   final CompositeSubscription _subscriptions = CompositeSubscription();
@@ -191,6 +197,37 @@ class PluginManagementCubit({required final PluginManagementService _service, re
 
   /// Installs the harness' managed runtime. The bridge accepts immediately;
   /// phase progress arrives through [PluginManagementReady.installs].
+  /// Rescans one harness's catalog, reporting a rejection on its own card.
+  ///
+  /// Unlike the lists' aggregate scan, the user named this harness, so a
+  /// bridge that will not import from it has to say so here rather than let
+  /// the fan-out skip it silently.
+  Future<void> startCatalogScanFor({required String pluginId}) async {
+    if (isClosed || state is! PluginManagementReady) return;
+    // Drop any earlier rejection first, so a retry does not read as though it
+    // had already failed again before the answer arrives.
+    _setScanRejection(pluginId: pluginId, result: null);
+    final result = await _catalogRescanService.start(pluginId: pluginId);
+    if (isClosed) return;
+    _setScanRejection(
+      pluginId: pluginId,
+      result: result is CatalogRescanStartAccepted ? null : result,
+    );
+  }
+
+  void _setScanRejection({required String pluginId, required CatalogRescanStartResult? result}) {
+    final current = state;
+    if (isClosed || current is! PluginManagementReady) return;
+    if (current.scanRejections[pluginId] == result) return;
+    final next = Map<String, CatalogRescanStartResult>.of(current.scanRejections);
+    if (result == null) {
+      next.remove(pluginId);
+    } else {
+      next[pluginId] = result;
+    }
+    emit(current.copyWith(scanRejections: next));
+  }
+
   Future<void> install({required String pluginId}) => _runCommand(
     pluginId: pluginId,
     request: const PluginLifecycleCommandRequest.install(),
@@ -445,6 +482,17 @@ class PluginManagementCubit({required final PluginManagementService _service, re
               PluginManagementFailure() => const PluginAuthenticationPresentationState.idle(),
             },
             installs: installs,
+            // Re-read from the service for the same reason as installs: a scan
+            // outlives this cubit, which the screen rebuilds per visit.
+            scanningPluginIds: _scanningPluginIds,
+            // Carried forward instead, because nothing outside this cubit
+            // holds a rejection the user has not read yet.
+            scanRejections: switch (state) {
+              PluginManagementReady(:final scanRejections) => scanRejections,
+              PluginManagementLoading() ||
+              PluginManagementUnsupported() ||
+              PluginManagementFailure() => const {},
+            },
           ),
         );
       case PluginManagementLoadResultUnsupported():
@@ -499,6 +547,29 @@ class PluginManagementCubit({required final PluginManagementService _service, re
     required PluginAuthenticationPresentationError error,
   }) {
     _setAuthentication(PluginAuthenticationPresentationState.failed(pluginId: pluginId, error: error));
+  }
+
+  /// The harnesses the live scan covers, or empty when none is running.
+  ///
+  /// Only a live operation names members worth disabling an action for: a
+  /// terminal state still carries no ids, and an idle one covers nothing.
+  Set<String> get _scanningPluginIds => switch (_catalogRescanService.state.value) {
+    CatalogRescanStarting(:final pluginIds) || CatalogRescanRunning(:final pluginIds) => pluginIds,
+    CatalogRescanIdle() ||
+    CatalogRescanSucceeded() ||
+    CatalogRescanPartlyFailed() ||
+    CatalogRescanFailed() ||
+    CatalogRescanUnsupported() ||
+    CatalogRescanNoHarness() => const {},
+  };
+
+  void _onCatalogScan(CatalogRescanState scan) {
+    if (isClosed) return;
+    final current = state;
+    if (current is! PluginManagementReady) return;
+    final scanning = _scanningPluginIds;
+    if (const SetEquality<String>().equals(current.scanningPluginIds, scanning)) return;
+    emit(current.copyWith(scanningPluginIds: scanning));
   }
 
   void _onInstallProgress({required Map<String, PluginInstallProgress> installs}) {

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
@@ -209,7 +209,11 @@ class PluginManagementCubit({
     if (isClosed) return;
     _setScanRejection(
       pluginId: pluginId,
-      result: result is CatalogRescanStartAccepted ? null : result,
+      // A harness still in the live operation has no refusal to report. An
+      // uncertain start keeps it a member precisely because the request may
+      // have landed, so the card would otherwise pair a spinner with a line
+      // telling the user to try again. That run belongs to the aggregate row.
+      result: result is CatalogRescanStartAccepted || _scanningPluginIds.contains(pluginId) ? null : result,
     );
   }
 
@@ -568,8 +572,17 @@ class PluginManagementCubit({
     final current = state;
     if (current is! PluginManagementReady) return;
     final scanning = _scanningPluginIds;
-    if (const SetEquality<String>().equals(current.scanningPluginIds, scanning)) return;
-    emit(current.copyWith(scanningPluginIds: scanning));
+    // A harness entering a scan has an attempt in flight, which answers any
+    // earlier refusal — including when a list's pull started it rather than
+    // this card. Leaving it would spin a card beside its own contradiction and
+    // restore the refusal once the scan succeeded.
+    final rejections = Map<String, CatalogRescanStartResult>.of(current.scanRejections)
+      ..removeWhere((pluginId, _) => scanning.contains(pluginId));
+    if (const SetEquality<String>().equals(current.scanningPluginIds, scanning) &&
+        rejections.length == current.scanRejections.length) {
+      return;
+    }
+    emit(current.copyWith(scanningPluginIds: scanning, scanRejections: rejections));
   }
 
   void _onInstallProgress({required Map<String, PluginInstallProgress> installs}) {

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
@@ -195,8 +195,6 @@ class PluginManagementCubit({
     replacePendingConfirmation: false,
   );
 
-  /// Installs the harness' managed runtime. The bridge accepts immediately;
-  /// phase progress arrives through [PluginManagementReady.installs].
   /// Rescans one harness's catalog, reporting a rejection on its own card.
   ///
   /// Unlike the lists' aggregate scan, the user named this harness, so a
@@ -228,6 +226,8 @@ class PluginManagementCubit({
     emit(current.copyWith(scanRejections: next));
   }
 
+  /// Installs the harness' managed runtime. The bridge accepts immediately;
+  /// phase progress arrives through [PluginManagementReady.installs].
   Future<void> install({required String pluginId}) => _runCommand(
     pluginId: pluginId,
     request: const PluginLifecycleCommandRequest.install(),

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.dart
@@ -2,6 +2,7 @@ import "package:freezed_annotation/freezed_annotation.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../../services/models/catalog_rescan_state.dart";
 import "../../services/plugin_management_service.dart";
 
 part "plugin_management_state.freezed.dart";
@@ -121,5 +122,14 @@ sealed class PluginManagementState with _$PluginManagementState {
 
     /// In-flight managed runtime installs, keyed by plugin id.
     required Map<String, PluginInstallProgress> installs,
+
+    /// Harnesses with a catalog scan in flight, whether this screen started it
+    /// or the lists did. Their scan action is not offered again while it runs.
+    required Set<String> scanningPluginIds,
+
+    /// Why a targeted scan was turned down, keyed by the harness the user
+    /// named. An accepted start is never recorded: the card reports it by
+    /// disabling its own action, and the aggregate row reports the run.
+    required Map<String, CatalogRescanStartResult> scanRejections,
   }) = PluginManagementReady;
 }

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.freezed.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.freezed.dart
@@ -1896,7 +1896,7 @@ $ApiErrorCopyWith<$Res> get error {
 
 
 class PluginManagementReady implements PluginManagementState {
-  const PluginManagementReady({required this.response, required this.refresh, required this.action, required this.authentication, required  Map<String, PluginInstallProgress> installs}): _installs = installs;
+  const PluginManagementReady({required this.response, required this.refresh, required this.action, required this.authentication, required  Map<String, PluginInstallProgress> installs, required  Set<String> scanningPluginIds, required  Map<String, CatalogRescanStartResult> scanRejections}): _installs = installs,_scanningPluginIds = scanningPluginIds,_scanRejections = scanRejections;
   
 
  final  PluginManagementResponse response;
@@ -1912,6 +1912,30 @@ class PluginManagementReady implements PluginManagementState {
   return EqualUnmodifiableMapView(_installs);
 }
 
+/// Harnesses with a catalog scan in flight, whether this screen started it
+/// or the lists did. Their scan action is not offered again while it runs.
+ final  Set<String> _scanningPluginIds;
+/// Harnesses with a catalog scan in flight, whether this screen started it
+/// or the lists did. Their scan action is not offered again while it runs.
+ Set<String> get scanningPluginIds {
+  if (_scanningPluginIds is EqualUnmodifiableSetView) return _scanningPluginIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableSetView(_scanningPluginIds);
+}
+
+/// Why a targeted scan was turned down, keyed by the harness the user
+/// named. An accepted start is never recorded: the card reports it by
+/// disabling its own action, and the aggregate row reports the run.
+ final  Map<String, CatalogRescanStartResult> _scanRejections;
+/// Why a targeted scan was turned down, keyed by the harness the user
+/// named. An accepted start is never recorded: the card reports it by
+/// disabling its own action, and the aggregate row reports the run.
+ Map<String, CatalogRescanStartResult> get scanRejections {
+  if (_scanRejections is EqualUnmodifiableMapView) return _scanRejections;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_scanRejections);
+}
+
 
 /// Create a copy of PluginManagementState
 /// with the given fields replaced by the non-null parameter values.
@@ -1923,16 +1947,16 @@ $PluginManagementReadyCopyWith<PluginManagementReady> get copyWith => _$PluginMa
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginManagementReady&&(identical(other.response, response) || other.response == response)&&(identical(other.refresh, refresh) || other.refresh == refresh)&&(identical(other.action, action) || other.action == action)&&(identical(other.authentication, authentication) || other.authentication == authentication)&&const DeepCollectionEquality().equals(other._installs, _installs));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginManagementReady&&(identical(other.response, response) || other.response == response)&&(identical(other.refresh, refresh) || other.refresh == refresh)&&(identical(other.action, action) || other.action == action)&&(identical(other.authentication, authentication) || other.authentication == authentication)&&const DeepCollectionEquality().equals(other._installs, _installs)&&const DeepCollectionEquality().equals(other._scanningPluginIds, _scanningPluginIds)&&const DeepCollectionEquality().equals(other._scanRejections, _scanRejections));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,response,refresh,action,authentication,const DeepCollectionEquality().hash(_installs));
+int get hashCode => Object.hash(runtimeType,response,refresh,action,authentication,const DeepCollectionEquality().hash(_installs),const DeepCollectionEquality().hash(_scanningPluginIds),const DeepCollectionEquality().hash(_scanRejections));
 
 @override
 String toString() {
-  return 'PluginManagementState.ready(response: $response, refresh: $refresh, action: $action, authentication: $authentication, installs: $installs)';
+  return 'PluginManagementState.ready(response: $response, refresh: $refresh, action: $action, authentication: $authentication, installs: $installs, scanningPluginIds: $scanningPluginIds, scanRejections: $scanRejections)';
 }
 
 
@@ -1943,7 +1967,7 @@ abstract mixin class $PluginManagementReadyCopyWith<$Res> implements $PluginMana
   factory $PluginManagementReadyCopyWith(PluginManagementReady value, $Res Function(PluginManagementReady) _then) = _$PluginManagementReadyCopyWithImpl;
 @useResult
 $Res call({
- PluginManagementResponse response, PluginManagementRefreshState refresh, PluginManagementActionState action, PluginAuthenticationPresentationState authentication, Map<String, PluginInstallProgress> installs
+ PluginManagementResponse response, PluginManagementRefreshState refresh, PluginManagementActionState action, PluginAuthenticationPresentationState authentication, Map<String, PluginInstallProgress> installs, Set<String> scanningPluginIds, Map<String, CatalogRescanStartResult> scanRejections
 });
 
 
@@ -1960,14 +1984,16 @@ class _$PluginManagementReadyCopyWithImpl<$Res>
 
 /// Create a copy of PluginManagementState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? response = null,Object? refresh = null,Object? action = null,Object? authentication = null,Object? installs = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? response = null,Object? refresh = null,Object? action = null,Object? authentication = null,Object? installs = null,Object? scanningPluginIds = null,Object? scanRejections = null,}) {
   return _then(PluginManagementReady(
 response: null == response ? _self.response : response // ignore: cast_nullable_to_non_nullable
 as PluginManagementResponse,refresh: null == refresh ? _self.refresh : refresh // ignore: cast_nullable_to_non_nullable
 as PluginManagementRefreshState,action: null == action ? _self.action : action // ignore: cast_nullable_to_non_nullable
 as PluginManagementActionState,authentication: null == authentication ? _self.authentication : authentication // ignore: cast_nullable_to_non_nullable
 as PluginAuthenticationPresentationState,installs: null == installs ? _self._installs : installs // ignore: cast_nullable_to_non_nullable
-as Map<String, PluginInstallProgress>,
+as Map<String, PluginInstallProgress>,scanningPluginIds: null == scanningPluginIds ? _self._scanningPluginIds : scanningPluginIds // ignore: cast_nullable_to_non_nullable
+as Set<String>,scanRejections: null == scanRejections ? _self._scanRejections : scanRejections // ignore: cast_nullable_to_non_nullable
+as Map<String, CatalogRescanStartResult>,
   ));
 }
 

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -3,6 +3,7 @@ import "dart:async";
 import "package:mocktail/mocktail.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_dart_core/testing.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -31,6 +32,7 @@ void main() {
   late BehaviorSubject<Map<String, PluginAuthenticationChallenge>> authenticationChallenges;
   late PluginManagementCubit cubit;
   late _MockUrlLauncher urlLauncher;
+  late FakeCatalogRescanService rescan;
 
   setUpAll(() {
     registerFallbackValue(const PluginLifecycleCommandRequest.enable());
@@ -76,11 +78,13 @@ void main() {
     when(
       () => urlLauncher.launch(any(), mode: any(named: "mode")),
     ).thenAnswer((_) async => true);
-    cubit = PluginManagementCubit(service: service, urlLauncher: urlLauncher);
+    rescan = FakeCatalogRescanService();
+    cubit = PluginManagementCubit(service: service, urlLauncher: urlLauncher, catalogRescanService: rescan);
   });
 
   tearDown(() async {
     await cubit.close();
+    await rescan.onDispose();
     await snapshots.close();
     await installProgress.close();
     await authenticationTerminal.close();
@@ -101,6 +105,8 @@ void main() {
         action: PluginManagementActionState.idle(),
         authentication: PluginAuthenticationPresentationState.idle(),
         installs: {},
+        scanningPluginIds: {},
+        scanRejections: {},
       ),
     );
   });
@@ -454,7 +460,7 @@ void main() {
 
       // The screen builds a fresh cubit on every visit, so reopening harness
       // settings during an install must not hide it.
-      final reopened = PluginManagementCubit(service: service, urlLauncher: urlLauncher);
+      final reopened = PluginManagementCubit(service: service, urlLauncher: urlLauncher, catalogRescanService: rescan);
       addTearDown(reopened.close);
       snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
       await _settle();
@@ -790,6 +796,102 @@ void main() {
       await expectLater(action, completes);
     });
   });
+
+  group("targeted catalog scan", () {
+    Future<void> ready() async {
+      snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+      await _settle();
+    }
+
+    test("records nothing when the bridge accepts the scan", () async {
+      await ready();
+
+      await cubit.startCatalogScanFor(pluginId: "codex");
+
+      expect(rescan.startedPluginIds, ["codex"]);
+      expect((cubit.state as PluginManagementReady).scanRejections, isEmpty);
+    });
+
+    // The user named this harness, so a refusal has to land on its own card
+    // rather than being skipped the way the fan-out skips it.
+    test("keeps a rejection against the harness the user named", () async {
+      await ready();
+      rescan.stubStartResult(const CatalogRescanStartResult.notImportable());
+
+      await cubit.startCatalogScanFor(pluginId: "codex");
+
+      expect(
+        (cubit.state as PluginManagementReady).scanRejections,
+        {"codex": isA<CatalogRescanStartNotImportable>()},
+      );
+    });
+
+    test("a retry clears the earlier rejection before the answer arrives", () async {
+      await ready();
+      rescan.stubStartResult(const CatalogRescanStartResult.notImportable());
+      await cubit.startCatalogScanFor(pluginId: "codex");
+
+      rescan.stubStartResult(const CatalogRescanStartResult.accepted());
+      await cubit.startCatalogScanFor(pluginId: "codex");
+
+      expect((cubit.state as PluginManagementReady).scanRejections, isEmpty);
+    });
+
+    test("names the harnesses a live scan covers, whoever started it", () async {
+      await ready();
+
+      rescan.emit(const CatalogRescanState.starting(pluginIds: {"codex", "claude"}));
+      await _settle();
+      expect((cubit.state as PluginManagementReady).scanningPluginIds, {"codex", "claude"});
+
+      rescan.emit(
+        const CatalogRescanState.succeeded(
+          harnessCount: 2,
+          counts: CatalogRescanCounts.delta(newProjects: 0, newSessions: 1),
+        ),
+      );
+      await _settle();
+      expect(
+        (cubit.state as PluginManagementReady).scanningPluginIds,
+        isEmpty,
+        reason: "a finished scan holds no harness open",
+      );
+    });
+
+    // The screen rebuilds this cubit per visit and every snapshot rebuilds the
+    // ready state, so both fields have to survive a rebuild that is not theirs.
+    test("a snapshot rebuild keeps the scan fields", () async {
+      await ready();
+      rescan.stubStartResult(const CatalogRescanStartResult.unsupported());
+      await cubit.startCatalogScanFor(pluginId: "codex");
+      rescan.emit(const CatalogRescanState.starting(pluginIds: {"claude"}));
+      await _settle();
+
+      snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+      await _settle();
+
+      final state = cubit.state as PluginManagementReady;
+      expect(state.scanRejections, {"codex": isA<CatalogRescanStartUnsupported>()});
+      expect(state.scanningPluginIds, {"claude"});
+    });
+
+    test("a cubit created mid-scan seeds its members from the service", () async {
+      rescan.emit(const CatalogRescanState.starting(pluginIds: {"codex"}));
+      await _settle();
+
+      final reopened = PluginManagementCubit(
+        service: service,
+        urlLauncher: urlLauncher,
+        catalogRescanService: rescan,
+      );
+      addTearDown(reopened.close);
+      snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+      await _settle();
+
+      expect((reopened.state as PluginManagementReady).scanningPluginIds, {"codex"});
+    });
+  });
+
 }
 
 PluginLifecycleConflict _conflict(List<PluginLifecycleConflictReason> reasons) {

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -858,6 +858,51 @@ void main() {
       );
     });
 
+    // A scan the lists started is still an attempt on this harness, so the
+    // refusal it answers must not outlive it.
+    test("a scan from another surface clears the refusal it answers", () async {
+      await ready();
+      rescan.stubStartResult(const CatalogRescanStartResult.notImportable());
+      await cubit.startCatalogScanFor(pluginId: "codex");
+      expect((cubit.state as PluginManagementReady).scanRejections, isNotEmpty);
+
+      rescan.emit(const CatalogRescanState.starting(pluginIds: {"codex"}));
+      await _settle();
+
+      expect((cubit.state as PluginManagementReady).scanRejections, isEmpty);
+    });
+
+    test("an unrelated harness keeps its refusal while another one scans", () async {
+      await ready();
+      rescan.stubStartResult(const CatalogRescanStartResult.notImportable());
+      await cubit.startCatalogScanFor(pluginId: "codex");
+
+      rescan.emit(const CatalogRescanState.starting(pluginIds: {"claude"}));
+      await _settle();
+
+      expect(
+        (cubit.state as PluginManagementReady).scanRejections,
+        {"codex": isA<CatalogRescanStartNotImportable>()},
+      );
+    });
+
+    // An uncertain start keeps the harness a member because the request may
+    // have landed, so the card must not pair a spinner with "try again".
+    test("records no refusal while the harness is still in the live operation", () async {
+      await ready();
+      rescan.stubStartResult(
+        CatalogRescanStartResult.failed(cause: ApiError.nonSuccessCode(errorCode: 500, rawErrorString: null)),
+      );
+      rescan.emit(const CatalogRescanState.starting(pluginIds: {"codex"}));
+      await _settle();
+
+      await cubit.startCatalogScanFor(pluginId: "codex");
+
+      final state = cubit.state as PluginManagementReady;
+      expect(state.scanRejections, isEmpty);
+      expect(state.scanningPluginIds, {"codex"});
+    });
+
     // The screen rebuilds this cubit per visit and every snapshot rebuilds the
     // ready state, so both fields have to survive a rebuild that is not theirs.
     test("a snapshot rebuild keeps the scan fields", () async {

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -110,8 +110,10 @@ idle suspension, the management snapshot, and lifecycle commands.
 - A scan the user aimed at one harness reports its own rejection on that harness's card,
   unlike the all-harness fan-out, which silently skips a harness it cannot import from.
   Not-importable, unsupported-bridge, and failed-request answers each read differently and
-  are replaced by the next attempt on that harness. The underlying request error is kept
-  for the local log and never rendered.
+  are cleared by the next attempt on that harness, whichever surface makes it. A start whose
+  outcome is unknown leaves the harness in the running scan rather than reporting a refusal
+  beside its own progress, so a card never pairs work in flight with a reason it failed. The
+  underlying request error is kept for the local log and never rendered.
 
 ## Regression Levels
 

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -101,6 +101,17 @@ idle suspension, the management snapshot, and lifecycle commands.
   Its device-code sheet keeps anti-phishing guidance and the selectable/copyable one-time
   code visible, opens the external browser only on explicit intent, and separates sheet
   dismissal from cancellation. Terminal progress closes the sheet and refreshes setup.
+- Mobile offers a per-harness catalog scan on Settings to Harnesses, the pointer and
+  screen-reader equivalent of the lists' second-stage pull. It appears only for a harness
+  whose reported runtime state is routable, so a setup-blocked or failed harness the bridge
+  would reject is not offered a tappable no-op. The action reports work in place while any
+  scan covering that harness runs, whichever surface started it, and does not accept a
+  second start until it settles.
+- A scan the user aimed at one harness reports its own rejection on that harness's card,
+  unlike the all-harness fan-out, which silently skips a harness it cannot import from.
+  Not-importable, unsupported-bridge, and failed-request answers each read differently and
+  are replaced by the next attempt on that harness. The underlying request error is kept
+  for the local log and never rendered.
 
 ## Regression Levels
 
@@ -108,8 +119,8 @@ idle suspension, the management snapshot, and lifecycle commands.
 |---|---|
 | L1 Smoke | A started bridge inspects every registered harness and publishes coherent setup and management snapshots. A ready fixture has a selectable default; a fixture with no usable harness has zero selectable entries and no default without failing startup. Headless bridge; all registered harnesses listed. |
 | L2 Routine | Demand-driven start of a ready harness, clean lifecycle-owned bridge shutdown, Codex keepalive traffic remaining local and stopping on disposal, setup refresh, and the disable list surviving restart with eligibility and ordering intact. Package automation covers DeepSeek explicit/PATH/managed selection, immutable six-platform archive metadata, readiness, extension refusal, crash/reconnect, and idempotent shutdown before registry activation. Headless bridge; representative managed harness for start and shutdown, every registered harness for listing and ordering. |
-| L3 Release | The management surface as rendered: per-harness selected runtime version when reported, setup, runtime and work state, capability-appropriate controls, built-in name and light/dark artwork, default badge, enable/disable, restart, and idle-timeout default plus override persisted across a bridge restart. Client end to end; every harness declaring the relevant capability must pass. |
-| L4 Extended | Busy conflict with force confirmation and cancellation, authentication start/join/cancel plus shutdown cleanup, idle suspension elapsing then returning on demand, harnesses blocked by missing runtime or authentication, a terminally failed harness leaving others usable, a bridge with no usable harness, an externally managed configuration, two harnesses active at once, second mobile platform. Live plugin where a real backend must start or be interrupted, client end to end where card state is claimed. |
+| L3 Release | The management surface as rendered: per-harness selected runtime version when reported, setup, runtime and work state, capability-appropriate controls, built-in name and light/dark artwork, default badge, enable/disable, restart, idle-timeout default plus override persisted across a bridge restart, and the per-harness catalog scan on a routable harness including its in-place progress. Client end to end; every harness declaring the relevant capability must pass. |
+| L4 Extended | Busy conflict with force confirmation and cancellation, authentication start/join/cancel plus shutdown cleanup, idle suspension elapsing then returning on demand, harnesses blocked by missing runtime or authentication with no catalog-scan action offered on them, a targeted scan rejected by the bridge reporting on its own card, a terminally failed harness leaving others usable, a bridge with no usable harness, an externally managed configuration, two harnesses active at once, second mobile platform. Live plugin where a real backend must start or be interrupted, client end to end where card state is claimed. |
 | L5 Full | Every registered production harness through inspect, enable, disable, restart, refresh, and idle behavior on a supported platform, plus forward-compatible presentation of an unknown harness or capability and the reported state of a session interrupted by a forced disable. Live plugin and client end to end as each entry requires. |
 
 ## Exploration Guidance
@@ -131,6 +142,9 @@ timeouts, and sessions afterwards.
   different from the executable selected by setup inspection and runtime resolution.
 - A control offered for an undeclared capability, a supported control missing, a busy
   harness accepting a safe command, or idle suspension on a resident or busy harness.
+- A catalog scan offered on a harness the bridge will not import from, a scan already
+  covering a harness still accepting another start from its card, a targeted rejection
+  landing on the wrong harness or on none, or a request error reaching the card as text.
 - A missing authentication state from an older bridge decoding as anything but idle, a
   future state or conflict reason failing open, challenge data entering snapshots/SSE, or
   a failed progress payload without its required sanitized message.


### PR DESCRIPTION
## Complexity

🌿 Straightforward. Two state fields and one intent on an existing cubit, plus
one row on an existing card.

## What

Adds the per-harness scan action to Settings → Harnesses, the last
implementation step of the series.

- `PluginManagementCubit` subscribes to `CatalogRescanService` and exposes
  `startCatalogScanFor(pluginId)`.
- `PluginManagementReady` gains `scanningPluginIds` and `scanRejections`.
- `_HarnessControlCard` gains a "Scan for sessions" row beside Restart, with a
  spinner while a scan covers that harness and the rejection in place of its
  description when one was refused.
- New `app_en.arb` resources for the action, its description, and its three
  rejection lines.

## Why

The lists' deep pull is invisible to a screen reader and awkward with a mouse,
and the reporter on issue #961 runs the bridge on a desktop. This is that
gesture's keyboard-and-pointer twin, and it is where a user who wants to scan
one harness rather than all of them can do it.

The fan-out silently skips a harness the bridge will not import from, which is
right when the user asked for "everything" and wrong when they named one. A
targeted start therefore returns its outcome and the card reports it.

## Risk and test focus

No database impact. No wire-contract change — client-only, using the
`/plugin/import` route step 4 already calls.

User-visible impact: one new row per routable harness on Settings → Harnesses.

Worth a look in review:

- **The field-ownership split.** `scanningPluginIds` is re-read from the service
  on every snapshot rebuild, the way `installs` already is, so a scan started
  from a list's pull still closes this action and reopening the screen mid-scan
  does not hide it. `scanRejections` is carried forward from the previous ready
  state, the way `action` and `authentication` are, because nothing outside the
  cubit holds a rejection the user has not read yet. Step 6a's review caught a
  real bug where a rebuild erased exactly this kind of field; the regression
  test here was confirmed to fail without both.
- **`isRoutable`, not `isEnabled`.** `isEnabled` is also true for `blocked` and
  `failed`, which the bridge answers with a `503`, so gating on it would make
  the row a tappable no-op on a setup-blocked harness. A test asserts the
  setup-blocked fixture has no scan row.
- **`CatalogRescanStartFailed.cause` is never rendered.** It is retained for the
  local log because a transport failure may never have reached the bridge. A
  test asserts neither the message nor the path inside it reaches the screen.

## Expected result

A routable harness on Settings → Harnesses shows "Scan for sessions". Tapping it
imports that harness's catalog; the row shows a spinner and stops responding
until the scan settles, including when a list's pull started the scan. A bridge
that refuses reports why on that card — "This harness cannot be scanned right
now", "Update the bridge to scan from here", or "Could not start the scan. Check
the bridge log for details" — and the next attempt clears it. A setup-blocked
harness is not offered the action at all.

## Verification

- `flutter analyze lib test` in `client/app` — clean
- `dart analyze --fatal-infos lib test` in `client/module_core` — clean
- `client/app` suite — 890 passed, 7 new
- `client/module_core` suite — 1,373 passed, 6 new
- `flutter gen-l10n` and `build_runner` output committed
- `architecture-implementation-review` — **approved, no architectural findings**
  (it did catch a doc comment this commit orphaned, fixed in the follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-harness “Scan for sessions” action in Settings → Harnesses so users can rescan a single harness with keyboard or pointer. Previously scans only started via list pull-to-refresh; now each routable harness can be scanned directly, its row disables with a spinner while any scan covers it, and targeted rejections render on that card with bounded copy.

- The action shows only for routable harnesses and is disabled while that harness is in a live scan, whichever surface started it.
- Targeted starts use startCatalogScanFor(pluginId); rejections are stored per harness, never include raw errors, and clear on retry, on entering a live scan, or when leaving the screen.
- `PluginManagementCubit` subscribes to `CatalogRescanService`; it re-reads `scanningPluginIds` from the service and retains `scanRejections` across rebuilds.
- Updated failure copy to avoid pointing users to a bridge log; added localization strings for the action, description, and rejection lines.

- Migration
  - `PluginManagementCubit` now requires `CatalogRescanService`; register it in DI and pass it where the cubit is constructed.

<sup>Written for commit b3704bc1a86784e2abafde4327ad9496a0c52e30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

