### PR TITLE
🚧 [project-voice-glossary] Forward cached context to voice [step 8/8]

### DIFF
--- a/bridge/app/lib/src/orchestrator.dart
+++ b/bridge/app/lib/src/orchestrator.dart
@@ -351,7 +351,14 @@ class Orchestrator({
       prSyncService: prSyncService,
       settingsService: pullRequestRefreshSettingsService,
     );
-    final currentProjectService = CurrentProjectService(projectRepository: projectRepository);
+    final projectGlossaryScopeService = ProjectGlossaryScopeService(
+      repository: ProjectGlossaryScopeRepository(gitCliApi: gitCliApi),
+      bridgeIdProvider: _bridgeRegistrationService,
+    );
+    final currentProjectService = CurrentProjectService(
+      projectRepository: projectRepository,
+      projectGlossaryScopeService: projectGlossaryScopeService,
+    );
     final sesoriServerApi = SesoriServerApi(
       authBackendUrl: config.authBackendURL,
       client: _httpClient,
@@ -360,10 +367,7 @@ class Orchestrator({
     );
     final projectGlossaryPopulationService = ProjectGlossaryPopulationService(
       projectRepository: projectRepository,
-      scopeService: ProjectGlossaryScopeService(
-        repository: ProjectGlossaryScopeRepository(gitCliApi: gitCliApi),
-        bridgeIdProvider: _bridgeRegistrationService,
-      ),
+      scopeService: projectGlossaryScopeService,
       glossaryRepository: ProjectGlossaryRepository(
         gitCliApi: gitCliApi,
         filesystemApi: const FilesystemApi(),

--- a/bridge/app/lib/src/orchestrator.dart
+++ b/bridge/app/lib/src/orchestrator.dart
@@ -151,6 +151,7 @@ import "services/pr_sync_service.dart";
 import "services/project_activity_service.dart";
 import "services/project_glossary_population_service.dart";
 import "services/project_glossary_scope_service.dart";
+import "services/project_glossary_scope_tracker.dart";
 import "services/project_glossary_term_calculator.dart";
 import "services/project_initialization_service.dart";
 import "services/project_mutation_service.dart";
@@ -351,13 +352,17 @@ class Orchestrator({
       prSyncService: prSyncService,
       settingsService: pullRequestRefreshSettingsService,
     );
+    final projectGlossaryScopeTracker = ProjectGlossaryScopeTracker(
+      bridgeIdProvider: _bridgeRegistrationService,
+    );
     final projectGlossaryScopeService = ProjectGlossaryScopeService(
       repository: ProjectGlossaryScopeRepository(gitCliApi: gitCliApi),
       bridgeIdProvider: _bridgeRegistrationService,
+      scopeTracker: projectGlossaryScopeTracker,
     );
     final currentProjectService = CurrentProjectService(
       projectRepository: projectRepository,
-      projectGlossaryScopeService: projectGlossaryScopeService,
+      projectGlossaryScopeTracker: projectGlossaryScopeTracker,
     );
     final sesoriServerApi = SesoriServerApi(
       authBackendUrl: config.authBackendURL,

--- a/bridge/app/lib/src/repositories/mappers/project_catalog_mapper.dart
+++ b/bridge/app/lib/src/repositories/mappers/project_catalog_mapper.dart
@@ -31,6 +31,7 @@ class const ProjectCatalogMapper() {
       hasUnseenChanges: hasUnseenChanges,
       directoryMissing: directoryMissing,
       supportsDedicatedWorktrees: supportsDedicatedWorktrees,
+      voiceGlossaryKey: null,
     );
   }
 

--- a/bridge/app/lib/src/repositories/project_repository.dart
+++ b/bridge/app/lib/src/repositories/project_repository.dart
@@ -113,6 +113,7 @@ class ProjectRepository({
       path: canonical,
       time: null,
       supportsDedicatedWorktrees: await _supportsDedicatedWorktrees(path: canonical),
+      voiceGlossaryKey: null,
     );
   }
 

--- a/bridge/app/lib/src/services/current_project_service.dart
+++ b/bridge/app/lib/src/services/current_project_service.dart
@@ -3,13 +3,13 @@ import "dart:async";
 import "package:sesori_shared/sesori_shared.dart" show Project;
 
 import "../repositories/project_repository.dart";
-import "project_glossary_scope_service.dart";
+import "project_glossary_scope_tracker.dart";
 
 /// Loads the current project for the route boundary and publishes successful
 /// loads for independent background consumers.
 class CurrentProjectService({
   required final ProjectRepository _projectRepository,
-  required final ProjectGlossaryScopeService _projectGlossaryScopeService,
+  required final ProjectGlossaryScopeTracker _projectGlossaryScopeTracker,
 }) {
   final StreamController<String> _loadedProjectIds = StreamController<String>.broadcast(sync: true);
   bool _disposed = false;
@@ -19,7 +19,7 @@ class CurrentProjectService({
   Future<Project> getCurrentProject({required String projectId}) async {
     final project = await _projectRepository.getProject(projectId: projectId);
     final response = project.copyWith(
-      voiceGlossaryKey: _projectGlossaryScopeService.cachedProjectKey(projectPath: project.path),
+      voiceGlossaryKey: _projectGlossaryScopeTracker.projectKeyFor(projectPath: project.path),
     );
     if (!_disposed) {
       _loadedProjectIds.add(response.id);

--- a/bridge/app/lib/src/services/current_project_service.dart
+++ b/bridge/app/lib/src/services/current_project_service.dart
@@ -3,10 +3,14 @@ import "dart:async";
 import "package:sesori_shared/sesori_shared.dart" show Project;
 
 import "../repositories/project_repository.dart";
+import "project_glossary_scope_service.dart";
 
 /// Loads the current project for the route boundary and publishes successful
 /// loads for independent background consumers.
-class CurrentProjectService({required final ProjectRepository _projectRepository}) {
+class CurrentProjectService({
+  required final ProjectRepository _projectRepository,
+  required final ProjectGlossaryScopeService _projectGlossaryScopeService,
+}) {
   final StreamController<String> _loadedProjectIds = StreamController<String>.broadcast(sync: true);
   bool _disposed = false;
 
@@ -14,10 +18,13 @@ class CurrentProjectService({required final ProjectRepository _projectRepository
 
   Future<Project> getCurrentProject({required String projectId}) async {
     final project = await _projectRepository.getProject(projectId: projectId);
+    final response = project.copyWith(
+      voiceGlossaryKey: _projectGlossaryScopeService.cachedProjectKey(projectPath: project.path),
+    );
     if (!_disposed) {
-      _loadedProjectIds.add(project.id);
+      _loadedProjectIds.add(response.id);
     }
-    return project;
+    return response;
   }
 
   Future<void> dispose() async {

--- a/bridge/app/lib/src/services/project_glossary_population_service.dart
+++ b/bridge/app/lib/src/services/project_glossary_population_service.dart
@@ -20,49 +20,62 @@ class ProjectGlossaryPopulationService({
   static const int _maximumMutationWords = 100;
 
   final ParallelLock _populationLock = ParallelLock(maxParallelOperations: 1);
+  final Map<String, Future<void>> _populationByProjectId = {};
   Future<void>? _disposeFuture;
   bool _accepting = true;
 
   Future<void> populate({required String projectId}) {
     if (!_accepting) return Future<void>.value();
 
-    return _populationLock.use(
-      operation: () async {
-        if (!_accepting) return;
+    final existing = _populationByProjectId[projectId];
+    if (existing != null) return existing;
 
-        final project = await _projectRepository.getProject(projectId: projectId);
-        if (!_accepting) return;
+    late final Future<void> tracked;
+    tracked = _populationLock
+        .use(
+          operation: () async {
+            if (!_accepting) return;
 
-        final scope = await _scopeService.resolve(projectPath: project.path);
-        if (scope == null || !_accepting) return;
+            final project = await _projectRepository.getProject(projectId: projectId);
+            if (!_accepting) return;
 
-        final source = await _glossaryRepository.loadSource(projectPath: project.path);
-        final desiredWords = _termCalculator.calculate(source: source);
-        if (!_accepting) return;
+            final scope = await _scopeService.resolve(projectPath: project.path);
+            if (scope == null || !_accepting) return;
 
-        final existingWords = await _publicationRepository.getWords(projectKey: scope.projectKey);
-        if (!_accepting) return;
+            final source = await _glossaryRepository.loadSource(projectPath: project.path);
+            final desiredWords = _termCalculator.calculate(source: source);
+            if (!_accepting) return;
 
-        // The read is project-wide and deduplicated across exact owners. Add
-        // every desired word idempotently so this scope retains independent
-        // ownership even when another scope already contributed the same word.
-        if (desiredWords.isNotEmpty) {
-          await _publicationRepository.addWords(scope: scope, words: desiredWords);
-        }
-        if (!_accepting) return;
+            final existingWords = await _publicationRepository.getWords(projectKey: scope.projectKey);
+            if (!_accepting) return;
 
-        final desiredWordSet = desiredWords.toSet();
-        final staleWords = existingWords.where((word) => !desiredWordSet.contains(word)).toList(growable: false);
-        for (var start = 0; start < staleWords.length; start += _maximumMutationWords) {
-          if (!_accepting) return;
-          final end = min(start + _maximumMutationWords, staleWords.length);
-          await _publicationRepository.removeWords(
-            scope: scope,
-            words: staleWords.sublist(start, end),
-          );
-        }
-      },
-    );
+            // The read is project-wide and deduplicated across exact owners. Add
+            // every desired word idempotently so this scope retains independent
+            // ownership even when another scope already contributed the same word.
+            if (desiredWords.isNotEmpty) {
+              await _publicationRepository.addWords(scope: scope, words: desiredWords);
+            }
+            if (!_accepting) return;
+
+            final desiredWordSet = desiredWords.toSet();
+            final staleWords = existingWords.where((word) => !desiredWordSet.contains(word)).toList(growable: false);
+            for (var start = 0; start < staleWords.length; start += _maximumMutationWords) {
+              if (!_accepting) return;
+              final end = min(start + _maximumMutationWords, staleWords.length);
+              await _publicationRepository.removeWords(
+                scope: scope,
+                words: staleWords.sublist(start, end),
+              );
+            }
+          },
+        )
+        .whenComplete(() {
+          if (identical(_populationByProjectId[projectId], tracked)) {
+            _populationByProjectId.remove(projectId);
+          }
+        });
+    _populationByProjectId[projectId] = tracked;
+    return tracked;
   }
 
   void beginShutdown() {

--- a/bridge/app/lib/src/services/project_glossary_scope_service.dart
+++ b/bridge/app/lib/src/services/project_glossary_scope_service.dart
@@ -6,34 +6,18 @@ import "package:sesori_shared/sesori_shared.dart";
 import "../auth/bridge_id_provider.dart";
 import "../repositories/models/project_glossary_scope_identity.dart";
 import "../repositories/project_glossary_scope_repository.dart";
+import "project_glossary_scope_tracker.dart";
 
 /// Derives the exact opaque auth scope for a local project without exposing its
 /// network origin or filesystem path outside the bridge.
 class ProjectGlossaryScopeService({
   required final ProjectGlossaryScopeRepository _repository,
   required final BridgeIdProvider _bridgeIdProvider,
+  required final ProjectGlossaryScopeTracker _scopeTracker,
 }) {
   static const String _repositoryDomain = "sesori-repo-glossary-v1\u0000";
   static const String _bridgeLocalDomain = "sesori-local-glossary-v1\u0000";
   static const String _keyPrefix = "prj_v1_";
-
-  final Map<String, ProjectGlossaryScope> _scopeByProjectPath = {};
-
-  ProjectGlossaryKey? cachedProjectKey({required String projectPath}) {
-    if (projectPath.trim().isEmpty) return null;
-    final normalizedPath = normalizeProjectDirectory(directory: projectPath);
-    final scope = _scopeByProjectPath[normalizedPath];
-    return switch (scope) {
-      RepositoryProjectGlossaryScope(:final projectKey) => projectKey,
-      BridgeLocalProjectGlossaryScope(:final projectKey, :final bridgeId) when bridgeId == _bridgeIdProvider.bridgeId =>
-        projectKey,
-      BridgeLocalProjectGlossaryScope() => () {
-        _scopeByProjectPath.remove(normalizedPath);
-        return null;
-      }(),
-      null => null,
-    };
-  }
 
   Future<ProjectGlossaryScope?> resolve({required String projectPath}) async {
     if (projectPath.trim().isEmpty) return null;
@@ -48,11 +32,7 @@ class ProjectGlossaryScopeService({
       ),
       null => null,
     };
-    if (scope == null) {
-      _scopeByProjectPath.remove(normalizedPath);
-    } else {
-      _scopeByProjectPath[normalizedPath] = scope;
-    }
+    _scopeTracker.record(projectPath: normalizedPath, scope: scope);
     return scope;
   }
 

--- a/bridge/app/lib/src/services/project_glossary_scope_service.dart
+++ b/bridge/app/lib/src/services/project_glossary_scope_service.dart
@@ -1,5 +1,6 @@
 import "dart:convert";
 
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show normalizeProjectDirectory;
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../auth/bridge_id_provider.dart";
@@ -16,9 +17,29 @@ class ProjectGlossaryScopeService({
   static const String _bridgeLocalDomain = "sesori-local-glossary-v1\u0000";
   static const String _keyPrefix = "prj_v1_";
 
+  final Map<String, ProjectGlossaryScope> _scopeByProjectPath = {};
+
+  ProjectGlossaryKey? cachedProjectKey({required String projectPath}) {
+    if (projectPath.trim().isEmpty) return null;
+    final normalizedPath = normalizeProjectDirectory(directory: projectPath);
+    final scope = _scopeByProjectPath[normalizedPath];
+    return switch (scope) {
+      RepositoryProjectGlossaryScope(:final projectKey) => projectKey,
+      BridgeLocalProjectGlossaryScope(:final projectKey, :final bridgeId) when bridgeId == _bridgeIdProvider.bridgeId =>
+        projectKey,
+      BridgeLocalProjectGlossaryScope() => () {
+        _scopeByProjectPath.remove(normalizedPath);
+        return null;
+      }(),
+      null => null,
+    };
+  }
+
   Future<ProjectGlossaryScope?> resolve({required String projectPath}) async {
-    final identity = await _repository.resolveIdentity(projectPath: projectPath);
-    return switch (identity) {
+    if (projectPath.trim().isEmpty) return null;
+    final normalizedPath = normalizeProjectDirectory(directory: projectPath);
+    final identity = await _repository.resolveIdentity(projectPath: normalizedPath);
+    final scope = switch (identity) {
       RepositoryProjectGlossaryIdentity(:final canonicalOrigin) => ProjectGlossaryScope.repository(
         projectKey: await _calculateKey(input: "$_repositoryDomain$canonicalOrigin"),
       ),
@@ -27,6 +48,12 @@ class ProjectGlossaryScopeService({
       ),
       null => null,
     };
+    if (scope == null) {
+      _scopeByProjectPath.remove(normalizedPath);
+    } else {
+      _scopeByProjectPath[normalizedPath] = scope;
+    }
+    return scope;
   }
 
   Future<ProjectGlossaryScope?> _resolveBridgeLocal({required String normalizedAbsolutePath}) async {

--- a/bridge/app/lib/src/services/project_glossary_scope_tracker.dart
+++ b/bridge/app/lib/src/services/project_glossary_scope_tracker.dart
@@ -1,0 +1,40 @@
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show normalizeProjectDirectory;
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../auth/bridge_id_provider.dart";
+
+/// Tracks the latest resolved glossary scope for each normalized project path.
+class ProjectGlossaryScopeTracker({
+  required final BridgeIdProvider _bridgeIdProvider,
+}) {
+  final Map<String, ProjectGlossaryScope> _scopeByProjectPath = {};
+
+  void record({
+    required String projectPath,
+    required ProjectGlossaryScope? scope,
+  }) {
+    if (projectPath.trim().isEmpty) return;
+    final normalizedPath = normalizeProjectDirectory(directory: projectPath);
+    if (scope == null) {
+      _scopeByProjectPath.remove(normalizedPath);
+    } else {
+      _scopeByProjectPath[normalizedPath] = scope;
+    }
+  }
+
+  ProjectGlossaryKey? projectKeyFor({required String projectPath}) {
+    if (projectPath.trim().isEmpty) return null;
+    final normalizedPath = normalizeProjectDirectory(directory: projectPath);
+    final scope = _scopeByProjectPath[normalizedPath];
+    return switch (scope) {
+      RepositoryProjectGlossaryScope(:final projectKey) => projectKey,
+      BridgeLocalProjectGlossaryScope(:final projectKey, :final bridgeId) when bridgeId == _bridgeIdProvider.bridgeId =>
+        projectKey,
+      BridgeLocalProjectGlossaryScope() => () {
+        _scopeByProjectPath.remove(normalizedPath);
+        return null;
+      }(),
+      null => null,
+    };
+  }
+}

--- a/bridge/app/test/bridge/routing/get_current_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_current_project_handler_test.dart
@@ -4,7 +4,7 @@ import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/routing/get_current_project_handler.dart";
 import "package:sesori_bridge/src/services/current_project_service.dart";
-import "package:sesori_bridge/src/services/project_glossary_scope_service.dart";
+import "package:sesori_bridge/src/services/project_glossary_scope_tracker.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -34,7 +34,7 @@ void main() {
           unseenCalculator: const SessionUnseenCalculator(),
           filesystemApi: FakeFilesystemApi(),
         ),
-        projectGlossaryScopeService: _NoGlossaryScopeService(),
+        projectGlossaryScopeTracker: _NoGlossaryScopeTracker(),
       );
       handler = GetCurrentProjectHandler(currentProjectService: currentProjectService);
     });
@@ -120,9 +120,9 @@ void main() {
   });
 }
 
-final class _NoGlossaryScopeService() implements ProjectGlossaryScopeService {
+final class _NoGlossaryScopeTracker() implements ProjectGlossaryScopeTracker {
   @override
-  ProjectGlossaryKey? cachedProjectKey({required String projectPath}) => null;
+  ProjectGlossaryKey? projectKeyFor({required String projectPath}) => null;
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/bridge/app/test/bridge/routing/get_current_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_current_project_handler_test.dart
@@ -4,6 +4,7 @@ import "package:sesori_bridge/src/api/database/database.dart";
 import "package:sesori_bridge/src/repositories/session_unseen_calculator.dart";
 import "package:sesori_bridge/src/routing/get_current_project_handler.dart";
 import "package:sesori_bridge/src/services/current_project_service.dart";
+import "package:sesori_bridge/src/services/project_glossary_scope_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -33,6 +34,7 @@ void main() {
           unseenCalculator: const SessionUnseenCalculator(),
           filesystemApi: FakeFilesystemApi(),
         ),
+        projectGlossaryScopeService: _NoGlossaryScopeService(),
       );
       handler = GetCurrentProjectHandler(currentProjectService: currentProjectService);
     });
@@ -116,4 +118,12 @@ void main() {
       expect(plugin.lastGetCurrentProjectProjectId, isNot(equals("/unknown")));
     });
   });
+}
+
+final class _NoGlossaryScopeService() implements ProjectGlossaryScopeService {
+  @override
+  ProjectGlossaryKey? cachedProjectKey({required String projectPath}) => null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/bridge/app/test/bridge/services/current_project_service_test.dart
+++ b/bridge/app/test/bridge/services/current_project_service_test.dart
@@ -1,20 +1,20 @@
 import "package:sesori_bridge/src/repositories/project_repository.dart";
 import "package:sesori_bridge/src/services/current_project_service.dart";
-import "package:sesori_bridge/src/services/project_glossary_scope_service.dart";
+import "package:sesori_bridge/src/services/project_glossary_scope_tracker.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
 void main() {
   late _FakeProjectRepository repository;
-  late _FakeProjectGlossaryScopeService scopeService;
+  late _FakeProjectGlossaryScopeTracker scopeTracker;
   late CurrentProjectService service;
 
   setUp(() {
     repository = _FakeProjectRepository();
-    scopeService = _FakeProjectGlossaryScopeService();
+    scopeTracker = _FakeProjectGlossaryScopeTracker();
     service = CurrentProjectService(
       projectRepository: repository,
-      projectGlossaryScopeService: scopeService,
+      projectGlossaryScopeTracker: scopeTracker,
     );
     addTearDown(service.dispose);
   });
@@ -23,14 +23,14 @@ void main() {
     final glossaryKey = ProjectGlossaryKey.parse(
       value: "prj_v1_1yuLLmK3NKRJfpiX26q507WHb9ZxINRCpBKCBTgnGlQ",
     );
-    scopeService.cachedKey = glossaryKey;
+    scopeTracker.cachedKey = glossaryKey;
     final loadedProjectId = service.loadedProjectIds.first;
 
     final project = await service.getCurrentProject(projectId: "requested-id");
 
     expect(project.id, "authoritative-id");
     expect(project.voiceGlossaryKey, glossaryKey);
-    expect(scopeService.projectPaths, ["/workspace/project"]);
+    expect(scopeTracker.projectPaths, ["/workspace/project"]);
     expect(await loadedProjectId, "authoritative-id");
   });
 
@@ -68,12 +68,12 @@ final class _FakeProjectRepository() implements ProjectRepository {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-final class _FakeProjectGlossaryScopeService() implements ProjectGlossaryScopeService {
+final class _FakeProjectGlossaryScopeTracker() implements ProjectGlossaryScopeTracker {
   ProjectGlossaryKey? cachedKey;
   final List<String> projectPaths = [];
 
   @override
-  ProjectGlossaryKey? cachedProjectKey({required String projectPath}) {
+  ProjectGlossaryKey? projectKeyFor({required String projectPath}) {
     projectPaths.add(projectPath);
     return cachedKey;
   }

--- a/bridge/app/test/bridge/services/current_project_service_test.dart
+++ b/bridge/app/test/bridge/services/current_project_service_test.dart
@@ -1,24 +1,36 @@
 import "package:sesori_bridge/src/repositories/project_repository.dart";
 import "package:sesori_bridge/src/services/current_project_service.dart";
+import "package:sesori_bridge/src/services/project_glossary_scope_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
 void main() {
   late _FakeProjectRepository repository;
+  late _FakeProjectGlossaryScopeService scopeService;
   late CurrentProjectService service;
 
   setUp(() {
     repository = _FakeProjectRepository();
-    service = CurrentProjectService(projectRepository: repository);
+    scopeService = _FakeProjectGlossaryScopeService();
+    service = CurrentProjectService(
+      projectRepository: repository,
+      projectGlossaryScopeService: scopeService,
+    );
     addTearDown(service.dispose);
   });
 
-  test("publishes the authoritative id after a successful load", () async {
+  test("publishes the authoritative id and cached glossary key after a successful load", () async {
+    final glossaryKey = ProjectGlossaryKey.parse(
+      value: "prj_v1_1yuLLmK3NKRJfpiX26q507WHb9ZxINRCpBKCBTgnGlQ",
+    );
+    scopeService.cachedKey = glossaryKey;
     final loadedProjectId = service.loadedProjectIds.first;
 
     final project = await service.getCurrentProject(projectId: "requested-id");
 
     expect(project.id, "authoritative-id");
+    expect(project.voiceGlossaryKey, glossaryKey);
+    expect(scopeService.projectPaths, ["/workspace/project"]);
     expect(await loadedProjectId, "authoritative-id");
   });
 
@@ -48,7 +60,22 @@ final class _FakeProjectRepository() implements ProjectRepository {
       name: "Project",
       path: "/workspace/project",
       time: null,
+      voiceGlossaryKey: null,
     );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+final class _FakeProjectGlossaryScopeService() implements ProjectGlossaryScopeService {
+  ProjectGlossaryKey? cachedKey;
+  final List<String> projectPaths = [];
+
+  @override
+  ProjectGlossaryKey? cachedProjectKey({required String projectPath}) {
+    projectPaths.add(projectPath);
+    return cachedKey;
   }
 
   @override

--- a/bridge/app/test/bridge/services/project_glossary_population_service_test.dart
+++ b/bridge/app/test/bridge/services/project_glossary_population_service_test.dart
@@ -139,6 +139,7 @@ final class _FakeProjectRepository() implements ProjectRepository {
       name: "Project",
       path: "/workspace/project",
       time: null,
+      voiceGlossaryKey: null,
     );
   }
 
@@ -149,6 +150,9 @@ final class _FakeProjectRepository() implements ProjectRepository {
 final class _FakeProjectGlossaryScopeService({required var ProjectGlossaryScope? scope})
     implements ProjectGlossaryScopeService {
   final List<String> projectPaths = [];
+
+  @override
+  ProjectGlossaryKey? cachedProjectKey({required String projectPath}) => null;
 
   @override
   Future<ProjectGlossaryScope?> resolve({required String projectPath}) async {

--- a/bridge/app/test/bridge/services/project_glossary_population_service_test.dart
+++ b/bridge/app/test/bridge/services/project_glossary_population_service_test.dart
@@ -152,9 +152,6 @@ final class _FakeProjectGlossaryScopeService({required var ProjectGlossaryScope?
   final List<String> projectPaths = [];
 
   @override
-  ProjectGlossaryKey? cachedProjectKey({required String projectPath}) => null;
-
-  @override
   Future<ProjectGlossaryScope?> resolve({required String projectPath}) async {
     projectPaths.add(projectPath);
     return scope;

--- a/bridge/app/test/bridge/services/project_glossary_population_service_test.dart
+++ b/bridge/app/test/bridge/services/project_glossary_population_service_test.dart
@@ -84,6 +84,25 @@ void main() {
     expect(publicationRepository.operations, isEmpty);
   });
 
+  test("coalesces concurrent population requests for the same project", () async {
+    final getStarted = Completer<void>();
+    final releaseGet = Completer<void>();
+    publicationRepository
+      ..getStarted = getStarted
+      ..releaseGet = releaseGet;
+
+    final first = service.populate(projectId: "project-1");
+    await getStarted.future;
+    final second = service.populate(projectId: "project-1");
+
+    expect(identical(first, second), isTrue);
+    releaseGet.complete();
+    await Future.wait([first, second]);
+
+    expect(projectRepository.requestedProjectIds, ["project-1"]);
+    expect(publicationRepository.operations, ["get"]);
+  });
+
   test("serializes concurrent population requests", () async {
     final getStarted = Completer<void>();
     final releaseGet = Completer<void>();

--- a/bridge/app/test/bridge/services/project_glossary_scope_service_test.dart
+++ b/bridge/app/test/bridge/services/project_glossary_scope_service_test.dart
@@ -2,6 +2,7 @@ import "package:sesori_bridge/src/auth/bridge_id_provider.dart";
 import "package:sesori_bridge/src/repositories/models/project_glossary_scope_identity.dart";
 import "package:sesori_bridge/src/repositories/project_glossary_scope_repository.dart";
 import "package:sesori_bridge/src/services/project_glossary_scope_service.dart";
+import "package:sesori_bridge/src/services/project_glossary_scope_tracker.dart";
 import "package:test/test.dart";
 
 void main() {
@@ -20,10 +21,6 @@ void main() {
       "projectKey": "prj_v1_1yuLLmK3NKRJfpiX26q507WHb9ZxINRCpBKCBTgnGlQ",
     });
     expect(scope?.toJson().toString(), isNot(contains("/private/repository/path")));
-    expect(
-      service.cachedProjectKey(projectPath: "/private/repository/path"),
-      scope?.projectKey,
-    );
   });
 
   test("derives a bridge-owned local scope from normalized path", () async {
@@ -42,25 +39,6 @@ void main() {
       "bridgeId": "br_bridge0001",
     });
     expect(scope?.toJson().toString(), isNot(contains("/tmp/projects/sesori")));
-  });
-
-  test("invalidates a cached local scope when the registered bridge changes", () async {
-    final bridgeIdProvider = _FakeBridgeIdProvider(bridgeId: "br_bridge0001");
-    final service = ProjectGlossaryScopeService(
-      repository: _FakeProjectGlossaryScopeRepository(
-        identity: const BridgeLocalProjectGlossaryIdentity(
-          normalizedAbsolutePath: "/tmp/projects/sesori",
-        ),
-      ),
-      bridgeIdProvider: bridgeIdProvider,
-    );
-
-    final scope = await service.resolve(projectPath: "/tmp/projects/sesori");
-    expect(service.cachedProjectKey(projectPath: "/tmp/projects/sesori"), scope?.projectKey);
-
-    bridgeIdProvider.bridgeId = "br_bridge0002";
-
-    expect(service.cachedProjectKey(projectPath: "/tmp/projects/sesori"), isNull);
   });
 
   test("returns no local scope before bridge registration", () async {
@@ -85,9 +63,11 @@ ProjectGlossaryScopeService _service({
   required ProjectGlossaryScopeIdentity? identity,
   required String? bridgeId,
 }) {
+  final bridgeIdProvider = _FakeBridgeIdProvider(bridgeId: bridgeId);
   return ProjectGlossaryScopeService(
     repository: _FakeProjectGlossaryScopeRepository(identity: identity),
-    bridgeIdProvider: _FakeBridgeIdProvider(bridgeId: bridgeId),
+    bridgeIdProvider: bridgeIdProvider,
+    scopeTracker: ProjectGlossaryScopeTracker(bridgeIdProvider: bridgeIdProvider),
   );
 }
 

--- a/bridge/app/test/bridge/services/project_glossary_scope_service_test.dart
+++ b/bridge/app/test/bridge/services/project_glossary_scope_service_test.dart
@@ -20,6 +20,10 @@ void main() {
       "projectKey": "prj_v1_1yuLLmK3NKRJfpiX26q507WHb9ZxINRCpBKCBTgnGlQ",
     });
     expect(scope?.toJson().toString(), isNot(contains("/private/repository/path")));
+    expect(
+      service.cachedProjectKey(projectPath: "/private/repository/path"),
+      scope?.projectKey,
+    );
   });
 
   test("derives a bridge-owned local scope from normalized path", () async {
@@ -38,6 +42,25 @@ void main() {
       "bridgeId": "br_bridge0001",
     });
     expect(scope?.toJson().toString(), isNot(contains("/tmp/projects/sesori")));
+  });
+
+  test("invalidates a cached local scope when the registered bridge changes", () async {
+    final bridgeIdProvider = _FakeBridgeIdProvider(bridgeId: "br_bridge0001");
+    final service = ProjectGlossaryScopeService(
+      repository: _FakeProjectGlossaryScopeRepository(
+        identity: const BridgeLocalProjectGlossaryIdentity(
+          normalizedAbsolutePath: "/tmp/projects/sesori",
+        ),
+      ),
+      bridgeIdProvider: bridgeIdProvider,
+    );
+
+    final scope = await service.resolve(projectPath: "/tmp/projects/sesori");
+    expect(service.cachedProjectKey(projectPath: "/tmp/projects/sesori"), scope?.projectKey);
+
+    bridgeIdProvider.bridgeId = "br_bridge0002";
+
+    expect(service.cachedProjectKey(projectPath: "/tmp/projects/sesori"), isNull);
   });
 
   test("returns no local scope before bridge registration", () async {
@@ -74,4 +97,4 @@ class _FakeProjectGlossaryScopeRepository({required final ProjectGlossaryScopeId
   Future<ProjectGlossaryScopeIdentity?> resolveIdentity({required String projectPath}) async => identity;
 }
 
-class _FakeBridgeIdProvider({@override required final String? bridgeId}) implements BridgeIdProvider;
+class _FakeBridgeIdProvider({@override required var String? bridgeId}) implements BridgeIdProvider;

--- a/bridge/app/test/bridge/services/project_glossary_scope_tracker_test.dart
+++ b/bridge/app/test/bridge/services/project_glossary_scope_tracker_test.dart
@@ -1,0 +1,60 @@
+import "package:sesori_bridge/src/auth/bridge_id_provider.dart";
+import "package:sesori_bridge/src/services/project_glossary_scope_tracker.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  final projectKey = ProjectGlossaryKey.parse(
+    value: "prj_v1_1yuLLmK3NKRJfpiX26q507WHb9ZxINRCpBKCBTgnGlQ",
+  );
+
+  test("records, reads, and removes scopes by normalized project path", () {
+    final tracker = ProjectGlossaryScopeTracker(
+      bridgeIdProvider: _FakeBridgeIdProvider(bridgeId: "br_bridge0001"),
+    );
+    final scope = ProjectGlossaryScope.repository(projectKey: projectKey);
+
+    tracker.record(projectPath: "/tmp/projects/sesori/", scope: scope);
+
+    expect(tracker.projectKeyFor(projectPath: "/tmp/projects/sesori"), projectKey);
+
+    tracker.record(projectPath: "/tmp/projects/sesori", scope: null);
+
+    expect(tracker.projectKeyFor(projectPath: "/tmp/projects/sesori/"), isNull);
+  });
+
+  test("invalidates a bridge-local scope when the registered bridge changes", () {
+    final bridgeIdProvider = _FakeBridgeIdProvider(bridgeId: "br_bridge0001");
+    final tracker = ProjectGlossaryScopeTracker(bridgeIdProvider: bridgeIdProvider);
+    tracker.record(
+      projectPath: "/tmp/projects/sesori",
+      scope: ProjectGlossaryScope.bridgeLocal(
+        projectKey: projectKey,
+        bridgeId: "br_bridge0001",
+      ),
+    );
+
+    expect(tracker.projectKeyFor(projectPath: "/tmp/projects/sesori"), projectKey);
+
+    bridgeIdProvider.bridgeId = "br_bridge0002";
+
+    expect(tracker.projectKeyFor(projectPath: "/tmp/projects/sesori"), isNull);
+    bridgeIdProvider.bridgeId = "br_bridge0001";
+    expect(tracker.projectKeyFor(projectPath: "/tmp/projects/sesori"), isNull);
+  });
+
+  test("retains repository scopes across bridge registration changes", () {
+    final bridgeIdProvider = _FakeBridgeIdProvider(bridgeId: "br_bridge0001");
+    final tracker = ProjectGlossaryScopeTracker(bridgeIdProvider: bridgeIdProvider);
+    tracker.record(
+      projectPath: "/tmp/projects/sesori",
+      scope: ProjectGlossaryScope.repository(projectKey: projectKey),
+    );
+
+    bridgeIdProvider.bridgeId = "br_bridge0002";
+
+    expect(tracker.projectKeyFor(projectPath: "/tmp/projects/sesori"), projectKey);
+  });
+}
+
+class _FakeBridgeIdProvider({@override required var String? bridgeId}) implements BridgeIdProvider;

--- a/bridge/app/test/bridge/services/project_mutation_service_test.dart
+++ b/bridge/app/test/bridge/services/project_mutation_service_test.dart
@@ -219,6 +219,7 @@ class _ProjectActivityService({required final List<String> events, required fina
       path: path,
       time: null,
       supportsDedicatedWorktrees: false,
+      voiceGlossaryKey: null,
     );
   }
 

--- a/client/app/lib/features/new_session/new_session_screen.dart
+++ b/client/app/lib/features/new_session/new_session_screen.dart
@@ -507,10 +507,13 @@ class _NewSessionBodyState() extends State<_NewSessionBody> {
                           Padding(
                             padding: const EdgeInsets.symmetric(horizontal: 16),
                             child: BlocProvider(
-                              create: (_) => VoiceInputCubit(
-                                service: getIt<VoiceTranscriptionService>(),
-                                projectId: widget.projectId,
-                              ),
+                              create: (_) {
+                                final service = getIt<VoiceTranscriptionService>();
+                                return VoiceInputCubit(
+                                  service: service,
+                                  session: service.createSession(projectId: widget.projectId),
+                                );
+                              },
                               child: Semantics(
                                 enabled: isComposerEnabled,
                                 child: ExcludeFocus(

--- a/client/app/lib/features/new_session/new_session_screen.dart
+++ b/client/app/lib/features/new_session/new_session_screen.dart
@@ -509,6 +509,7 @@ class _NewSessionBodyState() extends State<_NewSessionBody> {
                             child: BlocProvider(
                               create: (_) => VoiceInputCubit(
                                 service: getIt<VoiceTranscriptionService>(),
+                                projectId: widget.projectId,
                               ),
                               child: Semantics(
                                 enabled: isComposerEnabled,

--- a/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
@@ -282,10 +282,13 @@ class _SessionDetailLoadedViewState() extends State<SessionDetailLoadedView> {
     );
     if (widget.readOnly) return content;
     return BlocProvider(
-      create: (_) => VoiceInputCubit(
-        service: getIt<VoiceTranscriptionService>(),
-        projectId: widget.projectId,
-      ),
+      create: (_) {
+        final service = getIt<VoiceTranscriptionService>();
+        return VoiceInputCubit(
+          service: service,
+          session: service.createSession(projectId: widget.projectId),
+        );
+      },
       child: content,
     );
   }

--- a/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
@@ -282,7 +282,10 @@ class _SessionDetailLoadedViewState() extends State<SessionDetailLoadedView> {
     );
     if (widget.readOnly) return content;
     return BlocProvider(
-      create: (_) => VoiceInputCubit(service: getIt<VoiceTranscriptionService>()),
+      create: (_) => VoiceInputCubit(
+        service: getIt<VoiceTranscriptionService>(),
+        projectId: widget.projectId,
+      ),
       child: content,
     );
   }

--- a/client/app/test/core/routing/adaptive_session_router_test_harness.dart
+++ b/client/app/test/core/routing/adaptive_session_router_test_harness.dart
@@ -101,6 +101,7 @@ class AdaptiveSessionRouterTestHarness() {
           path: "/$projectId",
           time: null,
           supportsDedicatedWorktrees: true,
+          voiceGlossaryKey: null,
         ),
       );
     });

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -412,6 +412,7 @@ void main() {
           path: "/project-one",
           time: null,
           supportsDedicatedWorktrees: true,
+          voiceGlossaryKey: null,
         ),
       ),
     );
@@ -496,6 +497,7 @@ void main() {
           path: "/project-one",
           time: null,
           supportsDedicatedWorktrees: false,
+          voiceGlossaryKey: null,
         ),
       ),
     );
@@ -517,6 +519,7 @@ void main() {
                 path: "/project-one",
                 time: null,
                 supportsDedicatedWorktrees: true,
+                voiceGlossaryKey: null,
               ),
             );
     });
@@ -1163,6 +1166,7 @@ void main() {
           path: "/plain-folder",
           time: null,
           supportsDedicatedWorktrees: false,
+          voiceGlossaryKey: null,
         ),
       ),
     );

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -272,7 +272,10 @@ void main() {
         providers: [
           BlocProvider<ChatInputModeCubit>(create: (_) => StubChatInputModeCubit()),
           BlocProvider<VoiceInputCubit>(
-            create: (_) => VoiceInputCubit(service: voiceTranscriptionService),
+            create: (_) => VoiceInputCubit(
+              service: voiceTranscriptionService,
+              projectId: "/project",
+            ),
           ),
         ],
         child: MaterialApp(

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -274,7 +274,7 @@ void main() {
           BlocProvider<VoiceInputCubit>(
             create: (_) => VoiceInputCubit(
               service: voiceTranscriptionService,
-              projectId: "/project",
+              session: voiceSession,
             ),
           ),
         ],

--- a/client/app/test/helpers/voice_test_helpers.dart
+++ b/client/app/test/helpers/voice_test_helpers.dart
@@ -11,7 +11,9 @@ MockVoiceTranscriptionSession stubVoiceTranscriptionService({
   Stream<double> amplitudeStream = const Stream<double>.empty(),
 }) {
   final session = MockVoiceTranscriptionSession();
-  when(service.createSession).thenReturn(session);
+  when(
+    () => service.createSession(projectId: any(named: "projectId")),
+  ).thenReturn(session);
   when(() => service.maxDurationReachedStream(session: session)).thenAnswer((_) => maxDurationStream);
   when(() => service.amplitudeStream(session: session)).thenAnswer((_) => amplitudeStream);
   when(() => service.prewarm(session: session)).thenAnswer((_) async {});

--- a/client/module_core/lib/src/capabilities/voice/voice_api.dart
+++ b/client/module_core/lib/src/capabilities/voice/voice_api.dart
@@ -5,6 +5,7 @@ import "dart:io";
 import "package:http/http.dart" as http;
 import "package:injectable/injectable.dart";
 import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_shared/sesori_shared.dart" show ProjectGlossaryKey;
 
 import "../../logging/logging.dart";
 import "voice_transcription_failure_metadata.dart";
@@ -25,6 +26,7 @@ class VoiceApi(final AuthenticatedHttpApiClient _client) {
   Future<VoiceTranscriptionApiResult> transcribe({
     required String audioFilePath,
     required String mimeType,
+    required ProjectGlossaryKey? projectGlossaryKey,
   }) async {
     final uri = Uri.parse("$authBaseUrl/voice/transcribe");
 
@@ -36,6 +38,7 @@ class VoiceApi(final AuthenticatedHttpApiClient _client) {
       final response = await _client.postMultipart(
         uri,
         fromJson: _parseTranscript,
+        fields: projectGlossaryKey == null ? null : {"projectKey": projectGlossaryKey.value},
         createFiles: () async => [
           await http.MultipartFile.fromPath(
             "audio",

--- a/client/module_core/lib/src/cubits/voice_input/voice_input_cubit.dart
+++ b/client/module_core/lib/src/cubits/voice_input/voice_input_cubit.dart
@@ -8,9 +8,8 @@ import "voice_input_state.dart";
 
 class VoiceInputCubit({
   required final VoiceTranscriptionService _service,
-  required final String? projectId,
+  required final VoiceTranscriptionSession _session,
 }) extends Cubit<VoiceInputState> {
-  late final VoiceTranscriptionSession _session = _service.createSession(projectId: projectId);
   late final StreamSubscription<void> _maxDurationSubscription;
 
   this : super(const VoiceInputState.idle()) {

--- a/client/module_core/lib/src/cubits/voice_input/voice_input_cubit.dart
+++ b/client/module_core/lib/src/cubits/voice_input/voice_input_cubit.dart
@@ -6,8 +6,11 @@ import "../../logging/logging.dart";
 import "../../services/voice_transcription_service.dart";
 import "voice_input_state.dart";
 
-class VoiceInputCubit({required final VoiceTranscriptionService _service}) extends Cubit<VoiceInputState> {
-  late final VoiceTranscriptionSession _session = _service.createSession();
+class VoiceInputCubit({
+  required final VoiceTranscriptionService _service,
+  required final String? projectId,
+}) extends Cubit<VoiceInputState> {
+  late final VoiceTranscriptionSession _session = _service.createSession(projectId: projectId);
   late final StreamSubscription<void> _maxDurationSubscription;
 
   this : super(const VoiceInputState.idle()) {

--- a/client/module_core/lib/src/di/injection.config.dart
+++ b/client/module_core/lib/src/di/injection.config.dart
@@ -84,7 +84,7 @@ import 'package:sesori_dart_core/src/repositories/notification_preferences_repos
 import 'package:sesori_dart_core/src/repositories/notification_repository.dart'
     as _i471;
 import 'package:sesori_dart_core/src/repositories/permission_repository.dart'
-    as _i680;
+    as _i679;
 import 'package:sesori_dart_core/src/repositories/plugin_preference_repository.dart'
     as _i594;
 import 'package:sesori_dart_core/src/repositories/plugin_repository.dart'
@@ -147,7 +147,7 @@ import 'package:sesori_dart_core/src/services/session_viewing_service.dart'
     as _i18;
 import 'package:sesori_dart_core/src/services/sse_event_tracker.dart' as _i508;
 import 'package:sesori_dart_core/src/services/voice_transcription_service.dart'
-    as _i679;
+    as _i680;
 import 'package:sesori_dart_core/src/utils/model_filter/default_model_selector.dart'
     as _i895;
 import 'package:sesori_shared/sesori_shared.dart' as _i553;
@@ -240,12 +240,6 @@ extension GetItInjectableX on _i174.GetIt {
         localNotificationClient: gh<_i1037.LocalNotificationClient>(),
         routeDispatcher: gh<_i951.RouteDispatcher>(),
         routeSource: gh<_i366.RouteSource>(),
-      ),
-    );
-    gh.lazySingleton<_i679.VoiceTranscriptionService>(
-      () => _i679.VoiceTranscriptionService(
-        repository: gh<_i107.VoiceRepository>(),
-        capture: gh<_i359.VoiceCapture>(),
       ),
     );
     gh.lazySingleton<_i896.RoomKeyStorage>(
@@ -435,8 +429,8 @@ extension GetItInjectableX on _i174.GetIt {
         attachmentThumbnailStorage: gh<_i894.AttachmentThumbnailStorage>(),
       ),
     );
-    gh.lazySingleton<_i680.PermissionRepository>(
-      () => _i680.PermissionRepository(api: gh<_i231.PermissionApi>()),
+    gh.lazySingleton<_i679.PermissionRepository>(
+      () => _i679.PermissionRepository(api: gh<_i231.PermissionApi>()),
     );
     gh.lazySingleton<_i80.ProjectRepository>(
       () => _i80.ProjectRepository(
@@ -467,6 +461,13 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i74.NewSessionOptionsService(
         sessionRepository: gh<_i7.SessionRepository>(),
         defaultModelSelector: gh<_i895.DefaultModelSelector>(),
+      ),
+    );
+    gh.lazySingleton<_i680.VoiceTranscriptionService>(
+      () => _i680.VoiceTranscriptionService(
+        repository: gh<_i107.VoiceRepository>(),
+        projectRepository: gh<_i80.ProjectRepository>(),
+        capture: gh<_i359.VoiceCapture>(),
       ),
     );
     gh.lazySingleton<_i110.PluginManagementService>(

--- a/client/module_core/lib/src/repositories/voice_repository.dart
+++ b/client/module_core/lib/src/repositories/voice_repository.dart
@@ -1,5 +1,6 @@
 import "package:injectable/injectable.dart";
 import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_shared/sesori_shared.dart" show ProjectGlossaryKey;
 
 import "../capabilities/voice/voice_api.dart";
 
@@ -8,8 +9,13 @@ class VoiceRepository({required final VoiceApi _api}) {
   Future<VoiceTranscriptionOutcome> transcribe({
     required String audioFilePath,
     required String mimeType,
+    required ProjectGlossaryKey? projectGlossaryKey,
   }) async {
-    final response = await _api.transcribe(audioFilePath: audioFilePath, mimeType: mimeType);
+    final response = await _api.transcribe(
+      audioFilePath: audioFilePath,
+      mimeType: mimeType,
+      projectGlossaryKey: projectGlossaryKey,
+    );
     return switch (response) {
       VoiceTranscriptionApiSuccess(:final transcript) => VoiceTranscriptionOutcome.success(
         transcript: transcript,

--- a/client/module_core/lib/src/services/voice_transcription_service.dart
+++ b/client/module_core/lib/src/services/voice_transcription_service.dart
@@ -1,9 +1,12 @@
 import "dart:async";
 
 import "package:injectable/injectable.dart";
+import "package:sesori_auth/sesori_auth.dart" show ErrorResponse, SuccessResponse;
+import "package:sesori_shared/sesori_shared.dart" show ProjectGlossaryKey;
 
 import "../logging/logging.dart";
 import "../platform/voice_capture.dart";
+import "../repositories/project_repository.dart";
 import "../repositories/voice_repository.dart";
 
 const maxRecordingDuration = Duration(minutes: 15);
@@ -12,11 +15,41 @@ const _recorderPrewarmTimeout = Duration(seconds: 2);
 @lazySingleton
 class VoiceTranscriptionService({
   required final VoiceRepository _repository,
+  required final ProjectRepository _projectRepository,
   required final VoiceCapture _capture,
 }) {
-  VoiceTranscriptionSession createSession() => VoiceTranscriptionSession._(
-    captureSession: _capture.createSession(),
-  );
+  VoiceTranscriptionSession createSession({required String? projectId}) {
+    final session = VoiceTranscriptionSession._(
+      captureSession: _capture.createSession(),
+    );
+    if (projectId != null && projectId.trim().isNotEmpty) {
+      unawaited(
+        _loadProjectGlossaryKey(
+          session: session,
+          projectId: projectId,
+        ),
+      );
+    }
+    return session;
+  }
+
+  Future<void> _loadProjectGlossaryKey({
+    required VoiceTranscriptionSession session,
+    required String projectId,
+  }) async {
+    try {
+      final response = await _projectRepository.getProject(projectId: projectId);
+      if (session._state is _VoiceSessionClosing || session._state is _VoiceSessionDisposed) return;
+      switch (response) {
+        case SuccessResponse(:final data):
+          session._availableProjectGlossaryKey = data.voiceGlossaryKey;
+        case ErrorResponse(:final error):
+          logw("Could not load optional project voice context; continuing unscoped", error);
+      }
+    } catch (error, stackTrace) {
+      logw("Could not load optional project voice context; continuing unscoped", error, stackTrace);
+    }
+  }
 
   Stream<double> amplitudeStream({required VoiceTranscriptionSession session}) =>
       session._captureSession.amplitudeStream;
@@ -64,6 +97,7 @@ class VoiceTranscriptionService({
   Future<void> _start({required VoiceTranscriptionSession session}) async {
     final generation = ++session._generation;
     session._state = const _VoiceSessionStarting();
+    session._interactionProjectGlossaryKey = session._availableProjectGlossaryKey;
 
     try {
       final prewarmFuture = session._prewarmFuture;
@@ -178,6 +212,7 @@ class VoiceTranscriptionService({
       final outcome = await _repository.transcribe(
         audioFilePath: artifact.path,
         mimeType: artifact.mimeType,
+        projectGlossaryKey: session._interactionProjectGlossaryKey,
       );
       if (!_ownsGeneration(session: session, generation: generation)) {
         throw VoiceTranscriptionError.cancelled();
@@ -411,6 +446,8 @@ class VoiceTranscriptionSession._({required final VoiceCaptureSession _captureSe
   Future<VoiceRecordingArtifact>? _stopFuture;
   Future<void>? _cancelFuture;
   Timer? _maxDurationTimer;
+  ProjectGlossaryKey? _availableProjectGlossaryKey;
+  ProjectGlossaryKey? _interactionProjectGlossaryKey;
   int _generation = 0;
 }
 

--- a/client/module_core/lib/src/services/voice_transcription_service.dart
+++ b/client/module_core/lib/src/services/voice_transcription_service.dart
@@ -21,16 +21,29 @@ class VoiceTranscriptionService({
   VoiceTranscriptionSession createSession({required String? projectId}) {
     final session = VoiceTranscriptionSession._(
       captureSession: _capture.createSession(),
+      projectId: projectId == null || projectId.trim().isEmpty ? null : projectId,
     );
-    if (projectId != null && projectId.trim().isNotEmpty) {
-      unawaited(
-        _loadProjectGlossaryKey(
-          session: session,
-          projectId: projectId,
-        ),
-      );
-    }
+    _refreshProjectGlossaryKey(session: session);
     return session;
+  }
+
+  void _refreshProjectGlossaryKey({required VoiceTranscriptionSession session}) {
+    final projectId = session._projectId;
+    if (projectId == null ||
+        session._availableProjectGlossaryKey != null ||
+        session._projectGlossaryKeyLoad != null ||
+        session._state is _VoiceSessionClosing ||
+        session._state is _VoiceSessionDisposed) {
+      return;
+    }
+
+    late final Future<void> tracked;
+    tracked = _loadProjectGlossaryKey(session: session, projectId: projectId).whenComplete(() {
+      if (identical(session._projectGlossaryKeyLoad, tracked)) {
+        session._projectGlossaryKeyLoad = null;
+      }
+    });
+    session._projectGlossaryKeyLoad = tracked;
   }
 
   Future<void> _loadProjectGlossaryKey({
@@ -98,6 +111,7 @@ class VoiceTranscriptionService({
     final generation = ++session._generation;
     session._state = const _VoiceSessionStarting();
     session._interactionProjectGlossaryKey = session._availableProjectGlossaryKey;
+    _refreshProjectGlossaryKey(session: session);
 
     try {
       final prewarmFuture = session._prewarmFuture;
@@ -437,7 +451,10 @@ class VoiceTranscriptionService({
   }
 }
 
-class VoiceTranscriptionSession._({required final VoiceCaptureSession _captureSession}) {
+class VoiceTranscriptionSession._({
+  required final VoiceCaptureSession _captureSession,
+  required final String? _projectId,
+}) {
   final StreamController<void> _maxDurationReachedController = StreamController<void>.broadcast();
 
   _VoiceSessionState _state = const _VoiceSessionIdle();
@@ -445,6 +462,7 @@ class VoiceTranscriptionSession._({required final VoiceCaptureSession _captureSe
   Future<void>? _startFuture;
   Future<VoiceRecordingArtifact>? _stopFuture;
   Future<void>? _cancelFuture;
+  Future<void>? _projectGlossaryKeyLoad;
   Timer? _maxDurationTimer;
   ProjectGlossaryKey? _availableProjectGlossaryKey;
   ProjectGlossaryKey? _interactionProjectGlossaryKey;

--- a/client/module_core/test/api/project_api_test.dart
+++ b/client/module_core/test/api/project_api_test.dart
@@ -3,6 +3,7 @@ import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_dart_core/src/api/project_api.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
+
 import "../helpers/test_helpers.dart";
 
 void main() {
@@ -50,7 +51,13 @@ void main() {
 
   group("createProject", () {
     test("posts the project path and returns the project", () async {
-      const project = Project(id: "project-1", name: "Project 1", path: "/project-1", time: null);
+      const project = Project(
+        id: "project-1",
+        name: "Project 1",
+        path: "/project-1",
+        time: null,
+        voiceGlossaryKey: null,
+      );
       when(
         () => client.post<Project>(
           "/project/create",
@@ -89,7 +96,13 @@ void main() {
 
   group("discoverProject", () {
     test("posts the project path and returns the project", () async {
-      const project = Project(id: "project-1", name: "Project 1", path: "/project-1", time: null);
+      const project = Project(
+        id: "project-1",
+        name: "Project 1",
+        path: "/project-1",
+        time: null,
+        voiceGlossaryKey: null,
+      );
       when(
         () => client.post<Project>(
           "/project/open",
@@ -137,7 +150,13 @@ void main() {
 
   group("getProject", () {
     test("posts the project ID and returns the project", () async {
-      const project = Project(id: "project-1", name: "Project 1", path: "/project-1", time: null);
+      const project = Project(
+        id: "project-1",
+        name: "Project 1",
+        path: "/project-1",
+        time: null,
+        voiceGlossaryKey: null,
+      );
       when(
         () => client.post<Project>(
           "/project/current",
@@ -238,7 +257,7 @@ void main() {
 
   group("renameProject", () {
     test("patches the project name and returns the project", () async {
-      const project = Project(id: "project-1", name: "Renamed", path: "/project-1", time: null);
+      const project = Project(id: "project-1", name: "Renamed", path: "/project-1", time: null, voiceGlossaryKey: null);
       when(
         () => client.patch<Project>(
           "/project/name",

--- a/client/module_core/test/capabilities/voice/voice_api_test.dart
+++ b/client/module_core/test/capabilities/voice/voice_api_test.dart
@@ -6,6 +6,7 @@ import "package:mocktail/mocktail.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_dart_core/src/capabilities/voice/voice_api.dart";
 import "package:sesori_dart_core/testing.dart";
+import "package:sesori_shared/sesori_shared.dart" show ProjectGlossaryKey;
 import "package:test/test.dart";
 
 void main() {
@@ -28,19 +29,27 @@ void main() {
       return audioFile.path;
     }
 
-    test("success: sends multipart request and returns transcript", () async {
+    test("success: sends multipart request with optional opaque context", () async {
       final audioPath = await createAudioPath();
+      final glossaryKey = ProjectGlossaryKey.parse(
+        value: "prj_v1_1yuLLmK3NKRJfpiX26q507WHb9ZxINRCpBKCBTgnGlQ",
+      );
 
       when(
         () => mockAuthenticatedHttpApiClient.postMultipart<String>(
           any(),
           fromJson: any(named: "fromJson"),
           createFiles: any(named: "createFiles"),
+          fields: any(named: "fields"),
           timeout: any(named: "timeout"),
         ),
       ).thenAnswer((_) async => ApiResponse.success("transcribed text"));
 
-      final result = await voiceApi.transcribe(audioFilePath: audioPath, mimeType: "audio/mp4");
+      final result = await voiceApi.transcribe(
+        audioFilePath: audioPath,
+        mimeType: "audio/mp4",
+        projectGlossaryKey: glossaryKey,
+      );
 
       expect(
         result,
@@ -56,6 +65,7 @@ void main() {
           captureAny(),
           fromJson: captureAny(named: "fromJson"),
           createFiles: captureAny(named: "createFiles"),
+          fields: captureAny(named: "fields"),
           timeout: captureAny(named: "timeout"),
         ),
       ).captured;
@@ -73,7 +83,38 @@ void main() {
       expect(multipartFile.field, "audio");
       expect(multipartFile.filename, "clip.m4a");
 
-      expect(captured[3], const Duration(seconds: 30));
+      expect(captured[3], {"projectKey": glossaryKey.value});
+      expect(captured[4], const Duration(seconds: 30));
+    });
+
+    test("omits multipart project context when no key is available", () async {
+      final audioPath = await createAudioPath();
+      when(
+        () => mockAuthenticatedHttpApiClient.postMultipart<String>(
+          any(),
+          fromJson: any(named: "fromJson"),
+          createFiles: any(named: "createFiles"),
+          fields: any(named: "fields"),
+          timeout: any(named: "timeout"),
+        ),
+      ).thenAnswer((_) async => ApiResponse.success("transcribed text"));
+
+      await voiceApi.transcribe(
+        audioFilePath: audioPath,
+        mimeType: "audio/mp4",
+        projectGlossaryKey: null,
+      );
+
+      final fields = verify(
+        () => mockAuthenticatedHttpApiClient.postMultipart<String>(
+          any(),
+          fromJson: any(named: "fromJson"),
+          createFiles: any(named: "createFiles"),
+          fields: captureAny(named: "fields"),
+          timeout: any(named: "timeout"),
+        ),
+      ).captured.single;
+      expect(fields, isNull);
     });
 
     test("API error: parses authoritative retryability from the failure body", () async {
@@ -87,11 +128,16 @@ void main() {
           any(),
           fromJson: any(named: "fromJson"),
           createFiles: any(named: "createFiles"),
+          fields: any(named: "fields"),
           timeout: any(named: "timeout"),
         ),
       ).thenAnswer((_) async => ApiResponse.error(apiError));
 
-      final result = await voiceApi.transcribe(audioFilePath: audioPath, mimeType: "audio/mp4");
+      final result = await voiceApi.transcribe(
+        audioFilePath: audioPath,
+        mimeType: "audio/mp4",
+        projectGlossaryKey: null,
+      );
 
       expect(
         result,
@@ -127,6 +173,7 @@ void main() {
         final result = await voiceApi.transcribe(
           audioFilePath: audioPath,
           mimeType: "audio/mp4",
+          projectGlossaryKey: null,
         );
 
         expect(
@@ -151,13 +198,18 @@ void main() {
           any(),
           fromJson: any(named: "fromJson"),
           createFiles: any(named: "createFiles"),
+          fields: any(named: "fields"),
           timeout: any(named: "timeout"),
         ),
       ).thenAnswer(
         (_) => Future<ApiResponse<String>>.error(TimeoutException("Request timed out")),
       );
 
-      final result = await voiceApi.transcribe(audioFilePath: audioPath, mimeType: "audio/mp4");
+      final result = await voiceApi.transcribe(
+        audioFilePath: audioPath,
+        mimeType: "audio/mp4",
+        projectGlossaryKey: null,
+      );
 
       expect(
         result,
@@ -176,13 +228,18 @@ void main() {
           any(),
           fromJson: any(named: "fromJson"),
           createFiles: any(named: "createFiles"),
+          fields: any(named: "fields"),
           timeout: any(named: "timeout"),
         ),
       ).thenAnswer(
         (_) => Future<ApiResponse<String>>.error(const SocketException("Network unreachable")),
       );
 
-      final result = await voiceApi.transcribe(audioFilePath: audioPath, mimeType: "audio/mp4");
+      final result = await voiceApi.transcribe(
+        audioFilePath: audioPath,
+        mimeType: "audio/mp4",
+        projectGlossaryKey: null,
+      );
 
       expect(
         result,
@@ -201,11 +258,16 @@ void main() {
           any(),
           fromJson: any(named: "fromJson"),
           createFiles: any(named: "createFiles"),
+          fields: any(named: "fields"),
           timeout: any(named: "timeout"),
         ),
       ).thenAnswer((_) async => ApiResponse.error(ApiError.jsonParsing("not json")));
 
-      final result = await voiceApi.transcribe(audioFilePath: audioPath, mimeType: "audio/mp4");
+      final result = await voiceApi.transcribe(
+        audioFilePath: audioPath,
+        mimeType: "audio/mp4",
+        projectGlossaryKey: null,
+      );
 
       expect(
         result,
@@ -222,13 +284,18 @@ void main() {
           any(),
           fromJson: any(named: "fromJson"),
           createFiles: any(named: "createFiles"),
+          fields: any(named: "fields"),
           timeout: any(named: "timeout"),
         ),
       ).thenAnswer(
         (_) => Future<ApiResponse<String>>.error(const HandshakeException("TLS failed")),
       );
 
-      final result = await voiceApi.transcribe(audioFilePath: audioPath, mimeType: "audio/mp4");
+      final result = await voiceApi.transcribe(
+        audioFilePath: audioPath,
+        mimeType: "audio/mp4",
+        projectGlossaryKey: null,
+      );
 
       expect(
         result,

--- a/client/module_core/test/cubits/new_session/new_session_cubit_test.dart
+++ b/client/module_core/test/cubits/new_session/new_session_cubit_test.dart
@@ -129,6 +129,7 @@ void main() {
             path: "/project",
             time: null,
             supportsDedicatedWorktrees: true,
+            voiceGlossaryKey: null,
           ),
         ),
       );
@@ -1020,6 +1021,7 @@ void main() {
             path: "/plain-folder",
             time: null,
             supportsDedicatedWorktrees: false,
+            voiceGlossaryKey: null,
           ),
         ),
       );

--- a/client/module_core/test/cubits/new_session/new_session_plugin_selection_test.dart
+++ b/client/module_core/test/cubits/new_session/new_session_plugin_selection_test.dart
@@ -123,6 +123,7 @@ void main() {
             path: "/project",
             time: null,
             supportsDedicatedWorktrees: true,
+            voiceGlossaryKey: null,
           ),
         ),
       );
@@ -257,6 +258,7 @@ void main() {
                 path: "/project",
                 time: null,
                 supportsDedicatedWorktrees: true,
+                voiceGlossaryKey: null,
               ),
             ),
           );

--- a/client/module_core/test/cubits/voice_input/voice_input_cubit_test.dart
+++ b/client/module_core/test/cubits/voice_input/voice_input_cubit_test.dart
@@ -18,9 +18,6 @@ void main() {
     service = MockVoiceTranscriptionService();
     session = MockVoiceTranscriptionSession();
     maxDurationController = StreamController<void>.broadcast();
-    when(
-      () => service.createSession(projectId: any(named: "projectId")),
-    ).thenReturn(session);
     when(() => service.amplitudeStream(session: session)).thenAnswer((_) => const Stream<double>.empty());
     when(() => service.maxDurationReachedStream(session: session)).thenAnswer((_) => maxDurationController.stream);
     when(() => service.prewarm(session: session)).thenAnswer((_) async {});
@@ -37,16 +34,16 @@ void main() {
     await maxDurationController.close();
   });
 
-  test("passes nullable project context into the composer-owned service session", () async {
-    final cubit = VoiceInputCubit(service: service, projectId: "project-1");
+  test("uses the composer-owned session injected at composition", () async {
+    final cubit = VoiceInputCubit(service: service, session: session);
 
-    verify(() => service.createSession(projectId: "project-1")).called(1);
+    expect(cubit.amplitudeStream, isA<Stream<double>>());
     await cubit.close();
   });
 
   blocTest<VoiceInputCubit, VoiceInputState>(
     "starts, transcribes, acknowledges, and keeps orchestration behind the service",
-    build: () => VoiceInputCubit(service: service, projectId: null),
+    build: () => VoiceInputCubit(service: service, session: session),
     act: (cubit) async {
       await cubit.startRecording();
       await cubit.stopAndTranscribe(limitReached: false);
@@ -74,7 +71,7 @@ void main() {
         ),
       );
     },
-    build: () => VoiceInputCubit(service: service, projectId: null),
+    build: () => VoiceInputCubit(service: service, session: session),
     act: (cubit) => cubit.startRecording(),
     expect: () => [
       const VoiceInputState.starting(),
@@ -91,7 +88,7 @@ void main() {
     setUp: () {
       when(() => service.stopAndTranscribe(session: session)).thenThrow(VoiceTranscriptionError.networkError());
     },
-    build: () => VoiceInputCubit(service: service, projectId: null),
+    build: () => VoiceInputCubit(service: service, session: session),
     act: (cubit) async {
       await cubit.startRecording();
       await cubit.stopAndTranscribe(limitReached: false);
@@ -115,7 +112,7 @@ void main() {
         VoiceTranscriptionError.retryableServerError(statusCode: 503),
       );
     },
-    build: () => VoiceInputCubit(service: service, projectId: null),
+    build: () => VoiceInputCubit(service: service, session: session),
     act: (cubit) async {
       await cubit.startRecording();
       await cubit.stopAndTranscribe(limitReached: false);
@@ -139,7 +136,7 @@ void main() {
         VoiceTranscriptionError.serverError(statusCode: 400),
       );
     },
-    build: () => VoiceInputCubit(service: service, projectId: null),
+    build: () => VoiceInputCubit(service: service, session: session),
     act: (cubit) async {
       await cubit.startRecording();
       await cubit.stopAndTranscribe(limitReached: false);
@@ -158,7 +155,7 @@ void main() {
       VoiceTranscriptionError.networkError(),
     );
     when(() => service.retry(session: session)).thenAnswer((_) => retryCompleter.future);
-    final cubit = VoiceInputCubit(service: service, projectId: null);
+    final cubit = VoiceInputCubit(service: service, session: session);
     addTearDown(cubit.close);
     await cubit.startRecording();
     await cubit.stopAndTranscribe(limitReached: false);
@@ -180,7 +177,7 @@ void main() {
       VoiceTranscriptionError.networkError(),
     );
     when(() => service.retry(session: session)).thenAnswer((_) => retryCompleter.future);
-    final cubit = VoiceInputCubit(service: service, projectId: null);
+    final cubit = VoiceInputCubit(service: service, session: session);
     addTearDown(cubit.close);
     await cubit.startRecording();
     await cubit.stopAndTranscribe(limitReached: false);
@@ -203,14 +200,14 @@ void main() {
   blocTest<VoiceInputCubit, VoiceInputState>(
     "discards a retained recording and returns to idle",
     seed: () => VoiceInputState.retryPending(error: VoiceTranscriptionError.networkError()),
-    build: () => VoiceInputCubit(service: service, projectId: null),
+    build: () => VoiceInputCubit(service: service, session: session),
     act: (cubit) => cubit.discard(),
     expect: () => const [VoiceInputState.discarding(), VoiceInputState.idle()],
     verify: (_) => verify(() => service.discard(session: session)).called(1),
   );
 
   test("maximum duration auto-stops through the Cubit with its reason preserved", () async {
-    final cubit = VoiceInputCubit(service: service, projectId: null);
+    final cubit = VoiceInputCubit(service: service, session: session);
     addTearDown(cubit.close);
     await cubit.startRecording();
 
@@ -224,7 +221,7 @@ void main() {
 
   blocTest<VoiceInputCubit, VoiceInputState>(
     "cancels active work and returns to idle",
-    build: () => VoiceInputCubit(service: service, projectId: null),
+    build: () => VoiceInputCubit(service: service, session: session),
     act: (cubit) async {
       await cubit.startRecording();
       await cubit.cancel();
@@ -239,7 +236,7 @@ void main() {
   );
 
   test("close synchronously invalidates before asynchronous cleanup", () async {
-    final cubit = VoiceInputCubit(service: service, projectId: null);
+    final cubit = VoiceInputCubit(service: service, session: session);
 
     await cubit.close();
 

--- a/client/module_core/test/cubits/voice_input/voice_input_cubit_test.dart
+++ b/client/module_core/test/cubits/voice_input/voice_input_cubit_test.dart
@@ -18,7 +18,9 @@ void main() {
     service = MockVoiceTranscriptionService();
     session = MockVoiceTranscriptionSession();
     maxDurationController = StreamController<void>.broadcast();
-    when(service.createSession).thenReturn(session);
+    when(
+      () => service.createSession(projectId: any(named: "projectId")),
+    ).thenReturn(session);
     when(() => service.amplitudeStream(session: session)).thenAnswer((_) => const Stream<double>.empty());
     when(() => service.maxDurationReachedStream(session: session)).thenAnswer((_) => maxDurationController.stream);
     when(() => service.prewarm(session: session)).thenAnswer((_) async {});
@@ -35,9 +37,16 @@ void main() {
     await maxDurationController.close();
   });
 
+  test("passes nullable project context into the composer-owned service session", () async {
+    final cubit = VoiceInputCubit(service: service, projectId: "project-1");
+
+    verify(() => service.createSession(projectId: "project-1")).called(1);
+    await cubit.close();
+  });
+
   blocTest<VoiceInputCubit, VoiceInputState>(
     "starts, transcribes, acknowledges, and keeps orchestration behind the service",
-    build: () => VoiceInputCubit(service: service),
+    build: () => VoiceInputCubit(service: service, projectId: null),
     act: (cubit) async {
       await cubit.startRecording();
       await cubit.stopAndTranscribe(limitReached: false);
@@ -65,7 +74,7 @@ void main() {
         ),
       );
     },
-    build: () => VoiceInputCubit(service: service),
+    build: () => VoiceInputCubit(service: service, projectId: null),
     act: (cubit) => cubit.startRecording(),
     expect: () => [
       const VoiceInputState.starting(),
@@ -82,7 +91,7 @@ void main() {
     setUp: () {
       when(() => service.stopAndTranscribe(session: session)).thenThrow(VoiceTranscriptionError.networkError());
     },
-    build: () => VoiceInputCubit(service: service),
+    build: () => VoiceInputCubit(service: service, projectId: null),
     act: (cubit) async {
       await cubit.startRecording();
       await cubit.stopAndTranscribe(limitReached: false);
@@ -106,7 +115,7 @@ void main() {
         VoiceTranscriptionError.retryableServerError(statusCode: 503),
       );
     },
-    build: () => VoiceInputCubit(service: service),
+    build: () => VoiceInputCubit(service: service, projectId: null),
     act: (cubit) async {
       await cubit.startRecording();
       await cubit.stopAndTranscribe(limitReached: false);
@@ -130,7 +139,7 @@ void main() {
         VoiceTranscriptionError.serverError(statusCode: 400),
       );
     },
-    build: () => VoiceInputCubit(service: service),
+    build: () => VoiceInputCubit(service: service, projectId: null),
     act: (cubit) async {
       await cubit.startRecording();
       await cubit.stopAndTranscribe(limitReached: false);
@@ -149,7 +158,7 @@ void main() {
       VoiceTranscriptionError.networkError(),
     );
     when(() => service.retry(session: session)).thenAnswer((_) => retryCompleter.future);
-    final cubit = VoiceInputCubit(service: service);
+    final cubit = VoiceInputCubit(service: service, projectId: null);
     addTearDown(cubit.close);
     await cubit.startRecording();
     await cubit.stopAndTranscribe(limitReached: false);
@@ -171,7 +180,7 @@ void main() {
       VoiceTranscriptionError.networkError(),
     );
     when(() => service.retry(session: session)).thenAnswer((_) => retryCompleter.future);
-    final cubit = VoiceInputCubit(service: service);
+    final cubit = VoiceInputCubit(service: service, projectId: null);
     addTearDown(cubit.close);
     await cubit.startRecording();
     await cubit.stopAndTranscribe(limitReached: false);
@@ -194,14 +203,14 @@ void main() {
   blocTest<VoiceInputCubit, VoiceInputState>(
     "discards a retained recording and returns to idle",
     seed: () => VoiceInputState.retryPending(error: VoiceTranscriptionError.networkError()),
-    build: () => VoiceInputCubit(service: service),
+    build: () => VoiceInputCubit(service: service, projectId: null),
     act: (cubit) => cubit.discard(),
     expect: () => const [VoiceInputState.discarding(), VoiceInputState.idle()],
     verify: (_) => verify(() => service.discard(session: session)).called(1),
   );
 
   test("maximum duration auto-stops through the Cubit with its reason preserved", () async {
-    final cubit = VoiceInputCubit(service: service);
+    final cubit = VoiceInputCubit(service: service, projectId: null);
     addTearDown(cubit.close);
     await cubit.startRecording();
 
@@ -215,7 +224,7 @@ void main() {
 
   blocTest<VoiceInputCubit, VoiceInputState>(
     "cancels active work and returns to idle",
-    build: () => VoiceInputCubit(service: service),
+    build: () => VoiceInputCubit(service: service, projectId: null),
     act: (cubit) async {
       await cubit.startRecording();
       await cubit.cancel();
@@ -230,7 +239,7 @@ void main() {
   );
 
   test("close synchronously invalidates before asynchronous cleanup", () async {
-    final cubit = VoiceInputCubit(service: service);
+    final cubit = VoiceInputCubit(service: service, projectId: null);
 
     await cubit.close();
 

--- a/client/module_core/test/repositories/project_repository_test.dart
+++ b/client/module_core/test/repositories/project_repository_test.dart
@@ -18,7 +18,7 @@ void main() {
       filesystemApi: filesystemApi,
       sessionApi: MockSessionApi(),
     );
-    const project = Project(id: "project-1", name: "Project 1", path: "/project-1", time: null);
+    const project = Project(id: "project-1", name: "Project 1", path: "/project-1", time: null, voiceGlossaryKey: null);
     const projectSummary = ProjectSummary(id: "project-1", name: "Project 1", path: "/project-1", time: null);
     const projects = Projects(data: [projectSummary]);
     const suggestions = FilesystemSuggestions(data: [], path: null);
@@ -94,7 +94,13 @@ void main() {
         filesystemApi: MockFilesystemApi(),
         sessionApi: MockSessionApi(),
       );
-      const project = Project(id: "project-1", name: "Project 1", path: r"C:\projects\project-1", time: null);
+      const project = Project(
+        id: "project-1",
+        name: "Project 1",
+        path: r"C:\projects\project-1",
+        time: null,
+        voiceGlossaryKey: null,
+      );
       when(
         () => api.createProject(path: r"C:\projects\project-1"),
       ).thenAnswer((_) async => ApiResponse.success(project));

--- a/client/module_core/test/repositories/voice_repository_test.dart
+++ b/client/module_core/test/repositories/voice_repository_test.dart
@@ -1,5 +1,6 @@
 import "package:mocktail/mocktail.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_shared/sesori_shared.dart" show ProjectGlossaryKey;
 import "package:test/test.dart";
 
 class MockVoiceApi() extends Mock implements VoiceApi;
@@ -13,11 +14,15 @@ void main() {
     repository = VoiceRepository(api: api);
   });
 
-  test("maps success and forwards the typed artifact facts", () async {
+  test("maps success and forwards typed artifact and glossary context", () async {
+    final glossaryKey = ProjectGlossaryKey.parse(
+      value: "prj_v1_1yuLLmK3NKRJfpiX26q507WHb9ZxINRCpBKCBTgnGlQ",
+    );
     when(
       () => api.transcribe(
         audioFilePath: any(named: "audioFilePath"),
         mimeType: any(named: "mimeType"),
+        projectGlossaryKey: any(named: "projectGlossaryKey"),
       ),
     ).thenAnswer(
       (_) async => const VoiceTranscriptionApiResult.success(transcript: "hello"),
@@ -26,6 +31,7 @@ void main() {
     final outcome = await repository.transcribe(
       audioFilePath: "/tmp/voice.m4a",
       mimeType: "audio/mp4",
+      projectGlossaryKey: glossaryKey,
     );
 
     expect(
@@ -36,6 +42,7 @@ void main() {
       () => api.transcribe(
         audioFilePath: "/tmp/voice.m4a",
         mimeType: "audio/mp4",
+        projectGlossaryKey: glossaryKey,
       ),
     ).called(1);
   });
@@ -71,12 +78,14 @@ void main() {
         () => api.transcribe(
           audioFilePath: any(named: "audioFilePath"),
           mimeType: any(named: "mimeType"),
+          projectGlossaryKey: any(named: "projectGlossaryKey"),
         ),
       ).thenAnswer((_) async => candidate.result);
 
       final outcome = await repository.transcribe(
         audioFilePath: "/tmp/voice.m4a",
         mimeType: "audio/mp4",
+        projectGlossaryKey: null,
       );
 
       expect(outcome.runtimeType, candidate.outcomeType);
@@ -98,6 +107,7 @@ void main() {
         () => api.transcribe(
           audioFilePath: any(named: "audioFilePath"),
           mimeType: any(named: "mimeType"),
+          projectGlossaryKey: any(named: "projectGlossaryKey"),
         ),
       ).thenAnswer(
         (_) async => VoiceTranscriptionApiResult.failure(error: error, retryable: null),
@@ -106,6 +116,7 @@ void main() {
       final outcome = await repository.transcribe(
         audioFilePath: "/tmp/voice.m4a",
         mimeType: "audio/mp4",
+        projectGlossaryKey: null,
       );
 
       expect(outcome.runtimeType, outcomeType);

--- a/client/module_core/test/services/voice_transcription_service_test.dart
+++ b/client/module_core/test/services/voice_transcription_service_test.dart
@@ -3,9 +3,12 @@ import "dart:async";
 import "package:fake_async/fake_async.dart";
 import "package:mocktail/mocktail.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_shared/sesori_shared.dart" show Project, ProjectGlossaryKey;
 import "package:test/test.dart";
 
 class MockVoiceRepository() extends Mock implements VoiceRepository;
+
+class MockProjectRepository() extends Mock implements ProjectRepository;
 
 class MockVoiceCapture() extends Mock implements VoiceCapture;
 
@@ -13,6 +16,7 @@ class MockVoiceCaptureSession() extends Mock implements VoiceCaptureSession;
 
 void main() {
   late MockVoiceRepository repository;
+  late MockProjectRepository projectRepository;
   late MockVoiceCapture capture;
   late MockVoiceCaptureSession captureSession;
   late VoiceTranscriptionService service;
@@ -26,6 +30,7 @@ void main() {
 
   setUp(() {
     repository = MockVoiceRepository();
+    projectRepository = MockProjectRepository();
     capture = MockVoiceCapture();
     captureSession = MockVoiceCaptureSession();
     when(capture.createSession).thenReturn(captureSession);
@@ -44,10 +49,15 @@ void main() {
       () => repository.transcribe(
         audioFilePath: any(named: "audioFilePath"),
         mimeType: any(named: "mimeType"),
+        projectGlossaryKey: any(named: "projectGlossaryKey"),
       ),
     ).thenAnswer((_) async => const VoiceTranscriptionOutcome.success(transcript: "hello"));
-    service = VoiceTranscriptionService(repository: repository, capture: capture);
-    session = service.createSession();
+    service = VoiceTranscriptionService(
+      repository: repository,
+      projectRepository: projectRepository,
+      capture: capture,
+    );
+    session = service.createSession(projectId: null);
   });
 
   test("creates one distinct platform session for each composer", () {
@@ -56,8 +66,8 @@ void main() {
     var created = 0;
     when(capture.createSession).thenAnswer((_) => created++ == 0 ? firstCapture : secondCapture);
 
-    final first = service.createSession();
-    final second = service.createSession();
+    final first = service.createSession(projectId: null);
+    final second = service.createSession(projectId: null);
 
     expect(identical(first, second), isFalse);
     expect(created, 2);
@@ -71,13 +81,88 @@ void main() {
     verify(captureSession.start).called(1);
     verify(captureSession.stop).called(1);
     verify(
-      () => repository.transcribe(audioFilePath: artifact.path, mimeType: artifact.mimeType),
+      () => repository.transcribe(
+        audioFilePath: artifact.path,
+        mimeType: artifact.mimeType,
+        projectGlossaryKey: null,
+      ),
     ).called(1);
     verify(captureSession.releaseOperation).called(1);
     verify(() => captureSession.deleteArtifact(artifact: artifact)).called(1);
 
     await service.start(session: session);
     verify(captureSession.start).called(1);
+  });
+
+  test("forwards an available opaque project glossary key", () async {
+    final glossaryKey = ProjectGlossaryKey.parse(
+      value: "prj_v1_1yuLLmK3NKRJfpiX26q507WHb9ZxINRCpBKCBTgnGlQ",
+    );
+    when(
+      () => projectRepository.getProject(projectId: "project-1"),
+    ).thenAnswer(
+      (_) async => ApiResponse.success(
+        Project(
+          id: "project-1",
+          name: "Project",
+          path: "/project",
+          time: null,
+          voiceGlossaryKey: glossaryKey,
+        ),
+      ),
+    );
+    final scopedSession = service.createSession(projectId: "project-1");
+    await untilCalled(() => projectRepository.getProject(projectId: "project-1"));
+    await Future<void>.delayed(Duration.zero);
+
+    await service.start(session: scopedSession);
+    await service.stopAndTranscribe(session: scopedSession);
+
+    verify(
+      () => repository.transcribe(
+        audioFilePath: artifact.path,
+        mimeType: artifact.mimeType,
+        projectGlossaryKey: glossaryKey,
+      ),
+    ).called(1);
+  });
+
+  test("a pending project context keeps the active interaction unscoped", () async {
+    final glossaryKey = ProjectGlossaryKey.parse(
+      value: "prj_v1_1yuLLmK3NKRJfpiX26q507WHb9ZxINRCpBKCBTgnGlQ",
+    );
+    final projectResponse = Completer<ApiResponse<Project>>();
+    when(
+      () => projectRepository.getProject(projectId: "project-1"),
+    ).thenAnswer((_) => projectResponse.future);
+    final scopedSession = service.createSession(projectId: "project-1");
+    await untilCalled(() => projectRepository.getProject(projectId: "project-1"));
+
+    await service.start(session: scopedSession);
+    await service.stopAndTranscribe(session: scopedSession);
+    projectResponse.complete(
+      ApiResponse.success(
+        Project(
+          id: "project-1",
+          name: "Project",
+          path: "/project",
+          time: null,
+          voiceGlossaryKey: glossaryKey,
+        ),
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+    await service.start(session: scopedSession);
+    await service.stopAndTranscribe(session: scopedSession);
+
+    final forwardedKeys = verify(
+      () => repository.transcribe(
+        audioFilePath: artifact.path,
+        mimeType: artifact.mimeType,
+        projectGlossaryKey: captureAny(named: "projectGlossaryKey"),
+      ),
+    ).captured;
+    expect(forwardedKeys, [null, glossaryKey]);
   });
 
   test("shares one in-flight prewarm attempt per composer session", () async {
@@ -147,9 +232,10 @@ void main() {
         () => repository.transcribe(
           audioFilePath: any(named: "audioFilePath"),
           mimeType: any(named: "mimeType"),
+          projectGlossaryKey: any(named: "projectGlossaryKey"),
         ),
       ).thenAnswer((_) async => outcome);
-      final candidateSession = service.createSession();
+      final candidateSession = service.createSession(projectId: null);
 
       await service.start(session: candidateSession);
       await expectLater(
@@ -167,6 +253,7 @@ void main() {
       () => repository.transcribe(
         audioFilePath: any(named: "audioFilePath"),
         mimeType: any(named: "mimeType"),
+        projectGlossaryKey: any(named: "projectGlossaryKey"),
       ),
     ).thenAnswer(
       (_) async => attempts++ == 0
@@ -185,7 +272,11 @@ void main() {
     verify(captureSession.start).called(1);
     verify(captureSession.stop).called(1);
     verify(
-      () => repository.transcribe(audioFilePath: artifact.path, mimeType: artifact.mimeType),
+      () => repository.transcribe(
+        audioFilePath: artifact.path,
+        mimeType: artifact.mimeType,
+        projectGlossaryKey: null,
+      ),
     ).called(2);
     verify(() => captureSession.deleteArtifact(artifact: artifact)).called(1);
   });
@@ -197,6 +288,7 @@ void main() {
       () => repository.transcribe(
         audioFilePath: any(named: "audioFilePath"),
         mimeType: any(named: "mimeType"),
+        projectGlossaryKey: any(named: "projectGlossaryKey"),
       ),
     ).thenAnswer((_) async => const VoiceTranscriptionOutcome.networkFailure());
 
@@ -227,6 +319,7 @@ void main() {
       () => repository.transcribe(
         audioFilePath: any(named: "audioFilePath"),
         mimeType: any(named: "mimeType"),
+        projectGlossaryKey: any(named: "projectGlossaryKey"),
       ),
     ).thenAnswer((_) {
       attempts++;
@@ -263,6 +356,7 @@ void main() {
       () => repository.transcribe(
         audioFilePath: any(named: "audioFilePath"),
         mimeType: any(named: "mimeType"),
+        projectGlossaryKey: any(named: "projectGlossaryKey"),
       ),
     ).thenAnswer((_) async => const VoiceTranscriptionOutcome.networkFailure());
 
@@ -283,6 +377,7 @@ void main() {
       () => repository.transcribe(
         audioFilePath: any(named: "audioFilePath"),
         mimeType: any(named: "mimeType"),
+        projectGlossaryKey: any(named: "projectGlossaryKey"),
       ),
     ).thenAnswer((_) async => const VoiceTranscriptionOutcome.networkFailure());
     when(() => captureSession.artifactExists(artifact: artifact)).thenAnswer((_) async => false);
@@ -307,6 +402,7 @@ void main() {
       () => repository.transcribe(
         audioFilePath: any(named: "audioFilePath"),
         mimeType: any(named: "mimeType"),
+        projectGlossaryKey: any(named: "projectGlossaryKey"),
       ),
     ).thenAnswer((_) async => const VoiceTranscriptionOutcome.networkFailure());
 
@@ -351,6 +447,7 @@ void main() {
       () => repository.transcribe(
         audioFilePath: any(named: "audioFilePath"),
         mimeType: any(named: "mimeType"),
+        projectGlossaryKey: any(named: "projectGlossaryKey"),
       ),
     ).thenAnswer((_) => response.future);
 

--- a/client/module_core/test/services/voice_transcription_service_test.dart
+++ b/client/module_core/test/services/voice_transcription_service_test.dart
@@ -165,6 +165,67 @@ void main() {
     expect(forwardedKeys, [null, glossaryKey]);
   });
 
+  test("refreshes missing context for a later interaction without delaying capture", () async {
+    final glossaryKey = ProjectGlossaryKey.parse(
+      value: "prj_v1_1yuLLmK3NKRJfpiX26q507WHb9ZxINRCpBKCBTgnGlQ",
+    );
+    final refreshRequested = Completer<void>();
+    final refreshResponse = Completer<ApiResponse<Project>>();
+    var requestCount = 0;
+    when(
+      () => projectRepository.getProject(projectId: "project-1"),
+    ).thenAnswer((_) {
+      requestCount++;
+      if (requestCount == 1) {
+        return Future.value(
+          ApiResponse.success(
+            const Project(
+              id: "project-1",
+              name: "Project",
+              path: "/project",
+              time: null,
+              voiceGlossaryKey: null,
+            ),
+          ),
+        );
+      }
+      refreshRequested.complete();
+      return refreshResponse.future;
+    });
+    final scopedSession = service.createSession(projectId: "project-1");
+    await untilCalled(() => projectRepository.getProject(projectId: "project-1"));
+    await Future<void>.delayed(Duration.zero);
+
+    await service.start(session: scopedSession);
+    await refreshRequested.future;
+    await service.stopAndTranscribe(session: scopedSession);
+    refreshResponse.complete(
+      ApiResponse.success(
+        Project(
+          id: "project-1",
+          name: "Project",
+          path: "/project",
+          time: null,
+          voiceGlossaryKey: glossaryKey,
+        ),
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    await service.start(session: scopedSession);
+    await service.stopAndTranscribe(session: scopedSession);
+
+    final forwardedKeys = verify(
+      () => repository.transcribe(
+        audioFilePath: artifact.path,
+        mimeType: artifact.mimeType,
+        projectGlossaryKey: captureAny(named: "projectGlossaryKey"),
+      ),
+    ).captured;
+    expect(forwardedKeys, [null, glossaryKey]);
+    expect(requestCount, 2);
+  });
+
   test("shares one in-flight prewarm attempt per composer session", () async {
     final completer = Completer<void>();
     when(capture.prewarm).thenAnswer((_) => completer.future);

--- a/client/module_core/test/services/voice_transcription_service_test.dart
+++ b/client/module_core/test/services/voice_transcription_service_test.dart
@@ -342,6 +342,68 @@ void main() {
     verify(() => captureSession.deleteArtifact(artifact: artifact)).called(1);
   });
 
+  test("retry retains its interaction snapshot after project context becomes available", () async {
+    final glossaryKey = ProjectGlossaryKey.parse(
+      value: "prj_v1_1yuLLmK3NKRJfpiX26q507WHb9ZxINRCpBKCBTgnGlQ",
+    );
+    final projectResponse = Completer<ApiResponse<Project>>();
+    when(
+      () => projectRepository.getProject(projectId: "project-1"),
+    ).thenAnswer((_) => projectResponse.future);
+    var attempts = 0;
+    when(
+      () => repository.transcribe(
+        audioFilePath: any(named: "audioFilePath"),
+        mimeType: any(named: "mimeType"),
+        projectGlossaryKey: any(named: "projectGlossaryKey"),
+      ),
+    ).thenAnswer(
+      (_) async => switch (attempts++) {
+        0 => const VoiceTranscriptionOutcome.networkFailure(),
+        1 => const VoiceTranscriptionOutcome.success(transcript: "retried"),
+        _ => const VoiceTranscriptionOutcome.success(transcript: "next interaction"),
+      },
+    );
+    final scopedSession = service.createSession(projectId: "project-1");
+    await untilCalled(() => projectRepository.getProject(projectId: "project-1"));
+
+    await service.start(session: scopedSession);
+    await expectLater(
+      service.stopAndTranscribe(session: scopedSession),
+      throwsA(isA<NetworkVoiceError>()),
+    );
+    projectResponse.complete(
+      ApiResponse.success(
+        Project(
+          id: "project-1",
+          name: "Project",
+          path: "/project",
+          time: null,
+          voiceGlossaryKey: glossaryKey,
+        ),
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(await service.retry(session: scopedSession), "retried");
+    await service.start(session: scopedSession);
+    expect(
+      await service.stopAndTranscribe(session: scopedSession),
+      "next interaction",
+    );
+
+    final forwardedKeys = verify(
+      () => repository.transcribe(
+        audioFilePath: artifact.path,
+        mimeType: artifact.mimeType,
+        projectGlossaryKey: captureAny(named: "projectGlossaryKey"),
+      ),
+    ).captured;
+    expect(forwardedKeys, [null, null, glossaryKey]);
+    verify(captureSession.start).called(2);
+    verify(captureSession.stop).called(2);
+  });
+
   test("cancellation during capture release cannot strand a retained artifact", () async {
     final releaseCompleter = Completer<void>();
     when(captureSession.releaseOperation).thenAnswer((_) => releaseCompleter.future);

--- a/docs/regression/voice-input.md
+++ b/docs/regression/voice-input.md
@@ -15,9 +15,10 @@ independently prepares optional project-scoped vocabulary from bounded local evi
   incomplete recording.
 - Starting, recording, transcribing, and cancelling are mutually exclusive composer interactions; input from a stale
   interaction cannot reset or append text into a newer one.
-- Each composer requests current-project context in the background and snapshots only a validated, bridge-issued opaque
-  glossary key when an interaction starts. Missing, pending, invalid, unsupported, or failed context remains unscoped
-  without delaying capture. Retry preserves the original snapshot, and raw project identity never reaches auth.
+- Each composer requests current-project context in the background, refreshes missing context for later interactions,
+  and snapshots only a validated, bridge-issued opaque glossary key when an interaction starts. Missing, pending,
+  invalid, unsupported, or failed context remains unscoped without delaying capture. Retry preserves the original
+  snapshot, and raw project identity never reaches auth.
 - While recording the composer shows live amplitude, holds a stable layout, keeps the screen awake, and offers
   drag-to-cancel; recording reaches a maximum duration and signals auto-stop instead of running indefinitely.
 - Initial cancel stops the recorder, releases the wake lock, attempts audio-file deletion, and invalidates any
@@ -39,8 +40,8 @@ independently prepares optional project-scoped vocabulary from bounded local evi
 - Successful transcription reports one content-free analytics event. No audio, transcript, or prompt text reaches logs
   or analytics.
 - A successful current-project load or a project entering the active-view set starts best-effort bridge glossary
-  population. Both triggers delegate to one serialized coordinator and never delay the route response, recording, or
-  transcription.
+  population. Both triggers delegate to one serialized coordinator that coalesces concurrent work for the same project
+  and never delays the route response, recording, or transcription.
 - Glossary population derives an exact opaque repository or bridge-local scope, caches the validated key for later
   current-project responses, scans bounded local Git/filesystem evidence, filters credential-shaped content before
   tokenization, and reconciles at most 50 deterministic terms. Only the opaque scope and filtered terms leave the

--- a/docs/regression/voice-input.md
+++ b/docs/regression/voice-input.md
@@ -15,6 +15,9 @@ independently prepares optional project-scoped vocabulary from bounded local evi
   incomplete recording.
 - Starting, recording, transcribing, and cancelling are mutually exclusive composer interactions; input from a stale
   interaction cannot reset or append text into a newer one.
+- Each composer requests current-project context in the background and snapshots only a validated, bridge-issued opaque
+  glossary key when an interaction starts. Missing, pending, invalid, unsupported, or failed context remains unscoped
+  without delaying capture. Retry preserves the original snapshot, and raw project identity never reaches auth.
 - While recording the composer shows live amplitude, holds a stable layout, keeps the screen awake, and offers
   drag-to-cancel; recording reaches a maximum duration and signals auto-stop instead of running indefinitely.
 - Initial cancel stops the recorder, releases the wake lock, attempts audio-file deletion, and invalidates any
@@ -38,10 +41,10 @@ independently prepares optional project-scoped vocabulary from bounded local evi
 - A successful current-project load or a project entering the active-view set starts best-effort bridge glossary
   population. Both triggers delegate to one serialized coordinator and never delay the route response, recording, or
   transcription.
-- Glossary population derives an exact opaque repository or bridge-local scope, scans bounded local Git/filesystem
-  evidence, filters credential-shaped content before tokenization, and reconciles at most 50 deterministic terms.
-  Only the opaque scope and filtered terms leave the bridge. Scope, scan, or publication failure leaves voice input
-  available without an updated glossary.
+- Glossary population derives an exact opaque repository or bridge-local scope, caches the validated key for later
+  current-project responses, scans bounded local Git/filesystem evidence, filters credential-shaped content before
+  tokenization, and reconciles at most 50 deterministic terms. Only the opaque scope and filtered terms leave the
+  bridge. Scope, scan, or publication failure leaves voice input available without an updated glossary.
 - The preference defaults to voice-first, persists, and falls back to voice-first on a corrupt or unknown stored
   value.
 
@@ -50,7 +53,7 @@ independently prepares optional project-scoped vocabulary from bounded local evi
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Not included because microphone and transcription setup is too expensive for a heartbeat. |
-| L2 Routine | Automated, mobile client and bridge, no plugin, fake recorder, HTTP client, Git, and filesystem: permission denial, concurrent-start rejection, zero-byte rejection, cancel invalidating an in-flight upload, authoritative true/false/omitted/malformed retryability mapping, retained-artifact Retry/Discard and retry cancellation, serialized send-time abandonment including an active retry, terminal/missing cleanup, max-duration signalling, deletion failure logging, draft voice-span and input-mode derivation, current-project/active-view glossary triggers, serialized bounded inference, exact-scope reconciliation, and shutdown cancellation. |
+| L2 Routine | Automated, mobile client and bridge, no plugin, fake recorder, HTTP client, Git, and filesystem: permission denial, concurrent-start rejection, zero-byte rejection, cancel invalidating an in-flight upload, authoritative true/false/omitted/malformed retryability mapping, retained-artifact Retry/Discard and retry cancellation, serialized send-time abandonment including an active retry, available/pending/invalid opaque project context, terminal/missing cleanup, max-duration signalling, deletion failure logging, draft voice-span and input-mode derivation, current-project/active-view glossary triggers, serialized bounded inference, exact-scope reconciliation, and shutdown cancellation. |
 | L3 Release | Client end to end on the release-target client platform: hold to record, release to transcribe, transcript inserted and editable, drag-to-cancel, layout stability, and the voice-first/text-first preference changing which control leads. |
 | L4 Extended | Client end to end on the release-target client platform: background or system interruption, permission revoked between interactions, offline async upload failure followed by successful Retry without re-recording, explicit retryable and terminal server outcomes, older-server omission fallback, discard/disposal cleanup, wake lock released on every path. |
 | L5 Full | Real device microphone and live transcription endpoint on every supported mobile platform: audible speech yields usable text, a near-maximum recording auto-stops and still transcribes, iOS haptics and system sounds stay audible while recording. |
@@ -72,8 +75,9 @@ interruptions such as a call.
   terminal paths; a deletion failure is unlogged; or the wake lock stays held.
 - Audio is uploaded despite denied permission, or denial is reported as a generic network or server failure.
 - Text is sent without review, or a message with surviving voice text is classified as typed.
-- Any audio, transcript, or prompt content reaches logs or analytics; raw project paths, repository origins, filenames,
-  or metadata source text reach auth transport; glossary failure blocks recording or transcription; or concurrent
+- Any audio, transcript, or prompt content reaches logs or analytics; raw project identity, project paths, repository
+  origins, filenames, or metadata source text reach auth voice transport; glossary failure blocks recording or
+  transcription; or concurrent
   triggers run overlapping local scans.
 
 ## Known Limitations

--- a/shared/sesori_shared/lib/src/models/sesori/project.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project.dart
@@ -1,5 +1,7 @@
 import "package:freezed_annotation/freezed_annotation.dart";
 
+import "../../voice/project_glossary_key.dart";
+
 part "project.freezed.dart";
 
 part "project.g.dart";
@@ -64,9 +66,22 @@ sealed class Project with _$Project {
     // behavior the bridge can actually provide.
     // COMPATIBILITY 2026-07-17 (v1.5.2): Old bridges omit this capability. Default to the prior visible-toggle behavior; require the field once those bridges are unsupported.
     @Default(true) bool supportsDedicatedWorktrees,
+    // COMPATIBILITY 2026-08-28 (v1.8.2): Published older bridges omit the nullable glossary key.
+    // Remove omission-specific coverage when every supported bridge sends this field.
+    @ProjectGlossaryKeyJsonConverter() required ProjectGlossaryKey? voiceGlossaryKey,
   }) = _Project;
 
-  factory fromJson(Map<String, dynamic> json) => _$ProjectFromJson(json);
+  // Invalid optional glossary context must not make the project or voice input unavailable.
+  factory fromJson(Map<String, dynamic> json) {
+    final rawGlossaryKey = json["voiceGlossaryKey"];
+    final glossaryKey = rawGlossaryKey is String
+        ? ProjectGlossaryKey.tryParse(value: rawGlossaryKey)
+        : null;
+    return _$ProjectFromJson({
+      ...json,
+      "voiceGlossaryKey": glossaryKey?.value,
+    });
+  }
 }
 
 @Freezed(fromJson: true, toJson: true)

--- a/shared/sesori_shared/lib/src/models/sesori/project.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project.freezed.dart
@@ -326,7 +326,7 @@ $ProjectTimeCopyWith<$Res>? get time {
 /// @nodoc
 mixin _$Project {
 
- String get id; String? get name; String get path; ProjectTime? get time; bool get hasUnseenChanges; bool get directoryMissing; bool get supportsDedicatedWorktrees;
+ String get id; String? get name; String get path; ProjectTime? get time; bool get hasUnseenChanges; bool get directoryMissing; bool get supportsDedicatedWorktrees;@ProjectGlossaryKeyJsonConverter() ProjectGlossaryKey? get voiceGlossaryKey;
 /// Create a copy of Project
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -339,16 +339,16 @@ $ProjectCopyWith<Project> get copyWith => _$ProjectCopyWithImpl<Project>(this as
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Project&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.path, path) || other.path == path)&&(identical(other.time, time) || other.time == time)&&(identical(other.hasUnseenChanges, hasUnseenChanges) || other.hasUnseenChanges == hasUnseenChanges)&&(identical(other.directoryMissing, directoryMissing) || other.directoryMissing == directoryMissing)&&(identical(other.supportsDedicatedWorktrees, supportsDedicatedWorktrees) || other.supportsDedicatedWorktrees == supportsDedicatedWorktrees));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Project&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.path, path) || other.path == path)&&(identical(other.time, time) || other.time == time)&&(identical(other.hasUnseenChanges, hasUnseenChanges) || other.hasUnseenChanges == hasUnseenChanges)&&(identical(other.directoryMissing, directoryMissing) || other.directoryMissing == directoryMissing)&&(identical(other.supportsDedicatedWorktrees, supportsDedicatedWorktrees) || other.supportsDedicatedWorktrees == supportsDedicatedWorktrees)&&(identical(other.voiceGlossaryKey, voiceGlossaryKey) || other.voiceGlossaryKey == voiceGlossaryKey));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,path,time,hasUnseenChanges,directoryMissing,supportsDedicatedWorktrees);
+int get hashCode => Object.hash(runtimeType,id,name,path,time,hasUnseenChanges,directoryMissing,supportsDedicatedWorktrees,voiceGlossaryKey);
 
 @override
 String toString() {
-  return 'Project(id: $id, name: $name, path: $path, time: $time, hasUnseenChanges: $hasUnseenChanges, directoryMissing: $directoryMissing, supportsDedicatedWorktrees: $supportsDedicatedWorktrees)';
+  return 'Project(id: $id, name: $name, path: $path, time: $time, hasUnseenChanges: $hasUnseenChanges, directoryMissing: $directoryMissing, supportsDedicatedWorktrees: $supportsDedicatedWorktrees, voiceGlossaryKey: $voiceGlossaryKey)';
 }
 
 
@@ -359,7 +359,7 @@ abstract mixin class $ProjectCopyWith<$Res>  {
   factory $ProjectCopyWith(Project value, $Res Function(Project) _then) = _$ProjectCopyWithImpl;
 @useResult
 $Res call({
- String id, String? name, String path, ProjectTime? time, bool hasUnseenChanges, bool directoryMissing, bool supportsDedicatedWorktrees
+ String id, String? name, String path, ProjectTime? time, bool hasUnseenChanges, bool directoryMissing, bool supportsDedicatedWorktrees,@ProjectGlossaryKeyJsonConverter() ProjectGlossaryKey? voiceGlossaryKey
 });
 
 
@@ -376,7 +376,7 @@ class _$ProjectCopyWithImpl<$Res>
 
 /// Create a copy of Project
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = freezed,Object? path = null,Object? time = freezed,Object? hasUnseenChanges = null,Object? directoryMissing = null,Object? supportsDedicatedWorktrees = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = freezed,Object? path = null,Object? time = freezed,Object? hasUnseenChanges = null,Object? directoryMissing = null,Object? supportsDedicatedWorktrees = null,Object? voiceGlossaryKey = freezed,}) {
   return _then(Project(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -385,7 +385,8 @@ as String,time: freezed == time ? _self.time : time // ignore: cast_nullable_to_
 as ProjectTime?,hasUnseenChanges: null == hasUnseenChanges ? _self.hasUnseenChanges : hasUnseenChanges // ignore: cast_nullable_to_non_nullable
 as bool,directoryMissing: null == directoryMissing ? _self.directoryMissing : directoryMissing // ignore: cast_nullable_to_non_nullable
 as bool,supportsDedicatedWorktrees: null == supportsDedicatedWorktrees ? _self.supportsDedicatedWorktrees : supportsDedicatedWorktrees // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,voiceGlossaryKey: freezed == voiceGlossaryKey ? _self.voiceGlossaryKey : voiceGlossaryKey // ignore: cast_nullable_to_non_nullable
+as ProjectGlossaryKey?,
   ));
 }
 /// Create a copy of Project
@@ -409,7 +410,7 @@ $ProjectTimeCopyWith<$Res>? get time {
 @JsonSerializable()
 
 class _Project implements Project {
-  const _Project({required this.id, required this.name, this.path = "", required this.time, this.hasUnseenChanges = false, this.directoryMissing = false, this.supportsDedicatedWorktrees = true});
+  const _Project({required this.id, required this.name, this.path = "", required this.time, this.hasUnseenChanges = false, this.directoryMissing = false, this.supportsDedicatedWorktrees = true, @ProjectGlossaryKeyJsonConverter() required this.voiceGlossaryKey});
   factory _Project.fromJson(Map<String, dynamic> json) => _$ProjectFromJson(json);
 
 @override final  String id;
@@ -419,6 +420,7 @@ class _Project implements Project {
 @override@JsonKey() final  bool hasUnseenChanges;
 @override@JsonKey() final  bool directoryMissing;
 @override@JsonKey() final  bool supportsDedicatedWorktrees;
+@override@ProjectGlossaryKeyJsonConverter() final  ProjectGlossaryKey? voiceGlossaryKey;
 
 /// Create a copy of Project
 /// with the given fields replaced by the non-null parameter values.
@@ -433,16 +435,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Project&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.path, path) || other.path == path)&&(identical(other.time, time) || other.time == time)&&(identical(other.hasUnseenChanges, hasUnseenChanges) || other.hasUnseenChanges == hasUnseenChanges)&&(identical(other.directoryMissing, directoryMissing) || other.directoryMissing == directoryMissing)&&(identical(other.supportsDedicatedWorktrees, supportsDedicatedWorktrees) || other.supportsDedicatedWorktrees == supportsDedicatedWorktrees));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Project&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.path, path) || other.path == path)&&(identical(other.time, time) || other.time == time)&&(identical(other.hasUnseenChanges, hasUnseenChanges) || other.hasUnseenChanges == hasUnseenChanges)&&(identical(other.directoryMissing, directoryMissing) || other.directoryMissing == directoryMissing)&&(identical(other.supportsDedicatedWorktrees, supportsDedicatedWorktrees) || other.supportsDedicatedWorktrees == supportsDedicatedWorktrees)&&(identical(other.voiceGlossaryKey, voiceGlossaryKey) || other.voiceGlossaryKey == voiceGlossaryKey));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,path,time,hasUnseenChanges,directoryMissing,supportsDedicatedWorktrees);
+int get hashCode => Object.hash(runtimeType,id,name,path,time,hasUnseenChanges,directoryMissing,supportsDedicatedWorktrees,voiceGlossaryKey);
 
 @override
 String toString() {
-  return 'Project(id: $id, name: $name, path: $path, time: $time, hasUnseenChanges: $hasUnseenChanges, directoryMissing: $directoryMissing, supportsDedicatedWorktrees: $supportsDedicatedWorktrees)';
+  return 'Project(id: $id, name: $name, path: $path, time: $time, hasUnseenChanges: $hasUnseenChanges, directoryMissing: $directoryMissing, supportsDedicatedWorktrees: $supportsDedicatedWorktrees, voiceGlossaryKey: $voiceGlossaryKey)';
 }
 
 
@@ -453,7 +455,7 @@ abstract mixin class _$ProjectCopyWith<$Res> implements $ProjectCopyWith<$Res> {
   factory _$ProjectCopyWith(_Project value, $Res Function(_Project) _then) = __$ProjectCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String? name, String path, ProjectTime? time, bool hasUnseenChanges, bool directoryMissing, bool supportsDedicatedWorktrees
+ String id, String? name, String path, ProjectTime? time, bool hasUnseenChanges, bool directoryMissing, bool supportsDedicatedWorktrees,@ProjectGlossaryKeyJsonConverter() ProjectGlossaryKey? voiceGlossaryKey
 });
 
 
@@ -470,7 +472,7 @@ class __$ProjectCopyWithImpl<$Res>
 
 /// Create a copy of Project
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = freezed,Object? path = null,Object? time = freezed,Object? hasUnseenChanges = null,Object? directoryMissing = null,Object? supportsDedicatedWorktrees = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = freezed,Object? path = null,Object? time = freezed,Object? hasUnseenChanges = null,Object? directoryMissing = null,Object? supportsDedicatedWorktrees = null,Object? voiceGlossaryKey = freezed,}) {
   return _then(_Project(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -479,7 +481,8 @@ as String,time: freezed == time ? _self.time : time // ignore: cast_nullable_to_
 as ProjectTime?,hasUnseenChanges: null == hasUnseenChanges ? _self.hasUnseenChanges : hasUnseenChanges // ignore: cast_nullable_to_non_nullable
 as bool,directoryMissing: null == directoryMissing ? _self.directoryMissing : directoryMissing // ignore: cast_nullable_to_non_nullable
 as bool,supportsDedicatedWorktrees: null == supportsDedicatedWorktrees ? _self.supportsDedicatedWorktrees : supportsDedicatedWorktrees // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,voiceGlossaryKey: freezed == voiceGlossaryKey ? _self.voiceGlossaryKey : voiceGlossaryKey // ignore: cast_nullable_to_non_nullable
+as ProjectGlossaryKey?,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/project.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project.g.dart
@@ -46,6 +46,10 @@ _Project _$ProjectFromJson(Map json) => _Project(
   directoryMissing: json['directoryMissing'] as bool? ?? false,
   supportsDedicatedWorktrees:
       json['supportsDedicatedWorktrees'] as bool? ?? true,
+  voiceGlossaryKey: _$JsonConverterFromJson<String, ProjectGlossaryKey>(
+    json['voiceGlossaryKey'],
+    const ProjectGlossaryKeyJsonConverter().fromJson,
+  ),
 );
 
 Map<String, dynamic> _$ProjectToJson(_Project instance) => <String, dynamic>{
@@ -56,7 +60,21 @@ Map<String, dynamic> _$ProjectToJson(_Project instance) => <String, dynamic>{
   'hasUnseenChanges': instance.hasUnseenChanges,
   'directoryMissing': instance.directoryMissing,
   'supportsDedicatedWorktrees': instance.supportsDedicatedWorktrees,
+  'voiceGlossaryKey': ?_$JsonConverterToJson<String, ProjectGlossaryKey>(
+    instance.voiceGlossaryKey,
+    const ProjectGlossaryKeyJsonConverter().toJson,
+  ),
 };
+
+Value? _$JsonConverterFromJson<Json, Value>(
+  Object? json,
+  Value? Function(Json json) fromJson,
+) => json == null ? null : fromJson(json as Json);
+
+Json? _$JsonConverterToJson<Json, Value>(
+  Value? value,
+  Json? Function(Value value) toJson,
+) => value == null ? null : toJson(value);
 
 _ProjectTime _$ProjectTimeFromJson(Map json) => _ProjectTime(
   created: (json['created'] as num).toInt(),

--- a/shared/sesori_shared/test/models/project_management_models_test.dart
+++ b/shared/sesori_shared/test/models/project_management_models_test.dart
@@ -53,6 +53,7 @@ void main() {
         name: "A",
         path: "/moved/a",
         time: ProjectTime(created: 1, updated: 2),
+        voiceGlossaryKey: null,
       );
       final restored = Project.fromJson(original.toJson());
 
@@ -78,6 +79,37 @@ void main() {
       });
 
       expect(project.supportsDedicatedWorktrees, isTrue);
+    });
+
+    test("decodes and serializes a valid opaque voice glossary key", () {
+      const value = "prj_v1_1yuLLmK3NKRJfpiX26q507WHb9ZxINRCpBKCBTgnGlQ";
+
+      final project = Project.fromJson({
+        "id": "/projects/a",
+        "name": "A",
+        "time": null,
+        "voiceGlossaryKey": value,
+      });
+
+      expect(project.voiceGlossaryKey, ProjectGlossaryKey.parse(value: value));
+      expect(project.toJson()["voiceGlossaryKey"], value);
+    });
+
+    test("missing or invalid voice glossary context degrades to null", () {
+      final missing = Project.fromJson({
+        "id": "/projects/a",
+        "name": "A",
+        "time": null,
+      });
+      final invalid = Project.fromJson({
+        "id": "/projects/a",
+        "name": "A",
+        "time": null,
+        "voiceGlossaryKey": "/raw/project/path",
+      });
+
+      expect(missing.voiceGlossaryKey, isNull);
+      expect(invalid.voiceGlossaryKey, isNull);
     });
 
     test("ProjectTime ignores the removed initialized field", () {


### PR DESCRIPTION
## Complexity

🚧 Complex — this completes a cross-layer bridge/shared/client flow while preserving passive degradation and interaction-level retry consistency.

## What

- Cache bridge-derived glossary scopes and expose only an already-available typed opaque key on current-project responses.
- Add the optional `ProjectGlossaryKey` to the shared project contract, with missing or malformed values decoding to `null`.
- Load project context asynchronously per voice composer, snapshot the available key when recording starts, and forward it through Core API/repository/service boundaries to multipart transcription.
- Keep mobile surfaces limited to supplying project identity when they create the Core-owned voice session.
- Document the passive forwarding and degradation regression contract.

## Why

Repository and bridge-local glossary identity depends on private origin, path, and bridge ownership information that only the bridge has. Clients must forward the bridge-issued opaque key rather than derive one from client-visible project IDs.

## Risk and test focus

Primary risks are accidentally delaying recording, changing a retry's glossary context, rejecting older or malformed project payloads, and retaining a bridge-local cached key after bridge identity changes. Coverage exercises available, pending, missing, malformed, and failed context; interaction snapshotting and retry reuse; cache normalization/invalidation; route behavior; and typed multipart forwarding.

There is no database impact and no new UI. User-visible impact is limited to improved project vocabulary when context is already available; all other cases continue with unscoped transcription.

## Expected result

When the bridge has already resolved a project's glossary scope, later current-project responses may carry its opaque key. Voice interactions that have received that key send it as `projectKey`; interactions without it begin immediately and transcribe unscoped. Retries retain the key snapshot from the original interaction.

## Verification

- `shared/sesori_shared`: strict analysis; 19 project-model tests passed.
- `bridge/app`: strict analysis; 41 focused orchestrator/current-project/glossary tests passed.
- `client/module_core`: strict analysis; 70 focused project and voice tests passed.
- `client/app`: strict analysis; 135 focused composer tests passed.
- `client/desktop`: strict analysis passed.
- Architecture implementation review approved the bridge/shared/client boundaries represented by this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sends the bridge-issued project glossary key with voice transcription when one is cached, instead of always transcribing unscoped. Recordings without a cached key start immediately and transcribe unscoped.

**New Features**
- Bridge current-project responses include the cached opaque key once a project scope is resolved.
- The shared `Project` model gained optional `voiceGlossaryKey`; missing or malformed values decode to `null`.
- Voice composers load current-project context in the background, snapshot the key when recording starts, and refresh missing context for later interactions.
- Concurrent glossary population requests for the same project coalesce into one run.
- Retries reuse the original interaction's key snapshot.
- The key is sent as `projectKey` in the multipart transcription request; raw project identity never reaches auth transport.
- Cached keys from a previous bridge registration are invalidated on bridge identity change.

**Compatibility**
- Older bridges and responses without the field decode and behave as before.
- No database migration or UI changes are required.

<sup>Written for commit cc3ddfd01a7051a4236de0dbc5b9afa2ce68e38b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

