### PR TITLE
⚙️ Prevent duplicate transcript rows after replay

### DIFF
--- a/bridge/app/lib/src/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/repositories/chat_history_repository.dart
@@ -1,6 +1,7 @@
 import "dart:convert";
 import "dart:typed_data";
 
+import "package:crypto/crypto.dart" show sha256;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart";
 
@@ -30,6 +31,7 @@ typedef ChatHistoryPage = ({List<MessageWithParts> messages, int? nextCursor});
 
 /// Identity of one stored part inside its session.
 typedef StoredPartRef = ({String messageId, String partId});
+typedef _SemanticMessageFingerprints = ({String content, String context});
 
 /// How fresh a session's stored transcript is.
 ///
@@ -362,10 +364,11 @@ class ChatHistoryRepository({
   /// import has no such line to draw, so stored rows are otherwise kept.
   ///
   /// Backend replay identities can differ from the live identities Sesori
-  /// assigned to the same visible messages. Normalized semantic matching drops
-  /// those retained duplicates up to the imported multiplicity while preserving
-  /// truly live-only rows and additional identical messages. The imported row
-  /// remains authoritative for replay metadata.
+  /// assigned to the same visible messages. Normalized semantic matching in the
+  /// same nearest-distinct visible-message context drops retained duplicates up
+  /// to the imported multiplicity while preserving truly live-only rows and
+  /// additional identical messages. The imported row remains authoritative for
+  /// replay metadata.
   ///
   /// Retained rows rejoin the imported transcript at their recorded message
   /// time while their relative order stays stable. Thus an older backend-only
@@ -421,33 +424,50 @@ class ChatHistoryRepository({
       }
     }
 
-    final importedSemanticCounts = <String, int>{};
+    final importedSemanticFingerprints = <_SemanticMessageFingerprints?>[];
     for (var index = 0; index < messages.length; index++) {
       final message = messages[index];
-      final key = await _semanticMessageKey(
-        sessionId: sessionId,
-        messageId: message.info.id,
-        storageScope: storageScope,
-        infoJson: importedMessageRows[index].infoJson,
-        partJsons: importedPartJsonByMessage[message.info.id] ?? const [],
+      importedSemanticFingerprints.add(
+        await _semanticMessageFingerprints(
+          sessionId: sessionId,
+          messageId: message.info.id,
+          storageScope: storageScope,
+          infoJson: importedMessageRows[index].infoJson,
+          partJsons: importedPartJsonByMessage[message.info.id] ?? const [],
+        ),
       );
-      if (key != null) importedSemanticCounts[key] = (importedSemanticCounts[key] ?? 0) + 1;
+    }
+
+    final storedSemanticFingerprints = <_SemanticMessageFingerprints?>[];
+    for (final row in storedRows) {
+      storedSemanticFingerprints.add(
+        await _semanticMessageFingerprints(
+          sessionId: sessionId,
+          messageId: row.messageId,
+          storageScope: storageScope,
+          infoJson: row.infoJson,
+          partJsons: storedPartJsonByMessage[row.messageId] ?? const [],
+        ),
+      );
+    }
+
+    final importedSemanticContexts = _semanticContextFingerprints(fingerprints: importedSemanticFingerprints);
+    final storedSemanticContexts = _semanticContextFingerprints(fingerprints: storedSemanticFingerprints);
+    final importedSemanticCounts = <String, int>{};
+    for (final fingerprint in importedSemanticContexts) {
+      if (fingerprint != null) importedSemanticCounts[fingerprint] = (importedSemanticCounts[fingerprint] ?? 0) + 1;
     }
 
     final storedSemanticOccurrences = <String, int>{};
     final semanticallyImportedStoredIds = <String>{};
-    for (final row in storedRows) {
-      final key = await _semanticMessageKey(
-        sessionId: sessionId,
-        messageId: row.messageId,
-        storageScope: storageScope,
-        infoJson: row.infoJson,
-        partJsons: storedPartJsonByMessage[row.messageId] ?? const [],
-      );
-      if (key == null) continue;
-      final occurrence = (storedSemanticOccurrences[key] ?? 0) + 1;
-      storedSemanticOccurrences[key] = occurrence;
-      if (occurrence <= (importedSemanticCounts[key] ?? 0)) {
+    for (var index = 0; index < storedRows.length; index++) {
+      final row = storedRows[index];
+      if (importedIds.contains(row.messageId) || (lastImportedAt != null && row.updatedAt <= lastImportedAt)) continue;
+      final fingerprint = storedSemanticContexts[index];
+      if (fingerprint == null) continue;
+      final occurrence = (storedSemanticOccurrences[fingerprint] ?? 0) + 1;
+      storedSemanticOccurrences[fingerprint] = occurrence;
+      if (occurrence <= (importedSemanticCounts[fingerprint] ?? 0)) {
         semanticallyImportedStoredIds.add(row.messageId);
       }
     }
@@ -684,7 +704,7 @@ class ChatHistoryRepository({
     if (firstError != null) Error.throwWithStackTrace(firstError, firstStackTrace!);
   }
 
-  Future<String?> _semanticMessageKey({
+  Future<_SemanticMessageFingerprints?> _semanticMessageFingerprints({
     required String sessionId,
     required String messageId,
     required AttachmentStorageScope storageScope,
@@ -701,16 +721,25 @@ class ChatHistoryRepository({
         partJsons: partJsons,
         attachmentProjection: const StoredReferenceMessageAttachmentProjection(bridgeId: _semanticMatchBridgeId),
       );
-      return jsonEncode({
-        "info": info,
-        "parts": [
-          for (final part in parts)
-            _withoutFields(
-              source: part.toJson(),
-              fields: const {"id", "sessionID", "messageID"},
-            ),
-        ],
-      });
+      final canonicalParts = [
+        for (final part in parts)
+          _withoutFields(
+            source: part.toJson(),
+            fields: const {"id", "sessionID", "messageID"},
+          ),
+      ];
+      return (
+        content: _jsonFingerprint(value: {"info": info, "parts": canonicalParts}),
+        context: _jsonFingerprint(
+          value: {
+            "info": info,
+            "parts": [
+              for (var index = 0; index < parts.length; index++)
+                if (parts[index] is! MessagePartReasoning) canonicalParts[index],
+            ],
+          },
+        ),
+      );
     } on Object catch (error, stackTrace) {
       Log.w(
         "[history] could not compare message $messageId in session $sessionId during replay reconciliation",
@@ -719,6 +748,44 @@ class ChatHistoryRepository({
       );
       return null;
     }
+  }
+
+  String _jsonFingerprint({required Object value}) => sha256.convert(utf8.encode(jsonEncode(value))).toString();
+
+  List<String?> _semanticContextFingerprints({required List<_SemanticMessageFingerprints?> fingerprints}) {
+    final previousDistinct = List<String?>.filled(fingerprints.length, null);
+    String? currentRun;
+    String? beforeRun;
+    for (var index = 0; index < fingerprints.length; index++) {
+      final fingerprint = fingerprints[index]?.context;
+      if (fingerprint == null) continue;
+      if (fingerprint != currentRun) {
+        beforeRun = currentRun;
+        currentRun = fingerprint;
+      }
+      previousDistinct[index] = beforeRun;
+    }
+
+    final nextDistinct = List<String?>.filled(fingerprints.length, null);
+    currentRun = null;
+    String? afterRun;
+    for (var index = fingerprints.length - 1; index >= 0; index--) {
+      final fingerprint = fingerprints[index]?.context;
+      if (fingerprint == null) continue;
+      if (fingerprint != currentRun) {
+        afterRun = currentRun;
+        currentRun = fingerprint;
+      }
+      nextDistinct[index] = afterRun;
+    }
+
+    return [
+      for (var index = 0; index < fingerprints.length; index++)
+        if (fingerprints[index] case final _SemanticMessageFingerprints fingerprint)
+          jsonEncode([previousDistinct[index], fingerprint.content, nextDistinct[index]])
+        else
+          null,
+    ];
   }
 
   Map<String, dynamic> _withoutFields({

--- a/bridge/app/lib/src/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/repositories/chat_history_repository.dart
@@ -57,6 +57,7 @@ class ChatHistoryRepository({
   required final ArchivedSessionStorage _archivedSessionStorage,
 }) {
   static const _archiveSchemaVersion = 1;
+  static const _semanticMatchBridgeId = "history-semantic-match";
 
   Future<Uint8List?> readStoredAttachment({
     required AttachmentStorageScope storageScope,
@@ -358,7 +359,13 @@ class ChatHistoryRepository({
   /// an edited message rolls its session back, and a bridge that was not
   /// watching that backend sees the removal only as this gap. Keeping it would
   /// restore messages the user deleted elsewhere. A session with no completed
-  /// import has no such line to draw, so everything stored is kept.
+  /// import has no such line to draw, so stored rows are otherwise kept.
+  ///
+  /// Backend replay identities can differ from the live identities Sesori
+  /// assigned to the same visible messages. Normalized semantic matching drops
+  /// those retained duplicates up to the imported multiplicity while preserving
+  /// truly live-only rows and additional identical messages. The imported row
+  /// remains authoritative for replay metadata.
   ///
   /// Retained rows rejoin the imported transcript at their recorded message
   /// time while their relative order stays stable. Thus an older backend-only
@@ -375,39 +382,83 @@ class ChatHistoryRepository({
   }) async {
     final importedIds = {for (final message in messages) message.info.id};
     final storedRows = await _chatHistoryDao.getMessages(sessionId: sessionId);
-    final retained = [
-      for (final row in storedRows)
-        if (!importedIds.contains(row.messageId) && (lastImportedAt == null || row.updatedAt > lastImportedAt)) row,
-    ];
+    final storedPartRows = await _chatHistoryDao.getParts(sessionId: sessionId);
+    final storedPartJsonByMessage = <String, List<String>>{};
+    for (final row in storedPartRows) {
+      storedPartJsonByMessage.putIfAbsent(row.messageId, () => []).add(row.partJson);
+    }
 
     final importedMessageRows = <HistoryMessagesTableData>[];
+    final importedPartJsonByMessage = <String, List<String>>{};
     final partRows = <HistoryPartsTableData>[];
     var seq = 0;
     for (final message in messages) {
       seq++;
+      final infoJson = jsonEncode(message.info.toJson());
       importedMessageRows.add(
         HistoryMessagesTableData(
           sessionId: sessionId,
           messageId: message.info.id,
           seq: seq,
-          infoJson: jsonEncode(message.info.toJson()),
+          infoJson: infoJson,
           updatedAt: syncedAt,
         ),
       );
       for (var index = 0; index < message.parts.length; index++) {
         final part = message.parts[index];
+        final partJson = await _encodePart(storageScope: storageScope, part: part);
+        importedPartJsonByMessage.putIfAbsent(message.info.id, () => []).add(partJson);
         partRows.add(
           HistoryPartsTableData(
             sessionId: sessionId,
             messageId: message.info.id,
             partId: part.id,
             orderIndex: index,
-            partJson: await _encodePart(storageScope: storageScope, part: part),
+            partJson: partJson,
             updatedAt: syncedAt,
           ),
         );
       }
     }
+
+    final importedSemanticCounts = <String, int>{};
+    for (var index = 0; index < messages.length; index++) {
+      final message = messages[index];
+      final key = await _semanticMessageKey(
+        sessionId: sessionId,
+        messageId: message.info.id,
+        storageScope: storageScope,
+        infoJson: importedMessageRows[index].infoJson,
+        partJsons: importedPartJsonByMessage[message.info.id] ?? const [],
+      );
+      if (key != null) importedSemanticCounts[key] = (importedSemanticCounts[key] ?? 0) + 1;
+    }
+
+    final storedSemanticOccurrences = <String, int>{};
+    final semanticallyImportedStoredIds = <String>{};
+    for (final row in storedRows) {
+      final key = await _semanticMessageKey(
+        sessionId: sessionId,
+        messageId: row.messageId,
+        storageScope: storageScope,
+        infoJson: row.infoJson,
+        partJsons: storedPartJsonByMessage[row.messageId] ?? const [],
+      );
+      if (key == null) continue;
+      final occurrence = (storedSemanticOccurrences[key] ?? 0) + 1;
+      storedSemanticOccurrences[key] = occurrence;
+      if (occurrence <= (importedSemanticCounts[key] ?? 0)) {
+        semanticallyImportedStoredIds.add(row.messageId);
+      }
+    }
+
+    final retained = [
+      for (final row in storedRows)
+        if (!importedIds.contains(row.messageId) &&
+            !semanticallyImportedStoredIds.contains(row.messageId) &&
+            (lastImportedAt == null || row.updatedAt > lastImportedAt))
+          row,
+    ];
     final retainedCreatedAt = [
       for (final row in retained) Message.fromJson(jsonDecodeMap(row.infoJson)).time?.created,
     ];
@@ -631,6 +682,52 @@ class ChatHistoryRepository({
     }
     await _chatHistoryDao.reclaimFreedPages();
     if (firstError != null) Error.throwWithStackTrace(firstError, firstStackTrace!);
+  }
+
+  Future<String?> _semanticMessageKey({
+    required String sessionId,
+    required String messageId,
+    required AttachmentStorageScope storageScope,
+    required String infoJson,
+    required List<String> partJsons,
+  }) async {
+    try {
+      final info = _withoutFields(
+        source: Message.fromJson(jsonDecodeMap(infoJson)).toJson(),
+        fields: const {"id", "sessionID", "promptId", "time", "agent", "modelID", "providerID"},
+      );
+      final parts = await _rehydrateParts(
+        storageScope: storageScope,
+        partJsons: partJsons,
+        attachmentProjection: const StoredReferenceMessageAttachmentProjection(bridgeId: _semanticMatchBridgeId),
+      );
+      return jsonEncode({
+        "info": info,
+        "parts": [
+          for (final part in parts)
+            _withoutFields(
+              source: part.toJson(),
+              fields: const {"id", "sessionID", "messageID"},
+            ),
+        ],
+      });
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        "[history] could not compare message $messageId in session $sessionId during replay reconciliation",
+        error,
+        stackTrace,
+      );
+      return null;
+    }
+  }
+
+  Map<String, dynamic> _withoutFields({
+    required Map<String, dynamic> source,
+    required Set<String> fields,
+  }) {
+    final result = Map<String, dynamic>.of(source);
+    fields.forEach(result.remove);
+    return result;
   }
 
   /// The stored JSON for [part], with inline attachment bytes moved to spill

--- a/bridge/app/lib/src/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/repositories/chat_history_repository.dart
@@ -30,7 +30,7 @@ typedef ChatHistoryPage = ({List<MessageWithParts> messages, int? nextCursor});
 
 /// Identity of one stored part inside its session.
 typedef StoredPartRef = ({String messageId, String partId});
-typedef _SemanticMessageFingerprints = ({String content, String context});
+typedef _SemanticMessageFingerprints = ({String content, String context, int? createdAt});
 
 /// How fresh a session's stored transcript is.
 ///
@@ -367,8 +367,9 @@ class ChatHistoryRepository({
   /// same nearest-distinct visible-message context drops retained duplicates up
   /// to the imported multiplicity while preserving truly live-only rows and
   /// additional identical messages. Exact identities consume replay capacity
-  /// first, and stale rows due for removal do not shape semantic context. The
-  /// imported row remains authoritative for replay metadata.
+  /// first, stale rows due for removal do not shape semantic context, and a
+  /// partial repeated run matches only occurrences with equal creation times.
+  /// The imported row remains authoritative for replay metadata.
   ///
   /// Retained rows rejoin the imported transcript at their recorded message
   /// time while their relative order stays stable. Thus an older backend-only
@@ -458,24 +459,51 @@ class ChatHistoryRepository({
 
     final importedSemanticContexts = _semanticContextFingerprints(fingerprints: importedSemanticFingerprints);
     final storedSemanticContexts = _semanticContextFingerprints(fingerprints: storedSemanticFingerprints);
-    final importedSemanticCounts = <String, int>{};
+    final importedIndexesByContext = <String, List<int>>{};
     for (var index = 0; index < importedSemanticContexts.length; index++) {
       if (storedIds.contains(messages[index].info.id)) continue;
       final fingerprint = importedSemanticContexts[index];
-      if (fingerprint != null) importedSemanticCounts[fingerprint] = (importedSemanticCounts[fingerprint] ?? 0) + 1;
+      if (fingerprint != null) importedIndexesByContext.putIfAbsent(fingerprint, () => []).add(index);
     }
 
-    final storedSemanticOccurrences = <String, int>{};
-    final semanticallyImportedStoredIds = <String>{};
+    final storedIndexesByContext = <String, List<int>>{};
     for (var index = 0; index < storedContextRows.length; index++) {
       final row = storedContextRows[index];
       if (importedIds.contains(row.messageId)) continue;
       final fingerprint = storedSemanticContexts[index];
-      if (fingerprint == null) continue;
-      final occurrence = (storedSemanticOccurrences[fingerprint] ?? 0) + 1;
-      storedSemanticOccurrences[fingerprint] = occurrence;
-      if (occurrence <= (importedSemanticCounts[fingerprint] ?? 0)) {
-        semanticallyImportedStoredIds.add(row.messageId);
+      if (fingerprint != null) storedIndexesByContext.putIfAbsent(fingerprint, () => []).add(index);
+    }
+
+    final semanticallyImportedStoredIds = <String>{};
+    for (final entry in storedIndexesByContext.entries) {
+      final importedIndexes = importedIndexesByContext[entry.key] ?? const [];
+      final storedIndexes = entry.value;
+      if (importedIndexes.length >= storedIndexes.length) {
+        semanticallyImportedStoredIds.addAll({
+          for (final index in storedIndexes) storedContextRows[index].messageId,
+        });
+        continue;
+      }
+
+      // A partial repeated run is ambiguous by content and order alone. Match
+      // only equal creation times; null or differing times stay retained rather
+      // than risking deletion of a separate live-only occurrence.
+      final storedIndexesByCreatedAt = <int, List<int>>{};
+      for (final index in storedIndexes) {
+        final createdAt = storedSemanticFingerprints[index]?.createdAt;
+        if (createdAt != null) storedIndexesByCreatedAt.putIfAbsent(createdAt, () => []).add(index);
+      }
+      final importedCountsByCreatedAt = <int, int>{};
+      for (final index in importedIndexes) {
+        final createdAt = importedSemanticFingerprints[index]?.createdAt;
+        if (createdAt != null) importedCountsByCreatedAt[createdAt] = (importedCountsByCreatedAt[createdAt] ?? 0) + 1;
+      }
+      for (final entry in importedCountsByCreatedAt.entries) {
+        final matchingStoredIndexes = storedIndexesByCreatedAt[entry.key] ?? const [];
+        final matchCount = entry.value < matchingStoredIndexes.length ? entry.value : matchingStoredIndexes.length;
+        for (var index = 0; index < matchCount; index++) {
+          semanticallyImportedStoredIds.add(storedContextRows[matchingStoredIndexes[index]].messageId);
+        }
       }
     }
 
@@ -719,8 +747,9 @@ class ChatHistoryRepository({
     required List<String> partJsons,
   }) async {
     try {
+      final message = Message.fromJson(jsonDecodeMap(infoJson));
       final info = _withoutFields(
-        source: Message.fromJson(jsonDecodeMap(infoJson)).toJson(),
+        source: message.toJson(),
         fields: const {"id", "sessionID", "promptId", "time", "agent", "modelID", "providerID"},
       );
       final parts = await _rehydrateParts(
@@ -746,7 +775,7 @@ class ChatHistoryRepository({
       final context = contextParts.length == canonicalParts.length
           ? content
           : await _jsonFingerprint(value: {"info": info, "parts": contextParts});
-      return (content: content, context: context);
+      return (content: content, context: context, createdAt: message.time?.created);
     } on Object catch (error, stackTrace) {
       Log.w(
         "[history] could not compare message $messageId in session $sessionId during replay reconciliation",

--- a/bridge/app/lib/src/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/repositories/chat_history_repository.dart
@@ -11,6 +11,11 @@ import "../api/database/history/chat_history_database.dart";
 import "../api/models/archived_session_file_dto.dart";
 import "models/stored_session.dart";
 
+final class _HistoryReplayComparisonError({required final Object innerError}) implements Exception {
+  @override
+  String toString() => "Unable to normalize stored history for replay comparison";
+}
+
 /// Raised when an audit file was written by a newer bridge than this one.
 class ChatHistoryArchiveVersionException({
   required final String sessionId,
@@ -367,7 +372,8 @@ class ChatHistoryRepository({
   /// same nearest-distinct visible-message context drops retained duplicates up
   /// to the imported multiplicity while preserving truly live-only rows and
   /// additional identical messages. Exact identities consume replay capacity
-  /// first, stale rows due for removal do not shape semantic context, and a
+  /// first and anchor neighboring context by ID even when their payload changes;
+  /// stale rows due for removal do not shape semantic context, and a
   /// repeated run matches only occurrences with equal creation times. Conflicting
   /// known times also keep singleton rows distinct, while internal parts hidden
   /// from clients do not affect visible equivalence. The imported row remains
@@ -459,8 +465,20 @@ class ChatHistoryRepository({
       );
     }
 
-    final importedSemanticContexts = _semanticContextFingerprints(fingerprints: importedSemanticFingerprints);
-    final storedSemanticContexts = _semanticContextFingerprints(fingerprints: storedSemanticFingerprints);
+    final importedSemanticContexts = _semanticContextFingerprints(
+      fingerprints: importedSemanticFingerprints,
+      anchorOverrides: [
+        for (final message in messages)
+          storedIds.contains(message.info.id) ? _exactIdentityAnchor(messageId: message.info.id) : null,
+      ],
+    );
+    final storedSemanticContexts = _semanticContextFingerprints(
+      fingerprints: storedSemanticFingerprints,
+      anchorOverrides: [
+        for (final row in storedContextRows)
+          importedIds.contains(row.messageId) ? _exactIdentityAnchor(messageId: row.messageId) : null,
+      ],
+    );
     final importedIndexesByContext = <String, List<int>>{};
     for (var index = 0; index < importedSemanticContexts.length; index++) {
       if (storedIds.contains(messages[index].info.id)) continue;
@@ -784,7 +802,7 @@ class ChatHistoryRepository({
     } on Object catch (error, stackTrace) {
       Log.w(
         "[history] could not compare message $messageId in session $sessionId during replay reconciliation",
-        error,
+        error is FormatException ? _HistoryReplayComparisonError(innerError: error) : error,
         stackTrace,
       );
       return null;
@@ -796,12 +814,17 @@ class ChatHistoryRepository({
     return base64UrlEncode(digest);
   }
 
-  List<String?> _semanticContextFingerprints({required List<_SemanticMessageFingerprints?> fingerprints}) {
+  String _exactIdentityAnchor({required String messageId}) => jsonEncode({"exactMessageId": messageId});
+
+  List<String?> _semanticContextFingerprints({
+    required List<_SemanticMessageFingerprints?> fingerprints,
+    required List<String?> anchorOverrides,
+  }) {
     final previousDistinct = List<String?>.filled(fingerprints.length, null);
     String? currentRun;
     String? beforeRun;
     for (var index = 0; index < fingerprints.length; index++) {
-      final fingerprint = fingerprints[index]?.context;
+      final fingerprint = anchorOverrides[index] ?? fingerprints[index]?.context;
       if (fingerprint == null) continue;
       if (fingerprint != currentRun) {
         beforeRun = currentRun;
@@ -814,7 +837,7 @@ class ChatHistoryRepository({
     currentRun = null;
     String? afterRun;
     for (var index = fingerprints.length - 1; index >= 0; index--) {
-      final fingerprint = fingerprints[index]?.context;
+      final fingerprint = anchorOverrides[index] ?? fingerprints[index]?.context;
       if (fingerprint == null) continue;
       if (fingerprint != currentRun) {
         afterRun = currentRun;

--- a/bridge/app/lib/src/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/repositories/chat_history_repository.dart
@@ -728,17 +728,16 @@ class ChatHistoryRepository({
             fields: const {"id", "sessionID", "messageID"},
           ),
       ];
+      // Some backends omit live reasoning from replay. It remains part of the
+      // message's own identity, but not the visible neighbor anchor used to
+      // correlate an otherwise equivalent adjacent prompt or response.
+      final contextParts = [
+        for (var index = 0; index < parts.length; index++)
+          if (parts[index] is! MessagePartReasoning) canonicalParts[index],
+      ];
       return (
         content: _jsonFingerprint(value: {"info": info, "parts": canonicalParts}),
-        context: _jsonFingerprint(
-          value: {
-            "info": info,
-            "parts": [
-              for (var index = 0; index < parts.length; index++)
-                if (parts[index] is! MessagePartReasoning) canonicalParts[index],
-            ],
-          },
-        ),
+        context: _jsonFingerprint(value: {"info": info, "parts": contextParts}),
       );
     } on Object catch (error, stackTrace) {
       Log.w(

--- a/bridge/app/lib/src/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/repositories/chat_history_repository.dart
@@ -1,7 +1,6 @@
 import "dart:convert";
 import "dart:typed_data";
 
-import "package:crypto/crypto.dart" show sha256;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart";
 
@@ -367,8 +366,9 @@ class ChatHistoryRepository({
   /// assigned to the same visible messages. Normalized semantic matching in the
   /// same nearest-distinct visible-message context drops retained duplicates up
   /// to the imported multiplicity while preserving truly live-only rows and
-  /// additional identical messages. The imported row remains authoritative for
-  /// replay metadata.
+  /// additional identical messages. Exact identities consume replay capacity
+  /// first, and stale rows due for removal do not shape semantic context. The
+  /// imported row remains authoritative for replay metadata.
   ///
   /// Retained rows rejoin the imported transcript at their recorded message
   /// time while their relative order stays stable. Thus an older backend-only
@@ -385,6 +385,7 @@ class ChatHistoryRepository({
   }) async {
     final importedIds = {for (final message in messages) message.info.id};
     final storedRows = await _chatHistoryDao.getMessages(sessionId: sessionId);
+    final storedIds = {for (final row in storedRows) row.messageId};
     final storedPartRows = await _chatHistoryDao.getParts(sessionId: sessionId);
     final storedPartJsonByMessage = <String, List<String>>{};
     for (final row in storedPartRows) {
@@ -438,8 +439,12 @@ class ChatHistoryRepository({
       );
     }
 
+    final storedContextRows = [
+      for (final row in storedRows)
+        if (importedIds.contains(row.messageId) || lastImportedAt == null || row.updatedAt > lastImportedAt) row,
+    ];
     final storedSemanticFingerprints = <_SemanticMessageFingerprints?>[];
-    for (final row in storedRows) {
+    for (final row in storedContextRows) {
       storedSemanticFingerprints.add(
         await _semanticMessageFingerprints(
           sessionId: sessionId,
@@ -454,15 +459,17 @@ class ChatHistoryRepository({
     final importedSemanticContexts = _semanticContextFingerprints(fingerprints: importedSemanticFingerprints);
     final storedSemanticContexts = _semanticContextFingerprints(fingerprints: storedSemanticFingerprints);
     final importedSemanticCounts = <String, int>{};
-    for (final fingerprint in importedSemanticContexts) {
+    for (var index = 0; index < importedSemanticContexts.length; index++) {
+      if (storedIds.contains(messages[index].info.id)) continue;
+      final fingerprint = importedSemanticContexts[index];
       if (fingerprint != null) importedSemanticCounts[fingerprint] = (importedSemanticCounts[fingerprint] ?? 0) + 1;
     }
 
     final storedSemanticOccurrences = <String, int>{};
     final semanticallyImportedStoredIds = <String>{};
-    for (var index = 0; index < storedRows.length; index++) {
-      final row = storedRows[index];
-      if (importedIds.contains(row.messageId) || (lastImportedAt != null && row.updatedAt <= lastImportedAt)) continue;
+    for (var index = 0; index < storedContextRows.length; index++) {
+      final row = storedContextRows[index];
+      if (importedIds.contains(row.messageId)) continue;
       final fingerprint = storedSemanticContexts[index];
       if (fingerprint == null) continue;
       final occurrence = (storedSemanticOccurrences[fingerprint] ?? 0) + 1;
@@ -735,10 +742,11 @@ class ChatHistoryRepository({
         for (var index = 0; index < parts.length; index++)
           if (parts[index] is! MessagePartReasoning) canonicalParts[index],
       ];
-      return (
-        content: _jsonFingerprint(value: {"info": info, "parts": canonicalParts}),
-        context: _jsonFingerprint(value: {"info": info, "parts": contextParts}),
-      );
+      final content = await _jsonFingerprint(value: {"info": info, "parts": canonicalParts});
+      final context = contextParts.length == canonicalParts.length
+          ? content
+          : await _jsonFingerprint(value: {"info": info, "parts": contextParts});
+      return (content: content, context: context);
     } on Object catch (error, stackTrace) {
       Log.w(
         "[history] could not compare message $messageId in session $sessionId during replay reconciliation",
@@ -749,7 +757,10 @@ class ChatHistoryRepository({
     }
   }
 
-  String _jsonFingerprint({required Object value}) => sha256.convert(utf8.encode(jsonEncode(value))).toString();
+  Future<String> _jsonFingerprint({required Object value}) async {
+    final digest = await calculateSha256(message: utf8.encode(jsonEncode(value)));
+    return base64UrlEncode(digest);
+  }
 
   List<String?> _semanticContextFingerprints({required List<_SemanticMessageFingerprints?> fingerprints}) {
     final previousDistinct = List<String?>.filled(fingerprints.length, null);

--- a/bridge/app/lib/src/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/repositories/chat_history_repository.dart
@@ -368,8 +368,10 @@ class ChatHistoryRepository({
   /// to the imported multiplicity while preserving truly live-only rows and
   /// additional identical messages. Exact identities consume replay capacity
   /// first, stale rows due for removal do not shape semantic context, and a
-  /// repeated run matches only occurrences with equal creation times.
-  /// The imported row remains authoritative for replay metadata.
+  /// repeated run matches only occurrences with equal creation times. Conflicting
+  /// known times also keep singleton rows distinct, while internal parts hidden
+  /// from clients do not affect visible equivalence. The imported row remains
+  /// authoritative for replay metadata.
   ///
   /// Retained rows rejoin the imported transcript at their recorded message
   /// time while their relative order stays stable. Thus an older backend-only
@@ -479,7 +481,11 @@ class ChatHistoryRepository({
       final importedIndexes = importedIndexesByContext[entry.key] ?? const [];
       final storedIndexes = entry.value;
       if (importedIndexes.length == 1 && storedIndexes.length == 1) {
-        semanticallyImportedStoredIds.add(storedContextRows[storedIndexes.single].messageId);
+        final importedCreatedAt = importedSemanticFingerprints[importedIndexes.single]?.createdAt;
+        final storedCreatedAt = storedSemanticFingerprints[storedIndexes.single]?.createdAt;
+        if (importedCreatedAt == null || storedCreatedAt == null || importedCreatedAt == storedCreatedAt) {
+          semanticallyImportedStoredIds.add(storedContextRows[storedIndexes.single].messageId);
+        }
         continue;
       }
 
@@ -756,20 +762,20 @@ class ChatHistoryRepository({
         partJsons: partJsons,
         attachmentProjection: const StoredReferenceMessageAttachmentProjection(bridgeId: _semanticMatchBridgeId),
       );
-      final canonicalParts = [
-        for (final part in parts)
-          _withoutFields(
-            source: part.toJson(),
-            fields: const {"id", "sessionID", "messageID"},
-          ),
-      ];
-      // Some backends omit live reasoning from replay. It remains part of the
-      // message's own identity, but not the visible neighbor anchor used to
-      // correlate an otherwise equivalent adjacent prompt or response.
-      final contextParts = [
-        for (var index = 0; index < parts.length; index++)
-          if (parts[index] is! MessagePartReasoning) canonicalParts[index],
-      ];
+      final canonicalParts = <Map<String, dynamic>>[];
+      final contextParts = <Map<String, dynamic>>[];
+      for (final part in parts) {
+        if (!_isTranscriptVisiblePart(part: part)) continue;
+        final canonicalPart = _withoutFields(
+          source: part.toJson(),
+          fields: const {"id", "sessionID", "messageID"},
+        );
+        canonicalParts.add(canonicalPart);
+        // Some backends omit live reasoning from replay. It remains part of the
+        // message's own identity, but not the visible neighbor anchor used to
+        // correlate an otherwise equivalent adjacent prompt or response.
+        if (part is! MessagePartReasoning) contextParts.add(canonicalPart);
+      }
       final content = await _jsonFingerprint(value: {"info": info, "parts": canonicalParts});
       final context = contextParts.length == canonicalParts.length
           ? content
@@ -825,6 +831,9 @@ class ChatHistoryRepository({
           null,
     ];
   }
+
+  bool _isTranscriptVisiblePart({required MessagePart part}) =>
+      part is! MessagePartSnapshot && part is! MessagePartPatch && part is! MessagePartCompaction;
 
   Map<String, dynamic> _withoutFields({
     required Map<String, dynamic> source,

--- a/bridge/app/lib/src/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/repositories/chat_history_repository.dart
@@ -368,7 +368,7 @@ class ChatHistoryRepository({
   /// to the imported multiplicity while preserving truly live-only rows and
   /// additional identical messages. Exact identities consume replay capacity
   /// first, stale rows due for removal do not shape semantic context, and a
-  /// partial repeated run matches only occurrences with equal creation times.
+  /// repeated run matches only occurrences with equal creation times.
   /// The imported row remains authoritative for replay metadata.
   ///
   /// Retained rows rejoin the imported transcript at their recorded message
@@ -478,16 +478,15 @@ class ChatHistoryRepository({
     for (final entry in storedIndexesByContext.entries) {
       final importedIndexes = importedIndexesByContext[entry.key] ?? const [];
       final storedIndexes = entry.value;
-      if (importedIndexes.length >= storedIndexes.length) {
-        semanticallyImportedStoredIds.addAll({
-          for (final index in storedIndexes) storedContextRows[index].messageId,
-        });
+      if (importedIndexes.length == 1 && storedIndexes.length == 1) {
+        semanticallyImportedStoredIds.add(storedContextRows[storedIndexes.single].messageId);
         continue;
       }
 
-      // A partial repeated run is ambiguous by content and order alone. Match
-      // only equal creation times; null or differing times stay retained rather
-      // than risking deletion of a separate live-only occurrence.
+      // A repeated run is ambiguous by content and order alone, even when both
+      // sides have the same count. Match only equal creation times; null or
+      // differing times stay retained rather than risking deletion of a
+      // separate live-only occurrence.
       final storedIndexesByCreatedAt = <int, List<int>>{};
       for (final index in storedIndexes) {
         final createdAt = storedSemanticFingerprints[index]?.createdAt;

--- a/bridge/app/test/bridge/services/chat_history_capture_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_capture_test.dart
@@ -552,7 +552,7 @@ void main() {
       );
     });
 
-    test("semantic replay matching counts only rows eligible for retention", () async {
+    test("exact identity matches consume replay capacity before semantic matching", () async {
       final repository = _FakeSessionRepository(
         transcript: [_messageWithText(id: "replay", text: "repeated", createdAt: 100, promptId: null)],
       );
@@ -564,17 +564,47 @@ void main() {
         await _captureMessageWithParts(history: history, message: message);
       }
       await history.service.backfillSession(sessionId: "ses_a");
+      expect(
+        (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
+        const ["replay", "live-2"],
+      );
+
       await Future<void>.delayed(const Duration(milliseconds: 2));
       await _captureMessageWithParts(
         history: history,
         message: _messageWithText(id: "live-fresh", text: "repeated", createdAt: 300, promptId: "prompt-3"),
+      );
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      expect(
+        (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
+        const ["replay", "live-fresh"],
+      );
+    });
+
+    test("stale rows do not shape semantic replay context", () async {
+      final transcript = [
+        _messageWithText(id: "anchor", text: "anchor", createdAt: 100, promptId: null),
+        _messageWithText(id: "removed", text: "removed", createdAt: 200, promptId: null),
+      ];
+      final repository = _FakeSessionRepository(transcript: transcript);
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      transcript
+        ..removeWhere((message) => message.info.id == "removed")
+        ..add(_messageWithText(id: "replay-result", text: "same result", createdAt: 300, promptId: null));
+      await Future<void>.delayed(const Duration(milliseconds: 2));
+      await _captureMessageWithParts(
+        history: history,
+        message: _messageWithText(id: "live-result", text: "same result", createdAt: 300, promptId: "prompt-live"),
       );
 
       await history.service.backfillSession(sessionId: "ses_a");
 
       expect(
         (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
-        const ["replay"],
+        const ["anchor", "replay-result"],
       );
     });
 

--- a/bridge/app/test/bridge/services/chat_history_capture_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_capture_test.dart
@@ -422,6 +422,71 @@ void main() {
       );
     });
 
+    test("semantic replay matching preserves equal content in a different ordered context", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [
+          _messageWithText(id: "replay-prompt", text: "continue", createdAt: 300, promptId: null),
+          _assistantMessageWithText(
+            id: "replay-response",
+            text: "replayed response",
+            reasoning: null,
+            createdAt: 400,
+          ),
+        ],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      await _captureMessageWithParts(
+        history: history,
+        message: _messageWithText(id: "live-prompt", text: "continue", createdAt: 100, promptId: "prompt-live"),
+      );
+      await _captureMessageWithParts(
+        history: history,
+        message: _assistantMessageWithText(
+          id: "live-response",
+          text: "live-only response",
+          reasoning: null,
+          createdAt: 200,
+        ),
+      );
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      expect(
+        (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
+        const ["live-prompt", "live-response", "replay-prompt", "replay-response"],
+      );
+    });
+
+    test("semantic replay context ignores reasoning omitted by replay", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [
+          _messageWithText(id: "replay-prompt", text: "continue", createdAt: 100, promptId: null),
+          _assistantMessageWithText(id: "replay-response", text: "answer", reasoning: null, createdAt: 200),
+        ],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      await _captureMessageWithParts(
+        history: history,
+        message: _messageWithText(id: "live-prompt", text: "continue", createdAt: 100, promptId: "prompt-live"),
+      );
+      await _captureMessageWithParts(
+        history: history,
+        message: _assistantMessageWithText(
+          id: "live-response",
+          text: "answer",
+          reasoning: "live-only reasoning",
+          createdAt: 200,
+        ),
+      );
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      expect(
+        (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
+        const ["replay-prompt", "replay-response", "live-response"],
+      );
+    });
+
     test("semantic replay matching lets imported attribution replace matching live attribution", () async {
       final repository = _FakeSessionRepository(
         transcript: [
@@ -484,6 +549,32 @@ void main() {
       expect(
         (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
         const ["replay-1", "replay-2", "live-only"],
+      );
+    });
+
+    test("semantic replay matching counts only rows eligible for retention", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [_messageWithText(id: "replay", text: "repeated", createdAt: 100, promptId: null)],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      for (final message in [
+        _messageWithText(id: "live-1", text: "repeated", createdAt: 100, promptId: "prompt-1"),
+        _messageWithText(id: "live-2", text: "repeated", createdAt: 200, promptId: "prompt-2"),
+      ]) {
+        await _captureMessageWithParts(history: history, message: message);
+      }
+      await history.service.backfillSession(sessionId: "ses_a");
+      await Future<void>.delayed(const Duration(milliseconds: 2));
+      await _captureMessageWithParts(
+        history: history,
+        message: _messageWithText(id: "live-fresh", text: "repeated", createdAt: 300, promptId: "prompt-3"),
+      );
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      expect(
+        (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
+        const ["replay"],
       );
     });
 
@@ -780,6 +871,28 @@ MessageWithParts _messageWithText({
     time: MessageTime(created: createdAt, completed: null),
   ),
   parts: [_part(id: "$id-part", messageId: id, text: text)],
+);
+
+MessageWithParts _assistantMessageWithText({
+  required String id,
+  required String text,
+  required String? reasoning,
+  required int createdAt,
+}) => MessageWithParts(
+  info: Message.assistant(
+    id: id,
+    sessionID: "ses_a",
+    agent: "copilot",
+    modelID: null,
+    providerID: null,
+    sender: MessageSender.agent,
+    time: MessageTime(created: createdAt, completed: createdAt),
+  ),
+  parts: [
+    if (reasoning != null)
+      MessagePart.reasoning(id: "$id-reasoning", sessionID: "ses_a", messageID: id, text: reasoning),
+    _part(id: "$id-part", messageId: id, text: text),
+  ],
 );
 
 Future<void> _captureMessageWithParts({

--- a/bridge/app/test/bridge/services/chat_history_capture_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_capture_test.dart
@@ -392,6 +392,132 @@ void main() {
       );
     });
 
+    test("a first replay replaces semantically identical live rows with different identities", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [
+          _messageWithText(
+            id: "replay",
+            text: "same content",
+            createdAt: 200,
+            promptId: null,
+          ),
+        ],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      await _captureMessageWithParts(
+        history: history,
+        message: _messageWithText(
+          id: "live",
+          text: "same content",
+          createdAt: 100,
+          promptId: "prompt-live",
+        ),
+      );
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      expect(
+        (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
+        const ["replay"],
+      );
+    });
+
+    test("semantic replay matching lets imported attribution replace matching live attribution", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [
+          MessageWithParts(
+            info: const Message.assistant(
+              id: "replay",
+              sessionID: "ses_a",
+              agent: "copilot",
+              modelID: "model-2",
+              providerID: "copilot",
+              sender: MessageSender.agent,
+              time: MessageTime(created: 200, completed: 201),
+            ),
+            parts: [_part(id: "replay-part", messageId: "replay", text: "same response")],
+          ),
+        ],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      await _captureMessageWithParts(
+        history: history,
+        message: MessageWithParts(
+          info: const Message.assistant(
+            id: "live",
+            sessionID: "ses_a",
+            agent: "copilot",
+            modelID: null,
+            providerID: null,
+            sender: MessageSender.agent,
+            time: MessageTime(created: 100, completed: 101),
+          ),
+          parts: [_part(id: "live-part", messageId: "live", text: "same response")],
+        ),
+      );
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      final stored = await _storedMessages(history: history, sessionId: "ses_a");
+      expect(stored.map((message) => message.info.id), const ["replay"]);
+      expect((stored.single.info as MessageAssistant).modelID, "model-2");
+    });
+
+    test("semantic replay matching preserves repeated-message multiplicity", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [
+          _messageWithText(id: "replay-1", text: "repeated", createdAt: 100, promptId: null),
+          _messageWithText(id: "replay-2", text: "repeated", createdAt: 200, promptId: null),
+        ],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      for (final message in [
+        _messageWithText(id: "live-1", text: "repeated", createdAt: 100, promptId: "prompt-1"),
+        _messageWithText(id: "live-2", text: "repeated", createdAt: 200, promptId: "prompt-2"),
+        _messageWithText(id: "live-only", text: "repeated", createdAt: 300, promptId: "prompt-3"),
+      ]) {
+        await _captureMessageWithParts(history: history, message: message);
+      }
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      expect(
+        (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
+        const ["replay-1", "replay-2", "live-only"],
+      );
+    });
+
+    test("semantic replay matching compares normalized stored attachments", () async {
+      const attachment = MessageAttachment.inlineImage(
+        mime: "image/png",
+        base64: "AQID",
+        filename: "fixture.png",
+      );
+      final repository = _FakeSessionRepository(
+        transcript: [
+          MessageWithParts(
+            info: _messageAt(id: "replay", createdAt: 200),
+            parts: [_part(id: "replay-part", messageId: "replay", text: "", attachment: attachment)],
+          ),
+        ],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      await _captureMessageWithParts(
+        history: history,
+        message: MessageWithParts(
+          info: _messageAt(id: "live", createdAt: 100),
+          parts: [_part(id: "live-part", messageId: "live", text: "", attachment: attachment)],
+        ),
+      );
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      expect(
+        (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
+        const ["replay"],
+      );
+    });
+
     test("a re-import restores retained messages to timestamp order", () async {
       final repository = _FakeSessionRepository(
         transcript: [
@@ -639,6 +765,32 @@ MessagePart _part({
     : MessagePart.file(id: id, sessionID: "ses_a", messageID: messageId, attachment: attachment);
 
 MessageWithParts _messageWithParts({required String id}) => _messageWithPartsAt(id: id, createdAt: 1);
+
+MessageWithParts _messageWithText({
+  required String id,
+  required String text,
+  required int createdAt,
+  required String? promptId,
+}) => MessageWithParts(
+  info: Message.user(
+    promptId: promptId,
+    id: id,
+    sessionID: "ses_a",
+    agent: null,
+    time: MessageTime(created: createdAt, completed: null),
+  ),
+  parts: [_part(id: "$id-part", messageId: id, text: text)],
+);
+
+Future<void> _captureMessageWithParts({
+  required TestChatHistory history,
+  required MessageWithParts message,
+}) async {
+  await history.service.captureMessage(sessionId: "ses_a", message: message.info);
+  for (final part in message.parts) {
+    await history.service.capturePart(sessionId: "ses_a", part: part);
+  }
+}
 
 MessageWithParts _messageWithPartsAt({required String id, required int createdAt}) => MessageWithParts(
   info: _messageAt(id: id, createdAt: createdAt),

--- a/bridge/app/test/bridge/services/chat_history_capture_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_capture_test.dart
@@ -409,7 +409,7 @@ void main() {
         message: _messageWithText(
           id: "live",
           text: "same content",
-          createdAt: 100,
+          createdAt: 200,
           promptId: "prompt-live",
         ),
       );
@@ -454,6 +454,31 @@ void main() {
       expect(
         (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
         const ["live-prompt", "live-response", "replay-prompt", "replay-response"],
+      );
+    });
+
+    test("semantic replay matching preserves singleton content with conflicting creation times", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [
+          _messageWithText(id: "anchor", text: "anchor", createdAt: 50, promptId: null),
+          _messageWithText(id: "replay", text: "same content", createdAt: 200, promptId: null),
+          _messageWithText(id: "end", text: "end", createdAt: 300, promptId: null),
+        ],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      for (final message in [
+        _messageWithText(id: "anchor", text: "anchor", createdAt: 50, promptId: "anchor-live"),
+        _messageWithText(id: "live", text: "same content", createdAt: 100, promptId: "prompt-live"),
+        _messageWithText(id: "end", text: "end", createdAt: 300, promptId: "end-live"),
+      ]) {
+        await _captureMessageWithParts(history: history, message: message);
+      }
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      expect(
+        (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
+        const ["anchor", "live", "replay", "end"],
       );
     });
 
@@ -515,7 +540,7 @@ void main() {
             modelID: null,
             providerID: null,
             sender: MessageSender.agent,
-            time: MessageTime(created: 100, completed: 101),
+            time: MessageTime(created: 200, completed: 201),
           ),
           parts: [_part(id: "live-part", messageId: "live", text: "same response")],
         ),
@@ -697,8 +722,34 @@ void main() {
       await _captureMessageWithParts(
         history: history,
         message: MessageWithParts(
-          info: _messageAt(id: "live", createdAt: 100),
+          info: _messageAt(id: "live", createdAt: 200),
           parts: [_part(id: "live-part", messageId: "live", text: "", attachment: attachment)],
+        ),
+      );
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      expect(
+        (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
+        const ["replay"],
+      );
+    });
+
+    test("semantic replay matching ignores persisted parts hidden from transcripts", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [_messageWithText(id: "replay", text: "visible", createdAt: 100, promptId: null)],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      await _captureMessageWithParts(
+        history: history,
+        message: MessageWithParts(
+          info: _messageAt(id: "live", createdAt: 100),
+          parts: [
+            const MessagePart.snapshot(id: "snapshot", sessionID: "ses_a", messageID: "live"),
+            _part(id: "text", messageId: "live", text: "visible"),
+            const MessagePart.patch(id: "patch", sessionID: "ses_a", messageID: "live"),
+            const MessagePart.compaction(id: "compaction", sessionID: "ses_a", messageID: "live"),
+          ],
         ),
       );
 

--- a/bridge/app/test/bridge/services/chat_history_capture_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_capture_test.dart
@@ -9,6 +9,7 @@ import "package:sesori_bridge/src/repositories/models/stored_session.dart";
 import "package:sesori_bridge/src/repositories/session_repository.dart";
 import "package:sesori_bridge/src/services/chat_history_reconcile_service.dart";
 import "package:sesori_bridge/src/services/session_event_dispatcher.dart";
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -482,6 +483,31 @@ void main() {
       );
     });
 
+    test("exact identity anchors tolerate replayed payload updates", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [
+          _messageWithText(id: "anchor", text: "final anchor", createdAt: 50, promptId: null),
+          _messageWithText(id: "replay", text: "same content", createdAt: 100, promptId: null),
+          _messageWithText(id: "end", text: "final end", createdAt: 150, promptId: null),
+        ],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      for (final message in [
+        _messageWithText(id: "anchor", text: "draft anchor", createdAt: 50, promptId: "anchor-live"),
+        _messageWithText(id: "live", text: "same content", createdAt: 100, promptId: "prompt-live"),
+        _messageWithText(id: "end", text: "draft end", createdAt: 150, promptId: "end-live"),
+      ]) {
+        await _captureMessageWithParts(history: history, message: message);
+      }
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      expect(
+        (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
+        const ["anchor", "replay", "end"],
+      );
+    });
+
     test("semantic replay context ignores reasoning omitted by replay", () async {
       final repository = _FakeSessionRepository(
         transcript: [
@@ -761,6 +787,26 @@ void main() {
       );
     });
 
+    test("semantic reconciliation does not log malformed transcript content", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [_messageWithText(id: "replay", text: "replayed", createdAt: 200, promptId: null)],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      await _captureMessageWithParts(
+        history: history,
+        message: _messageWithText(id: "live", text: "live", createdAt: 100, promptId: "prompt-live"),
+      );
+      await history.database.customStatement(
+        "UPDATE history_parts SET part_json = 'secret_payload_fragment' "
+        "WHERE session_id = 'ses_a' AND message_id = 'live'",
+      );
+
+      final warning = await _captureWarningLog(() => history.service.backfillSession(sessionId: "ses_a"));
+
+      expect(warning, contains("Unable to normalize stored history for replay comparison"));
+      expect(warning, isNot(contains("secret_payload_fragment")));
+    });
+
     test("a re-import restores retained messages to timestamp order", () async {
       final repository = _FakeSessionRepository(
         transcript: [
@@ -978,6 +1024,18 @@ void main() {
       expect(await history.repository.getSyncState(sessionId: "ses_orphan"), isNull);
     });
   });
+}
+
+Future<String> _captureWarningLog(Future<void> Function() action) async {
+  final output = BufferingStdout();
+  final previousLevel = Log.level;
+  try {
+    Log.level = LogLevel.warning;
+    await IOOverrides.runZoned(action, stderr: () => output);
+  } finally {
+    Log.level = previousLevel;
+  }
+  return output.text;
 }
 
 Future<List<MessageWithParts>> _storedMessages({

--- a/bridge/app/test/bridge/services/chat_history_capture_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_capture_test.dart
@@ -576,6 +576,29 @@ void main() {
       );
     });
 
+    test("equal-sized shifted replay aligns repeated rows by creation time", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [
+          _messageWithText(id: "replay-2", text: "continue", createdAt: 200, promptId: null),
+          _messageWithText(id: "replay-3", text: "continue", createdAt: 300, promptId: null),
+        ],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      for (final message in [
+        _messageWithText(id: "live-1", text: "continue", createdAt: 100, promptId: "prompt-1"),
+        _messageWithText(id: "live-2", text: "continue", createdAt: 200, promptId: "prompt-2"),
+      ]) {
+        await _captureMessageWithParts(history: history, message: message);
+      }
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      expect(
+        (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
+        const ["live-1", "replay-2", "replay-3"],
+      );
+    });
+
     test("partial replay keeps repeated rows when creation times are absent", () async {
       final repository = _FakeSessionRepository(
         transcript: [

--- a/bridge/app/test/bridge/services/chat_history_capture_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_capture_test.dart
@@ -552,6 +552,54 @@ void main() {
       );
     });
 
+    test("partial replay matches repeated rows by creation time", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [
+          _messageWithText(id: "replay-2", text: "continue", createdAt: 200, promptId: null),
+          _messageWithText(id: "replay-3", text: "continue", createdAt: 300, promptId: null),
+        ],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      for (final message in [
+        _messageWithText(id: "live-1", text: "continue", createdAt: 100, promptId: "prompt-1"),
+        _messageWithText(id: "live-2", text: "continue", createdAt: 200, promptId: "prompt-2"),
+        _messageWithText(id: "live-3", text: "continue", createdAt: 300, promptId: "prompt-3"),
+      ]) {
+        await _captureMessageWithParts(history: history, message: message);
+      }
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      expect(
+        (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
+        const ["live-1", "replay-2", "replay-3"],
+      );
+    });
+
+    test("partial replay keeps repeated rows when creation times are absent", () async {
+      final repository = _FakeSessionRepository(
+        transcript: [
+          _messageWithText(id: "replay-1", text: "continue", createdAt: null, promptId: null),
+          _messageWithText(id: "replay-2", text: "continue", createdAt: null, promptId: null),
+        ],
+      );
+      final history = createTestChatHistory(sessionRepository: repository);
+      for (final message in [
+        _messageWithText(id: "live-1", text: "continue", createdAt: null, promptId: "prompt-1"),
+        _messageWithText(id: "live-2", text: "continue", createdAt: null, promptId: "prompt-2"),
+        _messageWithText(id: "live-3", text: "continue", createdAt: null, promptId: "prompt-3"),
+      ]) {
+        await _captureMessageWithParts(history: history, message: message);
+      }
+
+      await history.service.backfillSession(sessionId: "ses_a");
+
+      expect(
+        (await _storedMessages(history: history, sessionId: "ses_a")).map((message) => message.info.id),
+        const ["replay-1", "replay-2", "live-1", "live-2", "live-3"],
+      );
+    });
+
     test("exact identity matches consume replay capacity before semantic matching", () async {
       final repository = _FakeSessionRepository(
         transcript: [_messageWithText(id: "replay", text: "repeated", createdAt: 100, promptId: null)],
@@ -890,7 +938,7 @@ MessageWithParts _messageWithParts({required String id}) => _messageWithPartsAt(
 MessageWithParts _messageWithText({
   required String id,
   required String text,
-  required int createdAt,
+  required int? createdAt,
   required String? promptId,
 }) => MessageWithParts(
   info: Message.user(
@@ -898,7 +946,7 @@ MessageWithParts _messageWithText({
     id: id,
     sessionID: "ses_a",
     agent: null,
-    time: MessageTime(created: createdAt, completed: null),
+    time: createdAt == null ? null : MessageTime(created: createdAt, completed: null),
   ),
   parts: [_part(id: "$id-part", messageId: id, text: text)],
 );

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -31,13 +31,18 @@ reconnect or restart.
   before the next prompt without duplicating replay into the live stream. Sesori
   uses the public protocol and never reads Copilot credential or history files.
 - Messages visible live but absent from the backend's replay remain visible
-  after a stale re-read. They rejoin at their recorded creation time while
-  preserving relative order, so a catalog re-import cannot move old rows to the
-  newest edge. A message a backend replay once contained is the opposite case:
-  its later absence is a removal, so a re-read drops it. That is how a session
-  rolled back outside Sesori — an edited message in the backend's own client,
-  with no removal events reaching this bridge — stops showing the messages it
-  replaced.
+  after a stale re-read unless replay contains the same normalized message in
+  the same nearest-distinct visible-message context under a different identity. In that
+  case, replay replaces the live row up to replay's multiplicity; equal content
+  in another ordered context and additional repeated occurrences remain. The
+  comparison ignores identity, time, and agent/model attribution, normalizes
+  spilled attachments, and keeps replay metadata authoritative. Other retained
+  rows rejoin at their recorded creation time while preserving relative order,
+  so a catalog re-import cannot move old rows to the newest edge. A message a
+  backend replay once contained is the opposite case: its later absence is a
+  removal, so a re-read drops it. That is how a session rolled back outside
+  Sesori — an edited message in the backend's own client, with no removal events
+  reaching this bridge — stops showing the messages it replaced.
 - Live streamed messages and parts become queryable immediately after they
   finalize, with the same visibility filtering and tool-output bound a backend
   fetch returns. Reasoning finalizes when the stream advances to assistant or
@@ -89,7 +94,7 @@ reconnect or restart.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Headless bridge, one representative plugin: a previously synced session's transcript is served with every backend stopped. |
-| L2 Routine | Live plugin, representative: first backfill, replayed prompt-default persistence and response precedence, live capture that becomes immediately queryable, stale re-read ordering for retained live-only rows, and paging older messages on a transcript longer than one page. Automated OpenCode, Codex, Claude, and Pi coverage preserves available historical effort or thinking-level variants from assistant/error messages; Pi covers active-branch attribution and file fallback. Automated Pi coverage also includes v1-v3 fallback migration, compaction visibility, hidden-context decoding, bounded tool/image mapping, content-index streaming, cumulative tool updates, and live/replay final parity. |
+| L2 Routine | Live plugin, representative: first backfill, replayed prompt-default persistence and response precedence, live capture that becomes immediately queryable, semantic identity reconciliation with ordered-context and multiplicity preservation (including normalized attachments), stale re-read ordering for retained live-only rows, and paging older messages on a transcript longer than one page. Automated OpenCode, Codex, Claude, and Pi coverage preserves available historical effort or thinking-level variants from assistant/error messages; Pi covers active-branch attribution and file fallback. Automated Pi coverage also includes v1-v3 fallback migration, compaction visibility, hidden-context decoding, bounded tool/image mapping, content-index streaming, cumulative tool updates, and live/replay final parity. |
 | L3 Release | Client end to end on the release-target client platform, every supporting production plugin: open a long session, page back, continue a live turn, reopen cold, and confirm live and replayed content converge including tool and image parts. |
 | L4 Extended | Relay integration plus owning client automated coverage, every supporting production plugin: session advanced through the backend's own CLI, plugin restart and event-stream-gap invalidation, bridge restart, client reconnect inside and outside the replay window without refresh losing concurrently finalized content, two clients on one session, a slow request beside unrelated traffic. Copilot additionally replaces its ACP process, reloads the same session, and converges standard replay with the bridge transcript without duplicate live delivery. |
 | L5 Full | Automated and headless bridge for unreadable or partial store artifacts, interrupted backfill, and startup reconciliation; packaged or external for pagination's released-client shape; live plugin for very large transcripts. Every supporting production plugin. |
@@ -115,9 +120,11 @@ image parts converge by their own rules.
   reattachment, or triggers repeated requests while one page is in flight.
 - A session advanced outside Sesori keeps serving the old transcript, or stored
   transcripts are marked complete after a gap without a full re-sync.
-- A stale re-read moves an older retained message to the newest edge, or keeps
-  showing a message the backend removed — a rolled-back turn reappearing above
-  the edited one that replaced it.
+- A stale re-read moves an older retained message to the newest edge, keeps a
+  second copy of one visible message solely because replay changed its identity,
+  collapses equal content from a different ordered context or beyond replay's
+  multiplicity, or keeps showing a message the backend removed — a rolled-back
+  turn reappearing above the edited one that replaced it.
 - A released database row or audit file is rejected because a known message-part
   payload omitted variant-specific data, or a decoded known variant still carries
   null variant data.

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -34,9 +34,11 @@ reconnect or restart.
   after a stale re-read. Exact identities satisfy their replay occurrences
   first. Among the remaining rows, replay replaces a live row only when it has
   the same normalized message and nearest-distinct visible-message context,
-  up to the remaining replay multiplicity. Equal content in another ordered
-  context and additional repeated occurrences remain, while stored rows already
-  stale at this import do not shape the comparison context. The comparison
+  up to the remaining replay multiplicity. When replay covers only part of a
+  repeated run, equal creation times align its occurrences; ambiguous rows with
+  absent or different times remain. Equal content in another ordered context
+  and additional repeated occurrences remain, while stored rows already stale
+  at this import do not shape the comparison context. The comparison
   ignores identity, time, and agent/model attribution, normalizes spilled
   attachments, and keeps replay metadata authoritative. Other retained rows
   rejoin at their recorded creation time while preserving relative order, so a

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -34,9 +34,10 @@ reconnect or restart.
   after a stale re-read. Exact identities satisfy their replay occurrences
   first. Among the remaining rows, replay replaces a live row only when it has
   the same normalized message and nearest-distinct visible-message context,
-  up to the remaining replay multiplicity. When replay covers only part of a
-  repeated run, equal creation times align its occurrences; ambiguous rows with
-  absent or different times remain. Equal content in another ordered context
+  up to the remaining replay multiplicity. When either side contains repeated
+  occurrences in one context, equal creation times align them even at equal
+  cardinality; ambiguous rows with absent or different times remain. Equal
+  content in another ordered context
   and additional repeated occurrences remain, while stored rows already stale
   at this import do not shape the comparison context. The comparison
   ignores identity, time, and agent/model attribution, normalizes spilled

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -31,18 +31,20 @@ reconnect or restart.
   before the next prompt without duplicating replay into the live stream. Sesori
   uses the public protocol and never reads Copilot credential or history files.
 - Messages visible live but absent from the backend's replay remain visible
-  after a stale re-read unless replay contains the same normalized message in
-  the same nearest-distinct visible-message context under a different identity. In that
-  case, replay replaces the live row up to replay's multiplicity; equal content
-  in another ordered context and additional repeated occurrences remain. The
-  comparison ignores identity, time, and agent/model attribution, normalizes
-  spilled attachments, and keeps replay metadata authoritative. Other retained
-  rows rejoin at their recorded creation time while preserving relative order,
-  so a catalog re-import cannot move old rows to the newest edge. A message a
-  backend replay once contained is the opposite case: its later absence is a
-  removal, so a re-read drops it. That is how a session rolled back outside
-  Sesori — an edited message in the backend's own client, with no removal events
-  reaching this bridge — stops showing the messages it replaced.
+  after a stale re-read. Exact identities satisfy their replay occurrences
+  first. Among the remaining rows, replay replaces a live row only when it has
+  the same normalized message and nearest-distinct visible-message context,
+  up to the remaining replay multiplicity. Equal content in another ordered
+  context and additional repeated occurrences remain, while stored rows already
+  stale at this import do not shape the comparison context. The comparison
+  ignores identity, time, and agent/model attribution, normalizes spilled
+  attachments, and keeps replay metadata authoritative. Other retained rows
+  rejoin at their recorded creation time while preserving relative order, so a
+  catalog re-import cannot move old rows to the newest edge. A message a backend
+  replay once contained is the opposite case: its later absence is a removal,
+  so a re-read drops it. That is how a session rolled back outside Sesori — an
+  edited message in the backend's own client, with no removal events reaching
+  this bridge — stops showing the messages it replaced.
 - Live streamed messages and parts become queryable immediately after they
   finalize, with the same visibility filtering and tool-output bound a backend
   fetch returns. Reasoning finalizes when the stream advances to assistant or

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -36,12 +36,14 @@ reconnect or restart.
   the same normalized message and nearest-distinct visible-message context,
   up to the remaining replay multiplicity. When either side contains repeated
   occurrences in one context, equal creation times align them even at equal
-  cardinality; ambiguous rows with absent or different times remain. Equal
-  content in another ordered context
-  and additional repeated occurrences remain, while stored rows already stale
-  at this import do not shape the comparison context. The comparison
-  ignores identity, time, and agent/model attribution, normalizes spilled
-  attachments, and keeps replay metadata authoritative. Other retained rows
+  cardinality; ambiguous rows with absent or different times remain. Conflicting
+  known creation times also keep a singleton pair distinct. Equal content in
+  another ordered context and additional repeated occurrences remain, while
+  stored rows already stale at this import do not shape the comparison context.
+  The content fingerprint ignores identity, time, agent/model attribution, and
+  internal parts hidden from transcripts; alignment still uses available
+  creation times as above, normalizes spilled attachments, and keeps replay
+  metadata authoritative. Other retained rows
   rejoin at their recorded creation time while preserving relative order, so a
   catalog re-import cannot move old rows to the newest edge. A message a backend
   replay once contained is the opposite case: its later absence is a removal,

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -32,7 +32,8 @@ reconnect or restart.
   uses the public protocol and never reads Copilot credential or history files.
 - Messages visible live but absent from the backend's replay remain visible
   after a stale re-read. Exact identities satisfy their replay occurrences
-  first. Among the remaining rows, replay replaces a live row only when it has
+  first and anchor neighboring order by identity even when replay revises their
+  payload. Among the remaining rows, replay replaces a live row only when it has
   the same normalized message and nearest-distinct visible-message context,
   up to the remaining replay multiplicity. When either side contains repeated
   occurrences in one context, equal creation times align them even at equal
@@ -132,6 +133,8 @@ image parts converge by their own rules.
   collapses equal content from a different ordered context or beyond replay's
   multiplicity, or keeps showing a message the backend removed — a rolled-back
   turn reappearing above the edited one that replaced it.
+- Replay reconciliation logs malformed persisted prompt, transcript, or tool
+  content instead of a privacy-safe decode failure with message/session context.
 - A released database row or audit file is rejected because a known message-part
   payload omitted variant-specific data, or a decoded known variant still carries
   null variant data.


### PR DESCRIPTION
## Complexity

⚙️ Moderate — changes persisted transcript reconciliation while preserving existing retention, rollback, attachment, and multiplicity behavior.

## What

- normalize imported and stored messages to the same persisted attachment representation and exclude internal parts hidden from transcripts before replay reconciliation
- compare replay and live-captured rows semantically when identities differ, their nearest distinct visible-message context agrees, and known singleton creation times do not conflict
- retain eligible occurrences beyond replay multiplicity; repeated runs align only by exact creation time even at equal cardinality, and ambiguous missing-time rows remain
- keep imported replay rows authoritative for model/agent attribution and other replay metadata, while exact IDs anchor neighboring context even if their payload changes
- sanitize malformed persisted-payload decode errors before recovered reconciliation logs them
- document the persisted replay-reconciliation contract and add focused coverage for identity drift, exact anchors, ordered-context safety, omitted replay reasoning, attribution replacement, repeated content, attachment normalization, and existing retention/removal races

## Why

GitHub Copilot ACP replay uses different message identities from its live stream. On the first cold backfill after a clean bridge restart, the history repository treated every earlier live row as absent from replay and retained it beside its equivalent replay row. Live regression expanded two transcripts from 33→63 and 17→29 messages.

## Risk and test focus

Risk is moderate and localized to transcript backfill. Focus review on avoiding false collapse of equal content from different ordered contexts or conflicting known times, aligning repeated runs without consuming shifted occurrences even at equal cardinality, using exact IDs rather than mutable payloads as context anchors, ignoring internal non-visible parts without dropping visible content, preserving ambiguous or live-only rows, satisfying exact-ID replay occurrences before semantic matching, excluding stale rows from reconciliation context, keeping backend removals authoritative, sanitizing malformed payload logs, and comparing spilled attachments without exposing bytes. There is no schema, migration, wire-contract, database-column, client, or plugin-specific change. Existing already-duplicated rows are not migrated.

## Expected result

The first cold backfill after a bridge restart replaces semantically equivalent live rows even when replay identities differ, while retaining unmatched live content. A fresh live Copilot reproduction remained at two messages with two unique semantic messages and zero duplicates after restart. Normal live rendering is unchanged.

## Verification

- `cd bridge/app && dart analyze --fatal-infos`
- 90 focused chat-history reconciliation, serving, attachment, pagination, live-delivery, and tool-finalization tests pass
- live Copilot `1.0.80` bridge restart: 2 live-stored messages → 2 cold-replayed messages; 0 semantic duplicates
- architecture plan review: approved
- architecture implementation review: approved
- `git diff --check origin/main...HEAD`
