### PR TITLE
🚧 [project-voice-glossary] Publish glossaries from project lifecycle [step 7/8]

### DIFF
--- a/bridge/app/lib/src/listeners/current_project_glossary_listener.dart
+++ b/bridge/app/lib/src/listeners/current_project_glossary_listener.dart
@@ -1,0 +1,51 @@
+import "dart:async";
+
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show PendingOperations;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
+import "../repositories/project_glossary_publication_repository.dart";
+import "../services/project_glossary_population_service.dart";
+
+/// Populates glossaries after successful current-project route loads.
+class CurrentProjectGlossaryListener({
+  required final Stream<String> _source,
+  required final ProjectGlossaryPopulationService _service,
+}) {
+  final PendingOperations _pending = PendingOperations();
+  StreamSubscription<String>? _subscription;
+  Future<void>? _disposeFuture;
+  bool _disposed = false;
+
+  void start() {
+    if (_subscription != null || _disposed) return;
+    _subscription = _source.listen(
+      (projectId) {
+        if (_disposed) return;
+        unawaited(_pending.track(operation: _populate(projectId: projectId)));
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        if (_disposed) return;
+        Log.w("Current-project glossary trigger stream failed", error, stackTrace);
+      },
+    );
+  }
+
+  Future<void> _populate({required String projectId}) async {
+    try {
+      await _service.populate(projectId: projectId);
+    } on ProjectGlossaryPublicationAbortedException {
+      // Expected when bridge shutdown aborts publication transport.
+    } on Object catch (error, stackTrace) {
+      if (_disposed) return;
+      Log.w("Current-project glossary population failed; continuing without an updated glossary", error, stackTrace);
+    }
+  }
+
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
+    _disposed = true;
+    await _subscription?.cancel();
+    await _pending.drain();
+  }
+}

--- a/bridge/app/lib/src/listeners/viewed_project_glossary_listener.dart
+++ b/bridge/app/lib/src/listeners/viewed_project_glossary_listener.dart
@@ -1,0 +1,57 @@
+import "dart:async";
+
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show PendingOperations;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
+import "../repositories/project_glossary_publication_repository.dart";
+import "../services/project_glossary_population_service.dart";
+import "../services/project_view_tracker.dart";
+
+/// Populates glossaries when a project enters the aggregate active-view set.
+class ViewedProjectGlossaryListener({
+  required final ProjectViewTracker _tracker,
+  required final ProjectGlossaryPopulationService _service,
+}) {
+  final PendingOperations _pending = PendingOperations();
+  StreamSubscription<ProjectViewChange>? _subscription;
+  Future<void>? _disposeFuture;
+  bool _disposed = false;
+
+  void start() {
+    if (_subscription != null || _disposed) return;
+    _subscription = _tracker.changes.listen(
+      (change) => _populateAll(projectIds: change.newlyAddedProjectIds),
+      onError: (Object error, StackTrace stackTrace) {
+        if (_disposed) return;
+        Log.w("Viewed-project glossary trigger stream failed", error, stackTrace);
+      },
+    );
+    _populateAll(projectIds: _tracker.activeProjectIds);
+  }
+
+  void _populateAll({required Set<String> projectIds}) {
+    if (_disposed) return;
+    for (final projectId in projectIds) {
+      unawaited(_pending.track(operation: _populate(projectId: projectId)));
+    }
+  }
+
+  Future<void> _populate({required String projectId}) async {
+    try {
+      await _service.populate(projectId: projectId);
+    } on ProjectGlossaryPublicationAbortedException {
+      // Expected when bridge shutdown aborts publication transport.
+    } on Object catch (error, stackTrace) {
+      if (_disposed) return;
+      Log.w("Viewed-project glossary population failed; continuing without an updated glossary", error, stackTrace);
+    }
+  }
+
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
+    _disposed = true;
+    await _subscription?.cancel();
+    await _pending.drain();
+  }
+}

--- a/bridge/app/lib/src/orchestrator.dart
+++ b/bridge/app/lib/src/orchestrator.dart
@@ -33,12 +33,14 @@ import "foundation/relay_client.dart";
 import "foundation/streaming_process_runner.dart";
 import "listeners/chat_history_activity_listener.dart";
 import "listeners/chat_history_listener.dart";
+import "listeners/current_project_glossary_listener.dart";
 import "listeners/plugin_catalog_hydration_listener.dart";
 import "listeners/plugin_event_listener.dart";
 import "listeners/session_binding_commit_listener.dart";
 import "listeners/session_mutation_listener.dart";
 import "listeners/session_options_changed_refresh_listener.dart";
 import "listeners/session_options_creation_refresh_listener.dart";
+import "listeners/viewed_project_glossary_listener.dart";
 import "listeners/viewed_project_pr_refresh_listener.dart";
 import "models/bridge_config.dart";
 import "push/completion_notifier.dart";
@@ -65,6 +67,9 @@ import "repositories/permission_repository.dart";
 import "repositories/pr_source_repository.dart";
 import "repositories/project_activity_repository.dart";
 import "repositories/project_catalog_identity_calculator.dart";
+import "repositories/project_glossary_publication_repository.dart";
+import "repositories/project_glossary_repository.dart";
+import "repositories/project_glossary_scope_repository.dart";
 import "repositories/project_repository.dart";
 import "repositories/provider_repository.dart";
 import "repositories/pull_request_repository.dart";
@@ -137,12 +142,16 @@ import "services/archived_session_validator.dart";
 import "services/catalog_import_service.dart";
 import "services/chat_history_reconcile_service.dart";
 import "services/chat_history_service.dart";
+import "services/current_project_service.dart";
 import "services/deleted_session_storage_cleanup_service.dart";
 import "services/pending_interaction_service.dart";
 import "services/permission_auto_approval_service.dart";
 import "services/plugin_lifecycle_service.dart";
 import "services/pr_sync_service.dart";
 import "services/project_activity_service.dart";
+import "services/project_glossary_population_service.dart";
+import "services/project_glossary_scope_service.dart";
+import "services/project_glossary_term_calculator.dart";
 import "services/project_initialization_service.dart";
 import "services/project_mutation_service.dart";
 import "services/project_view_tracker.dart";
@@ -342,6 +351,34 @@ class Orchestrator({
       prSyncService: prSyncService,
       settingsService: pullRequestRefreshSettingsService,
     );
+    final currentProjectService = CurrentProjectService(projectRepository: projectRepository);
+    final sesoriServerApi = SesoriServerApi(
+      authBackendUrl: config.authBackendURL,
+      client: _httpClient,
+      requestDeadline: SesoriServerApi.defaultRequestDeadline,
+      tokenRefresher: _tokenRefresher,
+    );
+    final projectGlossaryPopulationService = ProjectGlossaryPopulationService(
+      projectRepository: projectRepository,
+      scopeService: ProjectGlossaryScopeService(
+        repository: ProjectGlossaryScopeRepository(gitCliApi: gitCliApi),
+        bridgeIdProvider: _bridgeRegistrationService,
+      ),
+      glossaryRepository: ProjectGlossaryRepository(
+        gitCliApi: gitCliApi,
+        filesystemApi: const FilesystemApi(),
+      ),
+      termCalculator: const ProjectGlossaryTermCalculator(),
+      publicationRepository: ProjectGlossaryPublicationRepository(api: sesoriServerApi),
+    );
+    final currentProjectGlossaryListener = CurrentProjectGlossaryListener(
+      source: currentProjectService.loadedProjectIds,
+      service: projectGlossaryPopulationService,
+    );
+    final viewedProjectGlossaryListener = ViewedProjectGlossaryListener(
+      tracker: projectViewTracker,
+      service: projectGlossaryPopulationService,
+    );
     final projectActivityService = ProjectActivityService(
       projectRepository: projectRepository,
       projectActivityRepository: ProjectActivityRepository(
@@ -384,14 +421,7 @@ class Orchestrator({
       archivedSessionValidator: archivedSessionValidator,
     );
     final sessionCreationService = SessionCreationService(
-      sessionMetadataRepository: SessionMetadataRepository(
-        api: SesoriServerApi(
-          authBackendUrl: config.authBackendURL,
-          client: _httpClient,
-          requestDeadline: SesoriServerApi.defaultRequestDeadline,
-          tokenRefresher: _tokenRefresher,
-        ),
-      ),
+      sessionMetadataRepository: SessionMetadataRepository(api: sesoriServerApi),
       worktreeService: worktreeService,
       sessionRepository: sessionRepository,
       newSessionDefaultsRepository: newSessionDefaultsRepository,
@@ -557,7 +587,7 @@ class Orchestrator({
           pluginIds: pluginComposition.sessionOptionsScopeById.keys.toSet(),
         ),
         RestartBridgeHandler(restartService: _restartService),
-        GetCurrentProjectHandler(projectRepository: projectRepository),
+        GetCurrentProjectHandler(currentProjectService: currentProjectService),
         GetProjectsHandler(projectActivityService: projectActivityService),
         GetCommandsHandler(sessionRepository: sessionRepository),
         GetSessionStatusesHandler(sessionRepository: sessionRepository),
@@ -648,6 +678,10 @@ class Orchestrator({
       sessionRepository: sessionRepository,
       prSyncService: prSyncService,
       viewedProjectPrRefreshListener: viewedProjectPrRefreshListener,
+      currentProjectGlossaryListener: currentProjectGlossaryListener,
+      viewedProjectGlossaryListener: viewedProjectGlossaryListener,
+      projectGlossaryPopulationService: projectGlossaryPopulationService,
+      currentProjectService: currentProjectService,
       sessionUnseenService: sessionUnseenService,
       sessionViewTracker: sessionViewTracker,
       projectViewTracker: projectViewTracker,
@@ -746,6 +780,10 @@ class OrchestratorSession._({
     required final SessionRepository _sessionRepository,
     required final PrSyncService _prSyncService,
     required final ViewedProjectPrRefreshListener _viewedProjectPrRefreshListener,
+    required final CurrentProjectGlossaryListener _currentProjectGlossaryListener,
+    required final ViewedProjectGlossaryListener _viewedProjectGlossaryListener,
+    required final ProjectGlossaryPopulationService _projectGlossaryPopulationService,
+    required final CurrentProjectService _currentProjectService,
     required final SessionUnseenService _sessionUnseenService,
     required final SessionViewTracker _sessionViewTracker,
     required final ProjectViewTracker _projectViewTracker,
@@ -898,6 +936,8 @@ class OrchestratorSession._({
     _sessionOptionsCreationRefreshListener.start();
     _sessionOptionsChangedRefreshListener.start();
     _viewedProjectPrRefreshListener.start();
+    _currentProjectGlossaryListener.start();
+    _viewedProjectGlossaryListener.start();
     _chatHistoryActivityListener.start();
     final readiness = Completer<OrchestratorSessionStartResult>();
     final lifecycleFuture = Future<void>.microtask(
@@ -1049,6 +1089,7 @@ class OrchestratorSession._({
     _routedRequestDispatcher.beginShutdown();
     _sessionCreationService.beginShutdown();
     _prSyncService.beginShutdown();
+    _projectGlossaryPopulationService.beginShutdown();
     final teardownSw = Stopwatch()..start();
     Object? firstTeardownError;
     StackTrace? firstTeardownStackTrace;
@@ -1077,9 +1118,15 @@ class OrchestratorSession._({
       attempt(_sessionBindingCommitListener.dispose),
       attempt(_chatHistoryListener.dispose),
       attempt(_chatHistoryActivityListener.dispose),
+      attempt(_currentProjectGlossaryListener.dispose),
+      attempt(_viewedProjectGlossaryListener.dispose),
     ]);
     Log.v("[shutdown] event producers cancelled (+${teardownSw.elapsedMilliseconds}ms)");
     await Future.wait([attempt(_routedRequestDispatcher.drain), attempt(_drainRelayCompletions)]);
+    await Future.wait([
+      attempt(_currentProjectService.dispose),
+      attempt(_projectGlossaryPopulationService.dispose),
+    ]);
     Log.v(
       "[shutdown] routed requests and relay completions drained "
       "(+${teardownSw.elapsedMilliseconds}ms)",
@@ -1264,6 +1311,7 @@ class OrchestratorSession._({
     _routedRequestDispatcher.beginShutdown();
     _sessionCreationService.beginShutdown();
     _prSyncService.beginShutdown();
+    _projectGlossaryPopulationService.beginShutdown();
     if (_cancelRequestedAt == null) {
       _cancelRequestedAt = DateTime.now();
       Log.d(

--- a/bridge/app/lib/src/routing/get_current_project_handler.dart
+++ b/bridge/app/lib/src/routing/get_current_project_handler.dart
@@ -1,10 +1,10 @@
 import "package:sesori_shared/sesori_shared.dart";
 
-import "../repositories/project_repository.dart";
+import "../services/current_project_service.dart";
 import "request_handler.dart";
 
 /// Handles `POST /project/current` — returns project for a given project id.
-class GetCurrentProjectHandler({required final ProjectRepository _projectRepository})
+class GetCurrentProjectHandler({required final CurrentProjectService _currentProjectService})
     extends BodyRequestHandler<ProjectIdRequest, Project> {
   this
     : super(
@@ -21,6 +21,6 @@ class GetCurrentProjectHandler({required final ProjectRepository _projectReposit
     final projectId = body.projectId;
     requireNonEmpty(request: request, value: projectId, label: "project id");
 
-    return await _projectRepository.getProject(projectId: projectId);
+    return await _currentProjectService.getCurrentProject(projectId: projectId);
   }
 }

--- a/bridge/app/lib/src/services/current_project_service.dart
+++ b/bridge/app/lib/src/services/current_project_service.dart
@@ -1,0 +1,28 @@
+import "dart:async";
+
+import "package:sesori_shared/sesori_shared.dart" show Project;
+
+import "../repositories/project_repository.dart";
+
+/// Loads the current project for the route boundary and publishes successful
+/// loads for independent background consumers.
+class CurrentProjectService({required final ProjectRepository _projectRepository}) {
+  final StreamController<String> _loadedProjectIds = StreamController<String>.broadcast(sync: true);
+  bool _disposed = false;
+
+  Stream<String> get loadedProjectIds => _loadedProjectIds.stream;
+
+  Future<Project> getCurrentProject({required String projectId}) async {
+    final project = await _projectRepository.getProject(projectId: projectId);
+    if (!_disposed) {
+      _loadedProjectIds.add(project.id);
+    }
+    return project;
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await _loadedProjectIds.close();
+  }
+}

--- a/bridge/app/lib/src/services/project_glossary_population_service.dart
+++ b/bridge/app/lib/src/services/project_glossary_population_service.dart
@@ -1,0 +1,80 @@
+import "dart:math" show min;
+
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show ParallelLock;
+
+import "../repositories/project_glossary_publication_repository.dart";
+import "../repositories/project_glossary_repository.dart";
+import "../repositories/project_repository.dart";
+import "project_glossary_scope_service.dart";
+import "project_glossary_term_calculator.dart";
+
+/// Serializes bounded project scans and reconciles their filtered terms into
+/// the bridge's exact glossary ownership scope.
+class ProjectGlossaryPopulationService({
+  required final ProjectRepository _projectRepository,
+  required final ProjectGlossaryScopeService _scopeService,
+  required final ProjectGlossaryRepository _glossaryRepository,
+  required final ProjectGlossaryTermCalculator _termCalculator,
+  required final ProjectGlossaryPublicationRepository _publicationRepository,
+}) {
+  static const int _maximumMutationWords = 100;
+
+  final ParallelLock _populationLock = ParallelLock(maxParallelOperations: 1);
+  Future<void>? _disposeFuture;
+  bool _accepting = true;
+
+  Future<void> populate({required String projectId}) {
+    if (!_accepting) return Future<void>.value();
+
+    return _populationLock.use(
+      operation: () async {
+        if (!_accepting) return;
+
+        final project = await _projectRepository.getProject(projectId: projectId);
+        if (!_accepting) return;
+
+        final scope = await _scopeService.resolve(projectPath: project.path);
+        if (scope == null || !_accepting) return;
+
+        final source = await _glossaryRepository.loadSource(projectPath: project.path);
+        final desiredWords = _termCalculator.calculate(source: source);
+        if (!_accepting) return;
+
+        final existingWords = await _publicationRepository.getWords(projectKey: scope.projectKey);
+        if (!_accepting) return;
+
+        // The read is project-wide and deduplicated across exact owners. Add
+        // every desired word idempotently so this scope retains independent
+        // ownership even when another scope already contributed the same word.
+        if (desiredWords.isNotEmpty) {
+          await _publicationRepository.addWords(scope: scope, words: desiredWords);
+        }
+        if (!_accepting) return;
+
+        final desiredWordSet = desiredWords.toSet();
+        final staleWords = existingWords.where((word) => !desiredWordSet.contains(word)).toList(growable: false);
+        for (var start = 0; start < staleWords.length; start += _maximumMutationWords) {
+          if (!_accepting) return;
+          final end = min(start + _maximumMutationWords, staleWords.length);
+          await _publicationRepository.removeWords(
+            scope: scope,
+            words: staleWords.sublist(start, end),
+          );
+        }
+      },
+    );
+  }
+
+  void beginShutdown() {
+    if (!_accepting) return;
+    _accepting = false;
+    _publicationRepository.beginShutdown();
+  }
+
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
+    beginShutdown();
+    await _populationLock.idle;
+  }
+}

--- a/bridge/app/test/bridge/routing/get_current_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_current_project_handler_test.dart
@@ -3,6 +3,7 @@ import "dart:convert";
 import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/routing/get_current_project_handler.dart";
+import "package:sesori_bridge/src/services/current_project_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -16,6 +17,7 @@ void main() {
   group("GetCurrentProjectHandler", () {
     late FakeBridgePlugin plugin;
     late AppDatabase db;
+    late CurrentProjectService currentProjectService;
     late GetCurrentProjectHandler handler;
 
     setUp(() async {
@@ -23,7 +25,7 @@ void main() {
       db = createTestDatabase();
       await db.projectsDao.insertProjectsIfMissing(projectIds: ["/tmp/project"]);
       await db.projectsDao.setActivity(projectId: "/tmp/project", createdAt: 101, updatedAt: 202);
-      handler = GetCurrentProjectHandler(
+      currentProjectService = CurrentProjectService(
         projectRepository: singlePluginProjectRepository(
           gitCliApi: FakeGitCliApi(),
           projectsDao: db.projectsDao,
@@ -32,9 +34,11 @@ void main() {
           filesystemApi: FakeFilesystemApi(),
         ),
       );
+      handler = GetCurrentProjectHandler(currentProjectService: currentProjectService);
     });
 
     tearDown(() async {
+      await currentProjectService.dispose();
       await plugin.close();
       await db.close();
     });
@@ -61,13 +65,15 @@ void main() {
       );
     });
 
-    test("returns typed project", () async {
+    test("returns typed project and publishes its successful load", () async {
+      final loadedProjectId = currentProjectService.loadedProjectIds.first;
       final response = await handler.handle(
         makeRequest("POST", "/project/current"),
         body: const ProjectIdRequest(projectId: "/tmp/project"),
       );
 
       expect(response, isA<Project>());
+      expect(await loadedProjectId, "/tmp/project");
     });
 
     test("maps fields", () async {

--- a/bridge/app/test/bridge/services/current_project_service_test.dart
+++ b/bridge/app/test/bridge/services/current_project_service_test.dart
@@ -1,0 +1,56 @@
+import "package:sesori_bridge/src/repositories/project_repository.dart";
+import "package:sesori_bridge/src/services/current_project_service.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  late _FakeProjectRepository repository;
+  late CurrentProjectService service;
+
+  setUp(() {
+    repository = _FakeProjectRepository();
+    service = CurrentProjectService(projectRepository: repository);
+    addTearDown(service.dispose);
+  });
+
+  test("publishes the authoritative id after a successful load", () async {
+    final loadedProjectId = service.loadedProjectIds.first;
+
+    final project = await service.getCurrentProject(projectId: "requested-id");
+
+    expect(project.id, "authoritative-id");
+    expect(await loadedProjectId, "authoritative-id");
+  });
+
+  test("does not publish a failed load", () async {
+    final loadedProjectIds = <String>[];
+    final subscription = service.loadedProjectIds.listen(loadedProjectIds.add);
+    addTearDown(subscription.cancel);
+    repository.error = StateError("missing project");
+
+    await expectLater(
+      service.getCurrentProject(projectId: "missing-id"),
+      throwsA(same(repository.error)),
+    );
+
+    expect(loadedProjectIds, isEmpty);
+  });
+}
+
+final class _FakeProjectRepository() implements ProjectRepository {
+  Object? error;
+
+  @override
+  Future<Project> getProject({required String projectId}) async {
+    if (error case final error?) throw error;
+    return const Project(
+      id: "authoritative-id",
+      name: "Project",
+      path: "/workspace/project",
+      time: null,
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/bridge/services/project_glossary_population_service_test.dart
+++ b/bridge/app/test/bridge/services/project_glossary_population_service_test.dart
@@ -1,0 +1,225 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/repositories/models/project_glossary_source.dart";
+import "package:sesori_bridge/src/repositories/project_glossary_publication_repository.dart";
+import "package:sesori_bridge/src/repositories/project_glossary_repository.dart";
+import "package:sesori_bridge/src/repositories/project_repository.dart";
+import "package:sesori_bridge/src/services/project_glossary_population_service.dart";
+import "package:sesori_bridge/src/services/project_glossary_scope_service.dart";
+import "package:sesori_bridge/src/services/project_glossary_term_calculator.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  late _FakeProjectRepository projectRepository;
+  late _FakeProjectGlossaryScopeService scopeService;
+  late _FakeProjectGlossaryRepository glossaryRepository;
+  late _FakeProjectGlossaryTermCalculator termCalculator;
+  late _FakeProjectGlossaryPublicationRepository publicationRepository;
+  late ProjectGlossaryPopulationService service;
+
+  final scope = ProjectGlossaryScope.repository(
+    projectKey: ProjectGlossaryKey.parse(
+      value: "prj_v1_1yuLLmK3NKRJfpiX26q507WHb9ZxINRCpBKCBTgnGlQ",
+    ),
+  );
+
+  setUp(() {
+    projectRepository = _FakeProjectRepository();
+    scopeService = _FakeProjectGlossaryScopeService(scope: scope);
+    glossaryRepository = _FakeProjectGlossaryRepository();
+    termCalculator = _FakeProjectGlossaryTermCalculator();
+    publicationRepository = _FakeProjectGlossaryPublicationRepository();
+    service = ProjectGlossaryPopulationService(
+      projectRepository: projectRepository,
+      scopeService: scopeService,
+      glossaryRepository: glossaryRepository,
+      termCalculator: termCalculator,
+      publicationRepository: publicationRepository,
+    );
+    addTearDown(service.dispose);
+  });
+
+  test("adds exact ownership before removing stale words in bounded mutations", () async {
+    termCalculator.words = ["CurrentTerm", "SharedTerm"];
+    publicationRepository.existingWords = [
+      "SharedTerm",
+      for (var index = 0; index < 203; index++) "LegacyTerm$index",
+    ];
+
+    await service.populate(projectId: "project-1");
+
+    expect(projectRepository.requestedProjectIds, ["project-1"]);
+    expect(scopeService.projectPaths, ["/workspace/project"]);
+    expect(glossaryRepository.projectPaths, ["/workspace/project"]);
+    expect(publicationRepository.operations, ["get", "add", "remove", "remove", "remove"]);
+    expect(publicationRepository.additions, hasLength(1));
+    expect(publicationRepository.additions.single.scope, scope);
+    expect(publicationRepository.additions.single.words, ["CurrentTerm", "SharedTerm"]);
+    expect(publicationRepository.removals.map((mutation) => mutation.scope), everyElement(scope));
+    expect(publicationRepository.removals.map((mutation) => mutation.words.length), [100, 100, 3]);
+    expect(
+      publicationRepository.removals.expand((mutation) => mutation.words),
+      [for (var index = 0; index < 203; index++) "LegacyTerm$index"],
+    );
+  });
+
+  test("removes this scope's stale ownership when inference yields no terms", () async {
+    publicationRepository.existingWords = ["LegacyOne", "LegacyTwo"];
+
+    await service.populate(projectId: "project-1");
+
+    expect(publicationRepository.additions, isEmpty);
+    expect(publicationRepository.removals, hasLength(1));
+    expect(publicationRepository.removals.single.scope, scope);
+    expect(publicationRepository.removals.single.words, ["LegacyOne", "LegacyTwo"]);
+  });
+
+  test("does not scan or publish when no exact scope is available", () async {
+    scopeService.scope = null;
+
+    await service.populate(projectId: "project-1");
+
+    expect(glossaryRepository.projectPaths, isEmpty);
+    expect(publicationRepository.operations, isEmpty);
+  });
+
+  test("serializes concurrent population requests", () async {
+    final getStarted = Completer<void>();
+    final releaseGet = Completer<void>();
+    publicationRepository
+      ..getStarted = getStarted
+      ..releaseGet = releaseGet;
+    termCalculator.words = ["CurrentTerm"];
+    publicationRepository.existingWords = ["CurrentTerm"];
+
+    final first = service.populate(projectId: "project-1");
+    await getStarted.future;
+    final second = service.populate(projectId: "project-2");
+    await Future<void>.delayed(Duration.zero);
+
+    expect(projectRepository.requestedProjectIds, ["project-1"]);
+    releaseGet.complete();
+    await Future.wait([first, second]);
+
+    expect(projectRepository.requestedProjectIds, ["project-1", "project-2"]);
+    expect(publicationRepository.maximumConcurrentReads, 1);
+  });
+
+  test("shutdown aborts transport and rejects later population", () async {
+    service.beginShutdown();
+
+    await service.populate(projectId: "project-1");
+
+    expect(publicationRepository.shutdownCount, 1);
+    expect(projectRepository.requestedProjectIds, isEmpty);
+  });
+
+  test("fails closed before publication when bounded source loading fails", () async {
+    final failure = StateError("git failed");
+    glossaryRepository.error = failure;
+
+    await expectLater(
+      service.populate(projectId: "project-1"),
+      throwsA(same(failure)),
+    );
+
+    expect(publicationRepository.operations, isEmpty);
+  });
+}
+
+final class _FakeProjectRepository() implements ProjectRepository {
+  final List<String> requestedProjectIds = [];
+
+  @override
+  Future<Project> getProject({required String projectId}) async {
+    requestedProjectIds.add(projectId);
+    return Project(
+      id: projectId,
+      name: "Project",
+      path: "/workspace/project",
+      time: null,
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+final class _FakeProjectGlossaryScopeService({required var ProjectGlossaryScope? scope})
+    implements ProjectGlossaryScopeService {
+  final List<String> projectPaths = [];
+
+  @override
+  Future<ProjectGlossaryScope?> resolve({required String projectPath}) async {
+    projectPaths.add(projectPath);
+    return scope;
+  }
+}
+
+final class _FakeProjectGlossaryRepository() implements ProjectGlossaryRepository {
+  final List<String> projectPaths = [];
+  Object? error;
+
+  @override
+  Future<ProjectGlossarySource> loadSource({required String projectPath}) async {
+    projectPaths.add(projectPath);
+    if (error case final error?) throw error;
+    return ProjectGlossarySource(
+      projectName: "Project",
+      repositoryName: null,
+      trackedPaths: const [],
+      metadataDocuments: const [],
+    );
+  }
+}
+
+final class _FakeProjectGlossaryTermCalculator() implements ProjectGlossaryTermCalculator {
+  List<String> words = [];
+
+  @override
+  List<String> calculate({required ProjectGlossarySource source}) => List<String>.of(words);
+}
+
+final class _FakeProjectGlossaryPublicationRepository() implements ProjectGlossaryPublicationRepository {
+  List<String> existingWords = [];
+  final List<String> operations = [];
+  final List<({ProjectGlossaryScope scope, List<String> words})> additions = [];
+  final List<({ProjectGlossaryScope scope, List<String> words})> removals = [];
+  Completer<void>? getStarted;
+  Completer<void>? releaseGet;
+  int activeReads = 0;
+  int maximumConcurrentReads = 0;
+  int shutdownCount = 0;
+
+  @override
+  void beginShutdown() {
+    shutdownCount++;
+  }
+
+  @override
+  Future<List<String>> getWords({required ProjectGlossaryKey projectKey}) async {
+    operations.add("get");
+    activeReads++;
+    maximumConcurrentReads = activeReads > maximumConcurrentReads ? activeReads : maximumConcurrentReads;
+    final started = getStarted;
+    if (started != null && !started.isCompleted) started.complete();
+    await releaseGet?.future;
+    activeReads--;
+    return List<String>.of(existingWords);
+  }
+
+  @override
+  Future<List<String>> addWords({required ProjectGlossaryScope scope, required List<String> words}) async {
+    operations.add("add");
+    additions.add((scope: scope, words: List<String>.of(words)));
+    return List<String>.of(words);
+  }
+
+  @override
+  Future<int> removeWords({required ProjectGlossaryScope scope, required List<String> words}) async {
+    operations.add("remove");
+    removals.add((scope: scope, words: List<String>.of(words)));
+    return words.length;
+  }
+}

--- a/bridge/app/test/listeners/project_glossary_listeners_test.dart
+++ b/bridge/app/test/listeners/project_glossary_listeners_test.dart
@@ -1,0 +1,104 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/listeners/current_project_glossary_listener.dart";
+import "package:sesori_bridge/src/listeners/viewed_project_glossary_listener.dart";
+import "package:sesori_bridge/src/services/project_glossary_population_service.dart";
+import "package:sesori_bridge/src/services/project_view_tracker.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("CurrentProjectGlossaryListener", () {
+    late StreamController<String> source;
+    late _FakeProjectGlossaryPopulationService service;
+    late CurrentProjectGlossaryListener listener;
+
+    setUp(() {
+      source = StreamController<String>.broadcast(sync: true);
+      service = _FakeProjectGlossaryPopulationService();
+      listener = CurrentProjectGlossaryListener(source: source.stream, service: service)..start();
+    });
+
+    tearDown(() async {
+      await listener.dispose();
+      await source.close();
+    });
+
+    test("delegates each successful current-project load", () async {
+      source
+        ..add("project-1")
+        ..add("project-2");
+
+      await listener.dispose();
+
+      expect(service.projectIds, ["project-1", "project-2"]);
+    });
+
+    test("contains population failures and continues listening", () async {
+      service.failProjectIds.add("project-1");
+      source
+        ..add("project-1")
+        ..add("project-2");
+
+      await listener.dispose();
+
+      expect(service.projectIds, ["project-1", "project-2"]);
+    });
+  });
+
+  group("ViewedProjectGlossaryListener", () {
+    late ProjectViewTracker tracker;
+    late _FakeProjectGlossaryPopulationService service;
+    late ViewedProjectGlossaryListener listener;
+
+    setUp(() {
+      tracker = ProjectViewTracker();
+      service = _FakeProjectGlossaryPopulationService();
+    });
+
+    tearDown(() async {
+      await listener.dispose();
+      await tracker.dispose();
+    });
+
+    test("populates active and newly viewed projects without viewer-count duplicates", () async {
+      tracker.setViewing(connID: 1, projectId: "project-1");
+      listener = ViewedProjectGlossaryListener(tracker: tracker, service: service)..start();
+
+      tracker.setViewing(connID: 2, projectId: "project-1");
+      tracker.setViewing(connID: 1, projectId: "project-2");
+      tracker.releaseConnection(connID: 2);
+      tracker.setViewing(connID: 2, projectId: "project-1");
+      await listener.dispose();
+
+      expect(service.projectIds, ["project-1", "project-2", "project-1"]);
+    });
+
+    test("does not populate projects after disposal", () async {
+      listener = ViewedProjectGlossaryListener(tracker: tracker, service: service)..start();
+      await listener.dispose();
+
+      tracker.setViewing(connID: 1, projectId: "project-1");
+
+      expect(service.projectIds, isEmpty);
+    });
+  });
+}
+
+final class _FakeProjectGlossaryPopulationService() implements ProjectGlossaryPopulationService {
+  final List<String> projectIds = [];
+  final Set<String> failProjectIds = {};
+
+  @override
+  Future<void> populate({required String projectId}) async {
+    projectIds.add(projectId);
+    if (failProjectIds.contains(projectId)) {
+      throw StateError("population failed");
+    }
+  }
+
+  @override
+  void beginShutdown() {}
+
+  @override
+  Future<void> dispose() async {}
+}

--- a/docs/regression/voice-input.md
+++ b/docs/regression/voice-input.md
@@ -4,8 +4,8 @@
 
 The mobile composer records speech while the user holds the mic control, uploads the audio to the Sesori auth server
 for transcription, and inserts the text into the prompt field for review before sending. A voice-first or text-first
-preference decides which control leads. No bridge route or backend plugin participates; the device microphone and
-transcription endpoint are external.
+preference decides which control leads. The device microphone and transcription endpoint are external. The bridge
+independently prepares optional project-scoped vocabulary from bounded local evidence; no backend plugin participates.
 
 ## Required Behavior
 
@@ -35,6 +35,13 @@ transcription endpoint are external.
   as voice-assisted input.
 - Successful transcription reports one content-free analytics event. No audio, transcript, or prompt text reaches logs
   or analytics.
+- A successful current-project load or a project entering the active-view set starts best-effort bridge glossary
+  population. Both triggers delegate to one serialized coordinator and never delay the route response, recording, or
+  transcription.
+- Glossary population derives an exact opaque repository or bridge-local scope, scans bounded local Git/filesystem
+  evidence, filters credential-shaped content before tokenization, and reconciles at most 50 deterministic terms.
+  Only the opaque scope and filtered terms leave the bridge. Scope, scan, or publication failure leaves voice input
+  available without an updated glossary.
 - The preference defaults to voice-first, persists, and falls back to voice-first on a corrupt or unknown stored
   value.
 
@@ -43,7 +50,7 @@ transcription endpoint are external.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Not included because microphone and transcription setup is too expensive for a heartbeat. |
-| L2 Routine | Automated, mobile client, no plugin, fake recorder and HTTP client: permission denial, concurrent-start rejection, zero-byte rejection, cancel invalidating an in-flight upload, authoritative true/false/omitted/malformed retryability mapping, retained-artifact Retry/Discard and retry cancellation, serialized send-time abandonment including an active retry, terminal/missing cleanup, max-duration signalling, deletion failure logging, draft voice-span and input-mode derivation. |
+| L2 Routine | Automated, mobile client and bridge, no plugin, fake recorder, HTTP client, Git, and filesystem: permission denial, concurrent-start rejection, zero-byte rejection, cancel invalidating an in-flight upload, authoritative true/false/omitted/malformed retryability mapping, retained-artifact Retry/Discard and retry cancellation, serialized send-time abandonment including an active retry, terminal/missing cleanup, max-duration signalling, deletion failure logging, draft voice-span and input-mode derivation, current-project/active-view glossary triggers, serialized bounded inference, exact-scope reconciliation, and shutdown cancellation. |
 | L3 Release | Client end to end on the release-target client platform: hold to record, release to transcribe, transcript inserted and editable, drag-to-cancel, layout stability, and the voice-first/text-first preference changing which control leads. |
 | L4 Extended | Client end to end on the release-target client platform: background or system interruption, permission revoked between interactions, offline async upload failure followed by successful Retry without re-recording, explicit retryable and terminal server outcomes, older-server omission fallback, discard/disposal cleanup, wake lock released on every path. |
 | L5 Full | Real device microphone and live transcription endpoint on every supported mobile platform: audible speech yields usable text, a near-maximum recording auto-stops and still transcribes, iOS haptics and system sounds stay audible while recording. |
@@ -65,7 +72,9 @@ interruptions such as a call.
   terminal paths; a deletion failure is unlogged; or the wake lock stays held.
 - Audio is uploaded despite denied permission, or denial is reported as a generic network or server failure.
 - Text is sent without review, or a message with surviving voice text is classified as typed.
-- Any audio, transcript, or prompt content reaches logs or analytics.
+- Any audio, transcript, or prompt content reaches logs or analytics; raw project paths, repository origins, filenames,
+  or metadata source text reach auth transport; glossary failure blocks recording or transcription; or concurrent
+  triggers run overlapping local scans.
 
 ## Known Limitations
 
@@ -82,7 +91,9 @@ interruptions such as a call.
 
 ## Sources
 
-`client/app/test/capabilities/voice/`, `client/app/test/features/session_detail/widgets/`, and
-`client/module_core/test/{capabilities,cubits,repositories,services}/`; production code under
-`client/app/lib/core/platform/`, `client/app/lib/features/session_detail/widgets/`, and
-`client/module_core/lib/src/{capabilities,cubits,platform,repositories,services}/`.
+`client/app/test/capabilities/voice/`, `client/app/test/features/session_detail/widgets/`,
+`client/module_core/test/{capabilities,cubits,repositories,services}/`, and bridge glossary tests under
+`bridge/app/test/{bridge,listeners}/`; production code under `client/app/lib/core/platform/`,
+`client/app/lib/features/session_detail/widgets/`,
+`client/module_core/lib/src/{capabilities,cubits,platform,repositories,services}/`, and
+`bridge/app/lib/src/{listeners,repositories,services}/`.


### PR DESCRIPTION
## Complexity

🚧 Complex — this composes two independent lifecycle triggers, serialized bounded scans, exact ownership reconciliation, and shutdown cancellation across bridge layers.

## What

- Added a current-project service that publishes successful project-load signals without delaying route responses.
- Added separate current-project and active-view glossary listeners that delegate to one population service and contain background failures.
- Added serialized glossary population that resolves exact scopes, infers bounded terms, establishes exact ownership idempotently, and removes stale words in 100-word mutations.
- Composed population and ordered shutdown in the Orchestrator.
- Updated voice regression coverage and added focused service, listener, route, composition, and shutdown tests.

## Why

Glossary derivation is bridge-owned and should follow project lifecycle naturally rather than requiring a client command. Trigger-specific listeners keep lifecycle ownership symmetric while one service enforces serialization, privacy, and exact-scope reconciliation.

## Risk and test focus

High internal integration risk around overlapping triggers, project-wide reads versus exact ownership, bounded mutation limits, failure isolation, and shutdown races. Focused tests cover both trigger paths, viewer-count deduplication, successful-load-only notifications, serialized scans, add-before-remove reconciliation, 100-word removal chunks, unavailable scopes, fail-closed source errors, post-shutdown rejection, Orchestrator startup, and teardown.

No immediate user-visible change: Step 8 still supplies passive glossary-key forwarding during transcription. Persisted-data impact: viewing or loading a project can now add or remove auth-server glossary ownership rows for that exact repository or bridge-local scope. There is no local database schema change.

## Expected result

A current-project load or a project entering the active-view set starts best-effort background population. Only opaque exact scopes and filtered terms leave the bridge; raw paths, origins, filenames, and source documents remain local. Failures never block project loading, recording, or transcription, and concurrent triggers never run overlapping scans.

## Verification

- `cd bridge/app && dart test test/bridge/services/current_project_service_test.dart test/bridge/services/project_glossary_population_service_test.dart test/listeners/project_glossary_listeners_test.dart test/bridge/routing/get_current_project_handler_test.dart test/bridge/orchestrator_registration_test.dart` — 35 tests passed
- `cd bridge/app && dart analyze --fatal-infos --fatal-warnings` — no issues
- architecture implementation review — approved the coordinator, trigger-specific listener boundaries, serialization, exact-scope publication, privacy, and shutdown ownership


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes glossaries from project lifecycle events: a successful current-project load or a project entering the active-view set now triggers best-effort background population without delaying route responses, recording, or transcription.

**Service composition**
- Adds `CurrentProjectService` to publish successful loads from the current-project route.
- Adds two trigger-specific listeners that delegate to one `ProjectGlossaryPopulationService` and isolate background failures.
- Wires population and ordered shutdown into the Orchestrator.

**Population and reconciliation**
- Serializes scans so concurrent triggers never overlap.
- Resolves an exact opaque scope, infers bounded terms, and adds desired words idempotently before removing stale words in 100-word chunks.
- Fails closed on unavailable scope or source errors; post-shutdown population is rejected.
- Adds focused tests for both triggers, serialization, reconciliation, bounded removals, failure containment, and shutdown.

No schema change; the persisted effect is auth-server ownership rows for the exact scope. Raw paths, origins, filenames, and source documents stay local.

<sup>Written for commit 8a11d98cf9c0e887ee46581c9dee7a1b3ccfe2ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

