### PR TITLE
🌱 Raise default harness idle timeout to 45 minutes

### DIFF
--- a/bridge/app/README.md
+++ b/bridge/app/README.md
@@ -191,7 +191,7 @@ To disable a plugin or configure lifecycle timeouts, add a `plugins` object:
 
 All keys are optional. Plugins absent from `disabled` remain eligible. Timeout
 values are integer minutes; plugin-specific values override `default`, and an
-absent value falls back to 10 minutes. Values less than or equal to zero mean
+absent value falls back to 45 minutes. Values less than or equal to zero mean
 never idle-stop once the demand-start lifecycle is enabled. Unknown plugin
 objects and disabled IDs are preserved for forward compatibility. The current
 default is derived from setup-ready plugins in display-name order; missing

--- a/bridge/app/lib/src/repositories/bridge_settings.dart
+++ b/bridge/app/lib/src/repositories/bridge_settings.dart
@@ -1,6 +1,6 @@
 import '../updater/foundation/release_track.dart';
 
-const int defaultPluginIdleTimeoutMins = 10;
+const int defaultPluginIdleTimeoutMins = 45;
 const int defaultPullRequestRefreshIntervalSeconds = 30;
 const int minimumPullRequestRefreshIntervalSeconds = 15;
 const int maximumPullRequestRefreshIntervalSeconds = 3600;

--- a/bridge/app/test/bridge_settings_test.dart
+++ b/bridge/app/test/bridge_settings_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('BridgeSettings', () {
-    test('uses stable non-plugin defaults and omits an untouched plugins root', () {
+    test('uses stable defaults and omits an untouched plugins root', () {
       const settings = BridgeSettings();
 
       expect(settings.sleepPrevention, SleepPreventionMode.always);
@@ -12,7 +12,7 @@ void main() {
       expect(settings.releaseTrack, ReleaseTrack.stable);
       expect(settings.pullRequestRefreshIntervalSeconds, defaultPullRequestRefreshIntervalSeconds);
       expect(settings.plugins.disabledPluginIds, isEmpty);
-      expect(settings.plugins.idleTimeoutMinsFor(pluginId: 'opencode'), defaultPluginIdleTimeoutMins);
+      expect(settings.plugins.idleTimeoutMinsFor(pluginId: 'opencode'), 45);
       expect(settings.toJson(), {
         'sleepPrevention': 'always',
         'yolo': false,

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -59,9 +59,10 @@ idle suspension, the management snapshot, and lifecycle commands.
   generic icon; surfaces without metadata retain the same generic icon and
   raw-id fallback rather than teaching shared widgets a backend name.
 - Harnesses start on demand unless eager; a transient one may suspend after a confirmed
-  idle window and a resident one never does, and idle timeouts survive restart.
-  Enable, disable, restart, and refresh are offered only where declared, with enable
-  persisting eligibility, re-inspecting setup, then starting when ready.
+  idle window and a resident one never does, and idle timeouts survive restart. With no
+  configured default or per-harness override, every harness uses the bridge's 45-minute
+  fallback. Enable, disable, restart, and refresh are offered only where declared, with
+  enable persisting eligibility, re-inspecting setup, then starting when ready.
 - A resident harness that keeps the idle-timeout capability (Claude Code or Pi) reports
   the configured timeout instead of zero and consumes it internally through the host.
   Each plugin reaps its idle per-session CLI/RPC child process after that window and


### PR DESCRIPTION
## Complexity

🌱 Trivial — updates one generic bridge fallback and its supporting test and documentation.

## What

- Raise the default plugin idle timeout from 10 minutes to 45 minutes.
- Apply the fallback generically to every harness without a configured bridge default or per-harness override.
- Update the bridge README and lifecycle regression contract.

## Why

A longer default keeps harness session processes resident while detached background work may still be completing, without adding extension-specific lifecycle tracking.

## Risk and test focus

Existing bridge-level and per-harness timeout overrides remain authoritative. The management UI will visibly report 45 minutes for an unconfigured default; there is no database impact. Test focus is fallback resolution and lifecycle timer propagation.

## Expected result

Every harness without an explicit idle-timeout setting remains resident for 45 idle minutes before being reaped.

## Verification

- `dart test test/bridge_settings_test.dart`
- `dart test test/services/plugin_lifecycle_service_test.dart --name 'successful timeout writes resync live timers while failed writes change nothing|idle suspension requires every safe-stop gate and a full timeout'`
- `dart analyze --fatal-infos`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the default harness idle timeout from 10 to 45 minutes so detached background work can finish before a harness is reaped.

- Applies the 45-minute fallback to every harness without a configured bridge default or per-harness override.
- Existing bridge-level and per-harness timeout overrides remain authoritative.
- The management UI reports 45 minutes for unconfigured defaults; there is no database impact.

<sup>Written for commit e2f44a6783ae99aeff944c170bd832fb2fcbd124. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

