### PR TITLE
🌱 Bump release version to 1.8.2

### DIFF
--- a/bridge/app/lib/src/version.dart
+++ b/bridge/app/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '1.8.1';
+const String appVersion = '1.8.2';

--- a/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-arm64",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS ARM64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.1",
+    "releaseTag": "v1.8.2",
     "releaseArtifact": "sesori-bridge-macos-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-darwin-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-x64",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS x64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.1",
+    "releaseTag": "v1.8.2",
     "releaseArtifact": "sesori-bridge-macos-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-arm64",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux ARM64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.1",
+    "releaseTag": "v1.8.2",
     "releaseArtifact": "sesori-bridge-linux-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-x64",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux x64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.1",
+    "releaseTag": "v1.8.2",
     "releaseArtifact": "sesori-bridge-linux-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-arm64",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows ARM64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.1",
+    "releaseTag": "v1.8.2",
     "releaseArtifact": "sesori-bridge-windows-arm64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-x64",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows x64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.1",
+    "releaseTag": "v1.8.2",
     "releaseArtifact": "sesori-bridge-windows-x64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge/package.json
+++ b/bridge/app/npm/sesori-bridge/package.json
@@ -1,22 +1,22 @@
 {
   "name": "@sesori/bridge",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Bootstrap launcher for the managed Sesori Bridge runtime",
   "bin": {
     "sesori-bridge": "bin/bridge.js"
   },
   "optionalDependencies": {
-    "@sesori/bridge-darwin-arm64": "1.8.1",
-    "@sesori/bridge-darwin-x64": "1.8.1",
-    "@sesori/bridge-linux-x64": "1.8.1",
-    "@sesori/bridge-linux-arm64": "1.8.1",
-    "@sesori/bridge-win32-x64": "1.8.1",
-    "@sesori/bridge-win32-arm64": "1.8.1"
+    "@sesori/bridge-darwin-arm64": "1.8.2",
+    "@sesori/bridge-darwin-x64": "1.8.2",
+    "@sesori/bridge-linux-x64": "1.8.2",
+    "@sesori/bridge-linux-arm64": "1.8.2",
+    "@sesori/bridge-win32-x64": "1.8.2",
+    "@sesori/bridge-win32-arm64": "1.8.2"
   },
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.1",
+    "releaseTag": "v1.8.2",
     "runtimeBundleSource": "github-release-assets"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sesori_bridge
 description: Dart implementation of the Sesori Bridge CLI for WebSocket communication.
-version: 1.8.1
+version: 1.8.2
 publish_to: none
 resolution: workspace
 

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -17,7 +17,7 @@ resolution: workspace
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.8.1+1
+version: 1.8.2+1
 environment:
   sdk: ^3.13.1
 


### PR DESCRIPTION
## Complexity

🌱 Trivial — synchronized release metadata only.

## What

- Bump the bridge and mobile app release version from 1.8.1 to 1.8.2.
- Align all bridge npm package versions, optional dependencies, and release tags with v1.8.2.

## Why

Prepare the shared app and bridge release metadata for the 1.8.2 release.

## Risk and test focus

Low risk. Verify all release manifests remain synchronized. There is no database impact; the user-visible impact is limited to the reported app/bridge version.

## Expected result

Release tooling builds and publishes the bridge and mobile app as version 1.8.2.

## Verification

- `make bump-version VERSION=1.8.2`
- `make bump-version-check VERSION=1.8.2`
- `git diff --check`
- Targeted Dart version-tool tests were attempted, but Dart pub failed while running build hooks with `Bad state: Attempting to send request on closed client`.
