### PR TITLE
🌱 Remove noisy Pi extension UI debug log

### DIFF
--- a/bridge/sesori_plugin_pi/lib/src/services/pi_extension_ui_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_extension_ui_service.dart
@@ -76,7 +76,6 @@ final class PiExtensionUiService({
         return;
       case PiExtensionDecorationRequest():
       case PiUnknownExtensionUiRequest():
-        Log.d("[pi] ignored unsupported extension UI decoration");
         return;
       case final PiExtensionDialogRequest dialog:
         final elapsed = Stopwatch()..start();


### PR DESCRIPTION
## Complexity

🌱 Trivial

## What

Removes the debug log line that `PiExtensionUiService` emitted for every
`PiExtensionDecorationRequest` and `PiUnknownExtensionUiRequest`:

```
[PiExtensionUiService][pi] ignored unsupported extension UI decoration
```

## Why

The Pi backend sends extension UI decorations the bridge does not render, so
this line fired once per unsupported request and flooded the log without
diagnostic value. This is a normal, expected, handled path — not a recovered
failure that needs to stay observable — so the user prefers no log at all.

## Risk and test focus

No behavior change: the requests are still ignored exactly as before, only
the log call is gone. No user-visible or database impact.

Verified locally with the pinned toolchain:

- `dart analyze --fatal-infos` in `bridge/sesori_plugin_pi` — no issues
- `dart test test/pi_extension_ui_service_test.dart` — 11/11 pass

## Expected result

Bridge logs no longer contain repeated
`ignored unsupported extension UI decoration` lines.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the debug log line that `PiExtensionUiService` emits for every unsupported extension UI request, so bridge logs no longer flood with repeated `ignored unsupported extension UI decoration` lines. No behavior change: requests are still ignored exactly as before, only the log call is gone.

<sup>Written for commit 6eb2578849c3b5ba99011204140a03f4faa1fc6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

