### PR TITLE
⚙️ [github-copilot-harness] feat(copilot): install the managed Copilot CLI [step 4/7]

### DIFF
--- a/.plan/active/github-copilot-harness/PLAN.md
+++ b/.plan/active/github-copilot-harness/PLAN.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Plan slug:** `github-copilot-harness`
-- **Status:** active; Steps 1-2/7 merged (#1154, #1155), Step 3/7 in review (#1158)
+- **Status:** active; Steps 1-3/7 merged (#1154, #1155, #1158), Step 4/7 implemented and verified locally
 - **Plan date:** 2026-08-27
 - **Implementation base:** current `origin/main`
 - **Delivery:** seven PRs with the fixed titles below

--- a/.plan/active/github-copilot-harness/TRACKER.md
+++ b/.plan/active/github-copilot-harness/TRACKER.md
@@ -12,13 +12,14 @@ Plan: [PLAN.md](PLAN.md)
   - State: merged
   - PR: [#1155](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1155)
   - Evidence: package tests and analyzer pass; architecture implementation review passed
-- [ ] **Step 3/7** — `⚙️ [github-copilot-harness] feat(copilot): add runtime setup and lifecycle [step 3/7]`
-  - State: in review
+- [x] **Step 3/7** — `⚙️ [github-copilot-harness] feat(copilot): add runtime setup and lifecycle [step 3/7]`
+  - State: merged
   - PR: [#1158](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1158)
-  - Evidence: 6 Copilot package tests and 266 shared ACP tests pass; both analyzers report no issues; Makefile verification includes the package; live `1.0.80` probes confirmed authenticated scratch discovery and `session/set_config_option`; architecture implementation review passed
+  - Evidence: 5 Copilot package tests, 266 shared ACP tests, and 47 focused app tests pass; owning analyzers report no issues; Makefile verification includes the package; live `1.0.80` probes confirmed authenticated scratch discovery and `session/set_config_option`; architecture implementation review passed
 - [ ] **Step 4/7** — `⚙️ [github-copilot-harness] feat(copilot): install the managed Copilot CLI [step 4/7]`
-  - State: not started
+  - State: implemented and verified locally on `github-copilot-harness/step-4-install`; ready for review
   - PR: pending
+  - Evidence: 13 package tests pass; analyzer reports no issues; all six official `1.0.80` asset names and SHA-256 digests match the GitHub release API; architecture implementation review passed
 - [ ] **Step 5/7** — `⚙️ [github-copilot-harness] feat(app): activate and brand GitHub Copilot [step 5/7]`
   - State: not started
   - PR: pending

--- a/bridge/sesori_plugin_copilot/lib/src/runtime/copilot_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_copilot/lib/src/runtime/copilot_plugin_descriptor.dart
@@ -1,6 +1,7 @@
 import "dart:io" as io;
 
 import "package:acp_plugin/acp_plugin.dart";
+import "package:http/http.dart" as http;
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
@@ -81,6 +82,24 @@ final class const CopilotPluginDescriptor({
   }
 
   @override
+  Set<PluginControlCapability> managementCapabilities({required PluginConfig config}) {
+    return {
+      ...super.managementCapabilities(config: config),
+      if (_supportsManagedInstall(config: config)) PluginControlCapability.install,
+    };
+  }
+
+  bool _supportsManagedInstall({required PluginConfig config}) {
+    if (_explicitBin(config: config) != null) return false;
+    try {
+      return const CopilotRuntimeManifest().supportsManagedInstallOn(target: PlatformTarget.current());
+    } on Object catch (error, stack) {
+      Log.w("[${CopilotPluginIdentity.id}] platform detection failed; managed install unavailable", error, stack);
+      return false;
+    }
+  }
+
+  @override
   Stream<RuntimeProvisionProgress> ensureRuntime({required PluginHost host}) async* {
     const manifest = CopilotRuntimeManifest();
     yield* ManagedRuntimeProvisionService(
@@ -94,6 +113,49 @@ final class const CopilotPluginDescriptor({
       host: host,
       explicitExecutablePath: _explicitBin(config: host.config),
     );
+  }
+
+  @override
+  Stream<RuntimeProvisionProgress> installRuntime({
+    required PluginConfig config,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+    required String stateDirectory,
+    required StartAbortSignal startAborted,
+  }) async* {
+    const manifest = CopilotRuntimeManifest();
+    final commandExecutor = HostProcessCommandExecutor(
+      processes: processes,
+      runInShell: io.Platform.isWindows,
+      maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
+    );
+    final httpClient = http.Client();
+    try {
+      final service = ManagedRuntimeInstallService(
+        manifest: manifest,
+        versionValidator: RuntimeVersionValidator(
+          commandExecutor: commandExecutor,
+          manifest: manifest,
+          probeTimeout: _versionProbeTimeout,
+        ),
+        installService: RuntimeInstallService(
+          downloadClient: BinaryDownloadClient(httpClient: httpClient),
+          checksumValidator: ChecksumValidator(),
+          archiveExtractor: ArchiveExtractor(commandExecutor: commandExecutor),
+          commandExecutor: commandExecutor,
+          runtimeId: manifest.runtimeId,
+        ),
+        cleaner: ManagedRuntimeCleaner(runtimeId: manifest.runtimeId),
+        assetResolver: ({required target}) async => manifest.assetFor(target: target),
+      );
+      yield* service.install(
+        environment: environment,
+        stateDirectory: stateDirectory,
+        startAborted: startAborted,
+      );
+    } finally {
+      httpClient.close();
+    }
   }
 
   @override
@@ -125,6 +187,7 @@ final class const CopilotPluginDescriptor({
       ManagedRuntimeAutomaticNotSelected(:final primaryRejection, :final managedRejection) => _automaticSetupStatus(
         primaryRejection: primaryRejection,
         managedRejection: managedRejection,
+        supportsManagedInstall: _supportsManagedInstall(config: config),
       ),
     };
   }
@@ -146,14 +209,17 @@ final class const CopilotPluginDescriptor({
   PluginSetupStatus _automaticSetupStatus({
     required ManagedRuntimeRejection primaryRejection,
     required ManagedRuntimeRejection managedRejection,
+    required bool supportsManagedInstall,
   }) {
     if (_isUnknownRejection(primaryRejection) || _isUnknownRejection(managedRejection)) {
       return const PluginSetupUnknown(
         actionHint: "GitHub Copilot setup could not be determined. Verify the local CLI and retry.",
       );
     }
-    return const PluginSetupRuntimeMissing(
-      actionHint: "Install GitHub Copilot CLI locally, authenticate with `copilot login`, then retry setup detection.",
+    return PluginSetupRuntimeMissing(
+      actionHint: supportsManagedInstall
+          ? "Install GitHub Copilot from Sesori, or install it locally and retry setup detection."
+          : "Install GitHub Copilot CLI locally, authenticate with `copilot login`, then retry setup detection.",
     );
   }
 

--- a/bridge/sesori_plugin_copilot/lib/src/runtime/copilot_runtime_manifest.dart
+++ b/bridge/sesori_plugin_copilot/lib/src/runtime/copilot_runtime_manifest.dart
@@ -6,12 +6,64 @@ import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 import "../copilot_binary.dart";
 import "../copilot_identity.dart";
 
+/// Version, path, and pinned managed-release policy for GitHub Copilot CLI.
 class const CopilotRuntimeManifest() extends RuntimeManifest {
   static final SemanticRuntimeVersion _minPathVersion = SemanticRuntimeVersion.parse(value: "1.0.78");
 
   static const String targetVersion = "1.0.80";
 
   static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: targetVersion);
+
+  static const Map<PlatformOs, Map<PlatformArch, RuntimeAsset>> _assets = {
+    PlatformOs.macos: {
+      PlatformArch.arm64: ArchiveRuntimeAsset(
+        assetName: "copilot-darwin-arm64.tar.gz",
+        format: ArchiveFormat.tarGz,
+        sha256: "2346bb691981c2997d65c1c5bc3cef1aeddc9edd37dcb2f970b911aa597e59f6",
+        archiveBinaryName: "copilot",
+        layout: RuntimeArchiveLayout.singleBinary,
+      ),
+      PlatformArch.x64: ArchiveRuntimeAsset(
+        assetName: "copilot-darwin-x64.tar.gz",
+        format: ArchiveFormat.tarGz,
+        sha256: "a1a9c1f25740f9a27b34eb14b70b5d3175794dc8bb410875531aa198b3abc18f",
+        archiveBinaryName: "copilot",
+        layout: RuntimeArchiveLayout.singleBinary,
+      ),
+    },
+    PlatformOs.linux: {
+      PlatformArch.arm64: ArchiveRuntimeAsset(
+        assetName: "copilot-linux-arm64.tar.gz",
+        format: ArchiveFormat.tarGz,
+        sha256: "3ed85e711955e13be523bf492bc6c93b40b69925bcb7f817c9d08abf4839cf89",
+        archiveBinaryName: "copilot",
+        layout: RuntimeArchiveLayout.singleBinary,
+      ),
+      PlatformArch.x64: ArchiveRuntimeAsset(
+        assetName: "copilot-linux-x64.tar.gz",
+        format: ArchiveFormat.tarGz,
+        sha256: "039933c9247686131c4406abb1d439bdbf68103edc1ff585bd70d5b0dc940f72",
+        archiveBinaryName: "copilot",
+        layout: RuntimeArchiveLayout.singleBinary,
+      ),
+    },
+    PlatformOs.windows: {
+      PlatformArch.arm64: ArchiveRuntimeAsset(
+        assetName: "copilot-win32-arm64.zip",
+        format: ArchiveFormat.zip,
+        sha256: "c551da2377b99f08ff95cca6c1603c0006295c2ca7786ba1c8be7c05dc7943a7",
+        archiveBinaryName: "copilot.exe",
+        layout: RuntimeArchiveLayout.singleBinary,
+      ),
+      PlatformArch.x64: ArchiveRuntimeAsset(
+        assetName: "copilot-win32-x64.zip",
+        format: ArchiveFormat.zip,
+        sha256: "e9ea2063913faa8a9f1cf374529c5fea075da0545a894d7469026166f854c541",
+        archiveBinaryName: "copilot.exe",
+        layout: RuntimeArchiveLayout.singleBinary,
+      ),
+    },
+  };
 
   @override
   String get runtimeId => CopilotPluginIdentity.id;
@@ -43,7 +95,7 @@ class const CopilotRuntimeManifest() extends RuntimeManifest {
   }
 
   @override
-  RuntimeAsset? assetFor({required PlatformTarget target}) => null;
+  RuntimeAsset? assetFor({required PlatformTarget target}) => _assets[target.os]?[target.arch];
 
   @override
   String downloadUrlFor({required RuntimeAsset asset}) => githubReleaseAssetUrl(

--- a/bridge/sesori_plugin_copilot/pubspec.yaml
+++ b/bridge/sesori_plugin_copilot/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   acp_plugin:
     path: ../sesori_plugin_acp
+  http: ^1.6.0
   sesori_bridge_foundation:
     path: ../sesori_bridge_foundation
   sesori_plugin_interface:

--- a/bridge/sesori_plugin_copilot/test/copilot_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_copilot/test/copilot_plugin_descriptor_test.dart
@@ -1,0 +1,111 @@
+import "dart:convert";
+import "dart:io";
+
+import "package:copilot_plugin/copilot_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  const defaultConfig = PluginConfig(values: {CopilotPluginDescriptor.binOption: "copilot"});
+
+  test("offers managed install only for automatic runtime selection", () {
+    final descriptor = CopilotPluginDescriptor.production();
+    expect(descriptor.managementCapabilities(config: defaultConfig), contains(PluginControlCapability.install));
+    expect(
+      descriptor.managementCapabilities(
+        config: const PluginConfig(values: {CopilotPluginDescriptor.binOption: "/custom/copilot"}),
+      ),
+      isNot(contains(PluginControlCapability.install)),
+    );
+  });
+
+  test("reports a supported PATH runtime ready without starting ACP", () async {
+    final result = await CopilotPluginDescriptor.production().inspectSetup(
+      config: defaultConfig,
+      processes: _Processes(
+        outputs: const [_Output(stdout: "GitHub Copilot CLI 1.0.80.\nRun 'copilot update' to check.\n", exitCode: 0)],
+      ),
+      environment: const {"COPILOT_HOME": "/profile"},
+      stateDirectory: "/state",
+    );
+
+    expect(result, const PluginSetupReady.versioned(runtimeVersion: "1.0.80"));
+  });
+
+  test("classifies an unrelated explicit runtime as unrecognized", () async {
+    final unknown = await CopilotPluginDescriptor.production().inspectSetup(
+      config: const PluginConfig(values: {CopilotPluginDescriptor.binOption: "/custom/copilot"}),
+      processes: _Processes(outputs: const [_Output(stdout: "git version 2.43.0\n", exitCode: 0)]),
+      environment: const {},
+      stateDirectory: "/state",
+    );
+
+    expect(unknown, isA<PluginSetupUnknown>());
+  });
+
+  test("does not launch when runtime provisioning rejected every candidate", () async {
+    await expectLater(
+      CopilotPluginDescriptor.production().start(const _Host(provisionedRuntimePath: null)),
+      throwsA(isA<PluginStartException>()),
+    );
+  });
+
+  test("an aborted managed install stops before process or network work", () async {
+    final controller = StartAbortController()..abort();
+    await expectLater(
+      CopilotPluginDescriptor.production()
+          .installRuntime(
+            config: defaultConfig,
+            processes: _Processes(),
+            environment: const {},
+            stateDirectory: "/state",
+            startAborted: controller.signal,
+          )
+          .toList(),
+      throwsA(isA<PluginStartAbortedException>()),
+    );
+  });
+}
+
+class const _Host({@override required final String? provisionedRuntimePath}) implements PluginHost {
+  @override
+  StartAbortSignal get startAborted => StartAbortSignal.never;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class const _Output({required final String stdout, required final int exitCode});
+
+class _Processes({final List<_Output> outputs = const []}) implements HostProcessService {
+  int _index = 0;
+
+  @override
+  Future<SpawnedProcess> spawn({
+    required String executable,
+    required List<String> arguments,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+    required bool runInShell,
+  }) async {
+    if (_index >= outputs.length) throw ProcessException(executable, arguments, "missing", 2);
+    return _ProbeProcess(output: outputs[_index++]);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _ProbeProcess({required _Output output}) implements SpawnedProcess {
+  @override
+  final Stream<List<int>> stdout = Stream.value(utf8.encode(output.stdout));
+
+  @override
+  final Future<int> exitCode = Future.value(output.exitCode);
+
+  @override
+  Stream<List<int>> get stderr => const Stream.empty();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/sesori_plugin_copilot/test/copilot_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_copilot/test/copilot_runtime_manifest_test.dart
@@ -1,0 +1,81 @@
+import "package:copilot_plugin/copilot_plugin.dart";
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("CopilotRuntimeManifest", () {
+    const manifest = CopilotRuntimeManifest();
+
+    test("pins the validated ACP floor and managed target", () {
+      expect(manifest.runtimeId, "copilot");
+      expect(manifest.minPathVersion.raw, "1.0.78");
+      expect(manifest.bundledVersion.raw, CopilotRuntimeManifest.targetVersion);
+      expect(manifest.bundledVersion.raw, "1.0.80");
+    });
+
+    test("pins all six official single-binary release archives", () {
+      final expected =
+          <PlatformTarget, ({String assetName, ArchiveFormat format, String sha256, String archiveBinaryName})>{
+            const PlatformTarget(os: PlatformOs.macos, arch: PlatformArch.arm64): (
+              assetName: "copilot-darwin-arm64.tar.gz",
+              format: ArchiveFormat.tarGz,
+              sha256: "2346bb691981c2997d65c1c5bc3cef1aeddc9edd37dcb2f970b911aa597e59f6",
+              archiveBinaryName: "copilot",
+            ),
+            const PlatformTarget(os: PlatformOs.macos, arch: PlatformArch.x64): (
+              assetName: "copilot-darwin-x64.tar.gz",
+              format: ArchiveFormat.tarGz,
+              sha256: "a1a9c1f25740f9a27b34eb14b70b5d3175794dc8bb410875531aa198b3abc18f",
+              archiveBinaryName: "copilot",
+            ),
+            const PlatformTarget(os: PlatformOs.linux, arch: PlatformArch.arm64): (
+              assetName: "copilot-linux-arm64.tar.gz",
+              format: ArchiveFormat.tarGz,
+              sha256: "3ed85e711955e13be523bf492bc6c93b40b69925bcb7f817c9d08abf4839cf89",
+              archiveBinaryName: "copilot",
+            ),
+            const PlatformTarget(os: PlatformOs.linux, arch: PlatformArch.x64): (
+              assetName: "copilot-linux-x64.tar.gz",
+              format: ArchiveFormat.tarGz,
+              sha256: "039933c9247686131c4406abb1d439bdbf68103edc1ff585bd70d5b0dc940f72",
+              archiveBinaryName: "copilot",
+            ),
+            const PlatformTarget(os: PlatformOs.windows, arch: PlatformArch.arm64): (
+              assetName: "copilot-win32-arm64.zip",
+              format: ArchiveFormat.zip,
+              sha256: "c551da2377b99f08ff95cca6c1603c0006295c2ca7786ba1c8be7c05dc7943a7",
+              archiveBinaryName: "copilot.exe",
+            ),
+            const PlatformTarget(os: PlatformOs.windows, arch: PlatformArch.x64): (
+              assetName: "copilot-win32-x64.zip",
+              format: ArchiveFormat.zip,
+              sha256: "e9ea2063913faa8a9f1cf374529c5fea075da0545a894d7469026166f854c541",
+              archiveBinaryName: "copilot.exe",
+            ),
+          };
+
+      for (final entry in expected.entries) {
+        final asset = manifest.assetFor(target: entry.key);
+        expect(asset, isA<ArchiveRuntimeAsset>(), reason: entry.key.key);
+        if (asset is! ArchiveRuntimeAsset) continue;
+        expect(asset.assetName, entry.value.assetName);
+        expect(asset.format, entry.value.format);
+        expect(asset.sha256, entry.value.sha256);
+        expect(asset.archiveBinaryName, entry.value.archiveBinaryName);
+        expect(asset.layout, RuntimeArchiveLayout.singleBinary);
+      }
+    });
+
+    test("builds the official pinned release URL", () {
+      final asset = manifest.assetFor(
+        target: const PlatformTarget(os: PlatformOs.macos, arch: PlatformArch.arm64),
+      );
+      if (asset == null) fail("missing macOS arm64 asset");
+      expect(
+        manifest.downloadUrlFor(asset: asset),
+        "https://github.com/github/copilot-cli/releases/download/v1.0.80/copilot-darwin-arm64.tar.gz",
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Complexity

⚙️ Moderate — wires a six-platform, checksum-pinned runtime manifest into the shared managed-install lifecycle with cancellation and post-install validation.

## What

- pin GitHub Copilot CLI `1.0.80` for macOS, Linux, and Windows on arm64 and x64
- map each official single-binary archive to its exact filename, archive format, binary name, and SHA-256 digest
- build direct download URLs from the official `github/copilot-cli` GitHub release
- advertise install capability only for automatic runtime selection on a supported platform; explicit binary paths remain user-owned
- install through the shared download, checksum, extraction, cleanup, and exact-version validation services
- close the install HTTP client reliably and honor cancellation before process or network work
- keep the Copilot package unregistered until Step 5

## Why

Step 3 can select explicit, PATH, or existing managed runtimes, but it cannot yet provision a missing supported CLI. This step adds the pinned managed-install path without duplicating generic installation mechanics or weakening runtime validation.

## Risk and test focus

Medium risk, localized to Copilot runtime installation. The highest-value checks are platform/architecture asset selection, exact digest and release URL data, install-capability gating, cancellation, archive layout, cleanup, and branded post-install version validation. Authentication remains out of band. There is no database, persisted-data, or wire-contract change, and no user-visible harness yet because Copilot remains unregistered.

## Expected result

When Copilot is activated in the following step, an automatically configured bridge on any supported target can explicitly install the official pinned `1.0.80` CLI and then launch only the digest-verified, version-validated binary. Explicit custom binary configurations are never overwritten. No current user-visible behavior or database state changes in this PR.

## Verification

- `cd bridge/sesori_plugin_copilot && dart analyze --fatal-infos` — no issues
- `cd bridge/sesori_plugin_copilot && dart test` — 13 tests passed
- all six official `1.0.80` asset names and SHA-256 digests match the GitHub release API
- architecture implementation review — passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a checksum-pinned managed install path for the GitHub Copilot CLI so automatic runtime selection can provision a missing CLI instead of only detecting existing ones. Copilot stays unregistered until Step 5, so there is no user-visible behavior change yet.

**New Features**
- Pins Copilot CLI 1.0.80 for macOS, Linux, and Windows on arm64 and x64 with exact SHA-256 digests.
- Offers the install capability only for automatic runtime selection; explicit binary paths remain user-owned.
- Routes through shared download, checksum, extraction, cleanup, and version-validation services, closes the HTTP client, and honors cancellation before process or network work.
- Updates the missing-runtime setup hint to offer a managed install when supported.

<sup>Written for commit e02c49b7f1ecb7bcf1e30d1bb67d399244942b47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

