### PR TITLE
🌱 Keep final session clear of new-task button

### DIFF
--- a/client/app/lib/features/session_list/session_list_scaffold.dart
+++ b/client/app/lib/features/session_list/session_list_scaffold.dart
@@ -21,6 +21,25 @@ class const SessionListScaffold({
   required final VoidCallback onNewSession,
   required final VoidCallback? onBack,
 }) extends StatelessWidget {
+  static const double _newTaskButtonBaseClearance = 96;
+
+  /// The default reservation matches the project list's spacing. The xl
+  /// button's label stays on one line, but its line box grows under accessibility
+  /// text scaling, so add that growth without increasing the default gap.
+  static double _newTaskButtonClearance({required BuildContext context}) {
+    final bottomInset = MediaQuery.paddingOf(context).bottom;
+    final textStyle = context.prego.textTheme.textMd.bold;
+    final fontSize = textStyle.fontSize;
+    if (fontSize == null) return bottomInset + _newTaskButtonBaseClearance;
+
+    final heightMultiplier = textStyle.height ?? 1;
+    final unscaledLabelHeight = fontSize * heightMultiplier;
+    final scaledLabelHeight = MediaQuery.textScalerOf(context).scale(fontSize) * heightMultiplier;
+    final labelGrowth = scaledLabelHeight > unscaledLabelHeight ? scaledLabelHeight - unscaledLabelHeight : 0.0;
+
+    return bottomInset + _newTaskButtonBaseClearance + labelGrowth;
+  }
+
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
@@ -87,7 +106,9 @@ class const SessionListScaffold({
         ),
         if (state is SessionListLoaded && state.sessions.isNotEmpty)
           // Clear the floating new-task button and the home indicator.
-          SliverToBoxAdapter(child: SizedBox(height: MediaQuery.paddingOf(context).bottom + 96)),
+          SliverToBoxAdapter(
+            child: SizedBox(height: _newTaskButtonClearance(context: context)),
+          ),
       ],
     );
   }

--- a/client/app/lib/features/session_list/session_list_scaffold.dart
+++ b/client/app/lib/features/session_list/session_list_scaffold.dart
@@ -85,6 +85,9 @@ class const SessionListScaffold({
           onSessionTap: onSessionTap,
           sessionMenuEntries: sessionMenuEntries,
         ),
+        if (state is SessionListLoaded && state.sessions.isNotEmpty)
+          // Clear the floating new-task button and the home indicator.
+          SliverToBoxAdapter(child: SizedBox(height: MediaQuery.paddingOf(context).bottom + 96)),
       ],
     );
   }

--- a/client/app/test/features/session_list/session_list_bar_test.dart
+++ b/client/app/test/features/session_list/session_list_bar_test.dart
@@ -5,7 +5,9 @@ import "package:material_ui/material_ui.dart";
 import "package:mocktail/mocktail.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/features/session_list/session_list_scaffold.dart";
+import "package:sesori_mobile/features/session_list/session_tile.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
 import "package:theme_prego/module_prego.dart";
 
 import "../../helpers/test_helpers.dart";
@@ -176,5 +178,26 @@ void main() {
 
     // The popover shows the same (already-complete) slug — a second occurrence.
     expect(find.text("sesori-ai/sesori_apps_monorepo"), findsNWidgets(2));
+  });
+
+  testWidgets("last session scrolls clear of the floating new-task button", (tester) async {
+    final sessions = [
+      for (var index = 0; index < 12; index++) testSession(id: "s$index", title: "Task $index"),
+    ];
+    await pumpScaffold(
+      tester,
+      state: SessionListState.loaded(sessions: sessions, baseBranch: "main", repoSlug: "org/repo"),
+    );
+
+    final scrollView = tester.widget<CustomScrollView>(find.byType(CustomScrollView));
+    scrollView.controller!.jumpTo(scrollView.controller!.position.maxScrollExtent);
+    await tester.pump();
+
+    final lastTile = find.ancestor(of: find.text("Task 11"), matching: find.byType(SessionTile));
+    final loc = AppLocalizations.of(tester.element(find.byType(SessionListScaffold)))!;
+    final newTaskButton = find.widgetWithText(PregoButtonsSolid, loc.sessionListNewTask);
+    expect(lastTile, findsOneWidget);
+    expect(newTaskButton, findsOneWidget);
+    expect(tester.getBottomLeft(lastTile).dy, lessThan(tester.getTopLeft(newTaskButton).dy));
   });
 }

--- a/client/app/test/features/session_list/session_list_bar_test.dart
+++ b/client/app/test/features/session_list/session_list_bar_test.dart
@@ -30,6 +30,7 @@ void main() {
     required SessionListState state,
     ConnectionOverlayState overlay = const ConnectionOverlayState.hidden(connected: true),
     String? projectName = "Sesori_app_monorepo",
+    TextScaler textScaler = TextScaler.noScaling,
   }) async {
     when(() => cubit.state).thenReturn(state);
 
@@ -40,6 +41,10 @@ void main() {
           theme: ThemeData(extensions: [PregoDesignSystem.light]),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
+          builder: (context, child) => MediaQuery(
+            data: MediaQuery.of(context).copyWith(textScaler: textScaler),
+            child: child!,
+          ),
           home: BlocProvider<SessionListCubit>.value(
             value: cubit,
             child: SessionListScaffold(
@@ -180,13 +185,15 @@ void main() {
     expect(find.text("sesori-ai/sesori_apps_monorepo"), findsNWidgets(2));
   });
 
-  testWidgets("last session scrolls clear of the floating new-task button", (tester) async {
+  testWidgets("last session scrolls clear of the floating new-task button at large text scales", (tester) async {
     final sessions = [
       for (var index = 0; index < 12; index++) testSession(id: "s$index", title: "Task $index"),
     ];
     await pumpScaffold(
       tester,
-      state: SessionListState.loaded(sessions: sessions, baseBranch: "main", repoSlug: "org/repo"),
+      state: SessionListState.loaded(sessions: sessions, baseBranch: "main", repoSlug: null),
+      projectName: "P",
+      textScaler: const TextScaler.linear(2.5),
     );
 
     final scrollView = tester.widget<CustomScrollView>(find.byType(CustomScrollView));
@@ -198,6 +205,7 @@ void main() {
     final newTaskButton = find.widgetWithText(PregoButtonsSolid, loc.sessionListNewTask);
     expect(lastTile, findsOneWidget);
     expect(newTaskButton, findsOneWidget);
+    expect(tester.getSize(newTaskButton).height, greaterThan(80));
     expect(tester.getBottomLeft(lastTile).dy, lessThan(tester.getTopLeft(newTaskButton).dy));
   });
 }

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -98,8 +98,9 @@ child sessions with titles, activity, statuses, and unseen state.
   outcome when it settles.
 - At the end of either full-screen list, the final project or session row
   scrolls above its floating creation button and the bottom safe area instead
-  of remaining obscured. The wide split-view session pane has no floating
-  action and does not reserve that clearance.
+  of remaining obscured. Session-list clearance grows with accessibility text
+  scaling when its labelled action becomes taller. The wide split-view session
+  pane has no floating action and does not reserve that clearance.
 - A pull that crossed the deeper catalog-scan threshold runs no ordinary refresh
   at all: the scan reaches the same backend and settles into a list refresh of
   its own. It stops holding the content the moment that stage fires — including

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -96,6 +96,10 @@ child sessions with titles, activity, statuses, and unseen state.
   platform, releasing an ordinary pull while its refresh is pending keeps the
   pane content displaced and its Cupertino indicator visible, and reports the
   outcome when it settles.
+- At the end of either full-screen list, the final project or session row
+  scrolls above its floating creation button and the bottom safe area instead
+  of remaining obscured. The wide split-view session pane has no floating
+  action and does not reserve that clearance.
 - A pull that crossed the deeper catalog-scan threshold runs no ordinary refresh
   at all: the scan reaches the same backend and settles into a list refresh of
   its own. It stops holding the content the moment that stage fires — including
@@ -245,6 +249,9 @@ leave the surface that started one. Restore harness eligibility afterwards.
   has no active system back gesture stops accepting row actions.
 - A wide session pane starts an ordinary refresh without showing or holding its
   pull indicator until the operation completes.
+- The final row in a full-screen project or session list remains behind its
+  floating creation button when scrolled to the end, or the wide pane gains an
+  unnecessary matching gap.
 - A pull that started a scan comes to rest an indicator's height below the top
   before collapsing, rather than settling to the top in one movement.
 - A scan offered for a harness the bridge will not import from, a pull
@@ -314,6 +321,7 @@ leave the surface that started one. Restore harness eligibility afterwards.
   `client/app/test/core/extensions/build_context_x_test.dart`,
   `client/app/test/core/widgets/catalog_scan_row_test.dart`,
   `client/app/test/features/project_list/project_list_catalog_scan_test.dart`,
+  `client/app/test/features/session_list/session_list_bar_test.dart`, and
   `client/app/test/features/session_list/session_list_panel_test.dart`
 - Client row swipe behavior:
   `client/module_prego/lib/interactions/prego_swipe_actions.dart`


### PR DESCRIPTION
## Complexity

🌱 Trivial — a localized full-screen list inset with focused widget coverage.

## What

- Add trailing scroll clearance to non-empty full-screen session lists, matching the project list behavior.
- Keep the wide split-view session pane unchanged because its creation action is not floating.
- Add a widget regression test and document the supported behavior.

## Why

The final session row could remain underneath the floating **New task** button when the list was scrolled to the end.

## Risk and test focus

Low-risk, UI-only layout change. The user-visible impact is limited to extra scroll room at the end of the full-screen session list. There is no database, transport, or backend impact.

## Expected result

At the end of a non-empty full-screen session list, the final row can scroll fully above the floating **New task** button and bottom safe area.

## Verification

- `flutter test test/features/session_list/session_list_bar_test.dart`
- `dart analyze` (from `client/app`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds trailing clearance to the full-screen session list so the final row scrolls above the floating **New task** button; clearance now grows with accessibility text scaling. The wide split-view session pane stays unchanged.

- Adds a widget regression test covering the clearance at large text scales.
- Documents the behavior and the unaffected wide pane in `docs/regression/projects-and-sessions.md`.

<sup>Written for commit 5458442111423c000cd0646d546f2ed5a283a4dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

