### PR TITLE
🌿 [grok-harness] feat(grok): scaffold the Grok plugin package [step 2/9]

### DIFF
--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -3,12 +3,13 @@
 ## Current State
 
 - **Plan:** `.plan/active/grok-harness/PLAN.md`
-- **Status:** Step 1/9 merged; Step 2/9 verified and ready for PR
+- **Status:** Step 1/9 merged; Step 2/9 in PR
 - **Current branch:** `grok-harness-step-2-scaffold`
 - **Base:** `origin/main`
 - **Architecture plan review:** approved 2026-08-27 after catalog ownership and auth-policy corrections
 - **Merged predecessor:** #1152 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1152>
-- **Current step:** `grok-harness-step-2-scaffold`; scaffold implemented, verified, and ready to publish
+- **Open PR:** #1156 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1156>
+- **Current step:** `grok-harness-step-2-scaffold`; scaffold implemented, verified, and under review
 
 ## Fixed Series
 
@@ -16,7 +17,7 @@
    - **State:** merged in #1152.
    - **Evidence:** architecture-approved plan; released-binary facts, titles, paths, and whitespace passed.
 2. `🌿 [grok-harness] feat(grok): scaffold the Grok plugin package [step 2/9]`
-   - **State:** verified locally and ready to open.
+   - **State:** in PR #1156.
    - **Evidence:** workspace package, launch spec, typed model-state DTOs, synthetic protocol fixtures, generated output,
      package tests/analyzer, LSP diagnostics, and the 1,500-line budget pass.
 3. `⚙️ [grok-harness] feat(grok): expose models and reasoning effort [step 3/9]`
@@ -61,7 +62,7 @@
 - [x] Run package tests, fatal-info analysis, and Dart LSP diagnostics.
 - [x] Run architecture implementation review for `origin/main...HEAD`; approved with no findings.
 - [x] Keep the measured change below the 1,500-line soft cap by leaving initialize/session envelope DTOs for Step 3.
-- [x] Commit the completed successor locally; do not push or open it before #1152 merges.
+- [x] After #1152 merged, sync to `origin/main`, publish PR #1156, and start its monitor.
 
 ## Decisions And Evidence
 

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -3,21 +3,22 @@
 ## Current State
 
 - **Plan:** `.plan/active/grok-harness/PLAN.md`
-- **Status:** Step 1/9 in PR
-- **Current branch:** `grok-code-harness-inquiry`
+- **Status:** Step 1/9 merged; Step 2/9 verified and ready for PR
+- **Current branch:** `grok-harness-step-2-scaffold`
 - **Base:** `origin/main`
 - **Architecture plan review:** approved 2026-08-27 after catalog ownership and auth-policy corrections
-- **Open PR:** #1152 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1152>
-- **Local successor:** `grok-harness-step-2-scaffold`; released-binary research started and held locally
+- **Merged predecessor:** #1152 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1152>
+- **Current step:** `grok-harness-step-2-scaffold`; scaffold implemented, verified, and ready to publish
 
 ## Fixed Series
 
 1. `🌱 [grok-harness] docs: plan Grok Build harness support [step 1/9]`
-   - **State:** in PR #1152.
-   - **Evidence:** current revision architecture-approved; released-binary facts, titles, paths, and whitespace pass.
+   - **State:** merged in #1152.
+   - **Evidence:** architecture-approved plan; released-binary facts, titles, paths, and whitespace passed.
 2. `🌿 [grok-harness] feat(grok): scaffold the Grok plugin package [step 2/9]`
-   - **State:** started locally; held until #1152 merges.
-   - **Evidence:** isolated released 1.0.5 binary/version/help/initialize contract captured; package files not started.
+   - **State:** verified locally and ready to open.
+   - **Evidence:** workspace package, launch spec, typed model-state DTOs, synthetic protocol fixtures, generated output,
+     package tests/analyzer, LSP diagnostics, and the 1,500-line budget pass.
 3. `⚙️ [grok-harness] feat(grok): expose models and reasoning effort [step 3/9]`
    - **State:** not started.
 4. `⚙️ [grok-harness] feat(grok): compose ACP sessions and turns [step 4/9]`
@@ -49,6 +50,18 @@
 - [x] Commit, push, and open Step 1 PR (#1152).
 - [x] Start the PR monitor.
 - [x] Create the Step 2 successor branch in this worktree and begin released-binary research locally.
+
+## Step 2 Checklist
+
+- [x] Validate the official 1.0.5 artifact, build ID, SHA-256, launch arguments, and initialize structure.
+- [x] Add `sesori_plugin_grok` to workspace, Makefile/CI inventory, bridge module docs, and package docs.
+- [x] Add Grok identity and the dedicated no-update/no-leader ask-mode ACP launch spec.
+- [x] Add typed Freezed model/reasoning DTOs plus privacy-safe synthetic initialize/session fixtures.
+- [x] Generate source; do not hand-edit generated files.
+- [x] Run package tests, fatal-info analysis, and Dart LSP diagnostics.
+- [x] Run architecture implementation review for `origin/main...HEAD`; approved with no findings.
+- [x] Keep the measured change below the 1,500-line soft cap by leaving initialize/session envelope DTOs for Step 3.
+- [x] Commit the completed successor locally; do not push or open it before #1152 merges.
 
 ## Decisions And Evidence
 

--- a/bridge/AGENTS.md
+++ b/bridge/AGENTS.md
@@ -39,8 +39,9 @@ Dependencies flow in one direction:
 7. `sesori_plugin_omp` — Oh My Pi adapter; depends on interface + foundation + runtime + ACP
 8. `sesori_plugin_claude` — Claude Code adapter; depends on interface + foundation + `sesori_shared`
 9. `sesori_plugin_hermes` — Hermes ACP adapter; depends on interface + foundation + ACP
-10. `sesori_plugin_pi` — Pi adapter; depends on interface + foundation + runtime + `sesori_shared`
-11. `app` — depends on interface + foundation + registered concrete plugins + `sesori_shared` (NOT runtime)
+10. `sesori_plugin_grok` — Grok Build ACP adapter; depends on interface + foundation + ACP
+11. `sesori_plugin_pi` — Pi adapter; depends on interface + foundation + runtime + `sesori_shared`
+12. `app` — depends on interface + foundation + registered concrete plugins + `sesori_shared` (NOT runtime)
 
 When changing shared types, update in this order.
 

--- a/bridge/Makefile
+++ b/bridge/Makefile
@@ -2,7 +2,21 @@ TOOL_VERSIONS := $(shell git rev-parse --show-toplevel)/.tool-versions
 FLUTTER_VERSION := $(shell grep '^flutter' $(TOOL_VERSIONS) | awk '{print $$2}')
 DART := $(HOME)/.asdf/installs/flutter/$(FLUTTER_VERSION)/bin/cache/dart-sdk/bin/dart
 
-MODULES := sesori_plugin_interface sesori_bridge_foundation sesori_plugin_runtime sesori_plugin_opencode sesori_plugin_codex sesori_plugin_acp sesori_plugin_cursor sesori_plugin_omp sesori_plugin_claude sesori_plugin_pi sesori_plugin_hermes sesori_plugin_deepseek app
+MODULES := \
+	sesori_plugin_interface \
+	sesori_bridge_foundation \
+	sesori_plugin_runtime \
+	sesori_plugin_opencode \
+	sesori_plugin_codex \
+	sesori_plugin_acp \
+	sesori_plugin_cursor \
+	sesori_plugin_omp \
+	sesori_plugin_claude \
+	sesori_plugin_pi \
+	sesori_plugin_hermes \
+	sesori_plugin_grok \
+	sesori_plugin_deepseek \
+	app
 
 .PHONY: codegen opencode-codegen pub-get test analyze
 

--- a/bridge/Makefile
+++ b/bridge/Makefile
@@ -2,21 +2,7 @@ TOOL_VERSIONS := $(shell git rev-parse --show-toplevel)/.tool-versions
 FLUTTER_VERSION := $(shell grep '^flutter' $(TOOL_VERSIONS) | awk '{print $$2}')
 DART := $(HOME)/.asdf/installs/flutter/$(FLUTTER_VERSION)/bin/cache/dart-sdk/bin/dart
 
-MODULES := \
-	sesori_plugin_interface \
-	sesori_bridge_foundation \
-	sesori_plugin_runtime \
-	sesori_plugin_opencode \
-	sesori_plugin_codex \
-	sesori_plugin_acp \
-	sesori_plugin_cursor \
-	sesori_plugin_omp \
-	sesori_plugin_claude \
-	sesori_plugin_pi \
-	sesori_plugin_hermes \
-	sesori_plugin_grok \
-	sesori_plugin_deepseek \
-	app
+MODULES := sesori_plugin_interface sesori_bridge_foundation sesori_plugin_runtime sesori_plugin_opencode sesori_plugin_codex sesori_plugin_acp sesori_plugin_cursor sesori_plugin_omp sesori_plugin_claude sesori_plugin_pi sesori_plugin_hermes sesori_plugin_grok sesori_plugin_deepseek app
 
 .PHONY: codegen opencode-codegen pub-get test analyze
 

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -22,6 +22,7 @@ Clients <--(E2E encrypted)--> Relay Server <--(E2E encrypted)--> Bridge CLI -> [
 | `sesori_plugin_omp` | Oh My Pi implementation over ACP |
 | `sesori_plugin_claude` | Claude Code backend implementation |
 | `sesori_plugin_hermes` | Hermes implementation over ACP |
+| `sesori_plugin_grok` | Grok Build implementation over ACP |
 | `sesori_plugin_pi` | Pi backend implementation |
 | `app` | CLI entry point: auth, relay, encryption, catalog, request routing, and plugin composition |
 

--- a/bridge/pubspec.yaml
+++ b/bridge/pubspec.yaml
@@ -17,4 +17,5 @@ workspace:
   - sesori_plugin_claude
   - sesori_plugin_pi
   - sesori_plugin_hermes
+  - sesori_plugin_grok
   - sesori_plugin_deepseek

--- a/bridge/sesori_plugin_grok/analysis_options.yaml
+++ b/bridge/sesori_plugin_grok/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../app/analysis_options.yaml

--- a/bridge/sesori_plugin_grok/analysis_options.yaml
+++ b/bridge/sesori_plugin_grok/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: ../app/analysis_options.yaml
+include: ../analysis_options.yaml

--- a/bridge/sesori_plugin_grok/build.yaml
+++ b/bridge/sesori_plugin_grok/build.yaml
@@ -1,0 +1,13 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          any_map: true
+          explicit_to_json: true
+          include_if_null: false
+      freezed:
+        options:
+          format: false
+          map: false
+          when: false

--- a/bridge/sesori_plugin_grok/lib/grok_plugin.dart
+++ b/bridge/sesori_plugin_grok/lib/grok_plugin.dart
@@ -1,0 +1,6 @@
+// Grok Build backend for the Sesori bridge.
+//
+// Drives the official `grok agent stdio` ACP server through Sesori's generic
+// ACP machinery. Production composition lands in later grok-harness steps.
+export "src/grok_binary.dart";
+export "src/grok_identity.dart";

--- a/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.dart
+++ b/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.dart
@@ -1,0 +1,54 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "grok_protocol_dto.freezed.dart";
+part "grok_protocol_dto.g.dart";
+
+/// One reasoning-effort option advertised in a Grok model's ACP metadata.
+@freezed
+sealed class GrokReasoningEffortOptionDto with _$GrokReasoningEffortOptionDto {
+  const factory({
+    required String? id,
+    required String? value,
+    required String? label,
+    required String? description,
+    @JsonKey(name: "default") @Default(false) bool isDefault,
+  }) = _GrokReasoningEffortOptionDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$GrokReasoningEffortOptionDtoFromJson(json);
+}
+
+/// Grok-owned metadata attached to one ACP model entry.
+@freezed
+sealed class GrokModelMetadataDto with _$GrokModelMetadataDto {
+  const factory({
+    required bool? supportsReasoningEffort,
+    @Default(<GrokReasoningEffortOptionDto>[]) List<GrokReasoningEffortOptionDto> reasoningEfforts,
+    required String? reasoningEffort,
+  }) = _GrokModelMetadataDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$GrokModelMetadataDtoFromJson(json);
+}
+
+/// One model advertised by Grok's legacy ACP model-state surface.
+@freezed
+sealed class GrokModelInfoDto with _$GrokModelInfoDto {
+  const factory({
+    required String? modelId,
+    required String? name,
+    required String? description,
+    @JsonKey(name: "_meta") required GrokModelMetadataDto? metadata,
+  }) = _GrokModelInfoDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$GrokModelInfoDtoFromJson(json);
+}
+
+/// Current model plus the models available to a Grok ACP session.
+@freezed
+sealed class GrokSessionModelStateDto with _$GrokSessionModelStateDto {
+  const factory({
+    @Default(<GrokModelInfoDto>[]) List<GrokModelInfoDto> availableModels,
+    required String? currentModelId,
+  }) = _GrokSessionModelStateDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$GrokSessionModelStateDtoFromJson(json);
+}

--- a/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.freezed.dart
+++ b/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.freezed.dart
@@ -1,0 +1,617 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint, type=warning, deprecated_member_use, deprecated_member_use_from_same_package
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'grok_protocol_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$GrokReasoningEffortOptionDto {
+
+ String? get id; String? get value; String? get label; String? get description;@JsonKey(name: "default") bool get isDefault;
+/// Create a copy of GrokReasoningEffortOptionDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GrokReasoningEffortOptionDtoCopyWith<GrokReasoningEffortOptionDto> get copyWith => _$GrokReasoningEffortOptionDtoCopyWithImpl<GrokReasoningEffortOptionDto>(this as GrokReasoningEffortOptionDto, _$identity);
+
+  /// Serializes this GrokReasoningEffortOptionDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GrokReasoningEffortOptionDto&&(identical(other.id, id) || other.id == id)&&(identical(other.value, value) || other.value == value)&&(identical(other.label, label) || other.label == label)&&(identical(other.description, description) || other.description == description)&&(identical(other.isDefault, isDefault) || other.isDefault == isDefault));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,value,label,description,isDefault);
+
+@override
+String toString() {
+  return 'GrokReasoningEffortOptionDto(id: $id, value: $value, label: $label, description: $description, isDefault: $isDefault)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GrokReasoningEffortOptionDtoCopyWith<$Res>  {
+  factory $GrokReasoningEffortOptionDtoCopyWith(GrokReasoningEffortOptionDto value, $Res Function(GrokReasoningEffortOptionDto) _then) = _$GrokReasoningEffortOptionDtoCopyWithImpl;
+@useResult
+$Res call({
+ String? id, String? value, String? label, String? description,@JsonKey(name: "default") bool isDefault
+});
+
+
+
+
+}
+/// @nodoc
+class _$GrokReasoningEffortOptionDtoCopyWithImpl<$Res>
+    implements $GrokReasoningEffortOptionDtoCopyWith<$Res> {
+  _$GrokReasoningEffortOptionDtoCopyWithImpl(this._self, this._then);
+
+  final GrokReasoningEffortOptionDto _self;
+  final $Res Function(GrokReasoningEffortOptionDto) _then;
+
+/// Create a copy of GrokReasoningEffortOptionDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? value = freezed,Object? label = freezed,Object? description = freezed,Object? isDefault = null,}) {
+  return _then(GrokReasoningEffortOptionDto(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,value: freezed == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String?,label: freezed == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,isDefault: null == isDefault ? _self.isDefault : isDefault // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _GrokReasoningEffortOptionDto implements GrokReasoningEffortOptionDto {
+  const _GrokReasoningEffortOptionDto({required this.id, required this.value, required this.label, required this.description, @JsonKey(name: "default") this.isDefault = false});
+  factory _GrokReasoningEffortOptionDto.fromJson(Map<String, dynamic> json) => _$GrokReasoningEffortOptionDtoFromJson(json);
+
+@override final  String? id;
+@override final  String? value;
+@override final  String? label;
+@override final  String? description;
+@override@JsonKey(name: "default") final  bool isDefault;
+
+/// Create a copy of GrokReasoningEffortOptionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GrokReasoningEffortOptionDtoCopyWith<_GrokReasoningEffortOptionDto> get copyWith => __$GrokReasoningEffortOptionDtoCopyWithImpl<_GrokReasoningEffortOptionDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GrokReasoningEffortOptionDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GrokReasoningEffortOptionDto&&(identical(other.id, id) || other.id == id)&&(identical(other.value, value) || other.value == value)&&(identical(other.label, label) || other.label == label)&&(identical(other.description, description) || other.description == description)&&(identical(other.isDefault, isDefault) || other.isDefault == isDefault));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,value,label,description,isDefault);
+
+@override
+String toString() {
+  return 'GrokReasoningEffortOptionDto(id: $id, value: $value, label: $label, description: $description, isDefault: $isDefault)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GrokReasoningEffortOptionDtoCopyWith<$Res> implements $GrokReasoningEffortOptionDtoCopyWith<$Res> {
+  factory _$GrokReasoningEffortOptionDtoCopyWith(_GrokReasoningEffortOptionDto value, $Res Function(_GrokReasoningEffortOptionDto) _then) = __$GrokReasoningEffortOptionDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String? id, String? value, String? label, String? description,@JsonKey(name: "default") bool isDefault
+});
+
+
+
+
+}
+/// @nodoc
+class __$GrokReasoningEffortOptionDtoCopyWithImpl<$Res>
+    implements _$GrokReasoningEffortOptionDtoCopyWith<$Res> {
+  __$GrokReasoningEffortOptionDtoCopyWithImpl(this._self, this._then);
+
+  final _GrokReasoningEffortOptionDto _self;
+  final $Res Function(_GrokReasoningEffortOptionDto) _then;
+
+/// Create a copy of GrokReasoningEffortOptionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? value = freezed,Object? label = freezed,Object? description = freezed,Object? isDefault = null,}) {
+  return _then(_GrokReasoningEffortOptionDto(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,value: freezed == value ? _self.value : value // ignore: cast_nullable_to_non_nullable
+as String?,label: freezed == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,isDefault: null == isDefault ? _self.isDefault : isDefault // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$GrokModelMetadataDto {
+
+ bool? get supportsReasoningEffort; List<GrokReasoningEffortOptionDto> get reasoningEfforts; String? get reasoningEffort;
+/// Create a copy of GrokModelMetadataDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GrokModelMetadataDtoCopyWith<GrokModelMetadataDto> get copyWith => _$GrokModelMetadataDtoCopyWithImpl<GrokModelMetadataDto>(this as GrokModelMetadataDto, _$identity);
+
+  /// Serializes this GrokModelMetadataDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GrokModelMetadataDto&&(identical(other.supportsReasoningEffort, supportsReasoningEffort) || other.supportsReasoningEffort == supportsReasoningEffort)&&const DeepCollectionEquality().equals(other.reasoningEfforts, reasoningEfforts)&&(identical(other.reasoningEffort, reasoningEffort) || other.reasoningEffort == reasoningEffort));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,supportsReasoningEffort,const DeepCollectionEquality().hash(reasoningEfforts),reasoningEffort);
+
+@override
+String toString() {
+  return 'GrokModelMetadataDto(supportsReasoningEffort: $supportsReasoningEffort, reasoningEfforts: $reasoningEfforts, reasoningEffort: $reasoningEffort)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GrokModelMetadataDtoCopyWith<$Res>  {
+  factory $GrokModelMetadataDtoCopyWith(GrokModelMetadataDto value, $Res Function(GrokModelMetadataDto) _then) = _$GrokModelMetadataDtoCopyWithImpl;
+@useResult
+$Res call({
+ bool? supportsReasoningEffort, List<GrokReasoningEffortOptionDto> reasoningEfforts, String? reasoningEffort
+});
+
+
+
+
+}
+/// @nodoc
+class _$GrokModelMetadataDtoCopyWithImpl<$Res>
+    implements $GrokModelMetadataDtoCopyWith<$Res> {
+  _$GrokModelMetadataDtoCopyWithImpl(this._self, this._then);
+
+  final GrokModelMetadataDto _self;
+  final $Res Function(GrokModelMetadataDto) _then;
+
+/// Create a copy of GrokModelMetadataDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? supportsReasoningEffort = freezed,Object? reasoningEfforts = null,Object? reasoningEffort = freezed,}) {
+  return _then(GrokModelMetadataDto(
+supportsReasoningEffort: freezed == supportsReasoningEffort ? _self.supportsReasoningEffort : supportsReasoningEffort // ignore: cast_nullable_to_non_nullable
+as bool?,reasoningEfforts: null == reasoningEfforts ? _self.reasoningEfforts : reasoningEfforts // ignore: cast_nullable_to_non_nullable
+as List<GrokReasoningEffortOptionDto>,reasoningEffort: freezed == reasoningEffort ? _self.reasoningEffort : reasoningEffort // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _GrokModelMetadataDto implements GrokModelMetadataDto {
+  const _GrokModelMetadataDto({required this.supportsReasoningEffort,  List<GrokReasoningEffortOptionDto> reasoningEfforts = const <GrokReasoningEffortOptionDto>[], required this.reasoningEffort}): _reasoningEfforts = reasoningEfforts;
+  factory _GrokModelMetadataDto.fromJson(Map<String, dynamic> json) => _$GrokModelMetadataDtoFromJson(json);
+
+@override final  bool? supportsReasoningEffort;
+ final  List<GrokReasoningEffortOptionDto> _reasoningEfforts;
+@override@JsonKey() List<GrokReasoningEffortOptionDto> get reasoningEfforts {
+  if (_reasoningEfforts is EqualUnmodifiableListView) return _reasoningEfforts;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_reasoningEfforts);
+}
+
+@override final  String? reasoningEffort;
+
+/// Create a copy of GrokModelMetadataDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GrokModelMetadataDtoCopyWith<_GrokModelMetadataDto> get copyWith => __$GrokModelMetadataDtoCopyWithImpl<_GrokModelMetadataDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GrokModelMetadataDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GrokModelMetadataDto&&(identical(other.supportsReasoningEffort, supportsReasoningEffort) || other.supportsReasoningEffort == supportsReasoningEffort)&&const DeepCollectionEquality().equals(other._reasoningEfforts, _reasoningEfforts)&&(identical(other.reasoningEffort, reasoningEffort) || other.reasoningEffort == reasoningEffort));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,supportsReasoningEffort,const DeepCollectionEquality().hash(_reasoningEfforts),reasoningEffort);
+
+@override
+String toString() {
+  return 'GrokModelMetadataDto(supportsReasoningEffort: $supportsReasoningEffort, reasoningEfforts: $reasoningEfforts, reasoningEffort: $reasoningEffort)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GrokModelMetadataDtoCopyWith<$Res> implements $GrokModelMetadataDtoCopyWith<$Res> {
+  factory _$GrokModelMetadataDtoCopyWith(_GrokModelMetadataDto value, $Res Function(_GrokModelMetadataDto) _then) = __$GrokModelMetadataDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ bool? supportsReasoningEffort, List<GrokReasoningEffortOptionDto> reasoningEfforts, String? reasoningEffort
+});
+
+
+
+
+}
+/// @nodoc
+class __$GrokModelMetadataDtoCopyWithImpl<$Res>
+    implements _$GrokModelMetadataDtoCopyWith<$Res> {
+  __$GrokModelMetadataDtoCopyWithImpl(this._self, this._then);
+
+  final _GrokModelMetadataDto _self;
+  final $Res Function(_GrokModelMetadataDto) _then;
+
+/// Create a copy of GrokModelMetadataDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? supportsReasoningEffort = freezed,Object? reasoningEfforts = null,Object? reasoningEffort = freezed,}) {
+  return _then(_GrokModelMetadataDto(
+supportsReasoningEffort: freezed == supportsReasoningEffort ? _self.supportsReasoningEffort : supportsReasoningEffort // ignore: cast_nullable_to_non_nullable
+as bool?,reasoningEfforts: null == reasoningEfforts ? _self._reasoningEfforts : reasoningEfforts // ignore: cast_nullable_to_non_nullable
+as List<GrokReasoningEffortOptionDto>,reasoningEffort: freezed == reasoningEffort ? _self.reasoningEffort : reasoningEffort // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$GrokModelInfoDto {
+
+ String? get modelId; String? get name; String? get description;@JsonKey(name: "_meta") GrokModelMetadataDto? get metadata;
+/// Create a copy of GrokModelInfoDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GrokModelInfoDtoCopyWith<GrokModelInfoDto> get copyWith => _$GrokModelInfoDtoCopyWithImpl<GrokModelInfoDto>(this as GrokModelInfoDto, _$identity);
+
+  /// Serializes this GrokModelInfoDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GrokModelInfoDto&&(identical(other.modelId, modelId) || other.modelId == modelId)&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description)&&(identical(other.metadata, metadata) || other.metadata == metadata));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,modelId,name,description,metadata);
+
+@override
+String toString() {
+  return 'GrokModelInfoDto(modelId: $modelId, name: $name, description: $description, metadata: $metadata)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GrokModelInfoDtoCopyWith<$Res>  {
+  factory $GrokModelInfoDtoCopyWith(GrokModelInfoDto value, $Res Function(GrokModelInfoDto) _then) = _$GrokModelInfoDtoCopyWithImpl;
+@useResult
+$Res call({
+ String? modelId, String? name, String? description,@JsonKey(name: "_meta") GrokModelMetadataDto? metadata
+});
+
+
+$GrokModelMetadataDtoCopyWith<$Res>? get metadata;
+
+}
+/// @nodoc
+class _$GrokModelInfoDtoCopyWithImpl<$Res>
+    implements $GrokModelInfoDtoCopyWith<$Res> {
+  _$GrokModelInfoDtoCopyWithImpl(this._self, this._then);
+
+  final GrokModelInfoDto _self;
+  final $Res Function(GrokModelInfoDto) _then;
+
+/// Create a copy of GrokModelInfoDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? modelId = freezed,Object? name = freezed,Object? description = freezed,Object? metadata = freezed,}) {
+  return _then(GrokModelInfoDto(
+modelId: freezed == modelId ? _self.modelId : modelId // ignore: cast_nullable_to_non_nullable
+as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as GrokModelMetadataDto?,
+  ));
+}
+/// Create a copy of GrokModelInfoDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GrokModelMetadataDtoCopyWith<$Res>? get metadata {
+    if (_self.metadata == null) {
+    return null;
+  }
+
+  return $GrokModelMetadataDtoCopyWith<$Res>(_self.metadata!, (value) {
+    return _then(_self.copyWith(metadata: value));
+  });
+}
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _GrokModelInfoDto implements GrokModelInfoDto {
+  const _GrokModelInfoDto({required this.modelId, required this.name, required this.description, @JsonKey(name: "_meta") required this.metadata});
+  factory _GrokModelInfoDto.fromJson(Map<String, dynamic> json) => _$GrokModelInfoDtoFromJson(json);
+
+@override final  String? modelId;
+@override final  String? name;
+@override final  String? description;
+@override@JsonKey(name: "_meta") final  GrokModelMetadataDto? metadata;
+
+/// Create a copy of GrokModelInfoDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GrokModelInfoDtoCopyWith<_GrokModelInfoDto> get copyWith => __$GrokModelInfoDtoCopyWithImpl<_GrokModelInfoDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GrokModelInfoDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GrokModelInfoDto&&(identical(other.modelId, modelId) || other.modelId == modelId)&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description)&&(identical(other.metadata, metadata) || other.metadata == metadata));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,modelId,name,description,metadata);
+
+@override
+String toString() {
+  return 'GrokModelInfoDto(modelId: $modelId, name: $name, description: $description, metadata: $metadata)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GrokModelInfoDtoCopyWith<$Res> implements $GrokModelInfoDtoCopyWith<$Res> {
+  factory _$GrokModelInfoDtoCopyWith(_GrokModelInfoDto value, $Res Function(_GrokModelInfoDto) _then) = __$GrokModelInfoDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String? modelId, String? name, String? description,@JsonKey(name: "_meta") GrokModelMetadataDto? metadata
+});
+
+
+@override $GrokModelMetadataDtoCopyWith<$Res>? get metadata;
+
+}
+/// @nodoc
+class __$GrokModelInfoDtoCopyWithImpl<$Res>
+    implements _$GrokModelInfoDtoCopyWith<$Res> {
+  __$GrokModelInfoDtoCopyWithImpl(this._self, this._then);
+
+  final _GrokModelInfoDto _self;
+  final $Res Function(_GrokModelInfoDto) _then;
+
+/// Create a copy of GrokModelInfoDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? modelId = freezed,Object? name = freezed,Object? description = freezed,Object? metadata = freezed,}) {
+  return _then(_GrokModelInfoDto(
+modelId: freezed == modelId ? _self.modelId : modelId // ignore: cast_nullable_to_non_nullable
+as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as GrokModelMetadataDto?,
+  ));
+}
+
+/// Create a copy of GrokModelInfoDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GrokModelMetadataDtoCopyWith<$Res>? get metadata {
+    if (_self.metadata == null) {
+    return null;
+  }
+
+  return $GrokModelMetadataDtoCopyWith<$Res>(_self.metadata!, (value) {
+    return _then(_self.copyWith(metadata: value));
+  });
+}
+}
+
+
+/// @nodoc
+mixin _$GrokSessionModelStateDto {
+
+ List<GrokModelInfoDto> get availableModels; String? get currentModelId;
+/// Create a copy of GrokSessionModelStateDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GrokSessionModelStateDtoCopyWith<GrokSessionModelStateDto> get copyWith => _$GrokSessionModelStateDtoCopyWithImpl<GrokSessionModelStateDto>(this as GrokSessionModelStateDto, _$identity);
+
+  /// Serializes this GrokSessionModelStateDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GrokSessionModelStateDto&&const DeepCollectionEquality().equals(other.availableModels, availableModels)&&(identical(other.currentModelId, currentModelId) || other.currentModelId == currentModelId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(availableModels),currentModelId);
+
+@override
+String toString() {
+  return 'GrokSessionModelStateDto(availableModels: $availableModels, currentModelId: $currentModelId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GrokSessionModelStateDtoCopyWith<$Res>  {
+  factory $GrokSessionModelStateDtoCopyWith(GrokSessionModelStateDto value, $Res Function(GrokSessionModelStateDto) _then) = _$GrokSessionModelStateDtoCopyWithImpl;
+@useResult
+$Res call({
+ List<GrokModelInfoDto> availableModels, String? currentModelId
+});
+
+
+
+
+}
+/// @nodoc
+class _$GrokSessionModelStateDtoCopyWithImpl<$Res>
+    implements $GrokSessionModelStateDtoCopyWith<$Res> {
+  _$GrokSessionModelStateDtoCopyWithImpl(this._self, this._then);
+
+  final GrokSessionModelStateDto _self;
+  final $Res Function(GrokSessionModelStateDto) _then;
+
+/// Create a copy of GrokSessionModelStateDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? availableModels = null,Object? currentModelId = freezed,}) {
+  return _then(GrokSessionModelStateDto(
+availableModels: null == availableModels ? _self.availableModels : availableModels // ignore: cast_nullable_to_non_nullable
+as List<GrokModelInfoDto>,currentModelId: freezed == currentModelId ? _self.currentModelId : currentModelId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _GrokSessionModelStateDto implements GrokSessionModelStateDto {
+  const _GrokSessionModelStateDto({ List<GrokModelInfoDto> availableModels = const <GrokModelInfoDto>[], required this.currentModelId}): _availableModels = availableModels;
+  factory _GrokSessionModelStateDto.fromJson(Map<String, dynamic> json) => _$GrokSessionModelStateDtoFromJson(json);
+
+ final  List<GrokModelInfoDto> _availableModels;
+@override@JsonKey() List<GrokModelInfoDto> get availableModels {
+  if (_availableModels is EqualUnmodifiableListView) return _availableModels;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_availableModels);
+}
+
+@override final  String? currentModelId;
+
+/// Create a copy of GrokSessionModelStateDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GrokSessionModelStateDtoCopyWith<_GrokSessionModelStateDto> get copyWith => __$GrokSessionModelStateDtoCopyWithImpl<_GrokSessionModelStateDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GrokSessionModelStateDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GrokSessionModelStateDto&&const DeepCollectionEquality().equals(other._availableModels, _availableModels)&&(identical(other.currentModelId, currentModelId) || other.currentModelId == currentModelId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_availableModels),currentModelId);
+
+@override
+String toString() {
+  return 'GrokSessionModelStateDto(availableModels: $availableModels, currentModelId: $currentModelId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GrokSessionModelStateDtoCopyWith<$Res> implements $GrokSessionModelStateDtoCopyWith<$Res> {
+  factory _$GrokSessionModelStateDtoCopyWith(_GrokSessionModelStateDto value, $Res Function(_GrokSessionModelStateDto) _then) = __$GrokSessionModelStateDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ List<GrokModelInfoDto> availableModels, String? currentModelId
+});
+
+
+
+
+}
+/// @nodoc
+class __$GrokSessionModelStateDtoCopyWithImpl<$Res>
+    implements _$GrokSessionModelStateDtoCopyWith<$Res> {
+  __$GrokSessionModelStateDtoCopyWithImpl(this._self, this._then);
+
+  final _GrokSessionModelStateDto _self;
+  final $Res Function(_GrokSessionModelStateDto) _then;
+
+/// Create a copy of GrokSessionModelStateDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? availableModels = null,Object? currentModelId = freezed,}) {
+  return _then(_GrokSessionModelStateDto(
+availableModels: null == availableModels ? _self._availableModels : availableModels // ignore: cast_nullable_to_non_nullable
+as List<GrokModelInfoDto>,currentModelId: freezed == currentModelId ? _self.currentModelId : currentModelId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.g.dart
+++ b/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.g.dart
@@ -1,0 +1,90 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'grok_protocol_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_GrokReasoningEffortOptionDto _$GrokReasoningEffortOptionDtoFromJson(
+  Map json,
+) => _GrokReasoningEffortOptionDto(
+  id: json['id'] as String?,
+  value: json['value'] as String?,
+  label: json['label'] as String?,
+  description: json['description'] as String?,
+  isDefault: json['default'] as bool? ?? false,
+);
+
+Map<String, dynamic> _$GrokReasoningEffortOptionDtoToJson(
+  _GrokReasoningEffortOptionDto instance,
+) => <String, dynamic>{
+  'id': ?instance.id,
+  'value': ?instance.value,
+  'label': ?instance.label,
+  'description': ?instance.description,
+  'default': instance.isDefault,
+};
+
+_GrokModelMetadataDto _$GrokModelMetadataDtoFromJson(Map json) =>
+    _GrokModelMetadataDto(
+      supportsReasoningEffort: json['supportsReasoningEffort'] as bool?,
+      reasoningEfforts:
+          (json['reasoningEfforts'] as List<dynamic>?)
+              ?.map(
+                (e) => GrokReasoningEffortOptionDto.fromJson(
+                  Map<String, dynamic>.from(e as Map),
+                ),
+              )
+              .toList() ??
+          const <GrokReasoningEffortOptionDto>[],
+      reasoningEffort: json['reasoningEffort'] as String?,
+    );
+
+Map<String, dynamic> _$GrokModelMetadataDtoToJson(
+  _GrokModelMetadataDto instance,
+) => <String, dynamic>{
+  'supportsReasoningEffort': ?instance.supportsReasoningEffort,
+  'reasoningEfforts': instance.reasoningEfforts.map((e) => e.toJson()).toList(),
+  'reasoningEffort': ?instance.reasoningEffort,
+};
+
+_GrokModelInfoDto _$GrokModelInfoDtoFromJson(Map json) => _GrokModelInfoDto(
+  modelId: json['modelId'] as String?,
+  name: json['name'] as String?,
+  description: json['description'] as String?,
+  metadata: json['_meta'] == null
+      ? null
+      : GrokModelMetadataDto.fromJson(
+          Map<String, dynamic>.from(json['_meta'] as Map),
+        ),
+);
+
+Map<String, dynamic> _$GrokModelInfoDtoToJson(_GrokModelInfoDto instance) =>
+    <String, dynamic>{
+      'modelId': ?instance.modelId,
+      'name': ?instance.name,
+      'description': ?instance.description,
+      '_meta': ?instance.metadata?.toJson(),
+    };
+
+_GrokSessionModelStateDto _$GrokSessionModelStateDtoFromJson(Map json) =>
+    _GrokSessionModelStateDto(
+      availableModels:
+          (json['availableModels'] as List<dynamic>?)
+              ?.map(
+                (e) => GrokModelInfoDto.fromJson(
+                  Map<String, dynamic>.from(e as Map),
+                ),
+              )
+              .toList() ??
+          const <GrokModelInfoDto>[],
+      currentModelId: json['currentModelId'] as String?,
+    );
+
+Map<String, dynamic> _$GrokSessionModelStateDtoToJson(
+  _GrokSessionModelStateDto instance,
+) => <String, dynamic>{
+  'availableModels': instance.availableModels.map((e) => e.toJson()).toList(),
+  'currentModelId': ?instance.currentModelId,
+};

--- a/bridge/sesori_plugin_grok/lib/src/grok_binary.dart
+++ b/bridge/sesori_plugin_grok/lib/src/grok_binary.dart
@@ -1,0 +1,30 @@
+import "package:acp_plugin/acp_plugin.dart";
+
+/// Builds the launch specification for Grok Build's official ACP server.
+///
+/// The bridge owns a dedicated local agent process: it neither attaches to
+/// Grok's shared leader nor lets the child update its executable. Ask-mode is
+/// intentionally left enabled, so standard ACP permission requests reach the
+/// Sesori client.
+abstract final class GrokBinary() {
+  /// Grok Build's CLI launcher, resolved on PATH by default.
+  static const String defaultBinary = "grok";
+
+  static AcpLaunchSpec launchSpec({
+    required String binary,
+    required String? cwd,
+    required Map<String, String> environment,
+  }) {
+    return AcpLaunchSpec(
+      command: binary,
+      args: const [
+        "--no-auto-update",
+        "agent",
+        "--no-leader",
+        "stdio",
+      ],
+      cwd: cwd,
+      environment: environment,
+    );
+  }
+}

--- a/bridge/sesori_plugin_grok/lib/src/grok_identity.dart
+++ b/bridge/sesori_plugin_grok/lib/src/grok_identity.dart
@@ -1,0 +1,8 @@
+/// Identity constants for the Grok Build harness plugin.
+///
+/// The transport keeps plugin IDs as strings; client-side built-in branding
+/// recognizes the stable [id] only after the plugin is activated.
+abstract final class GrokPluginIdentity() {
+  static const String id = "grok";
+  static const String displayName = "Grok Build";
+}

--- a/bridge/sesori_plugin_grok/pubspec.yaml
+++ b/bridge/sesori_plugin_grok/pubspec.yaml
@@ -1,0 +1,20 @@
+name: grok_plugin
+version: 0.1.0
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.13.1
+
+dependencies:
+  acp_plugin:
+    path: ../sesori_plugin_acp
+  freezed_annotation: ^3.1.0
+  json_annotation: ^4.12.0
+
+dev_dependencies:
+  build_runner: any
+  freezed: 4.0.0-dev.3
+  json_serializable: ^6.14.1
+  lints: ^6.1.0
+  test: ^1.31.2

--- a/bridge/sesori_plugin_grok/test/fixtures/protocol/v1/README.md
+++ b/bridge/sesori_plugin_grok/test/fixtures/protocol/v1/README.md
@@ -1,0 +1,15 @@
+# Grok Build ACP v1 fixture source
+
+Validated on 2026-08-27 against the official macOS arm64 artifact:
+
+- Version: `grok 1.0.5 (5115b46bc909)`
+- URL: <https://x.ai/cli/grok-1.0.5-macos-aarch64>
+- SHA-256: `3dfa7f04fbb5427a8fbead286591543aaecb478b3a0ab222c4329eca1a3b2f86`
+- Launch: `grok --no-auto-update agent --no-leader stdio`
+
+An isolated initialize negotiated ACP v1, advertised load/list/resume/close, disabled image/audio prompts, enabled
+embedded context, returned Grok identity/version metadata, and exposed model entries with structured reasoning-effort
+metadata. With no credentials, it advertised only interactive `grok.com` authentication.
+
+The JSON fixtures preserve only that schema. Model IDs, names, descriptions, effort labels, and session IDs are
+synthetic; no account data, credentials, prompts, transcripts, source paths, or raw released response are retained.

--- a/bridge/sesori_plugin_grok/test/fixtures/protocol/v1/initialize.json
+++ b/bridge/sesori_plugin_grok/test/fixtures/protocol/v1/initialize.json
@@ -1,0 +1,66 @@
+{
+  "protocolVersion": 1,
+  "agentCapabilities": {
+    "loadSession": true,
+    "promptCapabilities": {
+      "image": false,
+      "audio": false,
+      "embeddedContext": true
+    },
+    "sessionCapabilities": {
+      "list": {},
+      "resume": {},
+      "close": {}
+    }
+  },
+  "authMethods": [
+    {
+      "id": "grok.com",
+      "name": "Interactive login"
+    }
+  ],
+  "_meta": {
+    "grokShell": true,
+    "agentVersion": "1.0.5",
+    "modelState": {
+      "currentModelId": "synthetic:model-alpha",
+      "availableModels": [
+        {
+          "modelId": "synthetic:model-alpha",
+          "name": "Model Alpha",
+          "description": "Synthetic reasoning model",
+          "_meta": {
+            "supportsReasoningEffort": true,
+            "reasoningEffort": "high",
+            "reasoningEfforts": [
+              {
+                "id": "low",
+                "value": "low",
+                "label": "Low",
+                "description": "Synthetic low effort",
+                "default": false
+              },
+              {
+                "id": "high",
+                "value": "high",
+                "label": "High",
+                "description": "Synthetic high effort",
+                "default": true
+              }
+            ]
+          }
+        },
+        {
+          "modelId": "opaque/provider:model-beta",
+          "name": "Model Beta",
+          "description": null,
+          "_meta": {
+            "supportsReasoningEffort": false,
+            "reasoningEffort": null,
+            "reasoningEfforts": []
+          }
+        }
+      ]
+    }
+  }
+}

--- a/bridge/sesori_plugin_grok/test/fixtures/protocol/v1/session.json
+++ b/bridge/sesori_plugin_grok/test/fixtures/protocol/v1/session.json
@@ -1,0 +1,36 @@
+{
+  "sessionId": "synthetic-session",
+  "models": {
+    "currentModelId": "opaque/provider:model-beta",
+    "availableModels": [
+      {
+        "modelId": "synthetic:model-alpha",
+        "name": "Model Alpha",
+        "description": "Synthetic reasoning model",
+        "_meta": {
+          "supportsReasoningEffort": true,
+          "reasoningEffort": "low",
+          "reasoningEfforts": [
+            {
+              "id": "low",
+              "value": "low",
+              "label": "Low",
+              "description": null,
+              "default": true
+            }
+          ]
+        }
+      },
+      {
+        "modelId": "opaque/provider:model-beta",
+        "name": "Model Beta",
+        "description": null,
+        "_meta": {
+          "supportsReasoningEffort": false,
+          "reasoningEffort": null,
+          "reasoningEfforts": []
+        }
+      }
+    ]
+  }
+}

--- a/bridge/sesori_plugin_grok/test/grok_binary_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_binary_test.dart
@@ -1,0 +1,26 @@
+import "package:grok_plugin/grok_plugin.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("declares stable Grok identity", () {
+    expect(GrokPluginIdentity.id, "grok");
+    expect(GrokPluginIdentity.displayName, "Grok Build");
+    expect(GrokBinary.defaultBinary, "grok");
+  });
+
+  test("launches a dedicated non-updating ACP process in ask mode", () {
+    const environment = {"GROK_HOME": "/isolated/grok"};
+    final spec = GrokBinary.launchSpec(
+      binary: "/custom/grok",
+      cwd: "/workspace/project",
+      environment: environment,
+    );
+
+    expect(spec.command, "/custom/grok");
+    expect(spec.args, ["--no-auto-update", "agent", "--no-leader", "stdio"]);
+    expect(spec.args, isNot(contains("--always-approve")));
+    expect(spec.args, isNot(contains("--yolo")));
+    expect(spec.cwd, "/workspace/project");
+    expect(spec.environment, environment);
+  });
+}

--- a/bridge/sesori_plugin_grok/test/grok_protocol_dto_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_protocol_dto_test.dart
@@ -1,0 +1,71 @@
+import "dart:convert";
+import "dart:io";
+
+import "package:grok_plugin/src/api/models/grok_protocol_dto.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("parses released initialize model-state structure", () {
+    final fixture = _fixture(name: "initialize.json");
+    final metadata = _map(value: fixture["_meta"]);
+    final modelState = GrokSessionModelStateDto.fromJson(_map(value: metadata["modelState"]));
+
+    expect(metadata["grokShell"], isTrue);
+    expect(metadata["agentVersion"], "1.0.5");
+    expect(modelState.currentModelId, "synthetic:model-alpha");
+    expect(modelState.availableModels, hasLength(2));
+
+    final primary = modelState.availableModels.first;
+    expect(primary.modelId, "synthetic:model-alpha");
+    expect(primary.name, "Model Alpha");
+    expect(primary.metadata?.supportsReasoningEffort, isTrue);
+    expect(primary.metadata?.reasoningEffort, "high");
+    expect(primary.metadata?.reasoningEfforts.map((option) => option.value), ["low", "high"]);
+    expect(primary.metadata?.reasoningEfforts.last.isDefault, isTrue);
+  });
+
+  test("parses model state from session responses without interpreting ids", () {
+    final fixture = _fixture(name: "session.json");
+    final modelState = GrokSessionModelStateDto.fromJson(_map(value: fixture["models"]));
+
+    expect(modelState.currentModelId, "opaque/provider:model-beta");
+    expect(modelState.availableModels.last.modelId, "opaque/provider:model-beta");
+    expect(modelState.availableModels.last.metadata?.supportsReasoningEffort, isFalse);
+    expect(modelState.availableModels.last.metadata?.reasoningEfforts, isEmpty);
+  });
+
+  test("accepts omitted optional model metadata", () {
+    final modelState = GrokSessionModelStateDto.fromJson({
+      "availableModels": [
+        {
+          "modelId": "future-model",
+          "name": "Future Model",
+          "description": null,
+        },
+      ],
+      "currentModelId": "future-model",
+    });
+
+    expect(modelState.availableModels.single.metadata, isNull);
+  });
+
+  test("keeps the reasoning option default field on the wire", () {
+    const option = GrokReasoningEffortOptionDto(
+      id: "high",
+      value: "high",
+      label: "High",
+      description: "Synthetic fixture",
+      isDefault: true,
+    );
+
+    expect(option.toJson()["default"], isTrue);
+    expect(option.toJson(), isNot(contains("isDefault")));
+  });
+}
+
+Map<String, dynamic> _fixture({required String name}) {
+  final decoded = jsonDecode(File("test/fixtures/protocol/v1/$name").readAsStringSync());
+  return _map(value: decoded);
+}
+
+Map<String, dynamic> _map({required Object? value}) => (value! as Map<dynamic, dynamic>).cast<String, dynamic>();


### PR DESCRIPTION
## Complexity

🌿 Straightforward — this adds an isolated plugin-package scaffold and generated DTOs without runtime registration, session lifecycle wiring, or shared contract changes.

## What

- Added `sesori_plugin_grok` to the bridge workspace, Makefile/CI inventory, and module documentation.
- Added Grok identity and a dedicated ACP launch specification using exactly `--no-auto-update agent --no-leader stdio` while preserving ask-mode permissions.
- Added typed Freezed DTOs for Grok's legacy model/reasoning state plus privacy-safe synthetic initialize/session fixtures.
- Captured the validated Grok 1.0.5 artifact, build, checksum, and ACP contract evidence in fixture documentation.
- Added focused launch and protocol parsing tests and generated serialization code.

## Why

The Grok harness needs a reviewed package boundary and frozen released-binary contract before later steps add model services, ACP session composition, setup, and activation.

## Risk and test focus

Risk is low and isolated because the package is not registered or depended on by the bridge app yet. The highest-value checks are the exact process arguments, absence of approval-bypass flags, opaque model-ID parsing, reasoning-effort schema handling, and synthetic fixture privacy. There is no user-visible or database impact.

## Expected result

The bridge workspace recognizes and validates the dormant Grok plugin package, with a safe launch contract and typed model-state foundation ready for Step 3. No existing harness behavior, transport shape, persisted data, or UI changes.

## Verification

- `dart test` — 6 tests passed
- `dart analyze --fatal-infos` — no issues
- Dart LSP diagnostics — 0 diagnostics across 8 files
- `make -n analyze | grep -F sesori_plugin_grok` — package included in workspace analysis
- `git diff --check` — passed
- Architecture implementation review of `origin/main...HEAD` — approved with no findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `sesori_plugin_grok` package as a dormant scaffold for the Grok Build harness. The package is not registered or depended on by the bridge app, so existing harness behavior is unchanged.

**Details**
- Adds the package to the workspace, Makefile/CI inventory, and module docs, using the shared bridge analysis rules.
- Defines Grok's ACP launch spec as `--no-auto-update agent --no-leader stdio` with ask-mode permissions intact.
- Adds Freezed DTOs for model and reasoning-effort state, parsing model IDs opaquely without interpreting them.
- Includes synthetic protocol fixtures with no account data, credentials, or raw responses, validated against the official 1.0.5 artifact.

<sup>Written for commit 1f3dc6c50f44371ff4c1a2d2bd20a91d22721d25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

