### PR TITLE
⚙️ [catalog-rescan] Quieten the scan row and its pull [step 6d/8]

### DIFF
--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -636,4 +636,21 @@ duplicate-emission nicety.
   the scan state at report time rather than threading a flag through the
   gesture, so a fetch that resolved before the pull crossed 1.8x would still
   raise one toast
+- **Step 6d review comments:** three bot findings. Two were defects the polish
+  itself introduced and are fixed in `7a75b73be1`: `SizeTransition` only changes
+  layout, so the retained card kept its labels and its live action button
+  mounted at zero height where a keyboard could still reach them; and the reveal
+  ignored the OS reduced-motion preference that the router transitions, the
+  message list, the image viewer and `PregoActivityIndicator` all honour through
+  `context.isReducedMotion`. Both regression tests were confirmed to fail
+  without their fix — the reduced-motion one only after being rewritten, because
+  the first version asserted `greaterThan(0)` and `easeOutCubic` is already at
+  ~17% one frame in
+- **Step 6d toast narrowing:** the third finding was half right and the half it
+  got right was a regression: suppressing the refresh toast whenever a scan was
+  live also hid *failed* pulls. Now only a success is suppressed. Declined
+  tying suppression to the gesture that fired, which needs a flag threaded
+  through two stateless session hosts to restore a success confirmation for a
+  shallow pull taken during someone else's scan, where a progress row is already
+  on screen
 - **Final disposition:** pending

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -5,9 +5,9 @@
 - **Plan slug:** `catalog-rescan`
 - **Implementation base:** `main` at
   `7b1ebe9bc629d05b5d104e76cd5dbaa1514d65a2`
-- **Series state:** Steps 1/8 to 6b/8 merged; Step 6c/8 open
-- **Current step:** scan one harness from Settings
-- **Next action:** land 6c, then reconcile the regression docs in step 7
+- **Series state:** Steps 1/8 to 6c/8 merged; Step 6d/8 open
+- **Current step:** quieten the scan row and its pull
+- **Next action:** land 6d, then reconcile projects-and-sessions.md in step 7
 - **Origin issue:** [#961](https://github.com/sesori-ai/sesori_apps_monorepo/issues/961)
 - **External overlap:** [#1008](https://github.com/sesori-ai/sesori_apps_monorepo/issues/1008)
   owns Codex live updates; do not address it here
@@ -136,7 +136,8 @@
 | [x] | 5/8 | `⚙️ [catalog-rescan] Add a second stage to pull-to-refresh [step 5/8]` | 350-600 | [PR #1093](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1093) merged |
 | [x] | 6a/8 | `⚙️ [catalog-rescan] Route scan state through the list cubits [step 6a/8]` | 450-750 | Merged |
 | [x] | 6b/8 | `⚙️ [catalog-rescan] Show the catalog scan in the lists [step 6b/8]` | 500-800 | [PR #1103](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1103) merged |
-| [ ] | 6c/8 | `🌿 [catalog-rescan] Scan one harness from Settings [step 6c/8]` | 350-600 | Open |
+| [x] | 6c/8 | `🌿 [catalog-rescan] Scan one harness from Settings [step 6c/8]` | 350-600 | [PR #1113](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1113) merged |
+| [ ] | 6d/8 | `⚙️ [catalog-rescan] Quieten the scan row and its pull [step 6d/8]` | 400-700 | [PR #1114](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1114) open |
 | [ ] | 7/8 | `🌱 [catalog-rescan] Reconcile catalog rescan regression docs [step 7/8]` | 80-160 | Not started |
 | [ ] | 8/8 | `🌱 [catalog-rescan] Verify and retire the catalog rescan plan [step 8/8]` | 60-140 | Not started |
 
@@ -608,4 +609,31 @@ duplicate-emission nicety.
   `settled` to `catalogChanged` and already updating part of
   `docs/regression/projects-and-sessions.md`. Step 7's scope is therefore
   smaller than the plan text describes and must be re-derived from the file
+- **Step 6c declined finding:** a third bot round asked for a connection-epoch
+  fence on `startCatalogScanFor`, so a POST pending across a disconnect could
+  not overwrite a later retry's rejection. Declined: it needs a disconnect,
+  reconnect and retry inside one pending request, and the worst outcome is one
+  stale line until the next tap or until Settings is left. Same call the plan
+  already recorded for the recovery read
+- **Step 6d base:** `main` at `2c3ef6d` (merged forward to pick up 6c)
+- **Step 6d origin:** owner feedback from a running build, eight points. Not a
+  planned step — the feature worked and looked wrong
+- **Step 6d component reversal:** 6b chose `PregoInlineAlertsNotifications` to
+  avoid a bespoke card. Wrong component: it paints `colors.fgPrimary`, the
+  contrast-inverted foreground, so the row was a near-black slab over a light
+  list. Replaced with a tinted card in each state's own colour family. The
+  instinct to reuse was right; the component is an interrupt surface and this is
+  ambient status
+- **Step 6d animation root cause:** starting an `AnimationController` from
+  `build` races its own frame, which inside a `SliverToBoxAdapter` leaves the
+  row pinned at zero height. This is also why 6b's `AnimatedSize` attempt never
+  grew and was removed as unworkable. Driven from `didUpdateWidget` now, and the
+  tests pump the extra frame a controller needs before its first tick carries
+  elapsed time
+- **Step 6d residues:** the overscroll still holds its extent while the finger
+  is down, which is scroll physics rather than something the control can cancel
+  mid-gesture; the area it holds is simply empty. The toast suppression reads
+  the scan state at report time rather than threading a flag through the
+  gesture, so a fetch that resolved before the pull crossed 1.8x would still
+  raise one toast
 - **Final disposition:** pending

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -54,10 +54,13 @@
 
 | Decision | Chosen | Rationale |
 |---|---|---|
-| Refresh model | Two-stage pull: soft unchanged, deep fires past `1.6 x triggerDistance` | A rescan boots every enabled harness backend, so it must be deliberate |
+| Refresh model | Two-stage pull: soft unchanged, deep fires past `1.8 x triggerDistance` | A rescan boots every enabled harness backend, so it must be deliberate. Raised from 1.6 in 6d: too easy to reach by accident |
 | Deep-pull commit | On crossing the threshold, not on release | `CupertinoSliverRefreshControl` fires `onRefresh` on crossing and never on release, so release semantics were unbuildable. Owner decision 2026-08-24 |
 | Gesture owner | One `module_prego` `PregoSliverRefreshControl` | Three hosts, only two of which use `PregoGlassScaffold`; the pane must not re-implement thresholds in `client/app` |
 | Row weight | Tinted card, distinct from the surrounding tiles | Reads as status rather than content, so it is never mistaken for an openable row |
+| Row component | Bespoke tinted card, not `PregoInlineAlertsNotifications` | 6b reused the inline alert to avoid building one; it paints `colors.fgPrimary`, so the row was a near-black slab over a light list. An alert interrupts, this reports |
+| Post-fire pull | The control renders nothing at all once the threshold is crossed | The row is already on screen reporting the run, so the spinner and caption narrated it twice |
+| Row height | Fixed across every state; the detail line is always rendered | The detail arrives one event after the row, and a line appearing under it moved the list a second time |
 | Running detail | The harness and its live session count | A "2 of 3" line goes still during a long single-harness scan, which is when reassurance matters most |
 | Copy | "Scan" led, sessions first, projects only in the result | Owner decision 2026-08-24: "rescan" named the mechanism, not the outcome |
 | Progress presentation | One aggregate row | Fixed height; the top of the list never reflows as harnesses finish at different times |

--- a/client/app/lib/core/widgets/catalog_scan_row.dart
+++ b/client/app/lib/core/widgets/catalog_scan_row.dart
@@ -72,8 +72,20 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with SingleTickerProv
   bool get _hasContent => widget._scan is! CatalogRescanIdle;
 
   @override
+  void initState() {
+    super.initState();
+    // Drops the retained card once it has finished folding away. Without this
+    // its labels and its live action button stay mounted at zero height, where
+    // a keyboard or screen reader can still reach an invisible control.
+    _reveal.addStatusListener(_onRevealStatus);
+  }
+
+  @override
   void didUpdateWidget(CatalogScanRow oldWidget) {
     super.didUpdateWidget(oldWidget);
+    // Read per change rather than once: the OS preference can be turned on
+    // while this row is on screen.
+    _reveal.duration = context.isReducedMotion ? Duration.zero : _revealDuration;
     if (_hasContent) {
       _reveal.forward();
     } else {
@@ -81,8 +93,14 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with SingleTickerProv
     }
   }
 
+  void _onRevealStatus(AnimationStatus status) {
+    if (status != AnimationStatus.dismissed || _shown == null) return;
+    setState(() => _shown = null);
+  }
+
   @override
   void dispose() {
+    _reveal.removeStatusListener(_onRevealStatus);
     _curve.dispose();
     _reveal.dispose();
     super.dispose();

--- a/client/app/lib/core/widgets/catalog_scan_row.dart
+++ b/client/app/lib/core/widgets/catalog_scan_row.dart
@@ -1,19 +1,24 @@
 import "package:material_ui/material_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
 import "package:theme_prego/module_prego.dart";
 
 import "../../l10n/app_localizations.dart";
 import "../extensions/build_context_x.dart";
 
-/// The catalog scan reported as one row above a list.
+/// How long the row takes to grow in or fold away.
+const Duration _revealDuration = Duration(milliseconds: 260);
+
+/// The catalog scan reported as one quiet row above a list.
 ///
-/// Every scan state renders through the shared inline alert, so the row picks
-/// up the design system's tinted card, spinner, and action buttons rather than
-/// owning a bespoke treatment. The scan is one aggregate however many harnesses
-/// take part, so this is one row rather than one per harness.
+/// Deliberately not an inline alert: that component paints the inverted
+/// foreground and is built to interrupt, which is wrong for something a pull
+/// starts and that clears itself. This is a tinted card in the state's own
+/// colour family, weighted to sit above the list rather than on top of it.
 ///
-/// Sized by its state: [CatalogRescanIdle] takes no space at all, so a host can
-/// mount the row unconditionally and let the scan decide whether it shows.
+/// Its height never changes with the state. The supporting line always occupies
+/// a row, so a scan that starts before it can name a harness does not shove the
+/// list down again the moment the first progress event lands.
 class const CatalogScanRow({
   super.key,
 
@@ -27,47 +32,93 @@ class const CatalogScanRow({
 
   /// Clears a finished scan the user has read.
   required final VoidCallback _onDismiss,
-}) extends StatelessWidget {
-  /// The pull-to-refresh second stage that starts a scan, carrying the captions
-  /// that say what crossing the deeper threshold will do.
+}) extends StatefulWidget {
+  /// The pull-to-refresh second stage that starts a scan, carrying the caption
+  /// that says what crossing the deeper threshold will do.
   ///
   /// Lives beside the row so the gesture that starts a scan and the row that
   /// reports it stay worded together, and every list gets the same invitation.
   static PregoDeepRefresh deepRefresh({required BuildContext context, required VoidCallback onStart}) {
-    return PregoDeepRefresh(
-      onDeepRefresh: onStart,
-      pullCaption: context.loc.catalogScanPullCaption,
-      deepCaption: context.loc.catalogScanDeepCaption,
-    );
+    return PregoDeepRefresh(onDeepRefresh: onStart, pullCaption: context.loc.catalogScanPullCaption);
+  }
+
+  @override
+  State<CatalogScanRow> createState() => _CatalogScanRowState();
+}
+
+class _CatalogScanRowState() extends State<CatalogScanRow> with SingleTickerProviderStateMixin {
+  late final AnimationController _reveal = AnimationController(
+    vsync: this,
+    duration: _revealDuration,
+    // A scan already running when this mounts is not news: the list is being
+    // revisited mid-run, so the row is simply there rather than arriving.
+    value: _hasContent ? 1 : 0,
+  );
+  late final CurvedAnimation _curve = CurvedAnimation(
+    parent: _reveal,
+    curve: Curves.easeOutCubic,
+    reverseCurve: Curves.easeInCubic,
+  );
+
+  /// The last content worth showing, kept while the row folds away.
+  ///
+  /// Without it the card would vanish on the frame the scan cleared and leave
+  /// an empty box collapsing behind it.
+  _RowContent? _shown;
+
+  /// Whether the current scan has anything to report. Decided from the scan
+  /// alone, so the animation can be driven from lifecycle callbacks rather than
+  /// from [build], where starting a controller races its own frame.
+  bool get _hasContent => widget._scan is! CatalogRescanIdle;
+
+  @override
+  void didUpdateWidget(CatalogScanRow oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (_hasContent) {
+      _reveal.forward();
+    } else {
+      _reveal.reverse();
+    }
+  }
+
+  @override
+  void dispose() {
+    _curve.dispose();
+    _reveal.dispose();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    final content = _contentFor(loc: context.loc);
-    if (content == null) return const SizedBox.shrink();
-    return Padding(
-      padding: EdgeInsetsDirectional.fromSTEB(
-        context.prego.spacing.lg,
-        context.prego.spacing.md,
-        context.prego.spacing.lg,
-        context.prego.spacing.sm,
-      ),
-      // Announced when it appears without moving focus, the same treatment the
-      // connection banner uses: a scan started by a pull finishes with no other
-      // signal that it is done. Every state announces except the running one,
-      // whose session count changes with each enumerated session and would
-      // otherwise interrupt a screen reader hundreds of times during one scan.
-      child: Semantics(
-        container: true,
-        liveRegion: _scan is! CatalogRescanRunning,
-        child: PregoInlineAlertsNotifications(
-          type: content.type,
-          title: content.title,
-          supportingText: content.detail,
-          icon: content.icon,
-          secondaryAction: PregoInlineAlertsNotificationsAction(
-            label: content.actionLabel,
-            onPressed: content.onAction,
+    final content = _contentFor(loc: context.loc, scan: widget._scan);
+    if (content != null) _shown = content;
+    final shown = _shown;
+    if (shown == null) return const SizedBox(width: double.infinity);
+
+    return SizeTransition(
+      sizeFactor: _curve,
+      // Grow downward from the top edge so the list below slides rather than
+      // the row expanding around its own centre.
+      alignment: AlignmentDirectional.topStart,
+      child: FadeTransition(
+        opacity: _curve,
+        child: Padding(
+          padding: EdgeInsetsDirectional.fromSTEB(
+            context.prego.spacing.lg,
+            context.prego.spacing.md,
+            context.prego.spacing.lg,
+            context.prego.spacing.sm,
+          ),
+          // Announced when it appears without moving focus, the same treatment
+          // the connection banner uses: a scan started by a pull finishes with
+          // no other signal that it is done. Every state announces except the
+          // running one, whose session count changes with each enumerated
+          // session and would otherwise interrupt a screen reader hundreds of
+          // times during one scan.
+          child: Semantics(
+            container: true,
+            liveRegion: widget._scan is! CatalogRescanRunning,
+            child: _ScanCard(content: shown),
           ),
         ),
       ),
@@ -76,80 +127,71 @@ class const CatalogScanRow({
 
   /// The one place the scan state decides how the row reads.
   ///
-  /// `null` is the idle row, which renders nothing.
-  ({
-    PregoInlineAlertsNotificationsType type,
-    String title,
-    String? detail,
-    IconData? icon,
-    String actionLabel,
-    VoidCallback onAction,
-  })?
-  _contentFor({required AppLocalizations loc}) => switch (_scan) {
+  /// `null` is the idle row, which folds away to nothing.
+  _RowContent? _contentFor({required AppLocalizations loc, required CatalogRescanState scan}) => switch (scan) {
     CatalogRescanIdle() => null,
-    // The spinner the loading type brings is the progress report: a scan has
-    // no total to count towards, so there is nothing to fill a bar with.
-    CatalogRescanStarting() => (
-      type: PregoInlineAlertsNotificationsType.loading,
+    // The spinner is the progress report: a scan has no total to count towards,
+    // so there is nothing to fill a bar with. The detail line holds its place
+    // until the first harness reports.
+    CatalogRescanStarting() => _RowContent(
+      tone: _ScanTone.working,
       title: loc.catalogScanRunningTitle,
-      detail: null,
-      icon: null,
+      detail: loc.catalogScanStartingDetail,
       actionLabel: loc.catalogScanCancel,
-      onAction: _onCancel,
+      onAction: widget._onCancel,
     ),
-    CatalogRescanRunning(:final activePluginName, :final sessionsSeen) => (
-      type: PregoInlineAlertsNotificationsType.loading,
+    CatalogRescanRunning(:final activePluginName, :final sessionsSeen) => _RowContent(
+      tone: _ScanTone.working,
       title: loc.catalogScanRunningTitle,
       detail: loc.catalogScanRunningDetail(activePluginName, sessionsSeen),
-      icon: null,
       actionLabel: loc.catalogScanCancel,
-      onAction: _onCancel,
+      onAction: widget._onCancel,
     ),
-    CatalogRescanSucceeded(:final counts) => (
-      type: PregoInlineAlertsNotificationsType.success,
+    CatalogRescanSucceeded(:final counts) => _RowContent(
+      tone: _ScanTone.done,
+      icon: TablerRegular.circle_check,
       title: loc.catalogScanCompleteTitle,
       detail: _countsLine(loc: loc, counts: counts),
-      icon: null,
       actionLabel: loc.catalogScanDismiss,
-      onAction: _onDismiss,
+      onAction: widget._onDismiss,
     ),
-    CatalogRescanPartlyFailed(:final succeededCount, :final failedCount) => (
-      type: PregoInlineAlertsNotificationsType.warning,
+    CatalogRescanPartlyFailed(:final succeededCount, :final failedCount) => _RowContent(
+      tone: _ScanTone.attention,
+      icon: TablerRegular.alert_triangle,
       title: loc.catalogScanPartlyFailedTitle,
       detail: loc.catalogScanPartlyFailedDetail(failedCount, succeededCount + failedCount),
-      icon: null,
       actionLabel: loc.catalogScanDismiss,
-      onAction: _onDismiss,
+      onAction: widget._onDismiss,
     ),
     // The bridge's own error text never reaches the client, so the row names
     // the log that has it rather than guessing at a cause.
-    CatalogRescanFailed() => (
-      type: PregoInlineAlertsNotificationsType.error,
+    CatalogRescanFailed() => _RowContent(
+      tone: _ScanTone.problem,
+      icon: TablerRegular.alert_circle,
       title: loc.catalogScanFailedTitle,
       detail: loc.catalogScanFailedDetail,
-      icon: null,
       actionLabel: loc.catalogScanDismiss,
-      onAction: _onDismiss,
+      onAction: widget._onDismiss,
     ),
     // Not a failure of this scan but of the pairing, so it reads as something
     // to fix rather than something to retry.
-    CatalogRescanUnsupported() => (
-      type: PregoInlineAlertsNotificationsType.warning,
+    CatalogRescanUnsupported() => _RowContent(
+      tone: _ScanTone.attention,
+      icon: TablerRegular.arrow_up_circle,
       title: loc.catalogScanUnsupportedTitle,
       detail: loc.catalogScanUnsupportedDetail,
-      icon: TablerRegular.arrow_up_circle,
       actionLabel: loc.catalogScanDismiss,
-      onAction: _onDismiss,
+      onAction: widget._onDismiss,
     ),
     // Nothing was ever asked of the bridge, so the row says what is missing
     // instead of leaving the pull that started it with no answer.
-    CatalogRescanNoHarness() => (
-      type: PregoInlineAlertsNotificationsType.warning,
+    CatalogRescanNoHarness() => _RowContent(
+      tone: _ScanTone.attention,
+      icon: TablerRegular.plug_connected_x,
       title: loc.catalogScanNoHarnessTitle,
       detail: loc.catalogScanNoHarnessDetail,
-      icon: TablerRegular.plug_connected_x,
       actionLabel: loc.catalogScanDismiss,
-      onAction: _onDismiss,
+      onAction: widget._onDismiss,
     ),
   };
 
@@ -177,5 +219,101 @@ class const CatalogScanRow({
       (null, final projects?) => projects,
       (null, null) => loc.catalogScanNothingNew,
     };
+  }
+}
+
+/// The colour family a scan state reads in.
+///
+/// Four tones rather than one per state, because several states share both a
+/// severity and a treatment; the icon is what tells them apart.
+enum _ScanTone() { working, done, attention, problem }
+
+/// One state's whole presentation, resolved before anything is built.
+class const _RowContent({
+  required final _ScanTone tone,
+
+  /// `null` means the leading slot shows a spinner instead, which is what the
+  /// live states use.
+  final IconData? icon,
+  required final String title,
+  required final String detail,
+  required final String actionLabel,
+  required final VoidCallback onAction,
+});
+
+/// The tinted card itself: leading mark, two fixed lines, one action.
+class const _ScanCard({required final _RowContent content}) extends StatelessWidget {
+  /// Leading glyph and spinner size. Smaller than an alert's, because this row
+  /// reports rather than interrupts.
+  static const double _markSize = 18;
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    final colors = prego.colors;
+    final (background, foreground) = switch (content.tone) {
+      _ScanTone.working => (colors.bgSecondary, colors.fgBrandPrimary),
+      _ScanTone.done => (colors.bgSuccessPrimary, colors.fgSuccessPrimary),
+      _ScanTone.attention => (colors.bgWarningPrimary, colors.fgWarningPrimary),
+      _ScanTone.problem => (colors.bgErrorPrimary, colors.fgErrorPrimary),
+    };
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(PregoRadius.lg),
+        border: Border.all(color: colors.borderSecondary),
+      ),
+      child: Padding(
+        padding: const EdgeInsetsDirectional.fromSTEB(
+          PregoSpacing.lg,
+          PregoSpacing.lg,
+          PregoSpacing.md,
+          PregoSpacing.lg,
+        ),
+        child: Row(
+          children: [
+            SizedBox.square(
+              dimension: _markSize,
+              child: switch (content.icon) {
+                final icon? => Icon(icon, size: _markSize, color: foreground),
+                null => PregoActivityIndicator(color: foreground),
+              },
+            ),
+            const SizedBox(width: PregoSpacing.lg),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    content.title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: prego.textTheme.textSm.medium.copyWith(color: colors.textPrimary),
+                  ),
+                  // Always rendered, never conditional: the detail arrives one
+                  // event after the row does, and a line appearing under it
+                  // would move the whole list a second time.
+                  Text(
+                    content.detail,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: prego.textTheme.textXs.regular.copyWith(color: colors.textTertiary),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: PregoSpacing.sm),
+            PregoButtonsSolid(
+              label: content.actionLabel,
+              hierarchy: PregoButtonsSolidHierarchy.tertiary,
+              size: PregoButtonsSolidSize.sm,
+              onPressed: content.onAction,
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -361,6 +361,13 @@ class _ProjectListBodyState() extends State<_ProjectListBody> {
     final loc = context.loc;
     final success = await context.read<ProjectListCubit>().refreshProjects();
     if (!context.mounted) return;
+    // One pull, one report. The same gesture that reaches this also crosses the
+    // deeper threshold, and the scan row it started already says the list is
+    // being brought up to date — a toast beside it would announce the smaller
+    // half of the same action.
+    if (context.read<ProjectListCubit>().state case ProjectListLoaded(catalogScan: final scan) when scan.isLive) {
+      return;
+    }
     PregoPopupAlertPresenter.of(context).show(
       title: success ? loc.projectListRefreshSuccess : loc.projectListRefreshFailed,
       variant: success ? PregoPopupAlertsNotificationsVariant.success : PregoPopupAlertsNotificationsVariant.error,

--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -361,12 +361,16 @@ class _ProjectListBodyState() extends State<_ProjectListBody> {
     final loc = context.loc;
     final success = await context.read<ProjectListCubit>().refreshProjects();
     if (!context.mounted) return;
-    // One pull, one report. The same gesture that reaches this also crosses the
-    // deeper threshold, and the scan row it started already says the list is
-    // being brought up to date — a toast beside it would announce the smaller
-    // half of the same action.
-    if (context.read<ProjectListCubit>().state case ProjectListLoaded(catalogScan: final scan) when scan.isLive) {
-      return;
+    // One pull, one report — but only for a confirmation. A live scan row
+    // already says the list is being brought up to date, so a "Projects
+    // updated" toast beside it announces the smaller half of the same action.
+    // A *failure* is never suppressed: the row reports the scan, not this
+    // read, and a pull that silently did nothing is worse than one toast too
+    // many.
+    if (success) {
+      if (context.read<ProjectListCubit>().state case ProjectListLoaded(catalogScan: final scan) when scan.isLive) {
+        return;
+      }
     }
     PregoPopupAlertPresenter.of(context).show(
       title: success ? loc.projectListRefreshSuccess : loc.projectListRefreshFailed,

--- a/client/app/lib/features/session_list/session_list_content.dart
+++ b/client/app/lib/features/session_list/session_list_content.dart
@@ -21,12 +21,15 @@ Future<void> refreshSessionList(BuildContext context) async {
   final loc = context.loc;
   final success = await context.read<SessionListCubit>().refreshSessions(waitForPrData: true);
   if (!context.mounted) return;
-  // One pull, one report. The same gesture that reaches this also crosses the
-  // deeper threshold, and the scan row it started already says the list is
-  // being brought up to date — a toast beside it would announce the smaller
-  // half of the same action.
-  if (context.read<SessionListCubit>().state case SessionListLoaded(catalogScan: final scan) when scan.isLive) {
-    return;
+  // One pull, one report — but only for a confirmation. A live scan row already
+  // says the list is being brought up to date, so a "Sessions updated" toast
+  // beside it announces the smaller half of the same action. A *failure* is
+  // never suppressed: the row reports the scan, not this read, and a pull that
+  // silently did nothing is worse than one toast too many.
+  if (success) {
+    if (context.read<SessionListCubit>().state case SessionListLoaded(catalogScan: final scan) when scan.isLive) {
+      return;
+    }
   }
 
   PregoPopupAlertPresenter.of(context).show(

--- a/client/app/lib/features/session_list/session_list_content.dart
+++ b/client/app/lib/features/session_list/session_list_content.dart
@@ -21,6 +21,13 @@ Future<void> refreshSessionList(BuildContext context) async {
   final loc = context.loc;
   final success = await context.read<SessionListCubit>().refreshSessions(waitForPrData: true);
   if (!context.mounted) return;
+  // One pull, one report. The same gesture that reaches this also crosses the
+  // deeper threshold, and the scan row it started already says the list is
+  // being brought up to date — a toast beside it would announce the smaller
+  // half of the same action.
+  if (context.read<SessionListCubit>().state case SessionListLoaded(catalogScan: final scan) when scan.isLive) {
+    return;
+  }
 
   PregoPopupAlertPresenter.of(context).show(
     title: success ? loc.sessionListRefreshSuccess : loc.sessionListRefreshFailed,

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -1035,13 +1035,13 @@
   "@catalogScanPullCaption": {
     "description": "Caption under the pull-to-refresh spinner once the pull has passed the ordinary trigger, inviting the user to keep pulling to start a full catalog scan."
   },
-  "catalogScanDeepCaption": "Scanning for new sessions",
-  "@catalogScanDeepCaption": {
-    "description": "Caption under the pull-to-refresh spinner once the deep pull has fired and the catalog scan has already started."
-  },
   "catalogScanRunningTitle": "Scanning all harnesses",
   "@catalogScanRunningTitle": {
     "description": "Title of the row above a list while a catalog scan is in flight across every enabled harness."
+  },
+  "catalogScanStartingDetail": "Starting…",
+  "@catalogScanStartingDetail": {
+    "description": "Supporting line on the scan row between dispatch and the first progress event, when no harness has reported yet. Holds the line's place so the row does not change height when the real detail arrives."
   },
   "catalogScanRunningDetail": "{harness} — {sessions, plural, =1{1 session} other{{sessions} sessions}}",
   "@catalogScanRunningDetail": {

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -3277,17 +3277,17 @@ abstract class AppLocalizations {
   /// **'Keep pulling to scan all harnesses'**
   String get catalogScanPullCaption;
 
-  /// Caption under the pull-to-refresh spinner once the deep pull has fired and the catalog scan has already started.
-  ///
-  /// In en, this message translates to:
-  /// **'Scanning for new sessions'**
-  String get catalogScanDeepCaption;
-
   /// Title of the row above a list while a catalog scan is in flight across every enabled harness.
   ///
   /// In en, this message translates to:
   /// **'Scanning all harnesses'**
   String get catalogScanRunningTitle;
+
+  /// Supporting line on the scan row between dispatch and the first progress event, when no harness has reported yet. Holds the line's place so the row does not change height when the real detail arrives.
+  ///
+  /// In en, this message translates to:
+  /// **'Starting…'**
+  String get catalogScanStartingDetail;
 
   /// Supporting line on the running scan row: the harness currently being scanned and how many sessions it has reported so far.
   ///

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -1747,10 +1747,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get catalogScanPullCaption => 'Keep pulling to scan all harnesses';
 
   @override
-  String get catalogScanDeepCaption => 'Scanning for new sessions';
+  String get catalogScanRunningTitle => 'Scanning all harnesses';
 
   @override
-  String get catalogScanRunningTitle => 'Scanning all harnesses';
+  String get catalogScanStartingDetail => 'Starting…';
 
   @override
   String catalogScanRunningDetail(String harness, int sessions) {

--- a/client/app/test/core/widgets/catalog_scan_row_test.dart
+++ b/client/app/test/core/widgets/catalog_scan_row_test.dart
@@ -3,6 +3,7 @@ import "package:material_ui/material_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/core/widgets/catalog_scan_row.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
 import "package:theme_prego/module_prego.dart";
 
 void main() {
@@ -16,17 +17,26 @@ void main() {
 
   /// Pumps the row and runs its reveal to completion, so the card is at full
   /// height and hittable. A live row spins forever, so this never settles.
-  Future<void> pumpRow(WidgetTester tester, CatalogRescanState scan) async {
+  Future<void> pumpRow(
+    WidgetTester tester,
+    CatalogRescanState scan, {
+    bool reducedMotion = false,
+  }) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(extensions: [PregoDesignSystem.light]),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
-          body: CatalogScanRow(
-            scan: scan,
-            onCancel: () => cancelCount++,
-            onDismiss: () => dismissCount++,
+          body: Builder(
+            builder: (context) => MediaQuery(
+              data: MediaQuery.of(context).copyWith(disableAnimations: reducedMotion),
+              child: CatalogScanRow(
+                scan: scan,
+                onCancel: () => cancelCount++,
+                onDismiss: () => dismissCount++,
+              ),
+            ),
           ),
         ),
       ),
@@ -219,6 +229,77 @@ void main() {
           const CatalogRescanState.running(activePluginName: "Codex", sessionsSeen: 9, pluginIds: {"codex"}),
         ),
         isFalse,
+      );
+    });
+
+    // SizeTransition only changes layout, so a retained card would keep its
+    // labels and its live action button reachable by keyboard at zero height.
+    testWidgets("unmounts the card once it has folded away", (tester) async {
+      await pumpRow(tester, const CatalogRescanState.failed(harnessCount: 1));
+      final loc = await AppLocalizations.delegate.load(const Locale("en"));
+      expect(find.text(loc.catalogScanDismiss, skipOffstage: false), findsOneWidget);
+
+      await pumpRow(tester, const CatalogRescanState.idle());
+
+      expect(
+        find.text(loc.catalogScanDismiss, skipOffstage: false),
+        findsNothing,
+        reason: "an invisible action must not stay in the tree",
+      );
+      expect(find.byType(PregoButtonsSolid, skipOffstage: false), findsNothing);
+    });
+
+    testWidgets("arrives without a transition when the OS asks for reduced motion", (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(extensions: [PregoDesignSystem.light]),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => MediaQuery(
+                data: MediaQuery.of(context).copyWith(disableAnimations: true),
+                child: CatalogScanRow(
+                  scan: const CatalogRescanState.idle(),
+                  onCancel: () => cancelCount++,
+                  onDismiss: () => dismissCount++,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      // Rebuilt in place and pumped exactly one frame — far short of the 260ms
+      // transition, so any height at all means it never ran.
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(extensions: [PregoDesignSystem.light]),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => MediaQuery(
+                data: MediaQuery.of(context).copyWith(disableAnimations: true),
+                child: CatalogScanRow(
+                  scan: const CatalogRescanState.starting(pluginIds: {"codex"}),
+                  onCancel: () => cancelCount++,
+                  onDismiss: () => dismissCount++,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 16));
+      final afterOneFrame = tester.getSize(find.byType(CatalogScanRow, skipOffstage: false)).height;
+      await tester.pump(const Duration(milliseconds: 400));
+      final settled = tester.getSize(find.byType(CatalogScanRow, skipOffstage: false)).height;
+
+      expect(settled, greaterThan(0));
+      expect(
+        afterOneFrame,
+        settled,
+        reason: "reduced motion means the row is simply there, not part-way through arriving",
       );
     });
 

--- a/client/app/test/core/widgets/catalog_scan_row_test.dart
+++ b/client/app/test/core/widgets/catalog_scan_row_test.dart
@@ -14,8 +14,10 @@ void main() {
     dismissCount = 0;
   });
 
-  Future<void> pumpRow(WidgetTester tester, CatalogRescanState scan) {
-    return tester.pumpWidget(
+  /// Pumps the row and runs its reveal to completion, so the card is at full
+  /// height and hittable. A live row spins forever, so this never settles.
+  Future<void> pumpRow(WidgetTester tester, CatalogRescanState scan) async {
+    await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(extensions: [PregoDesignSystem.light]),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -29,14 +31,41 @@ void main() {
         ),
       ),
     );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
   }
 
   group("CatalogScanRow", () {
-    testWidgets("renders nothing at all while idle", (tester) async {
+    testWidgets("takes no space at all while idle", (tester) async {
       await pumpRow(tester, const CatalogRescanState.idle());
 
-      expect(find.byType(PregoInlineAlertsNotifications), findsNothing);
-      expect(tester.getSize(find.byType(CatalogScanRow)).height, 0);
+      final loc = await AppLocalizations.delegate.load(const Locale("en"));
+      expect(find.text(loc.catalogScanRunningTitle), findsNothing);
+      expect(tester.getSize(find.byType(CatalogScanRow, skipOffstage: false)).height, 0);
+    });
+
+    // The detail line is rendered even before a harness reports, so the row
+    // does not shove the list down a second time when the first event lands.
+    testWidgets("keeps the same height from starting through running", (tester) async {
+      Future<double> heightFor(CatalogRescanState scan) async {
+        await pumpRow(tester, scan);
+        return tester.getSize(find.byType(CatalogScanRow)).height;
+      }
+
+      final starting = await heightFor(const CatalogRescanState.starting(pluginIds: {"codex"}));
+      final running = await heightFor(
+        const CatalogRescanState.running(activePluginName: "Codex", sessionsSeen: 148, pluginIds: {"codex"}),
+      );
+      final done = await heightFor(
+        const CatalogRescanState.succeeded(
+          harnessCount: 1,
+          counts: CatalogRescanCounts.delta(newProjects: 0, newSessions: 3),
+        ),
+      );
+
+      expect(starting, greaterThan(0));
+      expect(running, starting);
+      expect(done, starting);
     });
 
     testWidgets("reports the scan before any harness has reported progress", (tester) async {

--- a/client/app/test/features/project_list/project_list_catalog_scan_test.dart
+++ b/client/app/test/features/project_list/project_list_catalog_scan_test.dart
@@ -86,9 +86,14 @@ void main() {
     return await AppLocalizations.delegate.load(const Locale("en"));
   }
 
-  /// Publishes [scan] and lets the list rebuild around it.
+  /// Publishes [scan] and runs the row's reveal to completion.
+  ///
+  /// Three frames, not two: the first rebuilds the list around the new state,
+  /// the second is the reveal's first tick — which only establishes its start
+  /// time — and the third carries it to the end.
   Future<void> emitScan(WidgetTester tester, CatalogRescanState scan) async {
     rescanService.emit(scan);
+    await tester.pump();
     await tester.pump();
     await tester.pump(_rowSettled);
   }
@@ -119,7 +124,9 @@ void main() {
     // is why the row that reports it has to offer its own cancel.
     await pullFurtherUntil(tester, gesture, () => rescanService.startAllCalls > 0);
     expect(rescanService.startAllCalls, 1);
-    expect(find.text(loc.catalogScanDeepCaption), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 300));
+    // The control hands reporting to the scan row and says nothing more.
+    expect(find.text(loc.catalogScanPullCaption), findsNothing);
 
     // Still one scan however much further the same pull travels.
     await pullFurtherUntil(tester, gesture, () => false);
@@ -131,7 +138,7 @@ void main() {
 
   testWidgets("reports a running scan above the list without displacing it", (tester) async {
     final loc = await pumpLoadedList(tester);
-    expect(find.byType(PregoInlineAlertsNotifications), findsNothing);
+    expect(find.text(loc.catalogScanRunningTitle), findsNothing);
 
     await emitScan(
       tester,
@@ -146,11 +153,12 @@ void main() {
   testWidgets("clears the row once the scan is dismissed", (tester) async {
     await pumpLoadedList(tester);
 
+    final loc = await AppLocalizations.delegate.load(const Locale("en"));
     await emitScan(tester, const CatalogRescanState.starting(pluginIds: {"codex"}));
-    expect(find.byType(PregoInlineAlertsNotifications), findsOneWidget);
+    expect(find.text(loc.catalogScanRunningTitle), findsOneWidget);
 
     await emitScan(tester, const CatalogRescanState.idle());
-    expect(find.byType(PregoInlineAlertsNotifications), findsNothing);
+    expect(find.text(loc.catalogScanRunningTitle), findsNothing);
     expect(find.text("My Project"), findsOneWidget);
   });
 

--- a/client/module_prego/lib/components/navigation/prego_sliver_refresh_control.dart
+++ b/client/module_prego/lib/components/navigation/prego_sliver_refresh_control.dart
@@ -5,9 +5,9 @@ import "package:material_ui/material_ui.dart";
 import "../../module_prego.dart";
 
 /// How much further than the normal trigger a pull must travel to arm the
-/// second stage. Far enough that an ordinary refresh never reaches it, close
-/// enough to be discoverable once the caption appears.
-const double _deepPullFactor = 1.6;
+/// second stage. Far enough that an ordinary refresh never reaches it by
+/// accident, close enough to be discoverable once the caption appears.
+const double _deepPullFactor = 1.8;
 
 /// A second stage for a pull-to-refresh, opted into with its captions.
 ///
@@ -23,13 +23,10 @@ class const PregoDeepRefresh({
   required final void Function() onDeepRefresh,
 
   /// Shown once the pull passes the ordinary trigger, inviting the user to
-  /// keep going.
+  /// keep going. It is the only thing this control says: once the threshold is
+  /// crossed the control empties itself and the host's own progress surface
+  /// takes over reporting.
   required final String pullCaption,
-
-  /// Shown once [onDeepRefresh] has fired, so the caption reports what has
-  /// already started rather than what releasing would do. It gives way to the
-  /// host's own progress surface as the pull retracts.
-  required final String deepCaption,
 });
 
 /// The pull-to-refresh control every Prego surface uses.
@@ -109,6 +106,15 @@ class _PregoSliverRefreshControlState() extends State<PregoSliverRefreshControl>
           );
         }
 
+        // Once the second stage has fired the control has nothing left to say:
+        // the host's own progress surface is already on screen reporting the
+        // run, so a spinner and a caption beside it would report the same thing
+        // twice. Emptying it also stops the pulled area from reading as
+        // something still waiting to happen.
+        if (_deepFired) {
+          return widget._decorate?.call(context, const SizedBox.shrink()) ?? const SizedBox.shrink();
+        }
+
         final indicator = CupertinoSliverRefreshControl.buildRefreshIndicator(
           context,
           refreshState,
@@ -116,20 +122,15 @@ class _PregoSliverRefreshControlState() extends State<PregoSliverRefreshControl>
           triggerDistance,
           indicatorExtent,
         );
-        // Both phases follow the *live* extent, because the extent is what
+        // The caption follows the *live* extent, because the extent is what
         // decides whether there is room. Once the finger lifts the control
         // collapses to a held indicator extent far shorter than the trigger,
         // and a caption pinned inside it would sit on top of the spinner.
-        // Retracting loses nothing: the host's progress surface takes over as
-        // the pull collapses, which is where the rest of the run is reported.
-        final caption = deepRefresh == null || pulledExtent <= triggerDistance
-            ? null
-            : _deepFired
-            ? deepRefresh.deepCaption
-            : deepRefresh.pullCaption;
-        final content = caption == null
-            ? indicator
-            : _CaptionedIndicator(indicator: indicator, caption: caption, fired: _deepFired);
+        final invite = deepRefresh != null && pulledExtent > triggerDistance;
+        final content = _CaptionedIndicator(
+          indicator: indicator,
+          caption: invite ? deepRefresh.pullCaption : null,
+        );
         return widget._decorate?.call(context, content) ?? content;
       },
     );
@@ -138,7 +139,7 @@ class _PregoSliverRefreshControlState() extends State<PregoSliverRefreshControl>
 
 }
 
-/// The stock indicator with the stage-two caption beneath it.
+/// The stock indicator with the stage-two invitation beneath it.
 ///
 /// Both sit inside the extent the refresh control already reserved, so the
 /// caption never paints over the first row of the list below. The control
@@ -146,22 +147,24 @@ class _PregoSliverRefreshControlState() extends State<PregoSliverRefreshControl>
 /// trigger distance whenever a caption is shown, so there is always room.
 class const _CaptionedIndicator({
   required final Widget indicator,
-  required final String caption,
-  required final bool fired,
+  required final String? _caption,
 }) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
+    final caption = _caption;
     return Stack(
       alignment: Alignment.center,
       children: [
         indicator,
         Positioned(
           bottom: prego.spacing.md,
-          // Cross-faded and keyed on the phase, so passing the threshold reads
-          // as one label becoming another rather than a flicker.
+          // Faded in and out against an empty box rather than switched between
+          // captions, so the invitation arrives as the pull reaches the trigger
+          // instead of appearing fully formed. Backing off below the trigger
+          // fades it away again.
           child: AnimatedSwitcher(
-            duration: const Duration(milliseconds: 160),
+            duration: const Duration(milliseconds: 180),
             switchInCurve: Curves.easeOut,
             switchOutCurve: Curves.easeIn,
             transitionBuilder: (child, animation) => FadeTransition(
@@ -171,13 +174,9 @@ class const _CaptionedIndicator({
                 child: child,
               ),
             ),
-            child: _CaptionLabel(
-              // The phase, not the text: a host changing wording mid-pull must
-              // not look like the stage changed.
-              key: ValueKey(fired),
-              caption: caption,
-              fired: fired,
-            ),
+            child: caption == null
+                ? const SizedBox.shrink()
+                : _CaptionLabel(key: const ValueKey("invite"), caption: caption),
           ),
         ),
       ],
@@ -185,38 +184,26 @@ class const _CaptionedIndicator({
   }
 }
 
-/// One phase of the caption.
-///
-/// The invitation is quiet and text-only. Once the second stage has fired the
-/// label takes the brand colour and gains its icon, so the moment of commitment
-/// is visible at a glance rather than needing the wording to be read.
+/// The quiet, text-only invitation to keep pulling.
 class const _CaptionLabel({
   super.key,
   required final String caption,
-  required final bool fired,
 }) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
-    final color = fired ? prego.colors.textBrandSecondary : prego.colors.textTertiary;
+    // Flexible so the ellipsis can actually engage: a Row measures a plain
+    // Text against the space it asks for, so at large accessibility text
+    // scales an unconstrained label overflows instead of truncating.
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (fired) ...[
-          Icon(TablerRegular.rotate_clockwise, size: prego.spacing.lg, color: color),
-          SizedBox(width: prego.spacing.sm),
-        ],
-        // Flexible so the ellipsis can actually engage: a Row measures a plain
-        // Text against the space it asks for, so at large accessibility text
-        // scales an unconstrained label overflows instead of truncating.
         Flexible(
           child: Text(
             caption,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
-            style: fired
-                ? prego.textTheme.textXs.medium.copyWith(color: color)
-                : prego.textTheme.textXs.regular.copyWith(color: color),
+            style: prego.textTheme.textXs.regular.copyWith(color: prego.colors.textTertiary),
           ),
         ),
       ],

--- a/client/module_prego/test/components/prego_sliver_refresh_control_test.dart
+++ b/client/module_prego/test/components/prego_sliver_refresh_control_test.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:cupertino_ui/cupertino_ui.dart" show CupertinoActivityIndicator;
 import "package:flutter_test/flutter_test.dart";
 import "package:material_ui/material_ui.dart";
 import "package:theme_prego/module_prego.dart";
@@ -8,7 +9,7 @@ import "package:theme_prego/module_prego.dart";
 /// the deep stage arms at 160. Drags keep a margin on their side of each
 /// threshold, since a drag loses some distance to touch slop.
 const double _softTrigger = 100;
-const double _deepTrigger = _softTrigger * 1.6;
+const double _deepTrigger = _softTrigger * 1.8;
 
 void main() {
   group("PregoSliverRefreshControl", () {
@@ -35,7 +36,6 @@ void main() {
                     ? PregoDeepRefresh(
                         onDeepRefresh: () => deepRefreshes++,
                         pullCaption: "Keep pulling to scan all harnesses",
-                        deepCaption: "Scanning for new sessions",
                       )
                     : null,
               ),
@@ -99,45 +99,38 @@ void main() {
       expect(deepRefreshes, 0);
     });
 
-    testWidgets("captions appear only past the ordinary trigger and switch at the deep one", (
+    testWidgets("the invitation appears past the ordinary trigger and is gone once fired", (
       tester,
     ) async {
       await tester.pumpWidget(harness(withDeepRefresh: true));
       final gesture = await tester.startGesture(const Offset(200, 100));
 
-      // Bouncing physics damps overscroll, so the captions are driven by a
-      // gradual pull and asserted on their order rather than on a distance.
-      final order = <String>[];
-      void record() {
-        if (find.text("Keep pulling to scan all harnesses").evaluate().isNotEmpty) order.add("pull");
-        if (find.text("Scanning for new sessions").evaluate().isNotEmpty) order.add("deep");
-      }
+      // Bouncing physics damps overscroll, so the caption is driven by a
+      // gradual pull and asserted on its order rather than on a distance.
+      var invited = false;
 
       await gesture.moveBy(const Offset(0, 20));
       await tester.pump();
       expect(find.text("Keep pulling to scan all harnesses"), findsNothing);
-      expect(find.text("Scanning for new sessions"), findsNothing);
 
       for (var step = 0; step < 16; step++) {
         await gesture.moveBy(const Offset(0, 40));
         await tester.pump();
-        record();
+        if (find.text("Keep pulling to scan all harnesses").evaluate().isNotEmpty) invited = true;
       }
+      await tester.pump(const Duration(milliseconds: 300));
 
-      expect(order, contains("pull"), reason: "a pull past the trigger must invite the second stage");
-      expect(order, contains("deep"), reason: "and report once the rescan has fired");
-      expect(
-        order.indexOf("pull"),
-        lessThan(order.indexOf("deep")),
-        reason: "the invitation comes before the rescan",
-      );
-      expect(order.last, "deep");
+      expect(invited, isTrue, reason: "a pull past the trigger must invite the second stage");
+      expect(deepRefreshes, 1);
+      // Crossing the threshold hands reporting to the host's own row, so the
+      // control says nothing more rather than narrating the same run twice.
+      expect(find.text("Keep pulling to scan all harnesses"), findsNothing);
 
       await gesture.up();
       await tester.pumpAndSettle();
     });
 
-    testWidgets("the fired caption is visually distinct from the invitation", (tester) async {
+    testWidgets("the control empties itself once the second stage has fired", (tester) async {
       await tester.pumpWidget(harness(withDeepRefresh: true));
       final gesture = await tester.startGesture(const Offset(200, 100));
 
@@ -147,16 +140,17 @@ void main() {
         await tester.pump();
       }
       expect(find.text("Keep pulling to scan all harnesses"), findsOneWidget);
-      expect(find.byIcon(TablerRegular.rotate_clockwise), findsNothing);
+      expect(find.byType(CupertinoActivityIndicator), findsWidgets);
 
-      // Past the deep threshold: the label gains its icon.
-      for (var step = 0; step < 6; step++) {
+      // Past the deep threshold: caption and spinner both go, because the
+      // host's progress row is what reports the run from here.
+      for (var step = 0; step < 8; step++) {
         await gesture.moveBy(const Offset(0, 40));
         await tester.pump();
       }
       await tester.pump(const Duration(milliseconds: 300));
-      expect(find.text("Scanning for new sessions"), findsOneWidget);
-      expect(find.byIcon(TablerRegular.rotate_clockwise), findsOneWidget);
+      expect(find.text("Keep pulling to scan all harnesses"), findsNothing);
+      expect(find.byType(CupertinoActivityIndicator), findsNothing);
 
       await gesture.up();
       await tester.pumpAndSettle();
@@ -181,7 +175,6 @@ void main() {
                   deepRefresh: PregoDeepRefresh(
                     onDeepRefresh: () => deepRefreshes++,
                     pullCaption: "Keep pulling to scan all harnesses",
-                    deepCaption: "Scanning for new sessions",
                   ),
                 ),
                 SliverList.list(
@@ -202,6 +195,9 @@ void main() {
 
       await gesture.up();
       await tester.pump();
+      // Two frames: the first settles the extent, which is what tells the
+      // caption to leave; the second runs its fade-out to completion.
+      await tester.pump(const Duration(milliseconds: 500));
       await tester.pump(const Duration(milliseconds: 300));
 
       expect(
@@ -255,7 +251,6 @@ void main() {
                   deepRefresh: PregoDeepRefresh(
                     onDeepRefresh: () => deepRefreshes++,
                     pullCaption: "Keep pulling to scan all harnesses",
-                    deepCaption: "Scanning for new sessions",
                   ),
                 ),
                 SliverList.list(
@@ -273,17 +268,17 @@ void main() {
         await tester.pump();
       }
       await tester.pump(const Duration(milliseconds: 300));
-      expect(find.text("Scanning for new sessions"), findsOneWidget);
       expect(deepRefreshes, 1);
+      expect(find.text("Keep pulling to scan all harnesses"), findsNothing);
 
       await gesture.up();
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 300));
 
       expect(
-        find.text("Scanning for new sessions"),
+        find.text("Keep pulling to scan all harnesses"),
         findsNothing,
-        reason: "the held extent cannot hold a caption without covering the spinner",
+        reason: "a fired pull leaves nothing behind for the held extent to show",
       );
 
       completer.complete();
@@ -309,7 +304,6 @@ void main() {
                     deepRefresh: PregoDeepRefresh(
                       onDeepRefresh: () => deepRefreshes++,
                       pullCaption: "Keep pulling to scan every harness for sessions you have not seen",
-                      deepCaption: "Scanning for new sessions",
                     ),
                   ),
                   SliverList.list(


### PR DESCRIPTION
## Complexity

⚙️ Moderate. One widget rewritten, the shared refresh control's second stage
reworked, and two toast call sites gated.

## What

Owner feedback from a running build, all eight points.

| Reported | Change |
|---|---|
| The row is a big black box on a light background | It was `PregoInlineAlertsNotifications`, which paints `colors.fgPrimary` — the contrast-inverted foreground, built to interrupt. Replaced with a tinted card in the state's own colour family (`bgSecondary` / `bgSuccessPrimary` / `bgWarningPrimary` / `bgErrorPrimary`) with a hairline border, an 18pt mark, and a small tertiary action |
| It enters without a subtitle, then jumps when one arrives | The supporting line is always rendered. `starting` gets its own "Starting…" so the row's height is identical from dispatch through running to the result |
| Enter and exit are jarring | `SizeTransition` + `FadeTransition` from the top edge, driven from `didUpdateWidget` rather than `build`. A scan already running when the row mounts starts at full height — revisiting a list mid-scan is not an arrival |
| Soft and full refresh both fire | The ordinary refresh no longer raises its toast when the same gesture started a scan. One pull, one report |
| The invitation should animate in | Cross-faded against an empty box, so it arrives as the pull reaches the trigger instead of appearing fully formed |
| The invitation should disappear once the threshold is passed | It does, and so does the spinner: past the threshold the control renders nothing at all, because the row is already on screen reporting the run |
| The indicator should not stay pulled once the row shows | Same change — the pulled area is empty from the moment the second stage fires |
| 1.6x is too easy to trigger | Now 1.8x |

`PregoDeepRefresh` loses `deepCaption`: the control has nothing to say after
firing, so the second caption had no reader.

## Why

The row was reached by picking the design system's existing inline alert rather
than building something new. That was the right instinct and the wrong
component: the alert is an interrupt surface, and this is ambient status for
something the user started and that clears itself.

## Risk and test focus

No database impact. No wire-contract change. Client-only, and no behaviour
changes — this is what the feature looks and feels like, not what it does.

Worth a look in review:

- **The two-frame reveal.** Starting an `AnimationController` from `build`
  raced its own frame and left the row at zero height inside a sliver — which is
  also why the earlier `AnimatedSize` attempt never grew. It is now driven from
  `didUpdateWidget`, and the tests pump the extra frame a controller needs
  before its first tick carries any elapsed time.
- **The toast suppression** reads the cubit's own `catalogScan` at report time
  rather than threading a flag through the gesture. A pull fast enough to cross
  1.8x before the ordinary refresh's fetch resolves is the normal case, so this
  holds in practice; if the fetch were to resolve first, the worst outcome is
  the old behaviour of one extra toast.
- **The overscroll itself** still holds its extent while the finger is down —
  that is scroll physics, not something the control can cancel mid-gesture. The
  area it holds is now empty, which is the part that was reading as "something
  is still about to happen".

## Expected result

Pulling a list past the ordinary trigger fades in "Keep pulling to scan all
harnesses". Pulling to 1.8x starts the scan, and the caption and spinner
disappear at once, leaving an empty pulled area that retracts on release. A
light tinted card grows in at the top of the list, keeps one height throughout,
and folds away when the scan clears. No refresh toast accompanies it.

## Verification

- `flutter analyze lib test` in `client/app` and `client/module_prego` — clean
- `client/module_prego` suite — 232 passed
- `client/app` suite — 884 passed
- `flutter gen-l10n` output committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quiets the catalog rescan UI and deep pull-to-refresh so they report once, smoothly, and without interrupting the list. Previously the row used an inline alert and a second-stage caption; now it’s a constant-height tinted card with a fade/size reveal; the deep pull invites at 1.8x and goes silent once fired; refresh toasts are suppressed while a scan is live.

- The scan row is a tinted card with steady height and a “Starting…” detail to avoid layout jumps.
- The row reveals with size+fade (260ms) and folds away; animation is driven from lifecycle, not build.
- The deep pull invite cross-fades in past the normal trigger; once the threshold fires, the control renders nothing and hands off to the row.
- Deep pull threshold increases from 1.6x to 1.8x.
- Project and session lists no longer show a refresh toast if the same pull started a scan.

**Migration**
- `PregoDeepRefresh` no longer accepts `deepCaption`; remove this argument at call sites.
- Replace the removed `catalogScanDeepCaption` with the new `catalogScanStartingDetail` key and run flutter gen-l10n.

<sup>Written for commit c76c87ed03b41e1c0abb92d11390bd61395146cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

