### PR TITLE
⚙️ Prevent Pi aborts from stalling later sends

### DIFF
--- a/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
+++ b/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
@@ -65,6 +65,10 @@ final class PiPlugin._({
       identityTracker: identities,
       startupExitTimeout: startupExitTimeout,
       historyRpcTimeout: historyRpcTimeout,
+      // Pi's abort response waits for full agent idleness, which can include
+      // an already queued steering continuation. Bound that acknowledgement
+      // tightly so Stop can force process replacement instead of stalling.
+      abortRpcTimeout: const Duration(seconds: 1),
       // Pi can run model-backed automatic compaction before acknowledging a
       // prompt, so prompt preflight needs the same generous bound as a turn.
       promptRpcTimeout: const Duration(minutes: 30),

--- a/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
@@ -110,6 +110,7 @@ final class PiSessionProcessRepository({
   required final PiMessageIdentityTracker _identityTracker,
   required final Duration _startupExitTimeout,
   required final Duration _historyRpcTimeout,
+  required final Duration _abortRpcTimeout,
   required final Duration _promptRpcTimeout,
 }) {
   final Map<String, String> _environment = Map.unmodifiable(environment);
@@ -421,7 +422,7 @@ final class PiSessionProcessRepository({
       await _requiredResident(connection).client.send(
         command: PiRpcCommand.abort,
         arguments: const {},
-        timeout: _historyRpcTimeout,
+        timeout: _abortRpcTimeout,
       );
       return const PiSessionAbortAcknowledged();
     } on PiRpcProcessExitException catch (error, stackTrace) {

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -953,6 +953,7 @@ final class PiSessionService({
     if (hadQueuedPresentations) _emitQueueUpdate(sessionId: sessionId, state: state);
     _extensionUi.cancelForOwner(sessionId: sessionId, processGeneration: null);
     final connection = cancelled.firstOrNull?.connection;
+    var forceTeardown = false;
     try {
       final idleReap = state.idleReap;
       if (idleReap != null) await idleReap;
@@ -961,15 +962,30 @@ final class PiSessionService({
           case PiSessionAbortAcknowledged():
             break;
           case PiSessionAbortProcessExited(:final innerError, :final innerStackTrace):
+            forceTeardown = true;
             if (!processExitIsExpected) {
               Log.w("[pi] abort command failed for session id=$sessionId", innerError, innerStackTrace);
             }
         }
       }
+    } on TimeoutException catch (error, stack) {
+      forceTeardown = true;
+      if (!processExitIsExpected) {
+        Log.w(
+          "[pi] abort acknowledgement timed out; forcing process replacement for session id=$sessionId",
+          error,
+          stack,
+        );
+      }
     } on Object catch (error, stack) {
+      forceTeardown = true;
       Log.w("[pi] abort command failed for session id=$sessionId", error, stack);
     } finally {
-      await _processes.teardown(sessionId: sessionId);
+      if (forceTeardown) {
+        await _processes.teardown(sessionId: sessionId, gracefulTimeout: Duration.zero);
+      } else {
+        await _processes.teardown(sessionId: sessionId);
+      }
     }
     _emit(
       BridgeSseSessionStatus(

--- a/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
@@ -471,6 +471,7 @@ final class _ProcessFixture({required final FakePiExtensionSessionStorageApi sto
     identityTracker: PiMessageIdentityTracker(pluginId: "pi"),
     startupExitTimeout: const Duration(milliseconds: 50),
     historyRpcTimeout: const Duration(seconds: 2),
+    abortRpcTimeout: const Duration(seconds: 1),
     promptRpcTimeout: const Duration(minutes: 30),
   );
 

--- a/bridge/sesori_plugin_pi/test/pi_session_process_repository_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_process_repository_test.dart
@@ -472,6 +472,7 @@ PiSessionProcessRepository _repository({
   PiMessageIdentityTracker? identityTracker,
   Duration startupExitTimeout = const Duration(seconds: 5),
   Duration historyRpcTimeout = const Duration(minutes: 2),
+  Duration abortRpcTimeout = const Duration(seconds: 1),
 }) {
   final storage = storageApi ?? _ProcessStorage();
   return PiSessionProcessRepository(
@@ -484,6 +485,7 @@ PiSessionProcessRepository _repository({
     identityTracker: identityTracker ?? PiMessageIdentityTracker(pluginId: "pi"),
     startupExitTimeout: startupExitTimeout,
     historyRpcTimeout: historyRpcTimeout,
+    abortRpcTimeout: abortRpcTimeout,
     promptRpcTimeout: const Duration(minutes: 30),
   );
 }

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -275,6 +275,7 @@ void main() {
       identityTracker: identities,
       startupExitTimeout: const Duration(milliseconds: 50),
       historyRpcTimeout: const Duration(seconds: 2),
+      abortRpcTimeout: const Duration(seconds: 1),
       promptRpcTimeout: const Duration(minutes: 30),
     );
     addTearDown(repository.dispose);
@@ -1710,6 +1711,49 @@ void main() {
     expect(events.whereType<BridgeSseMessageRemoved>().single.messageID, compactionMessageId);
   });
 
+  test("abort force-replaces Pi when its acknowledgement waits on hidden steering", () async {
+    final process = FakePiProcess();
+    final fixture = _Fixture(processes: [process])..abortRpcTimeout = const Duration(milliseconds: 10);
+    addTearDown(fixture.dispose);
+    final service = fixture.service();
+
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "prompt-active",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "active")],
+      userVisibleText: "active",
+      variant: null,
+      model: null,
+    );
+    await service.sendPrompt(
+      sessionId: "session",
+      promptId: "prompt-steering",
+      directory: "/project",
+      parts: [const PluginPromptPart.text(text: "steering")],
+      userVisibleText: "steering",
+      variant: null,
+      model: null,
+    );
+    await _answerEntries(process);
+    final prompt = await waitForCommand(process: process, type: "prompt");
+    process.emitResponse(id: prompt["id"]! as String, command: "prompt");
+    process.emit(frame: {"type": "agent_start"});
+    final steeringPrompt = await _waitForNthCommand(process: process, type: "prompt", count: 2);
+    process.emitResponse(id: steeringPrompt["id"]! as String, command: "prompt");
+
+    final warnings = await _captureWarnings(() async {
+      final abort = service.abort(sessionId: "session");
+      await waitForCommand(process: process, type: "abort");
+      await abort;
+    });
+
+    expect(warnings, contains("abort acknowledgement timed out; forcing process replacement"));
+    expect(process.killed, isTrue);
+    expect(fixture.repository.residentSessionIds, isEmpty);
+    expect(service.sessionStatuses["session"], const PluginSessionStatus.idle());
+  });
+
   test("shutdown interruption accepts process exit before abort response", () async {
     final process = FakePiProcess();
     final fixture = _Fixture(processes: [process]);
@@ -2301,6 +2345,7 @@ final class _Fixture({
   final List<FakePiProcess> _processes = List.of(processes);
   Duration? idleTimeout = const Duration(minutes: 5);
   Duration historyRpcTimeout = const Duration(seconds: 2);
+  Duration abortRpcTimeout = const Duration(seconds: 1);
   Duration promptRpcTimeout = const Duration(seconds: 2);
   late final _Storage storage = storageOverride ?? _Storage(initialResolvedSession: _resolved());
   final List<PiLaunchSpec> spawned = [];
@@ -2322,6 +2367,7 @@ final class _Fixture({
     identityTracker: identities,
     startupExitTimeout: const Duration(milliseconds: 50),
     historyRpcTimeout: historyRpcTimeout,
+    abortRpcTimeout: abortRpcTimeout,
     promptRpcTimeout: promptRpcTimeout,
   );
 

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -103,7 +103,10 @@ defaults and queued client sends coherent.
   session is busy, and a successful command with no agent run crosses `get_state`
   before returning the lane idle.
   Abort rejects queued work and replaces the process so hidden steering or
-  follow-up input cannot leak into the next turn.
+  follow-up input cannot leak into the next turn. Its control acknowledgement
+  has a short bound: if Pi waits for queued continuation idleness instead of
+  answering, the bridge force-replaces the resident rather than holding later
+  sends in the session lane for the general history/control timeout.
 - Pi accepts only bounded, valid inline GIF, JPEG, PNG, and WebP data. Paths,
   URLs, non-image data, malformed base64, and oversized images fail visibly
   before admission and are never fetched, stringified, or silently omitted.
@@ -304,6 +307,8 @@ replay, and abort after output has started.
 - An abort, permission reply, or question reply stalls behind a send to a
   busy session on the same session lane, or a Cursor/Hermes follow-up waits for
   the active turn to finish naturally instead of cancelling it before dispatch.
+  A Pi abort waits for the general history/control timeout, lets hidden steering
+  resume after Stop, or leaves later sends stuck in their sending state.
 - Recovery or interruption artifacts from an aborted turn appear in the next
   user turn.
 - A normalized user message fails to advance the existing activity marker, or


### PR DESCRIPTION
## Complexity

⚙️ Moderate — localized Pi process-lifecycle timing with serialized session-lane behavior.

## What

- Give Pi abort acknowledgements a dedicated one-second timeout instead of the general two-minute history/control timeout.
- Force-replace the resident Pi process when that acknowledgement stalls, while preserving the normal acknowledged-abort path.
- Add regression coverage for an abort blocked by already accepted steering input and document the failure signal.

## Why

Pi RPC waits for the agent to become fully idle before acknowledging `abort`. If Pi already holds steering input, that continuation can resume after the current turn is aborted, so the bridge waits for the full control timeout while later sends remain in `Sending`. A user retry can then become a second prompt once the process is finally replaced.

## Risk and test focus

The main risk is process teardown timing: normal abort acknowledgements must remain graceful, while stalled acknowledgements must not hold the session lane or leak hidden steering into the next turn. Shutdown-time process exits remain non-noisy.

There is no database, schema, persisted-data, or wire-contract impact. The user-visible impact is that Stop recovers promptly and later messages no longer sit in `Sending` for roughly two minutes.

## Expected result

A normal Pi abort behaves as before. If Pi does not acknowledge within one second, the bridge force-replaces that session's resident process, releases the serialized lane, and prevents already queued Pi steering from continuing after Stop.

## Verification

- `dart test test/pi_session_service_test.dart --name '(abort force-replaces Pi|shutdown interruption accepts process exit)'`
- `dart test` — 281 tests passed
- `dart analyze --fatal-infos`
- Dart LSP diagnostics — 0 diagnostics across touched Pi plugin files
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Pi abort acknowledgements stalling the session lane by bounding the acknowledgement to one second and force-replacing the process when it times out.

- Abort acknowledgements now use a dedicated one-second timeout instead of the general history/control timeout.
- A stalled acknowledgement force-replaces the resident Pi process; normal acknowledged aborts and shutdown-time process exits behave as before.
- Adds regression coverage for an abort blocked by already accepted steering input.
- Documents the failure signal in the regression notes.

<sup>Written for commit f5816250177c668ebf50d60ee486ba5676047b14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

