### PR TITLE
⚙️ [grok-harness] feat(grok): expose models and reasoning effort [step 3/9]

### DIFF
--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -23,7 +23,7 @@
 3. `⚙️ [grok-harness] feat(grok): expose models and reasoning effort [step 3/9]`
    - **State:** in PR #1160.
    - **Evidence:** initialize-only API, typed mapping, repositories, sole-owner tracker, options service, generated output,
-     18 package tests, fatal-info analysis, LSP diagnostics, architecture approval, and the 1,500-line budget pass.
+     19 package tests, fatal-info analysis, LSP diagnostics, architecture approval, and the 1,500-line budget pass.
 4. `⚙️ [grok-harness] feat(grok): compose ACP sessions and turns [step 4/9]`
    - **State:** not started.
 5. `⚙️ [grok-harness] feat(grok): add direct-CLI setup and lifecycle [step 5/9]`
@@ -73,8 +73,9 @@
 - [x] Add exact `session/set_model` model/optional-effort writes with typed cause-preserving failures.
 - [x] Keep `GrokCatalogTracker` as the sole last-good catalog owner across initialize, new/load, and refresh capture.
 - [x] Expose one primary agent/provider with opaque model IDs and exact canonical effort strings.
-- [x] Cover malformed/empty/partial catalogs, default ordering, refresh retention, selection variants, and failed writes.
-- [x] Run 18 package tests, fatal-info analysis, Dart LSP diagnostics, line-width checks, and `git diff --check`.
+- [x] Cover malformed/empty/partial catalogs, default ordering, refresh retention, load-default isolation, stale options,
+  effort-only fallback, selection variants, and failed writes.
+- [x] Run 19 package tests, fatal-info analysis, Dart LSP diagnostics, line-width checks, and `git diff --check`.
 - [x] Keep the measured Step 3 change below the 1,500-line soft cap (currently 1,305 lines before tracker updates).
 - [x] Run architecture implementation review over the Step 3 branch against the Step 2 branch; approved.
 - [x] After #1156 merged, sync to `origin/main`, publish PR #1160, and start its monitor.

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -3,13 +3,12 @@
 ## Current State
 
 - **Plan:** `.plan/active/grok-harness/PLAN.md`
-- **Status:** Step 1/9 merged; Step 2/9 in PR
-- **Current branch:** `grok-harness-step-2-scaffold`
+- **Status:** Steps 1-2/9 merged; Step 3/9 verified and ready for PR
+- **Current branch:** `grok-harness-step-3-models`
 - **Base:** `origin/main`
 - **Architecture plan review:** approved 2026-08-27 after catalog ownership and auth-policy corrections
-- **Merged predecessor:** #1152 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1152>
-- **Open PR:** #1156 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1156>
-- **Current step:** `grok-harness-step-2-scaffold`; scaffold implemented, verified, and under review
+- **Merged predecessor:** #1156 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1156>
+- **Current step:** `grok-harness-step-3-models`; model/effort collaborators verified and ready to publish
 
 ## Fixed Series
 
@@ -17,11 +16,13 @@
    - **State:** merged in #1152.
    - **Evidence:** architecture-approved plan; released-binary facts, titles, paths, and whitespace passed.
 2. `🌿 [grok-harness] feat(grok): scaffold the Grok plugin package [step 2/9]`
-   - **State:** in PR #1156.
+   - **State:** merged in #1156.
    - **Evidence:** workspace package, launch spec, typed model-state DTOs, synthetic protocol fixtures, generated output,
      package tests/analyzer, LSP diagnostics, and the 1,500-line budget pass.
 3. `⚙️ [grok-harness] feat(grok): expose models and reasoning effort [step 3/9]`
-   - **State:** not started.
+   - **State:** verified locally and ready to open.
+   - **Evidence:** initialize-only API, typed mapping, repositories, sole-owner tracker, options service, generated output,
+     18 package tests, fatal-info analysis, LSP diagnostics, architecture approval, and the 1,500-line budget pass.
 4. `⚙️ [grok-harness] feat(grok): compose ACP sessions and turns [step 4/9]`
    - **State:** not started.
 5. `⚙️ [grok-harness] feat(grok): add direct-CLI setup and lifecycle [step 5/9]`
@@ -63,6 +64,19 @@
 - [x] Run architecture implementation review for `origin/main...HEAD`; approved with no findings.
 - [x] Keep the measured change below the 1,500-line soft cap by leaving initialize/session envelope DTOs for Step 3.
 - [x] After #1152 merged, sync to `origin/main`, publish PR #1156, and start its monitor.
+
+## Step 3 Checklist
+
+- [x] Add typed initialize/session envelopes and regenerate source without hand edits.
+- [x] Add initialize-only catalog probing with headless-auth filtering and clean process disposal.
+- [x] Add exact `session/set_model` model/optional-effort writes with typed cause-preserving failures.
+- [x] Keep `GrokCatalogTracker` as the sole last-good catalog owner across initialize, new/load, and refresh capture.
+- [x] Expose one primary agent/provider with opaque model IDs and exact canonical effort strings.
+- [x] Cover malformed/empty/partial catalogs, default ordering, refresh retention, selection variants, and failed writes.
+- [x] Run 18 package tests, fatal-info analysis, Dart LSP diagnostics, line-width checks, and `git diff --check`.
+- [x] Keep the measured Step 3 change below the 1,500-line soft cap (currently 1,305 lines before tracker updates).
+- [x] Run architecture implementation review over the Step 3 branch against the Step 2 branch; approved.
+- [x] Commit the completed successor locally; do not publish before #1156 merges.
 
 ## Decisions And Evidence
 

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -73,8 +73,8 @@
 - [x] Add exact `session/set_model` model/optional-effort writes with typed cause-preserving failures.
 - [x] Keep `GrokCatalogTracker` as the sole last-good catalog owner across initialize, new/load, and refresh capture.
 - [x] Expose one primary agent/provider with opaque model IDs and exact canonical effort strings.
-- [x] Cover malformed/empty/partial catalogs, default ordering, refresh retention, load-default isolation, stale options,
-  effort-only fallback, selection variants, and failed writes.
+- [x] Cover malformed/empty/partial catalogs, default ordering, refresh retention,
+  load-default/effort isolation, stale options, effort-only fallback, selection variants, and failed writes.
 - [x] Run 19 package tests, fatal-info analysis, Dart LSP diagnostics, line-width checks, and `git diff --check`.
 - [x] Keep the measured Step 3 change below the 1,500-line soft cap (currently 1,305 lines before tracker updates).
 - [x] Run architecture implementation review over the Step 3 branch against the Step 2 branch; approved.

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -3,13 +3,13 @@
 ## Current State
 
 - **Plan:** `.plan/active/grok-harness/PLAN.md`
-- **Status:** Steps 1-2/9 merged; Step 3/9 in PR
+- **Status:** Steps 1-2/9 merged; Step 3/9 in PR and held for consolidated correctness audit
 - **Current branch:** `grok-harness-step-3-models`
 - **Base:** `origin/main`
 - **Architecture plan review:** approved 2026-08-27 after catalog ownership and auth-policy corrections
 - **Merged predecessor:** #1156 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1156>
 - **Open PR:** #1160 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1160>
-- **Current step:** `grok-harness-step-3-models`; model/effort collaborators verified and under review
+- **Current step:** `grok-harness-step-3-models`; consolidated correctness audit approved, update ready to publish
 
 ## Fixed Series
 
@@ -18,8 +18,7 @@
    - **Evidence:** architecture-approved plan; released-binary facts, titles, paths, and whitespace passed.
 2. `🌿 [grok-harness] feat(grok): scaffold the Grok plugin package [step 2/9]`
    - **State:** merged in #1156.
-   - **Evidence:** workspace package, launch spec, typed model-state DTOs, synthetic protocol fixtures, generated output,
-     package tests/analyzer, LSP diagnostics, and the 1,500-line budget pass.
+   - **Evidence:** workspace package, launch spec, typed fixtures/codegen, tests/analyzer, LSP, and budget.
 3. `⚙️ [grok-harness] feat(grok): expose models and reasoning effort [step 3/9]`
    - **State:** in PR #1160.
 4. `⚙️ [grok-harness] feat(grok): compose ACP sessions and turns [step 4/9]`
@@ -66,11 +65,21 @@
 
 ## Step 3 Checklist
 - [x] Add typed envelopes, initialize-only probing, exact selection writes, and cause-preserving failures.
-- [x] Keep catalog and session selection behind one tracker each; expose opaque models and canonical effort values.
-- [x] Cover catalog edge cases, defaults, load isolation, stale options, selection variants, and failed writes.
-- [x] Pass 19 tests, analysis, LSP, line/diff checks, the 1,500-line target, two architecture reviews, and PR setup.
+- [x] Keep catalog and selection state in their trackers; preserve opaque models and canonical effort values.
+- [x] Cover hostile wire siblings, tuple fallbacks, default reset, stale tracked state, and failed writes.
+- [x] Pass 267 ACP and 27 Grok tests, analysis, LSP, line/diff checks, and two architecture reviews.
+- [x] Accept 1,821 lines: audit-required boundary/transition coverage takes precedence over the soft cap.
+- [x] Complete hostile wire, state-invariant, and post-fix general correctness reviews; final verdict approved.
+
 ## Decisions And Evidence
 
+- 2026-08-28: Repeated substantive feedback exposed an incomplete parser/selection invariant matrix. The PR was removed
+  from readiness and the monitor paused while hostile wire, state-transition, and general-correctness audits ran.
+- 2026-08-28: The consolidated correction masks irrelevant envelope branches, preserves valid catalog siblings,
+  rejects malformed owned containers, rejects stale tracked models, keeps model/effort as one tuple, and distinguishes
+  explicit model-default reset from omitted selection. Official Grok source confirms a bare model switch resolves that
+  model's declared default effort; explicit effort remains an override. Malformed optional effort lists remain fail-soft
+  by plan: preserve the model with no variants, while malformed catalog/model containers reject.
 - 2026-08-27: Initial delivery is direct CLI only. Managed install is excluded because xAI owns an official installer
   and self-update channel; Sesori has no current need to duplicate that lifecycle.
 - 2026-08-27: Grok launches without yolo/always-approve, with leader attachment and auto-update disabled.

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -22,8 +22,6 @@
      package tests/analyzer, LSP diagnostics, and the 1,500-line budget pass.
 3. `⚙️ [grok-harness] feat(grok): expose models and reasoning effort [step 3/9]`
    - **State:** in PR #1160.
-   - **Evidence:** initialize-only API, typed mapping, repositories, sole-owner tracker, options service, generated output,
-     19 package tests, fatal-info analysis, LSP diagnostics, architecture approval, and the 1,500-line budget pass.
 4. `⚙️ [grok-harness] feat(grok): compose ACP sessions and turns [step 4/9]`
    - **State:** not started.
 5. `⚙️ [grok-harness] feat(grok): add direct-CLI setup and lifecycle [step 5/9]`
@@ -67,19 +65,10 @@
 - [x] After #1152 merged, sync to `origin/main`, publish PR #1156, and start its monitor.
 
 ## Step 3 Checklist
-
-- [x] Add typed initialize/session envelopes and regenerate source without hand edits.
-- [x] Add initialize-only catalog probing with headless-auth filtering and clean process disposal.
-- [x] Add exact `session/set_model` model/optional-effort writes with typed cause-preserving failures.
-- [x] Keep `GrokCatalogTracker` as the sole last-good catalog owner across initialize, new/load, and refresh capture.
-- [x] Expose one primary agent/provider with opaque model IDs and exact canonical effort strings.
-- [x] Cover malformed/empty/partial catalogs, default ordering, refresh retention,
-  load-default/effort isolation, stale options, effort-only fallback, selection variants, and failed writes.
-- [x] Run 19 package tests, fatal-info analysis, Dart LSP diagnostics, line-width checks, and `git diff --check`.
-- [x] Keep the measured Step 3 change below the 1,500-line soft cap (currently 1,305 lines before tracker updates).
-- [x] Run architecture implementation review over the Step 3 branch against the Step 2 branch; approved.
-- [x] After #1156 merged, sync to `origin/main`, publish PR #1160, and start its monitor.
-
+- [x] Add typed envelopes, initialize-only probing, exact selection writes, and cause-preserving failures.
+- [x] Keep one catalog owner; expose opaque models and canonical effort strings through typed collaborators.
+- [x] Cover catalog edge cases, defaults, load isolation, stale options, selection variants, and failed writes.
+- [x] Pass 19 tests, analysis, LSP, line/diff checks, the 1,500-line target, architecture review, and PR setup.
 ## Decisions And Evidence
 
 - 2026-08-27: Initial delivery is direct CLI only. Managed install is excluded because xAI owns an official installer

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -3,12 +3,13 @@
 ## Current State
 
 - **Plan:** `.plan/active/grok-harness/PLAN.md`
-- **Status:** Steps 1-2/9 merged; Step 3/9 verified and ready for PR
+- **Status:** Steps 1-2/9 merged; Step 3/9 in PR
 - **Current branch:** `grok-harness-step-3-models`
 - **Base:** `origin/main`
 - **Architecture plan review:** approved 2026-08-27 after catalog ownership and auth-policy corrections
 - **Merged predecessor:** #1156 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1156>
-- **Current step:** `grok-harness-step-3-models`; model/effort collaborators verified and ready to publish
+- **Open PR:** #1160 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1160>
+- **Current step:** `grok-harness-step-3-models`; model/effort collaborators verified and under review
 
 ## Fixed Series
 
@@ -20,7 +21,7 @@
    - **Evidence:** workspace package, launch spec, typed model-state DTOs, synthetic protocol fixtures, generated output,
      package tests/analyzer, LSP diagnostics, and the 1,500-line budget pass.
 3. `⚙️ [grok-harness] feat(grok): expose models and reasoning effort [step 3/9]`
-   - **State:** verified locally and ready to open.
+   - **State:** in PR #1160.
    - **Evidence:** initialize-only API, typed mapping, repositories, sole-owner tracker, options service, generated output,
      18 package tests, fatal-info analysis, LSP diagnostics, architecture approval, and the 1,500-line budget pass.
 4. `⚙️ [grok-harness] feat(grok): compose ACP sessions and turns [step 4/9]`
@@ -76,7 +77,7 @@
 - [x] Run 18 package tests, fatal-info analysis, Dart LSP diagnostics, line-width checks, and `git diff --check`.
 - [x] Keep the measured Step 3 change below the 1,500-line soft cap (currently 1,305 lines before tracker updates).
 - [x] Run architecture implementation review over the Step 3 branch against the Step 2 branch; approved.
-- [x] Commit the completed successor locally; do not publish before #1156 merges.
+- [x] After #1156 merged, sync to `origin/main`, publish PR #1160, and start its monitor.
 
 ## Decisions And Evidence
 

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -66,9 +66,9 @@
 
 ## Step 3 Checklist
 - [x] Add typed envelopes, initialize-only probing, exact selection writes, and cause-preserving failures.
-- [x] Keep one catalog owner; expose opaque models and canonical effort strings through typed collaborators.
+- [x] Keep catalog and session selection behind one tracker each; expose opaque models and canonical effort values.
 - [x] Cover catalog edge cases, defaults, load isolation, stale options, selection variants, and failed writes.
-- [x] Pass 19 tests, analysis, LSP, line/diff checks, the 1,500-line target, architecture review, and PR setup.
+- [x] Pass 19 tests, analysis, LSP, line/diff checks, the 1,500-line target, two architecture reviews, and PR setup.
 ## Decisions And Evidence
 
 - 2026-08-27: Initial delivery is direct CLI only. Managed install is excluded because xAI owns an official installer

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_configuration_tracker.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_configuration_tracker.dart
@@ -1,34 +1,44 @@
-/// Immutable provider/model selection used for ACP message translation.
+/// Immutable provider/model/variant selection used for ACP message translation.
 class const AcpSessionConfigurationSnapshot({
   required final String? modelId,
   required final String? providerId,
+  required final String? variantId,
 });
 
-/// Owns process defaults and per-session ACP provider/model overrides.
+/// Owns process defaults and per-session ACP selection overrides.
 class AcpSessionConfigurationTracker() {
   String? _defaultModelId;
   String? _defaultProviderId;
+  String? _defaultVariantId;
   final Map<String, String> _sessionModelIds = {};
   final Map<String, String> _sessionProviderIds = {};
+  final Map<String, String?> _sessionVariantIds = {};
 
   AcpSessionConfigurationSnapshot get processDefaults => AcpSessionConfigurationSnapshot(
     modelId: _defaultModelId,
     providerId: _defaultProviderId,
+    variantId: _defaultVariantId,
   );
 
   AcpSessionConfigurationSnapshot snapshotForSession({required String sessionId}) {
     return AcpSessionConfigurationSnapshot(
       modelId: _sessionModelIds[sessionId] ?? _defaultModelId,
       providerId: _sessionProviderIds[sessionId] ?? _defaultProviderId,
+      variantId: _sessionVariantIds.containsKey(sessionId) ? _sessionVariantIds[sessionId] : _defaultVariantId,
     );
   }
 
-  void setProcessDefaults({
+  void setProcessDefaults({required String? modelId, required String? providerId}) =>
+      setProcessSelection(modelId: modelId, providerId: providerId, variantId: null);
+
+  void setProcessSelection({
     required String? modelId,
     required String? providerId,
+    required String? variantId,
   }) {
     _defaultModelId = _useful(value: modelId);
     _defaultProviderId = _useful(value: providerId);
+    _defaultVariantId = _useful(value: variantId);
   }
 
   void setSessionOverride({
@@ -48,18 +58,32 @@ class AcpSessionConfigurationTracker() {
     } else {
       _sessionProviderIds[sessionId] = resolvedProviderId;
     }
+    _sessionVariantIds[sessionId] = null;
+  }
+
+  void setSessionSelection({
+    required String sessionId,
+    required String? modelId,
+    required String? providerId,
+    required String? variantId,
+  }) {
+    setSessionOverride(sessionId: sessionId, modelId: modelId, providerId: providerId);
+    _sessionVariantIds[sessionId] = _useful(value: variantId);
   }
 
   void forgetSession({required String sessionId}) {
     _sessionModelIds.remove(sessionId);
     _sessionProviderIds.remove(sessionId);
+    _sessionVariantIds.remove(sessionId);
   }
 
   void clear() {
     _defaultModelId = null;
     _defaultProviderId = null;
+    _defaultVariantId = null;
     _sessionModelIds.clear();
     _sessionProviderIds.clear();
+    _sessionVariantIds.clear();
   }
 
   String? _useful({required String? value}) {

--- a/bridge/sesori_plugin_acp/test/acp_session_options_service_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_options_service_test.dart
@@ -35,6 +35,23 @@ void main() {
     expect(mapper.providerForSession(sessionId: "session"), "provider");
   });
 
+  test("configuration tracker keeps explicit null variant distinct from no session override", () {
+    final tracker = AcpSessionConfigurationTracker()
+      ..setProcessSelection(modelId: "default-model", providerId: "provider", variantId: "high")
+      ..setSessionSelection(
+        sessionId: "session",
+        modelId: "plain-model",
+        providerId: "provider",
+        variantId: null,
+      );
+
+    expect(tracker.snapshotForSession(sessionId: "session").variantId, isNull);
+    tracker.forgetSession(sessionId: "session");
+    expect(tracker.snapshotForSession(sessionId: "session").variantId, "high");
+    tracker.clear();
+    expect(tracker.processDefaults.variantId, isNull);
+  });
+
   test("ACP aggregate becomes complete after an authoritative command snapshot", () {
     final configurationTracker = AcpSessionConfigurationTracker()
       ..setProcessDefaults(modelId: "model", providerId: "provider");

--- a/bridge/sesori_plugin_grok/lib/src/api/grok_acp_api.dart
+++ b/bridge/sesori_plugin_grok/lib/src/api/grok_acp_api.dart
@@ -1,0 +1,138 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, PluginAuthenticationRequiredException;
+
+import "../grok_binary.dart";
+
+/// Grok's initialize-only catalog probe and legacy model-selection RPC.
+class GrokAcpApi({
+  required final String _binaryPath,
+  required final AcpProcessFactory _processFactory,
+  required final Map<String, String> _environment,
+}) {
+  static const String sessionSetModelMethod = "session/set_model";
+  static const Set<String> _headlessAuthMethodIds = {"xai.api_key", "cached_token"};
+
+  Future<AcpInitializeResult> probeCatalog({
+    required String cwd,
+    required Duration timeout,
+  }) async {
+    final client = AcpStdioClient(
+      launchSpec: GrokBinary.launchSpec(
+        binary: _binaryPath,
+        cwd: cwd,
+        environment: _environment,
+      ),
+      processFactory: _processFactory,
+      logTag: "grok-catalog",
+    );
+    final stopwatch = Stopwatch()..start();
+    AcpInitializeResult? result;
+    Object? operationError;
+    StackTrace? operationStack;
+    try {
+      await client.connect().timeout(_remaining(timeout: timeout, stopwatch: stopwatch));
+      result = await _initialize(
+        client: client,
+        timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
+      );
+    } on Object catch (error, stackTrace) {
+      operationError = error;
+      operationStack = stackTrace;
+    }
+
+    try {
+      await client.dispose(gracefulTimeout: const Duration(seconds: 5));
+    } on Object catch (error, stackTrace) {
+      if (operationError == null) Error.throwWithStackTrace(error, stackTrace);
+      Log.w("[grok] catalog probe cleanup also failed", error, stackTrace);
+    }
+    if (operationError != null) {
+      final stackTrace = operationStack;
+      if (stackTrace == null) throw operationError;
+      Error.throwWithStackTrace(operationError, stackTrace);
+    }
+    final completedResult = result;
+    if (completedResult == null) throw StateError("Grok catalog probe produced no result");
+    return completedResult;
+  }
+
+  Future<void> setModel({
+    required AcpStdioClient liveClient,
+    required String sessionId,
+    required String modelId,
+    required String? reasoningEffort,
+    required Duration timeout,
+  }) => liveClient.request(
+    method: sessionSetModelMethod,
+    params: {
+      "sessionId": sessionId,
+      "modelId": modelId,
+      if (reasoningEffort != null) "_meta": {"reasoningEffort": reasoningEffort},
+    },
+    timeout: timeout,
+  );
+
+  Future<AcpInitializeResult> _initialize({
+    required AcpStdioClient client,
+    required Duration timeout,
+  }) async {
+    final stopwatch = Stopwatch()..start();
+    final raw = await client.request(
+      method: AcpMethods.initialize,
+      params: buildInitializeParams(formElicitation: false, capabilityMeta: null),
+      timeout: timeout,
+    );
+    final result = AcpInitializeResult.fromJson(_json(raw: raw));
+    if (result.protocolVersion != acpProtocolVersion) {
+      throw StateError("Grok negotiated unsupported ACP version ${result.protocolVersion}");
+    }
+    if (!result.requiresAuth) return result;
+
+    final methodId = _headlessMethod(result: result);
+    if (methodId == null) {
+      throw const PluginAuthenticationRequiredException(
+        AcpMethods.authenticate,
+        actionHint: "Authenticate Grok locally with a headless credential, then retry.",
+        message: "Grok did not advertise a headless authentication method",
+      );
+    }
+    try {
+      await client.request(
+        method: AcpMethods.authenticate,
+        params: {"methodId": methodId},
+        timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
+      );
+    } on AcpRpcException catch (error) {
+      if (error.method != "<response>") rethrow;
+      throw PluginAuthenticationRequiredException(
+        AcpMethods.authenticate,
+        actionHint: "Authenticate Grok locally with a headless credential, then retry.",
+        message: "Grok rejected the configured authentication method",
+        cause: error,
+      );
+    }
+    return result;
+  }
+
+  String? _headlessMethod({required AcpInitializeResult result}) {
+    for (final method in result.authMethods) {
+      if (_headlessAuthMethodIds.contains(method.id)) return method.id;
+    }
+    return null;
+  }
+
+  // ignore: no_slop_linter/prefer_specific_type, ACP response and JSON object values are heterogeneous
+  Map<String, dynamic> _json({required Object? raw}) {
+    if (raw is! Map) throw const FormatException("Grok initialize returned a non-object result");
+    // ignore: no_slop_linter/prefer_specific_type, JSON object values are heterogeneous
+    return raw.cast<String, dynamic>();
+  }
+
+  Duration _remaining({required Duration timeout, required Stopwatch stopwatch}) {
+    final remaining = timeout - stopwatch.elapsed;
+    if (remaining <= Duration.zero) throw TimeoutException("Grok catalog probe exceeded its deadline");
+    return remaining;
+  }
+}

--- a/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.dart
+++ b/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.dart
@@ -18,7 +18,7 @@ sealed class GrokReasoningEffortOptionDto with _$GrokReasoningEffortOptionDto {
 }
 
 /// Grok-owned metadata attached to one ACP model entry.
-@freezed
+@Freezed(fromJson: true, toJson: false)
 sealed class GrokModelMetadataDto with _$GrokModelMetadataDto {
   const factory({
     required bool? supportsReasoningEffort,
@@ -26,11 +26,30 @@ sealed class GrokModelMetadataDto with _$GrokModelMetadataDto {
     required String? reasoningEffort,
   }) = _GrokModelMetadataDto;
 
-  factory fromJson(Map<String, dynamic> json) => _$GrokModelMetadataDtoFromJson(json);
+  factory fromJson(Map<String, dynamic> json) {
+    final sanitized = {...json};
+    final reasoningEfforts = json["reasoningEfforts"];
+    if (reasoningEfforts is! List) {
+      sanitized.remove("reasoningEfforts");
+    } else {
+      sanitized["reasoningEfforts"] = reasoningEfforts
+          .where(
+            (entry) =>
+                entry is Map &&
+                (entry["id"] == null || entry["id"] is String) &&
+                (entry["value"] == null || entry["value"] is String) &&
+                (entry["label"] == null || entry["label"] is String) &&
+                (entry["description"] == null || entry["description"] is String) &&
+                (entry["default"] == null || entry["default"] is bool),
+          )
+          .toList(growable: false);
+    }
+    return _$GrokModelMetadataDtoFromJson(sanitized);
+  }
 }
 
 /// One model advertised by Grok's legacy ACP model-state surface.
-@freezed
+@Freezed(toJson: false)
 sealed class GrokModelInfoDto with _$GrokModelInfoDto {
   const factory({
     required String? modelId,
@@ -43,7 +62,7 @@ sealed class GrokModelInfoDto with _$GrokModelInfoDto {
 }
 
 /// Current model plus the models available to a Grok ACP session.
-@freezed
+@Freezed(toJson: false)
 sealed class GrokSessionModelStateDto with _$GrokSessionModelStateDto {
   const factory({
     @Default(<GrokModelInfoDto>[]) List<GrokModelInfoDto> availableModels,

--- a/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.dart
+++ b/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.dart
@@ -52,3 +52,26 @@ sealed class GrokSessionModelStateDto with _$GrokSessionModelStateDto {
 
   factory fromJson(Map<String, dynamic> json) => _$GrokSessionModelStateDtoFromJson(json);
 }
+
+/// Grok-specific portion of ACP initialize metadata.
+@Freezed(toJson: false)
+sealed class GrokInitializeMetadataDto with _$GrokInitializeMetadataDto {
+  const factory({
+    required bool? grokShell,
+    required String? agentVersion,
+    required GrokSessionModelStateDto? modelState,
+  }) = _GrokInitializeMetadataDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$GrokInitializeMetadataDtoFromJson(json);
+}
+
+/// Typed envelope for initialize and session activation model state.
+@Freezed(toJson: false)
+sealed class GrokModelStateEnvelopeDto with _$GrokModelStateEnvelopeDto {
+  const factory({
+    @JsonKey(name: "_meta") required GrokInitializeMetadataDto? metadata,
+    required GrokSessionModelStateDto? models,
+  }) = _GrokModelStateEnvelopeDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$GrokModelStateEnvelopeDtoFromJson(json);
+}

--- a/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.dart
+++ b/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.dart
@@ -28,6 +28,8 @@ sealed class GrokModelMetadataDto with _$GrokModelMetadataDto {
 
   factory fromJson(Map<String, dynamic> json) {
     final sanitized = {...json};
+    if (json["supportsReasoningEffort"] is! bool) sanitized["supportsReasoningEffort"] = null;
+    if (json["reasoningEffort"] is! String) sanitized["reasoningEffort"] = null;
     final reasoningEfforts = json["reasoningEfforts"];
     if (reasoningEfforts is! List) {
       sanitized.remove("reasoningEfforts");
@@ -36,6 +38,7 @@ sealed class GrokModelMetadataDto with _$GrokModelMetadataDto {
           .where(
             (entry) =>
                 entry is Map &&
+                entry.keys.every((key) => key is String) &&
                 (entry["id"] == null || entry["id"] is String) &&
                 (entry["value"] == null || entry["value"] is String) &&
                 (entry["label"] == null || entry["label"] is String) &&
@@ -49,7 +52,7 @@ sealed class GrokModelMetadataDto with _$GrokModelMetadataDto {
 }
 
 /// One model advertised by Grok's legacy ACP model-state surface.
-@Freezed(toJson: false)
+@Freezed(fromJson: true, toJson: false)
 sealed class GrokModelInfoDto with _$GrokModelInfoDto {
   const factory({
     required String? modelId,
@@ -58,22 +61,43 @@ sealed class GrokModelInfoDto with _$GrokModelInfoDto {
     @JsonKey(name: "_meta") required GrokModelMetadataDto? metadata,
   }) = _GrokModelInfoDto;
 
-  factory fromJson(Map<String, dynamic> json) => _$GrokModelInfoDtoFromJson(json);
+  factory fromJson(Map<String, dynamic> json) {
+    final sanitized = {...json};
+    if (json["modelId"] is! String) sanitized["modelId"] = null;
+    if (json["name"] is! String) sanitized["name"] = null;
+    if (json["description"] is! String) sanitized["description"] = null;
+    final metadata = json["_meta"];
+    if (metadata is! Map || !metadata.keys.every((key) => key is String)) sanitized["_meta"] = null;
+    return _$GrokModelInfoDtoFromJson(sanitized);
+  }
 }
 
 /// Current model plus the models available to a Grok ACP session.
-@Freezed(toJson: false)
+@Freezed(fromJson: true, toJson: false)
 sealed class GrokSessionModelStateDto with _$GrokSessionModelStateDto {
   const factory({
     @Default(<GrokModelInfoDto>[]) List<GrokModelInfoDto> availableModels,
     required String? currentModelId,
   }) = _GrokSessionModelStateDto;
 
-  factory fromJson(Map<String, dynamic> json) => _$GrokSessionModelStateDtoFromJson(json);
+  factory fromJson(Map<String, dynamic> json) {
+    final sanitized = {...json};
+    final availableModels = json["availableModels"];
+    if (availableModels != null && availableModels is! List) {
+      throw const FormatException("Grok availableModels must be a list");
+    }
+    if (availableModels is List) {
+      sanitized["availableModels"] = availableModels
+          .where((entry) => entry is Map && entry.keys.every((key) => key is String))
+          .toList(growable: false);
+    }
+    if (json["currentModelId"] is! String) sanitized["currentModelId"] = null;
+    return _$GrokSessionModelStateDtoFromJson(sanitized);
+  }
 }
 
 /// Grok-specific portion of ACP initialize metadata.
-@Freezed(toJson: false)
+@Freezed(fromJson: true, toJson: false)
 sealed class GrokInitializeMetadataDto with _$GrokInitializeMetadataDto {
   const factory({
     required bool? grokShell,
@@ -81,10 +105,17 @@ sealed class GrokInitializeMetadataDto with _$GrokInitializeMetadataDto {
     required GrokSessionModelStateDto? modelState,
   }) = _GrokInitializeMetadataDto;
 
-  factory fromJson(Map<String, dynamic> json) => _$GrokInitializeMetadataDtoFromJson(json);
+  factory fromJson(Map<String, dynamic> json) {
+    final sanitized = {...json};
+    if (json["grokShell"] is! bool) sanitized["grokShell"] = null;
+    if (json["agentVersion"] is! String) sanitized["agentVersion"] = null;
+    final modelState = json["modelState"];
+    if (modelState is! Map || !modelState.keys.every((key) => key is String)) sanitized["modelState"] = null;
+    return _$GrokInitializeMetadataDtoFromJson(sanitized);
+  }
 }
 
-/// Typed envelope for initialize and session activation model state.
+/// Typed envelope whose caller masks the irrelevant initialize/session branch.
 @Freezed(toJson: false)
 sealed class GrokModelStateEnvelopeDto with _$GrokModelStateEnvelopeDto {
   const factory({

--- a/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.freezed.dart
+++ b/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.freezed.dart
@@ -614,4 +614,343 @@ as String?,
 
 }
 
+
+/// @nodoc
+mixin _$GrokInitializeMetadataDto {
+
+ bool? get grokShell; String? get agentVersion; GrokSessionModelStateDto? get modelState;
+/// Create a copy of GrokInitializeMetadataDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GrokInitializeMetadataDtoCopyWith<GrokInitializeMetadataDto> get copyWith => _$GrokInitializeMetadataDtoCopyWithImpl<GrokInitializeMetadataDto>(this as GrokInitializeMetadataDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GrokInitializeMetadataDto&&(identical(other.grokShell, grokShell) || other.grokShell == grokShell)&&(identical(other.agentVersion, agentVersion) || other.agentVersion == agentVersion)&&(identical(other.modelState, modelState) || other.modelState == modelState));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,grokShell,agentVersion,modelState);
+
+@override
+String toString() {
+  return 'GrokInitializeMetadataDto(grokShell: $grokShell, agentVersion: $agentVersion, modelState: $modelState)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GrokInitializeMetadataDtoCopyWith<$Res>  {
+  factory $GrokInitializeMetadataDtoCopyWith(GrokInitializeMetadataDto value, $Res Function(GrokInitializeMetadataDto) _then) = _$GrokInitializeMetadataDtoCopyWithImpl;
+@useResult
+$Res call({
+ bool? grokShell, String? agentVersion, GrokSessionModelStateDto? modelState
+});
+
+
+$GrokSessionModelStateDtoCopyWith<$Res>? get modelState;
+
+}
+/// @nodoc
+class _$GrokInitializeMetadataDtoCopyWithImpl<$Res>
+    implements $GrokInitializeMetadataDtoCopyWith<$Res> {
+  _$GrokInitializeMetadataDtoCopyWithImpl(this._self, this._then);
+
+  final GrokInitializeMetadataDto _self;
+  final $Res Function(GrokInitializeMetadataDto) _then;
+
+/// Create a copy of GrokInitializeMetadataDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? grokShell = freezed,Object? agentVersion = freezed,Object? modelState = freezed,}) {
+  return _then(GrokInitializeMetadataDto(
+grokShell: freezed == grokShell ? _self.grokShell : grokShell // ignore: cast_nullable_to_non_nullable
+as bool?,agentVersion: freezed == agentVersion ? _self.agentVersion : agentVersion // ignore: cast_nullable_to_non_nullable
+as String?,modelState: freezed == modelState ? _self.modelState : modelState // ignore: cast_nullable_to_non_nullable
+as GrokSessionModelStateDto?,
+  ));
+}
+/// Create a copy of GrokInitializeMetadataDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GrokSessionModelStateDtoCopyWith<$Res>? get modelState {
+    if (_self.modelState == null) {
+    return null;
+  }
+
+  return $GrokSessionModelStateDtoCopyWith<$Res>(_self.modelState!, (value) {
+    return _then(_self.copyWith(modelState: value));
+  });
+}
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _GrokInitializeMetadataDto implements GrokInitializeMetadataDto {
+  const _GrokInitializeMetadataDto({required this.grokShell, required this.agentVersion, required this.modelState});
+  factory _GrokInitializeMetadataDto.fromJson(Map<String, dynamic> json) => _$GrokInitializeMetadataDtoFromJson(json);
+
+@override final  bool? grokShell;
+@override final  String? agentVersion;
+@override final  GrokSessionModelStateDto? modelState;
+
+/// Create a copy of GrokInitializeMetadataDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GrokInitializeMetadataDtoCopyWith<_GrokInitializeMetadataDto> get copyWith => __$GrokInitializeMetadataDtoCopyWithImpl<_GrokInitializeMetadataDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GrokInitializeMetadataDto&&(identical(other.grokShell, grokShell) || other.grokShell == grokShell)&&(identical(other.agentVersion, agentVersion) || other.agentVersion == agentVersion)&&(identical(other.modelState, modelState) || other.modelState == modelState));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,grokShell,agentVersion,modelState);
+
+@override
+String toString() {
+  return 'GrokInitializeMetadataDto(grokShell: $grokShell, agentVersion: $agentVersion, modelState: $modelState)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GrokInitializeMetadataDtoCopyWith<$Res> implements $GrokInitializeMetadataDtoCopyWith<$Res> {
+  factory _$GrokInitializeMetadataDtoCopyWith(_GrokInitializeMetadataDto value, $Res Function(_GrokInitializeMetadataDto) _then) = __$GrokInitializeMetadataDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ bool? grokShell, String? agentVersion, GrokSessionModelStateDto? modelState
+});
+
+
+@override $GrokSessionModelStateDtoCopyWith<$Res>? get modelState;
+
+}
+/// @nodoc
+class __$GrokInitializeMetadataDtoCopyWithImpl<$Res>
+    implements _$GrokInitializeMetadataDtoCopyWith<$Res> {
+  __$GrokInitializeMetadataDtoCopyWithImpl(this._self, this._then);
+
+  final _GrokInitializeMetadataDto _self;
+  final $Res Function(_GrokInitializeMetadataDto) _then;
+
+/// Create a copy of GrokInitializeMetadataDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? grokShell = freezed,Object? agentVersion = freezed,Object? modelState = freezed,}) {
+  return _then(_GrokInitializeMetadataDto(
+grokShell: freezed == grokShell ? _self.grokShell : grokShell // ignore: cast_nullable_to_non_nullable
+as bool?,agentVersion: freezed == agentVersion ? _self.agentVersion : agentVersion // ignore: cast_nullable_to_non_nullable
+as String?,modelState: freezed == modelState ? _self.modelState : modelState // ignore: cast_nullable_to_non_nullable
+as GrokSessionModelStateDto?,
+  ));
+}
+
+/// Create a copy of GrokInitializeMetadataDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GrokSessionModelStateDtoCopyWith<$Res>? get modelState {
+    if (_self.modelState == null) {
+    return null;
+  }
+
+  return $GrokSessionModelStateDtoCopyWith<$Res>(_self.modelState!, (value) {
+    return _then(_self.copyWith(modelState: value));
+  });
+}
+}
+
+
+/// @nodoc
+mixin _$GrokModelStateEnvelopeDto {
+
+@JsonKey(name: "_meta") GrokInitializeMetadataDto? get metadata; GrokSessionModelStateDto? get models;
+/// Create a copy of GrokModelStateEnvelopeDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GrokModelStateEnvelopeDtoCopyWith<GrokModelStateEnvelopeDto> get copyWith => _$GrokModelStateEnvelopeDtoCopyWithImpl<GrokModelStateEnvelopeDto>(this as GrokModelStateEnvelopeDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GrokModelStateEnvelopeDto&&(identical(other.metadata, metadata) || other.metadata == metadata)&&(identical(other.models, models) || other.models == models));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,metadata,models);
+
+@override
+String toString() {
+  return 'GrokModelStateEnvelopeDto(metadata: $metadata, models: $models)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GrokModelStateEnvelopeDtoCopyWith<$Res>  {
+  factory $GrokModelStateEnvelopeDtoCopyWith(GrokModelStateEnvelopeDto value, $Res Function(GrokModelStateEnvelopeDto) _then) = _$GrokModelStateEnvelopeDtoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: "_meta") GrokInitializeMetadataDto? metadata, GrokSessionModelStateDto? models
+});
+
+
+$GrokInitializeMetadataDtoCopyWith<$Res>? get metadata;$GrokSessionModelStateDtoCopyWith<$Res>? get models;
+
+}
+/// @nodoc
+class _$GrokModelStateEnvelopeDtoCopyWithImpl<$Res>
+    implements $GrokModelStateEnvelopeDtoCopyWith<$Res> {
+  _$GrokModelStateEnvelopeDtoCopyWithImpl(this._self, this._then);
+
+  final GrokModelStateEnvelopeDto _self;
+  final $Res Function(GrokModelStateEnvelopeDto) _then;
+
+/// Create a copy of GrokModelStateEnvelopeDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? metadata = freezed,Object? models = freezed,}) {
+  return _then(GrokModelStateEnvelopeDto(
+metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as GrokInitializeMetadataDto?,models: freezed == models ? _self.models : models // ignore: cast_nullable_to_non_nullable
+as GrokSessionModelStateDto?,
+  ));
+}
+/// Create a copy of GrokModelStateEnvelopeDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GrokInitializeMetadataDtoCopyWith<$Res>? get metadata {
+    if (_self.metadata == null) {
+    return null;
+  }
+
+  return $GrokInitializeMetadataDtoCopyWith<$Res>(_self.metadata!, (value) {
+    return _then(_self.copyWith(metadata: value));
+  });
+}/// Create a copy of GrokModelStateEnvelopeDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GrokSessionModelStateDtoCopyWith<$Res>? get models {
+    if (_self.models == null) {
+    return null;
+  }
+
+  return $GrokSessionModelStateDtoCopyWith<$Res>(_self.models!, (value) {
+    return _then(_self.copyWith(models: value));
+  });
+}
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _GrokModelStateEnvelopeDto implements GrokModelStateEnvelopeDto {
+  const _GrokModelStateEnvelopeDto({@JsonKey(name: "_meta") required this.metadata, required this.models});
+  factory _GrokModelStateEnvelopeDto.fromJson(Map<String, dynamic> json) => _$GrokModelStateEnvelopeDtoFromJson(json);
+
+@override@JsonKey(name: "_meta") final  GrokInitializeMetadataDto? metadata;
+@override final  GrokSessionModelStateDto? models;
+
+/// Create a copy of GrokModelStateEnvelopeDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GrokModelStateEnvelopeDtoCopyWith<_GrokModelStateEnvelopeDto> get copyWith => __$GrokModelStateEnvelopeDtoCopyWithImpl<_GrokModelStateEnvelopeDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GrokModelStateEnvelopeDto&&(identical(other.metadata, metadata) || other.metadata == metadata)&&(identical(other.models, models) || other.models == models));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,metadata,models);
+
+@override
+String toString() {
+  return 'GrokModelStateEnvelopeDto(metadata: $metadata, models: $models)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GrokModelStateEnvelopeDtoCopyWith<$Res> implements $GrokModelStateEnvelopeDtoCopyWith<$Res> {
+  factory _$GrokModelStateEnvelopeDtoCopyWith(_GrokModelStateEnvelopeDto value, $Res Function(_GrokModelStateEnvelopeDto) _then) = __$GrokModelStateEnvelopeDtoCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: "_meta") GrokInitializeMetadataDto? metadata, GrokSessionModelStateDto? models
+});
+
+
+@override $GrokInitializeMetadataDtoCopyWith<$Res>? get metadata;@override $GrokSessionModelStateDtoCopyWith<$Res>? get models;
+
+}
+/// @nodoc
+class __$GrokModelStateEnvelopeDtoCopyWithImpl<$Res>
+    implements _$GrokModelStateEnvelopeDtoCopyWith<$Res> {
+  __$GrokModelStateEnvelopeDtoCopyWithImpl(this._self, this._then);
+
+  final _GrokModelStateEnvelopeDto _self;
+  final $Res Function(_GrokModelStateEnvelopeDto) _then;
+
+/// Create a copy of GrokModelStateEnvelopeDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? metadata = freezed,Object? models = freezed,}) {
+  return _then(_GrokModelStateEnvelopeDto(
+metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as GrokInitializeMetadataDto?,models: freezed == models ? _self.models : models // ignore: cast_nullable_to_non_nullable
+as GrokSessionModelStateDto?,
+  ));
+}
+
+/// Create a copy of GrokModelStateEnvelopeDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GrokInitializeMetadataDtoCopyWith<$Res>? get metadata {
+    if (_self.metadata == null) {
+    return null;
+  }
+
+  return $GrokInitializeMetadataDtoCopyWith<$Res>(_self.metadata!, (value) {
+    return _then(_self.copyWith(metadata: value));
+  });
+}/// Create a copy of GrokModelStateEnvelopeDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GrokSessionModelStateDtoCopyWith<$Res>? get models {
+    if (_self.models == null) {
+    return null;
+  }
+
+  return $GrokSessionModelStateDtoCopyWith<$Res>(_self.models!, (value) {
+    return _then(_self.copyWith(models: value));
+  });
+}
+}
+
 // dart format on

--- a/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.freezed.dart
+++ b/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.freezed.dart
@@ -169,8 +169,6 @@ mixin _$GrokModelMetadataDto {
 @pragma('vm:prefer-inline')
 $GrokModelMetadataDtoCopyWith<GrokModelMetadataDto> get copyWith => _$GrokModelMetadataDtoCopyWithImpl<GrokModelMetadataDto>(this as GrokModelMetadataDto, _$identity);
 
-  /// Serializes this GrokModelMetadataDto to a JSON map.
-  Map<String, dynamic> toJson();
 
 
 @override
@@ -226,7 +224,7 @@ as String?,
 
 
 /// @nodoc
-@JsonSerializable()
+@JsonSerializable(createToJson: false)
 
 class _GrokModelMetadataDto implements GrokModelMetadataDto {
   const _GrokModelMetadataDto({required this.supportsReasoningEffort,  List<GrokReasoningEffortOptionDto> reasoningEfforts = const <GrokReasoningEffortOptionDto>[], required this.reasoningEffort}): _reasoningEfforts = reasoningEfforts;
@@ -248,10 +246,7 @@ class _GrokModelMetadataDto implements GrokModelMetadataDto {
 @pragma('vm:prefer-inline')
 _$GrokModelMetadataDtoCopyWith<_GrokModelMetadataDto> get copyWith => __$GrokModelMetadataDtoCopyWithImpl<_GrokModelMetadataDto>(this, _$identity);
 
-@override
-Map<String, dynamic> toJson() {
-  return _$GrokModelMetadataDtoToJson(this, );
-}
+
 
 @override
 bool operator ==(Object other) {
@@ -315,8 +310,6 @@ mixin _$GrokModelInfoDto {
 @pragma('vm:prefer-inline')
 $GrokModelInfoDtoCopyWith<GrokModelInfoDto> get copyWith => _$GrokModelInfoDtoCopyWithImpl<GrokModelInfoDto>(this as GrokModelInfoDto, _$identity);
 
-  /// Serializes this GrokModelInfoDto to a JSON map.
-  Map<String, dynamic> toJson();
 
 
 @override
@@ -385,7 +378,7 @@ $GrokModelMetadataDtoCopyWith<$Res>? get metadata {
 
 
 /// @nodoc
-@JsonSerializable()
+@JsonSerializable(createToJson: false)
 
 class _GrokModelInfoDto implements GrokModelInfoDto {
   const _GrokModelInfoDto({required this.modelId, required this.name, required this.description, @JsonKey(name: "_meta") required this.metadata});
@@ -402,10 +395,7 @@ class _GrokModelInfoDto implements GrokModelInfoDto {
 @pragma('vm:prefer-inline')
 _$GrokModelInfoDtoCopyWith<_GrokModelInfoDto> get copyWith => __$GrokModelInfoDtoCopyWithImpl<_GrokModelInfoDto>(this, _$identity);
 
-@override
-Map<String, dynamic> toJson() {
-  return _$GrokModelInfoDtoToJson(this, );
-}
+
 
 @override
 bool operator ==(Object other) {
@@ -482,8 +472,6 @@ mixin _$GrokSessionModelStateDto {
 @pragma('vm:prefer-inline')
 $GrokSessionModelStateDtoCopyWith<GrokSessionModelStateDto> get copyWith => _$GrokSessionModelStateDtoCopyWithImpl<GrokSessionModelStateDto>(this as GrokSessionModelStateDto, _$identity);
 
-  /// Serializes this GrokSessionModelStateDto to a JSON map.
-  Map<String, dynamic> toJson();
 
 
 @override
@@ -538,7 +526,7 @@ as String?,
 
 
 /// @nodoc
-@JsonSerializable()
+@JsonSerializable(createToJson: false)
 
 class _GrokSessionModelStateDto implements GrokSessionModelStateDto {
   const _GrokSessionModelStateDto({ List<GrokModelInfoDto> availableModels = const <GrokModelInfoDto>[], required this.currentModelId}): _availableModels = availableModels;
@@ -559,10 +547,7 @@ class _GrokSessionModelStateDto implements GrokSessionModelStateDto {
 @pragma('vm:prefer-inline')
 _$GrokSessionModelStateDtoCopyWith<_GrokSessionModelStateDto> get copyWith => __$GrokSessionModelStateDtoCopyWithImpl<_GrokSessionModelStateDto>(this, _$identity);
 
-@override
-Map<String, dynamic> toJson() {
-  return _$GrokSessionModelStateDtoToJson(this, );
-}
+
 
 @override
 bool operator ==(Object other) {

--- a/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.g.dart
+++ b/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.g.dart
@@ -88,3 +88,28 @@ Map<String, dynamic> _$GrokSessionModelStateDtoToJson(
   'availableModels': instance.availableModels.map((e) => e.toJson()).toList(),
   'currentModelId': ?instance.currentModelId,
 };
+
+_GrokInitializeMetadataDto _$GrokInitializeMetadataDtoFromJson(Map json) =>
+    _GrokInitializeMetadataDto(
+      grokShell: json['grokShell'] as bool?,
+      agentVersion: json['agentVersion'] as String?,
+      modelState: json['modelState'] == null
+          ? null
+          : GrokSessionModelStateDto.fromJson(
+              Map<String, dynamic>.from(json['modelState'] as Map),
+            ),
+    );
+
+_GrokModelStateEnvelopeDto _$GrokModelStateEnvelopeDtoFromJson(Map json) =>
+    _GrokModelStateEnvelopeDto(
+      metadata: json['_meta'] == null
+          ? null
+          : GrokInitializeMetadataDto.fromJson(
+              Map<String, dynamic>.from(json['_meta'] as Map),
+            ),
+      models: json['models'] == null
+          ? null
+          : GrokSessionModelStateDto.fromJson(
+              Map<String, dynamic>.from(json['models'] as Map),
+            ),
+    );

--- a/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.g.dart
+++ b/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.g.dart
@@ -41,14 +41,6 @@ _GrokModelMetadataDto _$GrokModelMetadataDtoFromJson(Map json) =>
       reasoningEffort: json['reasoningEffort'] as String?,
     );
 
-Map<String, dynamic> _$GrokModelMetadataDtoToJson(
-  _GrokModelMetadataDto instance,
-) => <String, dynamic>{
-  'supportsReasoningEffort': ?instance.supportsReasoningEffort,
-  'reasoningEfforts': instance.reasoningEfforts.map((e) => e.toJson()).toList(),
-  'reasoningEffort': ?instance.reasoningEffort,
-};
-
 _GrokModelInfoDto _$GrokModelInfoDtoFromJson(Map json) => _GrokModelInfoDto(
   modelId: json['modelId'] as String?,
   name: json['name'] as String?,
@@ -59,14 +51,6 @@ _GrokModelInfoDto _$GrokModelInfoDtoFromJson(Map json) => _GrokModelInfoDto(
           Map<String, dynamic>.from(json['_meta'] as Map),
         ),
 );
-
-Map<String, dynamic> _$GrokModelInfoDtoToJson(_GrokModelInfoDto instance) =>
-    <String, dynamic>{
-      'modelId': ?instance.modelId,
-      'name': ?instance.name,
-      'description': ?instance.description,
-      '_meta': ?instance.metadata?.toJson(),
-    };
 
 _GrokSessionModelStateDto _$GrokSessionModelStateDtoFromJson(Map json) =>
     _GrokSessionModelStateDto(
@@ -81,13 +65,6 @@ _GrokSessionModelStateDto _$GrokSessionModelStateDtoFromJson(Map json) =>
           const <GrokModelInfoDto>[],
       currentModelId: json['currentModelId'] as String?,
     );
-
-Map<String, dynamic> _$GrokSessionModelStateDtoToJson(
-  _GrokSessionModelStateDto instance,
-) => <String, dynamic>{
-  'availableModels': instance.availableModels.map((e) => e.toJson()).toList(),
-  'currentModelId': ?instance.currentModelId,
-};
 
 _GrokInitializeMetadataDto _$GrokInitializeMetadataDtoFromJson(Map json) =>
     _GrokInitializeMetadataDto(

--- a/bridge/sesori_plugin_grok/lib/src/models/grok_model_catalog.dart
+++ b/bridge/sesori_plugin_grok/lib/src/models/grok_model_catalog.dart
@@ -1,0 +1,29 @@
+/// One valid Grok model and its exact advertised reasoning values.
+class GrokCatalogModel({
+  required final String id,
+  required final String name,
+  required List<String> reasoningEfforts,
+  required final String? currentReasoningEffort,
+}) {
+  final List<String> reasoningEfforts = List.unmodifiable(reasoningEfforts);
+}
+
+/// Immutable last-good Grok model catalog.
+class GrokModelCatalog({
+  required List<GrokCatalogModel> models,
+  required String? currentModelId,
+}) {
+  final List<GrokCatalogModel> models = List.unmodifiable(models);
+  final String? _currentModelId = currentModelId;
+
+  GrokCatalogModel? get currentModel => _currentModelId == null ? null : modelById(id: _currentModelId);
+  String? get currentModelId => currentModel?.id;
+  GrokCatalogModel? get defaultModel => currentModel ?? models.firstOrNull;
+
+  GrokCatalogModel? modelById({required String id}) {
+    for (final model in models) {
+      if (model.id == id) return model;
+    }
+    return null;
+  }
+}

--- a/bridge/sesori_plugin_grok/lib/src/models/grok_model_catalog.dart
+++ b/bridge/sesori_plugin_grok/lib/src/models/grok_model_catalog.dart
@@ -3,6 +3,7 @@ class GrokCatalogModel({
   required final String id,
   required final String name,
   required List<String> reasoningEfforts,
+  required final String? defaultReasoningEffort,
   required final String? currentReasoningEffort,
 }) {
   final List<String> reasoningEfforts = List.unmodifiable(reasoningEfforts);

--- a/bridge/sesori_plugin_grok/lib/src/repositories/grok_catalog_repository.dart
+++ b/bridge/sesori_plugin_grok/lib/src/repositories/grok_catalog_repository.dart
@@ -1,0 +1,73 @@
+import "package:acp_plugin/acp_plugin.dart" show AcpInitializeResult, AcpNewSessionResult;
+
+import "../api/grok_acp_api.dart";
+import "../api/models/grok_protocol_dto.dart";
+import "../models/grok_model_catalog.dart";
+
+/// Validates Grok identity and maps its legacy model-state wire shape.
+class GrokCatalogRepository({required final GrokAcpApi _api}) {
+  Future<GrokModelCatalog> discoverCatalog({
+    required String cwd,
+    required Duration timeout,
+  }) async => mapInitializeResult(
+    result: await _api.probeCatalog(cwd: cwd, timeout: timeout),
+  );
+
+  GrokModelCatalog mapInitializeResult({required AcpInitializeResult result}) {
+    final envelope = GrokModelStateEnvelopeDto.fromJson(result.raw);
+    final metadata = envelope.metadata;
+    if (metadata?.grokShell != true) throw StateError("ACP initialize result is not from Grok Build");
+    final state = metadata?.modelState;
+    if (state == null) throw StateError("Grok initialize result omitted model state");
+    return _mapState(state: state);
+  }
+
+  GrokModelCatalog? mapSessionResult({required AcpNewSessionResult result}) {
+    final state = GrokModelStateEnvelopeDto.fromJson(result.raw).models;
+    return state == null ? null : _mapState(state: state);
+  }
+
+  GrokModelCatalog _mapState({required GrokSessionModelStateDto state}) {
+    final models = <GrokCatalogModel>[];
+    for (final entry in state.availableModels) {
+      final id = entry.modelId;
+      if (id == null || id.trim().isEmpty) continue;
+      final metadata = entry.metadata;
+      final effortOptions = (metadata?.supportsReasoningEffort ?? false)
+          ? metadata?.reasoningEfforts ?? const <GrokReasoningEffortOptionDto>[]
+          : const <GrokReasoningEffortOptionDto>[];
+      final efforts = _reasoningEfforts(options: effortOptions);
+      final currentEffort = metadata?.reasoningEffort;
+      final name = entry.name?.trim();
+      models.add(
+        GrokCatalogModel(
+          id: id,
+          name: name == null || name.isEmpty ? id : name,
+          reasoningEfforts: efforts,
+          currentReasoningEffort: currentEffort != null && efforts.contains(currentEffort) ? currentEffort : null,
+        ),
+      );
+    }
+    final currentModelId = state.currentModelId;
+    return GrokModelCatalog(
+      models: models,
+      currentModelId: currentModelId != null && models.any((model) => model.id == currentModelId)
+          ? currentModelId
+          : null,
+    );
+  }
+
+  List<String> _reasoningEfforts({required List<GrokReasoningEffortOptionDto> options}) {
+    final values = <String>[];
+    String? defaultValue;
+    for (final option in options) {
+      final value = option.value;
+      if (value == null || value.trim().isEmpty) continue;
+      values.add(value);
+      if (option.isDefault) defaultValue ??= value;
+    }
+    final defaultIndex = defaultValue == null ? -1 : values.indexOf(defaultValue);
+    if (defaultIndex > 0) values.insert(0, values.removeAt(defaultIndex));
+    return List.unmodifiable(values);
+  }
+}

--- a/bridge/sesori_plugin_grok/lib/src/repositories/grok_catalog_repository.dart
+++ b/bridge/sesori_plugin_grok/lib/src/repositories/grok_catalog_repository.dart
@@ -14,7 +14,7 @@ class GrokCatalogRepository({required final GrokAcpApi _api}) {
   );
 
   GrokModelCatalog mapInitializeResult({required AcpInitializeResult result}) {
-    final envelope = GrokModelStateEnvelopeDto.fromJson(result.raw);
+    final envelope = GrokModelStateEnvelopeDto.fromJson({...result.raw, "models": null});
     final metadata = envelope.metadata;
     if (metadata?.grokShell != true) throw StateError("ACP initialize result is not from Grok Build");
     final state = metadata?.modelState;
@@ -23,7 +23,7 @@ class GrokCatalogRepository({required final GrokAcpApi _api}) {
   }
 
   GrokModelCatalog? mapSessionResult({required AcpNewSessionResult result}) {
-    final state = GrokModelStateEnvelopeDto.fromJson(result.raw).models;
+    final state = GrokModelStateEnvelopeDto.fromJson({...result.raw, "_meta": null}).models;
     return state == null ? null : _mapState(state: state);
   }
 
@@ -43,8 +43,11 @@ class GrokCatalogRepository({required final GrokAcpApi _api}) {
         GrokCatalogModel(
           id: id,
           name: name == null || name.isEmpty ? id : name,
-          reasoningEfforts: efforts,
-          currentReasoningEffort: currentEffort != null && efforts.contains(currentEffort) ? currentEffort : null,
+          reasoningEfforts: efforts.values,
+          defaultReasoningEffort: efforts.defaultValue,
+          currentReasoningEffort: currentEffort != null && efforts.values.contains(currentEffort)
+              ? currentEffort
+              : null,
         ),
       );
     }
@@ -57,7 +60,9 @@ class GrokCatalogRepository({required final GrokAcpApi _api}) {
     );
   }
 
-  List<String> _reasoningEfforts({required List<GrokReasoningEffortOptionDto> options}) {
+  ({List<String> values, String? defaultValue}) _reasoningEfforts({
+    required List<GrokReasoningEffortOptionDto> options,
+  }) {
     final values = <String>[];
     String? defaultValue;
     for (final option in options) {
@@ -68,6 +73,6 @@ class GrokCatalogRepository({required final GrokAcpApi _api}) {
     }
     final defaultIndex = defaultValue == null ? -1 : values.indexOf(defaultValue);
     if (defaultIndex > 0) values.insert(0, values.removeAt(defaultIndex));
-    return List.unmodifiable(values);
+    return (values: List.unmodifiable(values), defaultValue: defaultValue);
   }
 }

--- a/bridge/sesori_plugin_grok/lib/src/repositories/grok_session_config_repository.dart
+++ b/bridge/sesori_plugin_grok/lib/src/repositories/grok_session_config_repository.dart
@@ -1,0 +1,40 @@
+import "package:acp_plugin/acp_plugin.dart" show AcpStdioClient;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginOperationException;
+
+import "../api/grok_acp_api.dart";
+
+/// Validates and delegates exact Grok session-local model writes.
+class GrokSessionConfigRepository({required final GrokAcpApi _api}) {
+  Future<void> setSelection({
+    required AcpStdioClient liveClient,
+    required String sessionId,
+    required String modelId,
+    required String? reasoningEffort,
+    required Duration timeout,
+  }) async {
+    if (sessionId.isEmpty || modelId.isEmpty || (reasoningEffort?.isEmpty ?? false)) {
+      throw const PluginOperationException(
+        GrokAcpApi.sessionSetModelMethod,
+        message: "Grok selection values must not be empty",
+      );
+    }
+    try {
+      await _api.setModel(
+        liveClient: liveClient,
+        sessionId: sessionId,
+        modelId: modelId,
+        reasoningEffort: reasoningEffort,
+        timeout: timeout,
+      );
+    } on Object catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        PluginOperationException(
+          GrokAcpApi.sessionSetModelMethod,
+          message: "Grok rejected the requested session options",
+          cause: error,
+        ),
+        stackTrace,
+      );
+    }
+  }
+}

--- a/bridge/sesori_plugin_grok/lib/src/repositories/grok_session_config_repository.dart
+++ b/bridge/sesori_plugin_grok/lib/src/repositories/grok_session_config_repository.dart
@@ -5,6 +5,8 @@ import "../api/grok_acp_api.dart";
 
 /// Validates and delegates exact Grok session-local model writes.
 class GrokSessionConfigRepository({required final GrokAcpApi _api}) {
+  static const String selectionOperation = GrokAcpApi.sessionSetModelMethod;
+
   Future<void> setSelection({
     required AcpStdioClient liveClient,
     required String sessionId,
@@ -14,7 +16,7 @@ class GrokSessionConfigRepository({required final GrokAcpApi _api}) {
   }) async {
     if (sessionId.isEmpty || modelId.isEmpty || (reasoningEffort?.isEmpty ?? false)) {
       throw const PluginOperationException(
-        GrokAcpApi.sessionSetModelMethod,
+        selectionOperation,
         message: "Grok selection values must not be empty",
       );
     }
@@ -29,7 +31,7 @@ class GrokSessionConfigRepository({required final GrokAcpApi _api}) {
     } on Object catch (error, stackTrace) {
       Error.throwWithStackTrace(
         PluginOperationException(
-          GrokAcpApi.sessionSetModelMethod,
+          selectionOperation,
           message: "Grok rejected the requested session options",
           cause: error,
         ),

--- a/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
+++ b/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
@@ -70,17 +70,11 @@ class GrokSessionOptionsService({
     _replaceCatalog(catalog: catalog, updateProcessDefaults: fromNewSession);
     if (sessionId != null) {
       final currentModel = catalog.currentModel;
-      _configurationTracker.setSessionOverride(
+      _setSessionSelection(
         sessionId: sessionId,
-        modelId: currentModel?.id,
-        providerId: currentModel == null ? null : _pluginId,
+        model: currentModel,
+        reasoningEffort: currentModel?.currentReasoningEffort,
       );
-      final reasoningEffort = currentModel?.currentReasoningEffort;
-      if (reasoningEffort == null) {
-        _sessionReasoningEfforts.remove(sessionId);
-      } else {
-        _sessionReasoningEfforts[sessionId] = reasoningEffort;
-      }
     }
   }
 
@@ -125,10 +119,10 @@ class GrokSessionOptionsService({
       reasoningEffort: reasoningEffort,
       timeout: _selectionTimeout,
     );
-    _configurationTracker.setSessionOverride(
+    _setSessionSelection(
       sessionId: sessionId,
-      modelId: selectedModelId,
-      providerId: _pluginId,
+      model: catalogModel,
+      reasoningEffort: reasoningEffort ?? catalogModel.currentReasoningEffort,
     );
   }
 
@@ -142,6 +136,23 @@ class GrokSessionOptionsService({
   void resetConnection() {
     _configurationTracker.clear();
     _sessionReasoningEfforts.clear();
+  }
+
+  void _setSessionSelection({
+    required String sessionId,
+    required GrokCatalogModel? model,
+    required String? reasoningEffort,
+  }) {
+    _configurationTracker.setSessionOverride(
+      sessionId: sessionId,
+      modelId: model?.id,
+      providerId: model == null ? null : _pluginId,
+    );
+    if (reasoningEffort == null) {
+      _sessionReasoningEfforts.remove(sessionId);
+    } else {
+      _sessionReasoningEfforts[sessionId] = reasoningEffort;
+    }
   }
 
   Future<void> _ensureCatalog() async {

--- a/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
+++ b/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
@@ -22,6 +22,7 @@ class GrokSessionOptionsService({
   static const Duration _selectionTimeout = Duration(seconds: 30);
 
   String? _processDefaultReasoningEffort;
+  final Map<String, String> _sessionReasoningEfforts = {};
 
   Future<PluginSessionOptionsDiscoveryResult> getSessionOptions({
     required PluginSessionOptionsDiscoveryMode discoveryMode,
@@ -68,11 +69,18 @@ class GrokSessionOptionsService({
     if (catalog == null) return;
     _replaceCatalog(catalog: catalog, updateProcessDefaults: fromNewSession);
     if (sessionId != null) {
+      final currentModel = catalog.currentModel;
       _configurationTracker.setSessionOverride(
         sessionId: sessionId,
-        modelId: catalog.currentModel?.id,
-        providerId: catalog.currentModel == null ? null : _pluginId,
+        modelId: currentModel?.id,
+        providerId: currentModel == null ? null : _pluginId,
       );
+      final reasoningEffort = currentModel?.currentReasoningEffort;
+      if (reasoningEffort == null) {
+        _sessionReasoningEfforts.remove(sessionId);
+      } else {
+        _sessionReasoningEfforts[sessionId] = reasoningEffort;
+      }
     }
   }
 
@@ -124,9 +132,17 @@ class GrokSessionOptionsService({
     );
   }
 
-  void forgetSession({required String sessionId}) => _configurationTracker.forgetSession(sessionId: sessionId);
+  String? reasoningEffortForSession({required String sessionId}) => _sessionReasoningEfforts[sessionId];
 
-  void resetConnection() => _configurationTracker.clear();
+  void forgetSession({required String sessionId}) {
+    _configurationTracker.forgetSession(sessionId: sessionId);
+    _sessionReasoningEfforts.remove(sessionId);
+  }
+
+  void resetConnection() {
+    _configurationTracker.clear();
+    _sessionReasoningEfforts.clear();
+  }
 
   Future<void> _ensureCatalog() async {
     if (_catalogTracker.snapshot != null) return;

--- a/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
+++ b/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
@@ -92,8 +92,20 @@ class GrokSessionOptionsService({
     final catalog = _catalogTracker.snapshot;
     final current = _configurationTracker.snapshotForSession(sessionId: sessionId);
     final currentModelId = current.modelId;
-    final trackedModel = currentModelId == null ? null : catalog?.modelById(id: currentModelId);
-    final catalogModel = model == null ? trackedModel ?? catalog?.defaultModel : catalog?.modelById(id: model.modelID);
+    GrokCatalogModel? catalogModel;
+    if (model != null) {
+      catalogModel = catalog?.modelById(id: model.modelID);
+    } else if (currentModelId != null) {
+      catalogModel = catalog?.modelById(id: currentModelId);
+      if (catalogModel == null) {
+        throw const PluginStaleOptionsException(
+          GrokSessionConfigRepository.selectionOperation,
+          message: "Grok no longer offers the session's selected model",
+        );
+      }
+    } else {
+      catalogModel = catalog?.defaultModel;
+    }
     if (catalogModel == null) {
       throw const PluginStaleOptionsException(
         GrokSessionConfigRepository.selectionOperation,
@@ -108,8 +120,6 @@ class GrokSessionOptionsService({
       );
     }
     final selectedModelId = catalogModel.id;
-    if (selectedModelId == current.modelId && reasoningEffort == null) return;
-
     await _configRepository.setSelection(
       liveClient: liveClient,
       sessionId: sessionId,
@@ -121,7 +131,7 @@ class GrokSessionOptionsService({
       sessionId: sessionId,
       modelId: selectedModelId,
       providerId: _pluginId,
-      variantId: reasoningEffort ?? catalogModel.currentReasoningEffort,
+      variantId: reasoningEffort ?? catalogModel.defaultReasoningEffort,
     );
   }
 
@@ -157,9 +167,9 @@ class GrokSessionOptionsService({
     final configuredModelId = processDefaults.modelId;
     final selected = configuredModelId == null ? null : catalog?.modelById(id: configuredModelId);
     final defaultModel = selected ?? catalog?.defaultModel;
-    final processDefaultReasoningEffort = defaultModel?.reasoningEfforts.contains(processDefaults.variantId) ?? false
+    final processDefaultReasoningEffort = selected?.reasoningEfforts.contains(processDefaults.variantId) ?? false
         ? processDefaults.variantId
-        : null;
+        : defaultModel?.defaultReasoningEffort;
     return PluginSessionOptions(
       agents: [
         PluginAgent(

--- a/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
+++ b/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
@@ -2,7 +2,6 @@ import "package:acp_plugin/acp_plugin.dart"
     show AcpCommandTracker, AcpInitializeResult, AcpNewSessionResult, AcpSessionConfigurationTracker, AcpStdioClient;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
-import "../api/grok_acp_api.dart";
 import "../models/grok_model_catalog.dart";
 import "../repositories/grok_catalog_repository.dart";
 import "../repositories/grok_session_config_repository.dart";
@@ -84,7 +83,7 @@ class GrokSessionOptionsService({
     if (model == null && variant == null) return;
     if (model != null && model.providerID != _pluginId) {
       throw const PluginOperationException(
-        GrokAcpApi.sessionSetModelMethod,
+        GrokSessionConfigRepository.selectionOperation,
         message: "Requested Grok provider is unavailable",
       );
     }
@@ -94,14 +93,14 @@ class GrokSessionOptionsService({
     final catalogModel = modelId == null ? null : catalog?.modelById(id: modelId);
     if (catalogModel == null) {
       throw const PluginOperationException(
-        GrokAcpApi.sessionSetModelMethod,
+        GrokSessionConfigRepository.selectionOperation,
         message: "Requested Grok model is unavailable",
       );
     }
     final reasoningEffort = variant?.id;
     if (reasoningEffort != null && !catalogModel.reasoningEfforts.contains(reasoningEffort)) {
       throw const PluginOperationException(
-        GrokAcpApi.sessionSetModelMethod,
+        GrokSessionConfigRepository.selectionOperation,
         message: "Requested Grok reasoning effort is unavailable",
       );
     }

--- a/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
+++ b/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
@@ -1,0 +1,197 @@
+import "package:acp_plugin/acp_plugin.dart"
+    show AcpCommandTracker, AcpInitializeResult, AcpNewSessionResult, AcpSessionConfigurationTracker, AcpStdioClient;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../api/grok_acp_api.dart";
+import "../models/grok_model_catalog.dart";
+import "../repositories/grok_catalog_repository.dart";
+import "../repositories/grok_session_config_repository.dart";
+import "../trackers/grok_catalog_tracker.dart";
+
+/// Coordinates Grok catalog discovery, presentation, and exact turn selection.
+class GrokSessionOptionsService({
+  required final GrokCatalogRepository _catalogRepository,
+  required final GrokSessionConfigRepository _configRepository,
+  required final GrokCatalogTracker _catalogTracker,
+  required final AcpSessionConfigurationTracker _configurationTracker,
+  required final AcpCommandTracker _commandTracker,
+  required final String _launchDirectory,
+  required final String _pluginId,
+  required final String _displayName,
+  required final Duration _discoveryTimeout,
+}) {
+  static const Duration _selectionTimeout = Duration(seconds: 30);
+
+  Future<PluginSessionOptionsDiscoveryResult> getSessionOptions({
+    required PluginSessionOptionsDiscoveryMode discoveryMode,
+  }) async {
+    if (discoveryMode == PluginSessionOptionsDiscoveryMode.reuse && _catalogTracker.snapshot != null) {
+      return PluginSessionOptionsDiscoveryResult.observed(options: _options());
+    }
+    try {
+      final catalog = await _catalogRepository.discoverCatalog(
+        cwd: _launchDirectory,
+        timeout: _discoveryTimeout,
+      );
+      _replaceCatalog(catalog: catalog, updateProcessDefaults: true);
+      return PluginSessionOptionsDiscoveryResult.observed(options: _options());
+    } on Object catch (error, stackTrace) {
+      Log.w("[$_pluginId] model catalog discovery failed", error, stackTrace);
+      return const PluginSessionOptionsDiscoveryResult.failed();
+    }
+  }
+
+  Future<List<PluginAgent>> listAgents() async {
+    await _ensureCatalog();
+    return _options().agents;
+  }
+
+  Future<PluginProvidersResult> listProviders() async {
+    await _ensureCatalog();
+    return _options().providers;
+  }
+
+  void captureInitializeResult({required AcpInitializeResult result}) {
+    _replaceCatalog(
+      catalog: _catalogRepository.mapInitializeResult(result: result),
+      updateProcessDefaults: true,
+    );
+  }
+
+  void captureSessionConfig({
+    required AcpNewSessionResult result,
+    required String? sessionId,
+    required bool fromNewSession,
+  }) {
+    final catalog = _catalogRepository.mapSessionResult(result: result);
+    if (catalog == null) return;
+    _replaceCatalog(catalog: catalog, updateProcessDefaults: fromNewSession);
+    if (sessionId != null) {
+      _configurationTracker.setSessionOverride(
+        sessionId: sessionId,
+        modelId: catalog.currentModel?.id,
+        providerId: catalog.currentModel == null ? null : _pluginId,
+      );
+    }
+  }
+
+  Future<void> applyTurnSelection({
+    required AcpStdioClient liveClient,
+    required String sessionId,
+    required ({String providerID, String modelID})? model,
+    required PluginSessionVariant? variant,
+  }) async {
+    if (model == null && variant == null) return;
+    if (model != null && model.providerID != _pluginId) {
+      throw const PluginOperationException(
+        GrokAcpApi.sessionSetModelMethod,
+        message: "Requested Grok provider is unavailable",
+      );
+    }
+    final catalog = _catalogTracker.snapshot;
+    final current = _configurationTracker.snapshotForSession(sessionId: sessionId);
+    final modelId = model?.modelID ?? current.modelId ?? catalog?.currentModel?.id;
+    final catalogModel = modelId == null ? null : catalog?.modelById(id: modelId);
+    if (catalogModel == null) {
+      throw const PluginOperationException(
+        GrokAcpApi.sessionSetModelMethod,
+        message: "Requested Grok model is unavailable",
+      );
+    }
+    final reasoningEffort = variant?.id;
+    if (reasoningEffort != null && !catalogModel.reasoningEfforts.contains(reasoningEffort)) {
+      throw const PluginOperationException(
+        GrokAcpApi.sessionSetModelMethod,
+        message: "Requested Grok reasoning effort is unavailable",
+      );
+    }
+    final selectedModelId = catalogModel.id;
+    if (selectedModelId == current.modelId && reasoningEffort == null) return;
+
+    await _configRepository.setSelection(
+      liveClient: liveClient,
+      sessionId: sessionId,
+      modelId: selectedModelId,
+      reasoningEffort: reasoningEffort,
+      timeout: _selectionTimeout,
+    );
+    _configurationTracker.setSessionOverride(
+      sessionId: sessionId,
+      modelId: selectedModelId,
+      providerId: _pluginId,
+    );
+  }
+
+  void forgetSession({required String sessionId}) => _configurationTracker.forgetSession(sessionId: sessionId);
+
+  void resetConnection() => _configurationTracker.clear();
+
+  Future<void> _ensureCatalog() async {
+    if (_catalogTracker.snapshot != null) return;
+    await getSessionOptions(discoveryMode: PluginSessionOptionsDiscoveryMode.reuse);
+  }
+
+  void _replaceCatalog({
+    required GrokModelCatalog catalog,
+    required bool updateProcessDefaults,
+  }) {
+    _catalogTracker.replaceCatalog(catalog: catalog);
+    if (!updateProcessDefaults) return;
+    final current = catalog.currentModel;
+    _configurationTracker.setProcessDefaults(
+      modelId: current?.id,
+      providerId: current == null ? null : _pluginId,
+    );
+  }
+
+  PluginSessionOptions _options() {
+    final catalog = _catalogTracker.snapshot;
+    final configuredModelId = _configurationTracker.processDefaults.modelId;
+    final selected = configuredModelId == null ? null : catalog?.modelById(id: configuredModelId);
+    final defaultModel = selected ?? catalog?.defaultModel;
+    return PluginSessionOptions(
+      agents: [
+        PluginAgent(
+          name: _pluginId,
+          description: "$_displayName session",
+          model: defaultModel == null
+              ? null
+              : PluginAgentModel(
+                  modelID: defaultModel.id,
+                  providerID: _pluginId,
+                  variant: defaultModel.currentReasoningEffort,
+                ),
+          mode: PluginAgentMode.primary,
+          hidden: false,
+        ),
+      ],
+      providers: PluginProvidersResult(
+        providers: catalog == null || catalog.models.isEmpty
+            ? const []
+            : [
+                PluginProvider(
+                  id: _pluginId,
+                  name: _displayName,
+                  authType: PluginProviderAuthType.unknown,
+                  models: [
+                    for (final model in catalog.models)
+                      PluginModel(
+                        id: model.id,
+                        name: model.name,
+                        variants: model.reasoningEfforts,
+                        family: null,
+                        isAvailable: true,
+                        releaseDate: null,
+                      ),
+                  ],
+                  defaultModelID: defaultModel?.id,
+                ),
+              ],
+      ),
+      commands: _commandTracker.commands,
+      completeness: catalog != null && _commandTracker.hasSnapshot
+          ? PluginSessionOptionsCompleteness.complete
+          : PluginSessionOptionsCompleteness.partial,
+    );
+  }
+}

--- a/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
+++ b/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
@@ -21,6 +21,8 @@ class GrokSessionOptionsService({
 }) {
   static const Duration _selectionTimeout = Duration(seconds: 30);
 
+  String? _processDefaultReasoningEffort;
+
   Future<PluginSessionOptionsDiscoveryResult> getSessionOptions({
     required PluginSessionOptionsDiscoveryMode discoveryMode,
   }) async {
@@ -82,26 +84,27 @@ class GrokSessionOptionsService({
   }) async {
     if (model == null && variant == null) return;
     if (model != null && model.providerID != _pluginId) {
-      throw const PluginOperationException(
+      throw const PluginStaleOptionsException(
         GrokSessionConfigRepository.selectionOperation,
-        message: "Requested Grok provider is unavailable",
+        message: "Grok no longer offers the requested provider",
       );
     }
     final catalog = _catalogTracker.snapshot;
     final current = _configurationTracker.snapshotForSession(sessionId: sessionId);
-    final modelId = model?.modelID ?? current.modelId ?? catalog?.currentModel?.id;
-    final catalogModel = modelId == null ? null : catalog?.modelById(id: modelId);
+    final currentModelId = current.modelId;
+    final trackedModel = currentModelId == null ? null : catalog?.modelById(id: currentModelId);
+    final catalogModel = model == null ? trackedModel ?? catalog?.defaultModel : catalog?.modelById(id: model.modelID);
     if (catalogModel == null) {
-      throw const PluginOperationException(
+      throw const PluginStaleOptionsException(
         GrokSessionConfigRepository.selectionOperation,
-        message: "Requested Grok model is unavailable",
+        message: "Grok no longer offers the requested model",
       );
     }
     final reasoningEffort = variant?.id;
     if (reasoningEffort != null && !catalogModel.reasoningEfforts.contains(reasoningEffort)) {
-      throw const PluginOperationException(
+      throw const PluginStaleOptionsException(
         GrokSessionConfigRepository.selectionOperation,
-        message: "Requested Grok reasoning effort is unavailable",
+        message: "Grok no longer offers the requested reasoning effort",
       );
     }
     final selectedModelId = catalogModel.id;
@@ -137,6 +140,7 @@ class GrokSessionOptionsService({
     _catalogTracker.replaceCatalog(catalog: catalog);
     if (!updateProcessDefaults) return;
     final current = catalog.currentModel;
+    _processDefaultReasoningEffort = current?.currentReasoningEffort;
     _configurationTracker.setProcessDefaults(
       modelId: current?.id,
       providerId: current == null ? null : _pluginId,
@@ -148,6 +152,10 @@ class GrokSessionOptionsService({
     final configuredModelId = _configurationTracker.processDefaults.modelId;
     final selected = configuredModelId == null ? null : catalog?.modelById(id: configuredModelId);
     final defaultModel = selected ?? catalog?.defaultModel;
+    final processDefaultReasoningEffort =
+        defaultModel?.reasoningEfforts.contains(_processDefaultReasoningEffort) ?? false
+        ? _processDefaultReasoningEffort
+        : null;
     return PluginSessionOptions(
       agents: [
         PluginAgent(
@@ -158,7 +166,7 @@ class GrokSessionOptionsService({
               : PluginAgentModel(
                   modelID: defaultModel.id,
                   providerID: _pluginId,
-                  variant: defaultModel.currentReasoningEffort,
+                  variant: processDefaultReasoningEffort,
                 ),
           mode: PluginAgentMode.primary,
           hidden: false,

--- a/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
+++ b/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
@@ -21,9 +21,6 @@ class GrokSessionOptionsService({
 }) {
   static const Duration _selectionTimeout = Duration(seconds: 30);
 
-  String? _processDefaultReasoningEffort;
-  final Map<String, String> _sessionReasoningEfforts = {};
-
   Future<PluginSessionOptionsDiscoveryResult> getSessionOptions({
     required PluginSessionOptionsDiscoveryMode discoveryMode,
   }) async {
@@ -70,10 +67,11 @@ class GrokSessionOptionsService({
     _replaceCatalog(catalog: catalog, updateProcessDefaults: fromNewSession);
     if (sessionId != null) {
       final currentModel = catalog.currentModel;
-      _setSessionSelection(
+      _configurationTracker.setSessionSelection(
         sessionId: sessionId,
-        model: currentModel,
-        reasoningEffort: currentModel?.currentReasoningEffort,
+        modelId: currentModel?.id,
+        providerId: currentModel == null ? null : _pluginId,
+        variantId: currentModel?.currentReasoningEffort,
       );
     }
   }
@@ -119,41 +117,20 @@ class GrokSessionOptionsService({
       reasoningEffort: reasoningEffort,
       timeout: _selectionTimeout,
     );
-    _setSessionSelection(
+    _configurationTracker.setSessionSelection(
       sessionId: sessionId,
-      model: catalogModel,
-      reasoningEffort: reasoningEffort ?? catalogModel.currentReasoningEffort,
+      modelId: selectedModelId,
+      providerId: _pluginId,
+      variantId: reasoningEffort ?? catalogModel.currentReasoningEffort,
     );
   }
 
-  String? reasoningEffortForSession({required String sessionId}) => _sessionReasoningEfforts[sessionId];
+  String? reasoningEffortForSession({required String sessionId}) =>
+      _configurationTracker.snapshotForSession(sessionId: sessionId).variantId;
 
-  void forgetSession({required String sessionId}) {
-    _configurationTracker.forgetSession(sessionId: sessionId);
-    _sessionReasoningEfforts.remove(sessionId);
-  }
+  void forgetSession({required String sessionId}) => _configurationTracker.forgetSession(sessionId: sessionId);
 
-  void resetConnection() {
-    _configurationTracker.clear();
-    _sessionReasoningEfforts.clear();
-  }
-
-  void _setSessionSelection({
-    required String sessionId,
-    required GrokCatalogModel? model,
-    required String? reasoningEffort,
-  }) {
-    _configurationTracker.setSessionOverride(
-      sessionId: sessionId,
-      modelId: model?.id,
-      providerId: model == null ? null : _pluginId,
-    );
-    if (reasoningEffort == null) {
-      _sessionReasoningEfforts.remove(sessionId);
-    } else {
-      _sessionReasoningEfforts[sessionId] = reasoningEffort;
-    }
-  }
+  void resetConnection() => _configurationTracker.clear();
 
   Future<void> _ensureCatalog() async {
     if (_catalogTracker.snapshot != null) return;
@@ -167,21 +144,21 @@ class GrokSessionOptionsService({
     _catalogTracker.replaceCatalog(catalog: catalog);
     if (!updateProcessDefaults) return;
     final current = catalog.currentModel;
-    _processDefaultReasoningEffort = current?.currentReasoningEffort;
-    _configurationTracker.setProcessDefaults(
+    _configurationTracker.setProcessSelection(
       modelId: current?.id,
       providerId: current == null ? null : _pluginId,
+      variantId: current?.currentReasoningEffort,
     );
   }
 
   PluginSessionOptions _options() {
     final catalog = _catalogTracker.snapshot;
-    final configuredModelId = _configurationTracker.processDefaults.modelId;
+    final processDefaults = _configurationTracker.processDefaults;
+    final configuredModelId = processDefaults.modelId;
     final selected = configuredModelId == null ? null : catalog?.modelById(id: configuredModelId);
     final defaultModel = selected ?? catalog?.defaultModel;
-    final processDefaultReasoningEffort =
-        defaultModel?.reasoningEfforts.contains(_processDefaultReasoningEffort) ?? false
-        ? _processDefaultReasoningEffort
+    final processDefaultReasoningEffort = defaultModel?.reasoningEfforts.contains(processDefaults.variantId) ?? false
+        ? processDefaults.variantId
         : null;
     return PluginSessionOptions(
       agents: [

--- a/bridge/sesori_plugin_grok/lib/src/trackers/grok_catalog_tracker.dart
+++ b/bridge/sesori_plugin_grok/lib/src/trackers/grok_catalog_tracker.dart
@@ -1,0 +1,10 @@
+import "../models/grok_model_catalog.dart";
+
+/// Sole owner of Grok's last successfully observed immutable catalog.
+class GrokCatalogTracker() {
+  GrokModelCatalog? _catalog;
+
+  GrokModelCatalog? get snapshot => _catalog;
+
+  void replaceCatalog({required GrokModelCatalog catalog}) => _catalog = catalog;
+}

--- a/bridge/sesori_plugin_grok/pubspec.yaml
+++ b/bridge/sesori_plugin_grok/pubspec.yaml
@@ -10,6 +10,8 @@ dependencies:
   acp_plugin:
     path: ../sesori_plugin_acp
   freezed_annotation: ^3.1.0
+  sesori_plugin_interface:
+    path: ../sesori_plugin_interface
   json_annotation: ^4.12.0
 
 dev_dependencies:

--- a/bridge/sesori_plugin_grok/test/grok_acp_api_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_acp_api_test.dart
@@ -1,0 +1,132 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:grok_plugin/src/api/grok_acp_api.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginAuthenticationRequiredException;
+import "package:test/test.dart";
+
+void main() {
+  test("catalog probe authenticates only through an advertised headless method", () async {
+    final fake = FakeAcpProcess();
+    addTearDown(fake.close);
+    final api = _api(processFactory: (_) async => fake);
+
+    final probing = api.probeCatalog(cwd: "/repo", timeout: const Duration(seconds: 2));
+    final initialize = await _waitForFrame(fake: fake, method: AcpMethods.initialize);
+    fake.emit({
+      "jsonrpc": "2.0",
+      "id": initialize["id"],
+      "result": _initializeResult(
+        authMethods: const [
+          {"id": "grok.com", "name": "Interactive login"},
+          {"id": "cached_token", "name": "Cached token"},
+        ],
+      ),
+    });
+    final authenticate = await _waitForFrame(fake: fake, method: AcpMethods.authenticate);
+    expect(authenticate["params"], {"methodId": "cached_token"});
+    fake.emit({"jsonrpc": "2.0", "id": authenticate["id"], "result": <String, dynamic>{}});
+
+    expect((await probing).raw["_meta"], {"grokShell": true, "modelState": _emptyModelState});
+  });
+
+  test("catalog probe rejects interactive-only authentication before calling it", () async {
+    final fake = FakeAcpProcess();
+    addTearDown(fake.close);
+    final api = _api(processFactory: (_) async => fake);
+
+    final probing = api.probeCatalog(cwd: "/repo", timeout: const Duration(seconds: 2));
+    final initialize = await _waitForFrame(fake: fake, method: AcpMethods.initialize);
+    fake.emit({
+      "jsonrpc": "2.0",
+      "id": initialize["id"],
+      "result": _initializeResult(
+        authMethods: const [
+          {"id": "grok.com", "name": "Interactive login"},
+        ],
+      ),
+    });
+
+    await expectLater(probing, throwsA(isA<PluginAuthenticationRequiredException>()));
+    expect(fake.written.where((frame) => frame["method"] == AcpMethods.authenticate), isEmpty);
+  });
+
+  test("setModel sends exact model and optional reasoning metadata", () async {
+    final fake = FakeAcpProcess();
+    final client = AcpStdioClient(
+      launchSpec: const AcpLaunchSpec(command: "grok", args: []),
+      processFactory: (_) async => fake,
+    );
+    addTearDown(() async {
+      await client.dispose();
+      await fake.close();
+    });
+    await client.connect();
+    final api = _api(processFactory: (_) => throw StateError("unused"));
+
+    final withEffort = api.setModel(
+      liveClient: client,
+      sessionId: "s1",
+      modelId: "opaque/provider:model-alpha",
+      reasoningEffort: "high",
+      timeout: const Duration(seconds: 2),
+    );
+    final first = await _waitForFrame(fake: fake, method: GrokAcpApi.sessionSetModelMethod);
+    expect(first["params"], {
+      "sessionId": "s1",
+      "modelId": "opaque/provider:model-alpha",
+      "_meta": {"reasoningEffort": "high"},
+    });
+    fake.emit({"jsonrpc": "2.0", "id": first["id"], "result": <String, dynamic>{}});
+    await withEffort;
+
+    final modelOnly = api.setModel(
+      liveClient: client,
+      sessionId: "s1",
+      modelId: "model-beta",
+      reasoningEffort: null,
+      timeout: const Duration(seconds: 2),
+    );
+    final second = await _waitForFrame(
+      fake: fake,
+      method: GrokAcpApi.sessionSetModelMethod,
+      afterId: first["id"],
+    );
+    expect(second["params"], {"sessionId": "s1", "modelId": "model-beta"});
+    fake.emit({"jsonrpc": "2.0", "id": second["id"], "result": <String, dynamic>{}});
+    await modelOnly;
+  });
+}
+
+const Map<String, dynamic> _emptyModelState = {
+  "currentModelId": null,
+  "availableModels": <Object?>[],
+};
+
+Map<String, dynamic> _initializeResult({required List<Map<String, dynamic>> authMethods}) => {
+  "protocolVersion": 1,
+  "agentCapabilities": <String, dynamic>{},
+  "authMethods": authMethods,
+  "_meta": {"grokShell": true, "modelState": _emptyModelState},
+};
+
+GrokAcpApi _api({required AcpProcessFactory processFactory}) => GrokAcpApi(
+  binaryPath: "grok",
+  processFactory: processFactory,
+  environment: const {},
+);
+
+Future<Map<String, dynamic>> _waitForFrame({
+  required FakeAcpProcess fake,
+  required String method,
+  Object? afterId,
+}) async {
+  for (var attempt = 0; attempt < 50; attempt++) {
+    for (final frame in fake.written) {
+      if (frame["method"] == method && frame["id"] != afterId) return frame;
+    }
+    await Future<void>.delayed(Duration.zero);
+  }
+  throw StateError("agent never received '$method'");
+}

--- a/bridge/sesori_plugin_grok/test/grok_acp_api_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_acp_api_test.dart
@@ -52,6 +52,42 @@ void main() {
     expect(fake.written.where((frame) => frame["method"] == AcpMethods.authenticate), isEmpty);
   });
 
+  test("catalog probe preserves an advertised authentication rejection", () async {
+    final fake = FakeAcpProcess();
+    addTearDown(fake.close);
+    final api = _api(processFactory: (_) async => fake);
+
+    final probing = api.probeCatalog(cwd: "/repo", timeout: const Duration(seconds: 2));
+    final initialize = await _waitForFrame(fake: fake, method: AcpMethods.initialize);
+    fake.emit({
+      "jsonrpc": "2.0",
+      "id": initialize["id"],
+      "result": _initializeResult(
+        authMethods: const [
+          {"id": "cached_token", "name": "Cached token"},
+        ],
+      ),
+    });
+    final authenticate = await _waitForFrame(fake: fake, method: AcpMethods.authenticate);
+    fake.emit({
+      "jsonrpc": "2.0",
+      "id": authenticate["id"],
+      "error": {"code": -32000, "message": "Rejected"},
+    });
+
+    await expectLater(
+      probing,
+      throwsA(
+        isA<PluginAuthenticationRequiredException>().having(
+          (error) => error.cause,
+          "cause",
+          isA<AcpRpcException>(),
+        ),
+      ),
+    );
+    expect(await fake.exitCode, -15);
+  });
+
   test("setModel sends exact model and optional reasoning metadata", () async {
     final fake = FakeAcpProcess();
     final client = AcpStdioClient(

--- a/bridge/sesori_plugin_grok/test/grok_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_catalog_repository_test.dart
@@ -20,6 +20,7 @@ void main() {
       "opaque/provider:model-beta",
     ]);
     expect(catalog.models.first.reasoningEfforts, ["high", "low"]);
+    expect(catalog.models.first.defaultReasoningEffort, "high");
     expect(catalog.models.first.currentReasoningEffort, "high");
     expect(catalog.models.last.reasoningEfforts, isEmpty);
   });
@@ -55,7 +56,116 @@ void main() {
     expect(catalog.models.single.id, "opaque:model");
     expect(catalog.models.single.name, "opaque:model");
     expect(catalog.models.single.reasoningEfforts, ["medium"]);
+    expect(catalog.models.single.defaultReasoningEffort, "medium");
     expect(catalog.models.single.currentReasoningEffort, isNull);
+  });
+
+  test("ignores malformed irrelevant envelope branches", () {
+    final initialize = _fixture(name: "initialize.json")..["models"] = 7;
+    expect(
+      repository.mapInitializeResult(result: AcpInitializeResult.fromJson(initialize)).currentModel?.id,
+      "synthetic:model-alpha",
+    );
+
+    final initializeMetadata = initialize["_meta"] as Map<String, dynamic>;
+    final session = AcpNewSessionResult.fromJson({
+      "sessionId": "s1",
+      "models": initializeMetadata["modelState"],
+      "_meta": 7,
+    });
+    expect(repository.mapSessionResult(result: session)?.currentModel?.id, "synthetic:model-alpha");
+  });
+
+  test("retains valid models while sanitizing malformed siblings and optional fields", () {
+    final result = AcpNewSessionResult.fromJson({
+      "sessionId": "s1",
+      "models": {
+        "currentModelId": 7,
+        "availableModels": [
+          7,
+          {1: "non-string key"},
+          {"modelId": 7, "name": "Invalid identity"},
+          {"modelId": "plain", "name": 7, "description": false, "_meta": "invalid"},
+          {
+            "modelId": "unsupported",
+            "_meta": {
+              "supportsReasoningEffort": "invalid",
+              "reasoningEfforts": [
+                {"value": "low", "default": true},
+              ],
+            },
+          },
+          {
+            "modelId": "reasoning",
+            "name": "Reasoning",
+            "_meta": {
+              "supportsReasoningEffort": true,
+              "reasoningEffort": 7,
+              "reasoningEfforts": [
+                {1: "non-string key", "value": "xhigh"},
+                {"value": 7, "default": true},
+                {"value": "low", "default": true},
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    final catalog = repository.mapSessionResult(result: result)!;
+    expect(catalog.currentModel, isNull);
+    expect(catalog.models.map((model) => model.id), ["plain", "unsupported", "reasoning"]);
+    expect(catalog.models.first.name, "plain");
+    expect(catalog.models.take(2).every((model) => model.reasoningEfforts.isEmpty), isTrue);
+    expect(catalog.models.last.reasoningEfforts, ["low"]);
+    expect(catalog.models.last.defaultReasoningEffort, "low");
+    expect(catalog.models.last.currentReasoningEffort, isNull);
+  });
+
+  test("preserves a selected model when its optional effort container is malformed", () {
+    const modelState = {
+      "currentModelId": "opaque:model",
+      "availableModels": [
+        {
+          "modelId": "opaque:model",
+          "name": "Opaque model",
+          "_meta": {
+            "supportsReasoningEffort": true,
+            "reasoningEffort": "high",
+            "reasoningEfforts": "invalid",
+          },
+        },
+      ],
+    };
+    final catalogs = [
+      repository.mapInitializeResult(
+        result: AcpInitializeResult.fromJson({
+          "protocolVersion": 1,
+          "_meta": {"grokShell": true, "modelState": modelState},
+        }),
+      ),
+      repository.mapSessionResult(
+        result: AcpNewSessionResult.fromJson({"sessionId": "s1", "models": modelState}),
+      )!,
+    ];
+
+    for (final catalog in catalogs) {
+      expect(catalog.currentModel?.id, "opaque:model");
+      expect(catalog.models.single.reasoningEfforts, isEmpty);
+      expect(catalog.models.single.defaultReasoningEffort, isNull);
+      expect(catalog.models.single.currentReasoningEffort, isNull);
+    }
+  });
+
+  test("rejects a malformed available-models container without replacing it with empty", () {
+    final result = AcpNewSessionResult.fromJson({
+      "sessionId": "s1",
+      "models": {"currentModelId": null, "availableModels": "invalid"},
+    });
+    expect(
+      () => repository.mapSessionResult(result: result),
+      throwsA(isA<FormatException>()),
+    );
   });
 
   test("accepts an explicit empty catalog but rejects missing Grok identity", () {

--- a/bridge/sesori_plugin_grok/test/grok_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_catalog_repository_test.dart
@@ -39,6 +39,8 @@ void main() {
               "supportsReasoningEffort": true,
               "reasoningEffort": "unknown",
               "reasoningEfforts": [
+                7,
+                {"value": 7, "default": true},
                 {"value": null, "default": true},
                 {"value": "medium", "default": true},
               ],

--- a/bridge/sesori_plugin_grok/test/grok_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_catalog_repository_test.dart
@@ -1,0 +1,93 @@
+import "dart:convert";
+import "dart:io";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:grok_plugin/src/api/grok_acp_api.dart";
+import "package:grok_plugin/src/repositories/grok_catalog_repository.dart";
+import "package:test/test.dart";
+
+void main() {
+  final repository = GrokCatalogRepository(api: _FakeGrokAcpApi());
+
+  test("maps initialize model state without interpreting opaque ids", () {
+    final catalog = repository.mapInitializeResult(
+      result: AcpInitializeResult.fromJson(_fixture(name: "initialize.json")),
+    );
+
+    expect(catalog.currentModel?.id, "synthetic:model-alpha");
+    expect(catalog.models.map((model) => model.id), [
+      "synthetic:model-alpha",
+      "opaque/provider:model-beta",
+    ]);
+    expect(catalog.models.first.reasoningEfforts, ["high", "low"]);
+    expect(catalog.models.first.currentReasoningEffort, "high");
+    expect(catalog.models.last.reasoningEfforts, isEmpty);
+  });
+
+  test("maps session state and skips malformed model and effort entries", () {
+    final result = AcpNewSessionResult.fromJson({
+      "sessionId": "s1",
+      "models": {
+        "currentModelId": "missing-model",
+        "availableModels": [
+          {"modelId": "", "name": "Invalid", "description": null},
+          {
+            "modelId": "opaque:model",
+            "name": " ",
+            "description": null,
+            "_meta": {
+              "supportsReasoningEffort": true,
+              "reasoningEffort": "unknown",
+              "reasoningEfforts": [
+                {"value": null, "default": true},
+                {"value": "medium", "default": true},
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    final catalog = repository.mapSessionResult(result: result)!;
+    expect(catalog.currentModel, isNull);
+    expect(catalog.models.single.id, "opaque:model");
+    expect(catalog.models.single.name, "opaque:model");
+    expect(catalog.models.single.reasoningEfforts, ["medium"]);
+    expect(catalog.models.single.currentReasoningEffort, isNull);
+  });
+
+  test("accepts an explicit empty catalog but rejects missing Grok identity", () {
+    final empty = repository.mapInitializeResult(
+      result: AcpInitializeResult.fromJson({
+        "protocolVersion": 1,
+        "_meta": {"grokShell": true, "modelState": _emptyModelState},
+      }),
+    );
+    expect(empty.models, isEmpty);
+
+    expect(
+      () => repository.mapInitializeResult(
+        result: AcpInitializeResult.fromJson({
+          "protocolVersion": 1,
+          "_meta": {"grokShell": false, "modelState": _emptyModelState},
+        }),
+      ),
+      throwsStateError,
+    );
+  });
+}
+
+const Map<String, dynamic> _emptyModelState = {
+  "currentModelId": null,
+  "availableModels": <Object?>[],
+};
+
+Map<String, dynamic> _fixture({required String name}) {
+  final decoded = jsonDecode(File("test/fixtures/protocol/v1/$name").readAsStringSync());
+  return (decoded! as Map<dynamic, dynamic>).cast<String, dynamic>();
+}
+
+class _FakeGrokAcpApi() implements GrokAcpApi {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/sesori_plugin_grok/test/grok_session_options_service_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_session_options_service_test.dart
@@ -50,13 +50,22 @@ void main() {
     expect(api.probeCount, 2);
   });
 
-  test("initialize, new, and load captures replace catalog through its tracker", () async {
+  test("initialize, new, and load captures replace catalog without load changing process defaults", () async {
     final fixture = _service(api: _FakeGrokAcpApi());
     fixture.service.captureInitializeResult(result: _initializeResult());
     expect(fixture.catalogTracker.snapshot?.currentModel?.id, "synthetic:model-alpha");
+    expect((await fixture.service.listAgents()).single.model?.variant, "high");
 
+    final loaded = _jsonFixture(name: "initialize.json");
+    final loadedMeta = loaded["_meta"] as Map<String, dynamic>;
+    final loadedModelState = loadedMeta["modelState"] as Map<String, dynamic>;
+    loadedModelState["currentModelId"] = "opaque/provider:model-beta";
+    final loadedModels = loadedModelState["availableModels"] as List<dynamic>;
+    final loadedDefaultModel = loadedModels.first as Map<String, dynamic>;
+    final loadedDefaultMeta = loadedDefaultModel["_meta"] as Map<String, dynamic>;
+    loadedDefaultMeta["reasoningEffort"] = "low";
     fixture.service.captureSessionConfig(
-      result: AcpNewSessionResult.fromJson(_jsonFixture(name: "session.json")),
+      result: AcpNewSessionResult.fromJson({"sessionId": "loaded-session", "models": loadedModelState}),
       sessionId: "loaded-session",
       fromNewSession: false,
     );
@@ -66,6 +75,7 @@ void main() {
       fixture.configurationTracker.snapshotForSession(sessionId: "loaded-session").modelId,
       "opaque/provider:model-beta",
     );
+    expect((await fixture.service.listAgents()).single.model?.variant, "high");
 
     fixture.service.captureSessionConfig(
       result: AcpNewSessionResult.fromJson(_jsonFixture(name: "session.json")),
@@ -99,6 +109,27 @@ void main() {
     ]);
   });
 
+  test("effort-only selection uses the advertised model fallback", () async {
+    final api = _FakeGrokAcpApi();
+    final fixture = _service(api: api);
+    final initialize = _jsonFixture(name: "initialize.json");
+    final meta = initialize["_meta"] as Map<String, dynamic>;
+    final modelState = meta["modelState"] as Map<String, dynamic>;
+    modelState.remove("currentModelId");
+    fixture.service.captureInitializeResult(result: AcpInitializeResult.fromJson(initialize));
+
+    final options = await fixture.service.listProviders();
+    expect(options.providers.single.defaultModelID, "synthetic:model-alpha");
+    await fixture.service.applyTurnSelection(
+      liveClient: _FakeAcpStdioClient(),
+      sessionId: "s1",
+      model: null,
+      variant: const PluginSessionVariant(id: "low"),
+    );
+
+    expect(api.selections.single, (sessionId: "s1", modelId: "synthetic:model-alpha", reasoningEffort: "low"));
+  });
+
   test("rejects stale selections before the API call", () async {
     final api = _FakeGrokAcpApi();
     final fixture = _service(api: api);
@@ -108,10 +139,19 @@ void main() {
       fixture.service.applyTurnSelection(
         liveClient: _FakeAcpStdioClient(),
         sessionId: "s1",
+        model: const (providerID: "removed-provider", modelID: "synthetic:model-alpha"),
+        variant: null,
+      ),
+      throwsA(isA<PluginStaleOptionsException>()),
+    );
+    await expectLater(
+      fixture.service.applyTurnSelection(
+        liveClient: _FakeAcpStdioClient(),
+        sessionId: "s1",
         model: const (providerID: GrokPluginIdentity.id, modelID: "missing"),
         variant: null,
       ),
-      throwsA(isA<PluginOperationException>()),
+      throwsA(isA<PluginStaleOptionsException>()),
     );
     await expectLater(
       fixture.service.applyTurnSelection(
@@ -120,7 +160,7 @@ void main() {
         model: null,
         variant: const PluginSessionVariant(id: "unknown"),
       ),
-      throwsA(isA<PluginOperationException>()),
+      throwsA(isA<PluginStaleOptionsException>()),
     );
     expect(api.selections, isEmpty);
   });

--- a/bridge/sesori_plugin_grok/test/grok_session_options_service_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_session_options_service_test.dart
@@ -76,7 +76,16 @@ void main() {
       "opaque/provider:model-beta",
     );
     expect((await fixture.service.listAgents()).single.model?.variant, "high");
+    expect(fixture.service.reasoningEffortForSession(sessionId: "loaded-session"), isNull);
 
+    loadedModelState["currentModelId"] = "synthetic:model-alpha";
+    fixture.service.captureSessionConfig(
+      result: AcpNewSessionResult.fromJson({"sessionId": "reasoning-session", "models": loadedModelState}),
+      sessionId: "reasoning-session",
+      fromNewSession: false,
+    );
+    expect(fixture.service.reasoningEffortForSession(sessionId: "reasoning-session"), "low");
+    expect((await fixture.service.listAgents()).single.model?.variant, "high");
     fixture.service.captureSessionConfig(
       result: AcpNewSessionResult.fromJson(_jsonFixture(name: "session.json")),
       sessionId: "new-session",

--- a/bridge/sesori_plugin_grok/test/grok_session_options_service_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_session_options_service_test.dart
@@ -105,12 +105,14 @@ void main() {
       model: null,
       variant: const PluginSessionVariant(id: "low"),
     );
+    expect(fixture.service.reasoningEffortForSession(sessionId: "s1"), "low");
     await fixture.service.applyTurnSelection(
       liveClient: _FakeAcpStdioClient(),
       sessionId: "s1",
       model: const (providerID: GrokPluginIdentity.id, modelID: "opaque/provider:model-beta"),
       variant: null,
     );
+    expect(fixture.service.reasoningEffortForSession(sessionId: "s1"), isNull);
 
     expect(api.selections, [
       (sessionId: "s1", modelId: "synthetic:model-alpha", reasoningEffort: "low"),

--- a/bridge/sesori_plugin_grok/test/grok_session_options_service_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_session_options_service_test.dart
@@ -15,6 +15,7 @@ void main() {
   test("discovers and reuses one Grok provider with exact reasoning values", () async {
     final api = _FakeGrokAcpApi()..probes.add(() async => _initializeResult());
     final fixture = _service(api: api);
+
     final first = await fixture.service.getSessionOptions(
       discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
     );
@@ -26,6 +27,7 @@ void main() {
     expect(provider.models.first.variants, ["high", "low"]);
     expect(options.agents.single.model?.variant, "high");
     expect(options.completeness, PluginSessionOptionsCompleteness.complete);
+
     await fixture.service.getSessionOptions(discoveryMode: PluginSessionOptionsDiscoveryMode.reuse);
     expect(api.probeCount, 1);
   });
@@ -35,6 +37,7 @@ void main() {
       ..probes.add(() async => _initializeResult())
       ..probes.add(() => Future.error(StateError("refresh failed")));
     final fixture = _service(api: api);
+
     await fixture.service.getSessionOptions(discoveryMode: PluginSessionOptionsDiscoveryMode.reuse);
     expect(
       await fixture.service.getSessionOptions(discoveryMode: PluginSessionOptionsDiscoveryMode.refresh),
@@ -46,11 +49,13 @@ void main() {
     expect((reused as PluginSessionOptionsDiscoveryObserved).options.providers.providers, hasLength(1));
     expect(api.probeCount, 2);
   });
+
   test("initialize, new, and load captures replace catalog without load changing process defaults", () async {
     final fixture = _service(api: _FakeGrokAcpApi());
     fixture.service.captureInitializeResult(result: _initializeResult());
     expect(fixture.catalogTracker.snapshot?.currentModel?.id, "synthetic:model-alpha");
     expect((await fixture.service.listAgents()).single.model?.variant, "high");
+
     final loaded = _jsonFixture(name: "initialize.json");
     final loadedMeta = loaded["_meta"] as Map<String, dynamic>;
     final loadedModelState = loadedMeta["modelState"] as Map<String, dynamic>;
@@ -72,6 +77,7 @@ void main() {
     );
     expect((await fixture.service.listAgents()).single.model?.variant, "high");
     expect(fixture.service.reasoningEffortForSession(sessionId: "loaded-session"), isNull);
+
     loadedModelState["currentModelId"] = "synthetic:model-alpha";
     fixture.service.captureSessionConfig(
       result: AcpNewSessionResult.fromJson({"sessionId": "reasoning-session", "models": loadedModelState}),
@@ -92,6 +98,7 @@ void main() {
     final api = _FakeGrokAcpApi();
     final fixture = _service(api: api);
     fixture.service.captureInitializeResult(result: _initializeResult());
+
     await fixture.service.applyTurnSelection(
       liveClient: _FakeAcpStdioClient(),
       sessionId: "s1",
@@ -113,6 +120,31 @@ void main() {
     ]);
   });
 
+  test("explicit same-model selection resets effort to the declared default", () async {
+    final api = _FakeGrokAcpApi();
+    final fixture = _service(api: api);
+    fixture.service.captureInitializeResult(result: _initializeResult());
+
+    await fixture.service.applyTurnSelection(
+      liveClient: _FakeAcpStdioClient(),
+      sessionId: "s1",
+      model: null,
+      variant: const PluginSessionVariant(id: "low"),
+    );
+    await fixture.service.applyTurnSelection(
+      liveClient: _FakeAcpStdioClient(),
+      sessionId: "s1",
+      model: const (providerID: GrokPluginIdentity.id, modelID: "synthetic:model-alpha"),
+      variant: null,
+    );
+
+    expect(api.selections, [
+      (sessionId: "s1", modelId: "synthetic:model-alpha", reasoningEffort: "low"),
+      (sessionId: "s1", modelId: "synthetic:model-alpha", reasoningEffort: null),
+    ]);
+    expect(fixture.service.reasoningEffortForSession(sessionId: "s1"), "high");
+  });
+
   test("effort-only selection uses the advertised model fallback", () async {
     final api = _FakeGrokAcpApi();
     final fixture = _service(api: api);
@@ -132,6 +164,67 @@ void main() {
     );
 
     expect(api.selections.single, (sessionId: "s1", modelId: "synthetic:model-alpha", reasoningEffort: "low"));
+  });
+
+  test("effort-only selection rejects a stale tracked model instead of switching models", () async {
+    final api = _FakeGrokAcpApi();
+    final fixture = _service(api: api);
+    fixture.service.captureInitializeResult(result: _initializeResult());
+    fixture.service.captureSessionConfig(
+      result: AcpNewSessionResult.fromJson(_jsonFixture(name: "session.json")),
+      sessionId: "s1",
+      fromNewSession: false,
+    );
+    final refreshed = _jsonFixture(name: "initialize.json");
+    final refreshedMetadata = refreshed["_meta"] as Map<String, dynamic>;
+    final refreshedState = refreshedMetadata["modelState"] as Map<String, dynamic>;
+    (refreshedState["availableModels"] as List<dynamic>).removeLast();
+    fixture.service.captureInitializeResult(result: AcpInitializeResult.fromJson(refreshed));
+
+    await expectLater(
+      fixture.service.applyTurnSelection(
+        liveClient: _FakeAcpStdioClient(),
+        sessionId: "s1",
+        model: null,
+        variant: const PluginSessionVariant(id: "high"),
+      ),
+      throwsA(isA<PluginStaleOptionsException>()),
+    );
+    expect(api.selections, isEmpty);
+    expect(fixture.configurationTracker.snapshotForSession(sessionId: "s1").modelId, "opaque/provider:model-beta");
+  });
+
+  test("fallback projection uses the replacement model's declared default effort", () async {
+    final fixture = _service(api: _FakeGrokAcpApi());
+    fixture.service.captureInitializeResult(result: _initializeResult());
+    fixture.service.captureSessionConfig(
+      result: AcpNewSessionResult.fromJson({
+        "sessionId": "loaded",
+        "models": {
+          "currentModelId": "replacement",
+          "availableModels": [
+            {
+              "modelId": "replacement",
+              "name": "Replacement",
+              "_meta": {
+                "supportsReasoningEffort": true,
+                "reasoningEffort": "high",
+                "reasoningEfforts": [
+                  {"value": "low", "default": true},
+                  {"value": "high", "default": false},
+                ],
+              },
+            },
+          ],
+        },
+      }),
+      sessionId: "loaded",
+      fromNewSession: false,
+    );
+
+    final agentModel = (await fixture.service.listAgents()).single.model!;
+    expect((agentModel.modelID, agentModel.variant), ("replacement", "low"));
+    expect(fixture.service.reasoningEffortForSession(sessionId: "loaded"), "high");
   });
 
   test("rejects stale selections before the API call", () async {
@@ -187,7 +280,8 @@ void main() {
     }
     expect(failure, isA<PluginOperationException>());
     expect((failure! as PluginOperationException).cause, isA<StateError>());
-    expect(fixture.configurationTracker.snapshotForSession(sessionId: "s1").modelId, "synthetic:model-alpha");
+    final retained = fixture.configurationTracker.snapshotForSession(sessionId: "s1");
+    expect((retained.modelId, retained.variantId), ("synthetic:model-alpha", "high"));
   });
 }
 

--- a/bridge/sesori_plugin_grok/test/grok_session_options_service_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_session_options_service_test.dart
@@ -1,0 +1,216 @@
+import "dart:convert";
+import "dart:io";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:grok_plugin/src/api/grok_acp_api.dart";
+import "package:grok_plugin/src/grok_identity.dart";
+import "package:grok_plugin/src/repositories/grok_catalog_repository.dart";
+import "package:grok_plugin/src/repositories/grok_session_config_repository.dart";
+import "package:grok_plugin/src/services/grok_session_options_service.dart";
+import "package:grok_plugin/src/trackers/grok_catalog_tracker.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("discovers and reuses one Grok provider with exact reasoning values", () async {
+    final api = _FakeGrokAcpApi()..probes.add(() async => _initializeResult());
+    final fixture = _service(api: api);
+
+    final first = await fixture.service.getSessionOptions(
+      discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+    );
+    final options = (first as PluginSessionOptionsDiscoveryObserved).options;
+    final provider = options.providers.providers.single;
+    expect(api.probeCount, 1);
+    expect(provider.id, GrokPluginIdentity.id);
+    expect(provider.defaultModelID, "synthetic:model-alpha");
+    expect(provider.models.first.variants, ["high", "low"]);
+    expect(options.agents.single.model?.variant, "high");
+    expect(options.completeness, PluginSessionOptionsCompleteness.complete);
+
+    await fixture.service.getSessionOptions(discoveryMode: PluginSessionOptionsDiscoveryMode.reuse);
+    expect(api.probeCount, 1);
+  });
+
+  test("failed refresh retains the last-good catalog without reporting success", () async {
+    final api = _FakeGrokAcpApi()
+      ..probes.add(() async => _initializeResult())
+      ..probes.add(() => Future.error(StateError("refresh failed")));
+    final fixture = _service(api: api);
+
+    await fixture.service.getSessionOptions(discoveryMode: PluginSessionOptionsDiscoveryMode.reuse);
+    expect(
+      await fixture.service.getSessionOptions(discoveryMode: PluginSessionOptionsDiscoveryMode.refresh),
+      isA<PluginSessionOptionsDiscoveryFailed>(),
+    );
+    final reused = await fixture.service.getSessionOptions(
+      discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
+    );
+    expect((reused as PluginSessionOptionsDiscoveryObserved).options.providers.providers, hasLength(1));
+    expect(api.probeCount, 2);
+  });
+
+  test("initialize, new, and load captures replace catalog through its tracker", () async {
+    final fixture = _service(api: _FakeGrokAcpApi());
+    fixture.service.captureInitializeResult(result: _initializeResult());
+    expect(fixture.catalogTracker.snapshot?.currentModel?.id, "synthetic:model-alpha");
+
+    fixture.service.captureSessionConfig(
+      result: AcpNewSessionResult.fromJson(_jsonFixture(name: "session.json")),
+      sessionId: "loaded-session",
+      fromNewSession: false,
+    );
+    expect(fixture.catalogTracker.snapshot?.currentModel?.id, "opaque/provider:model-beta");
+    expect(fixture.configurationTracker.processDefaults.modelId, "synthetic:model-alpha");
+    expect(
+      fixture.configurationTracker.snapshotForSession(sessionId: "loaded-session").modelId,
+      "opaque/provider:model-beta",
+    );
+
+    fixture.service.captureSessionConfig(
+      result: AcpNewSessionResult.fromJson(_jsonFixture(name: "session.json")),
+      sessionId: "new-session",
+      fromNewSession: true,
+    );
+    expect(fixture.configurationTracker.processDefaults.modelId, "opaque/provider:model-beta");
+  });
+
+  test("applies model-only and effort selections through the config repository", () async {
+    final api = _FakeGrokAcpApi();
+    final fixture = _service(api: api);
+    fixture.service.captureInitializeResult(result: _initializeResult());
+
+    await fixture.service.applyTurnSelection(
+      liveClient: _FakeAcpStdioClient(),
+      sessionId: "s1",
+      model: null,
+      variant: const PluginSessionVariant(id: "low"),
+    );
+    await fixture.service.applyTurnSelection(
+      liveClient: _FakeAcpStdioClient(),
+      sessionId: "s1",
+      model: const (providerID: GrokPluginIdentity.id, modelID: "opaque/provider:model-beta"),
+      variant: null,
+    );
+
+    expect(api.selections, [
+      (sessionId: "s1", modelId: "synthetic:model-alpha", reasoningEffort: "low"),
+      (sessionId: "s1", modelId: "opaque/provider:model-beta", reasoningEffort: null),
+    ]);
+  });
+
+  test("rejects stale selections before the API call", () async {
+    final api = _FakeGrokAcpApi();
+    final fixture = _service(api: api);
+    fixture.service.captureInitializeResult(result: _initializeResult());
+
+    await expectLater(
+      fixture.service.applyTurnSelection(
+        liveClient: _FakeAcpStdioClient(),
+        sessionId: "s1",
+        model: const (providerID: GrokPluginIdentity.id, modelID: "missing"),
+        variant: null,
+      ),
+      throwsA(isA<PluginOperationException>()),
+    );
+    await expectLater(
+      fixture.service.applyTurnSelection(
+        liveClient: _FakeAcpStdioClient(),
+        sessionId: "s1",
+        model: null,
+        variant: const PluginSessionVariant(id: "unknown"),
+      ),
+      throwsA(isA<PluginOperationException>()),
+    );
+    expect(api.selections, isEmpty);
+  });
+
+  test("failed selection preserves the original cause and tracker state", () async {
+    final api = _FakeGrokAcpApi()..selectionError = StateError("rejected");
+    final fixture = _service(api: api);
+    fixture.service.captureInitializeResult(result: _initializeResult());
+
+    Object? failure;
+    try {
+      await fixture.service.applyTurnSelection(
+        liveClient: _FakeAcpStdioClient(),
+        sessionId: "s1",
+        model: const (providerID: GrokPluginIdentity.id, modelID: "opaque/provider:model-beta"),
+        variant: null,
+      );
+    } on Object catch (error) {
+      failure = error;
+    }
+    expect(failure, isA<PluginOperationException>());
+    expect((failure! as PluginOperationException).cause, isA<StateError>());
+    expect(fixture.configurationTracker.snapshotForSession(sessionId: "s1").modelId, "synthetic:model-alpha");
+  });
+}
+
+({
+  GrokSessionOptionsService service,
+  GrokCatalogTracker catalogTracker,
+  AcpSessionConfigurationTracker configurationTracker,
+})
+_service({required _FakeGrokAcpApi api}) {
+  final catalogTracker = GrokCatalogTracker();
+  final configurationTracker = AcpSessionConfigurationTracker();
+  final commandTracker = AcpCommandTracker()..replaceSnapshot(commands: const []);
+  final catalogRepository = GrokCatalogRepository(api: api);
+  return (
+    service: GrokSessionOptionsService(
+      catalogRepository: catalogRepository,
+      configRepository: GrokSessionConfigRepository(api: api),
+      catalogTracker: catalogTracker,
+      configurationTracker: configurationTracker,
+      commandTracker: commandTracker,
+      launchDirectory: "/repo",
+      pluginId: GrokPluginIdentity.id,
+      displayName: GrokPluginIdentity.displayName,
+      discoveryTimeout: const Duration(seconds: 2),
+    ),
+    catalogTracker: catalogTracker,
+    configurationTracker: configurationTracker,
+  );
+}
+
+AcpInitializeResult _initializeResult() => AcpInitializeResult.fromJson(
+  _jsonFixture(name: "initialize.json"),
+);
+
+Map<String, dynamic> _jsonFixture({required String name}) {
+  final decoded = jsonDecode(File("test/fixtures/protocol/v1/$name").readAsStringSync());
+  return (decoded! as Map<dynamic, dynamic>).cast<String, dynamic>();
+}
+
+class _FakeGrokAcpApi() implements GrokAcpApi {
+  final List<Future<AcpInitializeResult> Function()> probes = [];
+  final List<({String sessionId, String modelId, String? reasoningEffort})> selections = [];
+  int probeCount = 0;
+  Object? selectionError;
+
+  @override
+  Future<AcpInitializeResult> probeCatalog({required String cwd, required Duration timeout}) {
+    final probe = probes[probeCount];
+    probeCount++;
+    return probe();
+  }
+
+  @override
+  Future<void> setModel({
+    required AcpStdioClient liveClient,
+    required String sessionId,
+    required String modelId,
+    required String? reasoningEffort,
+    required Duration timeout,
+  }) async {
+    final error = selectionError;
+    if (error != null) throw error;
+    selections.add((sessionId: sessionId, modelId: modelId, reasoningEffort: reasoningEffort));
+  }
+}
+
+class _FakeAcpStdioClient() implements AcpStdioClient {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/sesori_plugin_grok/test/grok_session_options_service_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_session_options_service_test.dart
@@ -15,7 +15,6 @@ void main() {
   test("discovers and reuses one Grok provider with exact reasoning values", () async {
     final api = _FakeGrokAcpApi()..probes.add(() async => _initializeResult());
     final fixture = _service(api: api);
-
     final first = await fixture.service.getSessionOptions(
       discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
     );
@@ -27,7 +26,6 @@ void main() {
     expect(provider.models.first.variants, ["high", "low"]);
     expect(options.agents.single.model?.variant, "high");
     expect(options.completeness, PluginSessionOptionsCompleteness.complete);
-
     await fixture.service.getSessionOptions(discoveryMode: PluginSessionOptionsDiscoveryMode.reuse);
     expect(api.probeCount, 1);
   });
@@ -37,7 +35,6 @@ void main() {
       ..probes.add(() async => _initializeResult())
       ..probes.add(() => Future.error(StateError("refresh failed")));
     final fixture = _service(api: api);
-
     await fixture.service.getSessionOptions(discoveryMode: PluginSessionOptionsDiscoveryMode.reuse);
     expect(
       await fixture.service.getSessionOptions(discoveryMode: PluginSessionOptionsDiscoveryMode.refresh),
@@ -49,13 +46,11 @@ void main() {
     expect((reused as PluginSessionOptionsDiscoveryObserved).options.providers.providers, hasLength(1));
     expect(api.probeCount, 2);
   });
-
   test("initialize, new, and load captures replace catalog without load changing process defaults", () async {
     final fixture = _service(api: _FakeGrokAcpApi());
     fixture.service.captureInitializeResult(result: _initializeResult());
     expect(fixture.catalogTracker.snapshot?.currentModel?.id, "synthetic:model-alpha");
     expect((await fixture.service.listAgents()).single.model?.variant, "high");
-
     final loaded = _jsonFixture(name: "initialize.json");
     final loadedMeta = loaded["_meta"] as Map<String, dynamic>;
     final loadedModelState = loadedMeta["modelState"] as Map<String, dynamic>;
@@ -77,7 +72,6 @@ void main() {
     );
     expect((await fixture.service.listAgents()).single.model?.variant, "high");
     expect(fixture.service.reasoningEffortForSession(sessionId: "loaded-session"), isNull);
-
     loadedModelState["currentModelId"] = "synthetic:model-alpha";
     fixture.service.captureSessionConfig(
       result: AcpNewSessionResult.fromJson({"sessionId": "reasoning-session", "models": loadedModelState}),
@@ -98,7 +92,6 @@ void main() {
     final api = _FakeGrokAcpApi();
     final fixture = _service(api: api);
     fixture.service.captureInitializeResult(result: _initializeResult());
-
     await fixture.service.applyTurnSelection(
       liveClient: _FakeAcpStdioClient(),
       sessionId: "s1",


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this adds Grok-local legacy ACP model handling plus shared atomic model/provider/variant selection tracking.

## What

- Added typed initialize/session model-state parsing with context-specific branch isolation and fail-soft optional-field handling.
- Added an initialize-only Grok ACP catalog probe restricted to advertised `xai.api_key` or `cached_token` authentication, with guaranteed process disposal.
- Added exact `session/set_model` writes with optional `_meta.reasoningEffort` and cause-preserving typed failures.
- Added catalog/config repositories, immutable catalog models, and sole-owner catalog and selection trackers.
- Added one primary Grok agent/provider projection using opaque model IDs and exact canonical effort values.
- Added hostile-wire and state-transition matrices covering malformed siblings, declared versus active defaults, stale tracked state, explicit default reset, tuple-safe fallbacks, refresh retention, and failed writes.

## Why

Grok 1.0.5 exposes model and reasoning selection through a deprecated Grok-owned ACP surface rather than current generic ACP contracts. Keeping that wire behavior inside `sesori_plugin_grok`, while using the shared configuration tracker for complete selections, avoids backend leakage and duplicate mutable ownership.

## Risk and test focus

Risk is moderate but dormant: Grok is not registered until later plan steps. The consolidated audit focuses on hostile external data, process versus session defaults, explicit-null versus absent variants, stale catalog transitions, state mutation only after successful RPCs, and cleanup/error-cause preservation. There is no current user-visible, transport, or database impact.

## Expected result

The dormant Grok package can discover and project valid model/reasoning options, retain usable siblings from partially malformed responses, reject structurally invalid catalogs and stale selections, and apply coherent session selections without changing existing harness behavior.

## Verification

- `bridge/sesori_plugin_acp`: `dart test` — 267 passed
- `bridge/sesori_plugin_grok`: `dart test` — 27 passed
- Both packages: `dart analyze --fatal-infos` — no issues
- Dart LSP diagnostics — 0 diagnostics across changed Dart files
- `git diff --check` and authored 120-column check — passed
- Two architecture implementation reviews — approved
- Hostile-wire, state-invariant, and independent post-fix general correctness reviews — approved
- Scope — 1,821 changed lines against Step 2; intentionally above the 1,500-line soft cap because the consolidated audit added required boundary and transition coverage
