### PR TITLE
⚙️ Distinguish automated session messages

### DIFF
--- a/bridge/app/lib/src/push/push_session_state_tracker.dart
+++ b/bridge/app/lib/src/push/push_session_state_tracker.dart
@@ -30,11 +30,12 @@ class PushSessionStateTracker({required final DateTime Function() _now}) {
         }
       case SesoriMessageUpdated(:final info):
         _messageRoles[info.id] = _PushTrackedMessageRole(
-          role: info is MessageAssistant
-              ? "assistant"
-              : info is MessageUser
-              ? "user"
-              : "error",
+          role: switch (info) {
+            MessageAssistant(sender: MessageSender.agent) => _PushMessageRole.assistant,
+            MessageAssistant() => _PushMessageRole.system,
+            MessageUser() => _PushMessageRole.user,
+            MessageError() => _PushMessageRole.error,
+          },
           sessionId: info.sessionID,
           updatedAt: now,
         );
@@ -275,7 +276,9 @@ class PushSessionStateTracker({required final DateTime Function() _now}) {
       latestAssistantTextCount: latestAssistantTextCount,
       latestAssistantTextCharCount: latestAssistantTextCharCount,
       messageRoleCount: _messageRoles.length,
-      assistantMessageRoleCount: _messageRoles.values.where((messageRole) => messageRole.role == "assistant").length,
+      assistantMessageRoleCount: _messageRoles.values
+          .where((messageRole) => messageRole.role == _PushMessageRole.assistant)
+          .length,
       oldestSessionActivityAt: oldestSessionActivityAt,
       oldestMessageRoleUpdatedAt: oldestMessageRoleUpdatedAt,
       prunableRoots: _findPrunableRoots(),
@@ -499,11 +502,7 @@ class PushSessionStateTracker({required final DateTime Function() _now}) {
     if (part is! MessagePartText || messageRole == null) {
       return;
     }
-    final isAssistant = switch (messageRole.role) {
-      "assistant" => true,
-      _ => false,
-    };
-    if (!isAssistant) return;
+    if (messageRole.role != _PushMessageRole.assistant) return;
 
     _stateForSession(sessionId: part.sessionID).latestAssistantText = part.text;
   }
@@ -542,8 +541,10 @@ final class _PushTrackedSessionState() {
   DateTime? lastTouchedAt;
 }
 
+enum _PushMessageRole() { user, assistant, system, error }
+
 final class const _PushTrackedMessageRole({
-  required final String role,
+  required final _PushMessageRole role,
   required final String sessionId,
   required final DateTime updatedAt,
 });

--- a/bridge/app/lib/src/repositories/mappers/plugin_message_mapper.dart
+++ b/bridge/app/lib/src/repositories/mappers/plugin_message_mapper.dart
@@ -13,13 +13,21 @@ extension PluginMessageMapper on PluginMessage {
       time: time.toShared(),
       promptId: promptId,
     ),
-    PluginMessageAssistant(:final id, :final agent, :final modelID, :final providerID, :final time) =>
+    PluginMessageAssistant(
+      :final id,
+      :final agent,
+      :final modelID,
+      :final providerID,
+      :final sender,
+      :final time,
+    ) =>
       Message.assistant(
         id: id,
         sessionID: sessionId,
         agent: agent,
         modelID: modelID,
         providerID: providerID,
+        sender: sender.toShared(),
         time: time.toShared(),
       ),
     PluginMessageError(
@@ -41,6 +49,14 @@ extension PluginMessageMapper on PluginMessage {
         errorMessage: errorMessage,
         time: time.toShared(),
       ),
+  };
+}
+
+extension on PluginMessageSender {
+  MessageSender toShared() => switch (this) {
+    PluginMessageSender.agent => MessageSender.agent,
+    PluginMessageSender.system => MessageSender.system,
+    PluginMessageSender.unknown => MessageSender.unknown,
   };
 }
 
@@ -71,14 +87,20 @@ extension PluginMessagePromptDefaultsMapper on List<PluginMessageWithParts> {
     for (var index = length - 1; index >= 0; index--) {
       final ({String? agent, String? modelID, String? providerID, String? variant})? selection =
           switch (this[index].info) {
-            PluginMessageAssistant(:final agent, :final modelID, :final providerID, :final variant) ||
+            PluginMessageAssistant(
+              sender: PluginMessageSender.agent,
+              :final agent,
+              :final modelID,
+              :final providerID,
+              :final variant,
+            ) ||
             PluginMessageError(:final agent, :final modelID, :final providerID, :final variant) => (
               agent: agent,
               modelID: modelID,
               providerID: providerID,
               variant: variant,
             ),
-            PluginMessageUser() => null,
+            PluginMessageAssistant() || PluginMessageUser() => null,
           };
       if (selection == null) continue;
       final (:agent, :modelID, :providerID, :variant) = selection;

--- a/bridge/app/test/bridge/repositories/mappers/plugin_message_mapper_test.dart
+++ b/bridge/app/test/bridge/repositories/mappers/plugin_message_mapper_test.dart
@@ -36,6 +36,7 @@ void main() {
         modelID: "gpt",
         providerID: "openai",
         variant: "high",
+        sender: PluginMessageSender.agent,
         time: PluginMessageTime(created: 1718400000000, completed: 1718400005000),
       );
 
@@ -48,6 +49,7 @@ void main() {
             agent: "build",
             modelID: "gpt",
             providerID: "openai",
+            sender: MessageSender.agent,
             time: MessageTime(created: 1718400000000, completed: 1718400005000),
           ),
         ),
@@ -60,6 +62,25 @@ void main() {
           model: AgentModel(providerID: "openai", modelID: "gpt", variant: "high"),
         ),
       );
+    });
+
+    test("maps system attribution without using it as prompt defaults", () {
+      const message = PluginMessage.assistant(
+        id: "m-system",
+        sessionID: "s1",
+        agent: null,
+        modelID: null,
+        providerID: null,
+        variant: null,
+        sender: PluginMessageSender.system,
+        time: PluginMessageTime(created: 1718400000000, completed: null),
+      );
+
+      final shared = message.toSharedMessage(sessionId: "stable-session");
+
+      expect(shared, isA<MessageAssistant>());
+      expect((shared as MessageAssistant).sender, MessageSender.system);
+      expect([const PluginMessageWithParts(info: message, parts: [])].latestPromptDefaults(), isNull);
     });
 
     test("preserves time on an error message", () {
@@ -114,6 +135,7 @@ void main() {
             modelID: "gpt",
             providerID: "openai",
             variant: "low",
+            sender: PluginMessageSender.agent,
             time: null,
           ),
           parts: [],
@@ -160,6 +182,7 @@ void main() {
             modelID: "claude-sonnet-4-5",
             providerID: "anthropic",
             variant: "high",
+            sender: PluginMessageSender.agent,
             time: null,
           ),
           parts: [],
@@ -172,6 +195,7 @@ void main() {
             modelID: null,
             providerID: null,
             variant: null,
+            sender: PluginMessageSender.agent,
             time: null,
           ),
           parts: [],

--- a/bridge/app/test/bridge/routing/get_session_messages_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_session_messages_handler_test.dart
@@ -105,6 +105,7 @@ void main() {
             modelID: "gpt-5",
             providerID: "openai",
             variant: "high",
+            sender: PluginMessageSender.agent,
             time: null,
           ),
           parts: [],

--- a/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
+++ b/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
@@ -73,6 +73,28 @@ void main() {
       );
     });
 
+    test("maps a system sender through the shared message update", () {
+      final result = mapEvent(
+        BridgeSseMessageUpdated(
+          info: const PluginMessage.assistant(
+            id: "m-system",
+            sessionID: "s1",
+            agent: null,
+            modelID: null,
+            providerID: null,
+            variant: null,
+            sender: PluginMessageSender.system,
+            time: null,
+          ).toJson(),
+        ),
+      );
+
+      expect(result, isA<SesoriMessageUpdated>());
+      final event = result! as SesoriMessageUpdated;
+      expect(event.info, isA<MessageAssistant>());
+      expect((event.info as MessageAssistant).sender, MessageSender.system);
+    });
+
     test("maps serialized plugin retry status through the shared SSE union", () {
       final result = mapEvent(
         BridgeSseSessionStatus(

--- a/bridge/app/test/push/push_session_state_tracker_test.dart
+++ b/bridge/app/test/push/push_session_state_tracker_test.dart
@@ -157,6 +157,33 @@ void main() {
       );
 
       expect(tracker.getLatestAssistantText("session-a"), equals("latest"));
+
+      tracker.handleEvent(
+        const SesoriSseEvent.messageUpdated(
+          info: Message.assistant(
+            id: "system-msg",
+            sessionID: "session-a",
+            agent: null,
+            modelID: null,
+            providerID: null,
+            sender: MessageSender.system,
+            time: null,
+          ),
+        ),
+      );
+      tracker.handleEvent(
+        const SesoriSseEvent.messagePartUpdated(
+          part: MessagePart.text(
+            id: "part-system",
+            sessionID: "session-a",
+            messageID: "system-msg",
+            text: "automation",
+          ),
+        ),
+      );
+
+      expect(tracker.getLatestAssistantText("session-a"), equals("latest"));
+      expect(tracker.createTelemetrySnapshot().assistantMessageRoleCount, equals(1));
     });
 
     test("tracks pending questions and clears on replied or rejected", () {

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -992,6 +992,7 @@ class AcpEventMapper({
         agent: pluginId,
         modelID: modelForSession(sessionId: sessionId),
         providerID: providerForSession(sessionId: sessionId),
+        sender: shared.MessageSender.agent,
         time: time == null ? null : shared.MessageTime(created: time.created, completed: time.completed),
       ).toJson(),
     );
@@ -1047,6 +1048,7 @@ class AcpEventMapper({
         agent: pluginId,
         modelID: modelForSession(sessionId: sessionId),
         providerID: providerForSession(sessionId: sessionId),
+        sender: shared.MessageSender.agent,
         time: time == null ? null : shared.MessageTime(created: time.created, completed: time.completed),
       ),
     };

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -341,6 +341,7 @@ class AcpReplayCollector({
       modelID: modelId,
       providerID: providerId,
       variant: null,
+      sender: PluginMessageSender.agent,
       time: draft.time,
     );
   }

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -424,6 +424,7 @@ final class ClaudeEventDispatcher({
     modelID: _models[sessionId],
     providerID: "anthropic",
     variant: null,
+    sender: PluginMessageSender.agent,
     time: time,
   );
 

--- a/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
@@ -135,6 +135,7 @@ final class const ClaudeHistoryMapper({
         modelID: entry.model,
         providerID: "anthropic",
         variant: entry.variant,
+        sender: PluginMessageSender.agent,
         time: _messageTime(entry.timestamp),
       ),
       parts: List.unmodifiable(parts),

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -577,7 +577,7 @@ class CodexEventMapper({
         info: _assistantMessage(itemId: itemId, threadId: threadId, time: time).toJson(),
       ),
       BridgeSseMessagePartUpdated(
-part: PluginMessagePart.tool(
+        part: PluginMessagePart.tool(
           id: "$itemId-tool",
           sessionID: threadId,
           messageID: itemId,
@@ -709,6 +709,7 @@ part: PluginMessagePart.tool(
       agent: "codex",
       modelID: _threadModel[threadId] ?? config.model,
       providerID: _threadProvider[threadId] ?? config.modelProvider ?? "openai",
+      sender: shared.MessageSender.agent,
       time: time,
     );
   }

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
@@ -92,6 +92,7 @@ class CodexMessageRepository({
       modelID: currentModel ?? config.model,
       providerID: sessionProvider ?? config.modelProvider ?? "openai",
       variant: currentVariant,
+      sender: PluginMessageSender.agent,
       time: time,
     );
 

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_message.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_message.dart
@@ -294,11 +294,18 @@ sealed class PluginToolState with _$PluginToolState {
   }) = _PluginToolState;
 }
 
+/// Identifies who authored a plugin's non-user message envelope.
+///
+/// [unknown] lets a plugin preserve uncertain attribution without presenting
+/// the message as agent-authored.
+@JsonEnum()
+enum PluginMessageSender() { agent, system, unknown }
+
 /// Sealed class representing a plugin-level message.
 ///
 /// Three variants:
 /// - [PluginMessageUser]: a message sent by the user
-/// - [PluginMessageAssistant]: a regular assistant response
+/// - [PluginMessageAssistant]: a non-user message with explicit sender attribution
 /// - [PluginMessageError]: an assistant message that failed with an error
 ///
 /// The JSON serialization uses `"role"` as the union key.
@@ -324,6 +331,7 @@ sealed class PluginMessage with _$PluginMessage {
     required String? modelID,
     required String? providerID,
     required String? variant,
+    required PluginMessageSender sender,
     required PluginMessageTime? time,
   }) = PluginMessageAssistant;
 

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_message.freezed.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_message.freezed.dart
@@ -1888,7 +1888,7 @@ $PluginMessageTimeCopyWith<$Res>? get time {
 @JsonSerializable(createFactory: false)
 
 class PluginMessageAssistant implements PluginMessage {
-  const PluginMessageAssistant({required this.id, required this.sessionID, required this.agent, required this.modelID, required this.providerID, required this.variant, required this.time,  String? $type}): $type = $type ?? 'assistant';
+  const PluginMessageAssistant({required this.id, required this.sessionID, required this.agent, required this.modelID, required this.providerID, required this.variant, required this.sender, required this.time,  String? $type}): $type = $type ?? 'assistant';
   
 
 @override final  String id;
@@ -1897,6 +1897,7 @@ class PluginMessageAssistant implements PluginMessage {
  final  String? modelID;
  final  String? providerID;
  final  String? variant;
+ final  PluginMessageSender sender;
 @override final  PluginMessageTime? time;
 
 @JsonKey(name: 'role')
@@ -1916,16 +1917,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginMessageAssistant&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.modelID, modelID) || other.modelID == modelID)&&(identical(other.providerID, providerID) || other.providerID == providerID)&&(identical(other.variant, variant) || other.variant == variant)&&(identical(other.time, time) || other.time == time));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginMessageAssistant&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.modelID, modelID) || other.modelID == modelID)&&(identical(other.providerID, providerID) || other.providerID == providerID)&&(identical(other.variant, variant) || other.variant == variant)&&(identical(other.sender, sender) || other.sender == sender)&&(identical(other.time, time) || other.time == time));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,sessionID,agent,modelID,providerID,variant,time);
+int get hashCode => Object.hash(runtimeType,id,sessionID,agent,modelID,providerID,variant,sender,time);
 
 @override
 String toString() {
-  return 'PluginMessage.assistant(id: $id, sessionID: $sessionID, agent: $agent, modelID: $modelID, providerID: $providerID, variant: $variant, time: $time)';
+  return 'PluginMessage.assistant(id: $id, sessionID: $sessionID, agent: $agent, modelID: $modelID, providerID: $providerID, variant: $variant, sender: $sender, time: $time)';
 }
 
 
@@ -1936,7 +1937,7 @@ abstract mixin class $PluginMessageAssistantCopyWith<$Res> implements $PluginMes
   factory $PluginMessageAssistantCopyWith(PluginMessageAssistant value, $Res Function(PluginMessageAssistant) _then) = _$PluginMessageAssistantCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String sessionID, String? agent, String? modelID, String? providerID, String? variant, PluginMessageTime? time
+ String id, String sessionID, String? agent, String? modelID, String? providerID, String? variant, PluginMessageSender sender, PluginMessageTime? time
 });
 
 
@@ -1953,7 +1954,7 @@ class _$PluginMessageAssistantCopyWithImpl<$Res>
 
 /// Create a copy of PluginMessage
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? agent = freezed,Object? modelID = freezed,Object? providerID = freezed,Object? variant = freezed,Object? time = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? agent = freezed,Object? modelID = freezed,Object? providerID = freezed,Object? variant = freezed,Object? sender = null,Object? time = freezed,}) {
   return _then(PluginMessageAssistant(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
@@ -1961,7 +1962,8 @@ as String,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullable
 as String?,modelID: freezed == modelID ? _self.modelID : modelID // ignore: cast_nullable_to_non_nullable
 as String?,providerID: freezed == providerID ? _self.providerID : providerID // ignore: cast_nullable_to_non_nullable
 as String?,variant: freezed == variant ? _self.variant : variant // ignore: cast_nullable_to_non_nullable
-as String?,time: freezed == time ? _self.time : time // ignore: cast_nullable_to_non_nullable
+as String?,sender: null == sender ? _self.sender : sender // ignore: cast_nullable_to_non_nullable
+as PluginMessageSender,time: freezed == time ? _self.time : time // ignore: cast_nullable_to_non_nullable
 as PluginMessageTime?,
   ));
 }

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_message.g.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_message.g.dart
@@ -203,8 +203,15 @@ Map<String, dynamic> _$PluginMessageAssistantToJson(
   'modelID': ?instance.modelID,
   'providerID': ?instance.providerID,
   'variant': ?instance.variant,
+  'sender': _$PluginMessageSenderEnumMap[instance.sender]!,
   'time': ?instance.time?.toJson(),
   'role': instance.$type,
+};
+
+const _$PluginMessageSenderEnumMap = {
+  PluginMessageSender.agent: 'agent',
+  PluginMessageSender.system: 'system',
+  PluginMessageSender.unknown: 'unknown',
 };
 
 Map<String, dynamic> _$PluginMessageErrorToJson(PluginMessageError instance) =>

--- a/bridge/sesori_plugin_opencode/lib/src/assistant_message_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/assistant_message_mapper.dart
@@ -28,6 +28,7 @@ class const AssistantMessageMapper() {
         modelID: message.modelID,
         providerID: message.providerID,
         variant: message.variant,
+        sender: PluginMessageSender.agent,
         time: time,
       );
     }

--- a/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_history_mapper.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_history_mapper.dart
@@ -303,7 +303,7 @@ final class PiHistoryMapper({
     if (!message.display) return null;
     final text = _visibleCustomText(content: message.content, warnings: <_PiHistoryWarning>{});
     if (text == null) return null;
-    final draft = _textMessage(
+    final draft = _systemMessage(
       sessionId: sessionId,
       messageId: messageId,
       timestamp: message.timestamp,
@@ -320,7 +320,7 @@ final class PiHistoryMapper({
     if (!entry.display) return null;
     final text = _visibleCustomText(content: entry.content, warnings: <_PiHistoryWarning>{});
     if (text == null) return null;
-    final draft = _textMessage(sessionId: sessionId, messageId: messageId, timestamp: null, text: text);
+    final draft = _systemMessage(sessionId: sessionId, messageId: messageId, timestamp: null, text: text);
     return PluginMessageWithParts(info: draft.info, parts: draft.parts);
   }
 
@@ -414,7 +414,7 @@ final class PiHistoryMapper({
               final text = _visibleCustomText(content: message.content, warnings: warnings);
               if (text == null) continue;
               messages.add(
-                _textMessage(sessionId: sessionId, messageId: messageId, timestamp: message.timestamp, text: text),
+                _systemMessage(sessionId: sessionId, messageId: messageId, timestamp: message.timestamp, text: text),
               );
             case PiBranchSummaryMessageDto() || PiCompactionSummaryMessageDto():
               continue;
@@ -431,7 +431,7 @@ final class PiHistoryMapper({
           final text = _visibleCustomText(content: content, warnings: warnings);
           if (text == null) continue;
           messages.add(
-            _textMessage(
+            _systemMessage(
               sessionId: sessionId,
               messageId: messageId,
               timestamp: null,
@@ -673,12 +673,13 @@ final class PiHistoryMapper({
         modelID: model,
         providerID: provider,
         variant: variant,
+        sender: PluginMessageSender.agent,
         time: _time(timestamp),
       ),
     };
   }
 
-  _MessageDraft _textMessage({
+  _MessageDraft _systemMessage({
     required String sessionId,
     required String messageId,
     required int? timestamp,
@@ -688,10 +689,11 @@ final class PiHistoryMapper({
       info: PluginMessage.assistant(
         id: messageId,
         sessionID: sessionId,
-        agent: _pluginId,
+        agent: null,
         modelID: null,
         providerID: null,
         variant: null,
+        sender: PluginMessageSender.system,
         time: _time(timestamp),
       ),
       parts: [
@@ -723,6 +725,7 @@ final class PiHistoryMapper({
         modelID: null,
         providerID: null,
         variant: null,
+        sender: PluginMessageSender.agent,
         time: _time(timestamp),
       ),
       parts: [

--- a/bridge/sesori_plugin_pi/test/pi_history_mapper_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_history_mapper_test.dart
@@ -538,6 +538,10 @@ void main() {
         "pi:session:custom:${PiMessageIdentityBuilder.customMessageTimestampSentinel}:1",
         "pi:session:custom:${PiMessageIdentityBuilder.customMessageTimestampSentinel}:2",
       ]);
+      expect(
+        messages.map((message) => (message.info as PluginMessageAssistant).sender),
+        everyElement(PluginMessageSender.system),
+      );
       expect(messages.first.info.time?.created, 7);
       expect(messages[1].info.time, isNull);
       expect(messages[2].info.time, isNull);

--- a/bridge/sesori_plugin_pi/test/pi_session_process_repository_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_process_repository_test.dart
@@ -420,6 +420,7 @@ void main() {
 
       final messages = await _loadFileFallback(storage: storage);
 
+      expect((messages.single.info as PluginMessageAssistant).sender, PluginMessageSender.system);
       expect(messages.single.parts.single.text, "hook content");
     });
 

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -1810,6 +1810,9 @@ void main() {
     await _waitForIdle(service: service, sessionId: "session");
     await _waitForEventCount<BridgeSseMessageUpdated>(events: events, count: 2);
 
+    final messageInfos = events.whereType<BridgeSseMessageUpdated>().map((event) => event.info).toList();
+    expect(messageInfos.map((info) => info["role"]), ["assistant", "assistant"]);
+    expect(messageInfos.map((info) => info["sender"]), ["system", "agent"]);
     expect(
       events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part.text),
       containsAllInOrder(["[PR Monitor] report", "Handled report"]),

--- a/client/app/lib/features/session_detail/widgets/assistant_message_card.dart
+++ b/client/app/lib/features/session_detail/widgets/assistant_message_card.dart
@@ -16,11 +16,12 @@ class const AssistantMessageCard({
   required final Map<String, String> streamingText,
   required final List<Session> children,
   required final Map<String, SessionStatus> childStatuses,
+  required final EdgeInsetsGeometry contentPadding,
 }) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      padding: contentPadding,
       child: SelectionArea(
         child: Column(
           crossAxisAlignment: .start,

--- a/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -15,6 +15,7 @@ import "message_timestamp_reveal.dart";
 import "queued_message_bubble.dart";
 import "retry_error_message_card.dart";
 import "scroll_follow_tracker.dart";
+import "system_message_card.dart";
 import "user_message_card.dart";
 
 /// Chat-style message list for the session detail screen.
@@ -518,7 +519,15 @@ class _SessionDetailMessageListState() extends State<SessionDetailMessageList> w
     }
     final card = switch (message.info) {
       MessageUser() => UserMessageCard(message: message),
-      MessageAssistant() => AssistantMessageCard(
+      MessageAssistant(sender: MessageSender.agent) => AssistantMessageCard(
+        projectId: widget.projectId,
+        message: message,
+        streamingText: streamingText,
+        children: children,
+        childStatuses: childStatuses,
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      ),
+      MessageAssistant() => SystemMessageCard(
         projectId: widget.projectId,
         message: message,
         streamingText: streamingText,

--- a/client/app/lib/features/session_detail/widgets/system_message_card.dart
+++ b/client/app/lib/features/session_detail/widgets/system_message_card.dart
@@ -1,0 +1,57 @@
+import "package:material_ui/material_ui.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/module_prego.dart";
+
+import "../../../core/extensions/build_context_x.dart";
+import "assistant_message_card.dart";
+
+/// A neutral inline surface for transcript messages authored by automation.
+class const SystemMessageCard({
+  super.key,
+  required final String? projectId,
+  required final MessageWithParts message,
+  required final Map<String, String> streamingText,
+  required final List<Session> children,
+  required final Map<String, SessionStatus> childStatuses,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: PregoSpacing.xl,
+        vertical: PregoSpacing.xs,
+      ),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: prego.colors.bgSecondary,
+          border: Border.all(color: prego.colors.borderSecondary),
+          borderRadius: BorderRadius.circular(PregoRadius.x2l),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(PregoSpacing.lg),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              PregoTag(
+                icon: TablerRegular.robot,
+                label: context.loc.sessionDetailAutomation,
+              ),
+              const SizedBox(height: PregoSpacing.md),
+              AssistantMessageCard(
+                projectId: projectId,
+                message: message,
+                streamingText: streamingText,
+                children: children,
+                childStatuses: childStatuses,
+                contentPadding: EdgeInsets.zero,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -436,6 +436,10 @@
   "sessionDetailLoadingSemantics": "Loading session",
   "sessionDetailEmpty": "No messages yet",
   "sessionDetailErrorTitle": "Failed to load messages",
+  "sessionDetailAutomation": "Automation",
+  "@sessionDetailAutomation": {
+    "description": "Label on a transcript message injected by session automation rather than authored by the user or agent."
+  },
   "sessionDetailRetry": "Retry",
   "sessionDetailPromptHint": "Ask anything...",
   "sessionDetailHoldToTalk": "Hold to talk",

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -1531,6 +1531,12 @@ abstract class AppLocalizations {
   /// **'Failed to load messages'**
   String get sessionDetailErrorTitle;
 
+  /// Label on a transcript message injected by session automation rather than authored by the user or agent.
+  ///
+  /// In en, this message translates to:
+  /// **'Automation'**
+  String get sessionDetailAutomation;
+
   /// No description provided for @sessionDetailRetry.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -782,6 +782,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionDetailErrorTitle => 'Failed to load messages';
 
   @override
+  String get sessionDetailAutomation => 'Automation';
+
+  @override
   String get sessionDetailRetry => 'Retry';
 
   @override

--- a/client/app/test/features/session_detail/widgets/assistant_message_card_test.dart
+++ b/client/app/test/features/session_detail/widgets/assistant_message_card_test.dart
@@ -61,6 +61,7 @@ class _AssistantMessageCardHarnessState() extends State<_AssistantMessageCardHar
           streamingText: _streamingText,
           children: const <Session>[],
           childStatuses: const <String, SessionStatus>{},
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
         ),
       ),
     );

--- a/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -5,10 +5,12 @@ import "package:flutter_test/flutter_test.dart";
 import "package:material_ui/material_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/core/widgets/code_block.dart";
+import "package:sesori_mobile/features/session_detail/widgets/assistant_message_card.dart";
 import "package:sesori_mobile/features/session_detail/widgets/message_timestamp_reveal.dart";
 import "package:sesori_mobile/features/session_detail/widgets/queued_message_bubble.dart";
 import "package:sesori_mobile/features/session_detail/widgets/retry_error_message_card.dart";
 import "package:sesori_mobile/features/session_detail/widgets/session_detail_message_list.dart";
+import "package:sesori_mobile/features/session_detail/widgets/system_message_card.dart";
 import "package:sesori_mobile/features/session_detail/widgets/user_message_card.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -185,6 +187,32 @@ MessageWithParts _message({
   );
 }
 
+MessageWithParts _automatedMessage({
+  required String messageId,
+  required String text,
+  required MessageSender sender,
+}) {
+  return MessageWithParts(
+    info: Message.assistant(
+      id: messageId,
+      sessionID: "session-1",
+      agent: null,
+      modelID: null,
+      providerID: null,
+      sender: sender,
+      time: null,
+    ),
+    parts: [
+      MessagePart.text(
+        id: "$messageId-part",
+        sessionID: "session-1",
+        messageID: messageId,
+        text: text,
+      ),
+    ],
+  );
+}
+
 const _emptyUserMessage = MessageWithParts(
   info: Message.user(
     promptId: null,
@@ -244,6 +272,28 @@ Future<void> _detachViewport(WidgetTester tester) async {
 }
 
 void main() {
+  testWidgets("renders system and unknown senders as automation instead of agent output", (tester) async {
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        initialMessages: [
+          _message(messageId: "agent", role: "assistant", text: "Agent reply"),
+          _automatedMessage(messageId: "system", text: "Automation report", sender: MessageSender.system),
+          _automatedMessage(messageId: "unknown", text: "Future sender", sender: MessageSender.unknown),
+        ],
+        initialStreamingText: const {},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AssistantMessageCard), findsNWidgets(3));
+    expect(find.byType(SystemMessageCard), findsNWidgets(2));
+    expect(find.byType(PregoTag), findsNWidgets(2));
+    expect(find.text("Automation"), findsNWidgets(2));
+    expect(find.text("Agent reply"), findsOneWidget);
+    expect(find.text("Automation report"), findsOneWidget);
+    expect(find.text("Future sender"), findsOneWidget);
+  });
+
   testWidgets("renders bridge-queued prompts as cancellable queued bubbles", (tester) async {
     final harnessKey = GlobalKey<_SessionDetailMessageListHarnessState>();
     await tester.pumpWidget(

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -681,11 +681,16 @@ class SessionDetailCubit(
     return availableCommands.firstWhereOrNull((c) => c.name == stagedCommand.name);
   }
 
-  /// Returns the latest assistant or error [Message] from the list, or null if none.
+  /// Returns the latest agent-authored assistant or error [Message], or null if none.
   Message? _latestAssistantOrErrorMessage(List<MessageWithParts> messages) {
     for (var i = messages.length - 1; i >= 0; i--) {
       final info = messages[i].info;
-      if (info is MessageAssistant || info is MessageError) return info;
+      switch (info) {
+        case MessageAssistant(sender: MessageSender.agent) || MessageError():
+          return info;
+        case MessageAssistant() || MessageUser():
+          continue;
+      }
     }
     return null;
   }
@@ -1091,7 +1096,7 @@ class SessionDetailCubit(
     if (isClosed) return;
 
     if (message case
-        MessageAssistant(:final providerID, :final modelID, :final agent) ||
+        MessageAssistant(sender: MessageSender.agent, :final providerID, :final modelID, :final agent) ||
         MessageError(:final providerID, :final modelID, :final agent)) {
       final assistantAgentModel = providerID != null && modelID != null
           ? _resolveAgentModel(
@@ -2216,9 +2221,10 @@ class SessionDetailCubit(
     final childIds = children.map((child) => child.id).toSet();
     final agents = snapshot.agents.where((agent) => !agent.hidden && agent.mode != AgentMode.subagent).toList();
     final assistantAgentModel = switch (latestAssistant) {
-      MessageAssistant(:final modelID, :final providerID) || MessageError(:final modelID, :final providerID) =>
+      MessageAssistant(sender: MessageSender.agent, :final modelID, :final providerID) ||
+      MessageError(:final modelID, :final providerID) =>
         _resolveAgentModel(agents: agents, providerID: providerID, modelID: modelID),
-      MessageUser() || null => null,
+      MessageAssistant() || MessageUser() || null => null,
     };
     return (
       latestAssistant: latestAssistant,

--- a/client/module_core/lib/src/testing/test_helpers.dart
+++ b/client/module_core/lib/src/testing/test_helpers.dart
@@ -679,6 +679,7 @@ MessageWithParts testMessageWithParts({String? id = _noString}) {
       agent: null,
       modelID: null,
       providerID: null,
+      sender: MessageSender.agent,
       time: null,
     ),
     parts: [

--- a/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
@@ -157,6 +157,26 @@ void main() {
       expect(state.messages.length, 1);
       expect(state.messages.first.info.id, "msg-1");
       expect(state.agent, "build");
+
+      sessionEvents.add(
+        const SesoriMessageUpdated(
+          info: Message.assistant(
+            id: "system-1",
+            sessionID: _sessionId,
+            agent: "automation",
+            modelID: "automation-model",
+            providerID: "automation-provider",
+            sender: MessageSender.system,
+            time: null,
+          ),
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final afterSystem = cubit.state as SessionDetailLoaded;
+      expect(afterSystem.messages.map((message) => message.info.id), ["msg-1", "system-1"]);
+      expect(afterSystem.agent, "build");
+      expect(afterSystem.assistantAgentModel, state.assistantAgentModel);
     });
 
     test("a live error updates assistant model attribution", () async {

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -89,9 +89,14 @@ defaults and queued client sends coherent.
   maps each stored payload through the same user-message path before clearing
   the queue. Process exit settles dispatched work before queued work reconnects.
   A resident Pi extension may initiate a turn after the bridge queue becomes
-  idle. Its visible custom message, assistant/tool output, and busy-to-idle
-  lifecycle still reach clients, and its activity restarts the resident idle
-  window instead of being discarded or reaped mid-turn.
+  idle. Its visible custom message is attributed as system automation live and
+  after replay, while assistant/tool output remains agent-authored. The client
+  renders automation on a neutral labelled surface, and it cannot replace
+  agent/model prompt defaults or completion-notification text. The complete
+  busy-to-idle lifecycle still reaches clients and restarts the resident idle
+  window instead of being discarded or reaped mid-turn. An older bridge's
+  omitted sender decodes as agent, while an older client ignores the additive
+  sender field and retains its prior assistant styling.
 - Pi slash commands are accepted by their correlated response or a matching
   extension dialog and remain in the request's sending state until then rather
   than exposing a cancellable bridge-queue entry. Commands reject while that
@@ -232,8 +237,8 @@ defaults and queued client sends coherent.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Live plugin, representative: a prompt streams assistant output and returns the session to idle. |
-| L2 Routine | Live plugin, representative: slash command returns on acceptance; prompt defaults update; first and stale transcript replay reconciles prompt defaults before the opening snapshot is applied; abort stops a turn and reports its outcome; finalized messages are immediately readable from history; a recognized stale option returns the typed rejection only after cache invalidation. |
-| L3 Release | Client end to end (phone), every supporting production plugin: text, reasoning, tool, and status events stream with consistent normalization and the shared output bound; agent, model, and variant apply per send; streaming, composer, sending/queued feedback, and abort render; a stale selection refreshes, warns, and retries once without losing the queued prompt. |
+| L2 Routine | Live plugin, representative: slash command returns on acceptance; prompt defaults update; first and stale transcript replay reconciles prompt defaults before the opening snapshot is applied; abort stops a turn and reports its outcome; finalized messages are immediately readable from history; a recognized stale option returns the typed rejection only after cache invalidation. Automated Pi coverage keeps visible custom messages system-attributed across live and replay without changing agent defaults or completion text. |
+| L3 Release | Client end to end (phone), every supporting production plugin: text, reasoning, tool, and status events stream with consistent normalization and the shared output bound; agent, model, and variant apply per send; streaming, composer, sending/queued feedback, and abort render; a stale selection refreshes, warns, and retries once without losing the queued prompt. A Pi custom message renders as labelled automation rather than agent output. |
 | L4 Extended | Relay integration, every supporting production plugin: a slow or unresponsive plugin leaves other sessions, plugins, and the relay responsive; archived sends and queued-prompt cancels are refused without racing archiving; disconnect and reconnect mid-turn resumes without lost or duplicated parts; bridge-owned prompts survive leaving and reopening in order and appear on a second client; a prompt waiting at a dispatch boundary can be cancelled; a permission reply lands while a command or selection-changing prompt waits behind the running turn; a second client observes the same turn and steering prompt. |
 | L5 Full | Client end to end, every supporting production plugin: retry status surfaces with attempt and timing; concurrent sends across sessions and plugins interleave without ordering damage; background and resume mid-turn recovers live state; an aborted turn triggers no completion notification. |
 
@@ -261,7 +266,9 @@ replay, and abort after output has started.
   command, or bare `/compact` leaves both its local bubble and backend echo in
   the transcript.
 - Internal backend command records or synthetic model attribution appear in
-  the conversation or replayed history.
+  the conversation or replayed history. A visible Pi custom message renders as
+  agent output, loses its automation attribution between live and replay,
+  changes agent/model defaults, or becomes completion-notification text.
 - Prompt defaults regress, an approved plan exit does not restore Agent
   across clients and restart, or a defaults-write failure fails the send.
 - Reopening or importing a session silently switches its latest transcript

--- a/shared/sesori_shared/lib/src/models/sesori/message.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message.dart
@@ -4,17 +4,23 @@ part "message.freezed.dart";
 
 part "message.g.dart";
 
+/// Identifies who authored a non-user message.
+///
+/// [unknown] is forward-compatible and must be presented as non-agent output.
+@JsonEnum()
+enum MessageSender() { agent, system, unknown }
+
 /// Sealed class representing a message in a session.
 ///
 /// Three variants:
 /// - [MessageUser]: a message sent by the user
-/// - [MessageAssistant]: a regular assistant response
+/// - [MessageAssistant]: a non-user message with explicit sender attribution
 /// - [MessageError]: an assistant message that failed with an error
 ///
 /// The JSON serialization uses `"role"` as the union key. Each variant
 /// serializes with its corresponding role value:
 /// - `MessageUser`: `"user"`
-/// - `MessageAssistant`: `"assistant"`
+/// - `MessageAssistant`: `"assistant"` (including compatibility-safe system messages)
 /// - `MessageError`: `"error"`
 ///
 /// The bridge layer is responsible for flattening backend-specific error
@@ -43,6 +49,14 @@ sealed class const Message._() with _$Message {
     required String? agent,
     required String? modelID,
     required String? providerID,
+
+    /// Whether this envelope was authored by the agent or by session automation.
+    // COMPATIBILITY 2026-08-27 (v1.8.2): Older bridges omit sender because assistant envelopes did not
+    // distinguish automation. Default to agent until the minimum supported bridge always sends sender, then remove
+    // @Default.
+    @JsonKey(unknownEnumValue: MessageSender.unknown)
+    @Default(MessageSender.agent)
+    MessageSender sender,
     required MessageTime? time,
   }) = MessageAssistant;
 

--- a/shared/sesori_shared/lib/src/models/sesori/message.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message.freezed.dart
@@ -221,7 +221,7 @@ $MessageTimeCopyWith<$Res>? get time {
 @JsonSerializable()
 
 class MessageAssistant extends Message {
-  const MessageAssistant({required this.id, required this.sessionID, required this.agent, required this.modelID, required this.providerID, required this.time,  String? $type}): $type = $type ?? 'assistant',super._();
+  const MessageAssistant({required this.id, required this.sessionID, required this.agent, required this.modelID, required this.providerID, @JsonKey(unknownEnumValue: MessageSender.unknown) this.sender = MessageSender.agent, required this.time,  String? $type}): $type = $type ?? 'assistant',super._();
   factory MessageAssistant.fromJson(Map<String, dynamic> json) => _$MessageAssistantFromJson(json);
 
 @override final  String id;
@@ -229,6 +229,8 @@ class MessageAssistant extends Message {
 @override final  String? agent;
  final  String? modelID;
  final  String? providerID;
+/// Whether this envelope was authored by the agent or by session automation.
+@JsonKey(unknownEnumValue: MessageSender.unknown) final  MessageSender sender;
 @override final  MessageTime? time;
 
 @JsonKey(name: 'role')
@@ -248,16 +250,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MessageAssistant&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.modelID, modelID) || other.modelID == modelID)&&(identical(other.providerID, providerID) || other.providerID == providerID)&&(identical(other.time, time) || other.time == time));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MessageAssistant&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.modelID, modelID) || other.modelID == modelID)&&(identical(other.providerID, providerID) || other.providerID == providerID)&&(identical(other.sender, sender) || other.sender == sender)&&(identical(other.time, time) || other.time == time));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,sessionID,agent,modelID,providerID,time);
+int get hashCode => Object.hash(runtimeType,id,sessionID,agent,modelID,providerID,sender,time);
 
 @override
 String toString() {
-  return 'Message.assistant(id: $id, sessionID: $sessionID, agent: $agent, modelID: $modelID, providerID: $providerID, time: $time)';
+  return 'Message.assistant(id: $id, sessionID: $sessionID, agent: $agent, modelID: $modelID, providerID: $providerID, sender: $sender, time: $time)';
 }
 
 
@@ -268,7 +270,7 @@ abstract mixin class $MessageAssistantCopyWith<$Res> implements $MessageCopyWith
   factory $MessageAssistantCopyWith(MessageAssistant value, $Res Function(MessageAssistant) _then) = _$MessageAssistantCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String sessionID, String? agent, String? modelID, String? providerID, MessageTime? time
+ String id, String sessionID, String? agent, String? modelID, String? providerID,@JsonKey(unknownEnumValue: MessageSender.unknown) MessageSender sender, MessageTime? time
 });
 
 
@@ -285,14 +287,15 @@ class _$MessageAssistantCopyWithImpl<$Res>
 
 /// Create a copy of Message
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? agent = freezed,Object? modelID = freezed,Object? providerID = freezed,Object? time = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? agent = freezed,Object? modelID = freezed,Object? providerID = freezed,Object? sender = null,Object? time = freezed,}) {
   return _then(MessageAssistant(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
 as String,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullable_to_non_nullable
 as String?,modelID: freezed == modelID ? _self.modelID : modelID // ignore: cast_nullable_to_non_nullable
 as String?,providerID: freezed == providerID ? _self.providerID : providerID // ignore: cast_nullable_to_non_nullable
-as String?,time: freezed == time ? _self.time : time // ignore: cast_nullable_to_non_nullable
+as String?,sender: null == sender ? _self.sender : sender // ignore: cast_nullable_to_non_nullable
+as MessageSender,time: freezed == time ? _self.time : time // ignore: cast_nullable_to_non_nullable
 as MessageTime?,
   ));
 }

--- a/shared/sesori_shared/lib/src/models/sesori/message.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message.g.dart
@@ -33,6 +33,13 @@ MessageAssistant _$MessageAssistantFromJson(Map json) => MessageAssistant(
   agent: json['agent'] as String?,
   modelID: json['modelID'] as String?,
   providerID: json['providerID'] as String?,
+  sender:
+      $enumDecodeNullable(
+        _$MessageSenderEnumMap,
+        json['sender'],
+        unknownValue: MessageSender.unknown,
+      ) ??
+      MessageSender.agent,
   time: json['time'] == null
       ? null
       : MessageTime.fromJson(Map<String, dynamic>.from(json['time'] as Map)),
@@ -46,9 +53,16 @@ Map<String, dynamic> _$MessageAssistantToJson(MessageAssistant instance) =>
       'agent': ?instance.agent,
       'modelID': ?instance.modelID,
       'providerID': ?instance.providerID,
+      'sender': _$MessageSenderEnumMap[instance.sender]!,
       'time': ?instance.time?.toJson(),
       'role': instance.$type,
     };
+
+const _$MessageSenderEnumMap = {
+  MessageSender.agent: 'agent',
+  MessageSender.system: 'system',
+  MessageSender.unknown: 'unknown',
+};
 
 MessageError _$MessageErrorFromJson(Map json) => MessageError(
   id: json['id'] as String,

--- a/shared/sesori_shared/test/models/message_sender_test.dart
+++ b/shared/sesori_shared/test/models/message_sender_test.dart
@@ -1,0 +1,50 @@
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("MessageAssistant.sender", () {
+    test("defaults an older bridge payload to agent", () {
+      final message = Message.fromJson({
+        "role": "assistant",
+        "id": "msg-1",
+        "sessionID": "session-1",
+        "agent": null,
+        "modelID": null,
+        "providerID": null,
+        "time": null,
+      });
+
+      expect(message, isA<MessageAssistant>());
+      expect((message as MessageAssistant).sender, MessageSender.agent);
+    });
+
+    test("round-trips system attribution on the assistant wire envelope", () {
+      const message = Message.assistant(
+        id: "msg-1",
+        sessionID: "session-1",
+        agent: null,
+        modelID: null,
+        providerID: null,
+        sender: MessageSender.system,
+        time: null,
+      );
+
+      final json = message.toJson();
+
+      expect(json["role"], "assistant");
+      expect(json["sender"], "system");
+      expect(Message.fromJson(json), message);
+    });
+
+    test("decodes a future sender as unknown", () {
+      final message = Message.fromJson({
+        "role": "assistant",
+        "id": "msg-1",
+        "sessionID": "session-1",
+        "sender": "future-sender",
+      });
+
+      expect((message as MessageAssistant).sender, MessageSender.unknown);
+    });
+  });
+}


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this adds an additive sender-attribution contract across plugin, bridge, shared, and mobile layers, while preserving the released assistant wire discriminator.

## What

- Add typed `agent`, `system`, and forward-compatible `unknown` sender attribution to non-user message envelopes.
- Classify visible Pi custom messages, including migrated hook messages, as system automation in both live events and history replay.
- Keep system messages out of agent/model prompt defaults and completion-notification assistant text.
- Render system and unknown senders in a neutral Prego-styled **Automation** card instead of regular agent styling.
- Document and test wire compatibility, live/replay mapping, state derivation, push behavior, and mobile rendering.

## Why

Session extensions can inject visible messages that are authored by neither the user nor the coding agent. PR Monitor reports were consequently presented as agent output, which made automated session activity easy to misread.

## Risk and test focus

Moderate contract and presentation risk. The highest-value checks are additive wire compatibility (older bridges omit `sender`; older clients ignore it), symmetric Pi live/history attribution, preservation of agent/model selection, exclusion from completion summaries, and distinct mobile rendering. No security posture, authentication, encryption, or database schema changes.

## Expected result

Injected Pi automation such as PR Monitor reports reaches clients with system attribution and appears in a clearly labelled neutral card. Ordinary user, agent, tool, and error messages keep their existing behavior and styling. Existing stored messages remain readable; there is no database migration or destructive data impact.

## Verification

- `dart analyze` passed in `shared/sesori_shared`, `bridge/sesori_plugin_interface`, `bridge/sesori_plugin_acp`, `bridge/sesori_plugin_claude`, `bridge/sesori_plugin_codex`, `bridge/sesori_plugin_opencode`, `bridge/sesori_plugin_pi`, `bridge/app`, `client/module_core`, and `client/app`.
- Focused shared sender serialization tests passed.
- Focused bridge history/live mapping and push-tracker tests passed.
- Focused Pi history, file fallback, and session-service tests passed.
- Focused module-core session state and Flutter transcript widget tests passed.
- Architecture implementation review approved with no findings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tracks sender attribution on non-user messages so injected Pi automation (like PR Monitor reports) no longer appears as agent output and renders in a neutral labelled Automation card.

- Adds `sender` (`agent`, `system`, `unknown`) to assistant message envelopes across plugin, bridge, shared, and mobile layers.
- Classifies visible Pi custom messages as system automation in live events and history replay.
- Excludes system messages from agent/model prompt defaults and completion-notification assistant text.
- Older bridges omitting `sender` decode as agent; older clients ignore the additive field.

<sup>Written for commit d3d5411c145a5929b97a968fbcf170767afcfdef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

