### PR TITLE
🌿 Make Pi startup extensions see the selected model

### DIFF
--- a/bridge/sesori_plugin_pi/lib/src/api/pi_launch_spec.dart
+++ b/bridge/sesori_plugin_pi/lib/src/api/pi_launch_spec.dart
@@ -43,10 +43,14 @@ bool isValidPiSessionId({required String sessionId}) => _sessionIdPattern.hasMat
 ///
 /// One process serves one session and inherits the user's environment so Pi can
 /// use normal credentials, configuration, packages, and session directories.
+/// The first turn's requested selection is part of the command line so Pi
+/// extensions observe it during `session_start`, before RPC commands are read.
 class PiLaunchSpec({
   required final String binaryPath,
   required final String workingDirectory,
   required final PiSessionLaunch launch,
+  required final ({String providerID, String modelID})? model,
+  required final String? thinkingLevel,
   required Map<String, String> environment,
 }) {
   this {
@@ -58,18 +62,31 @@ class PiLaunchSpec({
   /// Additional entries merged over the inherited process environment.
   final Map<String, String> environment = Map.unmodifiable({...environment, "PI_SKIP_VERSION_CHECK": "1"});
 
-  List<String> get arguments => switch (launch) {
-    PiNoSession() => ["--mode", "rpc", "--no-session", "--approve"],
-    PiNewSession(:final sessionId) => ["--mode", "rpc", "--approve", "--session-id", sessionId],
-    PiForkedSession(:final sessionId, :final parentSessionPath) => [
-      "--mode",
-      "rpc",
-      "--approve",
-      "--fork",
-      parentSessionPath,
-      "--session-id",
-      sessionId,
-    ],
-    PiResumedSession(:final sessionPath) => ["--mode", "rpc", "--approve", "--session", sessionPath],
-  };
+  List<String> get arguments {
+    final selectedModel = model;
+    final selectedThinkingLevel = thinkingLevel;
+    return [
+      ...switch (launch) {
+        PiNoSession() => ["--mode", "rpc", "--no-session", "--approve"],
+        PiNewSession(:final sessionId) => ["--mode", "rpc", "--approve", "--session-id", sessionId],
+        PiForkedSession(:final sessionId, :final parentSessionPath) => [
+          "--mode",
+          "rpc",
+          "--approve",
+          "--fork",
+          parentSessionPath,
+          "--session-id",
+          sessionId,
+        ],
+        PiResumedSession(:final sessionPath) => ["--mode", "rpc", "--approve", "--session", sessionPath],
+      },
+      if (selectedModel != null) ...[
+        "--provider",
+        selectedModel.providerID,
+        "--model",
+        selectedModel.modelID,
+      ],
+      if (selectedThinkingLevel != null) ...["--thinking", selectedThinkingLevel],
+    ];
+  }
 }

--- a/bridge/sesori_plugin_pi/lib/src/repositories/pi_backend_catalog_repository.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/pi_backend_catalog_repository.dart
@@ -53,6 +53,8 @@ class PiBackendCatalogRepository({
         binaryPath: _binaryPath,
         workingDirectory: normalizedProject,
         launch: const PiNoSession(),
+        model: null,
+        thinkingLevel: null,
         environment: _environment,
       ),
       processFactory: _processFactory,

--- a/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
@@ -189,14 +189,23 @@ final class PiSessionProcessRepository({
   Future<PiSessionConnection> ensureResident({
     required String sessionId,
     required Set<String> knownDirectories,
+    required ({String providerID, String modelID})? model,
+    required PluginSessionVariant? variant,
   }) => _withSessionOperation(
     sessionId: sessionId,
-    operation: () => _ensureResident(sessionId: sessionId, knownDirectories: knownDirectories),
+    operation: () => _ensureResident(
+      sessionId: sessionId,
+      knownDirectories: knownDirectories,
+      model: model,
+      variant: variant,
+    ),
   );
 
   Future<PiSessionConnection> _ensureResident({
     required String sessionId,
     required Set<String> knownDirectories,
+    required ({String providerID, String modelID})? model,
+    required PluginSessionVariant? variant,
   }) async {
     if (_disposed) throw const PiRpcDisposedException();
     final resident = _residents[sessionId];
@@ -205,7 +214,12 @@ final class PiSessionProcessRepository({
     }
     final connecting = _connecting[sessionId];
     if (connecting != null) return await connecting;
-    final future = _connect(sessionId: sessionId, knownDirectories: knownDirectories);
+    final future = _connect(
+      sessionId: sessionId,
+      knownDirectories: knownDirectories,
+      model: model,
+      variant: variant,
+    );
     _connecting[sessionId] = future;
     try {
       return await future;
@@ -217,6 +231,8 @@ final class PiSessionProcessRepository({
   Future<PiSessionConnection> _connect({
     required String sessionId,
     required Set<String> knownDirectories,
+    required ({String providerID, String modelID})? model,
+    required PluginSessionVariant? variant,
   }) async {
     final generation = ++_nextConnectionGeneration;
     _generations[sessionId] = generation;
@@ -258,6 +274,8 @@ final class PiSessionProcessRepository({
         binaryPath: _binaryPath,
         workingDirectory: cwd,
         launch: launch,
+        model: model,
+        thinkingLevel: variant?.id,
         environment: _environment,
       ),
       processFactory: _processFactory,
@@ -582,6 +600,8 @@ final class PiSessionProcessRepository({
         binaryPath: _binaryPath,
         workingDirectory: resolved.metadata.cwd,
         launch: PiResumedSession(sessionPath: resolved.path),
+        model: null,
+        thinkingLevel: null,
         environment: _environment,
       ),
       processFactory: _processFactory,
@@ -828,6 +848,8 @@ final class PiSessionProcessRepository({
         binaryPath: _binaryPath,
         workingDirectory: resolved.metadata.cwd,
         launch: PiResumedSession(sessionPath: resolved.path),
+        model: null,
+        thinkingLevel: null,
         environment: _environment,
       ),
       processFactory: _processFactory,

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -450,6 +450,8 @@ final class PiSessionService({
       final connection = await _processes.ensureResident(
         sessionId: sessionId,
         knownDirectories: {state.directory},
+        model: turn.model,
+        variant: turn.variant,
       );
       if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) {
         throw PiTurnCancelledException(sessionId: sessionId);

--- a/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
@@ -490,7 +490,12 @@ final class _ProcessFixture({required final FakePiExtensionSessionStorageApi sto
 
   Future<void> start({required String sessionId, required String directory}) async {
     final process = processes.last;
-    final connecting = repository.ensureResident(sessionId: sessionId, knownDirectories: {directory});
+    final connecting = repository.ensureResident(
+      sessionId: sessionId,
+      knownDirectories: {directory},
+      model: null,
+      variant: null,
+    );
     final command = await _waitForCommand(process: process, type: "get_entries");
     process.emitResponse(
       id: command["id"]! as String,

--- a/bridge/sesori_plugin_pi/test/pi_launch_spec_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_launch_spec_test.dart
@@ -10,10 +10,37 @@ void main() {
         binaryPath: "pi",
         workingDirectory: "/tmp/project",
         launch: PiNewSession(sessionId: "sesori.session-1"),
+        model: null,
+        thinkingLevel: null,
         environment: const {},
       );
 
       expect(spec.arguments, ["--mode", "rpc", "--approve", "--session-id", "sesori.session-1"]);
+    });
+
+    test("starts a session with the requested model and thinking level", () {
+      final spec = PiLaunchSpec(
+        binaryPath: "pi",
+        workingDirectory: "/tmp/project",
+        launch: PiNewSession(sessionId: "selected-session"),
+        model: (providerID: "openai-codex", modelID: "gpt-5.6-sol"),
+        thinkingLevel: "max",
+        environment: const {},
+      );
+
+      expect(spec.arguments, [
+        "--mode",
+        "rpc",
+        "--approve",
+        "--session-id",
+        "selected-session",
+        "--provider",
+        "openai-codex",
+        "--model",
+        "gpt-5.6-sol",
+        "--thinking",
+        "max",
+      ]);
     });
 
     test("builds the exact parent-fork RPC argument vector", () {
@@ -22,6 +49,8 @@ void main() {
         binaryPath: "pi",
         workingDirectory: "/tmp/project",
         launch: PiForkedSession(sessionId: "child", parentSessionPath: parentPath),
+        model: null,
+        thinkingLevel: null,
         environment: const {},
       );
 
@@ -45,6 +74,8 @@ void main() {
         binaryPath: "pi",
         workingDirectory: "/tmp/project",
         launch: const PiNoSession(),
+        model: null,
+        thinkingLevel: null,
         environment: const {},
       );
 
@@ -57,6 +88,8 @@ void main() {
         binaryPath: "pi",
         workingDirectory: "/tmp/project",
         launch: PiResumedSession(sessionPath: absolutePath),
+        model: null,
+        thinkingLevel: null,
         environment: const {},
       );
 
@@ -69,6 +102,8 @@ void main() {
         binaryPath: r"C:\managed-pi\pi.exe",
         workingDirectory: r"C:\project",
         launch: PiNewSession(sessionId: "session-1"),
+        model: null,
+        thinkingLevel: null,
         environment: const {},
       );
 
@@ -81,6 +116,8 @@ void main() {
         binaryPath: "pi",
         workingDirectory: "/tmp/project",
         launch: PiNewSession(sessionId: "session-1"),
+        model: null,
+        thinkingLevel: null,
         environment: environment,
       );
 
@@ -96,6 +133,8 @@ void main() {
           binaryPath: "pi",
           workingDirectory: "/tmp/project",
           launch: PiNewSession(sessionId: "session-1"),
+          model: null,
+          thinkingLevel: null,
           environment: const {"HOME": "/tmp/isolated", "ANTHROPIC_API_KEY": secret},
         ),
         throwsA(

--- a/bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart
@@ -235,6 +235,8 @@ void main() {
           binaryPath: "/managed/pi",
           workingDirectory: "/project",
           launch: const PiNoSession(),
+          model: null,
+          thinkingLevel: null,
           environment: const {"ANTHROPIC_API_KEY": "secret"},
         ),
       );

--- a/bridge/sesori_plugin_pi/test/pi_session_process_repository_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_process_repository_test.dart
@@ -57,7 +57,12 @@ void main() {
         identityTracker: identities,
       );
       addTearDown(repository.dispose);
-      final connecting = repository.ensureResident(sessionId: "session", knownDirectories: const {});
+      final connecting = repository.ensureResident(
+        sessionId: "session",
+        knownDirectories: const {},
+        model: null,
+        variant: null,
+      );
       final initial = await waitForCommand(process: process, type: "get_entries");
       process.emitResponse(
         id: initial["id"]! as String,

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -83,8 +83,18 @@ void main() {
     final frames = <PiSessionProcessFrame>[];
     fixture.repository.frames.listen(frames.add);
 
-    final first = fixture.repository.ensureResident(sessionId: "session", knownDirectories: const {"/project"});
-    final second = fixture.repository.ensureResident(sessionId: "session", knownDirectories: const {"/project"});
+    final first = fixture.repository.ensureResident(
+      sessionId: "session",
+      knownDirectories: const {"/project"},
+      model: null,
+      variant: null,
+    );
+    final second = fixture.repository.ensureResident(
+      sessionId: "session",
+      knownDirectories: const {"/project"},
+      model: null,
+      variant: null,
+    );
     process.emit(frame: {"type": "agent_start"});
     await pump();
     expect(frames, isEmpty);
@@ -105,7 +115,12 @@ void main() {
     final fixture = _Fixture(processes: [process], storageOverride: storage);
     addTearDown(fixture.dispose);
 
-    final resident = fixture.repository.ensureResident(sessionId: "session", knownDirectories: const {"/project"});
+    final resident = fixture.repository.ensureResident(
+      sessionId: "session",
+      knownDirectories: const {"/project"},
+      model: null,
+      variant: null,
+    );
     await waitForCommand(process: process, type: "get_entries");
     expect(storage.pending, isNull);
     expect(storage.clearedDirectories, containsAll({"/project"}));
@@ -126,6 +141,8 @@ void main() {
       final connection = failedCleanupFixture.repository.ensureResident(
         sessionId: "other",
         knownDirectories: const {"/project"},
+        model: null,
+        variant: null,
       );
       await _answerEntries(failedCleanupProcess);
       await connection;
@@ -145,7 +162,12 @@ void main() {
     final fixture = _Fixture(processes: [resumed, created], storageOverride: storage);
     addTearDown(fixture.dispose);
 
-    final resident = fixture.repository.ensureResident(sessionId: "session", knownDirectories: const {"/project"});
+    final resident = fixture.repository.ensureResident(
+      sessionId: "session",
+      knownDirectories: const {"/project"},
+      model: null,
+      variant: null,
+    );
     await _answerEntries(resumed);
     await resident;
     expect(fixture.spawned.single.launch, isA<PiResumedSession>());
@@ -154,7 +176,12 @@ void main() {
     storage
       ..resolved = null
       ..pending = const PiPendingNewSession(id: "session", cwd: "/pending", parentSessionPath: null);
-    final pending = fixture.repository.ensureResident(sessionId: "session", knownDirectories: const {"/pending"});
+    final pending = fixture.repository.ensureResident(
+      sessionId: "session",
+      knownDirectories: const {"/pending"},
+      model: null,
+      variant: null,
+    );
     await _answerEntries(created);
     await pending;
     expect(fixture.spawned.last.launch, isA<PiNewSession>());
@@ -222,6 +249,8 @@ void main() {
     final connecting = fixture.repository.ensureResident(
       sessionId: "session",
       knownDirectories: const {"/project"},
+      model: null,
+      variant: null,
     );
     await waitForCommand(process: process, type: "get_entries");
 
@@ -250,7 +279,12 @@ void main() {
     );
     addTearDown(repository.dispose);
 
-    final connecting = repository.ensureResident(sessionId: "session", knownDirectories: const {"/project"});
+    final connecting = repository.ensureResident(
+      sessionId: "session",
+      knownDirectories: const {"/project"},
+      model: null,
+      variant: null,
+    );
     await pump();
     await repository.teardown(sessionId: "session");
     spawn.complete(process);
@@ -269,6 +303,8 @@ void main() {
     final firstConnection = fixture.repository.ensureResident(
       sessionId: "session",
       knownDirectories: const {"/project"},
+      model: null,
+      variant: null,
     );
     await _answerEntries(first);
     final firstGeneration = (await firstConnection).generation;
@@ -277,6 +313,8 @@ void main() {
     final secondConnection = fixture.repository.ensureResident(
       sessionId: "session",
       knownDirectories: const {"/project"},
+      model: null,
+      variant: null,
     );
     await _answerEntries(second);
     expect((await secondConnection).generation, greaterThan(firstGeneration));
@@ -288,7 +326,12 @@ void main() {
     final fixture = _Fixture(processes: [resident, transient]);
     addTearDown(fixture.dispose);
 
-    final connecting = fixture.repository.ensureResident(sessionId: "session", knownDirectories: const {"/project"});
+    final connecting = fixture.repository.ensureResident(
+      sessionId: "session",
+      knownDirectories: const {"/project"},
+      model: null,
+      variant: null,
+    );
     final history = fixture.repository.loadHistory(sessionId: "session", knownDirectories: const {"/project"});
     final rename = fixture.repository.renameSession(
       sessionId: "session",
@@ -343,6 +386,8 @@ void main() {
       final connecting = fixture.repository.ensureResident(
         sessionId: "session",
         knownDirectories: const {"/project"},
+        model: null,
+        variant: null,
       );
       gate.complete();
 
@@ -362,7 +407,7 @@ void main() {
     });
   }
 
-  test("selection completes before prompt dispatch", () async {
+  test("selection is present at process startup and completes before prompt dispatch", () async {
     final process = FakePiProcess();
     final fixture = _Fixture(processes: [process]);
     addTearDown(fixture.dispose);
@@ -378,6 +423,19 @@ void main() {
       model: (providerID: "provider", modelID: "model"),
     );
     await _answerEntries(process);
+    expect(fixture.spawned.single.arguments, [
+      "--mode",
+      "rpc",
+      "--approve",
+      "--session",
+      "/sessions/session.jsonl",
+      "--provider",
+      "provider",
+      "--model",
+      "model",
+      "--thinking",
+      "high",
+    ]);
     final model = await waitForCommand(process: process, type: "set_model");
     expect(process.written.where((frame) => frame["type"] == "prompt"), isEmpty);
     process.emitResponse(id: model["id"]! as String, command: "set_model");
@@ -1835,7 +1893,12 @@ void main() {
     await pump();
     expect(first.killed, isTrue);
 
-    final resident = fixture.repository.ensureResident(sessionId: "two", knownDirectories: const {"/project"});
+    final resident = fixture.repository.ensureResident(
+      sessionId: "two",
+      knownDirectories: const {"/project"},
+      model: null,
+      variant: null,
+    );
     await _answerEntries(second);
     await resident;
     await service.dispose();

--- a/bridge/sesori_plugin_pi/test/support/pi_rpc_client_test_factory.dart
+++ b/bridge/sesori_plugin_pi/test/support/pi_rpc_client_test_factory.dart
@@ -14,6 +14,8 @@ PiLaunchSpec testLaunchSpec() => PiLaunchSpec(
   binaryPath: "pi",
   workingDirectory: "/tmp/project",
   launch: PiNewSession(sessionId: "sesori-pi-1"),
+  model: null,
+  thinkingLevel: null,
   environment: const {},
 );
 

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -66,8 +66,11 @@ defaults and queued client sends coherent.
   and model, effort, or permission-mode changes wait for a turn boundary
   instead of changing the active turn.
 - Pi keeps at most one lazy resident RPC process per active session and allows
-  different sessions to run concurrently. Startup replays and hydrates message
-  identity before live frames attach or a turn dispatches. Same-session prompts
+  different sessions to run concurrently. A cold resident starts with the
+  turn's requested model and thinking level on Pi's command line so
+  `session_start` extensions observe the same selection that the turn will use.
+  Startup replays and hydrates message identity before live frames attach or a
+  turn dispatches. Same-session prompts
   remain FIFO, and same-selection ordinary follow-ups dispatch with Pi's
   `steer` streaming behavior as soon as the preceding prompt is accepted, so Pi
   injects them at the next tool boundary instead of waiting for the run to
@@ -280,8 +283,10 @@ replay, and abort after output has started.
   staged prompt, changes FIFO order or prompt identity, refreshes and retries
   without a bound, or leaves a corrected selection on a variant the picker does
   not display.
-- A cold Pi follow-up wakes the process but times out in pre-prompt automatic
-  compaction before reaching the agent; an initial or later viewer exposes only
+- A cold Pi process exposes a stale default model or thinking level to startup
+  extensions instead of the pending turn's selection, or a cold follow-up wakes
+  the process but times out in pre-prompt automatic compaction before reaching
+  the agent; an initial or later viewer exposes only
   the queued prompt while compaction is underway; the running card is replaced
   instead of updated when compaction ends, or survives an abort or process
   exit.


### PR DESCRIPTION
## Complexity

🌿 Straightforward — threads the already-validated turn selection into the Pi process launch without changing shared contracts.

## What

- Add the pending turn's provider, model, and thinking level to cold Pi RPC process arguments.
- Keep the existing RPC selection barrier before prompt dispatch.
- Cover launch argument construction and cold resident startup sequencing.
- Record the behavior in the session-turn regression guide.

## Why

Pi emits `session_start` before it begins reading RPC commands. Sesori previously launched Pi without a selection and applied the requested model afterward through `set_model`, so startup extensions such as Fast Mode observed and announced Pi's stale default model even though the actual turn used the requested model.

## Risk and test focus

The main risk is argument construction across new, resumed, and forked Pi sessions. Catalog and history-only probes continue to launch without selection overrides, and turn selection is still reapplied through RPC before prompting. This has a user-visible notification correction and no database or client/bridge wire-contract impact.

## Expected result

A cold Pi session starts with the selected model and thinking level already active, so `session_start` extensions report the same selection used by the first turn. For example, a SOL Max session reports SOL rather than a previously configured Terra default.

## Verification

- `cd bridge && dart pub get`
- `cd bridge/sesori_plugin_pi && dart analyze --fatal-infos`
- `cd bridge/sesori_plugin_pi && dart test`
- Live Pi RPC smoke check: Fast Mode reported `openai-codex/gpt-5.6-sol` when launched with SOL Max arguments.
- Architecture implementation review: approved.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Passes the pending turn's model and thinking level to cold Pi RPC processes on the command line, so startup extensions like Fast Mode see the selected model in `session_start` instead of Pi's stale default.

- Applies to new, resumed, and forked sessions; catalog and history-only probes still launch without selection overrides.
- Keeps the existing RPC selection barrier before prompt dispatch.
- No database or bridge wire-contract impact; the only user-visible change is corrected startup notifications.

<sup>Written for commit d8cd8ab3f54e4d90d9ba36c8ac8bb0ef087c5174. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

