### PR TITLE
🌿 Keep Pi question prompts readable in sheets

### DIFF
--- a/bridge/sesori_plugin_pi/lib/src/services/pi_extension_ui_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_extension_ui_service.dart
@@ -258,8 +258,12 @@ final class PiExtensionUiService({
         displaySessionId: shared.displaySessionId,
         projectId: shared.projectId,
         question: PluginQuestionInfo(
-          question: "Choose one option.",
-          header: _header(title, fallback: "Pi extension"),
+          question: _dialogPrompt(
+            title: title,
+            detail: null,
+            fallback: "Choose one option.",
+          ),
+          header: "Pi extension",
           options: [for (final option in options) PluginQuestionOption(label: option, description: "")],
           multiple: false,
           custom: false,
@@ -275,7 +279,7 @@ final class PiExtensionUiService({
         projectId: shared.projectId,
         question: PluginQuestionInfo(
           question: _boundedNullable(message) ?? "Confirm this action.",
-          header: _header(title, fallback: "Confirmation"),
+          header: _boundedNullable(title) ?? "Confirmation",
           options: const [
             PluginQuestionOption(label: "Yes", description: ""),
             PluginQuestionOption(label: "No", description: ""),
@@ -292,8 +296,12 @@ final class PiExtensionUiService({
         displaySessionId: shared.displaySessionId,
         projectId: shared.projectId,
         question: PluginQuestionInfo(
-          question: _boundedNullable(placeholder) ?? "Enter a value.",
-          header: _header(title, fallback: "Pi extension"),
+          question: _dialogPrompt(
+            title: title,
+            detail: _inputHint(placeholder: placeholder),
+            fallback: "Enter a value.",
+          ),
+          header: "Pi extension",
           options: const [],
           multiple: false,
           custom: true,
@@ -307,8 +315,12 @@ final class PiExtensionUiService({
         displaySessionId: shared.displaySessionId,
         projectId: shared.projectId,
         question: PluginQuestionInfo(
-          question: _editorPrompt(prefill),
-          header: _header(title, fallback: "Editor"),
+          question: _dialogPrompt(
+            title: title,
+            detail: _editorPrompt(prefill),
+            fallback: "Reply with the complete replacement text.",
+          ),
+          header: "Editor",
           options: const [],
           multiple: false,
           custom: true,
@@ -412,7 +424,23 @@ PiExtensionUiReply? _replyFor({
   };
 }
 
-String _header(String? value, {required String fallback}) => _boundedNullable(value) ?? fallback;
+// Pi's select, input, and editor APIs carry their authoritative prompt in
+// `title`; keep it in the scrollable body instead of ellipsized sheet chrome.
+String _dialogPrompt({
+  required String? title,
+  required String? detail,
+  required String fallback,
+}) {
+  final prompt = _boundedNullable(title);
+  if (prompt == null) return detail ?? fallback;
+  if (detail == null || detail == prompt) return prompt;
+  return "$prompt\n\n$detail";
+}
+
+String? _inputHint({required String? placeholder}) {
+  final value = _boundedNullable(placeholder);
+  return value == null ? null : "Input hint: $value";
+}
 
 String? _boundedNullable(String? value) => value == null || value.isEmpty ? null : _bounded(value);
 

--- a/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_extension_ui_service_test.dart
@@ -45,13 +45,16 @@ void main() {
     await processes.dispose();
   });
 
-  test("maps dialogs, indexes imported scope, and sends exact reply variants", () async {
+  test("maps dialog prompts into the body and sends exact reply variants", () async {
+    const selectPrompt =
+        "Which implementation approach should Sesori use for this change?\n\n"
+        "Compare the trade-offs before choosing the final direction.";
     await service.handleRequest(
       ownerSessionId: "child",
       processGeneration: processes.generation,
       request: const PiSelectDialogRequest(
         id: "select-wire",
-        title: "Choose",
+        title: selectPrompt,
         options: ["one", "two"],
         timeoutMs: null,
         raw: {},
@@ -60,6 +63,8 @@ void main() {
     final select = service.getPendingQuestions(sessionId: "root").single;
     expect(select.sessionID, "child");
     expect(select.displaySessionId, "root");
+    expect(select.questions.single.header, "Pi extension");
+    expect(select.questions.single.question, selectPrompt);
     expect(select.questions.single.options.map((option) => option.label), ["one", "two"]);
     expect(service.getProjectQuestions(projectId: projectId).single.id, select.id);
 
@@ -79,13 +84,15 @@ void main() {
       processGeneration: processes.generation,
       request: const PiConfirmDialogRequest(
         id: "confirm-wire",
-        title: null,
-        message: "Proceed?",
+        title: "Confirm change",
+        message: "Continue with the selected implementation?",
         timeoutMs: null,
         raw: {},
       ),
     );
     final confirm = service.getPendingQuestions(sessionId: "child").single;
+    expect(confirm.questions.single.header, "Confirm change");
+    expect(confirm.questions.single.question, "Continue with the selected implementation?");
     service.replyToQuestion(
       questionId: confirm.id,
       sessionId: "child",
@@ -100,13 +107,18 @@ void main() {
       processGeneration: processes.generation,
       request: const PiInputDialogRequest(
         id: "input-wire",
-        title: null,
-        placeholder: "Value",
+        title: "What value should be used?",
+        placeholder: "For example, staging",
         timeoutMs: null,
         raw: {},
       ),
     );
     final input = service.getPendingQuestions(sessionId: "child").single;
+    expect(input.questions.single.header, "Pi extension");
+    expect(
+      input.questions.single.question,
+      "What value should be used?\n\nInput hint: For example, staging",
+    );
     service.replyToQuestion(
       questionId: input.id,
       sessionId: "child",
@@ -123,13 +135,19 @@ void main() {
       processGeneration: processes.generation,
       request: PiEditorDialogRequest(
         id: "editor-wire",
-        title: "Edit",
+        title: "Replace the complete deployment notes without dropping any omitted lines.",
         prefill: _repeat("x", 600),
         raw: const {},
       ),
     );
     final editor = service.getPendingQuestions(sessionId: "child").single;
-    final prompt = editor.questions.single.question;
+    final question = editor.questions.single;
+    final prompt = question.question;
+    expect(question.header, "Editor");
+    expect(
+      prompt,
+      startsWith("Replace the complete deployment notes without dropping any omitted lines.\n\n"),
+    );
     expect(prompt, contains("complete replacement"));
     expect(prompt, contains("Prefill was truncated"));
     expect(prompt, isNot(contains(_repeat("x", 501))));

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -21,8 +21,13 @@ reaches the backend so the turn continues.
   exposing prompt/default content in diagnostics.
 - Pi extension `select`, `confirm`, `input`, and `editor` dialogs map to one
   single-select, Yes/No, or custom-answer question and return the exact Pi value,
-  confirmation, or cancellation shape. Editor answers replace the full value;
-  a bounded labelled prefill excerpt never implies that omitted text is retained.
+  confirmation, or cancellation shape. For select, input, and editor dialogs,
+  Pi's title is the user-facing prompt, so it remains fully readable in the
+  scrollable question body instead of the ellipsized sheet heading. Confirm
+  dialogs preserve their distinct title and message, while input hints and
+  editor guidance remain visible with the prompt. Editor answers replace the full
+  value; a bounded labelled prefill excerpt never implies that omitted text is
+  retained.
 - Pi mirrors upstream dialog expiry to retire the card, owns editor expiry,
   rejects pending cards on process/session cleanup, indexes imported children
   under their top-most display root and owning worktree project, and does not
@@ -82,7 +87,7 @@ reaches the backend so the turn continues.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Live plugin, one representative plugin: a permission raised by a real turn appears as pending and one reply lets the turn proceed. |
-| L2 Routine | Live plugin, representative: question variants (single, multiple, custom, reject), typed ACP scalar forms where supported, unsupported-form decline, abort cancellation, per-session and per-project pending listing, repeated or unknown request ids answered without corrupting state. Automated Pi coverage: select/confirm/input/editor exact replies and timeout cleanup. Automated DeepSeek coverage: exact two-session question correlation, permission once/reject, ordered multi/custom/free-form and plan-review answers, invalid-answer settlement, abort, late reply, and disposal. |
+| L2 Routine | Live plugin, representative: question variants (single, multiple, custom, reject), typed ACP scalar forms where supported, unsupported-form decline, abort cancellation, per-session and per-project pending listing, repeated or unknown request ids answered without corrupting state. Automated Pi coverage: select/confirm/input/editor prompt placement, exact replies, and timeout cleanup. Automated DeepSeek coverage: exact two-session question correlation, permission once/reject, ordered multi/custom/free-form and plan-review answers, invalid-answer settlement, abort, late reply, and disposal. |
 | L3 Release | Client end to end on the release-target client platform, every supporting production plugin: every request kind the plugin exposes, per-plugin "always" availability, child attribution, archived-session refusal, and pending requests suppressing completion notifications until resolved. Copilot covers the always-visible Once/Reject actions, Always only when advertised, exact selected-or-cancelled ACP outcomes, and an honestly absent question capability. |
 | L4 Extended | Relay integration, every supporting production plugin: per-session empty lists while stopped or terminally failed, project-wide question unavailability with no active plugin, pending state re-read after restart, competing replies to one request, two logical clients observing one request and its retirement, and reconnect inside the replay window. |
 | L5 Full | Headless bridge and live plugin for malformed requests and degenerate option sets; packaged or external on alternate client platforms for an older bridge not declaring "always". Every supporting production plugin where applicable. |
@@ -112,9 +117,11 @@ capability surfaces do not claim questions.
   user chose, or leaves the turn blocked.
 - An ACP form answer changes scalar type, uses a display label instead of the
   backend value, reaches the wrong session, or remains pending after abort.
-- A Pi dialog loses multiline input, silently retains truncated editor prefill,
-  replies with the wrong wire variant, survives timeout/process cleanup, or
-  appears outside its imported display root or owning project.
+- A Pi select, input, or editor dialog leaves its user-facing prompt only in the
+  ellipsized sheet heading, or any Pi dialog loses its confirm message, input
+  hint, multiline input, or editor guidance; silently retains truncated editor
+  prefill; replies with the wrong wire variant; survives timeout/process cleanup;
+  or appears outside its imported display root or owning project.
 - A DeepSeek question loses supplemental detail, changes answer ordering or
   scope, accepts custom plan-review input, or survives abort/process cleanup.
 - A resolved request stays visible, keeps suppressing notifications, or returns


### PR DESCRIPTION
## Complexity

🌿 Straightforward — localized Pi dialog mapping, focused regression coverage, and documentation.

## What

- Put Pi `select`, `input`, and `editor` prompts in the scrollable question body instead of the single-line sheet heading.
- Keep Pi `confirm` title/message semantics intact and retain input hints plus editor replacement guidance.
- Add focused mapping assertions and update the questions/permissions regression contract.
- Audit every production question-producing harness; OpenCode, Claude, Codex, Cursor, DeepSeek, and ACP-based plugins already place authoritative prompts in the question body. Copilot does not expose questions.

## Why

Pi carries the authoritative prompt in the `title` field for `select`, `input`, and `editor`. Mapping that field to the bottom-sheet title made long prompts unreadable because sheet chrome is intentionally ellipsized.

## Risk and test focus

Low risk. The change is presentation mapping inside the Pi plugin and does not change reply wire shapes, persistence, or database state. The user-visible impact is that complete Pi prompts and their supporting hints/guidance are readable in the modal body.

Focus testing on prompt/header placement, exact Pi reply variants, and editor prefill behavior.

## Expected result

Pi-driven questions show a concise sheet heading and the complete prompt below it, while answers continue to reach Pi with the same value, confirmation, or cancellation shape.

## Verification

- `dart pub get` from `bridge/`
- `dart test test/pi_extension_ui_service_test.dart` from `bridge/sesori_plugin_pi/`
- `dart analyze --fatal-infos` from `bridge/sesori_plugin_pi/`
- Dart LSP diagnostics on the changed production and test files
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Pi `select`, `input`, and `editor` prompts readable by moving them from the ellipsized sheet heading into the scrollable question body. The heading is now a fixed label, and Pi's `title` plus any hint or editor guidance appears in full in the body; `confirm` dialogs still keep the title in the heading and the message in the body.

- Pi's authoritative `title` becomes the question body for select, input, and editor; the sheet heading is a fixed label.
- Placeholders are surfaced as `Input hint:` lines, and editor replacement guidance stays with the prompt.
- Updates the regression contract and focused tests to cover prompt placement, exact reply variants, and editor prefill behavior.

<sup>Written for commit ca0e0c775aa48812d6001b4fbca8c415fea5a575. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

