### PR TITLE
🌱 Decode Markdown entities in thought previews

### DIFF
--- a/client/app/lib/features/session_detail/widgets/reasoning_part_card.dart
+++ b/client/app/lib/features/session_detail/widgets/reasoning_part_card.dart
@@ -197,7 +197,9 @@ class _ReasoningPartCardState() extends State<ReasoningPartCard> {
     final firstLine = _extractFirstLine(markdown);
     if (firstLine.isEmpty) return markdown.trim();
 
-    final document = md.Document();
+    // The AST is rendered directly into a Text widget rather than serialized
+    // to HTML, so decode Markdown character references instead of re-escaping them.
+    final document = md.Document(encodeHtml: false);
     final nodes = document.parse(firstLine);
 
     for (final node in nodes) {

--- a/client/app/test/features/session_detail/widgets/reasoning_part_card_test.dart
+++ b/client/app/test/features/session_detail/widgets/reasoning_part_card_test.dart
@@ -91,6 +91,24 @@ void main() {
       expect(find.text("Checking foo() method"), findsOneWidget);
     });
 
+    testWidgets("decodes HTML character references in preview", (tester) async {
+      await tester.pumpWidget(
+        buildApp(text: "The user wants &quot;quoted text&quot;.\n\nDetails here.", isStreaming: false),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('The user wants "quoted text".'), findsOneWidget);
+    });
+
+    testWidgets("preserves HTML character references inside inline code", (tester) async {
+      await tester.pumpWidget(
+        buildApp(text: "The literal entity is `&quot;`.\n\nDetails here.", isStreaming: false),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text("The literal entity is &quot;."), findsOneWidget);
+    });
+
     testWidgets("strips link markdown from preview", (tester) async {
       await tester.pumpWidget(
         buildApp(text: "See [docs](https://example.com)\n\nDetails here.", isStreaming: false),


### PR DESCRIPTION
## Complexity

🌱 Trivial — a localized Markdown parser option plus focused widget coverage.

## What

- Decode Markdown character references when building the completed Thought-card preview.
- Preserve character references written inside inline code as literal text.
- Add regression tests for both cases.

## Why

Pi/provider output can legitimately contain Markdown entities such as `&quot;`. The full Markdown renderer interprets them as quotation marks, but the collapsed Thought preview parsed with HTML encoding enabled and then displayed the encoded AST text directly.

## Risk and test focus

Low risk, limited to completed reasoning-card preview text. The tests cover normal Markdown entities and inline-code literals. There is no database or wire-contract impact.

## Expected result

A Thought preview displays `&quot;quoted text&quot;` as `"quoted text"`, while inline code containing `&quot;` remains unchanged.

## Verification

- `flutter test test/features/session_detail/widgets/reasoning_part_card_test.dart`
- `dart analyze` (from `client/app`)
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decodes Markdown character references in Thought-card previews so `&quot;quoted text&quot;` now renders as `"quoted text"` instead of showing the encoded entities.

**Bug Fixes**
- Markdown entities are decoded in previews; entities inside inline code stay as literal text.
- Adds regression tests for both decoding and inline-code preservation.

<sup>Written for commit 45b1bb468ffc76dc25e2efc395f28b2702d1365a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

