### PR TITLE
🌱 Fix Pi session status SSE mapping

### DIFF
--- a/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
@@ -1,4 +1,5 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" as shared;
 
 import "../api/models/pi_assistant_delta.dart";
 import "../api/models/pi_event.dart";
@@ -564,7 +565,17 @@ final class PiEventDispatcher({
 
   List<BridgeSseEvent> _status({required String sessionId, required PiEvent event, required DateTime? now}) {
     final status = sessionStatusFor(event: event, now: now);
-    return status == null ? const [] : [BridgeSseSessionStatus(sessionID: sessionId, status: status.toJson())];
+    if (status == null) return const [];
+    final sharedStatus = switch (status) {
+      PluginSessionStatusIdle() => const shared.SessionStatus.idle(),
+      PluginSessionStatusBusy() => const shared.SessionStatus.busy(),
+      PluginSessionStatusRetry(:final attempt, :final message, :final next) => shared.SessionStatus.retry(
+        attempt: attempt,
+        message: message,
+        next: next,
+      ),
+    };
+    return [BridgeSseSessionStatus(sessionID: sessionId, status: sharedStatus.toJson())];
   }
 
   List<BridgeSseEvent> _compactionStart({

--- a/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
@@ -613,12 +613,12 @@ void main() {
       "attempt": 2,
       "message": "Pi is retrying the provider request.",
       "next": 1500,
-      "runtimeType": "retry",
+      "type": "retry",
     });
     expect(agentEnd, isEmpty);
-    expect((autoRetryResumed.single as BridgeSseSessionStatus).status, {"runtimeType": "busy"});
-    expect((summarizationResumed.single as BridgeSseSessionStatus).status, {"runtimeType": "busy"});
-    expect(compacting.whereType<BridgeSseSessionStatus>().single.status, {"runtimeType": "busy"});
+    expect((autoRetryResumed.single as BridgeSseSessionStatus).status, {"type": "busy"});
+    expect((summarizationResumed.single as BridgeSseSessionStatus).status, {"type": "busy"});
+    expect(compacting.whereType<BridgeSseSessionStatus>().single.status, {"type": "busy"});
     final runningMessage = compacting.whereType<BridgeSseMessageUpdated>().single;
     expect(runningMessage.info["id"], "pi:session:compaction:compaction:1");
     final runningPart = compacting.whereType<BridgeSseMessagePartUpdated>().single.part;


### PR DESCRIPTION
## Complexity

🌱 Trivial — localized Pi event serialization fix.

## What

- Convert Pi's internal session-status variants to the shared wire model before emitting SSE payloads.
- Update the Pi event-dispatcher regression coverage to require the shared `type` discriminator.

## Why

Pi serialized its internal Freezed status union with the default `runtimeType` discriminator. The shared SSE contract requires `type`, so `BridgeEventMapper` rejected Pi retry and busy status events.

## Risk and test focus

Low risk and isolated to Pi session-status payload serialization. No database impact. User-visible impact is limited to restoring Pi retry and busy status updates.

## Expected result

Pi session-status SSE events decode successfully instead of being dropped with an invalid union-type error.

## Verification

From `bridge/sesori_plugin_pi`:

- `dart test test/pi_event_dispatcher_test.dart`
- `dart analyze --fatal-infos`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Pi session status SSE events so they use the shared `type` discriminator instead of the internal `runtimeType`, restoring retry and busy status updates that were being dropped.

<sup>Written for commit 9df3ff5d29299821c17e644005a946faf6b904af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

