### PR TITLE
🌿 Add Firebase signup and login outcomes

### DIFF
--- a/.opencode/skills/add-analytics/SKILL.md
+++ b/.opencode/skills/add-analytics/SKILL.md
@@ -34,9 +34,10 @@ state under `services/models/`:
 
 - Consumers call `ProductAnalyticsService` for authenticated account-linked
   events.
-- The three approved pre-auth login events call
-  `InstallationAnalyticsService`; they are account-less and preference-exempt
-  by explicit product decision.
+- Five approved account-less authentication events call
+  `InstallationAnalyticsService`: the started/completed/failed attempt funnel
+  plus Firebase's recommended `sign_up` and `login` outcomes. They are
+  preference-exempt by explicit product decision.
 - Delivery flows `Client (Foundation) -> API -> Repository -> Service ->
   Consumer`. Cubits/widgets/listeners never hold `AnalyticsClient` or
   `AnalyticsApi` directly.
@@ -52,7 +53,7 @@ state under `services/models/`:
 | Reactive state | Dedicated listener or bounded transition guard | Bridge/screen state |
 | Screen | `GoRouterRouteSource` -> exhaustive `AnalyticsScreen` mapping | `product_screen_viewed` |
 | Flutter-only capability | UI call site after capability succeeds, calling Layer-3 service | Voice transcription completed |
-| Pre-auth login | `LoginCubit` terminal state through `InstallationAnalyticsService` | Timeout by provider |
+| Account-less authentication | `LoginCubit` terminal state through `InstallationAnalyticsService` | Attempt failure or server-confirmed signup/login |
 
 Never use a widget tap as a proxy when a confirmed outcome exists. Never emit a
 success event when an operation is queued, merely attempted, or later requeued.
@@ -100,8 +101,10 @@ Never report:
 
 Account-linked events use only the pseudonymous custom `user_key` produced in
 the repository. Never set Firebase global `user_id` for the new design.
-Installation login events carry no `user_key` or attempt ID and may not be
-extended beyond their approved provider/failure enums without a new decision.
+Installation authentication events carry no `user_key` or attempt ID. Funnel
+events use only approved provider/failure enums; recommended `sign_up`/`login`
+events use only the same pinned provider enum as `method`. Any broader
+parameters require a new decision.
 
 ## Implementation checklist
 

--- a/client/app/docs/PRODUCT_ANALYTICS_DISCLOSURE.md
+++ b/client/app/docs/PRODUCT_ANALYTICS_DISCLOSURE.md
@@ -25,25 +25,33 @@ The control does not stop:
 
 - Firebase automatic installation-level events or Firebase's pseudonymous
   installation/device and approximate-location processing;
+- Firebase's release-only account-less sign-in attempt funnel and recommended
+  `sign_up`/`login` outcomes, carrying only a pinned sign-in provider, bounded
+  failure kind, or pinned authentication method;
 - Singular's release-only install/session attribution, SDK-generated device
   identifier, and parameter-free standard authentication conversion events;
   this integration limits advertising identifiers and partner data sharing and
   sets no Sesori user identity;
-- the bounded account-less sign-in funnel, which carries only a pinned sign-in
-  provider and bounded failure kind;
 - account and bridge records required to operate Sesori;
 - behavior from an older app version; or
 - a remote supported installation until it next establishes authentication or
   explicitly refreshes its preference.
 
-The account-less sign-in funnel has no account key or attempt identifier and
-cannot be reliably filtered for internal/test release traffic. It is diagnostic
-only and must not be represented as an account conversion metric. Separately,
-Singular receives `sng_login` after every successful interactive authentication
-and `sng_complete_registration` immediately before it only when the auth server
-reports that the operation created the account. Those standard events carry no
-provider, account identifier, or other event attributes and are not sent for
-session restore, token refresh, failure, cancellation, or a displaced attempt.
+The Firebase account-less authentication catalog has no account key or attempt
+identifier and cannot be reliably filtered for internal/test release traffic.
+The attempt funnel is diagnostic only. Firebase receives `sign_up` only when
+the auth server reports that the operation created the account, and receives
+`login` only for a confirmed existing account; a forward-unknown status produces
+neither recommended event. Both carry only the pinned `method`. GA4 may use
+`sign_up` as an acquisition key event, but it is not the canonical account
+registration metric; recurring `login` remains a normal event.
+
+Separately, Singular receives `sng_login` after every successful interactive
+authentication and `sng_complete_registration` immediately before it only when
+the auth server reports that the operation created the account. Those standard
+events carry no provider, account identifier, or other event attributes. Neither
+Firebase nor Singular authentication outcomes are sent for session restore,
+token refresh, failure, cancellation, or a displaced attempt.
 
 ## Singular attribution release gate
 
@@ -88,6 +96,9 @@ requires a separate privacy and product decision.
       control rather than an account-wide or Firebase-wide kill switch.
 - [ ] Review Singular's bundled privacy manifest and update store declarations
       before distributing a binary that contains the SDK.
+- [ ] Confirm Firebase receives mutually exclusive `sign_up`/`login` outcomes,
+      GA4 marks only `sign_up` as a key event, and neither is used as the
+      canonical account-registration count.
 - [ ] Confirm Singular retention/deletion settings and record product/privacy
       counsel approval before a production release.
 - [ ] Record product/privacy counsel approval and the first approved app version

--- a/client/app/test/core/platform/firebase_analytics_client_test.dart
+++ b/client/app/test/core/platform/firebase_analytics_client_test.dart
@@ -196,6 +196,31 @@ void main() {
     expect(parameters, isNot(contains("user_key")));
     verifyNoMoreInteractions(analytics);
   });
+
+  test("logs recommended authentication outcomes with method only", () async {
+    await client.logInstallationEvent(
+      event: const InstallationAnalyticsEvent.accountCreated(
+        method: AnalyticsLoginProvider.google,
+      ),
+    );
+    await client.logInstallationEvent(
+      event: const InstallationAnalyticsEvent.accountLogin(
+        method: AnalyticsLoginProvider.email,
+      ),
+    );
+
+    verifyInOrder([
+      () => analytics.logEvent(
+        name: "sign_up",
+        parameters: {"method": "google", "schema_version": 1},
+      ),
+      () => analytics.logEvent(
+        name: "login",
+        parameters: {"method": "email", "schema_version": 1},
+      ),
+    ]);
+    verifyNoMoreInteractions(analytics);
+  });
 }
 
 ProductAnalyticsEnvelope _productEnvelope({required ProductAnalyticsEvent event}) {

--- a/client/module_core/lib/src/foundation/models/product_analytics/installation_analytics_event.dart
+++ b/client/module_core/lib/src/foundation/models/product_analytics/installation_analytics_event.dart
@@ -19,6 +19,8 @@ enum AnalyticsLoginFailureKind({required final String wireValue}) {
 sealed class const InstallationAnalyticsEvent() {
   const factory loginAttemptStarted({required AnalyticsLoginProvider provider}) = LoginAttemptStartedEvent;
   const factory loginAttemptCompleted({required AnalyticsLoginProvider provider}) = LoginAttemptCompletedEvent;
+  const factory accountCreated({required AnalyticsLoginProvider method}) = AccountCreatedEvent;
+  const factory accountLogin({required AnalyticsLoginProvider method}) = AccountLoginEvent;
   const factory loginAttemptFailed({
     required AnalyticsLoginProvider provider,
     required AnalyticsLoginFailureKind failureKind,
@@ -58,6 +60,23 @@ final class const LoginAttemptCompletedEvent({required final AnalyticsLoginProvi
 
   @override
   Map<String, String> get parameters => {"provider": provider.wireValue};
+}
+
+final class const AccountCreatedEvent({required final AnalyticsLoginProvider method})
+    extends InstallationAnalyticsEvent {
+  @override
+  String get wireName => "sign_up";
+
+  @override
+  Map<String, String> get parameters => {"method": method.wireValue};
+}
+
+final class const AccountLoginEvent({required final AnalyticsLoginProvider method}) extends InstallationAnalyticsEvent {
+  @override
+  String get wireName => "login";
+
+  @override
+  Map<String, String> get parameters => {"method": method.wireValue};
 }
 
 final class const LoginAttemptFailedEvent({

--- a/client/module_core/lib/src/services/installation_analytics_service.dart
+++ b/client/module_core/lib/src/services/installation_analytics_service.dart
@@ -30,12 +30,19 @@ class InstallationAnalyticsService({
     required AuthProvider provider,
     required AccountStatus accountStatus,
   }) async {
+    final analyticsProvider = _analyticsProvider(provider: provider);
+    final accountOutcomeEvent = switch (accountStatus) {
+      AccountStatus.created => InstallationAnalyticsEvent.accountCreated(method: analyticsProvider),
+      AccountStatus.existing => InstallationAnalyticsEvent.accountLogin(method: analyticsProvider),
+      AccountStatus.unknown => null,
+    };
     final results = await Future.wait([
       _log(
         event: InstallationAnalyticsEvent.loginAttemptCompleted(
-          provider: _analyticsProvider(provider: provider),
+          provider: analyticsProvider,
         ),
       ),
+      if (accountOutcomeEvent != null) _log(event: accountOutcomeEvent),
       _logAttribution(accountStatus: accountStatus),
     ]);
 

--- a/client/module_core/test/foundation/product_analytics_event_test.dart
+++ b/client/module_core/test/foundation/product_analytics_event_test.dart
@@ -168,6 +168,8 @@ void main() {
   test("installation events stay account-less and use only bounded parameters", () {
     const started = InstallationAnalyticsEvent.loginAttemptStarted(provider: AnalyticsLoginProvider.github);
     const completed = InstallationAnalyticsEvent.loginAttemptCompleted(provider: AnalyticsLoginProvider.apple);
+    const signedUp = InstallationAnalyticsEvent.accountCreated(method: AnalyticsLoginProvider.google);
+    const loggedIn = InstallationAnalyticsEvent.accountLogin(method: AnalyticsLoginProvider.email);
     const failed = InstallationAnalyticsEvent.loginAttemptFailed(
       provider: AnalyticsLoginProvider.email,
       failureKind: AnalyticsLoginFailureKind.timeout,
@@ -177,9 +179,14 @@ void main() {
     expect(started.parameters, {"provider": "github"});
     expect(completed.wireName, "login_attempt_completed");
     expect(completed.parameters, {"provider": "apple"});
+    expect(signedUp.wireName, "sign_up");
+    expect(signedUp.parameters, {"method": "google"});
+    expect(loggedIn.wireName, "login");
+    expect(loggedIn.parameters, {"method": "email"});
     expect(failed.wireName, "login_attempt_failed");
     expect(failed.parameters, {"provider": "email", "failure_kind": "timeout"});
-    for (final event in [started, completed, failed]) {
+    for (final event in [started, completed, signedUp, loggedIn, failed]) {
+      expect(event.wireName.length, lessThanOrEqualTo(40));
       expect(event.parameters, isNot(contains("user_key")));
       expect(event.parameters, isNot(contains("attempt_id")));
     }

--- a/client/module_core/test/services/installation_analytics_service_test.dart
+++ b/client/module_core/test/services/installation_analytics_service_test.dart
@@ -104,7 +104,7 @@ void main() {
     );
   });
 
-  test("created accounts report registration before login", () async {
+  test("created accounts report Firebase signup and Singular registration before login", () async {
     final repository = _RecordingAnalyticsRepository();
     final attributionRepository = _RecordingAttributionRepository();
     final service = InstallationAnalyticsService(
@@ -121,6 +121,7 @@ void main() {
     expect(result, AnalyticsDeliveryResult.acceptedBySdk);
     expect(repository.events, [
       const InstallationAnalyticsEvent.loginAttemptCompleted(provider: AnalyticsLoginProvider.google),
+      const InstallationAnalyticsEvent.accountCreated(method: AnalyticsLoginProvider.google),
     ]);
     expect(attributionRepository.events, [
       AttributionEvent.accountCreated,
@@ -153,22 +154,45 @@ void main() {
     expect(await completion, AnalyticsDeliveryResult.acceptedBySdk);
   });
 
-  test("existing and unknown account statuses report login without registration", () async {
-    for (final accountStatus in [AccountStatus.existing, AccountStatus.unknown]) {
-      final attributionRepository = _RecordingAttributionRepository();
-      final service = InstallationAnalyticsService(
-        capability: const AnalyticsRuntimeCapability.enabled(),
-        repository: _RecordingAnalyticsRepository(),
-        attributionRepository: attributionRepository,
-      );
+  test("existing accounts report Firebase and Singular login", () async {
+    final repository = _RecordingAnalyticsRepository();
+    final attributionRepository = _RecordingAttributionRepository();
+    final service = InstallationAnalyticsService(
+      capability: const AnalyticsRuntimeCapability.enabled(),
+      repository: repository,
+      attributionRepository: attributionRepository,
+    );
 
-      await service.loginAttemptCompleted(
-        provider: AuthProvider.apple,
-        accountStatus: accountStatus,
-      );
+    await service.loginAttemptCompleted(
+      provider: AuthProvider.apple,
+      accountStatus: AccountStatus.existing,
+    );
 
-      expect(attributionRepository.events, [AttributionEvent.accountLogin]);
-    }
+    expect(repository.events, [
+      const InstallationAnalyticsEvent.loginAttemptCompleted(provider: AnalyticsLoginProvider.apple),
+      const InstallationAnalyticsEvent.accountLogin(method: AnalyticsLoginProvider.apple),
+    ]);
+    expect(attributionRepository.events, [AttributionEvent.accountLogin]);
+  });
+
+  test("unknown account status does not infer a Firebase signup or login", () async {
+    final repository = _RecordingAnalyticsRepository();
+    final attributionRepository = _RecordingAttributionRepository();
+    final service = InstallationAnalyticsService(
+      capability: const AnalyticsRuntimeCapability.enabled(),
+      repository: repository,
+      attributionRepository: attributionRepository,
+    );
+
+    await service.loginAttemptCompleted(
+      provider: AuthProvider.apple,
+      accountStatus: AccountStatus.unknown,
+    );
+
+    expect(repository.events, [
+      const InstallationAnalyticsEvent.loginAttemptCompleted(provider: AnalyticsLoginProvider.apple),
+    ]);
+    expect(attributionRepository.events, [AttributionEvent.accountLogin]);
   });
 
   test("disabled installation analytics does not gate attribution", () async {

--- a/docs/regression/analytics.md
+++ b/docs/regression/analytics.md
@@ -4,25 +4,27 @@
 
 The mobile client reports a closed set of privacy-safe product events answering activation, retention, and feature
 adoption questions. Account-linked events carry a server-derived pseudonymous key and are governed by an account
-preference; a small account-less login funnel is the only exception. Separately, eligible Android/iOS release builds
-start Singular for install/session attribution and standard authentication conversion events with release-injected
-credentials. Desktop uses a no-op sink, the bridge is excluded, and the warehouse is external.
+preference; five bounded account-less authentication events are the only exception: a three-event attempt funnel and
+Firebase's recommended `sign_up`/`login` outcomes. Separately, eligible Android/iOS release builds start Singular for
+install/session attribution and standard authentication conversion events with release-injected credentials. Desktop
+uses a no-op sink, the bridge is excluded, and the warehouse is external.
 
 ## Required Behavior
 
 - The contract is closed: only declared sealed variants and pinned enum parameters, never an arbitrary event name or
   parameter map. No account-linked event may carry code, prompts, transcripts, coding-provider, model, agent, tool, or
   command names, paths, repository, project, session, branch or worktree names, raw error text, OAuth identity, email,
-  or raw or hashed project, session, bridge, or device identifiers. The account-less login funnel's pinned
-  login-provider enum is the explicit provider-name exception.
+  or raw or hashed project, session, bridge, or device identifiers. The account-less authentication catalog's pinned
+  provider/method enum is the explicit provider-name exception.
 - Account-linked events require an enabled runtime capability (release build, supported platform, sink present),
   authentication, and a server preference resolved to enabled for that generation; anything else suppresses them.
   They carry the validated server-derived key, never a raw account ID, and never set Firebase's global SDK identity.
 - Disable applies immediately here and records durable local intent before any network work; a failed sync shows
   pending, never saved, and survives logout and restart. Enable activates only after server success plus local
   persistence.
-- Login-funnel events carry only a pinned provider and bounded failure kind and no user key. Settings copy must not
-  claim the switch stops vendor automatic events, the login funnel, or older installed binaries.
+- Account-less authentication events carry only a pinned provider or method plus the attempt funnel's bounded failure
+  kind, and no user key. Settings copy must not claim the switch stops vendor automatic events, these authentication
+  events, or older installed binaries.
 - Screens use the pinned route mapping with vendor automatic reporting disabled. Events fire at authoritative
   outcomes, not taps, capture occurrence time at their seam, and deferred candidates emit at most once, dropping on
   disable, logout, or account switch. Results state SDK acceptance, not delivery.
@@ -40,20 +42,25 @@ credentials. Desktop uses a no-op sink, the bridge is excluded, and the warehous
   advertising identifiers and partner data sharing, removes Android advertising-ID permissions, and sets no custom
   user ID, custom events, deep-link handler, or uninstall token. The Basic Usage Analytics preference does not claim
   to control this separate attribution scope.
-- A successful interactive authentication reports Singular's parameter-free standard `sng_login` event. It first
-  reports parameter-free `sng_complete_registration` only when the auth server's operation-scoped account status is
-  `created`; `existing` and forward-unknown statuses report login only. The client never infers creation from local
-  state and emits neither event for restore, refresh, failure, cancellation, or a stale/displaced attempt.
+- A successful interactive authentication always reports Firebase's `login_attempt_completed`. A server-confirmed
+  `created` status additionally reports the recommended `sign_up` event; `existing` reports the recommended `login`
+  event; and forward-unknown status reports neither recommended event. `sign_up` and `login` are mutually exclusive,
+  carry only the pinned `method`, remain account-less, and are not sent for restore, refresh, failure, cancellation, or
+  a stale/displaced attempt. GA4 uses `sign_up` as an acquisition key event and leaves recurring `login` unmarked;
+  neither event replaces the auth-server account record as the canonical registration metric.
+- The same successful authentication reports Singular's parameter-free standard `sng_login` event. It first reports
+  parameter-free `sng_complete_registration` only when the auth server's operation-scoped account status is `created`;
+  `existing` and forward-unknown statuses report Singular login only. The client never infers creation from local state.
 
 ## Regression Levels
 
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Not included because analytics must never gate the product heartbeat. |
-| L2 Routine | Automated, mobile client, no plugin: wire names and pinned parameters, exhaustive route-to-screen and provider mappings, a check that no variant can carry a free-form string, preference storage state transitions, native default-off configuration, the build-window predicate, release-lane build stamp, typed account-status parsing, and Singular eligibility/deferred-start configuration plus standard-event mapping with a fake static adapter. |
-| L3 Release | Automated with a fake sink: suppression while unknown, disabled, unauthenticated, or non-release; activation only after readiness and enabled preference; bounded deferral emitted once with preserved occurrence time; generation change dropping stale work; outcome seams firing on success only; and Singular registration-before-login only for server-confirmed account creation. |
+| L2 Routine | Automated, mobile client, no plugin: wire names and pinned parameters, exhaustive route-to-screen and provider mappings, a check that no variant can carry a free-form string, preference storage state transitions, native default-off configuration, the build-window predicate, release-lane build stamp, typed account-status parsing, Firebase recommended authentication-event mapping, and Singular eligibility/deferred-start configuration plus standard-event mapping with fake adapters. |
+| L3 Release | Automated with fake sinks: suppression while unknown, disabled, unauthenticated, or non-release; activation only after readiness and enabled preference; bounded deferral emitted once with preserved occurrence time; generation change dropping stale work; outcome seams firing on success only; mutually exclusive Firebase signup/existing-account login classification; and Singular registration-before-login only for server-confirmed account creation. |
 | L4 Extended | Client end to end on the release-target client platform against the real auth-server preference endpoint: disable and re-enable, pending state after a sync failure, persistence across restart, logout with a pending disable, account switch isolation, and no product event while disabled. |
-| L5 Full | Release build against the real analytics properties: expected pinned events and parameters observed upstream, automatic screen reporting confirmed off at runtime, a Play pre-launch report producing no Firebase or Singular rows inside the build window, Singular install/session attribution and standard login/registration events observed without an advertising ID, custom user identity, or event attributes, and warehouse checks that exported rows carry no prohibited field and internal accounts are excluded. |
+| L5 Full | Release build against the real analytics properties: expected pinned events and parameters observed upstream, `sign_up` configured as a GA4 key event while `login` remains a normal event, automatic screen reporting confirmed off at runtime, a Play pre-launch report producing no Firebase or Singular rows inside the build window, Singular install/session attribution and standard login/registration events observed without an advertising ID, custom user identity, or event attributes, and warehouse checks that exported rows carry no prohibited field and internal accounts are excluded. |
 
 ## Exploration Guidance
 
@@ -66,6 +73,9 @@ account against a real property.
 
 - Any event carries a prohibited field, a free-form string, or an entity identifier including a hashed one; or a login
   event carries a user key.
+- Firebase reports `sign_up` and `login` for the same completed attempt, reports either for a forward-unknown account
+  status, omits the status-appropriate event, adds parameters beyond pinned `method` and shared schema, marks recurring
+  `login` as a GA4 key event, or treats installation-level `sign_up` as the canonical account-registration count.
 - An account-linked event is emitted while unknown, disabled, unauthenticated, or in a debug or profile build.
 - Any automatic or Sesori-defined event is emitted by a debug/profile process, or by an unauthenticated release
   process inside its build window.
@@ -85,7 +95,8 @@ account against a real property.
 - The vendor SDK, property, warehouse, and dashboards are external; their correctness is never passed from client
   evidence. SDK acceptance is not delivery: a missing upstream row may be sampling, latency, retention, or exclusion.
 - Firebase's Active users report counts active app instances, not authenticated Sesori accounts. Internal release
-  installs still appear there; use curated account-keyed reporting for product user counts.
+  installs still appear there, and account-less `sign_up`/`login` outcomes can include internal/test traffic; use the
+  auth export for registration counts and curated account-keyed reporting for product user counts.
 - The preference governs account-linked events here and server reporting only, and a remote change applies on the next
   authenticated generation, process start, or explicit settings action. It does not stop Singular install/session
   attribution. Warehouse rollout remains an active plan.
@@ -97,5 +108,7 @@ account against a real property.
 
 `client/module_core/test/foundation/`, `client/module_core/test/services/`,
 `client/module_core/test/cubits/product_analytics_preference/`, `client/app/test/core/platform/`; production contracts
-under `client/module_core/lib/src/foundation/models/product_analytics/`; Singular startup and event delivery live under
+under `client/module_core/lib/src/foundation/models/product_analytics/`; account-outcome dispatch lives in
+`client/module_core/lib/src/services/installation_analytics_service.dart`; Firebase delivery lives in
+`client/app/lib/core/platform/firebase_analytics_client.dart`; Singular startup and delivery live under
 `client/app/lib/core/platform/singular/` and `client/app/lib/core/platform/singular_attribution_startup.dart`.


### PR DESCRIPTION
## Complexity

Straightforward. Extends the existing closed authentication analytics contract and reuses the existing server-confirmed outcome seam. No user-visible or database impact.

## What

- Add Firebase/GA4 recommended `sign_up` and `login` installation events with bounded `method` values.
- Emit `sign_up` only for server-confirmed account creation and `login` only for confirmed existing accounts, while preserving `login_attempt_completed` and existing Singular reporting.
- Leave forward-unknown account statuses unclassified instead of inferring signup or login.
- Update privacy/regression guidance and exact wire/outcome tests.

## Why

Firebase currently records the authentication attempt funnel but cannot distinguish confirmed registration from returning-account login. The auth server already supplies operation-scoped account status for Singular, so Firebase can report the standard outcomes without new identity or UI inference.

## Risk and test focus

Primary risks are double-counting one authentication as both outcomes, misclassifying forward-unknown status, or attaching account identity. Tests pin mutually exclusive status mapping, exact standard names and `method` parameters, continued generic completion, disabled-runtime behavior, Singular independence, and absence of `user_key`/attempt identifiers.

## Expected result

An eligible release reports `login_attempt_completed` plus `sign_up` for a created account, `login_attempt_completed` plus `login` for an existing account, and only `login_attempt_completed` for an unknown status. `sign_up` is the acquisition key-event candidate; recurring `login` remains a normal event. Singular behavior is unchanged.

## Verification

- `dart test test/foundation/product_analytics_event_test.dart test/services/installation_analytics_service_test.dart` (`client/module_core`)
- `flutter test test/core/platform/firebase_analytics_client_test.dart` (`client/app`)
- `dart analyze` (`client/module_core`)
- `dart analyze` (`client/app`)
- `dart pub get` (`client`)
- Architecture implementation review: approved with no findings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Firebase `sign_up` and `login` installation events so Firebase can distinguish confirmed registration from returning-account login; previously Firebase only recorded the authentication attempt funnel.

- `sign_up` fires only for server-confirmed account creation, `login` only for confirmed existing accounts, and forward-unknown account statuses emit neither.
- Both events carry only the pinned `method` parameter, remain account-less, and never attach `user_key` or attempt identifiers.
- Existing `login_attempt_completed` and Singular `sng_*` reporting are unchanged, with no user-visible or database impact.

**Risk and test focus**
- Tests cover mutually exclusive status mapping, exact wire names and parameters, disabled-runtime behavior, Singular independence, and absence of identity fields.
- Privacy disclosure, regression guidance, and analytics skill docs are updated for the extended contract.

<sup>Written for commit 4bb027a4b4f350878a15bc3ed41c3e5e140f73ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

