### PR TITLE
🌿 [deepseek-question-timestamps] Activate DeepSeek adapter v0.1.2 [step 4/4]

### DIFF
--- a/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_runtime_manifest.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_runtime_manifest.dart
@@ -10,55 +10,55 @@ class const DeepSeekRuntimeManifest() extends RuntimeManifest {
   static final SemanticRuntimeVersion _minPathVersion = SemanticRuntimeVersion.parse(value: "0.1.0");
 
   /// The latest stable adapter release targeted by this plugin.
-  static const String targetVersion = "0.1.1";
+  static const String targetVersion = "0.1.2";
 
   static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: targetVersion);
 
   static const Map<PlatformOs, Map<PlatformArch, RuntimeAsset>> _assets = {
     PlatformOs.macos: {
       PlatformArch.arm64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.1-darwin-arm64.tar.gz",
+        assetName: "sesori-deepseek-acp-v0.1.2-darwin-arm64.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "795d2fd919b0936b3127927a55428b4b75457a97fab22926277d47b52e757638",
+        sha256: "46da85534fdad437940589740526689cf0765fa082d79f09a04d65099ea01fa4",
         archiveBinaryName: "sesori-deepseek-acp",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.1-darwin-x64.tar.gz",
+        assetName: "sesori-deepseek-acp-v0.1.2-darwin-x64.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "9aa584143f7b33e04150cfefb751d3020a04f316203ada1e0766b52bf72a5f76",
+        sha256: "d13d53574df6f8d1f78afdb3f74df99178551cc7424b9c59b8cad2607acd4200",
         archiveBinaryName: "sesori-deepseek-acp",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
     },
     PlatformOs.linux: {
       PlatformArch.arm64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.1-linux-arm64.tar.gz",
+        assetName: "sesori-deepseek-acp-v0.1.2-linux-arm64.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "83bb06b50a4c068b4951317fc50981cd9acbcdcac9b1e6fee490bcb5dbf5423a",
+        sha256: "c3b446df9d504ec4785bbaff1d1cf6f051307ede922e78ed53cba911a3776204",
         archiveBinaryName: "sesori-deepseek-acp",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.1-linux-x64.tar.gz",
+        assetName: "sesori-deepseek-acp-v0.1.2-linux-x64.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "f141bea834618acda4ae64967a21fd0c3fe3666dc623122c187038e7f56b7272",
+        sha256: "8085cc0975df95b8305046c228d252523efd93af4a8dfd868f63cc752fe7f1b8",
         archiveBinaryName: "sesori-deepseek-acp",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
     },
     PlatformOs.windows: {
       PlatformArch.arm64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.1-windows-arm64.zip",
+        assetName: "sesori-deepseek-acp-v0.1.2-windows-arm64.zip",
         format: ArchiveFormat.zip,
-        sha256: "a2a3b548bb4230953edde2f1a5d73eadd6fb35eb178da6d3ea9ce298599e3c0f",
+        sha256: "c96eae2ade5c213c61ce046cdd6efdb4ce6db98660ae210843aca06ba86e9af1",
         archiveBinaryName: "sesori-deepseek-acp.cmd",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.1-windows-x64.zip",
+        assetName: "sesori-deepseek-acp-v0.1.2-windows-x64.zip",
         format: ArchiveFormat.zip,
-        sha256: "b9666a7c341602f92a7ec116c07e3f512dcf4d32d97c5a4325522b1a4d9fa528",
+        sha256: "a4c3e29927d3510ec3781b7c0db7aab0abde375bf282de70b6b24e348d51956a",
         archiveBinaryName: "sesori-deepseek-acp.cmd",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),

--- a/bridge/sesori_plugin_deepseek/test/deepseek_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_runtime_manifest_test.dart
@@ -36,12 +36,12 @@ void main() {
     expect(
       assets.map((asset) => asset.assetName),
       {
-        "sesori-deepseek-acp-v0.1.1-darwin-arm64.tar.gz",
-        "sesori-deepseek-acp-v0.1.1-darwin-x64.tar.gz",
-        "sesori-deepseek-acp-v0.1.1-linux-arm64.tar.gz",
-        "sesori-deepseek-acp-v0.1.1-linux-x64.tar.gz",
-        "sesori-deepseek-acp-v0.1.1-windows-arm64.zip",
-        "sesori-deepseek-acp-v0.1.1-windows-x64.zip",
+        "sesori-deepseek-acp-v0.1.2-darwin-arm64.tar.gz",
+        "sesori-deepseek-acp-v0.1.2-darwin-x64.tar.gz",
+        "sesori-deepseek-acp-v0.1.2-linux-arm64.tar.gz",
+        "sesori-deepseek-acp-v0.1.2-linux-x64.tar.gz",
+        "sesori-deepseek-acp-v0.1.2-windows-arm64.zip",
+        "sesori-deepseek-acp-v0.1.2-windows-x64.zip",
       },
     );
     expect(assets.map((asset) => asset.sha256).toSet(), hasLength(6));
@@ -62,7 +62,7 @@ void main() {
     )!;
     expect(
       manifest.downloadUrlFor(asset: asset),
-      "https://github.com/sesori-ai/sesori-deepseek-acp/releases/download/v0.1.1/sesori-deepseek-acp-v0.1.1-darwin-arm64.tar.gz",
+      "https://github.com/sesori-ai/sesori-deepseek-acp/releases/download/v0.1.2/sesori-deepseek-acp-v0.1.2-darwin-arm64.tar.gz",
     );
   });
 }


### PR DESCRIPTION
## Complexity

🌿 Straightforward. This updates one managed-runtime manifest and its focused tests with immutable release asset names and checksums.

## What

- Pin the managed DeepSeek adapter to published release `v0.1.2`.
- Replace all six platform asset names and SHA-256 digests with the immutable GitHub release values.
- Preserve the compatible PATH floor at `0.1.0`.

## Why

Activate the merged DeepSeek ask-user and message-timestamp behavior in managed Sesori bridge installations.

## Risk and test focus

Risk is concentrated in downloading, checksum-validating, extracting, launching, and replaying through the new managed artifact. The published release matrix and a source-run bridge E2E exercise those boundaries. No database schema or migration is involved.

## Expected result

Managed setup installs DeepSeek adapter v0.1.2 on all supported platforms. DeepSeek sessions can complete provider turns, surface and answer model-initiated questions, and preserve message timestamps through cold replay. Existing compatible PATH adapters remain eligible.

## Verification

- `dart test` in `bridge/sesori_plugin_deepseek`: 41 passed
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_deepseek`: no issues
- Adapter v0.1.2 release: six platform package lifecycle smokes, cross-repository conformance, aggregate checksums, and publication passed
- Source-run bridge E2E on macOS arm64:
  - Installed the published managed v0.1.2 asset and removed superseded v0.1.1
  - Started the managed runtime and completed a configured provider turn
  - Surfaced a two-choice model question, accepted the selected answer, and cleared the pending question
  - Cold-restarted the bridge and replayed the completed question/tool transcript with its original timestamps

Provider note: the local profile's `deepseek-official` route returned a Harness execution failure; the configured `ninerouter-oai` route completed the E2E. This activation changes the adapter artifact, not provider credentials or routing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the managed DeepSeek adapter to release v0.1.2, activating ask-user and message-timestamp behavior in managed Sesori bridge installs. Asset names and SHA-256 digests updated for all six platforms; PATH floor remains at 0.1.0.

<sup>Written for commit 5d7ed3282584970d3755359c1cb39c53e83f284b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

