### PR TITLE
⚙️ [github-copilot-harness] feat(copilot): add the ACP harness package [step 2/7]

### DIFF
--- a/.plan/active/github-copilot-harness/PLAN.md
+++ b/.plan/active/github-copilot-harness/PLAN.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Plan slug:** `github-copilot-harness`
-- **Status:** active; Step 1/7 merged (#1154), Step 2/7 ready for review
+- **Status:** active; Step 1/7 merged (#1154), Step 2/7 in review (#1155)
 - **Plan date:** 2026-08-27
 - **Implementation base:** current `origin/main`
 - **Delivery:** seven PRs with the fixed titles below

--- a/.plan/active/github-copilot-harness/PLAN.md
+++ b/.plan/active/github-copilot-harness/PLAN.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Plan slug:** `github-copilot-harness`
-- **Status:** active; Step 1/7 ready for review
+- **Status:** active; Step 1/7 in review (#1154)
 - **Plan date:** 2026-08-27
 - **Implementation base:** current `origin/main`
 - **Delivery:** seven PRs with the fixed titles below

--- a/.plan/active/github-copilot-harness/PLAN.md
+++ b/.plan/active/github-copilot-harness/PLAN.md
@@ -1,0 +1,224 @@
+# GitHub Copilot Harness
+
+## Status
+
+- **Plan slug:** `github-copilot-harness`
+- **Status:** active; Step 1/7 ready for review
+- **Plan date:** 2026-08-27
+- **Implementation base:** current `origin/main`
+- **Delivery:** seven PRs with the fixed titles below
+
+## Goal
+
+Add GitHub Copilot CLI as a first-class Sesori harness through its native ACP v1
+stdio server. A configured Copilot installation should appear alongside the
+other harnesses, import and resume persisted Copilot ACP sessions, create and
+continue sessions, stream turns and tools, handle standard permissions, expose
+standard session options and commands, accept supported images, and remain
+isolated when its runtime or authentication fails.
+
+The first release keeps authentication out of band: users authenticate on the
+bridge machine with `copilot login`, a supported GitHub token environment
+variable, or Copilot BYOK configuration. Sesori does not read or persist Copilot
+credentials and does not initiate an interactive login flow from the phone.
+
+## Authoritative Upstream Facts
+
+Reviewed against stable GitHub Copilot CLI `1.0.80` and the official ACP server
+documentation on 2026-08-27:
+
+- `copilot --acp` starts an ACP v1 server; stdio is the default transport.
+- A local no-prompt protocol probe completed `initialize`, `authenticate`,
+  `session/list`, `session/new`, and `session/close` successfully. Initialize
+  advertised `loadSession`, session list/close, images, and embedded context.
+  Session creation emitted standard `config_option_update` and
+  `available_commands_update` notifications.
+- Authentication is inherited from a prior `copilot login`,
+  `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`, or configured BYOK
+  provider. ACP advertises `copilot-login` with terminal-auth metadata; Sesori's
+  headless runtime may call standard `authenticate` but must never execute the
+  advertised terminal login command automatically.
+- Copilot `1.0.78` added ACP `session/close`; it is the minimum PATH version for
+  this integration. Managed installation pins the validated stable `1.0.80`.
+- Copilot supports standard ACP permission requests, model/session config
+  updates, modes, plans, commands, custom agents, session loading, and images.
+  Exact entitled-account model and reasoning catalogs remain a live-verification
+  item because the isolated no-prompt probe exposed mode and permission options
+  but no model catalog.
+- Copilot does not yet forward its `ask_user` interaction to ACP clients
+  (github/copilot-cli#2109). Sesori therefore does not advertise or claim form
+  elicitation for this harness.
+- `session/close` releases a live ACP session; it is not treated as upstream
+  persisted-session deletion. Sesori deletion owns its local purge and
+  plugin-scoped tombstone and does not mutate Copilot's private storage.
+- `--no-auto-update` is available. Sesori launches both PATH and managed
+  runtimes with it so a bridge-owned ACP process cannot mutate its executable
+  or drift from the version that setup selected.
+- Stable `1.0.80` publishes six official single-binary archives with GitHub
+  release SHA-256 digests:
+
+| Host | Asset | SHA-256 |
+|---|---|---|
+| macOS arm64 | `copilot-darwin-arm64.tar.gz` | `2346bb691981c2997d65c1c5bc3cef1aeddc9edd37dcb2f970b911aa597e59f6` |
+| macOS x64 | `copilot-darwin-x64.tar.gz` | `a1a9c1f25740f9a27b34eb14b70b5d3175794dc8bb410875531aa198b3abc18f` |
+| Linux arm64 | `copilot-linux-arm64.tar.gz` | `3ed85e711955e13be523bf492bc6c93b40b69925bcb7f817c9d08abf4839cf89` |
+| Linux x64 | `copilot-linux-x64.tar.gz` | `039933c9247686131c4406abb1d439bdbf68103edc1ff585bd70d5b0dc940f72` |
+| Windows arm64 | `copilot-win32-arm64.zip` | `c551da2377b99f08ff95cca6c1603c0006295c2ca7786ba1c8be7c05dc7943a7` |
+| Windows x64 | `copilot-win32-x64.zip` | `e9ea2063913faa8a9f1cf374529c5fea075da0545a894d7469026166f854c541` |
+
+Sources:
+
+- <https://docs.github.com/en/copilot/reference/copilot-cli-reference/acp-server>
+- <https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli>
+- <https://github.com/github/copilot-cli/releases/tag/v1.0.80>
+- <https://github.com/github/copilot-cli/blob/main/LICENSE.md>
+- <https://github.com/github/copilot-cli/issues/2109>
+
+## Architecture And Scope
+
+```text
+client <-> relay <-> bridge <-> sesori_plugin_copilot <-> copilot --no-auto-update --acp
+```
+
+- `sesori_plugin_copilot` owns Copilot identity, executable arguments, version
+  policy, setup classification, managed-runtime metadata, and any demonstrated
+  Copilot-specific ACP policy.
+- `sesori_plugin_acp` remains the owner of standard ACP transport, session
+  enumeration/load/replay, prompts, events, config options, commands,
+  permissions, and process lifecycle. The Copilot descriptor constructs its
+  plugin with `hostProcessAcpFactory` and delegates startup/shutdown to
+  `AcpBridgePlugin.start`; it does not introduce a Copilot-local transport or
+  lifecycle wrapper. The new harness should require no generic ACP production
+  change unless a pinned-binary conformance test demonstrates a real protocol
+  mismatch.
+- The bridge app knows the concrete plugin only at
+  `bridge/app/lib/src/runtime/plugin_registry.dart` and its package dependency.
+- The client continues consuming backend-neutral plugin contracts. Shared wire
+  plugin ids remain strings; `Harness.copilot` is only the built-in identity
+  used for exact registry tests and client-owned presentation.
+- Copilot uses `PluginProjectOwnership.bridgeDerived` and
+  `PluginSessionOptionsScope.plugin`. The bridge derives projects from session
+  directories and persists its own catalog/transcript state.
+- Runtime precedence is an explicit `--copilot-bin`, then a compatible PATH
+  runtime (`>=1.0.78`), then the exact already-installed managed `1.0.80`.
+  `ensureRuntime` only resolves existing files. `installRuntime`, invoked by an
+  explicit management command, downloads the official release archive directly
+  from GitHub, verifies its immutable digest, extracts the single binary, and
+  sweeps superseded managed versions.
+- Managed Copilot bits are not bundled in Sesori artifacts. Installation is an
+  explicit upstream download of the unmodified binary. The implementation and
+  product documentation retain the upstream license link and do not claim any
+  GitHub service entitlement.
+- Runtime authentication remains the authority. Side-effect-free setup can
+  prove a compatible executable but cannot honestly infer every credential
+  source without starting ACP or reading private credential stores; it reports
+  the runtime ready, while an authentication failure during eager ACP handshake
+  becomes a plugin-local authentication-required/degraded state with local
+  `copilot login` guidance.
+- The stock ACP approval registry handles standard permission requests.
+  Copilot's missing ACP `ask_user` forwarding remains a documented limitation;
+  no custom question protocol or polling workaround is added.
+
+### Compatibility
+
+- No client/bridge wire shape or database schema changes.
+- Older clients connected to a Copilot-capable bridge retain the raw plugin id,
+  bridge-provided display name, and generic icon fallback.
+- Newer clients connected to an older bridge receive no Copilot entry.
+- Copilot CLI releases below `1.0.78` are setup-blocked rather than receiving a
+  compatibility shim for missing close and older ACP behavior.
+- Public production wire compatibility remains unchanged because plugin ids are
+  already opaque strings.
+
+### Complexity Budget And Cleanup
+
+- **New persistent mutable state:** none beyond the existing managed-runtime
+  directory and existing bridge catalog/tombstone rows used by every plugin.
+- **New in-memory mutable state:** none beyond one existing `AcpPlugin` instance
+  and its existing trackers.
+- **New coordination:** none; no locks, registries, timers, queues, credential
+  stores, storage readers, or Copilot-specific session maps.
+- **Deliberately omitted:** Copilot SDK shim, phone-initiated login, private
+  credential/session-file parsing, custom tool injection, `ask_user` emulation,
+  auto-update support, and speculative ACP extensions.
+- **Analytics:** existing backend-neutral harness-install outcome analytics
+  already cover the new managed install. No new event or plugin identifier is
+  sent.
+- **Cleanup assessment:** no existing production field, route, cache, watcher,
+  or compatibility path becomes obsolete. The implementation adds no causal
+  cleanup outside its own package and registry/branding entries.
+
+## Delivery Steps
+
+| Step | Fixed PR title | Scope and expected result |
+|---|---|---|
+| 1/7 | `🌱 [github-copilot-harness] docs: plan GitHub Copilot harness support [step 1/7]` | Add this reviewed plan and tracker. No user-visible or database change. |
+| 2/7 | `⚙️ [github-copilot-harness] feat(copilot): add the ACP harness package [step 2/7]` | Add the workspace package, stable identity, `--no-auto-update --acp` launch spec, stock-ACP plugin composition, and focused protocol/factory tests. The package is not registered yet; no user-visible or database change. |
+| 3/7 | `⚙️ [github-copilot-harness] feat(copilot): add runtime setup and lifecycle [step 3/7]` | In `bridge/sesori_plugin_copilot`, add the descriptor, semantic version parsing (`GitHub Copilot CLI X.Y.Z.` included), explicit/PATH runtime selection, setup statuses, authentication guidance, and descriptor tests. The descriptor composes `hostProcessAcpFactory` and `AcpBridgePlugin.start`; `sesori_plugin_acp` remains the sole owner of ACP stdio startup/shutdown. The plugin remains unregistered; no user-visible or database change. |
+| 4/7 | `⚙️ [github-copilot-harness] feat(copilot): install the managed Copilot CLI [step 4/7]` | Add the exact `1.0.80` six-platform manifest, direct official downloads, digest verification, install capability gating, cleanup, and manifest/install tests. No database change; still no user-visible harness until registration. |
+| 5/7 | `⚙️ [github-copilot-harness] feat(app): activate and brand GitHub Copilot [step 5/7]` | `bridge/app` adds the package dependency, registry entry, and exact registry fixtures; `shared/sesori_shared` adds only `Harness.copilot`; `client/module_prego` adds only Copilot display-name/artwork presentation and fallback-preserving tests. Root product documentation adds the support listing. No other client/shared package changes. Users can select, install, start, and use Copilot; no database migration. |
+| 6/7 | `🌱 [github-copilot-harness] docs: document Copilot regression coverage [step 6/7]` | Reconcile the affected feature documents under `docs/regression/`, including upstream limitations and exact boundaries/matrix. Documentation only. |
+| 7/7 | `🌱 [github-copilot-harness] docs: verify and retire the Copilot plan [step 7/7]` | Run and record the matrix below, keep any incomplete row honestly Partial/Blocked, and move the plan to `.plan/completed/github-copilot-harness/` only when all required coverage passes or the owner explicitly accepts a reduction. Documentation only. |
+
+No implementation PR is expected to exceed the 1,500 changed-line soft cap.
+If focused tests make a step materially exceed it, split within the same fixed
+step only after updating the tracker and preserving one independently valid PR
+per published step number; do not merge unrelated cleanup into the series.
+
+## Regression And Retirement Matrix
+
+Highest required level is **L3 Release** for the new selectable production
+harness, plus the named L4 authentication/restart/recovery checks. Unchanged
+plugins retain existing evidence, while every registered-plugin registry and
+branding check includes Copilot.
+
+| Feature document | Required Copilot evidence | Boundary and matrix |
+|---|---|---|
+| `plugin-runtime-installation.md` | Explicit/PATH/managed precedence; too-old and malformed versions; exact six-asset metadata; digest failure; install cancellation; superseded cleanup | Automated all six targets + packaged/live install on release-target bridge host |
+| `plugin-setup-and-lifecycle.md` | Missing/old/current/explicit runtime; install capability gating; configured start; local-login-required failure; enable/disable/restart; plugin-local crash/reconnect; clean shutdown | Automated + headless bridge + live plugin; release-target host and one alternate host when available |
+| `projects-and-sessions.md` | Explicit Copilot import; database-only normal reads; standard list pagination; failed/cancelled import preserves last committed catalog | Headless bridge + live plugin |
+| `session-creation-and-options.md` | Create with standard mode/model/reasoning/agent options actually advertised to the entitled account; stable Copilot identity; unsupported options are not invented | Client E2E + live plugin |
+| `session-turns.md` | Text, plan, reasoning when emitted, tools, statuses, queued follow-up cancellation, abort, and two independent sessions | Client E2E + live plugin |
+| `session-history-and-recovery.md` | Standard load replay, bridge transcript backfill, plugin restart, bridge restart, and process replacement converge without duplicate live replay | Headless bridge + live plugin |
+| `questions-and-permissions.md` | Standard permission allow/reject/always correlation; abort cleanup; explicitly confirm no claimed `ask_user` support | Client E2E + live plugin |
+| `attachments-and-images.md` | Advertised image reaches a vision-capable selected model; model/account rejection remains visible | Client E2E + live plugin |
+| `tools-and-file-changes.md` | Tool lifecycle, permission linkage, diffs, and bounded output normalize live and after replay | Client E2E + live plugin |
+| `session-archiving-and-deletion.md` | Local purge plus tombstone prevents re-import while retained upstream Copilot persistence is documented | Headless bridge + live plugin |
+| Compatibility and branding | Unknown-id fallback remains intact; older client contract tolerates `copilot`; older bridge supplies no entry; exact built-in artwork/name render in both themes | Automated + client E2E for presentation claim |
+
+Step 7 records Copilot version, bridge/app build, bridge host, client platform,
+account type without identifiers, chosen model/mode, privacy-safe evidence,
+cleanup, and Pass/Partial/Fail/Blocked for each row. Prompts, transcripts, paths,
+tokens, session ids, account ids, and raw logs stay out of the repository.
+
+## Risks And Test Focus
+
+- **ACP preview drift:** pin and probe a validated release; protocol v1 alone is
+  insufficient if behavior changes. Fail setup for unsupported versions.
+- **Authentication:** terminal-auth metadata is guidance, not permission to run
+  login. Verify prior CLI login, environment token/BYOK where available, and a
+  genuinely unauthenticated home separately.
+- **Supply chain:** install only official immutable release assets, verify the
+  exact per-platform digest before extraction, disable runtime self-update, and
+  keep explicit paths authoritative.
+- **Catalog truth:** verify model/reasoning/custom-agent options with an entitled
+  account. Do not synthesize choices that the ACP server did not advertise.
+- **Permissions:** standard ACP permission requests must correlate with tool
+  calls. Do not treat process-wide launch flags as per-session authorization.
+- **Questions:** Copilot's current missing ACP `ask_user` forwarding is a product
+  limitation, not a reason to add a custom protocol.
+- **Deletion:** close is not private-storage deletion. Verify Sesori's tombstone
+  prevents a later explicit import from resurrecting a locally deleted row.
+- **Privacy:** never commit credentials, account details, paths, prompts,
+  transcripts, tool payloads, or raw Copilot output.
+
+## Expected Result
+
+A supported GitHub Copilot CLI appears as `GitHub Copilot` in Sesori, can be
+installed from the harness management surface or resolved from a compatible
+local installation, and runs through the existing encrypted client/relay/bridge
+path. Standard Copilot ACP sessions can be imported, created, resumed, streamed,
+approved, and closed without backend concepts escaping the plugin. Missing or
+old runtimes and authentication failures affect only Copilot and present local,
+privacy-safe recovery guidance. No database migration or wire-contract change
+is introduced.

--- a/.plan/active/github-copilot-harness/TRACKER.md
+++ b/.plan/active/github-copilot-harness/TRACKER.md
@@ -9,8 +9,8 @@ Plan: [PLAN.md](PLAN.md)
   - PR: [#1154](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1154)
   - Evidence: upstream ACP/release/license research and no-prompt `1.0.80` protocol probe recorded in the plan
 - [ ] **Step 2/7** — `⚙️ [github-copilot-harness] feat(copilot): add the ACP harness package [step 2/7]`
-  - State: ready for review on `github-copilot-harness/step-2-package`
-  - PR: pending
+  - State: in review
+  - PR: [#1155](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1155)
   - Evidence: package tests and analyzer pass; architecture implementation review passed
 - [ ] **Step 3/7** — `⚙️ [github-copilot-harness] feat(copilot): add runtime setup and lifecycle [step 3/7]`
   - State: not started

--- a/.plan/active/github-copilot-harness/TRACKER.md
+++ b/.plan/active/github-copilot-harness/TRACKER.md
@@ -9,7 +9,7 @@ Plan: [PLAN.md](PLAN.md)
   - PR: [#1154](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1154)
   - Evidence: upstream ACP/release/license research and no-prompt `1.0.80` protocol probe recorded in the plan
 - [ ] **Step 2/7** — `⚙️ [github-copilot-harness] feat(copilot): add the ACP harness package [step 2/7]`
-  - State: not started
+  - State: in progress on `github-copilot-harness/step-2-package`
   - PR: pending
 - [ ] **Step 3/7** — `⚙️ [github-copilot-harness] feat(copilot): add runtime setup and lifecycle [step 3/7]`
   - State: not started

--- a/.plan/active/github-copilot-harness/TRACKER.md
+++ b/.plan/active/github-copilot-harness/TRACKER.md
@@ -5,8 +5,8 @@ Plan: [PLAN.md](PLAN.md)
 ## Delivery
 
 - [ ] **Step 1/7** — `🌱 [github-copilot-harness] docs: plan GitHub Copilot harness support [step 1/7]`
-  - State: ready for review
-  - PR: pending
+  - State: in review
+  - PR: [#1154](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1154)
   - Evidence: upstream ACP/release/license research and no-prompt `1.0.80` protocol probe recorded in the plan
 - [ ] **Step 2/7** — `⚙️ [github-copilot-harness] feat(copilot): add the ACP harness package [step 2/7]`
   - State: not started

--- a/.plan/active/github-copilot-harness/TRACKER.md
+++ b/.plan/active/github-copilot-harness/TRACKER.md
@@ -1,0 +1,44 @@
+# GitHub Copilot Harness Tracker
+
+Plan: [PLAN.md](PLAN.md)
+
+## Delivery
+
+- [ ] **Step 1/7** — `🌱 [github-copilot-harness] docs: plan GitHub Copilot harness support [step 1/7]`
+  - State: ready for review
+  - PR: pending
+  - Evidence: upstream ACP/release/license research and no-prompt `1.0.80` protocol probe recorded in the plan
+- [ ] **Step 2/7** — `⚙️ [github-copilot-harness] feat(copilot): add the ACP harness package [step 2/7]`
+  - State: not started
+  - PR: pending
+- [ ] **Step 3/7** — `⚙️ [github-copilot-harness] feat(copilot): add runtime setup and lifecycle [step 3/7]`
+  - State: not started
+  - PR: pending
+- [ ] **Step 4/7** — `⚙️ [github-copilot-harness] feat(copilot): install the managed Copilot CLI [step 4/7]`
+  - State: not started
+  - PR: pending
+- [ ] **Step 5/7** — `⚙️ [github-copilot-harness] feat(app): activate and brand GitHub Copilot [step 5/7]`
+  - State: not started
+  - PR: pending
+- [ ] **Step 6/7** — `🌱 [github-copilot-harness] docs: document Copilot regression coverage [step 6/7]`
+  - State: not started
+  - PR: pending
+- [ ] **Step 7/7** — `🌱 [github-copilot-harness] docs: verify and retire the Copilot plan [step 7/7]`
+  - State: not started
+  - PR: pending
+
+## Decisions
+
+- Use native ACP, not the Copilot SDK.
+- Require local/out-of-band authentication in v1; do not run terminal-auth commands from the bridge.
+- Pin managed runtime `1.0.80`; accept compatible PATH versions `>=1.0.78`.
+- Launch with `--no-auto-update --acp`.
+- Keep Copilot `ask_user` unsupported until upstream forwards it over ACP.
+- Do not read Copilot credential or private session files.
+- Do not bundle Copilot binaries; managed installation downloads the official unmodified asset directly from GitHub after explicit user intent.
+
+## Review And Verification
+
+- Architecture plan review: approved after clarifying ACP lifecycle and bridge/client/shared ownership
+- Architecture implementation review: required after each architecture-bearing implementation step, scoped to that step's branch against its target
+- Final regression matrix: pending; see `PLAN.md`

--- a/bridge/pubspec.yaml
+++ b/bridge/pubspec.yaml
@@ -9,6 +9,7 @@ workspace:
   - sesori_bridge_foundation
   - sesori_plugin_opencode
   - sesori_plugin_codex
+  - sesori_plugin_copilot
   - sesori_plugin_runtime
   - sesori_plugin_interface
   - sesori_plugin_acp

--- a/bridge/sesori_plugin_copilot/analysis_options.yaml
+++ b/bridge/sesori_plugin_copilot/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../app/analysis_options.yaml

--- a/bridge/sesori_plugin_copilot/analysis_options.yaml
+++ b/bridge/sesori_plugin_copilot/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: ../app/analysis_options.yaml
+include: ../analysis_options.yaml

--- a/bridge/sesori_plugin_copilot/lib/copilot_plugin.dart
+++ b/bridge/sesori_plugin_copilot/lib/copilot_plugin.dart
@@ -1,0 +1,7 @@
+// GitHub Copilot CLI backend for the Sesori bridge.
+//
+// Drives `copilot --no-auto-update --acp` through the shared ACP package while
+// keeping Copilot identity, launch arguments, and protocol policy local.
+export "src/copilot_binary.dart";
+export "src/copilot_identity.dart";
+export "src/copilot_plugin_impl.dart";

--- a/bridge/sesori_plugin_copilot/lib/src/copilot_binary.dart
+++ b/bridge/sesori_plugin_copilot/lib/src/copilot_binary.dart
@@ -1,0 +1,28 @@
+import "package:acp_plugin/acp_plugin.dart";
+
+/// Builds the launch specification for GitHub Copilot CLI's ACP server.
+///
+/// Authentication remains out of band. The process inherits credentials from
+/// a prior `copilot login`, supported GitHub token environment variables, or a
+/// configured BYOK provider through the host-owned process factory.
+abstract final class CopilotBinary() {
+  static const String defaultBinary = "copilot";
+
+  /// Copilot's standard ACP authentication method for its local login state.
+  static const String acpAuthMethodId = "copilot-login";
+
+  static AcpLaunchSpec launchSpec({
+    required String binary,
+    required String cwd,
+    required Map<String, String> environment,
+  }) {
+    return AcpLaunchSpec(
+      command: binary,
+      // A bridge-owned process must not replace the runtime selected and
+      // version-gated by its descriptor while that process is starting.
+      args: const ["--no-auto-update", "--acp"],
+      cwd: cwd,
+      environment: environment,
+    );
+  }
+}

--- a/bridge/sesori_plugin_copilot/lib/src/copilot_identity.dart
+++ b/bridge/sesori_plugin_copilot/lib/src/copilot_identity.dart
@@ -1,0 +1,5 @@
+/// Stable identity for the GitHub Copilot CLI harness plugin.
+abstract final class CopilotPluginIdentity() {
+  static const String id = "copilot";
+  static const String displayName = "GitHub Copilot";
+}

--- a/bridge/sesori_plugin_copilot/lib/src/copilot_plugin_impl.dart
+++ b/bridge/sesori_plugin_copilot/lib/src/copilot_plugin_impl.dart
@@ -1,0 +1,62 @@
+import "package:acp_plugin/acp_plugin.dart";
+
+import "copilot_binary.dart";
+import "copilot_identity.dart";
+
+/// GitHub Copilot CLI backend over standard ACP v1.
+///
+/// Copilot uses the shared ACP transport, session persistence/replay, command,
+/// config-option, and permission surfaces without a private protocol dialect.
+/// It supports standard cancellation but does not currently forward its
+/// `ask_user` interaction over ACP, so form elicitation remains unadvertised.
+class CopilotPlugin._({
+  required super.launchSpec,
+  required super.launchDirectory,
+  required super.eventMapper,
+  required super.commandTracker,
+  required super.sessionOptionsService,
+  required super.processFactory,
+}) extends AcpPlugin {
+  factory({
+    required String binaryPath,
+    required String launchDirectory,
+    required Map<String, String> environment,
+    required AcpProcessFactory processFactory,
+  }) {
+    final configurationTracker = AcpSessionConfigurationTracker();
+    final commandTracker = AcpCommandTracker();
+    return CopilotPlugin._(
+      launchSpec: CopilotBinary.launchSpec(
+        binary: binaryPath,
+        cwd: launchDirectory,
+        environment: environment,
+      ),
+      launchDirectory: launchDirectory,
+      eventMapper: AcpEventMapper(
+        launchDirectory: launchDirectory,
+        pluginId: CopilotPluginIdentity.id,
+        configurationTracker: configurationTracker,
+      ),
+      commandTracker: commandTracker,
+      sessionOptionsService: AcpSessionOptionsService(
+        configurationTracker: configurationTracker,
+        commandTracker: commandTracker,
+        pluginId: CopilotPluginIdentity.id,
+        agentDisplayName: CopilotPluginIdentity.displayName,
+      ),
+      processFactory: processFactory,
+    );
+  }
+
+  this
+    : super(
+        id: CopilotPluginIdentity.id,
+        agentDisplayName: CopilotPluginIdentity.displayName,
+      );
+
+  @override
+  String? get authMethodId => CopilotBinary.acpAuthMethodId;
+
+  @override
+  bool get cancelsActiveTurnForQueuedInput => true;
+}

--- a/bridge/sesori_plugin_copilot/pubspec.yaml
+++ b/bridge/sesori_plugin_copilot/pubspec.yaml
@@ -1,0 +1,17 @@
+name: copilot_plugin
+version: 0.1.0
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.13.1
+
+dependencies:
+  acp_plugin:
+    path: ../sesori_plugin_acp
+  sesori_plugin_interface:
+    path: ../sesori_plugin_interface
+
+dev_dependencies:
+  lints: ^6.1.0
+  test: ^1.31.2

--- a/bridge/sesori_plugin_copilot/test/copilot_plugin_test.dart
+++ b/bridge/sesori_plugin_copilot/test/copilot_plugin_test.dart
@@ -1,0 +1,112 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_testing.dart";
+import "package:copilot_plugin/copilot_plugin.dart";
+import "package:test/test.dart";
+
+const Map<String, dynamic> _copilotInitializeResult = {
+  "protocolVersion": 1,
+  "agentCapabilities": {
+    "loadSession": true,
+    "mcpCapabilities": {"http": true, "sse": true},
+    "promptCapabilities": {"image": true, "audio": false, "embeddedContext": true},
+    "sessionCapabilities": {
+      "close": <String, dynamic>{},
+      "list": <String, dynamic>{},
+    },
+  },
+  "authMethods": [
+    {
+      "id": "copilot-login",
+      "name": "Log in with Copilot CLI",
+      "description": "Run `copilot login` in the terminal",
+      "_meta": {
+        "terminal-auth": {
+          "command": "/opt/copilot",
+          "args": ["login"],
+          "label": "Copilot Login",
+        },
+      },
+    },
+  ],
+  "agentInfo": {"name": "Copilot", "title": "Copilot", "version": "1.0.80"},
+};
+
+void main() {
+  group("CopilotPlugin", () {
+    late FakeAcpProcess fake;
+    late CopilotPlugin plugin;
+    late Set<Object?> handledFrameIds;
+
+    setUp(() {
+      fake = FakeAcpProcess();
+      handledFrameIds = {};
+      plugin = CopilotPlugin(
+        binaryPath: "/opt/copilot",
+        launchDirectory: "/repo",
+        environment: const {"COPILOT_HOME": "/state/copilot"},
+        processFactory: (_) async => fake,
+      );
+    });
+
+    tearDown(() async {
+      await plugin.dispose();
+      await fake.close();
+    });
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+    Future<Map<String, dynamic>> waitForFrame({required String method}) async {
+      for (var i = 0; i < 50; i++) {
+        final matches = fake.written.where(
+          (frame) => frame["method"] == method && !handledFrameIds.contains(frame["id"]),
+        );
+        if (matches.isNotEmpty) {
+          final frame = matches.first;
+          handledFrameIds.add(frame["id"]);
+          return frame;
+        }
+        await pump();
+      }
+      throw StateError("agent never wrote a '$method' frame");
+    }
+
+    test("owns the stable Copilot identity and launch arguments", () {
+      expect(CopilotPluginIdentity.id, "copilot");
+      expect(CopilotPluginIdentity.displayName, "GitHub Copilot");
+      expect(plugin.id, CopilotPluginIdentity.id);
+      expect(plugin.launchSpec.command, "/opt/copilot");
+      expect(plugin.launchSpec.args, ["--no-auto-update", "--acp"]);
+      expect(plugin.launchSpec.cwd, "/repo");
+      expect(plugin.launchSpec.environment, const {"COPILOT_HOME": "/state/copilot"});
+    });
+
+    test("keeps stock ACP policies except Copilot auth and stop-and-send", () {
+      expect(plugin.authMethodId, CopilotBinary.acpAuthMethodId);
+      expect(plugin.initializeCapabilityMeta, isNull);
+      expect(plugin.supportsFormElicitation, isFalse);
+      expect(plugin.serializesPromptsProcessWide, isFalse);
+      expect(plugin.cancelsActiveTurnForQueuedInput, isTrue);
+      expect(plugin.failsTurnOnSelectionError, isTrue);
+    });
+
+    test("completes Copilot's standard ACP handshake", () async {
+      final connecting = plugin.ensureConnected();
+      final initialize = await waitForFrame(method: "initialize");
+      final initializeParams = (initialize["params"] as Map).cast<String, dynamic>();
+      final clientCapabilities = (initializeParams["clientCapabilities"] as Map).cast<String, dynamic>();
+      expect(clientCapabilities, isNot(contains("elicitation")));
+      fake.emit({"jsonrpc": "2.0", "id": initialize["id"], "result": _copilotInitializeResult});
+
+      final authenticate = await waitForFrame(method: "authenticate");
+      expect(
+        (authenticate["params"] as Map).cast<String, dynamic>()["methodId"],
+        CopilotBinary.acpAuthMethodId,
+      );
+      fake.emit({"jsonrpc": "2.0", "id": authenticate["id"], "result": <String, dynamic>{}});
+
+      expect(await connecting, isTrue);
+      expect(await plugin.getAgents(projectId: "/repo"), hasLength(1));
+    });
+  });
+}


### PR DESCRIPTION
## Complexity

⚙️ Moderate — introduces a new bridge plugin package and production ACP composition, while deliberately reusing the existing transport and lifecycle owners.

## What

- Adds `bridge/sesori_plugin_copilot` to the Dart workspace.
- Defines the stable `copilot` / `GitHub Copilot` plugin identity.
- Launches Copilot as `copilot --no-auto-update --acp` with inherited host credentials and configuration.
- Composes the stock `AcpPlugin` trackers, mapper, session options, permissions, history, and transport behavior.
- Pins Copilot's ACP auth method and enables existing stop-and-send cancellation behavior.
- Adds focused launch-policy and ACP-handshake tests using the shared fake stdio process.

The package is not registered in the production bridge yet.

## Why

GitHub Copilot CLI exposes native ACP v1, so the smallest integration is a thin backend-specific package over Sesori's existing generic ACP boundary. This step establishes that package without mixing runtime setup, managed installation, registry activation, or client branding from later plan steps.

## Risk and test focus

Moderate implementation risk, low current product blast radius because the package is unregistered. Review should focus on dependency direction, keeping generic ACP lifecycle ownership in `sesori_plugin_acp`, exact launch arguments, authentication-method selection, and avoiding Copilot-specific coordination state.

## Expected result

No user-visible behavior and no database or persisted-data change. The workspace contains a tested Copilot ACP package that later steps can wrap with descriptor/runtime setup and activate through the existing plugin registry.

## Verification

- `cd bridge && dart pub get`
- `cd bridge/sesori_plugin_copilot && dart test` — 3 tests passed
- `cd bridge/sesori_plugin_copilot && dart analyze --fatal-infos` — no issues
- `dart format --line-length 120 sesori_plugin_copilot/lib sesori_plugin_copilot/test` — clean
- `git diff --check`
- Architecture implementation review of the Step 2 commit: PASS, no findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the new `bridge/sesori_plugin_copilot` package that drives GitHub Copilot CLI's native ACP v1 through the shared ACP boundary. No user-visible behavior changes yet because the package is not registered in the production bridge.

**New Features**
- Launches `copilot --no-auto-update --acp` with inherited host credentials and configuration.
- Composes the existing `AcpPlugin` trackers, mapper, session options, permissions, and transport.
- Pins the `copilot-login` auth method and enables the existing stop-and-send cancellation.
- Adds launch-policy and ACP-handshake tests using the shared fake stdio process.
- Inherits the shared bridge analysis options for linting.

<sup>Written for commit b0dc7069556637efa72512c0d3f94b6669606fb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

