### PR TITLE
⚙️ [grok-harness] feat(grok): add direct-CLI setup and lifecycle [step 5/9]

### DIFF
--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -3,13 +3,13 @@
 ## Current State
 
 - **Plan:** `.plan/active/grok-harness/PLAN.md`
-- **Status:** Steps 1-3/9 merged; Step 4/9 in PR
-- **Current branch:** `grok-harness-step-4-core`
-- **Base:** `origin/main` after merged PR #1160
+- **Status:** Steps 1-3/9 merged; Step 4/9 in PR; Step 5/9 implemented locally
+- **Current branch:** `grok-harness-step-5-lifecycle`
+- **Base:** `grok-harness-step-4-core` (PR #1169)
 - **Architecture plan review:** approved 2026-08-27 after catalog ownership and auth-policy corrections
 - **Merged predecessor:** #1160 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1160>
 - **Open PR:** #1169 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1169>
-- **Current step:** `grok-harness-step-4-core`; monitor CI and review, then advance the local Step 5 successor
+- **Local successor:** `grok-harness-step-5-lifecycle`; descriptor/setup implementation under verification
 
 ## Fixed Series
 
@@ -26,7 +26,7 @@
    - **Evidence:** generic auth allowlist, Grok plugin composition, 270 ACP tests, 42 Grok tests, affected-package
      analyzers, LSP diagnostics, two architecture approvals, and the 1,500-line budget pass.
 5. `⚙️ [grok-harness] feat(grok): add direct-CLI setup and lifecycle [step 5/9]`
-   - **State:** not started.
+   - **State:** implemented locally; held until #1169 merges.
 6. `⚙️ [grok-harness] feat(bridge): activate Grok Build [step 6/9]`
    - **State:** not started.
 7. `🌿 [grok-harness] feat(client): brand Grok Build [step 7/9]`
@@ -90,6 +90,19 @@
 - [x] Run initial and final architecture implementation reviews over Step 4 against Step 3; both approved.
 - [x] Complete the post-rebase general correctness review; final verdict approved.
 - [x] Publish Step 4 as PR #1169 after #1160's merge and start its PR monitor.
+
+## Step 5 Checklist
+
+- [x] Add `--grok-bin`, the frozen 1.0.5 floor/target, and explicit-before-PATH selection.
+- [x] Classify missing, malformed, outdated, current, and bounded-output version probes without reading credentials.
+- [x] Revalidate the selected runtime in `ensureRuntime`; never install, update, or fall back from an explicit path.
+- [x] Compose one host-process-backed `GrokPlugin`/`AcpBridgePlugin` with bounded eager connection.
+- [x] Surface local `grok login`/headless-credential guidance while isolating auth/start/crash degradation to Grok.
+- [x] Cover setup, provisioning, abort, auth rejection, crash/reconnect, reported version, and owned shutdown.
+- [x] Pass 52 Grok tests, fatal-info analysis, LSP diagnostics, whitespace, and authored line-width checks.
+- [x] Keep the measured Step 5 change below the 1,500-line soft cap (currently 844 lines).
+- [x] Run architecture implementation review over Step 5 against Step 4; approved with no findings.
+- [x] Commit the completed successor locally; do not publish before #1169 merges.
 
 ## Decisions And Evidence
 

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -3,13 +3,13 @@
 ## Current State
 
 - **Plan:** `.plan/active/grok-harness/PLAN.md`
-- **Status:** Steps 1-3/9 merged; Step 4/9 in PR; Step 5/9 implemented locally
+- **Status:** Steps 1-4/9 merged; Step 5/9 in PR
 - **Current branch:** `grok-harness-step-5-lifecycle`
-- **Base:** `grok-harness-step-4-core` (PR #1169)
+- **Base:** `origin/main` after merged PR #1169
 - **Architecture plan review:** approved 2026-08-27 after catalog ownership and auth-policy corrections
-- **Merged predecessor:** #1160 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1160>
-- **Open PR:** #1169 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1169>
-- **Local successor:** `grok-harness-step-5-lifecycle`; descriptor/setup implementation under verification
+- **Merged predecessor:** #1169 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1169>
+- **Open PR:** #1175 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1175>
+- **Local successor:** Step 6 starts after Step 5 publication
 
 ## Fixed Series
 
@@ -22,11 +22,11 @@
 3. `⚙️ [grok-harness] feat(grok): expose models and reasoning effort [step 3/9]`
    - **State:** merged in #1160.
 4. `⚙️ [grok-harness] feat(grok): compose ACP sessions and turns [step 4/9]`
-   - **State:** in PR #1169.
+   - **State:** merged in #1169.
    - **Evidence:** generic auth allowlist, Grok plugin composition, 270 ACP tests, 42 Grok tests, affected-package
      analyzers, LSP diagnostics, two architecture approvals, and the 1,500-line budget pass.
 5. `⚙️ [grok-harness] feat(grok): add direct-CLI setup and lifecycle [step 5/9]`
-   - **State:** implemented locally; held until #1169 merges.
+   - **State:** in PR #1175.
 6. `⚙️ [grok-harness] feat(bridge): activate Grok Build [step 6/9]`
    - **State:** not started.
 7. `🌿 [grok-harness] feat(client): brand Grok Build [step 7/9]`
@@ -100,9 +100,10 @@
 - [x] Surface local `grok login`/headless-credential guidance while isolating auth/start/crash degradation to Grok.
 - [x] Cover setup, provisioning, abort, auth rejection, crash/reconnect, reported version, and owned shutdown.
 - [x] Pass 52 Grok tests, fatal-info analysis, LSP diagnostics, whitespace, and authored line-width checks.
-- [x] Keep the measured Step 5 change below the 1,500-line soft cap (currently 844 lines).
+- [x] Keep the measured Step 5 change below the 1,500-line soft cap (currently 845 lines).
 - [x] Run architecture implementation review over Step 5 against Step 4; approved with no findings.
 - [x] Commit the completed successor locally; do not publish before #1169 merges.
+- [x] Rebase onto merged #1169, reverify, publish PR #1175, and start its monitor.
 
 ## Decisions And Evidence
 

--- a/bridge/sesori_plugin_grok/lib/grok_plugin.dart
+++ b/bridge/sesori_plugin_grok/lib/grok_plugin.dart
@@ -1,7 +1,9 @@
 // Grok Build backend for the Sesori bridge.
 //
 // Drives the official `grok agent stdio` ACP server through Sesori's generic
-// ACP machinery. Production composition lands in later grok-harness steps.
+// ACP machinery using the user's installed direct-CLI runtime.
 export "src/grok_binary.dart";
 export "src/grok_identity.dart";
 export "src/grok_plugin_impl.dart";
+// Plugin-lifecycle entry point: the const descriptor the bridge registers.
+export "src/runtime/grok_plugin_descriptor.dart";

--- a/bridge/sesori_plugin_grok/lib/src/grok_plugin_impl.dart
+++ b/bridge/sesori_plugin_grok/lib/src/grok_plugin_impl.dart
@@ -79,6 +79,11 @@ class GrokPlugin._({
   Set<String> get authMethodAllowlist => GrokAcpApi.headlessAuthMethodIds;
 
   @override
+  String? get authenticationFailureActionHint => super.authenticationFailureActionHint == null
+      ? null
+      : "Run `grok login` or configure a headless Grok credential locally, then retry.";
+
+  @override
   bool get cancelsActiveTurnForQueuedInput => true;
 
   @override

--- a/bridge/sesori_plugin_grok/lib/src/runtime/grok_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_grok/lib/src/runtime/grok_plugin_descriptor.dart
@@ -1,0 +1,233 @@
+import "dart:async";
+import "dart:io" as io;
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart"
+    show CommandResult, HostProcessCommandExecutor, SemanticVersion, stripAnsi;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../grok_binary.dart";
+import "../grok_identity.dart";
+import "../grok_plugin_impl.dart";
+
+const int _setupProbeOutputLimit = 64 * 1024;
+
+/// Direct-CLI descriptor for the user-installed Grok Build runtime.
+///
+/// Sesori never installs or updates Grok. Setup and provisioning only run a
+/// bounded `--version` probe, while authentication remains authoritative at the
+/// ACP initialize handshake.
+class const GrokPluginDescriptor() extends BridgePluginDescriptor {
+  static const Duration _connectBudget = Duration(seconds: 15);
+  static const Duration _versionProbeTimeout = Duration(seconds: 10);
+
+  /// Oldest and latest stable Grok Build release validated for this plugin.
+  static const String minVersion = "1.0.5";
+  static const String targetVersion = "1.0.5";
+
+  static final SemanticVersion _minimumVersion = SemanticVersion.parse(value: minVersion);
+
+  /// Namespaced by the bridge CLI mapper as `--grok-bin`.
+  static const String binOption = "bin";
+
+  static const List<PluginOption> cliOptions = [
+    PluginValueOption(
+      name: binOption,
+      help: "Path to the Grok Build CLI binary (grok)",
+      defaultsTo: GrokBinary.defaultBinary,
+      allowedValues: null,
+      valueHelp: "path",
+      validate: null,
+    ),
+  ];
+
+  @override
+  String get id => GrokPluginIdentity.id;
+
+  @override
+  String get displayName => GrokPluginIdentity.displayName;
+
+  @override
+  PluginProjectOwnership get projectOwnership => PluginProjectOwnership.bridgeDerived;
+
+  @override
+  PluginSessionOptionsScope get sessionOptionsScope => PluginSessionOptionsScope.plugin;
+
+  @override
+  bool get supportsPromptAttachments => false;
+
+  @override
+  List<PluginOption> get options => cliOptions;
+
+  String? _explicitBin({required PluginConfig config}) {
+    final value = config.value(binOption)?.trim();
+    if (value == null || value.isEmpty || value == GrokBinary.defaultBinary) return null;
+    return value;
+  }
+
+  @override
+  Stream<RuntimeProvisionProgress> ensureRuntime({required PluginHost host}) async* {
+    if (host.startAborted.isAborted) throw const PluginStartAbortedException();
+
+    final executablePath = _explicitBin(config: host.config) ?? GrokBinary.defaultBinary;
+    final runtime = await _probeRuntime(
+      executablePath: executablePath,
+      processes: host.processes,
+      environment: host.environment,
+    );
+    if (host.startAborted.isAborted) throw const PluginStartAbortedException();
+
+    switch (runtime) {
+      case _GrokRuntimeReady():
+        yield ProvisionReady(binaryPath: executablePath);
+      case _GrokRuntimeMissing():
+        yield const ProvisionFailed(
+          message: "Grok Build is unavailable. Install it with xAI's official installer, then retry.",
+        );
+      case _GrokRuntimeOutdated():
+        yield const ProvisionFailed(
+          message: "The Grok Build version is too old. Update Grok, then retry.",
+        );
+      case _GrokRuntimeUnknown() || _GrokRuntimeUnrecognized():
+        yield const ProvisionFailed(
+          message: "The Grok Build runtime could not be verified. Check the local install, then retry.",
+        );
+    }
+  }
+
+  @override
+  Future<PluginSetupStatus> inspectSetup({
+    required PluginConfig config,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+    required String stateDirectory,
+  }) async {
+    final explicitBin = _explicitBin(config: config);
+    final runtime = await _probeRuntime(
+      executablePath: explicitBin ?? GrokBinary.defaultBinary,
+      processes: processes,
+      environment: environment,
+    );
+
+    return switch (runtime) {
+      _GrokRuntimeReady(:final version) => PluginSetupReady.versioned(runtimeVersion: version),
+      _GrokRuntimeMissing() => PluginSetupRuntimeMissing(
+        actionHint: explicitBin == null
+            ? "Install Grok Build with xAI's official installer, then restart the bridge."
+            : "Fix the configured Grok Build binary path, then restart the bridge.",
+      ),
+      _GrokRuntimeOutdated() => PluginSetupUnavailable(
+        actionHint: explicitBin == null
+            ? "Update Grok Build with xAI's official installer, then restart the bridge."
+            : "Update the configured Grok Build binary or fix `--grok-bin`, then restart the bridge.",
+      ),
+      _GrokRuntimeUnknown() || _GrokRuntimeUnrecognized() => const PluginSetupUnknown(
+        actionHint: "Grok Build setup could not be verified. Run `grok --version` locally, then retry.",
+      ),
+    };
+  }
+
+  Future<_GrokRuntimeProbe> _probeRuntime({
+    required String executablePath,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+  }) async {
+    final executor = HostProcessCommandExecutor(
+      processes: processes,
+      runInShell: io.Platform.isWindows,
+      maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
+    );
+    final CommandResult result;
+    try {
+      result = await executor.run(
+        executablePath,
+        const ["--version"],
+        environment: environment,
+        timeout: _versionProbeTimeout,
+      );
+    } on TimeoutException catch (error, stackTrace) {
+      Log.w(
+        "[grok] version probe '$executablePath --version' did not exit within "
+        "${_versionProbeTimeout.inSeconds}s",
+        error,
+        stackTrace,
+      );
+      return const _GrokRuntimeUnknown();
+    } on io.ProcessException catch (error, stackTrace) {
+      if (error.errorCode == 2) return const _GrokRuntimeMissing();
+      Log.w("[grok] version probe could not launch '$executablePath --version'", error, stackTrace);
+      return const _GrokRuntimeUnknown();
+    } on Object catch (error, stackTrace) {
+      Log.w("[grok] version probe could not launch '$executablePath --version'", error, stackTrace);
+      return const _GrokRuntimeUnknown();
+    }
+
+    if (result.exitCode != 0) {
+      final stderr = result.stderr.toLowerCase();
+      if (_isShellCommandNotFound(stderr: stderr)) return const _GrokRuntimeMissing();
+      Log.w("[grok] version probe '$executablePath --version' exited with code ${result.exitCode}");
+      return const _GrokRuntimeUnknown();
+    }
+
+    final parsed = _tryParseVersion(output: "${result.stdout}\n${result.stderr}");
+    if (parsed == null) return const _GrokRuntimeUnrecognized();
+    if (parsed.compareTo(_minimumVersion) < 0) {
+      Log.w(
+        "[grok] Grok Build ${parsed.toString()} is below the supported minimum ${_minimumVersion.toString()}",
+      );
+      return const _GrokRuntimeOutdated();
+    }
+    return _GrokRuntimeReady(version: parsed.toString());
+  }
+
+  bool _isShellCommandNotFound({required String stderr}) =>
+      stderr.contains("is not recognized as an internal or external command") ||
+      stderr.contains("is not recognized as the name of a cmdlet") ||
+      stderr.contains("command not found");
+
+  SemanticVersion? _tryParseVersion({required String output}) {
+    final sanitized = stripAnsi(value: output);
+    for (final rawLine in sanitized.split("\n")) {
+      final tokens = rawLine.trim().split(RegExp(r"\s+"));
+      if (tokens.isEmpty || tokens.first.toLowerCase() != GrokBinary.defaultBinary) continue;
+      var versionIndex = 1;
+      if (tokens.length > versionIndex && tokens[versionIndex].toLowerCase() == "version") versionIndex++;
+      if (tokens.length <= versionIndex) continue;
+      final token = tokens[versionIndex];
+      final candidate = (token.startsWith("v") || token.startsWith("V")) ? token.substring(1) : token;
+      final version = SemanticVersion.tryParse(value: candidate);
+      if (version != null) return version;
+    }
+    return null;
+  }
+
+  @override
+  Future<BridgePlugin> start(PluginHost host) async {
+    if (host.startAborted.isAborted) throw const PluginStartAbortedException();
+
+    final binaryPath = _explicitBin(config: host.config) ?? host.provisionedRuntimePath ?? GrokBinary.defaultBinary;
+    final cwd = io.Directory.current.path;
+    final grok = GrokPlugin(
+      binaryPath: binaryPath,
+      launchDirectory: cwd,
+      environment: host.environment,
+      processFactory: hostProcessAcpFactory(
+        processes: host.processes,
+        environment: host.environment,
+      ),
+    );
+    return await AcpBridgePlugin.start(plugin: grok, host: host, connectBudget: _connectBudget);
+  }
+}
+
+sealed class const _GrokRuntimeProbe();
+
+final class const _GrokRuntimeReady({required final String version}) extends _GrokRuntimeProbe;
+
+final class const _GrokRuntimeMissing() extends _GrokRuntimeProbe;
+
+final class const _GrokRuntimeOutdated() extends _GrokRuntimeProbe;
+
+final class const _GrokRuntimeUnknown() extends _GrokRuntimeProbe;
+
+final class const _GrokRuntimeUnrecognized() extends _GrokRuntimeProbe;

--- a/bridge/sesori_plugin_grok/pubspec.yaml
+++ b/bridge/sesori_plugin_grok/pubspec.yaml
@@ -10,6 +10,8 @@ dependencies:
   acp_plugin:
     path: ../sesori_plugin_acp
   freezed_annotation: ^3.1.0
+  sesori_bridge_foundation:
+    path: ../sesori_bridge_foundation
   sesori_plugin_interface:
     path: ../sesori_plugin_interface
   json_annotation: ^4.12.0

--- a/bridge/sesori_plugin_grok/test/grok_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_plugin_descriptor_test.dart
@@ -1,0 +1,577 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:grok_plugin/grok_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("GrokPluginDescriptor", () {
+    const stateDirectory = "/state";
+    const config = PluginConfig(
+      values: {GrokPluginDescriptor.binOption: GrokBinary.defaultBinary},
+    );
+
+    test("pins direct-CLI identity and capability facts", () {
+      const descriptor = GrokPluginDescriptor();
+      expect(descriptor.id, "grok");
+      expect(descriptor.displayName, "Grok Build");
+      expect(descriptor.projectOwnership, PluginProjectOwnership.bridgeDerived);
+      expect(descriptor.sessionOptionsScope, PluginSessionOptionsScope.plugin);
+      expect(descriptor.supportsPromptAttachments, isFalse);
+      expect(GrokPluginDescriptor.minVersion, "1.0.5");
+      expect(GrokPluginDescriptor.targetVersion, "1.0.5");
+      expect(descriptor.options.single.name, GrokPluginDescriptor.binOption);
+      expect(
+        descriptor.managementCapabilities(config: config),
+        isNot(contains(PluginControlCapability.install)),
+        reason: "Grok owns its installer and update lifecycle",
+      );
+    });
+
+    test("reports a current PATH runtime and its sanitized version", () async {
+      final processes = _ProbeProcessService(
+        spawnError: null,
+        processSequence: [
+          _ProbeProcess.completed(
+            pid: 1,
+            stdoutBytes: utf8.encode(
+              "warning: helper runtime 9.9.9\n"
+              "grok \u001b[32m1.0.5\u001b[0m (synthetic-build)\n",
+            ),
+            stderrBytes: const [],
+            resultCode: 0,
+          ),
+        ],
+        servesHeadlessAcp: false,
+      );
+
+      final result = await const GrokPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const {},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "1.0.5"));
+      expect(processes.spawnedExecutables, ["grok"]);
+      expect(processes.spawnedArguments, [
+        const ["--version"],
+      ]);
+    });
+
+    test("bounds noisy version output instead of parsing a version beyond the capture limit", () async {
+      final oversizedPrefix = List.filled(70 * 1024, "x").join();
+      final processes = _ProbeProcessService(
+        spawnError: null,
+        processSequence: [
+          _ProbeProcess.completed(
+            pid: 2,
+            stdoutBytes: utf8.encode("$oversizedPrefix grok 1.0.5\n"),
+            stderrBytes: const [],
+            resultCode: 0,
+          ),
+        ],
+        servesHeadlessAcp: false,
+      );
+
+      final result = await const GrokPluginDescriptor().inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const {},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, isA<PluginSetupUnknown>());
+    });
+
+    test("reports missing, malformed, and outdated runtimes distinctly", () async {
+      final missing = await const GrokPluginDescriptor().inspectSetup(
+        config: config,
+        processes: _ProbeProcessService(
+          spawnError: const ProcessException("grok", ["--version"], "No such file", 2),
+          processSequence: const [],
+          servesHeadlessAcp: false,
+        ),
+        environment: const {},
+        stateDirectory: stateDirectory,
+      );
+      final malformed = await const GrokPluginDescriptor().inspectSetup(
+        config: config,
+        processes: _ProbeProcessService(
+          spawnError: null,
+          processSequence: [
+            _ProbeProcess.completed(
+              pid: 2,
+              stdoutBytes: utf8.encode("grok development build\n"),
+              stderrBytes: const [],
+              resultCode: 0,
+            ),
+          ],
+          servesHeadlessAcp: false,
+        ),
+        environment: const {},
+        stateDirectory: stateDirectory,
+      );
+      final outdated = await const GrokPluginDescriptor().inspectSetup(
+        config: config,
+        processes: _ProbeProcessService(
+          spawnError: null,
+          processSequence: [
+            _ProbeProcess.completed(
+              pid: 3,
+              stdoutBytes: utf8.encode("grok 1.0.4 (old-build)\n"),
+              stderrBytes: const [],
+              resultCode: 0,
+            ),
+          ],
+          servesHeadlessAcp: false,
+        ),
+        environment: const {},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(missing, isA<PluginSetupRuntimeMissing>());
+      expect(malformed, isA<PluginSetupUnknown>());
+      expect(outdated, isA<PluginSetupUnavailable>());
+    });
+
+    test("the explicit binary is authoritative for inspection and provisioning", () async {
+      final inspectProcesses = _ProbeProcessService(
+        spawnError: const ProcessException("/custom/grok", ["--version"], "No such file", 2),
+        processSequence: const [],
+        servesHeadlessAcp: false,
+      );
+      const explicitConfig = PluginConfig(
+        values: {GrokPluginDescriptor.binOption: "/custom/grok"},
+      );
+
+      final setup = await const GrokPluginDescriptor().inspectSetup(
+        config: explicitConfig,
+        processes: inspectProcesses,
+        environment: const {},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(setup, isA<PluginSetupRuntimeMissing>());
+      expect((setup as PluginSetupRuntimeMissing).actionHint, contains("configured Grok Build binary path"));
+      expect(inspectProcesses.spawnedExecutables, ["/custom/grok"]);
+
+      final provisionProcesses = _ProbeProcessService(
+        spawnError: null,
+        processSequence: [
+          _ProbeProcess.completed(
+            pid: 4,
+            stdoutBytes: utf8.encode("grok 1.0.5 (current)\n"),
+            stderrBytes: const [],
+            resultCode: 0,
+          ),
+        ],
+        servesHeadlessAcp: false,
+      );
+      final events = await const GrokPluginDescriptor()
+          .ensureRuntime(
+            host: _StartPluginHost(
+              processes: provisionProcesses,
+              config: explicitConfig,
+              provisionedRuntimePath: null,
+              startAborted: StartAbortSignal.never,
+            ),
+          )
+          .toList();
+
+      expect(
+        events,
+        [isA<ProvisionReady>().having((event) => event.binaryPath, "binaryPath", "/custom/grok")],
+      );
+      expect(provisionProcesses.spawnedExecutables, ["/custom/grok"]);
+    });
+
+    test("ensureRuntime revalidates PATH and reports an outdated runtime", () async {
+      final processes = _ProbeProcessService(
+        spawnError: null,
+        processSequence: [
+          _ProbeProcess.completed(
+            pid: 5,
+            stdoutBytes: utf8.encode("grok 1.0.4 (old-build)\n"),
+            stderrBytes: const [],
+            resultCode: 0,
+          ),
+        ],
+        servesHeadlessAcp: false,
+      );
+
+      final events = await const GrokPluginDescriptor()
+          .ensureRuntime(
+            host: _StartPluginHost(
+              processes: processes,
+              config: config,
+              provisionedRuntimePath: null,
+              startAborted: StartAbortSignal.never,
+            ),
+          )
+          .toList();
+
+      expect(events, [isA<ProvisionFailed>().having((event) => event.message, "message", contains("too old"))]);
+      expect(processes.spawnedArguments, [
+        const ["--version"],
+      ]);
+    });
+
+    test("an aborted provision does not launch a probe", () async {
+      final abort = StartAbortController()..abort();
+      final processes = _ProbeProcessService(
+        spawnError: StateError("must not spawn"),
+        processSequence: const [],
+        servesHeadlessAcp: false,
+      );
+
+      await expectLater(
+        const GrokPluginDescriptor()
+            .ensureRuntime(
+              host: _StartPluginHost(
+                processes: processes,
+                config: config,
+                provisionedRuntimePath: null,
+                startAborted: abort.signal,
+              ),
+            )
+            .toList(),
+        throwsA(isA<PluginStartAbortedException>()),
+      );
+      expect(processes.spawnedExecutables, isEmpty);
+    });
+
+    test("start uses the resolved binary and clean shutdown reaps the owned agent", () async {
+      final processes = _ProbeProcessService(
+        spawnError: null,
+        processSequence: const [],
+        servesHeadlessAcp: true,
+      );
+
+      final plugin = await const GrokPluginDescriptor().start(
+        _StartPluginHost(
+          processes: processes,
+          config: config,
+          provisionedRuntimePath: "/resolved/grok",
+          startAborted: StartAbortSignal.never,
+        ),
+      );
+
+      expect(plugin.currentStatus, isA<PluginReady>());
+      expect(plugin.describe().endpoint, "/resolved/grok");
+      expect(processes.spawnedExecutables, ["/resolved/grok"]);
+      expect(processes.spawnedArguments, [
+        GrokBinary.launchSpec(binary: "grok", cwd: null, environment: const {}).args,
+      ]);
+
+      await plugin.shutdown(budget: null);
+      await plugin.shutdown(budget: null);
+      expect(plugin.currentStatus, isA<PluginStopped>());
+      expect(processes.gracefulSignals, hasLength(1));
+    });
+
+    test("interactive-only authentication degrades only Grok with local guidance", () async {
+      final processes = _ProbeProcessService(
+        spawnError: null,
+        processSequence: const [],
+        servesHeadlessAcp: false,
+        servesInteractiveAcp: true,
+      );
+
+      final plugin = await const GrokPluginDescriptor().start(
+        _StartPluginHost(
+          processes: processes,
+          config: config,
+          provisionedRuntimePath: "/resolved/grok",
+          startAborted: StartAbortSignal.never,
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      final status = plugin.currentStatus as PluginDegraded;
+      expect(status.recoverable, isTrue);
+      expect(status.requiresUserAction, isTrue);
+      expect(status.userActionHint, contains("grok login"));
+      expect(processes.receivedAuthenticate, isFalse);
+      await plugin.shutdown(budget: null);
+    });
+
+    test("an unexpected crash degrades and the stable API reconnects", () async {
+      final processes = _ProbeProcessService(
+        spawnError: null,
+        processSequence: const [],
+        servesHeadlessAcp: true,
+      );
+      final plugin = await const GrokPluginDescriptor().start(
+        _StartPluginHost(
+          processes: processes,
+          config: config,
+          provisionedRuntimePath: "/resolved/grok",
+          startAborted: StartAbortSignal.never,
+        ),
+      );
+      final api = plugin.api as GrokPlugin;
+      final firstApi = plugin.api;
+
+      processes.acpProcesses.single.exit(1);
+      await _settleUntil(() => plugin.currentStatus is PluginDegraded);
+      expect(plugin.currentStatus, isA<PluginDegraded>());
+
+      expect(await api.ensureConnected(), isTrue);
+      await _settleUntil(() => plugin.currentStatus is PluginReady);
+      expect(plugin.currentStatus, isA<PluginReady>());
+      expect(identical(plugin.api, firstApi), isTrue);
+      expect(processes.acpProcesses, hasLength(2));
+
+      await plugin.shutdown(budget: null);
+      expect(processes.acpProcesses.last.exitCode, completion(-15));
+    });
+  });
+}
+
+Future<void> _settleUntil(bool Function() condition) async {
+  for (var attempt = 0; attempt < 100 && !condition(); attempt++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+class _StartPluginHost({
+  @override required final HostProcessService processes,
+  @override required final PluginConfig config,
+  @override required final String? provisionedRuntimePath,
+  @override required final StartAbortSignal startAborted,
+}) implements PluginHost {
+  @override
+  Map<String, String> get environment => const {"HOME": "/tmp"};
+
+  @override
+  ServerClock get clock => const _ImmediateClock();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class const _ImmediateClock() extends ServerClock {
+  @override
+  DateTime now() => DateTime.utc(2026, 8, 28);
+
+  @override
+  Future<void> delay({required Duration duration}) => Future<void>.value();
+}
+
+class _ProbeProcessService({
+  required final Object? spawnError,
+  required final List<_ProbeProcess> processSequence,
+  required final bool servesHeadlessAcp,
+  final bool servesInteractiveAcp = false,
+}) implements HostProcessService {
+  int _nextProcess = 0;
+  int _nextAcpPid = 100;
+  final List<_AcpProcess> acpProcesses = [];
+  final List<String> spawnedExecutables = [];
+  final List<List<String>> spawnedArguments = [];
+  final List<int> gracefulSignals = [];
+  bool receivedAuthenticate = false;
+
+  @override
+  Future<SpawnedProcess> spawn({
+    required String executable,
+    required List<String> arguments,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+    required bool runInShell,
+  }) async {
+    spawnedExecutables.add(executable);
+    spawnedArguments.add(List.unmodifiable(arguments));
+    final error = spawnError;
+    if (error != null) throw error;
+    if ((servesHeadlessAcp || servesInteractiveAcp) &&
+        arguments.length == 4 &&
+        arguments[0] == "--no-auto-update" &&
+        arguments[1] == "agent" &&
+        arguments[2] == "--no-leader" &&
+        arguments[3] == "stdio") {
+      final process = _AcpProcess(
+        pid: _nextAcpPid++,
+        headlessAuthentication: servesHeadlessAcp,
+        onAuthenticate: () => receivedAuthenticate = true,
+      );
+      acpProcesses.add(process);
+      return process;
+    }
+    if (_nextProcess < processSequence.length) return processSequence[_nextProcess++];
+    throw StateError("No canned process remains for $executable ${arguments.join(' ')}");
+  }
+
+  @override
+  Future<ProcessIdentity?> inspect({required int pid}) async => null;
+
+  @override
+  Future<SignalResult> signalGraceful({required int pid}) async {
+    gracefulSignals.add(pid);
+    for (final process in acpProcesses.where((candidate) => candidate.pid == pid)) {
+      process.exit(-15);
+    }
+    return _signal(
+      pid: pid,
+      requestedSignal: ShutdownSignal.graceful,
+      deliveredSignal: ProcessSignal.sigterm,
+    );
+  }
+
+  @override
+  Future<SignalResult> signalForce({required int pid}) async {
+    for (final process in acpProcesses.where((candidate) => candidate.pid == pid)) {
+      process.exit(-9);
+    }
+    return _signal(
+      pid: pid,
+      requestedSignal: ShutdownSignal.force,
+      deliveredSignal: ProcessSignal.sigkill,
+    );
+  }
+
+  SignalResult _signal({
+    required int pid,
+    required ShutdownSignal requestedSignal,
+    required ProcessSignal deliveredSignal,
+  }) => SignalResult(
+    pid: pid,
+    requestedSignal: requestedSignal,
+    deliveredSignal: deliveredSignal,
+    wasRequested: true,
+    attemptedAt: DateTime.utc(2026, 8, 28),
+  );
+}
+
+class _ProbeProcess.completed({
+  @override required final int pid,
+  required final List<int> stdoutBytes,
+  required final List<int> stderrBytes,
+  required final int resultCode,
+}) implements SpawnedProcess {
+  final List<int> _stdoutBytes = stdoutBytes;
+  final List<int> _stderrBytes = stderrBytes;
+  final int _completedExitCode = resultCode;
+
+  @override
+  Future<int> get exitCode => Future.value(_completedExitCode);
+
+  @override
+  Stream<List<int>> get stdout => Stream.value(_stdoutBytes);
+
+  @override
+  Stream<List<int>> get stderr => Stream.value(_stderrBytes);
+
+  @override
+  IOSink get stdin => throw UnimplementedError();
+
+  @override
+  ProcessIdentity get identity => throw UnimplementedError();
+}
+
+class _AcpProcess({
+  @override required final int pid,
+  required final bool headlessAuthentication,
+  required final void Function() onAuthenticate,
+}) implements SpawnedProcess {
+  this {
+    stdin = IOSink(_InputSink(onLine: _handleLine));
+  }
+
+  final StreamController<List<int>> _stdout = StreamController();
+  final Completer<int> _exit = Completer();
+
+  @override
+  late final IOSink stdin;
+
+  void _handleLine(String line) {
+    final frame = jsonDecode(line) as Map<String, dynamic>;
+    switch (frame["method"]) {
+      case AcpMethods.initialize:
+        _respond(
+          id: frame["id"],
+          result: {
+            "protocolVersion": 1,
+            "agentCapabilities": {
+              "loadSession": true,
+              "sessionCapabilities": {
+                "list": <String, dynamic>{},
+                "resume": <String, dynamic>{},
+                "close": <String, dynamic>{},
+              },
+            },
+            "authMethods": [
+              if (headlessAuthentication)
+                {"id": "cached_token", "name": "Cached token"}
+              else
+                {"id": "grok.com", "name": "Interactive login"},
+            ],
+            "_meta": {
+              "grokShell": true,
+              "agentVersion": "1.0.5",
+              "modelState": {
+                "currentModelId": "synthetic:model",
+                "availableModels": [
+                  {
+                    "modelId": "synthetic:model",
+                    "name": "Synthetic model",
+                    "_meta": {
+                      "supportsReasoningEffort": false,
+                      "reasoningEfforts": <Object?>[],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        );
+      case AcpMethods.authenticate:
+        onAuthenticate();
+        _respond(id: frame["id"], result: <String, dynamic>{});
+    }
+  }
+
+  void _respond({required Object? id, required Map<String, dynamic> result}) {
+    _stdout.add(utf8.encode("${jsonEncode({"jsonrpc": "2.0", "id": id, "result": result})}\n"));
+  }
+
+  void exit(int code) {
+    if (!_exit.isCompleted) _exit.complete(code);
+    if (!_stdout.isClosed) unawaited(_stdout.close());
+  }
+
+  @override
+  Future<int> get exitCode => _exit.future;
+
+  @override
+  Stream<List<int>> get stdout => _stdout.stream;
+
+  @override
+  Stream<List<int>> get stderr => const Stream.empty();
+
+  @override
+  ProcessIdentity get identity => throw UnimplementedError();
+}
+
+class _InputSink({required final void Function(String line) onLine}) implements StreamConsumer<List<int>> {
+  final StringBuffer _buffer = StringBuffer();
+
+  @override
+  Future<void> addStream(Stream<List<int>> stream) async {
+    await for (final bytes in stream) {
+      _buffer.write(utf8.decode(bytes));
+      final lines = _buffer.toString().split("\n");
+      _buffer
+        ..clear()
+        ..write(lines.removeLast());
+      lines.where((line) => line.isNotEmpty).forEach(onLine);
+    }
+  }
+
+  @override
+  Future<void> close() async {}
+}


### PR DESCRIPTION
## Complexity

⚙️ **Moderate** — this adds bounded runtime discovery and composes Grok into the shared host-process ACP lifecycle without introducing a managed installer.

## What

- Added the `GrokPluginDescriptor`, `--grok-bin`, and frozen Grok Build `1.0.5` minimum/target version.
- Added explicit-path-before-PATH selection plus bounded, ANSI-safe `grok --version` probing through `HostProcessCommandExecutor`.
- Classified missing, malformed, outdated, current, timed-out, and failed probes without inspecting credentials or starting ACP.
- Revalidated the runtime in `ensureRuntime` and provided local `grok login`/headless credential guidance; no install or update capability is advertised.
- Composed `GrokPlugin` through `hostProcessAcpFactory` and `AcpBridgePlugin`, with bounded eager connection, abort support, reconnect behavior, and owned-process shutdown.
- Added descriptor coverage for setup, provisioning, authentication isolation, crashes, reported versions, aborts, and idempotent disposal.

## Why

Initial Grok Build support deliberately uses xAI's official user-installed CLI instead of duplicating its installer or updater. The descriptor supplies the bridge lifecycle seam while keeping setup inspection read-only, credential-blind, and isolated from other harnesses.

## Risk and test focus

**Moderate risk.** The sensitive areas are command/path authority, bounded process output and timeout behavior, version evidence, authentication failure classification, and exact process ownership. Tests focus on explicit paths never falling through to PATH, malformed or unrelated version output not being trusted, ACP startup using the shared process host, Grok-only degradation, and clean shutdown/reconnect behavior.

## Expected result

Once Grok is activated in Step 6, a supported user-installed binary can be discovered or selected with `--grok-bin`, validated without reading credentials, and launched through the shared ACP lifecycle. Missing or unsupported runtimes receive actionable local guidance, while Grok failures do not affect other harnesses.

There is no database or persisted-data impact. Grok is not yet registered in the bridge app, so this step alone adds no user-visible built-in harness availability.

## Verification

- `bridge/sesori_plugin_grok`: `dart test` — 52 passed
- `bridge/sesori_plugin_grok`: `dart analyze --fatal-infos` — no issues
- Dart LSP diagnostics — 0 across the four changed Dart implementation/test files
- `git diff --check origin/main...HEAD` — passed
- Authored line-width check — no lines over 120 characters
- Scope — 845 changed lines against `origin/main`, below the 1,500-line target
- Architecture implementation review over Step 5 against Step 4 — approved with no findings
