### PR TITLE
🌱 Show DeepSeek model names in session headers

### DIFF
--- a/client/app/lib/features/session_detail/widgets/session_detail_body.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_body.dart
@@ -17,6 +17,16 @@ import "question_modal.dart";
 import "session_detail_loaded_view.dart";
 import "session_detail_scaffold_sections.dart";
 
+String? _resolveModelName({required AgentModel? model, required List<ProviderInfo> providers}) {
+  if (model == null) return null;
+  for (final provider in providers) {
+    if (provider.id == model.providerID) {
+      return provider.models[model.modelID]?.name ?? model.modelID;
+    }
+  }
+  return model.modelID;
+}
+
 class const SessionDetailBody({
   super.key,
   required final String projectId,
@@ -89,9 +99,9 @@ class _SessionDetailBodyState() extends State<SessionDetailBody> {
     final subtitle = switch (state) {
       // Both parts are null-aware: with a null agent/model the join must yield
       // an empty string (no subtitle), never a literal "null" under the title.
-      SessionDetailLoaded(:final agent, :final assistantAgentModel) => [
+      SessionDetailLoaded(:final agent, :final assistantAgentModel, :final availableProviders) => [
         ?agent,
-        ?assistantAgentModel?.modelID,
+        ?_resolveModelName(model: assistantAgentModel, providers: availableProviders),
       ].join(" · "),
       SessionDetailLoading() || SessionDetailFailed() => "",
     };

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -592,6 +592,50 @@ void main() {
     expect(find.text("Follow up..."), findsNothing);
   });
 
+  testWidgets("header resolves an opaque assistant model ID through the provider catalog", (tester) async {
+    const modelID = "v1WyJkZWVwc2Vlay1vZmZpY2lhbCIsImRlZXBzZWVrLXY0LXBybyJd";
+    final state = _loadedState(pendingQuestions: const [], pendingPermissions: const []).copyWith(
+      agent: "deepseek",
+      assistantAgentModel: const AgentModel(
+        providerID: "deepseek-official",
+        modelID: modelID,
+        variant: "high",
+      ),
+      availableProviders: const [
+        ProviderInfo(
+          id: "deepseek-official",
+          name: "DeepSeek Official",
+          models: {
+            modelID: ProviderModel(
+              id: modelID,
+              providerID: "deepseek-official",
+              name: "DeepSeek V4 Pro",
+              variants: ["high"],
+              family: null,
+              releaseDate: null,
+            ),
+          },
+          defaultModelID: modelID,
+        ),
+      ],
+      selectedAgent: "deepseek",
+      selectedAgentModel: const AgentModel(
+        providerID: "deepseek-official",
+        modelID: modelID,
+        variant: "high",
+      ),
+      availableVariants: const [SessionVariant(id: "high")],
+    );
+    when(() => cubit.state).thenReturn(state);
+    whenListen(cubit, const Stream<SessionDetailState>.empty(), initialState: state);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    expect(find.text("deepseek · DeepSeek V4 Pro"), findsOneWidget);
+    expect(find.textContaining(modelID), findsNothing);
+  });
+
   testWidgets("opens the variant picker and forwards the selection to the cubit", (tester) async {
     await tester.pumpWidget(_buildApp(cubit: cubit));
     await tester.pumpAndSettle();

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -44,9 +44,11 @@ variant, and worktree mode, and creating the session with its first input.
   total provider failure is explicit so bridge-owned cache retention applies.
   The plugin writes `deepseek.model` and then `deepseek.reasoning_effort`
   before prompt dispatch, fails closed on either rejection, and records the
-  selected identity only after every requested write succeeds. Catalog reads use
-  the connected adapter without creating a session or model request; selection
-  is session-local and never writes normal `DSH_HOME` settings.
+  selected identity only after every requested write succeeds. The session
+  header resolves that opaque identity through the loaded provider catalog and
+  shows the model name when available. Catalog reads use the connected adapter
+  without creating a session or model request; selection is session-local and
+  never writes normal `DSH_HOME` settings.
 - Read intents stay distinct: a normal load may serve a valid cache or discover,
   a cache-only read never discovers and reports cache-unavailable, and an
   explicit refresh forces fresh discovery.
@@ -177,8 +179,9 @@ reconnect or option refresh while restoration is pending.
   `color-animal` form, or collides with an existing branch or path.
 - Bridge-owned context renders as the user's own message or command arguments.
 - A DeepSeek catalog loses sound providers because one provider failed, parses
-  an opaque model ID, dispatches before both requested config writes settle, or
-  records a partially applied selection as successful.
+  an opaque model ID, exposes a catalog-resolvable opaque ID in the session
+  header, dispatches before both requested config writes settle, or records a
+  partially applied selection as successful.
 - Creation succeeds for a non-routable plugin or unknown project.
 - Metadata completion delays the create response, creates an unqueryable session,
   overwrites a user title, resurrects a deletion, or loses the local title when


### PR DESCRIPTION
## Complexity

🌱 Trivial — localized display-name resolution plus a focused widget regression test.

## What

- Resolve the latest assistant model identity through the loaded provider catalog before rendering the session header.
- Keep the exact model ID as the fallback when the catalog cannot resolve it.
- Document the expected DeepSeek header behavior in the regression guide.

## Why

DeepSeek model selection IDs are intentionally opaque. The session header rendered that transport identity directly even though the provider catalog already supplied the human-readable model name.

## Risk and test focus

Low-risk, UI-only change. There is no transport, persistence, or database impact. Testing focuses on a DeepSeek-style opaque ID resolving to its catalog name without leaking the ID into rendered text.

## Expected result

A DeepSeek V4 Pro session shows `deepseek · DeepSeek V4 Pro` in the header instead of the opaque `v1...` selection ID.

## Verification

- `flutter test test/features/session_detail/widgets/session_detail_body_test.dart` (86 tests passed)
- `dart analyze` from `client/app` (no issues)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders DeepSeek session headers with the human-readable model name from the provider catalog instead of the opaque selection ID. Falls back to the raw model ID when the catalog can't resolve it, and updates the regression guide.

<sup>Written for commit 3172793393f06113698783fb4e383163f77e39ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

