### PR TITLE
🌿 Show rejected ACP prompts as inline errors

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -224,6 +224,25 @@ class AcpEventMapper({
     _liveTools.remove(sessionId);
   }
 
+  /// Maps a rejected `session/prompt` into a durable inline error. A session
+  /// error event carries no diagnostic text, so emitting only that event would
+  /// make an accepted prompt appear to finish silently.
+  BridgeSseMessageUpdated mapPromptError({
+    required String sessionId,
+    required String message,
+  }) => BridgeSseMessageUpdated(
+    info: shared.Message.error(
+      id: "$sessionId-t${_turn(sessionId)}-error",
+      sessionID: sessionId,
+      agent: pluginId,
+      modelID: modelForSession(sessionId: sessionId),
+      providerID: providerForSession(sessionId: sessionId),
+      errorName: "ACP prompt failed",
+      errorMessage: message,
+      time: null,
+    ).toJson(),
+  );
+
   /// Emits complete snapshots for text and reasoning parts streamed during the
   /// current turn. The caller owns the turn boundary and must call this before
   /// the next turn starts.

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1263,9 +1263,24 @@ abstract class AcpPlugin({
       // backend failure must remain observable rather than silently dropping
       // the accepted prompt.
       Log.w("[$id] accepted session/prompt for $sessionId failed", error, stack);
+      _eventBuffer.add(
+        eventMapper.mapPromptError(
+          sessionId: sessionId,
+          message: _promptFailureMessage(error: error),
+        ),
+      );
       _finishTurn(sessionId: sessionId, state: state, turn: turn, failed: true, refused: false);
       mapPromptFailure(sessionId: sessionId, error: error).forEach(_eventBuffer.add);
     }
+  }
+
+  String _promptFailureMessage({required Object error}) {
+    if (error case AcpRpcException(:final message, :final data)) {
+      final Object? details = data is Map<Object?, Object?> ? data["details"] : null;
+      if (details case final String details when details.trim().isNotEmpty) return details;
+      if (message.trim().isNotEmpty) return message;
+    }
+    return error.toString();
   }
 
   bool _turnWasCancelled({

--- a/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
@@ -434,7 +434,7 @@ void main() {
       expect(s1.directory, cwd, reason: "a blank cwd must fall back to the launch directory");
     });
 
-    test("a session/prompt rejection after dispatch surfaces a session error, not a silent idle", () async {
+    test("a session/prompt rejection after dispatch surfaces its backend detail inline", () async {
       await connect();
       final creating = plugin.createSession(
         directory: "/repo",
@@ -465,15 +465,23 @@ void main() {
       fake().emit({
         "jsonrpc": "2.0",
         "id": promptFrame["id"],
-        "error": {"code": -32000, "message": "boom"},
+        "error": {
+          "code": -32603,
+          "message": "Internal error",
+          "data": {"details": "Agent is already processing."},
+        },
       });
       await pump();
       await pump();
 
+      final inlineError = events.whereType<BridgeSseMessageUpdated>().singleWhere(
+        (event) => event.info["role"] == "error",
+      );
+      expect(inlineError.info["errorMessage"], "Agent is already processing.");
       expect(
         events.whereType<BridgeSseSessionError>(),
         isNotEmpty,
-        reason: "a post-dispatch prompt rejection must surface as an error, not a silent idle",
+        reason: "the generic session failure signal remains available to lifecycle consumers",
       );
     });
 

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -131,8 +131,10 @@ defaults and queued client sends coherent.
   immediately cancelling the active turn and dispatching the queued input after
   cancellation settles. Further already-queued inputs retain FIFO order. Their
   synthetic user transcript message is published only after its frame flushes
-  successfully to the agent's stdin. Follow-up and replayed user messages
-  preserve ordered text and bounded data-backed image parts, including
+  successfully to the agent's stdin. A prompt rejected after that dispatch
+  renders a durable inline error, preserving the agent's diagnostic detail
+  rather than transitioning silently to idle. Follow-up and replayed user
+  messages preserve ordered text and bounded data-backed image parts, including
   attachment-only prompts. Initial projection contains only normalized
   user-visible text plus those images; injected context, local paths, and URLs
   remain absent. OMP runs different sessions concurrently because its permission
@@ -251,6 +253,8 @@ replay, and abort after output has started.
 
 - A slash command holds the client request open for the whole run, or a slow
   plugin blocks unrelated sessions, other plugins, or relay traffic.
+- An accepted ACP prompt rejection returns the session to idle without a durable
+  inline error containing the backend's diagnostic detail.
 - Streaming stalls, duplicates or loses parts, shows an empty user bubble, or
   orders a late envelope at the wrong transcript position; the session never
   returns to idle. A terminal provider failure returns to idle without showing


### PR DESCRIPTION
## Complexity

🌿 Straightforward — a localized ACP error-projection change with focused regression coverage.

## What

- Project a post-dispatch `session/prompt` rejection as a durable inline error message.
- Prefer the ACP error payload's diagnostic `data.details` over a generic wrapper such as `Internal error`.
- Preserve the existing session-error lifecycle signal and harness-specific failure hooks.
- Document the supported behavior in the session-turn regression guide.

## Why

A locally observed OMP session continued an ownerless background-result turn after Stop. Follow-up ACP prompts were rejected because the agent was still processing. Sesori logged that rejection and emitted a detail-less session-error event, but the client does not render that event, so each accepted prompt appeared to finish silently.

The OMP autonomous-turn lifecycle remains an upstream concern; this change fixes Sesori's silent failure handling so the actual backend diagnostic is visible and durable.

## Risk and test focus

Low implementation risk. The main risks are duplicate terminal errors, losing the backend detail inside a generic JSON-RPC message, and changing turn settlement ordering. Coverage verifies that the inline error carries the backend detail while the existing lifecycle signal remains present.

This has a user-visible impact: rejected ACP prompts now show red inline diagnostic text. There is no database schema or migration impact; the message uses the existing durable chat-history contract.

## Expected result

When an ACP agent rejects a prompt after its frame was dispatched, the transcript shows the agent's diagnostic instead of transitioning to idle with no output.

## Verification

- `dart analyze --fatal-infos` in `bridge/sesori_plugin_acp`
- `dart test` in `bridge/sesori_plugin_acp` — 265 tests passed
- Dart LSP diagnostics — 0 diagnostics across changed Dart files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows rejected ACP prompts as durable inline errors so an accepted prompt no longer appears to finish silently when the agent rejects it after dispatch.

- The client does not render the existing session-error event, which also carries no diagnostic text.
- The inline error prefers the backend's `data.details`, falling back to the RPC message or the error string.
- The existing session-error lifecycle signal and harness-specific failure hooks are preserved.
- No schema or migration impact; the message uses the existing chat-history contract.
- Regression coverage now asserts the inline error carries the backend detail, and the session-turn guide documents the behavior.

<sup>Written for commit 178ca2911c3b41fd27be0c2bcac4bf660b91b91b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

