### PR TITLE
⚙️ Widen the Play crawl analytics window to 48h and lift it at login

### DIFF
--- a/client/app/android/fastlane/Fastfile
+++ b/client/app/android/fastlane/Fastfile
@@ -249,12 +249,13 @@ platform :android do
   # not from the fastlane folder. Output lands at
   # client/app/build/app/outputs/bundle/release/app-release.aab thanks to the
   # build dir redirect in client/app/android/build.gradle.kts.
-  # SESORI_BUILD_EPOCH_SECONDS lets the app keep analytics off for two hours
+  # SESORI_BUILD_EPOCH_SECONDS lets the app keep analytics off for 48 hours
   # after compilation, when an unauthenticated launch is almost certainly Play's
-  # pre-launch crawl rather than a person. submit_android promotes this exact
-  # binary, so the stamp travels to production unchanged: promoting inside
-  # those two hours hides unauthenticated first launches for what is left of
-  # them. Nothing enforces a delay; it is an accepted trade for a stable count.
+  # pre-launch crawl rather than a person; a login lifts the gate immediately.
+  # submit_android promotes this exact binary, so the stamp travels to
+  # production unchanged: promoting inside those 48 hours hides unauthenticated
+  # first launches for what is left of them. Nothing enforces a delay; it is an
+  # accepted trade for a stable count.
   private_lane :_flutter_build_appbundle do |options|
     build_number = options[:build_number]
     flutter_root = File.expand_path(File.join("..", ".."), Dir.pwd)

--- a/client/app/lib/core/di/injection.config.dart
+++ b/client/app/lib/core/di/injection.config.dart
@@ -49,6 +49,8 @@ import 'package:sesori_mobile/core/platform/firebase/no_op_push_messaging_source
     as _i483;
 import 'package:sesori_mobile/core/platform/firebase_analytics_client.dart'
     as _i326;
+import 'package:sesori_mobile/core/platform/firebase_analytics_startup.dart'
+    as _i950;
 import 'package:sesori_mobile/core/platform/firebase_push_messaging_source.dart'
     as _i1042;
 import 'package:sesori_mobile/core/platform/flutter_attachment_thumbnail_storage.dart'
@@ -188,6 +190,12 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i901.NoOpAnalyticsClient(),
       registerFor: {_firebaseDisabled},
     );
+    gh.lazySingleton<_i950.FirebaseAnalyticsStartup>(
+      () => _i950.FirebaseAnalyticsStartup(
+        analytics: gh<_i398.FirebaseAnalytics>(),
+      ),
+      registerFor: {_firebaseEnabled},
+    );
     gh.lazySingleton<_i948.AttachmentThumbnailStorage>(
       () => _i963.FlutterAttachmentThumbnailStorage(
         temporaryDirectoryClient: gh<_i908.TemporaryDirectoryClient>(),
@@ -195,6 +203,14 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i553.FailureReporter>(
       () => _i534.CrashlyticsFailureReporter(gh<_i141.FirebaseCrashlytics>()),
+      registerFor: {_firebaseEnabled},
+    );
+    gh.lazySingleton<_i948.AnalyticsClient>(
+      () => _i326.FirebaseAnalyticsClient(
+        analytics: gh<_i398.FirebaseAnalytics>(),
+        capability: gh<_i948.AnalyticsRuntimeCapability>(),
+        startup: gh<_i950.FirebaseAnalyticsStartup>(),
+      ),
       registerFor: {_firebaseEnabled},
     );
     gh.lazySingleton<_i948.PushMessagingSource>(
@@ -219,13 +235,6 @@ extension GetItInjectableX on _i174.GetIt {
         audioFormat: gh<_i430.AudioFormatConfig>(),
         temporaryDirectoryClient: gh<_i908.TemporaryDirectoryClient>(),
       ),
-    );
-    gh.lazySingleton<_i948.AnalyticsClient>(
-      () => _i326.FirebaseAnalyticsClient(
-        analytics: gh<_i398.FirebaseAnalytics>(),
-        capability: gh<_i948.AnalyticsRuntimeCapability>(),
-      ),
-      registerFor: {_firebaseEnabled},
     );
     gh.lazySingleton<_i948.ImageClipboard>(
       () => _i274.FlutterImageClipboard(

--- a/client/app/lib/core/platform/firebase/no_op_analytics_client.dart
+++ b/client/app/lib/core/platform/firebase/no_op_analytics_client.dart
@@ -13,4 +13,7 @@ class NoOpAnalyticsClient() implements AnalyticsClient {
 
   @override
   Future<void> logInstallationEvent({required InstallationAnalyticsEvent event}) async {}
+
+  @override
+  Future<void> activateAfterInteractiveAuthentication() async {}
 }

--- a/client/app/lib/core/platform/firebase_analytics_client.dart
+++ b/client/app/lib/core/platform/firebase_analytics_client.dart
@@ -3,13 +3,19 @@ import "package:injectable/injectable.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 
 import "../di/firebase_register_module.dart";
+import "firebase_analytics_startup.dart";
 
 @firebaseEnabledEnvironment
 @LazySingleton(as: AnalyticsClient)
 class FirebaseAnalyticsClient({
   required final FirebaseAnalytics _analytics,
   required final AnalyticsRuntimeCapability _capability,
+  required final FirebaseAnalyticsStartup _startup,
 }) implements AnalyticsClient {
+  @override
+  Future<void> activateAfterInteractiveAuthentication() =>
+      _startup.activateAfterInteractiveAuthentication();
+
   @override
   Future<void> logProductEvent({required ProductAnalyticsEnvelope envelope, required String userKey}) async {
     if (!_capability.isEnabled) throw StateError("Product analytics runtime is disabled");

--- a/client/app/lib/core/platform/firebase_analytics_startup.dart
+++ b/client/app/lib/core/platform/firebase_analytics_startup.dart
@@ -1,14 +1,26 @@
-import "dart:async";
-
 import "package:firebase_analytics/firebase_analytics.dart";
+import "package:injectable/injectable.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 
-class const FirebaseAnalyticsStartup({required final FirebaseAnalytics _analytics}) {
+import "../di/firebase_register_module.dart";
+
+@firebaseEnabledEnvironment
+@lazySingleton
+class FirebaseAnalyticsStartup({required final FirebaseAnalytics _analytics}) {
+  bool _isSuspendedForStoreCrawl = false;
+
   /// Configures the Firebase analytics SDK for this process and reports the
   /// resulting runtime capability. [ineligibilityReason] states why this
-  /// process must not report, or is null when it may.
+  /// process must never report, or is null when it may.
+  ///
+  /// [suspendForStoreCrawl] keeps the SDK's own collection off for an eligible
+  /// process that may be a Play pre-launch crawl. The Sesori runtime stays
+  /// operational — its events are simply discarded by the suspended SDK — and
+  /// [activateAfterInteractiveAuthentication] lifts the suspension once a
+  /// person proves they are using this process.
   Future<AnalyticsRuntimeCapability> configure({
     required AnalyticsRuntimeDisabledReason? ineligibilityReason,
+    required bool suspendForStoreCrawl,
   }) async {
     try {
       // Native configuration starts fresh installs off. Enforce that decision
@@ -25,23 +37,25 @@ class const FirebaseAnalyticsStartup({required final FirebaseAnalytics _analytic
       return AnalyticsRuntimeCapability.disabled(reason: reason);
     }
 
+    if (suspendForStoreCrawl) {
+      _isSuspendedForStoreCrawl = true;
+      logi("Firebase analytics collection suspended for a possible store crawl");
+      return const AnalyticsRuntimeCapability.enabled();
+    }
+
     return await _enableCollection();
   }
 
-  /// Lifts the build-window suspension once [authStates] reports a signed-in
-  /// user, proving this process is a person rather than a store crawl. Only the
-  /// SDK's own measurement resumes; the process-wide runtime capability was
-  /// already published as disabled, so Sesori-defined events stay off until the
-  /// next launch.
-  void enableOnceAuthenticated({required Stream<AuthState> authStates}) {
-    unawaited(
-      authStates.firstWhere((state) => state is AuthAuthenticated).then((_) async {
-        final capability = await _enableCollection();
-        if (capability.isEnabled) {
-          logi("Firebase analytics collection enabled after authentication inside the build window");
-        }
-      }),
-    );
+  /// Lifts the store-crawl suspension for the rest of this process; a no-op
+  /// when nothing is suspended. Best-effort: a failure keeps the SDK
+  /// suspended, which discards subsequent events instead of blocking callers.
+  Future<void> activateAfterInteractiveAuthentication() async {
+    if (!_isSuspendedForStoreCrawl) return;
+    final capability = await _enableCollection();
+    if (capability.isEnabled) {
+      _isSuspendedForStoreCrawl = false;
+      logi("Firebase analytics collection enabled after interactive authentication");
+    }
   }
 
   Future<AnalyticsRuntimeCapability> _enableCollection() async {

--- a/client/app/lib/core/platform/firebase_analytics_startup.dart
+++ b/client/app/lib/core/platform/firebase_analytics_startup.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:firebase_analytics/firebase_analytics.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 
@@ -23,6 +25,26 @@ class const FirebaseAnalyticsStartup({required final FirebaseAnalytics _analytic
       return AnalyticsRuntimeCapability.disabled(reason: reason);
     }
 
+    return await _enableCollection();
+  }
+
+  /// Lifts the build-window suspension once [authStates] reports a signed-in
+  /// user, proving this process is a person rather than a store crawl. Only the
+  /// SDK's own measurement resumes; the process-wide runtime capability was
+  /// already published as disabled, so Sesori-defined events stay off until the
+  /// next launch.
+  void enableOnceAuthenticated({required Stream<AuthState> authStates}) {
+    unawaited(
+      authStates.firstWhere((state) => state is AuthAuthenticated).then((_) async {
+        final capability = await _enableCollection();
+        if (capability.isEnabled) {
+          logi("Firebase analytics collection enabled after authentication inside the build window");
+        }
+      }),
+    );
+  }
+
+  Future<AnalyticsRuntimeCapability> _enableCollection() async {
     try {
       await _analytics.setConsent(
         adPersonalizationSignalsConsentGranted: false,

--- a/client/app/lib/core/platform/singular_attribution_startup.dart
+++ b/client/app/lib/core/platform/singular_attribution_startup.dart
@@ -14,12 +14,11 @@ class SingularAttributionStartup({required final SingularStaticAdapter _singular
   void start({
     required bool isSupportedPlatform,
     required AnalyticsRuntimeDisabledReason? ineligibilityReason,
+    required bool deferUntilInteractiveAuthentication,
     required String sdkKey,
     required String sdkSecret,
   }) {
-    if (!isSupportedPlatform ||
-        ineligibilityReason != null &&
-            ineligibilityReason != AnalyticsRuntimeDisabledReason.recentBuildUnauthenticated) {
+    if (!isSupportedPlatform || ineligibilityReason != null) {
       return;
     }
 
@@ -33,7 +32,7 @@ class SingularAttributionStartup({required final SingularStaticAdapter _singular
       ..skAdNetworkEnabled = true
       ..enableLogging = false;
 
-    if (ineligibilityReason == AnalyticsRuntimeDisabledReason.recentBuildUnauthenticated) {
+    if (deferUntilInteractiveAuthentication) {
       _deferredStartConfig = config;
       logi("Singular attribution deferred until interactive authentication");
       return;

--- a/client/app/lib/main.dart
+++ b/client/app/lib/main.dart
@@ -170,15 +170,20 @@ Future<AnalyticsRuntimeCapability> _createAnalyticsRuntimeCapability({
   required bool supportsFirebaseAnalytics,
   required AuthSession authSession,
 }) async {
-  final capability = !shouldInitializeFirebase || !supportsFirebaseAnalytics
-      ? const AnalyticsRuntimeCapability.disabled(
-          reason: AnalyticsRuntimeDisabledReason.analyticsSinkUnavailable,
-        )
-      : await FirebaseAnalyticsStartup(analytics: FirebaseAnalytics.instance).configure(
-          ineligibilityReason: await _measurementIneligibilityReason(authSession: authSession),
-        );
+  if (!shouldInitializeFirebase || !supportsFirebaseAnalytics) {
+    return const AnalyticsRuntimeCapability.disabled(
+      reason: AnalyticsRuntimeDisabledReason.analyticsSinkUnavailable,
+    );
+  }
+  final startup = FirebaseAnalyticsStartup(analytics: FirebaseAnalytics.instance);
+  final capability = await startup.configure(
+    ineligibilityReason: await _measurementIneligibilityReason(authSession: authSession),
+  );
   if (capability case AnalyticsRuntimeDisabled(:final reason)) {
     logi("Firebase analytics runtime disabled (${reason.name})");
+    if (reason == AnalyticsRuntimeDisabledReason.recentBuildUnauthenticated) {
+      startup.enableOnceAuthenticated(authStates: authSession.authStateStream);
+    }
   }
   return capability;
 }
@@ -198,9 +203,12 @@ Future<void> _startSingularAttribution() async {
 const _buildEpochSeconds = int.fromEnvironment("SESORI_BUILD_EPOCH_SECONDS");
 
 /// How long after compilation a store may still be crawling the binary. Play
-/// runs its pre-launch report against every track upload "subject to capacity",
-/// so this is a heuristic on Google's scheduling delay, not a contract.
-const _buildWindow = Duration(hours: 2);
+/// runs its pre-launch report against every track upload "subject to capacity"
+/// and documents results arriving up to a day later; two hours proved too
+/// short in practice, so this doubles that documented ceiling. The width only
+/// delays anonymous installs of a fresh binary: an authenticated launch, or an
+/// interactive login inside the window, reports regardless.
+const _buildWindow = Duration(hours: 48);
 
 /// Whether a binary stamped at [buildEpochSeconds] could still be under a store
 /// pre-launch crawl at [now]. A clock behind the stamp says nothing about the
@@ -216,7 +224,9 @@ bool isWithinBuildWindow({required int buildEpochSeconds, required DateTime now}
 /// Play's pre-launch report is the only store process that launches the app
 /// after an upload; TestFlight runs nothing, so only Android is gated. Crawlers
 /// never sign in, so an unauthenticated launch inside the build window is
-/// treated as one. A signed-in device keeps reporting at any time.
+/// treated as one. A signed-in device keeps reporting at any time, and an
+/// interactive login inside the window lifts the SDK suspension for the rest
+/// of the process.
 Future<AnalyticsRuntimeDisabledReason?> _measurementIneligibilityReason({required AuthSession authSession}) async {
   if (!kReleaseMode) return AnalyticsRuntimeDisabledReason.debugOrProfile;
   if (defaultTargetPlatform == TargetPlatform.android &&

--- a/client/app/lib/main.dart
+++ b/client/app/lib/main.dart
@@ -2,7 +2,6 @@ import "dart:async";
 import "dart:ui" as ui;
 
 import "package:cupertino_ui/cupertino_ui.dart";
-import "package:firebase_analytics/firebase_analytics.dart";
 import "package:firebase_core/firebase_core.dart";
 import "package:firebase_crashlytics/firebase_crashlytics.dart";
 import "package:firebase_messaging/firebase_messaging.dart";
@@ -175,15 +174,12 @@ Future<AnalyticsRuntimeCapability> _createAnalyticsRuntimeCapability({
       reason: AnalyticsRuntimeDisabledReason.analyticsSinkUnavailable,
     );
   }
-  final startup = FirebaseAnalyticsStartup(analytics: FirebaseAnalytics.instance);
-  final capability = await startup.configure(
-    ineligibilityReason: await _measurementIneligibilityReason(authSession: authSession),
+  final capability = await getIt<FirebaseAnalyticsStartup>().configure(
+    ineligibilityReason: _measurementIneligibilityReason(),
+    suspendForStoreCrawl: await _isUnauthenticatedInsideCrawlWindow(authSession: authSession),
   );
   if (capability case AnalyticsRuntimeDisabled(:final reason)) {
     logi("Firebase analytics runtime disabled (${reason.name})");
-    if (reason == AnalyticsRuntimeDisabledReason.recentBuildUnauthenticated) {
-      startup.enableOnceAuthenticated(authStates: authSession.authStateStream);
-    }
   }
   return capability;
 }
@@ -191,7 +187,9 @@ Future<AnalyticsRuntimeCapability> _createAnalyticsRuntimeCapability({
 Future<void> _startSingularAttribution() async {
   getIt<SingularAttributionStartup>().start(
     isSupportedPlatform: _supportsSingular,
-    ineligibilityReason: await _measurementIneligibilityReason(authSession: getIt<AuthSession>()),
+    ineligibilityReason: _measurementIneligibilityReason(),
+    deferUntilInteractiveAuthentication:
+        await _isUnauthenticatedInsideCrawlWindow(authSession: getIt<AuthSession>()),
     sdkKey: _singularSdkKeyDefine,
     sdkSecret: _singularSdkSecretDefine,
   );
@@ -219,22 +217,23 @@ bool isWithinBuildWindow({required int buildEpochSeconds, required DateTime now}
   return !now.isBefore(buildTime) && now.isBefore(buildTime.add(_buildWindow));
 }
 
-/// Why this process must not report analytics, or null when it may.
+/// Why this process must never report analytics, or null when it may.
+AnalyticsRuntimeDisabledReason? _measurementIneligibilityReason() =>
+    kReleaseMode ? null : AnalyticsRuntimeDisabledReason.debugOrProfile;
+
+/// Whether this process may be a Play pre-launch crawl and must keep the
+/// measurement SDKs suspended until a person proves otherwise.
 ///
 /// Play's pre-launch report is the only store process that launches the app
 /// after an upload; TestFlight runs nothing, so only Android is gated. Crawlers
 /// never sign in, so an unauthenticated launch inside the build window is
-/// treated as one. A signed-in device keeps reporting at any time, and an
-/// interactive login inside the window lifts the SDK suspension for the rest
-/// of the process.
-Future<AnalyticsRuntimeDisabledReason?> _measurementIneligibilityReason({required AuthSession authSession}) async {
-  if (!kReleaseMode) return AnalyticsRuntimeDisabledReason.debugOrProfile;
-  if (defaultTargetPlatform == TargetPlatform.android &&
+/// treated as one. A signed-in device reports at any time, and a
+/// server-confirmed interactive login lifts the suspension for the rest of
+/// the process.
+Future<bool> _isUnauthenticatedInsideCrawlWindow({required AuthSession authSession}) async {
+  return defaultTargetPlatform == TargetPlatform.android &&
       isWithinBuildWindow(buildEpochSeconds: _buildEpochSeconds, now: DateTime.now()) &&
-      !await authSession.hasLocallyValidSession()) {
-    return AnalyticsRuntimeDisabledReason.recentBuildUnauthenticated;
-  }
-  return null;
+      !await authSession.hasLocallyValidSession();
 }
 
 Future<void> startNotificationStartup({

--- a/client/app/test/analytics_build_window_test.dart
+++ b/client/app/test/analytics_build_window_test.dart
@@ -12,9 +12,16 @@ void main() {
     );
   });
 
-  test("the window closes two hours after compilation", () {
+  test("a launch a day after compilation is still inside the window", () {
     expect(
-      isWithinBuildWindow(buildEpochSeconds: buildEpochSeconds, now: buildTime.add(const Duration(hours: 2))),
+      isWithinBuildWindow(buildEpochSeconds: buildEpochSeconds, now: buildTime.add(const Duration(hours: 24))),
+      isTrue,
+    );
+  });
+
+  test("the window closes 48 hours after compilation", () {
+    expect(
+      isWithinBuildWindow(buildEpochSeconds: buildEpochSeconds, now: buildTime.add(const Duration(hours: 48))),
       isFalse,
     );
   });

--- a/client/app/test/core/platform/firebase_analytics_client_test.dart
+++ b/client/app/test/core/platform/firebase_analytics_client_test.dart
@@ -3,6 +3,7 @@ import "package:flutter_test/flutter_test.dart";
 import "package:mocktail/mocktail.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/core/platform/firebase_analytics_client.dart";
+import "package:sesori_mobile/core/platform/firebase_analytics_startup.dart";
 
 const _serverDerivedUserKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 const _occurredAtMicros = 1720000000123456;
@@ -18,6 +19,7 @@ void main() {
     client = FirebaseAnalyticsClient(
       analytics: analytics,
       capability: const AnalyticsRuntimeCapability.enabled(),
+      startup: FirebaseAnalyticsStartup(analytics: analytics),
     );
     when(
       () => analytics.logEvent(
@@ -85,6 +87,7 @@ void main() {
       capability: const AnalyticsRuntimeCapability.disabled(
         reason: AnalyticsRuntimeDisabledReason.debugOrProfile,
       ),
+      startup: FirebaseAnalyticsStartup(analytics: analytics),
     );
 
     await expectLater(

--- a/client/app/test/core/platform/firebase_analytics_startup_test.dart
+++ b/client/app/test/core/platform/firebase_analytics_startup_test.dart
@@ -1,8 +1,11 @@
+import "dart:async";
+
 import "package:firebase_analytics/firebase_analytics.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:mocktail/mocktail.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/core/platform/firebase_analytics_startup.dart";
+import "package:sesori_shared/sesori_shared.dart";
 
 class MockFirebaseAnalytics() extends Mock implements FirebaseAnalytics;
 
@@ -61,6 +64,42 @@ void main() {
     }
 
     verify(() => analytics.setAnalyticsCollectionEnabled(false)).called(2);
+    verifyNoMoreInteractions(analytics);
+  });
+
+  test("authentication inside the build window lifts the suspension", () async {
+    final authStates = StreamController<AuthState>();
+    addTearDown(authStates.close);
+
+    final capability = await startup.configure(
+      ineligibilityReason: AnalyticsRuntimeDisabledReason.recentBuildUnauthenticated,
+    );
+    expect(capability, isA<AnalyticsRuntimeDisabled>());
+    startup.enableOnceAuthenticated(authStates: authStates.stream);
+
+    authStates.add(const AuthState.authenticating());
+    await pumpEventQueue();
+    verify(() => analytics.setAnalyticsCollectionEnabled(false)).called(1);
+    verifyNoMoreInteractions(analytics);
+
+    authStates.add(
+      const AuthState.authenticated(
+        user: AuthUser(id: "user-1", provider: AuthProvider.github, providerUserId: "gh-1", providerUsername: null),
+      ),
+    );
+    await pumpEventQueue();
+    verifyInOrder([
+      () => analytics.setConsent(
+        adPersonalizationSignalsConsentGranted: false,
+        adStorageConsentGranted: false,
+        adUserDataConsentGranted: false,
+        personalizationStorageConsentGranted: false,
+        securityStorageConsentGranted: false,
+        analyticsStorageConsentGranted: true,
+        functionalityStorageConsentGranted: true,
+      ),
+      () => analytics.setAnalyticsCollectionEnabled(true),
+    ]);
     verifyNoMoreInteractions(analytics);
   });
 

--- a/client/app/test/core/platform/firebase_analytics_startup_test.dart
+++ b/client/app/test/core/platform/firebase_analytics_startup_test.dart
@@ -1,11 +1,8 @@
-import "dart:async";
-
 import "package:firebase_analytics/firebase_analytics.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:mocktail/mocktail.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/core/platform/firebase_analytics_startup.dart";
-import "package:sesori_shared/sesori_shared.dart";
 
 class MockFirebaseAnalytics() extends Mock implements FirebaseAnalytics;
 
@@ -31,7 +28,10 @@ void main() {
   });
 
   test("enables a new release install only after suspension and consent", () async {
-    final capability = await startup.configure(ineligibilityReason: null);
+    final capability = await startup.configure(
+      ineligibilityReason: null,
+      suspendForStoreCrawl: false,
+    );
 
     expect(capability, isA<AnalyticsRuntimeEnabled>());
     verifyInOrder([
@@ -53,9 +53,12 @@ void main() {
   test("keeps collection off for ineligible processes", () async {
     for (final reason in [
       AnalyticsRuntimeDisabledReason.debugOrProfile,
-      AnalyticsRuntimeDisabledReason.recentBuildUnauthenticated,
+      AnalyticsRuntimeDisabledReason.unsupportedPlatform,
     ]) {
-      final capability = await startup.configure(ineligibilityReason: reason);
+      final capability = await startup.configure(
+        ineligibilityReason: reason,
+        suspendForStoreCrawl: false,
+      );
 
       expect(
         capability,
@@ -67,28 +70,25 @@ void main() {
     verifyNoMoreInteractions(analytics);
   });
 
-  test("authentication inside the build window lifts the suspension", () async {
-    final authStates = StreamController<AuthState>();
-    addTearDown(authStates.close);
-
+  test("a store-crawl suspension keeps the SDK off with an operational runtime", () async {
     final capability = await startup.configure(
-      ineligibilityReason: AnalyticsRuntimeDisabledReason.recentBuildUnauthenticated,
+      ineligibilityReason: null,
+      suspendForStoreCrawl: true,
     );
-    expect(capability, isA<AnalyticsRuntimeDisabled>());
-    startup.enableOnceAuthenticated(authStates: authStates.stream);
 
-    authStates.add(const AuthState.authenticating());
-    await pumpEventQueue();
+    expect(capability, isA<AnalyticsRuntimeEnabled>());
     verify(() => analytics.setAnalyticsCollectionEnabled(false)).called(1);
     verifyNoMoreInteractions(analytics);
+  });
 
-    authStates.add(
-      const AuthState.authenticated(
-        user: AuthUser(id: "user-1", provider: AuthProvider.github, providerUserId: "gh-1", providerUsername: null),
-      ),
-    );
-    await pumpEventQueue();
+  test("interactive authentication lifts the store-crawl suspension once", () async {
+    await startup.configure(ineligibilityReason: null, suspendForStoreCrawl: true);
+
+    await startup.activateAfterInteractiveAuthentication();
+    await startup.activateAfterInteractiveAuthentication();
+
     verifyInOrder([
+      () => analytics.setAnalyticsCollectionEnabled(false),
       () => analytics.setConsent(
         adPersonalizationSignalsConsentGranted: false,
         adStorageConsentGranted: false,
@@ -103,12 +103,24 @@ void main() {
     verifyNoMoreInteractions(analytics);
   });
 
+  test("activation without a suspension is a no-op", () async {
+    await startup.configure(ineligibilityReason: null, suspendForStoreCrawl: false);
+    clearInteractions(analytics);
+
+    await startup.activateAfterInteractiveAuthentication();
+
+    verifyZeroInteractions(analytics);
+  });
+
   test("fails closed when collection cannot be suspended", () async {
     when(
       () => analytics.setAnalyticsCollectionEnabled(false),
     ).thenAnswer((_) async => throw StateError("suspend failed"));
 
-    final capability = await startup.configure(ineligibilityReason: null);
+    final capability = await startup.configure(
+      ineligibilityReason: null,
+      suspendForStoreCrawl: false,
+    );
 
     expect(
       capability,
@@ -127,7 +139,10 @@ void main() {
       () => analytics.setAnalyticsCollectionEnabled(true),
     ).thenAnswer((_) async => throw StateError("enable failed"));
 
-    final capability = await startup.configure(ineligibilityReason: null);
+    final capability = await startup.configure(
+      ineligibilityReason: null,
+      suspendForStoreCrawl: false,
+    );
 
     expect(
       capability,

--- a/client/app/test/core/platform/singular_attribution_client_test.dart
+++ b/client/app/test/core/platform/singular_attribution_client_test.dart
@@ -15,6 +15,7 @@ void main() {
       ..start(
         isSupportedPlatform: true,
         ineligibilityReason: null,
+        deferUntilInteractiveAuthentication: false,
         sdkKey: "sdk-key",
         sdkSecret: "sdk-secret",
       );
@@ -51,7 +52,8 @@ void main() {
     final startup = SingularAttributionStartup(singular: singular)
       ..start(
         isSupportedPlatform: true,
-        ineligibilityReason: AnalyticsRuntimeDisabledReason.recentBuildUnauthenticated,
+        ineligibilityReason: null,
+        deferUntilInteractiveAuthentication: true,
         sdkKey: "sdk-key",
         sdkSecret: "sdk-secret",
       );

--- a/client/app/test/core/platform/singular_attribution_startup_test.dart
+++ b/client/app/test/core/platform/singular_attribution_startup_test.dart
@@ -24,6 +24,7 @@ void main() {
     startup.start(
       isSupportedPlatform: true,
       ineligibilityReason: null,
+      deferUntilInteractiveAuthentication: false,
       sdkKey: "test-sdk-key",
       sdkSecret: "test-sdk-secret",
     );
@@ -48,12 +49,22 @@ void main() {
     startup.start(
       isSupportedPlatform: false,
       ineligibilityReason: null,
+      deferUntilInteractiveAuthentication: false,
       sdkKey: "test-sdk-key",
       sdkSecret: "test-sdk-secret",
     );
     startup.start(
       isSupportedPlatform: true,
       ineligibilityReason: AnalyticsRuntimeDisabledReason.debugOrProfile,
+      deferUntilInteractiveAuthentication: false,
+      sdkKey: "test-sdk-key",
+      sdkSecret: "test-sdk-secret",
+    );
+    // An ineligible process never defers: eligibility outranks the crawl gate.
+    startup.start(
+      isSupportedPlatform: true,
+      ineligibilityReason: AnalyticsRuntimeDisabledReason.debugOrProfile,
+      deferUntilInteractiveAuthentication: true,
       sdkKey: "test-sdk-key",
       sdkSecret: "test-sdk-secret",
     );
@@ -66,7 +77,8 @@ void main() {
   test("defers a crawl-gated startup until interactive authentication reports an event", () {
     startup.start(
       isSupportedPlatform: true,
-      ineligibilityReason: AnalyticsRuntimeDisabledReason.recentBuildUnauthenticated,
+      ineligibilityReason: null,
+      deferUntilInteractiveAuthentication: true,
       sdkKey: "test-sdk-key",
       sdkSecret: "test-sdk-secret",
     );
@@ -92,6 +104,7 @@ void main() {
       () => startup.start(
         isSupportedPlatform: true,
         ineligibilityReason: null,
+        deferUntilInteractiveAuthentication: false,
         sdkKey: "test-sdk-key",
         sdkSecret: "test-sdk-secret",
       ),

--- a/client/desktop/lib/core/platform/no_op_analytics_client.dart
+++ b/client/desktop/lib/core/platform/no_op_analytics_client.dart
@@ -8,4 +8,7 @@ class NoOpAnalyticsClient() implements AnalyticsClient {
 
   @override
   Future<void> logInstallationEvent({required InstallationAnalyticsEvent event}) async {}
+
+  @override
+  Future<void> activateAfterInteractiveAuthentication() async {}
 }

--- a/client/module_core/lib/src/api/analytics_api.dart
+++ b/client/module_core/lib/src/api/analytics_api.dart
@@ -13,4 +13,8 @@ class AnalyticsApi({required final AnalyticsClient _client}) {
   Future<void> logInstallationEvent({required InstallationAnalyticsEvent event}) {
     return _client.logInstallationEvent(event: event);
   }
+
+  Future<void> activateAfterInteractiveAuthentication() {
+    return _client.activateAfterInteractiveAuthentication();
+  }
 }

--- a/client/module_core/lib/src/foundation/models/product_analytics/analytics_runtime_capability.dart
+++ b/client/module_core/lib/src/foundation/models/product_analytics/analytics_runtime_capability.dart
@@ -1,6 +1,5 @@
 enum AnalyticsRuntimeDisabledReason() {
   debugOrProfile,
-  recentBuildUnauthenticated,
   unsupportedPlatform,
   analyticsSinkUnavailable,
 }

--- a/client/module_core/lib/src/foundation/platform/analytics_client.dart
+++ b/client/module_core/lib/src/foundation/platform/analytics_client.dart
@@ -5,4 +5,9 @@ abstract interface class AnalyticsClient() {
   Future<void> logProductEvent({required ProductAnalyticsEnvelope envelope, required String userKey});
 
   Future<void> logInstallationEvent({required InstallationAnalyticsEvent event});
+
+  /// Lifts any store-crawl suspension of the underlying SDK. Called when a
+  /// server-confirmed interactive authentication proves this process is a
+  /// person rather than a crawler; a no-op when nothing is suspended.
+  Future<void> activateAfterInteractiveAuthentication();
 }

--- a/client/module_core/lib/src/repositories/analytics_repository.dart
+++ b/client/module_core/lib/src/repositories/analytics_repository.dart
@@ -4,6 +4,7 @@ import "package:meta/meta.dart";
 import "../api/analytics_api.dart";
 import "../foundation/models/product_analytics/installation_analytics_event.dart";
 import "../foundation/models/product_analytics/product_analytics_event.dart";
+import "../logging/logging.dart";
 import "models/analytics_delivery_result.dart";
 
 const _analyticsDeliveryDeadline = Duration(seconds: 10);
@@ -31,6 +32,16 @@ class AnalyticsRepository {
 
   Future<AnalyticsDeliveryResult> logInstallationEvent({required InstallationAnalyticsEvent event}) =>
       _deliver(operation: () => _api.logInstallationEvent(event: event));
+
+  /// Best-effort: a suspension that cannot be lifted must not block the login
+  /// flow; the outcome events then reach a suspended SDK and are discarded.
+  Future<void> activateAfterInteractiveAuthentication() async {
+    try {
+      await _api.activateAfterInteractiveAuthentication().timeout(_deliveryDeadline);
+    } on Object catch (error, stackTrace) {
+      logw("Failed to activate analytics after interactive authentication", error, stackTrace);
+    }
+  }
 
   Future<AnalyticsDeliveryResult> _deliver({required Future<void> Function() operation}) async {
     try {

--- a/client/module_core/lib/src/services/installation_analytics_service.dart
+++ b/client/module_core/lib/src/services/installation_analytics_service.dart
@@ -30,24 +30,35 @@ class InstallationAnalyticsService({
     required AuthProvider provider,
     required AccountStatus accountStatus,
   }) async {
-    // A server-confirmed interactive authentication is the proof-of-human that
-    // lifts the store-crawl suspension, so activate before logging the
-    // one-time outcome events.
-    await _repository.activateAfterInteractiveAuthentication();
     final analyticsProvider = _analyticsProvider(provider: provider);
+    // Attribution is an independent sink; only the Firebase outcome events
+    // wait for the store-crawl suspension to lift.
+    final results = await Future.wait([
+      _activateThenLogOutcomes(provider: analyticsProvider, accountStatus: accountStatus),
+      _logAttribution(accountStatus: accountStatus),
+    ]);
+
+    return results.every((result) => result == AnalyticsDeliveryResult.acceptedBySdk)
+        ? AnalyticsDeliveryResult.acceptedBySdk
+        : AnalyticsDeliveryResult.failed;
+  }
+
+  /// A server-confirmed interactive authentication is the proof-of-human that
+  /// lifts the store-crawl suspension, so activate before logging the one-time
+  /// outcome events.
+  Future<AnalyticsDeliveryResult> _activateThenLogOutcomes({
+    required AnalyticsLoginProvider provider,
+    required AccountStatus accountStatus,
+  }) async {
+    await _repository.activateAfterInteractiveAuthentication();
     final accountOutcomeEvent = switch (accountStatus) {
-      AccountStatus.created => InstallationAnalyticsEvent.accountCreated(method: analyticsProvider),
-      AccountStatus.existing => InstallationAnalyticsEvent.accountLogin(method: analyticsProvider),
+      AccountStatus.created => InstallationAnalyticsEvent.accountCreated(method: provider),
+      AccountStatus.existing => InstallationAnalyticsEvent.accountLogin(method: provider),
       AccountStatus.unknown => null,
     };
     final results = await Future.wait([
-      _log(
-        event: InstallationAnalyticsEvent.loginAttemptCompleted(
-          provider: analyticsProvider,
-        ),
-      ),
+      _log(event: InstallationAnalyticsEvent.loginAttemptCompleted(provider: provider)),
       if (accountOutcomeEvent != null) _log(event: accountOutcomeEvent),
-      _logAttribution(accountStatus: accountStatus),
     ]);
 
     return results.every((result) => result == AnalyticsDeliveryResult.acceptedBySdk)

--- a/client/module_core/lib/src/services/installation_analytics_service.dart
+++ b/client/module_core/lib/src/services/installation_analytics_service.dart
@@ -30,6 +30,10 @@ class InstallationAnalyticsService({
     required AuthProvider provider,
     required AccountStatus accountStatus,
   }) async {
+    // A server-confirmed interactive authentication is the proof-of-human that
+    // lifts the store-crawl suspension, so activate before logging the
+    // one-time outcome events.
+    await _repository.activateAfterInteractiveAuthentication();
     final analyticsProvider = _analyticsProvider(provider: provider);
     final accountOutcomeEvent = switch (accountStatus) {
       AccountStatus.created => InstallationAnalyticsEvent.accountCreated(method: analyticsProvider),

--- a/client/module_core/test/services/installation_analytics_service_test.dart
+++ b/client/module_core/test/services/installation_analytics_service_test.dart
@@ -36,6 +36,19 @@ class _DeferredAnalyticsRepository() extends Mock implements AnalyticsRepository
   Future<void> activateAfterInteractiveAuthentication() async {}
 }
 
+class _StalledActivationAnalyticsRepository() extends Mock implements AnalyticsRepository {
+  final events = <InstallationAnalyticsEvent>[];
+
+  @override
+  Future<AnalyticsDeliveryResult> logInstallationEvent({required InstallationAnalyticsEvent event}) async {
+    events.add(event);
+    return AnalyticsDeliveryResult.acceptedBySdk;
+  }
+
+  @override
+  Future<void> activateAfterInteractiveAuthentication() => Completer<void>().future;
+}
+
 class _RecordingAttributionRepository() extends Mock implements AttributionRepository {
   final events = <AttributionEvent>[];
   AnalyticsDeliveryResult result = AnalyticsDeliveryResult.acceptedBySdk;
@@ -208,6 +221,27 @@ void main() {
     // one-time outcome event is logged.
     expect(repository.activationCalls, 1);
     expect(repository.eventsSeenAtActivation, 0);
+  });
+
+  test("a stalled activation does not delay attribution", () async {
+    final repository = _StalledActivationAnalyticsRepository();
+    final attributionRepository = _RecordingAttributionRepository();
+    final service = InstallationAnalyticsService(
+      capability: const AnalyticsRuntimeCapability.enabled(),
+      repository: repository,
+      attributionRepository: attributionRepository,
+    );
+
+    unawaited(
+      service.loginAttemptCompleted(
+        provider: AuthProvider.github,
+        accountStatus: AccountStatus.existing,
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(attributionRepository.events, [AttributionEvent.accountLogin]);
+    expect(repository.events, isEmpty);
   });
 
   test("disabled installation analytics does not gate attribution", () async {

--- a/client/module_core/test/services/installation_analytics_service_test.dart
+++ b/client/module_core/test/services/installation_analytics_service_test.dart
@@ -8,11 +8,19 @@ import "package:test/test.dart";
 class _RecordingAnalyticsRepository() extends Mock implements AnalyticsRepository {
   final events = <InstallationAnalyticsEvent>[];
   AnalyticsDeliveryResult result = AnalyticsDeliveryResult.acceptedBySdk;
+  int activationCalls = 0;
+  int eventsSeenAtActivation = -1;
 
   @override
   Future<AnalyticsDeliveryResult> logInstallationEvent({required InstallationAnalyticsEvent event}) async {
     events.add(event);
     return result;
+  }
+
+  @override
+  Future<void> activateAfterInteractiveAuthentication() async {
+    activationCalls += 1;
+    eventsSeenAtActivation = events.length;
   }
 }
 
@@ -23,6 +31,9 @@ class _DeferredAnalyticsRepository() extends Mock implements AnalyticsRepository
   Future<AnalyticsDeliveryResult> logInstallationEvent({required InstallationAnalyticsEvent event}) {
     return completion.future;
   }
+
+  @override
+  Future<void> activateAfterInteractiveAuthentication() async {}
 }
 
 class _RecordingAttributionRepository() extends Mock implements AttributionRepository {
@@ -193,6 +204,10 @@ void main() {
       const InstallationAnalyticsEvent.loginAttemptCompleted(provider: AnalyticsLoginProvider.apple),
     ]);
     expect(attributionRepository.events, [AttributionEvent.accountLogin]);
+    // Interactive authentication lifts the store-crawl suspension before any
+    // one-time outcome event is logged.
+    expect(repository.activationCalls, 1);
+    expect(repository.eventsSeenAtActivation, 0);
   });
 
   test("disabled installation analytics does not gate attribution", () async {
@@ -200,7 +215,7 @@ void main() {
     final attributionRepository = _RecordingAttributionRepository();
     final service = InstallationAnalyticsService(
       capability: const AnalyticsRuntimeCapability.disabled(
-        reason: AnalyticsRuntimeDisabledReason.recentBuildUnauthenticated,
+        reason: AnalyticsRuntimeDisabledReason.debugOrProfile,
       ),
       repository: repository,
       attributionRepository: attributionRepository,

--- a/docs/regression/analytics.md
+++ b/docs/regression/analytics.md
@@ -30,11 +30,13 @@ uses a no-op sink, the bridge is excluded, and the warehouse is external.
   disable, logout, or account switch. Results state SDK acceptance, not delivery.
 - Firebase Analytics collection defaults off at native startup and is enabled only after consent in an eligible release
   process. Debug/profile runs emit neither automatic nor Sesori-defined analytics events. The release lanes stamp each
-  binary with its build time; for two hours after that stamp an unauthenticated Android launch is treated as a Play
-  pre-launch crawl and stays off, while a device with a locally valid session reports at any time. The window is a
-  heuristic on Play's crawl scheduling, so a late crawl can still register as an install, and a build promoted to
-  production inside its window hides unauthenticated first launches for the remainder; the L5 pre-launch check
-  measures the crawl residue.
+  binary with its build time; for 48 hours after that stamp an unauthenticated Android launch is treated as a Play
+  pre-launch crawl and stays off, while a device with a locally valid session reports at any time. An interactive
+  login inside the window lifts the SDK suspension for the rest of that process so the session and user are counted,
+  but the process-wide runtime capability stays disabled, so Sesori-defined events resume only at the next launch.
+  The window is a heuristic on Play's crawl scheduling, so a late crawl can still register as an install, and a build
+  promoted to production inside its window hides unauthenticated first launches for the remainder; the L5 pre-launch
+  check measures the crawl residue.
 - Singular starts only on Android/iOS, in the same eligible release-build population, with required credentials
   injected outside Git. An unauthenticated Android launch inside the Play crawl window arms startup but defers it until
   a successful interactive authentication reports its first conversion event; a crawler that never authenticates

--- a/docs/regression/analytics.md
+++ b/docs/regression/analytics.md
@@ -30,13 +30,14 @@ uses a no-op sink, the bridge is excluded, and the warehouse is external.
   disable, logout, or account switch. Results state SDK acceptance, not delivery.
 - Firebase Analytics collection defaults off at native startup and is enabled only after consent in an eligible release
   process. Debug/profile runs emit neither automatic nor Sesori-defined analytics events. The release lanes stamp each
-  binary with its build time; for 48 hours after that stamp an unauthenticated Android launch is treated as a Play
-  pre-launch crawl and stays off, while a device with a locally valid session reports at any time. An interactive
-  login inside the window lifts the SDK suspension for the rest of that process so the session and user are counted,
-  but the process-wide runtime capability stays disabled, so Sesori-defined events resume only at the next launch.
-  The window is a heuristic on Play's crawl scheduling, so a late crawl can still register as an install, and a build
-  promoted to production inside its window hides unauthenticated first launches for the remainder; the L5 pre-launch
-  check measures the crawl residue.
+  binary with its build time; for 48 hours after that stamp an unauthenticated Android launch keeps the SDK's own
+  collection suspended as a possible Play pre-launch crawl, while a device with a locally valid session reports at any
+  time. The Sesori runtime stays operational during the suspension: pre-authentication events are accepted but
+  discarded by the suspended SDK, and a server-confirmed interactive authentication lifts the suspension before the
+  one-time login outcome events are logged, so `login_attempt_completed` and the account outcome still report from
+  inside the window. The window is a heuristic on Play's crawl scheduling, so a late crawl can still register as an
+  install, and a build promoted to production inside its window discards pre-authentication events of unauthenticated
+  launches for the remainder; the L5 pre-launch check measures the crawl residue.
 - Singular starts only on Android/iOS, in the same eligible release-build population, with required credentials
   injected outside Git. An unauthenticated Android launch inside the Play crawl window arms startup but defers it until
   a successful interactive authentication reports its first conversion event; a crawler that never authenticates
@@ -79,8 +80,8 @@ account against a real property.
   status, omits the status-appropriate event, adds parameters beyond pinned `method` and shared schema, marks recurring
   `login` as a GA4 key event, or treats installation-level `sign_up` as the canonical account-registration count.
 - An account-linked event is emitted while unknown, disabled, unauthenticated, or in a debug or profile build.
-- Any automatic or Sesori-defined event is emitted by a debug/profile process, or by an unauthenticated release
-  process inside its build window.
+- Any automatic or Sesori-defined event reaches Firebase from a debug/profile process, or from a release process
+  inside its build window before a server-confirmed interactive authentication.
 - Disable is delayed, reported saved while sync failed, or lost across restart or logout; enable activates before
   server success plus local persistence.
 - An event fires on a tap or failed operation, is duplicated after deferral, has a rewritten occurrence time, or


### PR DESCRIPTION
## Complexity

Moderate: one constant widened, and the crawl gate moved from the process-wide runtime capability into the Firebase SDK collection switch with a login-time activation seam through the module-core analytics chain, mirroring the pre-existing Singular deferral.

## What

- Widens the post-build analytics suspension window from 2 hours to 48 hours (`_buildWindow` in `client/app/lib/main.dart`).
- Removes the `recentBuildUnauthenticated` capability reason. Inside the window the Sesori analytics runtime stays operational; the suspension now lives solely in the Firebase SDK collection switch, owned by `FirebaseAnalyticsStartup` (now a `@firebaseEnabledEnvironment` DI singleton).
- Adds `AnalyticsClient.activateAfterInteractiveAuthentication()` through the module-core chain (`AnalyticsApi` → `AnalyticsRepository` → called by `InstallationAnalyticsService.loginAttemptCompleted`). A server-confirmed interactive login lifts the SDK suspension *before* the one-time outcome events are logged, so `login_attempt_completed` and `sign_up`/`login` are delivered even from inside the window. No-op client implementations updated in lockstep.
- `SingularAttributionStartup` deferral is now driven by an explicit `deferUntilInteractiveAuthentication` flag instead of the removed enum value; behavior unchanged.
- Updates tests (window boundaries, suspension/activation, service activation ordering), the regression doc, and the Fastlane comment.

## Why

The 2h window shipped in #1056 but phantom `first_open` events with `country = (not set)` kept appearing: Play schedules pre-launch crawls "subject to capacity", up to a day after upload, so crawls regularly start more than 2h after the build stamp. The window needed widening, but naively widening it would silently drop the one-time login-funnel outcome events for every real user who installs a <48h-old binary and signs in — exactly the launch-spike cohort. Moving the suspension to the SDK switch with login-time activation keeps crawl filtering intact (a crawler never completes authentication, so nothing it triggers ever reaches Firebase) while preserving the documented invariant that a successful interactive authentication always reports its outcome events.

## Risk and test focus

- No user-visible or database impact; no wire contract changes. Android release builds only.
- A crawl later than 48h after compilation would still report; that is beyond Play's documented latency.
- Inside the window, pre-authentication events (`login_attempt_started`/`_failed`) are accepted but discarded by the suspended SDK — required, since Robo crawls tap login buttons too. Outcome events survive via the activation seam.
- Test focus: window boundaries (24h inside, 48h outside, unstamped, clock-behind); suspension returning an operational capability with the SDK off; activation running once with consent before enable; service activation ordering before outcome events; Singular defer flag paths.

## Expected result

Internal-track uploads stop producing phantom Firebase users: crawls launch inside the window, never authenticate, and report nothing. Signed-in devices report at any time; a new real user is fully counted from the moment they log in, including `login_attempt_completed` and `sign_up`/`login`.

## Verification

`flutter analyze` clean on `client/app`, `client/module_core`, `client/desktop`. Tests: `client/app` platform suite + build-window suite 102/102, `client/module_core` 1431/1431. Architecture implementation review (sub-agent): APPROVED, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
