### PR TITLE
🌿 Document provider route conformance

### DIFF
--- a/docs/regression/README.md
+++ b/docs/regression/README.md
@@ -158,6 +158,7 @@ failed, or unexecuted required coverage keeps the plan active.
 - [Plugin runtime installation](plugin-runtime-installation.md)
 - [Plugin setup and lifecycle](plugin-setup-and-lifecycle.md)
 - [Popup alerts](popup-alerts.md)
+- [Provider route conformance](provider-route-conformance.md)
 - [Projects and sessions](projects-and-sessions.md)
 - [Pull request monitoring](pull-request-monitoring.md)
 - [Questions and permissions](questions-and-permissions.md)

--- a/docs/regression/provider-route-conformance.md
+++ b/docs/regression/provider-route-conformance.md
@@ -1,0 +1,118 @@
+# Provider Route Conformance
+
+## Capability
+
+A configured model route preserves its declared protocol, model identity,
+modalities, tools, and response semantics through the provider, coding harness,
+bridge, relay, and client boundaries that claim to support them.
+
+## Required Behavior
+
+- Catalog or setup success proves configuration readability only. Each route is
+  exercised at every capability claimed for it: text, tools, images, questions,
+  permissions, streaming, and replay where applicable.
+- Each protocol route is selected independently with its intended model. A
+  successful fallback or cross-protocol model substitution is not a pass.
+- A raw provider probe runs before Harness or Sesori participates. For tool
+  routes, advertise one uniquely named disposable tool such as `sesori_probe`;
+  the provider must return that exact name. Prefixing, suffixing, translating,
+  or selecting an unadvertised name fails tool conformance even when the HTTP
+  response and stop reason report success.
+- Record response framing as well as status. A non-streaming request returned as
+  an event stream is acceptable only when the configured consumer supports that
+  framing and still settles exactly once.
+- The Harness catalog exposes the intended provider/model pair as an available
+  opaque selection, and a direct Harness turn attributes terminal output to that
+  same pair.
+- Tool conformance requires a real completed call and result. A model response
+  that claims success after an unknown, rejected, malformed, or failed call is a
+  failure.
+- Image conformance uses a bounded non-sensitive fixture and verifies that the
+  model interprets image content rather than a filename or prompt description.
+- Question conformance requires a model-facing question producer. A composed
+  question service/provider without a model-facing tool or another real
+  consumer proves transport readiness, not ordinary model-initiated questions.
+- Permission conformance runs with bridge auto-approval disabled and verifies
+  both one-time approval and rejection without broadening either answer.
+- After bridge and client restart, completed text, images, tools, message
+  timestamps supplied by the backend, and terminal states replay without
+  duplication or attribution drift.
+
+## Execution Runbook
+
+1. Declare the exact protocol and claimed capabilities for every route. Keep
+   credentials in the provider's private local store; never place them in a
+   command, committed fixture, screenshot, transcript, or evidence file.
+2. Use a disposable prompt, image, tool, and session. Capture only bounded
+   status, framing, stop reason, requested/returned tool name, provider/model
+   attribution, interaction outcome, and cleanup result.
+3. Probe the provider's native protocol boundary without Harness or Sesori.
+   Run a text request first, then advertise only `sesori_probe` and require one
+   call to it. Stop tool testing for that route if the returned name differs.
+4. Refresh Harness options and verify the exact provider/model selection. Run
+   one direct text turn, then the route's claimed tool and image capabilities.
+5. Traverse the headless bridge boundary. Verify opaque selection round-trip,
+   terminal attribution, normalized tool lifecycle, and useful local errors.
+6. Traverse the release-target client -> relay -> bridge -> plugin path. Verify
+   rendering and settlement for the claimed rich capabilities rather than
+   treating a debug route as client evidence.
+7. Restart the bridge and client, reopen the session, and compare durable
+   messages, timestamps, parts, tool states, and model attribution.
+8. Delete disposable sessions through product APIs, restore auto-approval and
+   other changed settings, remove only named proof files, and stop test-owned
+   processes. Never recursively delete a provider, Harness, plugin, or user
+   state root as cleanup.
+
+## Failure Attribution
+
+| First divergent boundary | Likely owner |
+|---|---|
+| Raw provider request fails or returns a renamed/unadvertised tool | Provider, router, or selected model |
+| Raw provider passes but direct Harness fails | Harness provider adapter or local profile |
+| Direct Harness passes but bridge debug path fails | Backend plugin or runtime adapter |
+| Bridge path passes but relay/client path fails | Bridge routing, relay, shared contract, or client |
+| Live path passes but restart replay differs | Adapter persistence/history or bridge cache mapping |
+
+Do not add a downstream alias, tool-name rewrite, retry, or compatibility shim
+until the first divergent boundary demonstrates that downstream code owns the
+problem.
+
+## Regression Levels
+
+| Level | Additional coverage |
+|---|---|
+| L1 Smoke | One text route through its raw provider boundary and direct Harness selection. |
+| L2 Routine | Every configured protocol route; exact tool-name probe and each route's claimed text/tool/image capabilities. |
+| L3 Release | Release-target client through relay and bridge; questions and permissions for every route claiming them. |
+| L4 Extended | Bridge/client restart replay, provider errors, malformed tool calls, rejection, abort, and two concurrent sessions. |
+| L5 Full | Every release provider profile and advertised host/client matrix, including alternate framing and compatibility builds where claimed. |
+
+## Failure Signals
+
+- A route reports success under a provider, model, or protocol other than the
+  one selected.
+- A provider returns a tool name different from the only advertised tool.
+- A failed tool is narrated as success, or a one-time permission becomes a
+  standing grant.
+- A model sees a filename or prompt text but not the attached image bytes.
+- A question seam exists but no real model-facing consumer can raise a question.
+- Rich content, timestamps, terminal state, or attribution changes after reopen.
+- Evidence or logs contain credentials, source, prompts, transcripts, paths,
+  raw provider output, account identifiers, or image bytes.
+
+## Known Limitations
+
+- Provider and model behavior can be nondeterministic. A failure should be
+  reproduced at the lowest boundary before assigning ownership.
+- Passing text does not imply tool, image, question, or permission support.
+- A route may intentionally claim only a subset of capabilities; omitted
+  capabilities are recorded as unsupported, not silently counted as passing.
+
+## Sources
+
+- Provider profile and model catalog contracts in the owning Harness adapter.
+- `session-creation-and-options.md`, `session-turns.md`,
+  `questions-and-permissions.md`, `attachments-and-images.md`, and
+  `tools-and-file-changes.md`.
+- Bridge debug routes, plugin option/session APIs, and release-target client
+  interaction surfaces.

--- a/docs/regression/provider-route-conformance.md
+++ b/docs/regression/provider-route-conformance.md
@@ -40,7 +40,9 @@ bridge, relay, and client boundaries that claim to support them.
 
 ## Execution Runbook
 
-1. Declare the exact protocol and claimed capabilities for every route. Keep
+1. Declare the exact protocol and claimed capabilities for every route. Validate
+   the endpoint, authentication, model, and native request shape separately so
+   an invalid probe is blocked setup rather than a provider failure. Keep
    credentials in the provider's private local store; never place them in a
    command, committed fixture, screenshot, transcript, or evidence file.
 2. Use a disposable prompt, image, tool, and session. Capture only bounded
@@ -56,8 +58,9 @@ bridge, relay, and client boundaries that claim to support them.
 6. Traverse the release-target client -> relay -> bridge -> plugin path. Verify
    rendering and settlement for the claimed rich capabilities rather than
    treating a debug route as client evidence.
-7. Restart the bridge and client, reopen the session, and compare durable
-   messages, timestamps, parts, tool states, and model attribution.
+7. Restart the bridge first and inspect its headless history replay. Then restart
+   the client, reopen the session, and compare durable messages, timestamps,
+   parts, tool states, and model attribution at each boundary.
 8. Delete disposable sessions through product APIs, restore auto-approval and
    other changed settings, remove only named proof files, and stop test-owned
    processes. Never recursively delete a provider, Harness, plugin, or user
@@ -67,11 +70,13 @@ bridge, relay, and client boundaries that claim to support them.
 
 | First divergent boundary | Likely owner |
 |---|---|
-| Raw provider request fails or returns a renamed/unadvertised tool | Provider, router, or selected model |
+| Raw probe has invalid endpoint, authentication, model, or request shape | Local probe setup or provider profile |
+| Valid raw provider request fails or returns a renamed/unadvertised tool | Provider, router, or selected model |
 | Raw provider passes but direct Harness fails | Harness provider adapter or local profile |
 | Direct Harness passes but bridge debug path fails | Backend plugin or runtime adapter |
 | Bridge path passes but relay/client path fails | Bridge routing, relay, shared contract, or client |
-| Live path passes but restart replay differs | Adapter persistence/history or bridge cache mapping |
+| Live path passes but headless bridge restart replay differs | Adapter persistence/history or bridge cache mapping |
+| Headless bridge replay passes but client cold-load replay differs | Client cache or merge behavior |
 
 Do not add a downstream alias, tool-name rewrite, retry, or compatibility shim
 until the first divergent boundary demonstrates that downstream code owns the
@@ -97,8 +102,11 @@ problem.
 - A model sees a filename or prompt text but not the attached image bytes.
 - A question seam exists but no real model-facing consumer can raise a question.
 - Rich content, timestamps, terminal state, or attribution changes after reopen.
-- Evidence or logs contain credentials, source, prompts, transcripts, paths,
-  raw provider output, account identifiers, or image bytes.
+- Committed or shared evidence contains credentials, source, prompts,
+  transcripts, paths, raw provider output, account identifiers, or image bytes.
+- Local diagnostics suppress useful errors, stack traces, paths, identifiers, or
+  operation context instead of selectively removing known credentials, prompts,
+  transcripts, or image payloads.
 
 ## Known Limitations
 


### PR DESCRIPTION
## Complexity

Straightforward documentation change. It defines a reusable boundary-by-boundary runbook without changing production behavior.

## What

- Add provider route conformance requirements and execution steps.
- Require exact tool-name preservation and independent protocol/model attribution.
- Cover text, tools, images, questions, permissions, restart replay, privacy-safe evidence, cleanup, and failure ownership.
- Link the runbook from the regression index.

## Why

A successful catalog lookup or text turn does not prove that a configured route preserves richer capabilities. A direct Anthropic-compatible probe demonstrated that a route can return HTTP success while rewriting the only advertised tool name, so conformance must be established at the lowest boundary before Harness or Sesori is blamed or adapted around the behavior.

## Risk and test focus

There is no user-visible or database impact. Review should focus on whether the runbook assigns failures at the first divergent boundary, avoids downstream compatibility shims, and keeps credentials and product data out of evidence.

## Expected result

Future provider-route checks distinguish provider/router defects from Harness, plugin, relay, and client defects, and rich capability claims require direct evidence rather than inference from text success.

## Verification

- `git diff --cached --check`
- Staged documentation newline and trailing-whitespace validation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provider-route conformance runbook to the regression docs and links it from the index. It defines how to verify that a configured route preserves its declared protocol, model, tools, and capabilities, because HTTP success alone doesn't prove conformance when routes can rewrite tool names. No production behavior changes.

- Requires exact tool-name preservation and independent model attribution.
- Covers text, tools, images, questions, permissions, restart replay, and cleanup.
- Assigns failures at the first divergent boundary and forbids downstream shims until ownership is proven.

<sup>Written for commit b02e3440d0ba9e329230953b90f12da2b36a3e32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

