### PR TITLE
⚙️ Fix Claude queued image prompts

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 import "dart:collection";
+import "dart:convert";
 
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
@@ -204,8 +205,8 @@ final class ClaudeSessionProcessRepository({
 
     process.interrupted = false;
     // A resident process can absorb several stdin messages into one agent turn.
-    // Replayed user frames mark which queued messages joined that turn, and its
-    // result settles exactly that started prefix.
+    // User echoes mark which queued messages joined that turn, and its result
+    // settles exactly that started prefix.
     final turnWasActive = process.turnActive;
     final pending = _PendingTurn(
       promptId: promptId,
@@ -382,12 +383,17 @@ final class ClaudeSessionProcessRepository({
 
   String? _trackTurnMessage({required _ResidentProcess process, required ClaudeStreamMessage message}) {
     switch (message) {
-      case ClaudeUserMessage(parentToolUseId: null, raw: {"isReplay": true}):
+      case ClaudeUserMessage(parentToolUseId: null):
+        // Claude normally marks stdin echoes with `isReplay`, but attachment
+        // echoes can omit it. Their full image source still identifies the
+        // bridge-dispatched turn; unmarked text stays uncorrelated.
+        final isReplay = message.raw["isReplay"] == true;
         for (final pending in process.pendingTurns) {
           final replayContent = pending.replayContent;
           if (pending.replayObserved ||
               replayContent == null ||
-              !_sameJsonValue(replayContent, message.message["content"])) {
+              (!isReplay && !_containsImageContent(replayContent)) ||
+              !_samePromptContent(replayContent, message.message["content"])) {
             continue;
           }
           pending.replayObserved = true;
@@ -439,22 +445,65 @@ final class ClaudeSessionProcessRepository({
   }
 }
 
-bool _sameJsonValue(Object? left, Object? right) {
-  if (left is List && right is List) {
-    if (left.length != right.length) return false;
-    for (var index = 0; index < left.length; index++) {
-      if (!_sameJsonValue(left[index], right[index])) return false;
+/// Matches an echoed stdin payload to the prompt that wrote it.
+///
+/// Claude decorates image blocks on some stream-json paths (for example with
+/// cache directives), although the image source itself is unchanged. Compare
+/// image blocks by their semantic source fields so that decoration cannot
+/// strand the queued prompt; all other values retain exact JSON matching.
+bool _samePromptContent(Object? expected, Object? actual) {
+  if (expected is List && actual is List) {
+    if (expected.length != actual.length) return false;
+    for (var index = 0; index < expected.length; index++) {
+      if (!_samePromptContent(expected[index], actual[index])) return false;
     }
     return true;
   }
-  if (left is Map && right is Map) {
-    if (left.length != right.length) return false;
-    for (final entry in left.entries) {
-      if (!right.containsKey(entry.key) || !_sameJsonValue(entry.value, right[entry.key])) return false;
+  if (expected is Map && actual is Map) {
+    if (expected["type"] == "image" && actual["type"] == "image") {
+      return _sameImageContent(
+        expected: expected.cast<Object?, Object?>(),
+        actual: actual.cast<Object?, Object?>(),
+      );
+    }
+    if (expected.length != actual.length) return false;
+    for (final entry in expected.entries) {
+      if (!actual.containsKey(entry.key) || !_samePromptContent(entry.value, actual[entry.key])) return false;
     }
     return true;
   }
-  return left == right;
+  return expected == actual;
+}
+
+bool _containsImageContent(Object? content) =>
+    content is List && content.any((block) => block is Map && block["type"] == "image");
+
+bool _sameImageContent({
+  required Map<Object?, Object?> expected,
+  required Map<Object?, Object?> actual,
+}) {
+  final expectedSource = expected["source"];
+  final actualSource = actual["source"];
+  if (expectedSource is! Map || actualSource is! Map) return false;
+  final expectedType = expectedSource["type"];
+  final actualType = actualSource["type"];
+  if (expectedType != actualType || expectedType != "base64") return false;
+  final expectedMime = expectedSource["media_type"];
+  final actualMime = actualSource["media_type"];
+  if (expectedMime is! String ||
+      actualMime is! String ||
+      expectedMime.trim().toLowerCase() != actualMime.trim().toLowerCase()) {
+    return false;
+  }
+  final expectedData = expectedSource["data"];
+  final actualData = actualSource["data"];
+  if (expectedData is! String || actualData is! String) return false;
+  if (expectedData == actualData) return true;
+  try {
+    return base64.normalize(expectedData) == base64.normalize(actualData);
+  } on FormatException {
+    return false;
+  }
 }
 
 List<Map<String, Object?>> _promptContent(List<PluginPromptPart> parts) => [

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -301,6 +301,48 @@ void main() {
       await subscription.cancel();
     });
 
+    test("stamps an unmarked decorated image echo and consumes its queued entry", () async {
+      await harness.createSession();
+      final first = harness.processes.single;
+      await waitForFrame(first, "user");
+      first.emit(_result());
+      await pump();
+      final events = <BridgeSseEvent>[];
+      final subscription = harness.plugin.events.listen(events.add);
+
+      await harness.plugin.sendPrompt(
+        promptId: "prm_image",
+        sessionId: testSessionId,
+        parts: const [
+          PluginPromptPart.text(text: "inspect image"),
+          PluginPromptPart.fileData(mime: "image/JPEG", base64: "aA==", filename: "image.jpg"),
+        ],
+        variant: null,
+        agent: "Agent",
+        model: (providerID: "anthropic", modelID: "default"),
+      );
+      await _waitForUserText(first, "inspect image");
+      final written = first.written.lastWhere((frame) => frame["type"] == "user");
+
+      first.emit(_decoratedImageEcho(written: written, uuid: "echo-image"));
+      await pump();
+      await pump();
+
+      final user = events.whereType<BridgeSseMessageUpdated>().singleWhere(
+        (event) => event.info["id"] == "echo-image",
+      );
+      expect(user.info["promptId"], "prm_image");
+      expect(
+        events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part.type),
+        containsAll([
+          PluginMessagePartType.text,
+          PluginMessagePartType.file,
+        ]),
+      );
+      expect(await harness.plugin.getQueuedPrompts(sessionId: testSessionId), isEmpty);
+      await subscription.cancel();
+    });
+
     test("queues a steering prompt, stamps its echo, and consumes the entry after the message", () async {
       await harness.createSession();
       final first = harness.processes.single;
@@ -925,6 +967,33 @@ Map<String, Object?> _replayOf(Map<String, Object?> written, {required String uu
   "isReplay": true,
   "timestamp": "2026-08-11T12:00:00.000Z",
 };
+
+Map<String, Object?> _decoratedImageEcho({required Map<String, Object?> written, required String uuid}) {
+  final message = (written["message"]! as Map).cast<String, Object?>();
+  final content = (message["content"]! as List).cast<Object?>();
+  final image = (content[1]! as Map).cast<String, Object?>();
+  final source = (image["source"]! as Map).cast<String, Object?>();
+  return {
+    ...written,
+    "uuid": uuid,
+    "message": {
+      ...message,
+      "content": [
+        content.first,
+        {
+          ...image,
+          "cache_control": {"type": "ephemeral"},
+          "source": {
+            ...source,
+            "media_type": "image/jpeg",
+            "data": "aA",
+            "cache_control": {"type": "ephemeral"},
+          },
+        },
+      ],
+    },
+  };
+}
 
 final class _ThrowingDeleteTranscriptApi() extends ClaudeTranscriptApi {
   this : super(environment: const {});

--- a/bridge/sesori_plugin_claude/test/claude_session_process_repository_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_session_process_repository_test.dart
@@ -111,6 +111,59 @@ void main() {
       await subscription.cancel();
     });
 
+    test("correlates an unmarked decorated image echo with its prompt", () async {
+      await _ensure(repository, createNew: true);
+      final process = harness.processes.single;
+      final promptIds = <String?>[];
+      final subscription = repository.events
+          .where((event) => event is ClaudeSessionProcessMessage)
+          .cast<ClaudeSessionProcessMessage>()
+          .where((event) => event.message is ClaudeUserMessage)
+          .listen((event) => promptIds.add(event.promptId));
+      final turn = repository.sendTurn(
+        sessionId: testSessionId,
+        parts: const [
+          PluginPromptPart.text(text: "inspect this"),
+          PluginPromptPart.fileData(mime: "image/JPEG", base64: "aA==", filename: "image.jpg"),
+        ],
+        promptId: "prompt-image",
+      );
+      final written = await waitForFrame(process, "user");
+
+      process.emit(_decoratedImageEcho(written: written, uuid: "echo-image"));
+      await pump();
+
+      expect(promptIds, ["prompt-image"]);
+      process.emit(_result());
+      expect(await turn.outcome, isA<ClaudeTurnCompleted>());
+      await subscription.cancel();
+    });
+
+    test("does not correlate an unmarked text user message", () async {
+      await _ensure(repository, createNew: true);
+      final process = harness.processes.single;
+      final promptIds = <String?>[];
+      final subscription = repository.events
+          .where((event) => event is ClaudeSessionProcessMessage)
+          .cast<ClaudeSessionProcessMessage>()
+          .where((event) => event.message is ClaudeUserMessage)
+          .listen((event) => promptIds.add(event.promptId));
+      final turn = repository.sendTurn(
+        sessionId: testSessionId,
+        parts: const [PluginPromptPart.text(text: "ordinary text")],
+        promptId: "prompt-text",
+      );
+      final written = await waitForFrame(process, "user");
+
+      process.emit({...written, "uuid": "unmarked-text"});
+      await pump();
+
+      expect(promptIds, [null]);
+      process.emit(_result());
+      expect(await turn.outcome, isA<ClaudeTurnCompleted>());
+      await subscription.cancel();
+    });
+
     test("a late replay does not make an idle process look active", () async {
       await _ensure(repository, createNew: true);
       final process = harness.processes.single;
@@ -290,6 +343,33 @@ Map<String, Object?> _replayOf(Map<String, Object?> written, {required String uu
   "uuid": uuid,
   "isReplay": true,
 };
+
+Map<String, Object?> _decoratedImageEcho({required Map<String, Object?> written, required String uuid}) {
+  final message = (written["message"]! as Map).cast<String, Object?>();
+  final content = (message["content"]! as List).cast<Object?>();
+  final image = (content[1]! as Map).cast<String, Object?>();
+  final source = (image["source"]! as Map).cast<String, Object?>();
+  return {
+    ...written,
+    "uuid": uuid,
+    "message": {
+      ...message,
+      "content": [
+        content.first,
+        {
+          ...image,
+          "cache_control": {"type": "ephemeral"},
+          "source": {
+            ...source,
+            "media_type": "image/jpeg",
+            "data": "aA",
+            "cache_control": {"type": "ephemeral"},
+          },
+        },
+      ],
+    },
+  };
+}
 
 final class _ProcessHarness() {
   final List<ClaudeLaunchSpec> specs = [];

--- a/client/app/lib/features/session_detail/widgets/queued_message_bubble.dart
+++ b/client/app/lib/features/session_detail/widgets/queued_message_bubble.dart
@@ -1,4 +1,5 @@
 import "package:material_ui/material_ui.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:theme_prego/module_prego.dart";
 
 import "../../../core/extensions/build_context_x.dart";
@@ -22,6 +23,11 @@ class const QueuedMessageBubble({
   required final String? displayText,
   required final bool isCommand,
   required final int attachmentCount,
+
+  /// Image bytes remain local while a submission is sending or awaiting the
+  /// bridge queue. Once another surface owns the queue, only its bounded count
+  /// is available and the bubble renders an attachment indicator instead.
+  required final List<ComposerAttachment> localAttachments,
   required final QueuedMessageBubblePresentation presentation,
 }) extends StatelessWidget {
   @override
@@ -89,8 +95,12 @@ class const QueuedMessageBubble({
       mainAxisSize: MainAxisSize.min,
       children: [
         UserMessageBubble(
-          markdown: displayText ?? loc.sessionDetailQueuedAttachmentCount(attachmentCount),
-          attachments: const [],
+          markdown: displayText,
+          attachments: [
+            if (localAttachments.isNotEmpty) _QueuedAttachmentPreviews(attachments: localAttachments),
+            if (attachmentCount > 0 && (localAttachments.isEmpty || displayText == null))
+              _QueuedAttachmentCount(count: attachmentCount),
+          ],
           outlined: isPending,
           transitionDuration: duration,
         ),
@@ -133,6 +143,65 @@ class const QueuedMessageBubble({
           ),
         ),
       ],
+    );
+  }
+}
+
+class const _QueuedAttachmentPreviews({required final List<ComposerAttachment> attachments}) extends StatelessWidget {
+  static const double _thumbnailSize = 64;
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(bottom: PregoSpacing.sm),
+      child: Wrap(
+        spacing: PregoSpacing.sm,
+        runSpacing: PregoSpacing.sm,
+        children: [
+          for (final attachment in attachments)
+            Semantics(
+              image: true,
+              label: attachment.filename ?? context.loc.sessionDetailAttachedImage,
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(prego.radius.lg),
+                child: Image.memory(
+                  attachment.bytes,
+                  width: _thumbnailSize,
+                  height: _thumbnailSize,
+                  cacheWidth: (_thumbnailSize * MediaQuery.devicePixelRatioOf(context)).round(),
+                  fit: BoxFit.cover,
+                  gaplessPlayback: true,
+                  errorBuilder: (_, _, _) => ColoredBox(
+                    color: prego.colors.bgSurface2,
+                    child: Icon(Icons.broken_image, color: prego.colors.textSecondary),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class const _QueuedAttachmentCount({required final int count}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(bottom: PregoSpacing.sm),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(TablerRegular.photo, size: 16, color: prego.colors.textBrandPrimary),
+          const SizedBox(width: PregoSpacing.xs),
+          Text(
+            context.loc.sessionDetailQueuedAttachmentCount(count),
+            style: prego.textTheme.textSm.medium.copyWith(color: prego.colors.textBrandPrimary),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -477,6 +477,7 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
               displayText: _bridgePromptDisplayText(prompt),
               isCommand: prompt.command != null,
               attachmentCount: prompt.attachmentCount,
+              localAttachments: const [],
               presentation: onCancel == null
                   ? const QueuedMessageBubblePresentation.pendingReadOnly()
                   : QueuedMessageBubblePresentation.pending(onCancel: () => onCancel(prompt.id)),
@@ -497,6 +498,7 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
             displayText: submission.displayText,
             isCommand: submission.isCommand,
             attachmentCount: submission.attachments.length,
+            localAttachments: submission.attachments,
             presentation: transientSubmission.isSending
                 ? const QueuedMessageBubblePresentation.sending()
                 : transientSubmission.awaitingBridge || onCancelQueuedMessage == null

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -2742,7 +2742,7 @@ void main() {
     );
   });
 
-  testWidgets("a queued attachment-only submission shows an image count instead of a blank bubble", (tester) async {
+  testWidgets("a queued attachment-only submission shows its thumbnail and image count", (tester) async {
     final state = _loadedState(pendingQuestions: const [], pendingPermissions: const []).copyWith(
       queuedMessages: [
         QueuedSessionSubmission.text(
@@ -2764,19 +2764,22 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text("1 image"), findsOneWidget);
+    expect(find.descendant(of: find.byType(QueuedMessageBubble), matching: find.byType(Image)), findsOneWidget);
   });
 
   testWidgets("a queued submission renders inline with the transcript", (tester) async {
-    const submission = QueuedSessionSubmission.text(
+    final submission = QueuedSessionSubmission.text(
       promptId: "prompt-1",
       text: "Please **review** `main.dart`",
       inputMode: ComposerInputMode.typed,
-      attachments: [],
+      attachments: [
+        ComposerAttachment(mime: "image/png", bytes: _tinyPng, filename: "reference.png"),
+      ],
       agent: "coder",
       agentModel: null,
     );
     final state = _loadedState(pendingQuestions: const [], pendingPermissions: const []).copyWith(
-      queuedMessages: const [submission],
+      queuedMessages: [submission],
     );
     when(() => cubit.state).thenReturn(state);
     whenListen(cubit, const Stream<SessionDetailState>.empty(), initialState: state);
@@ -2805,6 +2808,7 @@ void main() {
     );
     expect(bubble.outlined, isTrue);
     expect(find.descendant(of: find.byType(QueuedMessageBubble), matching: find.byType(MarkdownBody)), findsOneWidget);
+    expect(find.descendant(of: find.byType(QueuedMessageBubble), matching: find.byType(Image)), findsOneWidget);
     expect(find.text("Queued"), findsOneWidget);
     expect(find.text("Cancel"), findsOneWidget);
     expect(tester.getSize(find.widgetWithText(TextButton, "Cancel")).height, 44);

--- a/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -252,7 +252,7 @@ void main() {
         initialMessages: const [],
         initialStreamingText: const {},
         initialBridgeQueuedPrompts: const [
-          QueuedSessionPrompt(id: "prm_1", text: "steer it", command: null, attachmentCount: 0, createdAt: 100),
+          QueuedSessionPrompt(id: "prm_1", text: "steer it", command: null, attachmentCount: 1, createdAt: 100),
           QueuedSessionPrompt(id: "prm_2", text: "src", command: "review", attachmentCount: 0, createdAt: 200),
         ],
       ),
@@ -260,6 +260,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text("steer it"), findsOneWidget);
+    expect(find.text("1 image"), findsOneWidget);
     expect(find.text("/review src"), findsOneWidget);
     expect(find.text("Cancel"), findsNWidgets(2));
 

--- a/docs/regression/attachments-and-images.md
+++ b/docs/regression/attachments-and-images.md
@@ -21,7 +21,10 @@ content the transcript renders live and after reload.
   settlement. A failed current-route launch restores those attachments together
   with text/voice/command intent before the composer remounts; failure after route
   exit never restores them. Reconnect and options refresh cannot erase a pending
-  one-shot restoration.
+  one-shot restoration. While that local submission is sending or awaiting the
+  bridge queue, its transcript row previews its staged images; a bridge-owned
+  queued row exposes only its attachment count so image bytes are not rebroadcast
+  to other surfaces.
 - Maximum-size staged input is encoded with bounded event-loop yields through
   attachment base64, request JSON, and relay-envelope JSON/UTF-8. Encoding
   preserves exact bytes without copying attachment buffers through an isolate.

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -175,12 +175,15 @@ defaults and queued client sends coherent.
   dispatch, using the link its backend exposes — Claude's queue entry, ACP's
   accepted send, Pi's dispatcher, Codex's client-supplied identifier, and
   OpenCode's server-reserved ordered message identifier that the bridge reuses
-  for the real dispatch. OpenCode applies the same correlation to prompts,
-  slash commands, and manual compaction. Compaction renders only the user-entered
-  command arguments; bridge-authored guidance remains backend-only. A message
-  authored in the backend's own UI carries no prompt id and renders as an
-  ordinary transcript message. A harness that publishes no user echo at all
-  leaves the client's own copy to be settled by the next snapshot instead.
+  for the real dispatch. Claude compares image echoes by their semantic source
+  fields, including an image echo that omits the usual replay marker, so
+  backend-added metadata cannot strand the queued row. OpenCode applies the same
+  correlation to prompts, slash commands, and manual compaction.
+  Compaction renders only the user-entered command arguments; bridge-authored
+  guidance remains backend-only. A message authored in the backend's own UI
+  carries no prompt id and renders as an ordinary transcript message. A harness
+  that publishes no user echo at all leaves the client's own copy to be settled
+  by the next snapshot instead.
 - Queued and sending text render as the newest rows inside the scrollable
   transcript, never as controls pinned above the composer. They use the same
   brand bubble and Markdown rendering as settled user text; a compact status


### PR DESCRIPTION
## Complexity
⚙️ Moderate — localized Claude stream correlation plus queued-message presentation.

## What
- Correlate Claude image echoes even when the CLI omits `isReplay` or decorates image metadata.
- Stamp the resulting user message with the queued prompt ID so it replaces the queued row.
- Show locally staged image thumbnails in queued bubbles and a bounded image count for bridge-owned queued prompts.

## Why
Claude Code can surface an image user echo without the usual replay marker. The bridge then rendered the image as an uncorrelated message while leaving its queued copy visible.

## Risk and test focus
User-visible session transcript and queue handoff behavior only. No database impact. The image fallback remains content-exact and applies to unmarked image echoes only; unmarked text remains uncorrelated.

## Expected result
An image prompt appears once as its sent message, its queued bubble clears as soon as the echo is rendered, and queued image state visibly indicates its attachment.

## Verification
- `cd bridge && dart test sesori_plugin_claude/test/claude_session_process_repository_test.dart sesori_plugin_claude/test/claude_plugin_impl_test.dart`
- `cd bridge && dart analyze sesori_plugin_claude`
- `cd client && flutter test app/test/features/session_detail/widgets/session_detail_body_test.dart app/test/features/session_detail/widgets/session_detail_message_list_test.dart`
- `cd client && dart analyze app`
