### PR TITLE
🌿 Drop rolled-back messages on a history re-read

### DIFF
--- a/bridge/app/lib/src/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/repositories/chat_history_repository.dart
@@ -350,14 +350,25 @@ class ChatHistoryRepository({
   /// Replaces the session's transcript with [messages], numbering them in
   /// transcript order.
   ///
-  /// Rows the transcript does not contain are retained. Their recorded message
-  /// time determines where they rejoin the imported transcript while their
-  /// relative order stays stable. Thus an older backend-only row cannot jump to
-  /// the newest edge on re-import, while a genuinely newer live row stays there.
+  /// Rows the transcript does not contain are retained only when they were
+  /// written after [lastImportedAt], the moment the previous import finished.
+  /// Those are the rows that import could not have covered: a live capture
+  /// since, or one the backend never reports at all. An older row was in an
+  /// earlier transcript and is not in this one, so the backend removed it —
+  /// an edited message rolls its session back, and a bridge that was not
+  /// watching that backend sees the removal only as this gap. Keeping it would
+  /// restore messages the user deleted elsewhere. A session with no completed
+  /// import has no such line to draw, so everything stored is kept.
+  ///
+  /// Retained rows rejoin the imported transcript at their recorded message
+  /// time while their relative order stays stable. Thus an older backend-only
+  /// row cannot jump to the newest edge on re-import, while a genuinely newer
+  /// live row stays there.
   Future<void> replaceSessionMessages({
     required String sessionId,
     required AttachmentStorageScope storageScope,
     required List<MessageWithParts> messages,
+    required int? lastImportedAt,
     required int watermark,
     required int backendActivityAt,
     required int syncedAt,
@@ -366,7 +377,7 @@ class ChatHistoryRepository({
     final storedRows = await _chatHistoryDao.getMessages(sessionId: sessionId);
     final retained = [
       for (final row in storedRows)
-        if (!importedIds.contains(row.messageId)) row,
+        if (!importedIds.contains(row.messageId) && (lastImportedAt == null || row.updatedAt > lastImportedAt)) row,
     ];
 
     final importedMessageRows = <HistoryMessagesTableData>[];

--- a/bridge/app/lib/src/services/chat_history_service.dart
+++ b/bridge/app/lib/src/services/chat_history_service.dart
@@ -625,6 +625,7 @@ class ChatHistoryService({
           sessionId: sessionId,
           storageScope: storageScope,
           messages: messages,
+          lastImportedAt: observedBefore?.syncedAt,
           watermark: backendActivityAt,
           backendActivityAt: backendActivityAt,
           syncedAt: DateTime.now().millisecondsSinceEpoch,

--- a/bridge/app/test/bridge/services/chat_history_capture_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_capture_test.dart
@@ -401,6 +401,9 @@ void main() {
       );
       final history = createTestChatHistory(sessionRepository: repository);
       await history.service.backfillSession(sessionId: "ses_a");
+      // Write times are what separate a live capture from the import it follows,
+      // and this whole setup runs inside one millisecond otherwise.
+      await Future<void>.delayed(const Duration(milliseconds: 2));
       await history.service.captureMessage(
         sessionId: "ses_a",
         message: _messageAt(id: "retained", createdAt: 200),
@@ -424,6 +427,29 @@ void main() {
       expect(
         (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
         const ["before", "retained", "retained-error", "after"],
+      );
+    });
+
+    // Editing a message in the backend's own client rolls the session back and
+    // deletes what followed. A bridge that was not watching never sees the
+    // removal events, so the re-import's gap is the only evidence it gets.
+    test("drops a message an earlier transcript contained and this one omits", () async {
+      final transcript = [
+        _messageWithPartsAt(id: "kept", createdAt: 100),
+        _messageWithPartsAt(id: "reverted", createdAt: 200),
+      ];
+      final repository = _FakeSessionRepository(transcript: transcript);
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      transcript
+        ..removeWhere((message) => message.info.id == "reverted")
+        ..add(_messageWithPartsAt(id: "replacement", createdAt: 300));
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      expect(
+        (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
+        const ["kept", "replacement"],
       );
     });
 

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -15,7 +15,11 @@ and rejoined after a client reconnect, plugin restart, or bridge restart.
 - Messages visible live but absent from the backend's replay remain visible
   after a stale re-read. They rejoin at their recorded creation time while
   preserving relative order, so a catalog re-import cannot move old rows to the
-  newest edge.
+  newest edge. A message a backend replay once contained is the opposite case:
+  its later absence is a removal, so a re-read drops it. That is how a session
+  rolled back outside Sesori — an edited message in the backend's own client,
+  with no removal events reaching this bridge — stops showing the messages it
+  replaced.
 - Live streamed messages and parts become queryable immediately after they
   finalize, with the same visibility filtering and tool-output bound a backend
   fetch returns. Reasoning finalizes when the stream advances to assistant or
@@ -90,7 +94,9 @@ image parts converge by their own rules.
   reattachment, or triggers repeated requests while one page is in flight.
 - A session advanced outside Sesori keeps serving the old transcript, or stored
   transcripts are marked complete after a gap without a full re-sync.
-- A stale re-read moves an older retained message to the newest edge.
+- A stale re-read moves an older retained message to the newest edge, or keeps
+  showing a message the backend removed — a rolled-back turn reappearing above
+  the edited one that replaced it.
 - A released database row or audit file is rejected because a known message-part
   payload omitted variant-specific data, or a decoded known variant still carries
   null variant data.


### PR DESCRIPTION
## Complexity

Straightforward. One changed condition in the re-import merge, plus the
timestamp it compares against.

## What

`replaceSessionMessages` retained every stored row the fetched transcript
omitted. It now retains only rows written after the previous import
finished:

```dart
if (!importedIds.contains(row.messageId) && (lastImportedAt == null || row.updatedAt > lastImportedAt))
```

Those are the rows that import could not have covered — a live capture
since, or one the backend never reports at all. An older row was in an
earlier transcript and is not in this one, so the backend removed it. A
session with no completed import has no such line to draw, so everything
stored is kept.

No schema change and no migration. `lastImportedAt` is the sync state's
existing `syncedAt`, read before the backfill overwrites it.

## Why

Reported from a running build: a message edited in OpenCode's own web client
rolled the session back and replaced the turn, and after a deep pull to
refresh Sesori showed both the old message and its reply *and* the edited
message and its reply.

OpenCode emits `message.removed` on that rollback and the bridge handles it
(`orchestrator.dart` -> `captureMessageRemoved`) — but only while it is
watching that server. The edit happened on a separate OpenCode server, so no
event arrived, and the catalog rescan's staleness re-read was the only
recovery path. That path could add messages and never remove them.

## Risk and test focus

No user-visible change beyond removed messages no longer reappearing. No
database, wire, or client change.

The behaviour to watch is the one the retention exists for — a live-captured
message the backend's replay does not contain must still survive a re-read,
and must still rejoin at its creation time rather than at the newest edge.
Both existing tests for that pass; one gained a 2ms delay because its whole
setup otherwise runs inside a single millisecond, and write time is what now
separates a capture from the import it follows.

Known residue, accepted as not worth more machinery: a message captured in
the same millisecond an import completes is dropped at the next import if the
backend also omits it, and messages already duplicated in existing stores
stay until their session is re-read. Both are cosmetic and self-correcting.

## Expected result

Editing a message in the backend's own client while the bridge is not
watching, then re-reading the session in Sesori, shows the edited turn only.
Live-only messages, ordering, and paging are unchanged.

## Verification

- `dart test test/bridge/services/ test/drift/chat_history/` — 354 passed,
  including the two retention guarantees and a new test for the rollback.
- `dart analyze lib test` in `bridge/app` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
