### PR TITLE
⚙️ [grok-harness] feat(bridge): activate Grok Build [step 6/9]

### DIFF
--- a/.opencode/skills/update-backend-runtimes/SKILL.md
+++ b/.opencode/skills/update-backend-runtimes/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: update-backend-runtimes
-description: Update the target OpenCode, Codex, GitHub Copilot, Cursor, DeepSeek, Claude Code, Hermes Agent, Pi, and OMP CLI versions used by the Sesori bridge. Use when asked to update, bump, or refresh coding harness targets, managed runtimes, or release checksums while preserving compatibility minimums.
+description: >-
+  Update the target OpenCode, Codex, GitHub Copilot, Cursor, DeepSeek, Grok
+  Build, Claude Code, Hermes Agent, Pi, and OMP CLI versions used by the Sesori
+  bridge. Use when asked to update, bump, or refresh coding harness targets,
+  managed runtimes, or release checksums while preserving compatibility minimums.
 ---
 
 # Update Plugin Harness Targets
@@ -42,6 +46,10 @@ Dart/Flutter dependency update workflow.
 - DeepSeek runtime and lifecycle tests:
   `bridge/sesori_plugin_deepseek/test/deepseek_runtime_manifest_test.dart`
   `bridge/sesori_plugin_deepseek/test/deepseek_plugin_descriptor_test.dart`
+- Grok Build direct-CLI target and minimum:
+  `bridge/sesori_plugin_grok/lib/src/runtime/grok_plugin_descriptor.dart`
+- Grok Build descriptor tests:
+  `bridge/sesori_plugin_grok/test/grok_plugin_descriptor_test.dart`
 - Hermes Agent direct-CLI target and minimum:
   `bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart`
 - Hermes Agent descriptor tests:
@@ -65,8 +73,8 @@ Read `bridge/AGENTS.md` before editing. Never hand-edit generated files.
 
 Before release discovery, inspect `knownPlugins` in `plugin_registry.dart` and
 confirm every concrete descriptor has a section in this skill. The current
-closed set is OpenCode, Codex, GitHub Copilot, Cursor, DeepSeek, Claude Code,
-Hermes Agent, Pi, and Oh My Pi. Shared interface, runtime, and ACP packages are
+closed set is OpenCode, Codex, GitHub Copilot, Cursor, DeepSeek, Grok Build,
+Claude Code, Hermes Agent, Pi, and Oh My Pi. Shared interface, runtime, and ACP packages are
 not harnesses. If the
 registry has gained another harness, extend this skill for it as part of the
 same change instead of silently skipping it.
@@ -81,6 +89,7 @@ Every harness must expose an independent compatibility minimum and target:
 | Claude Code | `ClaudePluginDescriptor.minVersion` | `ClaudePluginDescriptor.targetVersion` |
 | Cursor | `CursorRuntimeManifest.minPathVersion` | `CursorRuntimeManifest.targetVersion` |
 | DeepSeek | `DeepSeekRuntimeManifest.minPathVersion` | `DeepSeekRuntimeManifest.targetVersion` |
+| Grok Build | `GrokPluginDescriptor.minVersion` | `GrokPluginDescriptor.targetVersion` |
 | Hermes Agent | `HermesPluginDescriptor.minVersion` | `HermesPluginDescriptor.targetVersion` |
 | Pi | `PiRuntimeManifest.minPathVersion` | `PiRuntimeManifest.targetVersion` |
 | Oh My Pi | `OmpRuntimeManifest.minPathVersion` | `OmpRuntimeManifest.targetVersion` |
@@ -106,6 +115,8 @@ surface was validated; they do not gate otherwise-compatible local installs.
 - Update DeepSeek's `targetVersion` to the latest stable `sesori-ai/sesori-deepseek-acp`
   release only after its six package archives, extension protocol v1, and
   reported DeepSeek Harness pin pass the release checks below.
+- Update Grok Build's direct-CLI `targetVersion` to the official xAI stable channel only after the dedicated
+  no-auto-update/no-leader ACP v1 probe passes.
 - Update Hermes Agent's direct-CLI `targetVersion` to the semantic package
   version in the latest stable `NousResearch/hermes-agent` release after its
   ACP v1 probe passes. Its calendar release tag is not the CLI version.
@@ -267,6 +278,24 @@ smoke through initialize, list, new, prompt, history, restart/load, and close.
 Stop if the extension version or reported DeepSeek pin changes unexpectedly;
 update the adapter and consumer contract together rather than accepting drift.
 
+### Grok Build
+
+Read the current release from xAI's official stable channel at
+`https://x.ai/cli/stable` and confirm the corresponding public
+`xai-org/grok-build` source revision. Do not execute the remote installer merely
+to discover a version, and do not add Sesori-managed artifacts or checksums:
+Grok remains a user-installed direct CLI.
+
+Download the official current-host candidate into an isolated temporary
+directory and verify its branded `grok <version> (<build>)` output. Launch it
+with an isolated home through the exact production entry point,
+`grok --no-auto-update agent --no-leader stdio`; never pass `--always-approve`
+or `--yolo`. Verify ACP v1 initialize identity and advertised list/load/resume/
+close capabilities. With safe authenticated test credentials, also verify new,
+prompt, replay, model selection, and close. Stop rather than updating the target
+when required authenticated evidence is unavailable or the Grok-owned model
+metadata/`session/set_model` surface changes.
+
 ### Hermes Agent
 
 ```bash
@@ -317,13 +346,25 @@ Before changing the pin, run the official candidate in an isolated temporary cwd
 5. Update `CursorRuntimeManifest.targetVersion` to the official current build and refresh all four computed SHA-256 values.
 6. Update `DeepSeekRuntimeManifest.targetVersion` only after all six release
    digests, the aggregate manifest, and the isolated packaged ACP probe agree.
-7. Update Hermes Agent's direct-CLI target and descriptor test fixtures after the tagged-source ACP probe passes.
-8. Update `PiRuntimeManifest.targetVersion` only after the isolated JSONL RPC probe passes; refresh all six SHA-256 values and preserve complete package-directory placement.
-9. Update `OmpRuntimeManifest.targetVersion` only after the isolated ACP probe passes; refresh all seven SHA-256 values and preserve glibc/musl and unsupported Windows arm64 mapping.
-10. Verify every minimum is unchanged from the base branch. A target-only update must not modify a minimum-version line or an outdated-version test boundary.
-11. Update hard-coded version URLs, version assertions, and recent-target fixtures in all manifest/availability tests.
-12. Search the affected plugin packages for the replaced target versions. Update only references that describe the current target; preserve minimum-version fixtures, historical comments, and protocol-shape observations tied to older versions.
-13. Update the setup/lifecycle regression document only for a separately requested compatibility-floor change, then run `dart format` on changed Dart files.
+7. Update Grok Build's direct-CLI target and descriptor fixtures only after the isolated ACP probe passes.
+8. Update Hermes Agent's direct-CLI target and descriptor test fixtures after
+   the tagged-source ACP probe passes.
+9. Update `PiRuntimeManifest.targetVersion` only after the isolated JSONL RPC
+   probe passes; refresh all six SHA-256 values and preserve complete
+   package-directory placement.
+10. Update `OmpRuntimeManifest.targetVersion` only after the isolated ACP probe
+    passes; refresh all seven SHA-256 values and preserve glibc/musl and
+    unsupported Windows arm64 mapping.
+11. Verify every minimum is unchanged from the base branch. A target-only update
+    must not modify a minimum-version line or an outdated-version test boundary.
+12. Update hard-coded version URLs, version assertions, and recent-target
+    fixtures in all manifest/availability tests.
+13. Search affected plugin packages for the replaced target versions. Update
+    only references that describe the current target; preserve minimum-version
+    fixtures, historical comments, and protocol observations tied to older versions.
+14. Update the setup/lifecycle regression document only for a separately
+    requested compatibility-floor change, then run `dart format` on changed
+    Dart files.
 
 Use `apply_patch` for manual edits.
 
@@ -338,6 +379,7 @@ Run the plugin suites independently; they may run in parallel:
 (cd bridge/sesori_plugin_claude && dart test && dart analyze --fatal-infos)
 (cd bridge/sesori_plugin_cursor && dart test && dart analyze --fatal-infos)
 (cd bridge/sesori_plugin_deepseek && dart test && dart analyze --fatal-infos)
+(cd bridge/sesori_plugin_grok && dart test && dart analyze --fatal-infos)
 (cd bridge/sesori_plugin_hermes && dart test && dart analyze --fatal-infos)
 (cd bridge/sesori_plugin_pi && dart test && dart analyze --fatal-infos)
 (cd bridge/sesori_plugin_omp && dart test && dart analyze --fatal-infos)
@@ -365,6 +407,7 @@ Before finishing, report:
 - Cursor's installer-advertised build, and whether its four managed-runtime digests were recomputed
 - DeepSeek's adapter release, six verified package-archive digests, reported
   DeepSeek Harness pin, and packaged ACP probe result
+- Grok Build's xAI stable release, build identifier, unchanged direct-CLI floor, and isolated ACP probe result
 - Hermes Agent's calendar release tag, semantic CLI target, unchanged direct-CLI floor, and isolated ACP probe result
 - Pi's release, six verified package-archive digests, and JSONL RPC probe result
 - OMP's release, seven verified bare-executable digests, and ACP probe result

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -3,13 +3,13 @@
 ## Current State
 
 - **Plan:** `.plan/active/grok-harness/PLAN.md`
-- **Status:** Steps 1-4/9 merged; Step 5/9 in PR
-- **Current branch:** `grok-harness-step-5-lifecycle`
-- **Base:** `origin/main` after merged PR #1169
+- **Status:** Steps 1-4/9 merged; Step 5/9 in PR; Step 6/9 implemented locally
+- **Current branch:** `grok-harness-step-6-activation`
+- **Base:** `grok-harness-step-5-lifecycle` (PR #1175)
 - **Architecture plan review:** approved 2026-08-27 after catalog ownership and auth-policy corrections
 - **Merged predecessor:** #1169 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1169>
 - **Open PR:** #1175 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1175>
-- **Local successor:** Step 6 starts after Step 5 publication
+- **Local successor:** `grok-harness-step-6-activation`; bridge activation under review
 
 ## Fixed Series
 
@@ -28,7 +28,7 @@
 5. `⚙️ [grok-harness] feat(grok): add direct-CLI setup and lifecycle [step 5/9]`
    - **State:** in PR #1175.
 6. `⚙️ [grok-harness] feat(bridge): activate Grok Build [step 6/9]`
-   - **State:** not started.
+   - **State:** implemented locally; held until #1175 merges.
 7. `🌿 [grok-harness] feat(client): brand Grok Build [step 7/9]`
    - **State:** not started.
 8. `🌱 [grok-harness] docs: reconcile Grok regression coverage [step 8/9]`
@@ -104,6 +104,19 @@
 - [x] Run architecture implementation review over Step 5 against Step 4; approved with no findings.
 - [x] Commit the completed successor locally; do not publish before #1169 merges.
 - [x] Rebase onto merged #1169, reverify, publish PR #1175, and start its monitor.
+
+## Step 6 Checklist
+
+- [x] Add the Grok package dependency and register `GrokPluginDescriptor` only at the app composition point.
+- [x] Add `Harness.grok`; keep plugin IDs string-based on transport and preserve unknown-client fallbacks.
+- [x] Keep OpenCode preferred while making Grok eligible by default and startable only on demand after setup.
+- [x] Cover the exact built-in registry and namespaced `--grok-bin` CLI option.
+- [x] Update app composition/runtime inventories and reconcile missing Copilot, DeepSeek, and Grok architecture edges.
+- [x] Add no analytics event; generic plugin lifecycle outcomes remain authoritative.
+- [x] Pass app fatal-info analysis, 7 focused app tests, shared analysis, 392 shared tests, pub resolution, and LSP.
+- [x] Keep the measured Step 6 change below the 1,500-line soft cap (currently 140 lines).
+- [x] Run architecture implementation review over Step 6 against Step 5; approved with no findings.
+- [x] Commit the completed successor locally; do not publish before #1175 merges.
 
 ## Decisions And Evidence
 

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -112,9 +112,10 @@
 - [x] Keep OpenCode preferred while making Grok eligible by default and startable only on demand after setup.
 - [x] Cover the exact built-in registry and namespaced `--grok-bin` CLI option.
 - [x] Update app composition/runtime inventories and reconcile missing Copilot, DeepSeek, and Grok architecture edges.
+- [x] Record activation-specific Grok setup/auth/lifecycle regression behavior; Step 8 retains full reconciliation.
 - [x] Add no analytics event; generic plugin lifecycle outcomes remain authoritative.
 - [x] Pass app fatal-info analysis, 7 focused app tests, shared analysis, 392 shared tests, pub resolution, and LSP.
-- [x] Keep the measured Step 6 change below the 1,500-line soft cap (currently 141 lines).
+- [x] Keep the measured Step 6 change below the 1,500-line soft cap (currently 172 lines).
 - [x] Run architecture implementation review over Step 6 against Step 5; approved with no findings.
 - [x] Commit the completed successor locally; do not publish before #1175 merges.
 - [x] Rebase onto merged #1175, reverify, publish PR #1177, and start its monitor.

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -3,13 +3,13 @@
 ## Current State
 
 - **Plan:** `.plan/active/grok-harness/PLAN.md`
-- **Status:** Steps 1-4/9 merged; Step 5/9 in PR; Step 6/9 implemented locally
+- **Status:** Steps 1-5/9 merged; Step 6/9 in PR
 - **Current branch:** `grok-harness-step-6-activation`
-- **Base:** `grok-harness-step-5-lifecycle` (PR #1175)
+- **Base:** `origin/main` after merged PR #1175
 - **Architecture plan review:** approved 2026-08-27 after catalog ownership and auth-policy corrections
-- **Merged predecessor:** #1169 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1169>
-- **Open PR:** #1175 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1175>
-- **Local successor:** `grok-harness-step-6-activation`; bridge activation under review
+- **Merged predecessor:** #1175 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1175>
+- **Open PR:** #1177 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1177>
+- **Local successor:** Step 7 starts after Step 6 publication
 
 ## Fixed Series
 
@@ -26,9 +26,9 @@
    - **Evidence:** generic auth allowlist, Grok plugin composition, 270 ACP tests, 42 Grok tests, affected-package
      analyzers, LSP diagnostics, two architecture approvals, and the 1,500-line budget pass.
 5. `⚙️ [grok-harness] feat(grok): add direct-CLI setup and lifecycle [step 5/9]`
-   - **State:** in PR #1175.
+   - **State:** merged in #1175.
 6. `⚙️ [grok-harness] feat(bridge): activate Grok Build [step 6/9]`
-   - **State:** implemented locally; held until #1175 merges.
+   - **State:** in PR #1177.
 7. `🌿 [grok-harness] feat(client): brand Grok Build [step 7/9]`
    - **State:** not started.
 8. `🌱 [grok-harness] docs: reconcile Grok regression coverage [step 8/9]`
@@ -114,9 +114,10 @@
 - [x] Update app composition/runtime inventories and reconcile missing Copilot, DeepSeek, and Grok architecture edges.
 - [x] Add no analytics event; generic plugin lifecycle outcomes remain authoritative.
 - [x] Pass app fatal-info analysis, 7 focused app tests, shared analysis, 392 shared tests, pub resolution, and LSP.
-- [x] Keep the measured Step 6 change below the 1,500-line soft cap (currently 140 lines).
+- [x] Keep the measured Step 6 change below the 1,500-line soft cap (currently 141 lines).
 - [x] Run architecture implementation review over Step 6 against Step 5; approved with no findings.
 - [x] Commit the completed successor locally; do not publish before #1175 merges.
+- [x] Rebase onto merged #1175, reverify, publish PR #1177, and start its monitor.
 
 ## Decisions And Evidence
 

--- a/bridge/app/AGENTS.md
+++ b/bridge/app/AGENTS.md
@@ -1,6 +1,8 @@
 # Sesori Bridge (Dart)
 
-Dart CLI compiled to a native bundle. Runs headlessly on a laptop or VM, authenticates via OAuth PKCE, connects to the relay, and routes E2E-encrypted traffic between clients and independently managed backend plugins. OpenCode, Codex, and Cursor can run concurrently in one bridge.
+Dart CLI compiled to a native bundle. It runs headlessly on a laptop or VM, authenticates via OAuth PKCE, connects to
+the relay, and routes E2E-encrypted traffic between clients and independently managed backend plugins. Registered
+harnesses can run concurrently in one bridge.
 
 ## STRUCTURE
 
@@ -34,7 +36,14 @@ bridge/ workspace modules (siblings of app/):
 ├── sesori_plugin_opencode/    OpenCode implementation
 ├── sesori_plugin_codex/       Codex implementation
 ├── sesori_plugin_acp/         ACP protocol plugin base
-└── sesori_plugin_cursor/      Cursor implementation over ACP
+├── sesori_plugin_cursor/      Cursor implementation over ACP
+├── sesori_plugin_omp/         Oh My Pi implementation over ACP
+├── sesori_plugin_claude/      Claude Code implementation
+├── sesori_plugin_hermes/      Hermes implementation over ACP
+├── sesori_plugin_grok/        Grok Build implementation over ACP
+├── sesori_plugin_pi/          Pi implementation
+├── sesori_plugin_deepseek/    DeepSeek implementation over ACP
+└── sesori_plugin_copilot/     GitHub Copilot implementation over ACP
 ```
 
 ## WHERE TO LOOK
@@ -48,12 +57,16 @@ bridge/ workspace modules (siblings of app/):
 | Request routing  | `lib/src/routing/`                 | Explicit handlers; unmatched routes return 404          |
 | Trigger listeners | `lib/src/listeners/`               | One trigger lifecycle per class; typed output only      |
 | Plugin interface | `../sesori_plugin_interface/`       | BridgePlugin contract for all backends                  |
+| Plugin registry  | `lib/src/runtime/plugin_registry.dart` | Only bridge-app composition point for concrete plugins |
 | OpenCode plugin  | `../sesori_plugin_opencode/`        | OpenCode backend implementation + models + tests        |
 | Bridge instances | `lib/src/server/`                  | Single-live-bridge enforcement, startup mutex, plugin host abstractions |
 
 ## CONVENTIONS
 
-- **Plugin architecture** — all backend-specific code lives in sibling plugin packages under `bridge/`. Core repositories, services, handlers, and shared contracts remain backend-neutral. `plugin_registry.dart` is the supported composition point that imports the OpenCode, Codex, and Cursor descriptors; do not import concrete plugins elsewhere in bridge core.
+- **Plugin architecture** — all backend-specific code lives in sibling plugin packages under `bridge/`. Core
+  repositories, services, handlers, and shared contracts remain backend-neutral. `plugin_registry.dart` is the
+  supported composition point that imports concrete descriptors; do not import concrete plugins elsewhere in bridge
+  core.
 - **Plugin eligibility** — `plugins.disabled` is the only persisted eligibility policy. Every registered ID absent from that set is eligible; setup readiness independently gates routing. All plugin CLI options are registered, while `--plugin` and allowlists do not exist. Lists use case-insensitive display-name order with ID tie-breaking. The derived default prefers OpenCode when selectable and otherwise uses the first plugin in that order. Missing legacy `pluginId` still means OpenCode, not the first enabled plugin.
 - **Plugin CLI options are namespaced** — plugins declare **bare** option names in their descriptor (`port`, `host`, `bin`, …). `PluginCliOptionsMapper` namespaces each to `--<pluginId>-<name>` (e.g. `--opencode-host`) at registration so options can't collide once multiple plugins run in parallel. Never bake the plugin prefix into the declared name. Plugin code reads values by the **bare** name through `PluginConfig`, unaware of namespacing.
 - **Catalog and import semantics** — project/root/detail/child reads use only the durable database catalog. `POST`, `DELETE`, and `GET /plugin/import` start, cancel, and report independent per-plugin imports; progress SSE is plugin-attributed. Imports are atomic/non-destructive, and concurrent catalog reads observe the last committed snapshot.

--- a/bridge/app/lib/src/runtime/plugin_registry.dart
+++ b/bridge/app/lib/src/runtime/plugin_registry.dart
@@ -3,6 +3,7 @@ import "package:codex_plugin/codex_plugin.dart" show CodexPluginDescriptor;
 import "package:copilot_plugin/copilot_plugin.dart" show CopilotPluginDescriptor;
 import "package:cursor_plugin/cursor_plugin.dart" show CursorPluginDescriptor;
 import "package:deepseek_plugin/deepseek_plugin.dart" show DeepSeekPluginDescriptor;
+import "package:grok_plugin/grok_plugin.dart" show GrokPluginDescriptor;
 import "package:hermes_plugin/hermes_plugin.dart" show HermesPluginDescriptor;
 import "package:omp_plugin/omp_plugin.dart" show OmpPluginDescriptor;
 import "package:opencode_plugin/opencode_plugin.dart" show OpenCodePluginDescriptor;
@@ -23,6 +24,7 @@ final List<BridgePluginDescriptor> knownPlugins = List.unmodifiable([
   PiPluginDescriptor.production(),
   OmpPluginDescriptor.production(),
   const DeepSeekPluginDescriptor(),
+  const GrokPluginDescriptor(),
 ]);
 
 /// Product-preferred default when OpenCode is selectable. Lifecycle policy

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -40,6 +40,8 @@ dependencies:
     path: ../sesori_plugin_claude
   hermes_plugin:
     path: ../sesori_plugin_hermes
+  grok_plugin:
+    path: ../sesori_plugin_grok
   pi_plugin:
     path: ../sesori_plugin_pi
   omp_plugin:

--- a/bridge/app/test/bridge/runtime/plugin_registry_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_registry_test.dart
@@ -8,8 +8,12 @@ void main() {
 
     expect(
       ids,
-      unorderedEquals(["opencode", "codex", "copilot", "cursor", "claude", "hermes", "pi", "omp", "deepseek"]),
+      unorderedEquals(["opencode", "codex", "copilot", "cursor", "claude", "hermes", "pi", "omp", "deepseek", "grok"]),
     );
+  });
+
+  test("OpenCode remains the preferred default", () {
+    expect(preferredDefaultPluginId, Harness.opencode.name);
   });
 
   test("every registered plugin id is a built-in Harness identity", () {

--- a/bridge/app/test/bridge/runtime/run_command_catalog_import_test.dart
+++ b/bridge/app/test/bridge/runtime/run_command_catalog_import_test.dart
@@ -7,7 +7,10 @@ void main() {
   test("run command registers every plugin option and no selector", () {
     final options = RunCommand().argParser.options;
 
-    expect(options.keys, containsAll(["opencode-bin", "codex-bin", "copilot-bin", "cursor-bin", "deepseek-bin"]));
+    expect(
+      options.keys,
+      containsAll(["opencode-bin", "codex-bin", "copilot-bin", "cursor-bin", "deepseek-bin", "grok-bin"]),
+    );
     expect(options, isNot(contains("plugin")));
   });
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,6 +15,9 @@ sesori_apps_monorepo/
 │   sesori_plugin_codex/        # Codex backend plugin
 │   sesori_plugin_acp/          # Agent Client Protocol backend plugin
 │   sesori_plugin_cursor/       # Cursor ACP backend plugin
+│   sesori_plugin_copilot/      # GitHub Copilot ACP backend plugin
+│   sesori_plugin_grok/         # Grok Build ACP backend plugin
+│   sesori_plugin_deepseek/     # DeepSeek ACP backend plugin
 │   sesori_plugin_omp/          # Oh My Pi ACP backend plugin
 │   sesori_plugin_claude/       # Claude Code backend plugin
 │   sesori_plugin_hermes/       # Hermes ACP backend plugin
@@ -44,6 +47,9 @@ graph TD
   bridge_app --> sesori_plugin_codex[bridge/sesori_plugin_codex]
   bridge_app --> sesori_plugin_acp[bridge/sesori_plugin_acp]
   bridge_app --> sesori_plugin_cursor[bridge/sesori_plugin_cursor]
+  bridge_app --> sesori_plugin_copilot[bridge/sesori_plugin_copilot]
+  bridge_app --> sesori_plugin_grok[bridge/sesori_plugin_grok]
+  bridge_app --> sesori_plugin_deepseek[bridge/sesori_plugin_deepseek]
   bridge_app --> sesori_plugin_omp[bridge/sesori_plugin_omp]
   bridge_app --> sesori_plugin_claude[bridge/sesori_plugin_claude]
   bridge_app --> sesori_plugin_hermes[bridge/sesori_plugin_hermes]
@@ -68,6 +74,17 @@ graph TD
   sesori_plugin_cursor --> sesori_plugin_acp
   sesori_plugin_cursor --> sesori_plugin_runtime
   sesori_plugin_cursor --> sesori_shared
+  sesori_plugin_copilot --> sesori_plugin_interface
+  sesori_plugin_copilot --> sesori_bridge_foundation
+  sesori_plugin_copilot --> sesori_plugin_acp
+  sesori_plugin_copilot --> sesori_plugin_runtime
+  sesori_plugin_grok --> sesori_plugin_interface
+  sesori_plugin_grok --> sesori_bridge_foundation
+  sesori_plugin_grok --> sesori_plugin_acp
+  sesori_plugin_deepseek --> sesori_plugin_interface
+  sesori_plugin_deepseek --> sesori_bridge_foundation
+  sesori_plugin_deepseek --> sesori_plugin_acp
+  sesori_plugin_deepseek --> sesori_plugin_runtime
   sesori_plugin_omp --> sesori_plugin_interface
   sesori_plugin_omp --> sesori_bridge_foundation
   sesori_plugin_omp --> sesori_plugin_runtime

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -47,6 +47,16 @@ idle suspension, the management snapshot, and lifecycle commands.
   local and out of band; setup never reads credentials or runs `copilot login`.
   An unexpected owned-process exit degrades only Copilot, and demand reconnects
   it without affecting another harness.
+- Grok Build is a direct-CLI ACP v1 harness with no managed install. An explicit
+  `--grok-bin` path is authoritative; otherwise setup uses `grok` from PATH and
+  requires version `1.0.5` or newer. Setup inspection and pre-start resolution
+  run only a bounded `--version` probe: they never read credentials, invoke
+  login, create a session, or start ACP. Startup launches exactly
+  `--no-auto-update agent --no-leader stdio` through the host process seam and
+  accepts only advertised headless authentication. Interactive-only
+  authentication becomes local-login-required without invoking it. An
+  unexpected exit degrades only Grok, demand reconnects it, and owned shutdown
+  remains idempotent and is not reported as a crash.
 - Pi and Oh My Pi are registered harnesses with managed installs where a platform
   archive exists and explicit `--pi-bin`/`--omp-bin` paths stay authoritative. Pi
   sessions always launch with `--approve` (project-local Pi settings, extensions,
@@ -146,9 +156,9 @@ idle suspension, the management snapshot, and lifecycle commands.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | A started bridge inspects every registered harness and publishes coherent setup and management snapshots. A ready fixture has a selectable default; a fixture with no usable harness has zero selectable entries and no default without failing startup. Headless bridge; all registered harnesses listed. |
-| L2 Routine | Demand-driven start of a ready harness, clean lifecycle-owned bridge shutdown, Codex keepalive traffic remaining local and stopping on disposal, setup refresh, and the disable list surviving restart with eligibility and ordering intact. Package automation covers DeepSeek explicit/PATH/managed selection, immutable six-platform archive metadata, readiness, extension refusal, crash/reconnect, and idempotent shutdown. Copilot package automation covers branded version parsing, explicit/PATH/managed precedence, exact six-archive metadata, provisioning-authoritative startup, and local-login-required failure. Headless bridge; representative managed harness for start and shutdown, every registered harness for listing and ordering. |
+| L2 Routine | Demand-driven start of a ready harness, clean lifecycle-owned bridge shutdown, Codex keepalive traffic remaining local and stopping on disposal, setup refresh, and the disable list surviving restart with eligibility and ordering intact. Package automation covers DeepSeek explicit/PATH/managed selection, immutable six-platform archive metadata, readiness, extension refusal, crash/reconnect, and idempotent shutdown. Copilot package automation covers branded version parsing, explicit/PATH/managed precedence, exact six-archive metadata, provisioning-authoritative startup, and local-login-required failure. Grok package automation covers explicit/PATH authority, bounded branded version parsing, read-only inspection, local-login-required startup, crash/reconnect, and owned shutdown. Headless bridge; representative managed harness for start and shutdown, every registered harness for listing and ordering. |
 | L3 Release | The management surface as rendered: per-harness selected runtime version when reported, setup, runtime and work state, capability-appropriate controls, built-in name and light/dark artwork, default badge, enable/disable, restart, idle-timeout default plus override persisted across a bridge restart, and the per-harness catalog scan on a routable harness including its in-place progress and the announcement of what it found. Copilot renders the exact `GitHub Copilot` name and Primer interface icon in both themes. Client end to end; every harness declaring the relevant capability must pass. |
-| L4 Extended | Busy conflict with force confirmation and cancellation, authentication start/join/cancel plus shutdown cleanup, idle suspension elapsing then returning on demand, harnesses blocked by missing runtime or authentication with no catalog-scan action offered on them, a targeted scan rejected by the bridge reporting on its own card, a terminally failed harness leaving others usable, a bridge with no usable harness, an externally managed configuration, two harnesses active at once, second mobile platform. Copilot live coverage includes an unexpected owned-process exit followed by demand reconnect and a deliberate clean shutdown that is not reported as a crash. Live plugin where a real backend must start or be interrupted, client end to end where card state is claimed. |
+| L4 Extended | Busy conflict with force confirmation and cancellation, authentication start/join/cancel plus shutdown cleanup, idle suspension elapsing then returning on demand, harnesses blocked by missing runtime or authentication with no catalog-scan action offered on them, a targeted scan rejected by the bridge reporting on its own card, a terminally failed harness leaving others usable, a bridge with no usable harness, an externally managed configuration, two harnesses active at once, second mobile platform. Copilot live coverage includes an unexpected owned-process exit followed by demand reconnect and a deliberate clean shutdown that is not reported as a crash. Grok live coverage includes the same failure isolation and demand reconnect with a supported user-installed release. Live plugin where a real backend must start or be interrupted, client end to end where card state is claimed. |
 | L5 Full | Every registered production harness through inspect, enable, disable, restart, refresh, and idle behavior on a supported platform, plus forward-compatible presentation of an unknown harness or capability and the reported state of a session interrupted by a forced disable. Compatibility pairs prove an older client treats `copilot` as an unknown raw-id/generic-icon harness without decode failure, while an older bridge simply supplies no Copilot entry to a newer client. Live plugin and client end to end as each entry requires. |
 
 ## Exploration Guidance
@@ -160,7 +170,9 @@ directories. For Hermes, vary missing and pre-ACP installs, a release below `0.2
 unconfigured model/provider, PATH discovery, and `--hermes-bin`. Restore eligibility,
 timeouts, and sessions afterwards. For Copilot, vary missing, malformed, too-old,
 compatible PATH, managed, and explicit runtimes; authenticated and unauthenticated
-normal configuration; owned-process exit; and bridge restart.
+normal configuration; owned-process exit; and bridge restart. For Grok, vary
+missing, malformed, too-old, current PATH, and authoritative explicit binaries;
+headless and interactive-only authentication; owned-process exit; and restart.
 
 ## Failure Signals
 
@@ -198,6 +210,10 @@ normal configuration; owned-process exit; and bridge restart.
 - Copilot setup accepts unbranded version output, falls back from a provisioned
   runtime during start, mutates the user's configuration, offers in-app login,
   or leaves another harness unavailable after Copilot exits.
+- Grok setup accepts an unrelated or malformed version line, falls through from
+  an explicit path to PATH, performs login or ACP work during inspection, offers
+  managed installation, launches with leader/auto-update attachment enabled, or
+  leaves another harness unavailable after Grok exits.
 
 ## Known Limitations
 
@@ -231,6 +247,8 @@ normal configuration; owned-process exit; and bridge restart.
 - `bridge/sesori_plugin_hermes/lib/src/runtime/hermes_plugin_descriptor.dart` and its tests
 - `bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_plugin_descriptor.dart` and its tests
 - `bridge/sesori_plugin_copilot/lib/src/runtime/copilot_plugin_descriptor.dart` and its tests
+- `bridge/sesori_plugin_grok/lib/src/runtime/grok_plugin_descriptor.dart` and its tests
+- `bridge/sesori_plugin_grok/lib/src/grok_plugin_impl.dart` and `grok_plugin_test.dart`
 - `bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart` and `codex_plugin_write_path_test.dart`
 - `client/module_core/.../plugin_management_service.dart`, `PregoBrandLogo`, and the
   harness settings screen

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_identity.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_identity.dart
@@ -13,7 +13,8 @@ enum Harness() {
   hermes,
   pi,
   omp,
-  deepseek;
+  deepseek,
+  grok;
 }
 
 // COMPATIBILITY 2026-07-13 (v1.5.0): Old peers omit pluginId and mean OpenCode. Remove constant/export with defaults.


### PR DESCRIPTION
## Complexity

⚙️ **Moderate** — this activates an existing plugin across the bridge composition and shared built-in identity boundaries while preserving generic lifecycle and compatibility behavior.

## What

- Added the Grok plugin package as a bridge-app dependency and registered `GrokPluginDescriptor` at the sole concrete composition point.
- Added `Harness.grok` without changing string-based transport contracts or unknown-plugin fallback behavior.
- Extended exact registry and CLI-option coverage for the built-in `grok` identity and namespaced `--grok-bin` option.
- Added an explicit assertion that OpenCode remains the preferred default.
- Updated app and root architecture inventories, including previously omitted Copilot and DeepSeek edges.
- Added Grok Build to the closed runtime-target update procedure with its direct-CLI validation requirements.
- Recorded activation-specific setup, authentication, lifecycle, exploration, failure, and source regression coverage.

## Why

The Grok package and lifecycle descriptor landed in the preceding steps but were intentionally not available to the shipping bridge. This step activates that descriptor through the existing plugin-neutral registry so Grok inherits setup gating, eligibility, on-demand startup, failure isolation, and lifecycle controls without adding a backend-specific app path.

## Risk and test focus

**Moderate risk.** Registration affects the built-in harness set and CLI option catalog. The most valuable checks are exact one-time registration, namespaced option exposure, OpenCode default preservation, shared identity coverage, dependency resolution, and compilation through the bridge app. Grok still uses the existing generic lifecycle; no new route, trigger, persistence, or analytics path is introduced.

## Expected result

A bridge built from this change advertises Grok Build as an eligible built-in harness and exposes `--grok-bin`. Grok starts only on demand after its existing setup checks allow it, and a Grok failure remains isolated from other harnesses. OpenCode remains the preferred default.

There is no database schema or persisted-data migration. Older clients continue to receive string plugin IDs and can use their existing unknown-plugin fallback. Dedicated Grok client branding remains Step 7.

## Verification

- `bridge`: `dart pub get` — passed
- `bridge/app`: `dart analyze --fatal-infos` — no issues
- Focused bridge app registry/CLI tests — 7 passed
- `shared/sesori_shared`: `dart analyze` — no issues
- `shared/sesori_shared`: `dart test` — 392 passed
- Dart LSP diagnostics — 0 across the four changed Dart implementation/test files
- `git diff --check origin/main...HEAD` — passed
- Authored line-width check — no added lines over 120 characters
- Scope — 172 changed lines against `origin/main`, below the 1,500-line target
- Architecture implementation review over Step 6 against Step 5 — approved with no findings
