### PR TITLE
⚙️ [grok-harness] feat(grok): compose ACP sessions and turns [step 4/9]

### DIFF
--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -83,9 +83,10 @@
 - [x] Cover identity validation, two sessions, accepted-send timing, cancellation, reasoning/tools, permissions, close,
   reconnect, disposal, stale prevalidation, loaded-effort replay, and selection failure; retain history suppression.
 - [x] Keep replay initialize validation pure and validate effort-only tuples after a stored session becomes resident.
+- [x] Materialize replay with one complete selection tuple; expose no externally mutable collector selection fields.
 - [x] Remove redundant Grok cleanup/command overrides; the shared tracker and command path remain authoritative.
-- [x] Run 270 ACP tests, 42 Grok tests, six affected-package analyzers, Dart LSP diagnostics, and whitespace checks.
-- [x] Keep the measured Step 4 change below the 1,500-line soft cap (currently 1,068 lines).
+- [x] Run 270 ACP, 42 Grok, and 41 DeepSeek tests plus affected-package analyzers, LSP, and whitespace checks.
+- [x] Keep the measured Step 4 change below the 1,500-line soft cap (currently 1,135 lines).
 - [x] Run initial and final architecture implementation reviews over Step 4 against Step 3; both approved.
 - [x] Complete the post-rebase general correctness review; final verdict approved.
 - [x] Publish Step 4 as PR #1169 after #1160's merge and start its PR monitor.

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -3,12 +3,13 @@
 ## Current State
 
 - **Plan:** `.plan/active/grok-harness/PLAN.md`
-- **Status:** Steps 1-3/9 merged; Step 4/9 verified locally and ready to publish
+- **Status:** Steps 1-3/9 merged; Step 4/9 in PR
 - **Current branch:** `grok-harness-step-4-core`
 - **Base:** `origin/main` after merged PR #1160
 - **Architecture plan review:** approved 2026-08-27 after catalog ownership and auth-policy corrections
 - **Merged predecessor:** #1160 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1160>
-- **Current step:** `grok-harness-step-4-core`; post-rebase correctness review approved, publish next
+- **Open PR:** #1169 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1169>
+- **Current step:** `grok-harness-step-4-core`; monitor CI and review, then advance the local Step 5 successor
 
 ## Fixed Series
 
@@ -21,7 +22,7 @@
 3. `⚙️ [grok-harness] feat(grok): expose models and reasoning effort [step 3/9]`
    - **State:** merged in #1160.
 4. `⚙️ [grok-harness] feat(grok): compose ACP sessions and turns [step 4/9]`
-   - **State:** verified locally; ready for PR.
+   - **State:** in PR #1169.
    - **Evidence:** generic auth allowlist, Grok plugin composition, 270 ACP tests, 42 Grok tests, affected-package
      analyzers, LSP diagnostics, two architecture approvals, and the 1,500-line budget pass.
 5. `⚙️ [grok-harness] feat(grok): add direct-CLI setup and lifecycle [step 5/9]`
@@ -84,10 +85,10 @@
 - [x] Keep replay initialize validation pure and validate effort-only tuples after a stored session becomes resident.
 - [x] Remove redundant Grok cleanup/command overrides; the shared tracker and command path remain authoritative.
 - [x] Run 270 ACP tests, 42 Grok tests, six affected-package analyzers, Dart LSP diagnostics, and whitespace checks.
-- [x] Keep the measured Step 4 change below the 1,500-line soft cap (currently 1,067 lines).
+- [x] Keep the measured Step 4 change below the 1,500-line soft cap (currently 1,068 lines).
 - [x] Run initial and final architecture implementation reviews over Step 4 against Step 3; both approved.
 - [x] Complete the post-rebase general correctness review; final verdict approved.
-- [ ] Publish Step 4 after #1160's merge and start its PR monitor.
+- [x] Publish Step 4 as PR #1169 after #1160's merge and start its PR monitor.
 
 ## Decisions And Evidence
 

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -86,7 +86,7 @@
 - [x] Materialize replay with one complete selection tuple; expose no externally mutable collector selection fields.
 - [x] Remove redundant Grok cleanup/command overrides; the shared tracker and command path remain authoritative.
 - [x] Run 270 ACP, 42 Grok, and 41 DeepSeek tests plus affected-package analyzers, LSP, and whitespace checks.
-- [x] Keep the measured Step 4 change below the 1,500-line soft cap (currently 1,135 lines).
+- [x] Keep the measured Step 4 change below the 1,500-line soft cap (currently 1,143 lines).
 - [x] Run initial and final architecture implementation reviews over Step 4 against Step 3; both approved.
 - [x] Complete the post-rebase general correctness review; final verdict approved.
 - [x] Publish Step 4 as PR #1169 after #1160's merge and start its PR monitor.

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -3,13 +3,12 @@
 ## Current State
 
 - **Plan:** `.plan/active/grok-harness/PLAN.md`
-- **Status:** Steps 1-2/9 merged; Step 3/9 in PR and held for consolidated correctness audit
-- **Current branch:** `grok-harness-step-3-models`
-- **Base:** `origin/main`
+- **Status:** Steps 1-3/9 merged; Step 4/9 verified locally and ready to publish
+- **Current branch:** `grok-harness-step-4-core`
+- **Base:** `origin/main` after merged PR #1160
 - **Architecture plan review:** approved 2026-08-27 after catalog ownership and auth-policy corrections
-- **Merged predecessor:** #1156 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1156>
-- **Open PR:** #1160 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1160>
-- **Current step:** `grok-harness-step-3-models`; consolidated correctness audit approved, update ready to publish
+- **Merged predecessor:** #1160 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1160>
+- **Current step:** `grok-harness-step-4-core`; post-rebase correctness review approved, publish next
 
 ## Fixed Series
 
@@ -20,9 +19,11 @@
    - **State:** merged in #1156.
    - **Evidence:** workspace package, launch spec, typed fixtures/codegen, tests/analyzer, LSP, and budget.
 3. `⚙️ [grok-harness] feat(grok): expose models and reasoning effort [step 3/9]`
-   - **State:** in PR #1160.
+   - **State:** merged in #1160.
 4. `⚙️ [grok-harness] feat(grok): compose ACP sessions and turns [step 4/9]`
-   - **State:** not started.
+   - **State:** verified locally; ready for PR.
+   - **Evidence:** generic auth allowlist, Grok plugin composition, 270 ACP tests, 42 Grok tests, affected-package
+     analyzers, LSP diagnostics, two architecture approvals, and the 1,500-line budget pass.
 5. `⚙️ [grok-harness] feat(grok): add direct-CLI setup and lifecycle [step 5/9]`
    - **State:** not started.
 6. `⚙️ [grok-harness] feat(bridge): activate Grok Build [step 6/9]`
@@ -70,6 +71,23 @@
 - [x] Pass 267 ACP and 27 Grok tests, analysis, LSP, line/diff checks, and two architecture reviews.
 - [x] Accept 1,821 lines: audit-required boundary/transition coverage takes precedence over the soft cap.
 - [x] Complete hostile wire, state-invariant, and post-fix general correctness reviews; final verdict approved.
+
+## Step 4 Checklist
+
+- [x] Add an optional generic advertised-auth allowlist while preserving every existing ACP default.
+- [x] Cover allowed, interactive-only, and rejected allowlisted authentication outcomes.
+- [x] Compose `GrokPlugin` over the shared ACP mapper, trackers, transport, and Step 3 collaborators.
+- [x] Wire live initialize/new/load capture, exact pre-turn selection, one provider, commands, and connection reset.
+- [x] Enable stop-and-send and fail-closed selection without Grok-specific permission or event machinery.
+- [x] Cover identity validation, two sessions, accepted-send timing, cancellation, reasoning/tools, permissions, close,
+  reconnect, disposal, stale prevalidation, loaded-effort replay, and selection failure; retain history suppression.
+- [x] Keep replay initialize validation pure and validate effort-only tuples after a stored session becomes resident.
+- [x] Remove redundant Grok cleanup/command overrides; the shared tracker and command path remain authoritative.
+- [x] Run 270 ACP tests, 42 Grok tests, six affected-package analyzers, Dart LSP diagnostics, and whitespace checks.
+- [x] Keep the measured Step 4 change below the 1,500-line soft cap (currently 1,067 lines).
+- [x] Run initial and final architecture implementation reviews over Step 4 against Step 3; both approved.
+- [x] Complete the post-rebase general correctness review; final verdict approved.
+- [ ] Publish Step 4 after #1160's merge and start its PR monitor.
 
 ## Decisions And Evidence
 

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1587,8 +1587,6 @@ abstract class AcpPlugin({
       // Replayed messages must carry the same `agent` the live mapper stamps,
       // or a reloaded session reports a different agent than the live one did.
       agentId: eventMapper.pluginId,
-      modelId: eventMapper.modelForSession(sessionId: sessionId),
-      providerId: eventMapper.providerForSession(sessionId: sessionId),
       initialUserMessageId: _syntheticInitialPromptSessions.contains(sessionId)
           ? AcpEventMapper.initialUserMessageId(sessionId)
           : null,
@@ -1597,7 +1595,12 @@ abstract class AcpPlugin({
       // Reclassify a halt notice (e.g. Cursor's account/plan gate) the same way
       // the live stream does, so reloaded history renders it identically.
       haltClassifier: eventMapper.classifyHaltNotice,
-    )..variant = replayVariantForSession(sessionId: sessionId);
+    );
+    List<PluginMessageWithParts> buildReplay() => collector.buildWithAssistantSelection(
+      modelId: eventMapper.modelForSession(sessionId: sessionId),
+      providerId: eventMapper.providerForSession(sessionId: sessionId),
+      variant: replayVariantForSession(sessionId: sessionId),
+    );
     StreamSubscription<AcpNotification>? sub;
     AcpCommandListener? commandListener;
     List<BridgeSseEvent>? deferredCommandRefresh;
@@ -1667,7 +1670,7 @@ abstract class AcpPlugin({
           // the process-global tracker, so consumers still need the refresh
           // nudge — same flush as the success path below.
           flushDeferredCommandRefresh();
-          return collector.build();
+          return buildReplay();
         }
         // Any other RPC error is a genuine load failure — wrapped typed below.
         rethrow;
@@ -1682,10 +1685,7 @@ abstract class AcpPlugin({
       // is captured in full, bounded so a chatty agent can't hang the request.
       await _drainReplay(() => received);
       flushDeferredCommandRefresh();
-      collector.modelId = eventMapper.modelForSession(sessionId: sessionId);
-      collector.providerId = eventMapper.providerForSession(sessionId: sessionId);
-      collector.variant = replayVariantForSession(sessionId: sessionId);
-      return collector.build();
+      return buildReplay();
     } on PluginAuthenticationRequiredException {
       flushDeferredCommandRefresh();
       rethrow;

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -27,7 +27,7 @@ import "repositories/acp_session_config_repository.dart";
 ///
 /// Every policy and behavior hook has a stock-ACP default, so a compliant agent
 /// needs only identity, launch spec, and trackers. A harness overrides what
-/// differs: protocol policies ([authMethodId], [initializeCapabilityMeta],
+/// differs: protocol policies ([authMethodId], [authMethodAllowlist], [initializeCapabilityMeta],
 /// [supportsFormElicitation], [serializesPromptsProcessWide],
 /// [cancelsActiveTurnForQueuedInput], [failsTurnOnSelectionError],
 /// [sessionCloseSettlementTimeout]) and behavior hooks ([buildApprovalRegistry],
@@ -186,6 +186,10 @@ abstract class AcpPlugin({
   /// never complete an interactive terminal flow (see [AcpAgentApi.initialize]).
   String? get authMethodId => null;
 
+  /// Optional allowlist applied when [authMethodId] is `null`. The stock
+  /// behavior accepts every advertised non-terminal method.
+  Set<String>? get authMethodAllowlist => null;
+
   /// Non-standard capability hints sent under `clientCapabilities._meta`
   /// (e.g. Cursor's `parameterizedModelPicker`).
   Map<String, dynamic>? get initializeCapabilityMeta => null;
@@ -255,6 +259,11 @@ abstract class AcpPlugin({
     required bool fromNewSession,
   }) {}
 
+  /// Session-local variant stamped on replayed assistant messages after
+  /// [captureSessionConfig] observes the `session/load` result. Base ACP has no
+  /// variant state; harnesses with a session-specific variant may override.
+  String? replayVariantForSession({required String sessionId}) => null;
+
   Future<void> validateTurnSelection({
     required String operation,
     required ({String providerID, String modelID})? model,
@@ -279,9 +288,13 @@ abstract class AcpPlugin({
     required String? agent,
   }) async {}
 
-  /// Validates harness-specific initialize metadata after standard ACP parsing
-  /// and before the connection becomes available to session operations.
+  /// Validates harness-specific initialize metadata for live and replay
+  /// connections without mutating live process state.
   void validateInitializeResult(AcpInitializeResult result) {}
+
+  /// Captures initialize-owned state only for the live connection. Replay uses
+  /// a separate process and must not replace live process defaults.
+  void captureLiveInitializeResult(AcpInitializeResult result) {}
 
   /// Additional privacy-safe events for a prompt failure. The generic session
   /// error is always emitted separately.
@@ -365,7 +378,9 @@ abstract class AcpPlugin({
         final registry = buildApprovalRegistry(client);
         _approvalRegistry = registry;
         registry.attach(stream: client.serverRequests);
-        _initResult = await _initialize(client);
+        final initResult = await _initialize(client);
+        captureLiveInitializeResult(initResult);
+        _initResult = initResult;
         _syncWorkState();
         if (!_connected.isClosed) _connected.add(null);
         return true;
@@ -401,6 +416,7 @@ abstract class AcpPlugin({
       formElicitation: supportsFormElicitation,
       capabilityMeta: initializeCapabilityMeta,
       authMethodId: authMethodId,
+      authMethodAllowlist: authMethodAllowlist,
       timeout: AcpAgentApi.defaultRequestTimeout,
     );
     validateInitializeResult(result);
@@ -1581,7 +1597,7 @@ abstract class AcpPlugin({
       // Reclassify a halt notice (e.g. Cursor's account/plan gate) the same way
       // the live stream does, so reloaded history renders it identically.
       haltClassifier: eventMapper.classifyHaltNotice,
-    );
+    )..variant = replayVariantForSession(sessionId: sessionId);
     StreamSubscription<AcpNotification>? sub;
     AcpCommandListener? commandListener;
     List<BridgeSseEvent>? deferredCommandRefresh;
@@ -1668,6 +1684,7 @@ abstract class AcpPlugin({
       flushDeferredCommandRefresh();
       collector.modelId = eventMapper.modelForSession(sessionId: sessionId);
       collector.providerId = eventMapper.providerForSession(sessionId: sessionId);
+      collector.variant = replayVariantForSession(sessionId: sessionId);
       return collector.build();
     } on PluginAuthenticationRequiredException {
       flushDeferredCommandRefresh();

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -18,8 +18,8 @@ class AcpReplayCollector({
   required final String sessionId,
   required final String agentId,
 
-  /// Model/provider stamped on replayed assistant messages. Mutable so the
-  /// plugin can set the loaded session's real model after `session/load`
+  /// Model/provider/variant stamped on replayed assistant messages. Mutable so the
+  /// plugin can set the loaded session's real selection after `session/load`
   /// returns its catalog (the collector is created before the load runs).
   var String? modelId,
   var String? providerId,
@@ -39,6 +39,7 @@ class AcpReplayCollector({
 }) {
   static const AcpContentMapper _contentMapper = AcpContentMapper();
 
+  String? variant;
   final List<_Draft> _drafts = [];
   int _seq = 0;
   bool _hasUserDraft = false;
@@ -232,7 +233,7 @@ class AcpReplayCollector({
             agent: agentId,
             modelID: modelId,
             providerID: providerId,
-            variant: null,
+            variant: variant,
             errorName: halt.errorName,
             errorMessage: assistantText,
             time: draft.time,
@@ -340,7 +341,7 @@ class AcpReplayCollector({
       agent: agentId,
       modelID: modelId,
       providerID: providerId,
-      variant: null,
+      variant: variant,
       sender: PluginMessageSender.agent,
       time: draft.time,
     );

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -7,6 +7,7 @@ import "repositories/trackers/acp_tool_content_tracker.dart";
 
 typedef AcpReplayUserMessageIdOverride = String? Function({required String acpMessageId});
 typedef AcpReplayMessageTimeResolver = PluginMessageTime? Function({required Map<String, dynamic> params});
+typedef _AcpReplayAssistantSelection = ({String? modelId, String? providerId, String? variant});
 
 /// Accumulates the `session/update` notifications replayed by `session/load`
 /// into ordered [PluginMessageWithParts] for `getSessionMessages`.
@@ -17,12 +18,6 @@ typedef AcpReplayMessageTimeResolver = PluginMessageTime? Function({required Map
 class AcpReplayCollector({
   required final String sessionId,
   required final String agentId,
-
-  /// Model/provider/variant stamped on replayed assistant messages. Mutable so the
-  /// plugin can set the loaded session's real selection after `session/load`
-  /// returns its catalog (the collector is created before the load runs).
-  var String? modelId,
-  var String? providerId,
   required final String? initialUserMessageId,
 
   /// Overrides a replayed user's ACP message id with backend authority.
@@ -39,7 +34,6 @@ class AcpReplayCollector({
 }) {
   static const AcpContentMapper _contentMapper = AcpContentMapper();
 
-  String? variant;
   final List<_Draft> _drafts = [];
   int _seq = 0;
   bool _hasUserDraft = false;
@@ -205,13 +199,31 @@ class AcpReplayCollector({
     }
   }
 
-  List<PluginMessageWithParts> build() {
+  /// Materializes replay without model-selection metadata.
+  List<PluginMessageWithParts> build() => _build(
+    selection: (modelId: null, providerId: null, variant: null),
+  );
+
+  /// Materializes replay with one authoritative assistant selection tuple.
+  ///
+  /// Selection is supplied only after `session/load` settles, so callers never
+  /// mutate partially-known collector state while notifications are arriving.
+  List<PluginMessageWithParts> buildWithAssistantSelection({
+    required String? modelId,
+    required String? providerId,
+    required String? variant,
+  }) => _build(selection: (modelId: modelId, providerId: providerId, variant: variant));
+
+  List<PluginMessageWithParts> _build({required _AcpReplayAssistantSelection selection}) {
     return [
-      for (final draft in _drafts) _buildMessage(draft),
+      for (final draft in _drafts) _buildMessage(draft: draft, selection: selection),
     ];
   }
 
-  PluginMessageWithParts _buildMessage(_Draft draft) {
+  PluginMessageWithParts _buildMessage({
+    required _Draft draft,
+    required _AcpReplayAssistantSelection selection,
+  }) {
     // A recognized halt notice (e.g. Cursor's account/plan gate, streamed as a
     // lone assistant message) is surfaced as an error message so a reloaded
     // session matches the live rendering. Only a pure-text terminal notice
@@ -231,9 +243,9 @@ class AcpReplayCollector({
             id: draft.id,
             sessionID: sessionId,
             agent: agentId,
-            modelID: modelId,
-            providerID: providerId,
-            variant: variant,
+            modelID: selection.modelId,
+            providerID: selection.providerId,
+            variant: selection.variant,
             errorName: halt.errorName,
             errorMessage: assistantText,
             time: draft.time,
@@ -250,7 +262,10 @@ class AcpReplayCollector({
       parts.add(_textPart(draft, "text", PluginMessagePartType.text, draft.text.toString()));
     }
     parts.addAll(_chronologicalAssistantParts(draft: draft));
-    return PluginMessageWithParts(info: _message(draft), parts: parts);
+    return PluginMessageWithParts(
+      info: _message(draft: draft, selection: selection),
+      parts: parts,
+    );
   }
 
   bool _hasTrackableAssistantContent({
@@ -325,7 +340,7 @@ class AcpReplayCollector({
     return parts;
   }
 
-  PluginMessage _message(_Draft draft) {
+  PluginMessage _message({required _Draft draft, required _AcpReplayAssistantSelection selection}) {
     if (draft.role == "user") {
       return PluginMessage.user(
         id: draft.id,
@@ -339,9 +354,9 @@ class AcpReplayCollector({
       id: draft.id,
       sessionID: sessionId,
       agent: agentId,
-      modelID: modelId,
-      providerID: providerId,
-      variant: variant,
+      modelID: selection.modelId,
+      providerID: selection.providerId,
+      variant: selection.variant,
       sender: PluginMessageSender.agent,
       time: draft.time,
     );

--- a/bridge/sesori_plugin_acp/lib/src/api/acp_agent_api.dart
+++ b/bridge/sesori_plugin_acp/lib/src/api/acp_agent_api.dart
@@ -28,9 +28,9 @@ class AcpAgentApi({required final AcpStdioClient client}) {
   /// with a remaining budget (the scratch catalog/cleanup leases) cannot
   /// overrun it by a second full timeout on the auth round trip.
   ///
-  /// [authMethodId] names the method to authenticate with; `null` picks the
-  /// first advertised non-terminal method, because the headless bridge can
-  /// never complete an interactive terminal flow.
+  /// [authMethodId] names the method to authenticate with. When it is `null`,
+  /// the first advertised non-terminal method allowed by [authMethodAllowlist]
+  /// is selected. A `null` allowlist preserves the unrestricted stock behavior.
   ///
   /// Throws [StateError] when the agent negotiates a protocol version other
   /// than v1 (it could not understand our v1-shaped `session/*` calls),
@@ -41,6 +41,7 @@ class AcpAgentApi({required final AcpStdioClient client}) {
     required bool formElicitation,
     required Map<String, dynamic>? capabilityMeta,
     required String? authMethodId,
+    required Set<String>? authMethodAllowlist,
     required Duration timeout,
   }) async {
     final deadline = Stopwatch()..start();
@@ -62,7 +63,7 @@ class AcpAgentApi({required final AcpStdioClient client}) {
       );
     }
     if (!init.requiresAuth) return init;
-    final methodId = authMethodId ?? _firstNonTerminalAuthMethod(init);
+    final methodId = authMethodId ?? _firstNonTerminalAuthMethod(init: init, allowlist: authMethodAllowlist);
     if (methodId == null) {
       throw PluginAuthenticationRequiredException(
         AcpMethods.authenticate,
@@ -195,9 +196,14 @@ class AcpAgentApi({required final AcpStdioClient client}) {
   static Map<String, dynamic> _asJson(Object? raw) =>
       raw is Map ? raw.cast<String, dynamic>() : const <String, dynamic>{};
 
-  static String? _firstNonTerminalAuthMethod(AcpInitializeResult init) {
+  static String? _firstNonTerminalAuthMethod({
+    required AcpInitializeResult init,
+    required Set<String>? allowlist,
+  }) {
     for (final method in init.authMethods) {
-      if (method.type != AcpAuthMethodType.terminal) return method.id;
+      if (method.type != AcpAuthMethodType.terminal && (allowlist == null || allowlist.contains(method.id))) {
+        return method.id;
+      }
     }
     return null;
   }

--- a/bridge/sesori_plugin_acp/test/acp_agent_api_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_agent_api_test.dart
@@ -47,6 +47,7 @@ void main() {
         formElicitation: false,
         capabilityMeta: null,
         authMethodId: null,
+        authMethodAllowlist: null,
         timeout: const Duration(seconds: 5),
       );
       final initialize = await waitForFrame("initialize");
@@ -66,11 +67,96 @@ void main() {
       await initializing;
     });
 
+    test("an allowlist selects only an advertised permitted method", () async {
+      final initializing = api.initialize(
+        formElicitation: false,
+        capabilityMeta: null,
+        authMethodId: null,
+        authMethodAllowlist: const {"cached_token"},
+        timeout: const Duration(seconds: 5),
+      );
+      final initialize = await waitForFrame("initialize");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": initialize["id"],
+        "result": initializeResult(
+          authMethods: [
+            {"id": "grok.com", "name": "Interactive login"},
+            {"id": "cached_token", "name": "Cached token"},
+          ],
+        ),
+      });
+      final authenticate = await waitForFrame("authenticate");
+      expect(authenticate["params"], {"methodId": "cached_token"});
+      fake.emit({"jsonrpc": "2.0", "id": authenticate["id"], "result": <String, dynamic>{}});
+      await initializing;
+    });
+
+    test("a rejected allowlisted method becomes a typed authentication failure", () async {
+      final initializing = api.initialize(
+        formElicitation: false,
+        capabilityMeta: null,
+        authMethodId: null,
+        authMethodAllowlist: const {"cached_token"},
+        timeout: const Duration(seconds: 5),
+      );
+      final initialize = await waitForFrame("initialize");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": initialize["id"],
+        "result": initializeResult(
+          authMethods: [
+            {"id": "cached_token", "name": "Cached token"},
+          ],
+        ),
+      });
+      final authenticate = await waitForFrame("authenticate");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": authenticate["id"],
+        "error": {"code": -32000, "message": "Rejected"},
+      });
+
+      await expectLater(
+        initializing,
+        throwsA(
+          isA<PluginAuthenticationRequiredException>().having(
+            (error) => error.cause,
+            "cause",
+            isA<AcpRpcException>(),
+          ),
+        ),
+      );
+    });
+
+    test("an allowlist rejects an interactive-only advertised list", () async {
+      final initializing = api.initialize(
+        formElicitation: false,
+        capabilityMeta: null,
+        authMethodId: null,
+        authMethodAllowlist: const {"cached_token", "xai.api_key"},
+        timeout: const Duration(seconds: 5),
+      );
+      final initialize = await waitForFrame("initialize");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": initialize["id"],
+        "result": initializeResult(
+          authMethods: [
+            {"id": "grok.com", "name": "Interactive login"},
+          ],
+        ),
+      });
+      await expectLater(initializing, throwsA(isA<PluginAuthenticationRequiredException>()));
+      expect(fake.written.where((frame) => frame["method"] == "authenticate"), isEmpty);
+    });
+
     test("a terminal-only agent fails typed, naming the connection", () async {
       final initializing = api.initialize(
         formElicitation: false,
         capabilityMeta: null,
         authMethodId: null,
+        authMethodAllowlist: null,
         timeout: const Duration(seconds: 5),
       );
       final initialize = await waitForFrame("initialize");
@@ -103,6 +189,7 @@ void main() {
         formElicitation: false,
         capabilityMeta: null,
         authMethodId: "login",
+        authMethodAllowlist: null,
         timeout: timeout,
       );
       final initialize = await waitForFrame("initialize");

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -401,26 +401,29 @@ void main() {
       expect(toolPart.state.title, isNull);
     });
 
-    test("stamps replayed assistant messages with the loaded session model", () {
+    test("stamps replayed assistant messages with the loaded session selection", () {
       final collector =
           AcpReplayCollector(
-            sessionId: "s1",
-            agentId: "Cursor",
-            modelId: "claude-opus-4-8",
-            providerId: "cursor",
-            initialUserMessageId: null,
-            messageIdOverride: null,
-            messageTimeResolver: null,
-            haltClassifier: null,
-          )..consume(
-            upd({
-              "sessionUpdate": "agent_message_chunk",
-              "content": {"type": "text", "text": "hi"},
-            }),
-          );
+              sessionId: "s1",
+              agentId: "Cursor",
+              modelId: "claude-opus-4-8",
+              providerId: "cursor",
+              initialUserMessageId: null,
+              messageIdOverride: null,
+              messageTimeResolver: null,
+              haltClassifier: null,
+            )
+            ..variant = "high"
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "hi"},
+              }),
+            );
       final assistant = collector.build().single.info as PluginMessageAssistant;
       expect(assistant.modelID, "claude-opus-4-8");
       expect(assistant.providerID, "cursor");
+      expect(assistant.variant, "high");
     });
 
     test("a messageId change splits consecutive same-role chunks into two messages", () {

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -129,8 +129,6 @@ void main() {
               AcpReplayCollector(
                   sessionId: "s1",
                   agentId: "Cursor",
-                  modelId: null,
-                  providerId: null,
                   initialUserMessageId: "s1-initial-user",
                   messageIdOverride: null,
                   messageTimeResolver: null,
@@ -174,8 +172,6 @@ void main() {
           AcpReplayCollector(
               sessionId: "s1",
               agentId: "Cursor",
-              modelId: "gpt-5.5",
-              providerId: "cursor",
               initialUserMessageId: null,
               messageIdOverride: null,
               messageTimeResolver: null,
@@ -211,7 +207,11 @@ void main() {
               }),
             );
 
-      final messages = collector.build();
+      final messages = collector.buildWithAssistantSelection(
+        modelId: "gpt-5.5",
+        providerId: "cursor",
+        variant: null,
+      );
       expect(messages, hasLength(3));
 
       final user = messages.first;
@@ -404,23 +404,28 @@ void main() {
     test("stamps replayed assistant messages with the loaded session selection", () {
       final collector =
           AcpReplayCollector(
-              sessionId: "s1",
-              agentId: "Cursor",
-              modelId: "claude-opus-4-8",
-              providerId: "cursor",
-              initialUserMessageId: null,
-              messageIdOverride: null,
-              messageTimeResolver: null,
-              haltClassifier: null,
-            )
-            ..variant = "high"
-            ..consume(
-              upd({
-                "sessionUpdate": "agent_message_chunk",
-                "content": {"type": "text", "text": "hi"},
-              }),
-            );
-      final assistant = collector.build().single.info as PluginMessageAssistant;
+            sessionId: "s1",
+            agentId: "Cursor",
+            initialUserMessageId: null,
+            messageIdOverride: null,
+            messageTimeResolver: null,
+            haltClassifier: null,
+          )..consume(
+            upd({
+              "sessionUpdate": "agent_message_chunk",
+              "content": {"type": "text", "text": "hi"},
+            }),
+          );
+      final assistant =
+          collector
+                  .buildWithAssistantSelection(
+                    modelId: "claude-opus-4-8",
+                    providerId: "cursor",
+                    variant: "high",
+                  )
+                  .single
+                  .info
+              as PluginMessageAssistant;
       expect(assistant.modelID, "claude-opus-4-8");
       expect(assistant.providerID, "cursor");
       expect(assistant.variant, "high");
@@ -874,8 +879,6 @@ void main() {
           AcpReplayCollector(
             sessionId: "s1",
             agentId: "Cursor",
-            modelId: "claude-fable-5",
-            providerId: "cursor",
             initialUserMessageId: null,
             messageIdOverride: null,
             messageTimeResolver: null,
@@ -888,7 +891,13 @@ void main() {
             }),
           );
 
-      final message = collector.build().single;
+      final message = collector
+          .buildWithAssistantSelection(
+            modelId: "claude-fable-5",
+            providerId: "cursor",
+            variant: null,
+          )
+          .single;
       expect(message.info, isA<PluginMessageError>());
       expect((message.info as PluginMessageError).errorMessage, "\n\nCheck your settings to continue");
       expect(message.parts, isEmpty);

--- a/bridge/sesori_plugin_copilot/lib/src/api/copilot_catalog_probe_api.dart
+++ b/bridge/sesori_plugin_copilot/lib/src/api/copilot_catalog_probe_api.dart
@@ -22,6 +22,7 @@ class CopilotCatalogProbeApi({required final AcpStdioClient _client}) {
       formElicitation: false,
       capabilityMeta: null,
       authMethodId: CopilotBinary.acpAuthMethodId,
+      authMethodAllowlist: null,
       timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
     );
   }

--- a/bridge/sesori_plugin_cursor/lib/src/api/cursor_catalog_probe_api.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/api/cursor_catalog_probe_api.dart
@@ -28,6 +28,7 @@ class CursorCatalogProbeApi({required final AcpStdioClient _client}) {
       formElicitation: false,
       capabilityMeta: CursorBinary.acpCapabilityMeta,
       authMethodId: CursorBinary.acpAuthMethodId,
+      authMethodAllowlist: null,
       timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
     );
   }

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_history_repository.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_history_repository.dart
@@ -22,8 +22,6 @@ class DeepSeekHistoryRepository({
     final collector = AcpReplayCollector(
       sessionId: sessionId,
       agentId: pluginId,
-      modelId: eventMapper.modelForSession(sessionId: sessionId),
-      providerId: eventMapper.providerForSession(sessionId: sessionId),
       initialUserMessageId: null,
       messageIdOverride: ({required acpMessageId}) => acpMessageId,
       messageTimeResolver: ({required params}) => messageTimeParser.parse(params),
@@ -48,7 +46,11 @@ class DeepSeekHistoryRepository({
                 collector.consume(envelope.toJson());
               }
             }
-            return collector.build();
+            return collector.buildWithAssistantSelection(
+              modelId: eventMapper.modelForSession(sessionId: sessionId),
+              providerId: eventMapper.providerForSession(sessionId: sessionId),
+              variant: null,
+            );
           case DeepSeekPaginatedHistoryResponseDto(:final nextBeforeSeq):
             if (cursor != null && nextBeforeSeq >= cursor) {
               throw const FormatException("DeepSeek history cursor did not progress");

--- a/bridge/sesori_plugin_deepseek/test/deepseek_message_times_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_message_times_test.dart
@@ -74,8 +74,6 @@ void main() {
     final collector = AcpReplayCollector(
       sessionId: "s1",
       agentId: "deepseek",
-      modelId: null,
-      providerId: null,
       initialUserMessageId: null,
       messageIdOverride: ({required acpMessageId}) => acpMessageId,
       messageTimeResolver: ({required params}) => parser.parse(params),
@@ -115,8 +113,6 @@ void main() {
     AcpReplayCollector collector(AcpHaltNotice? Function({required String text})? classifier) => AcpReplayCollector(
       sessionId: "s1",
       agentId: "deepseek",
-      modelId: null,
-      providerId: null,
       initialUserMessageId: null,
       messageIdOverride: null,
       messageTimeResolver: ({required params}) => parser.parse(params),

--- a/bridge/sesori_plugin_grok/lib/grok_plugin.dart
+++ b/bridge/sesori_plugin_grok/lib/grok_plugin.dart
@@ -4,3 +4,4 @@
 // ACP machinery. Production composition lands in later grok-harness steps.
 export "src/grok_binary.dart";
 export "src/grok_identity.dart";
+export "src/grok_plugin_impl.dart";

--- a/bridge/sesori_plugin_grok/lib/src/api/grok_acp_api.dart
+++ b/bridge/sesori_plugin_grok/lib/src/api/grok_acp_api.dart
@@ -1,7 +1,7 @@
 import "dart:async";
 
 import "package:acp_plugin/acp_plugin.dart";
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, PluginAuthenticationRequiredException;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 import "../grok_binary.dart";
 
@@ -12,7 +12,7 @@ class GrokAcpApi({
   required final Map<String, String> _environment,
 }) {
   static const String sessionSetModelMethod = "session/set_model";
-  static const Set<String> _headlessAuthMethodIds = {"xai.api_key", "cached_token"};
+  static const Set<String> headlessAuthMethodIds = {"xai.api_key", "cached_token"};
 
   Future<AcpInitializeResult> probeCatalog({
     required String cwd,
@@ -77,58 +77,13 @@ class GrokAcpApi({
   Future<AcpInitializeResult> _initialize({
     required AcpStdioClient client,
     required Duration timeout,
-  }) async {
-    final stopwatch = Stopwatch()..start();
-    final raw = await client.request(
-      method: AcpMethods.initialize,
-      params: buildInitializeParams(formElicitation: false, capabilityMeta: null),
-      timeout: timeout,
-    );
-    final result = AcpInitializeResult.fromJson(_json(raw: raw));
-    if (result.protocolVersion != acpProtocolVersion) {
-      throw StateError("Grok negotiated unsupported ACP version ${result.protocolVersion}");
-    }
-    if (!result.requiresAuth) return result;
-
-    final methodId = _headlessMethod(result: result);
-    if (methodId == null) {
-      throw const PluginAuthenticationRequiredException(
-        AcpMethods.authenticate,
-        actionHint: "Authenticate Grok locally with a headless credential, then retry.",
-        message: "Grok did not advertise a headless authentication method",
-      );
-    }
-    try {
-      await client.request(
-        method: AcpMethods.authenticate,
-        params: {"methodId": methodId},
-        timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
-      );
-    } on AcpRpcException catch (error) {
-      if (error.method != "<response>") rethrow;
-      throw PluginAuthenticationRequiredException(
-        AcpMethods.authenticate,
-        actionHint: "Authenticate Grok locally with a headless credential, then retry.",
-        message: "Grok rejected the configured authentication method",
-        cause: error,
-      );
-    }
-    return result;
-  }
-
-  String? _headlessMethod({required AcpInitializeResult result}) {
-    for (final method in result.authMethods) {
-      if (_headlessAuthMethodIds.contains(method.id)) return method.id;
-    }
-    return null;
-  }
-
-  // ignore: no_slop_linter/prefer_specific_type, ACP response and JSON object values are heterogeneous
-  Map<String, dynamic> _json({required Object? raw}) {
-    if (raw is! Map) throw const FormatException("Grok initialize returned a non-object result");
-    // ignore: no_slop_linter/prefer_specific_type, JSON object values are heterogeneous
-    return raw.cast<String, dynamic>();
-  }
+  }) => AcpAgentApi(client: client).initialize(
+    formElicitation: false,
+    capabilityMeta: null,
+    authMethodId: null,
+    authMethodAllowlist: headlessAuthMethodIds,
+    timeout: timeout,
+  );
 
   Duration _remaining({required Duration timeout, required Stopwatch stopwatch}) {
     final remaining = timeout - stopwatch.elapsed;

--- a/bridge/sesori_plugin_grok/lib/src/grok_plugin_impl.dart
+++ b/bridge/sesori_plugin_grok/lib/src/grok_plugin_impl.dart
@@ -1,0 +1,151 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "api/grok_acp_api.dart";
+import "grok_binary.dart";
+import "grok_identity.dart";
+import "repositories/grok_catalog_repository.dart";
+import "repositories/grok_session_config_repository.dart";
+import "services/grok_session_options_service.dart";
+import "trackers/grok_catalog_tracker.dart";
+
+/// Grok Build backend over ACP v1 with plugin-local legacy model selection.
+class GrokPlugin._({
+  required super.launchSpec,
+  required super.launchDirectory,
+  required super.eventMapper,
+  required super.commandTracker,
+  required super.sessionOptionsService,
+  required super.processFactory,
+  required GrokSessionOptionsService grokSessionOptionsService,
+}) extends AcpPlugin {
+  factory({
+    required String binaryPath,
+    required String launchDirectory,
+    required Map<String, String> environment,
+    required AcpProcessFactory processFactory,
+  }) {
+    final configurationTracker = AcpSessionConfigurationTracker();
+    final commandTracker = AcpCommandTracker();
+    final api = GrokAcpApi(
+      binaryPath: binaryPath,
+      processFactory: processFactory,
+      environment: environment,
+    );
+    final grokSessionOptionsService = GrokSessionOptionsService(
+      catalogRepository: GrokCatalogRepository(api: api),
+      configRepository: GrokSessionConfigRepository(api: api),
+      catalogTracker: GrokCatalogTracker(),
+      configurationTracker: configurationTracker,
+      commandTracker: commandTracker,
+      launchDirectory: launchDirectory,
+      pluginId: GrokPluginIdentity.id,
+      displayName: GrokPluginIdentity.displayName,
+      discoveryTimeout: const Duration(seconds: 15),
+    );
+    return GrokPlugin._(
+      launchSpec: GrokBinary.launchSpec(
+        binary: binaryPath,
+        cwd: launchDirectory,
+        environment: environment,
+      ),
+      launchDirectory: launchDirectory,
+      eventMapper: AcpEventMapper(
+        launchDirectory: launchDirectory,
+        pluginId: GrokPluginIdentity.id,
+        configurationTracker: configurationTracker,
+      ),
+      commandTracker: commandTracker,
+      sessionOptionsService: AcpSessionOptionsService(
+        configurationTracker: configurationTracker,
+        commandTracker: commandTracker,
+        pluginId: GrokPluginIdentity.id,
+        agentDisplayName: GrokPluginIdentity.displayName,
+      ),
+      processFactory: processFactory,
+      grokSessionOptionsService: grokSessionOptionsService,
+    );
+  }
+
+  this
+    : super(
+        id: GrokPluginIdentity.id,
+        agentDisplayName: GrokPluginIdentity.displayName,
+      );
+
+  final GrokSessionOptionsService _grokSessionOptionsService = grokSessionOptionsService;
+
+  @override
+  Set<String> get authMethodAllowlist => GrokAcpApi.headlessAuthMethodIds;
+
+  @override
+  bool get cancelsActiveTurnForQueuedInput => true;
+
+  @override
+  void validateInitializeResult(AcpInitializeResult result) =>
+      _grokSessionOptionsService.validateInitializeResult(result: result);
+
+  @override
+  void captureLiveInitializeResult(AcpInitializeResult result) =>
+      _grokSessionOptionsService.captureInitializeResult(result: result);
+
+  @override
+  void captureSessionConfig(
+    AcpNewSessionResult result, {
+    required String? sessionId,
+    required bool fromNewSession,
+  }) => _grokSessionOptionsService.captureSessionConfig(
+    result: result,
+    sessionId: sessionId,
+    fromNewSession: fromNewSession,
+  );
+
+  @override
+  String? replayVariantForSession({required String sessionId}) =>
+      _grokSessionOptionsService.reasoningEffortForSession(sessionId: sessionId);
+
+  @override
+  Future<void> validateTurnSelection({
+    required String operation,
+    required ({String providerID, String modelID})? model,
+    required PluginSessionVariant? variant,
+    required String? agent,
+  }) async => _grokSessionOptionsService.validateTurnSelection(
+    model: model,
+    variant: variant,
+    agent: agent,
+  );
+
+  @override
+  Future<void> applyTurnSelection({
+    required AcpSessionConfigRepository configRepository,
+    required String sessionId,
+    required ({String providerID, String modelID})? model,
+    required PluginSessionVariant? variant,
+    required String? agent,
+  }) async {
+    final liveClient = client;
+    if (liveClient == null) throw StateError("Grok ACP client is not connected");
+    await _grokSessionOptionsService.applyTurnSelection(
+      liveClient: liveClient,
+      sessionId: sessionId,
+      model: model,
+      variant: variant,
+    );
+  }
+
+  @override
+  Future<PluginSessionOptionsDiscoveryResult> getSessionOptions({
+    required String projectId,
+    required PluginSessionOptionsDiscoveryMode discoveryMode,
+  }) => _grokSessionOptionsService.getSessionOptions(discoveryMode: discoveryMode);
+
+  @override
+  Future<List<PluginAgent>> getAgents({required String projectId}) => _grokSessionOptionsService.listAgents();
+
+  @override
+  Future<PluginProvidersResult> getProviders({required String projectId}) => _grokSessionOptionsService.listProviders();
+
+  @override
+  void onConnectionReset() => _grokSessionOptionsService.resetConnection();
+}

--- a/bridge/sesori_plugin_grok/lib/src/grok_plugin_impl.dart
+++ b/bridge/sesori_plugin_grok/lib/src/grok_plugin_impl.dart
@@ -111,6 +111,7 @@ class GrokPlugin._({
     required PluginSessionVariant? variant,
     required String? agent,
   }) async => _grokSessionOptionsService.validateTurnSelection(
+    operation: operation,
     model: model,
     variant: variant,
     agent: agent,

--- a/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
+++ b/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
@@ -50,6 +50,10 @@ class GrokSessionOptionsService({
     return _options().providers;
   }
 
+  void validateInitializeResult({required AcpInitializeResult result}) {
+    _catalogRepository.mapInitializeResult(result: result);
+  }
+
   void captureInitializeResult({required AcpInitializeResult result}) {
     _replaceCatalog(
       catalog: _catalogRepository.mapInitializeResult(result: result),
@@ -72,6 +76,48 @@ class GrokSessionOptionsService({
         modelId: currentModel?.id,
         providerId: currentModel == null ? null : _pluginId,
         variantId: currentModel?.currentReasoningEffort,
+      );
+    }
+  }
+
+  void validateTurnSelection({
+    required ({String providerID, String modelID})? model,
+    required PluginSessionVariant? variant,
+    required String? agent,
+  }) {
+    if (agent != null && agent.isNotEmpty && agent != _pluginId) {
+      throw const PluginStaleOptionsException(
+        GrokSessionConfigRepository.selectionOperation,
+        message: "Grok no longer offers the requested agent",
+      );
+    }
+    if (model != null && model.providerID != _pluginId) {
+      throw const PluginStaleOptionsException(
+        GrokSessionConfigRepository.selectionOperation,
+        message: "Grok no longer offers the requested provider",
+      );
+    }
+    final catalog = _catalogTracker.snapshot;
+    final requestedModel = model == null ? null : catalog?.modelById(id: model.modelID);
+    if (model != null && requestedModel == null) {
+      throw const PluginStaleOptionsException(
+        GrokSessionConfigRepository.selectionOperation,
+        message: "Grok no longer offers the requested model",
+      );
+    }
+    final effort = variant?.id;
+    if (effort == null) return;
+    // A stored session is not loaded yet when prevalidation runs, so an
+    // effort-only request has no authoritative model tuple until the resident
+    // load. Admit values from any current model here; applyTurnSelection
+    // validates the exact loaded-session tuple before prompt dispatch.
+    final offersEffort =
+        requestedModel?.reasoningEfforts.contains(effort) ??
+        (model == null && (catalog?.models.any((candidate) => candidate.reasoningEfforts.contains(effort)) ?? false));
+    if (!offersEffort) {
+      throw const PluginStaleOptionsException(
+        GrokSessionConfigRepository.selectionOperation,
+        message: "Grok no longer offers the requested reasoning effort",
       );
     }
   }
@@ -137,8 +183,6 @@ class GrokSessionOptionsService({
 
   String? reasoningEffortForSession({required String sessionId}) =>
       _configurationTracker.snapshotForSession(sessionId: sessionId).variantId;
-
-  void forgetSession({required String sessionId}) => _configurationTracker.forgetSession(sessionId: sessionId);
 
   void resetConnection() => _configurationTracker.clear();
 

--- a/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
+++ b/bridge/sesori_plugin_grok/lib/src/services/grok_session_options_service.dart
@@ -81,27 +81,28 @@ class GrokSessionOptionsService({
   }
 
   void validateTurnSelection({
+    required String operation,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
     required String? agent,
   }) {
     if (agent != null && agent.isNotEmpty && agent != _pluginId) {
-      throw const PluginStaleOptionsException(
-        GrokSessionConfigRepository.selectionOperation,
+      throw PluginStaleOptionsException(
+        operation,
         message: "Grok no longer offers the requested agent",
       );
     }
     if (model != null && model.providerID != _pluginId) {
-      throw const PluginStaleOptionsException(
-        GrokSessionConfigRepository.selectionOperation,
+      throw PluginStaleOptionsException(
+        operation,
         message: "Grok no longer offers the requested provider",
       );
     }
     final catalog = _catalogTracker.snapshot;
     final requestedModel = model == null ? null : catalog?.modelById(id: model.modelID);
     if (model != null && requestedModel == null) {
-      throw const PluginStaleOptionsException(
-        GrokSessionConfigRepository.selectionOperation,
+      throw PluginStaleOptionsException(
+        operation,
         message: "Grok no longer offers the requested model",
       );
     }
@@ -115,8 +116,8 @@ class GrokSessionOptionsService({
         requestedModel?.reasoningEfforts.contains(effort) ??
         (model == null && (catalog?.models.any((candidate) => candidate.reasoningEfforts.contains(effort)) ?? false));
     if (!offersEffort) {
-      throw const PluginStaleOptionsException(
-        GrokSessionConfigRepository.selectionOperation,
+      throw PluginStaleOptionsException(
+        operation,
         message: "Grok no longer offers the requested reasoning effort",
       );
     }

--- a/bridge/sesori_plugin_grok/test/grok_plugin_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_plugin_test.dart
@@ -497,7 +497,13 @@ void main() {
             agent: selection.agent,
             model: selection.model,
           ),
-          throwsA(isA<PluginStaleOptionsException>()),
+          throwsA(
+            isA<PluginStaleOptionsException>().having(
+              (error) => error.operation,
+              "operation",
+              "sendPrompt",
+            ),
+          ),
         );
       }
       expect(fake.written.where((frame) => frame["method"] == GrokAcpApi.sessionSetModelMethod), isEmpty);

--- a/bridge/sesori_plugin_grok/test/grok_plugin_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_plugin_test.dart
@@ -1,0 +1,592 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:grok_plugin/grok_plugin.dart";
+import "package:grok_plugin/src/api/grok_acp_api.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+const List<Map<String, dynamic>> _availableModels = [
+  {
+    "modelId": "synthetic:model-alpha",
+    "name": "Model Alpha",
+    "description": null,
+    "_meta": {
+      "supportsReasoningEffort": true,
+      "reasoningEffort": "high",
+      "reasoningEfforts": [
+        {"value": "low", "default": false},
+        {"value": "high", "default": true},
+      ],
+    },
+  },
+  {
+    "modelId": "opaque/provider:model-beta",
+    "name": "Model Beta",
+    "description": null,
+    "_meta": {
+      "supportsReasoningEffort": true,
+      "reasoningEffort": "max",
+      "reasoningEfforts": [
+        {"value": "max", "default": true},
+      ],
+    },
+  },
+];
+
+const Map<String, dynamic> _modelState = {
+  "currentModelId": "synthetic:model-alpha",
+  "availableModels": _availableModels,
+};
+
+const Map<String, dynamic> _betaModelState = {
+  "currentModelId": "opaque/provider:model-beta",
+  "availableModels": _availableModels,
+};
+
+const Map<String, dynamic> _initializeResult = {
+  "protocolVersion": 1,
+  "agentCapabilities": {
+    "loadSession": true,
+    "sessionCapabilities": {
+      "list": <String, dynamic>{},
+      "resume": <String, dynamic>{},
+      "close": <String, dynamic>{},
+    },
+  },
+  "authMethods": [
+    {"id": "grok.com", "name": "Interactive login"},
+    {"id": "cached_token", "name": "Cached token"},
+  ],
+  "_meta": {
+    "grokShell": true,
+    "agentVersion": "1.0.5",
+    "modelState": _modelState,
+  },
+};
+
+void main() {
+  group("GrokPlugin", () {
+    late FakeAcpProcess fake;
+    late GrokPlugin plugin;
+    late Set<Object?> handledFrameIds;
+
+    setUp(() {
+      fake = FakeAcpProcess();
+      handledFrameIds = {};
+      plugin = GrokPlugin(
+        binaryPath: "grok",
+        launchDirectory: "/repo",
+        environment: const {},
+        processFactory: (_) async => fake,
+      );
+    });
+
+    tearDown(() async {
+      await plugin.dispose();
+      await fake.close();
+    });
+
+    Future<Map<String, dynamic>> waitForFrame({required String method}) async {
+      for (var attempt = 0; attempt < 400; attempt++) {
+        final matches = fake.written.where(
+          (frame) => frame["method"] == method && !handledFrameIds.contains(frame["id"]),
+        );
+        if (matches.isNotEmpty) {
+          final frame = matches.first;
+          handledFrameIds.add(frame["id"]);
+          return frame;
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+      throw StateError("agent never received '$method'");
+    }
+
+    Future<void> respond({required String method, required Map<String, dynamic> result}) async {
+      final frame = await waitForFrame(method: method);
+      fake.emit({"jsonrpc": "2.0", "id": frame["id"], "result": result});
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    Future<void> connect() async {
+      final connecting = plugin.ensureConnected();
+      await respond(method: AcpMethods.initialize, result: _initializeResult);
+      final authenticate = await waitForFrame(method: AcpMethods.authenticate);
+      expect(authenticate["params"], {"methodId": "cached_token"});
+      fake.emit({"jsonrpc": "2.0", "id": authenticate["id"], "result": <String, dynamic>{}});
+      expect(await connecting, isTrue);
+    }
+
+    test("uses Grok identity, headless auth policy, and stop-and-send", () {
+      expect(plugin.id, "grok");
+      expect(plugin.authMethodId, isNull);
+      expect(plugin.authMethodAllowlist, {"xai.api_key", "cached_token"});
+      expect(plugin.supportsFormElicitation, isFalse);
+      expect(plugin.cancelsActiveTurnForQueuedInput, isTrue);
+      expect(plugin.failsTurnOnSelectionError, isTrue);
+    });
+
+    test("initialize captures one Grok provider without a scratch process", () async {
+      await connect();
+
+      final providers = await plugin.getProviders(projectId: "/repo");
+      expect(providers.providers.single.id, "grok");
+      expect(providers.providers.single.defaultModelID, "synthetic:model-alpha");
+      expect(providers.providers.single.models.first.variants, ["high", "low"]);
+    });
+
+    test("a process exit resets and reconnects Grok without losing the plugin", () async {
+      await connect();
+      final exited = fake;
+      exited.exit(1);
+      await plugin.resetConnectionAfterExit();
+      fake = FakeAcpProcess();
+      handledFrameIds.clear();
+      addTearDown(exited.close);
+
+      await connect();
+      expect((await plugin.getProviders(projectId: "/repo")).providers.single.id, "grok");
+    });
+
+    test("disposal is idempotent and reaps the owned Grok process", () async {
+      await connect();
+      final exitCode = fake.exitCode;
+
+      await plugin.dispose();
+      await plugin.dispose();
+
+      expect(await exitCode, -15);
+    });
+
+    test("a non-Grok ACP peer is rejected during initialize validation", () async {
+      final connecting = plugin.ensureConnected();
+      await respond(
+        method: AcpMethods.initialize,
+        result: {
+          ..._initializeResult,
+          "authMethods": const <Object?>[],
+          "_meta": const {"grokShell": false, "modelState": _modelState},
+        },
+      );
+
+      expect(await connecting, isFalse);
+    });
+
+    test("interactive-only authentication is rejected before authenticate", () async {
+      final connecting = plugin.ensureConnected();
+      await respond(
+        method: AcpMethods.initialize,
+        result: {
+          ..._initializeResult,
+          "authMethods": const [
+            {"id": "grok.com", "name": "Interactive login"},
+          ],
+        },
+      );
+
+      expect(await connecting, isFalse);
+      expect(fake.written.where((frame) => frame["method"] == AcpMethods.authenticate), isEmpty);
+    });
+
+    test("selected model and reasoning effort are applied before create completes", () async {
+      await connect();
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: const PluginSessionVariant(id: "low"),
+        agent: "grok",
+        model: const (providerID: "grok", modelID: "synthetic:model-alpha"),
+      );
+      await respond(
+        method: AcpMethods.sessionNew,
+        result: const {"sessionId": "s1", "models": _modelState},
+      );
+      final selection = await waitForFrame(method: GrokAcpApi.sessionSetModelMethod);
+      expect(selection["params"], {
+        "sessionId": "s1",
+        "modelId": "synthetic:model-alpha",
+        "_meta": {"reasoningEffort": "low"},
+      });
+      fake.emit({"jsonrpc": "2.0", "id": selection["id"], "result": <String, dynamic>{}});
+
+      expect((await creating).id, "s1");
+    });
+
+    test("effort-only selection waits for the loaded session model before tuple validation", () async {
+      await connect();
+      plugin.primeSessionDirectory(sessionId: "stored", directory: "/repo");
+
+      await plugin.sendPrompt(
+        promptId: "p1",
+        sessionId: "stored",
+        parts: const [PluginPromptPart.text(text: "Continue")],
+        variant: const PluginSessionVariant(id: "max"),
+        agent: null,
+        model: null,
+      );
+      await respond(
+        method: AcpMethods.sessionLoad,
+        result: const {"sessionId": "stored", "models": _betaModelState},
+      );
+      final selection = await waitForFrame(method: GrokAcpApi.sessionSetModelMethod);
+      expect(selection["params"], {
+        "sessionId": "stored",
+        "modelId": "opaque/provider:model-beta",
+        "_meta": {"reasoningEffort": "max"},
+      });
+      fake.emit({"jsonrpc": "2.0", "id": selection["id"], "result": <String, dynamic>{}});
+      final prompt = await waitForFrame(method: AcpMethods.sessionPrompt);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": prompt["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+    });
+
+    test("two sessions dispatch independently through the shared ACP lanes", () async {
+      await connect();
+      final creatingFirst = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond(
+        method: AcpMethods.sessionNew,
+        result: const {"sessionId": "s1", "models": _modelState},
+      );
+      await creatingFirst;
+      final creatingSecond = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond(
+        method: AcpMethods.sessionNew,
+        result: const {"sessionId": "s2", "models": _modelState},
+      );
+      await creatingSecond;
+
+      await plugin.sendPrompt(
+        promptId: "p1",
+        sessionId: "s1",
+        parts: const [PluginPromptPart.text(text: "first")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await plugin.sendPrompt(
+        promptId: "p2",
+        sessionId: "s2",
+        parts: const [PluginPromptPart.text(text: "second")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final first = await waitForFrame(method: AcpMethods.sessionPrompt);
+      final second = await waitForFrame(method: AcpMethods.sessionPrompt);
+      expect({(first["params"] as Map)["sessionId"], (second["params"] as Map)["sessionId"]}, {"s1", "s2"});
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": first["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": second["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+    });
+
+    test("a busy follow-up cancels before replacement prompt dispatch", () async {
+      await connect();
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond(
+        method: AcpMethods.sessionNew,
+        result: const {"sessionId": "s1", "models": _modelState},
+      );
+      await creating;
+
+      await plugin.sendPrompt(
+        promptId: "p1",
+        sessionId: "s1",
+        parts: const [PluginPromptPart.text(text: "first")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final first = await waitForFrame(method: AcpMethods.sessionPrompt);
+      await plugin.sendPrompt(
+        promptId: "p2",
+        sessionId: "s1",
+        parts: const [PluginPromptPart.text(text: "replacement")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final cancel = await waitForFrame(method: AcpMethods.sessionCancel);
+      expect(cancel["params"], {"sessionId": "s1"});
+      expect(fake.written.where((frame) => frame["method"] == AcpMethods.sessionPrompt), hasLength(1));
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": first["id"],
+        "result": {"stopReason": "cancelled"},
+      });
+      final replacement = await waitForFrame(method: AcpMethods.sessionPrompt);
+      expect(((replacement["params"] as Map)["prompt"] as List).single, {"type": "text", "text": "replacement"});
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": replacement["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+    });
+
+    test("standard reasoning, tools, and permissions stay phone-mediated", () async {
+      await connect();
+      final events = <BridgeSseEvent>[];
+      final subscription = plugin.events.listen(events.add);
+      addTearDown(subscription.cancel);
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond(
+        method: AcpMethods.sessionNew,
+        result: const {"sessionId": "s1", "models": _modelState},
+      );
+      await creating;
+      await plugin.sendPrompt(
+        promptId: "p1",
+        sessionId: "s1",
+        parts: const [PluginPromptPart.text(text: "Inspect")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final prompt = await waitForFrame(method: AcpMethods.sessionPrompt);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": AcpMethods.sessionUpdate,
+        "params": {
+          "sessionId": "s1",
+          "update": {
+            "sessionUpdate": "agent_thought_chunk",
+            "content": {"type": "text", "text": "Thinking"},
+          },
+        },
+      });
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": AcpMethods.sessionUpdate,
+        "params": {
+          "sessionId": "s1",
+          "update": {"sessionUpdate": "tool_call", "toolCallId": "t1", "kind": "execute", "status": "pending"},
+        },
+      });
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 90,
+        "method": AcpMethods.sessionRequestPermission,
+        "params": {
+          "sessionId": "s1",
+          "toolCall": {"toolCallId": "t1", "title": "Run tests", "kind": "execute"},
+          "options": [
+            {"optionId": "allow", "name": "Allow", "kind": "allow_once"},
+            {"optionId": "reject", "name": "Reject", "kind": "reject_once"},
+          ],
+        },
+      });
+      await Future<void>.delayed(Duration.zero);
+
+      final partTypes = events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part.type);
+      expect(partTypes, containsAll([PluginMessagePartType.reasoning, PluginMessagePartType.tool]));
+      final pending = (await plugin.getPendingPermissions(sessionId: "s1")).single;
+      expect(pending.tool, "execute");
+      await plugin.replyToPermission(requestId: pending.id, sessionId: "s1", reply: PluginPermissionReply.once);
+      expect(((fake.written.last["result"] as Map)["outcome"] as Map)["optionId"], "allow");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": prompt["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+    });
+
+    test("deletion closes only the resident process session", () async {
+      await connect();
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond(
+        method: AcpMethods.sessionNew,
+        result: const {"sessionId": "s1", "models": _modelState},
+      );
+      await creating;
+
+      final deleting = plugin.deleteSession("s1");
+      final close = await waitForFrame(method: AcpMethods.sessionClose);
+      expect(close["params"], {"sessionId": "s1"});
+      fake.emit({"jsonrpc": "2.0", "id": close["id"], "result": <String, dynamic>{}});
+      await deleting;
+    });
+
+    test("stale agent, provider, model, and effort fail before turn acceptance", () async {
+      await connect();
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond(
+        method: AcpMethods.sessionNew,
+        result: const {"sessionId": "s1", "models": _modelState},
+      );
+      await creating;
+      final staleSelections =
+          <({String? agent, ({String providerID, String modelID})? model, PluginSessionVariant? variant})>[
+            (agent: "removed-agent", model: null, variant: null),
+            (
+              agent: null,
+              model: const (providerID: "removed-provider", modelID: "synthetic:model-alpha"),
+              variant: null,
+            ),
+            (agent: null, model: const (providerID: "grok", modelID: "removed-model"), variant: null),
+            (agent: null, model: null, variant: const PluginSessionVariant(id: "removed-effort")),
+          ];
+
+      for (final selection in staleSelections) {
+        await expectLater(
+          plugin.sendPrompt(
+            promptId: "stale-${staleSelections.indexOf(selection)}",
+            sessionId: "s1",
+            parts: const [PluginPromptPart.text(text: "Hello")],
+            variant: selection.variant,
+            agent: selection.agent,
+            model: selection.model,
+          ),
+          throwsA(isA<PluginStaleOptionsException>()),
+        );
+      }
+      expect(fake.written.where((frame) => frame["method"] == GrokAcpApi.sessionSetModelMethod), isEmpty);
+      expect(fake.written.where((frame) => frame["method"] == AcpMethods.sessionPrompt), isEmpty);
+    });
+
+    test("history replay stamps the loaded selection without replacing live defaults", () async {
+      await connect();
+      plugin.primeSessionDirectory(sessionId: "stored", directory: "/repo");
+      expect((await plugin.getProviders(projectId: "/repo")).providers.single.defaultModelID, "synthetic:model-alpha");
+
+      fake = FakeAcpProcess();
+      handledFrameIds.clear();
+      final replaying = plugin.getSessionMessages("stored");
+      await respond(
+        method: AcpMethods.initialize,
+        result: {
+          ..._initializeResult,
+          "_meta": const {
+            "grokShell": true,
+            "agentVersion": "1.0.5",
+            "modelState": _betaModelState,
+          },
+        },
+      );
+      final authenticate = await waitForFrame(method: AcpMethods.authenticate);
+      fake.emit({"jsonrpc": "2.0", "id": authenticate["id"], "result": <String, dynamic>{}});
+      final load = await waitForFrame(method: AcpMethods.sessionLoad);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": AcpMethods.sessionUpdate,
+        "params": {
+          "sessionId": "stored",
+          "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "messageId": "replayed",
+            "content": {"type": "text", "text": "Replayed response"},
+          },
+        },
+      });
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": load["id"],
+        "result": const {"sessionId": "stored", "models": _betaModelState},
+      });
+
+      final assistant = (await replaying).single.info as PluginMessageAssistant;
+      expect(assistant.agent, "grok");
+      expect(assistant.modelID, "opaque/provider:model-beta");
+      expect(assistant.providerID, "grok");
+      expect(assistant.variant, "max");
+      expect((await plugin.getProviders(projectId: "/repo")).providers.single.defaultModelID, "synthetic:model-alpha");
+    });
+
+    test("a rejected selection fails the accepted turn before prompt dispatch", () async {
+      await connect();
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond(
+        method: AcpMethods.sessionNew,
+        result: const {"sessionId": "s1", "models": _modelState},
+      );
+      await creating;
+      final failed = plugin.events.where((event) => event is BridgeSseSessionError).first;
+
+      await plugin.sendPrompt(
+        promptId: "p1",
+        sessionId: "s1",
+        parts: const [PluginPromptPart.text(text: "Hello")],
+        variant: null,
+        agent: null,
+        model: const (providerID: "grok", modelID: "opaque/provider:model-beta"),
+      );
+      final selection = await waitForFrame(method: GrokAcpApi.sessionSetModelMethod);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": selection["id"],
+        "error": {"code": -32603, "message": "Rejected"},
+      });
+
+      await failed.timeout(const Duration(seconds: 1));
+      expect(fake.written.where((frame) => frame["method"] == AcpMethods.sessionPrompt), isEmpty);
+    });
+  });
+}

--- a/bridge/sesori_plugin_hermes/lib/src/api/hermes_acp_api.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/api/hermes_acp_api.dart
@@ -42,6 +42,7 @@ class HermesAcpApi({
       formElicitation: false,
       capabilityMeta: null,
       authMethodId: null,
+      authMethodAllowlist: null,
       timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
     );
   }

--- a/bridge/sesori_plugin_omp/lib/src/api/omp_acp_api.dart
+++ b/bridge/sesori_plugin_omp/lib/src/api/omp_acp_api.dart
@@ -54,6 +54,7 @@ class OmpAcpApi({
       formElicitation: false,
       capabilityMeta: null,
       authMethodId: OmpBinary.acpAuthMethodId,
+      authMethodAllowlist: null,
       timeout: _remaining(timeout: timeout, stopwatch: stopwatch),
     );
   }


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this composes the Grok ACP plugin across shared authentication, lifecycle, replay, and selection hooks while preserving existing harness defaults.

## What

- Added an optional advertised-auth allowlist to standard ACP initialization; every existing harness explicitly retains unrestricted behavior.
- Added production `GrokPlugin` composition over the shared ACP process, mapper, command, configuration, and approval machinery.
- Wired Grok identity validation, live initialize/new/load catalog capture, exact pre-turn model/reasoning selection, and one Grok provider/agent surface.
- Enabled fail-closed selection and standard stop-and-send cancellation without Grok-specific permission or event paths.
- Kept replay-process initialize validation pure and materialized replay with one atomic loaded model/provider/reasoning tuple.
- Reused shared deletion, command, reconnect, and disposal ownership rather than adding duplicate Grok cleanup paths.

## Why

Step 3 added Grok-local model contracts and collaborators but deliberately left them outside production ACP lifecycle hooks. This step connects those collaborators to the proven shared ACP implementation while keeping Grok's deprecated model API package-local and headless authentication fail-closed.

## Risk and test focus

Risk is moderate and currently dormant because Grok is not registered in the bridge app until Step 6. The highest-value checks cover auth-method filtering without regressions, live-versus-replay state ownership, stored-session effort validation after load, selection-before-prompt ordering, stop-and-send cancellation, replay identity stamping, connection reset, deletion, and idempotent disposal. There is no current user-visible or database impact, and existing ACP wire behavior is unchanged when no allowlist is supplied.

## Expected result

The Grok package now provides a complete headless ACP session/turn implementation with exact model and reasoning selection, standard permissions/events/history, safe reconnect behavior, and no activation in production routing yet.

## Verification

- `bridge/sesori_plugin_acp`: `dart test` — 270 passed
- `bridge/sesori_plugin_grok`: `dart test` — 42 passed
- `bridge/sesori_plugin_deepseek`: `dart test` — 41 passed
- ACP, Grok, DeepSeek, Copilot, Cursor, Hermes, and OMP: `dart analyze --fatal-infos` — no issues
- Dart LSP diagnostics — 0 diagnostics across 14 changed Dart files
- `git diff --check` and authored 120-column check — passed
- Two architecture implementation reviews — approved
- Post-rebase general correctness review — approved
- Scope — 1,143 changed lines against the Step 3 merge base, below the 1,500-line target
