### PR TITLE
⚙️ [project-voice-glossary] Add glossary publication transport [step 6/8]

### DIFF
--- a/bridge/app/lib/src/api/models/project_glossary_response.dart
+++ b/bridge/app/lib/src/api/models/project_glossary_response.dart
@@ -1,0 +1,25 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "project_glossary_response.freezed.dart";
+part "project_glossary_response.g.dart";
+
+@Freezed(fromJson: true, toJson: false)
+sealed class ProjectGlossaryWordsResponse with _$ProjectGlossaryWordsResponse {
+  const factory({required List<String> words}) = _ProjectGlossaryWordsResponse;
+
+  factory fromJson(Map<String, dynamic> json) => _$ProjectGlossaryWordsResponseFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class ProjectGlossaryAddedWordsResponse with _$ProjectGlossaryAddedWordsResponse {
+  const factory({required List<String> added}) = _ProjectGlossaryAddedWordsResponse;
+
+  factory fromJson(Map<String, dynamic> json) => _$ProjectGlossaryAddedWordsResponseFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class ProjectGlossaryRemovedWordsResponse with _$ProjectGlossaryRemovedWordsResponse {
+  const factory({required int removed}) = _ProjectGlossaryRemovedWordsResponse;
+
+  factory fromJson(Map<String, dynamic> json) => _$ProjectGlossaryRemovedWordsResponseFromJson(json);
+}

--- a/bridge/app/lib/src/api/models/project_glossary_response.freezed.dart
+++ b/bridge/app/lib/src/api/models/project_glossary_response.freezed.dart
@@ -1,0 +1,414 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint, type=warning, deprecated_member_use, deprecated_member_use_from_same_package
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'project_glossary_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ProjectGlossaryWordsResponse {
+
+ List<String> get words;
+/// Create a copy of ProjectGlossaryWordsResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ProjectGlossaryWordsResponseCopyWith<ProjectGlossaryWordsResponse> get copyWith => _$ProjectGlossaryWordsResponseCopyWithImpl<ProjectGlossaryWordsResponse>(this as ProjectGlossaryWordsResponse, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectGlossaryWordsResponse&&const DeepCollectionEquality().equals(other.words, words));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(words));
+
+@override
+String toString() {
+  return 'ProjectGlossaryWordsResponse(words: $words)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ProjectGlossaryWordsResponseCopyWith<$Res>  {
+  factory $ProjectGlossaryWordsResponseCopyWith(ProjectGlossaryWordsResponse value, $Res Function(ProjectGlossaryWordsResponse) _then) = _$ProjectGlossaryWordsResponseCopyWithImpl;
+@useResult
+$Res call({
+ List<String> words
+});
+
+
+
+
+}
+/// @nodoc
+class _$ProjectGlossaryWordsResponseCopyWithImpl<$Res>
+    implements $ProjectGlossaryWordsResponseCopyWith<$Res> {
+  _$ProjectGlossaryWordsResponseCopyWithImpl(this._self, this._then);
+
+  final ProjectGlossaryWordsResponse _self;
+  final $Res Function(ProjectGlossaryWordsResponse) _then;
+
+/// Create a copy of ProjectGlossaryWordsResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? words = null,}) {
+  return _then(ProjectGlossaryWordsResponse(
+words: null == words ? _self.words : words // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _ProjectGlossaryWordsResponse implements ProjectGlossaryWordsResponse {
+  const _ProjectGlossaryWordsResponse({required  List<String> words}): _words = words;
+  factory _ProjectGlossaryWordsResponse.fromJson(Map<String, dynamic> json) => _$ProjectGlossaryWordsResponseFromJson(json);
+
+ final  List<String> _words;
+@override List<String> get words {
+  if (_words is EqualUnmodifiableListView) return _words;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_words);
+}
+
+
+/// Create a copy of ProjectGlossaryWordsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ProjectGlossaryWordsResponseCopyWith<_ProjectGlossaryWordsResponse> get copyWith => __$ProjectGlossaryWordsResponseCopyWithImpl<_ProjectGlossaryWordsResponse>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ProjectGlossaryWordsResponse&&const DeepCollectionEquality().equals(other._words, _words));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_words));
+
+@override
+String toString() {
+  return 'ProjectGlossaryWordsResponse(words: $words)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ProjectGlossaryWordsResponseCopyWith<$Res> implements $ProjectGlossaryWordsResponseCopyWith<$Res> {
+  factory _$ProjectGlossaryWordsResponseCopyWith(_ProjectGlossaryWordsResponse value, $Res Function(_ProjectGlossaryWordsResponse) _then) = __$ProjectGlossaryWordsResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ List<String> words
+});
+
+
+
+
+}
+/// @nodoc
+class __$ProjectGlossaryWordsResponseCopyWithImpl<$Res>
+    implements _$ProjectGlossaryWordsResponseCopyWith<$Res> {
+  __$ProjectGlossaryWordsResponseCopyWithImpl(this._self, this._then);
+
+  final _ProjectGlossaryWordsResponse _self;
+  final $Res Function(_ProjectGlossaryWordsResponse) _then;
+
+/// Create a copy of ProjectGlossaryWordsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? words = null,}) {
+  return _then(_ProjectGlossaryWordsResponse(
+words: null == words ? _self._words : words // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$ProjectGlossaryAddedWordsResponse {
+
+ List<String> get added;
+/// Create a copy of ProjectGlossaryAddedWordsResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ProjectGlossaryAddedWordsResponseCopyWith<ProjectGlossaryAddedWordsResponse> get copyWith => _$ProjectGlossaryAddedWordsResponseCopyWithImpl<ProjectGlossaryAddedWordsResponse>(this as ProjectGlossaryAddedWordsResponse, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectGlossaryAddedWordsResponse&&const DeepCollectionEquality().equals(other.added, added));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(added));
+
+@override
+String toString() {
+  return 'ProjectGlossaryAddedWordsResponse(added: $added)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ProjectGlossaryAddedWordsResponseCopyWith<$Res>  {
+  factory $ProjectGlossaryAddedWordsResponseCopyWith(ProjectGlossaryAddedWordsResponse value, $Res Function(ProjectGlossaryAddedWordsResponse) _then) = _$ProjectGlossaryAddedWordsResponseCopyWithImpl;
+@useResult
+$Res call({
+ List<String> added
+});
+
+
+
+
+}
+/// @nodoc
+class _$ProjectGlossaryAddedWordsResponseCopyWithImpl<$Res>
+    implements $ProjectGlossaryAddedWordsResponseCopyWith<$Res> {
+  _$ProjectGlossaryAddedWordsResponseCopyWithImpl(this._self, this._then);
+
+  final ProjectGlossaryAddedWordsResponse _self;
+  final $Res Function(ProjectGlossaryAddedWordsResponse) _then;
+
+/// Create a copy of ProjectGlossaryAddedWordsResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? added = null,}) {
+  return _then(ProjectGlossaryAddedWordsResponse(
+added: null == added ? _self.added : added // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _ProjectGlossaryAddedWordsResponse implements ProjectGlossaryAddedWordsResponse {
+  const _ProjectGlossaryAddedWordsResponse({required  List<String> added}): _added = added;
+  factory _ProjectGlossaryAddedWordsResponse.fromJson(Map<String, dynamic> json) => _$ProjectGlossaryAddedWordsResponseFromJson(json);
+
+ final  List<String> _added;
+@override List<String> get added {
+  if (_added is EqualUnmodifiableListView) return _added;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_added);
+}
+
+
+/// Create a copy of ProjectGlossaryAddedWordsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ProjectGlossaryAddedWordsResponseCopyWith<_ProjectGlossaryAddedWordsResponse> get copyWith => __$ProjectGlossaryAddedWordsResponseCopyWithImpl<_ProjectGlossaryAddedWordsResponse>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ProjectGlossaryAddedWordsResponse&&const DeepCollectionEquality().equals(other._added, _added));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_added));
+
+@override
+String toString() {
+  return 'ProjectGlossaryAddedWordsResponse(added: $added)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ProjectGlossaryAddedWordsResponseCopyWith<$Res> implements $ProjectGlossaryAddedWordsResponseCopyWith<$Res> {
+  factory _$ProjectGlossaryAddedWordsResponseCopyWith(_ProjectGlossaryAddedWordsResponse value, $Res Function(_ProjectGlossaryAddedWordsResponse) _then) = __$ProjectGlossaryAddedWordsResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ List<String> added
+});
+
+
+
+
+}
+/// @nodoc
+class __$ProjectGlossaryAddedWordsResponseCopyWithImpl<$Res>
+    implements _$ProjectGlossaryAddedWordsResponseCopyWith<$Res> {
+  __$ProjectGlossaryAddedWordsResponseCopyWithImpl(this._self, this._then);
+
+  final _ProjectGlossaryAddedWordsResponse _self;
+  final $Res Function(_ProjectGlossaryAddedWordsResponse) _then;
+
+/// Create a copy of ProjectGlossaryAddedWordsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? added = null,}) {
+  return _then(_ProjectGlossaryAddedWordsResponse(
+added: null == added ? _self._added : added // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$ProjectGlossaryRemovedWordsResponse {
+
+ int get removed;
+/// Create a copy of ProjectGlossaryRemovedWordsResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ProjectGlossaryRemovedWordsResponseCopyWith<ProjectGlossaryRemovedWordsResponse> get copyWith => _$ProjectGlossaryRemovedWordsResponseCopyWithImpl<ProjectGlossaryRemovedWordsResponse>(this as ProjectGlossaryRemovedWordsResponse, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectGlossaryRemovedWordsResponse&&(identical(other.removed, removed) || other.removed == removed));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,removed);
+
+@override
+String toString() {
+  return 'ProjectGlossaryRemovedWordsResponse(removed: $removed)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ProjectGlossaryRemovedWordsResponseCopyWith<$Res>  {
+  factory $ProjectGlossaryRemovedWordsResponseCopyWith(ProjectGlossaryRemovedWordsResponse value, $Res Function(ProjectGlossaryRemovedWordsResponse) _then) = _$ProjectGlossaryRemovedWordsResponseCopyWithImpl;
+@useResult
+$Res call({
+ int removed
+});
+
+
+
+
+}
+/// @nodoc
+class _$ProjectGlossaryRemovedWordsResponseCopyWithImpl<$Res>
+    implements $ProjectGlossaryRemovedWordsResponseCopyWith<$Res> {
+  _$ProjectGlossaryRemovedWordsResponseCopyWithImpl(this._self, this._then);
+
+  final ProjectGlossaryRemovedWordsResponse _self;
+  final $Res Function(ProjectGlossaryRemovedWordsResponse) _then;
+
+/// Create a copy of ProjectGlossaryRemovedWordsResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? removed = null,}) {
+  return _then(ProjectGlossaryRemovedWordsResponse(
+removed: null == removed ? _self.removed : removed // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _ProjectGlossaryRemovedWordsResponse implements ProjectGlossaryRemovedWordsResponse {
+  const _ProjectGlossaryRemovedWordsResponse({required this.removed});
+  factory _ProjectGlossaryRemovedWordsResponse.fromJson(Map<String, dynamic> json) => _$ProjectGlossaryRemovedWordsResponseFromJson(json);
+
+@override final  int removed;
+
+/// Create a copy of ProjectGlossaryRemovedWordsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ProjectGlossaryRemovedWordsResponseCopyWith<_ProjectGlossaryRemovedWordsResponse> get copyWith => __$ProjectGlossaryRemovedWordsResponseCopyWithImpl<_ProjectGlossaryRemovedWordsResponse>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ProjectGlossaryRemovedWordsResponse&&(identical(other.removed, removed) || other.removed == removed));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,removed);
+
+@override
+String toString() {
+  return 'ProjectGlossaryRemovedWordsResponse(removed: $removed)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ProjectGlossaryRemovedWordsResponseCopyWith<$Res> implements $ProjectGlossaryRemovedWordsResponseCopyWith<$Res> {
+  factory _$ProjectGlossaryRemovedWordsResponseCopyWith(_ProjectGlossaryRemovedWordsResponse value, $Res Function(_ProjectGlossaryRemovedWordsResponse) _then) = __$ProjectGlossaryRemovedWordsResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ int removed
+});
+
+
+
+
+}
+/// @nodoc
+class __$ProjectGlossaryRemovedWordsResponseCopyWithImpl<$Res>
+    implements _$ProjectGlossaryRemovedWordsResponseCopyWith<$Res> {
+  __$ProjectGlossaryRemovedWordsResponseCopyWithImpl(this._self, this._then);
+
+  final _ProjectGlossaryRemovedWordsResponse _self;
+  final $Res Function(_ProjectGlossaryRemovedWordsResponse) _then;
+
+/// Create a copy of ProjectGlossaryRemovedWordsResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? removed = null,}) {
+  return _then(_ProjectGlossaryRemovedWordsResponse(
+removed: null == removed ? _self.removed : removed // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/app/lib/src/api/models/project_glossary_response.g.dart
+++ b/bridge/app/lib/src/api/models/project_glossary_response.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'project_glossary_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ProjectGlossaryWordsResponse _$ProjectGlossaryWordsResponseFromJson(
+  Map json,
+) => _ProjectGlossaryWordsResponse(
+  words: (json['words'] as List<dynamic>).map((e) => e as String).toList(),
+);
+
+_ProjectGlossaryAddedWordsResponse _$ProjectGlossaryAddedWordsResponseFromJson(
+  Map json,
+) => _ProjectGlossaryAddedWordsResponse(
+  added: (json['added'] as List<dynamic>).map((e) => e as String).toList(),
+);
+
+_ProjectGlossaryRemovedWordsResponse
+_$ProjectGlossaryRemovedWordsResponseFromJson(Map json) =>
+    _ProjectGlossaryRemovedWordsResponse(
+      removed: (json['removed'] as num).toInt(),
+    );

--- a/bridge/app/lib/src/api/sesori_server_api.dart
+++ b/bridge/app/lib/src/api/sesori_server_api.dart
@@ -2,13 +2,15 @@ import "dart:async";
 import "dart:convert";
 
 import "package:http/http.dart" as http;
-import "package:sesori_shared/sesori_shared.dart" show GenerateSessionMetadataRequest, jsonDecodeMap;
+import "package:sesori_shared/sesori_shared.dart"
+    show GenerateSessionMetadataRequest, ProjectGlossaryKey, ProjectGlossaryWordsRequest, jsonDecodeMap;
 
 import "../auth/token_refresher.dart";
 import "../foundation/abortable_request.dart";
 import "../foundation/auth_backend_url.dart";
 import "models/app_client_status_response.dart";
 import "models/generate_session_metadata_response.dart";
+import "models/project_glossary_response.dart";
 
 class SesoriServerApiException({
   required final String method,
@@ -88,6 +90,65 @@ class SesoriServerApi({
     return _parseSessionMetadata(uri: uri, response: retryResponse);
   }
 
+  Future<ProjectGlossaryWordsResponse> getProjectGlossary({
+    required ProjectGlossaryKey projectKey,
+    required AbortSignal abortSignal,
+  }) async {
+    final uri = Uri.parse("$_authBackendUrl/voice/glossary").replace(
+      queryParameters: {"projectKey": projectKey.value},
+    );
+    final response = await _sendProjectGlossaryRequest(
+      method: "GET",
+      uri: uri,
+      body: null,
+      abortSignal: abortSignal,
+    );
+    return _parseProjectGlossaryResponse<ProjectGlossaryWordsResponse>(
+      method: "GET",
+      uri: uri,
+      response: response,
+      fromJson: ProjectGlossaryWordsResponse.fromJson,
+    );
+  }
+
+  Future<ProjectGlossaryAddedWordsResponse> addProjectGlossaryWords({
+    required ProjectGlossaryWordsRequest request,
+    required AbortSignal abortSignal,
+  }) async {
+    final uri = Uri.parse("$_authBackendUrl/voice/glossary");
+    final response = await _sendProjectGlossaryRequest(
+      method: "POST",
+      uri: uri,
+      body: jsonEncode(request.toJson()),
+      abortSignal: abortSignal,
+    );
+    return _parseProjectGlossaryResponse<ProjectGlossaryAddedWordsResponse>(
+      method: "POST",
+      uri: uri,
+      response: response,
+      fromJson: ProjectGlossaryAddedWordsResponse.fromJson,
+    );
+  }
+
+  Future<ProjectGlossaryRemovedWordsResponse> removeProjectGlossaryWords({
+    required ProjectGlossaryWordsRequest request,
+    required AbortSignal abortSignal,
+  }) async {
+    final uri = Uri.parse("$_authBackendUrl/voice/glossary");
+    final response = await _sendProjectGlossaryRequest(
+      method: "DELETE",
+      uri: uri,
+      body: jsonEncode(request.toJson()),
+      abortSignal: abortSignal,
+    );
+    return _parseProjectGlossaryResponse<ProjectGlossaryRemovedWordsResponse>(
+      method: "DELETE",
+      uri: uri,
+      response: response,
+      fromJson: ProjectGlossaryRemovedWordsResponse.fromJson,
+    );
+  }
+
   Future<String> _getAccessTokenUnlessAborted({
     required Uri uri,
     required AbortSignal abortSignal,
@@ -146,6 +207,77 @@ class SesoriServerApi({
 
   void _throwIfAborted({required Uri uri, required AbortSignal abortSignal}) {
     if (abortSignal.isAborted) throw http.RequestAbortedException(uri);
+  }
+
+  Future<http.Response> _sendProjectGlossaryRequest({
+    required String method,
+    required Uri uri,
+    required String? body,
+    required AbortSignal abortSignal,
+  }) async {
+    final response = await _sendProjectGlossaryAttempt(
+      method: method,
+      uri: uri,
+      body: body,
+      forceRefresh: false,
+      abortSignal: abortSignal,
+    );
+    if (response.statusCode != 401) return response;
+
+    return await _sendProjectGlossaryAttempt(
+      method: method,
+      uri: uri,
+      body: body,
+      forceRefresh: true,
+      abortSignal: abortSignal,
+    );
+  }
+
+  Future<http.Response> _sendProjectGlossaryAttempt({
+    required String method,
+    required Uri uri,
+    required String? body,
+    required bool forceRefresh,
+    required AbortSignal abortSignal,
+  }) async {
+    final accessToken = await _getAccessTokenUnlessAborted(
+      uri: uri,
+      abortSignal: abortSignal,
+      forceRefresh: forceRefresh,
+    );
+    return await sendAbortableRequest(
+      client: _client,
+      method: method,
+      url: uri,
+      headers: {
+        "Authorization": "Bearer $accessToken",
+        if (body != null) "Content-Type": "application/json",
+      },
+      body: body,
+      deadline: _requestDeadline,
+      abortSignal: abortSignal,
+    );
+  }
+
+  T _parseProjectGlossaryResponse<T>({
+    required String method,
+    required Uri uri,
+    required http.Response response,
+    required T Function(Map<String, dynamic> json) fromJson,
+  }) {
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw SesoriServerApiException(method: method, statusCode: response.statusCode, uri: uri);
+    }
+    try {
+      return fromJson(jsonDecodeMap(response.body));
+    } on Object catch (error, stackTrace) {
+      throw SesoriServerApiResponseException(
+        method: method,
+        uri: uri,
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
   }
 
   GenerateSessionMetadataResponse _parseSessionMetadata({required Uri uri, required http.Response response}) {

--- a/bridge/app/lib/src/repositories/project_glossary_publication_repository.dart
+++ b/bridge/app/lib/src/repositories/project_glossary_publication_repository.dart
@@ -1,0 +1,71 @@
+import "package:http/http.dart" as http;
+import "package:sesori_shared/sesori_shared.dart"
+    show ProjectGlossaryKey, ProjectGlossaryScope, ProjectGlossaryWordsRequest;
+
+import "../api/sesori_server_api.dart";
+import "../foundation/abortable_request.dart";
+
+class ProjectGlossaryPublicationAbortedException({
+  required final Object innerError,
+  required final StackTrace innerStackTrace,
+}) implements Exception;
+
+/// Owns the cancellable auth-server transport for exact glossary scopes.
+class ProjectGlossaryPublicationRepository({required final SesoriServerApi _api}) {
+  final AbortSignal _abortSignal = AbortSignal();
+
+  void beginShutdown() => _abortSignal.abort();
+
+  Future<List<String>> getWords({required ProjectGlossaryKey projectKey}) {
+    return _mapAbort(
+      operation: () async {
+        final response = await _api.getProjectGlossary(
+          projectKey: projectKey,
+          abortSignal: _abortSignal,
+        );
+        return response.words;
+      },
+    );
+  }
+
+  Future<List<String>> addWords({
+    required ProjectGlossaryScope scope,
+    required List<String> words,
+  }) {
+    return _mapAbort(
+      operation: () async {
+        final response = await _api.addProjectGlossaryWords(
+          request: ProjectGlossaryWordsRequest(scope: scope, words: words),
+          abortSignal: _abortSignal,
+        );
+        return response.added;
+      },
+    );
+  }
+
+  Future<int> removeWords({
+    required ProjectGlossaryScope scope,
+    required List<String> words,
+  }) {
+    return _mapAbort(
+      operation: () async {
+        final response = await _api.removeProjectGlossaryWords(
+          request: ProjectGlossaryWordsRequest(scope: scope, words: words),
+          abortSignal: _abortSignal,
+        );
+        return response.removed;
+      },
+    );
+  }
+
+  Future<T> _mapAbort<T>({required Future<T> Function() operation}) async {
+    try {
+      return await operation();
+    } on http.RequestAbortedException catch (error, stackTrace) {
+      throw ProjectGlossaryPublicationAbortedException(
+        innerError: error,
+        innerStackTrace: stackTrace,
+      );
+    }
+  }
+}

--- a/bridge/app/test/api/sesori_server_api_test.dart
+++ b/bridge/app/test/api/sesori_server_api_test.dart
@@ -87,6 +87,181 @@ void main() {
     });
   });
 
+  group("SesoriServerApi project glossary", () {
+    final projectKey = ProjectGlossaryKey.parse(
+      value: "prj_v1_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    );
+
+    test("gets project words with an opaque key and bearer token", () async {
+      late http.Request request;
+      final tokenRefresher = FakeTokenRefresher(token: "secret-token");
+      final api = SesoriServerApi(
+        authBackendUrl: "https://auth.example.test/",
+        client: MockClient((incoming) async {
+          request = incoming;
+          return http.Response('{"words":["Sesori","XChaCha20"]}', 200);
+        }),
+        requestDeadline: const Duration(seconds: 1),
+        tokenRefresher: tokenRefresher,
+      );
+
+      final response = await api.getProjectGlossary(
+        projectKey: projectKey,
+        abortSignal: AbortSignal(),
+      );
+
+      expect(response.words, ["Sesori", "XChaCha20"]);
+      expect(request.method, "GET");
+      expect(
+        request.url,
+        Uri.parse("https://auth.example.test/voice/glossary?projectKey=${projectKey.value}"),
+      );
+      expect(request.headers["Authorization"], "Bearer secret-token");
+      expect(tokenRefresher.forceRefreshValues, [false]);
+    });
+
+    test("posts an exact repository scope and returns inserted words", () async {
+      late http.Request request;
+      final api = SesoriServerApi(
+        authBackendUrl: "https://auth.example.test",
+        client: MockClient((incoming) async {
+          request = incoming;
+          return http.Response('{"added":["Sesori"]}', 200);
+        }),
+        requestDeadline: const Duration(seconds: 1),
+        tokenRefresher: FakeTokenRefresher(token: "secret-token"),
+      );
+
+      final response = await api.addProjectGlossaryWords(
+        request: ProjectGlossaryWordsRequest(
+          scope: ProjectGlossaryScope.repository(projectKey: projectKey),
+          words: const ["Sesori", "XChaCha20"],
+        ),
+        abortSignal: AbortSignal(),
+      );
+
+      expect(response.added, ["Sesori"]);
+      expect(request.method, "POST");
+      expect(request.url, Uri.parse("https://auth.example.test/voice/glossary"));
+      expect(request.headers["Authorization"], "Bearer secret-token");
+      expect(request.headers["Content-Type"], startsWith("application/json"));
+      expect(jsonDecode(request.body), {
+        "scope": {"type": "repository", "projectKey": projectKey.value},
+        "words": ["Sesori", "XChaCha20"],
+      });
+    });
+
+    test("deletes an exact bridge-local scope and returns the removal count", () async {
+      late http.Request request;
+      final api = SesoriServerApi(
+        authBackendUrl: "https://auth.example.test",
+        client: MockClient((incoming) async {
+          request = incoming;
+          return http.Response('{"removed":2}', 200);
+        }),
+        requestDeadline: const Duration(seconds: 1),
+        tokenRefresher: FakeTokenRefresher(token: "secret-token"),
+      );
+
+      final response = await api.removeProjectGlossaryWords(
+        request: ProjectGlossaryWordsRequest(
+          scope: ProjectGlossaryScope.bridgeLocal(projectKey: projectKey, bridgeId: "bridge-1"),
+          words: const ["Sesori", "XChaCha20"],
+        ),
+        abortSignal: AbortSignal(),
+      );
+
+      expect(response.removed, 2);
+      expect(request.method, "DELETE");
+      expect(request.url, Uri.parse("https://auth.example.test/voice/glossary"));
+      expect(request.headers["Authorization"], "Bearer secret-token");
+      expect(request.headers["Content-Type"], startsWith("application/json"));
+      expect(jsonDecode(request.body), {
+        "scope": {
+          "type": "bridge_local",
+          "projectKey": projectKey.value,
+          "bridgeId": "bridge-1",
+        },
+        "words": ["Sesori", "XChaCha20"],
+      });
+    });
+
+    test("force-refreshes once after a glossary 401", () async {
+      final requests = <http.Request>[];
+      final tokenRefresher = FakeTokenRefresher(token: "stale", refreshedToken: "fresh");
+      final api = SesoriServerApi(
+        authBackendUrl: "https://auth.example.test",
+        client: MockClient((request) async {
+          requests.add(request);
+          return request.headers["Authorization"] == "Bearer stale"
+              ? http.Response("unauthorized", 401)
+              : http.Response('{"words":[]}', 200);
+        }),
+        requestDeadline: const Duration(seconds: 1),
+        tokenRefresher: tokenRefresher,
+      );
+
+      await api.getProjectGlossary(projectKey: projectKey, abortSignal: AbortSignal());
+
+      expect(requests, hasLength(2));
+      expect(requests.last.headers["Authorization"], "Bearer fresh");
+      expect(tokenRefresher.forceRefreshValues, [false, true]);
+    });
+
+    test("rejects non-success statuses and preserves malformed response causes", () async {
+      final statusApi = SesoriServerApi(
+        authBackendUrl: "https://auth.example.test",
+        client: MockClient((_) async => http.Response("failure", 503)),
+        requestDeadline: const Duration(seconds: 1),
+        tokenRefresher: FakeTokenRefresher(token: "token"),
+      );
+      final malformedApi = SesoriServerApi(
+        authBackendUrl: "https://auth.example.test",
+        client: MockClient((_) async => http.Response('{"words":"invalid"}', 200)),
+        requestDeadline: const Duration(seconds: 1),
+        tokenRefresher: FakeTokenRefresher(token: "token"),
+      );
+
+      await expectLater(
+        statusApi.getProjectGlossary(projectKey: projectKey, abortSignal: AbortSignal()),
+        throwsA(
+          isA<SesoriServerApiException>()
+              .having((error) => error.method, "method", "GET")
+              .having((error) => error.statusCode, "statusCode", 503),
+        ),
+      );
+      await expectLater(
+        malformedApi.getProjectGlossary(projectKey: projectKey, abortSignal: AbortSignal()),
+        throwsA(
+          isA<SesoriServerApiResponseException>()
+              .having((error) => error.innerError, "innerError", isA<TypeError>())
+              .having((error) => error.innerStackTrace, "innerStackTrace", isNot(StackTrace.empty)),
+        ),
+      );
+    });
+
+    test("aborts an in-flight glossary request during shutdown", () async {
+      final client = _AbortAwareClient();
+      final abortSignal = AbortSignal();
+      final api = SesoriServerApi(
+        authBackendUrl: "https://auth.example.test",
+        client: client,
+        requestDeadline: const Duration(seconds: 1),
+        tokenRefresher: FakeTokenRefresher(token: "token"),
+      );
+
+      final response = api.getProjectGlossary(
+        projectKey: projectKey,
+        abortSignal: abortSignal,
+      );
+      await client.sendStarted.future;
+      abortSignal.abort();
+
+      await expectLater(response, throwsA(isA<http.RequestAbortedException>()));
+      expect(client.abortObserved, isTrue);
+    });
+  });
+
   group("SesoriServerApi session metadata", () {
     test("acquires token and posts typed request while decoding title and branch", () async {
       late http.Request request;

--- a/bridge/app/test/bridge/repositories/project_glossary_publication_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_glossary_publication_repository_test.dart
@@ -1,0 +1,137 @@
+import "package:http/http.dart" as http;
+import "package:sesori_bridge/src/api/models/app_client_status_response.dart";
+import "package:sesori_bridge/src/api/models/generate_session_metadata_response.dart";
+import "package:sesori_bridge/src/api/models/project_glossary_response.dart";
+import "package:sesori_bridge/src/api/sesori_server_api.dart";
+import "package:sesori_bridge/src/foundation/abortable_request.dart";
+import "package:sesori_bridge/src/repositories/project_glossary_publication_repository.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  final projectKey = ProjectGlossaryKey.parse(
+    value: "prj_v1_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  );
+
+  group("ProjectGlossaryPublicationRepository", () {
+    test("maps typed list, add, and remove responses", () async {
+      final api = _FakeSesoriServerApi();
+      final repository = ProjectGlossaryPublicationRepository(api: api);
+      final repositoryScope = ProjectGlossaryScope.repository(projectKey: projectKey);
+      final localScope = ProjectGlossaryScope.bridgeLocal(projectKey: projectKey, bridgeId: "bridge-1");
+
+      expect(await repository.getWords(projectKey: projectKey), ["Existing"]);
+      expect(
+        await repository.addWords(scope: repositoryScope, words: const ["Sesori"]),
+        ["Sesori"],
+      );
+      expect(
+        await repository.removeWords(scope: localScope, words: const ["Obsolete"]),
+        1,
+      );
+
+      expect(api.listProjectKeys, [projectKey]);
+      expect(
+        api.addRequests,
+        [
+          ProjectGlossaryWordsRequest(scope: repositoryScope, words: const ["Sesori"]),
+        ],
+      );
+      expect(
+        api.removeRequests,
+        [
+          ProjectGlossaryWordsRequest(scope: localScope, words: const ["Obsolete"]),
+        ],
+      );
+      expect(api.abortSignals, everyElement(same(api.abortSignals.first)));
+      expect(api.abortSignals.first.isAborted, isFalse);
+    });
+
+    test("aborts every hosted glossary operation when shutdown begins", () async {
+      final api = _FakeSesoriServerApi();
+      final repository = ProjectGlossaryPublicationRepository(api: api);
+
+      await repository.getWords(projectKey: projectKey);
+      repository.beginShutdown();
+
+      expect(api.abortSignals.single.isAborted, isTrue);
+    });
+
+    test("translates HTTP aborts while preserving the transport error", () async {
+      final abort = http.RequestAbortedException(
+        Uri.parse("https://auth.example.test/voice/glossary"),
+      );
+      final repository = ProjectGlossaryPublicationRepository(
+        api: _FakeSesoriServerApi(failure: abort),
+      );
+
+      await expectLater(
+        repository.getWords(projectKey: projectKey),
+        throwsA(
+          isA<ProjectGlossaryPublicationAbortedException>()
+              .having((error) => error.innerError, "innerError", same(abort))
+              .having((error) => error.innerStackTrace, "innerStackTrace", isNot(StackTrace.empty)),
+        ),
+      );
+    });
+
+    test("surfaces non-abort transport failures unchanged", () async {
+      const error = FormatException("invalid glossary response");
+      final repository = ProjectGlossaryPublicationRepository(
+        api: _FakeSesoriServerApi(failure: error),
+      );
+
+      await expectLater(repository.getWords(projectKey: projectKey), throwsA(same(error)));
+    });
+  });
+}
+
+class _FakeSesoriServerApi({final Object? failure}) implements SesoriServerApi {
+  final Object? error = failure;
+  final List<ProjectGlossaryKey> listProjectKeys = [];
+  final List<ProjectGlossaryWordsRequest> addRequests = [];
+  final List<ProjectGlossaryWordsRequest> removeRequests = [];
+  final List<AbortSignal> abortSignals = [];
+
+  @override
+  Future<ProjectGlossaryWordsResponse> getProjectGlossary({
+    required ProjectGlossaryKey projectKey,
+    required AbortSignal abortSignal,
+  }) async {
+    listProjectKeys.add(projectKey);
+    abortSignals.add(abortSignal);
+    if (error case final error?) throw error;
+    return const ProjectGlossaryWordsResponse(words: ["Existing"]);
+  }
+
+  @override
+  Future<ProjectGlossaryAddedWordsResponse> addProjectGlossaryWords({
+    required ProjectGlossaryWordsRequest request,
+    required AbortSignal abortSignal,
+  }) async {
+    addRequests.add(request);
+    abortSignals.add(abortSignal);
+    if (error case final error?) throw error;
+    return const ProjectGlossaryAddedWordsResponse(added: ["Sesori"]);
+  }
+
+  @override
+  Future<ProjectGlossaryRemovedWordsResponse> removeProjectGlossaryWords({
+    required ProjectGlossaryWordsRequest request,
+    required AbortSignal abortSignal,
+  }) async {
+    removeRequests.add(request);
+    abortSignals.add(abortSignal);
+    if (error case final error?) throw error;
+    return const ProjectGlossaryRemovedWordsResponse(removed: 1);
+  }
+
+  @override
+  Future<AppClientStatusResponse> getAppClientStatus({required String accessToken}) => throw UnimplementedError();
+
+  @override
+  Future<GenerateSessionMetadataResponse> generateSessionMetadata({
+    required GenerateSessionMetadataRequest request,
+    required AbortSignal abortSignal,
+  }) => throw UnimplementedError();
+}

--- a/bridge/app/test/repositories/app_client_status_repository_test.dart
+++ b/bridge/app/test/repositories/app_client_status_repository_test.dart
@@ -1,5 +1,6 @@
 import "package:sesori_bridge/src/api/models/app_client_status_response.dart";
 import "package:sesori_bridge/src/api/models/generate_session_metadata_response.dart";
+import "package:sesori_bridge/src/api/models/project_glossary_response.dart";
 import "package:sesori_bridge/src/api/sesori_server_api.dart";
 import "package:sesori_bridge/src/foundation/abortable_request.dart";
 import "package:sesori_bridge/src/repositories/app_client_status_repository.dart";
@@ -65,6 +66,24 @@ class _FakeSesoriServerApi() implements SesoriServerApi {
   @override
   Future<GenerateSessionMetadataResponse> generateSessionMetadata({
     required GenerateSessionMetadataRequest request,
+    required AbortSignal abortSignal,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<ProjectGlossaryWordsResponse> getProjectGlossary({
+    required ProjectGlossaryKey projectKey,
+    required AbortSignal abortSignal,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<ProjectGlossaryAddedWordsResponse> addProjectGlossaryWords({
+    required ProjectGlossaryWordsRequest request,
+    required AbortSignal abortSignal,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<ProjectGlossaryRemovedWordsResponse> removeProjectGlossaryWords({
+    required ProjectGlossaryWordsRequest request,
     required AbortSignal abortSignal,
   }) => throw UnimplementedError();
 }

--- a/bridge/app/test/repositories/session_metadata_repository_test.dart
+++ b/bridge/app/test/repositories/session_metadata_repository_test.dart
@@ -1,6 +1,7 @@
 import "package:http/http.dart" as http;
 import "package:sesori_bridge/src/api/models/app_client_status_response.dart";
 import "package:sesori_bridge/src/api/models/generate_session_metadata_response.dart";
+import "package:sesori_bridge/src/api/models/project_glossary_response.dart";
 import "package:sesori_bridge/src/api/sesori_server_api.dart";
 import "package:sesori_bridge/src/foundation/abortable_request.dart";
 import "package:sesori_bridge/src/repositories/session_metadata_repository.dart";
@@ -119,4 +120,22 @@ class _FakeSesoriServerApi({final Object? failure}) implements SesoriServerApi {
 
   @override
   Future<AppClientStatusResponse> getAppClientStatus({required String accessToken}) => throw UnimplementedError();
+
+  @override
+  Future<ProjectGlossaryWordsResponse> getProjectGlossary({
+    required ProjectGlossaryKey projectKey,
+    required AbortSignal abortSignal,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<ProjectGlossaryAddedWordsResponse> addProjectGlossaryWords({
+    required ProjectGlossaryWordsRequest request,
+    required AbortSignal abortSignal,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<ProjectGlossaryRemovedWordsResponse> removeProjectGlossaryWords({
+    required ProjectGlossaryWordsRequest request,
+    required AbortSignal abortSignal,
+  }) => throw UnimplementedError();
 }


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this adds typed HTTP transport and repository-owned cancellation across several bridge layers without yet composing lifecycle behavior.

## What

- Added typed glossary read and mutation response DTOs.
- Added authenticated `GET`, `POST`, and `DELETE` glossary methods to `SesoriServerApi` using the shared discriminated repository and bridge-local scopes.
- Added `ProjectGlossaryPublicationRepository` to own one cancellation signal, translate HTTP aborts into a glossary-specific exception, and expose shutdown cancellation.
- Added focused transport, parsing, mutation-shape, cancellation, and regression coverage.

## Why

Step 7 needs a typed, privacy-safe publication seam beneath the lifecycle coordinator. Keeping HTTP parsing in the API and cancellation/error translation in the repository preserves the bridge's API → Repository → Service dependency flow.

## Risk and test focus

Moderate internal integration risk around exact request/response shapes, auth retry behavior, abort translation, and shutdown cancellation. Focused tests verify all three endpoint methods, both exact scope variants, malformed responses, cancellation during requests and token acquisition, and unchanged existing API/repository behavior.

No user-visible or database impact: no production lifecycle consumer invokes these methods until Step 7.

## Expected result

The bridge has a typed, cancellable way to read, add, and remove filtered words for an opaque exact glossary scope. No raw path, origin, filename, or source text enters transport, and existing bridge behavior remains unchanged until lifecycle composition is added.

## Verification

- `cd bridge/app && dart test test/api/sesori_server_api_test.dart test/bridge/repositories/project_glossary_publication_repository_test.dart test/repositories/app_client_status_repository_test.dart test/repositories/session_metadata_repository_test.dart` — 33 tests passed
- `cd bridge/app && dart analyze --fatal-infos --fatal-warnings` — no issues
- architecture implementation review — approved API/Repository layering, cancellation/error ownership, exact shared scope usage, and transport privacy


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typed, cancellable HTTP transport for publishing project glossary words, so Step 7 can compose lifecycle behavior on top of it.

- Adds `GET`, `POST`, and `DELETE` glossary methods to `SesoriServerApi` with typed response DTOs and one-time 401 force-refresh retry.
- Adds `ProjectGlossaryPublicationRepository` to own the shutdown cancellation signal and translate HTTP aborts into a glossary-specific exception.
- No production lifecycle consumer invokes these methods yet, so existing bridge behavior is unchanged.
- Tests cover all three endpoints, both exact scope variants, malformed responses, auth retry, and cancellation during requests and token acquisition.

<sup>Written for commit ed687f59340114a89647522adc1712d178b051c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

