### PR TITLE
🚧 [desktop-app] Add exit policy and prompt commands [step 4/22]

### DIFF
--- a/.plan/active/desktop-app/PLAN.md
+++ b/.plan/active/desktop-app/PLAN.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Plan slug:** `desktop-app`
-- **Status:** Active — step 3/22 (`BridgeProcessService`)
+- **Status:** Active — step 4/22 (exit-code state machine + prompt answers)
 - **Plan date:** 2026-08-28
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Current implementation base:** `main`

--- a/.plan/active/desktop-app/PLAN.md
+++ b/.plan/active/desktop-app/PLAN.md
@@ -218,8 +218,9 @@ binary resolution for dev builds (explicit configured path with a
 repo-sensible default); bundled-layout resolution is distribution-plan scope.
 First real GUI↔helper handshake since the prior plan's wire verification.
 
-**Step 4 — 🚧 Exit-code state machine + prompt answers.** In
-`BridgeProcessService`: 86→immediate respawn; 87→stop with login-required —
+**Step 4 — 🚧 Exit-code state machine + prompt answers.** Shared
+`BridgeSupervisedExitCode` drives both products: 86→immediate respawn;
+87→stop with login-required —
 and a successful sign-in restarts a helper whose desired state was On (a
 manual Off stays off), covered by the state-machine tests;
 88→stop with "another bridge is running" + Take-over; 0/expected→stop;
@@ -240,8 +241,8 @@ dispatcher, and the dispatcher stays inbound-only. The expected-stop
 repository's atomic stop operation (step 2), keeping that operation in one
 owner. Includes hidden-boot render
 policy: contention during a silent autostart surfaces as state, never a modal.
-*Overage: ~1.5k changed lines after review-driven lifecycle-race and per-helper
-prompt-ownership hardening.*
+*Overage: ~1.7k changed lines after review-driven lifecycle-race,
+per-helper prompt-ownership, and shared exit-contract hardening.*
 
 ### M2 — Control surface
 

--- a/.plan/active/desktop-app/PLAN.md
+++ b/.plan/active/desktop-app/PLAN.md
@@ -232,13 +232,16 @@ already guarantees the sentinel (the 86 latch at handoff plus the shutdown
 coordinator's budgeted backstop with emergency plugin disposal — verified for
 the restart path in step 5); exit 86 stays the single restart contract. Adds **`ControlCommandService`** (Layer 3): the
 owner of **conversational** GUI→helper sends (`prompt_response` here;
-`unregister_and_exit` in step 11) over `ControlChannelServer`, clearing
-answered prompts from `BridgePromptTracker` — cubits never touch the Layer-4
+`unregister_and_exit` in step 11). It validates the exact tracked prompt
+instance, then sends through the Layer-2 command repository and Layer-1 control
+API before clearing `BridgePromptTracker` — cubits never touch the Layer-4
 dispatcher, and the dispatcher stays inbound-only. The expected-stop
 `shutdown` frame is deliberately NOT here: it belongs to the process
 repository's atomic stop operation (step 2), keeping that operation in one
 owner. Includes hidden-boot render
 policy: contention during a silent autostart surfaces as state, never a modal.
+*Overage: ~1.5k changed lines after review-driven lifecycle-race and per-helper
+prompt-ownership hardening.*
 
 ### M2 — Control surface
 

--- a/.plan/active/desktop-app/PLAN.md
+++ b/.plan/active/desktop-app/PLAN.md
@@ -241,8 +241,8 @@ dispatcher, and the dispatcher stays inbound-only. The expected-stop
 repository's atomic stop operation (step 2), keeping that operation in one
 owner. Includes hidden-boot render
 policy: contention during a silent autostart surfaces as state, never a modal.
-*Overage: ~1.7k changed lines after review-driven lifecycle-race,
-per-helper prompt-ownership, and shared exit-contract hardening.*
+*Overage: ~1.8k changed lines after review-driven lifecycle-race,
+expected-exit ownership, prompt-ownership, and shared-contract hardening.*
 
 ### M2 — Control surface
 

--- a/.plan/active/desktop-app/TRACKER.md
+++ b/.plan/active/desktop-app/TRACKER.md
@@ -10,7 +10,7 @@ user-run checkpoints, not PRs; only the user marks them passed.
 | 1 | 🌿 Raise plan; supersede + delete old desktop plan | done |
 | 2 | 🚧 Bridge process primitives (API, repository, log tracker/storage) | done |
 | 3 | 🚧 `BridgeProcessService`: authenticated spawn + control channel live | done |
-| 4 | 🚧 Exit-code state machine + prompt-answer seam | pending |
+| 4 | 🚧 Exit-code state machine + prompt-answer seam | done |
 | 5 | 🌿 Status semantics + dead control-protocol removal | pending |
 | 6 | ⚙️ Tray + `BridgeControlCubit` + windowed fallback | pending |
 | 7 | ⚙️ Window + Prego theme + v1 contents | pending |

--- a/.plan/active/desktop-app/steps/step-04.md
+++ b/.plan/active/desktop-app/steps/step-04.md
@@ -50,15 +50,15 @@ and the two Layer-3 services do not depend on each other.
 ## Verification
 
 - `client/module_desktop_core`: `dart analyze --fatal-infos` — clean.
-- `client/module_desktop_core`: `dart test` — 108 tests passed.
-- Focused process/command/API/DI suites — 32 tests passed, covering all deliberate
+- `client/module_desktop_core`: `dart test` — 110 tests passed.
+- Focused process/command/API/DI suites — 34 tests passed, covering all deliberate
   exit classes, auth recovery versus manual Off, bounded give-up with recent
-  logs, disconnect-aware stable-runtime latching, pre-return/claimed-I/O exit
-  ownership, exit-86 serialization, timer cancellation, and prompt behavior.
+  logs, stable-runtime latching, rollback/stale expected-exit ownership,
+  claimed-I/O recovery, exit-86 serialization, timers, and prompt behavior.
 - `client/desktop`: `dart analyze --fatal-infos` — clean.
 - `client/desktop`: `flutter test` — 22 tests passed; four-phase DI resolves
   both Layer-3 services.
 - Regenerated desktop-core Injectable output with `build_runner`.
 - Shared/bridge contract analyzers are clean; 2 mapping and 26 runtime/coordinator tests passed.
-- Change size after review fixes: 1,697 changed lines including new files, a
-  197-line review-driven overage beyond the 1,500-line soft cap.
+- Change size after review fixes: 1,756 changed lines including new files, a
+  256-line review-driven overage beyond the 1,500-line soft cap.

--- a/.plan/active/desktop-app/steps/step-04.md
+++ b/.plan/active/desktop-app/steps/step-04.md
@@ -46,8 +46,8 @@ state, and inbound versus conversational control ownership stays separated.
 ## Verification
 
 - `client/module_desktop_core`: `dart analyze --fatal-infos` — clean.
-- `client/module_desktop_core`: `dart test` — 99 tests passed.
-- Focused process/command/DI suites — 23 tests passed, covering all deliberate
+- `client/module_desktop_core`: `dart test` — 102 tests passed.
+- Focused process/command/DI suites — 26 tests passed, covering all deliberate
   exit classes, auth recovery versus manual Off, bounded give-up with recent
   logs, stable-runtime reset, both manual timer-cancellation paths, and prompt
   send/retention/stale-id behavior.
@@ -55,5 +55,5 @@ state, and inbound versus conversational control ownership stays separated.
 - `client/desktop`: `flutter test` — 22 tests passed; four-phase DI resolves
   both Layer-3 services.
 - Regenerated desktop-core Injectable output with `build_runner`.
-- Change size: 1,104 changed lines including new files, under the 1,200-line
-  soft cap.
+- Change size after review fixes: 1,232 changed lines including new files,
+  under the 1,500-line soft cap.

--- a/.plan/active/desktop-app/steps/step-04.md
+++ b/.plan/active/desktop-app/steps/step-04.md
@@ -1,0 +1,59 @@
+# Step 4 — Exit-code state machine + prompt answers
+
+Date: 2026-08-28.
+
+## Delivered
+
+- Expanded Layer-3 `BridgeProcessService` with an independent desired-state
+  enum and typed lifecycle states for login-required, contention, scheduled
+  crash retry, and crash give-up.
+- Centralized the supervised exit vocabulary and mapped clean/expected exits to
+  stop, restart (86) to one immediate respawn, auth-required (87) to a
+  no-thrash login-required state, and bridge contention (88) to a state that
+  presentation can render without forcing a modal during hidden startup.
+- Kept desired On across auth-required and subscribed to `AuthSession`; a later
+  authenticated emission restarts the helper, while manual Off prevents that
+  restart.
+- Added bounded 1/2/4/8/16-second crash retries. A process that has remained up
+  for five minutes after its control handshake resets the crash budget; an
+  exhausted budget stops retrying and exposes the latest 20 helper log lines.
+- Added lifecycle generations and timer cancellation so manual Start/Off
+  supersedes an old exit decision or pending timer without a delayed duplicate
+  helper. Automatic startup failures re-enter the same bounded budget.
+- Added Layer-3 `ControlCommandService` as the sole conversational
+  GUI-to-helper sender. It sends typed `prompt_response` frames only for a
+  currently pending prompt and removes the prompt only after the live socket
+  accepts the frame. Expected `shutdown` remains in the repository's atomic
+  stop operation.
+- Registered/exported the new service and states and updated bridge-connectivity
+  regression guarantees and failure signals.
+
+Take-over is intentionally composition rather than another process command: an
+explicit `BridgeProcessService.start()` performs the plain respawn, then the
+fresh replacement prompt is accepted through `ControlCommandService`.
+
+No rendered UI or database behavior changes in this step; later tray/window
+steps consume these states and actions.
+
+## Architecture implementation review
+
+Approved 2026-08-28 with B-Client applied and no findings. The reviewer
+confirmed process and expected-stop ownership remain in the repository,
+Layer-3 dependencies point downward, the two services do not depend on each
+other, manual generations prevent duplicate lifecycle work, contention remains
+state, and inbound versus conversational control ownership stays separated.
+
+## Verification
+
+- `client/module_desktop_core`: `dart analyze --fatal-infos` — clean.
+- `client/module_desktop_core`: `dart test` — 99 tests passed.
+- Focused process/command/DI suites — 23 tests passed, covering all deliberate
+  exit classes, auth recovery versus manual Off, bounded give-up with recent
+  logs, stable-runtime reset, both manual timer-cancellation paths, and prompt
+  send/retention/stale-id behavior.
+- `client/desktop`: `dart analyze --fatal-infos` — clean.
+- `client/desktop`: `flutter test` — 22 tests passed; four-phase DI resolves
+  both Layer-3 services.
+- Regenerated desktop-core Injectable output with `build_runner`.
+- Change size: 1,104 changed lines including new files, under the 1,200-line
+  soft cap.

--- a/.plan/active/desktop-app/steps/step-04.md
+++ b/.plan/active/desktop-app/steps/step-04.md
@@ -7,8 +7,8 @@ Date: 2026-08-28.
 - Expanded Layer-3 `BridgeProcessService` with an independent desired-state
   enum and typed lifecycle states for login-required, contention, scheduled
   crash retry, and crash give-up.
-- Centralized the supervised exit vocabulary and mapped clean/expected exits to
-  stop, restart (86) to one immediate respawn, auth-required (87) to a
+- Centralized the supervised exit vocabulary in `sesori_shared` and mapped
+  clean/expected exits to stop, restart (86) to one immediate respawn, auth-required (87) to a
   no-thrash login-required state, and bridge contention (88) to a state that
   presentation can render without forcing a modal during hidden startup.
 - Kept desired On across auth-required and subscribed to `AuthSession`; a later
@@ -59,5 +59,6 @@ and the two Layer-3 services do not depend on each other.
 - `client/desktop`: `flutter test` — 22 tests passed; four-phase DI resolves
   both Layer-3 services.
 - Regenerated desktop-core Injectable output with `build_runner`.
-- Change size after review fixes: 1,520 changed lines including new files, a
-  20-line review-driven overage beyond the 1,500-line soft cap.
+- Shared/bridge contract analyzers are clean; 2 mapping and 26 runtime/coordinator tests passed.
+- Change size after review fixes: 1,657 changed lines including new files, a
+  157-line review-driven overage beyond the 1,500-line soft cap.

--- a/.plan/active/desktop-app/steps/step-04.md
+++ b/.plan/active/desktop-app/steps/step-04.md
@@ -14,16 +14,19 @@ Date: 2026-08-28.
 - Kept desired On across auth-required and subscribed to `AuthSession`; a later
   authenticated emission restarts the helper, while manual Off prevents that
   restart.
-- Added bounded 1/2/4/8/16-second crash retries. A process that has remained up
-  for five minutes after its control handshake resets the crash budget; an
-  exhausted budget stops retrying and exposes the latest 20 helper log lines.
+- Added bounded 1/2/4/8/16-second crash retries. Layer-3 supervision derives
+  the five-minute stable-runtime reset from Layer-2 `BridgeStatusTracker`, whose
+  connectivity is written by the dispatcher; an exhausted budget stops retrying
+  and exposes the latest 20 helper log lines.
 - Added lifecycle generations and timer cancellation so manual Start/Off
   supersedes an old exit decision or pending timer without a delayed duplicate
-  helper. Automatic startup failures re-enter the same bounded budget.
+  helper. Automatic startup failures re-enter the same bounded budget, and an
+  immediate sentinel restart waits for any failing startup slot to clear.
 - Added Layer-3 `ControlCommandService` as the sole conversational
-  GUI-to-helper sender. It sends typed `prompt_response` frames only for a
-  currently pending prompt and removes the prompt only after the live socket
-  accepts the frame. Expected `shutdown` remains in the repository's atomic
+  GUI-to-helper orchestrator. It validates prompt ownership, calls Layer-2
+  `ControlCommandRepository`, and removes the prompt only after Layer-1
+  `ControlChannelApi` serializes the typed response and the Layer-0 socket
+  accepts it. Expected `shutdown` remains in the process repository's atomic
   stop operation.
 - Registered/exported the new service and states and updated bridge-connectivity
   regression guarantees and failure signals.
@@ -37,23 +40,24 @@ steps consume these states and actions.
 
 ## Architecture implementation review
 
-Approved 2026-08-28 with B-Client applied and no findings. The reviewer
-confirmed process and expected-stop ownership remain in the repository,
-Layer-3 dependencies point downward, the two services do not depend on each
-other, manual generations prevent duplicate lifecycle work, contention remains
-state, and inbound versus conversational control ownership stays separated.
+Approved twice on 2026-08-28 with B-Client applied and no findings. The final
+review covered the review-driven architecture changes and confirmed the strict
+service → repository → API → foundation command path, Layer-2 status ownership,
+Layer-4 dispatcher writes, serialized restart ownership, and generated DI
+composition. Process/expected-stop ownership remains in the process repository,
+and the two Layer-3 services do not depend on each other.
 
 ## Verification
 
 - `client/module_desktop_core`: `dart analyze --fatal-infos` — clean.
-- `client/module_desktop_core`: `dart test` — 103 tests passed.
-- Focused process/command/DI suites — 27 tests passed, covering all deliberate
+- `client/module_desktop_core`: `dart test` — 106 tests passed.
+- Focused process/command/API/DI suites — 30 tests passed, covering all deliberate
   exit classes, auth recovery versus manual Off, bounded give-up with recent
-  logs, stable-runtime reset, both manual timer-cancellation paths, and prompt
-  send/retention/stale-id behavior.
+  logs, tracker-owned stable-runtime reset, early exit-86 restart serialization,
+  both manual timer-cancellation paths, and prompt send/retention/stale-id behavior.
 - `client/desktop`: `dart analyze --fatal-infos` — clean.
 - `client/desktop`: `flutter test` — 22 tests passed; four-phase DI resolves
   both Layer-3 services.
 - Regenerated desktop-core Injectable output with `build_runner`.
-- Change size after review fixes: 1,255 changed lines including new files,
+- Change size after review fixes: 1,397 changed lines including new files,
   under the 1,500-line soft cap.

--- a/.plan/active/desktop-app/steps/step-04.md
+++ b/.plan/active/desktop-app/steps/step-04.md
@@ -59,5 +59,5 @@ and the two Layer-3 services do not depend on each other.
 - `client/desktop`: `flutter test` — 22 tests passed; four-phase DI resolves
   both Layer-3 services.
 - Regenerated desktop-core Injectable output with `build_runner`.
-- Change size after review fixes: 1,497 changed lines including new files,
-  under the 1,500-line soft cap.
+- Change size after review fixes: 1,520 changed lines including new files, a
+  20-line review-driven overage beyond the 1,500-line soft cap.

--- a/.plan/active/desktop-app/steps/step-04.md
+++ b/.plan/active/desktop-app/steps/step-04.md
@@ -50,14 +50,14 @@ and the two Layer-3 services do not depend on each other.
 ## Verification
 
 - `client/module_desktop_core`: `dart analyze --fatal-infos` — clean.
-- `client/module_desktop_core`: `dart test` — 106 tests passed.
-- Focused process/command/API/DI suites — 30 tests passed, covering all deliberate
+- `client/module_desktop_core`: `dart test` — 108 tests passed.
+- Focused process/command/API/DI suites — 32 tests passed, covering all deliberate
   exit classes, auth recovery versus manual Off, bounded give-up with recent
-  logs, tracker-owned stable-runtime reset, early exit-86 restart serialization,
-  both manual timer-cancellation paths, and prompt send/retention/stale-id behavior.
+  logs, disconnect-aware stable-runtime reset, pre-return exit claiming, early
+  exit-86 serialization, timer cancellation, and prompt send/retention behavior.
 - `client/desktop`: `dart analyze --fatal-infos` — clean.
 - `client/desktop`: `flutter test` — 22 tests passed; four-phase DI resolves
   both Layer-3 services.
 - Regenerated desktop-core Injectable output with `build_runner`.
-- Change size after review fixes: 1,397 changed lines including new files,
+- Change size after review fixes: 1,497 changed lines including new files,
   under the 1,500-line soft cap.

--- a/.plan/active/desktop-app/steps/step-04.md
+++ b/.plan/active/desktop-app/steps/step-04.md
@@ -53,12 +53,12 @@ and the two Layer-3 services do not depend on each other.
 - `client/module_desktop_core`: `dart test` — 108 tests passed.
 - Focused process/command/API/DI suites — 32 tests passed, covering all deliberate
   exit classes, auth recovery versus manual Off, bounded give-up with recent
-  logs, disconnect-aware stable-runtime reset, pre-return exit claiming, early
-  exit-86 serialization, timer cancellation, and prompt send/retention behavior.
+  logs, disconnect-aware stable-runtime latching, pre-return/claimed-I/O exit
+  ownership, exit-86 serialization, timer cancellation, and prompt behavior.
 - `client/desktop`: `dart analyze --fatal-infos` — clean.
 - `client/desktop`: `flutter test` — 22 tests passed; four-phase DI resolves
   both Layer-3 services.
 - Regenerated desktop-core Injectable output with `build_runner`.
 - Shared/bridge contract analyzers are clean; 2 mapping and 26 runtime/coordinator tests passed.
-- Change size after review fixes: 1,657 changed lines including new files, a
-  157-line review-driven overage beyond the 1,500-line soft cap.
+- Change size after review fixes: 1,697 changed lines including new files, a
+  197-line review-driven overage beyond the 1,500-line soft cap.

--- a/.plan/active/desktop-app/steps/step-04.md
+++ b/.plan/active/desktop-app/steps/step-04.md
@@ -46,8 +46,8 @@ state, and inbound versus conversational control ownership stays separated.
 ## Verification
 
 - `client/module_desktop_core`: `dart analyze --fatal-infos` — clean.
-- `client/module_desktop_core`: `dart test` — 102 tests passed.
-- Focused process/command/DI suites — 26 tests passed, covering all deliberate
+- `client/module_desktop_core`: `dart test` — 103 tests passed.
+- Focused process/command/DI suites — 27 tests passed, covering all deliberate
   exit classes, auth recovery versus manual Off, bounded give-up with recent
   logs, stable-runtime reset, both manual timer-cancellation paths, and prompt
   send/retention/stale-id behavior.
@@ -55,5 +55,5 @@ state, and inbound versus conversational control ownership stays separated.
 - `client/desktop`: `flutter test` — 22 tests passed; four-phase DI resolves
   both Layer-3 services.
 - Regenerated desktop-core Injectable output with `build_runner`.
-- Change size after review fixes: 1,232 changed lines including new files,
+- Change size after review fixes: 1,255 changed lines including new files,
   under the 1,500-line soft cap.

--- a/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
@@ -25,7 +25,8 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
         ProcessUser,
         ServerClock,
         StartAbortController;
-import "package:sesori_shared/sesori_shared.dart" show AuthClientType, AuthDeviceInfoBuilder, DeviceInfo;
+import "package:sesori_shared/sesori_shared.dart"
+    show AuthClientType, AuthDeviceInfoBuilder, BridgeSupervisedExitCode, DeviceInfo;
 
 import "../api/app_onboarding_state_storage.dart";
 import "../api/archived_session_storage.dart";
@@ -128,46 +129,6 @@ import "plugin_registry.dart";
 import "plugin_runtime.dart";
 import "runtime_provision_formatter.dart";
 
-/// The deliberate exit outcomes of a supervised bridge, each carrying the
-/// process exit [code] the desktop GUI supervisor keys its respawn policy on.
-/// Anything not represented here reads to the GUI as a crash (backoff respawn).
-enum SupervisedExitCode(
-  /// The process exit code reported to the GUI supervisor.
-  final int code) {
-  /// A phone-triggered restart handed off by exiting: the GUI must respawn.
-  /// Distinct from a clean stop (0), a crash (other non-zero), and
-  /// control-channel loss (1) so the GUI supervisor can tell an intentional
-  /// restart apart and respawn rather than treat it as a crash.
-  restart(86),
-
-  /// The desktop GUI cannot supply an access token at bootstrap (signed out /
-  /// mid-login / unreachable). Distinct from a crash so the GUI supervisor
-  /// surfaces a login prompt instead of backoff-respawning a helper that can
-  /// never start. The exit code is the authoritative signal; the best-effort
-  /// `loginNeeded` prompt sent just before exiting is advisory.
-  authRequired(87),
-
-  /// Same-machine single-live contention kept this bridge from starting:
-  /// another bridge is already running (or holds the startup mutex) and the
-  /// replace ask ended in a decline or could not be answered (GUI declined /
-  /// unreachable / prompt timeout / teardown). Distinct from a crash so the
-  /// GUI supervisor can surface an "another bridge is running — take over?"
-  /// state instead of backoff-respawning a helper that would just re-prompt
-  /// forever. The incumbent bridge keeps running; taking over is a plain
-  /// respawn whose fresh replace prompt the GUI answers with accept.
-  bridgeContention(88),
-
-  /// A GUI-requested `shutdown` or `unregister_and_exit`: a deliberate clean
-  /// stop, so the GUI must not respawn.
-  cleanStop(0),
-
-  /// The control channel to the GUI was lost past the grace period (ADR A9):
-  /// an abnormal exit — the parent is gone, so a loss must never read as a
-  /// clean stop even when the shutdown itself completes fine.
-  controlChannelLost(1);
-
-}
-
 enum _PhoneConnectionWaitOutcome() { connected, sessionStopped }
 
 class const BridgeRuntimeRunner._() {
@@ -197,7 +158,7 @@ class const BridgeRuntimeRunner._() {
     // intentional exit outranks a pending control-channel loss), while the
     // loss listener assigns with `??=` so a loss never overwrites an already
     // decided intentional exit.
-    SupervisedExitCode? requestedSupervisedExit;
+    BridgeSupervisedExitCode? requestedSupervisedExit;
     // Shared by the ordered pluginDispose phase and the backstop's emergency
     // disposal so the two cannot drift.
     Future<void> shutdownStartedPlugins() => pluginRuntime?.shutdownStartedPlugins() ?? Future<void>.value();
@@ -384,7 +345,7 @@ class const BridgeRuntimeRunner._() {
           shutdownCoordinator: shutdownCoordinator,
           // `??=`: a loss must never demote an already decided intentional
           // exit (restart/auth/logout/contention) to the abnormal code.
-          requestAbnormalExit: () => requestedSupervisedExit ??= SupervisedExitCode.controlChannelLost,
+          requestAbnormalExit: () => requestedSupervisedExit ??= BridgeSupervisedExitCode.controlChannelLost,
         );
         // The GUI is the token authority in supervised mode: the bridge pulls
         // its access token from the control channel instead of the interactive
@@ -411,10 +372,10 @@ class const BridgeRuntimeRunner._() {
         // sentinel before teardown so a hung shutdown's backstop still reports
         // 0 rather than a latched-failure 1.
         Future<void> terminateSupervisedCleanly() {
-          requestedSupervisedExit = SupervisedExitCode.cleanStop;
+          requestedSupervisedExit = BridgeSupervisedExitCode.cleanStop;
           return _shutdownThenExit(
             shutdownCoordinator: shutdownCoordinator,
-            code: SupervisedExitCode.cleanStop.code,
+            code: BridgeSupervisedExitCode.cleanStop.code,
           );
         }
 
@@ -538,7 +499,7 @@ class const BridgeRuntimeRunner._() {
           authAccessToken = await supervisedTokenService.getAccessToken();
         } on ControlTokenUnavailableException catch (error, stackTrace) {
           final bool exitAlreadyRequested = requestedSupervisedExit != null;
-          final SupervisedExitCode tokenUnavailableExit = resolveSupervisedTokenUnavailableExit(
+          final BridgeSupervisedExitCode tokenUnavailableExit = resolveSupervisedTokenUnavailableExit(
             requestedExit: requestedSupervisedExit,
           );
           if (exitAlreadyRequested) {
@@ -796,7 +757,7 @@ class const BridgeRuntimeRunner._() {
         // before the shutdown it triggers — so the normal return, the error
         // paths, and a hung-teardown backstop all report the same code.
         onSupervisedRestartRequested: () {
-          requestedSupervisedExit = SupervisedExitCode.restart;
+          requestedSupervisedExit = BridgeSupervisedExitCode.restart;
         },
       );
 
@@ -972,17 +933,17 @@ class const BridgeRuntimeRunner._() {
       // respawning a helper that would just re-prompt forever.
       Log.e("$error");
       if (options.isSupervised) {
-        requestedSupervisedExit = SupervisedExitCode.bridgeContention;
-        return SupervisedExitCode.bridgeContention.code;
+        requestedSupervisedExit = BridgeSupervisedExitCode.bridgeContention;
+        return BridgeSupervisedExitCode.bridgeContention.code;
       }
       return 1;
     } catch (error, stackTrace) {
       // Honor an already-completed supervised restart handoff: a teardown error
       // after the handoff is still an intentional restart, so return the sentinel
       // (GUI respawns) rather than the crash code.
-      if (requestedSupervisedExit == SupervisedExitCode.restart) {
+      if (requestedSupervisedExit == BridgeSupervisedExitCode.restart) {
         Log.w("Session teardown failed after a supervised restart handoff", error, stackTrace);
-        return SupervisedExitCode.restart.code;
+        return BridgeSupervisedExitCode.restart.code;
       }
       Log.e("$error");
       return 1;
@@ -1000,16 +961,16 @@ class const BridgeRuntimeRunner._() {
         // clean stop and control-channel loss, whose graceful path exits the
         // process itself — preserve the loud-failure behaviour by rethrowing.
         switch (requestedSupervisedExit) {
-          case SupervisedExitCode.restart:
-          case SupervisedExitCode.authRequired:
-          case SupervisedExitCode.bridgeContention:
+          case BridgeSupervisedExitCode.restart:
+          case BridgeSupervisedExitCode.authRequired:
+          case BridgeSupervisedExitCode.bridgeContention:
             Log.w(
               "Shutdown error during a supervised sentinel exit; preserving the sentinel exit code",
               error,
               stackTrace,
             );
-          case SupervisedExitCode.cleanStop:
-          case SupervisedExitCode.controlChannelLost:
+          case BridgeSupervisedExitCode.cleanStop:
+          case BridgeSupervisedExitCode.controlChannelLost:
           case null:
             rethrow;
         }
@@ -1018,9 +979,9 @@ class const BridgeRuntimeRunner._() {
   }
 
   @visibleForTesting
-  static SupervisedExitCode resolveSupervisedTokenUnavailableExit({
-    required SupervisedExitCode? requestedExit,
-  }) => requestedExit ?? SupervisedExitCode.authRequired;
+  static BridgeSupervisedExitCode resolveSupervisedTokenUnavailableExit({
+    required BridgeSupervisedExitCode? requestedExit,
+  }) => requestedExit ?? BridgeSupervisedExitCode.authRequired;
 
   @visibleForTesting
   static bool shouldRunAppOnboarding({
@@ -1106,7 +1067,7 @@ class const BridgeRuntimeRunner._() {
       // The composition root owns the exit-code vocabulary, so the listener's
       // code is pinned to the enum here rather than relying on the listener's
       // own default staying in sync with it.
-      exitCode: SupervisedExitCode.controlChannelLost.code,
+      exitCode: BridgeSupervisedExitCode.controlChannelLost.code,
       // Don't hard-exit straight from the loss timer: that bypasses the ordered
       // plugin stop in the shutdown coordinator and could orphan an owned
       // backend runtime (e.g. OpenCode). Record the abnormal outcome (so the

--- a/bridge/app/test/bridge/runtime/bridge_runtime_runner_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_runner_test.dart
@@ -1,6 +1,7 @@
 import "dart:io";
 
 import "package:sesori_bridge/src/runtime/bridge_runtime_runner.dart";
+import "package:sesori_shared/sesori_shared.dart" show BridgeSupervisedExitCode;
 import "package:test/test.dart";
 
 import "../../helpers/fake_process_runner.dart";
@@ -30,15 +31,15 @@ void main() {
     test("uses auth-required when no lifecycle outcome exists", () {
       expect(
         BridgeRuntimeRunner.resolveSupervisedTokenUnavailableExit(requestedExit: null),
-        SupervisedExitCode.authRequired,
+        BridgeSupervisedExitCode.authRequired,
       );
     });
 
     test("preserves a lifecycle outcome selected before token cancellation", () {
-      for (final SupervisedExitCode requestedExit in <SupervisedExitCode>[
-        SupervisedExitCode.cleanStop,
-        SupervisedExitCode.controlChannelLost,
-        SupervisedExitCode.restart,
+      for (final BridgeSupervisedExitCode requestedExit in <BridgeSupervisedExitCode>[
+        BridgeSupervisedExitCode.cleanStop,
+        BridgeSupervisedExitCode.controlChannelLost,
+        BridgeSupervisedExitCode.restart,
       ]) {
         expect(
           BridgeRuntimeRunner.resolveSupervisedTokenUnavailableExit(requestedExit: requestedExit),

--- a/client/desktop/test/core/di/injection_test.dart
+++ b/client/desktop/test/core/di/injection_test.dart
@@ -33,7 +33,9 @@ void main() {
     expect(getIt.isRegistered<BridgeExecutablePathResolver>(), isTrue);
     expect(getIt.isRegistered<BridgeProcessLogStorage>(), isTrue);
     expect(getIt.isRegistered<BridgeProcessService>(), isTrue);
+    expect(getIt.isRegistered<ControlCommandService>(), isTrue);
     expect(getIt<BridgeProcessService>().state, isA<BridgeProcessStopped>());
+    expect(getIt<ControlCommandService>(), isA<ControlCommandService>());
   });
 
   test("desktop bootstrap leaves the mobile thumbnail cache unbound and unresolved", () {

--- a/client/module_desktop_core/lib/sesori_desktop_core.dart
+++ b/client/module_desktop_core/lib/sesori_desktop_core.dart
@@ -8,6 +8,7 @@ export "package:sesori_shared/sesori_shared.dart" show AuthUser;
 
 export "src/api/bridge_process_api.dart";
 export "src/api/bridge_process_log_storage.dart";
+export "src/api/control_channel_api.dart";
 export "src/control/control_message_dispatcher.dart";
 export "src/cubits/auth_gate/auth_gate_cubit.dart";
 export "src/cubits/auth_gate/auth_gate_state.dart";
@@ -16,6 +17,7 @@ export "src/foundation/control_channel_server.dart";
 export "src/foundation/platform/bridge_executable_path_resolver.dart";
 export "src/foundation/platform/desktop_application_support_directory.dart";
 export "src/repositories/bridge_process_repository.dart";
+export "src/repositories/control_command_repository.dart";
 export "src/services/bridge_process_service.dart";
 export "src/services/bridge_process_state.dart";
 export "src/services/control_command_service.dart";

--- a/client/module_desktop_core/lib/sesori_desktop_core.dart
+++ b/client/module_desktop_core/lib/sesori_desktop_core.dart
@@ -17,6 +17,8 @@ export "src/foundation/platform/bridge_executable_path_resolver.dart";
 export "src/foundation/platform/desktop_application_support_directory.dart";
 export "src/repositories/bridge_process_repository.dart";
 export "src/services/bridge_process_service.dart";
+export "src/services/bridge_process_state.dart";
+export "src/services/control_command_service.dart";
 export "src/trackers/bridge_control_status.dart";
 export "src/trackers/bridge_process_log_tracker.dart";
 export "src/trackers/bridge_prompt_tracker.dart";

--- a/client/module_desktop_core/lib/sesori_desktop_core.dart
+++ b/client/module_desktop_core/lib/sesori_desktop_core.dart
@@ -4,7 +4,7 @@ library;
 
 // The signed-in account carried by AuthGateState (move + re-export pattern,
 // so shell consumers don't need a direct sesori_shared import for it).
-export "package:sesori_shared/sesori_shared.dart" show AuthUser;
+export "package:sesori_shared/sesori_shared.dart" show AuthUser, BridgeSupervisedExitCode;
 
 export "src/api/bridge_process_api.dart";
 export "src/api/bridge_process_log_storage.dart";

--- a/client/module_desktop_core/lib/src/api/control_channel_api.dart
+++ b/client/module_desktop_core/lib/src/api/control_channel_api.dart
@@ -1,0 +1,17 @@
+import "dart:convert";
+
+import "package:injectable/injectable.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../foundation/control_channel_server.dart";
+
+/// Layer-1 typed write boundary over the GUI-hosted control channel.
+///
+/// Outbound callers provide protocol messages; this API owns their wire
+/// serialization and delegates only the encoded frame to the Layer-0 server.
+@lazySingleton
+class ControlChannelApi({required final ControlChannelServer _server}) {
+  void send({required ControlMessage message}) {
+    _server.send(jsonEncode(message.toJson()));
+  }
+}

--- a/client/module_desktop_core/lib/src/di/injection.config.dart
+++ b/client/module_desktop_core/lib/src/di/injection.config.dart
@@ -27,6 +27,8 @@ import 'package:sesori_desktop_core/src/repositories/bridge_process_repository.d
     as _i209;
 import 'package:sesori_desktop_core/src/services/bridge_process_service.dart'
     as _i765;
+import 'package:sesori_desktop_core/src/services/control_command_service.dart'
+    as _i175;
 import 'package:sesori_desktop_core/src/trackers/bridge_process_log_tracker.dart'
     as _i866;
 import 'package:sesori_desktop_core/src/trackers/bridge_prompt_tracker.dart'
@@ -75,6 +77,12 @@ extension GetItInjectableX on _i174.GetIt {
         controlChannelServer: gh<_i464.ControlChannelServer>(),
       ),
       dispose: (i) => i.dispose(),
+    );
+    gh.lazySingleton<_i175.ControlCommandService>(
+      () => _i175.ControlCommandService(
+        server: gh<_i464.ControlChannelServer>(),
+        promptTracker: gh<_i686.BridgePromptTracker>(),
+      ),
     );
     gh.lazySingleton<_i866.BridgeProcessLogTracker>(
       () => _i866.BridgeProcessLogTracker(

--- a/client/module_desktop_core/lib/src/di/injection.config.dart
+++ b/client/module_desktop_core/lib/src/di/injection.config.dart
@@ -15,6 +15,7 @@ import 'package:sesori_dart_core/sesori_dart_core.dart' as _i948;
 import 'package:sesori_desktop_core/src/api/bridge_process_api.dart' as _i874;
 import 'package:sesori_desktop_core/src/api/bridge_process_log_storage.dart'
     as _i570;
+import 'package:sesori_desktop_core/src/api/control_channel_api.dart' as _i639;
 import 'package:sesori_desktop_core/src/control/control_message_dispatcher.dart'
     as _i21;
 import 'package:sesori_desktop_core/src/foundation/control_channel_server.dart'
@@ -25,6 +26,8 @@ import 'package:sesori_desktop_core/src/foundation/platform/desktop_application_
     as _i695;
 import 'package:sesori_desktop_core/src/repositories/bridge_process_repository.dart'
     as _i209;
+import 'package:sesori_desktop_core/src/repositories/control_command_repository.dart'
+    as _i171;
 import 'package:sesori_desktop_core/src/services/bridge_process_service.dart'
     as _i765;
 import 'package:sesori_desktop_core/src/services/control_command_service.dart'
@@ -71,6 +74,9 @@ extension GetItInjectableX on _i174.GetIt {
       ),
       dispose: (i) => i.dispose(),
     );
+    gh.lazySingleton<_i639.ControlChannelApi>(
+      () => _i639.ControlChannelApi(server: gh<_i464.ControlChannelServer>()),
+    );
     gh.lazySingleton<_i209.BridgeProcessRepository>(
       () => _i209.BridgeProcessRepository(
         processApi: gh<_i874.BridgeProcessApi>(),
@@ -78,11 +84,8 @@ extension GetItInjectableX on _i174.GetIt {
       ),
       dispose: (i) => i.dispose(),
     );
-    gh.lazySingleton<_i175.ControlCommandService>(
-      () => _i175.ControlCommandService(
-        server: gh<_i464.ControlChannelServer>(),
-        promptTracker: gh<_i686.BridgePromptTracker>(),
-      ),
+    gh.lazySingleton<_i171.ControlCommandRepository>(
+      () => _i171.ControlCommandRepository(api: gh<_i639.ControlChannelApi>()),
     );
     gh.lazySingleton<_i866.BridgeProcessLogTracker>(
       () => _i866.BridgeProcessLogTracker(
@@ -90,10 +93,17 @@ extension GetItInjectableX on _i174.GetIt {
       ),
       dispose: (i) => i.dispose(),
     );
+    gh.lazySingleton<_i175.ControlCommandService>(
+      () => _i175.ControlCommandService(
+        repository: gh<_i171.ControlCommandRepository>(),
+        promptTracker: gh<_i686.BridgePromptTracker>(),
+      ),
+    );
     gh.lazySingleton<_i765.BridgeProcessService>(
       () => _i765.BridgeProcessService(
         repository: gh<_i209.BridgeProcessRepository>(),
         logTracker: gh<_i866.BridgeProcessLogTracker>(),
+        statusTracker: gh<_i227.BridgeStatusTracker>(),
         controlChannelServer: gh<_i464.ControlChannelServer>(),
         authSession: gh<_i948.AuthSession>(),
         executablePathResolver: gh<_i961.BridgeExecutablePathResolver>(),

--- a/client/module_desktop_core/lib/src/repositories/control_command_repository.dart
+++ b/client/module_desktop_core/lib/src/repositories/control_command_repository.dart
@@ -1,0 +1,18 @@
+import "package:injectable/injectable.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../api/control_channel_api.dart";
+
+/// Layer-2 owner of outbound conversational control commands.
+///
+/// Expected process shutdown remains the bridge-process repository's atomic
+/// operation. This repository exposes only commands initiated by the desktop
+/// conversation flow.
+@lazySingleton
+class ControlCommandRepository({required final ControlChannelApi _api}) {
+  void answerPrompt({required String id, required bool accepted}) {
+    _api.send(
+      message: ControlMessage.promptResponse(id: id, accepted: accepted),
+    );
+  }
+}

--- a/client/module_desktop_core/lib/src/services/bridge_process_service.dart
+++ b/client/module_desktop_core/lib/src/services/bridge_process_service.dart
@@ -9,37 +9,23 @@ import "../foundation/control_channel_server.dart";
 import "../foundation/platform/bridge_executable_path_resolver.dart";
 import "../repositories/bridge_process_repository.dart";
 import "../trackers/bridge_process_log_tracker.dart";
+import "bridge_process_state.dart";
 
-sealed class const BridgeProcessState();
-
-final class const BridgeProcessStopped() extends BridgeProcessState;
-
-final class const BridgeProcessLoginRequired() extends BridgeProcessState;
-
-final class const BridgeProcessStarting() extends BridgeProcessState;
-
-final class const BridgeProcessRunning({required final int pid}) extends BridgeProcessState;
-
-final class const BridgeProcessStopping({required final int pid}) extends BridgeProcessState;
-
-final class const BridgeProcessExitedDuringStartException({required final int pid}) implements Exception {
-  @override
-  String toString() => "BridgeProcessExitedDuringStartException: bridge process $pid exited during startup";
-}
-
+/// Reports a lifecycle warning without coupling tests to the global logger.
 @visibleForTesting
-typedef BridgeProcessServiceWarningReporter = void Function({
+typedef BridgeProcessWarningReporter = void Function({
   required String message,
   required Object error,
   required StackTrace stackTrace,
 });
 
-/// Layer-3 lifecycle owner for the desktop-supervised bridge helper.
+/// Layer-3 owner of authenticated helper spawn, restart policy, and teardown.
 ///
-/// A start is transactional: it creates one fresh control server, spawns only
-/// for an authenticated desktop session, attaches both child pipes, and sends
-/// the per-spawn secret over stdin. Any failure attempts an expected child stop
-/// and control-server teardown before rethrowing the original failure.
+/// It coordinates only lower layers: the process repository owns every raw
+/// process operation and the atomic expected-stop marker; the log tracker owns
+/// child-pipe draining; the control server owns the per-spawn secret and
+/// socket. Manual lifecycle actions supersede delayed policy work, so an old
+/// retry can never create a second helper after Off or an explicit retry.
 @lazySingleton
 class BridgeProcessService.forTesting({
   required final BridgeProcessRepository _repository,
@@ -47,18 +33,12 @@ class BridgeProcessService.forTesting({
   required final ControlChannelServer _controlChannelServer,
   required final AuthSession _authSession,
   required final BridgeExecutablePathResolver _executablePathResolver,
-  required final BridgeProcessServiceWarningReporter _reportWarning,
+  required final List<Duration> _crashBackoffDelays,
+  required final Duration _stableRuntime,
+  required final int _recentLogCount,
+  required final DateTime Function() _now,
+  required final BridgeProcessWarningReporter _reportWarning,
 }) {
-  late final StreamSubscription<BridgeProcessExit> _exitSubscription;
-  final BehaviorSubject<BridgeProcessState> _states = BehaviorSubject<BridgeProcessState>.seeded(
-    const BridgeProcessStopped(),
-  );
-  Future<void> _exitCleanup = Future<void>.value();
-  Future<void>? _startFuture;
-  Future<void>? _stopFuture;
-  int? _activePid;
-  bool _disposed = false;
-
   new({
     required BridgeProcessRepository repository,
     required BridgeProcessLogTracker logTracker,
@@ -71,33 +51,107 @@ class BridgeProcessService.forTesting({
          controlChannelServer: controlChannelServer,
          authSession: authSession,
          executablePathResolver: executablePathResolver,
+         crashBackoffDelays: defaultCrashBackoffDelays,
+         stableRuntime: defaultStableRuntime,
+         recentLogCount: defaultRecentLogCount,
+         now: DateTime.now,
          reportWarning: _logWarning,
        );
 
   @visibleForTesting
-  this {
+  this
+    : assert(!_stableRuntime.isNegative, "stableRuntime must not be negative"),
+      assert(_recentLogCount > 0, "recentLogCount must be positive"),
+      assert(
+        !_crashBackoffDelays.any((delay) => delay.isNegative),
+        "crashBackoffDelays must not contain negative durations",
+      ) {
     _exitSubscription = _repository.exits.listen(
       _onExit,
-      onError: _onExitError,
+      // ignore: no_slop_linter/prefer_required_named_parameters, Stream.listen error callbacks are positional
+      onError: (Object error, StackTrace stackTrace) => _onExitError(error: error, stackTrace: stackTrace),
+    );
+    _authSubscription = _authSession.authStateStream.listen(
+      (state) => _onAuthStateChanged(state: state),
+    );
+    _helperConnectionSubscription = _controlChannelServer.helperConnectionStream.listen(
+      (connected) => _onHelperConnectionChanged(connected: connected),
     );
   }
 
-  BridgeProcessState get state => _states.value;
+  static const List<Duration> defaultCrashBackoffDelays = <Duration>[
+    Duration(seconds: 1),
+    Duration(seconds: 2),
+    Duration(seconds: 4),
+    Duration(seconds: 8),
+    Duration(seconds: 16),
+  ];
+  static const Duration defaultStableRuntime = Duration(minutes: 5);
+  static const int defaultRecentLogCount = 20;
+
+  final BehaviorSubject<BridgeProcessState> _states = BehaviorSubject<BridgeProcessState>.seeded(
+    const BridgeProcessStopped(),
+  );
+  late final StreamSubscription<BridgeProcessExit> _exitSubscription;
+  late final StreamSubscription<AuthState> _authSubscription;
+  late final StreamSubscription<bool> _helperConnectionSubscription;
+
+  Future<void>? _startFuture;
+  Future<void>? _stopFuture;
+  Future<void>? _exitCleanup;
+  Timer? _retryTimer;
+  int _crashCount = 0;
+  int _lifecycleGeneration = 0;
+  int? _activePid;
+  DateTime? _healthySince;
+  bool _disposed = false;
+  BridgeProcessDesiredState _desiredState = BridgeProcessDesiredState.off;
 
   ValueStream<BridgeProcessState> get states => _states.stream;
 
-  Future<void> start() async {
+  BridgeProcessState get state => _states.value;
+
+  BridgeProcessDesiredState get desiredState => _desiredState;
+
+  /// Requests On now. A signed-out request remains desired On and resumes only
+  /// after the auth session emits a successful sign-in.
+  Future<void> start() {
     _ensureNotDisposed();
+    _beginManualAction(desiredState: BridgeProcessDesiredState.on);
+    return _requestStart();
+  }
+
+  /// Requests Off, cancels any delayed retry, and expected-stops the child.
+  Future<void> stop() {
+    _ensureNotDisposed();
+    _beginManualAction(desiredState: BridgeProcessDesiredState.off);
+    return _requestStop();
+  }
+
+  void _beginManualAction({required BridgeProcessDesiredState desiredState}) {
+    _lifecycleGeneration++;
+    _desiredState = desiredState;
+    _crashCount = 0;
+    _cancelRetry();
+  }
+
+  Future<void> _requestStart() {
     final Future<void>? existing = _startFuture;
     if (existing != null) {
-      await existing;
-      return;
+      return existing;
     }
-
     final Future<void> operation = _start();
     _startFuture = operation;
+    unawaited(_clearStartWhenComplete(operation: operation));
+    return operation;
+  }
+
+  Future<void> _clearStartWhenComplete({required Future<void> operation}) async {
     try {
       await operation;
+    } on Object {
+      // The original future retains the error for its caller. This observer
+      // only releases the serialized-operation slot.
     } finally {
       if (identical(_startFuture, operation)) {
         _startFuture = null;
@@ -106,66 +160,97 @@ class BridgeProcessService.forTesting({
   }
 
   Future<void> _start() async {
-    final Future<void>? stop = _stopFuture;
-    if (stop != null) {
-      await stop;
+    final Future<void>? pendingStop = _stopFuture;
+    if (pendingStop != null) {
+      await pendingStop;
     }
-    await _exitCleanup;
+    final Future<void>? pendingExitCleanup = _exitCleanup;
+    if (pendingExitCleanup != null) {
+      await pendingExitCleanup;
+    }
 
-    if (_activePid != null || _repository.isRunning) {
+    if (_desiredState == BridgeProcessDesiredState.off || _disposed) {
+      _publish(const BridgeProcessStopped());
+      return;
+    }
+    final int? activePid = _activePid;
+    if (activePid != null) {
+      _publish(BridgeProcessRunning(pid: activePid));
       return;
     }
     if (_authSession.currentState is! AuthAuthenticated) {
-      _setState(const BridgeProcessLoginRequired());
+      _publish(const BridgeProcessLoginRequired());
       return;
     }
 
-    _setState(const BridgeProcessStarting());
+    _publish(const BridgeProcessStarting());
     bool controlStartAttempted = false;
     bool childCreated = false;
     try {
       controlStartAttempted = true;
       await _controlChannelServer.start();
-      final Uri controlUrl = _controlChannelServer.url;
-      final String controlSecret = _controlChannelServer.secret;
+      _throwIfStartCancelled();
+
       final BridgeProcessStreams streams = await _repository.spawn(
         executable: _executablePathResolver.resolve(),
-        arguments: <String>["--control-url", controlUrl.toString()],
+        arguments: <String>["--control-url", _controlChannelServer.url.toString()],
         workingDirectory: null,
         environment: null,
       );
       childCreated = true;
       _activePid = streams.pid;
+      _healthySince = null;
+      _throwIfStartCancelled();
 
       await _logTracker.attach(stdout: streams.stdout, stderr: streams.stderr);
-      streams.stdin.writeln(controlSecret);
+      _throwIfStartCancelled();
+      streams.stdin.writeln(_controlChannelServer.secret);
       await streams.stdin.flush();
+      _throwIfStartCancelled();
 
       if (_activePid != streams.pid || !_repository.isRunning) {
         throw BridgeProcessExitedDuringStartException(pid: streams.pid);
       }
-      _setState(BridgeProcessRunning(pid: streams.pid));
-    } on Object catch (_) {
-      await _rollbackFailedStart(
-        childCreated: childCreated,
+      _publish(BridgeProcessRunning(pid: streams.pid));
+    } on _BridgeProcessStartCancelled {
+      await _cleanUpFailedStart(
         controlStartAttempted: controlStartAttempted,
+        childCreated: childCreated,
       );
+      _publish(_repository.isRunning ? BridgeProcessStopping(pid: _activePid) : const BridgeProcessStopped());
+    } on Object {
+      await _cleanUpFailedStart(
+        controlStartAttempted: controlStartAttempted,
+        childCreated: childCreated,
+      );
+      _publish(_repository.isRunning ? BridgeProcessStopping(pid: _activePid) : const BridgeProcessStopped());
       rethrow;
     }
   }
 
-  Future<void> stop() async {
-    _ensureNotDisposed();
+  void _throwIfStartCancelled() {
+    if (_desiredState == BridgeProcessDesiredState.off || _disposed) {
+      throw const _BridgeProcessStartCancelled();
+    }
+  }
+
+  Future<void> _requestStop() {
     final Future<void>? existing = _stopFuture;
     if (existing != null) {
-      await existing;
-      return;
+      return existing;
     }
-
     final Future<void> operation = _stop();
     _stopFuture = operation;
+    unawaited(_clearStopWhenComplete(operation: operation));
+    return operation;
+  }
+
+  Future<void> _clearStopWhenComplete({required Future<void> operation}) async {
     try {
       await operation;
+    } on Object {
+      // The original future retains the error for its caller. This observer
+      // only releases the serialized-operation slot.
     } finally {
       if (identical(_stopFuture, operation)) {
         _stopFuture = null;
@@ -174,108 +259,308 @@ class BridgeProcessService.forTesting({
   }
 
   Future<void> _stop() async {
-    final Future<void>? start = _startFuture;
-    if (start != null) {
+    final Future<void>? pendingStart = _startFuture;
+    if (pendingStart != null) {
       try {
-        await start;
+        await pendingStart;
       } on Object {
-        // The start caller receives the original failure, while its rollback
-        // already owns child/server cleanup. Continue this explicit stop.
+        // Startup already rolled back its own partial resources. Stop still
+        // completes the desired-Off transition.
       }
     }
 
-    final int? pid = _activePid ?? _repository.activePid;
-    if (pid != null) {
-      _setState(BridgeProcessStopping(pid: pid));
+    final int? pid = _activePid;
+    if (pid != null || _repository.isRunning) {
+      _publish(BridgeProcessStopping(pid: pid ?? _repository.activePid));
     }
     try {
       await _repository.stopExpected();
     } on Object {
-      if (_repository.isRunning && pid != null) {
-        _setState(BridgeProcessRunning(pid: pid));
+      if (_repository.isRunning) {
+        final int? recoveredPid = _repository.activePid ?? pid;
+        _publish(
+          recoveredPid == null ? const BridgeProcessStopping(pid: null) : BridgeProcessRunning(pid: recoveredPid),
+        );
       }
       rethrow;
     }
 
     _activePid = null;
-    await _exitCleanup;
+    _clearRunHealth();
+    final Future<void>? pendingExitCleanup = _exitCleanup;
+    if (pendingExitCleanup != null) {
+      await pendingExitCleanup;
+    }
     await _controlChannelServer.stop();
-    _setState(const BridgeProcessStopped());
-  }
-
-  Future<void> _rollbackFailedStart({
-    required bool childCreated,
-    required bool controlStartAttempted,
-  }) async {
-    if (childCreated) {
-      try {
-        await _repository.stopExpected();
-      } on Object catch (error, stackTrace) {
-        _reportWarning(
-          message: "Failed to stop the bridge after supervised startup failed",
-          error: error,
-          stackTrace: stackTrace,
-        );
-      }
-    }
-    await _exitCleanup;
-    if (controlStartAttempted) {
-      try {
-        await _controlChannelServer.stop();
-      } on Object catch (error, stackTrace) {
-        _reportWarning(
-          message: "Failed to stop the control channel after supervised startup failed",
-          error: error,
-          stackTrace: stackTrace,
-        );
-      }
-    }
-
-    if (_repository.isRunning) {
-      final int? pid = _repository.activePid ?? _activePid;
-      if (pid != null) {
-        _activePid = pid;
-        _setState(BridgeProcessStopping(pid: pid));
-        return;
-      }
-    }
-    _activePid = null;
-    _setState(const BridgeProcessStopped());
+    _publish(const BridgeProcessStopped());
   }
 
   void _onExit(BridgeProcessExit exit) {
     if (_activePid != exit.pid) {
       return;
     }
-    _activePid = null;
-    _exitCleanup = _cleanUpExitedProcess();
+    _beginExitCleanup(exit: exit);
   }
 
-  // ignore: no_slop_linter/prefer_required_named_parameters, Stream.listen error callbacks are positional
-  void _onExitError(Object error, StackTrace stackTrace) {
+  void _onExitError({required Object error, required StackTrace stackTrace}) {
     _reportWarning(
-      message: "Failed to observe the supervised bridge exit",
+      message: "Bridge process exit observation failed",
       error: error,
       stackTrace: stackTrace,
     );
-    _activePid = null;
-    _exitCleanup = _cleanUpExitedProcess();
+    if (_activePid == null) {
+      return;
+    }
+    _beginExitCleanup(exit: null);
   }
 
-  Future<void> _cleanUpExitedProcess() async {
+  void _beginExitCleanup({required BridgeProcessExit? exit}) {
+    _activePid = null;
+    final bool stableRun = _wasStableRun();
+    _clearRunHealth();
+    final int generation = _lifecycleGeneration;
+    final Future<void> cleanup = _stopControlServerAfterExit();
+    _exitCleanup = cleanup;
+    unawaited(
+      _finishExitCleanup(
+        cleanup: cleanup,
+        exit: exit,
+        stableRun: stableRun,
+        generation: generation,
+      ),
+    );
+  }
+
+  Future<void> _finishExitCleanup({
+    required Future<void> cleanup,
+    required BridgeProcessExit? exit,
+    required bool stableRun,
+    required int generation,
+  }) async {
+    await cleanup;
+    if (identical(_exitCleanup, cleanup)) {
+      _exitCleanup = null;
+    }
+    if (_disposed || generation != _lifecycleGeneration) {
+      return;
+    }
+    _applyExitPolicy(
+      exit: exit,
+      stableRun: stableRun,
+      generation: generation,
+    );
+  }
+
+  Future<void> _stopControlServerAfterExit() async {
     try {
       await _controlChannelServer.stop();
     } on Object catch (error, stackTrace) {
       _reportWarning(
-        message: "Failed to stop the control channel after the bridge exited",
+        message: "Failed to stop the bridge control server after process exit",
         error: error,
         stackTrace: stackTrace,
       );
     }
-    _setState(const BridgeProcessStopped());
   }
 
-  void _setState(BridgeProcessState state) {
+  void _applyExitPolicy({
+    required BridgeProcessExit? exit,
+    required bool stableRun,
+    required int generation,
+  }) {
+    if (stableRun) {
+      _crashCount = 0;
+    }
+    if (_desiredState == BridgeProcessDesiredState.off || (exit?.expected ?? false)) {
+      _publish(const BridgeProcessStopped());
+      return;
+    }
+
+    final int? exitCode = exit?.exitCode;
+    if (exitCode == null) {
+      _scheduleCrashRetry(
+        exitCode: null,
+        generation: generation,
+        source: _BridgeCrashSource.exitObservation,
+      );
+      return;
+    }
+
+    switch (BridgeSupervisedExitCode.fromCode(code: exitCode)) {
+      case BridgeSupervisedExitCode.cleanStop:
+        _desiredState = BridgeProcessDesiredState.off;
+        _crashCount = 0;
+        _publish(const BridgeProcessStopped());
+        return;
+      case BridgeSupervisedExitCode.restart:
+        _restartAutomatically(
+          generation: generation,
+          context: "Bridge restart after supervised restart exit",
+        );
+        return;
+      case BridgeSupervisedExitCode.authRequired:
+        _crashCount = 0;
+        _publish(const BridgeProcessLoginRequired());
+        return;
+      case BridgeSupervisedExitCode.bridgeContention:
+        _crashCount = 0;
+        _publish(const BridgeProcessContention());
+        return;
+      case null:
+        _scheduleCrashRetry(
+          exitCode: exitCode,
+          generation: generation,
+          source: _BridgeCrashSource.processExit,
+        );
+        return;
+    }
+  }
+
+  void _scheduleCrashRetry({
+    required int? exitCode,
+    required int generation,
+    required _BridgeCrashSource source,
+  }) {
+    if (_disposed || generation != _lifecycleGeneration || _desiredState == BridgeProcessDesiredState.off) {
+      return;
+    }
+    _crashCount++;
+    if (_crashCount > _crashBackoffDelays.length) {
+      final List<BridgeProcessLogEntry> snapshot = _logTracker.snapshot;
+      final int firstRecentIndex = snapshot.length > _recentLogCount ? snapshot.length - _recentLogCount : 0;
+      _publish(
+        BridgeProcessCrashGiveUp(
+          exitCode: exitCode,
+          crashCount: _crashCount,
+          recentLogs: snapshot.sublist(firstRecentIndex),
+        ),
+      );
+      return;
+    }
+
+    final Duration delay = _crashBackoffDelays[_crashCount - 1];
+    _publish(
+      BridgeProcessCrashRetryScheduled(
+        exitCode: exitCode,
+        crashCount: _crashCount,
+        delay: delay,
+      ),
+    );
+    _retryTimer = Timer(delay, () {
+      _retryTimer = null;
+      if (_disposed || generation != _lifecycleGeneration || _desiredState == BridgeProcessDesiredState.off) {
+        return;
+      }
+      _restartAutomatically(
+        generation: generation,
+        context: source.retryContext,
+      );
+    });
+  }
+
+  void _restartAutomatically({required int generation, required String context}) {
+    if (_disposed || generation != _lifecycleGeneration || _desiredState == BridgeProcessDesiredState.off) {
+      return;
+    }
+    unawaited(
+      _observeAutomaticStart(
+        operation: _requestStart(),
+        generation: generation,
+        context: context,
+      ),
+    );
+  }
+
+  Future<void> _observeAutomaticStart({
+    required Future<void> operation,
+    required int generation,
+    required String context,
+  }) async {
+    try {
+      await operation;
+    } on Object catch (error, stackTrace) {
+      _reportWarning(message: context, error: error, stackTrace: stackTrace);
+      if (!_repository.isRunning && _activePid == null) {
+        _scheduleCrashRetry(
+          exitCode: null,
+          generation: generation,
+          source: _BridgeCrashSource.automaticStart,
+        );
+      }
+    }
+  }
+
+  void _onAuthStateChanged({required AuthState state}) {
+    if (state is! AuthAuthenticated ||
+        _disposed ||
+        _desiredState == BridgeProcessDesiredState.off ||
+        this.state is! BridgeProcessLoginRequired) {
+      return;
+    }
+    _crashCount = 0;
+    _restartAutomatically(
+      generation: _lifecycleGeneration,
+      context: "Bridge start after successful authentication",
+    );
+  }
+
+  void _onHelperConnectionChanged({required bool connected}) {
+    if (connected && _activePid != null) {
+      _healthySince ??= _now();
+    }
+  }
+
+  bool _wasStableRun() {
+    final DateTime? healthySince = _healthySince;
+    if (healthySince == null) {
+      return false;
+    }
+    final Duration healthyRuntime = _now().difference(healthySince);
+    return !healthyRuntime.isNegative && healthyRuntime >= _stableRuntime;
+  }
+
+  void _clearRunHealth() {
+    _healthySince = null;
+  }
+
+  void _cancelRetry() {
+    _retryTimer?.cancel();
+    _retryTimer = null;
+  }
+
+  Future<void> _cleanUpFailedStart({
+    required bool controlStartAttempted,
+    required bool childCreated,
+  }) async {
+    if (childCreated) {
+      try {
+        await _repository.stopExpected();
+      } on Object catch (error, stackTrace) {
+        _reportWarning(
+          message: "Failed to stop a partially started bridge process",
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
+    }
+    if (controlStartAttempted) {
+      try {
+        await _controlChannelServer.stop();
+      } on Object catch (error, stackTrace) {
+        _reportWarning(
+          message: "Failed to stop the control server after bridge startup failed",
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
+    }
+    if (!_repository.isRunning) {
+      _activePid = null;
+      _clearRunHealth();
+    }
+  }
+
+  void _publish(BridgeProcessState state) {
     if (!_states.isClosed) {
       _states.add(state);
     }
@@ -302,9 +587,19 @@ class BridgeProcessService.forTesting({
       await stop();
     } finally {
       _disposed = true;
+      _cancelRetry();
+      await _authSubscription.cancel();
+      await _helperConnectionSubscription.cancel();
       await _exitSubscription.cancel();
-      await _controlChannelServer.stop();
       await _states.close();
     }
   }
+}
+
+final class const _BridgeProcessStartCancelled() implements Exception;
+
+enum _BridgeCrashSource({required final String retryContext}) {
+  processExit(retryContext: "Bridge restart after unexpected exit"),
+  exitObservation(retryContext: "Bridge restart after exit observer error"),
+  automaticStart(retryContext: "Bridge retry after automatic startup failure");
 }

--- a/client/module_desktop_core/lib/src/services/bridge_process_service.dart
+++ b/client/module_desktop_core/lib/src/services/bridge_process_service.dart
@@ -111,8 +111,10 @@ class BridgeProcessService.forTesting({
   int _successfulAuthenticationGeneration = 0;
   int _authenticationGenerationAtSpawn = 0;
   late AuthState _lastObservedAuthState;
+  BridgeProcessExit? _pendingStartupExit;
   int? _activePid;
   DateTime? _healthySince;
+  bool _startupExitPolicyClaimed = false;
   bool _disposed = false;
   BridgeProcessDesiredState _desiredState = BridgeProcessDesiredState.off;
 
@@ -184,6 +186,8 @@ class BridgeProcessService.forTesting({
       return;
     }
 
+    _pendingStartupExit = null;
+    _startupExitPolicyClaimed = false;
     _publish(const BridgeProcessStarting());
     bool controlStartAttempted = false;
     bool childCreated = false;
@@ -202,17 +206,20 @@ class BridgeProcessService.forTesting({
       _activePid = streams.pid;
       _authenticationGenerationAtSpawn = _successfulAuthenticationGeneration;
       _healthySince = null;
-      _throwIfStartCancelled();
-
-      await _logTracker.attach(stdout: streams.stdout, stderr: streams.stderr);
-      _throwIfStartCancelled();
-      streams.stdin.writeln(_controlChannelServer.secret);
-      await streams.stdin.flush();
-      _throwIfStartCancelled();
-
-      if (_activePid != streams.pid || !_repository.isRunning) {
+      final BridgeProcessExit? pendingStartupExit = _pendingStartupExit;
+      _pendingStartupExit = null;
+      if (pendingStartupExit?.pid == streams.pid) {
+        _beginExitCleanup(exit: pendingStartupExit);
         throw BridgeProcessExitedDuringStartException(pid: streams.pid);
       }
+      _throwIfStartCannotContinue(pid: streams.pid);
+
+      await _logTracker.attach(stdout: streams.stdout, stderr: streams.stderr);
+      _throwIfStartCannotContinue(pid: streams.pid);
+      streams.stdin.writeln(_controlChannelServer.secret);
+      await streams.stdin.flush();
+      _throwIfStartCannotContinue(pid: streams.pid);
+
       _publish(BridgeProcessRunning(pid: streams.pid));
     } on _BridgeProcessStartCancelled {
       await _cleanUpFailedStart(
@@ -225,8 +232,16 @@ class BridgeProcessService.forTesting({
         controlStartAttempted: controlStartAttempted,
         childCreated: childCreated,
       );
-      // The repository exit stream owns the resulting retry/stop policy and
-      // state. Publishing startup rollback state here would overwrite it.
+      _pendingStartupExit = null;
+      if (!_startupExitPolicyClaimed) {
+        _scheduleCrashRetry(
+          exitCode: null,
+          generation: _lifecycleGeneration,
+          source: _BridgeCrashSource.automaticStart,
+        );
+      }
+      // A claimed repository exit already owns its deliberate/crash policy;
+      // otherwise the startup fallback above prevents desired On from stalling.
       rethrow;
     } on Object {
       await _cleanUpFailedStart(
@@ -252,6 +267,13 @@ class BridgeProcessService.forTesting({
   void _throwIfStartCancelled() {
     if (_desiredState == BridgeProcessDesiredState.off || _disposed) {
       throw const _BridgeProcessStartCancelled();
+    }
+  }
+
+  void _throwIfStartCannotContinue({required int pid}) {
+    _throwIfStartCancelled();
+    if (_activePid != pid || !_repository.isRunning) {
+      throw BridgeProcessExitedDuringStartException(pid: pid);
     }
   }
 
@@ -318,6 +340,9 @@ class BridgeProcessService.forTesting({
 
   void _onExit(BridgeProcessExit exit) {
     if (_activePid != exit.pid) {
+      if (_activePid == null && state is BridgeProcessStarting) {
+        _pendingStartupExit = exit;
+      }
       return;
     }
     _beginExitCleanup(exit: exit);
@@ -336,6 +361,9 @@ class BridgeProcessService.forTesting({
   }
 
   void _beginExitCleanup({required BridgeProcessExit? exit}) {
+    if (state is BridgeProcessStarting) {
+      _startupExitPolicyClaimed = true;
+    }
     _activePid = null;
     final bool stableRun = _wasStableRun();
     final int authenticationGenerationAtSpawn = _authenticationGenerationAtSpawn;
@@ -577,7 +605,11 @@ class BridgeProcessService.forTesting({
   }
 
   void _onHelperConnectionChanged({required bool connected}) {
-    if (connected && _activePid != null) {
+    if (!connected) {
+      _healthySince = null;
+      return;
+    }
+    if (_activePid != null) {
       _healthySince ??= _now();
     }
   }

--- a/client/module_desktop_core/lib/src/services/bridge_process_service.dart
+++ b/client/module_desktop_core/lib/src/services/bridge_process_service.dart
@@ -4,6 +4,7 @@ import "package:injectable/injectable.dart";
 import "package:meta/meta.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_shared/sesori_shared.dart" show BridgeSupervisedExitCode;
 
 import "../foundation/control_channel_server.dart";
 import "../foundation/platform/bridge_executable_path_resolver.dart";
@@ -467,7 +468,7 @@ class BridgeProcessService.forTesting({
         _crashCount = 0;
         _publish(const BridgeProcessContention());
         return;
-      case null:
+      case BridgeSupervisedExitCode.controlChannelLost || null:
         _scheduleCrashRetry(
           exitCode: exitCode,
           generation: generation,

--- a/client/module_desktop_core/lib/src/services/bridge_process_service.dart
+++ b/client/module_desktop_core/lib/src/services/bridge_process_service.dart
@@ -66,6 +66,7 @@ class BridgeProcessService.forTesting({
         !_crashBackoffDelays.any((delay) => delay.isNegative),
         "crashBackoffDelays must not contain negative durations",
       ) {
+    _lastObservedAuthState = _authSession.currentState;
     _exitSubscription = _repository.exits.listen(
       _onExit,
       // ignore: no_slop_linter/prefer_required_named_parameters, Stream.listen error callbacks are positional
@@ -102,6 +103,8 @@ class BridgeProcessService.forTesting({
   Timer? _retryTimer;
   int _crashCount = 0;
   int _lifecycleGeneration = 0;
+  int _successfulAuthenticationGeneration = 0;
+  late AuthState _lastObservedAuthState;
   int? _activePid;
   DateTime? _healthySince;
   bool _disposed = false;
@@ -217,15 +220,34 @@ class BridgeProcessService.forTesting({
         controlStartAttempted: controlStartAttempted,
         childCreated: childCreated,
       );
-      _publish(_repository.isRunning ? BridgeProcessStopping(pid: _activePid) : const BridgeProcessStopped());
+      _publish(_stateAfterStartCleanup());
+    } on BridgeProcessExitedDuringStartException {
+      await _cleanUpFailedStart(
+        controlStartAttempted: controlStartAttempted,
+        childCreated: childCreated,
+      );
+      // The repository exit stream owns the resulting retry/stop policy and
+      // state. Publishing startup rollback state here would overwrite it.
+      rethrow;
     } on Object {
       await _cleanUpFailedStart(
         controlStartAttempted: controlStartAttempted,
         childCreated: childCreated,
       );
-      _publish(_repository.isRunning ? BridgeProcessStopping(pid: _activePid) : const BridgeProcessStopped());
+      _publish(_stateAfterStartCleanup());
       rethrow;
     }
+  }
+
+  BridgeProcessState _stateAfterStartCleanup() {
+    if (!_repository.isRunning) {
+      return const BridgeProcessStopped();
+    }
+    final int? pid = _repository.activePid;
+    if (pid == null) {
+      throw StateError("BridgeProcessRepository reported a running process without a PID");
+    }
+    return BridgeProcessStopping(pid: pid);
   }
 
   void _throwIfStartCancelled() {
@@ -269,18 +291,18 @@ class BridgeProcessService.forTesting({
       }
     }
 
-    final int? pid = _activePid;
-    if (pid != null || _repository.isRunning) {
-      _publish(BridgeProcessStopping(pid: pid ?? _repository.activePid));
+    final int? pid = _activePid ?? _repository.activePid;
+    if (pid != null) {
+      _publish(BridgeProcessStopping(pid: pid));
     }
     try {
       await _repository.stopExpected();
     } on Object {
       if (_repository.isRunning) {
         final int? recoveredPid = _repository.activePid ?? pid;
-        _publish(
-          recoveredPid == null ? const BridgeProcessStopping(pid: null) : BridgeProcessRunning(pid: recoveredPid),
-        );
+        if (recoveredPid != null) {
+          _publish(BridgeProcessRunning(pid: recoveredPid));
+        }
       }
       rethrow;
     }
@@ -319,6 +341,7 @@ class BridgeProcessService.forTesting({
     final bool stableRun = _wasStableRun();
     _clearRunHealth();
     final int generation = _lifecycleGeneration;
+    final int authenticationGeneration = _successfulAuthenticationGeneration;
     final Future<void> cleanup = _stopControlServerAfterExit();
     _exitCleanup = cleanup;
     unawaited(
@@ -327,6 +350,7 @@ class BridgeProcessService.forTesting({
         exit: exit,
         stableRun: stableRun,
         generation: generation,
+        authenticationGeneration: authenticationGeneration,
       ),
     );
   }
@@ -336,6 +360,7 @@ class BridgeProcessService.forTesting({
     required BridgeProcessExit? exit,
     required bool stableRun,
     required int generation,
+    required int authenticationGeneration,
   }) async {
     await cleanup;
     if (identical(_exitCleanup, cleanup)) {
@@ -348,6 +373,7 @@ class BridgeProcessService.forTesting({
       exit: exit,
       stableRun: stableRun,
       generation: generation,
+      authenticationGeneration: authenticationGeneration,
     );
   }
 
@@ -367,6 +393,7 @@ class BridgeProcessService.forTesting({
     required BridgeProcessExit? exit,
     required bool stableRun,
     required int generation,
+    required int authenticationGeneration,
   }) {
     if (stableRun) {
       _crashCount = 0;
@@ -401,6 +428,12 @@ class BridgeProcessService.forTesting({
       case BridgeSupervisedExitCode.authRequired:
         _crashCount = 0;
         _publish(const BridgeProcessLoginRequired());
+        if (_successfulAuthenticationGeneration > authenticationGeneration) {
+          _restartAutomatically(
+            generation: generation,
+            context: "Bridge start after authentication completed during exit cleanup",
+          );
+        }
         return;
       case BridgeSupervisedExitCode.bridgeContention:
         _crashCount = 0;
@@ -478,6 +511,11 @@ class BridgeProcessService.forTesting({
   }) async {
     try {
       await operation;
+    } on BridgeProcessExitedDuringStartException {
+      // The repository exit stream already owns this child and schedules its
+      // one policy action. Counting the same early exit here would consume two
+      // crash-budget entries and leave two retry timers.
+      return;
     } on Object catch (error, stackTrace) {
       _reportWarning(message: context, error: error, stackTrace: stackTrace);
       if (!_repository.isRunning && _activePid == null) {
@@ -491,6 +529,11 @@ class BridgeProcessService.forTesting({
   }
 
   void _onAuthStateChanged({required AuthState state}) {
+    final bool wasAuthenticated = _lastObservedAuthState is AuthAuthenticated;
+    _lastObservedAuthState = state;
+    if (state is AuthAuthenticated && !wasAuthenticated) {
+      _successfulAuthenticationGeneration++;
+    }
     if (state is! AuthAuthenticated ||
         _disposed ||
         _desiredState == BridgeProcessDesiredState.off ||
@@ -588,6 +631,17 @@ class BridgeProcessService.forTesting({
     } finally {
       _disposed = true;
       _cancelRetry();
+      try {
+        await _controlChannelServer.stop();
+      } on Object catch (error, stackTrace) {
+        // Disposal must preserve a stopExpected failure while still revoking
+        // the authenticated local socket as best effort.
+        _reportWarning(
+          message: "Failed to stop the bridge control server during disposal",
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
       await _authSubscription.cancel();
       await _helperConnectionSubscription.cancel();
       await _exitSubscription.cancel();

--- a/client/module_desktop_core/lib/src/services/bridge_process_service.dart
+++ b/client/module_desktop_core/lib/src/services/bridge_process_service.dart
@@ -116,7 +116,7 @@ class BridgeProcessService.forTesting({
   int? _activePid;
   DateTime? _healthySince;
   bool _stableRuntimeReached = false;
-  bool _startupExitPolicyClaimed = false;
+  _BridgeStartupExitClaim _startupExitClaim = _BridgeStartupExitClaim.none;
   bool _disposed = false;
   BridgeProcessDesiredState _desiredState = BridgeProcessDesiredState.off;
 
@@ -189,7 +189,7 @@ class BridgeProcessService.forTesting({
     }
 
     _pendingStartupExit = null;
-    _startupExitPolicyClaimed = false;
+    _startupExitClaim = _BridgeStartupExitClaim.none;
     _publish(const BridgeProcessStarting());
     bool controlStartAttempted = false;
     bool childCreated = false;
@@ -241,7 +241,7 @@ class BridgeProcessService.forTesting({
         childCreated: childCreated,
       );
       _pendingStartupExit = null;
-      if (!_startupExitPolicyClaimed) {
+      if (!_startupExitClaim.ownsRecovery) {
         _scheduleCrashRetry(
           exitCode: null,
           generation: _lifecycleGeneration,
@@ -257,7 +257,7 @@ class BridgeProcessService.forTesting({
         childCreated: childCreated,
       );
       final int? pid = spawnedPid;
-      if (_startupExitPolicyClaimed && pid != null) {
+      if (_startupExitClaim.ownsRecovery && pid != null) {
         throw BridgeProcessExitedDuringStartException(
           pid: pid,
           innerCause: AsyncError(error, stackTrace),
@@ -380,7 +380,9 @@ class BridgeProcessService.forTesting({
 
   void _beginExitCleanup({required BridgeProcessExit? exit}) {
     if (state is BridgeProcessStarting) {
-      _startupExitPolicyClaimed = true;
+      _startupExitClaim = exit?.expected ?? false
+          ? _BridgeStartupExitClaim.expected
+          : _BridgeStartupExitClaim.unexpected;
     }
     _activePid = null;
     final bool stableRun = _wasStableRun();
@@ -443,7 +445,8 @@ class BridgeProcessService.forTesting({
     if (stableRun) {
       _crashCount = 0;
     }
-    if (_desiredState == BridgeProcessDesiredState.off || (exit?.expected ?? false)) {
+    if (_desiredState == BridgeProcessDesiredState.off ||
+        ((exit?.expected ?? false) && _startupExitClaim == _BridgeStartupExitClaim.expected)) {
       _publish(const BridgeProcessStopped());
       return;
     }
@@ -460,6 +463,13 @@ class BridgeProcessService.forTesting({
 
     switch (BridgeSupervisedExitCode.fromCode(code: exitCode)) {
       case BridgeSupervisedExitCode.cleanStop:
+        if (exit?.expected ?? false) {
+          _restartAutomaticallyAfterCurrentStart(
+            generation: generation,
+            context: "Bridge restart after a superseded expected stop",
+          );
+          return;
+        }
         _desiredState = BridgeProcessDesiredState.off;
         _crashCount = 0;
         _publish(const BridgeProcessStopped());
@@ -743,6 +753,12 @@ class BridgeProcessService.forTesting({
 }
 
 final class const _BridgeProcessStartCancelled() implements Exception;
+
+enum _BridgeStartupExitClaim({required final bool ownsRecovery}) {
+  none(ownsRecovery: false),
+  expected(ownsRecovery: false),
+  unexpected(ownsRecovery: true);
+}
 
 enum _BridgeCrashSource({required final String retryContext}) {
   processExit(retryContext: "Bridge restart after unexpected exit"),

--- a/client/module_desktop_core/lib/src/services/bridge_process_service.dart
+++ b/client/module_desktop_core/lib/src/services/bridge_process_service.dart
@@ -104,6 +104,7 @@ class BridgeProcessService.forTesting({
   int _crashCount = 0;
   int _lifecycleGeneration = 0;
   int _successfulAuthenticationGeneration = 0;
+  int _authenticationGenerationAtSpawn = 0;
   late AuthState _lastObservedAuthState;
   int? _activePid;
   DateTime? _healthySince;
@@ -202,6 +203,7 @@ class BridgeProcessService.forTesting({
       );
       childCreated = true;
       _activePid = streams.pid;
+      _authenticationGenerationAtSpawn = _successfulAuthenticationGeneration;
       _healthySince = null;
       _throwIfStartCancelled();
 
@@ -339,9 +341,9 @@ class BridgeProcessService.forTesting({
   void _beginExitCleanup({required BridgeProcessExit? exit}) {
     _activePid = null;
     final bool stableRun = _wasStableRun();
+    final int authenticationGenerationAtSpawn = _authenticationGenerationAtSpawn;
     _clearRunHealth();
     final int generation = _lifecycleGeneration;
-    final int authenticationGeneration = _successfulAuthenticationGeneration;
     final Future<void> cleanup = _stopControlServerAfterExit();
     _exitCleanup = cleanup;
     unawaited(
@@ -350,7 +352,7 @@ class BridgeProcessService.forTesting({
         exit: exit,
         stableRun: stableRun,
         generation: generation,
-        authenticationGeneration: authenticationGeneration,
+        authenticationGenerationAtSpawn: authenticationGenerationAtSpawn,
       ),
     );
   }
@@ -360,7 +362,7 @@ class BridgeProcessService.forTesting({
     required BridgeProcessExit? exit,
     required bool stableRun,
     required int generation,
-    required int authenticationGeneration,
+    required int authenticationGenerationAtSpawn,
   }) async {
     await cleanup;
     if (identical(_exitCleanup, cleanup)) {
@@ -373,7 +375,7 @@ class BridgeProcessService.forTesting({
       exit: exit,
       stableRun: stableRun,
       generation: generation,
-      authenticationGeneration: authenticationGeneration,
+      authenticationGenerationAtSpawn: authenticationGenerationAtSpawn,
     );
   }
 
@@ -393,7 +395,7 @@ class BridgeProcessService.forTesting({
     required BridgeProcessExit? exit,
     required bool stableRun,
     required int generation,
-    required int authenticationGeneration,
+    required int authenticationGenerationAtSpawn,
   }) {
     if (stableRun) {
       _crashCount = 0;
@@ -428,10 +430,11 @@ class BridgeProcessService.forTesting({
       case BridgeSupervisedExitCode.authRequired:
         _crashCount = 0;
         _publish(const BridgeProcessLoginRequired());
-        if (_successfulAuthenticationGeneration > authenticationGeneration) {
+        if (_authSession.currentState is AuthAuthenticated &&
+            _successfulAuthenticationGeneration > authenticationGenerationAtSpawn) {
           _restartAutomatically(
             generation: generation,
-            context: "Bridge start after authentication completed during exit cleanup",
+            context: "Bridge start after authentication completed while the prior helper was exiting",
           );
         }
         return;
@@ -563,6 +566,7 @@ class BridgeProcessService.forTesting({
   }
 
   void _clearRunHealth() {
+    _authenticationGenerationAtSpawn = 0;
     _healthySince = null;
   }
 

--- a/client/module_desktop_core/lib/src/services/bridge_process_service.dart
+++ b/client/module_desktop_core/lib/src/services/bridge_process_service.dart
@@ -115,6 +115,7 @@ class BridgeProcessService.forTesting({
   BridgeProcessExit? _pendingStartupExit;
   int? _activePid;
   DateTime? _healthySince;
+  bool _stableRuntimeReached = false;
   bool _startupExitPolicyClaimed = false;
   bool _disposed = false;
   BridgeProcessDesiredState _desiredState = BridgeProcessDesiredState.off;
@@ -192,6 +193,7 @@ class BridgeProcessService.forTesting({
     _publish(const BridgeProcessStarting());
     bool controlStartAttempted = false;
     bool childCreated = false;
+    int? spawnedPid;
     try {
       controlStartAttempted = true;
       await _controlChannelServer.start();
@@ -204,14 +206,19 @@ class BridgeProcessService.forTesting({
         environment: null,
       );
       childCreated = true;
+      spawnedPid = streams.pid;
       _activePid = streams.pid;
       _authenticationGenerationAtSpawn = _successfulAuthenticationGeneration;
       _healthySince = null;
+      _stableRuntimeReached = false;
       final BridgeProcessExit? pendingStartupExit = _pendingStartupExit;
       _pendingStartupExit = null;
       if (pendingStartupExit?.pid == streams.pid) {
         _beginExitCleanup(exit: pendingStartupExit);
-        throw BridgeProcessExitedDuringStartException(pid: streams.pid);
+        throw BridgeProcessExitedDuringStartException(
+          pid: streams.pid,
+          innerCause: null,
+        );
       }
       _throwIfStartCannotContinue(pid: streams.pid);
 
@@ -244,11 +251,18 @@ class BridgeProcessService.forTesting({
       // A claimed repository exit already owns its deliberate/crash policy;
       // otherwise the startup fallback above prevents desired On from stalling.
       rethrow;
-    } on Object {
+    } on Object catch (error, stackTrace) {
       await _cleanUpFailedStart(
         controlStartAttempted: controlStartAttempted,
         childCreated: childCreated,
       );
+      final int? pid = spawnedPid;
+      if (_startupExitPolicyClaimed && pid != null) {
+        throw BridgeProcessExitedDuringStartException(
+          pid: pid,
+          innerCause: AsyncError(error, stackTrace),
+        );
+      }
       _publish(_stateAfterStartCleanup());
       rethrow;
     }
@@ -274,7 +288,10 @@ class BridgeProcessService.forTesting({
   void _throwIfStartCannotContinue({required int pid}) {
     _throwIfStartCancelled();
     if (_activePid != pid || !_repository.isRunning) {
-      throw BridgeProcessExitedDuringStartException(pid: pid);
+      throw BridgeProcessExitedDuringStartException(
+        pid: pid,
+        innerCause: null,
+      );
     }
   }
 
@@ -569,7 +586,15 @@ class BridgeProcessService.forTesting({
   }) async {
     try {
       await operation;
-    } on BridgeProcessExitedDuringStartException {
+    } on BridgeProcessExitedDuringStartException catch (error) {
+      final AsyncError? innerCause = error.innerCause;
+      if (innerCause != null) {
+        _reportWarning(
+          message: "Bridge startup failed after its process exit was already claimed",
+          error: innerCause.error,
+          stackTrace: innerCause.stackTrace,
+        );
+      }
       // The repository exit stream already owns this child and schedules its
       // one policy action. Counting the same early exit here would consume two
       // crash-budget entries and leave two retry timers.
@@ -607,6 +632,7 @@ class BridgeProcessService.forTesting({
 
   void _onHelperConnectionChanged({required bool connected}) {
     if (!connected) {
+      _stableRuntimeReached = _stableRuntimeReached || _currentHealthyIntervalIsStable();
       _healthySince = null;
       return;
     }
@@ -615,7 +641,9 @@ class BridgeProcessService.forTesting({
     }
   }
 
-  bool _wasStableRun() {
+  bool _wasStableRun() => _stableRuntimeReached || _currentHealthyIntervalIsStable();
+
+  bool _currentHealthyIntervalIsStable() {
     final DateTime? healthySince = _healthySince;
     if (healthySince == null) {
       return false;
@@ -627,6 +655,7 @@ class BridgeProcessService.forTesting({
   void _clearRunHealth() {
     _authenticationGenerationAtSpawn = 0;
     _healthySince = null;
+    _stableRuntimeReached = false;
   }
 
   void _cancelRetry() {

--- a/client/module_desktop_core/lib/src/services/bridge_process_service.dart
+++ b/client/module_desktop_core/lib/src/services/bridge_process_service.dart
@@ -9,6 +9,7 @@ import "../foundation/control_channel_server.dart";
 import "../foundation/platform/bridge_executable_path_resolver.dart";
 import "../repositories/bridge_process_repository.dart";
 import "../trackers/bridge_process_log_tracker.dart";
+import "../trackers/bridge_status_tracker.dart";
 import "bridge_process_state.dart";
 
 /// Reports a lifecycle warning without coupling tests to the global logger.
@@ -30,6 +31,7 @@ typedef BridgeProcessWarningReporter = void Function({
 class BridgeProcessService.forTesting({
   required final BridgeProcessRepository _repository,
   required final BridgeProcessLogTracker _logTracker,
+  required final BridgeStatusTracker _statusTracker,
   required final ControlChannelServer _controlChannelServer,
   required final AuthSession _authSession,
   required final BridgeExecutablePathResolver _executablePathResolver,
@@ -42,12 +44,14 @@ class BridgeProcessService.forTesting({
   new({
     required BridgeProcessRepository repository,
     required BridgeProcessLogTracker logTracker,
+    required BridgeStatusTracker statusTracker,
     required ControlChannelServer controlChannelServer,
     required AuthSession authSession,
     required BridgeExecutablePathResolver executablePathResolver,
   }) : this.forTesting(
          repository: repository,
          logTracker: logTracker,
+         statusTracker: statusTracker,
          controlChannelServer: controlChannelServer,
          authSession: authSession,
          executablePathResolver: executablePathResolver,
@@ -75,9 +79,10 @@ class BridgeProcessService.forTesting({
     _authSubscription = _authSession.authStateStream.listen(
       (state) => _onAuthStateChanged(state: state),
     );
-    _helperConnectionSubscription = _controlChannelServer.helperConnectionStream.listen(
-      (connected) => _onHelperConnectionChanged(connected: connected),
-    );
+    _helperStatusSubscription = _statusTracker.statusStream
+        .map((status) => status.helperOnline)
+        .distinct()
+        .listen((connected) => _onHelperConnectionChanged(connected: connected));
   }
 
   static const List<Duration> defaultCrashBackoffDelays = <Duration>[
@@ -95,7 +100,7 @@ class BridgeProcessService.forTesting({
   );
   late final StreamSubscription<BridgeProcessExit> _exitSubscription;
   late final StreamSubscription<AuthState> _authSubscription;
-  late final StreamSubscription<bool> _helperConnectionSubscription;
+  late final StreamSubscription<bool> _helperStatusSubscription;
 
   Future<void>? _startFuture;
   Future<void>? _stopFuture;
@@ -144,23 +149,15 @@ class BridgeProcessService.forTesting({
     if (existing != null) {
       return existing;
     }
-    final Future<void> operation = _start();
-    _startFuture = operation;
-    unawaited(_clearStartWhenComplete(operation: operation));
-    return operation;
-  }
-
-  Future<void> _clearStartWhenComplete({required Future<void> operation}) async {
-    try {
-      await operation;
-    } on Object {
-      // The original future retains the error for its caller. This observer
-      // only releases the serialized-operation slot.
-    } finally {
+    final Future<void> rawOperation = _start();
+    late final Future<void> operation;
+    operation = rawOperation.whenComplete(() {
       if (identical(_startFuture, operation)) {
         _startFuture = null;
       }
-    }
+    });
+    _startFuture = operation;
+    return operation;
   }
 
   Future<void> _start() async {
@@ -422,7 +419,7 @@ class BridgeProcessService.forTesting({
         _publish(const BridgeProcessStopped());
         return;
       case BridgeSupervisedExitCode.restart:
-        _restartAutomatically(
+        _restartAutomaticallyAfterCurrentStart(
           generation: generation,
           context: "Bridge restart after supervised restart exit",
         );
@@ -432,7 +429,7 @@ class BridgeProcessService.forTesting({
         _publish(const BridgeProcessLoginRequired());
         if (_authSession.currentState is AuthAuthenticated &&
             _successfulAuthenticationGeneration > authenticationGenerationAtSpawn) {
-          _restartAutomatically(
+          _restartAutomaticallyAfterCurrentStart(
             generation: generation,
             context: "Bridge start after authentication completed while the prior helper was exiting",
           );
@@ -494,6 +491,35 @@ class BridgeProcessService.forTesting({
     });
   }
 
+  void _restartAutomaticallyAfterCurrentStart({required int generation, required String context}) {
+    final Future<void>? currentStart = _startFuture;
+    if (currentStart == null) {
+      _restartAutomatically(generation: generation, context: context);
+      return;
+    }
+    unawaited(
+      _restartWhenCurrentStartCompletes(
+        currentStart: currentStart,
+        generation: generation,
+        context: context,
+      ),
+    );
+  }
+
+  Future<void> _restartWhenCurrentStartCompletes({
+    required Future<void> currentStart,
+    required int generation,
+    required String context,
+  }) async {
+    try {
+      await currentStart;
+    } on Object {
+      // The start's caller retains its outcome. Restart intent is independent
+      // and must wait until that serialized-operation slot has been released.
+    }
+    _restartAutomatically(generation: generation, context: context);
+  }
+
   void _restartAutomatically({required int generation, required String context}) {
     if (_disposed || generation != _lifecycleGeneration || _desiredState == BridgeProcessDesiredState.off) {
       return;
@@ -544,7 +570,7 @@ class BridgeProcessService.forTesting({
       return;
     }
     _crashCount = 0;
-    _restartAutomatically(
+    _restartAutomaticallyAfterCurrentStart(
       generation: _lifecycleGeneration,
       context: "Bridge start after successful authentication",
     );
@@ -647,7 +673,7 @@ class BridgeProcessService.forTesting({
         );
       }
       await _authSubscription.cancel();
-      await _helperConnectionSubscription.cancel();
+      await _helperStatusSubscription.cancel();
       await _exitSubscription.cancel();
       await _states.close();
     }

--- a/client/module_desktop_core/lib/src/services/bridge_process_state.dart
+++ b/client/module_desktop_core/lib/src/services/bridge_process_state.dart
@@ -1,0 +1,69 @@
+import "../trackers/bridge_process_log_tracker.dart";
+
+/// The user's in-memory intent for the supervised bridge.
+// WORKAROUND: dart_style 3.1.12 crashes on empty enhanced enum constructors.
+// ignore: use_primary_constructors
+enum BridgeProcessDesiredState { off, on }
+
+/// Deliberate child exit codes shared by the supervised bridge contract.
+enum BridgeSupervisedExitCode({required final int code}) {
+  cleanStop(code: 0),
+  restart(code: 86),
+  authRequired(code: 87),
+  bridgeContention(code: 88);
+
+  static BridgeSupervisedExitCode? fromCode({required int code}) {
+    for (final BridgeSupervisedExitCode value in values) {
+      if (value.code == code) {
+        return value;
+      }
+    }
+    return null;
+  }
+}
+
+/// Lifecycle state published by `BridgeProcessService`.
+sealed class const BridgeProcessState();
+
+/// No supervised helper is running or scheduled.
+final class const BridgeProcessStopped() extends BridgeProcessState;
+
+/// The bridge is desired On but an authenticated session is required first.
+final class const BridgeProcessLoginRequired() extends BridgeProcessState;
+
+/// The per-spawn control channel and child process are being created.
+final class const BridgeProcessStarting() extends BridgeProcessState;
+
+/// A supervised helper is currently running.
+final class const BridgeProcessRunning({required final int pid}) extends BridgeProcessState;
+
+/// An expected stop is in progress.
+final class const BridgeProcessStopping({required final int? pid}) extends BridgeProcessState;
+
+/// Another standalone or supervised bridge currently owns this machine.
+///
+/// Render this as state even during hidden startup; presentation layers decide
+/// when to surface a window and must never turn silent autostart into a modal.
+final class const BridgeProcessContention() extends BridgeProcessState;
+
+/// An unexpected exit is waiting for its bounded retry delay.
+final class const BridgeProcessCrashRetryScheduled({
+  required final int? exitCode,
+  required final int crashCount,
+  required final Duration delay,
+}) extends BridgeProcessState;
+
+/// The bounded crash budget is exhausted and automatic retries have stopped.
+final class BridgeProcessCrashGiveUp({
+  required final int? exitCode,
+  required final int crashCount,
+  required List<BridgeProcessLogEntry> recentLogs,
+}) extends BridgeProcessState {
+  final List<BridgeProcessLogEntry> recentLogs = List<BridgeProcessLogEntry>.unmodifiable(recentLogs);
+}
+
+/// The child exited after spawn but before startup could complete.
+final class const BridgeProcessExitedDuringStartException({required final int pid}) implements Exception {
+  @override
+  String toString() => "BridgeProcessExitedDuringStartException: bridge process $pid exited during startup";
+}

--- a/client/module_desktop_core/lib/src/services/bridge_process_state.dart
+++ b/client/module_desktop_core/lib/src/services/bridge_process_state.dart
@@ -5,23 +5,6 @@ import "../trackers/bridge_process_log_tracker.dart";
 // ignore: use_primary_constructors
 enum BridgeProcessDesiredState { off, on }
 
-/// Deliberate child exit codes shared by the supervised bridge contract.
-enum BridgeSupervisedExitCode({required final int code}) {
-  cleanStop(code: 0),
-  restart(code: 86),
-  authRequired(code: 87),
-  bridgeContention(code: 88);
-
-  static BridgeSupervisedExitCode? fromCode({required int code}) {
-    for (final BridgeSupervisedExitCode value in values) {
-      if (value.code == code) {
-        return value;
-      }
-    }
-    return null;
-  }
-}
-
 /// Lifecycle state published by `BridgeProcessService`.
 sealed class const BridgeProcessState();
 

--- a/client/module_desktop_core/lib/src/services/bridge_process_state.dart
+++ b/client/module_desktop_core/lib/src/services/bridge_process_state.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "../trackers/bridge_process_log_tracker.dart";
 
 /// The user's in-memory intent for the supervised bridge.
@@ -46,7 +48,10 @@ final class BridgeProcessCrashGiveUp({
 }
 
 /// The child exited after spawn but before startup could complete.
-final class const BridgeProcessExitedDuringStartException({required final int pid}) implements Exception {
+final class const BridgeProcessExitedDuringStartException({
+  required final int pid,
+  required final AsyncError? innerCause,
+}) implements Exception {
   @override
   String toString() => "BridgeProcessExitedDuringStartException: bridge process $pid exited during startup";
 }

--- a/client/module_desktop_core/lib/src/services/bridge_process_state.dart
+++ b/client/module_desktop_core/lib/src/services/bridge_process_state.dart
@@ -38,7 +38,7 @@ final class const BridgeProcessStarting() extends BridgeProcessState;
 final class const BridgeProcessRunning({required final int pid}) extends BridgeProcessState;
 
 /// An expected stop is in progress.
-final class const BridgeProcessStopping({required final int? pid}) extends BridgeProcessState;
+final class const BridgeProcessStopping({required final int pid}) extends BridgeProcessState;
 
 /// Another standalone or supervised bridge currently owns this machine.
 ///

--- a/client/module_desktop_core/lib/src/services/control_command_service.dart
+++ b/client/module_desktop_core/lib/src/services/control_command_service.dart
@@ -1,0 +1,37 @@
+import "dart:convert";
+
+import "package:injectable/injectable.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../foundation/control_channel_server.dart";
+import "../trackers/bridge_prompt_tracker.dart";
+
+/// The named prompt no longer belongs to the connected helper.
+final class const ControlPromptNotPendingException({required final String id}) implements Exception {
+  @override
+  String toString() => "ControlPromptNotPendingException: prompt $id is not pending";
+}
+
+/// Layer-3 owner of conversational GUI-to-helper control messages.
+///
+/// Expected process shutdown remains the repository's atomic operation. This
+/// service owns user answers such as `prompt_response`, and only removes a
+/// pending prompt after the frame was accepted by the live control socket.
+@lazySingleton
+class ControlCommandService({
+  required final ControlChannelServer _server,
+  required final BridgePromptTracker _promptTracker,
+}) {
+  void answerPrompt({required String id, required bool accepted}) {
+    if (!_promptTracker.prompts.any((prompt) => prompt.id == id)) {
+      throw ControlPromptNotPendingException(id: id);
+    }
+
+    final ControlMessage response = ControlMessage.promptResponse(
+      id: id,
+      accepted: accepted,
+    );
+    _server.send(jsonEncode(response.toJson()));
+    _promptTracker.removePrompt(id: id);
+  }
+}

--- a/client/module_desktop_core/lib/src/services/control_command_service.dart
+++ b/client/module_desktop_core/lib/src/services/control_command_service.dart
@@ -1,4 +1,5 @@
 import "package:injectable/injectable.dart";
+import "package:sesori_shared/sesori_shared.dart";
 
 import "../repositories/control_command_repository.dart";
 import "../trackers/bridge_prompt_tracker.dart";
@@ -19,12 +20,17 @@ class ControlCommandService({
   required final ControlCommandRepository _repository,
   required final BridgePromptTracker _promptTracker,
 }) {
-  void answerPrompt({required String id, required bool accepted}) {
-    if (!_promptTracker.prompts.any((prompt) => prompt.id == id)) {
-      throw ControlPromptNotPendingException(id: id);
+  /// Answers the exact pending prompt instance read from [BridgePromptTracker].
+  ///
+  /// Wire ids restart with each helper process. Identity therefore acts as the
+  /// local ownership token that prevents an old UI callback from approving a
+  /// replacement helper's same-id prompt.
+  void answerPrompt({required ControlPromptRequest prompt, required bool accepted}) {
+    if (!_promptTracker.prompts.any((pending) => identical(pending, prompt))) {
+      throw ControlPromptNotPendingException(id: prompt.id);
     }
 
-    _repository.answerPrompt(id: id, accepted: accepted);
-    _promptTracker.removePrompt(id: id);
+    _repository.answerPrompt(id: prompt.id, accepted: accepted);
+    _promptTracker.removePrompt(id: prompt.id);
   }
 }

--- a/client/module_desktop_core/lib/src/services/control_command_service.dart
+++ b/client/module_desktop_core/lib/src/services/control_command_service.dart
@@ -1,9 +1,6 @@
-import "dart:convert";
-
 import "package:injectable/injectable.dart";
-import "package:sesori_shared/sesori_shared.dart";
 
-import "../foundation/control_channel_server.dart";
+import "../repositories/control_command_repository.dart";
 import "../trackers/bridge_prompt_tracker.dart";
 
 /// The named prompt no longer belongs to the connected helper.
@@ -19,7 +16,7 @@ final class const ControlPromptNotPendingException({required final String id}) i
 /// pending prompt after the frame was accepted by the live control socket.
 @lazySingleton
 class ControlCommandService({
-  required final ControlChannelServer _server,
+  required final ControlCommandRepository _repository,
   required final BridgePromptTracker _promptTracker,
 }) {
   void answerPrompt({required String id, required bool accepted}) {
@@ -27,11 +24,7 @@ class ControlCommandService({
       throw ControlPromptNotPendingException(id: id);
     }
 
-    final ControlMessage response = ControlMessage.promptResponse(
-      id: id,
-      accepted: accepted,
-    );
-    _server.send(jsonEncode(response.toJson()));
+    _repository.answerPrompt(id: id, accepted: accepted);
     _promptTracker.removePrompt(id: id);
   }
 }

--- a/client/module_desktop_core/test/api/control_channel_api_test.dart
+++ b/client/module_desktop_core/test/api/control_channel_api_test.dart
@@ -1,0 +1,49 @@
+import "package:sesori_desktop_core/sesori_desktop_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("serializes a typed control message for the foundation server", () {
+    final _FakeControlChannelServer server = _FakeControlChannelServer();
+    final ControlChannelApi api = ControlChannelApi(server: server);
+
+    api.send(
+      message: const ControlMessage.promptResponse(id: "replace-1", accepted: true),
+    );
+
+    expect(server.sentFrames, hasLength(1));
+    expect(
+      ControlMessage.fromJson(jsonDecodeMap(server.sentFrames.single)),
+      const ControlMessage.promptResponse(id: "replace-1", accepted: true),
+    );
+  });
+
+  test("preserves the foundation transport failure", () {
+    final _FakeControlChannelServer server = _FakeControlChannelServer();
+    final ControlChannelApi api = ControlChannelApi(server: server);
+    final StateError failure = StateError("helper disconnected");
+    server.sendError = failure;
+
+    expect(
+      () => api.send(message: const ControlMessage.shutdown()),
+      throwsA(same(failure)),
+    );
+  });
+}
+
+class _FakeControlChannelServer() implements ControlChannelServer {
+  final List<String> sentFrames = <String>[];
+  Object? sendError;
+
+  @override
+  void send(String text) {
+    final Object? failure = sendError;
+    if (failure != null) {
+      throw failure;
+    }
+    sentFrames.add(text);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/client/module_desktop_core/test/di/injection_test.dart
+++ b/client/module_desktop_core/test/di/injection_test.dart
@@ -11,5 +11,7 @@ void main() {
     expect(getIt.isRegistered<BridgeProcessRepository>(), isTrue);
     expect(getIt.isRegistered<BridgeProcessLogStorage>(), isTrue);
     expect(getIt.isRegistered<BridgeProcessLogTracker>(), isTrue);
+    expect(getIt.isRegistered<BridgeProcessService>(), isTrue);
+    expect(getIt.isRegistered<ControlCommandService>(), isTrue);
   });
 }

--- a/client/module_desktop_core/test/di/injection_test.dart
+++ b/client/module_desktop_core/test/di/injection_test.dart
@@ -12,6 +12,8 @@ void main() {
     expect(getIt.isRegistered<BridgeProcessLogStorage>(), isTrue);
     expect(getIt.isRegistered<BridgeProcessLogTracker>(), isTrue);
     expect(getIt.isRegistered<BridgeProcessService>(), isTrue);
+    expect(getIt.isRegistered<ControlChannelApi>(), isTrue);
+    expect(getIt.isRegistered<ControlCommandRepository>(), isTrue);
     expect(getIt.isRegistered<ControlCommandService>(), isTrue);
   });
 }

--- a/client/module_desktop_core/test/services/bridge_process_service_test.dart
+++ b/client/module_desktop_core/test/services/bridge_process_service_test.dart
@@ -287,10 +287,13 @@ void main() {
       expect(service.state, isA<BridgeProcessRunning>());
     });
 
-    test("an automatically restarted child that exits during startup consumes one crash entry", () async {
+    test("a claimed exit followed by broken-pipe startup failure consumes one crash entry", () async {
       authSession.state = _authenticatedState;
       await service.start();
-      logTracker.onAttach = () => repository.emitExit(exitCode: 9, expected: false);
+      when(streams.stdin.flush).thenAnswer((_) {
+        repository.emitExit(exitCode: 9, expected: false);
+        return Future<void>.error(StateError("broken pipe"));
+      });
       final Future<BridgeProcessState> retryScheduled = service.states.firstWhere(
         (state) => state is BridgeProcessCrashRetryScheduled,
       );
@@ -307,6 +310,7 @@ void main() {
       );
       await pumpEventQueue();
       expect(service.state, same(retryState));
+      expect(warnings, contains("Bridge startup failed after its process exit was already claimed"));
     });
 
     test("an exit emitted before spawn returns is claimed by exactly one retry policy", () async {
@@ -514,6 +518,8 @@ void main() {
       statusTracker.markHelperConnected();
       await pumpEventQueue(times: 2);
       now = now.add(const Duration(minutes: 6));
+      statusTracker.markHelperDisconnected();
+      await pumpEventQueue(times: 2);
       repository.emitExit(exitCode: 21, expected: false);
       await pumpEventQueue();
 

--- a/client/module_desktop_core/test/services/bridge_process_service_test.dart
+++ b/client/module_desktop_core/test/services/bridge_process_service_test.dart
@@ -122,18 +122,18 @@ void main() {
       expect(service.state, isA<BridgeProcessStopped>());
     });
 
-    test("an unexpected child exit tears down the channel and schedules a bounded retry", () async {
+    test("control-channel loss tears down the channel and schedules a bounded retry", () async {
       authSession.state = _authenticatedState;
       await service.start();
 
-      repository.emitExit(exitCode: 7, expected: false);
+      repository.emitExit(exitCode: 1, expected: false);
       await pumpEventQueue();
 
       expect(controlServer.stopCalls, 1);
       expect(
         service.state,
         isA<BridgeProcessCrashRetryScheduled>()
-            .having((state) => state.exitCode, "exitCode", 7)
+            .having((state) => state.exitCode, "exitCode", 1)
             .having((state) => state.crashCount, "crashCount", 1)
             .having((state) => state.delay, "delay", const Duration(hours: 1)),
       );

--- a/client/module_desktop_core/test/services/bridge_process_service_test.dart
+++ b/client/module_desktop_core/test/services/bridge_process_service_test.dart
@@ -3,6 +3,7 @@ import "dart:convert";
 import "dart:io";
 
 import "package:mocktail/mocktail.dart";
+import "package:rxdart/rxdart.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_desktop_core/sesori_desktop_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -16,6 +17,7 @@ void main() {
     late _FakeControlChannelServer controlServer;
     late _FakeAuthSession authSession;
     late _FakeBridgeExecutablePathResolver executablePathResolver;
+    late DateTime now;
     late List<String> warnings;
     late BridgeProcessService service;
 
@@ -26,6 +28,7 @@ void main() {
       controlServer = _FakeControlChannelServer();
       authSession = _FakeAuthSession(initialState: const AuthState.unauthenticated());
       executablePathResolver = _FakeBridgeExecutablePathResolver(path: "/repo/bridge");
+      now = DateTime.utc(2026, 8, 28);
       warnings = <String>[];
       service = BridgeProcessService.forTesting(
         repository: repository,
@@ -33,17 +36,47 @@ void main() {
         controlChannelServer: controlServer,
         authSession: authSession,
         executablePathResolver: executablePathResolver,
+        crashBackoffDelays: const <Duration>[Duration(hours: 1)],
+        stableRuntime: const Duration(minutes: 5),
+        recentLogCount: 20,
+        now: () => now,
         reportWarning: ({required String message, required Object error, required StackTrace stackTrace}) {
           warnings.add(message);
         },
       );
     });
 
+    Future<void> rebuildService({
+      required List<Duration> crashBackoffDelays,
+      required Duration stableRuntime,
+      required int recentLogCount,
+    }) async {
+      await service.dispose();
+      repository.stopCalls = 0;
+      controlServer.stopCalls = 0;
+      service = BridgeProcessService.forTesting(
+        repository: repository,
+        logTracker: logTracker,
+        controlChannelServer: controlServer,
+        authSession: authSession,
+        executablePathResolver: executablePathResolver,
+        crashBackoffDelays: crashBackoffDelays,
+        stableRuntime: stableRuntime,
+        recentLogCount: recentLogCount,
+        now: () => now,
+        reportWarning: ({required String message, required Object error, required StackTrace stackTrace}) {
+          warnings.add(message);
+        },
+      );
+    }
+
     tearDown(() async {
       repository.stopError = null;
       controlServer.stopError = null;
       await service.dispose();
       await repository.disposeFake();
+      await authSession.disposeFake();
+      await controlServer.disposeFake();
     });
 
     test("signed-out start enters login-required without starting infrastructure", () async {
@@ -85,7 +118,7 @@ void main() {
       expect(service.state, isA<BridgeProcessStopped>());
     });
 
-    test("an observed child exit tears down the per-spawn channel", () async {
+    test("an unexpected child exit tears down the channel and schedules a bounded retry", () async {
       authSession.state = _authenticatedState;
       await service.start();
 
@@ -93,7 +126,13 @@ void main() {
       await pumpEventQueue();
 
       expect(controlServer.stopCalls, 1);
-      expect(service.state, isA<BridgeProcessStopped>());
+      expect(
+        service.state,
+        isA<BridgeProcessCrashRetryScheduled>()
+            .having((state) => state.exitCode, "exitCode", 7)
+            .having((state) => state.crashCount, "crashCount", 1)
+            .having((state) => state.delay, "delay", const Duration(hours: 1)),
+      );
     });
 
     test("control bind failure is cleaned up and permits retry", () async {
@@ -183,6 +222,204 @@ void main() {
       expect(warnings, hasLength(2));
       expect(service.state, isA<BridgeProcessStopping>());
     });
+
+    test("exit 86 immediately respawns exactly once", () async {
+      authSession.state = _authenticatedState;
+      await service.start();
+
+      repository.emitExit(exitCode: 86, expected: false);
+      await pumpEventQueue();
+
+      expect(repository.spawnCalls, 2);
+      expect(controlServer.startCalls, 2);
+      expect(service.state, isA<BridgeProcessRunning>());
+      await pumpEventQueue();
+      expect(repository.spawnCalls, 2);
+    });
+
+    test("exit 87 waits for a successful sign-in before restarting desired On", () async {
+      authSession.state = _authenticatedState;
+      await service.start();
+
+      repository.emitExit(exitCode: 87, expected: false);
+      await pumpEventQueue();
+
+      expect(service.state, isA<BridgeProcessLoginRequired>());
+      expect(service.desiredState, BridgeProcessDesiredState.on);
+      expect(repository.spawnCalls, 1);
+
+      authSession.state = const AuthState.unauthenticated();
+      authSession.state = _authenticatedState;
+      await pumpEventQueue();
+
+      expect(repository.spawnCalls, 2);
+      expect(service.state, isA<BridgeProcessRunning>());
+    });
+
+    test("manual Off while login is required prevents a later sign-in restart", () async {
+      authSession.state = _authenticatedState;
+      await service.start();
+      repository.emitExit(exitCode: 87, expected: false);
+      await pumpEventQueue();
+
+      await service.stop();
+      authSession.state = const AuthState.unauthenticated();
+      authSession.state = _authenticatedState;
+      await pumpEventQueue();
+
+      expect(service.desiredState, BridgeProcessDesiredState.off);
+      expect(service.state, isA<BridgeProcessStopped>());
+      expect(repository.spawnCalls, 1);
+    });
+
+    test("exit 88 surfaces contention and an explicit start performs a plain respawn", () async {
+      authSession.state = _authenticatedState;
+      await service.start();
+
+      repository.emitExit(exitCode: 88, expected: false);
+      await pumpEventQueue();
+
+      expect(service.state, isA<BridgeProcessContention>());
+      expect(repository.spawnCalls, 1);
+
+      await service.start();
+
+      expect(repository.spawnCalls, 2);
+      expect(service.state, isA<BridgeProcessRunning>());
+    });
+
+    test("clean and repository-expected exits never respawn", () async {
+      authSession.state = _authenticatedState;
+      await service.start();
+
+      repository.emitExit(exitCode: 0, expected: false);
+      await pumpEventQueue();
+
+      expect(service.state, isA<BridgeProcessStopped>());
+      expect(service.desiredState, BridgeProcessDesiredState.off);
+      expect(repository.spawnCalls, 1);
+
+      await service.start();
+      repository.emitExit(exitCode: 35, expected: true);
+      await pumpEventQueue();
+
+      expect(service.state, isA<BridgeProcessStopped>());
+      expect(repository.spawnCalls, 2);
+    });
+
+    test("rapid crashes exhaust the bounded budget and surface only recent log lines", () async {
+      await rebuildService(
+        crashBackoffDelays: const <Duration>[Duration.zero, Duration.zero],
+        stableRuntime: const Duration(minutes: 5),
+        recentLogCount: 2,
+      );
+      authSession.state = _authenticatedState;
+      logTracker.entries = <BridgeProcessLogEntry>[
+        BridgeProcessLogEntry(
+          timestamp: now,
+          source: BridgeProcessLogSource.stdout,
+          message: "old",
+        ),
+        BridgeProcessLogEntry(
+          timestamp: now,
+          source: BridgeProcessLogSource.stderr,
+          message: "recent-1",
+        ),
+        BridgeProcessLogEntry(
+          timestamp: now,
+          source: BridgeProcessLogSource.stdout,
+          message: "recent-2",
+        ),
+      ];
+      await service.start();
+
+      repository.emitExit(exitCode: 11, expected: false);
+      await pumpEventQueue();
+      expect(repository.spawnCalls, 2);
+      repository.emitExit(exitCode: 12, expected: false);
+      await pumpEventQueue();
+      expect(repository.spawnCalls, 3);
+      repository.emitExit(exitCode: 13, expected: false);
+      await pumpEventQueue();
+
+      expect(
+        service.state,
+        isA<BridgeProcessCrashGiveUp>()
+            .having((state) => state.exitCode, "exitCode", 13)
+            .having((state) => state.crashCount, "crashCount", 3)
+            .having(
+              (state) => state.recentLogs.map((entry) => entry.message),
+              "recent logs",
+              <String>["recent-1", "recent-2"],
+            ),
+      );
+      await pumpEventQueue();
+      expect(repository.spawnCalls, 3);
+    });
+
+    test("a stable control-connected runtime resets the crash budget", () async {
+      await rebuildService(
+        crashBackoffDelays: const <Duration>[Duration.zero, Duration(hours: 1)],
+        stableRuntime: const Duration(minutes: 5),
+        recentLogCount: 20,
+      );
+      authSession.state = _authenticatedState;
+      await service.start();
+
+      final Future<BridgeProcessState> respawned = service.states
+          .skip(1)
+          .firstWhere((state) => state is BridgeProcessRunning);
+      repository.emitExit(exitCode: 20, expected: false);
+      await respawned;
+      expect(repository.spawnCalls, 2);
+
+      controlServer.emitHelperConnected();
+      await pumpEventQueue(times: 2);
+      now = now.add(const Duration(minutes: 6));
+      repository.emitExit(exitCode: 21, expected: false);
+      await pumpEventQueue();
+
+      expect(repository.spawnCalls, 3);
+      expect(service.state, isA<BridgeProcessRunning>());
+    });
+
+    test("manual Start cancels a pending retry without a delayed second helper", () async {
+      await rebuildService(
+        crashBackoffDelays: const <Duration>[Duration(milliseconds: 25)],
+        stableRuntime: const Duration(minutes: 5),
+        recentLogCount: 20,
+      );
+      authSession.state = _authenticatedState;
+      await service.start();
+      repository.emitExit(exitCode: 30, expected: false);
+      await pumpEventQueue(times: 2);
+      expect(service.state, isA<BridgeProcessCrashRetryScheduled>());
+
+      await service.start();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(repository.spawnCalls, 2);
+      expect(service.state, isA<BridgeProcessRunning>());
+    });
+
+    test("manual Off cancels a pending retry", () async {
+      await rebuildService(
+        crashBackoffDelays: const <Duration>[Duration(milliseconds: 25)],
+        stableRuntime: const Duration(minutes: 5),
+        recentLogCount: 20,
+      );
+      authSession.state = _authenticatedState;
+      await service.start();
+      repository.emitExit(exitCode: 31, expected: false);
+      await pumpEventQueue(times: 2);
+      expect(service.state, isA<BridgeProcessCrashRetryScheduled>());
+
+      await service.stop();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(repository.spawnCalls, 1);
+      expect(service.state, isA<BridgeProcessStopped>());
+    });
   });
 
   test("dispatcher started before spawn completes a real authenticated token handshake", () async {
@@ -198,12 +435,17 @@ void main() {
       statusTracker: statusTracker,
       promptTracker: promptTracker,
     );
+    final _FakeAuthSession authSession = _FakeAuthSession(initialState: _authenticatedState);
     final BridgeProcessService service = BridgeProcessService.forTesting(
       repository: repository,
       logTracker: logTracker,
       controlChannelServer: server,
-      authSession: _FakeAuthSession(initialState: _authenticatedState),
+      authSession: authSession,
       executablePathResolver: _FakeBridgeExecutablePathResolver(path: "/repo/bridge"),
+      crashBackoffDelays: const <Duration>[Duration(hours: 1)],
+      stableRuntime: const Duration(minutes: 5),
+      recentLogCount: 20,
+      now: DateTime.now,
       reportWarning: ({required String message, required Object error, required StackTrace stackTrace}) {},
     );
     WebSocket? socket;
@@ -215,6 +457,7 @@ void main() {
       statusTracker.dispose();
       promptTracker.dispose();
       await repository.disposeFake();
+      await authSession.disposeFake();
     });
 
     dispatcher.start();
@@ -343,10 +586,14 @@ class _FakeBridgeProcessRepository({required final BridgeProcessStreams streams}
 
 class _FakeBridgeProcessLogTracker() implements BridgeProcessLogTracker {
   int attachCalls = 0;
+  List<BridgeProcessLogEntry> entries = <BridgeProcessLogEntry>[];
   Stream<List<int>>? attachedStdout;
   Stream<List<int>>? attachedStderr;
   Object? attachError;
   void Function()? onAttach;
+
+  @override
+  List<BridgeProcessLogEntry> get snapshot => List<BridgeProcessLogEntry>.unmodifiable(entries);
 
   @override
   Future<void> attach({required Stream<List<int>> stdout, required Stream<List<int>> stderr}) async {
@@ -365,11 +612,15 @@ class _FakeBridgeProcessLogTracker() implements BridgeProcessLogTracker {
 }
 
 class _FakeControlChannelServer() implements ControlChannelServer {
+  final BehaviorSubject<bool> _helperConnections = BehaviorSubject<bool>.seeded(false);
   int startCalls = 0;
   int stopCalls = 0;
   bool isRunning = false;
   Object? startError;
   Object? stopError;
+
+  @override
+  ValueStream<bool> get helperConnectionStream => _helperConnections.stream;
 
   @override
   Uri get url => Uri.parse("ws://127.0.0.1:${41000 + startCalls}");
@@ -391,21 +642,43 @@ class _FakeControlChannelServer() implements ControlChannelServer {
   Future<void> stop() async {
     stopCalls++;
     isRunning = false;
+    if (_helperConnections.value) {
+      _helperConnections.add(false);
+    }
     final Object? failure = stopError;
     if (failure != null) {
       throw failure;
     }
   }
 
+  void emitHelperConnected() {
+    _helperConnections.add(true);
+  }
+
+  Future<void> disposeFake() => _helperConnections.close();
+
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _FakeAuthSession({required AuthState initialState}) implements AuthSession {
-  AuthState state = initialState;
+  late final BehaviorSubject<AuthState> _states;
+
+  this {
+    _states = BehaviorSubject<AuthState>.seeded(initialState);
+  }
+
+  AuthState get state => _states.value;
+
+  set state(AuthState value) => _states.add(value);
+
+  @override
+  ValueStream<AuthState> get authStateStream => _states.stream;
 
   @override
   AuthState get currentState => state;
+
+  Future<void> disposeFake() => _states.close();
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/client/module_desktop_core/test/services/bridge_process_service_test.dart
+++ b/client/module_desktop_core/test/services/bridge_process_service_test.dart
@@ -206,8 +206,14 @@ void main() {
         ),
       );
 
+      await pumpEventQueue();
       expect(controlServer.stopCalls, greaterThanOrEqualTo(1));
-      expect(service.state, isA<BridgeProcessStopped>());
+      expect(
+        service.state,
+        isA<BridgeProcessCrashRetryScheduled>()
+            .having((state) => state.exitCode, "exitCode", 1)
+            .having((state) => state.crashCount, "crashCount", 1),
+      );
     });
 
     test("cleanup failures never replace the original startup error", () async {
@@ -220,7 +226,26 @@ void main() {
       await expectLater(service.start(), throwsA(same(attachError)));
 
       expect(warnings, hasLength(2));
-      expect(service.state, isA<BridgeProcessStopping>());
+      expect(
+        service.state,
+        isA<BridgeProcessStopping>().having((state) => state.pid, "pid", 42),
+      );
+    });
+
+    test("disposal revokes the control server while preserving the process-stop error", () async {
+      authSession.state = _authenticatedState;
+      await service.start();
+      final StateError stopError = StateError("process stop failed");
+      repository.stopError = stopError;
+      controlServer.stopError = StateError("control stop failed");
+
+      await expectLater(service.dispose(), throwsA(same(stopError)));
+
+      expect(controlServer.stopCalls, 1);
+      expect(
+        warnings,
+        contains("Failed to stop the bridge control server during disposal"),
+      );
     });
 
     test("exit 86 immediately respawns exactly once", () async {
@@ -237,6 +262,28 @@ void main() {
       expect(repository.spawnCalls, 2);
     });
 
+    test("an automatically restarted child that exits during startup consumes one crash entry", () async {
+      authSession.state = _authenticatedState;
+      await service.start();
+      logTracker.onAttach = () => repository.emitExit(exitCode: 9, expected: false);
+      final Future<BridgeProcessState> retryScheduled = service.states.firstWhere(
+        (state) => state is BridgeProcessCrashRetryScheduled,
+      );
+
+      repository.emitExit(exitCode: 86, expected: false);
+      final BridgeProcessState retryState = await retryScheduled;
+
+      expect(repository.spawnCalls, 2);
+      expect(
+        retryState,
+        isA<BridgeProcessCrashRetryScheduled>()
+            .having((state) => state.exitCode, "exitCode", 9)
+            .having((state) => state.crashCount, "crashCount", 1),
+      );
+      await pumpEventQueue();
+      expect(service.state, same(retryState));
+    });
+
     test("exit 87 waits for a successful sign-in before restarting desired On", () async {
       authSession.state = _authenticatedState;
       await service.start();
@@ -251,6 +298,28 @@ void main() {
       authSession.state = const AuthState.unauthenticated();
       authSession.state = _authenticatedState;
       await pumpEventQueue();
+
+      expect(repository.spawnCalls, 2);
+      expect(service.state, isA<BridgeProcessRunning>());
+    });
+
+    test("an authentication completed during exit-87 cleanup still restarts desired On", () async {
+      authSession.state = _authenticatedState;
+      await service.start();
+      controlServer.stopGate = Completer<void>();
+      final Future<BridgeProcessState> restarted = service.states
+          .skip(1)
+          .firstWhere(
+            (state) => state is BridgeProcessRunning,
+          );
+
+      repository.emitExit(exitCode: 87, expected: false);
+      await pumpEventQueue(times: 2);
+      authSession.state = const AuthState.unauthenticated();
+      authSession.state = _authenticatedState;
+      await pumpEventQueue(times: 2);
+      controlServer.stopGate!.complete();
+      await restarted;
 
       expect(repository.spawnCalls, 2);
       expect(service.state, isA<BridgeProcessRunning>());
@@ -618,6 +687,7 @@ class _FakeControlChannelServer() implements ControlChannelServer {
   bool isRunning = false;
   Object? startError;
   Object? stopError;
+  Completer<void>? stopGate;
 
   @override
   ValueStream<bool> get helperConnectionStream => _helperConnections.stream;
@@ -644,6 +714,10 @@ class _FakeControlChannelServer() implements ControlChannelServer {
     isRunning = false;
     if (_helperConnections.value) {
       _helperConnections.add(false);
+    }
+    final Completer<void>? gate = stopGate;
+    if (gate != null) {
+      await gate.future;
     }
     final Object? failure = stopError;
     if (failure != null) {

--- a/client/module_desktop_core/test/services/bridge_process_service_test.dart
+++ b/client/module_desktop_core/test/services/bridge_process_service_test.dart
@@ -193,6 +193,28 @@ void main() {
       expect(service.state, isA<BridgeProcessRunning>());
     });
 
+    test("rollback-generated expected exit still enters automatic startup retry", () async {
+      authSession.state = _authenticatedState;
+      await service.start();
+      logTracker.attachError = StateError("pipe attach failed");
+      repository.emitExpectedExitOnStop = true;
+      final Future<BridgeProcessState> retryScheduled = service.states.firstWhere(
+        (state) => state is BridgeProcessCrashRetryScheduled,
+      );
+
+      repository.emitExit(exitCode: 86, expected: false);
+      final BridgeProcessState retryState = await retryScheduled;
+
+      expect(repository.spawnCalls, 2);
+      expect(
+        retryState,
+        isA<BridgeProcessCrashRetryScheduled>()
+            .having((state) => state.exitCode, "exitCode", isNull)
+            .having((state) => state.crashCount, "crashCount", 1),
+      );
+      expect(service.desiredState, BridgeProcessDesiredState.on);
+    });
+
     test("exit during startup is surfaced and rolled back", () async {
       authSession.state = _authenticatedState;
       logTracker.onAttach = () {
@@ -430,7 +452,7 @@ void main() {
       expect(service.state, isA<BridgeProcessRunning>());
     });
 
-    test("clean and repository-expected exits never respawn", () async {
+    test("clean exit never respawns", () async {
       authSession.state = _authenticatedState;
       await service.start();
 
@@ -440,13 +462,29 @@ void main() {
       expect(service.state, isA<BridgeProcessStopped>());
       expect(service.desiredState, BridgeProcessDesiredState.off);
       expect(repository.spawnCalls, 1);
+    });
 
+    test("Start supersedes the expected marker retained by a failed Off", () async {
+      authSession.state = _authenticatedState;
       await service.start();
-      repository.emitExit(exitCode: 35, expected: true);
-      await pumpEventQueue();
+      repository.stopError = StateError("process remained alive");
+      await expectLater(service.stop(), throwsA(isA<StateError>()));
 
-      expect(service.state, isA<BridgeProcessStopped>());
-      expect(repository.spawnCalls, 2);
+      repository.stopError = null;
+      await service.start();
+      final Future<BridgeProcessState> retryScheduled = service.states.firstWhere(
+        (state) => state is BridgeProcessCrashRetryScheduled,
+      );
+      repository.emitExit(exitCode: 35, expected: true);
+      final BridgeProcessState retryState = await retryScheduled;
+
+      expect(
+        retryState,
+        isA<BridgeProcessCrashRetryScheduled>()
+            .having((state) => state.exitCode, "exitCode", 35)
+            .having((state) => state.crashCount, "crashCount", 1),
+      );
+      expect(service.desiredState, BridgeProcessDesiredState.on);
     });
 
     test("rapid crashes exhaust the bounded budget and surface only recent log lines", () async {
@@ -706,6 +744,7 @@ class _FakeBridgeProcessRepository({required final BridgeProcessStreams streams}
   List<String>? arguments;
   Object? spawnError;
   Object? stopError;
+  bool emitExpectedExitOnStop = false;
   void Function()? onSpawnBeforeReturn;
   bool _isRunning = false;
   int? _activePid;
@@ -745,6 +784,10 @@ class _FakeBridgeProcessRepository({required final BridgeProcessStreams streams}
     final Object? failure = stopError;
     if (failure != null) {
       throw failure;
+    }
+    if (emitExpectedExitOnStop) {
+      emitExit(exitCode: 0, expected: true);
+      return;
     }
     _isRunning = false;
     _activePid = null;

--- a/client/module_desktop_core/test/services/bridge_process_service_test.dart
+++ b/client/module_desktop_core/test/services/bridge_process_service_test.dart
@@ -14,6 +14,7 @@ void main() {
     late _ProcessStreamsFixture streams;
     late _FakeBridgeProcessRepository repository;
     late _FakeBridgeProcessLogTracker logTracker;
+    late BridgeStatusTracker statusTracker;
     late _FakeControlChannelServer controlServer;
     late _FakeAuthSession authSession;
     late _FakeBridgeExecutablePathResolver executablePathResolver;
@@ -25,6 +26,7 @@ void main() {
       streams = _ProcessStreamsFixture(pid: 42);
       repository = _FakeBridgeProcessRepository(streams: streams.value);
       logTracker = _FakeBridgeProcessLogTracker();
+      statusTracker = BridgeStatusTracker();
       controlServer = _FakeControlChannelServer();
       authSession = _FakeAuthSession(initialState: const AuthState.unauthenticated());
       executablePathResolver = _FakeBridgeExecutablePathResolver(path: "/repo/bridge");
@@ -33,6 +35,7 @@ void main() {
       service = BridgeProcessService.forTesting(
         repository: repository,
         logTracker: logTracker,
+        statusTracker: statusTracker,
         controlChannelServer: controlServer,
         authSession: authSession,
         executablePathResolver: executablePathResolver,
@@ -57,6 +60,7 @@ void main() {
       service = BridgeProcessService.forTesting(
         repository: repository,
         logTracker: logTracker,
+        statusTracker: statusTracker,
         controlChannelServer: controlServer,
         authSession: authSession,
         executablePathResolver: executablePathResolver,
@@ -76,7 +80,7 @@ void main() {
       await service.dispose();
       await repository.disposeFake();
       await authSession.disposeFake();
-      await controlServer.disposeFake();
+      statusTracker.dispose();
     });
 
     test("signed-out start enters login-required without starting infrastructure", () async {
@@ -260,6 +264,27 @@ void main() {
       expect(service.state, isA<BridgeProcessRunning>());
       await pumpEventQueue();
       expect(repository.spawnCalls, 2);
+    });
+
+    test("exit 86 during startup queues its respawn after the start slot clears", () async {
+      authSession.state = _authenticatedState;
+      logTracker.onAttach = () {
+        logTracker.onAttach = null;
+        repository.emitExit(exitCode: 86, expected: false);
+      };
+      final Future<BridgeProcessState> restarted = service.states.firstWhere(
+        (state) => state is BridgeProcessRunning,
+      );
+
+      await expectLater(
+        service.start(),
+        throwsA(isA<BridgeProcessExitedDuringStartException>()),
+      );
+      await restarted;
+
+      expect(repository.spawnCalls, 2);
+      expect(controlServer.startCalls, 2);
+      expect(service.state, isA<BridgeProcessRunning>());
     });
 
     test("an automatically restarted child that exits during startup consumes one crash entry", () async {
@@ -461,7 +486,7 @@ void main() {
       await respawned;
       expect(repository.spawnCalls, 2);
 
-      controlServer.emitHelperConnected();
+      statusTracker.markHelperConnected();
       await pumpEventQueue(times: 2);
       now = now.add(const Duration(minutes: 6));
       repository.emitExit(exitCode: 21, expected: false);
@@ -527,6 +552,7 @@ void main() {
     final BridgeProcessService service = BridgeProcessService.forTesting(
       repository: repository,
       logTracker: logTracker,
+      statusTracker: statusTracker,
       controlChannelServer: server,
       authSession: authSession,
       executablePathResolver: _FakeBridgeExecutablePathResolver(path: "/repo/bridge"),
@@ -700,16 +726,12 @@ class _FakeBridgeProcessLogTracker() implements BridgeProcessLogTracker {
 }
 
 class _FakeControlChannelServer() implements ControlChannelServer {
-  final BehaviorSubject<bool> _helperConnections = BehaviorSubject<bool>.seeded(false);
   int startCalls = 0;
   int stopCalls = 0;
   bool isRunning = false;
   Object? startError;
   Object? stopError;
   Completer<void>? stopGate;
-
-  @override
-  ValueStream<bool> get helperConnectionStream => _helperConnections.stream;
 
   @override
   Uri get url => Uri.parse("ws://127.0.0.1:${41000 + startCalls}");
@@ -731,9 +753,6 @@ class _FakeControlChannelServer() implements ControlChannelServer {
   Future<void> stop() async {
     stopCalls++;
     isRunning = false;
-    if (_helperConnections.value) {
-      _helperConnections.add(false);
-    }
     final Completer<void>? gate = stopGate;
     if (gate != null) {
       await gate.future;
@@ -743,12 +762,6 @@ class _FakeControlChannelServer() implements ControlChannelServer {
       throw failure;
     }
   }
-
-  void emitHelperConnected() {
-    _helperConnections.add(true);
-  }
-
-  Future<void> disposeFake() => _helperConnections.close();
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/client/module_desktop_core/test/services/bridge_process_service_test.dart
+++ b/client/module_desktop_core/test/services/bridge_process_service_test.dart
@@ -309,6 +309,31 @@ void main() {
       expect(service.state, same(retryState));
     });
 
+    test("an exit emitted before spawn returns is claimed by exactly one retry policy", () async {
+      authSession.state = _authenticatedState;
+      await service.start();
+      repository.onSpawnBeforeReturn = () {
+        repository.onSpawnBeforeReturn = null;
+        repository.emitExit(exitCode: 9, expected: false);
+      };
+      final Future<BridgeProcessState> retryScheduled = service.states.firstWhere(
+        (state) => state is BridgeProcessCrashRetryScheduled,
+      );
+
+      repository.emitExit(exitCode: 86, expected: false);
+      final BridgeProcessState retryState = await retryScheduled;
+
+      expect(repository.spawnCalls, 2);
+      expect(
+        retryState,
+        isA<BridgeProcessCrashRetryScheduled>()
+            .having((state) => state.exitCode, "exitCode", 9)
+            .having((state) => state.crashCount, "crashCount", 1),
+      );
+      await pumpEventQueue();
+      expect(service.state, same(retryState));
+    });
+
     test("exit 87 waits for a successful sign-in before restarting desired On", () async {
       authSession.state = _authenticatedState;
       await service.start();
@@ -496,6 +521,41 @@ void main() {
       expect(service.state, isA<BridgeProcessRunning>());
     });
 
+    test("a disconnected interval does not reset the crash budget", () async {
+      await rebuildService(
+        crashBackoffDelays: const <Duration>[Duration.zero, Duration(hours: 1)],
+        stableRuntime: const Duration(minutes: 5),
+        recentLogCount: 20,
+      );
+      authSession.state = _authenticatedState;
+      await service.start();
+
+      final Future<BridgeProcessState> respawned = service.states
+          .skip(1)
+          .firstWhere((state) => state is BridgeProcessRunning);
+      repository.emitExit(exitCode: 20, expected: false);
+      await respawned;
+
+      statusTracker.markHelperConnected();
+      await pumpEventQueue(times: 2);
+      now = now.add(const Duration(minutes: 4));
+      statusTracker.markHelperDisconnected();
+      await pumpEventQueue(times: 2);
+      statusTracker.markHelperConnected();
+      await pumpEventQueue(times: 2);
+      now = now.add(const Duration(minutes: 2));
+      repository.emitExit(exitCode: 21, expected: false);
+      await pumpEventQueue();
+
+      expect(
+        service.state,
+        isA<BridgeProcessCrashRetryScheduled>()
+            .having((state) => state.crashCount, "crashCount", 2)
+            .having((state) => state.delay, "delay", const Duration(hours: 1)),
+      );
+      expect(repository.spawnCalls, 2);
+    });
+
     test("manual Start cancels a pending retry without a delayed second helper", () async {
       await rebuildService(
         crashBackoffDelays: const <Duration>[Duration(milliseconds: 25)],
@@ -640,6 +700,7 @@ class _FakeBridgeProcessRepository({required final BridgeProcessStreams streams}
   List<String>? arguments;
   Object? spawnError;
   Object? stopError;
+  void Function()? onSpawnBeforeReturn;
   bool _isRunning = false;
   int? _activePid;
 
@@ -668,6 +729,7 @@ class _FakeBridgeProcessRepository({required final BridgeProcessStreams streams}
     }
     _isRunning = true;
     _activePid = streams.pid;
+    onSpawnBeforeReturn?.call();
     return streams;
   }
 

--- a/client/module_desktop_core/test/services/bridge_process_service_test.dart
+++ b/client/module_desktop_core/test/services/bridge_process_service_test.dart
@@ -303,6 +303,25 @@ void main() {
       expect(service.state, isA<BridgeProcessRunning>());
     });
 
+    test("an authentication completed before the exit-87 event still restarts desired On", () async {
+      authSession.state = _authenticatedState;
+      await service.start();
+      authSession.state = const AuthState.unauthenticated();
+      authSession.state = _authenticatedState;
+      await pumpEventQueue(times: 2);
+      final Future<BridgeProcessState> restarted = service.states
+          .skip(1)
+          .firstWhere(
+            (state) => state is BridgeProcessRunning,
+          );
+
+      repository.emitExit(exitCode: 87, expected: false);
+      await restarted;
+
+      expect(repository.spawnCalls, 2);
+      expect(service.state, isA<BridgeProcessRunning>());
+    });
+
     test("an authentication completed during exit-87 cleanup still restarts desired On", () async {
       authSession.state = _authenticatedState;
       await service.start();

--- a/client/module_desktop_core/test/services/control_command_service_test.dart
+++ b/client/module_desktop_core/test/services/control_command_service_test.dart
@@ -1,0 +1,86 @@
+import "package:sesori_desktop_core/sesori_desktop_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ControlCommandService", () {
+    late _FakeControlChannelServer server;
+    late BridgePromptTracker promptTracker;
+    late ControlCommandService service;
+
+    setUp(() {
+      server = _FakeControlChannelServer();
+      promptTracker = BridgePromptTracker();
+      service = ControlCommandService(
+        server: server,
+        promptTracker: promptTracker,
+      );
+    });
+
+    tearDown(() => promptTracker.dispose());
+
+    test("sends a typed prompt response and clears the answered prompt", () {
+      promptTracker.addPrompt(prompt: _prompt);
+
+      service.answerPrompt(id: _prompt.id, accepted: true);
+
+      expect(server.sentFrames, hasLength(1));
+      expect(
+        ControlMessage.fromJson(jsonDecodeMap(server.sentFrames.single)),
+        const ControlMessage.promptResponse(id: "replace-1", accepted: true),
+      );
+      expect(promptTracker.prompts, isEmpty);
+    });
+
+    test("retains the prompt when the connected helper cannot accept the frame", () {
+      promptTracker.addPrompt(prompt: _prompt);
+      const ControlHelperNotConnectedException sendError = ControlHelperNotConnectedException();
+      server.sendError = sendError;
+
+      expect(
+        () => service.answerPrompt(id: _prompt.id, accepted: false),
+        throwsA(same(sendError)),
+      );
+
+      expect(promptTracker.prompts, <ControlPromptRequest>[_prompt]);
+    });
+
+    test("rejects a stale prompt id before sending to a newer helper", () {
+      expect(
+        () => service.answerPrompt(id: "stale", accepted: true),
+        throwsA(
+          isA<ControlPromptNotPendingException>().having(
+            (error) => error.id,
+            "id",
+            "stale",
+          ),
+        ),
+      );
+
+      expect(server.sentFrames, isEmpty);
+    });
+  });
+}
+
+const ControlPromptRequest _prompt = ControlPromptRequest(
+  id: "replace-1",
+  kind: ControlPromptKind.replaceBridge,
+  message: "Replace the running bridge?",
+);
+
+class _FakeControlChannelServer() implements ControlChannelServer {
+  final List<String> sentFrames = <String>[];
+  Object? sendError;
+
+  @override
+  void send(String text) {
+    final Object? failure = sendError;
+    if (failure != null) {
+      throw failure;
+    }
+    sentFrames.add(text);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/client/module_desktop_core/test/services/control_command_service_test.dart
+++ b/client/module_desktop_core/test/services/control_command_service_test.dart
@@ -22,7 +22,7 @@ void main() {
     test("sends a typed prompt response and clears the answered prompt", () {
       promptTracker.addPrompt(prompt: _prompt);
 
-      service.answerPrompt(id: _prompt.id, accepted: true);
+      service.answerPrompt(prompt: _prompt, accepted: true);
 
       expect(
         api.sentMessages,
@@ -37,26 +37,36 @@ void main() {
       api.sendError = sendError;
 
       expect(
-        () => service.answerPrompt(id: _prompt.id, accepted: false),
+        () => service.answerPrompt(prompt: _prompt, accepted: false),
         throwsA(same(sendError)),
       );
 
       expect(promptTracker.prompts, <ControlPromptRequest>[_prompt]);
     });
 
-    test("rejects a stale prompt id before sending to a newer helper", () {
+    test("rejects a stale prompt instance when a replacement reuses its id", () {
+      promptTracker.addPrompt(prompt: _prompt);
+      promptTracker.clear();
+      final ControlPromptRequest replacement = ControlPromptRequest(
+        id: _prompt.id,
+        kind: _prompt.kind,
+        message: _prompt.message,
+      );
+      promptTracker.addPrompt(prompt: replacement);
+
       expect(
-        () => service.answerPrompt(id: "stale", accepted: true),
+        () => service.answerPrompt(prompt: _prompt, accepted: true),
         throwsA(
           isA<ControlPromptNotPendingException>().having(
             (error) => error.id,
             "id",
-            "stale",
+            _prompt.id,
           ),
         ),
       );
 
       expect(api.sentMessages, isEmpty);
+      expect(promptTracker.prompts, <ControlPromptRequest>[replacement]);
     });
   });
 }

--- a/client/module_desktop_core/test/services/control_command_service_test.dart
+++ b/client/module_desktop_core/test/services/control_command_service_test.dart
@@ -4,15 +4,15 @@ import "package:test/test.dart";
 
 void main() {
   group("ControlCommandService", () {
-    late _FakeControlChannelServer server;
+    late _FakeControlChannelApi api;
     late BridgePromptTracker promptTracker;
     late ControlCommandService service;
 
     setUp(() {
-      server = _FakeControlChannelServer();
+      api = _FakeControlChannelApi();
       promptTracker = BridgePromptTracker();
       service = ControlCommandService(
-        server: server,
+        repository: ControlCommandRepository(api: api),
         promptTracker: promptTracker,
       );
     });
@@ -24,10 +24,9 @@ void main() {
 
       service.answerPrompt(id: _prompt.id, accepted: true);
 
-      expect(server.sentFrames, hasLength(1));
       expect(
-        ControlMessage.fromJson(jsonDecodeMap(server.sentFrames.single)),
-        const ControlMessage.promptResponse(id: "replace-1", accepted: true),
+        api.sentMessages,
+        <ControlMessage>[const ControlMessage.promptResponse(id: "replace-1", accepted: true)],
       );
       expect(promptTracker.prompts, isEmpty);
     });
@@ -35,7 +34,7 @@ void main() {
     test("retains the prompt when the connected helper cannot accept the frame", () {
       promptTracker.addPrompt(prompt: _prompt);
       const ControlHelperNotConnectedException sendError = ControlHelperNotConnectedException();
-      server.sendError = sendError;
+      api.sendError = sendError;
 
       expect(
         () => service.answerPrompt(id: _prompt.id, accepted: false),
@@ -57,7 +56,7 @@ void main() {
         ),
       );
 
-      expect(server.sentFrames, isEmpty);
+      expect(api.sentMessages, isEmpty);
     });
   });
 }
@@ -68,19 +67,16 @@ const ControlPromptRequest _prompt = ControlPromptRequest(
   message: "Replace the running bridge?",
 );
 
-class _FakeControlChannelServer() implements ControlChannelServer {
-  final List<String> sentFrames = <String>[];
+class _FakeControlChannelApi() implements ControlChannelApi {
+  final List<ControlMessage> sentMessages = <ControlMessage>[];
   Object? sendError;
 
   @override
-  void send(String text) {
+  void send({required ControlMessage message}) {
     final Object? failure = sendError;
     if (failure != null) {
       throw failure;
     }
-    sentFrames.add(text);
+    sentMessages.add(message);
   }
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/docs/parallel-plugins/PLAN.md
+++ b/docs/parallel-plugins/PLAN.md
@@ -1699,7 +1699,7 @@ PR-level implementation plan:
     subscription and close its snapshot stream in `finally` even when `stopAll`
     fails; session listener/dispatcher/local-wire streams likewise close after
     their tails settle. Keep
-    `SupervisedExitCode` values `86/87/88/0/1`, contention/auth/restart sentinel
+    `BridgeSupervisedExitCode` values `86/87/88/0/1`, contention/auth/restart sentinel
     precedence, signal behavior, standalone exit behavior, and shutdown-error
     preservation unchanged. The stop-all ordered budget is one concurrent
     plugin budget, not the sum of plugin counts.

--- a/docs/regression/bridge-connectivity.md
+++ b/docs/regression/bridge-connectivity.md
@@ -57,6 +57,15 @@ explicit restart, and the connection states the app presents.
   restores retryable state, and rethrows the original failure.
 - The desktop's single inbound control dispatcher subscribes during shell
   bootstrap, before any helper spawn, so the first token request is answered.
+- Desktop exit policy treats 86 as one immediate restart, 87 as login-required
+  until a later successful sign-in when desired On, 88 as machine contention,
+  and clean or expected exits as stopped. Other exits retry after 1, 2, 4, 8,
+  and 16 seconds, then give up with the latest 20 helper log lines. Five minutes
+  of control-connected runtime resets that crash budget; every manual Start or
+  Off cancels a pending timer before acting.
+- Conversational GUI prompt answers are sent only for a prompt still owned by
+  the connected helper and clear that prompt only after the frame is accepted
+  by the live control socket. Expected shutdown remains repository-owned.
 
 ## Regression Levels
 
@@ -65,7 +74,7 @@ explicit restart, and the connection states the app presents.
 | L1 Smoke | A started bridge reaches readiness and answers a health request; a connected client reports connected. Headless bridge plus relay integration for the client-visible state; no plugin. |
 | L2 Routine | Relay integration for key exchange, a normal drop and reconnect, and clean shutdown; automated and headless bridge for stable machine-name registration plus sleep-policy enable, disable, warning, and wake-lock release. No plugin. |
 | L3 Release | The full connection state machine as presented, explicit restart with successor handoff, second-start ownership resolution, and a slow in-flight request not blocking key exchange or further requests. Client end to end plus headless bridge; a representative harness supplies the slow operation. |
-| L4 Extended | Relay integration or client end to end for takeover, revocation, live token re-authentication, handshake shutdown, app/network recovery, several clients, and alternate client platforms; headless supervised harness for control authentication, token rotation, prompts, status, provisioning progress, unregister, restart sentinels, normal shutdown during token bootstrap, owner loss, and POSIX/Windows orphan cleanup; desktop tests for authenticated spawn gating, first-token handshake, transactional spawn rollback/retry, malformed/newline-free output, bounded persistence, rotation, permissions, and transient storage-path failure recovery. |
+| L4 Extended | Relay integration or client end to end for takeover, revocation, live token re-authentication, handshake shutdown, app/network recovery, several clients, and alternate client platforms; headless supervised harness for control authentication, token rotation, prompts, status, provisioning progress, unregister, restart sentinels, normal shutdown during token bootstrap, owner loss, and POSIX/Windows orphan cleanup; desktop tests for authenticated spawn gating, first-token handshake, transactional spawn rollback/retry, every supervised exit class, bounded crash retry/give-up, stable-runtime budget reset, manual retry cancellation, prompt-answer ownership, malformed/newline-free output, bounded persistence, rotation, permissions, and transient storage-path failure recovery. |
 | L5 Full | Store-distributed app against a released bridge over production relay, older app against newer bridge and the reverse for the client/bridge wire contract, and a long-lived headless VM run over repeated reconnects. Packaged or external. |
 
 ## Exploration Guidance
@@ -98,6 +107,12 @@ the bridge starts, how many clients are present, and whether restart is explicit
 - A signed-out desktop spawning a helper, the control dispatcher starting after
   the helper, the control secret appearing in argv, a first token request going
   unread, or a failed spawn leaving its server or child alive and blocking retry.
+- Exit 86 spawning twice, exit 87 retrying before auth changes, exit 88 entering
+  crash backoff, an expected/clean exit respawning, an unbounded crash loop,
+  stable runtime failing to reset the budget, or a cancelled retry later
+  spawning a second helper after manual Start or Off.
+- A stale prompt answer reaching a newer helper, a failed prompt send removing
+  the pending prompt, or conversational sends bypassing the command service.
 
 ## Known Limitations
 

--- a/shared/sesori_shared/lib/sesori_shared.dart
+++ b/shared/sesori_shared/lib/sesori_shared.dart
@@ -89,6 +89,7 @@ export "src/models/sesori/success_empty_response.dart";
 export "src/models/sesori/update_session_archive_request.dart";
 export "src/models/sesori/yolo_settings.dart";
 export "src/notifications/session_notification_id.dart";
+export "src/protocol/bridge_supervised_exit_code.dart";
 export "src/protocol/close_codes.dart";
 export "src/protocol/constants.dart";
 export "src/protocol/control_message.dart";

--- a/shared/sesori_shared/lib/src/protocol/bridge_supervised_exit_code.dart
+++ b/shared/sesori_shared/lib/src/protocol/bridge_supervised_exit_code.dart
@@ -1,0 +1,31 @@
+/// Cross-product process exit contract between a supervised bridge and its
+/// desktop process supervisor.
+///
+/// Any code not represented here is an ordinary crash. The desktop may still
+/// apply crash policy to a represented outcome such as [controlChannelLost],
+/// but both products share one authoritative numeric meaning.
+enum BridgeSupervisedExitCode({required final int code}) {
+  /// A requested shutdown completed and the desktop must remain Off.
+  cleanStop(code: 0),
+
+  /// The local control-channel owner disappeared past its grace period.
+  controlChannelLost(code: 1),
+
+  /// An intentional restart handoff requires an immediate replacement helper.
+  restart(code: 86),
+
+  /// The GUI could not supply bootstrap authentication.
+  authRequired(code: 87),
+
+  /// Another same-machine bridge retained ownership.
+  bridgeContention(code: 88);
+
+  static BridgeSupervisedExitCode? fromCode({required int code}) {
+    for (final BridgeSupervisedExitCode value in values) {
+      if (value.code == code) {
+        return value;
+      }
+    }
+    return null;
+  }
+}

--- a/shared/sesori_shared/test/protocol/bridge_supervised_exit_code_test.dart
+++ b/shared/sesori_shared/test/protocol/bridge_supervised_exit_code_test.dart
@@ -1,0 +1,17 @@
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("maps every supervised bridge exit code from its process value", () {
+    for (final BridgeSupervisedExitCode value in BridgeSupervisedExitCode.values) {
+      expect(
+        BridgeSupervisedExitCode.fromCode(code: value.code),
+        same(value),
+      );
+    }
+  });
+
+  test("leaves ordinary crash codes outside the deliberate contract", () {
+    expect(BridgeSupervisedExitCode.fromCode(code: 42), isNull);
+  });
+}


### PR DESCRIPTION
## Complexity

🚧 Complex — this step adds concurrent lifecycle policy, cancellable delayed work, authenticated desired-state recovery, bounded crash handling, and a new outbound control-command owner.

## What

- Expanded `BridgeProcessService` with typed desired/lifecycle states for login-required, contention, scheduled crash retry, and crash give-up.
- Centralized the bridge/desktop process-exit ABI in shared `BridgeSupervisedExitCode`: clean/expected stop; 1 control-loss crash policy; 86 immediate restart; 87 login-required; 88 contention.
- Added bounded 1/2/4/8/16-second crash retries, a disconnect-aware and completion-latched five-minute stability reset derived from Layer-2 `BridgeStatusTracker`, and give-up state carrying the latest 20 helper log lines.
- Added lifecycle generations so Start/Off supersede stale markers/timers; restart waits for startup serialization, and pre-return, broken-pipe, or rollback-expected exits retain exactly one recovery owner.
- Added a strict `ControlCommandService` → `ControlCommandRepository` → `ControlChannelApi` → `ControlChannelServer` path for conversational `prompt_response`; actions must carry the exact tracked prompt instance, and prompts clear only after a successful socket send.
- Added DI/barrel wiring, state-machine and command tests, plan evidence, and regression guarantees.

## Why

The desktop supervisor needs one authoritative exit policy before tray/window orchestration can safely expose On/Off, login recovery, contention takeover, and crash diagnostics. Conversational GUI-to-helper commands also need a dedicated owner that does not couple cubits to the inbound dispatcher or move expected shutdown out of the process repository.

## Risk and test focus

Review focus should be exact exit-code classification, desired On versus manual Off across auth changes, retry-budget exhaustion/reset, timer cancellation under racing manual actions, exit 86 during startup, preservation of repository-owned expected stop, tracker-owned connection health, command-layer direction, contention remaining state during hidden startup, recent-log bounding, and prompt ownership when the helper disconnects.

## Expected result

No rendered UI or database change in this step. Internally, the supervised helper follows bounded and deterministic restart policy; login-required resumes only when still desired On; contention can be composed as a plain respawn plus acceptance of the fresh replacement prompt; and crash give-up exposes bounded local diagnostics.

## Verification

- `shared/sesori_shared`: analysis clean; 2 focused exit-contract tests passed
- `bridge/app`: analysis clean; 26 focused runtime/coordinator tests passed
- `client/module_desktop_core`: `dart analyze --fatal-infos` — clean
- `client/module_desktop_core`: `dart test` — 110 passed
- Focused process/command/API/DI suites — 34 passed
- `client/desktop`: `dart analyze --fatal-infos` — clean
- `client/desktop`: `flutter test` — 22 passed
- Desktop-core Injectable output regenerated with `build_runner`
- Dart LSP: 0 diagnostics across 9 affected Dart files
- Architecture implementation review: both B-Client passes approved with no findings
- `git diff --check` — clean
- 1,756 changed lines after review fixes, a 256-line review-driven overage beyond the 1,500-line soft cap

## Architecture review

Both allowed architecture implementation reviews approved the change with no findings. The final pass explicitly verified the service → repository → API → foundation command path, Layer-2 tracker ownership of connection health, Layer-4 dispatcher writes, serialized restart ownership, and generated DI composition. Process actions and expected-stop ownership remain in `BridgeProcessRepository`, and the Layer-3 services do not depend on each other.
