### PR TITLE
🚧 [default-new-session-prefill] prefill new sessions from plugin defaults [step 3/3]

### DIFF
--- a/bridge/app/lib/src/orchestrator.dart
+++ b/bridge/app/lib/src/orchestrator.dart
@@ -14,6 +14,7 @@ import "package:sesori_shared/sesori_shared.dart";
 
 import "api/archived_session_storage.dart";
 import "api/attachment_spill_storage.dart";
+import "api/database/daos/new_session_defaults_dao.dart";
 import "api/database/daos/session_options_cache_dao.dart";
 import "api/database/database.dart";
 import "api/database/history/chat_history_database.dart";
@@ -57,6 +58,7 @@ import "repositories/filesystem_repository.dart";
 import "repositories/health_repository.dart";
 import "repositories/mappers/git_diff_output_mapper.dart";
 import "repositories/mappers/session_event_mapper.dart";
+import "repositories/new_session_defaults_repository.dart";
 import "repositories/pending_interaction_support.dart";
 import "repositories/permission_repository.dart";
 import "repositories/pr_source_repository.dart";
@@ -221,6 +223,9 @@ class Orchestrator({
       projectCatalogIdentityCalculator: projectCatalogIdentityCalculator,
       aggregateSourceDeadline: aggregateSourceDeadline,
     );
+    final newSessionDefaultsRepository = NewSessionDefaultsRepository(
+      dao: NewSessionDefaultsDao(database: _database),
+    );
     final sessionOptionsRepository = SessionOptionsRepository(
       runtime: _pluginRuntime,
       projectsDao: _database.projectsDao,
@@ -229,6 +234,7 @@ class Orchestrator({
     );
     final sessionOptionsService = SessionOptionsService(
       repository: sessionOptionsRepository,
+      newSessionDefaultsRepository: newSessionDefaultsRepository,
       pluginScopes: pluginComposition.sessionOptionsScopeById,
       clock: _clock,
       retention: const Duration(days: 30),
@@ -383,6 +389,7 @@ class Orchestrator({
       ),
       worktreeService: worktreeService,
       sessionRepository: sessionRepository,
+      newSessionDefaultsRepository: newSessionDefaultsRepository,
       sessionMutationDispatcher: sessionMutationDispatcher,
     );
     final projectInitializationService = ProjectInitializationService(

--- a/bridge/app/lib/src/repositories/session_options_repository.dart
+++ b/bridge/app/lib/src/repositories/session_options_repository.dart
@@ -206,6 +206,7 @@ class SessionOptionsRepository({
           commands: CommandListResponse(
             items: options.commands.map((command) => command.toSharedCommandInfo()).toList(growable: false),
           ),
+          lastUsedPromptDefaults: null,
         ),
         completeness: options.completeness,
         generation: generation,
@@ -239,6 +240,7 @@ class SessionOptionsRepository({
         agents: Agents.fromJson(jsonDecodeMap(row.agentsJson)),
         providers: ProviderListResponse.fromJson(jsonDecodeMap(row.providersJson)),
         commands: CommandListResponse.fromJson(jsonDecodeMap(row.commandsJson)),
+        lastUsedPromptDefaults: null,
       ),
     );
   }

--- a/bridge/app/lib/src/services/session_creation_service.dart
+++ b/bridge/app/lib/src/services/session_creation_service.dart
@@ -6,6 +6,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../repositories/models/session_operation.dart";
+import "../repositories/new_session_defaults_repository.dart";
 import "../repositories/session_metadata_repository.dart";
 import "../repositories/session_repository.dart";
 import "session_mutation_dispatcher.dart";
@@ -16,6 +17,7 @@ class SessionCreationService({
   required final SessionMetadataRepository _sessionMetadataRepository,
   required final WorktreeService _worktreeService,
   required final SessionRepository _sessionRepository,
+  required final NewSessionDefaultsRepository _newSessionDefaultsRepository,
   required final SessionMutationDispatcher _sessionMutationDispatcher,
 }) {
   final PendingOperations _lateMetadataWork = PendingOperations();
@@ -27,7 +29,17 @@ class SessionCreationService({
     // The stored path is authoritative; unknown ids are not directories.
     final projectDirectory = await _sessionRepository.resolveProjectDirectory(projectId: request.projectId);
     final normalizedCommand = request.command?.normalize();
-    final agentModel = request.model;
+    final requestedModel = request.model;
+    final promptDefaults = SessionPromptDefaults(
+      agent: request.agent,
+      model: requestedModel == null
+          ? null
+          : AgentModel(
+              providerID: requestedModel.providerID,
+              modelID: requestedModel.modelID,
+              variant: request.variant?.id,
+            ),
+    );
     final userTexts = _extractTexts(parts: request.parts);
     final firstText = userTexts.firstOrNull;
     final userVisibleText = userTexts.isEmpty ? null : userTexts.join("\n\n");
@@ -60,14 +72,8 @@ class SessionCreationService({
       branchName: worktreeState.branchName,
       baseBranch: worktreeState.baseBranch,
       baseCommit: worktreeState.baseCommit,
-      lastAgent: request.agent,
-      lastAgentModel: agentModel != null
-          ? AgentModel(
-              providerID: agentModel.providerID,
-              modelID: agentModel.modelID,
-              variant: request.variant?.id,
-            )
-          : null,
+      lastAgent: promptDefaults.agent,
+      lastAgentModel: promptDefaults.model,
     );
     await _maybeSendCommand(
       session: created,
@@ -80,6 +86,11 @@ class SessionCreationService({
       variant: request.variant,
       agent: request.agent,
       model: request.model,
+    );
+    await _recordNewSessionDefaults(
+      sessionId: created.id,
+      pluginId: request.pluginId,
+      defaults: promptDefaults,
     );
     _startLateMetadata(session: created, firstText: firstText);
     return created;
@@ -177,6 +188,24 @@ class SessionCreationService({
           message: error.message,
           cause: error,
         ),
+        stackTrace,
+      );
+    }
+  }
+
+  Future<void> _recordNewSessionDefaults({
+    required String sessionId,
+    required String pluginId,
+    required SessionPromptDefaults defaults,
+  }) async {
+    try {
+      await _newSessionDefaultsRepository.write(pluginId: pluginId, defaults: defaults);
+    } on Object catch (error, stackTrace) {
+      // The backend session is already durable. Failing the request here would
+      // invite a duplicate retry for a preference write that can safely degrade.
+      Log.w(
+        "Failed to remember new-session defaults for plugin $pluginId after creating session $sessionId",
+        error,
         stackTrace,
       );
     }

--- a/bridge/app/lib/src/services/session_creation_service.dart
+++ b/bridge/app/lib/src/services/session_creation_service.dart
@@ -87,10 +87,12 @@ class SessionCreationService({
       agent: request.agent,
       model: request.model,
     );
-    await _recordNewSessionDefaults(
-      sessionId: created.id,
-      pluginId: request.pluginId,
-      defaults: promptDefaults,
+    unawaited(
+      _recordNewSessionDefaults(
+        sessionId: created.id,
+        pluginId: request.pluginId,
+        defaults: promptDefaults,
+      ),
     );
     _startLateMetadata(session: created, firstText: firstText);
     return created;

--- a/bridge/app/lib/src/services/session_options_service.dart
+++ b/bridge/app/lib/src/services/session_options_service.dart
@@ -5,6 +5,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../repositories/models/session_options_cache_key.dart";
+import "../repositories/new_session_defaults_repository.dart";
 import "../repositories/session_options_repository.dart";
 
 /// How long a cached snapshot stays fresh. Past it the bridge still serves the
@@ -41,6 +42,7 @@ final class const SessionOptionsAutomaticNoOp() extends SessionOptionsOutcome;
 
 class SessionOptionsService({
     required final SessionOptionsRepository _repository,
+    required final NewSessionDefaultsRepository _newSessionDefaultsRepository,
     required Map<String, PluginSessionOptionsScope> pluginScopes,
     required final ServerClock _clock,
     required final Duration _retention,
@@ -57,6 +59,16 @@ class SessionOptionsService({
   final Map<SessionOptionsCacheKey, int> _invalidationEpochs = {};
 
   Future<SessionOptionsOutcome> loadDynamic({
+    required String pluginId,
+    required String projectId,
+  }) {
+    return _withLastUsedPromptDefaults(
+      pluginId: pluginId,
+      outcome: _loadDynamic(pluginId: pluginId, projectId: projectId),
+    );
+  }
+
+  Future<SessionOptionsOutcome> _loadDynamic({
     required String pluginId,
     required String projectId,
   }) async {
@@ -125,6 +137,16 @@ class SessionOptionsService({
   Future<SessionOptionsOutcome> loadCacheOnly({
     required String pluginId,
     required String projectId,
+  }) {
+    return _withLastUsedPromptDefaults(
+      pluginId: pluginId,
+      outcome: _loadCacheOnly(pluginId: pluginId, projectId: projectId),
+    );
+  }
+
+  Future<SessionOptionsOutcome> _loadCacheOnly({
+    required String pluginId,
+    required String projectId,
   }) async {
     final resolved = await _resolve(pluginId: pluginId, projectId: projectId);
     if (resolved == null) return const SessionOptionsProjectNotFound();
@@ -143,6 +165,16 @@ class SessionOptionsService({
   Future<SessionOptionsOutcome> refreshExplicit({
     required String pluginId,
     required String projectId,
+  }) {
+    return _withLastUsedPromptDefaults(
+      pluginId: pluginId,
+      outcome: _refreshExplicit(pluginId: pluginId, projectId: projectId),
+    );
+  }
+
+  Future<SessionOptionsOutcome> _refreshExplicit({
+    required String pluginId,
+    required String projectId,
   }) async {
     final resolved = await _resolve(pluginId: pluginId, projectId: projectId);
     if (resolved == null) return const SessionOptionsProjectNotFound();
@@ -159,6 +191,23 @@ class SessionOptionsService({
         invalidationEpoch: invalidationEpoch,
       ),
     );
+  }
+
+  Future<SessionOptionsOutcome> _withLastUsedPromptDefaults({
+    required String pluginId,
+    required Future<SessionOptionsOutcome> outcome,
+  }) async {
+    final resolved = await outcome;
+    if (resolved case SessionOptionsAvailable(:final response)) {
+      try {
+        final defaults = await _newSessionDefaultsRepository.read(pluginId: pluginId);
+        return SessionOptionsAvailable(response: response.copyWith(lastUsedPromptDefaults: defaults));
+      } on Object catch (error, stackTrace) {
+        Log.w("Failed to read new-session defaults for plugin $pluginId", error, stackTrace);
+        return SessionOptionsAvailable(response: response.copyWith(lastUsedPromptDefaults: null));
+      }
+    }
+    return resolved;
   }
 
   /// Discards an options snapshot proven stale by a rejected send. The client

--- a/bridge/app/test/bridge/repositories/session_options_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_options_repository_test.dart
@@ -439,6 +439,7 @@ SessionOptionsResponse _response({required String marker}) {
         ),
       ],
     ),
+    lastUsedPromptDefaults: null,
   );
 }
 

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -1,10 +1,12 @@
 import "dart:async";
 import "dart:convert";
 
+import "package:sesori_bridge/src/api/database/daos/new_session_defaults_dao.dart";
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/api/database/tables/session_table.dart" show SessionDto;
 import "package:sesori_bridge/src/api/git_cli_api.dart";
 import "package:sesori_bridge/src/repositories/models/project_not_found_exception.dart";
+import "package:sesori_bridge/src/repositories/new_session_defaults_repository.dart";
 import "package:sesori_bridge/src/repositories/session_repository.dart";
 import "package:sesori_bridge/src/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/routing/create_session_handler.dart";
@@ -62,6 +64,7 @@ void main() {
     late FakeSessionMetadataRepository metadataRepository;
     late _FakeWorktreeService worktreeService;
     late SessionRepository sessionRepository;
+    late NewSessionDefaultsRepository defaultsRepository;
     late SessionOperationDispatcher sessionOperationDispatcher;
     late SessionMutationDispatcher sessionMutationDispatcher;
     late SessionCreationService sessionCreationService;
@@ -74,6 +77,9 @@ void main() {
       plugin = _OpenCodeFakeBridgePlugin();
       metadataRepository = FakeSessionMetadataRepository();
       worktreeService = _FakeWorktreeService(database: db);
+      defaultsRepository = NewSessionDefaultsRepository(
+        dao: NewSessionDefaultsDao(database: db),
+      );
       sessionRepository = singlePluginSessionRepository(
         plugin: plugin,
         sessionDao: db.sessionDao,
@@ -91,6 +97,7 @@ void main() {
         sessionMetadataRepository: metadataRepository,
         worktreeService: worktreeService,
         sessionRepository: sessionRepository,
+        newSessionDefaultsRepository: defaultsRepository,
         sessionMutationDispatcher: sessionMutationDispatcher,
       );
       handler = CreateSessionHandler(sessionCreationService: sessionCreationService);
@@ -468,6 +475,7 @@ void main() {
         sessionMetadataRepository: metadataRepository,
         worktreeService: worktreeService,
         sessionRepository: localRepository,
+        newSessionDefaultsRepository: defaultsRepository,
         sessionMutationDispatcher: localMutationDispatcher,
       );
       final localHandler = CreateSessionHandler(sessionCreationService: localCreationService);
@@ -977,6 +985,7 @@ void main() {
         sessionMetadataRepository: metadataRepository,
         worktreeService: worktreeService,
         sessionRepository: orderedRepository,
+        newSessionDefaultsRepository: defaultsRepository,
         sessionMutationDispatcher: orderedMutationDispatcher,
       );
       final localHandler = CreateSessionHandler(sessionCreationService: orderedCreationService);
@@ -1160,6 +1169,7 @@ void main() {
         sessionMetadataRepository: metadataRepository,
         worktreeService: worktreeService,
         sessionRepository: throwingRepository,
+        newSessionDefaultsRepository: defaultsRepository,
         sessionMutationDispatcher: throwingDispatcher,
       );
       final localHandler = CreateSessionHandler(sessionCreationService: localCreationService);

--- a/bridge/app/test/bridge/routing/post_session_options_handler_test.dart
+++ b/bridge/app/test/bridge/routing/post_session_options_handler_test.dart
@@ -175,6 +175,7 @@ const _optionsResponse = SessionOptionsResponse(
   agents: Agents(agents: []),
   providers: ProviderListResponse(items: [], connectedOnly: true),
   commands: CommandListResponse(items: []),
+  lastUsedPromptDefaults: null,
 );
 
 final _requestBody = jsonEncode(const PluginProjectIdRequest(projectId: "project", pluginId: "plugin").toJson());

--- a/bridge/app/test/bridge/services/session_creation_service_test.dart
+++ b/bridge/app/test/bridge/services/session_creation_service_test.dart
@@ -1,9 +1,11 @@
 import "dart:async";
 import "dart:io";
 
+import "package:sesori_bridge/src/api/database/daos/new_session_defaults_dao.dart";
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/api/git_cli_api.dart";
 import "package:sesori_bridge/src/repositories/models/project_not_found_exception.dart";
+import "package:sesori_bridge/src/repositories/new_session_defaults_repository.dart";
 import "package:sesori_bridge/src/repositories/session_metadata_repository.dart";
 import "package:sesori_bridge/src/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/services/session_creation_service.dart";
@@ -27,11 +29,15 @@ void main() {
     late _FakeWorktreeService worktreeService;
     late SessionOperationDispatcher operationDispatcher;
     late SessionMutationDispatcher mutationDispatcher;
+    late NewSessionDefaultsRepository defaultsRepository;
     late SessionCreationService service;
 
     setUp(() async {
       db = createTestDatabase();
       await db.projectsDao.insertProjectsIfMissing(projectIds: ["/repo"]);
+      defaultsRepository = NewSessionDefaultsRepository(
+        dao: NewSessionDefaultsDao(database: db),
+      );
       plugin = _FakePlugin();
       metadataRepository = _FakeSessionMetadataRepository();
       worktreeService = _FakeWorktreeService(
@@ -62,6 +68,7 @@ void main() {
         sessionMetadataRepository: metadataRepository,
         worktreeService: worktreeService,
         sessionRepository: repository,
+        newSessionDefaultsRepository: defaultsRepository,
         sessionMutationDispatcher: mutationDispatcher,
       );
     });
@@ -126,6 +133,7 @@ void main() {
         sessionMetadataRepository: metadataRepository,
         worktreeService: worktreeService,
         sessionRepository: repository,
+        newSessionDefaultsRepository: defaultsRepository,
         sessionMutationDispatcher: localMutationDispatcher,
       );
 
@@ -257,6 +265,7 @@ void main() {
         sessionMetadataRepository: metadataRepository,
         worktreeService: worktreeService,
         sessionRepository: repository,
+        newSessionDefaultsRepository: defaultsRepository,
         sessionMutationDispatcher: localMutationDispatcher,
       );
 
@@ -311,9 +320,10 @@ void main() {
         ),
       );
       expect(metadataRepository.generateCalls, isZero);
+      expect(await defaultsRepository.read(pluginId: "fake"), isNull);
     });
 
-    test("stores the created root with its explicit plugin and backend binding", () async {
+    test("stores the created root and remembers its complete plugin-scoped selection", () async {
       worktreeService.prepareResult = WorktreeSuccess(
         path: "/repo/.worktrees/session-one",
         branchName: "session-one",
@@ -327,9 +337,9 @@ void main() {
           pluginId: "fake",
           dedicatedWorktree: true,
           parts: [PromptPart.text(text: "Build it")],
-          variant: null,
-          agent: null,
-          model: null,
+          variant: SessionVariant(id: "high"),
+          agent: "build",
+          model: PromptModel(providerID: "provider", modelID: "model"),
           command: null,
         ),
       );
@@ -341,12 +351,56 @@ void main() {
       expect(stored!.backendSessionId, "backend-session");
       expect(stored.pluginId, "fake");
       expect(stored.projectId, "/repo");
+      expect(
+        await defaultsRepository.read(pluginId: "fake"),
+        const SessionPromptDefaults(
+          agent: "build",
+          model: AgentModel(providerID: "provider", modelID: "model", variant: "high"),
+        ),
+      );
       expect(stored.directory, "/repo/.worktrees/session-one");
       expect(stored.worktreePath, "/repo/.worktrees/session-one");
       expect(plugin.lastCreateDirectory, "/repo/.worktrees/session-one");
       expect(plugin.lastCreateUserVisibleText, "Build it");
       expect(plugin.lastCreateParts, hasLength(2));
       expect(plugin.lastCreateParts?.last, const PluginPromptPart.text(text: "Build it"));
+    });
+
+    test("a defaults write failure does not turn a durable creation into a retryable failure", () async {
+      final localService = SessionCreationService(
+        sessionMetadataRepository: metadataRepository,
+        worktreeService: worktreeService,
+        sessionRepository: singlePluginSessionRepository(
+          plugin: plugin,
+          sessionDao: db.sessionDao,
+          projectsDao: db.projectsDao,
+          pullRequestDao: db.pullRequestDao,
+          unseenCalculator: const SessionUnseenCalculator(),
+        ),
+        newSessionDefaultsRepository: _ThrowingNewSessionDefaultsRepository(),
+        sessionMutationDispatcher: mutationDispatcher,
+      );
+      late Session created;
+
+      final output = await _captureWarningLog(() async {
+        created = await localService.createSession(
+          request: const CreateSessionRequest(
+            projectId: "/repo",
+            pluginId: "fake",
+            dedicatedWorktree: false,
+            parts: [],
+            variant: null,
+            agent: null,
+            model: null,
+            command: null,
+          ),
+        );
+      });
+
+      expect(await db.sessionDao.getSession(sessionId: created.id), isNotNull);
+      expect(output, contains("Failed to remember new-session defaults for plugin fake"));
+      expect(output, contains("defaults write failed"));
+      await localService.drain();
     });
 
     test("applies dedicated-session metadata after returning the initial branch", () async {
@@ -697,6 +751,16 @@ class _FakeWorktreeService({required super.worktreeRepository}) extends Worktree
   }) async {
     rollbackCalls++;
   }
+}
+
+class _ThrowingNewSessionDefaultsRepository() implements NewSessionDefaultsRepository {
+  @override
+  Future<void> write({required String pluginId, required SessionPromptDefaults defaults}) {
+    return Future.error(StateError("defaults write failed"));
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _FakePlugin() implements NativeProjectsPluginApi {

--- a/bridge/app/test/bridge/services/session_creation_service_test.dart
+++ b/bridge/app/test/bridge/services/session_creation_service_test.dart
@@ -366,6 +366,50 @@ void main() {
       expect(plugin.lastCreateParts?.last, const PluginPromptPart.text(text: "Build it"));
     });
 
+    test("returns without waiting for defaults persistence", () async {
+      final gatedDefaultsRepository = _GatedNewSessionDefaultsRepository();
+      final localService = SessionCreationService(
+        sessionMetadataRepository: metadataRepository,
+        worktreeService: worktreeService,
+        sessionRepository: singlePluginSessionRepository(
+          plugin: plugin,
+          sessionDao: db.sessionDao,
+          projectsDao: db.projectsDao,
+          pullRequestDao: db.pullRequestDao,
+          unseenCalculator: const SessionUnseenCalculator(),
+        ),
+        newSessionDefaultsRepository: gatedDefaultsRepository,
+        sessionMutationDispatcher: mutationDispatcher,
+      );
+      var creationCompleted = false;
+      final creation = localService.createSession(
+        request: const CreateSessionRequest(
+          projectId: "/repo",
+          pluginId: "fake",
+          dedicatedWorktree: false,
+          parts: [],
+          variant: null,
+          agent: null,
+          model: null,
+          command: null,
+        ),
+      );
+      unawaited(creation.then((_) => creationCompleted = true));
+      addTearDown(() {
+        if (!gatedDefaultsRepository.writeGate.isCompleted) {
+          gatedDefaultsRepository.writeGate.complete();
+        }
+      });
+
+      await gatedDefaultsRepository.writeStarted.future;
+      await Future<void>.delayed(Duration.zero);
+
+      expect(creationCompleted, isTrue);
+      gatedDefaultsRepository.writeGate.complete();
+      await creation;
+      await localService.drain();
+    });
+
     test("a defaults write failure does not turn a durable creation into a retryable failure", () async {
       final localService = SessionCreationService(
         sessionMetadataRepository: metadataRepository,
@@ -395,6 +439,7 @@ void main() {
             command: null,
           ),
         );
+        await Future<void>.delayed(Duration.zero);
       });
 
       expect(await db.sessionDao.getSession(sessionId: created.id), isNotNull);
@@ -751,6 +796,20 @@ class _FakeWorktreeService({required super.worktreeRepository}) extends Worktree
   }) async {
     rollbackCalls++;
   }
+}
+
+class _GatedNewSessionDefaultsRepository() implements NewSessionDefaultsRepository {
+  final Completer<void> writeStarted = Completer<void>();
+  final Completer<void> writeGate = Completer<void>();
+
+  @override
+  Future<void> write({required String pluginId, required SessionPromptDefaults defaults}) async {
+    writeStarted.complete();
+    await writeGate.future;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _ThrowingNewSessionDefaultsRepository() implements NewSessionDefaultsRepository {

--- a/bridge/app/test/bridge/services/session_options_service_test.dart
+++ b/bridge/app/test/bridge/services/session_options_service_test.dart
@@ -2,6 +2,7 @@ import "dart:async";
 import "dart:io";
 
 import "package:sesori_bridge/src/repositories/models/session_options_cache_key.dart";
+import "package:sesori_bridge/src/repositories/new_session_defaults_repository.dart";
 import "package:sesori_bridge/src/repositories/session_options_repository.dart";
 import "package:sesori_bridge/src/services/session_options_service.dart";
 import "package:sesori_plugin_interface/plugin_interface_testing.dart";
@@ -36,6 +37,71 @@ void main() {
       expect(repository.captureCalls, isEmpty);
       expect(repository.commitCalls, isEmpty);
       expect(repository.runtimeChecks, 0);
+    });
+
+    test("client-facing options include the last successful creation defaults for that plugin", () async {
+      final repository = _FakeSessionOptionsRepository()
+        ..projectPaths["project-1"] = "/projects/one"
+        ..put(
+          _entry(
+            key: const SessionOptionsCacheKey.plugin(pluginId: "plugin-1"),
+            response: _response(marker: "cached"),
+            capturedAt: now,
+          ),
+        );
+      final defaultsRepository = _FakeNewSessionDefaultsRepository()
+        ..defaultsByPlugin["plugin-1"] = const SessionPromptDefaults(
+          agent: "build",
+          model: AgentModel(providerID: "provider", modelID: "model", variant: "high"),
+        );
+      final service = SessionOptionsService(
+        repository: repository,
+        newSessionDefaultsRepository: defaultsRepository,
+        pluginScopes: const {"plugin-1": PluginSessionOptionsScope.plugin},
+        clock: _FixedClock(nowValue: now),
+        retention: const Duration(days: 30),
+      );
+
+      final outcome = await service.loadCacheOnly(pluginId: "plugin-1", projectId: "project-1");
+
+      expect(
+        (outcome as SessionOptionsAvailable).response.lastUsedPromptDefaults,
+        defaultsRepository.defaultsByPlugin["plugin-1"],
+      );
+      expect(defaultsRepository.readCalls, 1);
+    });
+
+    test("a defaults read failure keeps the options catalog usable and observable", () async {
+      final repository = _FakeSessionOptionsRepository()
+        ..projectPaths["project-1"] = "/projects/one"
+        ..put(
+          _entry(
+            key: const SessionOptionsCacheKey.plugin(pluginId: "plugin-1"),
+            response: _response(marker: "cached"),
+            capturedAt: now,
+          ),
+        );
+      final defaultsRepository = _FakeNewSessionDefaultsRepository()..readError = StateError("defaults unavailable");
+      final service = SessionOptionsService(
+        repository: repository,
+        newSessionDefaultsRepository: defaultsRepository,
+        pluginScopes: const {"plugin-1": PluginSessionOptionsScope.plugin},
+        clock: _FixedClock(nowValue: now),
+        retention: const Duration(days: 30),
+      );
+
+      late SessionOptionsOutcome outcome;
+      final output = await _captureLogOutput(
+        level: LogLevel.debug,
+        action: () async {
+          outcome = await service.loadCacheOnly(pluginId: "plugin-1", projectId: "project-1");
+        },
+      );
+
+      expect(outcome, isA<SessionOptionsAvailable>());
+      expect((outcome as SessionOptionsAvailable).response.lastUsedPromptDefaults, isNull);
+      expect(output, contains("Failed to read new-session defaults for plugin plugin-1"));
+      expect(output, contains("defaults unavailable"));
     });
 
     test("cache-only load does not expose a project row after its path moves", () async {
@@ -877,6 +943,7 @@ void main() {
       );
       final service = SessionOptionsService(
         repository: repository,
+        newSessionDefaultsRepository: _FakeNewSessionDefaultsRepository(),
         pluginScopes: const {"plugin-1": PluginSessionOptionsScope.project},
         clock: clock,
         retention: Duration.zero,
@@ -1034,6 +1101,7 @@ void main() {
         };
       final service = SessionOptionsService(
         repository: repository,
+        newSessionDefaultsRepository: _FakeNewSessionDefaultsRepository(),
         pluginScopes: const {"plugin-1": PluginSessionOptionsScope.project},
         clock: clock,
         retention: Duration.zero,
@@ -1239,6 +1307,7 @@ void main() {
       };
       final service = SessionOptionsService(
         repository: repository,
+        newSessionDefaultsRepository: _FakeNewSessionDefaultsRepository(),
         pluginScopes: const {"plugin-1": PluginSessionOptionsScope.project},
         clock: _AdvancingClock(now: now),
         retention: const Duration(days: 30),
@@ -1538,6 +1607,7 @@ SessionOptionsService _service({
 }) {
   return SessionOptionsService(
     repository: repository,
+    newSessionDefaultsRepository: _FakeNewSessionDefaultsRepository(),
     pluginScopes: scopes,
     clock: _FixedClock(nowValue: now),
     retention: const Duration(days: 30),
@@ -1586,6 +1656,7 @@ SessionOptionsResponse _response({required String marker}) {
     ),
     providers: const ProviderListResponse(items: [], connectedOnly: true),
     commands: const CommandListResponse(items: []),
+    lastUsedPromptDefaults: null,
   );
 }
 
@@ -1653,6 +1724,23 @@ class const _CommitCall({
 });
 
 class const _ConditionalDeleteCall({required final SessionOptionsCacheKey key, required final int expectedRevision});
+
+class _FakeNewSessionDefaultsRepository() implements NewSessionDefaultsRepository {
+  final Map<String, SessionPromptDefaults> defaultsByPlugin = {};
+  Object? readError;
+  int readCalls = 0;
+
+  @override
+  Future<SessionPromptDefaults?> read({required String pluginId}) async {
+    readCalls++;
+    final error = readError;
+    if (error != null) throw error;
+    return defaultsByPlugin[pluginId];
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
 
 class _FakeSessionOptionsRepository() implements SessionOptionsRepository {
   final Map<String, String> projectPaths = {};

--- a/bridge/app/test/listeners/session_options_refresh_listeners_test.dart
+++ b/bridge/app/test/listeners/session_options_refresh_listeners_test.dart
@@ -155,6 +155,7 @@ const _optionsResponse = SessionOptionsResponse(
   agents: Agents(agents: []),
   providers: ProviderListResponse(items: [], connectedOnly: true),
   commands: CommandListResponse(items: []),
+  lastUsedPromptDefaults: null,
 );
 
 class _FakeSessionOptionsService() implements SessionOptionsService {

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -124,6 +124,7 @@ SessionOptionsCatalog _testSessionOptionsCatalog() => SessionOptionsCatalog(
   providers: testProviderListResponse().items,
   providersConnectedOnly: testProviderListResponse().connectedOnly,
   commands: const [],
+  lastUsedPromptDefaults: null,
 );
 
 Finder _pickerMenuItem(String label) => find.descendant(
@@ -355,6 +356,7 @@ void main() {
               providers: providerData.items,
               providersConnectedOnly: providerData.connectedOnly,
               commands: commandData.items,
+              lastUsedPromptDefaults: null,
             ),
           ),
         (ErrorResponse(:final error), _, _) => SessionOptionsRepositoryFailure(error: error),
@@ -387,6 +389,7 @@ void main() {
               providers: providerData.items,
               providersConnectedOnly: providerData.connectedOnly,
               commands: commandData.items,
+              lastUsedPromptDefaults: null,
             ),
           ),
         (ErrorResponse(:final error), _, _) => LegacySessionOptionsRepositoryFailure(
@@ -823,6 +826,43 @@ void main() {
 
     expect(find.text(loc.newSessionOptionsRefreshFailedUnavailable), findsOneWidget);
     expect(find.widgetWithText(PregoPickerButton, "coder"), findsNothing);
+  });
+
+  testWidgets("prefills the bridge-stored selection from the last successful creation", (tester) async {
+    when(
+      () => sessionRepository.loadSessionOptions(
+        projectId: "project-1",
+        pluginId: "plugin-1",
+        mode: any(named: "mode"),
+      ),
+    ).thenAnswer(
+      (_) async => SessionOptionsRepositoryAvailable(
+        isStale: false,
+        catalog: SessionOptionsCatalog(
+          agents: [
+            _testAgent(name: "coder", description: "A coding assistant", variant: "xhigh"),
+            _testAgent(name: "review", description: "A reviewing assistant", variant: "xhigh"),
+          ],
+          providers: testProviderListResponse().items,
+          providersConnectedOnly: false,
+          commands: const [],
+          lastUsedPromptDefaults: const SessionPromptDefaults(
+            agent: "review",
+            model: AgentModel(
+              providerID: "anthropic",
+              modelID: "claude-3-5-sonnet",
+              variant: "xhigh",
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(PregoPickerButton, "review"), findsOneWidget);
+    expect(find.widgetWithText(PregoPickerButton, "xhigh"), findsOneWidget);
   });
 
   testWidgets("shows variant picker when selected agent has a variant", (tester) async {

--- a/client/module_core/lib/src/repositories/models/session_options_repository_result.dart
+++ b/client/module_core/lib/src/repositories/models/session_options_repository_result.dart
@@ -6,6 +6,7 @@ final class SessionOptionsCatalog({
     required List<ProviderInfo> providers,
     required final bool providersConnectedOnly,
     required List<CommandInfo> commands,
+    required final SessionPromptDefaults? lastUsedPromptDefaults,
   }) {
 
   final List<AgentInfo> agents = List.unmodifiable(agents);

--- a/client/module_core/lib/src/repositories/session_repository.dart
+++ b/client/module_core/lib/src/repositories/session_repository.dart
@@ -153,6 +153,7 @@ class SessionRepository({
         SuccessResponse(:final data) => data.items,
         ErrorResponse() => const <CommandInfo>[],
       },
+      lastUsedPromptDefaults: null,
     );
     final errors = <LegacySessionOptionError>[
       if (agents case ErrorResponse(:final error))
@@ -192,6 +193,7 @@ class SessionRepository({
           providers: data.providers.items,
           providersConnectedOnly: data.providers.connectedOnly,
           commands: data.commands.items,
+          lastUsedPromptDefaults: data.lastUsedPromptDefaults,
         ),
         isStale: data.stale,
       ),

--- a/client/module_core/lib/src/services/new_session_options_service.dart
+++ b/client/module_core/lib/src/services/new_session_options_service.dart
@@ -175,6 +175,7 @@ class NewSessionOptionsService({
                 commands: failedSources.contains(LegacySessionOptionSource.commands)
                     ? previousOptions.commands
                     : catalog.commands,
+                lastUsedPromptDefaults: null,
               );
         return NewSessionOptionsLoaded(
           options: _resolve(
@@ -219,9 +220,13 @@ class NewSessionOptionsService({
         .toList(growable: false);
     final providers = catalog.providers;
     final commands = catalog.commands;
+    final effectiveSelection = _mergeSelection(
+      restoredSelection: restoredSelection,
+      lastUsedPromptDefaults: catalog.lastUsedPromptDefaults,
+    );
 
     final defaultAgent = agents.firstOrNull?.name;
-    final restoredAgent = restoredSelection?.agentName;
+    final restoredAgent = effectiveSelection?.agentName;
     final selectedAgent = restoredAgent != null && agents.any((agent) => agent.name == restoredAgent)
         ? restoredAgent
         : defaultAgent;
@@ -235,7 +240,7 @@ class NewSessionOptionsService({
         ) ??
         _pickDefaultModel(providers: providers);
 
-    final restoredModel = restoredSelection?.model;
+    final restoredModel = effectiveSelection?.model;
     final selectedAgentModel = _applyVariantIntent(
       providers: providers,
       model:
@@ -250,7 +255,7 @@ class NewSessionOptionsService({
                   ),
           ) ??
           defaultAgentModel,
-      variantIntent: restoredSelection?.variant,
+      variantIntent: effectiveSelection?.variant,
     );
     final stagedCommandName = previousOptions?.stagedCommand?.name;
     final stagedCommand = stagedCommandName == null
@@ -265,6 +270,32 @@ class NewSessionOptionsService({
       selectedAgentModel: selectedAgentModel,
       stagedCommand: stagedCommand,
       availableVariants: availableVariants(providers: providers, model: selectedAgentModel),
+    );
+  }
+
+  NewSessionSelectionIntent? _mergeSelection({
+    required NewSessionSelectionIntent? restoredSelection,
+    required SessionPromptDefaults? lastUsedPromptDefaults,
+  }) {
+    final rememberedModel = lastUsedPromptDefaults?.model;
+    final rememberedVariant = rememberedModel?.variant;
+    final remembered = lastUsedPromptDefaults == null
+        ? null
+        : NewSessionSelectionIntent(
+            agentName: lastUsedPromptDefaults.agent,
+            model: rememberedModel == null
+                ? null
+                : NewSessionModelIntent(
+                    providerId: rememberedModel.providerID,
+                    modelId: rememberedModel.modelID,
+                  ),
+            variant: rememberedVariant == null ? null : NewSessionVariantIntent(id: rememberedVariant),
+          );
+    if (restoredSelection == null) return remembered;
+    return NewSessionSelectionIntent(
+      agentName: restoredSelection.agentName ?? remembered?.agentName,
+      model: restoredSelection.model ?? remembered?.model,
+      variant: restoredSelection.variant ?? remembered?.variant,
     );
   }
 

--- a/client/module_core/lib/src/services/new_session_options_service.dart
+++ b/client/module_core/lib/src/services/new_session_options_service.dart
@@ -241,21 +241,22 @@ class NewSessionOptionsService({
         _pickDefaultModel(providers: providers);
 
     final restoredModel = effectiveSelection?.model;
+    final validatedRestoredModel = _validatedModel(
+      providers: providers,
+      model: restoredModel == null
+          ? null
+          : AgentModel(
+              providerID: restoredModel.providerId,
+              modelID: restoredModel.modelId,
+              variant: null,
+            ),
+    );
     final selectedAgentModel = _applyVariantIntent(
       providers: providers,
-      model:
-          _validatedModel(
-            providers: providers,
-            model: restoredModel == null
-                ? null
-                : AgentModel(
-                    providerID: restoredModel.providerId,
-                    modelID: restoredModel.modelId,
-                    variant: null,
-                  ),
-          ) ??
-          defaultAgentModel,
-      variantIntent: effectiveSelection?.variant,
+      model: validatedRestoredModel ?? defaultAgentModel,
+      variantIntent: restoredModel == null || validatedRestoredModel != null
+          ? effectiveSelection?.variant
+          : null,
     );
     final stagedCommandName = previousOptions?.stagedCommand?.name;
     final stagedCommand = stagedCommandName == null

--- a/client/module_core/lib/src/testing/test_helpers.dart
+++ b/client/module_core/lib/src/testing/test_helpers.dart
@@ -516,6 +516,7 @@ void delegateSessionOptionsRepository({
             providers: providerData.items,
             providersConnectedOnly: providerData.connectedOnly,
             commands: commandData.items,
+            lastUsedPromptDefaults: null,
           ),
         ),
       (ErrorResponse(:final error), _, _) => SessionOptionsRepositoryFailure(error: error),

--- a/client/module_core/test/api/session_api_test.dart
+++ b/client/module_core/test/api/session_api_test.dart
@@ -27,6 +27,7 @@ void main() {
       agents: Agents(agents: <AgentInfo>[]),
       providers: ProviderListResponse(items: <ProviderInfo>[], connectedOnly: false),
       commands: CommandListResponse(items: <CommandInfo>[]),
+      lastUsedPromptDefaults: null,
     );
 
     test("loadSessionOptions omits the query for dynamic loading", () async {

--- a/client/module_core/test/cubits/new_session/new_session_plugin_selection_test.dart
+++ b/client/module_core/test/cubits/new_session/new_session_plugin_selection_test.dart
@@ -703,6 +703,7 @@ void main() {
                   providers: const [],
                   providersConnectedOnly: false,
                   commands: [command],
+                  lastUsedPromptDefaults: null,
                 ),
               )
             : const SessionOptionsRepositoryRefreshFailedRetained();
@@ -741,6 +742,7 @@ void main() {
             providers: _providerResponse().items,
             providersConnectedOnly: false,
             commands: const [],
+            lastUsedPromptDefaults: null,
           ),
         );
       });
@@ -776,6 +778,7 @@ void main() {
             providers: _providerResponse().items,
             providersConnectedOnly: false,
             commands: const [],
+            lastUsedPromptDefaults: null,
           ),
         );
       });
@@ -825,6 +828,7 @@ void main() {
                   providers: const [],
                   providersConnectedOnly: false,
                   commands: [command],
+                  lastUsedPromptDefaults: null,
                 ),
               )
             : LegacySessionOptionsRepositoryFailure(
@@ -885,6 +889,7 @@ void main() {
                   providers: const [],
                   providersConnectedOnly: false,
                   commands: [command],
+                  lastUsedPromptDefaults: null,
                 ),
               )
             : SessionOptionsRepositoryFailure(error: ApiError.generic());
@@ -926,6 +931,7 @@ void main() {
             providers: const [],
             providersConnectedOnly: false,
             commands: [command],
+            lastUsedPromptDefaults: null,
           ),
         );
       });
@@ -973,6 +979,7 @@ void main() {
             providers: const [],
             providersConnectedOnly: false,
             commands: [command],
+            lastUsedPromptDefaults: null,
           ),
         );
       });
@@ -1025,6 +1032,7 @@ void main() {
             providers: const [],
             providersConnectedOnly: false,
             commands: [command],
+            lastUsedPromptDefaults: null,
           ),
         ),
       );
@@ -1071,6 +1079,7 @@ void main() {
                   providers: const [],
                   providersConnectedOnly: false,
                   commands: [command],
+                  lastUsedPromptDefaults: null,
                 ),
               )
             : SessionOptionsRepositoryProjectNotFound(error: ApiError.generic());
@@ -1109,6 +1118,7 @@ void main() {
                   providers: _providerResponse().items,
                   providersConnectedOnly: false,
                   commands: const [],
+                  lastUsedPromptDefaults: null,
                 ),
               )
             : const SessionOptionsRepositoryRefreshFailedUnavailable();
@@ -1963,6 +1973,7 @@ SessionOptionsRepositoryAvailable _optionsCatalog({
       providers: providers,
       providersConnectedOnly: false,
       commands: const [],
+      lastUsedPromptDefaults: null,
     ),
   );
 }

--- a/client/module_core/test/cubits/session_detail/session_detail_bridge_queue_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_bridge_queue_test.dart
@@ -50,6 +50,7 @@ SessionOptionsRepositoryResult _freshClaudeOptions() => SessionOptionsRepository
     providers: const [],
     providersConnectedOnly: false,
     commands: const [],
+    lastUsedPromptDefaults: null,
   ),
 );
 
@@ -83,6 +84,7 @@ SessionOptionsRepositoryResult _claudeOptionsWithVariants(List<String> variants)
     providers: _providerDataWithVariants(variants).items,
     providersConnectedOnly: false,
     commands: const [],
+    lastUsedPromptDefaults: null,
   ),
 );
 

--- a/client/module_core/test/repositories/session_repository_test.dart
+++ b/client/module_core/test/repositories/session_repository_test.dart
@@ -303,6 +303,10 @@ void main() {
       agents: Agents(agents: <AgentInfo>[]),
       providers: ProviderListResponse(items: <ProviderInfo>[], connectedOnly: false),
       commands: CommandListResponse(items: <CommandInfo>[]),
+      lastUsedPromptDefaults: SessionPromptDefaults(
+        agent: "review",
+        model: AgentModel(providerID: "provider-1", modelID: "model-1", variant: "high"),
+      ),
     );
     when(
       () => api.loadSessionOptions(
@@ -323,7 +327,12 @@ void main() {
       isA<SessionOptionsRepositoryAvailable>()
           .having((value) => value.catalog.agents, "agents", response.agents.agents)
           .having((value) => value.catalog.providers, "providers", response.providers.items)
-          .having((value) => value.catalog.commands, "commands", response.commands.items),
+          .having((value) => value.catalog.commands, "commands", response.commands.items)
+          .having(
+            (value) => value.catalog.lastUsedPromptDefaults,
+            "last used prompt defaults",
+            response.lastUsedPromptDefaults,
+          ),
     );
   });
 

--- a/client/module_core/test/services/new_session_options_service_test.dart
+++ b/client/module_core/test/services/new_session_options_service_test.dart
@@ -58,6 +58,7 @@ void main() {
         providers: _providers().items,
         providersConnectedOnly: false,
         commands: [_command(name: "review")],
+        lastUsedPromptDefaults: null,
       );
       when(
         () => repository.loadLegacySessionOptions(projectId: "project-1", pluginId: "plugin-1"),
@@ -98,6 +99,7 @@ void main() {
         providers: _providers().items,
         providersConnectedOnly: false,
         commands: [_command(name: "review")],
+        lastUsedPromptDefaults: null,
       );
       when(
         () => repository.loadLegacySessionOptions(projectId: "project-1", pluginId: "plugin-1"),
@@ -142,6 +144,7 @@ void main() {
         providers: const [],
         providersConnectedOnly: false,
         commands: [_command(name: "new-command")],
+        lastUsedPromptDefaults: null,
       );
       when(
         () => repository.loadLegacySessionOptions(projectId: "project-1", pluginId: "plugin-1"),
@@ -251,6 +254,7 @@ void main() {
         providers: _providers().items,
         providersConnectedOnly: false,
         commands: [_command(name: "review")],
+        lastUsedPromptDefaults: null,
       );
       when(
         () => repository.loadSessionOptions(
@@ -283,6 +287,81 @@ void main() {
       expect(result.source, NewSessionOptionsSource.aggregate);
     });
 
+    test("restores last successful creation defaults with deliberate dimensions taking precedence", () async {
+      final catalog = SessionOptionsCatalog(
+        agents: [_agent(name: "build"), _agent(name: "review")],
+        providers: _providers().items,
+        providersConnectedOnly: false,
+        commands: const [],
+        lastUsedPromptDefaults: const SessionPromptDefaults(
+          agent: "review",
+          model: AgentModel(providerID: "provider-a", modelID: "model-a", variant: "low"),
+        ),
+      );
+      when(
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "plugin-1",
+          mode: SessionOptionsRequestMode.dynamic,
+        ),
+      ).thenAnswer((_) async => SessionOptionsRepositoryAvailable(catalog: catalog, isStale: false));
+
+      final result =
+          await service.load(
+                projectId: "project-1",
+                pluginId: "plugin-1",
+                source: NewSessionOptionsSource.aggregate,
+                mode: NewSessionOptionsLoadMode.dynamicLoad,
+                restoredSelection: const NewSessionSelectionIntent(
+                  agentName: "build",
+                  model: null,
+                  variant: null,
+                ),
+                previousOptions: null,
+              )
+              as NewSessionOptionsLoaded;
+
+      expect(result.options.selectedAgent, "build");
+      expect(result.options.selectedAgentModel?.modelID, "model-a");
+      expect(result.options.selectedAgentModel?.variant, "low");
+    });
+
+    test("unavailable remembered defaults fall back by provider order", () async {
+      final catalog = SessionOptionsCatalog(
+        agents: [_agent(name: "build")],
+        providers: _providers().items,
+        providersConnectedOnly: false,
+        commands: const [],
+        lastUsedPromptDefaults: const SessionPromptDefaults(
+          agent: "missing",
+          model: AgentModel(providerID: "provider-a", modelID: "unavailable", variant: "stale"),
+        ),
+      );
+      when(
+        () => repository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "plugin-1",
+          mode: SessionOptionsRequestMode.dynamic,
+        ),
+      ).thenAnswer((_) async => SessionOptionsRepositoryAvailable(catalog: catalog, isStale: false));
+
+      final result =
+          await service.load(
+                projectId: "project-1",
+                pluginId: "plugin-1",
+                source: NewSessionOptionsSource.aggregate,
+                mode: NewSessionOptionsLoadMode.dynamicLoad,
+                restoredSelection: null,
+                previousOptions: null,
+              )
+              as NewSessionOptionsLoaded;
+
+      expect(result.options.selectedAgent, "build");
+      expect(result.options.selectedAgentModel?.providerID, "provider-a");
+      expect(result.options.selectedAgentModel?.modelID, "model-a");
+      expect(result.options.selectedAgentModel?.variant, "high");
+    });
+
     test("unavailable restored and agent models fall back by provider order", () async {
       final catalog = SessionOptionsCatalog(
         agents: [
@@ -294,6 +373,7 @@ void main() {
         providers: _providers().items,
         providersConnectedOnly: false,
         commands: const [],
+        lastUsedPromptDefaults: null,
       );
       when(
         () => repository.loadSessionOptions(
@@ -340,6 +420,7 @@ void main() {
         providers: _providers().items,
         providersConnectedOnly: false,
         commands: [refreshedCommand],
+        lastUsedPromptDefaults: null,
       );
       when(
         () => repository.loadSessionOptions(

--- a/client/module_core/test/services/new_session_options_service_test.dart
+++ b/client/module_core/test/services/new_session_options_service_test.dart
@@ -334,7 +334,7 @@ void main() {
         commands: const [],
         lastUsedPromptDefaults: const SessionPromptDefaults(
           agent: "missing",
-          model: AgentModel(providerID: "provider-a", modelID: "unavailable", variant: "stale"),
+          model: AgentModel(providerID: "provider-a", modelID: "unavailable", variant: "low"),
         ),
       );
       when(

--- a/client/module_core/test/services/session_detail_load_service_test.dart
+++ b/client/module_core/test/services/session_detail_load_service_test.dart
@@ -167,6 +167,7 @@ void main() {
             providers: catalog.providers,
             providersConnectedOnly: catalog.providersConnectedOnly,
             commands: const <CommandInfo>[],
+            lastUsedPromptDefaults: null,
           ),
           errors: [LegacySessionOptionError(source: LegacySessionOptionSource.commands, error: error)],
         ),
@@ -581,6 +582,7 @@ SessionOptionsCatalog _sessionOptionsCatalog() {
         subtask: false,
       ),
     ],
+    lastUsedPromptDefaults: null,
   );
 }
 

--- a/docs/regression/session-archiving-and-deletion.md
+++ b/docs/regression/session-archiving-and-deletion.md
@@ -24,7 +24,8 @@ entirely along with its transcript and, optionally, its worktree.
   only on a forced retry. Session retirement never deletes a Git branch.
 - Per-session prompt defaults are live composer cache, not audit data. Archiving
   clears them from the session row and omits them from the archive snapshot;
-  deletion removes them with the row.
+  deletion removes them with the row. The separate last-successful New Session
+  preference is plugin-scoped and survives retiring any individual session.
 - Once deletion cleanup starts, the bridge suppresses session-created and
   session-updated events for the named session and its persisted descendants.
   Suppression remains for the bridge lifetime after success and is removed if

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -20,6 +20,13 @@ variant, and worktree mode, and creating the session with its first input.
   default-first, and a model that offers variants always has one selected: the
   agent's declared variant when valid, otherwise the first available. Selecting a
   variant is therefore a switch between named levels, never a reset to unset.
+- After a new session and its first prompt or command are accepted, the bridge
+  remembers the complete agent, model, and effort selection per plugin. The next
+  New Session screen uses it as the prefill across projects for that plugin after
+  validating every value against the current catalog; removed values fall back to
+  current plugin defaults. A failed creation never replaces the remembered
+  selection. Preference read/write failures stay observable locally but never hide
+  usable options or turn an already-created session into a retryable failure.
 - Hermes Agent seeds its configured model and provider from `hermes status`,
   then discovers the available model catalog in a separate empty ACP session
   before the user creates one. The discovery process must exit before Sesori
@@ -134,7 +141,7 @@ variant, and worktree mode, and creating the session with its first input.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Headless bridge, representative plugin: a session is created with a first prompt and has attribution and a working directory. |
-| L2 Routine | Headless bridge, representative plugin: options return agents, models, commands; explicit refresh forces discovery; cache-only reports unavailable without discovering; a cache past the freshness window is served at once and reported stale; dedicated mode produces a local lowercase `color-animal` branch, worktree, and baseline; a gated metadata request does not gate a queryable create response; eligible generated branch refinement preserves the worktree path and publishes the updated session. |
+| L2 Routine | Headless bridge, representative plugin: options return agents, models, commands, and the last successful plugin-scoped creation selection; explicit refresh forces discovery; cache-only reports unavailable without discovering; a cache past the freshness window is served at once and reported stale; dedicated mode produces a local lowercase `color-animal` branch, worktree, and baseline; a gated metadata request does not gate a queryable create response; eligible generated branch refinement preserves the worktree path and publishes the updated session. |
 | L3 Release | Client end to end (phone), every supporting production plugin: Send immediately renders launch status at the unresolved route, blocks duplicate submit, and replaces with the durable session; Back leaves creation running; each declared option scope is honored and usable; chosen agent, model, and variant apply; slash-command start dispatches without rendering bridge context; generated title and eligible branch refinement arrive through `session.updated`; a stale-reported cache refreshes in the background with no loading state while the refresh action spins in place rather than vanishing; pickers, plugin chooser, detail loading, and no-harness states render. |
 | L4 Extended | Client end to end and live plugin, every supporting production plugin: definitive rejection and response-loss/timeout restore the exact in-route draft with duplicate-risk warning, reconnect/options refresh cannot erase it, and background failure does not restore an abandoned draft; occupied branch/path pairs are skipped and pair exhaustion uses a suffix; non-git, empty-repository, worktree-failure, metadata-failure, plugin-title-rename-failure, switched/detached/published branch, invalid generated ref, local/remote collision exhaustion, persistence failure, and shutdown cases retain a usable session; user rename/deletion wins over late title; failure with a retained cache still serves options while failure without one errors; concurrent requests coalesce; automatic refresh does not start a stopped plugin; a moved project invalidates its options. |
 | L5 Full | Client end to end, every supporting production plugin: cache expiry and an undecodable entry recover without wrong options; creation is refused for a non-routable plugin and an unknown project; attachment creation works only where declared; unattributed payloads resolve to the historical identity. |
@@ -156,6 +163,9 @@ reconnect or option refresh while restoration is pending.
 
 - Options are empty or stale where a discovery failure should be an explicit
   error, or a partial observation overwrites a complete cache.
+- A successful creation does not become the next per-plugin prefill, a failed
+  creation replaces it, one plugin's selection leaks into another, or a removed
+  saved value prevents current catalog defaults from loading.
 - A cache-only read starts a backend, or automatic refresh wakes a stopped one.
 - The refresh action disappears while its own load runs, gives no sign it was
   pressed, or renames itself after which load it happens to be repeating.

--- a/shared/sesori_shared/lib/src/models/sesori/session_options_response.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session_options_response.dart
@@ -3,6 +3,7 @@ import "package:freezed_annotation/freezed_annotation.dart";
 import "agent_info.dart";
 import "command_list_response.dart";
 import "provider_info.dart";
+import "session.dart";
 
 part "session_options_response.freezed.dart";
 part "session_options_response.g.dart";
@@ -13,6 +14,11 @@ sealed class SessionOptionsResponse with _$SessionOptionsResponse {
     required Agents agents,
     required ProviderListResponse providers,
     required CommandListResponse commands,
+    // COMPATIBILITY 2026-08-27 (v1.8.2): Bridges before v1.8.2 omit
+    // lastUsedPromptDefaults, which means no bridge-stored new-session selection
+    // is available. Missing nullable JSON fields decode to null.
+    required SessionPromptDefaults? lastUsedPromptDefaults,
+
     /// Whether the bridge served a cached snapshot older than its freshness
     /// window, making it worth a background refresh. Freshly discovered options
     /// are never stale.

--- a/shared/sesori_shared/lib/src/models/sesori/session_options_response.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session_options_response.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$SessionOptionsResponse {
 
- Agents get agents; ProviderListResponse get providers; CommandListResponse get commands;/// Whether the bridge served a cached snapshot older than its freshness
+ Agents get agents; ProviderListResponse get providers; CommandListResponse get commands; SessionPromptDefaults? get lastUsedPromptDefaults;/// Whether the bridge served a cached snapshot older than its freshness
 /// window, making it worth a background refresh. Freshly discovered options
 /// are never stale.
  bool get stale;
@@ -32,16 +32,16 @@ $SessionOptionsResponseCopyWith<SessionOptionsResponse> get copyWith => _$Sessio
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionOptionsResponse&&(identical(other.agents, agents) || other.agents == agents)&&(identical(other.providers, providers) || other.providers == providers)&&(identical(other.commands, commands) || other.commands == commands)&&(identical(other.stale, stale) || other.stale == stale));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionOptionsResponse&&(identical(other.agents, agents) || other.agents == agents)&&(identical(other.providers, providers) || other.providers == providers)&&(identical(other.commands, commands) || other.commands == commands)&&(identical(other.lastUsedPromptDefaults, lastUsedPromptDefaults) || other.lastUsedPromptDefaults == lastUsedPromptDefaults)&&(identical(other.stale, stale) || other.stale == stale));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,agents,providers,commands,stale);
+int get hashCode => Object.hash(runtimeType,agents,providers,commands,lastUsedPromptDefaults,stale);
 
 @override
 String toString() {
-  return 'SessionOptionsResponse(agents: $agents, providers: $providers, commands: $commands, stale: $stale)';
+  return 'SessionOptionsResponse(agents: $agents, providers: $providers, commands: $commands, lastUsedPromptDefaults: $lastUsedPromptDefaults, stale: $stale)';
 }
 
 
@@ -52,11 +52,11 @@ abstract mixin class $SessionOptionsResponseCopyWith<$Res>  {
   factory $SessionOptionsResponseCopyWith(SessionOptionsResponse value, $Res Function(SessionOptionsResponse) _then) = _$SessionOptionsResponseCopyWithImpl;
 @useResult
 $Res call({
- Agents agents, ProviderListResponse providers, CommandListResponse commands, bool stale
+ Agents agents, ProviderListResponse providers, CommandListResponse commands, SessionPromptDefaults? lastUsedPromptDefaults, bool stale
 });
 
 
-$AgentsCopyWith<$Res> get agents;$ProviderListResponseCopyWith<$Res> get providers;$CommandListResponseCopyWith<$Res> get commands;
+$AgentsCopyWith<$Res> get agents;$ProviderListResponseCopyWith<$Res> get providers;$CommandListResponseCopyWith<$Res> get commands;$SessionPromptDefaultsCopyWith<$Res>? get lastUsedPromptDefaults;
 
 }
 /// @nodoc
@@ -69,12 +69,13 @@ class _$SessionOptionsResponseCopyWithImpl<$Res>
 
 /// Create a copy of SessionOptionsResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? agents = null,Object? providers = null,Object? commands = null,Object? stale = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? agents = null,Object? providers = null,Object? commands = null,Object? lastUsedPromptDefaults = freezed,Object? stale = null,}) {
   return _then(SessionOptionsResponse(
 agents: null == agents ? _self.agents : agents // ignore: cast_nullable_to_non_nullable
 as Agents,providers: null == providers ? _self.providers : providers // ignore: cast_nullable_to_non_nullable
 as ProviderListResponse,commands: null == commands ? _self.commands : commands // ignore: cast_nullable_to_non_nullable
-as CommandListResponse,stale: null == stale ? _self.stale : stale // ignore: cast_nullable_to_non_nullable
+as CommandListResponse,lastUsedPromptDefaults: freezed == lastUsedPromptDefaults ? _self.lastUsedPromptDefaults : lastUsedPromptDefaults // ignore: cast_nullable_to_non_nullable
+as SessionPromptDefaults?,stale: null == stale ? _self.stale : stale // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }
@@ -105,6 +106,18 @@ $CommandListResponseCopyWith<$Res> get commands {
   return $CommandListResponseCopyWith<$Res>(_self.commands, (value) {
     return _then(_self.copyWith(commands: value));
   });
+}/// Create a copy of SessionOptionsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SessionPromptDefaultsCopyWith<$Res>? get lastUsedPromptDefaults {
+    if (_self.lastUsedPromptDefaults == null) {
+    return null;
+  }
+
+  return $SessionPromptDefaultsCopyWith<$Res>(_self.lastUsedPromptDefaults!, (value) {
+    return _then(_self.copyWith(lastUsedPromptDefaults: value));
+  });
 }
 }
 
@@ -114,12 +127,13 @@ $CommandListResponseCopyWith<$Res> get commands {
 @JsonSerializable()
 
 class _SessionOptionsResponse implements SessionOptionsResponse {
-  const _SessionOptionsResponse({required this.agents, required this.providers, required this.commands, this.stale = false});
+  const _SessionOptionsResponse({required this.agents, required this.providers, required this.commands, required this.lastUsedPromptDefaults, this.stale = false});
   factory _SessionOptionsResponse.fromJson(Map<String, dynamic> json) => _$SessionOptionsResponseFromJson(json);
 
 @override final  Agents agents;
 @override final  ProviderListResponse providers;
 @override final  CommandListResponse commands;
+@override final  SessionPromptDefaults? lastUsedPromptDefaults;
 /// Whether the bridge served a cached snapshot older than its freshness
 /// window, making it worth a background refresh. Freshly discovered options
 /// are never stale.
@@ -138,16 +152,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionOptionsResponse&&(identical(other.agents, agents) || other.agents == agents)&&(identical(other.providers, providers) || other.providers == providers)&&(identical(other.commands, commands) || other.commands == commands)&&(identical(other.stale, stale) || other.stale == stale));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionOptionsResponse&&(identical(other.agents, agents) || other.agents == agents)&&(identical(other.providers, providers) || other.providers == providers)&&(identical(other.commands, commands) || other.commands == commands)&&(identical(other.lastUsedPromptDefaults, lastUsedPromptDefaults) || other.lastUsedPromptDefaults == lastUsedPromptDefaults)&&(identical(other.stale, stale) || other.stale == stale));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,agents,providers,commands,stale);
+int get hashCode => Object.hash(runtimeType,agents,providers,commands,lastUsedPromptDefaults,stale);
 
 @override
 String toString() {
-  return 'SessionOptionsResponse(agents: $agents, providers: $providers, commands: $commands, stale: $stale)';
+  return 'SessionOptionsResponse(agents: $agents, providers: $providers, commands: $commands, lastUsedPromptDefaults: $lastUsedPromptDefaults, stale: $stale)';
 }
 
 
@@ -158,11 +172,11 @@ abstract mixin class _$SessionOptionsResponseCopyWith<$Res> implements $SessionO
   factory _$SessionOptionsResponseCopyWith(_SessionOptionsResponse value, $Res Function(_SessionOptionsResponse) _then) = __$SessionOptionsResponseCopyWithImpl;
 @override @useResult
 $Res call({
- Agents agents, ProviderListResponse providers, CommandListResponse commands, bool stale
+ Agents agents, ProviderListResponse providers, CommandListResponse commands, SessionPromptDefaults? lastUsedPromptDefaults, bool stale
 });
 
 
-@override $AgentsCopyWith<$Res> get agents;@override $ProviderListResponseCopyWith<$Res> get providers;@override $CommandListResponseCopyWith<$Res> get commands;
+@override $AgentsCopyWith<$Res> get agents;@override $ProviderListResponseCopyWith<$Res> get providers;@override $CommandListResponseCopyWith<$Res> get commands;@override $SessionPromptDefaultsCopyWith<$Res>? get lastUsedPromptDefaults;
 
 }
 /// @nodoc
@@ -175,12 +189,13 @@ class __$SessionOptionsResponseCopyWithImpl<$Res>
 
 /// Create a copy of SessionOptionsResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? agents = null,Object? providers = null,Object? commands = null,Object? stale = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? agents = null,Object? providers = null,Object? commands = null,Object? lastUsedPromptDefaults = freezed,Object? stale = null,}) {
   return _then(_SessionOptionsResponse(
 agents: null == agents ? _self.agents : agents // ignore: cast_nullable_to_non_nullable
 as Agents,providers: null == providers ? _self.providers : providers // ignore: cast_nullable_to_non_nullable
 as ProviderListResponse,commands: null == commands ? _self.commands : commands // ignore: cast_nullable_to_non_nullable
-as CommandListResponse,stale: null == stale ? _self.stale : stale // ignore: cast_nullable_to_non_nullable
+as CommandListResponse,lastUsedPromptDefaults: freezed == lastUsedPromptDefaults ? _self.lastUsedPromptDefaults : lastUsedPromptDefaults // ignore: cast_nullable_to_non_nullable
+as SessionPromptDefaults?,stale: null == stale ? _self.stale : stale // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }
@@ -211,6 +226,18 @@ $CommandListResponseCopyWith<$Res> get commands {
   
   return $CommandListResponseCopyWith<$Res>(_self.commands, (value) {
     return _then(_self.copyWith(commands: value));
+  });
+}/// Create a copy of SessionOptionsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SessionPromptDefaultsCopyWith<$Res>? get lastUsedPromptDefaults {
+    if (_self.lastUsedPromptDefaults == null) {
+    return null;
+  }
+
+  return $SessionPromptDefaultsCopyWith<$Res>(_self.lastUsedPromptDefaults!, (value) {
+    return _then(_self.copyWith(lastUsedPromptDefaults: value));
   });
 }
 }

--- a/shared/sesori_shared/lib/src/models/sesori/session_options_response.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session_options_response.g.dart
@@ -15,6 +15,11 @@ _SessionOptionsResponse _$SessionOptionsResponseFromJson(Map json) =>
       commands: CommandListResponse.fromJson(
         Map<String, dynamic>.from(json['commands'] as Map),
       ),
+      lastUsedPromptDefaults: json['lastUsedPromptDefaults'] == null
+          ? null
+          : SessionPromptDefaults.fromJson(
+              Map<String, dynamic>.from(json['lastUsedPromptDefaults'] as Map),
+            ),
       stale: json['stale'] as bool? ?? false,
     );
 
@@ -24,5 +29,6 @@ Map<String, dynamic> _$SessionOptionsResponseToJson(
   'agents': instance.agents.toJson(),
   'providers': instance.providers.toJson(),
   'commands': instance.commands.toJson(),
+  'lastUsedPromptDefaults': ?instance.lastUsedPromptDefaults?.toJson(),
   'stale': instance.stale,
 };

--- a/shared/sesori_shared/test/models/session_options_response_test.dart
+++ b/shared/sesori_shared/test/models/session_options_response_test.dart
@@ -40,6 +40,10 @@ void main() {
           ),
         ],
       ),
+      lastUsedPromptDefaults: SessionPromptDefaults(
+        agent: "build",
+        model: AgentModel(providerID: "openai", modelID: "gpt-5", variant: "high"),
+      ),
     );
 
     final json = response.toJson();
@@ -48,6 +52,12 @@ void main() {
     expect(json.keys, containsAllInOrder(["agents", "providers", "commands"]));
     // A bridge that predates the staleness signal simply never reports one.
     expect(SessionOptionsResponse.fromJson({...json}..remove("stale")).stale, isFalse);
+    // A bridge that predates remembered new-session defaults has no stored
+    // selection to apply.
+    expect(
+      SessionOptionsResponse.fromJson({...json}..remove("lastUsedPromptDefaults")).lastUsedPromptDefaults,
+      isNull,
+    );
   });
 
   test("session options errors round-trip known codes", () {


### PR DESCRIPTION
## Complexity

🚧 Complex — this completes a backend-neutral flow across the shared wire contract, bridge creation/options services, client repository/service resolution, and New Session UI behavior.

## What

- Persist the complete requested agent/model/effort selection per plugin after a session is created successfully and durably.
- Add nullable `lastUsedPromptDefaults` to the shared session-options response.
- Overlay remembered defaults after loading the option catalog, keeping preference state separate from the catalog cache.
- Map the preference through the client repository and use it to prefill New Session controls.
- Preserve deliberate in-memory choices by dimension and validate all remembered values against the current agent/model/variant catalogs.
- Add focused wire, bridge service, client service/repository, and widget coverage and complete the regression documentation.

## Why

Developers commonly create consecutive sessions with the same harness choices. Remembering the last successful selection removes repeated setup while keeping defaults isolated per plugin and avoiding stale or removed catalog values.

## Risk and test focus

- **Risk:** moderate, centered on cross-version transport behavior and selection fallback precedence.
- **User-visible impact:** the next New Session screen can preselect the last successfully used agent, model, and effort for the selected plugin.
- **Database impact:** no new schema in this step; it begins populating the v14 plugin-default table introduced in step 2 after successful creations. The preference intentionally survives retiring an individual session.
- **Wire compatibility:** older bridges omit the nullable field and newer clients fall back normally; older clients ignore the added response field.
- **Failure isolation:** preference read/write failures are logged but do not hide usable option catalogs or turn an already-created session into a retryable failure.
- **Analytics:** no new event; this convenience default does not introduce a distinct authoritative product outcome.

## Expected result

After a successful creation, reopening New Session with the same plugin preselects the prior agent, model, and effort when they remain available. Different plugins retain independent defaults. An unavailable remembered value falls back through existing catalog defaults, and active deliberate edits continue to win.

## Verification

- `dart analyze` in `shared/sesori_shared`, `client/module_core`, and `client/app`
- `dart analyze --fatal-infos` in `bridge/app`
- Shared session-options tests: 3 passed
- Focused bridge options/creation/route/listener suites: 131 passed
- Focused module-core API/repository/options/plugin/session-detail suites: 119 passed
- Mobile New Session widget tests: 41 passed
- `git diff --check`
- Architecture implementation review: approved

## Series

1. [Clear retired prompt defaults](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1140) — merged.
2. [Add plugin-default persistence](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1142) — merged.
3. **This PR:** connect successful creation, bridge options, and client prefill behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remembers the last successful agent, model, and effort selection per plugin after a session is created, and prefills the next New Session screen with it. Previously each plugin's choices reset to catalog defaults on every open.

- Adds nullable `lastUsedPromptDefaults` to the session-options response; older bridges omit it and decode as null.
- Persists the selection asynchronously after a successful creation, so a slow or failed write never delays the durable session; overlays it after loading the option catalog.
- Merges remembered defaults with any restored in-route selection, so deliberate per-dimension choices win.
- Validates remembered values against the current catalogs; removed values fall back to existing defaults, and an unavailable remembered model also drops its stored effort.

<sup>Written for commit e9c28dfebac7068d2483bdf010d6e63484db2f44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

