### PR TITLE
🌿 Keep live session activity timestamps current

### DIFF
--- a/client/module_core/lib/src/services/session_list_service.dart
+++ b/client/module_core/lib/src/services/session_list_service.dart
@@ -34,7 +34,13 @@ class SessionListService({
     required Map<String, SessionActivityInfo> activityBySessionId,
     required Map<String, SessionListItemState> listStateBySessionId,
   }) {
-    final visible = showArchived ? sessions : sessions.where((session) => session.time?.archived == null);
+    final projected = sessions.map(
+      (session) => _mergeLiveListState(
+        session: session,
+        listState: listStateBySessionId[session.id],
+      ),
+    );
+    final visible = showArchived ? projected : projected.where((session) => session.time?.archived == null);
     final running = <Session>[];
     final remaining = <Session>[];
     for (final session in visible) {
@@ -89,6 +95,31 @@ class SessionListService({
 
   List<Session> removeSession({required Iterable<Session> sessions, required String sessionId}) {
     return _sortSessions(sessions.where((session) => session.id != sessionId));
+  }
+
+  /// Projects a live user-activity marker into the row's displayed recency.
+  ///
+  /// REST session rows already fold this marker into `time.updated`, but a
+  /// newer marker can arrive over SSE after the fetch. Keeping the live
+  /// projection here ensures the row does not reorder on fresh activity while
+  /// continuing to display its stale REST timestamp.
+  Session _mergeLiveListState({
+    required Session session,
+    required SessionListItemState? listState,
+  }) {
+    final lastUserActivityAt = latestUserActivityAt(
+      first: session.lastUserActivityAt,
+      second: listState?.lastUserActivityAt,
+    );
+    final time = session.time;
+    if (time == null || lastUserActivityAt == null || lastUserActivityAt <= time.updated) {
+      if (lastUserActivityAt == session.lastUserActivityAt) return session;
+      return session.copyWith(lastUserActivityAt: lastUserActivityAt);
+    }
+    return session.copyWith(
+      time: time.copyWith(updated: lastUserActivityAt),
+      lastUserActivityAt: lastUserActivityAt,
+    );
   }
 
   List<Session> _sortSessions(Iterable<Session> sessions) {

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -2022,7 +2022,7 @@ void main() {
       expect((cubit.state as SessionListLoaded).unseenBySessionId, equals({"s1": true, "s2": false}));
     });
 
-    test("live tracker marker reorders sessions that are already running", () async {
+    test("live tracker marker reorders running sessions and advances displayed recency", () async {
       mockRouteSource = MockRouteSource(initialRoute: AppRouteDef.sessions);
       when(
         () => mockProjectRepository.listSessions(
@@ -2063,7 +2063,10 @@ void main() {
       });
       await Future<void>.delayed(Duration.zero);
 
-      expect((cubit.state as SessionListLoaded).sessions.map((session) => session.id), ["older", "newer"]);
+      final loaded = cubit.state as SessionListLoaded;
+      expect(loaded.sessions.map((session) => session.id), ["older", "newer"]);
+      expect(loaded.sessions.first.time?.updated, 30);
+      expect(loaded.sessions.first.lastUserActivityAt, 30);
     });
 
     test("live marker received during REST fetch wins over the stale seed", () async {

--- a/client/module_core/test/services/session_list_service_test.dart
+++ b/client/module_core/test/services/session_list_service_test.dart
@@ -40,6 +40,32 @@ void main() {
     );
   });
 
+  test("live activity advances displayed recency without regressing a newer backend time", () {
+    final service = SessionListService(
+      repository: _MockProjectRepository(),
+      activityCalculator: const SessionActivityCalculator(),
+    );
+
+    final result = service.visibleSessions(
+      sessions: [
+        _session(id: "live-newer", title: "Live", updatedAt: 100).copyWith(lastUserActivityAt: 80),
+        _session(id: "backend-newer", title: "Backend", updatedAt: 400).copyWith(lastUserActivityAt: 100),
+      ],
+      showArchived: true,
+      activityBySessionId: const {},
+      listStateBySessionId: const {
+        "live-newer": (unseen: false, lastUserActivityAt: 300),
+        "backend-newer": (unseen: false, lastUserActivityAt: 300),
+      },
+    );
+    final byId = {for (final session in result) session.id: session};
+
+    expect(byId["live-newer"]?.time?.updated, 300);
+    expect(byId["live-newer"]?.lastUserActivityAt, 300);
+    expect(byId["backend-newer"]?.time?.updated, 400);
+    expect(byId["backend-newer"]?.lastUserActivityAt, 300);
+  });
+
   test("running sessions use REST markers before updated-time fallback", () {
     final service = SessionListService(
       repository: _MockProjectRepository(),


### PR DESCRIPTION
## Complexity

🌿 Straightforward — localized shared-client projection and focused regression coverage.

## What

- Merge the latest live user-activity marker into each visible session's displayed `time.updated`.
- Preserve a newer backend-reported timestamp rather than regressing it.
- Cover the service projection and the session-list cubit's live update path.

## Why

A REST-loaded session could receive newer live activity and reorder correctly while still displaying the stale REST timestamp. This was especially visible for harnesses such as Pi whose backend timestamp does not advance on every turn.

## Risk and test focus

Low risk: this changes only the client-side session-list projection. There is no database, wire-contract, or persistence impact. The user-visible impact is limited to showing the correct relative activity time and corresponding list order.

## Expected result

A session used minutes ago displays that recent activity immediately, even when its original REST row was loaded hours earlier. A newer backend timestamp remains authoritative.

## Verification

- `cd client && dart pub get`
- `cd client/module_core && dart test test/services/session_list_service_test.dart test/cubits/session_list/session_list_cubit_test.dart`
- `cd client/module_core && dart analyze`
- `cd client/app && dart analyze`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the session list so live user activity now advances an already-loaded session's displayed activity time instead of leaving the stale REST timestamp visible, which was especially noticeable for Pi harnesses where the backend timestamp doesn't advance every turn.

- Projects the latest live activity marker into each session's `time.updated`.
- Keeps a newer backend-reported timestamp authoritative.
- Adds regression coverage for the service projection and the session-list cubit's live update path.

<sup>Written for commit 919d004d8dd7ee5f852ca20645e0a6c3a1e13ac1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

