### PR TITLE
⚙️ Preserve harness error details and Pi retry status

### DIFF
--- a/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
+++ b/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
@@ -73,6 +73,27 @@ void main() {
       );
     });
 
+    test("maps serialized plugin retry status through the shared SSE union", () {
+      final result = mapEvent(
+        BridgeSseSessionStatus(
+          sessionID: "s1",
+          status: const PluginSessionStatus.retry(
+            attempt: 1,
+            message: "provider overloaded",
+            next: 2000,
+          ).toJson(),
+        ),
+      );
+
+      expect(result, isA<SesoriSessionStatus>());
+      final event = result! as SesoriSessionStatus;
+      expect(event.sessionID, "s1");
+      expect(
+        event.status,
+        const SessionStatus.retry(attempt: 1, message: "provider overloaded", next: 2000),
+      );
+    });
+
     test("attributes command catalog updates to their source plugin", () {
       final result = mapper.map(
         event: const BridgeSseCommandCatalogUpdated(),

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -19,13 +19,12 @@ import "repositories/trackers/acp_tool_content_tracker.dart";
 /// backend that knows its own gate wording recognizes it (see
 /// [AcpEventMapper.classifyHaltNotice]) and it is surfaced as a
 /// [shared.Message.error] instead of quiet assistant text, giving the user an
-/// explicit "the turn did not run" signal.
+/// explicit "the turn did not run" signal. Classification carries no replacement
+/// message; the mapper always forwards the original backend text unchanged.
 class const AcpHaltNotice({
   /// Short stable label for the halt class (e.g. "cursor_gate"), carried in
   /// the error message's `errorName`.
   required final String errorName,
-  /// The user-facing notice text to show (the agent's own wording).
-  required final String message,
 });
 
 /// Translates ACP `session/update` notifications into bridge-neutral
@@ -517,10 +516,11 @@ class AcpEventMapper({
   /// that splits its notice across chunks) has to account for the live per-chunk
   /// shape.
   ///
-  /// Base backends never halt this way; harness subclasses that emit
-  /// recognizable gate text (e.g. Cursor) override this. Also consulted by the
-  /// history-replay collector so a reloaded session renders the notice the same
-  /// way it did live.
+  /// The returned notice classifies the text but cannot replace it; live and
+  /// replay mapping retain [text] verbatim. Base backends never halt this way;
+  /// harness subclasses that emit recognizable gate text (e.g. Cursor) override
+  /// this. The history-replay collector also consults it so a reloaded session
+  /// renders the notice the same way it did live.
   AcpHaltNotice? classifyHaltNotice({required String text}) => null;
 
   List<BridgeSseEvent> _assistantContentChunk({
@@ -600,7 +600,7 @@ class AcpEventMapper({
       final text = blocks.whereType<AcpMappedTextContentBlock>().map((block) => block.text).join();
       if (text.isNotEmpty) {
         final halt = classifyHaltNotice(text: text);
-        if (halt != null) return _haltNoticeEvents(sessionId: sessionId, notice: halt);
+        if (halt != null) return _haltNoticeEvents(sessionId: sessionId, notice: halt, message: text);
       }
     }
 
@@ -689,7 +689,7 @@ class AcpEventMapper({
     // text (no regression).
     if (partType == PluginMessagePartType.text) {
       final halt = classifyHaltNotice(text: text);
-      if (halt != null) return _haltNoticeEvents(sessionId: sessionId, notice: halt);
+      if (halt != null) return _haltNoticeEvents(sessionId: sessionId, notice: halt, message: text);
     }
 
     // ACP v1: chunks of one message share a `messageId`; a change starts a new
@@ -788,6 +788,7 @@ class AcpEventMapper({
   List<BridgeSseEvent> _haltNoticeEvents({
     required String sessionId,
     required AcpHaltNotice notice,
+    required String message,
   }) {
     final messageId = "$sessionId-t${_turn(sessionId)}-halt";
     final started = _startedParts.putIfAbsent(sessionId, () => <String>{});
@@ -808,7 +809,7 @@ class AcpEventMapper({
           modelID: modelForSession(sessionId: sessionId),
           providerID: providerForSession(sessionId: sessionId),
           errorName: notice.errorName,
-          errorMessage: notice.message,
+          errorMessage: message,
           time: null,
         ).toJson(),
       ),

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -212,7 +212,7 @@ class AcpReplayCollector({
             modelID: modelId,
             providerID: providerId,
             errorName: halt.errorName,
-            errorMessage: halt.message,
+            errorMessage: assistantText,
             time: null,
           ),
           parts: const [],

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -1239,7 +1239,7 @@ void main() {
         events.whereType<BridgeSseMessageUpdated>().single.info,
       );
       expect(message, isA<shared.MessageError>());
-      expect((message as shared.MessageError).errorMessage, "HALT: fix it");
+      expect((message as shared.MessageError).errorMessage, "\n\nHALT: fix it");
       // No assistant text part or delta — the notice rides in the error message.
       expect(events.whereType<BridgeSseMessagePartUpdated>(), isEmpty);
       expect(events.whereType<BridgeSseMessagePartDelta>(), isEmpty);
@@ -1418,7 +1418,7 @@ void main() {
 }
 
 /// Test double: classifies any message whose trimmed text starts with "HALT:"
-/// as a halt notice, using the trimmed text as the shown message.
+/// while the base mapper preserves the original text as the shown message.
 class _HaltMapper({required super.configurationTracker}) extends AcpEventMapper {
   this
     : super(
@@ -1430,7 +1430,7 @@ class _HaltMapper({required super.configurationTracker}) extends AcpEventMapper 
   AcpHaltNotice? classifyHaltNotice({required String text}) {
     final trimmed = text.trim();
     if (trimmed.startsWith("HALT:")) {
-      return AcpHaltNotice(errorName: "test_halt", message: trimmed);
+      return const AcpHaltNotice(errorName: "test_halt");
     }
     return null;
   }

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -855,9 +855,8 @@ void main() {
             providerId: "cursor",
             initialUserMessageId: null,
             messageIdOverride: null,
-            haltClassifier: ({required text}) => text.trim() == "Check your settings to continue"
-                ? const AcpHaltNotice(errorName: "cursor_gate", message: "Check your settings to continue")
-                : null,
+            haltClassifier: ({required text}) =>
+                text.trim() == "Check your settings to continue" ? const AcpHaltNotice(errorName: "cursor_gate") : null,
           )..consume(
             upd({
               "sessionUpdate": "agent_message_chunk",
@@ -867,7 +866,7 @@ void main() {
 
       final message = collector.build().single;
       expect(message.info, isA<PluginMessageError>());
-      expect((message.info as PluginMessageError).errorMessage, "Check your settings to continue");
+      expect((message.info as PluginMessageError).errorMessage, "\n\nCheck your settings to continue");
       expect(message.parts, isEmpty);
     });
 
@@ -878,7 +877,7 @@ void main() {
             agentId: "Cursor",
             initialUserMessageId: null,
             messageIdOverride: null,
-            haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate", message: "gate"),
+            haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate"),
           )..consume(
             upd({
               "sessionUpdate": "agent_message_chunk",
@@ -897,7 +896,7 @@ void main() {
             agentId: "Cursor",
             initialUserMessageId: null,
             messageIdOverride: null,
-            haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate", message: "gate"),
+            haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate"),
           )..consume(
             upd({
               "sessionUpdate": "agent_message_chunk",
@@ -929,7 +928,7 @@ void main() {
             agentId: "Cursor",
             initialUserMessageId: null,
             messageIdOverride: null,
-            haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate", message: "gate"),
+            haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate"),
           )..consume(
             upd({
               "sessionUpdate": "agent_message_chunk",

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
@@ -337,6 +337,9 @@ final class const ClaudeApiRetryMessage({
   required final int? retryDelayMs,
   required final int? errorStatus,
   required final ClaudeAssistantError error,
+
+  /// The CLI-provided retry error, retained verbatim for user-facing status.
+  required final String? rawError,
   required super.sessionId,
   required super.uuid,
   required super.raw,
@@ -351,6 +354,7 @@ final class const ClaudeApiRetryMessage({
     retryDelayMs: _intOrNull(json["retry_delay_ms"]),
     errorStatus: _intOrNull(json["error_status"]),
     error: ClaudeAssistantError.parse(json["error"]),
+    rawError: _stringOrNull(json["error"]),
     sessionId: sessionId,
     uuid: uuid,
     raw: json,

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -65,7 +65,7 @@ final class ClaudeEventDispatcher({
     if (attempt == null || delay == null) return null;
     return PluginSessionStatus.retry(
       attempt: attempt,
-      message: _retryMessage(message.error),
+      message: _retryMessage(message),
       next: now.millisecondsSinceEpoch + delay,
     );
   }
@@ -379,7 +379,7 @@ final class ClaudeEventDispatcher({
         sessionID: sessionId,
         status: shared.SessionStatus.retry(
           attempt: attempt,
-          message: _retryMessage(message.error),
+          message: _retryMessage(message),
           next: now.millisecondsSinceEpoch + delay,
         ).toJson(),
       ),
@@ -478,23 +478,18 @@ String? _realModel({required String? model}) {
 PluginMessageTime? _messageTime(DateTime? timestamp) =>
     timestamp == null ? null : PluginMessageTime(created: timestamp.millisecondsSinceEpoch, completed: null);
 
-String _retryMessage(ClaudeAssistantError error) => switch (error) {
-  ClaudeAssistantError.authenticationFailed ||
-  ClaudeAssistantError.oauthOrgNotAllowed => "Claude Code is retrying after an authentication failure.",
-  ClaudeAssistantError.billingError => "Claude Code is retrying after a billing failure.",
-  ClaudeAssistantError.rateLimit => "Claude Code is retrying after a rate limit.",
-  ClaudeAssistantError.overloaded => "Claude Code is retrying because the service is overloaded.",
-  ClaudeAssistantError.modelNotFound => "Claude Code is retrying with the selected model.",
-  ClaudeAssistantError.maxOutputTokens => "Claude Code is retrying after reaching the output limit.",
-  ClaudeAssistantError.invalidRequest ||
-  ClaudeAssistantError.serverError ||
-  ClaudeAssistantError.unknown => "Claude Code is retrying the request.",
-};
+String _retryMessage(ClaudeApiRetryMessage message) => message.rawError ?? "Claude Code is retrying the request.";
 
 ({String name, String message}) _resultError(ClaudeResultMessage result) {
   if (!result.isError && result.subtype == ClaudeResultSubtype.success && result.permissionDenials.isNotEmpty) {
     return (name: "permission_denied", message: "Claude Code denied a tool without requesting permission.");
   }
+  final fallback = _resultErrorFallback(result);
+  final rawError = result.errors.isNotEmpty ? result.errors.join("\n") : result.result;
+  return rawError == null ? fallback : (name: fallback.name, message: rawError);
+}
+
+({String name, String message}) _resultErrorFallback(ClaudeResultMessage result) {
   if (result.apiErrorStatus == 401 || result.apiErrorStatus == 403) {
     return (name: "authentication_failed", message: "Claude Code authentication failed.");
   }

--- a/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
@@ -569,7 +569,7 @@ void main() {
       expect(contextOnly, isEmpty);
     });
 
-    test("maps retry and terminal errors with parseable privacy-safe payloads", () {
+    test("maps retry and terminal errors without replacing backend text", () {
       final before = DateTime.now().millisecondsSinceEpoch;
       final retry =
           _map(
@@ -589,7 +589,7 @@ void main() {
               as BridgeSseSessionStatus;
       final status = shared.SessionStatus.fromJson(retry.status) as shared.SessionStatusRetry;
       expect(status.attempt, 2);
-      expect(status.message, "Claude Code is retrying after a rate limit.");
+      expect(status.message, "rate_limit");
       expect(status.next, inInclusiveRange(before + 5000, DateTime.now().millisecondsSinceEpoch + 5000));
 
       _startMessage(mapper, messageId: "msg-error", model: "claude-opus-5");
@@ -604,16 +604,32 @@ void main() {
                   "is_error": true,
                   "terminal_reason": "api_error",
                   "api_error_status": 404,
-                  "result": "raw backend detail must not be forwarded",
+                  "result": "  raw backend detail must be forwarded  ",
                 },
               ).single
               as BridgeSseMessageUpdated;
       final info = shared.Message.fromJson(error.info) as shared.MessageError;
       expect(info.errorName, "api_error");
-      expect(info.errorMessage, "Claude Code could not complete the API request (HTTP 404).");
-      expect(info.errorMessage, isNot(contains("raw backend detail")));
+      expect(info.errorMessage, "  raw backend detail must be forwarded  ");
       expect(info.modelID, "claude-opus-5");
       expect(info.providerID, "anthropic");
+
+      final multipleErrors =
+          _map(
+                mapper,
+                {
+                  "type": "result",
+                  "subtype": "error_during_execution",
+                  "session_id": "session-1",
+                  "uuid": "result-multiple-errors",
+                  "is_error": true,
+                  "terminal_reason": "api_error",
+                  "errors": ["first backend error", "second backend error"],
+                },
+              ).single
+              as BridgeSseMessageUpdated;
+      final multipleInfo = shared.Message.fromJson(multipleErrors.info) as shared.MessageError;
+      expect(multipleInfo.errorMessage, "first backend error\nsecond backend error");
     });
 
     test("complete live assistant shapes match transcript history", () {

--- a/bridge/sesori_plugin_claude/test/claude_stream_message_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_stream_message_test.dart
@@ -99,7 +99,7 @@ void main() {
       expect(message.permissionDenials.single["tool_name"], "Write");
     });
 
-    test("reads an API retry frame without retaining raw error text", () {
+    test("reads an API retry frame while retaining raw error text", () {
       final message =
           ClaudeStreamMessage.parse({
                 "type": "system",
@@ -118,6 +118,7 @@ void main() {
       expect(message.retryDelayMs, 1500);
       expect(message.errorStatus, 429);
       expect(message.error, ClaudeAssistantError.rateLimit);
+      expect(message.rawError, "rate_limit");
     });
 
     test("reads both declared and success-shaped error results", () {

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
@@ -107,8 +107,8 @@ class CursorEventMapper({
   @override
   AcpHaltNotice? classifyHaltNotice({required String text}) {
     if (_isGateNotice(text)) {
-      // Preserve cursor-agent's own wording (trimmed) as the shown message.
-      return AcpHaltNotice(errorName: "cursor_gate", message: text.trim());
+      // AcpEventMapper preserves cursor-agent's exact wording as the shown message.
+      return const AcpHaltNotice(errorName: "cursor_gate");
     }
     return null;
   }

--- a/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
@@ -331,7 +331,7 @@ void main() {
       expect(message, isA<shared.MessageError>());
       expect(
         (message as shared.MessageError).errorMessage,
-        "Check your settings to continue",
+        "\n\nCheck your settings to continue",
       );
       expect(events.whereType<BridgeSseMessagePartDelta>(), isEmpty);
     });

--- a/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
@@ -52,6 +52,8 @@ class const BridgeSseSessionError({required final String? sessionID}) extends Br
 
 class const BridgeSseSessionCompacted({required final String sessionID}) extends BridgeSseEvent;
 
+/// [status] uses the shared session-status JSON shape with a `type` discriminator.
+/// `PluginSessionStatus.toJson()` produces that shape for plugin-owned status.
 // ignore: no_slop_linter/prefer_specific_type, SSE payload values are heterogeneous
 class const BridgeSseSessionStatus({required final String sessionID, required final Map<String, dynamic> status})
     extends BridgeSseEvent;

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_message.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_message.dart
@@ -333,6 +333,9 @@ sealed class PluginMessage with _$PluginMessage {
     required String? modelID,
     required String? providerID,
     required String errorName,
+
+    /// Backend-provided error text must be preserved verbatim when present.
+    /// A plugin may synthesize a fallback only when its backend supplied no text.
     required String errorMessage,
     required PluginMessageTime? time,
   }) = PluginMessageError;

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_message.freezed.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_message.freezed.dart
@@ -1992,6 +1992,8 @@ class PluginMessageError implements PluginMessage {
  final  String? modelID;
  final  String? providerID;
  final  String errorName;
+/// Backend-provided error text must be preserved verbatim when present.
+/// A plugin may synthesize a fallback only when its backend supplied no text.
  final  String errorMessage;
 @override final  PluginMessageTime? time;
 

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_session_status.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_session_status.dart
@@ -4,7 +4,11 @@ part "plugin_session_status.freezed.dart";
 
 part "plugin_session_status.g.dart";
 
-@freezed
+/// Backend-neutral session status.
+///
+/// Its JSON shape intentionally matches shared `SessionStatus`, including the
+/// `type` discriminator consumed at the plugin-to-client SSE boundary.
+@Freezed(unionKey: "type")
 sealed class PluginSessionStatus with _$PluginSessionStatus {
   const factory idle() = PluginSessionStatusIdle;
   const factory busy() = PluginSessionStatusBusy;

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_session_status.freezed.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_session_status.freezed.dart
@@ -54,7 +54,7 @@ class PluginSessionStatusIdle implements PluginSessionStatus {
 
 
 
-@JsonKey(name: 'runtimeType')
+@JsonKey(name: 'type')
 final String $type;
 
 
@@ -93,7 +93,7 @@ class PluginSessionStatusBusy implements PluginSessionStatus {
 
 
 
-@JsonKey(name: 'runtimeType')
+@JsonKey(name: 'type')
 final String $type;
 
 
@@ -134,7 +134,7 @@ class PluginSessionStatusRetry implements PluginSessionStatus {
  final  String message;
  final  int next;
 
-@JsonKey(name: 'runtimeType')
+@JsonKey(name: 'type')
 final String $type;
 
 

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_session_status.g.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_session_status.g.dart
@@ -8,11 +8,11 @@ part of 'plugin_session_status.dart';
 
 Map<String, dynamic> _$PluginSessionStatusIdleToJson(
   PluginSessionStatusIdle instance,
-) => <String, dynamic>{'runtimeType': instance.$type};
+) => <String, dynamic>{'type': instance.$type};
 
 Map<String, dynamic> _$PluginSessionStatusBusyToJson(
   PluginSessionStatusBusy instance,
-) => <String, dynamic>{'runtimeType': instance.$type};
+) => <String, dynamic>{'type': instance.$type};
 
 Map<String, dynamic> _$PluginSessionStatusRetryToJson(
   PluginSessionStatusRetry instance,
@@ -20,5 +20,5 @@ Map<String, dynamic> _$PluginSessionStatusRetryToJson(
   'attempt': instance.attempt,
   'message': instance.message,
   'next': instance.next,
-  'runtimeType': instance.$type,
+  'type': instance.$type,
 };

--- a/bridge/sesori_plugin_pi/lib/src/api/models/pi_event.dart
+++ b/bridge/sesori_plugin_pi/lib/src/api/models/pi_event.dart
@@ -229,7 +229,7 @@ final class const PiAutoRetryStartEvent({
   required final int? maxAttempts,
   required final int? delayMs,
 
-  /// Raw provider text. It can carry request details, so it is never logged.
+  /// Raw provider text, forwarded unchanged in the user-facing retry status.
   required final String? errorMessage,
   required super.raw,
 }) extends PiEvent;
@@ -245,6 +245,8 @@ final class const PiSummarizationRetryScheduledEvent({
   required final int? attempt,
   required final int? maxAttempts,
   required final int? delayMs,
+
+  /// Raw provider text, forwarded unchanged in the user-facing retry status.
   required final String? errorMessage,
   required super.raw,
 }) extends PiEvent;

--- a/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_history_mapper.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_history_mapper.dart
@@ -192,6 +192,7 @@ final class PiHistoryMapper({
         provider: message.provider,
         model: message.model,
         stopReason: message.stopReason,
+        errorMessage: message.errorMessage,
         timestamp: message.timestamp,
       ),
       parts: parts,
@@ -631,6 +632,7 @@ final class PiHistoryMapper({
     required String? provider,
     required String? model,
     required PiAssistantStopReason? stopReason,
+    required String? errorMessage,
     required int? timestamp,
   }) {
     return switch (stopReason) {
@@ -641,7 +643,7 @@ final class PiHistoryMapper({
         modelID: model,
         providerID: provider,
         errorName: "Pi response failed",
-        errorMessage: "The Pi assistant response failed.",
+        errorMessage: errorMessage ?? "The Pi assistant response failed.",
         time: _time(timestamp),
       ),
       PiAssistantStopReason.aborted => PluginMessage.error(
@@ -651,7 +653,7 @@ final class PiHistoryMapper({
         modelID: model,
         providerID: provider,
         errorName: "Pi response aborted",
-        errorMessage: "The Pi assistant response was aborted.",
+        errorMessage: errorMessage ?? "The Pi assistant response was aborted.",
         time: _time(timestamp),
       ),
       _ => PluginMessage.assistant(

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
@@ -67,14 +67,16 @@ final class PiEventDispatcher({
     PiSummarizationRetryAttemptStartEvent() ||
     PiCompactionStartEvent() => const PluginSessionStatus.busy(),
     PiAgentSettledEvent() => const PluginSessionStatus.idle(),
-    PiAutoRetryStartEvent(:final attempt, :final delayMs) => _retryStatus(
+    PiAutoRetryStartEvent(:final attempt, :final delayMs, :final errorMessage) => _retryStatus(
       attempt: attempt,
       delayMs: delayMs,
+      errorMessage: errorMessage,
       now: now ?? DateTime.now(),
     ),
-    PiSummarizationRetryScheduledEvent(:final attempt, :final delayMs) => _retryStatus(
+    PiSummarizationRetryScheduledEvent(:final attempt, :final delayMs, :final errorMessage) => _retryStatus(
       attempt: attempt,
       delayMs: delayMs,
+      errorMessage: errorMessage,
       now: now ?? DateTime.now(),
     ),
     _ => null,
@@ -547,12 +549,13 @@ final class PiEventDispatcher({
   PluginSessionStatus? _retryStatus({
     required int? attempt,
     required int? delayMs,
+    required String? errorMessage,
     required DateTime now,
   }) {
     if (attempt == null || delayMs == null || attempt < 0 || delayMs < 0) return null;
     return PluginSessionStatus.retry(
       attempt: attempt,
-      message: "Pi is retrying the provider request.",
+      message: errorMessage ?? "Pi is retrying the provider request.",
       next: now.millisecondsSinceEpoch + delayMs,
     );
   }

--- a/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
@@ -456,7 +456,9 @@ void main() {
           .single;
 
       expect((live.single as BridgeSseMessageUpdated).info, replay.info.toJson());
-      expect(live.single.toString(), isNot(contains("private provider detail")));
+      if (reason == "error") {
+        expect((live.single as BridgeSseMessageUpdated).info["errorMessage"], "private provider detail");
+      }
     }
   });
 
@@ -584,7 +586,11 @@ void main() {
   test("retry and compaction map lifecycle while only agent_settled emits idle", () {
     final retry = dispatcher.map(
       sessionId: sessionId,
-      event: _event("auto_retry_start", {"attempt": 2, "delayMs": 500}),
+      event: _event("auto_retry_start", {
+        "attempt": 2,
+        "delayMs": 500,
+        "errorMessage": "provider overloaded",
+      }),
       now: DateTime.fromMillisecondsSinceEpoch(1000),
     );
     final autoRetryResumed = dispatcher.map(
@@ -611,14 +617,14 @@ void main() {
 
     expect((retry.single as BridgeSseSessionStatus).status, {
       "attempt": 2,
-      "message": "Pi is retrying the provider request.",
+      "message": "provider overloaded",
       "next": 1500,
-      "runtimeType": "retry",
+      "type": "retry",
     });
     expect(agentEnd, isEmpty);
-    expect((autoRetryResumed.single as BridgeSseSessionStatus).status, {"runtimeType": "busy"});
-    expect((summarizationResumed.single as BridgeSseSessionStatus).status, {"runtimeType": "busy"});
-    expect(compacting.whereType<BridgeSseSessionStatus>().single.status, {"runtimeType": "busy"});
+    expect((autoRetryResumed.single as BridgeSseSessionStatus).status, {"type": "busy"});
+    expect((summarizationResumed.single as BridgeSseSessionStatus).status, {"type": "busy"});
+    expect(compacting.whereType<BridgeSseSessionStatus>().single.status, {"type": "busy"});
     final runningMessage = compacting.whereType<BridgeSseMessageUpdated>().single;
     expect(runningMessage.info["id"], "pi:session:compaction:compaction:1");
     final runningPart = compacting.whereType<BridgeSseMessagePartUpdated>().single.part;

--- a/bridge/sesori_plugin_pi/test/pi_history_mapper_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_history_mapper_test.dart
@@ -212,8 +212,8 @@ void main() {
       expect(messages.toString(), isNot(contains(privateSummary)));
     });
 
-    test("logs assistant failure locally and maps it privately", () async {
-      const privateError = "secret provider payload";
+    test("logs assistant failure locally and forwards it unchanged", () async {
+      const backendError = "provider overload detail";
       late List<PluginMessageWithParts> messages;
       final warnings = await _captureWarnings(() async {
         messages = mapper.map(
@@ -234,7 +234,7 @@ void main() {
                 "provider": "provider",
                 "model": "model",
                 "stopReason": "error",
-                "errorMessage": privateError,
+                "errorMessage": backendError,
                 "timestamp": 1,
               }),
             ),
@@ -268,6 +268,7 @@ void main() {
 
       expect(messages, hasLength(2));
       expect(messages.first.info, isA<PluginMessageError>());
+      expect((messages.first.info as PluginMessageError).errorMessage, backendError);
       expect(_reasoning(messages), ["visible reasoning"]);
       final completed = messages.first.parts.singleWhere((part) => part.id == "completed");
       final unfinished = messages.first.parts.singleWhere((part) => part.id == "unfinished");
@@ -278,9 +279,8 @@ void main() {
       expect(unfinished.state.error, "Pi tool call did not complete.");
       expect(aborted.state.status, PluginToolStatus.error);
       expect(aborted.state.error, "Pi tool call did not complete.");
-      expect(messages.toString(), isNot(contains(privateError)));
       expect(messages.toString(), isNot(contains("private reasoning")));
-      expect(warnings, contains(privateError));
+      expect(warnings, contains(backendError));
     });
 
     test("enforces image candidate count", () {

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -101,8 +101,8 @@ image parts converge by their own rules.
   payload omitted variant-specific data, or a decoded known variant still carries
   null variant data.
 - Pi falls back after an arbitrary RPC failure, shows an abandoned branch or
-  summary payload, or exposes a private path, raw backend error, or hidden prompt
-  prefix in mapped history.
+  summary payload, exposes a private persisted path or hidden prompt prefix, or
+  rewrites backend-provided error text in mapped history.
 - A Pi streamed part changes identity when finalized, cumulative tool output is
   appended, a duplicate terminal tool event repeats a diff invalidation, or
   `agent_end` marks the session idle before `agent_settled`.

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -27,14 +27,16 @@ defaults and queued client sends coherent.
   concurrently on one plugin, and one slow session or plugin must not stall other
   sessions, other plugins, the relay read loop, or catalog reads.
 - Streaming produces incremental message and part events and a terminal status
-  transition back to idle; retry carries attempt, message, and timing and
-  returns to busy as soon as the retried request streams output again, and
-  finalized messages enter durable history matching a history read. A terminal
+  transition back to idle; retry carries attempt, backend-provided message, and
+  timing and returns to busy as soon as the retried request streams output again,
+  and finalized messages enter durable history matching a history read. A terminal
   provider failure appears as an inline error message and remains visible after
-  refresh or reopen. Backend-provided message timestamps remain present through
-  live updates and durable-history reloads, using the backend's authoritative
-  source for each path. Internal backend command records are not rendered as
-  conversation messages or used as assistant model attribution.
+  refresh or reopen. Backend-provided terminal and retry error text is forwarded
+  verbatim for every harness; plugins may flatten an error envelope but synthesize
+  text only when the backend supplied none. Backend-provided message timestamps
+  remain present through live updates and durable-history reloads, using the
+  backend's authoritative source for each path. Internal backend command records
+  are not rendered as conversation messages or used as assistant model attribution.
 - Claude user prompts appear in the live transcript from the CLI's replayed
   stdin echo under their transcript uuid, so a follow-up prompt stays visible
   and a later transcript backfill converges on the same message instead of
@@ -235,7 +237,9 @@ replay, and abort after output has started.
 - Streaming stalls, duplicates or loses parts, shows an empty user bubble, or
   orders a late envelope at the wrong transcript position; the session never
   returns to idle. A terminal provider failure returns to idle without showing
-  its error, the error disappears after refresh or reopen, or a live update
+  its error, a harness replaces backend-provided terminal or retry error text,
+  a plugin status serializes with a private discriminator and is dropped at the
+  shared SSE boundary, the error disappears after refresh or reopen, or a live update
   removes a backend-provided message timestamp. An OpenCode prompt, slash
   command, or bare `/compact` leaves both its local bubble and backend echo in
   the transcript.

--- a/shared/sesori_shared/lib/src/models/sesori/message.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message.dart
@@ -17,10 +17,10 @@ part "message.g.dart";
 /// - `MessageAssistant`: `"assistant"`
 /// - `MessageError`: `"error"`
 ///
-/// The bridge layer is responsible for normalizing backend-specific error
-/// shapes (e.g., a nested `error.data.message`) into the flat
-/// `errorName` and `errorMessage` fields before constructing a
-/// [MessageError].
+/// The bridge layer is responsible for flattening backend-specific error
+/// shapes (e.g., a nested `error.data.message`) into `errorName` and
+/// `errorMessage`. Backend-provided text is preserved verbatim; a harness may
+/// synthesize a fallback only when its backend supplied no error text.
 @Freezed(unionKey: "role", fromJson: true, toJson: true)
 sealed class const Message._() with _$Message {
   const factory user({
@@ -53,6 +53,8 @@ sealed class const Message._() with _$Message {
     required String? modelID,
     required String? providerID,
     required String errorName,
+
+    /// The backend-provided error text, unchanged when the backend supplied it.
     required String errorMessage,
     required MessageTime? time,
   }) = MessageError;

--- a/shared/sesori_shared/lib/src/models/sesori/message.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message.freezed.dart
@@ -325,6 +325,7 @@ class MessageError extends Message {
  final  String? modelID;
  final  String? providerID;
  final  String errorName;
+/// The backend-provided error text, unchanged when the backend supplied it.
  final  String errorMessage;
 @override final  MessageTime? time;
 


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this aligns one backend-neutral error contract across several plugin adapters and corrects an internal status serializer at the plugin-to-shared SSE boundary.

## What

- Forward backend-provided terminal and retry error text unchanged for Pi, Claude, and ACP/Cursor; synthesize text only when the backend supplied none.
- Keep ACP halt classification from rewriting the backend's original notice.
- Align `PluginSessionStatus.toJson()` with shared `SessionStatus` by using the required `type` discriminator instead of Freezed's private `runtimeType` default.
- Add mapper, live/replay, retry, and SSE-boundary regressions plus update the session regression contracts.
- Audit the other registered harness paths: OpenCode and Codex already forward supplied error text, while OMP, Hermes, and DeepSeek inherit the non-rewriting ACP path.

## Why

Pi currently replaces a concrete provider error such as `Codex error: Our servers are currently overloaded` with a generic failure card. The same run also exposed that Pi retry and busy events were dropped because their status payload used `runtimeType`, while the shared SSE decoder requires `type`.

Backend output intended for the user should cross the harness boundary without paraphrasing or redaction, and retry lifecycle events must remain parseable.

## Risk and test focus

The user-visible impact is that backend error text is now shown exactly as supplied, including backend wording and whitespace. Retry and busy state should now reach clients instead of producing `Invalid union type "null"` mapper warnings.

There is no database or persisted-data impact. The external shared SSE shape is unchanged; this fixes a malformed internal plugin payload so it conforms to that existing shape. No analytics were added because this changes presentation fidelity rather than introducing a product action or outcome.

Review focus: live/replay parity, fallback behavior when no backend text exists, ACP halt classification, and the plugin-status/shared-status discriminator seam.

## Expected result

Users see the actual harness/provider error. Pi retry and subsequent busy events decode normally, preserve the provider retry text, and no longer emit `BridgeEventMapper` union-type failures.

## Verification

- `cd bridge && dart pub get`
- Pi focused mapper/dispatcher tests: 44 passed; `dart analyze --fatal-infos`: passed
- Claude stream/dispatcher tests: 35 passed; `dart analyze --fatal-infos`: passed
- ACP live/replay mapper tests: 89 passed; `dart analyze --fatal-infos`: passed
- Cursor mapper tests: 16 passed; `dart analyze --fatal-infos`: passed
- Bridge SSE mapper tests: 21 passed; bridge app `dart analyze --fatal-infos`: passed
- Plugin interface code generation and `dart analyze --fatal-infos`: passed
- Shared package dependency resolution, code generation, and `dart analyze`: passed
- `git diff --check origin/main...HEAD`: passed
- Architecture implementation review: approved on both required passes

The pinned formatter still hits its known primary-constructor enum crash on `acp_event_mapper.dart` and `claude_stream_message.dart`; all changed lines remain within the 120-character limit and their owning fatal analyzers pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwards backend-provided error and retry text verbatim across the Pi, Claude, and ACP/Cursor harnesses, and fixes plugin status serialization so Pi retry and busy events decode at the shared SSE boundary. Previously Pi replaced provider errors like `Codex error: Our servers are currently overloaded` with a generic failure card, and retry/busy payloads used `runtimeType` where the shared decoder requires `type`, dropping those events.

**Error text preservation**
- Claude retry and result errors now forward the backend's raw text; a fallback is synthesized only when the backend supplies none.
- ACP halt classification no longer replaces backend notice text, so original wording and whitespace survive.
- Pi history and retry statuses forward the backend error message when present, with a synthesized fallback only when absent.
- OpenCode and Codex already forwarded supplied error text; OMP, Hermes, and DeepSeek inherit the non-rewriting ACP path.

**Status serializer fix**
- `PluginSessionStatus.toJson()` now emits the required `type` discriminator instead of Freezed's private `runtimeType` default, matching shared `SessionStatus`.
- Retry and busy events now reach clients instead of producing `Invalid union type "null"` mapper warnings.

<sup>Written for commit 15f8eee0f7de1684f3be6f7fbf1c414b6bb8384c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

