### PR TITLE
⚙️ [deepseek-question-timestamps] Consume DeepSeek message times [step 2/4]

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -856,6 +856,7 @@ class AcpEventMapper({
     final hasKind = update["kind"] is String && (update["kind"] as String).isNotEmpty;
     final mappedStatus = _contentMapper.toolStatus(status: update["status"]);
     final useCallTool = prior == null || (!prior.hasExplicitKind && (hasKind || prior.tool == "tool"));
+    final messageTime = _earliestMessageTime(prior?.time, time);
     final state = _LiveTool(
       // Fail-soft like the tool name and `_toolCallUpdate`'s title: a non-string
       // title (schema drift / malformed agent data) renders as null rather than
@@ -873,11 +874,13 @@ class AcpEventMapper({
       diffEmitted: prior?.diffEmitted ?? false,
       hasExplicitKind: (prior?.hasExplicitKind ?? false) || hasKind,
       hasExplicitStatus: (prior?.hasExplicitStatus ?? false) || mappedStatus != null,
+      time: messageTime,
     );
     (_liveTools[sessionId] ??= {})[toolCallId] = state;
     final events = <BridgeSseEvent>[
       ...boundaryEvents,
-      if (prior == null) _toolEnvelope(sessionId: sessionId, messageId: messageId, time: time),
+      if (prior == null || messageTime != prior.time)
+        _toolEnvelope(sessionId: sessionId, messageId: messageId, time: messageTime),
       _toolPartEvent(sessionId: sessionId, messageId: messageId, state: state),
     ];
     _appendCompletedMutationDiff(
@@ -918,6 +921,7 @@ class AcpEventMapper({
     final contentTracker = prior?.contentTracker ?? AcpToolContentTracker();
     contentTracker.apply(mutation: contentMutation);
     final mappedStatus = _contentMapper.toolStatus(status: update["status"]);
+    final messageTime = _earliestMessageTime(prior?.time, time);
     final state = _LiveTool(
       tool: hasKind
           ? _contentMapper.toolName(update: update)
@@ -934,6 +938,7 @@ class AcpEventMapper({
       diffEmitted: prior?.diffEmitted ?? false,
       hasExplicitKind: (prior?.hasExplicitKind ?? false) || hasKind,
       hasExplicitStatus: (prior?.hasExplicitStatus ?? false) || mappedStatus != null,
+      time: messageTime,
     );
     final events = <BridgeSseEvent>[
       ...boundaryEvents,
@@ -942,7 +947,8 @@ class AcpEventMapper({
       // first-seen, synthesize the message envelope — like `_textChunk` does —
       // so the client can render the part instead of receiving an orphan it
       // drops.
-      if (prior == null) _toolEnvelope(sessionId: sessionId, messageId: messageId, time: time),
+      if (prior == null || messageTime != prior.time)
+        _toolEnvelope(sessionId: sessionId, messageId: messageId, time: messageTime),
       _toolPartEvent(sessionId: sessionId, messageId: messageId, state: state),
     ];
     // Retained (not pruned on terminal) so a late reordered update still merges
@@ -989,6 +995,12 @@ class AcpEventMapper({
         time: time == null ? null : shared.MessageTime(created: time.created, completed: time.completed),
       ).toJson(),
     );
+  }
+
+  PluginMessageTime? _earliestMessageTime(PluginMessageTime? prior, PluginMessageTime? next) {
+    if (prior == null) return next;
+    if (next == null || prior.created <= next.created) return prior;
+    return next;
   }
 
   BridgeSseMessagePartUpdated _toolPartEvent({
@@ -1207,4 +1219,5 @@ class _LiveTool({
     required var bool diffEmitted,
     required final bool hasExplicitKind,
     required final bool hasExplicitStatus,
+    required final PluginMessageTime? time,
   });

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -67,6 +67,12 @@ class AcpEventMapper({
   String? providerForSession({required String sessionId}) =>
       _configurationTracker.snapshotForSession(sessionId: sessionId).providerId;
 
+  /// Backend extension time for a message-bearing ACP notification.
+  PluginMessageTime? messageTimeForNotification({required AcpNotification notification}) => null;
+
+  /// Backend-authoritative time for a locally projected accepted user message.
+  PluginMessageTime? localUserMessageTime({required int createdAtMs}) => null;
+
   /// Last-known per-session metadata (title/times), fed by the plugin from
   /// enumeration and creation (like [setSessionProject]). `session_info_update`
   /// merges against it so the emitted `session.updated` payload doesn't null
@@ -251,11 +257,13 @@ class AcpEventMapper({
   List<BridgeSseEvent> mapInitialPrompt({
     required String sessionId,
     required List<PluginPromptPart> parts,
+    required int createdAtMs,
   }) => _mapUserPrompt(
     sessionId: sessionId,
     messageId: initialUserMessageId(sessionId),
     promptId: null,
     parts: parts,
+    time: localUserMessageTime(createdAtMs: createdAtMs),
   );
 
   /// Derives the durable user-message identity from the accepted prompt id.
@@ -267,11 +275,13 @@ class AcpEventMapper({
     required String messageId,
     required String promptId,
     required List<PluginPromptPart> parts,
+    required int createdAtMs,
   }) => _mapUserPrompt(
     sessionId: sessionId,
     messageId: messageId,
     promptId: promptId,
     parts: parts,
+    time: localUserMessageTime(createdAtMs: createdAtMs),
   );
 
   List<BridgeSseEvent> _mapUserPrompt({
@@ -279,6 +289,7 @@ class AcpEventMapper({
     required String messageId,
     required String? promptId,
     required List<PluginPromptPart> parts,
+    required PluginMessageTime? time,
   }) {
     final content = <Map<String, dynamic>>[
       for (final part in parts)
@@ -302,7 +313,7 @@ class AcpEventMapper({
     if (mutations.isEmpty) return const [];
     return [
       BridgeSseMessageUpdated(
-        info: _messageFor(_ChunkRole.user, messageId, sessionId, promptId: promptId).toJson(),
+        info: _messageFor(_ChunkRole.user, messageId, sessionId, promptId: promptId, time: time).toJson(),
       ),
       for (final mutation in mutations)
         BridgeSseMessagePartUpdated(
@@ -368,11 +379,12 @@ class AcpEventMapper({
       return const [];
     }
 
+    final messageTime = messageTimeForNotification(notification: notification);
     switch (update["sessionUpdate"] as String?) {
       case "agent_message_chunk":
         return _afterReasoning(
           sessionId: sessionId,
-          events: _assistantContentChunk(sessionId: sessionId, update: update),
+          events: _assistantContentChunk(sessionId: sessionId, update: update, time: messageTime),
         );
       case "agent_thought_chunk":
         return _textChunk(
@@ -381,6 +393,7 @@ class AcpEventMapper({
           role: _ChunkRole.assistant,
           partSuffix: "reasoning",
           partType: PluginMessagePartType.reasoning,
+          time: messageTime,
         );
       case "user_message_chunk":
         // This plugin emits the accepted prompt itself. A live user chunk is
@@ -390,12 +403,12 @@ class AcpEventMapper({
       case "tool_call":
         return _afterReasoning(
           sessionId: sessionId,
-          events: _toolCall(sessionId: sessionId, update: update),
+          events: _toolCall(sessionId: sessionId, update: update, time: messageTime),
         );
       case "tool_call_update":
         return _afterReasoning(
           sessionId: sessionId,
-          events: _toolCallUpdate(sessionId: sessionId, update: update),
+          events: _toolCallUpdate(sessionId: sessionId, update: update, time: messageTime),
         );
       case "plan":
         return [BridgeSseTodoUpdated(sessionID: sessionId)];
@@ -526,6 +539,7 @@ class AcpEventMapper({
   List<BridgeSseEvent> _assistantContentChunk({
     required String sessionId,
     required Map<String, dynamic> update,
+    required PluginMessageTime? time,
   }) {
     final identity = _chunkIdentity(
       sessionId: sessionId,
@@ -545,6 +559,7 @@ class AcpEventMapper({
       identity: identity,
       tracker: tracker,
       blocks: blocks,
+      time: time,
     );
   }
 
@@ -576,6 +591,7 @@ class AcpEventMapper({
         identity: identity,
         tracker: tracker,
         blocks: blocks,
+        time: null,
       ),
     );
   }
@@ -585,6 +601,7 @@ class AcpEventMapper({
     required ({String messageId, bool hasAcpMessageId}) identity,
     required AcpContentTracker tracker,
     required Iterable<AcpMappedContentBlock> blocks,
+    required PluginMessageTime? time,
   }) {
     if (blocks.isEmpty) return const [];
     final hasTrackableContent = blocks.any(
@@ -600,7 +617,7 @@ class AcpEventMapper({
       final text = blocks.whereType<AcpMappedTextContentBlock>().map((block) => block.text).join();
       if (text.isNotEmpty) {
         final halt = classifyHaltNotice(text: text);
-        if (halt != null) return _haltNoticeEvents(sessionId: sessionId, notice: halt, message: text);
+        if (halt != null) return _haltNoticeEvents(sessionId: sessionId, notice: halt, message: text, time: time);
       }
     }
 
@@ -611,7 +628,7 @@ class AcpEventMapper({
     if (started.add(identity.messageId)) {
       events.add(
         BridgeSseMessageUpdated(
-          info: _messageFor(_ChunkRole.assistant, identity.messageId, sessionId, promptId: null).toJson(),
+          info: _messageFor(_ChunkRole.assistant, identity.messageId, sessionId, promptId: null, time: time).toJson(),
         ),
       );
     }
@@ -675,6 +692,7 @@ class AcpEventMapper({
     required _ChunkRole role,
     required String partSuffix,
     required PluginMessagePartType partType,
+    required PluginMessageTime? time,
   }) {
     final text = _contentMapper.text(content: update["content"]);
     if (text == null || text.isEmpty) return const [];
@@ -689,7 +707,7 @@ class AcpEventMapper({
     // text (no regression).
     if (partType == PluginMessagePartType.text) {
       final halt = classifyHaltNotice(text: text);
-      if (halt != null) return _haltNoticeEvents(sessionId: sessionId, notice: halt, message: text);
+      if (halt != null) return _haltNoticeEvents(sessionId: sessionId, notice: halt, message: text, time: time);
     }
 
     // ACP v1: chunks of one message share a `messageId`; a change starts a new
@@ -707,7 +725,7 @@ class AcpEventMapper({
     if (started.add(partId)) {
       if (started.add(messageId)) {
         events.add(
-          BridgeSseMessageUpdated(info: _messageFor(role, messageId, sessionId, promptId: null).toJson()),
+          BridgeSseMessageUpdated(info: _messageFor(role, messageId, sessionId, promptId: null, time: time).toJson()),
         );
       }
       events.add(
@@ -789,6 +807,7 @@ class AcpEventMapper({
     required String sessionId,
     required AcpHaltNotice notice,
     required String message,
+    required PluginMessageTime? time,
   }) {
     final messageId = "$sessionId-t${_turn(sessionId)}-halt";
     final started = _startedParts.putIfAbsent(sessionId, () => <String>{});
@@ -810,7 +829,7 @@ class AcpEventMapper({
           providerID: providerForSession(sessionId: sessionId),
           errorName: notice.errorName,
           errorMessage: message,
-          time: null,
+          time: time == null ? null : shared.MessageTime(created: time.created, completed: time.completed),
         ).toJson(),
       ),
     ];
@@ -819,6 +838,7 @@ class AcpEventMapper({
   List<BridgeSseEvent> _toolCall({
     required String sessionId,
     required Map<String, dynamic> update,
+    required PluginMessageTime? time,
   }) {
     final toolCallId = update["toolCallId"] as String?;
     if (toolCallId == null || toolCallId.isEmpty) return const [];
@@ -857,7 +877,7 @@ class AcpEventMapper({
     (_liveTools[sessionId] ??= {})[toolCallId] = state;
     final events = <BridgeSseEvent>[
       ...boundaryEvents,
-      if (prior == null) _toolEnvelope(sessionId: sessionId, messageId: messageId),
+      if (prior == null) _toolEnvelope(sessionId: sessionId, messageId: messageId, time: time),
       _toolPartEvent(sessionId: sessionId, messageId: messageId, state: state),
     ];
     _appendCompletedMutationDiff(
@@ -872,6 +892,7 @@ class AcpEventMapper({
   List<BridgeSseEvent> _toolCallUpdate({
     required String sessionId,
     required Map<String, dynamic> update,
+    required PluginMessageTime? time,
   }) {
     final toolCallId = update["toolCallId"] as String?;
     if (toolCallId == null || toolCallId.isEmpty) return const [];
@@ -921,7 +942,7 @@ class AcpEventMapper({
       // first-seen, synthesize the message envelope — like `_textChunk` does —
       // so the client can render the part instead of receiving an orphan it
       // drops.
-      if (prior == null) _toolEnvelope(sessionId: sessionId, messageId: messageId),
+      if (prior == null) _toolEnvelope(sessionId: sessionId, messageId: messageId, time: time),
       _toolPartEvent(sessionId: sessionId, messageId: messageId, state: state),
     ];
     // Retained (not pruned on terminal) so a late reordered update still merges
@@ -953,7 +974,11 @@ class AcpEventMapper({
   String _currentIdlessAssistantMessageId(String sessionId) =>
       "$sessionId-t${_turn(sessionId)}-${_ChunkRole.assistant.name}-a${_idlessAssistantSeq[sessionId] ?? 0}";
 
-  BridgeSseMessageUpdated _toolEnvelope({required String sessionId, required String messageId}) {
+  BridgeSseMessageUpdated _toolEnvelope({
+    required String sessionId,
+    required String messageId,
+    required PluginMessageTime? time,
+  }) {
     return BridgeSseMessageUpdated(
       info: shared.Message.assistant(
         id: messageId,
@@ -961,9 +986,7 @@ class AcpEventMapper({
         agent: pluginId,
         modelID: modelForSession(sessionId: sessionId),
         providerID: providerForSession(sessionId: sessionId),
-        // ACP carries no per-message timestamps; the mobile model treats a null
-        // time as "unknown".
-        time: null,
+        time: time == null ? null : shared.MessageTime(created: time.created, completed: time.completed),
       ).toJson(),
     );
   }
@@ -991,13 +1014,19 @@ class AcpEventMapper({
     );
   }
 
-  shared.Message _messageFor(_ChunkRole role, String messageId, String sessionId, {required String? promptId}) {
+  shared.Message _messageFor(
+    _ChunkRole role,
+    String messageId,
+    String sessionId, {
+    required String? promptId,
+    required PluginMessageTime? time,
+  }) {
     return switch (role) {
       _ChunkRole.user => shared.Message.user(
         id: messageId,
         sessionID: sessionId,
         agent: null,
-        time: null,
+        time: time == null ? null : shared.MessageTime(created: time.created, completed: time.completed),
         promptId: promptId,
       ),
       _ChunkRole.assistant => shared.Message.assistant(
@@ -1006,7 +1035,7 @@ class AcpEventMapper({
         agent: pluginId,
         modelID: modelForSession(sessionId: sessionId),
         providerID: providerForSession(sessionId: sessionId),
-        time: null,
+        time: time == null ? null : shared.MessageTime(created: time.created, completed: time.completed),
       ),
     };
   }

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1293,7 +1293,7 @@ abstract class AcpPlugin({
           messageId: turn.messageId,
           promptId: queuedPrompt.presentation.id,
           parts: queuedPrompt.visibleParts,
-          createdAtMs: queuedPrompt.presentation.createdAt,
+          createdAtMs: DateTime.now().millisecondsSinceEpoch,
         )
         .forEach(_eventBuffer.add);
     if (state.queue.remove(queuedPrompt)) {

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -777,6 +777,7 @@ abstract class AcpPlugin({
     final initialPromptEvents = eventMapper.mapInitialPrompt(
       sessionId: session.sessionId,
       parts: visibleParts,
+      createdAtMs: createdAt,
     );
     if (initialPromptEvents.isNotEmpty) {
       _syntheticInitialPromptSessions.add(session.sessionId);
@@ -1292,6 +1293,7 @@ abstract class AcpPlugin({
           messageId: turn.messageId,
           promptId: queuedPrompt.presentation.id,
           parts: queuedPrompt.visibleParts,
+          createdAtMs: queuedPrompt.presentation.createdAt,
         )
         .forEach(_eventBuffer.add);
     if (state.queue.remove(queuedPrompt)) {
@@ -1546,6 +1548,7 @@ abstract class AcpPlugin({
           ? AcpEventMapper.initialUserMessageId(sessionId)
           : null,
       messageIdOverride: null,
+      messageTimeResolver: null,
       // Reclassify a halt notice (e.g. Cursor's account/plan gate) the same way
       // the live stream does, so reloaded history renders it identically.
       haltClassifier: eventMapper.classifyHaltNotice,

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -6,6 +6,7 @@ import "repositories/trackers/acp_content_tracker.dart";
 import "repositories/trackers/acp_tool_content_tracker.dart";
 
 typedef AcpReplayUserMessageIdOverride = String? Function({required String acpMessageId});
+typedef AcpReplayMessageTimeResolver = PluginMessageTime? Function({required Map<String, dynamic> params});
 
 /// Accumulates the `session/update` notifications replayed by `session/load`
 /// into ordered [PluginMessageWithParts] for `getSessionMessages`.
@@ -27,6 +28,9 @@ class AcpReplayCollector({
   /// Overrides a replayed user's ACP message id with backend authority.
   required final AcpReplayUserMessageIdOverride? messageIdOverride,
 
+  /// Extracts an optional backend time from the complete replay envelope.
+  required final AcpReplayMessageTimeResolver? messageTimeResolver,
+
   /// Classifies a fully-accumulated assistant message as a backend halt notice
   /// (see [AcpEventMapper.classifyHaltNotice]) so a reloaded session renders the
   /// notice as an error message exactly as it appeared live. Null on backends
@@ -45,22 +49,28 @@ class AcpReplayCollector({
     if (update == null) return;
     final rawSessionUpdate = update["sessionUpdate"];
     final sessionUpdate = rawSessionUpdate is String ? rawSessionUpdate : null;
+    final time = messageTimeResolver?.call(params: params);
     if (sessionUpdate != "agent_message_chunk") {
       _pendingAssistantContent = null;
     }
     switch (sessionUpdate) {
       case "agent_message_chunk":
-        _consumeAssistantContent(update: update);
+        _consumeAssistantContent(update: update, time: time);
       case "agent_thought_chunk":
         final t = _contentMapper.text(content: update["content"]);
-        if (t != null) _assistant(messageId: _chunkMessageId(update)).reasoning.write(t);
+        if (t != null) {
+          final draft = _assistant(messageId: _chunkMessageId(update));
+          _retainTime(draft: draft, time: time);
+          draft.reasoning.write(t);
+        }
       case "user_message_chunk":
-        _consumeUserContent(update: update);
+        _consumeUserContent(update: update, time: time);
       case "tool_call":
         final id = update["toolCallId"] as String?;
         if (id == null) return;
         final contentMutation = _contentMapper.toolContent(update: update);
         final draft = _findTool(id);
+        _retainTime(draft: draft == null ? _assistantForTool() : _draftForTool(id)!, time: time);
         final hasKind = update["kind"] is String && (update["kind"] as String).isNotEmpty;
         final mappedStatus = _contentMapper.toolStatus(status: update["status"]);
         if (draft == null) {
@@ -93,6 +103,7 @@ class AcpReplayCollector({
         if (id == null) return;
         final contentMutation = _contentMapper.toolContent(update: update);
         final draft = _findTool(id);
+        _retainTime(draft: draft == null ? _assistantForTool() : _draftForTool(id)!, time: time);
         final hasKind = update["kind"] is String && (update["kind"] as String).isNotEmpty;
         final mappedStatus = _contentMapper.toolStatus(status: update["status"]);
         if (draft == null) {
@@ -132,8 +143,12 @@ class AcpReplayCollector({
     }
   }
 
-  void _consumeUserContent({required Map<String, dynamic> update}) {
+  void _consumeUserContent({
+    required Map<String, dynamic> update,
+    required PluginMessageTime? time,
+  }) {
     final draft = _user(messageId: _chunkMessageId(update));
+    _retainTime(draft: draft, time: time);
     final blocks = _contentMapper.mapScoped(
       content: _stripUserImageUris(update["content"]),
       scope: draft.contentTracker.mappingScope,
@@ -143,7 +158,10 @@ class AcpReplayCollector({
     }
   }
 
-  void _consumeAssistantContent({required Map<String, dynamic> update}) {
+  void _consumeAssistantContent({
+    required Map<String, dynamic> update,
+    required PluginMessageTime? time,
+  }) {
     final messageId = _chunkMessageId(update);
     final existing = _matchingRole(role: "assistant", messageId: messageId);
     final AcpContentTracker tracker;
@@ -159,6 +177,7 @@ class AcpReplayCollector({
         _pendingAssistantContent = _PendingAssistantContent(
           messageId: messageId,
           tracker: tracker,
+          time: time,
         );
       }
     }
@@ -177,7 +196,9 @@ class AcpReplayCollector({
           overrideId: null,
           contentTracker: tracker,
         );
+    final pendingTime = _pendingAssistantContent?.time;
     _pendingAssistantContent = null;
+    _retainTime(draft: draft, time: pendingTime ?? time);
     for (final mutation in mutations) {
       draft.entries.add(_AssistantContentEntry(mutation: mutation));
     }
@@ -214,7 +235,7 @@ class AcpReplayCollector({
             variant: null,
             errorName: halt.errorName,
             errorMessage: assistantText,
-            time: null,
+            time: draft.time,
           ),
           parts: const [],
         );
@@ -309,7 +330,7 @@ class AcpReplayCollector({
         id: draft.id,
         sessionID: sessionId,
         agent: null,
-        time: null,
+        time: draft.time,
         promptId: null,
       );
     }
@@ -320,7 +341,7 @@ class AcpReplayCollector({
       modelID: modelId,
       providerID: providerId,
       variant: null,
-      time: null,
+      time: draft.time,
     );
   }
 
@@ -379,6 +400,12 @@ class AcpReplayCollector({
         attachments: content.attachments,
       ),
     );
+  }
+
+  void _retainTime({required _Draft draft, required PluginMessageTime? time}) {
+    if (time != null && (draft.time == null || time.created < draft.time!.created)) {
+      draft.time = time;
+    }
   }
 
   _Draft _assistant({String? messageId}) => _ensureRole("assistant", messageId: messageId, overrideId: null);
@@ -464,10 +491,11 @@ class AcpReplayCollector({
     return id is String && id.isNotEmpty ? id : null;
   }
 
-  _ToolDraft? _findTool(String toolId) {
+  _ToolDraft? _findTool(String toolId) => _draftForTool(toolId)?.tools[toolId];
+
+  _Draft? _draftForTool(String toolId) {
     for (final draft in _drafts.reversed) {
-      final tool = draft.tools[toolId];
-      if (tool != null) return tool;
+      if (draft.tools.containsKey(toolId)) return draft;
     }
     return null;
   }
@@ -505,6 +533,7 @@ class _Draft({
   final StringBuffer reasoning = StringBuffer();
   final List<_AssistantDraftEntry> entries = [];
   final Map<String, _ToolDraft> tools = {};
+  PluginMessageTime? time;
 }
 
 sealed class const _AssistantDraftEntry();
@@ -517,6 +546,7 @@ final class const _AssistantToolEntry({required final String toolId, required fi
 final class const _PendingAssistantContent({
   required final String? messageId,
   required final AcpContentTracker tracker,
+  required final PluginMessageTime? time,
 });
 
 class _ToolDraft({

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -83,15 +83,19 @@ void main() {
         }),
       );
 
-      final parts = [
-        ...transition.whereType<BridgeSseMessagePartUpdated>(),
-        ...mapper.finalizeTurn(sessionId: "s1").whereType<BridgeSseMessagePartUpdated>(),
-      ].map((event) => event.part).where(
-        (part) => switch (part) {
-          PluginMessagePartText(:final text) || PluginMessagePartReasoning(:final text) => text.isNotEmpty,
-          _ => false,
-        },
-      ).toList();
+      final parts =
+          [
+                ...transition.whereType<BridgeSseMessagePartUpdated>(),
+                ...mapper.finalizeTurn(sessionId: "s1").whereType<BridgeSseMessagePartUpdated>(),
+              ]
+              .map((event) => event.part)
+              .where(
+                (part) => switch (part) {
+                  PluginMessagePartText(:final text) || PluginMessagePartReasoning(:final text) => text.isNotEmpty,
+                  _ => false,
+                },
+              )
+              .toList();
 
       expect(parts.map((part) => part.id), [
         "s1-t1-assistant-a0-reasoning",
@@ -370,6 +374,7 @@ void main() {
         messageId: "s1-sent-1-user",
         promptId: "prompt-1",
         sessionId: "s1",
+        createdAtMs: 1,
         parts: [
           const PluginPromptPart.text(text: "Hello"),
           const PluginPromptPart.text(text: "Cursor"),
@@ -401,6 +406,7 @@ void main() {
           messageId: "s1-sent-1-user",
           promptId: "prompt-1",
           sessionId: "s1",
+          createdAtMs: 1,
           parts: parts,
         );
 
@@ -420,6 +426,7 @@ void main() {
     test("an initial prompt uses the history-stable message and part identity", () {
       final events = mapper.mapInitialPrompt(
         sessionId: "s1",
+        createdAtMs: 1,
         parts: const [
           PluginPromptPart.text(text: "Hello"),
           PluginPromptPart.fileData(mime: "image/png", base64: "AA==", filename: "private.png"),
@@ -443,6 +450,7 @@ void main() {
         messageId: "s1-sent-1-user",
         promptId: "prompt-1",
         sessionId: "s1",
+        createdAtMs: 1,
         parts: [const PluginPromptPart.text(text: "Hello")],
       );
 

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -3,6 +3,18 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" as shared;
 import "package:test/test.dart";
 
+class _EnvelopeTimeEventMapper({
+  required super.launchDirectory,
+  required super.pluginId,
+  required super.configurationTracker,
+}) extends AcpEventMapper {
+  @override
+  PluginMessageTime? messageTimeForNotification({required AcpNotification notification}) {
+    final created = notification.params["messageCreatedAt"];
+    return created is int ? PluginMessageTime(created: created, completed: null) : null;
+  }
+}
+
 /// Asserts the mapper emits sesori-schema payloads — message envelopes must
 /// round-trip through `Message.fromJson`, exactly like the codex mapper.
 void main() {
@@ -684,6 +696,46 @@ void main() {
       );
       expect(events.whereType<BridgeSseMessageUpdated>(), hasLength(1));
       expect(events.whereType<BridgeSseMessagePartUpdated>(), hasLength(1));
+    });
+
+    test("a reordered tool call corrects its synthesized envelope time", () {
+      mapper = _EnvelopeTimeEventMapper(
+        launchDirectory: "/repo",
+        pluginId: "cursor",
+        configurationTracker: configurationTracker,
+      );
+      AcpNotification timedUpdate(Map<String, dynamic> body, int createdAt) => AcpNotification(
+        method: "session/update",
+        params: {
+          "sessionId": "s1",
+          "update": body,
+          "messageCreatedAt": createdAt,
+        },
+      );
+
+      final updateEvents = mapper.map(
+        timedUpdate({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "tc-reordered",
+          "status": "completed",
+        }, 20),
+      );
+      expect(
+        (updateEvents.whereType<BridgeSseMessageUpdated>().single.info["time"] as Map)["created"],
+        20,
+      );
+
+      final callEvents = mapper.map(
+        timedUpdate({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "tc-reordered",
+          "kind": "read",
+        }, 10),
+      );
+      expect(
+        (callEvents.whereType<BridgeSseMessageUpdated>().single.info["time"] as Map)["created"],
+        10,
+      );
     });
 
     test("a completed tool retains its state for a late in-turn update; beginTurn clears it", () {

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -86,6 +86,7 @@ void main() {
           agentId: "ACP",
           initialUserMessageId: null,
           messageIdOverride: null,
+          messageTimeResolver: null,
           haltClassifier: null,
         );
         final liveEvents = <BridgeSseEvent>[];
@@ -132,6 +133,7 @@ void main() {
                   providerId: null,
                   initialUserMessageId: "s1-initial-user",
                   messageIdOverride: null,
+                  messageTimeResolver: null,
                   haltClassifier: null,
                 )
                 ..consume(
@@ -176,6 +178,7 @@ void main() {
               providerId: "cursor",
               initialUserMessageId: null,
               messageIdOverride: null,
+              messageTimeResolver: null,
               haltClassifier: null,
             )
             ..consume(
@@ -230,6 +233,7 @@ void main() {
             agentId: "Cursor",
             initialUserMessageId: null,
             messageIdOverride: null,
+            messageTimeResolver: null,
             haltClassifier: null,
           )..consume(
             upd({
@@ -265,6 +269,7 @@ void main() {
               agentId: "Cursor",
               initialUserMessageId: null,
               messageIdOverride: null,
+              messageTimeResolver: null,
               haltClassifier: null,
             )
             ..consume(
@@ -302,6 +307,7 @@ void main() {
               agentId: "Cursor",
               initialUserMessageId: null,
               messageIdOverride: null,
+              messageTimeResolver: null,
               haltClassifier: null,
             )
             ..consume(
@@ -345,6 +351,7 @@ void main() {
               agentId: "Cursor",
               initialUserMessageId: null,
               messageIdOverride: null,
+              messageTimeResolver: null,
               haltClassifier: null,
             )
             ..consume(
@@ -377,6 +384,7 @@ void main() {
             agentId: "Cursor",
             initialUserMessageId: null,
             messageIdOverride: null,
+            messageTimeResolver: null,
             haltClassifier: null,
           )..consume(
             upd({
@@ -402,6 +410,7 @@ void main() {
             providerId: "cursor",
             initialUserMessageId: null,
             messageIdOverride: null,
+            messageTimeResolver: null,
             haltClassifier: null,
           )..consume(
             upd({
@@ -423,6 +432,7 @@ void main() {
               agentId: "Cursor",
               initialUserMessageId: null,
               messageIdOverride: null,
+              messageTimeResolver: null,
               haltClassifier: null,
             )
             ..consume(
@@ -461,6 +471,7 @@ void main() {
               agentId: "Cursor",
               initialUserMessageId: null,
               messageIdOverride: null,
+              messageTimeResolver: null,
               haltClassifier: null,
             )
             ..consume(
@@ -485,6 +496,7 @@ void main() {
               agentId: "Cursor",
               initialUserMessageId: null,
               messageIdOverride: null,
+              messageTimeResolver: null,
               haltClassifier: null,
             )
             ..consume(
@@ -509,6 +521,7 @@ void main() {
         agentId: "Cursor",
         initialUserMessageId: null,
         messageIdOverride: null,
+        messageTimeResolver: null,
         haltClassifier: null,
       );
 
@@ -525,6 +538,7 @@ void main() {
         agentId: "Cursor",
         initialUserMessageId: null,
         messageIdOverride: null,
+        messageTimeResolver: null,
         haltClassifier: null,
       );
       final output = _captureWarnings(() {
@@ -551,6 +565,7 @@ void main() {
               agentId: "Cursor",
               initialUserMessageId: null,
               messageIdOverride: null,
+              messageTimeResolver: null,
               haltClassifier: null,
             )
             ..consume(
@@ -661,6 +676,7 @@ void main() {
                 agentId: "Cursor",
                 initialUserMessageId: null,
                 messageIdOverride: null,
+                messageTimeResolver: null,
                 haltClassifier: null,
               )
               ..consume(
@@ -713,6 +729,7 @@ void main() {
               agentId: "Cursor",
               initialUserMessageId: null,
               messageIdOverride: null,
+              messageTimeResolver: null,
               haltClassifier: null,
             )
             ..consume(
@@ -752,6 +769,7 @@ void main() {
               agentId: "Cursor",
               initialUserMessageId: null,
               messageIdOverride: null,
+              messageTimeResolver: null,
               haltClassifier: null,
             )
             ..consume(
@@ -781,6 +799,7 @@ void main() {
               agentId: "Cursor",
               initialUserMessageId: null,
               messageIdOverride: null,
+              messageTimeResolver: null,
               haltClassifier: null,
             )
             ..consume(
@@ -810,6 +829,7 @@ void main() {
               agentId: "Cursor",
               initialUserMessageId: null,
               messageIdOverride: null,
+              messageTimeResolver: null,
               haltClassifier: null,
             )
             ..consume(
@@ -855,6 +875,7 @@ void main() {
             providerId: "cursor",
             initialUserMessageId: null,
             messageIdOverride: null,
+            messageTimeResolver: null,
             haltClassifier: ({required text}) =>
                 text.trim() == "Check your settings to continue" ? const AcpHaltNotice(errorName: "cursor_gate") : null,
           )..consume(
@@ -877,6 +898,7 @@ void main() {
             agentId: "Cursor",
             initialUserMessageId: null,
             messageIdOverride: null,
+            messageTimeResolver: null,
             haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate"),
           )..consume(
             upd({
@@ -896,6 +918,7 @@ void main() {
             agentId: "Cursor",
             initialUserMessageId: null,
             messageIdOverride: null,
+            messageTimeResolver: null,
             haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate"),
           )..consume(
             upd({
@@ -928,6 +951,7 @@ void main() {
             agentId: "Cursor",
             initialUserMessageId: null,
             messageIdOverride: null,
+            messageTimeResolver: null,
             haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate"),
           )..consume(
             upd({
@@ -951,6 +975,7 @@ void main() {
             agentId: "Cursor",
             initialUserMessageId: null,
             messageIdOverride: null,
+            messageTimeResolver: null,
             haltClassifier: null,
           )..consume(
             upd({

--- a/bridge/sesori_plugin_acp/test/acp_tool_content_integration_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_tool_content_integration_test.dart
@@ -613,6 +613,7 @@ AcpReplayCollector _collector() => AcpReplayCollector(
   agentId: "ACP",
   initialUserMessageId: null,
   messageIdOverride: null,
+  messageTimeResolver: null,
   haltClassifier: null,
 );
 

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -53,6 +53,16 @@ class _GatedSelectionPlugin({
   }
 }
 
+class _TimestampingEventMapper({
+  required super.launchDirectory,
+  required super.pluginId,
+  required super.configurationTracker,
+}) extends AcpEventMapper {
+  @override
+  PluginMessageTime localUserMessageTime({required int createdAtMs}) =>
+      PluginMessageTime(created: createdAtMs, completed: null);
+}
+
 class _FlushControlledAcpProcess() extends FakeAcpProcess {
   final _FlushControlledIOSink _controlledStdin = _FlushControlledIOSink();
 
@@ -293,6 +303,55 @@ void main() {
         promptId,
       );
       respondTo(prompt, {"stopReason": "end_turn"});
+    });
+
+    test("a queued prompt message uses its dispatch time", () async {
+      final configurationTracker = AcpSessionConfigurationTracker();
+      final commandTracker = AcpCommandTracker();
+      final timestampingPlugin = TestAcpPlugin(
+        id: "acp",
+        agentDisplayName: "ACP",
+        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+        launchDirectory: cwd,
+        eventMapper: _TimestampingEventMapper(
+          launchDirectory: cwd,
+          pluginId: "acp",
+          configurationTracker: configurationTracker,
+        ),
+        commandTracker: commandTracker,
+        sessionOptionsService: AcpSessionOptionsService(
+          configurationTracker: configurationTracker,
+          commandTracker: commandTracker,
+          pluginId: "acp",
+          agentDisplayName: "ACP",
+        ),
+        processFactory: (_) async => fake,
+      );
+      await plugin.dispose();
+      plugin = timestampingPlugin;
+      plugin.events.listen(emitted.add, onError: streamErrors.add);
+
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+      final firstPromptId = await sendPrompt(sessionId, "first");
+      final first = await waitForFrame("session/prompt");
+      final secondPromptId = await sendPrompt(sessionId, "second");
+      final queuedAt = (await plugin.getQueuedPrompts(sessionId: sessionId))
+          .singleWhere((prompt) => prompt.id == secondPromptId)
+          .createdAt;
+
+      await Future<void>.delayed(const Duration(milliseconds: 2));
+      respondTo(first, {"stopReason": "end_turn"});
+      final second = await waitForFrameCount("session/prompt", 2);
+      await pump();
+
+      final secondMessage = emitted.whereType<BridgeSseMessageUpdated>().singleWhere(
+        (event) => event.info["promptId"] == secondPromptId,
+      );
+      expect((secondMessage.info["time"] as Map)["created"], greaterThan(queuedAt));
+
+      expect(firstPromptId, isNot(secondPromptId));
+      respondTo(second, {"stopReason": "end_turn"});
     });
 
     test("a failed ACP frame flush never marks the prompt sent", () async {

--- a/bridge/sesori_plugin_deepseek/lib/deepseek_plugin.dart
+++ b/bridge/sesori_plugin_deepseek/lib/deepseek_plugin.dart
@@ -2,6 +2,7 @@ export "src/api/deepseek_acp_api.dart";
 export "src/api/models/deepseek_protocol_dto.dart";
 export "src/deepseek_binary.dart";
 export "src/deepseek_identity.dart";
+export "src/deepseek_message_time_parser.dart";
 export "src/deepseek_plugin_impl.dart";
 export "src/runtime/deepseek_plugin_descriptor.dart";
 export "src/runtime/deepseek_runtime_manifest.dart";

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_event_mapper.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_event_mapper.dart
@@ -3,13 +3,23 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "api/deepseek_acp_api.dart";
 import "api/models/deepseek_protocol_dto.dart";
+import "deepseek_message_time_parser.dart";
 
 class DeepSeekEventMapper({
   required super.launchDirectory,
   required super.pluginId,
   required super.configurationTracker,
   required final DeepSeekAcpApi api,
+  required final DeepSeekMessageTimeParser messageTimeParser,
 }) extends AcpEventMapper {
+  @override
+  PluginMessageTime? messageTimeForNotification({required AcpNotification notification}) =>
+      messageTimeParser.parse(notification.params);
+
+  @override
+  PluginMessageTime localUserMessageTime({required int createdAtMs}) =>
+      PluginMessageTime(created: createdAtMs, completed: null);
+
   @override
   List<BridgeSseEvent> mapExtension(AcpNotification notification) {
     if (notification.method != DeepSeekAcpApi.sessionStatusMethod) {

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_message_time_parser.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_message_time_parser.dart
@@ -1,0 +1,16 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+class const DeepSeekMessageTimeParser() {
+  static const String _metadataKey = "sesori.ai/deepseek";
+  static const int _maxSafeInteger = 9007199254740991;
+
+  PluginMessageTime? parse<T>(Map<String, T> params) {
+    final metadata = params["_meta"];
+    if (metadata is! Map) return null;
+    final envelope = metadata[_metadataKey];
+    if (envelope is! Map) return null;
+    final created = envelope["messageCreatedAt"];
+    if (created is! int || created < 0 || created > _maxSafeInteger) return null;
+    return PluginMessageTime(created: created, completed: null);
+  }
+}

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_history_repository.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_history_repository.dart
@@ -4,11 +4,13 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "../api/deepseek_acp_api.dart";
 import "../api/models/deepseek_protocol_dto.dart";
 import "../deepseek_event_mapper.dart";
+import "../deepseek_message_time_parser.dart";
 
 class DeepSeekHistoryRepository({
   required final DeepSeekAcpApi api,
   required final DeepSeekEventMapper eventMapper,
   required final String pluginId,
+  required final DeepSeekMessageTimeParser messageTimeParser,
 }) {
   static const int _maxPages = 100;
   static const int _pageSize = 100;
@@ -24,6 +26,7 @@ class DeepSeekHistoryRepository({
       providerId: eventMapper.providerForSession(sessionId: sessionId),
       initialUserMessageId: null,
       messageIdOverride: ({required acpMessageId}) => acpMessageId,
+      messageTimeResolver: ({required params}) => messageTimeParser.parse(params),
       haltClassifier: eventMapper.classifyHaltNotice,
     );
     int? cursor;

--- a/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_plugin_descriptor.dart
@@ -10,6 +10,7 @@ import "../api/deepseek_acp_api.dart";
 import "../deepseek_binary.dart";
 import "../deepseek_event_mapper.dart";
 import "../deepseek_identity.dart";
+import "../deepseek_message_time_parser.dart";
 import "../deepseek_plugin_impl.dart";
 import "../repositories/deepseek_catalog_repository.dart";
 import "../repositories/deepseek_history_repository.dart";
@@ -236,11 +237,13 @@ class const DeepSeekPluginDescriptor() extends BridgePluginDescriptor {
     final configurationTracker = AcpSessionConfigurationTracker();
     final commandTracker = AcpCommandTracker();
     const api = DeepSeekAcpApi(pluginId: DeepSeekIdentity.id);
+    const messageTimeParser = DeepSeekMessageTimeParser();
     final mapper = DeepSeekEventMapper(
       launchDirectory: cwd,
       pluginId: DeepSeekIdentity.id,
       configurationTracker: configurationTracker,
       api: api,
+      messageTimeParser: messageTimeParser,
     );
     const catalogMapper = DeepSeekCatalogMapper();
     const catalogRepository = DeepSeekCatalogRepository(api: api, mapper: catalogMapper);
@@ -264,6 +267,7 @@ class const DeepSeekPluginDescriptor() extends BridgePluginDescriptor {
         api: api,
         eventMapper: mapper,
         pluginId: DeepSeekIdentity.id,
+        messageTimeParser: messageTimeParser,
       ),
       deepSeekSessionService: const DeepSeekSessionService(
         repository: DeepSeekSessionRepository(api: api),

--- a/bridge/sesori_plugin_deepseek/test/deepseek_approval_registry_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_approval_registry_test.dart
@@ -50,6 +50,7 @@ void main() {
       pluginId: DeepSeekIdentity.id,
       configurationTracker: configurationTracker,
       api: api,
+      messageTimeParser: const DeepSeekMessageTimeParser(),
     );
     final plugin = DeepSeekPlugin(
       launchSpec: const AcpLaunchSpec(command: "deepseek", args: []),
@@ -57,7 +58,12 @@ void main() {
       processFactory: (_) async => fake,
       mapper: mapper,
       api: api,
-      historyRepository: DeepSeekHistoryRepository(api: api, eventMapper: mapper, pluginId: DeepSeekIdentity.id),
+      historyRepository: DeepSeekHistoryRepository(
+        api: api,
+        eventMapper: mapper,
+        pluginId: DeepSeekIdentity.id,
+        messageTimeParser: const DeepSeekMessageTimeParser(),
+      ),
       deepSeekSessionService: const DeepSeekSessionService(
         repository: DeepSeekSessionRepository(api: api),
       ),

--- a/bridge/sesori_plugin_deepseek/test/deepseek_history_repository_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_history_repository_test.dart
@@ -55,7 +55,9 @@ void main() {
 
 DeepSeekHistoryRepository _repository(DeepSeekAcpApi api) => DeepSeekHistoryRepository(
   api: api,
+  messageTimeParser: const DeepSeekMessageTimeParser(),
   eventMapper: DeepSeekEventMapper(
+    messageTimeParser: const DeepSeekMessageTimeParser(),
     launchDirectory: "/project",
     pluginId: DeepSeekIdentity.id,
     configurationTracker: AcpSessionConfigurationTracker(),

--- a/bridge/sesori_plugin_deepseek/test/deepseek_message_time_parser_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_message_time_parser_test.dart
@@ -1,0 +1,55 @@
+import "package:deepseek_plugin/deepseek_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  const parser = DeepSeekMessageTimeParser();
+
+  test("parses valid DeepSeek message creation time", () {
+    expect(
+      parser.parse({
+        "_meta": {
+          "sesori.ai/deepseek": {"messageCreatedAt": 1700000000123},
+        },
+      }),
+      const PluginMessageTime(created: 1700000000123, completed: null),
+    );
+  });
+
+  test("rejects omitted, null, invalid, negative, and unsafe times", () {
+    for (final params in <Map<String, dynamic>>[
+      {},
+      {"_meta": null},
+      {
+        "_meta": {"sesori.ai/deepseek": null},
+      },
+      {
+        "_meta": {
+          "sesori.ai/deepseek": {"messageCreatedAt": null},
+        },
+      },
+      {
+        "_meta": {
+          "sesori.ai/deepseek": {"messageCreatedAt": 1.0},
+        },
+      },
+      {
+        "_meta": {
+          "sesori.ai/deepseek": {"messageCreatedAt": "1"},
+        },
+      },
+      {
+        "_meta": {
+          "sesori.ai/deepseek": {"messageCreatedAt": -1},
+        },
+      },
+      {
+        "_meta": {
+          "sesori.ai/deepseek": {"messageCreatedAt": 9007199254740992},
+        },
+      },
+    ]) {
+      expect(parser.parse(params), isNull, reason: "$params");
+    }
+  });
+}

--- a/bridge/sesori_plugin_deepseek/test/deepseek_message_times_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_message_times_test.dart
@@ -1,0 +1,139 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:deepseek_plugin/src/api/deepseek_acp_api.dart";
+import "package:deepseek_plugin/src/deepseek_event_mapper.dart";
+import "package:deepseek_plugin/src/deepseek_message_time_parser.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  const parser = DeepSeekMessageTimeParser();
+  final mapper = DeepSeekEventMapper(
+    launchDirectory: "/repo",
+    pluginId: "deepseek",
+    configurationTracker: AcpSessionConfigurationTracker(),
+    api: const DeepSeekAcpApi(pluginId: "deepseek"),
+    messageTimeParser: parser,
+  );
+
+  AcpNotification notification(Map<String, dynamic> update, [int? createdAt]) => AcpNotification(
+    method: AcpMethods.sessionUpdate,
+    params: {
+      "sessionId": "s1",
+      "update": update,
+      if (createdAt != null)
+        "_meta": {
+          "sesori.ai/deepseek": {"messageCreatedAt": createdAt},
+        },
+    },
+  );
+
+  int? liveCreated(List<BridgeSseEvent> events) =>
+      (events.whereType<BridgeSseMessageUpdated>().single.info["time"] as Map?)?["created"] as int?;
+
+  test("live assistant and tool envelopes use DeepSeek metadata time", () {
+    expect(
+      liveCreated(mapper.map(notification({
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "a1",
+        "content": {"type": "text", "text": "hello"},
+      }, 10))),
+      10,
+    );
+    expect(
+      liveCreated(mapper.map(notification({
+        "sessionUpdate": "tool_call",
+        "toolCallId": "t1",
+        "kind": "read",
+      }, 20))),
+      20,
+    );
+  });
+
+  test("local initial and queued users use accepted creation times", () {
+    expect(
+      liveCreated(mapper.mapInitialPrompt(
+        sessionId: "s1",
+        parts: const [PluginPromptPart.text(text: "initial")],
+        createdAtMs: 30,
+      )),
+      30,
+    );
+    expect(
+      liveCreated(mapper.mapSentPrompt(
+        sessionId: "s1",
+        messageId: "queued-user",
+        promptId: "queued",
+        parts: const [PluginPromptPart.text(text: "queued")],
+        createdAtMs: 40,
+      )),
+      40,
+    );
+  });
+
+  test("replay retains earliest user, assistant, and tool creation times", () {
+    final collector = AcpReplayCollector(
+      sessionId: "s1",
+      agentId: "deepseek",
+      modelId: null,
+      providerId: null,
+      initialUserMessageId: null,
+      messageIdOverride: ({required acpMessageId}) => acpMessageId,
+      messageTimeResolver: ({required params}) => parser.parse(params),
+      haltClassifier: null,
+    );
+    collector.consume(notification({
+      "sessionUpdate": "user_message_chunk",
+      "messageId": "u1",
+      "content": {"type": "text", "text": "user"},
+    }, 30).params);
+    collector.consume(notification({
+      "sessionUpdate": "agent_message_chunk",
+      "messageId": "a1",
+      "content": {"type": "text", "text": "first"},
+    }, 20).params);
+    collector.consume(notification({
+      "sessionUpdate": "agent_message_chunk",
+      "messageId": "a1",
+      "content": {"type": "text", "text": "later"},
+    }, 50).params);
+    collector.consume(notification({
+      "sessionUpdate": "tool_call",
+      "toolCallId": "t1",
+      "kind": "read",
+    }, 10).params);
+    collector.consume(notification({
+      "sessionUpdate": "tool_call_update",
+      "toolCallId": "t1",
+      "status": "completed",
+    }, 60).params);
+
+    final messages = collector.build();
+    expect(messages.map((message) => message.info.time?.created), [30, 10]);
+  });
+
+  test("replay halt retains draft time and omitted metadata remains null", () {
+    AcpReplayCollector collector(AcpHaltNotice? Function({required String text})? classifier) => AcpReplayCollector(
+      sessionId: "s1",
+      agentId: "deepseek",
+      modelId: null,
+      providerId: null,
+      initialUserMessageId: null,
+      messageIdOverride: null,
+      messageTimeResolver: ({required params}) => parser.parse(params),
+      haltClassifier: classifier,
+    );
+    final halted = collector(({required text}) => const AcpHaltNotice(errorName: "halt"));
+    halted.consume(notification({
+      "sessionUpdate": "agent_message_chunk",
+      "content": {"type": "text", "text": "halt"},
+    }, 70).params);
+    expect(halted.build().single.info.time?.created, 70);
+    expect(halted.build().single.info.toJson()["errorName"], "halt");
+
+    final old = collector(null)..consume(notification({
+      "sessionUpdate": "agent_message_chunk",
+      "content": {"type": "text", "text": "old"},
+    }).params);
+    expect(old.build().single.info.time, isNull);
+  });
+}

--- a/bridge/sesori_plugin_deepseek/test/deepseek_protocol_conformance_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_protocol_conformance_test.dart
@@ -4,6 +4,7 @@ import "dart:io";
 import "package:deepseek_plugin/src/api/deepseek_acp_api.dart";
 import "package:deepseek_plugin/src/api/models/deepseek_protocol_dto.dart";
 import "package:deepseek_plugin/src/deepseek_identity.dart";
+import "package:deepseek_plugin/src/deepseek_message_time_parser.dart";
 import "package:test/test.dart";
 
 void main() {
@@ -19,9 +20,17 @@ void main() {
       expect(_decodeValid(api, definition, value), isA<Map<String, dynamic>>(), reason: definition);
     }
     expect(definitions, {
-      "initializeMetadata", "promptMetadata", "catalogRequest", "catalogResponse",
-      "historyRequest", "historyResponse", "renameRequest", "renameResponse",
-      "askUserQuestionRequest", "askUserQuestionResponse", "sessionStatusNotification",
+      "initializeMetadata",
+      "promptMetadata",
+      "catalogRequest",
+      "catalogResponse",
+      "historyRequest",
+      "historyResponse",
+      "renameRequest",
+      "renameResponse",
+      "askUserQuestionRequest",
+      "askUserQuestionResponse",
+      "sessionStatusNotification",
     });
   });
   test("all invalid runtime fixtures are rejected", () async {
@@ -37,9 +46,12 @@ void main() {
   });
   test("catalog rejects bounded collection and entry violations", () async {
     final corpus = jsonDecode(await File("${fixtureDirectory.path}/valid.json").readAsString()) as List;
-    Map<String, dynamic> fixture(String definition) => (corpus.cast<Map<String, dynamic>>().firstWhere(
-      (fixture) => fixture["definition"] == definition,
-    )["value"] as Map).cast<String, dynamic>();
+    Map<String, dynamic> fixture(String definition) =>
+        (corpus.cast<Map<String, dynamic>>().firstWhere(
+                  (fixture) => fixture["definition"] == definition,
+                )["value"]
+                as Map)
+            .cast<String, dynamic>();
     final valid = fixture("catalogResponse");
     Map<String, dynamic> copy() => (jsonDecode(jsonEncode(valid)) as Map).cast<String, dynamic>();
     Map<String, dynamic> mutate(void Function(Map<String, dynamic>) change) {
@@ -47,19 +59,30 @@ void main() {
       change(value);
       return value;
     }
+
     final provider = (valid["providers"] as List).single;
     final model = ((provider as Map)["models"] as List).single;
     final malformed = [
       mutate((value) => value["providers"] = List.filled(65, provider)),
       mutate((value) => ((value["providers"] as List).single as Map)["models"] = List.filled(257, model)),
-      mutate((value) => value["commands"] = [{"name": "", "description": "invalid"}]),
+      mutate(
+        (value) => value["commands"] = [
+          {"name": "", "description": "invalid"},
+        ],
+      ),
       mutate((value) => value["commands"] = List.filled(129, {"name": "valid", "description": "valid"})),
-      mutate((value) => value["failures"] = [
-        {"providerId": "provider", "category": "catalog", "message": "x".padRight(513, "x")},
-      ]),
-      mutate((value) => value["failures"] = List.filled(65, {
-        "providerId": "provider", "category": "catalog", "message": "failed",
-      })),
+      mutate(
+        (value) => value["failures"] = [
+          {"providerId": "provider", "category": "catalog", "message": "x".padRight(513, "x")},
+        ],
+      ),
+      mutate(
+        (value) => value["failures"] = List.filled(65, {
+          "providerId": "provider",
+          "category": "catalog",
+          "message": "failed",
+        }),
+      ),
     ];
     for (final catalog in malformed) {
       expect(() => api.parseCatalogResponse(catalog), throwsFormatException);
@@ -93,11 +116,17 @@ void _rejectInvalid(DeepSeekAcpApi api, String definition, Map<String, dynamic> 
     case "initializeMetadata" ||
         "promptMetadata" ||
         "catalogResponse" ||
-        "historyResponse" ||
         "askUserQuestionRequest" ||
         "askUserQuestionResponse" ||
         "sessionStatusNotification":
       _decodeValid(api, definition, value);
+    case "historyResponse":
+      final response = DeepSeekHistoryResponseDto.fromJson(value);
+      for (final update in response.updates) {
+        if (update.metadata != null && const DeepSeekMessageTimeParser().parse(update.toJson()) == null) {
+          throw const FormatException("messageCreatedAt");
+        }
+      }
     case "catalogRequest":
       final request = DeepSeekCatalogRequestDto.fromJson(value);
       if (!request.cwd.startsWith("/") && !RegExp(r"^[A-Za-z]:[\\/]").hasMatch(request.cwd)) {

--- a/bridge/sesori_plugin_deepseek/test/deepseek_protocol_integrity_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_protocol_integrity_test.dart
@@ -12,7 +12,7 @@ void main() {
     ) as Map<String, dynamic>;
 
     expect(manifest["repository"], "sesori-ai/sesori-deepseek-acp");
-    expect(manifest["commit"], "e23a5c7e435c61af9ee7b8c5cdd61ee39fd60c6d");
+    expect(manifest["commit"], "9731711f079dc0d7acf7e5eff29c81a3622bc4a0");
     final expected = (manifest["files"] as Map).cast<String, String>();
     expect(expected.keys.toSet(), {
       "deepseek-acp.schema.json",

--- a/bridge/sesori_plugin_deepseek/test/deepseek_scaffold_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_scaffold_test.dart
@@ -30,6 +30,7 @@ void main() {
       launchDirectory: "/project",
       pluginId: DeepSeekIdentity.id,
       configurationTracker: AcpSessionConfigurationTracker(),
+      messageTimeParser: const DeepSeekMessageTimeParser(),
       api: const DeepSeekAcpApi(pluginId: DeepSeekIdentity.id),
     );
     List<BridgeSseEvent> map(Map<String, dynamic> params) => mapper.map(
@@ -52,6 +53,7 @@ void main() {
       launchDirectory: "/project",
       pluginId: DeepSeekIdentity.id,
       configurationTracker: AcpSessionConfigurationTracker(),
+      messageTimeParser: const DeepSeekMessageTimeParser(),
       api: const DeepSeekAcpApi(pluginId: DeepSeekIdentity.id),
     )..beginTurn("session-1");
     final events = mapper.map(

--- a/bridge/sesori_plugin_deepseek/test/deepseek_session_metadata_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_session_metadata_test.dart
@@ -18,13 +18,19 @@ void main() {
       pluginId: DeepSeekIdentity.id,
       configurationTracker: configurationTracker,
       api: api,
+      messageTimeParser: const DeepSeekMessageTimeParser(),
     );
     final plugin = DeepSeekPlugin(
       launchSpec: const AcpLaunchSpec(command: "deepseek", args: [], cwd: "/repo", environment: {}),
       launchDirectory: "/repo",
       mapper: mapper,
       api: api,
-      historyRepository: DeepSeekHistoryRepository(api: api, eventMapper: mapper, pluginId: DeepSeekIdentity.id),
+      historyRepository: DeepSeekHistoryRepository(
+        api: api,
+        eventMapper: mapper,
+        pluginId: DeepSeekIdentity.id,
+        messageTimeParser: const DeepSeekMessageTimeParser(),
+      ),
       deepSeekSessionService: const DeepSeekSessionService(
         repository: DeepSeekSessionRepository(api: api),
       ),

--- a/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v1/deepseek-acp.schema.json
+++ b/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v1/deepseek-acp.schema.json
@@ -277,9 +277,27 @@
       ],
       "properties": {
         "_meta": {
-          "type": [
-            "object",
-            "null"
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "sesori.ai/deepseek": {
+                  "type": "object",
+                  "properties": {
+                    "messageCreatedAt": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              },
+              "additionalProperties": true
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "sessionId": {

--- a/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v1/invalid.json
+++ b/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v1/invalid.json
@@ -106,6 +106,25 @@
     }
   },
   {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [
+        {
+          "sessionId": "session-1",
+          "update": {
+            "sessionUpdate": "agent_message_chunk"
+          },
+          "_meta": {
+            "sesori.ai/deepseek": {
+              "messageCreatedAt": -1
+            }
+          }
+        }
+      ],
+      "hasMore": false
+    }
+  },
+  {
     "definition": "renameRequest",
     "value": {
       "sessionId": "session-1",

--- a/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v1/source_manifest.json
+++ b/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v1/source_manifest.json
@@ -1,9 +1,9 @@
 {
   "repository": "sesori-ai/sesori-deepseek-acp",
-  "commit": "e23a5c7e435c61af9ee7b8c5cdd61ee39fd60c6d",
+  "commit": "9731711f079dc0d7acf7e5eff29c81a3622bc4a0",
   "files": {
-    "deepseek-acp.schema.json": "ce54a19af67fffb673d2bd82e80f9335d8a89c28525451c88bbbe9432be5dc87",
-    "valid.json": "f438ad0659e0a69f1f87a292eed4551385ef7436096de6813d2d1006a2750780",
-    "invalid.json": "7f72b9d9a056af51214adb3c24134d3c806509a82d7de18ac8b17fcc88d5966d"
+    "deepseek-acp.schema.json": "eeb88ab1366ccb3fd470847fa5dbbfcd4252d9fafad6544c81494da886872167",
+    "valid.json": "6285b062d7c6bea07d3b7e42d091ad86edf0e032b1811bec2208d9ba678c475d",
+    "invalid.json": "bfe600877bb520fa42c2ad52cdcf795cdbd83ec94ad2ce9701fb7c5b796ca28c"
   }
 }

--- a/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v1/valid.json
+++ b/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v1/valid.json
@@ -98,6 +98,11 @@
           "sessionId": "session-1",
           "update": {
             "sessionUpdate": "agent_message_chunk"
+          },
+          "_meta": {
+            "sesori.ai/deepseek": {
+              "messageCreatedAt": 1787831943365
+            }
           }
         }
       ],


### PR DESCRIPTION
## Complexity

Moderate. This adds an optional backend-neutral timestamp seam to ACP while keeping DeepSeek metadata parsing inside the owning plugin.

## What

- Vendor the adapter extension corpus from `sesori-deepseek-acp@9731711`.
- Add a strict plugin-local parser for optional DeepSeek `messageCreatedAt` metadata.
- Inject that parser into DeepSeek live and history mapping.
- Preserve accepted local-user times and persisted user, assistant, tool, and halt-message times through ACP live/replay collection.
- Keep every other ACP plugin's message-time behavior unchanged.

## Why

Adapter step 1/4 exposes authoritative DSH event times in an optional namespaced envelope. The consumer must understand that contract before adapter v0.1.2 can be released against a passing vendored consumer commit.

## Risk and test focus

Focus on stable message grouping, first timestamp retention across chunks/tool updates, local prompt identity, halt replay, malformed metadata, and omitted/null v0.1.1 metadata. There is no user-visible or database impact in this step because the managed runtime remains pinned to adapter v0.1.1.

## Expected result

The bridge safely consumes timestamp-bearing DeepSeek envelopes while remaining compatible with the currently installed adapter that omits them.

## Series

1. Adapter implementation: sesori-ai/sesori-deepseek-acp#11.
2. This PR: compatible monorepo consumer.
3. Release adapter v0.1.2 against this merged consumer commit.
4. Activate v0.1.2 in the monorepo.

## Verification

- `dart test` in `bridge/sesori_plugin_acp` (263 passed)
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_acp`
- `dart test` in `bridge/sesori_plugin_deepseek` (41 passed)
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_deepseek`
- `make codegen` (no generated diff)
- `git diff --check`
- Architecture plan and implementation reviews approved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consumes optional DeepSeek message timestamps in the ACP bridge so a future adapter version can supply authoritative per-message times without affecting current behavior.

**Changes**
- Adds a backend-neutral timestamp seam (`messageTimeForNotification`, `localUserMessageTime`) to `AcpEventMapper` and a resolver to `AcpReplayCollector`.
- Adds a strict parser in the DeepSeek plugin for `messageCreatedAt` under the `sesori.ai/deepseek` metadata envelope and wires it into live mapping and history replay.
- Live and replayed envelopes retain the earliest timestamp per message, so reordered chunks and tool updates correct previously emitted times.
- No user-visible or database impact: the managed DeepSeek adapter stays pinned to v0.1.1, which omits these timestamps.

<sup>Written for commit b362fdc996469d8b67575e02635cc1052ad5e205. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

