### PR TITLE
🌿 [catalog-rescan] Report a Settings scan's outcome [step 6e/8]

### DIFF
--- a/.plan/active/catalog-rescan/PLAN.md
+++ b/.plan/active/catalog-rescan/PLAN.md
@@ -986,6 +986,13 @@ reviewer of one PR can see what belongs to it.
 - **6c** owns `PluginManagementCubit`'s subscription and
   `startCatalogScanFor(pluginId)`, the Settings action, its enablement and
   rejection, and its resources.
+- **6d** is owner feedback from a running build: the row's weight and its
+  transitions, the pull's threshold and captions, and one report per pull.
+- **6e** is how a Settings-started scan reports the way it ended. Not in the
+  original plan, and the gap it closes was created by the plan itself: the
+  aggregate row is hosted only by the three lists, and a success clears itself
+  after four seconds, so a scan started from Settings had its outcome published
+  where the user could never see it.
 
 ### Scope
 

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -676,5 +676,21 @@ duplicate-emission nicety.
   `dart analyze --fatal-infos lib test` clean on `client/module_core`; app 897
   tests passed, module_core 1,381 passed (9 new: 6 cubit, 3 widget). The popup
   test was confirmed to fail with the presenter call removed
+- **Step 6e review:** `architecture-implementation-review` **approved** with no
+  architectural findings. It confirmed `CatalogRescanOutcome` narrows the
+  service's eight states to the three a started scan can reach, so
+  `scanOutcome: running` is unrepresentable; that `scanOutcome` is carried
+  across a snapshot rebuild the way 6a's review required; that Freezed's
+  `copyWith(scanOutcome: null)` genuinely clears rather than no-ops, so the
+  popup cannot re-fire; and that `catalogScanCountsLine` belongs in
+  `core/widgets/` beside its two consumers, since it takes `AppLocalizations`
+  and could not move to module_core
+- **Step 6e claim leak:** the review traced one path where `_reportsScanOutcome`
+  survived its run — on a disconnect `PluginManagementService` emits `loading`
+  before `CatalogRescanService` emits `idle`, so the drop sat behind the
+  readiness check and never ran. It judged the leak unreachable today and did
+  not require a fix, but a regression test reproduced it directly: the claim
+  attached to the next run's outcome. Closed by dropping the claim before the
+  readiness check
 - **Step 6e PR:** pending
 - **Final disposition:** pending

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -5,9 +5,9 @@
 - **Plan slug:** `catalog-rescan`
 - **Implementation base:** `main` at
   `7b1ebe9bc629d05b5d104e76cd5dbaa1514d65a2`
-- **Series state:** Steps 1/8 to 6c/8 merged; Step 6d/8 open
-- **Current step:** quieten the scan row and its pull
-- **Next action:** land 6d, then reconcile projects-and-sessions.md in step 7
+- **Series state:** Steps 1/8 to 6d/8 merged; Step 6e/8 open
+- **Current step:** report a Settings-started scan's outcome
+- **Next action:** land 6e, then reconcile projects-and-sessions.md in step 7
 - **Origin issue:** [#961](https://github.com/sesori-ai/sesori_apps_monorepo/issues/961)
 - **External overlap:** [#1008](https://github.com/sesori-ai/sesori_apps_monorepo/issues/1008)
   owns Codex live updates; do not address it here
@@ -140,7 +140,8 @@
 | [x] | 6a/8 | `⚙️ [catalog-rescan] Route scan state through the list cubits [step 6a/8]` | 450-750 | Merged |
 | [x] | 6b/8 | `⚙️ [catalog-rescan] Show the catalog scan in the lists [step 6b/8]` | 500-800 | [PR #1103](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1103) merged |
 | [x] | 6c/8 | `🌿 [catalog-rescan] Scan one harness from Settings [step 6c/8]` | 350-600 | [PR #1113](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1113) merged |
-| [ ] | 6d/8 | `⚙️ [catalog-rescan] Quieten the scan row and its pull [step 6d/8]` | 400-700 | [PR #1114](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1114) open |
+| [x] | 6d/8 | `⚙️ [catalog-rescan] Quieten the scan row and its pull [step 6d/8]` | 400-700 | [PR #1114](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1114) merged |
+| [ ] | 6e/8 | `🌿 [catalog-rescan] Report a Settings scan's outcome [step 6e/8]` | 350-600 | Open |
 | [ ] | 7/8 | `🌱 [catalog-rescan] Reconcile catalog rescan regression docs [step 7/8]` | 80-160 | Not started |
 | [ ] | 8/8 | `🌱 [catalog-rescan] Verify and retire the catalog rescan plan [step 8/8]` | 60-140 | Not started |
 
@@ -656,4 +657,24 @@ duplicate-emission nicety.
   through two stateless session hosts to restore a success confirmation for a
   shallow pull taken during someone else's scan, where a progress row is already
   on screen
+- **Step 6e origin:** owner question — does a Settings-started scan indicate
+  success? It does not, and the gap is one this plan created. The aggregate row
+  is hosted only by the three lists, and `_successVisibleFor` clears a success
+  after four seconds, so the outcome of a Settings-started scan was published
+  where its user could never reach it. Only start-time rejections showed there;
+  a scan that started fine and then failed was equally silent
+- **Step 6e approach:** owner chose a popup on completion over hosting the
+  aggregate row on Settings or reporting inline on the card
+- **Step 6e ownership:** the cubit claims the run at dispatch, before the start
+  request resolves, because the run can reach a terminal state while that
+  request is still awaiting its own response. A start the bridge refuses drops
+  the claim, since the card already reports it; so does a run that ends without
+  a terminal state, so a dropped claim cannot attach itself to the next run
+- **Step 6e wording reuse:** `catalogScanCountsLine` was lifted out of
+  `CatalogScanRow` so the row and the popup cannot describe one scan two ways
+- **Step 6e verification:** `flutter analyze lib test` clean on `client/app`;
+  `dart analyze --fatal-infos lib test` clean on `client/module_core`; app 897
+  tests passed, module_core 1,381 passed (9 new: 6 cubit, 3 widget). The popup
+  test was confirmed to fail with the presenter call removed
+- **Step 6e PR:** pending
 - **Final disposition:** pending

--- a/.plan/active/catalog-rescan/TRACKER.md
+++ b/.plan/active/catalog-rescan/TRACKER.md
@@ -692,5 +692,24 @@ duplicate-emission nicety.
   not require a fix, but a regression test reproduced it directly: the claim
   attached to the next run's outcome. Closed by dropping the claim before the
   readiness check
-- **Step 6e PR:** pending
+- **Step 6e review comments:** three bot findings, all valid, fixed in
+  `2674825bf9`. Two were the same seam — the single `_reportsScanOutcome` flag.
+  A second card being refused cleared the only claim while the first harness was
+  still running, so that run ended in the silence this step exists to remove;
+  and a definite `CatalogImportMutationFailure` settles the operation *before*
+  `start()` returns, so membership could not tell a refusal from a run that had
+  already finished and been announced, producing both a finished-scan
+  announcement and a could-not-start line for one attempt. Replaced with
+  `Set<String> _scanClaims`: a refusal removes one harness, an announcement
+  spends the set. Both tests confirmed to fail against the old behaviour
+- **Step 6e accessibility gap:** the popup is silent to a screen reader — the
+  only `Semantics` in `prego_popup_alerts_notifications.dart` is its close
+  button — which undercut the step, since a screen-reader user is who this
+  surface is for. The outcome is now also sent through
+  `SemanticsService.sendAnnouncement`. Declined adding a live region to the
+  shared popup component: that fixes every popup in the app and is a
+  design-system change with its own call sites, not part of this step. Worth
+  doing separately
+- **Step 6e PR:** [#1118](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1118)
+  open
 - **Final disposition:** pending

--- a/client/app/lib/core/widgets/catalog_scan_row.dart
+++ b/client/app/lib/core/widgets/catalog_scan_row.dart
@@ -169,7 +169,7 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with SingleTickerProv
       tone: _ScanTone.done,
       icon: TablerRegular.circle_check,
       title: loc.catalogScanCompleteTitle,
-      detail: _countsLine(loc: loc, counts: counts),
+      detail: catalogScanCountsLine(loc: loc, counts: counts),
       actionLabel: loc.catalogScanDismiss,
       onAction: widget._onDismiss,
     ),
@@ -213,31 +213,36 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with SingleTickerProv
     ),
   };
 
-  /// What a finished scan found, sessions first.
-  ///
-  /// A clause counting nothing is dropped rather than joined, so an ordinary
-  /// result reads "3 new sessions" instead of trailing a zero, and a scan that
-  /// only turned up a project does not lead with the sessions it did not find.
-  String _countsLine({required AppLocalizations loc, required CatalogRescanCounts counts}) {
-    final (sessions, projects) = switch (counts) {
-      CatalogRescanDelta(:final newSessions, :final newProjects) => (
-        newSessions == 0 ? null : loc.catalogScanNewSessionCount(newSessions),
-        newProjects == 0 ? null : loc.catalogScanNewProjectCount(newProjects),
-      ),
-      // No delta to report, so the row names what the harnesses published
-      // instead of implying every one of them is new.
-      CatalogRescanTotals(:final sessions, :final projects) => (
-        sessions == 0 ? null : loc.catalogScanSessionCount(sessions),
-        projects == 0 ? null : loc.catalogScanProjectCount(projects),
-      ),
-    };
-    return switch ((sessions, projects)) {
-      (final sessions?, final projects?) => loc.catalogScanCountsJoined(sessions, projects),
-      (final sessions?, null) => sessions,
-      (null, final projects?) => projects,
-      (null, null) => loc.catalogScanNothingNew,
-    };
-  }
+
+}
+
+/// What a finished scan found, sessions first.
+///
+/// A clause counting nothing is dropped rather than joined, so an ordinary
+/// result reads "3 new sessions" instead of trailing a zero, and a scan that
+/// only turned up a project does not lead with the sessions it did not find.
+///
+/// Shared by the row and by the Settings toast, so one scan never reads two
+/// different ways depending on where it is reported.
+String catalogScanCountsLine({required AppLocalizations loc, required CatalogRescanCounts counts}) {
+  final (sessions, projects) = switch (counts) {
+    CatalogRescanDelta(:final newSessions, :final newProjects) => (
+      newSessions == 0 ? null : loc.catalogScanNewSessionCount(newSessions),
+      newProjects == 0 ? null : loc.catalogScanNewProjectCount(newProjects),
+    ),
+    // No delta to report, so the line names what the harnesses published
+    // instead of implying every one of them is new.
+    CatalogRescanTotals(:final sessions, :final projects) => (
+      sessions == 0 ? null : loc.catalogScanSessionCount(sessions),
+      projects == 0 ? null : loc.catalogScanProjectCount(projects),
+    ),
+  };
+  return switch ((sessions, projects)) {
+    (final sessions?, final projects?) => loc.catalogScanCountsJoined(sessions, projects),
+    (final sessions?, null) => sessions,
+    (null, final projects?) => projects,
+    (null, null) => loc.catalogScanNothingNew,
+  };
 }
 
 /// The colour family a scan state reads in.

--- a/client/app/lib/core/widgets/catalog_scan_row.dart
+++ b/client/app/lib/core/widgets/catalog_scan_row.dart
@@ -213,7 +213,6 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with SingleTickerProv
     ),
   };
 
-
 }
 
 /// What a finished scan found, sessions first.

--- a/client/app/lib/features/settings/harnesses_settings_screen.dart
+++ b/client/app/lib/features/settings/harnesses_settings_screen.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:flutter/semantics.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:go_router/go_router.dart";
 import "package:material_ui/material_ui.dart";
@@ -82,6 +83,14 @@ class const _HarnessesSettingsBody({required final HarnessSettingsPresentation p
               ),
             };
             PregoPopupAlertPresenter.of(context).show(title: title, variant: variant);
+            // Announced as well as shown. The popup renders ordinary text into
+            // an overlay, which moves no semantic focus and carries no live
+            // region, so on its own it tells a screen-reader user nothing —
+            // and they are the reason this surface exists, the pull being a
+            // gesture they cannot perform.
+            unawaited(
+              SemanticsService.sendAnnouncement(View.of(context), title, Directionality.of(context)),
+            );
             cubit.dismissCatalogScanOutcome();
           },
         ),

--- a/client/app/lib/features/settings/harnesses_settings_screen.dart
+++ b/client/app/lib/features/settings/harnesses_settings_screen.dart
@@ -12,6 +12,7 @@ import "../../core/di/injection.dart";
 import "../../core/extensions/build_context_x.dart";
 import "../../core/routing/app_router.dart";
 import "../../core/utils/copy_text_to_clipboard.dart";
+import "../../core/widgets/catalog_scan_row.dart";
 import "../../core/widgets/connection_banner.dart";
 import "widgets/settings_section.dart";
 
@@ -55,6 +56,33 @@ class const _HarnessesSettingsBody({required final HarnessSettingsPresentation p
             final confirmation = _forceConfirmation(state);
             if (confirmation == null) return;
             unawaited(_showForceConfirmation(context: context, cubit: cubit, confirmation: confirmation));
+          },
+        ),
+        // This screen hosts no progress row, so a scan started here would
+        // otherwise end in silence: the spinner stops and the service clears
+        // its result before the user could reach a list to read it.
+        BlocListener<PluginManagementCubit, PluginManagementState>(
+          listenWhen: (previous, current) => _scanOutcome(previous) == null && _scanOutcome(current) != null,
+          listener: (context, state) {
+            final outcome = _scanOutcome(state);
+            if (outcome == null) return;
+            final loc = context.loc;
+            final (title, variant) = switch (outcome) {
+              CatalogRescanOutcomeSucceeded(:final counts) => (
+                loc.harnessManagementScanFinished(catalogScanCountsLine(loc: loc, counts: counts)),
+                PregoPopupAlertsNotificationsVariant.success,
+              ),
+              CatalogRescanOutcomePartlyFailed(:final succeededCount, :final failedCount) => (
+                loc.harnessManagementScanPartlyFailed(failedCount, succeededCount + failedCount),
+                PregoPopupAlertsNotificationsVariant.error,
+              ),
+              CatalogRescanOutcomeFailed() => (
+                loc.harnessManagementScanFinishedFailed,
+                PregoPopupAlertsNotificationsVariant.error,
+              ),
+            };
+            PregoPopupAlertPresenter.of(context).show(title: title, variant: variant);
+            cubit.dismissCatalogScanOutcome();
           },
         ),
         BlocListener<PluginManagementCubit, PluginManagementState>(
@@ -125,6 +153,11 @@ PluginAuthenticationPresentationState? _authenticationChallenge({required Plugin
   PluginManagementUnsupported() ||
   PluginManagementFailure() => null,
     };
+
+CatalogRescanOutcome? _scanOutcome(PluginManagementState state) => switch (state) {
+  PluginManagementReady(:final scanOutcome) => scanOutcome,
+  PluginManagementLoading() || PluginManagementUnsupported() || PluginManagementFailure() => null,
+};
 
 PluginManagementActionForceConfirmationRequired? _forceConfirmation(PluginManagementState state) => switch (state) {
   PluginManagementReady(action: final PluginManagementActionForceConfirmationRequired confirmation) => confirmation,

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -1158,6 +1158,32 @@
   "@catalogScanNoHarnessDetail": {
     "description": "Supporting line on the no-harness scan row, naming where the user can see and fix their harness setup."
   },
+  "harnessManagementScanFinished": "Scan complete — {result}",
+  "@harnessManagementScanFinished": {
+    "description": "Popup shown on Settings to Harnesses when a scan started there finishes. The placeholder is the same result wording the lists' scan row uses, so one scan reads the same everywhere.",
+    "placeholders": {
+      "result": {
+        "type": "String",
+        "example": "5 new sessions in 2 new projects"
+      }
+    }
+  },
+  "harnessManagementScanPartlyFailed": "{failed} of {total} harnesses could not be scanned",
+  "@harnessManagementScanPartlyFailed": {
+    "description": "Popup shown on Settings to Harnesses when a scan started there finished with some harnesses failing. Both counts are at least one, so the total is always plural.",
+    "placeholders": {
+      "failed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "harnessManagementScanFinishedFailed": "Scan failed. Check the bridge log for details",
+  "@harnessManagementScanFinishedFailed": {
+    "description": "Popup shown on Settings to Harnesses when a scan started there failed outright. Names the bridge log because this outcome comes from the bridge's own progress events, unlike a request that never reached it."
+  },
   "harnessManagementScan": "Scan for sessions",
   "@harnessManagementScan": {
     "description": "Settings action on a harness card that re-imports that one harness's catalog, the pointer-and-keyboard equivalent of the lists' deep pull."

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -3391,6 +3391,24 @@ abstract class AppLocalizations {
   /// **'Check your harnesses in Settings'**
   String get catalogScanNoHarnessDetail;
 
+  /// Popup shown on Settings to Harnesses when a scan started there finishes. The placeholder is the same result wording the lists' scan row uses, so one scan reads the same everywhere.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan complete — {result}'**
+  String harnessManagementScanFinished(String result);
+
+  /// Popup shown on Settings to Harnesses when a scan started there finished with some harnesses failing. Both counts are at least one, so the total is always plural.
+  ///
+  /// In en, this message translates to:
+  /// **'{failed} of {total} harnesses could not be scanned'**
+  String harnessManagementScanPartlyFailed(int failed, int total);
+
+  /// Popup shown on Settings to Harnesses when a scan started there failed outright. Names the bridge log because this outcome comes from the bridge's own progress events, unlike a request that never reached it.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan failed. Check the bridge log for details'**
+  String get harnessManagementScanFinishedFailed;
+
   /// Settings action on a harness card that re-imports that one harness's catalog, the pointer-and-keyboard equivalent of the lists' deep pull.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -1848,6 +1848,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get catalogScanNoHarnessDetail => 'Check your harnesses in Settings';
 
   @override
+  String harnessManagementScanFinished(String result) {
+    return 'Scan complete — $result';
+  }
+
+  @override
+  String harnessManagementScanPartlyFailed(int failed, int total) {
+    return '$failed of $total harnesses could not be scanned';
+  }
+
+  @override
+  String get harnessManagementScanFinishedFailed => 'Scan failed. Check the bridge log for details';
+
+  @override
   String get harnessManagementScan => 'Scan for sessions';
 
   @override

--- a/client/app/test/features/settings/harnesses_settings_screen_test.dart
+++ b/client/app/test/features/settings/harnesses_settings_screen_test.dart
@@ -1491,6 +1491,53 @@ void main() {
       expect(find.textContaining("secret"), findsNothing);
     });
 
+    // This screen has no progress row, so without the popup a scan started
+    // here ends in silence and its result is auto-cleared before the user
+    // could reach a list to read it.
+    testWidgets("announces what a scan started here found", (tester) async {
+      await openHarnesses(tester);
+      await _openRow(tester, "harness_management_scan_future-harness");
+
+      rescan.emit(
+        const CatalogRescanState.succeeded(
+          harnessCount: 1,
+          counts: CatalogRescanCounts.delta(newProjects: 2, newSessions: 5),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.textContaining("5 new sessions in 2 new projects"), findsOneWidget);
+    });
+
+    testWidgets("announces a failure rather than letting the spinner just stop", (tester) async {
+      await openHarnesses(tester);
+      await _openRow(tester, "harness_management_scan_future-harness");
+
+      rescan.emit(const CatalogRescanState.failed(harnessCount: 1));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      final loc = await AppLocalizations.delegate.load(const Locale("en"));
+      expect(find.text(loc.harnessManagementScanFinishedFailed), findsOneWidget);
+    });
+
+    // The row above that list already reported it.
+    testWidgets("says nothing about a scan a list started", (tester) async {
+      await openHarnesses(tester);
+
+      rescan.emit(
+        const CatalogRescanState.succeeded(
+          harnessCount: 1,
+          counts: CatalogRescanCounts.delta(newProjects: 0, newSessions: 3),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(find.textContaining("3 new sessions"), findsNothing);
+    });
+
     testWidgets("a retry clears the rejection the previous attempt left", (tester) async {
       await openHarnesses(tester);
       rescan.stubStartResult(const CatalogRescanStartResult.notImportable());

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
@@ -26,6 +26,13 @@ class PluginManagementCubit({
   }
 
   final CompositeSubscription _subscriptions = CompositeSubscription();
+
+  /// Whether a scan this screen started is still owed an outcome.
+  ///
+  /// Only a run this screen began is announced here. A scan a list's pull
+  /// started is already reported by the row above that list, and toasting it
+  /// again on an unrelated screen would report one run in two places.
+  bool _reportsScanOutcome = false;
   int _actionGeneration = 0;
   int _authenticationGeneration = 0;
 
@@ -205,16 +212,30 @@ class PluginManagementCubit({
     // Drop any earlier rejection first, so a retry does not read as though it
     // had already failed again before the answer arrives.
     _setScanRejection(pluginId: pluginId, result: null);
+    // Claimed before dispatch, not after: the run can reach a terminal state
+    // while this request is still awaiting its own response.
+    _reportsScanOutcome = true;
     final result = await _catalogRescanService.start(pluginId: pluginId);
     if (isClosed) return;
+    final joined = result is CatalogRescanStartAccepted || _scanningPluginIds.contains(pluginId);
+    // A start the bridge refused outright never becomes an outcome: the card
+    // reports it, and a toast would say the same thing twice.
+    if (!joined) _reportsScanOutcome = false;
     _setScanRejection(
       pluginId: pluginId,
       // A harness still in the live operation has no refusal to report. An
       // uncertain start keeps it a member precisely because the request may
       // have landed, so the card would otherwise pair a spinner with a line
       // telling the user to try again. That run belongs to the aggregate row.
-      result: result is CatalogRescanStartAccepted || _scanningPluginIds.contains(pluginId) ? null : result,
+      result: joined ? null : result,
     );
+  }
+
+  /// Clears an outcome the screen has now reported, so it is announced once.
+  void dismissCatalogScanOutcome() {
+    final current = state;
+    if (isClosed || current is! PluginManagementReady || current.scanOutcome == null) return;
+    emit(current.copyWith(scanOutcome: null));
   }
 
   void _setScanRejection({required String pluginId, required CatalogRescanStartResult? result}) {
@@ -497,6 +518,12 @@ class PluginManagementCubit({
               PluginManagementUnsupported() ||
               PluginManagementFailure() => const {},
             },
+            scanOutcome: switch (state) {
+              PluginManagementReady(:final scanOutcome) => scanOutcome,
+              PluginManagementLoading() ||
+              PluginManagementUnsupported() ||
+              PluginManagementFailure() => null,
+            },
           ),
         );
       case PluginManagementLoadResultUnsupported():
@@ -578,12 +605,42 @@ class PluginManagementCubit({
     // restore the refusal once the scan succeeded.
     final rejections = Map<String, CatalogRescanStartResult>.of(current.scanRejections)
       ..removeWhere((pluginId, _) => scanning.contains(pluginId));
-    if (const SetEquality<String>().equals(current.scanningPluginIds, scanning) &&
+    final outcome = _reportsScanOutcome ? _outcomeOf(scan) : null;
+    // A run that ends without a terminal state — cancelled, or recovered and
+    // settled quietly — has nothing to announce, so the claim is dropped
+    // rather than left to attach itself to the next run.
+    if (outcome != null || scan is CatalogRescanIdle) _reportsScanOutcome = false;
+    if (outcome == null &&
+        const SetEquality<String>().equals(current.scanningPluginIds, scanning) &&
         rejections.length == current.scanRejections.length) {
       return;
     }
-    emit(current.copyWith(scanningPluginIds: scanning, scanRejections: rejections));
+    emit(
+      current.copyWith(
+        scanningPluginIds: scanning,
+        scanRejections: rejections,
+        scanOutcome: outcome ?? current.scanOutcome,
+      ),
+    );
   }
+
+  /// The three ways a scan that actually started can end.
+  ///
+  /// Everything else is either still running or an answer the harness card
+  /// already owns, so it produces nothing to announce.
+  CatalogRescanOutcome? _outcomeOf(CatalogRescanState scan) => switch (scan) {
+    CatalogRescanSucceeded(:final counts) => CatalogRescanOutcome.succeeded(counts: counts),
+    CatalogRescanPartlyFailed(:final succeededCount, :final failedCount) => CatalogRescanOutcome.partlyFailed(
+      succeededCount: succeededCount,
+      failedCount: failedCount,
+    ),
+    CatalogRescanFailed() => const CatalogRescanOutcome.failed(),
+    CatalogRescanIdle() ||
+    CatalogRescanStarting() ||
+    CatalogRescanRunning() ||
+    CatalogRescanUnsupported() ||
+    CatalogRescanNoHarness() => null,
+  };
 
   void _onInstallProgress({required Map<String, PluginInstallProgress> installs}) {
     if (isClosed) return;

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
@@ -596,6 +596,11 @@ class PluginManagementCubit({
 
   void _onCatalogScan(CatalogRescanState scan) {
     if (isClosed) return;
+    // Dropped before the readiness check, not after: a disconnect resets the
+    // scan to idle and reloads the snapshot, and the reload reaches this cubit
+    // first. Reading the claim only while ready would let it survive the run it
+    // belongs to.
+    if (scan is CatalogRescanIdle) _reportsScanOutcome = false;
     final current = state;
     if (current is! PluginManagementReady) return;
     final scanning = _scanningPluginIds;
@@ -605,11 +610,11 @@ class PluginManagementCubit({
     // restore the refusal once the scan succeeded.
     final rejections = Map<String, CatalogRescanStartResult>.of(current.scanRejections)
       ..removeWhere((pluginId, _) => scanning.contains(pluginId));
-    final outcome = _reportsScanOutcome ? _outcomeOf(scan) : null;
     // A run that ends without a terminal state — cancelled, or recovered and
-    // settled quietly — has nothing to announce, so the claim is dropped
-    // rather than left to attach itself to the next run.
-    if (outcome != null || scan is CatalogRescanIdle) _reportsScanOutcome = false;
+    // settled quietly — has nothing to announce, which the idle drop above
+    // covers. Announcing one spends the claim the same way.
+    final outcome = _reportsScanOutcome ? _outcomeOf(scan) : null;
+    if (outcome != null) _reportsScanOutcome = false;
     if (outcome == null &&
         const SetEquality<String>().equals(current.scanningPluginIds, scanning) &&
         rejections.length == current.scanRejections.length) {

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
@@ -27,12 +27,15 @@ class PluginManagementCubit({
 
   final CompositeSubscription _subscriptions = CompositeSubscription();
 
-  /// Whether a scan this screen started is still owed an outcome.
+  /// Harnesses this screen has started a scan for and not yet heard back about.
   ///
-  /// Only a run this screen began is announced here. A scan a list's pull
-  /// started is already reported by the row above that list, and toasting it
-  /// again on an unrelated screen would report one run in two places.
-  bool _reportsScanOutcome = false;
+  /// A set rather than a flag, because more than one card can be started before
+  /// the first finishes: a second harness being refused must not cancel the
+  /// first harness's claim on the outcome. Only a run this screen began is
+  /// announced here — a scan a list's pull started is already reported by the
+  /// row above that list, and announcing it again on an unrelated screen would
+  /// report one run in two places.
+  final Set<String> _scanClaims = {};
   int _actionGeneration = 0;
   int _authenticationGeneration = 0;
 
@@ -214,21 +217,25 @@ class PluginManagementCubit({
     _setScanRejection(pluginId: pluginId, result: null);
     // Claimed before dispatch, not after: the run can reach a terminal state
     // while this request is still awaiting its own response.
-    _reportsScanOutcome = true;
+    _scanClaims.add(pluginId);
     final result = await _catalogRescanService.start(pluginId: pluginId);
     if (isClosed) return;
-    final joined = result is CatalogRescanStartAccepted || _scanningPluginIds.contains(pluginId);
-    // A start the bridge refused outright never becomes an outcome: the card
-    // reports it, and a toast would say the same thing twice.
-    if (!joined) _reportsScanOutcome = false;
-    _setScanRejection(
-      pluginId: pluginId,
-      // A harness still in the live operation has no refusal to report. An
-      // uncertain start keeps it a member precisely because the request may
-      // have landed, so the card would otherwise pair a spinner with a line
-      // telling the user to try again. That run belongs to the aggregate row.
-      result: joined ? null : result,
-    );
+    // A harness still in the live operation has no refusal to report. An
+    // uncertain start keeps it a member precisely because the request may have
+    // landed, so the card would otherwise pair a spinner with a line telling
+    // the user to try again. That run belongs to the aggregate row.
+    if (result is CatalogRescanStartAccepted || _scanningPluginIds.contains(pluginId)) {
+      _setScanRejection(pluginId: pluginId, result: null);
+      return;
+    }
+    // Membership alone cannot tell a refusal from a run that already finished:
+    // a definite rejection settles the operation before this call returns, so
+    // the harness has left the live set either way. The claim can, because an
+    // announced outcome spends it. Without this, a bridge that answers with an
+    // error produces both a finished-scan announcement and a could-not-start
+    // line on the card for one attempt.
+    if (!_scanClaims.remove(pluginId)) return;
+    _setScanRejection(pluginId: pluginId, result: result);
   }
 
   /// Clears an outcome the screen has now reported, so it is announced once.
@@ -598,9 +605,9 @@ class PluginManagementCubit({
     if (isClosed) return;
     // Dropped before the readiness check, not after: a disconnect resets the
     // scan to idle and reloads the snapshot, and the reload reaches this cubit
-    // first. Reading the claim only while ready would let it survive the run it
-    // belongs to.
-    if (scan is CatalogRescanIdle) _reportsScanOutcome = false;
+    // first. Reading the claims only while ready would let them survive the run
+    // they belong to.
+    if (scan is CatalogRescanIdle) _scanClaims.clear();
     final current = state;
     if (current is! PluginManagementReady) return;
     final scanning = _scanningPluginIds;
@@ -611,10 +618,11 @@ class PluginManagementCubit({
     final rejections = Map<String, CatalogRescanStartResult>.of(current.scanRejections)
       ..removeWhere((pluginId, _) => scanning.contains(pluginId));
     // A run that ends without a terminal state — cancelled, or recovered and
-    // settled quietly — has nothing to announce, which the idle drop above
-    // covers. Announcing one spends the claim the same way.
-    final outcome = _reportsScanOutcome ? _outcomeOf(scan) : null;
-    if (outcome != null) _reportsScanOutcome = false;
+    // settled quietly — has nothing to announce, which the idle clear above
+    // covers. Announcing one spends every claim in it: the operation is one
+    // run however many cards started members of it, and it ends once.
+    final outcome = _scanClaims.isEmpty ? null : _outcomeOf(scan);
+    if (outcome != null) _scanClaims.clear();
     if (outcome == null &&
         const SetEquality<String>().equals(current.scanningPluginIds, scanning) &&
         rejections.length == current.scanRejections.length) {

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.dart
@@ -106,6 +106,23 @@ sealed class PluginAuthenticationPresentationState with _$PluginAuthenticationPr
   }) = PluginAuthenticationPresentationFailed;
 }
 
+/// How a catalog scan this screen started actually ended.
+///
+/// Only the three outcomes a *started* scan can reach. A bridge that refused
+/// the start never gets here: that answer is a [CatalogRescanStartResult] and
+/// belongs on the harness card, which is where the user aimed the request.
+@Freezed()
+sealed class CatalogRescanOutcome with _$CatalogRescanOutcome {
+  const factory succeeded({required CatalogRescanCounts counts}) = CatalogRescanOutcomeSucceeded;
+
+  const factory partlyFailed({
+    required int succeededCount,
+    required int failedCount,
+  }) = CatalogRescanOutcomePartlyFailed;
+
+  const factory failed() = CatalogRescanOutcomeFailed;
+}
+
 @Freezed()
 sealed class PluginManagementState with _$PluginManagementState {
   const factory loading() = PluginManagementLoading;
@@ -131,5 +148,13 @@ sealed class PluginManagementState with _$PluginManagementState {
     /// named. An accepted start is never recorded: the card reports it by
     /// disabling its own action, and the aggregate row reports the run.
     required Map<String, CatalogRescanStartResult> scanRejections,
+
+    /// How a scan started from this screen ended, held until it is reported.
+    ///
+    /// This screen hosts no progress row, so a scan started here would
+    /// otherwise finish in silence: the spinner simply stops, and the result
+    /// the service published is auto-cleared before the user could reach a
+    /// list to read it.
+    required CatalogRescanOutcome? scanOutcome,
   }) = PluginManagementReady;
 }

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.freezed.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.freezed.dart
@@ -1723,6 +1723,203 @@ $PluginAuthenticationPresentationErrorCopyWith<$Res> get error {
 }
 
 /// @nodoc
+mixin _$CatalogRescanOutcome {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CatalogRescanOutcome);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CatalogRescanOutcome()';
+}
+
+
+}
+
+/// @nodoc
+class $CatalogRescanOutcomeCopyWith<$Res>  {
+$CatalogRescanOutcomeCopyWith(CatalogRescanOutcome _, $Res Function(CatalogRescanOutcome) __);
+}
+
+
+
+/// @nodoc
+
+
+class CatalogRescanOutcomeSucceeded implements CatalogRescanOutcome {
+  const CatalogRescanOutcomeSucceeded({required this.counts});
+  
+
+ final  CatalogRescanCounts counts;
+
+/// Create a copy of CatalogRescanOutcome
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CatalogRescanOutcomeSucceededCopyWith<CatalogRescanOutcomeSucceeded> get copyWith => _$CatalogRescanOutcomeSucceededCopyWithImpl<CatalogRescanOutcomeSucceeded>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CatalogRescanOutcomeSucceeded&&(identical(other.counts, counts) || other.counts == counts));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,counts);
+
+@override
+String toString() {
+  return 'CatalogRescanOutcome.succeeded(counts: $counts)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CatalogRescanOutcomeSucceededCopyWith<$Res> implements $CatalogRescanOutcomeCopyWith<$Res> {
+  factory $CatalogRescanOutcomeSucceededCopyWith(CatalogRescanOutcomeSucceeded value, $Res Function(CatalogRescanOutcomeSucceeded) _then) = _$CatalogRescanOutcomeSucceededCopyWithImpl;
+@useResult
+$Res call({
+ CatalogRescanCounts counts
+});
+
+
+
+
+}
+/// @nodoc
+class _$CatalogRescanOutcomeSucceededCopyWithImpl<$Res>
+    implements $CatalogRescanOutcomeSucceededCopyWith<$Res> {
+  _$CatalogRescanOutcomeSucceededCopyWithImpl(this._self, this._then);
+
+  final CatalogRescanOutcomeSucceeded _self;
+  final $Res Function(CatalogRescanOutcomeSucceeded) _then;
+
+/// Create a copy of CatalogRescanOutcome
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? counts = null,}) {
+  return _then(CatalogRescanOutcomeSucceeded(
+counts: null == counts ? _self.counts : counts // ignore: cast_nullable_to_non_nullable
+as CatalogRescanCounts,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class CatalogRescanOutcomePartlyFailed implements CatalogRescanOutcome {
+  const CatalogRescanOutcomePartlyFailed({required this.succeededCount, required this.failedCount});
+  
+
+ final  int succeededCount;
+ final  int failedCount;
+
+/// Create a copy of CatalogRescanOutcome
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CatalogRescanOutcomePartlyFailedCopyWith<CatalogRescanOutcomePartlyFailed> get copyWith => _$CatalogRescanOutcomePartlyFailedCopyWithImpl<CatalogRescanOutcomePartlyFailed>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CatalogRescanOutcomePartlyFailed&&(identical(other.succeededCount, succeededCount) || other.succeededCount == succeededCount)&&(identical(other.failedCount, failedCount) || other.failedCount == failedCount));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,succeededCount,failedCount);
+
+@override
+String toString() {
+  return 'CatalogRescanOutcome.partlyFailed(succeededCount: $succeededCount, failedCount: $failedCount)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CatalogRescanOutcomePartlyFailedCopyWith<$Res> implements $CatalogRescanOutcomeCopyWith<$Res> {
+  factory $CatalogRescanOutcomePartlyFailedCopyWith(CatalogRescanOutcomePartlyFailed value, $Res Function(CatalogRescanOutcomePartlyFailed) _then) = _$CatalogRescanOutcomePartlyFailedCopyWithImpl;
+@useResult
+$Res call({
+ int succeededCount, int failedCount
+});
+
+
+
+
+}
+/// @nodoc
+class _$CatalogRescanOutcomePartlyFailedCopyWithImpl<$Res>
+    implements $CatalogRescanOutcomePartlyFailedCopyWith<$Res> {
+  _$CatalogRescanOutcomePartlyFailedCopyWithImpl(this._self, this._then);
+
+  final CatalogRescanOutcomePartlyFailed _self;
+  final $Res Function(CatalogRescanOutcomePartlyFailed) _then;
+
+/// Create a copy of CatalogRescanOutcome
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? succeededCount = null,Object? failedCount = null,}) {
+  return _then(CatalogRescanOutcomePartlyFailed(
+succeededCount: null == succeededCount ? _self.succeededCount : succeededCount // ignore: cast_nullable_to_non_nullable
+as int,failedCount: null == failedCount ? _self.failedCount : failedCount // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class CatalogRescanOutcomeFailed implements CatalogRescanOutcome {
+  const CatalogRescanOutcomeFailed();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CatalogRescanOutcomeFailed);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CatalogRescanOutcome.failed()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
 mixin _$PluginManagementState {
 
 
@@ -1896,7 +2093,7 @@ $ApiErrorCopyWith<$Res> get error {
 
 
 class PluginManagementReady implements PluginManagementState {
-  const PluginManagementReady({required this.response, required this.refresh, required this.action, required this.authentication, required  Map<String, PluginInstallProgress> installs, required  Set<String> scanningPluginIds, required  Map<String, CatalogRescanStartResult> scanRejections}): _installs = installs,_scanningPluginIds = scanningPluginIds,_scanRejections = scanRejections;
+  const PluginManagementReady({required this.response, required this.refresh, required this.action, required this.authentication, required  Map<String, PluginInstallProgress> installs, required  Set<String> scanningPluginIds, required  Map<String, CatalogRescanStartResult> scanRejections, required this.scanOutcome}): _installs = installs,_scanningPluginIds = scanningPluginIds,_scanRejections = scanRejections;
   
 
  final  PluginManagementResponse response;
@@ -1936,6 +2133,13 @@ class PluginManagementReady implements PluginManagementState {
   return EqualUnmodifiableMapView(_scanRejections);
 }
 
+/// How a scan started from this screen ended, held until it is reported.
+///
+/// This screen hosts no progress row, so a scan started here would
+/// otherwise finish in silence: the spinner simply stops, and the result
+/// the service published is auto-cleared before the user could reach a
+/// list to read it.
+ final  CatalogRescanOutcome? scanOutcome;
 
 /// Create a copy of PluginManagementState
 /// with the given fields replaced by the non-null parameter values.
@@ -1947,16 +2151,16 @@ $PluginManagementReadyCopyWith<PluginManagementReady> get copyWith => _$PluginMa
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginManagementReady&&(identical(other.response, response) || other.response == response)&&(identical(other.refresh, refresh) || other.refresh == refresh)&&(identical(other.action, action) || other.action == action)&&(identical(other.authentication, authentication) || other.authentication == authentication)&&const DeepCollectionEquality().equals(other._installs, _installs)&&const DeepCollectionEquality().equals(other._scanningPluginIds, _scanningPluginIds)&&const DeepCollectionEquality().equals(other._scanRejections, _scanRejections));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginManagementReady&&(identical(other.response, response) || other.response == response)&&(identical(other.refresh, refresh) || other.refresh == refresh)&&(identical(other.action, action) || other.action == action)&&(identical(other.authentication, authentication) || other.authentication == authentication)&&const DeepCollectionEquality().equals(other._installs, _installs)&&const DeepCollectionEquality().equals(other._scanningPluginIds, _scanningPluginIds)&&const DeepCollectionEquality().equals(other._scanRejections, _scanRejections)&&(identical(other.scanOutcome, scanOutcome) || other.scanOutcome == scanOutcome));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,response,refresh,action,authentication,const DeepCollectionEquality().hash(_installs),const DeepCollectionEquality().hash(_scanningPluginIds),const DeepCollectionEquality().hash(_scanRejections));
+int get hashCode => Object.hash(runtimeType,response,refresh,action,authentication,const DeepCollectionEquality().hash(_installs),const DeepCollectionEquality().hash(_scanningPluginIds),const DeepCollectionEquality().hash(_scanRejections),scanOutcome);
 
 @override
 String toString() {
-  return 'PluginManagementState.ready(response: $response, refresh: $refresh, action: $action, authentication: $authentication, installs: $installs, scanningPluginIds: $scanningPluginIds, scanRejections: $scanRejections)';
+  return 'PluginManagementState.ready(response: $response, refresh: $refresh, action: $action, authentication: $authentication, installs: $installs, scanningPluginIds: $scanningPluginIds, scanRejections: $scanRejections, scanOutcome: $scanOutcome)';
 }
 
 
@@ -1967,11 +2171,11 @@ abstract mixin class $PluginManagementReadyCopyWith<$Res> implements $PluginMana
   factory $PluginManagementReadyCopyWith(PluginManagementReady value, $Res Function(PluginManagementReady) _then) = _$PluginManagementReadyCopyWithImpl;
 @useResult
 $Res call({
- PluginManagementResponse response, PluginManagementRefreshState refresh, PluginManagementActionState action, PluginAuthenticationPresentationState authentication, Map<String, PluginInstallProgress> installs, Set<String> scanningPluginIds, Map<String, CatalogRescanStartResult> scanRejections
+ PluginManagementResponse response, PluginManagementRefreshState refresh, PluginManagementActionState action, PluginAuthenticationPresentationState authentication, Map<String, PluginInstallProgress> installs, Set<String> scanningPluginIds, Map<String, CatalogRescanStartResult> scanRejections, CatalogRescanOutcome? scanOutcome
 });
 
 
-$PluginManagementResponseCopyWith<$Res> get response;$PluginManagementRefreshStateCopyWith<$Res> get refresh;$PluginManagementActionStateCopyWith<$Res> get action;$PluginAuthenticationPresentationStateCopyWith<$Res> get authentication;
+$PluginManagementResponseCopyWith<$Res> get response;$PluginManagementRefreshStateCopyWith<$Res> get refresh;$PluginManagementActionStateCopyWith<$Res> get action;$PluginAuthenticationPresentationStateCopyWith<$Res> get authentication;$CatalogRescanOutcomeCopyWith<$Res>? get scanOutcome;
 
 }
 /// @nodoc
@@ -1984,7 +2188,7 @@ class _$PluginManagementReadyCopyWithImpl<$Res>
 
 /// Create a copy of PluginManagementState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? response = null,Object? refresh = null,Object? action = null,Object? authentication = null,Object? installs = null,Object? scanningPluginIds = null,Object? scanRejections = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? response = null,Object? refresh = null,Object? action = null,Object? authentication = null,Object? installs = null,Object? scanningPluginIds = null,Object? scanRejections = null,Object? scanOutcome = freezed,}) {
   return _then(PluginManagementReady(
 response: null == response ? _self.response : response // ignore: cast_nullable_to_non_nullable
 as PluginManagementResponse,refresh: null == refresh ? _self.refresh : refresh // ignore: cast_nullable_to_non_nullable
@@ -1993,7 +2197,8 @@ as PluginManagementActionState,authentication: null == authentication ? _self.au
 as PluginAuthenticationPresentationState,installs: null == installs ? _self._installs : installs // ignore: cast_nullable_to_non_nullable
 as Map<String, PluginInstallProgress>,scanningPluginIds: null == scanningPluginIds ? _self._scanningPluginIds : scanningPluginIds // ignore: cast_nullable_to_non_nullable
 as Set<String>,scanRejections: null == scanRejections ? _self._scanRejections : scanRejections // ignore: cast_nullable_to_non_nullable
-as Map<String, CatalogRescanStartResult>,
+as Map<String, CatalogRescanStartResult>,scanOutcome: freezed == scanOutcome ? _self.scanOutcome : scanOutcome // ignore: cast_nullable_to_non_nullable
+as CatalogRescanOutcome?,
   ));
 }
 
@@ -2032,6 +2237,18 @@ $PluginAuthenticationPresentationStateCopyWith<$Res> get authentication {
   
   return $PluginAuthenticationPresentationStateCopyWith<$Res>(_self.authentication, (value) {
     return _then(_self.copyWith(authentication: value));
+  });
+}/// Create a copy of PluginManagementState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CatalogRescanOutcomeCopyWith<$Res>? get scanOutcome {
+    if (_self.scanOutcome == null) {
+    return null;
+  }
+
+  return $CatalogRescanOutcomeCopyWith<$Res>(_self.scanOutcome!, (value) {
+    return _then(_self.copyWith(scanOutcome: value));
   });
 }
 }

--- a/client/module_core/lib/src/testing/test_helpers.dart
+++ b/client/module_core/lib/src/testing/test_helpers.dart
@@ -872,9 +872,15 @@ class FakeCatalogRescanService() implements CatalogRescanService {
   @override
   Future<void> startAll() async => _startAlls.add(null);
 
+  /// Runs inside [start] before it answers, so a test can drive the state the
+  /// real service would already have published by then. A definite rejection
+  /// settles the operation before the call returns.
+  void Function()? beforeStartAnswers;
+
   @override
   Future<CatalogRescanStartResult> start({required String pluginId}) async {
     startedPluginIds.add(pluginId);
+    beforeStartAnswers?.call();
     return _startResult;
   }
 

--- a/client/module_core/lib/src/testing/test_helpers.dart
+++ b/client/module_core/lib/src/testing/test_helpers.dart
@@ -872,15 +872,17 @@ class FakeCatalogRescanService() implements CatalogRescanService {
   @override
   Future<void> startAll() async => _startAlls.add(null);
 
-  /// Runs inside [start] before it answers, so a test can drive the state the
-  /// real service would already have published by then. A definite rejection
-  /// settles the operation before the call returns.
-  void Function()? beforeStartAnswers;
+  void Function()? _beforeStartAnswers;
+
+  /// Sets a hook that runs inside [start] before it answers, so a test can
+  /// drive the state the real service would already have published by then: a
+  /// definite rejection settles the operation before the call returns.
+  void stubBeforeStartAnswers(void Function() hook) => _beforeStartAnswers = hook;
 
   @override
   Future<CatalogRescanStartResult> start({required String pluginId}) async {
     startedPluginIds.add(pluginId);
-    beforeStartAnswers?.call();
+    _beforeStartAnswers?.call();
     return _startResult;
   }
 

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -991,6 +991,31 @@ void main() {
       );
     });
 
+    // A disconnect reloads the snapshot and resets the scan, and the reload
+    // reaches this cubit first — so the claim has to be dropped whether or not
+    // the state is ready when the reset lands.
+    test("a disconnect drops the claim rather than carrying it to the next run", () async {
+      await ready();
+      await cubit.startCatalogScanFor(pluginId: "codex");
+
+      snapshots.add(const PluginManagementLoadResult.loading());
+      await _settle();
+      rescan.emit(const CatalogRescanState.idle());
+      await _settle();
+      snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+      await _settle();
+
+      rescan.emit(
+        const CatalogRescanState.succeeded(
+          harnessCount: 1,
+          counts: CatalogRescanCounts.delta(newProjects: 0, newSessions: 7),
+        ),
+      );
+      await _settle();
+
+      expect((cubit.state as PluginManagementReady).scanOutcome, isNull);
+    });
+
     test("an announced outcome is cleared so it is reported once", () async {
       await ready();
       await cubit.startCatalogScanFor(pluginId: "codex");

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -107,6 +107,7 @@ void main() {
         installs: {},
         scanningPluginIds: {},
         scanRejections: {},
+        scanOutcome: null,
       ),
     );
   });
@@ -901,6 +902,104 @@ void main() {
       final state = cubit.state as PluginManagementReady;
       expect(state.scanRejections, isEmpty);
       expect(state.scanningPluginIds, {"codex"});
+    });
+
+    // This screen hosts no progress row, so a scan it started has to be
+    // announced here or the user never learns what it found.
+    test("keeps the outcome of a scan this screen started", () async {
+      await ready();
+      await cubit.startCatalogScanFor(pluginId: "codex");
+
+      rescan.emit(
+        const CatalogRescanState.succeeded(
+          harnessCount: 1,
+          counts: CatalogRescanCounts.delta(newProjects: 2, newSessions: 5),
+        ),
+      );
+      await _settle();
+
+      expect(
+        (cubit.state as PluginManagementReady).scanOutcome,
+        isA<CatalogRescanOutcomeSucceeded>().having(
+          (o) => o.counts,
+          "counts",
+          isA<CatalogRescanDelta>().having((c) => c.newSessions, "newSessions", 5),
+        ),
+      );
+    });
+
+    // The row above that list already reported it; announcing it again here
+    // would report one run in two places.
+    test("stays quiet about a scan this screen did not start", () async {
+      await ready();
+
+      rescan.emit(
+        const CatalogRescanState.succeeded(
+          harnessCount: 1,
+          counts: CatalogRescanCounts.delta(newProjects: 0, newSessions: 1),
+        ),
+      );
+      await _settle();
+
+      expect((cubit.state as PluginManagementReady).scanOutcome, isNull);
+    });
+
+    test("carries a failure through as its own outcome", () async {
+      await ready();
+      await cubit.startCatalogScanFor(pluginId: "codex");
+
+      rescan.emit(const CatalogRescanState.partlyFailed(succeededCount: 2, failedCount: 1));
+      await _settle();
+
+      expect(
+        (cubit.state as PluginManagementReady).scanOutcome,
+        isA<CatalogRescanOutcomePartlyFailed>().having((o) => o.failedCount, "failedCount", 1),
+      );
+    });
+
+    // A refused start is already on the card; a toast would say it twice.
+    test("a start the bridge refused produces no outcome", () async {
+      await ready();
+      rescan.stubStartResult(const CatalogRescanStartResult.notImportable());
+      await cubit.startCatalogScanFor(pluginId: "codex");
+
+      rescan.emit(const CatalogRescanState.failed(harnessCount: 1));
+      await _settle();
+
+      expect((cubit.state as PluginManagementReady).scanOutcome, isNull);
+    });
+
+    test("a run that ends without a terminal state announces nothing", () async {
+      await ready();
+      await cubit.startCatalogScanFor(pluginId: "codex");
+
+      // Cancelled from a list: the operation closes straight to idle.
+      rescan.emit(const CatalogRescanState.idle());
+      await _settle();
+      rescan.emit(
+        const CatalogRescanState.succeeded(
+          harnessCount: 1,
+          counts: CatalogRescanCounts.delta(newProjects: 0, newSessions: 9),
+        ),
+      );
+      await _settle();
+
+      expect(
+        (cubit.state as PluginManagementReady).scanOutcome,
+        isNull,
+        reason: "a dropped claim must not attach itself to the next run",
+      );
+    });
+
+    test("an announced outcome is cleared so it is reported once", () async {
+      await ready();
+      await cubit.startCatalogScanFor(pluginId: "codex");
+      rescan.emit(const CatalogRescanState.failed(harnessCount: 1));
+      await _settle();
+
+      cubit.dismissCatalogScanOutcome();
+
+      expect((cubit.state as PluginManagementReady).scanOutcome, isNull);
     });
 
     // The screen rebuilds this cubit per visit and every snapshot rebuilds the

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -1025,7 +1025,7 @@ void main() {
         ..stubStartResult(
           CatalogRescanStartResult.failed(cause: ApiError.nonSuccessCode(errorCode: 500, rawErrorString: null)),
         )
-        ..beforeStartAnswers = () => rescan.emit(const CatalogRescanState.failed(harnessCount: 1));
+        ..stubBeforeStartAnswers(() => rescan.emit(const CatalogRescanState.failed(harnessCount: 1)));
 
       await cubit.startCatalogScanFor(pluginId: "codex");
       await _settle();

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -1016,6 +1016,58 @@ void main() {
       expect((cubit.state as PluginManagementReady).scanOutcome, isNull);
     });
 
+    // A definite rejection settles the operation before start() returns, so the
+    // harness has left the live set by then — exactly as it would have if the
+    // run had simply finished. Only the claim can tell those apart.
+    test("a run that already announced its end adds no refusal to the card", () async {
+      await ready();
+      rescan
+        ..stubStartResult(
+          CatalogRescanStartResult.failed(cause: ApiError.nonSuccessCode(errorCode: 500, rawErrorString: null)),
+        )
+        ..beforeStartAnswers = () => rescan.emit(const CatalogRescanState.failed(harnessCount: 1));
+
+      await cubit.startCatalogScanFor(pluginId: "codex");
+      await _settle();
+
+      final state = cubit.state as PluginManagementReady;
+      expect(state.scanOutcome, isA<CatalogRescanOutcomeFailed>());
+      expect(
+        state.scanRejections,
+        isEmpty,
+        reason: "one attempt must not be reported as both a finished scan and a refused start",
+      );
+    });
+
+    // Cards for harnesses outside the live operation stay enabled, so a second
+    // one can be started and refused while the first is still running.
+    test("a second harness being refused leaves the first one's claim alone", () async {
+      await ready();
+      await cubit.startCatalogScanFor(pluginId: "codex");
+      rescan.emit(const CatalogRescanState.starting(pluginIds: {"codex"}));
+      await _settle();
+
+      rescan.stubStartResult(const CatalogRescanStartResult.notImportable());
+      await cubit.startCatalogScanFor(pluginId: "claude");
+      await _settle();
+
+      rescan.emit(
+        const CatalogRescanState.succeeded(
+          harnessCount: 1,
+          counts: CatalogRescanCounts.delta(newProjects: 0, newSessions: 4),
+        ),
+      );
+      await _settle();
+
+      final state = cubit.state as PluginManagementReady;
+      expect(state.scanRejections, {"claude": isA<CatalogRescanStartNotImportable>()});
+      expect(
+        state.scanOutcome,
+        isA<CatalogRescanOutcomeSucceeded>(),
+        reason: "the run codex started still ends with an announcement",
+      );
+    });
+
     test("an announced outcome is cleared so it is reported once", () async {
       await ready();
       await cubit.startCatalogScanFor(pluginId: "codex");

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -115,6 +115,12 @@ idle suspension, the management snapshot, and lifecycle commands.
   outcome is unknown leaves the harness in the running scan rather than reporting a refusal
   beside its own progress, so a card never pairs work in flight with a reason it failed. The
   underlying request error is kept for the local log and never rendered.
+- A scan started from the harness settings surface announces how it ended there, because that
+  surface carries no progress row and the published result clears itself before the user could
+  reach a list to read it. What it found, a partial failure, and a total failure each read
+  differently. A scan started from a list is not announced again here, and neither is a start
+  the bridge refused outright, which the harness card already reports; a run that ends without
+  a terminal outcome announces nothing at all.
 
 ## Regression Levels
 
@@ -122,7 +128,7 @@ idle suspension, the management snapshot, and lifecycle commands.
 |---|---|
 | L1 Smoke | A started bridge inspects every registered harness and publishes coherent setup and management snapshots. A ready fixture has a selectable default; a fixture with no usable harness has zero selectable entries and no default without failing startup. Headless bridge; all registered harnesses listed. |
 | L2 Routine | Demand-driven start of a ready harness, clean lifecycle-owned bridge shutdown, Codex keepalive traffic remaining local and stopping on disposal, setup refresh, and the disable list surviving restart with eligibility and ordering intact. Package automation covers DeepSeek explicit/PATH/managed selection, immutable six-platform archive metadata, readiness, extension refusal, crash/reconnect, and idempotent shutdown before registry activation. Headless bridge; representative managed harness for start and shutdown, every registered harness for listing and ordering. |
-| L3 Release | The management surface as rendered: per-harness selected runtime version when reported, setup, runtime and work state, capability-appropriate controls, built-in name and light/dark artwork, default badge, enable/disable, restart, idle-timeout default plus override persisted across a bridge restart, and the per-harness catalog scan on a routable harness including its in-place progress. Client end to end; every harness declaring the relevant capability must pass. |
+| L3 Release | The management surface as rendered: per-harness selected runtime version when reported, setup, runtime and work state, capability-appropriate controls, built-in name and light/dark artwork, default badge, enable/disable, restart, idle-timeout default plus override persisted across a bridge restart, and the per-harness catalog scan on a routable harness including its in-place progress and the announcement of what it found. Client end to end; every harness declaring the relevant capability must pass. |
 | L4 Extended | Busy conflict with force confirmation and cancellation, authentication start/join/cancel plus shutdown cleanup, idle suspension elapsing then returning on demand, harnesses blocked by missing runtime or authentication with no catalog-scan action offered on them, a targeted scan rejected by the bridge reporting on its own card, a terminally failed harness leaving others usable, a bridge with no usable harness, an externally managed configuration, two harnesses active at once, second mobile platform. Live plugin where a real backend must start or be interrupted, client end to end where card state is claimed. |
 | L5 Full | Every registered production harness through inspect, enable, disable, restart, refresh, and idle behavior on a supported platform, plus forward-compatible presentation of an unknown harness or capability and the reported state of a session interrupted by a forced disable. Live plugin and client end to end as each entry requires. |
 
@@ -148,6 +154,9 @@ timeouts, and sessions afterwards.
 - A catalog scan offered on a harness the bridge will not import from, a scan already
   covering a harness still accepting another start from its card, a targeted rejection
   landing on the wrong harness or on none, or a request error reaching the card as text.
+- A scan started from harness settings finishing with no announcement, one announced twice,
+  a scan started elsewhere announced there, or a refused start reported both on its card and
+  as a finished scan.
 - A missing authentication state from an older bridge decoding as anything but idle, a
   future state or conflict reason failing open, challenge data entering snapshots/SSE, or
   a failed progress payload without its required sanitized message.


### PR DESCRIPTION
## Complexity

🌿 Straightforward. One sealed type, one state field, one listener.

## What

A catalog scan started from Settings → Harnesses now says how it ended.

- `CatalogRescanOutcome` — the three ways a *started* scan can end: what it
  found, a partial failure, a total failure.
- `PluginManagementReady.scanOutcome` holds the outcome of a run this screen
  started, until it is announced.
- The screen announces it once through `PregoPopupAlertPresenter`, mirroring the
  force-confirmation and auth-challenge listeners already there, then clears it.
- `catalogScanCountsLine` lifted out of `CatalogScanRow`, so the row and the
  popup cannot word one scan two different ways.

## Why

Raised by the owner: does a Settings-initiated scan indicate success? It did
not — and the gap is one this plan created.

The result *was* computed and published. But `CatalogScanRow` is hosted only by
the project list, session list and split pane, and `_successVisibleFor` clears a
success after four seconds. So a Settings-started scan published its outcome
where its user could never read it: the spinner stopped, nothing else happened,
and by the time they reached a list it was gone. Only *start-time* rejections
showed on the card — a scan that started fine and then failed was equally
silent.

That is the surface built for pointer and screen-reader users, and the feature's
whole question is "did it find my missing sessions?"

## Risk and test focus

No database impact. No wire-contract change. Client-only.

Three judgement calls worth a look:

- **The claim is staked before the start request resolves**, not after. The run
  can reach a terminal state while that POST is still in flight, and a claim
  staked afterwards would miss it.
- **A start the bridge refuses drops the claim.** The card already says "this
  harness cannot be scanned right now"; a popup would say it twice.
- **A scan a list started is not announced here.** The row above that list
  already reports it, and announcing it on an unrelated screen would report one
  run in two places.

The architecture review traced one path where the claim outlived its run: on a
disconnect the management service emits `loading` before the rescan service
emits `idle`, so the drop sat behind the readiness check and never ran. It
judged that unreachable today and did not require a fix — but a regression test
reproduced it directly, with the claim attaching to the next run's outcome, so
it is closed in `f287e94ce9`.

## Expected result

Tapping "Scan for sessions" on a harness card and waiting shows a popup naming
what it found — "Scan complete — 5 new sessions in 2 new projects" — or how it
failed. Starting a scan from a list's pull and then opening Settings shows
nothing there; that run is reported by the row above the list. A harness the
bridge refuses still reports on its own card, with no popup.

## Verification

- `flutter analyze lib test` in `client/app` — clean
- `dart analyze --fatal-infos lib test` in `client/module_core` — clean
- `client/app` suite — 897 passed, 3 new
- `client/module_core` suite — 1,382 passed, 7 new
- Both the popup test and the claim-leak test confirmed to fail without their fix
- `flutter gen-l10n` and `build_runner` output committed
- `docs/regression/plugin-setup-and-lifecycle.md` updated in the same change
- `architecture-implementation-review` — **approved, no architectural findings**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
