### PR TITLE
🌱 [grok-harness] docs: plan Grok Build harness support [step 1/9]

### DIFF
--- a/.plan/active/grok-harness/PLAN.md
+++ b/.plan/active/grok-harness/PLAN.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Plan slug:** `grok-harness`
-- **Status:** active; Step 1/9 in progress
+- **Status:** active; Step 1/9 in PR #1152; current revision architecture-approved
 - **Plan date:** 2026-08-27
 - **Implementation base:** `origin/main`
 - **Delivery:** nine PRs with fixed titles and order below
@@ -29,9 +29,11 @@ Research baseline:
 - Official agent-mode documentation:
   <https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/15-agent-mode.md>.
 
-Facts verified in that documentation and source:
+Facts verified in that documentation/source and then confirmed against the isolated released `1.0.5` macOS arm64
+binary (build `5115b46bc909`):
 
-- The local ACP entry point is `grok agent stdio`; ACP is JSON-RPC 2.0 over newline-delimited stdio.
+- The accepted dedicated entry point is `grok --no-auto-update agent --no-leader stdio`; ACP is JSON-RPC 2.0 over
+  newline-delimited stdio.
 - `initialize` negotiates ACP protocol version 1 and advertises standard load plus session list, resume, and close.
 - Standard ACP owns session creation, load/replay, resume, prompt streaming, cancellation, tool updates, and permission
   requests.
@@ -39,14 +41,19 @@ Facts verified in that documentation and source:
 - `--no-leader` forces the spawned process to own its local agent rather than attaching to Grok's shared leader.
 - `--no-auto-update` suppresses update checks for an embedded/headless process.
 - Authentication is local to the bridge machine through `grok login`, `XAI_API_KEY`, enterprise auth, or a configured
-  custom model. ACP advertises usable auth methods and `authenticate` is the runtime authority.
+  custom model. ACP `authenticate` is the runtime authority.
+- An isolated logged-out 1.0.5 process advertises only `grok.com`, a non-terminal but interactive login flow. The
+  existing generic ACP rule would incorrectly select it and wait for browser/code input. Credential-backed headless
+  methods are `xai.api_key` and `cached_token`; Grok must select only those when the agent actually advertises them and
+  classify an interactive-only list as authentication-required without calling it.
 - Initialize metadata includes `grokShell`, `agentVersion`, and pre-session `modelState`. New/load responses also carry
   Grok's model state.
 - Grok 1.0.5 still exposes the older ACP `models` shape and `session/set_model`. Reasoning effort is carried in model
   metadata (`supportsReasoningEffort`, `reasoningEfforts`, and `reasoningEffort`) and selected through
   `_meta.reasoningEffort` on `session/set_model`.
-- The model surface is no longer part of current stable ACP. It is therefore a Grok-owned compatibility surface, not a
-  reason to widen generic `sesori_plugin_acp` contracts.
+- The model surface is no longer part of current stable ACP. It remains a Grok-owned compatibility surface. The only
+  shared ACP change is a narrow optional allowlist for advertised headless auth methods, demonstrated by the released
+  Grok login behavior; generic session/model contracts do not widen.
 - Prompt capability does not advertise images in the reviewed source. Initial Grok support is text/embedded-context
   only and must not claim image attachment support.
 - `session/close` releases a resident session but does not delete Grok persistence. Sesori deletion therefore keeps the
@@ -60,14 +67,15 @@ is corrected before production code relies on the mismatch.
 
 - Plugin ID is `grok`; display name is `Grok Build`.
 - Use the user's installed `grok` binary from PATH, or authoritative `--grok-bin <path>`.
-- Set the initial minimum and target versions to the released binary verified in Step 2. A lower floor is allowed only
-  with direct release evidence for every required capability.
+- Set the initial minimum and target versions to `1.0.5`, the released binary validated during Step 2 research. A lower
+  floor is allowed only with direct release evidence for every required capability.
 - Do not add a managed install. Grok already has an official six-target installer and self-update flow; Sesori will not
   duplicate it without a separate product request and immutable artifact-digest review.
 - Launch a dedicated process with auto-update and leader attachment disabled, but keep ask-mode permissions enabled.
 - Setup inspection is runtime-only. It never reads credential contents, invokes login, starts an ACP server, or treats
-  the mere presence of `auth.json` as proof. The live ACP initialize/authenticate handshake is authoritative and an auth
-  failure flips the existing plugin setup state with local-login guidance.
+  the mere presence of `auth.json` as proof. The live ACP handshake authenticates only through an advertised
+  `xai.api_key` or `cached_token` method. An interactive-only method list becomes authentication-required immediately
+  without launching login, and the existing plugin setup state carries local-login guidance.
 - Grok model IDs remain opaque. Expose them under one Grok-owned provider grouping and send the exact model ID back to
   `session/set_model`; never split or infer provider identity from punctuation.
 - Reasoning options use exact advertised values as variant IDs and advertised labels as presentation. Unknown or
@@ -84,6 +92,8 @@ is corrected before production code relies on the mismatch.
 ### Included
 
 - New pure-Dart `bridge/sesori_plugin_grok/` package over `sesori_plugin_acp`.
+- One optional generic ACP auth-method allowlist policy hook so a headless plugin can reject advertised interactive
+  methods before `authenticate`; every existing ACP plugin retains its current default behavior.
 - Typed Grok model-state and reasoning-option DTOs with generated JSON parsing.
 - Grok-local ACP API, catalog repository, session-options service, binary definition, plugin implementation, and
   descriptor.
@@ -120,7 +130,9 @@ client <-> relay <-> bridge app <-> sesori_plugin_grok <-> grok agent --no-leade
 
 - `sesori_plugin_interface` remains unchanged and backend-neutral.
 - `sesori_plugin_acp` continues to own standard ACP transport, handshake, process recovery, derived projects, session
-  enumeration/load, turn lanes, event mapping, replay, cancellation, commands, and permission mechanics.
+  enumeration/load, turn lanes, event mapping, replay, cancellation, commands, and permission mechanics. It gains one
+  optional advertised-auth allowlist policy; the default remains unrestricted except for existing terminal-method
+  rejection.
 - `sesori_plugin_grok` owns every Grok identifier, CLI argument, version/setup rule, initialize identity check,
   deprecated model-state shape, reasoning metadata, model selection call, and Grok-facing error guidance.
 - Bridge app imports Grok only at `plugin_registry.dart`, its supported composition point.
@@ -154,7 +166,8 @@ plugin start -> standard ACP initialize
              -> seed last-good options/defaults
 
 explicit option refresh -> short-lived dedicated grok ACP process
-                        -> initialize/authenticate only
+                        -> initialize
+                        -> authenticate only through an advertised allowed headless method
                         -> map modelState
                         -> dispose without session/new
                         -> replace last-good catalog only on success
@@ -166,9 +179,11 @@ create/send -> validate exact requested model + variant against catalog
 ```
 
 A short-lived refresh process is justified by a normal user flow: Grok model configuration can change while the bridge
-runs, while the reviewed public ACP surface has no stable model-list request. It creates no session or durable state.
-Concurrent refreshes may duplicate this bounded probe; no Grok-specific lock or in-flight registry is added because the
-impact is low and bridge-owned option caching already limits ordinary calls.
+runs, while the reviewed public ACP surface has no stable model-list request. It creates no session. Released Grok
+initialize may create or update ordinary Grok-owned config, logs, agent identity, and empty session directories under
+`GROK_HOME`; those remain upstream-owned state, not a Sesori store. Concurrent refreshes may duplicate this bounded
+probe; no Grok-specific lock or in-flight registry is added because the impact is low and bridge-owned option caching
+already limits ordinary calls.
 
 ### Setup And Authentication
 
@@ -177,10 +192,10 @@ runtime states with sanitized guidance. `ensureRuntime` repeats the same read-on
 An explicit path is authoritative and never falls through to PATH.
 
 The descriptor does not inspect `HOME`, `GROK_HOME`, `auth.json`, model config, or environment-key contents. Those are
-incomplete evidence because Grok supports several auth methods and custom model credentials. The live ACP handshake
-selects the first non-terminal method through existing generic behavior. A rejected/no-usable method remains a typed
-`PluginAuthenticationRequiredException`, allowing bridge lifecycle code to block only Grok and show local
-`grok login`/credential guidance.
+incomplete evidence because Grok supports several auth methods and custom model credentials. After initialize, the
+Grok plugin allows only advertised `xai.api_key` and `cached_token` methods. No allowed method becomes a typed
+`PluginAuthenticationRequiredException` before any interactive auth call; a rejected allowed method produces the same
+typed failure. Bridge lifecycle code then blocks only Grok and shows local `grok login`/credential guidance.
 
 ## Compatibility And Security
 
@@ -192,7 +207,8 @@ selects the first non-terminal method through existing generic behavior. A rejec
 - `--no-leader` keeps subprocess/session lifecycle within the plugin generation rather than attaching to an unrelated
   shared daemon. `--no-auto-update` prevents the owned child from mutating its executable during bridge operation.
 - Credentials, auth payloads, model configuration, raw initialize metadata, prompts, transcripts, paths, and tool
-  payloads are never logged or persisted by new Grok-specific code.
+  payloads are never logged or persisted by new Grok-specific code. Interactive `grok.com`/OIDC methods are never
+  invoked by the headless bridge.
 - Grok's own provider traffic, telemetry, retention, and enterprise policy remain governed by the user's Grok
   configuration; Sesori neither weakens nor silently overrides them.
 - Unknown model metadata is ignored at the typed boundary. Exact recognized values are retained without interpretation.
@@ -251,8 +267,8 @@ closed analytics privacy contract forbidding coding provider/model names.
    - Add the ACP API, catalog repository/tracker, options service, exact model/effort mapping, refresh/last-good
      behavior, selection calls, and tests.
 4. `⚙️ [grok-harness] feat(grok): compose ACP sessions and turns [step 4/9]`
-   - Add `GrokPlugin`, initialize identity/catalog capture, standard ACP lifecycle hooks, stop-and-send/fail-closed
-     behavior, history/permission/tool conformance tests, and idempotent disposal.
+   - Add the optional generic advertised-auth allowlist hook, `GrokPlugin`, initialize identity/catalog capture,
+     standard ACP lifecycle hooks, stop-and-send/fail-closed behavior, conformance tests, and idempotent disposal.
 5. `⚙️ [grok-harness] feat(grok): add direct-CLI setup and lifecycle [step 5/9]`
    - Add descriptor version/setup probes, explicit/PATH precedence, ensureRuntime revalidation, production composition,
      crash/reconnect/auth degradation tests, and local setup guidance.
@@ -287,8 +303,9 @@ exceed the cap and an independently valid boundary exists. The fixed nine-step t
 
 - Create `bridge/sesori_plugin_grok/` with workspace metadata, exports, build options, `GrokPluginIdentity`,
   `GrokBinary`, and typed model-state DTOs.
-- Validate Grok 1.0.5 `--version`, exact agent argument ordering, initialize identity/capabilities, auth-method shape,
-  model metadata, permission mode, and clean process exit without creating a session.
+- Record the released 1.0.5 output (`grok 1.0.5 (5115b46bc909)`), exact accepted agent argument ordering,
+  initialize identity/capabilities, interactive-only logged-out auth shape, model metadata, permission mode, ordinary
+  initialize-owned state effects, and clean process exit without creating a session.
 - Store privacy-safe deterministic fixtures derived from structure, never credentials or real model/account payloads.
 - Add package parsing and launch-spec tests; do not register the plugin yet.
 
@@ -306,6 +323,8 @@ exceed the cap and an independently valid boundary exists. The fixed nine-step t
 
 ### Step 4/9: ACP plugin core
 
+- Add an optional ACP allowlist that chooses only an advertised allowed auth method; preserve every existing plugin's
+  default behavior and cover both allowed-method success and interactive-only immediate rejection.
 - Compose the existing ACP trackers/mapper/process factory with Grok-specific options.
 - Validate Grok identity metadata before accepting the connection and capture refreshed model state after new/load.
 - Use standard per-session concurrency, cancellation, permission handling, command tracking, list/load/replay/close,
@@ -419,8 +438,8 @@ Release matrix:
   black-box released behavior before code relies on it.
 - **Unstable model surface:** Grok uses an ACP model API removed from current stable ACP. Keep it plugin-local, validate
   identity/version, parse tolerantly, and fail closed before prompting.
-- **Authentication diversity:** file/env presence cannot prove every supported auth mode. Keep setup runtime-only and
-  the live handshake authoritative.
+- **Authentication diversity:** file/env presence cannot prove every supported auth mode. Keep setup runtime-only,
+  allow only advertised credential-backed headless methods, and reject an interactive-only list without invoking it.
 - **Permission safety:** accidentally passing yolo/always-approve would bypass the core product interaction. Assert the
   exact launch arguments and observe a real permission request before retirement.
 - **Leader ownership:** attaching to a shared leader would break generation ownership and shutdown assumptions. Assert

--- a/.plan/active/grok-harness/PLAN.md
+++ b/.plan/active/grok-harness/PLAN.md
@@ -103,8 +103,8 @@ is corrected before production code relies on the mismatch.
   resume, and close behavior inherited from the shared ACP implementation.
 - Pre-session model discovery from initialize metadata, explicit refresh through a short-lived initialize-only ACP
   process, exact model/effort selection, and last-good catalog retention.
-- Bridge registry/workspace/CI inventory, built-in `Harness.grok` identity, client name/logo mapping, README and
-  architecture documentation.
+- Bridge workspace/Makefile/CI inventory during package scaffolding, then app registry activation, built-in
+  `Harness.grok` identity, client name/logo mapping, README, and architecture documentation.
 - Regression-document reconciliation and live Grok verification through the matrix below.
 
 ### Excluded
@@ -146,10 +146,13 @@ client <-> relay <-> bridge app <-> sesori_plugin_grok <-> grok agent --no-leade
   `GrokSessionModelStateDto`: typed boundary parsing for the reviewed Grok wire shape.
 - `GrokAcpApi`: initialize-only catalog probe plus `session/set_model`; no business mapping.
 - `GrokCatalogRepository`: validates Grok initialize identity and maps exact model/effort values into a catalog.
+- `GrokSessionConfigRepository`: validates and delegates exact session-local model/effort writes to `GrokAcpApi`,
+  preserving the original failure as the cause of a typed operation error.
 - `GrokCatalogTracker`: sole owner of the last-good immutable catalog and its replace-on-success/retain-on-failure
   invariant across initialize capture, new/load capture, and explicit refresh.
-- `GrokSessionOptionsService`: consumes the repository and tracker to coordinate discovery, project one primary
-  agent/provider, and apply exact session-local selections before turns without storing duplicate catalog state.
+- `GrokSessionOptionsService`: consumes both repositories and the tracker to coordinate discovery, project one primary
+  agent/provider, and apply exact session-local selections before turns without storing duplicate catalog state or
+  calling the API layer directly.
 - `GrokPlugin`: thin `AcpPlugin` specialization that captures initialize/new/load model state, exposes options, opts
   into fail-closed selection and stop-and-send, and delegates Grok-specific work.
 - `GrokPluginDescriptor`: CLI option, version/setup probes, pre-start runtime validation, composition, and lifecycle.
@@ -172,9 +175,10 @@ explicit option refresh -> short-lived dedicated grok ACP process
                         -> dispose without session/new
                         -> replace last-good catalog only on success
 
-create/send -> validate exact requested model + variant against catalog
-            -> session/set_model(sessionId, modelId, _meta.reasoningEffort?)
-            -> record selection only after success
+create/send -> service validates requested model + variant against catalog
+            -> GrokSessionConfigRepository
+            -> GrokAcpApi.session/set_model(sessionId, modelId, _meta.reasoningEffort?)
+            -> record selection only after repository success
             -> standard ACP session/prompt
 ```
 
@@ -206,9 +210,10 @@ typed failure. Bridge lifecycle code then blocks only Grok and shows local `grok
   under Grok's own permission/sandbox policy and standard ACP approvals remain phone-mediated.
 - `--no-leader` keeps subprocess/session lifecycle within the plugin generation rather than attaching to an unrelated
   shared daemon. `--no-auto-update` prevents the owned child from mutating its executable during bridge operation.
-- Credentials, auth payloads, model configuration, raw initialize metadata, prompts, transcripts, paths, and tool
-  payloads are never logged or persisted by new Grok-specific code. Interactive `grok.com`/OIDC methods are never
-  invoked by the headless bridge.
+- Credentials, auth payloads, model configuration values, raw initialize metadata, prompts, transcripts, and tool
+  payloads are never logged or persisted by new Grok-specific code. Local diagnostics preserve useful executable paths,
+  operation context, caught errors, and stack traces. Interactive `grok.com`/OIDC methods are never invoked by the
+  headless bridge.
 - Grok's own provider traffic, telemetry, retention, and enterprise policy remain governed by the user's Grok
   configuration; Sesori neither weakens nor silently overrides them.
 - Unknown model metadata is ignored at the typed boundary. Exact recognized values are retained without interpretation.
@@ -261,11 +266,11 @@ closed analytics privacy contract forbidding coding provider/model names.
 1. `🌱 [grok-harness] docs: plan Grok Build harness support [step 1/9]`
    - Add and architecture-review this plan/tracker; no production behavior.
 2. `🌿 [grok-harness] feat(grok): scaffold the Grok plugin package [step 2/9]`
-   - Add the workspace package, identity, binary launch spec, typed DTOs/fixtures, released-binary contract evidence,
-     and focused parsing/launch tests. Freeze the validated floor and invocation.
+   - Add the package plus bridge workspace/Makefile/CI inventory, identity, binary launch spec, typed DTOs/fixtures,
+     released-binary contract evidence, and focused parsing/launch tests. Freeze the validated floor and invocation.
 3. `⚙️ [grok-harness] feat(grok): expose models and reasoning effort [step 3/9]`
-   - Add the ACP API, catalog repository/tracker, options service, exact model/effort mapping, refresh/last-good
-     behavior, selection calls, and tests.
+   - Add the ACP API, catalog/config repositories, tracker, options service, exact model/effort mapping,
+     refresh/last-good behavior, selection calls, and direct collaborator tests without production plugin hooks.
 4. `⚙️ [grok-harness] feat(grok): compose ACP sessions and turns [step 4/9]`
    - Add the optional generic advertised-auth allowlist hook, `GrokPlugin`, initialize identity/catalog capture,
      standard ACP lifecycle hooks, stop-and-send/fail-closed behavior, conformance tests, and idempotent disposal.
@@ -286,9 +291,9 @@ closed analytics privacy contract forbidding coding provider/model names.
      plan to `.plan/completed/grok-harness/`, and update the tracker.
 
 Each step targets fewer than 1,500 changed lines, including tests and generated output. Step 3 may approach that cap
-because its typed generated DTOs and behavioral tests are one coherent mapping boundary; split only if measured changed
-lines
-exceed the cap and an independently valid boundary exists. The fixed nine-step total otherwise remains unchanged.
+because its typed generated DTOs and behavioral tests are one coherent mapping boundary; split only if measured
+changed lines exceed the cap and an independently valid boundary exists. The fixed nine-step total otherwise remains
+unchanged.
 
 ## Step Details
 
@@ -302,7 +307,9 @@ exceed the cap and an independently valid boundary exists. The fixed nine-step t
 ### Step 2/9: Scaffold and pin the released contract
 
 - Create `bridge/sesori_plugin_grok/` with workspace metadata, exports, build options, `GrokPluginIdentity`,
-  `GrokBinary`, and typed model-state DTOs.
+  `GrokBinary`, and typed model-state DTOs. Add it to `bridge/pubspec.yaml`, `bridge/Makefile`, and package-level CI
+  inventory now so resolution, generation, analysis, and tests run from this step onward; do not add the app dependency
+  or production registry entry yet.
 - Record the released 1.0.5 output (`grok 1.0.5 (5115b46bc909)`), exact accepted agent argument ordering,
   initialize identity/capabilities, interactive-only logged-out auth shape, model metadata, permission mode, ordinary
   initialize-owned state effects, and clean process exit without creating a session.
@@ -312,20 +319,23 @@ exceed the cap and an independently valid boundary exists. The fixed nine-step t
 ### Step 3/9: Models and reasoning effort
 
 - Implement typed initialize/new/load model-state mapping with exact opaque model IDs.
-- Add `GrokCatalogTracker` as the only owner of last-good catalog replacement and retention.
+- Add `GrokCatalogRepository`, `GrokSessionConfigRepository`, and `GrokCatalogTracker`; the tracker alone owns last-good
+  catalog replacement and retention.
 - Expose one primary Grok agent and one Grok-owned provider group; map per-model reasoning options to variants.
-- Route production initialize, new/load capture, and explicit initialize-only refresh through the tracker; a failed
-  refresh retains its prior catalog.
-- Send exact model plus optional `_meta.reasoningEffort` through `session/set_model` before a turn; reject unknown/stale
-  selections and retain original causes.
+- Exercise initialize/new/load capture and explicit initialize-only refresh directly through the repository, tracker,
+  and service; a failed refresh retains the prior catalog. Production `AcpPlugin` hook wiring waits for Step 4.
+- Send exact model plus optional `_meta.reasoningEffort` from service through the configuration repository before a
+  turn; reject unknown/stale selections, preserve original causes, and never call the API layer from the service.
 - Cover malformed peers, empty/partial catalogs, default ordering, refresh failure, model-only/effort-only changes, and
-  no partial tracker write.
+  no partial tracker write through direct collaborator tests.
 
 ### Step 4/9: ACP plugin core
 
 - Add an optional ACP allowlist that chooses only an advertised allowed auth method; preserve every existing plugin's
   default behavior and cover both allowed-method success and interactive-only immediate rejection.
 - Compose the existing ACP trackers/mapper/process factory with Grok-specific options.
+- Wire production initialize/new/load capture, explicit refresh, and pre-turn selection into the Step 3 repository,
+  tracker, and service collaborators.
 - Validate Grok identity metadata before accepting the connection and capture refreshed model state after new/load.
 - Use standard per-session concurrency, cancellation, permission handling, command tracking, list/load/replay/close,
   and crash recovery. Enable stop-and-send and fail-closed selection only where Grok's verified behavior requires them.
@@ -344,8 +354,8 @@ exceed the cap and an independently valid boundary exists. The fixed nine-step t
 ### Step 6/9: Activate the bridge
 
 - Add the app dependency and descriptor to `knownPlugins`; add `Harness.grok` so exact registry tests remain true.
-- Update bridge workspace/Makefile/module order, package inventories, app docs, root architecture, and relevant CI/test
-  fixtures.
+- Update app composition docs, root architecture, built-in/exact-set inventories, and activation-specific test fixtures;
+  package workspace/Makefile/CI registration already landed in Step 2.
 - Preserve OpenCode as preferred default. Grok is eligible by default but starts only on demand after setup allows it.
 - Verify unknown older clients remain safe because transport IDs are strings.
 
@@ -376,7 +386,10 @@ unchanged because Grok deliberately has no managed install.
 
 ### Step 9/9: Verify and retire
 
-- Run focused package/app/client tests and analyzers after the final code state.
+- Run `architecture-implementation-review` through a sub-agent over the Git-defined Step 2-7 production commit/PR
+  range after all architecture-bearing changes are present. Resolve valid in-scope findings before retirement, using at
+  most the two review passes allowed by repository policy.
+- Run focused package/app/client tests and analyzers after the final code state and any review fixes.
 - Execute the matrix below with a real supported Grok release and account.
 - Record Pass/Partial/Fail/Blocked with privacy-safe evidence and cleanup in `TRACKER.md`.
 - Do not retire on incomplete required coverage unless the user explicitly accepts a named reduction in this plan.

--- a/.plan/active/grok-harness/PLAN.md
+++ b/.plan/active/grok-harness/PLAN.md
@@ -78,8 +78,9 @@ is corrected before production code relies on the mismatch.
   without launching login, and the existing plugin setup state carries local-login guidance.
 - Grok model IDs remain opaque. Expose them under one Grok-owned provider grouping and send the exact model ID back to
   `session/set_model`; never split or infer provider identity from punctuation.
-- Reasoning options use exact advertised values as variant IDs and advertised labels as presentation. Unknown or
-  malformed options are skipped without rejecting otherwise usable models.
+- Reasoning options use exact advertised canonical values as both variant IDs and visible strings. The current
+  bridge/client contract carries only `List<String>` variants, so Grok's separate labels/descriptions are not
+  transported in initial support. Unknown or malformed options are skipped without rejecting otherwise usable models.
 - A requested model/effort change must succeed before prompt dispatch. On failure, preserve the original error as the
   cause, fail the accepted turn visibly, and do not record a partially applied selection.
 - Only standard ACP permission requests are supported. No Grok-specific question protocol or automatic approval is
@@ -321,7 +322,8 @@ unchanged.
 - Implement typed initialize/new/load model-state mapping with exact opaque model IDs.
 - Add `GrokCatalogRepository`, `GrokSessionConfigRepository`, and `GrokCatalogTracker`; the tracker alone owns last-good
   catalog replacement and retention.
-- Expose one primary Grok agent and one Grok-owned provider group; map per-model reasoning options to variants.
+- Expose one primary Grok agent and one Grok-owned provider group; map each per-model reasoning option's exact canonical
+  value to the existing string variant contract without claiming separate label support.
 - Exercise initialize/new/load capture and explicit initialize-only refresh directly through the repository, tracker,
   and service; a failed refresh retains the prior catalog. Production `AcpPlugin` hook wiring waits for Step 4.
 - Send exact model plus optional `_meta.reasoningEffort` from service through the configuration repository before a

--- a/.plan/active/grok-harness/PLAN.md
+++ b/.plan/active/grok-harness/PLAN.md
@@ -1,0 +1,443 @@
+# Grok Build Harness Support
+
+## Status
+
+- **Plan slug:** `grok-harness`
+- **Status:** active; Step 1/9 in progress
+- **Plan date:** 2026-08-27
+- **Implementation base:** `origin/main`
+- **Delivery:** nine PRs with fixed titles and order below
+- **Initial product scope:** user-installed Grok Build CLI; no bridge-managed runtime installation
+
+## Goal
+
+Add xAI's Grok Build CLI as a first-class Sesori harness through its official ACP v1 stdio mode. A configured
+Grok installation should appear in harness settings, import persisted Grok sessions, create and continue sessions,
+stream messages/reasoning/tools, request phone-mediated permissions, expose selectable models and reasoning effort,
+replay history, abort work, and recover after plugin or bridge restart.
+
+This plan deliberately integrates the Grok **harness**. Merely using an xAI model through an existing OpenCode or Pi
+provider remains a separate configuration path and needs no Grok plugin.
+
+## Authoritative Upstream Facts
+
+Research baseline:
+
+- Grok Build stable channel: `1.0.5` from <https://x.ai/cli/stable> on 2026-08-27.
+- Public source snapshot: `xai-org/grok-build` commit `9684fa3cdbf2995e30ea8b9b637f1db008f144fc`, synced
+  from monorepo revision `70ec060ec3d28e77b9c4593be43c2ab0128bcd21`.
+- Official agent-mode documentation:
+  <https://github.com/xai-org/grok-build/blob/main/crates/codegen/xai-grok-pager/docs/user-guide/15-agent-mode.md>.
+
+Facts verified in that documentation and source:
+
+- The local ACP entry point is `grok agent stdio`; ACP is JSON-RPC 2.0 over newline-delimited stdio.
+- `initialize` negotiates ACP protocol version 1 and advertises standard load plus session list, resume, and close.
+- Standard ACP owns session creation, load/replay, resume, prompt streaming, cancellation, tool updates, and permission
+  requests.
+- Normal ask mode remains active unless the caller passes `--always-approve`/`--yolo`. Sesori must not pass either.
+- `--no-leader` forces the spawned process to own its local agent rather than attaching to Grok's shared leader.
+- `--no-auto-update` suppresses update checks for an embedded/headless process.
+- Authentication is local to the bridge machine through `grok login`, `XAI_API_KEY`, enterprise auth, or a configured
+  custom model. ACP advertises usable auth methods and `authenticate` is the runtime authority.
+- Initialize metadata includes `grokShell`, `agentVersion`, and pre-session `modelState`. New/load responses also carry
+  Grok's model state.
+- Grok 1.0.5 still exposes the older ACP `models` shape and `session/set_model`. Reasoning effort is carried in model
+  metadata (`supportsReasoningEffort`, `reasoningEfforts`, and `reasoningEffort`) and selected through
+  `_meta.reasoningEffort` on `session/set_model`.
+- The model surface is no longer part of current stable ACP. It is therefore a Grok-owned compatibility surface, not a
+  reason to widen generic `sesori_plugin_acp` contracts.
+- Prompt capability does not advertise images in the reviewed source. Initial Grok support is text/embedded-context
+  only and must not claim image attachment support.
+- `session/close` releases a resident session but does not delete Grok persistence. Sesori deletion therefore keeps the
+  existing local tombstone behavior and does not invoke `grok sessions delete` in this plan.
+
+Step 2 must validate the released `1.0.5` binary itself before freezing `minVersion`, launch argument ordering, model
+fixtures, and setup expectations. If the binary contradicts these source facts, the released binary wins and this plan
+is corrected before production code relies on the mismatch.
+
+## Locked Product Decisions
+
+- Plugin ID is `grok`; display name is `Grok Build`.
+- Use the user's installed `grok` binary from PATH, or authoritative `--grok-bin <path>`.
+- Set the initial minimum and target versions to the released binary verified in Step 2. A lower floor is allowed only
+  with direct release evidence for every required capability.
+- Do not add a managed install. Grok already has an official six-target installer and self-update flow; Sesori will not
+  duplicate it without a separate product request and immutable artifact-digest review.
+- Launch a dedicated process with auto-update and leader attachment disabled, but keep ask-mode permissions enabled.
+- Setup inspection is runtime-only. It never reads credential contents, invokes login, starts an ACP server, or treats
+  the mere presence of `auth.json` as proof. The live ACP initialize/authenticate handshake is authoritative and an auth
+  failure flips the existing plugin setup state with local-login guidance.
+- Grok model IDs remain opaque. Expose them under one Grok-owned provider grouping and send the exact model ID back to
+  `session/set_model`; never split or infer provider identity from punctuation.
+- Reasoning options use exact advertised values as variant IDs and advertised labels as presentation. Unknown or
+  malformed options are skipped without rejecting otherwise usable models.
+- A requested model/effort change must succeed before prompt dispatch. On failure, preserve the original error as the
+  cause, fail the accepted turn visibly, and do not record a partially applied selection.
+- Only standard ACP permission requests are supported. No Grok-specific question protocol or automatic approval is
+  invented.
+- Existing generic plugin analytics remain unchanged. No Grok-specific event is added because no new product decision
+  requires one, and analytics policy forbids provider/model names.
+
+## Scope
+
+### Included
+
+- New pure-Dart `bridge/sesori_plugin_grok/` package over `sesori_plugin_acp`.
+- Typed Grok model-state and reasoning-option DTOs with generated JSON parsing.
+- Grok-local ACP API, catalog repository, session-options service, binary definition, plugin implementation, and
+  descriptor.
+- Runtime version probing, explicit/PATH precedence, read-only setup inspection, pre-start revalidation, dedicated ACP
+  process ownership, crash degradation/reconnect, and idempotent shutdown.
+- Standard ACP session import, creation, prompt/command delivery, streaming, permissions, abort, history replay,
+  resume, and close behavior inherited from the shared ACP implementation.
+- Pre-session model discovery from initialize metadata, explicit refresh through a short-lived initialize-only ACP
+  process, exact model/effort selection, and last-good catalog retention.
+- Bridge registry/workspace/CI inventory, built-in `Harness.grok` identity, client name/logo mapping, README and
+  architecture documentation.
+- Regression-document reconciliation and live Grok verification through the matrix below.
+
+### Excluded
+
+- Bridge-managed Grok download, installation, upgrade, rollback, or artifact checksums.
+- Browser/device login through the phone; users authenticate locally with Grok's supported flows.
+- Grok hosted WebSocket/relay mode, leader mode, cloud sandboxes, dashboard, plugins, or Grok-specific `x.ai/*`
+  extensions not required for the listed behavior.
+- Image prompts until Grok advertises and successfully verifies the standard ACP image capability.
+- Upstream session deletion, session fork/rewind, quota display, worktree APIs, or import from another harness.
+- Parsing model IDs to infer provider/family/release metadata.
+- New database tables, columns, bridge/client transport fields, preferences, routes, analytics events, or compatibility
+  shims.
+
+## Architecture
+
+```text
+client <-> relay <-> bridge app <-> sesori_plugin_grok <-> grok agent --no-leader stdio
+                                  \-> sesori_plugin_acp (standard ACP ownership)
+```
+
+### Ownership Boundaries
+
+- `sesori_plugin_interface` remains unchanged and backend-neutral.
+- `sesori_plugin_acp` continues to own standard ACP transport, handshake, process recovery, derived projects, session
+  enumeration/load, turn lanes, event mapping, replay, cancellation, commands, and permission mechanics.
+- `sesori_plugin_grok` owns every Grok identifier, CLI argument, version/setup rule, initialize identity check,
+  deprecated model-state shape, reasoning metadata, model selection call, and Grok-facing error guidance.
+- Bridge app imports Grok only at `plugin_registry.dart`, its supported composition point.
+- Client behavior continues to use opaque plugin IDs; only the built-in presentation mapping recognizes `grok`.
+
+### Planned Grok Collaborators
+
+- `GrokPluginIdentity`: stable `grok` ID and `Grok Build` display name.
+- `GrokBinary`: default executable and dedicated ACP launch spec.
+- `GrokModelInfoDto`, `GrokModelMetadataDto`, `GrokReasoningEffortOptionDto`, and
+  `GrokSessionModelStateDto`: typed boundary parsing for the reviewed Grok wire shape.
+- `GrokAcpApi`: initialize-only catalog probe plus `session/set_model`; no business mapping.
+- `GrokCatalogRepository`: validates Grok initialize identity and maps exact model/effort values into a catalog.
+- `GrokCatalogTracker`: sole owner of the last-good immutable catalog and its replace-on-success/retain-on-failure
+  invariant across initialize capture, new/load capture, and explicit refresh.
+- `GrokSessionOptionsService`: consumes the repository and tracker to coordinate discovery, project one primary
+  agent/provider, and apply exact session-local selections before turns without storing duplicate catalog state.
+- `GrokPlugin`: thin `AcpPlugin` specialization that captures initialize/new/load model state, exposes options, opts
+  into fail-closed selection and stop-and-send, and delegates Grok-specific work.
+- `GrokPluginDescriptor`: CLI option, version/setup probes, pre-start runtime validation, composition, and lifecycle.
+
+No Grok event mapper, approval registry, process supervisor, persistence store, timer, lock, dedupe set, or custom
+session registry is planned because standard ACP already owns those concerns.
+
+### Catalog And Selection Flow
+
+```text
+plugin start -> standard ACP initialize
+             -> validate grokShell + version metadata
+             -> map initialize._meta.modelState
+             -> seed last-good options/defaults
+
+explicit option refresh -> short-lived dedicated grok ACP process
+                        -> initialize/authenticate only
+                        -> map modelState
+                        -> dispose without session/new
+                        -> replace last-good catalog only on success
+
+create/send -> validate exact requested model + variant against catalog
+            -> session/set_model(sessionId, modelId, _meta.reasoningEffort?)
+            -> record selection only after success
+            -> standard ACP session/prompt
+```
+
+A short-lived refresh process is justified by a normal user flow: Grok model configuration can change while the bridge
+runs, while the reviewed public ACP surface has no stable model-list request. It creates no session or durable state.
+Concurrent refreshes may duplicate this bounded probe; no Grok-specific lock or in-flight registry is added because the
+impact is low and bridge-owned option caching already limits ordinary calls.
+
+### Setup And Authentication
+
+`inspectSetup` runs a bounded `--version` probe only. It classifies missing, malformed, below-floor, ready, and unknown
+runtime states with sanitized guidance. `ensureRuntime` repeats the same read-only resolution immediately before start.
+An explicit path is authoritative and never falls through to PATH.
+
+The descriptor does not inspect `HOME`, `GROK_HOME`, `auth.json`, model config, or environment-key contents. Those are
+incomplete evidence because Grok supports several auth methods and custom model credentials. The live ACP handshake
+selects the first non-terminal method through existing generic behavior. A rejected/no-usable method remains a typed
+`PluginAuthenticationRequiredException`, allowing bridge lifecycle code to block only Grok and show local
+`grok login`/credential guidance.
+
+## Compatibility And Security
+
+- Plugin IDs remain strings on the wire. Older clients show the generic icon and bridge-provided name; newer clients
+  connected to an older bridge receive no Grok entry.
+- No public production compatibility baseline contains Grok, so package-internal contracts can be introduced cleanly.
+- No `--always-approve`, `--yolo`, client terminal, or client filesystem capability is enabled. Grok's local tools run
+  under Grok's own permission/sandbox policy and standard ACP approvals remain phone-mediated.
+- `--no-leader` keeps subprocess/session lifecycle within the plugin generation rather than attaching to an unrelated
+  shared daemon. `--no-auto-update` prevents the owned child from mutating its executable during bridge operation.
+- Credentials, auth payloads, model configuration, raw initialize metadata, prompts, transcripts, paths, and tool
+  payloads are never logged or persisted by new Grok-specific code.
+- Grok's own provider traffic, telemetry, retention, and enterprise policy remain governed by the user's Grok
+  configuration; Sesori neither weakens nor silently overrides them.
+- Unknown model metadata is ignored at the typed boundary. Exact recognized values are retained without interpretation.
+- Standard close is used only for lifecycle cleanup; local deletion retains a plugin-scoped tombstone so an upstream
+  Grok row cannot reappear through later explicit import.
+
+## Complexity Budget And Cleanup
+
+New persistent mutable state:
+
+- None in Sesori. Existing session/catalog/history tables and tombstones are reused.
+- Grok continues to own its existing session/auth/config files; Sesori does not mutate their layout directly.
+
+New in-memory mutable state:
+
+- One last-good immutable Grok model catalog owned by `GrokCatalogTracker` inside the plugin generation. It is required
+  so options remain usable after a failed explicit refresh; initialize, new/load capture, and refresh all replace it
+  through that one owner.
+- Existing `AcpSessionConfigurationTracker` owns process defaults and per-session model identity. The service and plugin
+  store no duplicate catalog or selection map.
+
+Deliberately omitted coordination:
+
+- No refresh mutex, process pool, background watcher, timer, reconnect registry, auth cache, model-ID parser, or
+  secondary command/approval tracker.
+- No managed-runtime state or installer lifecycle.
+- No compatibility migration or database backfill.
+
+Cleanup assessment:
+
+- No existing field, route, cache, setting, listener, job, or compatibility path becomes obsolete.
+- Directly caused cleanup is limited to keeping hard-coded workspace/module/registry/branding inventories exact. Git
+  history remains the audit trail; no tombstone documentation for unshipped behavior is added.
+
+Evidence level for safeguards:
+
+- Dedicated process ownership, disabled auto-update, fail-closed selection, and permission ask mode protect ordinary
+  launch/turn flows with meaningful lifecycle or security impact.
+- Last-good catalog retention protects an ordinary explicit refresh failure.
+- Duplicate concurrent refresh probes are accepted as bounded and self-correcting rather than adding coordination.
+
+## Analytics Assessment
+
+No event is added. Existing authoritative session-creation and turn outcomes already measure generic product use without
+exposing harness/model identity. A Grok-specific event would not answer an approved decision and would conflict with the
+closed analytics privacy contract forbidding coding provider/model names.
+
+## Delivery Steps
+
+1. `🌱 [grok-harness] docs: plan Grok Build harness support [step 1/9]`
+   - Add and architecture-review this plan/tracker; no production behavior.
+2. `🌿 [grok-harness] feat(grok): scaffold the Grok plugin package [step 2/9]`
+   - Add the workspace package, identity, binary launch spec, typed DTOs/fixtures, released-binary contract evidence,
+     and focused parsing/launch tests. Freeze the validated floor and invocation.
+3. `⚙️ [grok-harness] feat(grok): expose models and reasoning effort [step 3/9]`
+   - Add the ACP API, catalog repository/tracker, options service, exact model/effort mapping, refresh/last-good
+     behavior, selection calls, and tests.
+4. `⚙️ [grok-harness] feat(grok): compose ACP sessions and turns [step 4/9]`
+   - Add `GrokPlugin`, initialize identity/catalog capture, standard ACP lifecycle hooks, stop-and-send/fail-closed
+     behavior, history/permission/tool conformance tests, and idempotent disposal.
+5. `⚙️ [grok-harness] feat(grok): add direct-CLI setup and lifecycle [step 5/9]`
+   - Add descriptor version/setup probes, explicit/PATH precedence, ensureRuntime revalidation, production composition,
+     crash/reconnect/auth degradation tests, and local setup guidance.
+6. `⚙️ [grok-harness] feat(bridge): activate Grok Build [step 6/9]`
+   - Add app dependency/registry and built-in identity, update exact-set fixtures and architecture inventories, enable
+     Grok by default, and verify backend-neutral listing/routing.
+7. `🌿 [grok-harness] feat(client): brand Grok Build [step 7/9]`
+   - Add approved official light/dark artwork, built-in name mapping, widget tests, README support/setup/security notes,
+     and unknown-ID fallback coverage.
+8. `🌱 [grok-harness] docs: reconcile Grok regression coverage [step 8/9]`
+   - Penultimate step: update affected `docs/regression/` contracts, matrices, sources, and honest limitations without
+     changing unrelated historical gaps.
+9. `⚙️ [grok-harness] test: verify Grok and retire the plan [step 9/9]`
+   - Run and record the required matrix against the released Grok binary, fix only in-scope defects, move the passing
+     plan to `.plan/completed/grok-harness/`, and update the tracker.
+
+Each step targets fewer than 1,500 changed lines, including tests and generated output. Step 3 may approach that cap
+because its typed generated DTOs and behavioral tests are one coherent mapping boundary; split only if measured changed
+lines
+exceed the cap and an independently valid boundary exists. The fixed nine-step total otherwise remains unchanged.
+
+## Step Details
+
+### Step 1/9: Plan Grok support
+
+- Record source-backed protocol facts, ownership, product limits, complexity budget, exact PR series, and retirement
+  matrix.
+- Run `architecture-plan-review` through a sub-agent and apply valid in-scope findings directly.
+- Validate only plan Markdown, links/paths, exact titles, and Git whitespace.
+
+### Step 2/9: Scaffold and pin the released contract
+
+- Create `bridge/sesori_plugin_grok/` with workspace metadata, exports, build options, `GrokPluginIdentity`,
+  `GrokBinary`, and typed model-state DTOs.
+- Validate Grok 1.0.5 `--version`, exact agent argument ordering, initialize identity/capabilities, auth-method shape,
+  model metadata, permission mode, and clean process exit without creating a session.
+- Store privacy-safe deterministic fixtures derived from structure, never credentials or real model/account payloads.
+- Add package parsing and launch-spec tests; do not register the plugin yet.
+
+### Step 3/9: Models and reasoning effort
+
+- Implement typed initialize/new/load model-state mapping with exact opaque model IDs.
+- Add `GrokCatalogTracker` as the only owner of last-good catalog replacement and retention.
+- Expose one primary Grok agent and one Grok-owned provider group; map per-model reasoning options to variants.
+- Route production initialize, new/load capture, and explicit initialize-only refresh through the tracker; a failed
+  refresh retains its prior catalog.
+- Send exact model plus optional `_meta.reasoningEffort` through `session/set_model` before a turn; reject unknown/stale
+  selections and retain original causes.
+- Cover malformed peers, empty/partial catalogs, default ordering, refresh failure, model-only/effort-only changes, and
+  no partial tracker write.
+
+### Step 4/9: ACP plugin core
+
+- Compose the existing ACP trackers/mapper/process factory with Grok-specific options.
+- Validate Grok identity metadata before accepting the connection and capture refreshed model state after new/load.
+- Use standard per-session concurrency, cancellation, permission handling, command tracking, list/load/replay/close,
+  and crash recovery. Enable stop-and-send and fail-closed selection only where Grok's verified behavior requires them.
+- Cover two sessions, accepted-send timing, cancellation, tool/reasoning mapping, permissions, history suppression,
+  reconnect, and disposal with deterministic ACP fakes.
+
+### Step 5/9: Descriptor and setup
+
+- Add `--grok-bin`, version parsing/floor, bounded output, explicit/PATH precedence, read-only setup classification,
+  ensureRuntime revalidation, and sanitized local install/login guidance.
+- Launch through `PluginHost.processes`; never call `io.Process.start` directly.
+- Compose one `AcpBridgePlugin`, connect within a bounded budget, and degrade only Grok on auth/start/crash failure.
+- Cover missing/malformed/outdated/current binaries, explicit-path authority, aborts, auth rejection, crash/reconnect,
+  reported version, and clean owned shutdown.
+
+### Step 6/9: Activate the bridge
+
+- Add the app dependency and descriptor to `knownPlugins`; add `Harness.grok` so exact registry tests remain true.
+- Update bridge workspace/Makefile/module order, package inventories, app docs, root architecture, and relevant CI/test
+  fixtures.
+- Preserve OpenCode as preferred default. Grok is eligible by default but starts only on demand after setup allows it.
+- Verify unknown older clients remain safe because transport IDs are strings.
+
+### Step 7/9: Brand and document
+
+- Source official Grok artwork from an xAI-controlled asset, record its origin, and add theme-appropriate SVGs without
+  embedding scripts, remote references, metadata, or unneeded complexity.
+- Extend `PregoBrandLogo` and tests for `grok`/`Grok Build`; retain generic fallback for unknown IDs.
+- Update README harness list and Grok notes: version floor, official install, `--grok-bin`, local auth, ask-mode
+  permissions, text-only attachments, model selection, session import, and retained upstream rows after local deletion.
+
+### Step 8/9: Reconcile regression documents
+
+Update at least:
+
+- `plugin-setup-and-lifecycle.md`
+- `projects-and-sessions.md`
+- `session-creation-and-options.md`
+- `session-turns.md`
+- `session-history-and-recovery.md`
+- `questions-and-permissions.md`
+- `tools-and-file-changes.md`
+- `session-archiving-and-deletion.md`
+
+Add `attachments-and-images.md` only if the implementation discovers an advertised image capability; otherwise keep the
+unsupported behavior in Grok support notes without manufacturing a feature claim. `plugin-runtime-installation.md` is
+unchanged because Grok deliberately has no managed install.
+
+### Step 9/9: Verify and retire
+
+- Run focused package/app/client tests and analyzers after the final code state.
+- Execute the matrix below with a real supported Grok release and account.
+- Record Pass/Partial/Fail/Blocked with privacy-safe evidence and cleanup in `TRACKER.md`.
+- Do not retire on incomplete required coverage unless the user explicitly accepts a named reduction in this plan.
+
+## Regression And Retirement Matrix
+
+Highest required level: **L3 Release** for every affected feature through Grok's complete authoritative boundary. L1-L3
+are cumulative. Existing non-Grok plugins need only unchanged automated registry/exact-set checks; the live matrix adds
+Grok as a newly supporting production plugin.
+
+Release matrix:
+
+- **Grok runtime:** released stable at or above the frozen Step 2 floor; record exact version.
+- **Bridge host:** macOS arm64 release-target host for live/client evidence; deterministic descriptor tests cover other
+  host-independent PATH behavior. No alternate-host packaged claim exists because there is no managed install.
+- **Client:** iOS simulator/device as the release-target client platform for L3 rendering and end-to-end flows.
+- **Account:** one locally authenticated Grok account/API-key/custom-model setup with at least two selectable models or
+  one model with two effort levels where the account catalog permits. Record only bounded capability presence, never
+  account/model identifiers.
+
+- **`plugin-setup-and-lifecycle.md`**
+  - Evidence: missing/malformed/below-floor/current PATH and explicit probes; inert registration; demand start; auth
+    failure isolation; version display; enable/disable/restart/idle override; branding and catalog refresh.
+  - Boundary: automated, headless bridge, live plugin, and client E2E.
+- **`projects-and-sessions.md`**
+  - Evidence: explicit import of persisted Grok sessions; DB-only ordinary reads; non-destructive re-import and plugin
+    attribution.
+  - Boundary: headless bridge and live plugin.
+- **`session-creation-and-options.md`**
+  - Evidence: current default, exact model IDs, advertised effort variants, stale rejection/refresh, creation, and
+    remembered plugin defaults.
+  - Boundary: automated, live plugin, and client E2E.
+- **`session-turns.md`**
+  - Evidence: text/reasoning/tool/status streaming, accepted-send timing, model/effort application, abort,
+    stop-and-send, two-session concurrency, visible failure, and idle completion.
+  - Boundary: live plugin and client E2E.
+- **`session-history-and-recovery.md`**
+  - Evidence: first load replay, long-session paging, live/replay parity, cold reopen, plugin restart, and bridge
+    restart.
+  - Boundary: headless bridge, live plugin, and client E2E.
+- **`questions-and-permissions.md`**
+  - Evidence: standard permission once/reject plus every advertised scope, exact session/tool correlation, abort
+    cleanup, and no auto-approval.
+  - Boundary: live plugin and client E2E.
+- **`tools-and-file-changes.md`**
+  - Evidence: tool lifecycle, bounded output, file diff content, and live/replay identity/status parity.
+  - Boundary: live plugin and client E2E.
+- **`session-archiving-and-deletion.md`**
+  - Evidence: archive/read-only behavior; active delete orders cancel/settle/close; local purge/tombstone prevents
+    re-import while the upstream row remains documented.
+  - Boundary: headless bridge, live plugin, and client E2E.
+- **Compatibility/presentation**
+  - Evidence: automated unknown-ID fallback and current-client Grok name/artwork; no new wire field or migration.
+  - Boundary: automated and client E2E.
+
+## Risks And Test Focus
+
+- **Released/source drift:** public source is a synchronized monorepo snapshot and may lead stable binaries. Step 2 pins
+  black-box released behavior before code relies on it.
+- **Unstable model surface:** Grok uses an ACP model API removed from current stable ACP. Keep it plugin-local, validate
+  identity/version, parse tolerantly, and fail closed before prompting.
+- **Authentication diversity:** file/env presence cannot prove every supported auth mode. Keep setup runtime-only and
+  the live handshake authoritative.
+- **Permission safety:** accidentally passing yolo/always-approve would bypass the core product interaction. Assert the
+  exact launch arguments and observe a real permission request before retirement.
+- **Leader ownership:** attaching to a shared leader would break generation ownership and shutdown assumptions. Assert
+  `--no-leader` and verify the owned child exits.
+- **Auto-update mutation:** a child update during operation could replace the runtime under the bridge. Assert
+  `--no-auto-update`; users update Grok out of band.
+- **Catalog refresh:** a second initialize-only process may fail or see a changing catalog. Replace only on complete
+  success and accept duplicate concurrent probes rather than adding coordination.
+- **History/delete semantics:** close is not delete. Verify tombstones prevent explicit re-import and document retained
+  Grok persistence honestly.
+- **Privacy:** keep model/account names, credentials, prompts, transcripts, paths, raw metadata, and logs out of
+  committed fixtures and verification evidence.
+
+## Expected Result
+
+A supported local Grok Build installation appears as a built-in, on-demand harness. Users can import or create Grok
+sessions, choose advertised models and reasoning effort, control ask-mode permissions, stream and recover work through
+the existing encrypted relay, and manage Grok independently of every other plugin. Sesori adds no credentials,
+database schema, transport shape, managed runtime, or Grok-specific analytics, and remains honest about text-only
+prompt support and retained upstream persistence after local deletion.

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -6,17 +6,18 @@
 - **Status:** Step 1/9 in PR
 - **Current branch:** `grok-code-harness-inquiry`
 - **Base:** `origin/main`
-- **Architecture plan review:** completed 2026-08-27; rejected one ownership issue, corrected below without re-review
+- **Architecture plan review:** approved 2026-08-27 after catalog ownership and auth-policy corrections
 - **Open PR:** #1152 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1152>
-- **Local successor:** not started
+- **Local successor:** `grok-harness-step-2-scaffold`; released-binary research started and held locally
 
 ## Fixed Series
 
 1. `🌱 [grok-harness] docs: plan Grok Build harness support [step 1/9]`
    - **State:** in PR #1152.
-   - **Evidence:** plan/tracker drafted; architecture finding corrected; titles, paths, line width, and whitespace pass.
+   - **Evidence:** current revision architecture-approved; released-binary facts, titles, paths, and whitespace pass.
 2. `🌿 [grok-harness] feat(grok): scaffold the Grok plugin package [step 2/9]`
-   - **State:** not started.
+   - **State:** started locally; held until #1152 merges.
+   - **Evidence:** isolated released 1.0.5 binary/version/help/initialize contract captured; package files not started.
 3. `⚙️ [grok-harness] feat(grok): expose models and reasoning effort [step 3/9]`
    - **State:** not started.
 4. `⚙️ [grok-harness] feat(grok): compose ACP sessions and turns [step 4/9]`
@@ -41,10 +42,12 @@
 - [x] Draft fixed scope, ownership, complexity budget, cleanup assessment, PR titles, and retirement matrix.
 - [x] Run architecture plan review through a sub-agent.
 - [x] Apply valid in-scope review findings and record the result.
-- [x] Validate Markdown paths/titles and `git diff --check`.
+- [x] Validate the released 1.0.5 binary and correct the plan's auth/state assumptions.
+- [x] Re-run architecture plan review for the material shared auth-policy hook; current revision approved.
+- [x] Revalidate Markdown paths/titles and `git diff --check` after that correction.
 - [x] Commit, push, and open Step 1 PR (#1152).
 - [x] Start the PR monitor.
-- [ ] Create the Step 2 successor branch in this worktree and begin package scaffolding locally.
+- [x] Create the Step 2 successor branch in this worktree and begin released-binary research locally.
 
 ## Decisions And Evidence
 
@@ -55,10 +58,18 @@
   authority across Grok login, API key, enterprise, and custom-model credentials.
 - 2026-08-27: Grok's removed-from-stable-ACP model surface remains package-local rather than changing generic ACP.
 - 2026-08-27: No database, transport, managed-runtime, analytics, or Grok-specific coordination state is planned.
+- 2026-08-27: Isolated Grok 1.0.5 (`5115b46bc909`) accepts
+  `--no-auto-update agent --no-leader stdio`, advertises ACP v1 list/load/resume/close, image false, embedded context,
+  two structurally valid model entries, and the documented reasoning metadata. Initialize creates ordinary Grok-owned
+  home/config/log/session-directory state but no session row.
+- 2026-08-27: A logged-out isolated process advertises only interactive `grok.com`. The generic first-nonterminal rule
+  would invoke it and wait for login input. The plan now adds one optional advertised-auth allowlist hook and allows
+  only Grok's `xai.api_key` and `cached_token`; an interactive-only list fails as authentication-required before a call.
 - 2026-08-27: Architecture plan review passed its pre-review gate and rejected one A2 ownership issue: the options
   service also owned last-good catalog state. The plan now gives that state and its replace/retain invariant solely to
   `GrokCatalogTracker`; the service consumes the tracker and stores no duplicate. Per repository policy, the valid
-  finding was applied directly and was not re-reviewed.
+  finding was applied directly. A later material auth-policy change justified one fresh review of the complete revised
+  plan; that current revision was approved with no findings.
 
 ## Required Final Evidence
 

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -45,6 +45,7 @@
 - [x] Validate the released 1.0.5 binary and correct the plan's auth/state assumptions.
 - [x] Re-run architecture plan review for the material shared auth-policy hook; current revision approved.
 - [x] Revalidate Markdown paths/titles and `git diff --check` after that correction.
+- [ ] Address all actionable #1152 review feedback and leave prefixed thread replies.
 - [x] Commit, push, and open Step 1 PR (#1152).
 - [x] Start the PR monitor.
 - [x] Create the Step 2 successor branch in this worktree and begin released-binary research locally.
@@ -70,6 +71,12 @@
   `GrokCatalogTracker`; the service consumes the tracker and stores no duplicate. Per repository policy, the valid
   finding was applied directly. A later material auth-policy change justified one fresh review of the complete revised
   plan; that current revision was approved with no findings.
+- 2026-08-27: #1152 review feedback added a configuration repository between service and API, moved
+  workspace/Makefile/CI registration into Step 2, moved production hook wiring into Step 4, preserved useful local
+  diagnostic paths, and
+  scheduled final Git-scoped architecture implementation review. The plan retains built-in `Harness.grok` branding
+  because identity/presentation is not backend behavior and the existing client contract intentionally maps built-ins;
+  it also retains penultimate regression reconciliation because that is the repository's mandated durable-plan flow.
 
 ## Required Final Evidence
 

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -3,17 +3,17 @@
 ## Current State
 
 - **Plan:** `.plan/active/grok-harness/PLAN.md`
-- **Status:** Step 1/9 ready to publish
+- **Status:** Step 1/9 in PR
 - **Current branch:** `grok-code-harness-inquiry`
 - **Base:** `origin/main`
 - **Architecture plan review:** completed 2026-08-27; rejected one ownership issue, corrected below without re-review
-- **Open PR:** none
+- **Open PR:** #1152 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1152>
 - **Local successor:** not started
 
 ## Fixed Series
 
 1. `🌱 [grok-harness] docs: plan Grok Build harness support [step 1/9]`
-   - **State:** ready to publish.
+   - **State:** in PR #1152.
    - **Evidence:** plan/tracker drafted; architecture finding corrected; titles, paths, line width, and whitespace pass.
 2. `🌿 [grok-harness] feat(grok): scaffold the Grok plugin package [step 2/9]`
    - **State:** not started.
@@ -42,8 +42,8 @@
 - [x] Run architecture plan review through a sub-agent.
 - [x] Apply valid in-scope review findings and record the result.
 - [x] Validate Markdown paths/titles and `git diff --check`.
-- [ ] Commit, push, and open Step 1 PR.
-- [ ] Start the PR monitor.
+- [x] Commit, push, and open Step 1 PR (#1152).
+- [x] Start the PR monitor.
 - [ ] Create the Step 2 successor branch in this worktree and begin package scaffolding locally.
 
 ## Decisions And Evidence

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -45,7 +45,7 @@
 - [x] Validate the released 1.0.5 binary and correct the plan's auth/state assumptions.
 - [x] Re-run architecture plan review for the material shared auth-policy hook; current revision approved.
 - [x] Revalidate Markdown paths/titles and `git diff --check` after that correction.
-- [ ] Address all actionable #1152 review feedback and leave prefixed thread replies.
+- [x] Address all actionable #1152 review feedback and leave prefixed thread replies.
 - [x] Commit, push, and open Step 1 PR (#1152).
 - [x] Start the PR monitor.
 - [x] Create the Step 2 successor branch in this worktree and begin released-binary research locally.

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -77,6 +77,9 @@
   scheduled final Git-scoped architecture implementation review. The plan retains built-in `Harness.grok` branding
   because identity/presentation is not backend behavior and the existing client contract intentionally maps built-ins;
   it also retains penultimate regression reconciliation because that is the repository's mandated durable-plan flow.
+- 2026-08-27: Follow-up #1152 feedback correctly identified that variants carry only strings. The plan now displays
+  exact canonical reasoning values and explicitly defers Grok's separate labels/descriptions instead of implying a
+  label-bearing transport/UI seam.
 
 ## Required Final Evidence
 

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -1,0 +1,74 @@
+# Grok Build Harness Support Tracker
+
+## Current State
+
+- **Plan:** `.plan/active/grok-harness/PLAN.md`
+- **Status:** Step 1/9 ready to publish
+- **Current branch:** `grok-code-harness-inquiry`
+- **Base:** `origin/main`
+- **Architecture plan review:** completed 2026-08-27; rejected one ownership issue, corrected below without re-review
+- **Open PR:** none
+- **Local successor:** not started
+
+## Fixed Series
+
+1. `🌱 [grok-harness] docs: plan Grok Build harness support [step 1/9]`
+   - **State:** ready to publish.
+   - **Evidence:** plan/tracker drafted; architecture finding corrected; titles, paths, line width, and whitespace pass.
+2. `🌿 [grok-harness] feat(grok): scaffold the Grok plugin package [step 2/9]`
+   - **State:** not started.
+3. `⚙️ [grok-harness] feat(grok): expose models and reasoning effort [step 3/9]`
+   - **State:** not started.
+4. `⚙️ [grok-harness] feat(grok): compose ACP sessions and turns [step 4/9]`
+   - **State:** not started.
+5. `⚙️ [grok-harness] feat(grok): add direct-CLI setup and lifecycle [step 5/9]`
+   - **State:** not started.
+6. `⚙️ [grok-harness] feat(bridge): activate Grok Build [step 6/9]`
+   - **State:** not started.
+7. `🌿 [grok-harness] feat(client): brand Grok Build [step 7/9]`
+   - **State:** not started.
+8. `🌱 [grok-harness] docs: reconcile Grok regression coverage [step 8/9]`
+   - **State:** not started.
+9. `⚙️ [grok-harness] test: verify Grok and retire the plan [step 9/9]`
+   - **State:** not started.
+
+## Step 1 Checklist
+
+- [x] Inspect repository instructions, current ACP/plugin architecture, Hermes precedent, and regression rules.
+- [x] Verify official Grok agent mode and current source-level ACP capabilities.
+- [x] Record the released stable pointer (`1.0.5`) and source snapshot identifiers.
+- [x] Assess analytics; no new event justified.
+- [x] Draft fixed scope, ownership, complexity budget, cleanup assessment, PR titles, and retirement matrix.
+- [x] Run architecture plan review through a sub-agent.
+- [x] Apply valid in-scope review findings and record the result.
+- [x] Validate Markdown paths/titles and `git diff --check`.
+- [ ] Commit, push, and open Step 1 PR.
+- [ ] Start the PR monitor.
+- [ ] Create the Step 2 successor branch in this worktree and begin package scaffolding locally.
+
+## Decisions And Evidence
+
+- 2026-08-27: Initial delivery is direct CLI only. Managed install is excluded because xAI owns an official installer
+  and self-update channel; Sesori has no current need to duplicate that lifecycle.
+- 2026-08-27: Grok launches without yolo/always-approve, with leader attachment and auto-update disabled.
+- 2026-08-27: Runtime setup inspection is intentionally not an authentication proof. The ACP handshake remains the
+  authority across Grok login, API key, enterprise, and custom-model credentials.
+- 2026-08-27: Grok's removed-from-stable-ACP model surface remains package-local rather than changing generic ACP.
+- 2026-08-27: No database, transport, managed-runtime, analytics, or Grok-specific coordination state is planned.
+- 2026-08-27: Architecture plan review passed its pre-review gate and rejected one A2 ownership issue: the options
+  service also owned last-good catalog state. The plan now gives that state and its replace/retain invariant solely to
+  `GrokCatalogTracker`; the service consumes the tracker and stores no duplicate. Per repository policy, the valid
+  finding was applied directly and was not re-reviewed.
+
+## Required Final Evidence
+
+Step 9 must record:
+
+- exact Grok release, bridge build/commit, bridge host, client build/platform, and bounded account capabilities;
+- automated package/app/client commands and results;
+- L3 matrix results for setup/lifecycle, projects/sessions, creation/options, turns, history/recovery,
+  permissions, tools/file changes, archiving/deletion, and compatibility/presentation;
+- privacy-safe live evidence, first divergent boundary for failures, and cleanup;
+- `Pass`, `Partial`, `Fail`, `Blocked`, or `Not run` for every matrix row.
+
+The plan stays active unless all required rows pass or the user explicitly accepts a named reduction in `PLAN.md`.


### PR DESCRIPTION
## Complexity

🌱 Trivial — documentation-only planning work with no production or persisted-state change.

## What

- Adds the active nine-step Grok Build harness implementation plan and tracker.
- Records the direct-CLI ACP architecture, security boundaries, fixed PR titles, complexity budget, and L3 retirement matrix.
- Incorporates black-box evidence from the released Grok 1.0.5 binary, including exact launch arguments, capabilities, model metadata, ordinary initialization state, and authentication behavior.
- Keeps Grok's legacy model-selection surface plugin-local and adds only one planned generic ACP hook: an optional allowlist for advertised headless authentication methods.
- Excludes managed installation from the initial scope.

## Why

Grok Build exposes an official ACP v1 stdio agent, so Sesori can add it through the existing plugin boundary without a custom transport. Released-binary validation also showed that the generic first-nonterminal auth rule would invoke Grok's interactive `grok.com` flow; the plan now rejects interactive-only method lists before calling authentication.

## Risk and test focus

Risk is low because this PR changes only planning documents. Review should focus on whether the released-binary assumptions, shared auth-policy hook, ownership boundaries, fixed delivery split, and required live/client verification are concrete and proportional.

The initial architecture review rejected one A2 ownership issue: the options service also owned last-good catalog state. The plan now gives that state solely to `GrokCatalogTracker`. Later released-binary evidence materially added the optional shared auth allowlist, so the complete revised plan received a fresh architecture review and was approved with no findings.

## Expected result

No user-visible or database impact. The repository gains an active, architecture-approved and implementation-ready Grok plan; production support remains unchanged until later steps merge.

## Verification

- Isolated Grok 1.0.5 (`5115b46bc909`) accepted `--no-auto-update agent --no-leader stdio` and returned the recorded ACP v1 structure.
- Plan/tracker contain the same nine exact titles in fixed order.
- Every referenced regression document exists.
- Markdown lines are within 120 characters.
- `git diff --check` passes.
- No Dart or Flutter suites were run for this documentation-only step.
