### PR TITLE
🌱 [grok-harness] docs: reconcile Grok regression coverage [step 8/9]

### DIFF
--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -3,13 +3,13 @@
 ## Current State
 
 - **Plan:** `.plan/active/grok-harness/PLAN.md`
-- **Status:** Steps 1-7/9 merged; Step 8/9 verified and ready to publish
+- **Status:** Steps 1-7/9 merged; Step 8/9 in PR #1181
 - **Current branch:** `grok-harness-step-8-regression`
 - **Base:** `origin/main` after merged PR #1179
 - **Architecture plan review:** approved 2026-08-27 after catalog ownership and auth-policy corrections
 - **Merged predecessor:** #1179 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1179>
-- **Open PR:** none; Step 8 publication is next
-- **Local successor:** none; Step 9 starts after Step 8 publication
+- **Open PR:** #1181 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1181>
+- **Local successor:** Step 9 starts after this tracker update is published
 
 ## Fixed Series
 
@@ -32,7 +32,7 @@
 7. `🌿 [grok-harness] feat(client): brand Grok Build [step 7/9]`
    - **State:** merged in #1179.
 8. `🌱 [grok-harness] docs: reconcile Grok regression coverage [step 8/9]`
-   - **State:** rebased onto merged #1179 and verified; ready to publish.
+   - **State:** in PR #1181.
 9. `⚙️ [grok-harness] test: verify Grok and retire the plan [step 9/9]`
    - **State:** not started.
 
@@ -150,7 +150,7 @@
 - [x] Skip architecture review because this step changes regression documentation only.
 - [x] Commit the completed successor locally; do not publish before #1179 merges.
 - [x] Rebase onto merged #1179 and repeat focused documentation validation.
-- [ ] Publish Step 8 and start its PR monitor.
+- [x] Publish Step 8 as PR #1181 and start its monitor.
 
 ## Decisions And Evidence
 

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -3,13 +3,13 @@
 ## Current State
 
 - **Plan:** `.plan/active/grok-harness/PLAN.md`
-- **Status:** Steps 1-6/9 merged; Step 7/9 in PR #1179; Step 8/9 implemented locally
+- **Status:** Steps 1-7/9 merged; Step 8/9 verified and ready to publish
 - **Current branch:** `grok-harness-step-8-regression`
-- **Base:** `grok-harness-step-7-branding` (PR #1179)
+- **Base:** `origin/main` after merged PR #1179
 - **Architecture plan review:** approved 2026-08-27 after catalog ownership and auth-policy corrections
-- **Merged predecessor:** #1177 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1177>
-- **Open PR:** #1179 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1179>
-- **Local successor:** `grok-harness-step-8-regression`; regression reconciliation under verification
+- **Merged predecessor:** #1179 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1179>
+- **Open PR:** none; Step 8 publication is next
+- **Local successor:** none; Step 9 starts after Step 8 publication
 
 ## Fixed Series
 
@@ -30,9 +30,9 @@
 6. `⚙️ [grok-harness] feat(bridge): activate Grok Build [step 6/9]`
    - **State:** merged in #1177.
 7. `🌿 [grok-harness] feat(client): brand Grok Build [step 7/9]`
-   - **State:** in PR #1179.
+   - **State:** merged in #1179.
 8. `🌱 [grok-harness] docs: reconcile Grok regression coverage [step 8/9]`
-   - **State:** implemented locally; held until #1179 merges.
+   - **State:** rebased onto merged #1179 and verified; ready to publish.
 9. `⚙️ [grok-harness] test: verify Grok and retire the plan [step 9/9]`
    - **State:** not started.
 
@@ -146,9 +146,11 @@
 - [x] Keep `plugin-runtime-installation.md` unchanged because Grok has no managed install.
 - [x] Add no production code, transport/persistence shape, analytics, or unrelated historical-gap changes.
 - [x] Validate headings, tables, source paths, plan coverage, line width, and Git whitespace.
-- [x] Keep the measured Step 8 change below the 1,500-line soft cap (currently 218 lines).
+- [x] Keep the measured Step 8 change below the 1,500-line soft cap (currently 226 lines).
 - [x] Skip architecture review because this step changes regression documentation only.
 - [x] Commit the completed successor locally; do not publish before #1179 merges.
+- [x] Rebase onto merged #1179 and repeat focused documentation validation.
+- [ ] Publish Step 8 and start its PR monitor.
 
 ## Decisions And Evidence
 

--- a/.plan/active/grok-harness/TRACKER.md
+++ b/.plan/active/grok-harness/TRACKER.md
@@ -3,13 +3,13 @@
 ## Current State
 
 - **Plan:** `.plan/active/grok-harness/PLAN.md`
-- **Status:** Steps 1-6/9 merged; Step 7/9 in PR #1179
-- **Current branch:** `grok-harness-step-7-branding`
-- **Base:** `origin/main` after merged PR #1177
+- **Status:** Steps 1-6/9 merged; Step 7/9 in PR #1179; Step 8/9 implemented locally
+- **Current branch:** `grok-harness-step-8-regression`
+- **Base:** `grok-harness-step-7-branding` (PR #1179)
 - **Architecture plan review:** approved 2026-08-27 after catalog ownership and auth-policy corrections
 - **Merged predecessor:** #1177 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1177>
 - **Open PR:** #1179 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1179>
-- **Local successor:** Step 8 starts after this tracker update is published
+- **Local successor:** `grok-harness-step-8-regression`; regression reconciliation under verification
 
 ## Fixed Series
 
@@ -32,7 +32,7 @@
 7. `🌿 [grok-harness] feat(client): brand Grok Build [step 7/9]`
    - **State:** in PR #1179.
 8. `🌱 [grok-harness] docs: reconcile Grok regression coverage [step 8/9]`
-   - **State:** not started.
+   - **State:** implemented locally; held until #1179 merges.
 9. `⚙️ [grok-harness] test: verify Grok and retire the plan [step 9/9]`
    - **State:** not started.
 
@@ -135,6 +135,20 @@
 - [x] Commit the completed successor locally; do not publish before #1177 merges.
 - [x] Rebase onto merged #1177 and repeat focused verification.
 - [x] Publish Step 7 as PR #1179 and start its monitor.
+
+## Step 8 Checklist
+
+- [x] Reconcile all eight affected regression contracts named by the plan.
+- [x] Record Grok setup, branding, import, exact options, turns, replay, permissions, tools, archive, and deletion.
+- [x] Extend each affected level matrix through the complete authoritative Grok boundary without duplicating behavior.
+- [x] Add Grok-specific exploration, material failure signals, honest limitations, and owning source paths.
+- [x] Keep `attachments-and-images.md` unchanged because Grok advertises no image capability.
+- [x] Keep `plugin-runtime-installation.md` unchanged because Grok has no managed install.
+- [x] Add no production code, transport/persistence shape, analytics, or unrelated historical-gap changes.
+- [x] Validate headings, tables, source paths, plan coverage, line width, and Git whitespace.
+- [x] Keep the measured Step 8 change below the 1,500-line soft cap (currently 218 lines).
+- [x] Skip architecture review because this step changes regression documentation only.
+- [x] Commit the completed successor locally; do not publish before #1179 merges.
 
 ## Decisions And Evidence
 

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -76,8 +76,10 @@ idle suspension, the management snapshot, and lifecycle commands.
   NousResearch logo, Pi as `Pi` with its official glyph, and Oh My Pi as `Oh My Pi`
   with its official icon. DeepSeek renders as `DeepSeek` with its official
   theme-independent brand-blue whale mark. GitHub Copilot renders with its
-  Primer interface icon in black or white for the active theme. Surfaces without
-  recognized metadata retain the generic icon and raw-id fallback.
+  Primer interface icon in black or white for the active theme. Grok renders as
+  `Grok Build` with xAI's dark mark on light UI and light mark on dark UI.
+  Surfaces without recognized metadata retain the generic icon and raw-id
+  fallback.
 - Harnesses start on demand unless eager; a transient one may suspend after a confirmed
   idle window and a resident one never does, and idle timeouts survive restart. With no
   configured default or per-harness override, every harness uses the bridge's 45-minute
@@ -157,9 +159,9 @@ idle suspension, the management snapshot, and lifecycle commands.
 |---|---|
 | L1 Smoke | A started bridge inspects every registered harness and publishes coherent setup and management snapshots. A ready fixture has a selectable default; a fixture with no usable harness has zero selectable entries and no default without failing startup. Headless bridge; all registered harnesses listed. |
 | L2 Routine | Demand-driven start of a ready harness, clean lifecycle-owned bridge shutdown, Codex keepalive traffic remaining local and stopping on disposal, setup refresh, and the disable list surviving restart with eligibility and ordering intact. Package automation covers DeepSeek explicit/PATH/managed selection, immutable six-platform archive metadata, readiness, extension refusal, crash/reconnect, and idempotent shutdown. Copilot package automation covers branded version parsing, explicit/PATH/managed precedence, exact six-archive metadata, provisioning-authoritative startup, and local-login-required failure. Grok package automation covers explicit/PATH authority, bounded branded version parsing, read-only inspection, local-login-required startup, crash/reconnect, and owned shutdown. Headless bridge; representative managed harness for start and shutdown, every registered harness for listing and ordering. |
-| L3 Release | The management surface as rendered: per-harness selected runtime version when reported, setup, runtime and work state, capability-appropriate controls, built-in name and light/dark artwork, default badge, enable/disable, restart, idle-timeout default plus override persisted across a bridge restart, and the per-harness catalog scan on a routable harness including its in-place progress and the announcement of what it found. Copilot renders the exact `GitHub Copilot` name and Primer interface icon in both themes. Client end to end; every harness declaring the relevant capability must pass. |
+| L3 Release | The management surface as rendered: per-harness selected runtime version when reported, setup, runtime and work state, capability-appropriate controls, built-in name and light/dark artwork, default badge, enable/disable, restart, idle-timeout default plus override persisted across a bridge restart, and the per-harness catalog scan on a routable harness including its in-place progress and the announcement of what it found. Copilot renders the exact `GitHub Copilot` name and Primer interface icon in both themes. Grok renders as `Grok Build` with the official contrasting mark, selected version, local setup guidance, and no managed-install control. Client end to end; every harness declaring the relevant capability must pass. |
 | L4 Extended | Busy conflict with force confirmation and cancellation, authentication start/join/cancel plus shutdown cleanup, idle suspension elapsing then returning on demand, harnesses blocked by missing runtime or authentication with no catalog-scan action offered on them, a targeted scan rejected by the bridge reporting on its own card, a terminally failed harness leaving others usable, a bridge with no usable harness, an externally managed configuration, two harnesses active at once, second mobile platform. Copilot live coverage includes an unexpected owned-process exit followed by demand reconnect and a deliberate clean shutdown that is not reported as a crash. Grok live coverage includes the same failure isolation and demand reconnect with a supported user-installed release. Live plugin where a real backend must start or be interrupted, client end to end where card state is claimed. |
-| L5 Full | Every registered production harness through inspect, enable, disable, restart, refresh, and idle behavior on a supported platform, plus forward-compatible presentation of an unknown harness or capability and the reported state of a session interrupted by a forced disable. Compatibility pairs prove an older client treats `copilot` as an unknown raw-id/generic-icon harness without decode failure, while an older bridge simply supplies no Copilot entry to a newer client. Live plugin and client end to end as each entry requires. |
+| L5 Full | Every registered production harness through inspect, enable, disable, restart, refresh, and idle behavior on a supported platform, plus forward-compatible presentation of an unknown harness or capability and the reported state of a session interrupted by a forced disable. Compatibility pairs prove an older client treats `copilot` and `grok` as unknown raw-id/generic-icon harnesses without decode failure, while an older bridge simply supplies no corresponding entry to a newer client. Live plugin and client end to end as each entry requires. |
 
 ## Exploration Guidance
 
@@ -172,7 +174,8 @@ timeouts, and sessions afterwards. For Copilot, vary missing, malformed, too-old
 compatible PATH, managed, and explicit runtimes; authenticated and unauthenticated
 normal configuration; owned-process exit; and bridge restart. For Grok, vary
 missing, malformed, too-old, current PATH, and authoritative explicit binaries;
-headless and interactive-only authentication; owned-process exit; and restart.
+headless and interactive-only authentication; catalog refresh; enable/disable;
+owned-process exit; and restart.
 
 ## Failure Signals
 
@@ -214,6 +217,8 @@ headless and interactive-only authentication; owned-process exit; and restart.
   an explicit path to PATH, performs login or ACP work during inspection, offers
   managed installation, launches with leader/auto-update attachment enabled, or
   leaves another harness unavailable after Grok exits.
+- A recognized Grok entry renders the raw ID or generic icon, swaps its supplied
+  light/dark marks, or an unknown plugin ID stops using the generic fallback.
 
 ## Known Limitations
 
@@ -223,7 +228,10 @@ headless and interactive-only authentication; owned-process exit; and restart.
   brand-blue artwork, local provider setup guidance, and managed install controls
   follow the same backend-neutral registry and client surfaces as every other harness.
 - Backend authentication and credential persistence happen on the bridge machine. A forced
-  disable leaves work interrupted. Copilot exposes local recovery guidance only;
+  disable leaves work interrupted. Grok installation, updates, interactive login,
+  API-key, enterprise, and custom-model configuration remain local and out of
+  band; readiness proves only the CLI version, not service entitlement. Copilot
+  exposes local recovery guidance only;
   Sesori neither implements its terminal-auth flow nor reads its credential store.
   Copilot CLI is an upstream public preview and still requires eligible GitHub
   Copilot access; entitlement and service availability are not install success.
@@ -250,6 +258,7 @@ headless and interactive-only authentication; owned-process exit; and restart.
 - `bridge/sesori_plugin_grok/lib/src/runtime/grok_plugin_descriptor.dart` and its tests
 - `bridge/sesori_plugin_grok/lib/src/grok_plugin_impl.dart` and `grok_plugin_test.dart`
 - `bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart` and `codex_plugin_write_path_test.dart`
-- `client/module_core/.../plugin_management_service.dart`, `PregoBrandLogo`, and the
-  harness settings screen
+- `client/module_core/.../plugin_management_service.dart`, `PregoBrandLogo`, the
+  Grok marks and `client/module_prego/BRAND_ASSETS.md`, and the harness settings
+  screen
 - Tests: `plugin_lifecycle_service_test.dart`, per-plugin setup and client suites

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -147,6 +147,11 @@ child sessions with titles, activity, statuses, and unseen state.
   failure leaves the prior catalog intact. A later-page failure logs the error
   and commits the pages gathered so far as a fail-soft partial observation;
   missing previously imported rows remain because import is non-destructive.
+- Grok explicit import likewise uses only its bounded standard ACP `session/list`
+  catalog, attributes every committed project and session to `grok`, and remains
+  non-destructive on re-import. Ordinary reads return to the bridge database;
+  Sesori never scans Grok's credential, configuration, or session files and does
+  not resume a listed session merely to catalog it.
 - Running root sessions remain ahead of inactive roots and order by the latest
   durable user-side activity marker, descending, then session ID. Projects with
   running roots likewise remain ahead of inactive projects and order by the
@@ -177,7 +182,7 @@ child sessions with titles, activity, statuses, and unseen state.
 |---|---|
 | L1 Smoke | Headless bridge, representative plugin: project list and one project's session list return committed data with plugin attribution. |
 | L2 Routine | Headless bridge, representative plugin: open, rename, hide; create a session and see it listed before metadata, then observe generated title and eligible branch refinement through the existing session update without unseen change; unseen otherwise advances and clears; the existing activity marker appears in REST and live list-state projections; statuses report idle/busy. A first import reports every published row as new, a re-import of an unchanged catalog reports the same totals with a zero delta, and a completion whose delta is absent reports its totals without claiming nothing changed. Focused client coverage holds pre-commit list reads through a completion, ignores a zero-count hydration completion, proves the post-commit snapshot wins and a second completion gets a trailing snapshot, retains a failed snapshot for the next refresh, proves an interrupted full-screen load and pull surface the winning failure while retaining session PR-data waiting, and covers a completion after immediate cancellation. Focused client coverage also proves the deeper pull starts one scan however far it travels, that a pull which fired it runs no ordinary refresh and raises no confirmation while an ordinary pull still does, that the row keeps one height from starting through running to its result, and that a scan started from harness settings is announced there while one started elsewhere is not. |
-| L3 Release | Client end to end (phone): every supporting production plugin still covers native/derived ownership, import, and child resolution; Pi imports configured/default/known roots with explicit names and resolvable lineage; Copilot exhausts a multi-page standard ACP catalog and exposes one newly imported session without a second manual refresh; one representative plugin proves two running roots and two projects with running roots reorder after committed user-side activity, inactive session/project order is unchanged, a live patch reorders without another status event or project summary, and omitted ordering facts use updated-time fallbacks. Focused ACP protocol and client ordering tests prove the exact awaiting-only state is not promoted because normal production root prompts remain running while awaiting input. Lists and unseen badges render; project and session row swipes stay inert from the iOS back edge and both Android gesture-navigation edges while remaining active at unreserved edges and under Android button navigation. A catalog scan started by the deeper pull renders its row through starting, running, and its result on one mobile platform and in the wide split-view pane, which drives its pull through a different scroll owner; two *routable* harnesses at once, so the fan-out has two members and a partial failure is reachable at all — enabled is not enough, since a blocked or failed harness is enabled and still left out; one native-ownership and one bridge-derived harness, which count new projects differently; and one run that genuinely imports a new session, visible in the list without a second manual refresh. |
+| L3 Release | Client end to end (phone): every supporting production plugin still covers native/derived ownership, import, and child resolution; Pi imports configured/default/known roots with explicit names and resolvable lineage; Copilot exhausts a multi-page standard ACP catalog and exposes one newly imported session without a second manual refresh; Grok explicitly imports a persisted session with `grok` attribution, then an unchanged re-import leaves the committed catalog intact; one representative plugin proves two running roots and two projects with running roots reorder after committed user-side activity, inactive session/project order is unchanged, a live patch reorders without another status event or project summary, and omitted ordering facts use updated-time fallbacks. Focused ACP protocol and client ordering tests prove the exact awaiting-only state is not promoted because normal production root prompts remain running while awaiting input. Lists and unseen badges render; project and session row swipes stay inert from the iOS back edge and both Android gesture-navigation edges while remaining active at unreserved edges and under Android button navigation. A catalog scan started by the deeper pull renders its row through starting, running, and its result on one mobile platform and in the wide split-view pane, which drives its pull through a different scroll owner; two *routable* harnesses at once, so the fan-out has two members and a partial failure is reachable at all — enabled is not enough, since a blocked or failed harness is enabled and still left out; one native-ownership and one bridge-derived harness, which count new projects differently; and one run that genuinely imports a new session, visible in the list without a second manual refresh. |
 | L4 Extended | Relay integration, every supporting production plugin: bridge and plugin restart preserve identity and overrides; a moved backend-native project keeps them while a moved bridge-derived project is discovered as new without mutating the old catalog; a cancelled or first-page failed import leaves the prior catalog intact; reads during import stay consistent; an unavailable plugin is reported while others keep listing. Copilot later-page failure commits gathered pages as a non-destructive fail-soft partial observation. Scanning against older and interrupted peers: a bridge that omits its new-item delta falls back to totals rather than reporting nothing new; a supported bridge with no import route at all reports that it cannot scan, and so does one that has the import route but not the management route the app needs to learn its harnesses — two different bridge versions reaching the same state by different paths; a bridge holding terminal import statuses is reconnected to without announcing a stale success; a disconnect mid-scan reconnects and settles without claiming a summary; and a bridge whose harnesses are all blocked reports that there is nothing to scan. |
 | L5 Full | Client end to end, every supporting production plugin: multiple clients observe consistent listings and unseen transitions; large catalogs and paged listings behave; unattributed payloads resolve to the historical identity. |
 
@@ -187,7 +192,8 @@ Vary the owning plugin, manual open versus import discovery, git and non-git
 folders, and whether the directory moved between runs. For Copilot, vary a
 single-page and multi-page ACP catalog, unchanged re-import, cancellation,
 first-page failure, and a later-page failure after a prior committed import.
-Alternate empty,
+For Grok, vary an empty and populated ACP catalog, first import, unchanged
+re-import, cancellation, and plugin or bridge restart. Alternate empty,
 child-only, and large projects, and reorder import, listing, creation. Remove
 disposable sessions and projects and restore hidden-state changes afterwards.
 For activity order, vary REST versus live delivery, null versus populated
@@ -232,6 +238,9 @@ leave the surface that started one. Restore harness eligibility afterwards.
   history, or a first-page failure mutates the committed catalog. A later-page
   fail-soft import drops prior rows instead of only adding gathered observations
   non-destructively.
+- A Grok import scans local files, resumes a listed session, loses `grok`
+  attribution, destructively removes an absent row, or ordinary catalog reads
+  start Grok after import.
 - A project or session row animates under a system back gesture, or an edge that
   has no active system back gesture stops accepting row actions.
 - A wide session pane starts an ordinary refresh without showing or holding its
@@ -259,10 +268,11 @@ leave the surface that started one. Restore harness eligibility afterwards.
 - Derived lists are bounded by backend enumeration; a directory-scoped backend
   only rediscovers sessions in directories the bridge already knows.
 - Only plugins registered in the build under test count.
-- Copilot discovery is limited to sessions its public ACP catalog reports; Sesori
-  does not infer additional sessions from private files. A failure after the
-  first successful page is logged but currently completes import with the pages
-  gathered so far rather than surfacing a partial status to the client.
+- Copilot and Grok discovery are limited to sessions their public ACP catalogs
+  report; Sesori does not infer additional sessions from private files. A
+  failure after Copilot's first successful page is logged but currently
+  completes import with the pages gathered so far rather than surfacing a
+  partial status to the client.
 - User-side activity is an ordering heuristic, not proof of human intent.
   Generated backend input normalized as a user message and lifecycle-generated
   replies or rejections that clear pending input can advance it.
@@ -288,8 +298,8 @@ leave the surface that started one. Restore harness eligibility afterwards.
 - Pi metadata catalog: `bridge/sesori_plugin_pi/lib/src/api/pi_session_storage_api.dart`,
   `bridge/sesori_plugin_pi/lib/src/repositories/pi_session_catalog_repository.dart`
 - DeepSeek catalog: `bridge/sesori_plugin_deepseek/lib/src/repositories/`
-- Copilot catalog: `bridge/sesori_plugin_acp/lib/src/acp_plugin.dart` and
-  `bridge/sesori_plugin_copilot/`
+- Copilot and Grok ACP catalogs: `bridge/sesori_plugin_acp/lib/src/acp_plugin.dart`,
+  `bridge/sesori_plugin_copilot/`, and `bridge/sesori_plugin_grok/`
 - Tests: `bridge/app/test/bridge/routing/catalog_read_handlers_test.dart`,
   `bridge/app/test/bridge/repositories/project_repository_test.dart`,
   `bridge/sesori_plugin_pi/test/pi_session_storage_api_test.dart`,

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -49,6 +49,12 @@ reaches the backend so the turn continues.
   custom answer variants, plan-review fixed choices, and supplemental free-form
   detail. Abort, process exit, and disposal cancel pending requests and reject
   late replies.
+- Grok runs in its normal ask mode without `--always-approve` or `--yolo`.
+  Standard ACP permissions preserve the exact session, tool call, and offered
+  option IDs; Once, Reject, and every scope the request actually advertises stay
+  phone-mediated unless an existing explicit bridge auto-approval rule applies.
+  Abort, process exit, and disposal cancel pending Grok requests rather than
+  broadening or silently approving them.
 - A sessionless backend request is attributed to the most recently dispatched
   active turn, falling back to the last dispatched turn at its settlement
   boundary. A backend requiring exact form correlation must serialize prompts
@@ -88,7 +94,7 @@ reaches the backend so the turn continues.
 |---|---|
 | L1 Smoke | Live plugin, one representative plugin: a permission raised by a real turn appears as pending and one reply lets the turn proceed. |
 | L2 Routine | Live plugin, representative: question variants (single, multiple, custom, reject), typed ACP scalar forms where supported, unsupported-form decline, abort cancellation, per-session and per-project pending listing, repeated or unknown request ids answered without corrupting state. Automated Pi coverage: select/confirm/input/editor prompt placement, exact replies, and timeout cleanup. Automated DeepSeek coverage: exact two-session question correlation, permission once/reject, ordered multi/custom/free-form and plan-review answers, invalid-answer settlement, abort, late reply, and disposal. |
-| L3 Release | Client end to end on the release-target client platform, every supporting production plugin: every request kind the plugin exposes, per-plugin "always" availability, child attribution, archived-session refusal, and pending requests suppressing completion notifications until resolved. Copilot covers the always-visible Once/Reject actions, Always only when advertised, exact selected-or-cancelled ACP outcomes, and an honestly absent question capability. |
+| L3 Release | Client end to end on the release-target client platform, every supporting production plugin: every request kind the plugin exposes, per-plugin "always" availability, child attribution, archived-session refusal, and pending requests suppressing completion notifications until resolved. Copilot covers the always-visible Once/Reject actions, Always only when advertised, exact selected-or-cancelled ACP outcomes, and an honestly absent question capability. Grok covers a real ask-mode tool request, Once and Reject plus every advertised scope, exact session/tool correlation, abort cleanup, and no implicit auto-approval. |
 | L4 Extended | Relay integration, every supporting production plugin: per-session empty lists while stopped or terminally failed, project-wide question unavailability with no active plugin, pending state re-read after restart, competing replies to one request, two logical clients observing one request and its retirement, and reconnect inside the replay window. |
 | L5 Full | Headless bridge and live plugin for malformed requests and degenerate option sets; packaged or external on alternate client platforms for an older bridge not declaring "always". Every supporting production plugin where applicable. |
 
@@ -102,7 +108,10 @@ different combination than the previous recorded run. For Copilot, provoke a
 real tool permission, exercise Once and Reject plus Always when surfaced, include
 an upstream option set lacking `allow_once` or reject to confirm safe
 cancellation, abort with a request pending, and confirm the management/session
-capability surfaces do not claim questions.
+capability surfaces do not claim questions. For Grok, provoke permissions from
+an ordinary text turn, exercise Once and Reject plus every scope actually
+advertised, vary two sessions and tool calls, abort with a request pending, and
+repeat after process restart without enabling approval-bypass launch flags.
 
 ## Failure Signals
 
@@ -140,6 +149,9 @@ capability surfaces do not claim questions.
 - An archived session accepts a reply.
 - Copilot offers a question surface or waits for a Sesori answer to an upstream
   `ask_user` interaction that the CLI did not forward over ACP.
+- A Grok request is silently approved by launch policy, loses its session or tool
+  correlation, maps to an unoffered scope, survives abort/process cleanup, or
+  one session's answer resolves another session's request.
 
 ## Known Limitations
 
@@ -151,6 +163,9 @@ capability surfaces do not claim questions.
   is not a failure.
 - GitHub Copilot CLI currently does not forward `ask_user` over ACP
   (`github/copilot-cli#2109`); only its standard permission requests are in scope.
+- Grok permission scopes are tool/account dependent. A scope not advertised by
+  the live request is absent capability, not failed coverage; Once and Reject
+  remain required.
 - The shared client models only whether Always is available. Once and Reject stay
   visible even when an unusual ACP request omits their exact option; choosing one
   then cancels safely rather than selecting a broader or different scope.
@@ -164,7 +179,7 @@ capability surfaces do not claim questions.
 - Bridge pending-interaction and archived-validator services; per-plugin
   approval registries; shared pending permission/question and reply models.
 - Client permission and question surfaces and their auto-dismiss behavior.
-- `bridge/sesori_plugin_copilot/lib/src/copilot_plugin_impl.dart` and the shared
-  ACP approval registry.
+- `bridge/sesori_plugin_copilot/lib/src/copilot_plugin_impl.dart`,
+  `bridge/sesori_plugin_grok/`, and the shared ACP approval registry.
 - Owning tests for pending interaction, reply routes, and pending state without
   a started backend.

--- a/docs/regression/session-archiving-and-deletion.md
+++ b/docs/regression/session-archiving-and-deletion.md
@@ -44,6 +44,11 @@ entirely along with its transcript and, optionally, its worktree.
   row and transcript, and retains the plugin-scoped tombstone so a later explicit
   ACP import cannot resurrect the retained upstream row. Sesori never deletes
   files from Copilot's normal configuration home.
+- Grok likewise exposes standard `session/close` but no delete/archive RPC.
+  Active deletion orders cancel, settlement, and close before purging Sesori's
+  row, transcript, and requested worktree state. A plugin-scoped tombstone keeps
+  the retained upstream Grok row from explicit re-import, and Sesori never scans
+  or deletes Grok's private local storage.
 - Cleanup safety rejection happens before mutation. Once cleanup starts, a later
   visible failure can leave the worktree already removed; an identical retry
   accepts that missing worktree and completes session retirement. The session is
@@ -64,7 +69,7 @@ entirely along with its transcript and, optionally, its worktree.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Headless bridge, one representative plugin: a session archives, stays readable, and refuses a later non-deletion mutation. |
-| L2 Routine | Headless bridge, representative: deletion removes the session immediately and purges its history and archive record, with a simulated purge failure logged and recovered by startup reconciliation; export and purge observed as a pair with honest completeness; cleanup rejection issues reported without deleting anything; a close-capable ACP session orders cancel, settlement, and close, while timeout preserves retryable state. Copilot additionally retains upstream history but its exhausted explicit re-import honors the local tombstone. |
+| L2 Routine | Headless bridge, representative: deletion removes the session immediately and purges its history and archive record, with a simulated purge failure logged and recovered by startup reconciliation; export and purge observed as a pair with honest completeness; cleanup rejection issues reported without deleting anything; a close-capable ACP session orders cancel, settlement, and close, while timeout preserves retryable state. Copilot and Grok additionally retain upstream history but their exhausted explicit re-import honors the local tombstone. |
 | L3 Release | Client end to end on the release-target client platform, every supporting production plugin: archive from the session list, read-only detail and archived listing, delete with and without worktree cleanup, refusals presented to the user, branch retained. |
 | L4 Extended | Relay integration, every supporting production plugin: archive or delete with a live turn, pending requests, or a stopped plugin; competing archive/delete/mutation on one family; a second client observing retirement; shared worktree and forced retry; bridge restart between export and flip. |
 | L5 Full | Headless bridge for unreadable or version-mismatched audit records, failed export, startup reconciliation, missing worktrees, and dirty or diverged repositories; packaged or external for released-client unarchive intent. Every supporting production plugin where backend export participates. |
@@ -79,6 +84,8 @@ with direct deletion. Delete disposable sessions and remove any test worktrees
 and branches that remain after the asserted cleanup behavior. For Copilot,
 compare idle and active deletion, verify standard close when resident, then run
 an exhausted explicit import and confirm the retained upstream row stays hidden.
+Repeat that matrix for Grok, including deletion with a permission pending and a
+restart before explicit re-import.
 
 ## Failure Signals
 
@@ -89,8 +96,8 @@ an exhausted explicit import and confirm the retained upstream row stays hidden.
   retains live prompt defaults.
 - Deletion residue survives startup reconciliation without an observable failure
   and later retry, or cleanup removes a worktree or branch that was not requested.
-- Copilot deletion removes private upstream files, omits the local tombstone, or
-  lets a later explicit import recreate the deleted local session.
+- Copilot or Grok deletion removes private upstream files, omits the local
+  tombstone, or lets a later explicit import recreate the deleted local session.
 - A close-capable backend is closed while its prompt is still settling, emits
   late events after local removal, reports timeout/close failure as success, or
   a late session upsert makes a deleting or deleted session visible again.
@@ -124,10 +131,14 @@ an exhausted explicit import and confirm the retained upstream row stays hidden.
 - Copilot's pinned CLI likewise has close but no delete/archive method. Its
   history can remain in the user's normal Copilot home after local deletion;
   Sesori's tombstone prevents re-import without inspecting or deleting that data.
+- Grok's supported CLI also has close but no delete/archive method. Its row can
+  remain in Grok storage after local deletion; Sesori's tombstone prevents
+  re-import without inspecting or deleting that data.
 
 ## Sources
 
 Bridge session lifecycle, deletion, archived-validator, and mutation dispatch
 services; chat-history export and purge; archived-record completeness model;
 worktree service; shared cleanup rejection model; OMP cleanup service; shared
-ACP close/tombstone behavior used by Copilot; client list/detail surfaces.
+ACP close/tombstone behavior used by Copilot and Grok; Grok package deletion
+tests; client list/detail surfaces.

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -49,6 +49,16 @@ variant, and worktree mode, and creating the session with its first input.
   shows the model name when available. Catalog reads use the connected adapter
   without creating a session or model request; selection is session-local and
   never writes normal `DSH_HOME` settings.
+- Grok exposes one primary agent and one provider group from initialize-owned
+  model state. Model IDs and canonical reasoning-effort values remain exact and
+  opaque; declared defaults stay distinct from the current selection. Explicit
+  refresh uses an initialize-only process, creates no session, and replaces the
+  last-good catalog only after a complete valid result. Malformed individual
+  models or efforts are filtered without inventing values. Before creation or a
+  turn, the complete model/effort tuple is validated against the current catalog
+  and applied through Grok's plugin-local `session/set_model` extension; a failed
+  write preserves the prior tracked selection and dispatches no prompt. An
+  effort-only load waits for the session's exact loaded model before validation.
 - GitHub Copilot discovers model, mode, model-specific reasoning, and slash-command
   options through a bounded isolated ACP session while retaining the user's normal
   Copilot configuration for login, settings, and BYOK. The probe closes its own
@@ -152,7 +162,7 @@ variant, and worktree mode, and creating the session with its first input.
 |---|---|
 | L1 Smoke | Headless bridge, representative plugin: a session is created with a first prompt and has attribution and a working directory. |
 | L2 Routine | Headless bridge, representative plugin: options return agents, models, commands, and the last successful plugin-scoped creation selection; explicit refresh forces discovery; cache-only reports unavailable without discovering; a cache past the freshness window is served at once and reported stale; dedicated mode produces a local lowercase `color-animal` branch, worktree, and baseline; a gated metadata request does not gate a queryable create response; eligible generated branch refinement preserves the worktree path and publishes the updated session. |
-| L3 Release | Client end to end (phone), every supporting production plugin: Send immediately renders launch status at the unresolved route, blocks duplicate submit, and replaces with the durable session; Back leaves creation running; each declared option scope is honored and usable; chosen agent, model, and variant apply; slash-command start dispatches without rendering bridge context; generated title and eligible branch refinement arrive through `session.updated`; a stale-reported cache refreshes in the background with no loading state while the refresh action spins in place rather than vanishing; pickers, plugin chooser, detail loading, and no-harness states render. Copilot uses only the model, mode, model-specific reasoning, and command values advertised to the entitled account, including a healthy no-mode catalog. |
+| L3 Release | Client end to end (phone), every supporting production plugin: Send immediately renders launch status at the unresolved route, blocks duplicate submit, and replaces with the durable session; Back leaves creation running; each declared option scope is honored and usable; chosen agent, model, and variant apply; slash-command start dispatches without rendering bridge context; generated title and eligible branch refinement arrive through `session.updated`; a stale-reported cache refreshes in the background with no loading state while the refresh action spins in place rather than vanishing; pickers, plugin chooser, detail loading, and no-harness states render. Copilot uses only the model, mode, model-specific reasoning, and command values advertised to the entitled account, including a healthy no-mode catalog. Grok shows its current default, sends exact advertised model/effort values, rejects a stale tuple, refreshes, and preserves the last successful plugin-scoped choice. |
 | L4 Extended | Client end to end and live plugin, every supporting production plugin: definitive rejection and response-loss/timeout restore the exact in-route draft with duplicate-risk warning, reconnect/options refresh cannot erase it, and background failure does not restore an abandoned draft; occupied branch/path pairs are skipped and pair exhaustion uses a suffix; non-git, empty-repository, worktree-failure, metadata-failure, plugin-title-rename-failure, switched/detached/published branch, invalid generated ref, local/remote collision exhaustion, persistence failure, and shutdown cases retain a usable session; user rename/deletion wins over late title; failure with a retained cache still serves options while failure without one errors; concurrent requests coalesce; automatic refresh does not start a stopped plugin; a moved project invalidates its options. |
 | L5 Full | Client end to end, every supporting production plugin: cache expiry and an undecodable entry recover without wrong options; creation is refused for a non-routable plugin and an unknown project; attachment creation works only where declared; unattributed payloads resolve to the historical identity. |
 
@@ -170,7 +180,10 @@ definitive rejection versus response loss, navigation before completion, and
 reconnect or option refresh while restoration is pending. For Copilot, vary the
 account's default and explicit model/mode/reasoning choices, a model change whose
 reasoning catalog differs, no advertised mode, an exact slash command, stale
-selection rejection, and authentication failure during discovery.
+selection rejection, and authentication failure during discovery. For Grok,
+vary default and explicit model/effort tuples, model-only and effort-only
+changes, changing catalogs, malformed optional entries, stale rejection,
+refresh failure with a last-good catalog, and headless-auth discovery failure.
 
 ## Failure Signals
 
@@ -196,6 +209,10 @@ selection rejection, and authentication failure during discovery.
 - A Copilot catalog invents an option, validates reasoning against another model,
   overlaps unlike probes, replaces a coherent cache after authentication failure,
   or accepts a stale selection before applying every requested config value.
+- A Grok catalog interprets an opaque ID, replaces its last-good state after a
+  failed or malformed refresh, creates a session during refresh, conflates
+  declared and current effort, validates effort against the wrong model, or
+  dispatches after a stale or partially applied selection.
 - Creation succeeds for a non-routable plugin or unknown project.
 - Metadata completion delays the create response, creates an unqueryable session,
   overwrites a user title, resurrects a deletion, or loses the local title when
@@ -217,6 +234,9 @@ selection rejection, and authentication failure during discovery.
 - Copilot's ACP catalog probe closes its scratch session, but the pinned CLI has
   no deletion method; low-impact upstream history residue can remain in the
   user's normal Copilot home.
+- Grok model and reasoning discovery uses its supported CLI's legacy ACP model
+  surface. Accounts and custom configurations can legitimately advertise one
+  model or no reasoning variants; absence is not a failure.
 
 ## Sources
 
@@ -229,6 +249,8 @@ selection rejection, and authentication failure during discovery.
   `lib/src/services/`, and package tests
 - Copilot: `bridge/sesori_plugin_copilot/lib/src/services/`,
   `lib/src/repositories/`, and package tests
+- Grok: `bridge/sesori_plugin_grok/lib/src/services/`,
+  `lib/src/repositories/`, `lib/src/trackers/`, and package tests
 - Contract:
   `bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin_descriptor.dart`
 - Client: `client/module_core/lib/src/services/new_session_options_service.dart`

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -30,6 +30,13 @@ reconnect or restart.
   reopening a prior session after plugin, process, or bridge restart loads it
   before the next prompt without duplicating replay into the live stream. Sesori
   uses the public protocol and never reads Copilot credential or history files.
+- Grok history also uses standard ACP `session/load` on a dedicated short-lived
+  connection and never reads its local credential or session files. Replay
+  initialization validates Grok identity without changing live process defaults;
+  after load, the session's complete model/provider/effort selection is captured
+  atomically and stamps replayed assistant/error messages. Cold continuation
+  loads that same session before prompting after process, plugin, or bridge
+  restart, while replay updates remain suppressed from the live event stream.
 - Messages visible live but absent from the backend's replay remain visible
   after a stale re-read. Exact identities satisfy their replay occurrences
   first and anchor neighboring order by identity even when replay revises their
@@ -103,8 +110,8 @@ reconnect or restart.
 |---|---|
 | L1 Smoke | Headless bridge, one representative plugin: a previously synced session's transcript is served with every backend stopped. |
 | L2 Routine | Live plugin, representative: first backfill, replayed prompt-default persistence and response precedence, live capture that becomes immediately queryable, semantic identity reconciliation with ordered-context and multiplicity preservation (including normalized attachments), stale re-read ordering for retained live-only rows, and paging older messages on a transcript longer than one page. Automated OpenCode, Codex, Claude, and Pi coverage preserves available historical effort or thinking-level variants from assistant/error messages; Pi covers active-branch attribution and file fallback. Automated Pi coverage also includes v1-v3 fallback migration, compaction visibility, hidden-context decoding, bounded tool/image mapping, content-index streaming, cumulative tool updates, and live/replay final parity. |
-| L3 Release | Client end to end on the release-target client platform, every supporting production plugin: open a long session, page back, continue a live turn, reopen cold, and confirm live and replayed content converge including tool and image parts. |
-| L4 Extended | Relay integration plus owning client automated coverage, every supporting production plugin: session advanced through the backend's own CLI, plugin restart and event-stream-gap invalidation, bridge restart, client reconnect inside and outside the replay window without refresh losing concurrently finalized content, two clients on one session, a slow request beside unrelated traffic. Copilot additionally replaces its ACP process, reloads the same session, and converges standard replay with the bridge transcript without duplicate live delivery. |
+| L3 Release | Client end to end on the release-target client platform, every supporting production plugin: open a long session, page back, continue a live turn, reopen cold, and confirm live and replayed content converge including tool parts and image parts where declared. Grok additionally retains its exact loaded model/effort attribution across first load, cold reopen, plugin restart, and bridge restart. |
+| L4 Extended | Relay integration plus owning client automated coverage, every supporting production plugin: session advanced through the backend's own CLI, plugin restart and event-stream-gap invalidation, bridge restart, client reconnect inside and outside the replay window without refresh losing concurrently finalized content, two clients on one session, a slow request beside unrelated traffic. Copilot and Grok additionally replace their ACP process, reload the same session, and converge standard replay with the bridge transcript without duplicate live delivery. |
 | L5 Full | Automated and headless bridge for unreadable or partial store artifacts, interrupted backfill, and startup reconciliation; packaged or external for pagination's released-client shape; live plugin for very large transcripts. Every supporting production plugin. |
 
 ## Exploration Guidance
@@ -112,10 +119,12 @@ reconnect or restart.
 Vary transcript size relative to page size and how far back you page. Vary the
 disruption: stop the plugin, restart the bridge, drop the client link briefly and
 then beyond the replay window, or advance the session from the backend's own CLI
-between reads. For Copilot, compare ordinary reopen, plugin restart, bridge
-restart, and forced ACP process replacement for the same imported session. Vary
-root versus child sessions and content types, since tool and
-image parts converge by their own rules.
+between reads. For Copilot and Grok, compare ordinary reopen, plugin restart,
+bridge restart, and forced ACP process replacement for the same imported
+session. For Grok, also vary a changed loaded model/effort and confirm replay
+uses the loaded tuple without replacing live defaults. Vary root versus child
+sessions and content types, since tool and image parts converge by their own
+rules where supported.
 
 ## Failure Signals
 
@@ -148,6 +157,9 @@ image parts converge by their own rules.
   request stalls other requests, plugins, or reconnects.
 - A Copilot restart prompts before `session/load`, duplicates replay as new live
   output, or reads private history files instead of the ACP replay boundary.
+- Grok replay mutates live defaults during initialize, stamps messages from an
+  incomplete tuple, loses loaded effort/model attribution, duplicates replay as
+  live output, prompts before cold load, or reads private local files.
 
 ## Known Limitations
 
@@ -165,5 +177,6 @@ image parts converge by their own rules.
 Bridge chat-history service, repository, reconcile service, history listeners,
 SSE replay window, and routed request dispatch; database and audit compatibility
 tests under `bridge/app/test/bridge/services/`; Pi session process repository,
-storage API, and history mapper; shared ACP session loader and Copilot plugin;
-shared pagination cursor; client detail load service and cubit.
+storage API, and history mapper; shared ACP session loader plus Copilot and Grok
+plugins and package tests; shared pagination cursor; client detail load service
+and cubit.

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -136,12 +136,18 @@ defaults and queued client sends coherent.
   parts. Its complete model/mode/reasoning selection is validated before
   prompt acceptance and applied before dispatch. Different Copilot sessions can
   run independently; prompts within one session remain serialized.
+- Grok uses standard ACP normalization for text, reasoning, tools, statuses,
+  commands, cancellation, and permission-mediated work. Initial prompts are
+  text-only because its initialize result does not advertise image capability.
+  The exact model/reasoning tuple is validated and applied before dispatch;
+  stale or rejected selection fails visibly without prompting. Different Grok
+  sessions run independently while one session remains serialized.
 - Existing-session ACP prompts remain bridge-queued while an earlier same-session
   turn, declared process-wide lane, resume, or selection blocks their
   `session/prompt` frame. ACP v1 has no standard steering operation, so Sesori
   never sends overlapping prompt requests. It does define `session/cancel`:
-  Cursor, Hermes, and Copilot therefore implement active-turn follow-ups as
-  stop-and-send, immediately cancelling the active turn and dispatching the queued input after
+  Cursor, Hermes, Copilot, and Grok therefore implement active-turn follow-ups
+  as stop-and-send, immediately cancelling the active turn and dispatching the queued input after
   cancellation settles. Further already-queued inputs retain FIFO order. Their
   synthetic user transcript message is published only after its frame flushes
   successfully to the agent's stdin. A prompt rejected after that dispatch
@@ -248,8 +254,8 @@ defaults and queued client sends coherent.
 |---|---|
 | L1 Smoke | Live plugin, representative: a prompt streams assistant output and returns the session to idle. |
 | L2 Routine | Live plugin, representative: slash command returns on acceptance; prompt defaults update; first and stale transcript replay reconciles prompt defaults before the opening snapshot is applied; abort stops a turn and reports its outcome; finalized messages are immediately readable from history; a recognized stale option returns the typed rejection only after cache invalidation. Automated Pi coverage keeps visible custom messages system-attributed across live and replay without changing agent defaults or completion text. |
-| L3 Release | Client end to end (phone), every supporting production plugin: text, reasoning, tool, and status events stream with consistent normalization and the shared output bound; agent, model, and variant apply per send; streaming, composer, sending/queued feedback, and abort render; a stale selection refreshes, warns, and retries once without losing the queued prompt. Copilot additionally covers an exact advertised slash command and reasoning only when its selected model emits it. A Pi custom message renders as labelled automation rather than agent output. |
-| L4 Extended | Relay integration, every supporting production plugin: a slow or unresponsive plugin leaves other sessions, plugins, and the relay responsive; archived sends and queued-prompt cancels are refused without racing archiving; disconnect and reconnect mid-turn resumes without lost or duplicated parts; bridge-owned prompts survive leaving and reopening in order and appear on a second client; a prompt waiting at a dispatch boundary can be cancelled; a permission reply lands while a command or selection-changing prompt waits behind the running turn; a second client observes the same turn and steering prompt. Two Copilot sessions run concurrently while each preserves its own ordering and selection. |
+| L3 Release | Client end to end (phone), every supporting production plugin: text, reasoning, tool, and status events stream with consistent normalization and the shared output bound; agent, model, and variant apply per send; streaming, composer, sending/queued feedback, and abort render; a stale selection refreshes, warns, and retries once without losing the queued prompt. Copilot additionally covers an exact advertised slash command and reasoning only when its selected model emits it. Grok covers exact model/effort application, accepted-send timing, abort, busy stop-and-send, visible failure, and idle completion without claiming image input. A Pi custom message renders as labelled automation rather than agent output. |
+| L4 Extended | Relay integration, every supporting production plugin: a slow or unresponsive plugin leaves other sessions, plugins, and the relay responsive; archived sends and queued-prompt cancels are refused without racing archiving; disconnect and reconnect mid-turn resumes without lost or duplicated parts; bridge-owned prompts survive leaving and reopening in order and appear on a second client; a prompt waiting at a dispatch boundary can be cancelled; a permission reply lands while a command or selection-changing prompt waits behind the running turn; a second client observes the same turn and steering prompt. Two Copilot sessions and two Grok sessions run concurrently while each preserves its own ordering and selection. |
 | L5 Full | Client end to end, every supporting production plugin: retry status surfaces with attempt and timing; concurrent sends across sessions and plugins interleave without ordering damage; background and resume mid-turn recovers live state; an aborted turn triggers no completion notification. |
 
 ## Exploration Guidance
@@ -262,7 +268,9 @@ reopening while an entry is visible, turn length, and client count. For Hermes,
 include text and image prompts, tool updates, a permission decision, cold history
 replay, and abort after output has started. For Copilot, include prose, an
 advertised command, tool use, a selected-option change, a queued follow-up
-cancellation, abort, and two independent sessions.
+cancellation, abort, and two independent sessions. For Grok, include text,
+reasoning and tool updates, default and changed model/effort, stale selection,
+provider failure, early and late abort, busy stop-and-send, and two sessions.
 
 ## Failure Signals
 
@@ -312,12 +320,15 @@ cancellation, abort, and two independent sessions.
   instead of updated when compaction ends, or survives an abort or process
   exit.
 - An abort, permission reply, or question reply stalls behind a send to a
-  busy session on the same session lane, or a Cursor/Hermes follow-up waits for
-  the active turn to finish naturally instead of cancelling it before dispatch.
+  busy session on the same session lane, or a Cursor/Hermes/Grok follow-up waits
+  for the active turn to finish naturally instead of cancelling it before dispatch.
   A Pi abort waits for the general history/control timeout, lets hidden steering
   resume after Stop, or leaves later sends stuck in their sending state.
 - Recovery or interruption artifacts from an aborted turn appear in the next
   user turn.
+- A Grok turn dispatches before exact model/effort selection settles, accepts a
+  stale tuple, overlaps same-session prompts, serializes unrelated sessions, or
+  loses text, reasoning, tool, status, or terminal failure output.
 - A normalized user message fails to advance the existing activity marker, or
   assistant/tool/title-only updates replace an established marker and move the
   running session as if they were user activity.
@@ -350,6 +361,8 @@ cancellation, abort, and two independent sessions.
   shape. Cold replay therefore shows only the slash-command token to avoid
   exposing bridge-owned arguments; live API-command presentation retains only
   the exact user-authored arguments.
+- Grok does not advertise ACP image prompt capability in the supported release;
+  image attachments are not Grok turn coverage.
 - Copilot reasoning is model/account dependent; absence is not a failure unless
   the selected advertised configuration is known to emit reasoning. Standard
   ACP plan updates currently produce only an internal todo invalidation that the
@@ -369,6 +382,7 @@ cancellation, abort, and two independent sessions.
   `shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart`
 - Hermes: `bridge/sesori_plugin_hermes/` and the shared ACP plugin implementation
 - Copilot: `bridge/sesori_plugin_copilot/` and the shared ACP plugin implementation
+- Grok: `bridge/sesori_plugin_grok/` and the shared ACP plugin implementation
 - Client: `client/module_core/lib/src/cubits/session_detail/`,
   `client/app/lib/features/session_detail/`
 - Plans (discovery only): `.plan/completed/relay-request-concurrency`,

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -39,6 +39,10 @@ signal that a tool changed files.
   terminal state, and diff content then converge after `session/load`; permission
   decisions are process-local and are not part of replay. Backend tool names
   remain presentation data rather than shared behavior.
+- Grok uses that standard ACP lifecycle with exact live permission linkage.
+  Tool-call identity, pending-to-terminal status, bounded output or error, and
+  diff content converge between live events and `session/load`; Grok tool names
+  remain presentation data and never become shared domain vocabulary.
 
 ## Regression Levels
 
@@ -46,7 +50,7 @@ signal that a tool changed files.
 |---|---|
 | L1 Smoke | Not included because proving tool behavior requires a live turn. |
 | L2 Routine | Live plugin, representative: a file-editing tool produces a tool part with name, terminal status, and bounded output. |
-| L3 Release | Client end to end (phone), every supporting production plugin: title, status, output bound, and errors normalize consistently; a mutating tool emits the file-change signal once and a read-only tool emits none; tool cards, errors, and subtask/agent parts render. Copilot covers one read-only tool, one file mutation with permission linkage and diff invalidation, and one failing tool. |
+| L3 Release | Client end to end (phone), every supporting production plugin: title, status, output bound, and errors normalize consistently; a mutating tool emits the file-change signal once and a read-only tool emits none; tool cards, errors, and subtask/agent parts render. Copilot covers one read-only tool, one file mutation with permission linkage and diff invalidation, and one failing tool. Grok covers a complete tool lifecycle with bounded output, a file diff and invalidation, live permission linkage, and cold-replay identity/status parity. |
 | L4 Extended | Live plugin, every supporting production plugin: tool parts survive history reload with identity, status, and output intact; a failing tool surfaces an error rather than a stuck running state; child-session tool activity is attributed correctly; repeated completion updates do not duplicate the file-change signal. |
 | L5 Full | Client end to end, every supporting production plugin: rune-boundary truncation is exact for multi-byte output; attachments render where emitted and unsafe or malformed sources degrade to metadata; unknown status from a newer peer degrades gracefully. |
 
@@ -57,7 +61,9 @@ shell-style execution, a failing tool, a sub-agent task. Alternate long,
 multi-byte, and empty output; compare live with a later reload. For Copilot,
 verify permission linkage against the live call, then cold-replay the resulting
 call identity, terminal tool state, bounded output, and diff without expecting
-its process-local permission decision to replay.
+its process-local permission decision to replay. For Grok, compare read-only,
+mutating, failing, and long-output tools live and after `session/load`, including
+one permission-gated mutation and one repeated terminal update.
 
 ## Failure Signals
 
@@ -73,6 +79,9 @@ its process-local permission decision to replay.
 - A Copilot tool loses permission correlation while live, or its call identity,
   terminal status, bounded output, or diff changes when reopened through ACP
   history.
+- A Grok tool loses live permission correlation, changes call identity or status
+  after replay, exposes unbounded output, loses diff content, or emits the wrong
+  number of file-change invalidations.
 - The file-change signal is missing after a real mutation, emitted for a
   read-only tool, emitted repeatedly for one call, or wrongly attributed.
 
@@ -95,8 +104,9 @@ its process-local permission decision to replay.
 - Contract: `bridge/sesori_plugin_interface/lib/src/models/plugin_message.dart`;
   `shared/sesori_shared/lib/src/models/sesori/message_part.dart`
 - Bridge: `bridge/app/lib/src/repositories/mappers/plugin_to_shared_mapping.dart`,
-  the shared ACP mapper used by `bridge/sesori_plugin_copilot/`,
-  `bridge/app/lib/src/sse/bridge_event_mapper.dart`; mappers and tests under
+  the shared ACP mapper used by `bridge/sesori_plugin_copilot/` and
+  `bridge/sesori_plugin_grok/`, `bridge/app/lib/src/sse/bridge_event_mapper.dart`;
+  mappers and tests under
   `bridge/sesori_plugin_*/`; `client/app/lib/features/session_detail/widgets/`
 - Tests: `shared/sesori_shared/test/models/message_attachment_test.dart`,
   `bridge/app/test/bridge/sse/bridge_event_mapper_test.dart`


### PR DESCRIPTION
## Complexity

🌱 Trivial — this step reconciles existing regression documentation only and changes no production behavior.

## What

- Reconciled Grok Build across all eight regression contracts named by the plan:
  - plugin setup and lifecycle
  - projects and sessions
  - session creation and options
  - session turns
  - session history and recovery
  - questions and permissions
  - tools and file changes
  - session archiving and deletion
- Added Grok's supported behavior, cumulative level matrix, exploration variants, material failure signals, honest limitations, and owning source paths to each affected capability.
- Kept `attachments-and-images.md` unchanged because Grok does not advertise image prompt capability.
- Kept `plugin-runtime-installation.md` unchanged because Grok deliberately has no managed installation.

## Why

Grok is now a production harness with client branding. Its setup, import, exact model/reasoning selection, turn, replay, permission, tool, and retained-upstream-deletion behavior must be part of Sesori's durable regression source of truth before final release verification and plan retirement.

## Risk and test focus

Low implementation risk because this is documentation-only. The main review risk is an inaccurate or over-broad product claim. Focus on consistency with the shipped Grok plugin, correct proof boundaries and cumulative levels, text-only capability, local credential ownership, plugin-local legacy model APIs, and close-without-upstream-delete semantics.

## Expected result

The Step 9 verification matrix can execute Grok through every affected authoritative boundary without inferring behavior from the implementation plan. There is no user-visible, database, persisted-data, transport, runtime, or analytics change.

## Verification

- Eight affected files contain the canonical heading order and well-formed level tables.
- Every planned Grok evidence category appears in the owning regression contract.
- Referenced Grok implementation, test, and brand-asset source paths exist.
- Added non-table lines stay within 120 characters.
- `attachments-and-images.md` and `plugin-runtime-installation.md` are unchanged.
- `git diff --check origin/main...HEAD`
- Scope — 226 changed lines against `origin/main`, below the 1,500-line target
- Dart/Flutter suites not run: repository policy requires documentation-only validation for this step
- Architecture implementation review not invoked: regression documentation only

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles Grok Build regression coverage across all eight contracts named in the plan and updates the tracker; this is documentation only and changes no behavior.

- Adds Grok's supported behavior, cumulative regression levels, exploration variants, failure signals, known limitations, and owning source paths to each contract.
- Leaves `attachments-and-images.md` unchanged because Grok does not advertise image capability, and `plugin-runtime-installation.md` unchanged because Grok has no managed install.
- Marks Step 8 as ready to publish in `.plan/active/grok-harness/TRACKER.md`.

**Verification**
- Confirms every planned evidence category lands in its owning regression contract and referenced source paths exist.
- Validates headings, level tables, line width, and whitespace; diff is 226 lines against `origin/main`.

<sup>Written for commit 5efede9afce0d1b67f956cd62b8f69b798a6eceb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

