### PR TITLE
🚧 [desktop-app] Add bridge process primitives [step 2/22]

### DIFF
--- a/.plan/active/desktop-app/PLAN.md
+++ b/.plan/active/desktop-app/PLAN.md
@@ -3,10 +3,10 @@
 ## Status
 
 - **Plan slug:** `desktop-app`
-- **Status:** Active — step 1/22 (plan + supersede)
+- **Status:** Active — step 2/22 (bridge process primitives)
 - **Plan date:** 2026-08-28
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
-- **Current implementation base:** `main` (branch `jade-lynx` worktree)
+- **Current implementation base:** `main`
 - **Delivery:** 22-step PR series titled
   `<emoji> [desktop-app] <description> [step <x>/22]`
 - **Architecture plan review:** performed 2026-08-28 (approve-with-fixes); all
@@ -139,8 +139,8 @@ client/desktop ──────────┼→ module_app_ui → module_cor
 
 ## Steps
 
-Sizes are soft-capped at 1,500 changed lines; steps 1, 14, 17, 18 record
-expected overages (mechanical deletions/moves) below. Any step that ships or
+Sizes are soft-capped at 1,500 changed lines; steps 1, 2, 14, 17, 18 record
+expected overages below. Any step that ships or
 materially changes user-facing behavior updates the directly affected
 `docs/regression/` feature document in the same PR; step 21 is final
 reconciliation only, never the first write.
@@ -159,7 +159,7 @@ verification: stale docstrings in `control_status_notifier.dart` /
 "Subsystem" (it is part of the core layered app). Docs/comments only — no
 behavior change. *Overage: ~3.1k deleted doc lines, mechanical.*
 
-**Step 2 — ⚙️ Bridge process primitives.** `module_desktop_core` Layer 1
+**Step 2 — 🚧 Bridge process primitives.** `module_desktop_core` Layer 1
 process API (spawn/kill/exit stream/stdout+stderr streams; non-positive-PID
 guard), Layer 2 `BridgeProcessRepository` — the **single Layer-2 boundary over
 the process API**: spawn, graceful-signal/kill, exit stream, raw stdio
@@ -194,7 +194,10 @@ rotation/replacement — helper output carries paths/identifiers/errors,
 mirroring the bridge's data-directory hardening; a storage write failure is
 caught and logged **rate-limited** by the tracker — a persistently unwritable
 disk must not turn every helper line into a warning — and never stops the
-drain). Pure Dart, fully unit-tested.
+drain). Pure Dart, fully unit-tested. *Overage: ~1.6k changed lines including
+generated control-union code and focused process, repository, storage, and
+pipe-drain test suites; the atomic stop and non-blocking log contracts land as
+one cohesive boundary.*
 
 **Step 3 — 🚧 `BridgeProcessService` (Layer 3): the channel comes alive.**
 Collaborators (all lower-layer): `BridgeProcessRepository` (all process

--- a/.plan/active/desktop-app/PLAN.md
+++ b/.plan/active/desktop-app/PLAN.md
@@ -194,7 +194,7 @@ rotation/replacement — helper output carries paths/identifiers/errors,
 mirroring the bridge's data-directory hardening; a storage write failure is
 caught and logged **rate-limited** by the tracker — a persistently unwritable
 disk must not turn every helper line into a warning — and never stops the
-drain). Pure Dart, fully unit-tested. *Overage: ~1.6k changed lines including
+drain). Pure Dart, fully unit-tested. *Overage: ~1.8k changed lines including
 generated control-union code and focused process, repository, storage, and
 pipe-drain test suites; the atomic stop and non-blocking log contracts land as
 one cohesive boundary.*

--- a/.plan/active/desktop-app/TRACKER.md
+++ b/.plan/active/desktop-app/TRACKER.md
@@ -7,8 +7,8 @@ user-run checkpoints, not PRs; only the user marks them passed.
 
 | Step | Title | Status |
 |---|---|---|
-| 1 | 🌿 Raise plan; supersede + delete old desktop plan | in-progress |
-| 2 | ⚙️ Bridge process primitives (API, repository, log tracker/storage) | pending |
+| 1 | 🌿 Raise plan; supersede + delete old desktop plan | done |
+| 2 | 🚧 Bridge process primitives (API, repository, log tracker/storage) | done |
 | 3 | 🚧 `BridgeProcessService`: authenticated spawn + control channel live | pending |
 | 4 | 🚧 Exit-code state machine + prompt-answer seam | pending |
 | 5 | 🌿 Status semantics + dead control-protocol removal | pending |

--- a/.plan/active/desktop-app/steps/step-02.md
+++ b/.plan/active/desktop-app/steps/step-02.md
@@ -15,12 +15,15 @@ Date: 2026-08-28.
   exit events with an expected marker, and an idempotent atomic expected stop
   that marks before sending `shutdown`, falls back to POSIX SIGTERM when the
   channel is absent, waits beyond the bridge's complete teardown/backstop
-  budget, and tree-kills without losing the marker.
+  budget, bounds the force-kill command and exit wait, permits a failed stop to
+  be retried while the child remains active, and tree-kills without losing the
+  marker.
 - Added desktop-owned rotating helper logs: a shell-provided application-support
   directory seam, Layer-1 `BridgeProcessLogStorage` with a 5 MiB active-file cap
   plus one rotation and POSIX 0700/0600 hardening, and Layer-2
   `BridgeProcessLogTracker` with malformed-UTF-8-tolerant continuous pipe drain,
-  a last-200 ring buffer, snapshots, and rate-limited persistence warnings.
+  a last-200 ring buffer, snapshots, a bounded/batched persistence queue, and
+  rate-limited persistence and overflow warnings.
 - Registered the new boundaries in desktop phase-1 / desktop-core phase-4 DI
   and exported their public contracts.
 
@@ -31,7 +34,7 @@ spawn and handshake remain step 3.
 
 Actual implementation complexity was revised from `⚙️` to `🚧`: the cohesive
 change crosses a shared wire contract, bridge lifecycle composition, OS process
-control, secure persistence, and desktop DI. The ~1.6k-line soft-cap overage is
+control, secure persistence, and desktop DI. The ~1.8k-line soft-cap overage is
 recorded in `PLAN.md`; generated union code and focused primitive tests account
 for the excess.
 
@@ -44,7 +47,7 @@ and class cohesion all match the plan.
 ## Verification
 
 - `client/module_desktop_core`: `dart analyze --fatal-infos` — clean.
-- `client/module_desktop_core`: `dart test` — 72 tests passed.
+- `client/module_desktop_core`: `dart test` — 75 tests passed.
 - `shared/sesori_shared`: `dart analyze --fatal-infos` — clean.
 - `shared/sesori_shared`: `dart test test/protocol/control_message_test.dart` —
   18 tests passed.

--- a/.plan/active/desktop-app/steps/step-02.md
+++ b/.plan/active/desktop-app/steps/step-02.md
@@ -1,0 +1,60 @@
+# Step 2 — Bridge process primitives
+
+Date: 2026-08-28.
+
+## Delivered
+
+- Added `ControlMessage.shutdown` to the shared control protocol and routed it
+  through the bridge's single inbound dispatcher to the composition-owned,
+  graceful exit-0 path. `unregister_and_exit` reuses that clean-stop path after
+  its unregister attempt.
+- Added the desktop Layer-1 `BridgeProcessApi`: raw stdio/exit hand-off,
+  non-positive-PID rejection, POSIX graceful signaling, Windows `taskkill /T`,
+  and POSIX descendant-first process-tree kill.
+- Added the sole Layer-2 `BridgeProcessRepository` boundary: one active child,
+  exit events with an expected marker, and an idempotent atomic expected stop
+  that marks before sending `shutdown`, falls back to POSIX SIGTERM when the
+  channel is absent, waits beyond the bridge's complete teardown/backstop
+  budget, and tree-kills without losing the marker.
+- Added desktop-owned rotating helper logs: a shell-provided application-support
+  directory seam, Layer-1 `BridgeProcessLogStorage` with a 5 MiB active-file cap
+  plus one rotation and POSIX 0700/0600 hardening, and Layer-2
+  `BridgeProcessLogTracker` with malformed-UTF-8-tolerant continuous pipe drain,
+  a last-200 ring buffer, snapshots, and rate-limited persistence warnings.
+- Registered the new boundaries in desktop phase-1 / desktop-core phase-4 DI
+  and exported their public contracts.
+
+No user-visible or database behavior changes in this step. The first real GUI
+spawn and handshake remain step 3.
+
+## Plan truth
+
+Actual implementation complexity was revised from `⚙️` to `🚧`: the cohesive
+change crosses a shared wire contract, bridge lifecycle composition, OS process
+control, secure persistence, and desktop DI. The ~1.6k-line soft-cap overage is
+recorded in `PLAN.md`; generated union code and focused primitive tests account
+for the excess.
+
+## Architecture implementation review
+
+Approved 2026-08-28. The reviewer applied B-Client, B-Bridge, and B-Shared and
+found no issues: dependency direction, lifecycle ownership, DI phase ordering,
+and class cohesion all match the plan.
+
+## Verification
+
+- `client/module_desktop_core`: `dart analyze --fatal-infos` — clean.
+- `client/module_desktop_core`: `dart test` — 72 tests passed.
+- `shared/sesori_shared`: `dart analyze --fatal-infos` — clean.
+- `shared/sesori_shared`: `dart test test/protocol/control_message_test.dart` —
+  18 tests passed.
+- `bridge/app`: `dart analyze --fatal-infos` — clean.
+- `bridge/app`: dispatcher + token-service focused tests — 28 tests passed.
+- `client/desktop`: `dart analyze --fatal-infos` and `flutter test` — passed.
+- Dart LSP: 0 diagnostics across 21 affected production files.
+- Regenerated shared Freezed/JSON and desktop Injectable outputs with
+  `build_runner`.
+
+Windows and Linux process-tree branches are unit-covered; their real OS build
+and execution evidence comes from desktop CI and later manual gates. No manual
+supervision gate is due until step 7.

--- a/bridge/app/lib/src/control/bridge_control_message_dispatcher.dart
+++ b/bridge/app/lib/src/control/bridge_control_message_dispatcher.dart
@@ -26,6 +26,7 @@ class BridgeControlMessageDispatcher({
   required final ControlChannelTokenService _tokenService,
   required final ControlPromptService _promptService,
   required final ControlUnregisterService _unregisterService,
+  required final Future<void> Function() _shutdown,
 }) {
   StreamSubscription<String>? _subscription;
 
@@ -60,6 +61,10 @@ class BridgeControlMessageDispatcher({
         _tokenService.handleTokenUpdate(accessToken: accessToken);
       case ControlPromptResponse(:final id, :final accepted):
         _promptService.handlePromptResponse(id: id, accepted: accepted);
+      case ControlShutdown():
+        // The composition root owns graceful teardown + exit. Fire-and-forget:
+        // a successful command terminates this process.
+        unawaited(_shutdown());
       case ControlUnregisterAndExit():
         // Unregisters then terminates the process; fire-and-forget because the
         // flow ends in a graceful shutdown + exit and owns its own errors.

--- a/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
@@ -157,9 +157,9 @@ enum SupervisedExitCode(
   /// respawn whose fresh replace prompt the GUI answers with accept.
   bridgeContention(88),
 
-  /// The GUI's `unregister_and_exit` logout command: a deliberate clean stop,
-  /// so the GUI must not respawn.
-  logout(0),
+  /// A GUI-requested `shutdown` or `unregister_and_exit`: a deliberate clean
+  /// stop, so the GUI must not respawn.
+  cleanStop(0),
 
   /// The control channel to the GUI was lost past the grace period (ADR A9):
   /// an abnormal exit — the parent is gone, so a loss must never read as a
@@ -186,7 +186,7 @@ class const BridgeRuntimeRunner._() {
     CatalogImportConsoleListener? catalogImportConsoleListener;
     Future<void>? sessionRun;
     // The single typed slot for a deliberate supervised exit (restart /
-    // auth-required / contention / logout / control-channel loss). Set at the
+    // auth-required / contention / clean stop / control-channel loss). Set at the
     // moment an outcome is decided — BEFORE any shutdown runs — so both the
     // explicit return and the coordinator backstop report the same code even
     // when the stop hangs or throws (the backstop's timing varies with how
@@ -406,19 +406,21 @@ class const BridgeRuntimeRunner._() {
           machineName: machineName,
         );
         shutdownCoordinator.add(disposable: supervisedRegistrationService.dispose);
-        // Handles the GUI's `unregister_and_exit` logout command: unregister the
-        // bridgeId, then gracefully shut down and exit 0 (a clean stop, so the
-        // GUI does not respawn us). Record the logout sentinel first so a hung
-        // shutdown's backstop still reports 0 rather than a latched-failure 1.
+        // Both GUI clean-stop commands share the same graceful teardown path;
+        // unregister_and_exit performs its DELETE first. Record the clean-stop
+        // sentinel before teardown so a hung shutdown's backstop still reports
+        // 0 rather than a latched-failure 1.
+        Future<void> terminateSupervisedCleanly() {
+          requestedSupervisedExit = SupervisedExitCode.cleanStop;
+          return _shutdownThenExit(
+            shutdownCoordinator: shutdownCoordinator,
+            code: SupervisedExitCode.cleanStop.code,
+          );
+        }
+
         final controlUnregisterService = ControlUnregisterService(
           registrationService: supervisedRegistrationService,
-          terminate: () {
-            requestedSupervisedExit = SupervisedExitCode.logout;
-            return _shutdownThenExit(
-              shutdownCoordinator: shutdownCoordinator,
-              code: SupervisedExitCode.logout.code,
-            );
-          },
+          terminate: terminateSupervisedCleanly,
         );
         // The single inbound subscriber: decodes GUI→helper frames once and
         // routes them to the owning service. Started before the bootstrap token
@@ -428,6 +430,7 @@ class const BridgeRuntimeRunner._() {
           tokenService: controlChannelTokenService,
           promptService: controlPromptService,
           unregisterService: controlUnregisterService,
+          shutdown: terminateSupervisedCleanly,
         );
         controlMessageDispatcher.start();
         shutdownCoordinator.add(disposable: controlMessageDispatcher.dispose);
@@ -982,7 +985,7 @@ class const BridgeRuntimeRunner._() {
         // that must NOT happen: the exit must stay the sentinel so the GUI
         // respawns (86), prompts for login (87), or offers a take-over (88)
         // rather than treating it as a crash. For every other exit — including
-        // logout and control-channel loss, whose graceful path exits the
+        // clean stop and control-channel loss, whose graceful path exits the
         // process itself — preserve the loud-failure behaviour by rethrowing.
         switch (requestedSupervisedExit) {
           case SupervisedExitCode.restart:
@@ -993,7 +996,7 @@ class const BridgeRuntimeRunner._() {
               error,
               stackTrace,
             );
-          case SupervisedExitCode.logout:
+          case SupervisedExitCode.cleanStop:
           case SupervisedExitCode.controlChannelLost:
           case null:
             rethrow;
@@ -1126,10 +1129,10 @@ class const BridgeRuntimeRunner._() {
   }
 
   /// Runs the ordered shutdown (stopping the plugin and any owned runtime),
-  /// then exits with [code]. Two supervised paths use it: the control-channel
-  /// parent-loss policy (ADR A9) and the GUI logout `unregister_and_exit`
-  /// command. Running the ordered shutdown first means a hard exit can never
-  /// orphan the backend process. If the stop hangs, the coordinator backstop
+  /// then exits with [code]. Supervised parent-loss, normal GUI `shutdown`, and
+  /// GUI logout `unregister_and_exit` all use it. Running the ordered shutdown
+  /// first means a hard exit can never orphan the backend process. If the stop
+  /// hangs, the coordinator backstop
   /// fires; for the loss path the abnormal code recorded via
   /// `requestAbnormalExit` is reported so a loss is never seen as a clean exit.
   /// The precise exit code the GUI observes is finalized in Phase 2 (PR 2.7).
@@ -1140,7 +1143,7 @@ class const BridgeRuntimeRunner._() {
     try {
       await shutdownCoordinator.shutdown();
     } catch (error, stackTrace) {
-      Log.w("[control] graceful shutdown after control-channel loss failed", error, stackTrace);
+      Log.w("[control] graceful supervised shutdown failed", error, stackTrace);
     }
     io.exit(code);
   }

--- a/bridge/app/test/control/bridge_control_message_dispatcher_test.dart
+++ b/bridge/app/test/control/bridge_control_message_dispatcher_test.dart
@@ -15,6 +15,7 @@ void main() {
     late _RecordingTokenService tokenService;
     late _RecordingPromptService promptService;
     late _RecordingUnregisterService unregisterService;
+    late int shutdownCalls;
     late BridgeControlMessageDispatcher dispatcher;
 
     setUp(() {
@@ -22,11 +23,15 @@ void main() {
       tokenService = _RecordingTokenService();
       promptService = _RecordingPromptService();
       unregisterService = _RecordingUnregisterService();
+      shutdownCalls = 0;
       dispatcher = BridgeControlMessageDispatcher(
         client: client,
         tokenService: tokenService,
         promptService: promptService,
         unregisterService: unregisterService,
+        shutdown: () async {
+          shutdownCalls++;
+        },
       );
       addTearDown(dispatcher.dispose);
     });
@@ -59,6 +64,15 @@ void main() {
 
       expect(promptService.responses, equals([("p-1", true), ("p-2", false)]));
       expect(tokenService.responses, isEmpty);
+    });
+
+    test("routes shutdown to the graceful exit delegate", () async {
+      dispatcher.start();
+      client.emit(_encode(const ControlMessage.shutdown()));
+      await pumpEventQueue();
+
+      expect(shutdownCalls, equals(1));
+      expect(unregisterService.calls, isZero);
     });
 
     test("routes unregister_and_exit to the unregister service delegate", () async {
@@ -114,6 +128,7 @@ void main() {
         tokenService: realTokenService,
         promptService: realPromptService,
         unregisterService: _RecordingUnregisterService(),
+        shutdown: () async {},
       );
       addTearDown(wired.dispose);
       wired.start();

--- a/bridge/app/test/services/control_channel_token_service_test.dart
+++ b/bridge/app/test/services/control_channel_token_service_test.dart
@@ -27,6 +27,7 @@ void main() {
       tokenService: service,
       promptService: ControlPromptService(client: client),
       unregisterService: _NoopUnregisterService(),
+      shutdown: () async {},
     )..start();
     addTearDown(dispatcher.dispose);
     return service;

--- a/bridge/app/tool/dev_control_host.dart
+++ b/bridge/app/tool/dev_control_host.dart
@@ -347,6 +347,7 @@ class _DevControlHost({
       case ControlStatus():
       case ControlPromptResponse():
       case ControlRestart():
+      case ControlShutdown():
       case ControlUnregisterAndExit():
       case ControlRegistered():
       case ControlProvisionProgressMessage():

--- a/client/desktop/lib/core/di/injection.config.dart
+++ b/client/desktop/lib/core/di/injection.config.dart
@@ -24,10 +24,13 @@ import 'package:sesori_desktop/core/platform/desktop_secure_storage_adapter.dart
     as _i757;
 import 'package:sesori_desktop/core/platform/desktop_url_launcher.dart'
     as _i137;
+import 'package:sesori_desktop/core/platform/flutter_desktop_application_support_directory.dart'
+    as _i11;
 import 'package:sesori_desktop/core/platform/no_op_analytics_client.dart'
     as _i262;
 import 'package:sesori_desktop/core/platform/no_op_attribution_client.dart'
     as _i91;
+import 'package:sesori_desktop_core/sesori_desktop_core.dart' as _i316;
 
 extension GetItInjectableX on _i174.GetIt {
   // initializes the registration of main-scope dependencies inside of GetIt
@@ -43,6 +46,9 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i558.FlutterSecureStorage>(
       () => registerModule.secureStorage,
+    );
+    gh.lazySingleton<_i316.DesktopApplicationSupportDirectory>(
+      () => _i11.FlutterDesktopApplicationSupportDirectory(),
     );
     gh.lazySingleton<_i948.OAuthDeviceDescriptorProvider>(
       () => _i20.DesktopOAuthDeviceDescriptorProvider(

--- a/client/desktop/lib/core/platform/flutter_desktop_application_support_directory.dart
+++ b/client/desktop/lib/core/platform/flutter_desktop_application_support_directory.dart
@@ -1,0 +1,15 @@
+import "dart:io";
+
+import "package:injectable/injectable.dart";
+import "package:path_provider/path_provider.dart" as path_provider;
+import "package:sesori_desktop_core/sesori_desktop_core.dart";
+
+/// Flutter/path-provider implementation of the desktop-owned application-data
+/// root used by supervision logs and later desktop-only persisted state.
+@LazySingleton(as: DesktopApplicationSupportDirectory)
+class FlutterDesktopApplicationSupportDirectory() implements DesktopApplicationSupportDirectory {
+  Future<Directory>? _directory;
+
+  @override
+  Future<Directory> resolve() => _directory ??= path_provider.getApplicationSupportDirectory();
+}

--- a/client/desktop/pubspec.yaml
+++ b/client/desktop/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   injectable: ^3.0.0
   material_ui: ^1.0.1
   package_info_plus: ^10.2.1
+  path_provider: ^2.1.6
   rxdart: ^0.28.0
   # DI-call only (configureAuthDependencies) — sesori_auth types MUST NOT be
   # imported outside lib/core/di/ (see client/AGENTS.md).

--- a/client/desktop/test/core/di/injection_test.dart
+++ b/client/desktop/test/core/di/injection_test.dart
@@ -2,6 +2,7 @@ import "package:flutter_test/flutter_test.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_desktop/core/di/injection.dart";
 import "package:sesori_desktop/core/platform/no_op_analytics_client.dart";
+import "package:sesori_desktop_core/sesori_desktop_core.dart";
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -28,6 +29,8 @@ void main() {
     expect(getIt<AnalyticsClient>(), isA<NoOpAnalyticsClient>());
     expect(getIt<AnalyticsRuntimeCapability>().isEnabled, isFalse);
     expect(getIt<ProductAnalyticsService>(), isA<ProductAnalyticsService>());
+    expect(getIt.isRegistered<DesktopApplicationSupportDirectory>(), isTrue);
+    expect(getIt.isRegistered<BridgeProcessLogStorage>(), isTrue);
   });
 
   test("desktop bootstrap leaves the mobile thumbnail cache unbound and unresolved", () {

--- a/client/module_desktop_core/lib/sesori_desktop_core.dart
+++ b/client/module_desktop_core/lib/sesori_desktop_core.dart
@@ -6,11 +6,16 @@ library;
 // so shell consumers don't need a direct sesori_shared import for it).
 export "package:sesori_shared/sesori_shared.dart" show AuthUser;
 
+export "src/api/bridge_process_api.dart";
+export "src/api/bridge_process_log_storage.dart";
 export "src/control/control_message_dispatcher.dart";
 export "src/cubits/auth_gate/auth_gate_cubit.dart";
 export "src/cubits/auth_gate/auth_gate_state.dart";
 export "src/di/injection.dart";
 export "src/foundation/control_channel_server.dart";
+export "src/foundation/platform/desktop_application_support_directory.dart";
+export "src/repositories/bridge_process_repository.dart";
 export "src/trackers/bridge_control_status.dart";
+export "src/trackers/bridge_process_log_tracker.dart";
 export "src/trackers/bridge_prompt_tracker.dart";
 export "src/trackers/bridge_status_tracker.dart";

--- a/client/module_desktop_core/lib/src/api/bridge_process_api.dart
+++ b/client/module_desktop_core/lib/src/api/bridge_process_api.dart
@@ -1,0 +1,210 @@
+import "dart:io";
+
+import "package:injectable/injectable.dart";
+import "package:meta/meta.dart";
+
+/// Starts a child process while keeping the platform calls replaceable in unit
+/// tests without introducing a production-only interface.
+@visibleForTesting
+typedef BridgeProcessStarter = Future<Process> Function({
+  required String executable,
+  required List<String> arguments,
+  required String? workingDirectory,
+  required Map<String, String>? environment,
+});
+
+/// Runs a short-lived platform process-tree command.
+@visibleForTesting
+typedef BridgeProcessCommandRunner = Future<ProcessResult> Function({
+  required String executable,
+  required List<String> arguments,
+});
+
+/// Sends an operating-system signal to one process id.
+@visibleForTesting
+typedef BridgeProcessSignalSender = bool Function({
+  required int pid,
+  required ProcessSignal signal,
+});
+
+/// The raw process resources returned by [BridgeProcessApi.spawn].
+class BridgeProcessApiHandle({
+  required final int pid,
+  required final IOSink stdin,
+  required final Stream<List<int>> stdout,
+  required final Stream<List<int>> stderr,
+  required final Future<int> exitCode,
+});
+
+/// Raised before any platform process command can receive an unsafe pid.
+final class const InvalidBridgeProcessIdException({required final int pid}) implements Exception {
+  @override
+  String toString() => "InvalidBridgeProcessIdException: bridge process id must be positive, got $pid";
+}
+
+/// Raised when an operating-system process-tree command rejects the kill.
+final class const BridgeProcessTreeKillException({
+  required final int pid,
+  required final String details,
+}) implements Exception {
+  @override
+  String toString() => "BridgeProcessTreeKillException(pid: $pid): $details";
+}
+
+/// Layer-1 wrapper around the operating-system child-process primitives used by
+/// the desktop bridge supervisor.
+///
+/// The API is intentionally dumb: it starts a process, exposes raw stdio and
+/// exit completion, sends the POSIX graceful signal, and force-kills a whole
+/// process tree. Expected-stop semantics belong to the Layer-2 repository.
+@lazySingleton
+class BridgeProcessApi.forTesting({
+  required final bool _isWindows,
+  required final BridgeProcessStarter _startProcess,
+  required final BridgeProcessCommandRunner _runCommand,
+  required final BridgeProcessSignalSender _sendSignal,
+}) {
+  new()
+    : this.forTesting(
+        isWindows: Platform.isWindows,
+        startProcess: _startProcessDefault,
+        runCommand: _runCommandDefault,
+        sendSignal: _sendSignalDefault,
+      );
+
+  @visibleForTesting
+  this;
+
+  Future<BridgeProcessApiHandle> spawn({
+    required String executable,
+    required List<String> arguments,
+    required String? workingDirectory,
+    required Map<String, String>? environment,
+  }) async {
+    final Process process = await _startProcess(
+      executable: executable,
+      arguments: arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+    );
+    try {
+      _requirePositivePid(pid: process.pid);
+    } on InvalidBridgeProcessIdException {
+      process.kill(ProcessSignal.sigkill);
+      rethrow;
+    }
+    return BridgeProcessApiHandle(
+      pid: process.pid,
+      stdin: process.stdin,
+      stdout: process.stdout,
+      stderr: process.stderr,
+      exitCode: process.exitCode,
+    );
+  }
+
+  /// Sends the bridge's catchable graceful-stop signal on POSIX.
+  ///
+  /// Windows has no equivalent catchable SIGTERM contract, so it returns false
+  /// and lets the repository move directly to its process-tree fallback when
+  /// the control channel is unavailable.
+  bool sendGracefulSignal({required int pid}) {
+    _requirePositivePid(pid: pid);
+    if (_isWindows) {
+      return false;
+    }
+    return _sendSignal(pid: pid, signal: ProcessSignal.sigterm);
+  }
+
+  /// Force-kills the helper and every descendant process it owns.
+  Future<void> killProcessTree({required int pid}) async {
+    _requirePositivePid(pid: pid);
+    if (_isWindows) {
+      await _killWindowsProcessTree(pid: pid);
+      return;
+    }
+    await _killPosixProcessTree(pid: pid);
+  }
+
+  Future<void> _killWindowsProcessTree({required int pid}) async {
+    final ProcessResult result = await _runCommand(
+      executable: "taskkill",
+      arguments: ["/PID", "$pid", "/T", "/F"],
+    );
+    if (result.exitCode != 0) {
+      final String stderr = result.stderr.toString().trim();
+      throw BridgeProcessTreeKillException(
+        pid: pid,
+        details: stderr.isEmpty ? "taskkill exited ${result.exitCode}" : stderr,
+      );
+    }
+  }
+
+  Future<void> _killPosixProcessTree({required int pid}) async {
+    final ProcessResult result = await _runCommand(
+      executable: "ps",
+      arguments: const ["-axo", "pid=,ppid="],
+    );
+    if (result.exitCode != 0) {
+      final String stderr = result.stderr.toString().trim();
+      throw BridgeProcessTreeKillException(
+        pid: pid,
+        details: stderr.isEmpty ? "ps exited ${result.exitCode}" : stderr,
+      );
+    }
+
+    final Map<int, List<int>> childrenByParent = <int, List<int>>{};
+    for (final String line in result.stdout.toString().split("\n")) {
+      final List<String> fields = line.trim().split(RegExp(r"\s+"));
+      if (fields.length < 2) {
+        continue;
+      }
+      final int? childPid = int.tryParse(fields[0]);
+      final int? parentPid = int.tryParse(fields[1]);
+      if (childPid == null || parentPid == null || childPid <= 0) {
+        continue;
+      }
+      childrenByParent.putIfAbsent(parentPid, () => <int>[]).add(childPid);
+    }
+
+    final List<int> descendants = <int>[];
+    void collectDescendants({required int parentPid}) {
+      for (final int childPid in childrenByParent[parentPid] ?? const <int>[]) {
+        collectDescendants(parentPid: childPid);
+        descendants.add(childPid);
+      }
+    }
+
+    collectDescendants(parentPid: pid);
+    for (final int descendantPid in descendants) {
+      _sendSignal(pid: descendantPid, signal: ProcessSignal.sigkill);
+    }
+    _sendSignal(pid: pid, signal: ProcessSignal.sigkill);
+  }
+
+  static void _requirePositivePid({required int pid}) {
+    if (pid <= 0) {
+      throw InvalidBridgeProcessIdException(pid: pid);
+    }
+  }
+
+  static Future<Process> _startProcessDefault({
+    required String executable,
+    required List<String> arguments,
+    required String? workingDirectory,
+    required Map<String, String>? environment,
+  }) => Process.start(
+    executable,
+    arguments,
+    workingDirectory: workingDirectory,
+    environment: environment,
+    runInShell: false,
+    mode: ProcessStartMode.normal,
+  );
+
+  static Future<ProcessResult> _runCommandDefault({
+    required String executable,
+    required List<String> arguments,
+  }) => Process.run(executable, arguments, runInShell: false);
+
+  static bool _sendSignalDefault({required int pid, required ProcessSignal signal}) => Process.killPid(pid, signal);
+}

--- a/client/module_desktop_core/lib/src/api/bridge_process_log_storage.dart
+++ b/client/module_desktop_core/lib/src/api/bridge_process_log_storage.dart
@@ -1,0 +1,162 @@
+import "dart:convert";
+import "dart:io";
+
+import "package:injectable/injectable.dart";
+import "package:meta/meta.dart";
+import "package:path/path.dart" as path;
+
+import "../foundation/platform/desktop_application_support_directory.dart";
+
+/// Applies one owner-only POSIX mode to a filesystem path.
+@visibleForTesting
+typedef BridgeLogPermissionSetter = Future<void> Function({
+  required String path,
+  required String mode,
+});
+
+/// Layer-1 rotating file storage for supervised helper output.
+///
+/// The active file and its single rotated predecessor live only under the
+/// desktop app's application-support directory. On POSIX, the log directory is
+/// hardened to 0700 and every current/rotated file to 0600 before content is
+/// written.
+@lazySingleton
+class BridgeProcessLogStorage.forTesting({
+  required final DesktopApplicationSupportDirectory _applicationSupportDirectory,
+  required final int _maxFileBytes,
+  required final bool _isWindows,
+  required final BridgeLogPermissionSetter _setPermissions,
+}) {
+  new({required DesktopApplicationSupportDirectory applicationSupportDirectory})
+    : this.forTesting(
+        applicationSupportDirectory: applicationSupportDirectory,
+        maxFileBytes: defaultMaxFileBytes,
+        isWindows: Platform.isWindows,
+        setPermissions: _setPosixPermissions,
+      );
+
+  @visibleForTesting
+  this : assert(_maxFileBytes > 0, "maxFileBytes must be positive");
+
+  static const int defaultMaxFileBytes = 5 * 1024 * 1024;
+  static const String _logsDirectoryName = "logs";
+  static const String _currentFileName = "bridge.log";
+  static const String _rotatedFileName = "bridge.log.1";
+
+  Future<void> _writeTail = Future<void>.value();
+  bool _directoryPrepared = false;
+  bool _currentFilePrepared = false;
+
+  /// The active helper log path used by the later desktop "open logs" action.
+  Future<String> get logFilePath async {
+    final Directory root = await _applicationSupportDirectory.resolve();
+    return path.join(root.path, _logsDirectoryName, _currentFileName);
+  }
+
+  /// Appends one logical line, serializing concurrent stdout/stderr writes and
+  /// rotating before the configured size cap would be exceeded.
+  Future<void> appendLine({required String line}) {
+    final Future<void> operation = _writeTail.then((_) => _appendLine(line: line));
+    // Keep the serialization tail usable after a failed write while returning
+    // the original failing future to the tracker, which reports it.
+    _writeTail = operation.then<void>((_) {}, onError: (Object _, StackTrace _) {});
+    return operation;
+  }
+
+  Future<void> _appendLine({required String line}) async {
+    final Directory root = await _applicationSupportDirectory.resolve();
+    final Directory logsDirectory = Directory(path.join(root.path, _logsDirectoryName));
+    final File currentFile = File(path.join(logsDirectory.path, _currentFileName));
+    final File rotatedFile = File(path.join(logsDirectory.path, _rotatedFileName));
+
+    try {
+      await _prepareDirectory(directory: logsDirectory);
+      await _prepareFile(file: currentFile);
+      final List<int> bytes = _fitLineToCap(line: line);
+      final int currentLength = await currentFile.length();
+      if (currentLength > 0 && currentLength + bytes.length > _maxFileBytes) {
+        await _rotate(currentFile: currentFile, rotatedFile: rotatedFile);
+      }
+      await currentFile.writeAsBytes(bytes, mode: FileMode.append, flush: true);
+    } on Object {
+      // A transient filesystem failure must not poison later retries.
+      _directoryPrepared = false;
+      _currentFilePrepared = false;
+      rethrow;
+    }
+  }
+
+  Future<void> _prepareDirectory({required Directory directory}) async {
+    // ignore: avoid_slow_async_io, async filesystem work must not block the desktop UI isolate
+    if (!await directory.exists()) {
+      await directory.create(recursive: true);
+      _directoryPrepared = false;
+    }
+    if (!_isWindows && !_directoryPrepared) {
+      await _setPermissions(path: directory.path, mode: "700");
+    }
+    _directoryPrepared = true;
+  }
+
+  Future<void> _prepareFile({required File file}) async {
+    // ignore: avoid_slow_async_io, async filesystem work must not block the desktop UI isolate
+    if (!await file.exists()) {
+      await file.create(recursive: true);
+      _currentFilePrepared = false;
+    }
+    if (!_isWindows && !_currentFilePrepared) {
+      await _setPermissions(path: file.path, mode: "600");
+    }
+    _currentFilePrepared = true;
+  }
+
+  Future<void> _rotate({required File currentFile, required File rotatedFile}) async {
+    // ignore: avoid_slow_async_io, async filesystem work must not block the desktop UI isolate
+    if (await rotatedFile.exists()) {
+      await rotatedFile.delete();
+    }
+    await currentFile.rename(rotatedFile.path);
+    if (!_isWindows) {
+      await _setPermissions(path: rotatedFile.path, mode: "600");
+    }
+    await currentFile.create(recursive: true);
+    if (!_isWindows) {
+      await _setPermissions(path: currentFile.path, mode: "600");
+    }
+    _currentFilePrepared = true;
+  }
+
+  List<int> _fitLineToCap({required String line}) {
+    final List<int> full = utf8.encode("$line\n");
+    if (full.length <= _maxFileBytes) {
+      return full;
+    }
+
+    // Keep the newest complete Unicode scalar values. This preserves valid
+    // UTF-8 while ensuring even one exceptionally large helper line cannot
+    // exceed the file-size cap.
+    final List<int> runes = line.runes.toList(growable: false);
+    int start = runes.length;
+    int byteLength = 1; // trailing newline
+    while (start > 0) {
+      final int runeLength = utf8.encode(String.fromCharCode(runes[start - 1])).length;
+      if (byteLength + runeLength > _maxFileBytes) {
+        break;
+      }
+      start--;
+      byteLength += runeLength;
+    }
+    return utf8.encode("${String.fromCharCodes(runes.skip(start))}\n");
+  }
+
+  static Future<void> _setPosixPermissions({required String path, required String mode}) async {
+    final ProcessResult result = await Process.run("chmod", <String>[mode, path], runInShell: false);
+    if (result.exitCode != 0) {
+      final String stderr = result.stderr.toString().trim();
+      throw FileSystemException(
+        stderr.isEmpty ? "chmod $mode failed with exit code ${result.exitCode}" : stderr,
+        path,
+      );
+    }
+  }
+}

--- a/client/module_desktop_core/lib/src/control/control_message_dispatcher.dart
+++ b/client/module_desktop_core/lib/src/control/control_message_dispatcher.dart
@@ -80,7 +80,11 @@ class ControlMessageDispatcher({
         // Advisory heads-up only — the exit-code sentinel is authoritative
         // for the supervisor's respawn decision.
         logd("Helper announced an intentional restart");
-      case ControlTokenResponse() || ControlTokenUpdate() || ControlPromptResponse() || ControlUnregisterAndExit():
+      case ControlTokenResponse() ||
+          ControlTokenUpdate() ||
+          ControlPromptResponse() ||
+          ControlShutdown() ||
+          ControlUnregisterAndExit():
         // GUI→helper-direction variants are never inbound commands.
         logd("Ignoring a GUI-direction control message arriving inbound");
     }

--- a/client/module_desktop_core/lib/src/di/injection.config.dart
+++ b/client/module_desktop_core/lib/src/di/injection.config.dart
@@ -12,10 +12,19 @@
 import 'package:get_it/get_it.dart' as _i174;
 import 'package:injectable/injectable.dart' as _i526;
 import 'package:sesori_dart_core/sesori_dart_core.dart' as _i948;
+import 'package:sesori_desktop_core/src/api/bridge_process_api.dart' as _i874;
+import 'package:sesori_desktop_core/src/api/bridge_process_log_storage.dart'
+    as _i570;
 import 'package:sesori_desktop_core/src/control/control_message_dispatcher.dart'
     as _i21;
 import 'package:sesori_desktop_core/src/foundation/control_channel_server.dart'
     as _i464;
+import 'package:sesori_desktop_core/src/foundation/platform/desktop_application_support_directory.dart'
+    as _i695;
+import 'package:sesori_desktop_core/src/repositories/bridge_process_repository.dart'
+    as _i209;
+import 'package:sesori_desktop_core/src/trackers/bridge_process_log_tracker.dart'
+    as _i866;
 import 'package:sesori_desktop_core/src/trackers/bridge_prompt_tracker.dart'
     as _i686;
 import 'package:sesori_desktop_core/src/trackers/bridge_status_tracker.dart'
@@ -28,6 +37,7 @@ extension GetItInjectableX on _i174.GetIt {
     _i526.EnvironmentFilter? environmentFilter,
   }) {
     final gh = _i526.GetItHelper(this, environment, environmentFilter);
+    gh.lazySingleton<_i874.BridgeProcessApi>(() => _i874.BridgeProcessApi());
     gh.lazySingleton<_i464.ControlChannelServer>(
       () => _i464.ControlChannelServer(),
       dispose: (i) => i.dispose(),
@@ -40,12 +50,31 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i227.BridgeStatusTracker(),
       dispose: (i) => i.dispose(),
     );
+    gh.lazySingleton<_i570.BridgeProcessLogStorage>(
+      () => _i570.BridgeProcessLogStorage(
+        applicationSupportDirectory:
+            gh<_i695.DesktopApplicationSupportDirectory>(),
+      ),
+    );
     gh.lazySingleton<_i21.ControlMessageDispatcher>(
       () => _i21.ControlMessageDispatcher(
         server: gh<_i464.ControlChannelServer>(),
         tokenProvider: gh<_i948.AuthTokenProvider>(),
         statusTracker: gh<_i227.BridgeStatusTracker>(),
         promptTracker: gh<_i686.BridgePromptTracker>(),
+      ),
+      dispose: (i) => i.dispose(),
+    );
+    gh.lazySingleton<_i209.BridgeProcessRepository>(
+      () => _i209.BridgeProcessRepository(
+        processApi: gh<_i874.BridgeProcessApi>(),
+        controlChannelServer: gh<_i464.ControlChannelServer>(),
+      ),
+      dispose: (i) => i.dispose(),
+    );
+    gh.lazySingleton<_i866.BridgeProcessLogTracker>(
+      () => _i866.BridgeProcessLogTracker(
+        storage: gh<_i570.BridgeProcessLogStorage>(),
       ),
       dispose: (i) => i.dispose(),
     );

--- a/client/module_desktop_core/lib/src/di/injection.dart
+++ b/client/module_desktop_core/lib/src/di/injection.dart
@@ -1,6 +1,8 @@
 import "package:get_it/get_it.dart";
 import "package:injectable/injectable.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart" show AuthTokenProvider;
 
+import "../foundation/platform/desktop_application_support_directory.dart";
 import "injection.config.dart";
 
 // Phase 4 of the desktop 4-phase DI init (see client/AGENTS.md):
@@ -11,5 +13,5 @@ import "injection.config.dart";
 //
 // Desktop services, repositories, and trackers register HERE (via annotations
 // in this package), never in the client/desktop shell.
-@InjectableInit()
+@InjectableInit(ignoreUnregisteredTypes: [AuthTokenProvider, DesktopApplicationSupportDirectory])
 void configureDesktopCoreDependencies(GetIt getIt) => getIt.init();

--- a/client/module_desktop_core/lib/src/foundation/platform/desktop_application_support_directory.dart
+++ b/client/module_desktop_core/lib/src/foundation/platform/desktop_application_support_directory.dart
@@ -1,0 +1,10 @@
+import "dart:io";
+
+/// Resolves the desktop app's private application-support directory.
+///
+/// The product shell implements this through its platform directory provider;
+/// desktop-core storage must never fall back to the bridge CLI's shared Sesori
+/// data root.
+abstract class DesktopApplicationSupportDirectory() {
+  Future<Directory> resolve();
+}

--- a/client/module_desktop_core/lib/src/repositories/bridge_process_repository.dart
+++ b/client/module_desktop_core/lib/src/repositories/bridge_process_repository.dart
@@ -1,0 +1,221 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+
+import "package:injectable/injectable.dart";
+import "package:meta/meta.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../api/bridge_process_api.dart";
+import "../foundation/control_channel_server.dart";
+
+/// The raw child streams handed upward after a successful repository spawn.
+/// Exit observation stays inside [BridgeProcessRepository].
+class BridgeProcessStreams({
+  required final int pid,
+  required final IOSink stdin,
+  required final Stream<List<int>> stdout,
+  required final Stream<List<int>> stderr,
+});
+
+/// One child-process completion with the expected-stop marker captured at the
+/// instant the process exited.
+@immutable
+class const BridgeProcessExit({
+  required final int pid,
+  required final int exitCode,
+  required final bool expected,
+}) {
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BridgeProcessExit && pid == other.pid && exitCode == other.exitCode && expected == other.expected;
+
+  @override
+  int get hashCode => Object.hash(pid, exitCode, expected);
+}
+
+final class const BridgeProcessAlreadyRunningException({required final int pid}) implements Exception {
+  @override
+  String toString() => "BridgeProcessAlreadyRunningException: bridge process $pid is still active";
+}
+
+/// The sole Layer-2 boundary over bridge child-process operations.
+///
+/// It owns the one active process, its expected-exit marker, exit events, raw
+/// stdio hand-off, and the atomic expected stop. The expected stop marks first,
+/// then asks the helper to shut down over the control channel. If that channel
+/// is absent it uses catchable SIGTERM on POSIX; if no graceful request can be
+/// delivered, or the full bridge teardown deadline expires, it force-kills the
+/// entire process tree without clearing the marker.
+@lazySingleton
+class BridgeProcessRepository.forTesting({
+  required final BridgeProcessApi _processApi,
+  required final ControlChannelServer _controlChannelServer,
+  required final Duration _gracefulShutdownTimeout,
+  required final Duration _forcedExitTimeout,
+}) {
+  new({
+    required BridgeProcessApi processApi,
+    required ControlChannelServer controlChannelServer,
+  }) : this.forTesting(
+         processApi: processApi,
+         controlChannelServer: controlChannelServer,
+         gracefulShutdownTimeout: defaultGracefulShutdownTimeout,
+         forcedExitTimeout: defaultForcedExitTimeout,
+       );
+
+  @visibleForTesting
+  this;
+
+  /// Strictly exceeds the bridge coordinator's maximum graceful path: current
+  /// phase budgets (30s) + backstop slack (10s) + emergency disposal cap (6s).
+  /// The desktop fallback therefore cannot pre-empt plugin/backend disposal.
+  static const Duration defaultGracefulShutdownTimeout = Duration(seconds: 60);
+  static const Duration defaultForcedExitTimeout = Duration(seconds: 5);
+
+  final StreamController<BridgeProcessExit> _exits = StreamController<BridgeProcessExit>.broadcast(sync: true);
+  _ActiveBridgeProcess? _active;
+
+  Stream<BridgeProcessExit> get exits => _exits.stream;
+
+  bool get isRunning => _active != null;
+
+  int? get activePid => _active?.handle.pid;
+
+  Future<BridgeProcessStreams> spawn({
+    required String executable,
+    required List<String> arguments,
+    required String? workingDirectory,
+    required Map<String, String>? environment,
+  }) async {
+    final _ActiveBridgeProcess? existing = _active;
+    if (existing != null) {
+      throw BridgeProcessAlreadyRunningException(pid: existing.handle.pid);
+    }
+
+    final BridgeProcessApiHandle handle = await _processApi.spawn(
+      executable: executable,
+      arguments: arguments,
+      workingDirectory: workingDirectory,
+      environment: environment,
+    );
+    final _ActiveBridgeProcess active = _ActiveBridgeProcess(handle: handle);
+    _active = active;
+    unawaited(_observeExit(active: active));
+    return BridgeProcessStreams(
+      pid: handle.pid,
+      stdin: handle.stdin,
+      stdout: handle.stdout,
+      stderr: handle.stderr,
+    );
+  }
+
+  /// Atomically marks the current child as expected and stops it.
+  ///
+  /// Repeated callers join the same stop operation. A force-kill fallback never
+  /// clears [BridgeProcessExit.expected], so exit-policy consumers cannot
+  /// mistake a helper that hung during an intentional stop for a crash.
+  Future<void> stopExpected() {
+    final _ActiveBridgeProcess? active = _active;
+    if (active == null) {
+      return Future<void>.value();
+    }
+    return active.stopFuture ??= _stopExpected(active: active);
+  }
+
+  Future<void> _stopExpected({required _ActiveBridgeProcess active}) async {
+    active.expected = true;
+    bool gracefulRequestDelivered = false;
+    try {
+      const ControlMessage message = ControlMessage.shutdown();
+      _controlChannelServer.send(jsonEncode(message.toJson()));
+      gracefulRequestDelivered = true;
+    } on ControlHelperNotConnectedException {
+      gracefulRequestDelivered = _tryGracefulSignal(active: active);
+    } on Object catch (error, stackTrace) {
+      logw("Failed to request bridge shutdown over the control channel", error, stackTrace);
+      gracefulRequestDelivered = _tryGracefulSignal(active: active);
+    }
+
+    if (!gracefulRequestDelivered) {
+      if (await _alreadyExited(active: active)) {
+        return;
+      }
+      await _forceKillAndWait(active: active);
+      return;
+    }
+
+    try {
+      await active.handle.exitCode.timeout(_gracefulShutdownTimeout);
+    } on TimeoutException {
+      await _forceKillAndWait(active: active);
+    }
+  }
+
+  bool _tryGracefulSignal({required _ActiveBridgeProcess active}) {
+    try {
+      return _processApi.sendGracefulSignal(pid: active.handle.pid);
+    } on Object catch (error, stackTrace) {
+      logw("Failed to signal the bridge process for graceful shutdown", error, stackTrace);
+      return false;
+    }
+  }
+
+  Future<bool> _alreadyExited({required _ActiveBridgeProcess active}) async {
+    try {
+      await active.handle.exitCode.timeout(Duration.zero);
+      return true;
+    } on TimeoutException {
+      return false;
+    }
+  }
+
+  Future<void> _forceKillAndWait({required _ActiveBridgeProcess active}) async {
+    await _processApi.killProcessTree(pid: active.handle.pid);
+    await active.handle.exitCode.timeout(_forcedExitTimeout);
+  }
+
+  Future<void> _observeExit({required _ActiveBridgeProcess active}) async {
+    try {
+      final int exitCode = await active.handle.exitCode;
+      if (identical(_active, active)) {
+        _active = null;
+      }
+      if (!_exits.isClosed) {
+        _exits.add(
+          BridgeProcessExit(
+            pid: active.handle.pid,
+            exitCode: exitCode,
+            expected: active.expected,
+          ),
+        );
+      }
+    } on Object catch (error, stackTrace) {
+      if (identical(_active, active)) {
+        _active = null;
+      }
+      if (!_exits.isClosed) {
+        _exits.addError(error, stackTrace);
+      }
+    } finally {
+      try {
+        await active.handle.stdin.close();
+      } on Object catch (error, stackTrace) {
+        logw("Failed to close bridge process stdin after exit", error, stackTrace);
+      }
+    }
+  }
+
+  @disposeMethod
+  Future<void> dispose() async {
+    await stopExpected();
+    await _exits.close();
+  }
+}
+
+class _ActiveBridgeProcess({required final BridgeProcessApiHandle handle}) {
+  bool expected = false;
+  Future<void>? stopFuture;
+}

--- a/client/module_desktop_core/lib/src/repositories/bridge_process_repository.dart
+++ b/client/module_desktop_core/lib/src/repositories/bridge_process_repository.dart
@@ -122,7 +122,20 @@ class BridgeProcessRepository.forTesting({
     if (active == null) {
       return Future<void>.value();
     }
-    return active.stopFuture ??= _stopExpected(active: active);
+    return active.stopFuture ??= _runStopExpected(active: active);
+  }
+
+  Future<void> _runStopExpected({required _ActiveBridgeProcess active}) async {
+    try {
+      await _stopExpected(active: active);
+    } on Object {
+      // Keep concurrent callers on one atomic stop attempt, but do not let one
+      // failed platform command permanently poison future Off/Quit retries.
+      if (identical(_active, active)) {
+        active.stopFuture = null;
+      }
+      rethrow;
+    }
   }
 
   Future<void> _stopExpected({required _ActiveBridgeProcess active}) async {
@@ -173,7 +186,7 @@ class BridgeProcessRepository.forTesting({
   }
 
   Future<void> _forceKillAndWait({required _ActiveBridgeProcess active}) async {
-    await _processApi.killProcessTree(pid: active.handle.pid);
+    await _processApi.killProcessTree(pid: active.handle.pid).timeout(_forcedExitTimeout);
     await active.handle.exitCode.timeout(_forcedExitTimeout);
   }
 

--- a/client/module_desktop_core/lib/src/trackers/bridge_process_log_tracker.dart
+++ b/client/module_desktop_core/lib/src/trackers/bridge_process_log_tracker.dart
@@ -42,6 +42,7 @@ typedef BridgeProcessLogWarningReporter = void Function({
 class BridgeProcessLogTracker.forTesting({
   required final BridgeProcessLogStorage _storage,
   required final int _maxEntries,
+  required final int _maxPendingPersistenceEntries,
   required final Duration _storageWarningInterval,
   required final DateTime Function() _now,
   required final BridgeProcessLogWarningReporter _reportWarning,
@@ -50,23 +51,29 @@ class BridgeProcessLogTracker.forTesting({
     : this.forTesting(
         storage: storage,
         maxEntries: defaultMaxEntries,
+        maxPendingPersistenceEntries: defaultMaxPendingPersistenceEntries,
         storageWarningInterval: defaultStorageWarningInterval,
         now: DateTime.now,
         reportWarning: _logWarning,
       );
 
   @visibleForTesting
-  this : assert(_maxEntries > 0, "maxEntries must be positive");
+  this
+    : assert(_maxEntries > 0, "maxEntries must be positive"),
+      assert(_maxPendingPersistenceEntries > 0, "maxPendingPersistenceEntries must be positive");
 
   static const int defaultMaxEntries = 200;
+  static const int defaultMaxPendingPersistenceEntries = 200;
   static const Duration defaultStorageWarningInterval = Duration(minutes: 1);
 
   final ListQueue<BridgeProcessLogEntry> _entries = ListQueue<BridgeProcessLogEntry>();
+  final ListQueue<BridgeProcessLogEntry> _pendingPersistenceEntries = ListQueue<BridgeProcessLogEntry>();
   final BehaviorSubject<List<BridgeProcessLogEntry>> _entrySnapshots =
       BehaviorSubject<List<BridgeProcessLogEntry>>.seeded(const <BridgeProcessLogEntry>[]);
-  final Set<Future<void>> _pendingPersistence = <Future<void>>{};
   CompositeSubscription _subscriptions = CompositeSubscription();
+  Future<void>? _persistenceDrain;
   DateTime? _nextStorageWarningAt;
+  DateTime? _nextQueueWarningAt;
 
   List<BridgeProcessLogEntry> get snapshot => List<BridgeProcessLogEntry>.unmodifiable(_entries);
 
@@ -113,18 +120,39 @@ class BridgeProcessLogTracker.forTesting({
     }
     _entrySnapshots.add(snapshot);
 
-    final Future<void> persistence = _persist(entry: entry);
-    _pendingPersistence.add(persistence);
-    unawaited(
-      persistence.whenComplete(() {
-        _pendingPersistence.remove(persistence);
-      }),
-    );
+    if (_pendingPersistenceEntries.length >= _maxPendingPersistenceEntries) {
+      _pendingPersistenceEntries.removeFirst();
+      _reportQueueOverflow();
+    }
+    _pendingPersistenceEntries.addLast(entry);
+    _persistenceDrain ??= _drainPersistence();
   }
 
-  Future<void> _persist({required BridgeProcessLogEntry entry}) async {
+  /// Persists at most one in-flight batch while retaining a bounded queue for
+  /// output that arrives during the write. One storage flush can therefore
+  /// cover the entire backlog, and a verbose helper cannot build an unbounded
+  /// future chain or make disposal await one write per captured line.
+  Future<void> _drainPersistence() async {
     try {
-      await _storage.appendLine(line: _format(entry: entry));
+      while (_pendingPersistenceEntries.isNotEmpty) {
+        final List<BridgeProcessLogEntry> batch = List<BridgeProcessLogEntry>.of(
+          _pendingPersistenceEntries,
+          growable: false,
+        );
+        _pendingPersistenceEntries.clear();
+        await _persist(entries: batch);
+      }
+    } finally {
+      _persistenceDrain = null;
+      if (_pendingPersistenceEntries.isNotEmpty) {
+        _persistenceDrain = _drainPersistence();
+      }
+    }
+  }
+
+  Future<void> _persist({required List<BridgeProcessLogEntry> entries}) async {
+    try {
+      await _storage.appendLine(line: entries.map((entry) => _format(entry: entry)).join("\n"));
       _nextStorageWarningAt = null;
     } on Object catch (error, stackTrace) {
       final DateTime now = _now();
@@ -140,6 +168,20 @@ class BridgeProcessLogTracker.forTesting({
     }
   }
 
+  void _reportQueueOverflow() {
+    final DateTime now = _now();
+    final DateTime? nextWarningAt = _nextQueueWarningAt;
+    if (nextWarningAt != null && now.isBefore(nextWarningAt)) {
+      return;
+    }
+    _nextQueueWarningAt = now.add(_storageWarningInterval);
+    _reportWarning(
+      message: "Supervised bridge output exceeded the bounded persistence queue; dropping oldest pending lines",
+      error: StateError("Bridge log persistence queue reached $_maxPendingPersistenceEntries entries"),
+      stackTrace: StackTrace.current,
+    );
+  }
+
   static String _format({required BridgeProcessLogEntry entry}) =>
       "${entry.timestamp.toUtc().toIso8601String()} [${entry.source.name}] ${entry.message}";
 
@@ -152,7 +194,13 @@ class BridgeProcessLogTracker.forTesting({
   @disposeMethod
   Future<void> dispose() async {
     await _subscriptions.cancel();
-    await Future.wait<void>(_pendingPersistence);
+    while (true) {
+      final Future<void>? drain = _persistenceDrain;
+      if (drain == null) {
+        break;
+      }
+      await drain;
+    }
     await _entrySnapshots.close();
   }
 }

--- a/client/module_desktop_core/lib/src/trackers/bridge_process_log_tracker.dart
+++ b/client/module_desktop_core/lib/src/trackers/bridge_process_log_tracker.dart
@@ -1,0 +1,158 @@
+import "dart:async";
+import "dart:collection";
+import "dart:convert";
+
+import "package:injectable/injectable.dart";
+import "package:meta/meta.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+
+import "../api/bridge_process_log_storage.dart";
+
+/// Which child pipe produced a helper log line.
+// WORKAROUND: dart_style 3.1.12 crashes on empty enhanced enum constructors in this file.
+// ignore: use_primary_constructors
+enum BridgeProcessLogSource { stdout, stderr }
+
+/// One line captured from the supervised bridge process.
+class const BridgeProcessLogEntry({
+  required final DateTime timestamp,
+  required final BridgeProcessLogSource source,
+  required final String message,
+});
+
+/// Reports a local pipe or persistence warning without coupling tests to the
+/// global logger implementation.
+@visibleForTesting
+typedef BridgeProcessLogWarningReporter = void Function({
+  required String message,
+  required Object error,
+  required StackTrace stackTrace,
+});
+
+/// Layer-2 owner of the supervised helper's stdout/stderr drain and recent-log
+/// state.
+///
+/// Both pipes are continuously decoded with malformed-byte tolerance, so a
+/// chatty or imperfect helper can never block on a full OS pipe. Every line is
+/// retained in a last-N in-memory ring and independently offered to rotating
+/// Layer-1 storage; storage failures are rate-limited in local logs and never
+/// cancel either drain subscription.
+@lazySingleton
+class BridgeProcessLogTracker.forTesting({
+  required final BridgeProcessLogStorage _storage,
+  required final int _maxEntries,
+  required final Duration _storageWarningInterval,
+  required final DateTime Function() _now,
+  required final BridgeProcessLogWarningReporter _reportWarning,
+}) {
+  new({required BridgeProcessLogStorage storage})
+    : this.forTesting(
+        storage: storage,
+        maxEntries: defaultMaxEntries,
+        storageWarningInterval: defaultStorageWarningInterval,
+        now: DateTime.now,
+        reportWarning: _logWarning,
+      );
+
+  @visibleForTesting
+  this : assert(_maxEntries > 0, "maxEntries must be positive");
+
+  static const int defaultMaxEntries = 200;
+  static const Duration defaultStorageWarningInterval = Duration(minutes: 1);
+
+  final ListQueue<BridgeProcessLogEntry> _entries = ListQueue<BridgeProcessLogEntry>();
+  final BehaviorSubject<List<BridgeProcessLogEntry>> _entrySnapshots =
+      BehaviorSubject<List<BridgeProcessLogEntry>>.seeded(const <BridgeProcessLogEntry>[]);
+  final Set<Future<void>> _pendingPersistence = <Future<void>>{};
+  CompositeSubscription _subscriptions = CompositeSubscription();
+  DateTime? _nextStorageWarningAt;
+
+  List<BridgeProcessLogEntry> get snapshot => List<BridgeProcessLogEntry>.unmodifiable(_entries);
+
+  ValueStream<List<BridgeProcessLogEntry>> get snapshots => _entrySnapshots.stream;
+
+  /// Replaces the current pipe subscriptions with a new child process's raw
+  /// byte streams. Cancelling the old subscriptions is awaited before the new
+  /// drain starts, so lines from two process generations cannot interleave.
+  Future<void> attach({
+    required Stream<List<int>> stdout,
+    required Stream<List<int>> stderr,
+  }) async {
+    await _subscriptions.cancel();
+    _subscriptions = CompositeSubscription();
+    _subscribe(stream: stdout, source: BridgeProcessLogSource.stdout).addTo(_subscriptions);
+    _subscribe(stream: stderr, source: BridgeProcessLogSource.stderr).addTo(_subscriptions);
+  }
+
+  StreamSubscription<String> _subscribe({
+    required Stream<List<int>> stream,
+    required BridgeProcessLogSource source,
+  }) => const Utf8Decoder(allowMalformed: true)
+      .bind(stream)
+      .transform(const LineSplitter())
+      .listen(
+        (line) => _record(source: source, message: line),
+        onError: (Object error, StackTrace stackTrace) => _reportWarning(
+          message: "Supervised bridge ${source.name} stream failed",
+          error: error,
+          stackTrace: stackTrace,
+        ),
+        cancelOnError: false,
+      );
+
+  void _record({required BridgeProcessLogSource source, required String message}) {
+    final BridgeProcessLogEntry entry = BridgeProcessLogEntry(
+      timestamp: _now().toUtc(),
+      source: source,
+      message: message,
+    );
+    _entries.addLast(entry);
+    while (_entries.length > _maxEntries) {
+      _entries.removeFirst();
+    }
+    _entrySnapshots.add(snapshot);
+
+    final Future<void> persistence = _persist(entry: entry);
+    _pendingPersistence.add(persistence);
+    unawaited(
+      persistence.whenComplete(() {
+        _pendingPersistence.remove(persistence);
+      }),
+    );
+  }
+
+  Future<void> _persist({required BridgeProcessLogEntry entry}) async {
+    try {
+      await _storage.appendLine(line: _format(entry: entry));
+      _nextStorageWarningAt = null;
+    } on Object catch (error, stackTrace) {
+      final DateTime now = _now();
+      final DateTime? nextWarningAt = _nextStorageWarningAt;
+      if (nextWarningAt == null || !now.isBefore(nextWarningAt)) {
+        _nextStorageWarningAt = now.add(_storageWarningInterval);
+        _reportWarning(
+          message: "Failed to persist supervised bridge output; continuing to drain child pipes",
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
+    }
+  }
+
+  static String _format({required BridgeProcessLogEntry entry}) =>
+      "${entry.timestamp.toUtc().toIso8601String()} [${entry.source.name}] ${entry.message}";
+
+  static void _logWarning({
+    required String message,
+    required Object error,
+    required StackTrace stackTrace,
+  }) => logw(message, error, stackTrace);
+
+  @disposeMethod
+  Future<void> dispose() async {
+    await _subscriptions.cancel();
+    await Future.wait<void>(_pendingPersistence);
+    await _entrySnapshots.close();
+  }
+}

--- a/client/module_desktop_core/pubspec.yaml
+++ b/client/module_desktop_core/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   get_it: ^9.2.1
   injectable: ^3.0.0
   meta: ^1.19.0
+  path: ^1.9.1
   rxdart: ^0.28.0
   sesori_dart_core:
     path: ../module_core

--- a/client/module_desktop_core/test/api/bridge_process_api_test.dart
+++ b/client/module_desktop_core/test/api/bridge_process_api_test.dart
@@ -1,0 +1,181 @@
+import "dart:async";
+import "dart:io";
+
+import "package:mocktail/mocktail.dart";
+import "package:sesori_desktop_core/sesori_desktop_core.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("BridgeProcessApi", () {
+    test("spawn returns raw stdio and forwards launch settings", () async {
+      final _ProcessFixture fixture = _ProcessFixture(pid: 42);
+      addTearDown(fixture.dispose);
+      String? launchedExecutable;
+      List<String>? launchedArguments;
+      String? launchedWorkingDirectory;
+      Map<String, String>? launchedEnvironment;
+      final BridgeProcessApi api = BridgeProcessApi.forTesting(
+        isWindows: false,
+        startProcess:
+            ({
+              required String executable,
+              required List<String> arguments,
+              required String? workingDirectory,
+              required Map<String, String>? environment,
+            }) async {
+              launchedExecutable = executable;
+              launchedArguments = arguments;
+              launchedWorkingDirectory = workingDirectory;
+              launchedEnvironment = environment;
+              return fixture.process;
+            },
+        runCommand: _unusedCommandRunner,
+        sendSignal: _unusedSignalSender,
+      );
+
+      final BridgeProcessApiHandle handle = await api.spawn(
+        executable: "/opt/sesori/bridge",
+        arguments: const ["--control-url", "ws://127.0.0.1:1"],
+        workingDirectory: "/workspace",
+        environment: const {"A": "B"},
+      );
+
+      expect(handle.pid, 42);
+      expect(handle.stdin, same(fixture.stdin));
+      expect(handle.stdout, same(fixture.stdout));
+      expect(handle.stderr, same(fixture.stderr));
+      expect(launchedExecutable, "/opt/sesori/bridge");
+      expect(launchedArguments, const ["--control-url", "ws://127.0.0.1:1"]);
+      expect(launchedWorkingDirectory, "/workspace");
+      expect(launchedEnvironment, const {"A": "B"});
+    });
+
+    test("spawn rejects a non-positive child pid before returning it", () async {
+      final _ProcessFixture fixture = _ProcessFixture(pid: 0);
+      addTearDown(fixture.dispose);
+      when(() => fixture.process.kill(ProcessSignal.sigkill)).thenReturn(true);
+      final BridgeProcessApi api = BridgeProcessApi.forTesting(
+        isWindows: false,
+        startProcess: ({
+          required String executable,
+          required List<String> arguments,
+          required String? workingDirectory,
+          required Map<String, String>? environment,
+        }) async => fixture.process,
+        runCommand: _unusedCommandRunner,
+        sendSignal: _unusedSignalSender,
+      );
+
+      await expectLater(
+        api.spawn(
+          executable: "bridge",
+          arguments: const <String>[],
+          workingDirectory: null,
+          environment: null,
+        ),
+        throwsA(isA<InvalidBridgeProcessIdException>()),
+      );
+      verify(() => fixture.process.kill(ProcessSignal.sigkill)).called(1);
+    });
+
+    test("POSIX process-tree kill signals descendants deepest-first, then the helper", () async {
+      final List<(int, ProcessSignal)> signals = <(int, ProcessSignal)>[];
+      final BridgeProcessApi api = BridgeProcessApi.forTesting(
+        isWindows: false,
+        startProcess: _unusedStarter,
+        runCommand: ({required String executable, required List<String> arguments}) async =>
+            ProcessResult(1, 0, "100 1\n101 100\n102 101\n103 100\n", ""),
+        sendSignal: ({required int pid, required ProcessSignal signal}) {
+          signals.add((pid, signal));
+          return true;
+        },
+      );
+
+      await api.killProcessTree(pid: 100);
+
+      expect(
+        signals,
+        equals(<(int, ProcessSignal)>[
+          (102, ProcessSignal.sigkill),
+          (101, ProcessSignal.sigkill),
+          (103, ProcessSignal.sigkill),
+          (100, ProcessSignal.sigkill),
+        ]),
+      );
+    });
+
+    test("Windows force-kill uses taskkill tree mode", () async {
+      String? launchedExecutable;
+      List<String>? launchedArguments;
+      final BridgeProcessApi api = BridgeProcessApi.forTesting(
+        isWindows: true,
+        startProcess: _unusedStarter,
+        runCommand: ({required String executable, required List<String> arguments}) async {
+          launchedExecutable = executable;
+          launchedArguments = arguments;
+          return ProcessResult(1, 0, "", "");
+        },
+        sendSignal: _unusedSignalSender,
+      );
+
+      await api.killProcessTree(pid: 321);
+
+      expect(launchedExecutable, "taskkill");
+      expect(launchedArguments, const ["/PID", "321", "/T", "/F"]);
+      expect(api.sendGracefulSignal(pid: 321), isFalse);
+    });
+
+    test("all signal and kill entry points reject non-positive pids", () async {
+      final BridgeProcessApi api = BridgeProcessApi.forTesting(
+        isWindows: false,
+        startProcess: _unusedStarter,
+        runCommand: _unusedCommandRunner,
+        sendSignal: _unusedSignalSender,
+      );
+
+      expect(() => api.sendGracefulSignal(pid: 0), throwsA(isA<InvalidBridgeProcessIdException>()));
+      await expectLater(api.killProcessTree(pid: -1), throwsA(isA<InvalidBridgeProcessIdException>()));
+    });
+  });
+}
+
+Future<Process> _unusedStarter({
+  required String executable,
+  required List<String> arguments,
+  required String? workingDirectory,
+  required Map<String, String>? environment,
+}) => throw UnimplementedError();
+
+Future<ProcessResult> _unusedCommandRunner({
+  required String executable,
+  required List<String> arguments,
+}) => throw UnimplementedError();
+
+bool _unusedSignalSender({required int pid, required ProcessSignal signal}) => throw UnimplementedError();
+
+class _ProcessFixture({required int pid}) {
+  final _MockProcess process = _MockProcess();
+  final _MockIOSink stdin = _MockIOSink();
+  final StreamController<List<int>> stdoutController = StreamController<List<int>>.broadcast();
+  final StreamController<List<int>> stderrController = StreamController<List<int>>.broadcast();
+  final Completer<int> exitCode = Completer<int>();
+  late final Stream<List<int>> stdout = stdoutController.stream;
+  late final Stream<List<int>> stderr = stderrController.stream;
+
+  this {
+    when(() => process.pid).thenReturn(pid);
+    when(() => process.stdin).thenReturn(stdin);
+    when(() => process.stdout).thenAnswer((_) => stdout);
+    when(() => process.stderr).thenAnswer((_) => stderr);
+    when(() => process.exitCode).thenAnswer((_) => exitCode.future);
+  }
+
+  Future<void> dispose() async {
+    await stdoutController.close();
+    await stderrController.close();
+  }
+}
+
+class _MockProcess() extends Mock implements Process;
+
+class _MockIOSink() extends Mock implements IOSink;

--- a/client/module_desktop_core/test/api/bridge_process_log_storage_test.dart
+++ b/client/module_desktop_core/test/api/bridge_process_log_storage_test.dart
@@ -1,0 +1,121 @@
+import "dart:io";
+
+import "package:path/path.dart" as path;
+import "package:sesori_desktop_core/sesori_desktop_core.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("BridgeProcessLogStorage", () {
+    late Directory root;
+    late _FixedApplicationSupportDirectory applicationSupportDirectory;
+
+    setUp(() {
+      root = Directory.systemTemp.createTempSync("sesori_bridge_logs_");
+      applicationSupportDirectory = _FixedApplicationSupportDirectory(directory: root);
+    });
+
+    tearDown(() {
+      if (root.existsSync()) {
+        root.deleteSync(recursive: true);
+      }
+    });
+
+    test("appends under desktop app data and rotates before the size cap", () async {
+      final BridgeProcessLogStorage storage = BridgeProcessLogStorage.forTesting(
+        applicationSupportDirectory: applicationSupportDirectory,
+        maxFileBytes: 12,
+        isWindows: true,
+        setPermissions: _noOpPermissionSetter,
+      );
+
+      await storage.appendLine(line: "first");
+      await storage.appendLine(line: "second");
+
+      final File current = File(await storage.logFilePath);
+      final File rotated = File(path.join(root.path, "logs", "bridge.log.1"));
+      expect(await current.readAsString(), "second\n");
+      expect(await rotated.readAsString(), "first\n");
+      expect(await current.length(), lessThanOrEqualTo(12));
+      expect(await rotated.length(), lessThanOrEqualTo(12));
+    });
+
+    test("one oversized line is UTF-8 valid and remains within the cap", () async {
+      final BridgeProcessLogStorage storage = BridgeProcessLogStorage.forTesting(
+        applicationSupportDirectory: applicationSupportDirectory,
+        maxFileBytes: 8,
+        isWindows: true,
+        setPermissions: _noOpPermissionSetter,
+      );
+
+      await storage.appendLine(line: "prefix-🙂🙂");
+
+      final File current = File(await storage.logFilePath);
+      expect(await current.length(), lessThanOrEqualTo(8));
+      expect(await current.readAsString(), "🙂\n");
+    });
+
+    test("hardens the POSIX directory and files, including rotation replacements", () async {
+      final List<(String, String)> permissions = <(String, String)>[];
+      final BridgeProcessLogStorage storage = BridgeProcessLogStorage.forTesting(
+        applicationSupportDirectory: applicationSupportDirectory,
+        maxFileBytes: 8,
+        isWindows: false,
+        setPermissions: ({required String path, required String mode}) async {
+          permissions.add((path, mode));
+        },
+      );
+
+      await storage.appendLine(line: "first");
+      await storage.appendLine(line: "second");
+
+      expect(permissions.where((entry) => entry.$2 == "700"), hasLength(1));
+      expect(permissions.where((entry) => entry.$2 == "600"), hasLength(3));
+      expect(permissions.any((entry) => entry.$1.endsWith("bridge.log.1") && entry.$2 == "600"), isTrue);
+    });
+
+    test("a failed initialization is surfaced and the next append retries", () async {
+      int permissionCalls = 0;
+      final BridgeProcessLogStorage storage = BridgeProcessLogStorage.forTesting(
+        applicationSupportDirectory: applicationSupportDirectory,
+        maxFileBytes: 100,
+        isWindows: false,
+        setPermissions: ({required String path, required String mode}) async {
+          permissionCalls++;
+          if (permissionCalls == 1) {
+            throw const FileSystemException("read-only");
+          }
+        },
+      );
+
+      await expectLater(storage.appendLine(line: "first"), throwsA(isA<FileSystemException>()));
+      await storage.appendLine(line: "second");
+
+      expect(await File(await storage.logFilePath).readAsString(), "second\n");
+      expect(permissionCalls, greaterThanOrEqualTo(3));
+    });
+
+    test("production POSIX permission setter creates owner-only paths", () async {
+      if (Platform.isWindows) {
+        return;
+      }
+      final BridgeProcessLogStorage storage = BridgeProcessLogStorage(
+        applicationSupportDirectory: applicationSupportDirectory,
+      );
+
+      await storage.appendLine(line: "private");
+
+      final File file = File(await storage.logFilePath);
+      final Directory directory = file.parent;
+      expect(directory.statSync().mode & 0x1FF, 0x1C0);
+      expect(file.statSync().mode & 0x1FF, 0x180);
+    });
+  });
+}
+
+Future<void> _noOpPermissionSetter({required String path, required String mode}) async {}
+
+class _FixedApplicationSupportDirectory({required final Directory directory})
+    implements DesktopApplicationSupportDirectory {
+  @override
+  Future<Directory> resolve() async => directory;
+}

--- a/client/module_desktop_core/test/control/control_message_dispatcher_test.dart
+++ b/client/module_desktop_core/test/control/control_message_dispatcher_test.dart
@@ -154,6 +154,7 @@ void main() {
 
     sendFromHelper(helper, const ControlMessage.restart());
     sendFromHelper(helper, const ControlMessage.tokenUpdate(accessToken: "x"));
+    sendFromHelper(helper, const ControlMessage.shutdown());
     sendFromHelper(helper, const ControlMessage.unregisterAndExit());
     sendFromHelper(
       helper,

--- a/client/module_desktop_core/test/di/injection_test.dart
+++ b/client/module_desktop_core/test/di/injection_test.dart
@@ -3,9 +3,13 @@ import "package:sesori_desktop_core/sesori_desktop_core.dart";
 import "package:test/test.dart";
 
 void main() {
-  test("configureDesktopCoreDependencies completes on a fresh container", () {
+  test("configureDesktopCoreDependencies registers supervision primitives on a fresh container", () {
     final GetIt getIt = GetIt.asNewInstance();
 
     expect(() => configureDesktopCoreDependencies(getIt), returnsNormally);
+    expect(getIt.isRegistered<BridgeProcessApi>(), isTrue);
+    expect(getIt.isRegistered<BridgeProcessRepository>(), isTrue);
+    expect(getIt.isRegistered<BridgeProcessLogStorage>(), isTrue);
+    expect(getIt.isRegistered<BridgeProcessLogTracker>(), isTrue);
   });
 }

--- a/client/module_desktop_core/test/repositories/bridge_process_repository_test.dart
+++ b/client/module_desktop_core/test/repositories/bridge_process_repository_test.dart
@@ -1,0 +1,208 @@
+import "dart:async";
+import "dart:io";
+
+import "package:mocktail/mocktail.dart";
+import "package:sesori_desktop_core/sesori_desktop_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("BridgeProcessRepository", () {
+    late _ProcessHandleFixture fixture;
+    late _FakeBridgeProcessApi processApi;
+    late _FakeControlChannelServer controlServer;
+    late BridgeProcessRepository repository;
+
+    setUp(() {
+      fixture = _ProcessHandleFixture(pid: 123);
+      processApi = _FakeBridgeProcessApi(handle: fixture.handle);
+      controlServer = _FakeControlChannelServer();
+      repository = BridgeProcessRepository.forTesting(
+        processApi: processApi,
+        controlChannelServer: controlServer,
+        gracefulShutdownTimeout: const Duration(milliseconds: 20),
+        forcedExitTimeout: const Duration(milliseconds: 20),
+      );
+    });
+
+    tearDown(() async {
+      if (!fixture.exitCode.isCompleted) {
+        fixture.exitCode.complete(0);
+      }
+      await pumpEventQueue();
+      await repository.dispose();
+      await fixture.dispose();
+    });
+
+    test("spawn hands off raw stdio and emits an unexpected exit", () async {
+      final Future<BridgeProcessExit> exit = repository.exits.first;
+
+      final BridgeProcessStreams streams = await _spawn(repository);
+
+      expect(streams.pid, 123);
+      expect(streams.stdin, same(fixture.stdin));
+      expect(streams.stdout, same(fixture.stdout));
+      expect(streams.stderr, same(fixture.stderr));
+      expect(repository.isRunning, isTrue);
+      await expectLater(_spawn(repository), throwsA(isA<BridgeProcessAlreadyRunningException>()));
+
+      fixture.exitCode.complete(7);
+      expect(await exit, const BridgeProcessExit(pid: 123, exitCode: 7, expected: false));
+      expect(repository.isRunning, isFalse);
+    });
+
+    test("expected stop marks before sending shutdown and emits expected exit", () async {
+      await _spawn(repository);
+      final Future<BridgeProcessExit> exit = repository.exits.first;
+      controlServer.onSend = () {
+        fixture.exitCode.complete(0);
+      };
+
+      await repository.stopExpected();
+
+      expect(controlServer.sentFrames, hasLength(1));
+      final ControlMessage message = ControlMessage.fromJson(jsonDecodeMap(controlServer.sentFrames.single));
+      expect(message, const ControlMessage.shutdown());
+      expect(await exit, const BridgeProcessExit(pid: 123, exitCode: 0, expected: true));
+      expect(processApi.gracefulSignalPids, isEmpty);
+      expect(processApi.killedTreePids, isEmpty);
+    });
+
+    test("channel loss falls back to POSIX graceful signal", () async {
+      await _spawn(repository);
+      final Future<BridgeProcessExit> exit = repository.exits.first;
+      controlServer.sendError = const ControlHelperNotConnectedException();
+      processApi.onGracefulSignal = () {
+        fixture.exitCode.complete(0);
+      };
+
+      await repository.stopExpected();
+
+      expect(processApi.gracefulSignalPids, [123]);
+      expect(processApi.killedTreePids, isEmpty);
+      expect((await exit).expected, isTrue);
+    });
+
+    test("no graceful path force-kills the whole tree immediately", () async {
+      await _spawn(repository);
+      final Future<BridgeProcessExit> exit = repository.exits.first;
+      controlServer.sendError = const ControlHelperNotConnectedException();
+      processApi.gracefulSignalResult = false;
+      processApi.onKill = () {
+        fixture.exitCode.complete(-9);
+      };
+
+      await repository.stopExpected();
+
+      expect(processApi.gracefulSignalPids, [123]);
+      expect(processApi.killedTreePids, [123]);
+      expect(await exit, const BridgeProcessExit(pid: 123, exitCode: -9, expected: true));
+    });
+
+    test("a helper that exceeds the graceful deadline is tree-killed without losing the marker", () async {
+      await _spawn(repository);
+      final Future<BridgeProcessExit> exit = repository.exits.first;
+      processApi.onKill = () {
+        fixture.exitCode.complete(-9);
+      };
+
+      final Future<void> first = repository.stopExpected();
+      final Future<void> second = repository.stopExpected();
+      expect(second, same(first));
+      await first;
+
+      expect(controlServer.sentFrames, hasLength(1));
+      expect(processApi.killedTreePids, [123]);
+      expect((await exit).expected, isTrue);
+    });
+
+    test("production grace strictly exceeds the bridge teardown maximum", () {
+      const Duration bridgeMaximum = Duration(seconds: 46);
+
+      expect(BridgeProcessRepository.defaultGracefulShutdownTimeout, greaterThan(bridgeMaximum));
+    });
+  });
+}
+
+Future<BridgeProcessStreams> _spawn(BridgeProcessRepository repository) => repository.spawn(
+  executable: "/tmp/bridge",
+  arguments: const ["--control-url", "ws://127.0.0.1:1"],
+  workingDirectory: null,
+  environment: null,
+);
+
+class _ProcessHandleFixture({required int pid}) {
+  final _MockIOSink stdin = _MockIOSink();
+  final StreamController<List<int>> stdoutController = StreamController<List<int>>.broadcast();
+  final StreamController<List<int>> stderrController = StreamController<List<int>>.broadcast();
+  final Completer<int> exitCode = Completer<int>();
+  late final Stream<List<int>> stdout = stdoutController.stream;
+  late final Stream<List<int>> stderr = stderrController.stream;
+  late final BridgeProcessApiHandle handle;
+
+  this {
+    when(stdin.close).thenAnswer((_) async {});
+    handle = BridgeProcessApiHandle(
+      pid: pid,
+      stdin: stdin,
+      stdout: stdout,
+      stderr: stderr,
+      exitCode: exitCode.future,
+    );
+  }
+
+  Future<void> dispose() async {
+    await stdoutController.close();
+    await stderrController.close();
+  }
+}
+
+class _MockIOSink() extends Mock implements IOSink;
+
+class _FakeBridgeProcessApi({required final BridgeProcessApiHandle handle}) implements BridgeProcessApi {
+  final List<int> gracefulSignalPids = <int>[];
+  final List<int> killedTreePids = <int>[];
+  bool gracefulSignalResult = true;
+  void Function()? onGracefulSignal;
+  void Function()? onKill;
+
+  @override
+  Future<BridgeProcessApiHandle> spawn({
+    required String executable,
+    required List<String> arguments,
+    required String? workingDirectory,
+    required Map<String, String>? environment,
+  }) async => handle;
+
+  @override
+  bool sendGracefulSignal({required int pid}) {
+    gracefulSignalPids.add(pid);
+    onGracefulSignal?.call();
+    return gracefulSignalResult;
+  }
+
+  @override
+  Future<void> killProcessTree({required int pid}) async {
+    killedTreePids.add(pid);
+    onKill?.call();
+  }
+}
+
+class _FakeControlChannelServer() implements ControlChannelServer {
+  final List<String> sentFrames = <String>[];
+  Object? sendError;
+  void Function()? onSend;
+
+  @override
+  void send(String text) {
+    final Object? error = sendError;
+    if (error != null) {
+      throw error;
+    }
+    sentFrames.add(text);
+    onSend?.call();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/client/module_desktop_core/test/repositories/bridge_process_repository_test.dart
+++ b/client/module_desktop_core/test/repositories/bridge_process_repository_test.dart
@@ -99,6 +99,46 @@ void main() {
       expect(await exit, const BridgeProcessExit(pid: 123, exitCode: -9, expected: true));
     });
 
+    test("a failed stop can be retried while the same child remains active", () async {
+      await _spawn(repository);
+      final Future<BridgeProcessExit> exit = repository.exits.first;
+      controlServer.sendError = const ControlHelperNotConnectedException();
+      processApi.gracefulSignalResult = false;
+      processApi.killError = StateError("taskkill failed");
+
+      await expectLater(repository.stopExpected(), throwsA(isA<StateError>()));
+      expect(repository.isRunning, isTrue);
+
+      processApi.killError = null;
+      processApi.onKill = () {
+        fixture.exitCode.complete(-9);
+      };
+      await repository.stopExpected();
+
+      expect(processApi.killedTreePids, [123, 123]);
+      expect((await exit).expected, isTrue);
+    });
+
+    test("a stalled process-tree kill is bounded and remains retryable", () async {
+      await _spawn(repository);
+      final Future<BridgeProcessExit> exit = repository.exits.first;
+      controlServer.sendError = const ControlHelperNotConnectedException();
+      processApi.gracefulSignalResult = false;
+      processApi.killFuture = Completer<void>().future;
+
+      await expectLater(repository.stopExpected(), throwsA(isA<TimeoutException>()));
+      expect(repository.isRunning, isTrue);
+
+      processApi.killFuture = null;
+      processApi.onKill = () {
+        fixture.exitCode.complete(-9);
+      };
+      await repository.stopExpected();
+
+      expect(processApi.killedTreePids, [123, 123]);
+      expect((await exit).expected, isTrue);
+    });
+
     test("a helper that exceeds the graceful deadline is tree-killed without losing the marker", () async {
       await _spawn(repository);
       final Future<BridgeProcessExit> exit = repository.exits.first;
@@ -165,6 +205,8 @@ class _FakeBridgeProcessApi({required final BridgeProcessApiHandle handle}) impl
   bool gracefulSignalResult = true;
   void Function()? onGracefulSignal;
   void Function()? onKill;
+  Object? killError;
+  Future<void>? killFuture;
 
   @override
   Future<BridgeProcessApiHandle> spawn({
@@ -184,7 +226,15 @@ class _FakeBridgeProcessApi({required final BridgeProcessApiHandle handle}) impl
   @override
   Future<void> killProcessTree({required int pid}) async {
     killedTreePids.add(pid);
+    final Object? failure = killError;
+    if (failure != null) {
+      throw failure;
+    }
     onKill?.call();
+    final Future<void>? pending = killFuture;
+    if (pending != null) {
+      await pending;
+    }
   }
 }
 

--- a/client/module_desktop_core/test/trackers/bridge_process_log_tracker_test.dart
+++ b/client/module_desktop_core/test/trackers/bridge_process_log_tracker_test.dart
@@ -1,0 +1,141 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:sesori_desktop_core/sesori_desktop_core.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("BridgeProcessLogTracker", () {
+    late _RecordingLogStorage storage;
+    late DateTime now;
+    late List<String> warnings;
+    late BridgeProcessLogTracker tracker;
+    late StreamController<List<int>> stdout;
+    late StreamController<List<int>> stderr;
+
+    setUp(() {
+      storage = _RecordingLogStorage();
+      now = DateTime.utc(2026, 8, 28, 12);
+      warnings = <String>[];
+      tracker = BridgeProcessLogTracker.forTesting(
+        storage: storage,
+        maxEntries: 2,
+        storageWarningInterval: const Duration(minutes: 1),
+        now: () => now,
+        reportWarning: ({required String message, required Object error, required StackTrace stackTrace}) {
+          warnings.add(message);
+        },
+      );
+      stdout = StreamController<List<int>>(sync: true);
+      stderr = StreamController<List<int>>(sync: true);
+    });
+
+    tearDown(() async {
+      if (!stdout.isClosed) {
+        await stdout.close();
+      }
+      if (!stderr.isClosed) {
+        await stderr.close();
+      }
+      await tracker.dispose();
+    });
+
+    test("drains fragmented stdout/stderr and retains the last-N snapshot", () async {
+      await tracker.attach(stdout: stdout.stream, stderr: stderr.stream);
+
+      stdout.add(utf8.encode("hel"));
+      stdout.add(utf8.encode("lo\none\n"));
+      stderr.add(utf8.encode("error\n"));
+      await stdout.close();
+      await stderr.close();
+      await pumpEventQueue();
+
+      expect(
+        tracker.snapshot.map((entry) => (entry.source, entry.message)),
+        equals(<(BridgeProcessLogSource, String)>[
+          (BridgeProcessLogSource.stdout, "one"),
+          (BridgeProcessLogSource.stderr, "error"),
+        ]),
+      );
+      expect(tracker.snapshots.value, tracker.snapshot);
+      expect(storage.lines, hasLength(3));
+      expect(storage.lines.first, contains("[stdout] hello"));
+      expect(storage.lines.last, contains("[stderr] error"));
+    });
+
+    test("malformed bytes cannot stop the pipe drain", () async {
+      await tracker.attach(stdout: stdout.stream, stderr: stderr.stream);
+
+      stdout
+        ..add(const [0xFF, 0x0A])
+        ..add(utf8.encode("after\n"));
+      await stdout.close();
+      await pumpEventQueue();
+
+      expect(tracker.snapshot.map((entry) => entry.message), containsAll(<String>["�", "after"]));
+      expect(storage.lines, hasLength(2));
+    });
+
+    test("storage failures are rate-limited and never stop capture", () async {
+      storage.error = StateError("disk full");
+      await tracker.attach(stdout: stdout.stream, stderr: stderr.stream);
+
+      stdout
+        ..add(utf8.encode("one\n"))
+        ..add(utf8.encode("two\n"));
+      await pumpEventQueue();
+
+      expect(tracker.snapshot.map((entry) => entry.message), ["one", "two"]);
+      expect(storage.attempts, 2);
+      expect(warnings, hasLength(1));
+
+      now = now.add(const Duration(seconds: 30));
+      stdout.add(utf8.encode("three\n"));
+      await pumpEventQueue();
+      expect(warnings, hasLength(1));
+
+      now = now.add(const Duration(seconds: 31));
+      stdout.add(utf8.encode("four\n"));
+      await pumpEventQueue();
+      expect(warnings, hasLength(2));
+      expect(tracker.snapshot.map((entry) => entry.message), ["three", "four"]);
+    });
+
+    test("attaching a new process cancels the old pipe subscriptions", () async {
+      await tracker.attach(stdout: stdout.stream, stderr: stderr.stream);
+      final StreamController<List<int>> replacementStdout = StreamController<List<int>>(sync: true);
+      final StreamController<List<int>> replacementStderr = StreamController<List<int>>(sync: true);
+      addTearDown(replacementStdout.close);
+      addTearDown(replacementStderr.close);
+
+      await tracker.attach(stdout: replacementStdout.stream, stderr: replacementStderr.stream);
+      stdout.add(utf8.encode("stale\n"));
+      replacementStdout.add(utf8.encode("current\n"));
+      await pumpEventQueue();
+
+      expect(tracker.snapshot.map((entry) => entry.message), ["current"]);
+    });
+  });
+}
+
+class _RecordingLogStorage() implements BridgeProcessLogStorage {
+  final List<String> lines = <String>[];
+  int attempts = 0;
+  Object? error;
+
+  @override
+  Future<void> appendLine({required String line}) async {
+    attempts++;
+    final Object? failure = error;
+    if (failure != null) {
+      throw failure;
+    }
+    lines.add(line);
+  }
+
+  @override
+  Future<String> get logFilePath async => "/tmp/bridge.log";
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/client/module_desktop_core/test/trackers/bridge_process_log_tracker_test.dart
+++ b/client/module_desktop_core/test/trackers/bridge_process_log_tracker_test.dart
@@ -20,6 +20,7 @@ void main() {
       tracker = BridgeProcessLogTracker.forTesting(
         storage: storage,
         maxEntries: 2,
+        maxPendingPersistenceEntries: 3,
         storageWarningInterval: const Duration(minutes: 1),
         now: () => now,
         reportWarning: ({required String message, required Object error, required StackTrace stackTrace}) {
@@ -58,9 +59,9 @@ void main() {
         ]),
       );
       expect(tracker.snapshots.value, tracker.snapshot);
-      expect(storage.lines, hasLength(3));
-      expect(storage.lines.first, contains("[stdout] hello"));
-      expect(storage.lines.last, contains("[stderr] error"));
+      expect(storage.logicalLines, hasLength(3));
+      expect(storage.logicalLines.first, contains("[stdout] hello"));
+      expect(storage.logicalLines.last, contains("[stderr] error"));
     });
 
     test("malformed bytes cannot stop the pipe drain", () async {
@@ -73,7 +74,7 @@ void main() {
       await pumpEventQueue();
 
       expect(tracker.snapshot.map((entry) => entry.message), containsAll(<String>["�", "after"]));
-      expect(storage.lines, hasLength(2));
+      expect(storage.logicalLines, hasLength(2));
     });
 
     test("storage failures are rate-limited and never stop capture", () async {
@@ -101,6 +102,32 @@ void main() {
       expect(tracker.snapshot.map((entry) => entry.message), ["three", "four"]);
     });
 
+    test("bounds queued persistence and batches the newest pending lines", () async {
+      final Completer<void> releaseWrite = Completer<void>();
+      storage.writeGate = releaseWrite.future;
+      await tracker.attach(stdout: stdout.stream, stderr: stderr.stream);
+
+      for (int index = 0; index < 10; index++) {
+        stdout.add(utf8.encode("line-$index\n"));
+      }
+      await pumpEventQueue();
+
+      expect(storage.attempts, 1);
+      expect(tracker.snapshot.map((entry) => entry.message), ["line-8", "line-9"]);
+      expect(warnings, hasLength(1));
+
+      releaseWrite.complete();
+      await pumpEventQueue();
+
+      expect(storage.attempts, 2);
+      expect(storage.logicalLines, hasLength(4));
+      expect(storage.logicalLines.first, endsWith("line-0"));
+      expect(
+        storage.logicalLines.skip(1),
+        everyElement(anyOf(endsWith("line-7"), endsWith("line-8"), endsWith("line-9"))),
+      );
+    });
+
     test("attaching a new process cancels the old pipe subscriptions", () async {
       await tracker.attach(stdout: stdout.stream, stderr: stderr.stream);
       final StreamController<List<int>> replacementStdout = StreamController<List<int>>(sync: true);
@@ -122,10 +149,17 @@ class _RecordingLogStorage() implements BridgeProcessLogStorage {
   final List<String> lines = <String>[];
   int attempts = 0;
   Object? error;
+  Future<void>? writeGate;
+
+  List<String> get logicalLines => lines.expand((chunk) => chunk.split("\n")).toList(growable: false);
 
   @override
   Future<void> appendLine({required String line}) async {
     attempts++;
+    final Future<void>? gate = writeGate;
+    if (gate != null) {
+      await gate;
+    }
     final Object? failure = error;
     if (failure != null) {
       throw failure;

--- a/shared/sesori_shared/lib/src/protocol/control_message.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_message.dart
@@ -69,6 +69,11 @@ sealed class ControlMessage with _$ControlMessage {
   @FreezedUnionValue("restart")
   const factory restart() = ControlRestart;
 
+  /// GUI → helper: gracefully stop the supervised bridge and exit 0 without
+  /// unregistering it. This is the normal desktop On → Off lifecycle command.
+  @FreezedUnionValue("shutdown")
+  const factory shutdown() = ControlShutdown;
+
   /// GUI → helper: unregister this bridge with the current token, then exit 0
   /// (logout ordering).
   @FreezedUnionValue("unregister_and_exit")

--- a/shared/sesori_shared/lib/src/protocol/control_message.freezed.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_message.freezed.dart
@@ -44,6 +44,10 @@ ControlMessage _$ControlMessageFromJson(
           return ControlRestart.fromJson(
             json
           );
+                case 'shutdown':
+          return ControlShutdown.fromJson(
+            json
+          );
                 case 'unregister_and_exit':
           return ControlUnregisterAndExit.fromJson(
             json
@@ -584,6 +588,45 @@ int get hashCode => runtimeType.hashCode;
 @override
 String toString() {
   return 'ControlMessage.restart()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlShutdown implements ControlMessage {
+  const ControlShutdown({ String? $type}): $type = $type ?? 'shutdown';
+  factory ControlShutdown.fromJson(Map<String, dynamic> json) => _$ControlShutdownFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlShutdownToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlShutdown);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'ControlMessage.shutdown()';
 }
 
 

--- a/shared/sesori_shared/lib/src/protocol/control_message.g.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_message.g.dart
@@ -133,6 +133,12 @@ ControlRestart _$ControlRestartFromJson(Map json) =>
 Map<String, dynamic> _$ControlRestartToJson(ControlRestart instance) =>
     <String, dynamic>{'type': instance.$type};
 
+ControlShutdown _$ControlShutdownFromJson(Map json) =>
+    ControlShutdown($type: json['type'] as String?);
+
+Map<String, dynamic> _$ControlShutdownToJson(ControlShutdown instance) =>
+    <String, dynamic>{'type': instance.$type};
+
 ControlUnregisterAndExit _$ControlUnregisterAndExitFromJson(Map json) =>
     ControlUnregisterAndExit($type: json['type'] as String?);
 

--- a/shared/sesori_shared/test/protocol/control_message_test.dart
+++ b/shared/sesori_shared/test/protocol/control_message_test.dart
@@ -19,6 +19,7 @@ void main() {
       ),
       "prompt_response": const ControlMessage.promptResponse(id: "p-1", accepted: true),
       "restart": const ControlMessage.restart(),
+      "shutdown": const ControlMessage.shutdown(),
       "unregister_and_exit": const ControlMessage.unregisterAndExit(),
       "registered": const ControlMessage.registered(bridgeId: "br_abc12345"),
       "provision_progress": const ControlMessage.provisionProgress(


### PR DESCRIPTION
## Complexity

🚧 Complex — this step crosses the shared control wire contract, bridge shutdown lifecycle, OS process-tree control, secure local log persistence, and desktop DI boundaries.

## What

- Added the GUI→helper `shutdown` control message and routed it to the bridge's graceful exit-0 path.
- Added desktop Layer-1 process and rotating-log APIs.
- Added the Layer-2 process repository with atomic expected-stop semantics and process-tree fallback.
- Added continuous stdout/stderr draining, recent-log snapshots, rate-limited persistence warnings, and owner-only POSIX log permissions.
- Registered the desktop application-support path adapter and desktop-core dependencies.
- Updated the desktop plan/tracker and recorded step evidence.

## Why

The desktop supervisor needs a safe process boundary before it can start the control server and spawn the real bridge in step 3. A control-channel shutdown must be primary on every OS, while forced stops must not orphan plugin/backend processes or misclassify an intentional stop as a crash.

## Risk and test focus

Risk is moderate-to-high around lifecycle ordering, Windows/POSIX process-tree behavior, full pipe draining, and local log permissions. Review focus should be the expected marker being set before every stop path, the 60-second grace exceeding the bridge's complete 46-second teardown/backstop budget, descendant-tree termination, and storage failures never cancelling pipe drains.

## Expected result

No user-visible or database change in this step. Internally, the desktop now has the tested primitives required to spawn, observe, gracefully stop, force-stop, and diagnose a supervised bridge. Real GUI spawn/handshake behavior lands in step 3.

## Verification

- `client/module_desktop_core`: `dart analyze --fatal-infos`
- `client/module_desktop_core`: `dart test` (72 passed)
- `shared/sesori_shared`: `dart analyze --fatal-infos`
- `shared/sesori_shared`: `dart test test/protocol/control_message_test.dart` (18 passed)
- `bridge/app`: `dart analyze --fatal-infos`
- `bridge/app`: focused dispatcher + token-service tests (28 passed)
- `client/desktop`: `dart analyze --fatal-infos`
- `client/desktop`: `flutter test`
- Dart LSP: 0 diagnostics across 21 affected production files

## Architecture review

Approved with no findings across B-Client, B-Bridge, and B-Shared.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the desktop bridge-supervisor primitives—process API, repository, and rotating logs—plus a new `shutdown` control command so the GUI can cleanly stop the bridge. No user-visible or database behavior changes land in this step.

- The bridge routes `shutdown` to its graceful exit-0 teardown; `unregister_and_exit` does its unregister DELETE first, then takes that same path.
- `BridgeProcessRepository` marks the process expected before every stop path, waits up to 60s (the bridge's full teardown budget is 46s), and falls back to POSIX SIGTERM when the control channel is absent.
- Force-stops kill the whole descendant tree on POSIX or `taskkill /T` on Windows without clearing the expected marker, so an intentional stop never reads as a crash; kill and exit waits are each bounded, and a failed stop retries while the child stays active.
- Both stdout/stderr pipes drain continuously with malformed-byte tolerance into a last-200 ring buffer; a 200-line bounded queue batches persistence, and failures are rate-limited without ever cancelling the drains.
- Logs rotate at a 5 MiB active-file cap (one predecessor) under the app's application-support directory with POSIX 0700/0600 hardening.
- The new API, repository, storage, and tracker register in desktop DI; the desktop shell supplies the `path_provider`-backed application-support directory, and real GUI spawn/handshake ships in step 3.
- Windows and Linux process-tree branches are unit-covered; real OS behavior is confirmed by CI and later manual gates.

<sup>Written for commit 1bba2e296d6f3757281b90501511e442fd69b068. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

