### PR TITLE
⚙️ [grok-harness] test: verify Grok and retire the plan [step 9/9]

### DIFF
--- a/.plan/completed/grok-harness/PLAN.md
+++ b/.plan/completed/grok-harness/PLAN.md
@@ -3,9 +3,9 @@
 ## Status
 
 - **Plan slug:** `grok-harness`
-- **Status:** active; Step 1/9 in PR #1152; current revision architecture-approved
+- **Status:** completed and retired on 2026-08-28; Steps 1-8 merged and the full Step 9 retirement matrix passed
 - **Plan date:** 2026-08-27
-- **Implementation base:** `origin/main`
+- **Implementation base:** `origin/main` at `cb9baa91dd` before the final retirement commit
 - **Delivery:** nine PRs with fixed titles and order below
 - **Initial product scope:** user-installed Grok Build CLI; no bridge-managed runtime installation
 

--- a/.plan/completed/grok-harness/TRACKER.md
+++ b/.plan/completed/grok-harness/TRACKER.md
@@ -165,15 +165,21 @@
 - [x] Re-run the affected live restart flow and the complete automated matrix after rebasing onto current main.
 - [x] Record privacy-safe evidence, remove disposable state, release the local-testing slot, and retire the plan.
 - [x] Publish final PR #1190 and start its monitor.
+- [x] Address #1190 review findings with required named turn parameters and prompt-write server-request ordering.
 
 ## Decisions And Evidence
 
 - 2026-08-28: Authenticated restart testing exposed one shared ACP defect: process-local fallback turn counters reused
   id-less assistant message IDs after a bridge restart, overwriting an earlier persisted answer. A second concrete race
   allowed an agent update to publish before the accepted user message while the prompt frame was still flushing. The
-  fix anchors fallback IDs to the accepted prompt identity and buffers those updates until the user message publishes.
-  Focused regressions, the complete ACP/downstream matrix, a live post-restart turn, and the final architecture review
-  all passed.
+  fix anchors fallback IDs to the accepted prompt identity and gates agent updates plus attributable server requests
+  until the user and preceding tool state publish. Focused regressions, the complete ACP/downstream matrix, a live
+  post-restart turn, and the final architecture review all passed.
+- 2026-08-28: PR #1190 review correctly required `beginTurn`'s nullable identity to remain named and required, and
+  identified that the prompt-write gate covered notifications but not the approval registry's separate server-request
+  stream. Every caller now states its identity choice, and attributable requests flush after the accepted user and
+  buffered tool updates. Deterministic slow-flush regressions cover cross-stream ordering and retain sessionless
+  attribution when another session dispatches before the first frame finishes flushing.
 - 2026-08-28: The released Grok 1.0.5 client matrix passed without a scope reduction. The authoritative YOLO-disabled
   runs exercised Once and Reject; the live requests advertised no Always action. Seven consecutive debug-only
   unrecognised-frame messages appeared only in the abandoned non-authoritative global-config launch; all six later
@@ -253,7 +259,7 @@ All required rows passed without a named reduction, so the plan is retired.
 
 | Scope | Commands | Result |
 |---|---|---|
-| Shared ACP | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 272 tests |
+| Shared ACP | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 274 tests |
 | Grok | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 52 tests |
 | Cursor | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 138 tests |
 | Copilot | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 13 tests |
@@ -265,7 +271,7 @@ All required rows passed without a named reduction, so the plan is retired.
 | Client workspace | `dart pub get` | Pass |
 | Prego | `dart analyze --fatal-infos`; `flutter test` | Pass: no issues; 245 tests |
 | Mobile and desktop | `dart analyze --fatal-infos` in each shell | Pass: no issues |
-| Changed Dart files | Dart LSP diagnostics | Pass: zero diagnostics across four files |
+| Changed Dart files | Dart LSP diagnostics | Pass: zero diagnostics across eight files |
 
 The final matrix ran again after rebasing onto current main. The Cursor suite's intentional missing-file case logged its
 expected `PathNotFoundException` while all 138 tests passed. Dart format 3.1.12 still crashes on the enhanced-enum
@@ -312,14 +318,17 @@ The real Grok transcript remained correct upstream, but after a bridge restart S
 showed a prior id-less assistant reply replaced by the next reply. The first divergent boundary was the shared ACP event
 mapper: fallback assistant IDs used a process-local turn counter that restarted at one. A second deterministic race
 showed an agent update could arrive while stdin flush was pending and publish before the synthetic accepted-user event.
+PR review extended that concrete race to a tool update followed by an attributable server request on the separate
+approval stream.
 
 `AcpEventMapper` now derives id-less assistant, halt, and error fallback IDs from the accepted prompt's stable user
-message ID. `AcpPlugin` buffers session updates only during the prompt-frame write, emits the accepted user first, then
-flushes the buffered updates, and drops the buffer on stale state, dispatch failure, or teardown. Two regressions cover
-mapper replacement and the flush race. A live post-restart turn then appeared and persisted as user followed by a
-separate assistant reply. There is no schema or migration; the fix prevents future overwrite/reordering. The
-deliberately
-corrupted disposable test database was removed rather than treated as production data.
+message ID. `AcpPlugin` gates session updates and server requests during the prompt-frame write, emits the accepted user
+first, flushes buffered updates before buffered requests, and drops both on stale state, dispatch failure, or teardown.
+Four regressions cover mapper replacement, the reply race, tool-before-permission ordering, and retained sessionless
+attribution. A live post-restart turn then appeared and persisted as user followed by a separate assistant reply. There
+is no schema or migration; the
+fix prevents future overwrite/reordering. The deliberately corrupted disposable test database was removed rather than
+treated as production data.
 
 ### Cleanup
 

--- a/.plan/completed/grok-harness/TRACKER.md
+++ b/.plan/completed/grok-harness/TRACKER.md
@@ -165,7 +165,7 @@
 - [x] Re-run the affected live restart flow and the complete automated matrix after rebasing onto current main.
 - [x] Record privacy-safe evidence, remove disposable state, release the local-testing slot, and retire the plan.
 - [x] Publish final PR #1190 and start its monitor.
-- [x] Address #1190 review findings with required named turn parameters and prompt-write server-request ordering.
+- [x] Address all #1190 review findings across named identity, prompt-write cancellation, and tool correlation.
 
 ## Decisions And Evidence
 
@@ -180,6 +180,10 @@
   stream. Every caller now states its identity choice, and attributable requests flush after the accepted user and
   buffered tool updates. Deterministic slow-flush regressions cover cross-stream ordering and retain sessionless
   attribution when another session dispatches before the first frame finishes flushing.
+- 2026-08-28: Follow-up #1190 review found that abort could precede buffered-request registration and that heuristic
+  session stamping could override Cursor's exact top-level tool-call correlation. Aborted write buffers now register
+  then cancel their requests in one flush, and exact mapped or buffered tool ownership wins without injecting a
+  session. Focused regressions cover both flows with concurrent sessions.
 - 2026-08-28: The released Grok 1.0.5 client matrix passed without a scope reduction. The authoritative YOLO-disabled
   runs exercised Once and Reject; the live requests advertised no Always action. Seven consecutive debug-only
   unrecognised-frame messages appeared only in the abandoned non-authoritative global-config launch; all six later
@@ -259,9 +263,9 @@ All required rows passed without a named reduction, so the plan is retired.
 
 | Scope | Commands | Result |
 |---|---|---|
-| Shared ACP | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 274 tests |
+| Shared ACP | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 275 tests |
 | Grok | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 52 tests |
-| Cursor | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 138 tests |
+| Cursor | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 139 tests |
 | Copilot | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 13 tests |
 | DeepSeek | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 41 tests |
 | Hermes | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 39 tests |
@@ -271,7 +275,7 @@ All required rows passed without a named reduction, so the plan is retired.
 | Client workspace | `dart pub get` | Pass |
 | Prego | `dart analyze --fatal-infos`; `flutter test` | Pass: no issues; 245 tests |
 | Mobile and desktop | `dart analyze --fatal-infos` in each shell | Pass: no issues |
-| Changed Dart files | Dart LSP diagnostics | Pass: zero diagnostics across eight files |
+| Changed Dart files | Dart LSP diagnostics | Pass: zero diagnostics across nine files |
 
 The final matrix ran again after rebasing onto current main. The Cursor suite's intentional missing-file case logged its
 expected `PathNotFoundException` while all 138 tests passed. Dart format 3.1.12 still crashes on the enhanced-enum
@@ -324,9 +328,11 @@ approval stream.
 `AcpEventMapper` now derives id-less assistant, halt, and error fallback IDs from the accepted prompt's stable user
 message ID. `AcpPlugin` gates session updates and server requests during the prompt-frame write, emits the accepted user
 first, flushes buffered updates before buffered requests, and drops both on stale state, dispatch failure, or teardown.
-Four regressions cover mapper replacement, the reply race, tool-before-permission ordering, and retained sessionless
-attribution. A live post-restart turn then appeared and persisted as user followed by a separate assistant reply. There
-is no schema or migration; the
+An abort marks the writing buffer so its requests are registered and cancelled together; exact tool-call ownership is
+preserved instead of being replaced by active-turn attribution. Six regressions cover mapper replacement, the reply
+race, tool-before-permission ordering, retained sessionless attribution, abort settlement, and Cursor tool correlation.
+A live post-restart turn then appeared and persisted as user followed by a separate assistant reply. There is no schema
+or migration; the
 fix prevents future overwrite/reordering. The deliberately corrupted disposable test database was removed rather than
 treated as production data.
 

--- a/.plan/completed/grok-harness/TRACKER.md
+++ b/.plan/completed/grok-harness/TRACKER.md
@@ -2,14 +2,14 @@
 
 ## Current State
 
-- **Plan:** `.plan/active/grok-harness/PLAN.md`
-- **Status:** Steps 1-7/9 merged; Step 8/9 in PR #1181
-- **Current branch:** `grok-harness-step-8-regression`
-- **Base:** `origin/main` after merged PR #1179
+- **Plan:** `.plan/completed/grok-harness/PLAN.md`
+- **Status:** completed through Step 9/9 and retired on 2026-08-28; every required row passed without reduction
+- **Current branch:** `grok-harness-step-9-verify-retire`
+- **Base:** `origin/main` at `cb9baa91dd`
 - **Architecture plan review:** approved 2026-08-27 after catalog ownership and auth-policy corrections
-- **Merged predecessor:** #1179 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1179>
-- **Open PR:** #1181 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1181>
-- **Local successor:** Step 9 starts after this tracker update is published
+- **Merged predecessor:** #1181 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1181>
+- **Open PR:** pending publication of Step 9
+- **Next action:** publish, review, and merge the final retirement PR
 
 ## Fixed Series
 
@@ -32,9 +32,9 @@
 7. `🌿 [grok-harness] feat(client): brand Grok Build [step 7/9]`
    - **State:** merged in #1179.
 8. `🌱 [grok-harness] docs: reconcile Grok regression coverage [step 8/9]`
-   - **State:** in PR #1181.
+   - **State:** merged in #1181.
 9. `⚙️ [grok-harness] test: verify Grok and retire the plan [step 9/9]`
-   - **State:** not started.
+   - **State:** verification and retirement complete; final PR pending publication.
 
 ## Step 1 Checklist
 
@@ -151,9 +151,32 @@
 - [x] Commit the completed successor locally; do not publish before #1179 merges.
 - [x] Rebase onto merged #1179 and repeat focused documentation validation.
 - [x] Publish Step 8 as PR #1181 and start its monitor.
+- [x] Merge Step 8 with all required checks passing.
+
+## Step 9 Checklist
+
+- [x] Rebase the final step onto merged #1181 and current `origin/main`.
+- [x] Run the required Git-scoped architecture review over Steps 2-7; approved with no findings.
+- [x] Run a final architecture review over the verification-discovered persisted-identity fix; approved with no
+  findings.
+- [x] Run the final package, app, shared, and client analyzer/test matrix.
+- [x] Exercise every required L1-L3 Grok row with an authenticated released CLI and iOS simulator client.
+- [x] Fix the live-discovered ACP restart identity and accepted-user ordering defect with deterministic regressions.
+- [x] Re-run the affected live restart flow and the complete automated matrix after rebasing onto current main.
+- [x] Record privacy-safe evidence, remove disposable state, release the local-testing slot, and retire the plan.
 
 ## Decisions And Evidence
 
+- 2026-08-28: Authenticated restart testing exposed one shared ACP defect: process-local fallback turn counters reused
+  id-less assistant message IDs after a bridge restart, overwriting an earlier persisted answer. A second concrete race
+  allowed an agent update to publish before the accepted user message while the prompt frame was still flushing. The
+  fix anchors fallback IDs to the accepted prompt identity and buffers those updates until the user message publishes.
+  Focused regressions, the complete ACP/downstream matrix, a live post-restart turn, and the final architecture review
+  all passed.
+- 2026-08-28: The released Grok 1.0.5 client matrix passed without a scope reduction. The authoritative YOLO-disabled
+  runs exercised Once and Reject; the live requests advertised no Always action. Seven consecutive debug-only
+  unrecognised-frame messages appeared only in the abandoned non-authoritative global-config launch; all six later
+  isolated bridge runs recorded none and showed no protocol loss.
 - 2026-08-28: Repeated substantive feedback exposed an incomplete parser/selection invariant matrix. The PR was removed
   from readiness and the monitor paused while hostile wire, state-transition, and general-correctness audits ran.
 - 2026-08-28: The consolidated correction masks irrelevant envelope branches, preserves valid catalog siblings,
@@ -201,4 +224,110 @@ Step 9 must record:
 - privacy-safe live evidence, first divergent boundary for failures, and cleanup;
 - `Pass`, `Partial`, `Fail`, `Blocked`, or `Not run` for every matrix row.
 
-The plan stays active unless all required rows pass or the user explicitly accepts a named reduction in `PLAN.md`.
+All required rows passed without a named reduction, so the plan is retired.
+
+## Step 9 Final Evidence
+
+### Release Boundary
+
+- **Grok runtime:** stable `1.0.5` build `5115b46bc909` from the user-installed `grok` on PATH.
+- **Bridge host:** Apple silicon (`arm64`), macOS 26.6.2; live source bridge at `ed10b6f04a` on main
+  `9395494962`. The identical fix was then rebased onto main `cb9baa91dd` and the automated matrix reran.
+- **Client:** source debug build at `5efede9afc`; iPhone 17 simulator named `sesori-dev-2` on iOS 26.5. The intervening
+  commits were documentation or unrelated code; the final current-source client analyzers and Prego suite also passed.
+- **Account capability:** one locally authenticated credential-backed account exposed at least two selectable models
+  and three reasoning-effort values. No account or model identifier is recorded.
+- **Permission posture:** the authoritative runs used an isolated home with bridge YOLO mode disabled. The process
+  retained Grok's normal ask mode and the exact no-auto-update/no-leader launch policy.
+- **Privacy:** committed evidence records versions, bounded capability/count outcomes, statuses, and build identifiers
+  only. It contains no credentials, account/model identifiers, prompts, transcripts, private paths, or protocol frames.
+
+### Architecture Review
+
+- **Pass:** the required Git-scoped review of Steps 2-7 found no architecture issues and returned `OK`.
+- **Pass:** the final review of the verification-discovered persisted identity and event-ordering fix found no issues
+  in identity ownership, lifecycle cleanup, the generic ACP boundary, or compatibility and returned `OK`.
+
+### Automated Matrix
+
+| Scope | Commands | Result |
+|---|---|---|
+| Shared ACP | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 272 tests |
+| Grok | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 52 tests |
+| Cursor | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 138 tests |
+| Copilot | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 13 tests |
+| DeepSeek | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 41 tests |
+| Hermes | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 39 tests |
+| OMP | `dart analyze --fatal-infos`; `dart test` | Pass: no issues; 53 tests |
+| Bridge app | `dart analyze --fatal-infos`; two focused test files | Pass: no issues; 7 tests |
+| Shared contracts | `dart analyze`; `dart test` | Pass: no issues; 393 tests |
+| Client workspace | `dart pub get` | Pass |
+| Prego | `dart analyze --fatal-infos`; `flutter test` | Pass: no issues; 245 tests |
+| Mobile and desktop | `dart analyze --fatal-infos` in each shell | Pass: no issues |
+| Changed Dart files | Dart LSP diagnostics | Pass: zero diagnostics across four files |
+
+The final matrix ran again after rebasing onto current main. The Cursor suite's intentional missing-file case logged its
+expected `PathNotFoundException` while all 138 tests passed. Dart format 3.1.12 still crashes on the enhanced-enum
+source shape in `acp_event_mapper.dart`; analyzer, focused tests, the full suites, LSP, and whitespace validation are
+the formatting/compile authorities for this file.
+
+### L3 Retirement Matrix
+
+- **Setup and lifecycle — Pass.** Deterministic probes covered missing, malformed, below-floor, PATH, and authoritative
+  explicit binaries. The client showed Grok available, enabled, branded, versioned, and without managed-install
+  controls. Live on-demand start, initialize-only refresh, child crash recovery, bridge restart, and owned shutdown all
+  completed.
+- **Projects and sessions — Pass.** Explicit live import scanned two projects and two sessions; unchanged and
+  post-delete scans added zero sessions. Ordinary listing/history reads used bridge state, and every imported row
+  retained `grok` attribution.
+- **Creation and options — Pass.** The client exposed the bounded multi-model/three-effort catalog, created sessions
+  with changed model/effort selections, and retained the exact selected tuple through cold load and restart. Automated
+  stale, refresh, default, and failed-write cases passed.
+- **Turns — Pass.** Text, reasoning, tools, status, idle completion, early/late stop, stop-and-send, visible process
+  failure, and two simultaneous sessions were exercised. A post-fix fast reply persisted after its accepted user
+  message.
+- **History and recovery — Pass.** An external session imported, replayed, continued, and grew to 57 messages; paging
+  crossed the 50-message first page. Cold reopen, process replacement, plugin restart, and bridge restart retained
+  content and exact option attribution. The live-discovered restart overwrite was fixed and reverified.
+- **Questions and permissions — Pass.** Real ask-mode execution requests appeared under the correct session/tool with
+  only the advertised `Once` and `Reject` actions and no `Always`. Reject produced a visible tool failure; Once
+  completed the exact tool. Later abort/process cleanup left no stale request, and deterministic ACP/Grok cleanup
+  coverage passed.
+- **Tools and file changes — Pass.** A live mutation produced the expected one-line content, completed tool card, and
+  file-change surface. Execution and mutation tools, running/done/failed states, cancellation, bounded output, and
+  replay identity were observed. The disposable file was removed.
+- **Archiving and deletion — Pass.** A Grok session archived from the list, remained readable, showed the permanent
+  read-only state, and exposed no composer. A separate running session deleted only after its long command was
+  cancelled; no child command survived. Its local row/history disappeared, one tombstone remained, the upstream
+  directory and prompt remained, and exhausted explicit imports before and after bridge restart scanned the catalog
+  while adding zero sessions.
+- **Compatibility and presentation — Pass.** The current client rendered the built-in name and official theme artwork.
+  Automated light/dark and unknown-ID fallback coverage passed; transport IDs remain strings and no wire field or
+  database migration was added.
+
+### First Divergent Boundary And Fix
+
+The real Grok transcript remained correct upstream, but after a bridge restart Sesori's `/session/messages` response
+showed a prior id-less assistant reply replaced by the next reply. The first divergent boundary was the shared ACP event
+mapper: fallback assistant IDs used a process-local turn counter that restarted at one. A second deterministic race
+showed an agent update could arrive while stdin flush was pending and publish before the synthetic accepted-user event.
+
+`AcpEventMapper` now derives id-less assistant, halt, and error fallback IDs from the accepted prompt's stable user
+message ID. `AcpPlugin` buffers session updates only during the prompt-frame write, emits the accepted user first, then
+flushes the buffered updates, and drops the buffer on stale state, dispatch failure, or teardown. Two regressions cover
+mapper replacement and the flush race. A live post-restart turn then appeared and persisted as user followed by a
+separate assistant reply. There is no schema or migration; the fix prevents future overwrite/reordering. The
+deliberately
+corrupted disposable test database was removed rather than treated as production data.
+
+### Cleanup
+
+- Stopped every source bridge and Grok child; port 9972 is free.
+- Shut down only the owned `sesori-dev-2` simulator and retained the device for later slot-2 reuse.
+- Removed the disposable workspace probe, temporary opaque-ID files, isolated Grok home, archive, and intentionally
+  corrupted slot database. Preserved only the slot's dev login token and bridge identity as directed by the testing
+  skill.
+- Left the real user Grok and Sesori configuration unchanged; authoritative permission evidence came only from the
+  isolated YOLO-disabled home.
+- Retained the Git worktree and branch, removed no source branch, and moved this passing plan to
+  `.plan/completed/grok-harness/`.

--- a/.plan/completed/grok-harness/TRACKER.md
+++ b/.plan/completed/grok-harness/TRACKER.md
@@ -8,8 +8,8 @@
 - **Base:** `origin/main` at `cb9baa91dd`
 - **Architecture plan review:** approved 2026-08-27 after catalog ownership and auth-policy corrections
 - **Merged predecessor:** #1181 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1181>
-- **Open PR:** pending publication of Step 9
-- **Next action:** publish, review, and merge the final retirement PR
+- **Open PR:** #1190 — <https://github.com/sesori-ai/sesori_apps_monorepo/pull/1190>
+- **Next action:** review and merge the final retirement PR
 
 ## Fixed Series
 
@@ -34,7 +34,7 @@
 8. `🌱 [grok-harness] docs: reconcile Grok regression coverage [step 8/9]`
    - **State:** merged in #1181.
 9. `⚙️ [grok-harness] test: verify Grok and retire the plan [step 9/9]`
-   - **State:** verification and retirement complete; final PR pending publication.
+   - **State:** verification and retirement complete in PR #1190.
 
 ## Step 1 Checklist
 
@@ -164,6 +164,7 @@
 - [x] Fix the live-discovered ACP restart identity and accepted-user ordering defect with deterministic regressions.
 - [x] Re-run the affected live restart flow and the complete automated matrix after rebasing onto current main.
 - [x] Record privacy-safe evidence, remove disposable state, release the local-testing slot, and retire the plan.
+- [x] Publish final PR #1190 and start its monitor.
 
 ## Decisions And Evidence
 

--- a/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
@@ -146,6 +146,9 @@ class AcpApprovalRegistry({
     );
   }
 
+  /// Routes one server request received by the owning plugin.
+  void handleServerRequest({required AcpServerRequest request}) => handleRequest(request);
+
   /// Responds to a server request with a result payload.
   void respond(Object acpId, Object? result) => _respond(acpId, result);
 

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -156,6 +156,7 @@ class AcpEventMapper({
     _sessionProject.remove(sessionId);
     _sessionSnapshots.remove(sessionId);
     _turnSeq.remove(sessionId);
+    _turnMessageIds.remove(sessionId);
     _startedParts.remove(sessionId);
     _contentTrackers.remove(sessionId);
     _textPartAccumulators.remove(sessionId);
@@ -187,6 +188,11 @@ class AcpEventMapper({
   /// sessionId -> current turn number, advanced by [beginTurn].
   final Map<String, int> _turnSeq = {};
 
+  /// Stable user-message identity for the current dispatched turn. Unlike the
+  /// process-local turn counter, this survives an agent or bridge restart via
+  /// the client's prompt id and cannot overwrite an earlier id-less reply.
+  final Map<String, String> _turnMessageIds = {};
+
   /// Per-session part ids whose envelope/part has already been emitted in the
   /// current turn. Scoped per session and pruned on [beginTurn] so it cannot
   /// grow without bound across a long-running session.
@@ -209,8 +215,15 @@ class AcpEventMapper({
 
   /// Advance the turn counter for [sessionId]. Call before `session/prompt`
   /// so the next batch of streamed chunks groups under a fresh message id.
-  void beginTurn(String sessionId) {
+  /// [messageId] is the accepted user-message identity and keeps fallback ACP
+  /// assistant ids unique when a new mapper starts for an existing session.
+  void beginTurn(String sessionId, {String? messageId}) {
     _turnSeq[sessionId] = (_turnSeq[sessionId] ?? 0) + 1;
+    if (messageId == null) {
+      _turnMessageIds.remove(sessionId);
+    } else {
+      _turnMessageIds[sessionId] = messageId;
+    }
     // The new turn uses fresh (turn-numbered) part ids, so the prior turn's are
     // dead weight — drop them to bound memory in long sessions.
     _startedParts.remove(sessionId);
@@ -232,7 +245,7 @@ class AcpEventMapper({
     required String message,
   }) => BridgeSseMessageUpdated(
     info: shared.Message.error(
-      id: "$sessionId-t${_turn(sessionId)}-error",
+      id: "${_fallbackTurnMessageId(sessionId)}-error",
       sessionID: sessionId,
       agent: pluginId,
       modelID: modelForSession(sessionId: sessionId),
@@ -267,6 +280,9 @@ class AcpEventMapper({
   }
 
   int _turn(String sessionId) => _turnSeq[sessionId] ?? 1;
+
+  String _fallbackTurnMessageId(String sessionId) =>
+      _turnMessageIds[sessionId] ?? "$sessionId-t${_turn(sessionId)}";
 
   static String initialUserMessageId(String sessionId) => "$sessionId-initial-user";
 
@@ -812,7 +828,7 @@ class AcpEventMapper({
     return (
       messageId: hasAcpMessageId
           ? "$sessionId-m$acpMessageId-${role.name}"
-          : "$sessionId-t${_turn(sessionId)}-${role.name}$fallbackSuffix",
+          : "${_fallbackTurnMessageId(sessionId)}-${role.name}$fallbackSuffix",
       hasAcpMessageId: hasAcpMessageId,
     );
   }
@@ -828,7 +844,7 @@ class AcpEventMapper({
     required String message,
     required PluginMessageTime? time,
   }) {
-    final messageId = "$sessionId-t${_turn(sessionId)}-halt";
+    final messageId = "${_fallbackTurnMessageId(sessionId)}-halt";
     final started = _startedParts.putIfAbsent(sessionId, () => <String>{});
     if (!started.add(messageId)) return const [];
     // Any id-less assistant envelope opened earlier this turn is abandoned: the
@@ -997,7 +1013,7 @@ class AcpEventMapper({
   }
 
   String _currentIdlessAssistantMessageId(String sessionId) =>
-      "$sessionId-t${_turn(sessionId)}-${_ChunkRole.assistant.name}-a${_idlessAssistantSeq[sessionId] ?? 0}";
+      "${_fallbackTurnMessageId(sessionId)}-${_ChunkRole.assistant.name}-a${_idlessAssistantSeq[sessionId] ?? 0}";
 
   BridgeSseMessageUpdated _toolEnvelope({
     required String sessionId,

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -217,7 +217,7 @@ class AcpEventMapper({
   /// so the next batch of streamed chunks groups under a fresh message id.
   /// [messageId] is the accepted user-message identity and keeps fallback ACP
   /// assistant ids unique when a new mapper starts for an existing session.
-  void beginTurn(String sessionId, {String? messageId}) {
+  void beginTurn({required String sessionId, required String? messageId}) {
     _turnSeq[sessionId] = (_turnSeq[sessionId] ?? 0) + 1;
     if (messageId == null) {
       _turnMessageIds.remove(sessionId);

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -127,6 +127,7 @@ abstract class AcpPlugin({
   /// update have entered the event stream.
   final Map<String, List<AcpNotification>> _promptWriteNotifications = {};
   final Map<String, List<AcpServerRequest>> _promptWriteServerRequests = {};
+  final Set<String> _cancelledPromptWriteSessions = {};
 
   /// Shared tail used only by agents that cannot correlate sessionless server
   /// requests while multiple prompts are in flight.
@@ -359,10 +360,12 @@ abstract class AcpPlugin({
   void _handleAgentServerRequest({required AcpServerRequest request}) {
     final registry = _approvalRegistry;
     if (registry == null) return;
-    final sessionId = _serverRequestSessionId(request: request);
-    // Pin sessionless attribution at receipt: another concurrent turn can
-    // dispatch before this request leaves the prompt-write buffer.
-    final routedRequest = sessionId == null
+    final attribution = _serverRequestAttribution(request: request);
+    final sessionId = attribution.sessionId;
+    // Pin heuristic sessionless attribution at receipt: another concurrent turn
+    // can dispatch before this request leaves the prompt-write buffer. Preserve
+    // exact tool correlation so a harness mapper can resolve its owning turn.
+    final routedRequest = sessionId == null || attribution.fromTool
         ? request
         : _serverRequestWithSession(request: request, sessionId: sessionId);
     if (sessionId != null && _isPromptFrameWriting(sessionId: sessionId)) {
@@ -382,12 +385,28 @@ abstract class AcpPlugin({
     );
   }
 
-  String? _serverRequestSessionId({required AcpServerRequest request}) {
+  ({String? sessionId, bool fromTool}) _serverRequestAttribution({required AcpServerRequest request}) {
     final rawSessionId = request.params["sessionId"];
-    if (rawSessionId != null && rawSessionId is! String) return null;
+    if (rawSessionId != null && rawSessionId is! String) return (sessionId: null, fromTool: false);
     final explicit = rawSessionId is String ? rawSessionId.trim() : null;
-    if (explicit != null && explicit.isNotEmpty) return explicit;
-    return activeTurnSessionId;
+    if (explicit != null && explicit.isNotEmpty) return (sessionId: explicit, fromTool: false);
+    final toolSessionId = _serverRequestToolSessionId(request: request);
+    if (toolSessionId != null) return (sessionId: toolSessionId, fromTool: true);
+    return (sessionId: activeTurnSessionId, fromTool: false);
+  }
+
+  String? _serverRequestToolSessionId({required AcpServerRequest request}) {
+    final rawToolCallId = request.params["toolCallId"];
+    if (rawToolCallId is! String || rawToolCallId.isEmpty) return null;
+    final mapped = eventMapper.sessionIdForToolCallId(toolCallId: rawToolCallId);
+    if (mapped != null) return mapped;
+    for (final entry in _promptWriteNotifications.entries) {
+      for (final notification in entry.value) {
+        final update = notification.params["update"];
+        if (update is Map && update["toolCallId"] == rawToolCallId) return entry.key;
+      }
+    }
+    return null;
   }
 
   bool _isPromptFrameWriting({required String sessionId}) =>
@@ -398,15 +417,20 @@ abstract class AcpPlugin({
     notifications?.forEach(handleAgentNotification);
     final requests = _promptWriteServerRequests.remove(sessionId);
     final registry = _approvalRegistry;
-    if (requests == null || registry == null) return;
-    for (final request in requests) {
-      registry.handleServerRequest(request: request);
+    if (requests != null && registry != null) {
+      for (final request in requests) {
+        registry.handleServerRequest(request: request);
+      }
+    }
+    if (_cancelledPromptWriteSessions.remove(sessionId)) {
+      registry?.cancelForSession(sessionId: sessionId);
     }
   }
 
   void _dropPromptWriteEvents({required String sessionId}) {
     _promptWriteNotifications.remove(sessionId);
     _promptWriteServerRequests.remove(sessionId);
+    _cancelledPromptWriteSessions.remove(sessionId);
   }
 
   /// Approval state participates in the activity summary, so invalidate that
@@ -548,6 +572,7 @@ abstract class AcpPlugin({
     _serverRequestSubscription = null;
     _promptWriteNotifications.clear();
     _promptWriteServerRequests.clear();
+    _cancelledPromptWriteSessions.clear();
     final commandListener = _commandListener;
     _commandListener = null;
     final registry = _approvalRegistry;
@@ -1077,6 +1102,7 @@ abstract class AcpPlugin({
 
   void _cancelActiveTurnForQueuedInput({required String sessionId}) {
     if (!cancelsActiveTurnForQueuedInput || !_inFlightTurnSessions.contains(sessionId)) return;
+    if (_isPromptFrameWriting(sessionId: sessionId)) _cancelledPromptWriteSessions.add(sessionId);
     _client?.notify(
       method: AcpMethods.sessionCancel,
       params: {"sessionId": sessionId},
@@ -1537,6 +1563,7 @@ abstract class AcpPlugin({
         _emitQueueUpdate(sessionId: sessionId, state: state);
       }
     }
+    if (_isPromptFrameWriting(sessionId: sessionId)) _cancelledPromptWriteSessions.add(sessionId);
     final client = _client;
     if (client == null) return;
     client.notify(

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -120,6 +120,11 @@ abstract class AcpPlugin({
   /// decisions live on this class — the state object only holds fields.
   final Map<String, _SessionTurnState> _turnStates = {};
 
+  /// Agent updates that raced the stdin flush for an accepted existing-session
+  /// prompt. The user message cannot publish before the flush succeeds, so hold
+  /// these updates until that message has entered the event stream.
+  final Map<String, List<AcpNotification>> _promptWriteNotifications = {};
+
   /// Shared tail used only by agents that cannot correlate sessionless server
   /// requests while multiple prompts are in flight.
   Future<void> _processTurnTail = Future<void>.value();
@@ -340,8 +345,21 @@ abstract class AcpPlugin({
         _suppressedReplayCounts[sid] = (_suppressedReplayCounts[sid] ?? 0) + 1;
         return;
       }
+      if (sid is String && _isPromptFrameWriting(sessionId: sid)) {
+        _promptWriteNotifications.putIfAbsent(sid, () => []).add(notification);
+        return;
+      }
     }
     eventMapper.map(notification).forEach(_eventBuffer.add);
+  }
+
+  bool _isPromptFrameWriting({required String sessionId}) =>
+      _turnStates[sessionId]?.queue.any((entry) => entry.phase == _QueuedAcpPromptPhase.writing) ?? false;
+
+  void _flushPromptWriteNotifications({required String sessionId}) {
+    final notifications = _promptWriteNotifications.remove(sessionId);
+    if (notifications == null) return;
+    notifications.forEach(handleAgentNotification);
   }
 
   /// Approval state participates in the activity summary, so invalidate that
@@ -472,6 +490,7 @@ abstract class AcpPlugin({
       Log.w("[$id] failed to cancel notification subscription", e, st);
     }
     _notificationSubscription = null;
+    _promptWriteNotifications.clear();
     final commandListener = _commandListener;
     _commandListener = null;
     final registry = _approvalRegistry;
@@ -1259,7 +1278,7 @@ abstract class AcpPlugin({
       _finishTurn(sessionId: sessionId, state: state, turn: turn, failed: false, refused: false);
       return;
     }
-    eventMapper.beginTurn(sessionId);
+    eventMapper.beginTurn(sessionId, messageId: turn.messageId);
     _inFlightTurnSessions.add(sessionId);
     _lastTurnSessionId = sessionId;
     try {
@@ -1289,6 +1308,7 @@ abstract class AcpPlugin({
         refused: result.stopReason == AcpStopReason.refusal,
       );
     } on Object catch (error, stack) {
+      _promptWriteNotifications.remove(sessionId);
       // The phone's send already returned success, so a dispatch or later
       // backend failure must remain observable rather than silently dropping
       // the accepted prompt.
@@ -1329,7 +1349,10 @@ abstract class AcpPlugin({
     required _SessionTurnState state,
     required _AcpTurn turn,
   }) {
-    if (!identical(_turnStates[sessionId], state)) return;
+    if (!identical(_turnStates[sessionId], state)) {
+      _promptWriteNotifications.remove(sessionId);
+      return;
+    }
     if (turn is! _QueuedAcpTurn) return;
     final queuedPrompt = turn.queuedPrompt;
     eventMapper
@@ -1345,6 +1368,7 @@ abstract class AcpPlugin({
       state.recordDispatchedPrompt(promptId: queuedPrompt.presentation.id);
       _emitQueueUpdate(sessionId: sessionId, state: state);
     }
+    _flushPromptWriteNotifications(sessionId: sessionId);
   }
 
   void _emitQueueUpdate({required String sessionId, required _SessionTurnState state}) {

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -91,6 +91,7 @@ abstract class AcpPlugin({
   Future<bool>? _connectFuture;
   PluginAuthenticationRequiredException? _authenticationFailure;
   StreamSubscription<AcpNotification>? _notificationSubscription;
+  StreamSubscription<AcpServerRequest>? _serverRequestSubscription;
   AcpApprovalRegistry? _approvalRegistry;
   AcpInitializeResult? _initResult;
 
@@ -120,10 +121,12 @@ abstract class AcpPlugin({
   /// decisions live on this class — the state object only holds fields.
   final Map<String, _SessionTurnState> _turnStates = {};
 
-  /// Agent updates that raced the stdin flush for an accepted existing-session
-  /// prompt. The user message cannot publish before the flush succeeds, so hold
-  /// these updates until that message has entered the event stream.
+  /// Agent updates and server requests that raced the stdin flush for an
+  /// accepted existing-session prompt. The user message cannot publish before
+  /// the flush succeeds, so hold both until that message and any preceding tool
+  /// update have entered the event stream.
   final Map<String, List<AcpNotification>> _promptWriteNotifications = {};
+  final Map<String, List<AcpServerRequest>> _promptWriteServerRequests = {};
 
   /// Shared tail used only by agents that cannot correlate sessionless server
   /// requests while multiple prompts are in flight.
@@ -353,13 +356,57 @@ abstract class AcpPlugin({
     eventMapper.map(notification).forEach(_eventBuffer.add);
   }
 
+  void _handleAgentServerRequest({required AcpServerRequest request}) {
+    final registry = _approvalRegistry;
+    if (registry == null) return;
+    final sessionId = _serverRequestSessionId(request: request);
+    // Pin sessionless attribution at receipt: another concurrent turn can
+    // dispatch before this request leaves the prompt-write buffer.
+    final routedRequest = sessionId == null
+        ? request
+        : _serverRequestWithSession(request: request, sessionId: sessionId);
+    if (sessionId != null && _isPromptFrameWriting(sessionId: sessionId)) {
+      _promptWriteServerRequests.putIfAbsent(sessionId, () => []).add(routedRequest);
+      return;
+    }
+    registry.handleServerRequest(request: routedRequest);
+  }
+
+  AcpServerRequest _serverRequestWithSession({required AcpServerRequest request, required String sessionId}) {
+    final explicitSessionId = request.params["sessionId"];
+    if (explicitSessionId is String && explicitSessionId.trim().isNotEmpty) return request;
+    return AcpServerRequest(
+      id: request.id,
+      method: request.method,
+      params: {...request.params, "sessionId": sessionId},
+    );
+  }
+
+  String? _serverRequestSessionId({required AcpServerRequest request}) {
+    final rawSessionId = request.params["sessionId"];
+    if (rawSessionId != null && rawSessionId is! String) return null;
+    final explicit = rawSessionId is String ? rawSessionId.trim() : null;
+    if (explicit != null && explicit.isNotEmpty) return explicit;
+    return activeTurnSessionId;
+  }
+
   bool _isPromptFrameWriting({required String sessionId}) =>
       _turnStates[sessionId]?.queue.any((entry) => entry.phase == _QueuedAcpPromptPhase.writing) ?? false;
 
-  void _flushPromptWriteNotifications({required String sessionId}) {
+  void _flushPromptWriteEvents({required String sessionId}) {
     final notifications = _promptWriteNotifications.remove(sessionId);
-    if (notifications == null) return;
-    notifications.forEach(handleAgentNotification);
+    notifications?.forEach(handleAgentNotification);
+    final requests = _promptWriteServerRequests.remove(sessionId);
+    final registry = _approvalRegistry;
+    if (requests == null || registry == null) return;
+    for (final request in requests) {
+      registry.handleServerRequest(request: request);
+    }
+  }
+
+  void _dropPromptWriteEvents({required String sessionId}) {
+    _promptWriteNotifications.remove(sessionId);
+    _promptWriteServerRequests.remove(sessionId);
   }
 
   /// Approval state participates in the activity summary, so invalidate that
@@ -395,7 +442,9 @@ abstract class AcpPlugin({
         _notificationSubscription = client.notifications.listen(handleAgentNotification);
         final registry = buildApprovalRegistry(client);
         _approvalRegistry = registry;
-        registry.attach(stream: client.serverRequests);
+        _serverRequestSubscription = client.serverRequests.listen(
+          (request) => _handleAgentServerRequest(request: request),
+        );
         final initResult = await _initialize(client);
         captureLiveInitializeResult(initResult);
         _initResult = initResult;
@@ -477,11 +526,11 @@ abstract class AcpPlugin({
   }
 
   /// Detaches and disposes the live connection's collaborators (notification
-  /// subscription, command listener, approval registry, client). The fields are
-  /// cleared before the first await so a concurrent [ensureConnected] never
-  /// sees a stale connection, and each step is isolated so a failure in one
-  /// (e.g. a hung subscription) cannot skip a later one (e.g. reaping the agent
-  /// subprocess). Never throws — log and continue.
+  /// and server-request subscriptions, command listener, approval registry,
+  /// client). The fields are cleared before the first await so a concurrent
+  /// [ensureConnected] never sees a stale connection, and each step is isolated
+  /// so a failure in one (e.g. a hung subscription) cannot skip a later one
+  /// (e.g. reaping the agent subprocess). Never throws — log and continue.
   Future<void> _teardownConnection() async {
     Future<void>? notificationCancellation;
     try {
@@ -490,7 +539,15 @@ abstract class AcpPlugin({
       Log.w("[$id] failed to cancel notification subscription", e, st);
     }
     _notificationSubscription = null;
+    Future<void>? serverRequestCancellation;
+    try {
+      serverRequestCancellation = _serverRequestSubscription?.cancel();
+    } on Object catch (e, st) {
+      Log.w("[$id] failed to cancel server-request subscription", e, st);
+    }
+    _serverRequestSubscription = null;
     _promptWriteNotifications.clear();
+    _promptWriteServerRequests.clear();
     final commandListener = _commandListener;
     _commandListener = null;
     final registry = _approvalRegistry;
@@ -501,6 +558,11 @@ abstract class AcpPlugin({
       await notificationCancellation;
     } on Object catch (e, st) {
       Log.w("[$id] failed to cancel notification subscription", e, st);
+    }
+    try {
+      await serverRequestCancellation;
+    } on Object catch (e, st) {
+      Log.w("[$id] failed to cancel server-request subscription", e, st);
     }
     try {
       await commandListener?.dispose();
@@ -1278,7 +1340,7 @@ abstract class AcpPlugin({
       _finishTurn(sessionId: sessionId, state: state, turn: turn, failed: false, refused: false);
       return;
     }
-    eventMapper.beginTurn(sessionId, messageId: turn.messageId);
+    eventMapper.beginTurn(sessionId: sessionId, messageId: turn.messageId);
     _inFlightTurnSessions.add(sessionId);
     _lastTurnSessionId = sessionId;
     try {
@@ -1308,7 +1370,7 @@ abstract class AcpPlugin({
         refused: result.stopReason == AcpStopReason.refusal,
       );
     } on Object catch (error, stack) {
-      _promptWriteNotifications.remove(sessionId);
+      _dropPromptWriteEvents(sessionId: sessionId);
       // The phone's send already returned success, so a dispatch or later
       // backend failure must remain observable rather than silently dropping
       // the accepted prompt.
@@ -1350,7 +1412,7 @@ abstract class AcpPlugin({
     required _AcpTurn turn,
   }) {
     if (!identical(_turnStates[sessionId], state)) {
-      _promptWriteNotifications.remove(sessionId);
+      _dropPromptWriteEvents(sessionId: sessionId);
       return;
     }
     if (turn is! _QueuedAcpTurn) return;
@@ -1368,7 +1430,7 @@ abstract class AcpPlugin({
       state.recordDispatchedPrompt(promptId: queuedPrompt.presentation.id);
       _emitQueueUpdate(sessionId: sessionId, state: state);
     }
-    _flushPromptWriteNotifications(sessionId: sessionId);
+    _flushPromptWriteEvents(sessionId: sessionId);
   }
 
   void _emitQueueUpdate({required String sessionId, required _SessionTurnState state}) {

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -38,7 +38,7 @@ void main() {
     );
 
     test("agent_message_chunk emits envelope + part + delta on first chunk", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       final events = mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -58,7 +58,10 @@ void main() {
 
     test("accepted prompt ids keep id-less replies unique across mapper restarts", () {
       String assistantId({required AcpEventMapper target, required String promptId}) {
-        target.beginTurn("s1", messageId: AcpEventMapper.sentUserMessageId(promptId: promptId));
+        target.beginTurn(
+          sessionId: "s1",
+          messageId: AcpEventMapper.sentUserMessageId(promptId: promptId),
+        );
         final events = target.map(
           update({
             "sessionUpdate": "agent_message_chunk",
@@ -82,7 +85,7 @@ void main() {
     });
 
     test("subsequent chunks emit only a delta on the same part", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -100,7 +103,7 @@ void main() {
     });
 
     test("reasoning transition and turn final emit complete snapshots", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       mapper.map(
         update({
           "sessionUpdate": "agent_thought_chunk",
@@ -147,7 +150,7 @@ void main() {
     });
 
     test("tool activity finalizes active reasoning before the turn ends", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       mapper.map(
         update({
           "sessionUpdate": "agent_thought_chunk",
@@ -195,7 +198,7 @@ void main() {
     });
 
     test("tool activity finalizes active assistant text before the turn ends", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -237,7 +240,7 @@ void main() {
     });
 
     test("a first-seen tool update finalizes active id-less assistant text", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -261,7 +264,7 @@ void main() {
     });
 
     test("a tool call does not finalize an explicit assistant message", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -300,7 +303,7 @@ void main() {
     });
 
     test("forgetSession drops pending text snapshots", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -314,7 +317,7 @@ void main() {
     });
 
     test("agent message content preserves mixed text and image order", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       final events = mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -349,7 +352,7 @@ void main() {
     });
 
     test("message trackers persist across chunks and reset at turn boundaries", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -375,7 +378,7 @@ void main() {
         "s1-mm1-assistant-text",
       );
 
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       final reset = mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -395,7 +398,7 @@ void main() {
     });
 
     test("agent_thought_chunk maps to a reasoning part", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       final events = mapper.map(
         update({
           "sessionUpdate": "agent_thought_chunk",
@@ -502,7 +505,7 @@ void main() {
     });
 
     test("id-less assistant content after a tool opens a later envelope", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       final beforeTool = mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -543,7 +546,7 @@ void main() {
     });
 
     test("an explicit assistant message closes the prior id-less envelope", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       final before = mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -764,7 +767,7 @@ void main() {
     });
 
     test("a completed tool retains its state for a late in-turn update; beginTurn clears it", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       mapper.map(
         update({
           "sessionUpdate": "tool_call",
@@ -797,7 +800,7 @@ void main() {
       expect(latePart.state.output, "final");
 
       // The next turn clears the prior turn's tools to keep the cache bounded.
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       final afterTurn = mapper.map(
         update({
           "sessionUpdate": "tool_call_update",
@@ -949,7 +952,7 @@ void main() {
     });
 
     test("chunks group by ACP messageId when present", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       final first = mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -1274,7 +1277,7 @@ void main() {
           modelId: "claude-opus-4-8",
           providerId: "cursor",
         );
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       final events = mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -1312,7 +1315,7 @@ void main() {
     );
 
     test("a classified halt notice becomes a lone error message, not assistant text", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       final events = mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -1331,7 +1334,7 @@ void main() {
     });
 
     test("a repeated identical halt chunk does not stack duplicate error cards", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -1348,7 +1351,7 @@ void main() {
     });
 
     test("a tool clears unrendered id-less state before a later halt", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       expect(
         mapper.map(
           update({
@@ -1380,7 +1383,7 @@ void main() {
     });
 
     test("id-less assistant text after a halt opens a fresh envelope", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       final before = mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -1414,7 +1417,7 @@ void main() {
     });
 
     test("a reasoning chunk is never classified as a halt notice", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       final events = mapper.map(
         update({
           "sessionUpdate": "agent_thought_chunk",
@@ -1428,7 +1431,7 @@ void main() {
     });
 
     test("an image-bearing halt-like message remains an assistant message", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       final events = mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -1455,7 +1458,7 @@ void main() {
     });
 
     test("an identified halt-like text chunk can receive a later image", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       final text = mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",
@@ -1486,7 +1489,7 @@ void main() {
     });
 
     test("ordinary assistant text still streams as an assistant message", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       final events = mapper.map(
         update({
           "sessionUpdate": "agent_message_chunk",

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -56,6 +56,31 @@ void main() {
       expect(delta.field, "text");
     });
 
+    test("accepted prompt ids keep id-less replies unique across mapper restarts", () {
+      String assistantId({required AcpEventMapper target, required String promptId}) {
+        target.beginTurn("s1", messageId: AcpEventMapper.sentUserMessageId(promptId: promptId));
+        final events = target.map(
+          update({
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "reply"},
+          }),
+        );
+        return shared.Message.fromJson(events.whereType<BridgeSseMessageUpdated>().single.info).id;
+      }
+
+      final beforeRestart = assistantId(target: mapper, promptId: "prompt-one");
+      final replacementMapper = AcpEventMapper(
+        launchDirectory: "/repo",
+        pluginId: "cursor",
+        configurationTracker: configurationTracker,
+      );
+      final afterRestart = assistantId(target: replacementMapper, promptId: "prompt-two");
+
+      expect(beforeRestart, "prompt-one-user-assistant-a0");
+      expect(afterRestart, "prompt-two-user-assistant-a0");
+      expect(afterRestart, isNot(beforeRestart));
+    });
+
     test("subsequent chunks emit only a delta on the same part", () {
       mapper.beginTurn("s1");
       mapper.map(

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -80,7 +80,7 @@ void main() {
           launchDirectory: "/repo",
           pluginId: "acp",
           configurationTracker: configurationTracker,
-        )..beginTurn("s1");
+        )..beginTurn(sessionId: "s1", messageId: null);
         final collector = AcpReplayCollector(
           sessionId: "s1",
           agentId: "ACP",

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -402,6 +402,45 @@ void main() {
       respondTo(prompt, {"stopReason": "end_turn"});
     });
 
+    test("aborting a writing turn settles its buffered permission after the flush", () async {
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+      emitted.clear();
+
+      final flush = fake.holdNextFlush();
+      await sendPrompt(sessionId, "cancel permission");
+      final prompt = await waitForFrame("session/prompt");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 92,
+        "method": AcpMethods.sessionRequestPermission,
+        "params": {
+          "sessionId": sessionId,
+          "toolCall": {"toolCallId": "tool-1", "title": "Run command", "kind": "execute"},
+          "options": [
+            {"optionId": "reject", "name": "Reject", "kind": "reject_once"},
+          ],
+        },
+      });
+      await pump();
+      expect(emitted.whereType<BridgeSsePermissionAsked>(), isEmpty);
+
+      await plugin.abortSession(sessionId: sessionId);
+      flush.complete();
+      for (var i = 0; i < 20 && !fake.written.any((frame) => frame["id"] == 92); i++) {
+        await pump();
+      }
+
+      final permission = emitted.whereType<BridgeSsePermissionAsked>().single;
+      final cancellation = emitted.whereType<BridgeSsePermissionReplied>().single;
+      expect(emitted.indexOf(permission), lessThan(emitted.indexOf(cancellation)));
+      expect(await plugin.getPendingPermissions(sessionId: sessionId), isEmpty);
+      final response = fake.written.singleWhere((frame) => frame["id"] == 92);
+      expect((response["result"] as Map)["outcome"], {"outcome": "cancelled"});
+
+      respondTo(prompt, {"stopReason": "end_turn"});
+    });
+
     test("a buffered sessionless permission keeps its writing-turn attribution", () async {
       await connect();
       final firstSessionId = await createSession(cwd, "s1");

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -305,6 +305,42 @@ void main() {
       respondTo(prompt, {"stopReason": "end_turn"});
     });
 
+    test("agent output racing the prompt flush follows the accepted user message", () async {
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+      emitted.clear();
+
+      final flush = fake.holdNextFlush();
+      final promptId = await sendPrompt(sessionId, "ordered prompt");
+      final prompt = await waitForFrame("session/prompt");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": sessionId,
+          "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "fast reply"},
+          },
+        },
+      });
+      await pump();
+
+      expect(emitted.whereType<BridgeSseMessageUpdated>(), isEmpty);
+
+      flush.complete();
+      for (var i = 0; i < 20 && emitted.whereType<BridgeSseMessageUpdated>().length < 2; i++) {
+        await pump();
+      }
+
+      final messages = emitted.whereType<BridgeSseMessageUpdated>().toList();
+      expect(messages.map((event) => event.info["role"]), ["user", "assistant"]);
+      expect(messages.first.info["promptId"], promptId);
+      expect(messages.last.info["id"], "$promptId-user-assistant-a0");
+
+      respondTo(prompt, {"stopReason": "end_turn"});
+    });
+
     test("a queued prompt message uses its dispatch time", () async {
       final configurationTracker = AcpSessionConfigurationTracker();
       final commandTracker = AcpCommandTracker();

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -341,6 +341,110 @@ void main() {
       respondTo(prompt, {"stopReason": "end_turn"});
     });
 
+    test("a permission racing the prompt flush follows its accepted user and tool", () async {
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+      emitted.clear();
+
+      final flush = fake.holdNextFlush();
+      await sendPrompt(sessionId, "permission ordering");
+      final prompt = await waitForFrame("session/prompt");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": AcpMethods.sessionUpdate,
+        "params": {
+          "sessionId": sessionId,
+          "update": {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "tool-1",
+            "kind": "execute",
+            "title": "Run command",
+            "status": "pending",
+          },
+        },
+      });
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 90,
+        "method": AcpMethods.sessionRequestPermission,
+        "params": {
+          "sessionId": sessionId,
+          "toolCall": {"toolCallId": "tool-1", "title": "Run command", "kind": "execute"},
+          "options": [
+            {"optionId": "reject", "name": "Reject", "kind": "reject_once"},
+          ],
+        },
+      });
+      await pump();
+
+      expect(emitted.whereType<BridgeSseMessageUpdated>(), isEmpty);
+      expect(emitted.whereType<BridgeSseMessagePartUpdated>(), isEmpty);
+      expect(emitted.whereType<BridgeSsePermissionAsked>(), isEmpty);
+
+      flush.complete();
+      for (var i = 0; i < 20 && emitted.whereType<BridgeSsePermissionAsked>().isEmpty; i++) {
+        await pump();
+      }
+
+      final user = emitted.whereType<BridgeSseMessageUpdated>().singleWhere((event) => event.info["role"] == "user");
+      final tool = emitted.whereType<BridgeSseMessagePartUpdated>().singleWhere(
+        (event) => event.part.type == PluginMessagePartType.tool,
+      );
+      final permission = emitted.whereType<BridgeSsePermissionAsked>().single;
+      expect(emitted.indexOf(user), lessThan(emitted.indexOf(tool)));
+      expect(emitted.indexOf(tool), lessThan(emitted.indexOf(permission)));
+
+      await plugin.replyToPermission(
+        requestId: permission.requestID,
+        sessionId: sessionId,
+        reply: PluginPermissionReply.reject,
+      );
+      respondTo(prompt, {"stopReason": "end_turn"});
+    });
+
+    test("a buffered sessionless permission keeps its writing-turn attribution", () async {
+      await connect();
+      final firstSessionId = await createSession(cwd, "s1");
+      final secondSessionId = await createSession(cwd, "s2");
+      emitted.clear();
+
+      final flush = fake.holdNextFlush();
+      await sendPrompt(firstSessionId, "first session");
+      final firstPrompt = await waitForFrameCount("session/prompt", 1);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 91,
+        "method": AcpMethods.sessionRequestPermission,
+        "params": {
+          "toolCall": {"toolCallId": "tool-1", "title": "Run command", "kind": "execute"},
+          "options": [
+            {"optionId": "reject", "name": "Reject", "kind": "reject_once"},
+          ],
+        },
+      });
+      await pump();
+      expect(emitted.whereType<BridgeSsePermissionAsked>(), isEmpty);
+
+      await sendPrompt(secondSessionId, "second session");
+      final secondPrompt = await waitForFrameCount("session/prompt", 2);
+      await pump();
+
+      flush.complete();
+      for (var i = 0; i < 20 && emitted.whereType<BridgeSsePermissionAsked>().isEmpty; i++) {
+        await pump();
+      }
+
+      final permission = emitted.whereType<BridgeSsePermissionAsked>().single;
+      expect(permission.sessionID, firstSessionId);
+      await plugin.replyToPermission(
+        requestId: permission.requestID,
+        sessionId: firstSessionId,
+        reply: PluginPermissionReply.reject,
+      );
+      respondTo(firstPrompt, {"stopReason": "end_turn"});
+      respondTo(secondPrompt, {"stopReason": "end_turn"});
+    });
+
     test("a queued prompt message uses its dispatch time", () async {
       final configurationTracker = AcpSessionConfigurationTracker();
       final commandTracker = AcpCommandTracker();

--- a/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
@@ -56,7 +56,7 @@ void main() {
     });
 
     test("standard session/update still works via the base mapper", () {
-      mapper.beginTurn("s1");
+      mapper.beginTurn(sessionId: "s1", messageId: null);
       final events = mapper.map(
         const AcpNotification(
           method: "session/update",
@@ -73,7 +73,7 @@ void main() {
     });
 
     test("cursor/generate_image maps to a standard inline file part", () async {
-      mapper.beginTurn("s-image");
+      mapper.beginTurn(sessionId: "s-image", messageId: null);
       final file = writeTempPng("cursor-event-mapper");
 
       final part = mapper
@@ -92,7 +92,7 @@ void main() {
 
     test("cursor/generate_image finalizes active reasoning before the image", () async {
       final imageMapper = buildMapper();
-      imageMapper.beginTurn("s-thinking-image");
+      imageMapper.beginTurn(sessionId: "s-thinking-image", messageId: null);
       imageMapper.map(
         const AcpNotification(
           method: "session/update",
@@ -122,7 +122,7 @@ void main() {
     });
 
     test("cursor/generate_image accepts legacy path params", () async {
-      mapper.beginTurn("s-image-legacy");
+      mapper.beginTurn(sessionId: "s-image-legacy", messageId: null);
       final file = writeTempPng("cursor-event-mapper-legacy");
 
       expect(
@@ -246,7 +246,7 @@ void main() {
       // the image joins the in-progress assistant message in stream order,
       // instead of being emitted as a standalone sidecar message.
       final orderedMapper = buildMapper();
-      orderedMapper.beginTurn("s1");
+      orderedMapper.beginTurn(sessionId: "s1", messageId: null);
       final file = writeTempPng("cursor-ordered-image");
       const messageId = "s1-t1-assistant-a0";
 
@@ -286,7 +286,7 @@ void main() {
     });
 
     test("standard ACP images still work alongside cursor generate_image", () {
-      mapper.beginTurn("s-image");
+      mapper.beginTurn(sessionId: "s-image", messageId: null);
       final standard = mapper.map(
         const AcpNotification(
           method: "session/update",
@@ -311,7 +311,7 @@ void main() {
     });
 
     test("an account/plan gate notice becomes an error message, not assistant text", () {
-      mapper.beginTurn("sg");
+      mapper.beginTurn(sessionId: "sg", messageId: null);
       final events = mapper.map(
         const AcpNotification(
           method: "session/update",

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
@@ -299,6 +299,94 @@ void main() {
       expect(events.whereType<BridgeSseSessionError>(), isEmpty);
     });
 
+    test("tool-correlated extensions keep the earlier session with two turns in flight", () async {
+      final events = <BridgeSseEvent>[];
+      final subscription = plugin.events.listen(events.add);
+      addTearDown(subscription.cancel);
+
+      final connecting = plugin.ensureConnected();
+      await respond("initialize", const {
+        "protocolVersion": 1,
+        "agentCapabilities": <String, dynamic>{},
+        "authMethods": <Object?>[],
+      });
+      expect(await connecting, isTrue);
+
+      Future<String> createSession({required String sessionId}) async {
+        final creating = plugin.createSession(
+          directory: "/repo",
+          parentSessionId: null,
+          parts: const [],
+          userVisibleText: null,
+          variant: null,
+          agent: null,
+          model: null,
+        );
+        await respond("session/new", {"sessionId": sessionId});
+        return (await creating).id;
+      }
+
+      final firstSessionId = await createSession(sessionId: "s-first");
+      final secondSessionId = await createSession(sessionId: "s-second");
+      await plugin.sendPrompt(
+        promptId: "prompt-first",
+        sessionId: firstSessionId,
+        parts: const [PluginPromptPart.text(text: "first")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final firstPrompt = await waitForFrame("session/prompt");
+      await plugin.sendPrompt(
+        promptId: "prompt-second",
+        sessionId: secondSessionId,
+        parts: const [PluginPromptPart.text(text: "second")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final secondPrompt = await waitForFrame("session/prompt");
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": AcpMethods.sessionUpdate,
+        "params": {
+          "sessionId": firstSessionId,
+          "update": {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "todo-tool",
+            "kind": "other",
+            "status": "pending",
+          },
+        },
+      });
+      await pump();
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 90,
+        "method": "cursor/update_todos",
+        "params": {"toolCallId": "todo-tool", "todos": <Object?>[]},
+      });
+      await pump();
+
+      expect(events.whereType<BridgeSseTodoUpdated>().single.sessionID, firstSessionId);
+      expect(
+        fake.written.singleWhere((frame) => frame["id"] == 90)["result"],
+        isA<Map<Object?, Object?>>(),
+      );
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": firstPrompt["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": secondPrompt["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+    });
+
     test("captureSessionConfig populates providers, effort variants, and mode agents", () async {
       capture(catalogResult(), fromNewSession: true);
 

--- a/bridge/sesori_plugin_deepseek/test/deepseek_scaffold_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_scaffold_test.dart
@@ -55,7 +55,7 @@ void main() {
       configurationTracker: AcpSessionConfigurationTracker(),
       messageTimeParser: const DeepSeekMessageTimeParser(),
       api: const DeepSeekAcpApi(pluginId: DeepSeekIdentity.id),
-    )..beginTurn("session-1");
+    )..beginTurn(sessionId: "session-1", messageId: null);
     final events = mapper.map(
       const AcpNotification(
         method: AcpMethods.sessionUpdate,

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -120,8 +120,9 @@ repeat after process restart without enabling approval-bypass launch flags.
   immediately. For DeepSeek, the underlying `session/prompt` remains pending
   through turn settlement, but ACP server requests and replies continue
   concurrently on the same transport.
-- A request never appears, appears under the wrong session, or omits options the
-  backend actually offered.
+- A request never appears, appears under the wrong session, omits options the
+  backend actually offered, or races ahead of its accepted user message and
+  preceding tool card while the prompt frame is still flushing.
 - An answer does not reach the backend, arrives with a different scope than the
   user chose, or leaves the turn blocked.
 - An ACP form answer changes scalar type, uses a display label instead of the

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -121,8 +121,9 @@ repeat after process restart without enabling approval-bypass launch flags.
   through turn settlement, but ACP server requests and replies continue
   concurrently on the same transport.
 - A request never appears, appears under the wrong session, omits options the
-  backend actually offered, or races ahead of its accepted user message and
-  preceding tool card while the prompt frame is still flushing.
+  backend actually offered, races ahead of its accepted user message and
+  preceding tool card while the prompt frame is still flushing, or surfaces as
+  pending after that writing turn was aborted.
 - An answer does not reach the backend, arrives with a different scope than the
   user chose, or leaves the turn blocked.
 - An ACP form answer changes scalar type, uses a display label instead of the

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -133,6 +133,8 @@ rules where supported.
 - Reasoning still says `Thinking...` after answer or tool output has started, or
   disappears after reopening because only its empty start snapshot was retained.
 - A page boundary duplicates, drops, or reorders messages, or history ends early.
+- An id-less ACP reply reuses a pre-restart fallback identity and overwrites an
+  earlier answer instead of remaining distinct.
 - Loading an older page shifts the reader's viewport, remains hidden until
   reattachment, or triggers repeated requests while one page is in flight.
 - A session advanced outside Sesori keeps serving the old transcript, or stored
@@ -177,6 +179,6 @@ rules where supported.
 Bridge chat-history service, repository, reconcile service, history listeners,
 SSE replay window, and routed request dispatch; database and audit compatibility
 tests under `bridge/app/test/bridge/services/`; Pi session process repository,
-storage API, and history mapper; shared ACP session loader plus Copilot and Grok
-plugins and package tests; shared pagination cursor; client detail load service
-and cubit.
+storage API, and history mapper; shared ACP event mapper, turn serialization,
+and session loader plus Copilot and Grok plugins and package tests; shared
+pagination cursor; client detail load service and cubit.

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -279,8 +279,9 @@ provider failure, early and late abort, busy stop-and-send, and two sessions.
 - An accepted ACP prompt rejection returns the session to idle without a durable
   inline error containing the backend's diagnostic detail.
 - Streaming stalls, duplicates or loses parts, shows an empty user bubble,
-  orders a fast assistant envelope before its accepted user message, or orders
-  a late envelope at the wrong transcript position; the session never
+  orders a fast assistant envelope before its accepted user message, exposes a
+  permission before that user or its preceding tool card, or orders a late
+  envelope at the wrong transcript position; the session never
   returns to idle. A terminal provider failure returns to idle without showing
   its error, a harness replaces backend-provided terminal or retry error text,
   a plugin status serializes with a private discriminator and is dropped at the

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -278,8 +278,9 @@ provider failure, early and late abort, busy stop-and-send, and two sessions.
   plugin blocks unrelated sessions, other plugins, or relay traffic.
 - An accepted ACP prompt rejection returns the session to idle without a durable
   inline error containing the backend's diagnostic detail.
-- Streaming stalls, duplicates or loses parts, shows an empty user bubble, or
-  orders a late envelope at the wrong transcript position; the session never
+- Streaming stalls, duplicates or loses parts, shows an empty user bubble,
+  orders a fast assistant envelope before its accepted user message, or orders
+  a late envelope at the wrong transcript position; the session never
   returns to idle. A terminal provider failure returns to idle without showing
   its error, a harness replaces backend-provided terminal or retry error text,
   a plugin status serializes with a private discriminator and is dropped at the

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -34,6 +34,9 @@ signal that a tool changed files.
   identity, bounded presenter output, terminal result/error state, and diff
   content. Presenter failure degrades to a generic bounded tool card instead of
   dropping the call or result.
+- Cursor's fire-and-forget tool extensions preserve their top-level tool-call
+  correlation before falling back to the active turn, including while another
+  session is in flight.
 - GitHub Copilot uses the same standard ACP tool lifecycle. Permission linkage
   must be exact while the request is live. Call identity, bounded output,
   terminal state, and diff content then converge after `session/load`; permission
@@ -76,6 +79,8 @@ one permission-gated mutation and one repeated terminal update.
 - A part carries fields owned by another variant, or a released known-type
   payload fails to decode because an older bridge omitted variant data, or a
   current peer serializes null variant data.
+- A Cursor tool extension with an originating call ID is attributed to a
+  different concurrently active session.
 - A Copilot tool loses permission correlation while live, or its call identity,
   terminal status, bounded output, or diff changes when reopened through ACP
   history.


### PR DESCRIPTION
## Complexity

⚙️ Moderate — the retirement step fixes shared ACP persisted-message identity and prompt-interaction ordering defects, then verifies every downstream ACP harness and the full Grok release matrix.

## What

- derives id-less ACP assistant/error/halt fallback IDs from the accepted prompt identity so bridge restarts cannot reuse a process-local turn ID;
- makes the turn identity parameters named and required, including the explicit nullable choice at every in-repository caller;
- gates agent updates and attributable server requests while the prompt frame is flushing, emitting the accepted user and preceding tool state before a permission/question;
- pins heuristic sessionless attribution at receipt while preserving exact top-level tool-call ownership;
- marks aborted write buffers so their requests register and cancel together, and clears all gate state on failure, stale state, or teardown;
- adds deterministic mapper-restart, fast-agent/slow-flush, tool-before-permission, concurrent attribution, abort-settlement, and Cursor tool-correlation regressions;
- records the passing authenticated Grok 1.0.5 L3 matrix, adds the discovered failure signals to regression docs, and moves `grok-harness` to `.plan/completed/`.

## Why

Authenticated release testing found that Grok's upstream transcript stayed correct while Sesori could overwrite an earlier id-less assistant reply after a bridge restart. The shared fallback ID used a process-local turn counter that restarted at one. The same investigation exposed a concrete race where a fast agent update could arrive before stdin flush completed and appear before the accepted user message.

PR review correctly identified that the approval registry consumed a separate server-request stream: a tool update could be buffered while its permission surfaced early. It also identified that an optional turn identity let future callers bypass the restart-safe invariant.

Follow-up review found that abort could run before a buffered request registered, and that heuristic session stamping could override Cursor's exact tool-call correlation. The gate now settles aborted requests during flush and preserves exact tool ownership.

The final plan cannot retire with these persisted-history and interaction-ownership defects unresolved.

## Risk and test focus

Moderate risk. The production change is shared by ACP-based Grok, Cursor, Copilot, DeepSeek, Hermes, and OMP, so review should focus on:

- stable uniqueness of future id-less assistant/error identities across mapper and bridge replacement;
- user-before-assistant event order when agent output races prompt-frame flush;
- user/tool-before-permission order across the separate notification and server-request streams;
- stable sessionless request attribution if another session dispatches while the first prompt is flushing;
- cancellation of buffered permissions/questions when abort precedes request registration;
- preservation of Cursor tool-call ownership across concurrent sessions;
- buffer and subscription cleanup on failed dispatch, stale turns, reset, and disposal;
- unchanged behavior for initial prompts and explicit backend message IDs.

No wire or database schema changes are introduced. Existing rows are not migrated or backfilled; future fallback IDs become prompt-derived. There is no managed-runtime, credential, analytics, or image-support impact.

## Expected result

Grok Build 1.0.5 is fully verified and the nine-step plan is retired. Users retain distinct assistant replies across restart; a fast reply cannot precede its accepted user message; a permission cannot precede that user or its tool card; and abort leaves no buffered request pending. Tool-correlated Cursor extensions remain on their owning session. Grok setup, import, options, turns, history, permissions, tools, archive, deletion, and unknown-client presentation continue to behave as documented.

Database impact is limited to stable opaque IDs for future id-less ACP messages; there is no schema migration or production-data rewrite. User-visible impact is the prevention of transcript overwrite/reordering.

## Verification

- Architecture implementation reviews: Steps 2-7 `OK`; final persisted-identity/order fix `OK`, no findings.
- Shared ACP: analysis passes; 275 tests pass.
- Grok: analysis passes; 52 tests pass.
- Downstream ACP plugins: Cursor 139, Copilot 13, DeepSeek 41, Hermes 39, and OMP 53 tests pass; every package analyzer passes.
- Bridge app: analysis passes; 7 focused registry/import tests pass.
- Shared contracts: analysis passes; 393 tests pass.
- Client: pub resolution passes; Prego analysis and 245 tests pass; mobile and desktop analysis pass.
- Dart LSP: zero diagnostics across the nine changed Dart files.
- Authenticated live boundary: stable Grok 1.0.5 on macOS arm64 with an iPhone 17 / iOS 26.5 simulator; all nine required L3 rows pass without reduction.
- Live recovery: post-fix restart persists user then a distinct assistant reply.
- Live deletion: active command cancels, local row/history purge, upstream row remains, and tombstone blocks exhausted explicit import before and after bridge restart.
- `git diff origin/main...HEAD --check` passes; 717 changed lines, below the 1,500-line target.

Dart format 3.1.12 still crashes on the repository's enhanced-enum source shape in `acp_event_mapper.dart`; analyzer, focused/full tests, LSP, and whitespace checks all pass.


