### PR TITLE
🚧 [desktop-app] Harden bridge supervision boundaries [step 2/22]

### DIFF
--- a/.plan/active/desktop-app/steps/step-02.md
+++ b/.plan/active/desktop-app/steps/step-02.md
@@ -44,16 +44,30 @@ Approved 2026-08-28. The reviewer applied B-Client, B-Bridge, and B-Shared and
 found no issues: dependency direction, lifecycle ownership, DI phase ordering,
 and class cohesion all match the plan.
 
+## Post-merge review follow-up
+
+A late automated review arrived after the step PR merged. Its five findings are
+addressed in a focused follow-up before step 3: the regression contract now
+covers supervised shutdown and diagnostics; partial helper lines are bounded
+before UTF-8 decoding; bootstrap token cancellation preserves a prior clean
+stop; transient application-support lookup failures can retry; and POSIX force
+stop now targets a helper-established process group instead of a process-table
+snapshot. The focused architecture plan and implementation reviews approved
+all B-Client/B-Bridge boundaries with no findings.
+
 ## Verification
 
 - `client/module_desktop_core`: `dart analyze --fatal-infos` — clean.
-- `client/module_desktop_core`: `dart test` — 75 tests passed.
+- `client/module_desktop_core`: `dart test` — 77 tests passed.
 - `shared/sesori_shared`: `dart analyze --fatal-infos` — clean.
 - `shared/sesori_shared`: `dart test test/protocol/control_message_test.dart` —
   18 tests passed.
 - `bridge/app`: `dart analyze --fatal-infos` — clean.
 - `bridge/app`: dispatcher + token-service focused tests — 28 tests passed.
-- `client/desktop`: `dart analyze --fatal-infos` and `flutter test` — passed.
+- Follow-up bridge process-group + runtime-decision tests — 14 tests passed;
+  host-native CLI build succeeded and a supervised launch reached the expected
+  refused control connection without a process-group FFI failure.
+- `client/desktop`: `dart analyze --fatal-infos` and `flutter test` — 18 tests passed.
 - Dart LSP: 0 diagnostics across 21 affected production files.
 - Regenerated shared Freezed/JSON and desktop Injectable outputs with
   `build_runner`.

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -22,6 +22,7 @@ import 'package:sesori_bridge/src/foundation/bridge_startup_banner_formatter.dar
 import 'package:sesori_bridge/src/foundation/data_directory_hardening.dart';
 import 'package:sesori_bridge/src/foundation/device_type_detector.dart';
 import 'package:sesori_bridge/src/foundation/filesystem_cleaner.dart';
+import 'package:sesori_bridge/src/foundation/process_group_isolation.dart';
 import 'package:sesori_bridge/src/foundation/process_runner.dart';
 import 'package:sesori_bridge/src/foundation/process_runner_command_executor.dart';
 import 'package:sesori_bridge/src/repositories/app_onboarding_state_repository.dart';
@@ -207,6 +208,7 @@ class RunCommand() extends cli.Command<void> {
     final exitCode = await BridgeRuntimeRunner.run(
       options: options,
       pluginConfigs: pluginConfigs,
+      processGroupIsolation: ProcessGroupIsolation(),
     );
     await sleepPreventionService.dispose();
     exit(exitCode);

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -172,6 +172,12 @@ class RunCommand() extends cli.Command<void> {
     }
     Log.level = LogLevel.values.byName(options.logLevelName);
 
+    if (options.isSupervised) {
+      // Establish ownership before sleep prevention or any other long-lived
+      // child starts, so the desktop can terminate the complete live group.
+      ProcessGroupIsolation().isolateCurrentProcess();
+    }
+
     if (!options.isSupervised) {
       final banner = BridgeStartupBannerFormatter(
         out: stdout,
@@ -208,7 +214,6 @@ class RunCommand() extends cli.Command<void> {
     final exitCode = await BridgeRuntimeRunner.run(
       options: options,
       pluginConfigs: pluginConfigs,
-      processGroupIsolation: ProcessGroupIsolation(),
     );
     await sleepPreventionService.dispose();
     exit(exitCode);

--- a/bridge/app/lib/src/foundation/process_group_isolation.dart
+++ b/bridge/app/lib/src/foundation/process_group_isolation.dart
@@ -23,11 +23,12 @@ final class const ProcessGroupIsolationException({required final int errorCode})
 
 /// Establishes the supervised bridge as a POSIX process-group leader.
 ///
-/// Every normally spawned backend inherits this group, allowing the desktop
-/// owner to terminate the complete live group rather than relying on a racy
-/// process-table snapshot. Windows uses `taskkill /T` at the desktop boundary
-/// and therefore requires no helper-side setup. Standalone bridge runs never
-/// invoke this primitive.
+/// The supervised CLI invokes this before sleep prevention or any other
+/// long-lived child starts. Those children inherit the group, allowing the
+/// desktop owner to terminate the complete live group rather than relying on a
+/// racy process-table snapshot. Windows uses `taskkill /T` at the desktop
+/// boundary and therefore requires no helper-side setup. Standalone bridge runs
+/// never invoke this primitive.
 class ProcessGroupIsolation.forTesting({
   required final bool _isWindows,
   required final PosixProcessGroupSetter _setProcessGroup,

--- a/bridge/app/lib/src/foundation/process_group_isolation.dart
+++ b/bridge/app/lib/src/foundation/process_group_isolation.dart
@@ -1,0 +1,69 @@
+import "dart:ffi";
+import "dart:io";
+
+import "package:meta/meta.dart";
+
+/// Calls the POSIX `setpgid` primitive.
+@visibleForTesting
+typedef PosixProcessGroupSetter = int Function({
+  required int processId,
+  required int processGroupId,
+});
+
+/// Reads the calling thread's POSIX errno value.
+@visibleForTesting
+typedef PosixErrorCodeReader = int Function();
+
+/// Raised when a supervised bridge cannot become its own POSIX process-group
+/// leader before it starts backend processes.
+final class const ProcessGroupIsolationException({required final int errorCode}) implements Exception {
+  @override
+  String toString() => "ProcessGroupIsolationException: setpgid(0, 0) failed with errno $errorCode";
+}
+
+/// Establishes the supervised bridge as a POSIX process-group leader.
+///
+/// Every normally spawned backend inherits this group, allowing the desktop
+/// owner to terminate the complete live group rather than relying on a racy
+/// process-table snapshot. Windows uses `taskkill /T` at the desktop boundary
+/// and therefore requires no helper-side setup. Standalone bridge runs never
+/// invoke this primitive.
+class ProcessGroupIsolation.forTesting({
+  required final bool _isWindows,
+  required final PosixProcessGroupSetter _setProcessGroup,
+  required final PosixErrorCodeReader _readErrorCode,
+}) {
+  new()
+    : this.forTesting(
+        isWindows: Platform.isWindows,
+        setProcessGroup: _setProcessGroupDefault,
+        readErrorCode: _readErrorCodeDefault,
+      );
+
+  @visibleForTesting
+  this;
+
+  void isolateCurrentProcess() {
+    if (_isWindows) {
+      return;
+    }
+    final int result = _setProcessGroup(processId: 0, processGroupId: 0);
+    if (result != 0) {
+      throw ProcessGroupIsolationException(errorCode: _readErrorCode());
+    }
+  }
+
+  static int _setProcessGroupDefault({required int processId, required int processGroupId}) =>
+      _nativeSetProcessGroup(processId, processGroupId);
+
+  static int _readErrorCodeDefault() => _nativeErrorAddress().value;
+
+  // FFI signatures must mirror the positional native C ABI.
+  static final int Function(int, int) _nativeSetProcessGroup = DynamicLibrary.process()
+      .lookupFunction<Int32 Function(Int32, Int32), int Function(int, int)>("setpgid");
+
+  static Pointer<Int32> Function() get _nativeErrorAddress {
+    final String symbol = Platform.isMacOS ? "__error" : "__errno_location";
+    return DynamicLibrary.process().lookupFunction<Pointer<Int32> Function(), Pointer<Int32> Function()>(symbol);
+  }
+}

--- a/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
@@ -58,7 +58,6 @@ import "../foundation/control_channel_client.dart";
 import "../foundation/data_directory_hardening.dart";
 import "../foundation/filesystem_cleaner.dart";
 import "../foundation/log_failure_reporter.dart";
-import "../foundation/process_group_isolation.dart";
 import "../foundation/process_runner.dart";
 import "../foundation/process_runner_command_executor.dart";
 import "../foundation/relay_client.dart";
@@ -179,7 +178,6 @@ class const BridgeRuntimeRunner._() {
   static Future<int> run({
     required BridgeCliOptions options,
     required Map<String, PluginConfig> pluginConfigs,
-    required ProcessGroupIsolation processGroupIsolation,
   }) async {
     final startAbortController = StartAbortController();
     PluginRuntime? pluginRuntime;
@@ -364,12 +362,6 @@ class const BridgeRuntimeRunner._() {
     );
 
     try {
-      if (options.isSupervised) {
-        // The desktop force-stop path targets this group atomically, including
-        // backend processes forked after any earlier process-table observation.
-        processGroupIsolation.isolateCurrentProcess();
-      }
-
       // Supervised mode (desktop GUI): bring up the loopback control channel
       // before anything else so the GUI sees the helper connect promptly. Every
       // step here is gated by `--control-url`; standalone startup is unchanged.

--- a/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
@@ -58,6 +58,7 @@ import "../foundation/control_channel_client.dart";
 import "../foundation/data_directory_hardening.dart";
 import "../foundation/filesystem_cleaner.dart";
 import "../foundation/log_failure_reporter.dart";
+import "../foundation/process_group_isolation.dart";
 import "../foundation/process_runner.dart";
 import "../foundation/process_runner_command_executor.dart";
 import "../foundation/relay_client.dart";
@@ -178,6 +179,7 @@ class const BridgeRuntimeRunner._() {
   static Future<int> run({
     required BridgeCliOptions options,
     required Map<String, PluginConfig> pluginConfigs,
+    required ProcessGroupIsolation processGroupIsolation,
   }) async {
     final startAbortController = StartAbortController();
     PluginRuntime? pluginRuntime;
@@ -362,6 +364,12 @@ class const BridgeRuntimeRunner._() {
     );
 
     try {
+      if (options.isSupervised) {
+        // The desktop force-stop path targets this group atomically, including
+        // backend processes forked after any earlier process-table observation.
+        processGroupIsolation.isolateCurrentProcess();
+      }
+
       // Supervised mode (desktop GUI): bring up the loopback control channel
       // before anything else so the GUI sees the helper connect promptly. Every
       // step here is gated by `--control-url`; standalone startup is unchanged.
@@ -537,14 +545,26 @@ class const BridgeRuntimeRunner._() {
         try {
           authAccessToken = await supervisedTokenService.getAccessToken();
         } on ControlTokenUnavailableException catch (error, stackTrace) {
+          final bool exitAlreadyRequested = requestedSupervisedExit != null;
+          final SupervisedExitCode tokenUnavailableExit = resolveSupervisedTokenUnavailableExit(
+            requestedExit: requestedSupervisedExit,
+          );
+          if (exitAlreadyRequested) {
+            // A concurrent GUI shutdown disposes the token request. Preserve
+            // the outcome selected before teardown instead of emitting a false
+            // login-needed prompt or replacing clean stop 0 with auth-required.
+            Log.d("Supervised token request ended during ${tokenUnavailableExit.name} shutdown");
+            return tokenUnavailableExit.code;
+          }
+
           // The GUI cannot supply a token (signed out / mid-login / down). Exit
           // with the auth-required sentinel so the GUI prompts for login instead
           // of backoff-respawning a helper that can never start. The prompt is
           // advisory (best-effort); the exit code is the authoritative signal.
           Log.e("Cannot start supervised — no access token from the desktop app", error, stackTrace);
           controlPromptService?.announceLoginNeeded();
-          requestedSupervisedExit = SupervisedExitCode.authRequired;
-          return SupervisedExitCode.authRequired.code;
+          requestedSupervisedExit = tokenUnavailableExit;
+          return tokenUnavailableExit.code;
         }
         accessTokenProvider = supervisedTokenService;
         tokenRefresher = supervisedTokenService;
@@ -1004,6 +1024,11 @@ class const BridgeRuntimeRunner._() {
       }
     }
   }
+
+  @visibleForTesting
+  static SupervisedExitCode resolveSupervisedTokenUnavailableExit({
+    required SupervisedExitCode? requestedExit,
+  }) => requestedExit ?? SupervisedExitCode.authRequired;
 
   @visibleForTesting
   static bool shouldRunAppOnboarding({

--- a/bridge/app/test/bridge/runtime/bridge_runtime_runner_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_runner_test.dart
@@ -26,6 +26,28 @@ void main() {
     });
   });
 
+  group("BridgeRuntimeRunner.resolveSupervisedTokenUnavailableExit", () {
+    test("uses auth-required when no lifecycle outcome exists", () {
+      expect(
+        BridgeRuntimeRunner.resolveSupervisedTokenUnavailableExit(requestedExit: null),
+        SupervisedExitCode.authRequired,
+      );
+    });
+
+    test("preserves a lifecycle outcome selected before token cancellation", () {
+      for (final SupervisedExitCode requestedExit in <SupervisedExitCode>[
+        SupervisedExitCode.cleanStop,
+        SupervisedExitCode.controlChannelLost,
+        SupervisedExitCode.restart,
+      ]) {
+        expect(
+          BridgeRuntimeRunner.resolveSupervisedTokenUnavailableExit(requestedExit: requestedExit),
+          requestedExit,
+        );
+      }
+    });
+  });
+
   group("BridgeRuntimeRunner.shouldRunAppOnboarding", () {
     test("runs for an interactive standalone start even without a plugin", () {
       expect(

--- a/bridge/app/test/foundation/process_group_isolation_test.dart
+++ b/bridge/app/test/foundation/process_group_isolation_test.dart
@@ -1,0 +1,60 @@
+import "package:sesori_bridge/src/foundation/process_group_isolation.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ProcessGroupIsolation", () {
+    test("makes the supervised POSIX bridge its own process-group leader", () {
+      int? capturedProcessId;
+      int? capturedProcessGroupId;
+      final ProcessGroupIsolation isolation = ProcessGroupIsolation.forTesting(
+        isWindows: false,
+        setProcessGroup: ({required int processId, required int processGroupId}) {
+          capturedProcessId = processId;
+          capturedProcessGroupId = processGroupId;
+          return 0;
+        },
+        readErrorCode: () => throw StateError("errno should not be read"),
+      );
+
+      isolation.isolateCurrentProcess();
+
+      expect(capturedProcessId, 0);
+      expect(capturedProcessGroupId, 0);
+    });
+
+    test("fails loudly when POSIX isolation is rejected", () {
+      final ProcessGroupIsolation isolation = ProcessGroupIsolation.forTesting(
+        isWindows: false,
+        setProcessGroup: ({required int processId, required int processGroupId}) => -1,
+        readErrorCode: () => 1,
+      );
+
+      expect(
+        isolation.isolateCurrentProcess,
+        throwsA(
+          isA<ProcessGroupIsolationException>().having(
+            (error) => error.errorCode,
+            "errorCode",
+            1,
+          ),
+        ),
+      );
+    });
+
+    test("does nothing on Windows where the desktop uses taskkill tree mode", () {
+      bool called = false;
+      final ProcessGroupIsolation isolation = ProcessGroupIsolation.forTesting(
+        isWindows: true,
+        setProcessGroup: ({required int processId, required int processGroupId}) {
+          called = true;
+          return 0;
+        },
+        readErrorCode: () => 0,
+      );
+
+      isolation.isolateCurrentProcess();
+
+      expect(called, isFalse);
+    });
+  });
+}

--- a/client/desktop/lib/core/platform/flutter_desktop_application_support_directory.dart
+++ b/client/desktop/lib/core/platform/flutter_desktop_application_support_directory.dart
@@ -1,15 +1,46 @@
+import "dart:async";
 import "dart:io";
 
+import "package:flutter/foundation.dart" show visibleForTesting;
 import "package:injectable/injectable.dart";
 import "package:path_provider/path_provider.dart" as path_provider;
 import "package:sesori_desktop_core/sesori_desktop_core.dart";
 
+@visibleForTesting
+typedef DesktopApplicationSupportDirectoryLoader = Future<Directory> Function();
+
 /// Flutter/path-provider implementation of the desktop-owned application-data
 /// root used by supervision logs and later desktop-only persisted state.
 @LazySingleton(as: DesktopApplicationSupportDirectory)
-class FlutterDesktopApplicationSupportDirectory() implements DesktopApplicationSupportDirectory {
+class FlutterDesktopApplicationSupportDirectory.forTesting({
+  required final DesktopApplicationSupportDirectoryLoader _load,
+}) implements DesktopApplicationSupportDirectory {
   Future<Directory>? _directory;
 
+  new() : this.forTesting(load: path_provider.getApplicationSupportDirectory);
+
+  @visibleForTesting
+  this;
+
   @override
-  Future<Directory> resolve() => _directory ??= path_provider.getApplicationSupportDirectory();
+  Future<Directory> resolve() {
+    final Future<Directory>? cached = _directory;
+    if (cached != null) {
+      return cached;
+    }
+
+    final Completer<Directory> completer = Completer<Directory>();
+    final Future<Directory> resolution = completer.future;
+    _directory = resolution;
+    Future<Directory>.sync(_load).then(
+      completer.complete,
+      onError: (Object error, StackTrace stackTrace) {
+        if (identical(_directory, resolution)) {
+          _directory = null;
+        }
+        completer.completeError(error, stackTrace);
+      },
+    );
+    return resolution;
+  }
 }

--- a/client/desktop/test/core/platform/flutter_desktop_application_support_directory_test.dart
+++ b/client/desktop/test/core/platform/flutter_desktop_application_support_directory_test.dart
@@ -1,0 +1,50 @@
+import "dart:async";
+import "dart:io";
+
+import "package:flutter_test/flutter_test.dart";
+import "package:sesori_desktop/core/platform/flutter_desktop_application_support_directory.dart";
+
+void main() {
+  group("FlutterDesktopApplicationSupportDirectory", () {
+    test("shares one successful lookup across callers", () async {
+      final Completer<Directory> lookup = Completer<Directory>();
+      int attempts = 0;
+      final FlutterDesktopApplicationSupportDirectory directory = FlutterDesktopApplicationSupportDirectory.forTesting(
+        load: () {
+          attempts++;
+          return lookup.future;
+        },
+      );
+
+      final Future<Directory> first = directory.resolve();
+      final Future<Directory> second = directory.resolve();
+      expect(second, same(first));
+
+      final Directory expected = Directory("/tmp/sesori-application-support");
+      lookup.complete(expected);
+
+      expect(await first, same(expected));
+      expect(await directory.resolve(), same(expected));
+      expect(attempts, 1);
+    });
+
+    test("evicts a failed lookup so a later write can retry", () async {
+      int attempts = 0;
+      final Directory expected = Directory("/tmp/sesori-application-support");
+      final FlutterDesktopApplicationSupportDirectory directory = FlutterDesktopApplicationSupportDirectory.forTesting(
+        load: () async {
+          attempts++;
+          if (attempts == 1) {
+            throw StateError("path provider unavailable");
+          }
+          return expected;
+        },
+      );
+
+      await expectLater(directory.resolve(), throwsA(isA<StateError>()));
+
+      expect(await directory.resolve(), same(expected));
+      expect(attempts, 2);
+    });
+  });
+}

--- a/client/module_desktop_core/lib/src/api/bridge_process_api.dart
+++ b/client/module_desktop_core/lib/src/api/bridge_process_api.dart
@@ -116,13 +116,18 @@ class BridgeProcessApi.forTesting({
   }
 
   /// Force-kills the helper and every descendant process it owns.
+  ///
+  /// A supervised POSIX helper makes itself the leader of a dedicated process
+  /// group before starting backends, so one verified group signal covers
+  /// descendants created at any point during teardown. Windows uses its native
+  /// `taskkill /T /F` tree operation.
   Future<void> killProcessTree({required int pid}) async {
     _requirePositivePid(pid: pid);
     if (_isWindows) {
       await _killWindowsProcessTree(pid: pid);
       return;
     }
-    await _killPosixProcessTree(pid: pid);
+    _killPosixProcessTree(pid: pid);
   }
 
   Future<void> _killWindowsProcessTree({required int pid}) async {
@@ -139,46 +144,14 @@ class BridgeProcessApi.forTesting({
     }
   }
 
-  Future<void> _killPosixProcessTree({required int pid}) async {
-    final ProcessResult result = await _runCommand(
-      executable: "ps",
-      arguments: const ["-axo", "pid=,ppid="],
-    );
-    if (result.exitCode != 0) {
-      final String stderr = result.stderr.toString().trim();
+  void _killPosixProcessTree({required int pid}) {
+    final bool delivered = _sendSignal(pid: -pid, signal: ProcessSignal.sigkill);
+    if (!delivered) {
       throw BridgeProcessTreeKillException(
         pid: pid,
-        details: stderr.isEmpty ? "ps exited ${result.exitCode}" : stderr,
+        details: "SIGKILL could not be delivered to process group $pid",
       );
     }
-
-    final Map<int, List<int>> childrenByParent = <int, List<int>>{};
-    for (final String line in result.stdout.toString().split("\n")) {
-      final List<String> fields = line.trim().split(RegExp(r"\s+"));
-      if (fields.length < 2) {
-        continue;
-      }
-      final int? childPid = int.tryParse(fields[0]);
-      final int? parentPid = int.tryParse(fields[1]);
-      if (childPid == null || parentPid == null || childPid <= 0) {
-        continue;
-      }
-      childrenByParent.putIfAbsent(parentPid, () => <int>[]).add(childPid);
-    }
-
-    final List<int> descendants = <int>[];
-    void collectDescendants({required int parentPid}) {
-      for (final int childPid in childrenByParent[parentPid] ?? const <int>[]) {
-        collectDescendants(parentPid: childPid);
-        descendants.add(childPid);
-      }
-    }
-
-    collectDescendants(parentPid: pid);
-    for (final int descendantPid in descendants) {
-      _sendSignal(pid: descendantPid, signal: ProcessSignal.sigkill);
-    }
-    _sendSignal(pid: pid, signal: ProcessSignal.sigkill);
   }
 
   static void _requirePositivePid({required int pid}) {

--- a/client/module_desktop_core/lib/src/trackers/bridge_process_log_tracker.dart
+++ b/client/module_desktop_core/lib/src/trackers/bridge_process_log_tracker.dart
@@ -33,8 +33,9 @@ typedef BridgeProcessLogWarningReporter = void Function({
 /// Layer-2 owner of the supervised helper's stdout/stderr drain and recent-log
 /// state.
 ///
-/// Both pipes are continuously decoded with malformed-byte tolerance, so a
-/// chatty or imperfect helper can never block on a full OS pipe. Every line is
+/// Both pipes are continuously split under a byte cap and decoded with
+/// malformed-byte tolerance, so a chatty or imperfect helper can never block
+/// on a full OS pipe or grow one unterminated line without bound. Every line is
 /// retained in a last-N in-memory ring and independently offered to rotating
 /// Layer-1 storage; storage failures are rate-limited in local logs and never
 /// cancel either drain subscription.
@@ -42,6 +43,7 @@ typedef BridgeProcessLogWarningReporter = void Function({
 class BridgeProcessLogTracker.forTesting({
   required final BridgeProcessLogStorage _storage,
   required final int _maxEntries,
+  required final int _maxLineBytes,
   required final int _maxPendingPersistenceEntries,
   required final Duration _storageWarningInterval,
   required final DateTime Function() _now,
@@ -51,6 +53,7 @@ class BridgeProcessLogTracker.forTesting({
     : this.forTesting(
         storage: storage,
         maxEntries: defaultMaxEntries,
+        maxLineBytes: defaultMaxLineBytes,
         maxPendingPersistenceEntries: defaultMaxPendingPersistenceEntries,
         storageWarningInterval: defaultStorageWarningInterval,
         now: DateTime.now,
@@ -60,9 +63,11 @@ class BridgeProcessLogTracker.forTesting({
   @visibleForTesting
   this
     : assert(_maxEntries > 0, "maxEntries must be positive"),
+      assert(_maxLineBytes > 0, "maxLineBytes must be positive"),
       assert(_maxPendingPersistenceEntries > 0, "maxPendingPersistenceEntries must be positive");
 
   static const int defaultMaxEntries = 200;
+  static const int defaultMaxLineBytes = 64 * 1024;
   static const int defaultMaxPendingPersistenceEntries = 200;
   static const Duration defaultStorageWarningInterval = Duration(minutes: 1);
 
@@ -95,9 +100,8 @@ class BridgeProcessLogTracker.forTesting({
   StreamSubscription<String> _subscribe({
     required Stream<List<int>> stream,
     required BridgeProcessLogSource source,
-  }) => const Utf8Decoder(allowMalformed: true)
-      .bind(stream)
-      .transform(const LineSplitter())
+  }) => stream
+      .transform(_boundedLineTransformer())
       .listen(
         (line) => _record(source: source, message: line),
         onError: (Object error, StackTrace stackTrace) => _reportWarning(
@@ -107,6 +111,53 @@ class BridgeProcessLogTracker.forTesting({
         ),
         cancelOnError: false,
       );
+
+  /// Splits raw child bytes before UTF-8 decoding so even a stream that never
+  /// emits a newline retains at most [_maxLineBytes]. Oversized lines keep
+  /// their leading diagnostic context and carry an explicit truncation marker.
+  StreamTransformer<List<int>, String> _boundedLineTransformer() {
+    const int carriageReturn = 0x0D;
+    const int lineFeed = 0x0A;
+    final List<int> lineBytes = <int>[];
+    bool lineTruncated = false;
+    bool previousDelimiterWasCarriageReturn = false;
+
+    void emitLine(EventSink<String> sink) {
+      final String line = const Utf8Decoder(allowMalformed: true).convert(lineBytes);
+      sink.add(lineTruncated ? "$line [truncated after $_maxLineBytes bytes]" : line);
+      lineBytes.clear();
+      lineTruncated = false;
+    }
+
+    return StreamTransformer<List<int>, String>.fromHandlers(
+      handleData: (chunk, sink) {
+        for (final int byte in chunk) {
+          if (previousDelimiterWasCarriageReturn) {
+            previousDelimiterWasCarriageReturn = false;
+            if (byte == lineFeed) {
+              continue;
+            }
+          }
+          if (byte == carriageReturn || byte == lineFeed) {
+            emitLine(sink);
+            previousDelimiterWasCarriageReturn = byte == carriageReturn;
+            continue;
+          }
+          if (lineBytes.length < _maxLineBytes) {
+            lineBytes.add(byte);
+          } else {
+            lineTruncated = true;
+          }
+        }
+      },
+      handleDone: (sink) {
+        if (lineBytes.isNotEmpty || lineTruncated) {
+          emitLine(sink);
+        }
+        sink.close();
+      },
+    );
+  }
 
   void _record({required BridgeProcessLogSource source, required String message}) {
     final BridgeProcessLogEntry entry = BridgeProcessLogEntry(

--- a/client/module_desktop_core/test/api/bridge_process_api_test.dart
+++ b/client/module_desktop_core/test/api/bridge_process_api_test.dart
@@ -78,13 +78,12 @@ void main() {
       verify(() => fixture.process.kill(ProcessSignal.sigkill)).called(1);
     });
 
-    test("POSIX process-tree kill signals descendants deepest-first, then the helper", () async {
+    test("POSIX process-tree kill targets the dedicated helper process group", () async {
       final List<(int, ProcessSignal)> signals = <(int, ProcessSignal)>[];
       final BridgeProcessApi api = BridgeProcessApi.forTesting(
         isWindows: false,
         startProcess: _unusedStarter,
-        runCommand: ({required String executable, required List<String> arguments}) async =>
-            ProcessResult(1, 0, "100 1\n101 100\n102 101\n103 100\n", ""),
+        runCommand: _unusedCommandRunner,
         sendSignal: ({required int pid, required ProcessSignal signal}) {
           signals.add((pid, signal));
           return true;
@@ -93,14 +92,24 @@ void main() {
 
       await api.killProcessTree(pid: 100);
 
-      expect(
-        signals,
-        equals(<(int, ProcessSignal)>[
-          (102, ProcessSignal.sigkill),
-          (101, ProcessSignal.sigkill),
-          (103, ProcessSignal.sigkill),
-          (100, ProcessSignal.sigkill),
-        ]),
+      expect(signals, equals(<(int, ProcessSignal)>[(-100, ProcessSignal.sigkill)]));
+    });
+
+    test("POSIX process-tree kill reports rejected group delivery", () async {
+      final BridgeProcessApi api = BridgeProcessApi.forTesting(
+        isWindows: false,
+        startProcess: _unusedStarter,
+        runCommand: _unusedCommandRunner,
+        sendSignal: ({required int pid, required ProcessSignal signal}) => false,
+      );
+
+      await expectLater(
+        api.killProcessTree(pid: 100),
+        throwsA(
+          isA<BridgeProcessTreeKillException>()
+              .having((error) => error.pid, "pid", 100)
+              .having((error) => error.details, "details", contains("process group 100")),
+        ),
       );
     });
 

--- a/client/module_desktop_core/test/trackers/bridge_process_log_tracker_test.dart
+++ b/client/module_desktop_core/test/trackers/bridge_process_log_tracker_test.dart
@@ -20,6 +20,7 @@ void main() {
       tracker = BridgeProcessLogTracker.forTesting(
         storage: storage,
         maxEntries: 2,
+        maxLineBytes: 8,
         maxPendingPersistenceEntries: 3,
         storageWarningInterval: const Duration(minutes: 1),
         now: () => now,
@@ -74,6 +75,25 @@ void main() {
       await pumpEventQueue();
 
       expect(tracker.snapshot.map((entry) => entry.message), containsAll(<String>["�", "after"]));
+      expect(storage.logicalLines, hasLength(2));
+    });
+
+    test("bounds a newline-free line before decoding and continues draining", () async {
+      await tracker.attach(stdout: stdout.stream, stderr: stderr.stream);
+
+      stdout
+        ..add(utf8.encode("12345678"))
+        ..add(utf8.encode("90"));
+      await pumpEventQueue();
+      expect(tracker.snapshot, isEmpty);
+
+      stdout.add(utf8.encode("\nafter\n"));
+      await pumpEventQueue();
+
+      expect(
+        tracker.snapshot.map((entry) => entry.message),
+        ["12345678 [truncated after 8 bytes]", "after"],
+      );
       expect(storage.logicalLines, hasLength(2));
     });
 

--- a/docs/regression/bridge-connectivity.md
+++ b/docs/regression/bridge-connectivity.md
@@ -43,7 +43,8 @@ explicit restart, and the connection states the app presents.
   exits 0 without unregistering, and cannot be reclassified as auth-required when
   teardown cancels an in-flight bootstrap token request.
 - The supervised bridge leads a dedicated POSIX process group before starting
-  backends; force-stop signals that complete live group atomically. Windows uses
+  sleep prevention or any other long-lived child; force-stop signals that
+  complete live group atomically. Windows uses
   `taskkill /T /F` for the equivalent descendant-tree guarantee.
 - Desktop supervision continuously drains both helper pipes with malformed-UTF-8
   tolerance, bounds partial lines and pending persistence, retains the latest 200

--- a/docs/regression/bridge-connectivity.md
+++ b/docs/regression/bridge-connectivity.md
@@ -39,6 +39,16 @@ explicit restart, and the connection states the app presents.
 - In supervised mode, the authenticated local control channel can supply tokens, report
   status and provisioning, resolve prompts, unregister, and request sentinel restarts;
   loss of its owner exits after the grace period without orphaning backend processes.
+- A GUI `shutdown` performs the same ordered graceful teardown as standalone stop,
+  exits 0 without unregistering, and cannot be reclassified as auth-required when
+  teardown cancels an in-flight bootstrap token request.
+- The supervised bridge leads a dedicated POSIX process group before starting
+  backends; force-stop signals that complete live group atomically. Windows uses
+  `taskkill /T /F` for the equivalent descendant-tree guarantee.
+- Desktop supervision continuously drains both helper pipes with malformed-UTF-8
+  tolerance, bounds partial lines and pending persistence, retains the latest 200
+  entries, and rotates owner-only local logs. Storage failures and queue overflow
+  remain observable without stopping either pipe drain.
 
 ## Regression Levels
 
@@ -47,7 +57,7 @@ explicit restart, and the connection states the app presents.
 | L1 Smoke | A started bridge reaches readiness and answers a health request; a connected client reports connected. Headless bridge plus relay integration for the client-visible state; no plugin. |
 | L2 Routine | Relay integration for key exchange, a normal drop and reconnect, and clean shutdown; automated and headless bridge for stable machine-name registration plus sleep-policy enable, disable, warning, and wake-lock release. No plugin. |
 | L3 Release | The full connection state machine as presented, explicit restart with successor handoff, second-start ownership resolution, and a slow in-flight request not blocking key exchange or further requests. Client end to end plus headless bridge; a representative harness supplies the slow operation. |
-| L4 Extended | Relay integration or client end to end for takeover, revocation, live token re-authentication, handshake shutdown, app/network recovery, several clients, and alternate client platforms; headless supervised harness for control authentication, token rotation, prompts, status, provisioning progress, unregister, restart sentinels, owner loss, and orphan cleanup. |
+| L4 Extended | Relay integration or client end to end for takeover, revocation, live token re-authentication, handshake shutdown, app/network recovery, several clients, and alternate client platforms; headless supervised harness for control authentication, token rotation, prompts, status, provisioning progress, unregister, restart sentinels, normal shutdown during token bootstrap, owner loss, and POSIX/Windows orphan cleanup; desktop tests for malformed/newline-free output, bounded persistence, rotation, permissions, and transient storage-path failure recovery. |
 | L5 Full | Store-distributed app against a released bridge over production relay, older app against newer bridge and the reverse for the client/bridge wire contract, and a long-lived headless VM run over repeated reconnects. Packaged or external. |
 
 ## Exploration Guidance
@@ -70,6 +80,13 @@ the bridge starts, how many clients are present, and whether restart is explicit
 - A bridge registering a network-derived numeric hostname as its machine name.
 - A clean shutdown producing reconnects, a cancelled handshake later sending auth, or an
   app stuck reconnecting after the bridge returns.
+- GUI shutdown unregistering the bridge, emitting login-needed, or exiting with the
+  auth-required sentinel because teardown cancelled the bootstrap token request.
+- A forced stop leaving a backend alive, targeting only one process-table snapshot,
+  or reporting success after process-group/tree termination was rejected.
+- Helper output blocking a child pipe, an unterminated line or persistence backlog
+  growing without bound, log files losing owner-only permissions, or one transient
+  application-support lookup failure permanently disabling persisted diagnostics.
 
 ## Known Limitations
 


### PR DESCRIPTION
## Complexity

🚧 Complex — this follow-up hardens a cross-process POSIX ownership contract, supervised bootstrap exit ordering, bounded raw-pipe framing, and desktop platform-cache recovery.

## What

- Makes a supervised POSIX bridge its own process-group leader via `setpgid(0, 0)` before sleep prevention or any other long-lived child starts.
- Replaces process-table snapshot killing with one verified group `SIGKILL`; Windows retains `taskkill /T /F`.
- Bounds helper output before UTF-8 decoding so newline-free output cannot grow memory without limit.
- Preserves an already selected clean/control-loss exit when shutdown cancels the bootstrap token request.
- Evicts failed application-support directory lookups so later diagnostic writes can retry.
- Updates the bridge-connectivity regression contract and Step 2 evidence.

## Why

A second automated review landed after #1178 merged and identified five valid gaps. This focused follow-up closes them before the dependent `BridgeProcessService` step builds on these primitives.

## Risk and test focus

Review focus should be POSIX process-group creation and negative-PID signaling on macOS/Linux, Windows remaining on native tree-kill behavior, standalone bridge startup remaining unchanged, bounded line framing across fragmented/malformed input, and clean-stop priority during token-request cancellation.

## Expected result

No user-visible or database change. Forced desktop stops cannot miss backends forked after a process snapshot, malformed/newline-free helper output stays bounded, intentional shutdown remains exit 0, and transient path-provider failure no longer disables persisted diagnostics for the process lifetime.

## Verification

- `client/module_desktop_core`: `dart analyze --fatal-infos` — clean
- `client/module_desktop_core`: `dart test` — 77 passed
- `client/desktop`: `dart analyze --fatal-infos` — clean
- `client/desktop`: `flutter test` — 18 passed
- `bridge/app`: `dart analyze` — clean after rebase
- `bridge/app`: focused process-group/runtime tests — 14 passed after rebase
- `bridge/app`: `make build-host` — host-native bundle built successfully
- Built supervised bridge reached the expected refused control connection without a process-group FFI failure
- Local macOS process-group probe verified one negative-PID `SIGKILL` terminates both leader and grandchild
- Dart LSP: 0 diagnostics across 11 affected Dart files
- `git diff origin/main --check` — clean

## Architecture review

Architecture plan review and both permitted implementation-review passes approved B-Client/B-Bridge with no findings. The final pass reviewed the clean rebased `origin/main..HEAD` range.

Follow-up to #1178.
