### PR TITLE
🌱 Format session dates using the device locale

### DIFF
--- a/client/app/lib/core/extensions/build_context_x.dart
+++ b/client/app/lib/core/extensions/build_context_x.dart
@@ -36,6 +36,12 @@ extension BuildContextLocalization on BuildContext {
     return localizations;
   }
 
+  /// The app currently resolves every English-speaking user to the generic
+  /// `en` translation, which loses the device's region. Date formatting uses
+  /// the full platform locale so, for example, `en_GB` does not inherit the
+  /// generic English month/day order.
+  String get _dateFormattingLocale => View.of(this).platformDispatcher.locale.toString();
+
   String formatTimestamp(int ms) {
     final date = DateTime.fromMillisecondsSinceEpoch(ms);
     final now = DateTime.now();
@@ -45,7 +51,7 @@ extension BuildContextLocalization on BuildContext {
     if (diff.inHours < 1) return loc.timestampMinutesAgo(diff.inMinutes);
     if (diff.inDays < 1) return loc.timestampHoursAgo(diff.inHours);
     if (diff.inDays < 30) return loc.timestampDaysAgo(diff.inDays);
-    return DateFormat.yMd(loc.localeName).format(date);
+    return DateFormat.yMd(_dateFormattingLocale).format(date);
   }
 
   /// The same instant as [formatTimestamp], shortened to what a list row's
@@ -69,7 +75,9 @@ extension BuildContextLocalization on BuildContext {
     if (diff.inDays < 1) return loc.timestampCompactHours(diff.inHours);
     if (diff.inDays < 30) return loc.timestampCompactDays(diff.inDays);
 
-    final pattern = date.year == now.year ? DateFormat.Md(loc.localeName) : DateFormat.yMd(loc.localeName);
+    final pattern = date.year == now.year
+        ? DateFormat.Md(_dateFormattingLocale)
+        : DateFormat.yMd(_dateFormattingLocale);
     return pattern.format(date);
   }
 
@@ -82,7 +90,7 @@ extension BuildContextLocalization on BuildContext {
   String formatMessageTimestamp(int ms) {
     final date = DateTime.fromMillisecondsSinceEpoch(ms);
     final now = DateTime.now();
-    final locale = loc.localeName;
+    final locale = _dateFormattingLocale;
     final time = DateFormat.jm(locale).format(date);
 
     final isToday = date.year == now.year && date.month == now.month && date.day == now.day;

--- a/client/app/test/core/extensions/build_context_x_test.dart
+++ b/client/app/test/core/extensions/build_context_x_test.dart
@@ -3,7 +3,13 @@ import "package:material_ui/material_ui.dart";
 import "package:sesori_mobile/core/extensions/build_context_x.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 
-Future<BuildContext> _pumpContext(WidgetTester tester) async {
+Future<BuildContext> _pumpContext(
+  WidgetTester tester, {
+  Locale platformLocale = const Locale("en", "US"),
+}) async {
+  tester.platformDispatcher.localeTestValue = platformLocale;
+  addTearDown(tester.platformDispatcher.clearLocaleTestValue);
+
   late BuildContext captured;
   await tester.pumpWidget(
     MaterialApp(
@@ -22,6 +28,22 @@ Future<BuildContext> _pumpContext(WidgetTester tester) async {
 }
 
 void main() {
+  group("formatTimestampCompact", () {
+    testWidgets("uses the user's full platform locale for old session dates", (tester) async {
+      final date = DateTime(DateTime.now().year - 1, 7, 8);
+
+      final britishContext = await _pumpContext(tester, platformLocale: const Locale("en", "GB"));
+      final britishLabel = britishContext.formatTimestampCompact(ms: date.millisecondsSinceEpoch);
+
+      expect(britishLabel, "08/07/${date.year}");
+
+      final americanContext = await _pumpContext(tester);
+      final americanLabel = americanContext.formatTimestampCompact(ms: date.millisecondsSinceEpoch);
+
+      expect(americanLabel, "7/8/${date.year}");
+    });
+  });
+
   group("formatMessageTimestamp", () {
     testWidgets("shows time only for messages from today", (tester) async {
       final context = await _pumpContext(tester);

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -114,6 +114,9 @@ child sessions with titles, activity, statuses, and unseen state.
 - Session listings are project-scoped and pageable and carry plugin attribution,
   times, worktree and branch facts, prompt defaults, and unseen state that
   advances on activity and clears on view or mark-as-read.
+- Session activity stays relative for 30 days. Older rows use a compact numeric
+  date whose field order and separators follow the user's full device locale;
+  dates from the current year omit the year, while earlier years remain explicit.
 - A listed session's `session.updated` reports the newest instant the bridge
   knows: the backend's own updated time, or the live user-message marker when
   that is newer. A plugin that reports an updated time only at import or rename
@@ -205,8 +208,9 @@ leave the surface that started one. Restore harness eligibility afterwards.
 - A running root or project stays alphabetically ordered, a stale marker masks
   newer committed activity, a null marker fails to use updated time,
   awaiting-only is promoted, or inactive session/project or child order changes.
-- A session prompted minutes ago reports a days-old updated time, or sorts to
-  the top of its list while still displaying that stale time.
+- A session prompted minutes ago reports a days-old updated time, sorts to the
+  top of its list while still displaying that stale time, or an older row uses
+  generic US month/day order despite a different device locale.
 - Unseen never clears, clears without viewing, or an unavailable plugin is idle.
 - Hiding destroys sessions, or a cancelled import destroys the committed catalog.
 - A project or session row animates under a system back gesture, or an edge that
@@ -271,6 +275,7 @@ leave the surface that started one. Restore harness eligibility afterwards.
   `client/module_core/test/cubits/session_list/session_list_cubit_test.dart`,
   `client/module_prego/test/interactions/prego_swipe_actions_test.dart`,
   `client/module_prego/test/components/prego_sliver_refresh_control_test.dart`,
+  `client/app/test/core/extensions/build_context_x_test.dart`,
   `client/app/test/core/widgets/catalog_scan_row_test.dart`,
   `client/app/test/features/project_list/project_list_catalog_scan_test.dart`,
   `client/app/test/features/session_list/session_list_panel_test.dart`


### PR DESCRIPTION
## Complexity

🌱 Trivial — this changes the locale source used by an existing timestamp formatter and adds focused coverage.

## What

- Format absolute timestamps with the user's full platform locale instead of the generic app translation locale.
- Cover British and American English date ordering for older session timestamps.
- Record locale-aware session dates in the projects-and-sessions regression contract.

## Why

The app currently has a generic `en` translation, so its localization locale drops the device region. That made users outside the US inherit generic English month/day ordering even when their device locale uses another order.

## Risk and test focus

Low. User-visible impact: absolute dates and times now follow the device locale; relative timestamps are unchanged. Database impact: none. Focus is the 30-day transition to absolute session dates and preservation of region-specific ordering.

## Expected result

Older session rows use locale-appropriate field order and separators, such as `08/07/2025` for `en_GB` and `7/8/2025` for `en_US`.

## Verification

- `cd client/app && flutter test test/core/extensions/build_context_x_test.dart`
- `cd client/app && flutter test test/features/session_list/session_tile_states_test.dart`
- `cd client/app && flutter analyze`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formats absolute session timestamps using the device's full platform locale so older session dates use region-correct order and separators instead of the generic `en` translation.

- Absolute dates for sessions older than 30 days now follow the device locale, e.g. `08/07/2025` for `en_GB` and `7/8/2025` for `en_US`.
- Relative timestamps are unchanged, and the projects-and-sessions regression contract now records locale-aware session dates.

<sup>Written for commit f54c76af9db67ec4f0e7996b4d0fb9164e83b150. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

