### PR TITLE
⚙️ Scope backend notifications to their sessions

### DIFF
--- a/bridge/app/lib/src/repositories/mappers/session_event_mapper.dart
+++ b/bridge/app/lib/src/repositories/mappers/session_event_mapper.dart
@@ -30,7 +30,7 @@ class const SessionEventMapper() {
       BridgeSseMessagePartRemoved(:final sessionID) ||
       BridgeSseQueuedPromptsUpdated(:final sessionID) ||
       BridgeSseTodoUpdated(:final sessionID) => {sessionID},
-      BridgeSseSessionError(:final sessionID) => {?sessionID},
+      BridgeSseSessionError(:final sessionID) || BridgeSseTuiToastShow(:final sessionID) => {?sessionID},
       BridgeSseMessageUpdated(:final info) => {Message.fromJson(info).sessionID},
       BridgeSseMessagePartUpdated(:final part) => {part.sessionID},
       BridgeSsePermissionAsked(:final sessionID, :final displaySessionId) ||
@@ -64,7 +64,6 @@ class const SessionEventMapper() {
       BridgeSseInstallationUpdateAvailable() ||
       BridgeSseWorkspaceReady() ||
       BridgeSseWorkspaceFailed() ||
-      BridgeSseTuiToastShow() ||
       BridgeSseWorktreeReady() ||
       BridgeSseWorktreeFailed() => const <String>{},
       BridgeSseSessionCreated() ||
@@ -271,6 +270,18 @@ class const SessionEventMapper() {
         final sessionId? => BridgeSseTodoUpdated(sessionID: sessionId),
         null => null,
       },
+      BridgeSseTuiToastShow(:final sessionID, :final title, :final message, :final variant) => switch (sessionID) {
+        final backendId? => switch (mapped(backendId)) {
+          final sessionId? => BridgeSseTuiToastShow(
+            sessionID: sessionId,
+            title: title,
+            message: message,
+            variant: variant,
+          ),
+          null => null,
+        },
+        null => event,
+      },
       BridgeSseServerConnected() ||
       BridgeSseServerHeartbeat() ||
       BridgeSseServerInstanceDisposed() ||
@@ -294,7 +305,6 @@ class const SessionEventMapper() {
       BridgeSseInstallationUpdateAvailable() ||
       BridgeSseWorkspaceReady() ||
       BridgeSseWorkspaceFailed() ||
-      BridgeSseTuiToastShow() ||
       BridgeSseWorktreeReady() ||
       BridgeSseWorktreeFailed() => event,
     };

--- a/bridge/app/lib/src/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/sse/bridge_event_mapper.dart
@@ -172,11 +172,13 @@ class BridgeEventMapper({
         ),
         BridgeSseWorkspaceReady(:final name) => SesoriSseEvent.workspaceReady(name: name),
         BridgeSseWorkspaceFailed(:final message) => SesoriSseEvent.workspaceFailed(message: message),
-        BridgeSseTuiToastShow(:final title, :final message, :final variant) => SesoriSseEvent.tuiToastShow(
-          title: title,
-          message: message,
-          variant: variant,
-        ),
+        BridgeSseTuiToastShow(:final sessionID, :final title, :final message, :final variant) =>
+          SesoriSseEvent.tuiToastShow(
+            sessionID: sessionID,
+            title: title,
+            message: message,
+            variant: variant,
+          ),
         BridgeSseWorktreeReady() => const SesoriSseEvent.worktreeReady(),
         BridgeSseWorktreeFailed() => const SesoriSseEvent.worktreeFailed(),
       };

--- a/bridge/app/test/bridge/repositories/mappers/session_event_mapper_test.dart
+++ b/bridge/app/test/bridge/repositories/mappers/session_event_mapper_test.dart
@@ -170,6 +170,16 @@ void main() {
           event: const BridgeSseTodoUpdated(sessionID: "backend-session"),
           expectedBackendIds: {"backend-session"},
         ),
+        (
+          name: "toast shown",
+          event: const BridgeSseTuiToastShow(
+            sessionID: "backend-session",
+            title: "Pi",
+            message: "Done",
+            variant: "success",
+          ),
+          expectedBackendIds: {"backend-session"},
+        ),
       ];
 
       for (final testCase in cases) {
@@ -219,6 +229,12 @@ void main() {
 
     test("preserves nullable session references and non-session events", () {
       const error = BridgeSseSessionError(sessionID: null);
+      const toast = BridgeSseTuiToastShow(
+        sessionID: null,
+        title: "Notice",
+        message: null,
+        variant: "info",
+      );
       const connected = BridgeSseServerConnected();
       const commandCatalogUpdated = BridgeSseCommandCatalogUpdated();
       const optionsChanged = BridgeSseSessionOptionsChanged(sessionID: "backend-session");
@@ -227,6 +243,8 @@ void main() {
       final mappedError = mapper.map(event: error, sessionIdsByBackendId: const {});
       expect(mappedError, isA<BridgeSseSessionError>());
       expect((mappedError! as BridgeSseSessionError).sessionID, isNull);
+      expect(mapper.backendSessionIds(event: toast), isEmpty);
+      expect(mapper.map(event: toast, sessionIdsByBackendId: const {}), same(toast));
       expect(mapper.map(event: connected, sessionIdsByBackendId: const {}), same(connected));
       expect(mapper.backendSessionIds(event: commandCatalogUpdated), isEmpty);
       expect(

--- a/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
+++ b/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
@@ -125,6 +125,27 @@ void main() {
       expect(result, const SesoriCommandCatalogUpdated(pluginId: "cursor"));
     });
 
+    test("maps toast session attribution to the wire event", () {
+      final result = mapEvent(
+        const BridgeSseTuiToastShow(
+          sessionID: "stable-session",
+          title: "Pi",
+          message: "Extension finished",
+          variant: "success",
+        ),
+      );
+
+      expect(
+        result,
+        const SesoriTuiToastShow(
+          sessionID: "stable-session",
+          title: "Pi",
+          message: "Extension finished",
+          variant: "success",
+        ),
+      );
+    });
+
     test("maps session.created with provided enriched payload", () {
       final result = mapEvent(
         const BridgeSseSessionCreated(

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -811,7 +811,8 @@ abstract class AcpPlugin({
           stack,
         );
         _eventBuffer.add(
-          const BridgeSseTuiToastShow(
+          BridgeSseTuiToastShow(
+            sessionID: session.sessionId,
             title: "Session options not applied",
             message: "The selected options will be retried before the first turn.",
             variant: "warning",

--- a/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
@@ -183,8 +183,14 @@ class const BridgeSseWorkspaceReady({final String? name}) extends BridgeSseEvent
 
 class const BridgeSseWorkspaceFailed({final String? message}) extends BridgeSseEvent;
 
-class const BridgeSseTuiToastShow({final String? title, final String? message, final String? variant})
-    extends BridgeSseEvent;
+/// Transient backend guidance. [sessionID] is the backend session identity
+/// before bridge-core remapping; null means genuinely global or unattributed.
+class const BridgeSseTuiToastShow({
+  required final String? sessionID,
+  required final String? title,
+  required final String? message,
+  required final String? variant,
+}) extends BridgeSseEvent;
 
 class const BridgeSseWorktreeReady() extends BridgeSseEvent;
 

--- a/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
+++ b/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
@@ -196,7 +196,14 @@ class OmpPlugin._({
     required Object error,
   }) {
     if (!_isMissingModel(error)) return const [];
-    return const [_missingModelToast];
+    return [
+      BridgeSseTuiToastShow(
+        sessionID: sessionId,
+        title: "Oh My Pi needs a model",
+        message: "Open OMP locally, run /login, then retry.",
+        variant: "warning",
+      ),
+    ];
   }
 
   @override
@@ -215,6 +222,7 @@ class OmpPlugin._({
   }
 
   static const BridgeSseTuiToastShow _missingModelToast = BridgeSseTuiToastShow(
+    sessionID: null,
     title: "Oh My Pi needs a model",
     message: "Open OMP locally, run /login, then retry.",
     variant: "warning",

--- a/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
@@ -576,6 +576,7 @@ void main() {
 
       expect(events.whereType<BridgeSseSessionError>(), hasLength(1));
       final toast = events.whereType<BridgeSseTuiToastShow>().single;
+      expect(toast.sessionID, session.id);
       expect(toast.message, contains("run /login"));
       expect(toast.message, isNot(contains("/Users/private")));
       expect(toast.message, isNot(contains("private prompt")));

--- a/bridge/sesori_plugin_opencode/lib/src/sse_event_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse_event_mapper.dart
@@ -165,6 +165,7 @@ class SseEventMapper({final AssistantMessageMapper _assistantMessageMapper = con
       SseWorkspaceReady(:final name) => BridgeSseWorkspaceReady(name: name),
       SseWorkspaceFailed(:final message) => BridgeSseWorkspaceFailed(message: message),
       SseTuiToastShow(:final title, :final message, :final variant) => BridgeSseTuiToastShow(
+        sessionID: null,
         title: title,
         message: message,
         variant: variant,

--- a/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
+++ b/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
@@ -482,7 +482,11 @@ final class PiPlugin._({
       throw _unsupportedSelection(operation: operation, message: "Unsupported Pi agent.", staleOptions: staleOptions);
     }
     if (variant != null && PiThinkingLevel.tryParse(value: variant.id) == null) {
-      throw _unsupportedSelection(operation: operation, message: "Unsupported Pi thinking level.", staleOptions: staleOptions);
+      throw _unsupportedSelection(
+        operation: operation,
+        message: "Unsupported Pi thinking level.",
+        staleOptions: staleOptions,
+      );
     }
     if (model == null) return;
     final options = await _catalogService.requireOptions(projectId: projectId);
@@ -529,7 +533,8 @@ final class PiPlugin._({
             sessionID: ownerSessionId,
             displaySessionId: displaySessionId,
           ),
-        PiExtensionUiToast(:final title, :final message, :final variant) => BridgeSseTuiToastShow(
+        PiExtensionUiToast(:final sessionId, :final title, :final message, :final variant) => BridgeSseTuiToastShow(
+          sessionID: sessionId,
           title: title,
           message: message,
           variant: switch (variant) {

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_extension_ui_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_extension_ui_service.dart
@@ -27,6 +27,7 @@ final class const PiExtensionUiQuestionRejected({
 }) extends PiExtensionUiEvent;
 
 final class const PiExtensionUiToast({
+  required final String sessionId,
   required final String title,
   required final String message,
   required final PiNotificationType variant,
@@ -64,7 +65,12 @@ final class PiExtensionUiService({
         final visible = message == null ? null : _bounded(message);
         if (visible != null && visible.isNotEmpty) {
           _events.add(
-            PiExtensionUiToast(title: "Pi", message: visible, variant: notifyType ?? PiNotificationType.info),
+            PiExtensionUiToast(
+              sessionId: ownerSessionId,
+              title: "Pi",
+              message: visible,
+              variant: notifyType ?? PiNotificationType.info,
+            ),
           );
         }
         return;

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -545,6 +545,7 @@ final class PiSessionService({
       if (presented.message?.contains("/login") ?? false) {
         _emit(
           BridgeSseTuiToastShow(
+            sessionID: sessionId,
             title: "Pi login required",
             message: presented.message,
             variant: "warning",
@@ -769,7 +770,8 @@ final class PiSessionService({
     );
     if (hasUncancelled && exit.authUnavailable) {
       _emit(
-        const BridgeSseTuiToastShow(
+        BridgeSseTuiToastShow(
+          sessionID: exit.sessionId,
           title: "Pi login required",
           message: "Pi has no model available. Run Pi locally and use /login, then try again.",
           variant: "warning",

--- a/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
@@ -229,6 +229,7 @@ void main() {
     expect(processes.replies.single.reply, isA<PiExtensionUiCancelledReply>());
     expect(events.whereType<PiExtensionUiQuestionRejected>(), hasLength(2));
     final toast = events.whereType<PiExtensionUiToast>().single;
+    expect(toast.sessionId, "child");
     expect(toast.message.runes.length, PiExtensionUiService.maxTextLength);
     expect(toast.variant, PiNotificationType.warning);
   });

--- a/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
@@ -237,7 +237,9 @@ void main() {
       }
 
       expect(events.whereType<BridgeSseQuestionAsked>().single.sessionID, session.id);
-      expect(events.whereType<BridgeSseTuiToastShow>().single.variant, "warning");
+      final toast = events.whereType<BridgeSseTuiToastShow>().single;
+      expect(toast.sessionID, session.id);
+      expect(toast.variant, "warning");
       expect(events.whereType<BridgeSseProjectUpdated>(), hasLength(projectUpdatesBeforeQuestion + 1));
       expect(await harness.plugin.getPendingPermissions(sessionId: session.id), isEmpty);
       await expectLater(

--- a/client/app/lib/main.dart
+++ b/client/app/lib/main.dart
@@ -351,7 +351,10 @@ class const _SesoriAppShell() extends StatelessWidget {
               getIt<RegisteredBridgesService>(),
             ),
             child: BlocProvider(
-              create: (_) => SseToastCubit(getIt<ConnectionService>()),
+              create: (_) => SseToastCubit(
+                connectionService: getIt<ConnectionService>(),
+                routeSource: getIt<RouteSource>(),
+              ),
               child: _SseToastListener(child: child ?? const SizedBox.shrink()),
             ),
           ),
@@ -361,9 +364,9 @@ class const _SesoriAppShell() extends StatelessWidget {
   }
 }
 
-/// Renders backend toast states through the design-system popup alert
-/// presenter, so guidance such as a local `/login` hint reaches the user on
-/// any screen, including startup routes with no scaffold.
+/// Renders accepted backend toast states through the design-system popup alert
+/// presenter on the root overlay, including global guidance on routes with no
+/// scaffold.
 class const _SseToastListener({required final Widget child}) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {

--- a/client/module_core/lib/src/capabilities/server_connection/models/sse_event.dart
+++ b/client/module_core/lib/src/capabilities/server_connection/models/sse_event.dart
@@ -29,6 +29,7 @@ class SseEvent({required final SesoriSseEvent data, final String? directory}) {
     SesoriPermissionReplied(:final sessionID) => sessionID,
     SesoriSessionPromptDefaultsChanged(:final sessionID) => sessionID,
     SesoriSessionQueuedPrompts(:final sessionID) => sessionID,
+    SesoriTuiToastShow(:final sessionID) => sessionID,
     SesoriServerConnected() ||
     SesoriServerHeartbeat() ||
     SesoriServerInstanceDisposed() ||
@@ -58,7 +59,6 @@ class SseEvent({required final SesoriSseEvent data, final String? directory}) {
     SesoriInstallationUpdateAvailable() ||
     SesoriWorkspaceReady() ||
     SesoriWorkspaceFailed() ||
-    SesoriTuiToastShow() ||
     SesoriWorktreeReady() ||
     SesoriWorktreeFailed() => null,
   };

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -745,7 +745,8 @@ class SessionDetailCubit(
             SesoriSessionDiff() ||
             SesoriSessionError() ||
             SesoriSessionCompacted() ||
-            SesoriTodoUpdated():
+            SesoriTodoUpdated() ||
+            SesoriTuiToastShow():
           break;
       }
     } catch (e, st) {

--- a/client/module_core/lib/src/cubits/sse_toast/sse_toast_cubit.dart
+++ b/client/module_core/lib/src/cubits/sse_toast/sse_toast_cubit.dart
@@ -5,25 +5,32 @@ import "package:sesori_shared/sesori_shared.dart";
 
 import "../../capabilities/server_connection/connection_service.dart";
 import "../../capabilities/server_connection/models/sse_event.dart";
+import "../../platform/route_source.dart";
+import "../../routing/app_routes.dart";
 import "sse_toast_state.dart";
 
 /// Surfaces backend-neutral `tui.toast.show` SSE events (backend notifications
-/// and guidance such as a local `/login` hint) as app-wide toast states.
+/// and guidance such as a local `/login` hint) as toast states.
 ///
-/// Every accepted event emits a new [SseToastShow] with a monotonic sequence,
-/// so equal repeated guidance is still a distinct effect. Events carrying no
-/// renderable text are dropped.
-class SseToastCubit(final ConnectionService _connectionService) extends Cubit<SseToastState> {
+/// Session-attributed events are accepted only while that session's detail or
+/// diffs route is the top route. Unattributed events remain app-wide. Every
+/// accepted event emits a new [SseToastShow] with a monotonic sequence, so equal
+/// repeated guidance is still a distinct effect. Events carrying no renderable
+/// text are dropped.
+class SseToastCubit({
+  required final ConnectionService _connectionService,
+  required final RouteSource _routeSource,
+}) extends Cubit<SseToastState> {
   late final StreamSubscription<SseEvent> _subscription;
   int _sequence = 0;
 
-  // ignore: no_slop_linter/prefer_required_named_parameters, public cubit constructor API
   this : super(const SseToastState.idle()) {
     _subscription = _connectionService.events.listen(_handleEvent);
   }
 
   void _handleEvent(SseEvent event) {
-    if (event.data case SesoriTuiToastShow(:final title, :final message, :final variant)) {
+    if (event.data case SesoriTuiToastShow(:final sessionID, :final title, :final message, :final variant)) {
+      if (sessionID != null && !_isShowingSession(sessionId: sessionID)) return;
       final trimmedTitle = title?.trim();
       final trimmedMessage = message?.trim();
       final normalizedTitle = trimmedTitle == null || trimmedTitle.isEmpty ? null : trimmedTitle;
@@ -39,6 +46,18 @@ class SseToastCubit(final ConnectionService _connectionService) extends Cubit<Ss
         ),
       );
     }
+  }
+
+  bool _isShowingSession({required String sessionId}) {
+    final route = _routeSource.currentRoute;
+    if (route == null || (route != AppRouteDef.sessionDetail && route != AppRouteDef.sessionDiffs)) return false;
+    final location = _routeSource.currentLocation;
+    final locationSegments = location == null ? null : Uri.tryParse(location)?.pathSegments;
+    if (locationSegments == null) return false;
+    final sessionIdIndex = Uri.parse(route.path).pathSegments.indexOf(":$sessionIdPathParam");
+    return sessionIdIndex >= 0 &&
+        sessionIdIndex < locationSegments.length &&
+        locationSegments[sessionIdIndex] == sessionId;
   }
 
   @override

--- a/client/module_core/lib/src/cubits/sse_toast/sse_toast_state.dart
+++ b/client/module_core/lib/src/cubits/sse_toast/sse_toast_state.dart
@@ -18,7 +18,7 @@ enum SseToastVariant() {
   };
 }
 
-/// What the app-wide toast surface should present.
+/// What the root toast surface should present.
 ///
 /// [SseToastShow.sequence] increases on every show so equal repeated guidance
 /// (for example the same `/login` hint twice) is still a distinct effect for

--- a/client/module_core/test/capabilities/server_connection/models/sse_event_test.dart
+++ b/client/module_core/test/capabilities/server_connection/models/sse_event_test.dart
@@ -14,6 +14,34 @@ void main() {
     expect(event.sessionId, equals("session-123"));
   });
 
+  test("session-attributed toast exposes its sessionId", () {
+    final event = SseEvent(
+      data: const SesoriSseEvent.tuiToastShow(
+        sessionID: "session-123",
+        title: "Pi",
+        message: "Done",
+        variant: "success",
+      ),
+    );
+
+    expect(event.sessionId, "session-123");
+    expect(event.data, isA<SesoriSessionEvent>());
+  });
+
+  test("unattributed toast remains outside every filtered session stream", () {
+    final event = SseEvent(
+      data: const SesoriSseEvent.tuiToastShow(
+        sessionID: null,
+        title: "Notice",
+        message: null,
+        variant: "info",
+      ),
+    );
+
+    expect(event.sessionId, isNull);
+    expect(event.data, isA<SesoriSessionEvent>());
+  });
+
   test("catalogImportProgress is a global non-session event", () {
     final event = SseEvent(
       data: const SesoriSseEvent.catalogImportProgress(

--- a/client/module_core/test/cubits/sse_toast/sse_toast_cubit_test.dart
+++ b/client/module_core/test/cubits/sse_toast/sse_toast_cubit_test.dart
@@ -5,6 +5,7 @@ import "package:mocktail/mocktail.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/models/sse_event.dart";
 import "package:sesori_dart_core/src/cubits/sse_toast/sse_toast_cubit.dart";
 import "package:sesori_dart_core/src/cubits/sse_toast/sse_toast_state.dart";
+import "package:sesori_dart_core/src/routing/app_routes.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -13,19 +14,25 @@ import "../../helpers/test_helpers.dart";
 void main() {
   group("SseToastCubit", () {
     late MockConnectionService connectionService;
+    late MockRouteSource routeSource;
     late StreamController<SseEvent> events;
 
     setUp(() {
       connectionService = MockConnectionService();
+      routeSource = MockRouteSource(initialRoute: AppRouteDef.projects, currentLocation: "/projects");
       events = StreamController<SseEvent>.broadcast();
       when(() => connectionService.events).thenAnswer((_) => events.stream);
     });
 
     tearDown(() async {
       await events.close();
+      await routeSource.dispose();
     });
 
-    SseToastCubit buildCubit() => SseToastCubit(connectionService);
+    SseToastCubit buildCubit() => SseToastCubit(
+      connectionService: connectionService,
+      routeSource: routeSource,
+    );
 
     blocTest<SseToastCubit, SseToastState>(
       "shows a toast with parsed variant and monotonic sequence for repeated equal guidance",
@@ -33,12 +40,22 @@ void main() {
       act: (cubit) {
         events.add(
           SseEvent(
-            data: const SesoriSseEvent.tuiToastShow(title: "Pi login required", message: "Run /login", variant: "warning"),
+            data: const SesoriSseEvent.tuiToastShow(
+              sessionID: null,
+              title: "Pi login required",
+              message: "Run /login",
+              variant: "warning",
+            ),
           ),
         );
         events.add(
           SseEvent(
-            data: const SesoriSseEvent.tuiToastShow(title: "Pi login required", message: "Run /login", variant: "warning"),
+            data: const SesoriSseEvent.tuiToastShow(
+              sessionID: null,
+              title: "Pi login required",
+              message: "Run /login",
+              variant: "warning",
+            ),
           ),
         );
       },
@@ -62,7 +79,14 @@ void main() {
       "falls back to the title as message and info variant for unknown variants",
       build: buildCubit,
       act: (cubit) => events.add(
-        SseEvent(data: const SesoriSseEvent.tuiToastShow(title: "Notice", message: "  ", variant: "sparkle")),
+        SseEvent(
+          data: const SesoriSseEvent.tuiToastShow(
+            sessionID: null,
+            title: "Notice",
+            message: "  ",
+            variant: "sparkle",
+          ),
+        ),
       ),
       expect: () => const [
         SseToastState.show(sequence: 1, title: null, message: "Notice", variant: SseToastVariant.info),
@@ -73,7 +97,14 @@ void main() {
       "normalizes a whitespace-only title to null when the message carries the text",
       build: buildCubit,
       act: (cubit) => events.add(
-        SseEvent(data: const SesoriSseEvent.tuiToastShow(title: "  ", message: "Run /login", variant: "warning")),
+        SseEvent(
+          data: const SesoriSseEvent.tuiToastShow(
+            sessionID: null,
+            title: "  ",
+            message: "Run /login",
+            variant: "warning",
+          ),
+        ),
       ),
       expect: () => const [
         SseToastState.show(sequence: 1, title: null, message: "Run /login", variant: SseToastVariant.warning),
@@ -81,11 +112,68 @@ void main() {
     );
 
     blocTest<SseToastCubit, SseToastState>(
+      "shows session-attributed toasts only on the matching session route",
+      build: buildCubit,
+      act: (cubit) async {
+        const toast = SesoriSseEvent.tuiToastShow(
+          sessionID: "session-1",
+          title: "Pi",
+          message: "Extension finished",
+          variant: "success",
+        );
+        events.add(SseEvent(data: toast));
+        await Future<void>.delayed(Duration.zero);
+        routeSource.emitRoute(AppRouteDef.sessionDetail);
+        routeSource.currentLocation = "/projects/project-1/sessions/session-2";
+        events.add(SseEvent(data: toast));
+        await Future<void>.delayed(Duration.zero);
+        routeSource.currentLocation = "/projects/project-1/sessions/session-1";
+        events.add(SseEvent(data: toast));
+        await Future<void>.delayed(Duration.zero);
+        routeSource.emitRoute(AppRouteDef.sessionDiffs);
+        routeSource.currentLocation = "/projects/project-1/sessions/session-1/diffs";
+        events.add(SseEvent(data: toast));
+      },
+      expect: () => const [
+        SseToastState.show(
+          sequence: 1,
+          title: "Pi",
+          message: "Extension finished",
+          variant: SseToastVariant.success,
+        ),
+        SseToastState.show(
+          sequence: 2,
+          title: "Pi",
+          message: "Extension finished",
+          variant: SseToastVariant.success,
+        ),
+      ],
+    );
+
+    blocTest<SseToastCubit, SseToastState>(
       "drops toasts with no renderable text and non-toast events",
       build: buildCubit,
       act: (cubit) {
-        events.add(SseEvent(data: const SesoriSseEvent.tuiToastShow(title: null, message: null, variant: "error")));
-        events.add(SseEvent(data: const SesoriSseEvent.tuiToastShow(title: " ", message: "", variant: null)));
+        events.add(
+          SseEvent(
+            data: const SesoriSseEvent.tuiToastShow(
+              sessionID: null,
+              title: null,
+              message: null,
+              variant: "error",
+            ),
+          ),
+        );
+        events.add(
+          SseEvent(
+            data: const SesoriSseEvent.tuiToastShow(
+              sessionID: null,
+              title: " ",
+              message: "",
+              variant: null,
+            ),
+          ),
+        );
         events.add(SseEvent(data: const SesoriSseEvent.projectUpdated(projectID: null, updatedAt: null)));
       },
       expect: () => const <SseToastState>[],

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -45,11 +45,12 @@ idle suspension, the management snapshot, and lifecycle commands.
   skills, and prompt templates are trusted without prompts); OMP launches `omp acp`
   without an approval-mode override, leaving approval behavior to OMP. Provider login
   for both happens locally, never from the phone.
-- Backend `tui.toast.show` SSE events render app-wide through the backend-neutral
-  toast surface, presented with the design-system popup alert on the root
-  navigator's overlay: every accepted toast is a new effect (equal repeated guidance
-  included), toasts with no renderable text are dropped, and unknown variants
-  degrade to info.
+- Backend `tui.toast.show` SSE events render through the backend-neutral toast
+  surface, presented with the design-system popup alert on the root navigator's
+  overlay. Session-attributed events appear only while that session's detail or
+  diffs route is on top; unattributed events remain app-wide. Every accepted toast
+  is a new effect (equal repeated guidance included), toasts with no renderable
+  text are dropped, and unknown variants degrade to info.
 - Listings order by display name case-insensitively with the identifier as tie-breaker,
   and the default is the preferred harness when selectable, else the first selectable.
 - Client-owned branding maps recognized built-in harness ids to their stable names and

--- a/docs/regression/popup-alerts.md
+++ b/docs/regression/popup-alerts.md
@@ -11,6 +11,8 @@ snackbars and render above the current route, below the top navigation bar.
   actions expand the card without clipping at accessibility text sizes.
 - The card is centered with 16 px screen margins and a 343 px maximum width.
 - A newly presented alert replaces the alert already visible on the same route.
+- Session-attributed backend alerts appear only while the matching session detail
+  or diffs route is on top; unattributed backend alerts remain app-wide.
 - Alerts dismiss after three seconds by default and dismiss immediately when
   the close button is tapped.
 - Swiping an alert upwards dismisses it, following the finger and completing on

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -27,7 +27,8 @@ reaches the backend so the turn continues.
   rejects pending cards on process/session cleanup, indexes imported children
   under their top-most display root and owning worktree project, and does not
   persist process-local dialog promises. Decorative extension UI is ignored;
-  bounded `notify` messages use the existing toast event.
+  bounded `notify` messages use the existing toast event attributed to their
+  owning session, so another session or an unrelated route does not present them.
 - DeepSeek standard ACP permissions use the request's explicit session ID when
   present and retain the ACP active-turn fallback when an agent omits it. They
   preserve the exact tool call ID and expose only the scopes the adapter offers;

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
@@ -417,8 +417,11 @@ sealed class SesoriSseEvent with _$SesoriSseEvent {
   // TUI
   // ---------------------------------------------------------------------------
 
+  /// Transient backend guidance. A null [sessionID] remains app-wide.
   @FreezedUnionValue("tui.toast.show")
+  @Implements<SesoriSessionEvent>()
   const factory tuiToastShow({
+    required String? sessionID,
     required String? title,
     required String? message,
     required String? variant,

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
@@ -3759,10 +3759,11 @@ as String?,
 /// @nodoc
 @JsonSerializable()
 
-class SesoriTuiToastShow implements SesoriSseEvent {
-  const SesoriTuiToastShow({required this.title, required this.message, required this.variant,  String? $type}): $type = $type ?? 'tui.toast.show';
+class SesoriTuiToastShow implements SesoriSseEvent, SesoriSessionEvent {
+  const SesoriTuiToastShow({required this.sessionID, required this.title, required this.message, required this.variant,  String? $type}): $type = $type ?? 'tui.toast.show';
   factory SesoriTuiToastShow.fromJson(Map<String, dynamic> json) => _$SesoriTuiToastShowFromJson(json);
 
+ final  String? sessionID;
  final  String? title;
  final  String? message;
  final  String? variant;
@@ -3784,16 +3785,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SesoriTuiToastShow&&(identical(other.title, title) || other.title == title)&&(identical(other.message, message) || other.message == message)&&(identical(other.variant, variant) || other.variant == variant));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SesoriTuiToastShow&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.title, title) || other.title == title)&&(identical(other.message, message) || other.message == message)&&(identical(other.variant, variant) || other.variant == variant));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,title,message,variant);
+int get hashCode => Object.hash(runtimeType,sessionID,title,message,variant);
 
 @override
 String toString() {
-  return 'SesoriSseEvent.tuiToastShow(title: $title, message: $message, variant: $variant)';
+  return 'SesoriSseEvent.tuiToastShow(sessionID: $sessionID, title: $title, message: $message, variant: $variant)';
 }
 
 
@@ -3804,7 +3805,7 @@ abstract mixin class $SesoriTuiToastShowCopyWith<$Res> implements $SesoriSseEven
   factory $SesoriTuiToastShowCopyWith(SesoriTuiToastShow value, $Res Function(SesoriTuiToastShow) _then) = _$SesoriTuiToastShowCopyWithImpl;
 @useResult
 $Res call({
- String? title, String? message, String? variant
+ String? sessionID, String? title, String? message, String? variant
 });
 
 
@@ -3821,9 +3822,10 @@ class _$SesoriTuiToastShowCopyWithImpl<$Res>
 
 /// Create a copy of SesoriSseEvent
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? title = freezed,Object? message = freezed,Object? variant = freezed,}) {
+@pragma('vm:prefer-inline') $Res call({Object? sessionID = freezed,Object? title = freezed,Object? message = freezed,Object? variant = freezed,}) {
   return _then(SesoriTuiToastShow(
-title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+sessionID: freezed == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
+as String?,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String?,message: freezed == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
 as String?,variant: freezed == variant ? _self.variant : variant // ignore: cast_nullable_to_non_nullable
 as String?,

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
@@ -653,6 +653,7 @@ Map<String, dynamic> _$SesoriWorkspaceFailedToJson(
 ) => <String, dynamic>{'message': ?instance.message, 'type': instance.$type};
 
 SesoriTuiToastShow _$SesoriTuiToastShowFromJson(Map json) => SesoriTuiToastShow(
+  sessionID: json['sessionID'] as String?,
   title: json['title'] as String?,
   message: json['message'] as String?,
   variant: json['variant'] as String?,
@@ -661,6 +662,7 @@ SesoriTuiToastShow _$SesoriTuiToastShowFromJson(Map json) => SesoriTuiToastShow(
 
 Map<String, dynamic> _$SesoriTuiToastShowToJson(SesoriTuiToastShow instance) =>
     <String, dynamic>{
+      'sessionID': ?instance.sessionID,
       'title': ?instance.title,
       'message': ?instance.message,
       'variant': ?instance.variant,

--- a/shared/sesori_shared/test/models/sesori_sse_event_test.dart
+++ b/shared/sesori_shared/test/models/sesori_sse_event_test.dart
@@ -126,6 +126,55 @@ void main() {
     expect(SesoriSseEvent.fromJson(json), event);
   });
 
+  group('tui.toast.show session scope', () {
+    test('round-trips a session-attributed toast', () {
+      const event = SesoriSseEvent.tuiToastShow(
+        sessionID: 'session-1',
+        title: 'Pi',
+        message: 'Extension finished',
+        variant: 'success',
+      );
+
+      final json = event.toJson();
+
+      expect(json, {
+        'type': 'tui.toast.show',
+        'sessionID': 'session-1',
+        'title': 'Pi',
+        'message': 'Extension finished',
+        'variant': 'success',
+      });
+      expect(SesoriSseEvent.fromJson(json), event);
+      expect(event, isA<SesoriSessionEvent>());
+    });
+
+    test('accepts legacy session omission as an unattributed toast', () {
+      final event = SesoriSseEvent.fromJson({
+        'type': 'tui.toast.show',
+        'title': 'Notice',
+        'message': 'Still global',
+        'variant': 'info',
+      });
+
+      expect(
+        event,
+        const SesoriSseEvent.tuiToastShow(
+          sessionID: null,
+          title: 'Notice',
+          message: 'Still global',
+          variant: 'info',
+        ),
+      );
+      expect(event.toJson(), {
+        'type': 'tui.toast.show',
+        'title': 'Notice',
+        'message': 'Still global',
+        'variant': 'info',
+      });
+      expect(event, isA<SesoriSessionEvent>());
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // Round-trip JSON compatibility
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this is a small UI policy change carried through the plugin, bridge mapping, shared SSE contract, and client routing layers.

## What

- Attribute Pi extension notifications and other session-owned backend guidance to the session that produced them.
- Remap backend session IDs through the existing stable-session binding before relay delivery.
- Add an additive nullable `sessionID` to `tui.toast.show` and keep omitted/unattributed events global.
- Show session-attributed popup alerts only while the matching session detail or diffs route is on top.
- Keep the existing popup visuals, severity, timing, and replacement behavior unchanged.

## Why

A Pi extension notification could appear while the user was viewing another session or an unrelated screen. The popup looked correct but lacked enough context to avoid confusion. Session scoping makes the existing presentation match the notification's actual relevance.

## Risk and test focus

The main risks are wire compatibility, backend-to-stable session ID translation, and route matching across detail and diffs screens. Legacy payloads that omit `sessionID` continue to decode as unattributed and remain app-wide. There is no database impact and no visual styling change; the user-visible change is limited to suppressing session-owned alerts outside their session.

## Expected result

Session-owned backend alerts appear only in their session context. Global or upstream-unattributed alerts continue to appear app-wide, with the same design-system presentation as before.

## Verification

- Shared Freezed/JSON code generation completed.
- Shared SSE model tests passed.
- Bridge session and wire mapper tests passed.
- Pi extension notification and plugin tests passed.
- OMP missing-model notification test passed.
- Client SSE extraction and toast route-gating tests passed.
- `dart analyze` passed for shared, client core, mobile, and desktop.
- `make analyze` passed across the bridge workspace.
- Architecture implementation review approved with no findings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes backend popup alerts to the session that produced them, so a Pi extension notification or other session-owned guidance no longer appears while viewing another session or an unrelated screen.

- Adds nullable `sessionID` to `tui.toast.show` across the bridge and shared SSE contract; legacy payloads omitting it stay app-wide.
- Client shows session-attributed alerts only when the matching session detail or diffs route is on top; unattributed alerts remain global.

<sup>Written for commit 441075541dae88cc6c579eb6cd3aa8dfb96923c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

