### PR TITLE
⚙️ Update dependencies and retire the go_router page workaround

### DIFF
--- a/.ai/skills/update-dependencies/SKILL.md
+++ b/.ai/skills/update-dependencies/SKILL.md
@@ -36,6 +36,9 @@ The repo has two Dart workspaces and two standalone packages. Workspace members 
 - `bridge/sesori_plugin_claude/pubspec.yaml`
 - `bridge/sesori_plugin_pi/pubspec.yaml`
 - `bridge/sesori_plugin_hermes/pubspec.yaml`
+- `bridge/sesori_plugin_copilot/pubspec.yaml`
+- `bridge/sesori_plugin_grok/pubspec.yaml`
+- `bridge/sesori_plugin_deepseek/pubspec.yaml`
 - `bridge/app/pubspec.yaml` (CLI relay server)
 
 **Standalone packages** (NOT in any workspace — resolve independently with their own lockfile):
@@ -119,6 +122,16 @@ flutter --version
 ```
 
 If `flutter --version` still reports the old version after `asdf set`, run `asdf reshim flutter` (or open a new shell) and re-run `flutter --version`.
+
+Two recurring environment traps on this machine (both hit 2026-08-28):
+
+- **The shell profile puts a pinned `~/.asdf/installs/flutter/<old>-stable/bin` on `PATH` ahead of `~/.asdf/shims`**, so `which flutter` keeps resolving the old SDK no matter what `asdf set` writes. `asdf current flutter` will correctly report the new version while `flutter --version` reports the old one. Prefix every `flutter`/`dart` command in this workflow with `export PATH="$HOME/.asdf/shims:$PATH"` (the Makefile targets included) and verify with `which flutter` before trusting any version output.
+- **`asdf install flutter latest` reports "already installed" for a half-extracted install.** If the version dir contains only `flutter_macos_*.zip`, or `flutter --version` fails with `fatal: not a git repository`, the extraction was interrupted. `asdf uninstall` alone is not enough — the plugin's `mv`-based install then fails with "Directory not empty". Fully remove both dirs and reinstall:
+
+  ```bash
+  rm -rf ~/.asdf/installs/flutter/<version> ~/.asdf/downloads/flutter/<version>
+  asdf install flutter <version>
+  ```
 </step>
 
 <step name="1.2">Check and update environment constraints in all pubspec.yaml files **except `shared/no_slop_linter/pubspec.yaml`** (manually managed).
@@ -158,6 +171,9 @@ For each pubspec.yaml below, read its `environment` section and update only the 
 | `bridge/sesori_plugin_claude/pubspec.yaml` | ✅ | — | caret |
 | `bridge/sesori_plugin_pi/pubspec.yaml` | ✅ | — | caret |
 | `bridge/sesori_plugin_hermes/pubspec.yaml` | ✅ | — | caret |
+| `bridge/sesori_plugin_copilot/pubspec.yaml` | ✅ | — | caret |
+| `bridge/sesori_plugin_grok/pubspec.yaml` | ✅ | — | caret |
+| `bridge/sesori_plugin_deepseek/pubspec.yaml` | ✅ | — | caret |
 | `shared/sesori_shared/pubspec.yaml` | ✅ | — | caret |
 
 Example:
@@ -238,6 +254,9 @@ set -e
 (cd bridge/sesori_plugin_claude && dart pub outdated)
 (cd bridge/sesori_plugin_pi && dart pub outdated)
 (cd bridge/sesori_plugin_hermes && dart pub outdated)
+(cd bridge/sesori_plugin_copilot && dart pub outdated)
+(cd bridge/sesori_plugin_grok && dart pub outdated)
+(cd bridge/sesori_plugin_deepseek && dart pub outdated)
 (cd bridge/app && dart pub outdated)
 ```
 
@@ -265,7 +284,7 @@ set -e
 <step name="3.1">For each pubspec.yaml, in this order:
 
 1. `shared/sesori_shared/pubspec.yaml` (consumed by both workspaces)
-2. Bridge workspace members (dependency order): `bridge/sesori_plugin_interface`, `bridge/sesori_bridge_foundation`, `bridge/sesori_plugin_runtime`, `bridge/sesori_plugin_opencode`, `bridge/sesori_plugin_codex`, `bridge/sesori_plugin_acp`, `bridge/sesori_plugin_cursor`, `bridge/sesori_plugin_omp`, `bridge/sesori_plugin_claude`, `bridge/sesori_plugin_pi`, `bridge/sesori_plugin_hermes`, `bridge/app`
+2. Bridge workspace members (dependency order): `bridge/sesori_plugin_interface`, `bridge/sesori_bridge_foundation`, `bridge/sesori_plugin_runtime`, `bridge/sesori_plugin_opencode`, `bridge/sesori_plugin_codex`, `bridge/sesori_plugin_acp`, `bridge/sesori_plugin_cursor`, `bridge/sesori_plugin_omp`, `bridge/sesori_plugin_claude`, `bridge/sesori_plugin_pi`, `bridge/sesori_plugin_hermes`, `bridge/sesori_plugin_copilot`, `bridge/sesori_plugin_grok`, `bridge/sesori_plugin_deepseek`, `bridge/app`
 3. Client workspace members (dependency order): `client/module_auth`, `client/module_core`, `client/module_prego`, `client/module_desktop_core`, `client/design_catalog`, `client/app`, `client/desktop`
 
 **SKIP** `shared/no_slop_linter/pubspec.yaml` — analyzer-plugin constraints are bumped manually (see the project structure note). Do not edit it here even if `pub outdated` reports newer versions.
@@ -544,7 +563,7 @@ Report this list at the end of the update process for visibility.
 <success_criteria>
 
 - Preflight discovery (Phase 0) ran; every discovered source pubspec and workspace member is accounted for, with none silently skipped
-- Environment constraints (sdk, flutter) updated in 22 pubspec.yaml files (every pubspec EXCEPT `shared/no_slop_linter/pubspec.yaml`, which is excluded entirely — 13 bridge, 8 client, and `shared/sesori_shared`)
+- Environment constraints (sdk, flutter) updated in 25 pubspec.yaml files (every pubspec EXCEPT `shared/no_slop_linter/pubspec.yaml`, which is excluded entirely — 16 bridge, 8 client, and `shared/sesori_shared`)
 - Version constraints bumped to latest resolvable versions in every pubspec EXCEPT `shared/no_slop_linter/pubspec.yaml`
 - All three workspaces (shared, bridge, client) are individually accounted for: each either has bumped constraints or provably had no upgradable deps (Phase 3.4)
 - All in-scope pubspec.lock files regenerated (bridge workspace, client workspace, and `shared/sesori_shared` = 3 lockfiles); `shared/no_slop_linter/pubspec.lock` remains untouched

--- a/.ai/skills/update-dependencies/SKILL.md
+++ b/.ai/skills/update-dependencies/SKILL.md
@@ -122,16 +122,6 @@ flutter --version
 ```
 
 If `flutter --version` still reports the old version after `asdf set`, run `asdf reshim flutter` (or open a new shell) and re-run `flutter --version`.
-
-Two recurring environment traps on this machine (both hit 2026-08-28):
-
-- **The shell profile puts a pinned `~/.asdf/installs/flutter/<old>-stable/bin` on `PATH` ahead of `~/.asdf/shims`**, so `which flutter` keeps resolving the old SDK no matter what `asdf set` writes. `asdf current flutter` will correctly report the new version while `flutter --version` reports the old one. Prefix every `flutter`/`dart` command in this workflow with `export PATH="$HOME/.asdf/shims:$PATH"` (the Makefile targets included) and verify with `which flutter` before trusting any version output.
-- **`asdf install flutter latest` reports "already installed" for a half-extracted install.** If the version dir contains only `flutter_macos_*.zip`, or `flutter --version` fails with `fatal: not a git repository`, the extraction was interrupted. `asdf uninstall` alone is not enough — the plugin's `mv`-based install then fails with "Directory not empty". Fully remove both dirs and reinstall:
-
-  ```bash
-  rm -rf ~/.asdf/installs/flutter/<version> ~/.asdf/downloads/flutter/<version>
-  asdf install flutter <version>
-  ```
 </step>
 
 <step name="1.2">Check and update environment constraints in all pubspec.yaml files **except `shared/no_slop_linter/pubspec.yaml`** (manually managed).

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-flutter 3.47.1-stable
+flutter 3.47.2-stable

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -60,6 +60,6 @@ dev_dependencies:
   # production code reaches sqlite3 only transitively through drift.
   sqlite3: ^3.5.2
   build_runner: any
-  freezed: 4.0.0-dev.3
+  freezed: ^4.0.0
   json_serializable: ^6.14.1
   drift_dev: 2.34.3

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   args: ^2.7.0

--- a/bridge/pubspec.lock
+++ b/bridge/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: be169cf6ac481e052c4538715d88841d567150dfe1df38aaec76461a4e7b39f2
+      sha256: ace891da0862b0e4cabbb064ee3fd87b2728b898949fdb366d83fe98342c9f19
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.0"
   args:
     dependency: transitive
     description:
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "3f88fc9c96c568d631356507355a2d1e983ee000c9ac008bdcb39b5bf53ce777"
+      sha256: "82ade9fc4273f29ed673e33166944465225b4f7fc5d4aaef48605cc751c18fc1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.12"
+    version: "3.1.13"
   drift:
     dependency: transitive
     description:
@@ -261,10 +261,10 @@ packages:
     dependency: transitive
     description:
       name: freezed
-      sha256: "9ec135696554923c59339d46dd50adbaf81099be06ffda0fb9c06f410aea9137"
+      sha256: "27585a6c2b9ac28ffb7b45d87fd1502332af1eb90e1c9f5eb1acb24c71d26e17"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0-dev.3"
+    version: "4.0.0"
   freezed_annotation:
     dependency: transitive
     description:
@@ -745,4 +745,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.13.1 <4.0.0"
+  dart: ">=3.13.2 <4.0.0"

--- a/bridge/pubspec.yaml
+++ b/bridge/pubspec.yaml
@@ -2,7 +2,7 @@ name: sesori_bridge_workspace
 publish_to: none
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 workspace:
   - app

--- a/bridge/sesori_bridge_foundation/pubspec.yaml
+++ b/bridge/sesori_bridge_foundation/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   crypto: ^3.0.7

--- a/bridge/sesori_plugin_acp/pubspec.yaml
+++ b/bridge/sesori_plugin_acp/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   sesori_plugin_interface:

--- a/bridge/sesori_plugin_acp/pubspec.yaml
+++ b/bridge/sesori_plugin_acp/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: any
-  freezed: 4.0.0-dev.3
+  freezed: ^4.0.0
   json_serializable: ^6.14.1
   test: ^1.31.2
   lints: ^6.1.0

--- a/bridge/sesori_plugin_claude/pubspec.yaml
+++ b/bridge/sesori_plugin_claude/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   sesori_plugin_interface:

--- a/bridge/sesori_plugin_claude/pubspec.yaml
+++ b/bridge/sesori_plugin_claude/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: any
-  freezed: 4.0.0-dev.3
+  freezed: ^4.0.0
   json_serializable: ^6.14.1
   test: ^1.31.2
   lints: ^6.1.0

--- a/bridge/sesori_plugin_codex/pubspec.yaml
+++ b/bridge/sesori_plugin_codex/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   sesori_bridge_foundation:

--- a/bridge/sesori_plugin_codex/pubspec.yaml
+++ b/bridge/sesori_plugin_codex/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: any
-  freezed: 4.0.0-dev.3
+  freezed: ^4.0.0
   json_serializable: ^6.14.1
   test: ^1.31.2
   lints: ^6.1.0

--- a/bridge/sesori_plugin_copilot/pubspec.yaml
+++ b/bridge/sesori_plugin_copilot/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   acp_plugin:

--- a/bridge/sesori_plugin_cursor/pubspec.yaml
+++ b/bridge/sesori_plugin_cursor/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   sesori_plugin_interface:

--- a/bridge/sesori_plugin_cursor/pubspec.yaml
+++ b/bridge/sesori_plugin_cursor/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: any
-  freezed: 4.0.0-dev.3
+  freezed: ^4.0.0
   json_serializable: ^6.14.1
   test: ^1.31.2
   lints: ^6.1.0

--- a/bridge/sesori_plugin_deepseek/pubspec.yaml
+++ b/bridge/sesori_plugin_deepseek/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   acp_plugin:

--- a/bridge/sesori_plugin_grok/pubspec.yaml
+++ b/bridge/sesori_plugin_grok/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: any
-  freezed: 4.0.0-dev.3
+  freezed: ^4.0.0
   json_serializable: ^6.14.1
   lints: ^6.1.0
   test: ^1.31.2

--- a/bridge/sesori_plugin_grok/pubspec.yaml
+++ b/bridge/sesori_plugin_grok/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   acp_plugin:

--- a/bridge/sesori_plugin_hermes/pubspec.yaml
+++ b/bridge/sesori_plugin_hermes/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   freezed_annotation: ^3.1.0

--- a/bridge/sesori_plugin_hermes/pubspec.yaml
+++ b/bridge/sesori_plugin_hermes/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: any
-  freezed: 4.0.0-dev.3
+  freezed: ^4.0.0
   json_serializable: ^6.14.1
   test: ^1.31.2
   lints: ^6.1.0

--- a/bridge/sesori_plugin_interface/pubspec.yaml
+++ b/bridge/sesori_plugin_interface/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   freezed_annotation: ^3.1.0

--- a/bridge/sesori_plugin_interface/pubspec.yaml
+++ b/bridge/sesori_plugin_interface/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
 dev_dependencies:
   lints: ^6.1.0
-  freezed: 4.0.0-dev.3
+  freezed: ^4.0.0
   json_serializable: ^6.14.1
   build_runner: any
   test: ^1.31.2

--- a/bridge/sesori_plugin_omp/pubspec.yaml
+++ b/bridge/sesori_plugin_omp/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   acp_plugin:

--- a/bridge/sesori_plugin_opencode/pubspec.yaml
+++ b/bridge/sesori_plugin_opencode/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   sesori_plugin_interface:

--- a/bridge/sesori_plugin_opencode/pubspec.yaml
+++ b/bridge/sesori_plugin_opencode/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
 dev_dependencies:
   build_runner: any
   fake_async: ^1.3.3
-  freezed: 4.0.0-dev.3
+  freezed: ^4.0.0
   json_serializable: ^6.14.1
   test: ^1.31.2
   lints: ^6.1.0

--- a/bridge/sesori_plugin_pi/pubspec.yaml
+++ b/bridge/sesori_plugin_pi/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: any
-  freezed: 4.0.0-dev.3
+  freezed: ^4.0.0
   json_serializable: ^6.14.1
   lints: ^6.1.0
   test: ^1.31.2

--- a/bridge/sesori_plugin_pi/pubspec.yaml
+++ b/bridge/sesori_plugin_pi/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   http: ^1.6.0

--- a/bridge/sesori_plugin_runtime/pubspec.yaml
+++ b/bridge/sesori_plugin_runtime/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   meta: ^1.19.0

--- a/bridge/sesori_plugin_runtime/pubspec.yaml
+++ b/bridge/sesori_plugin_runtime/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 dev_dependencies:
   lints: ^6.1.0
-  freezed: 4.0.0-dev.3
+  freezed: ^4.0.0
   json_serializable: ^6.14.1
   build_runner: any
   test: ^1.31.2

--- a/client/app/android/Gemfile.lock
+++ b/client/app/android/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1281.0)
+    aws-partitions (1.1282.0)
     aws-sdk-core (3.254.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -43,7 +43,7 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     erb (6.0.7)
-    excon (1.7.0)
+    excon (1.7.1)
       logger
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
@@ -117,7 +117,7 @@ GEM
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
     fastlane-sirp (1.1.0)
     gh_inspector (1.1.3)
-    google-apis-androidpublisher_v3 (0.106.0)
+    google-apis-androidpublisher_v3 (0.107.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-core (1.2.5)
       addressable (~> 2.9)
@@ -151,7 +151,7 @@ GEM
       googleauth (~> 1.9)
       mini_mime (~> 1.0)
     google-logging-utils (0.2.0)
-    googleauth (1.17.3)
+    googleauth (1.17.4)
       faraday (>= 1.0, < 3.a)
       google-cloud-env (~> 2.2)
       google-logging-utils (~> 0.1)
@@ -194,7 +194,7 @@ GEM
     pstore (0.2.1)
     public_suffix (7.0.5)
     rake (13.4.2)
-    rbs (4.1.3)
+    rbs (4.2.0)
       logger
       prism (>= 1.6.0)
       tsort
@@ -265,7 +265,7 @@ CHECKSUMS
   artifactory (3.0.17) sha256=3023d5c964c31674090d655a516f38ca75665c15084140c08b7f2841131af263
   atomos (0.1.3) sha256=7d43b22f2454a36bace5532d30785b06de3711399cb1c6bf932573eda536789f
   aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
-  aws-partitions (1.1281.0) sha256=97fcc7d6a068ab790a1efcd8c6587c08fb108b4bed7ff1409cb47e0d642782ec
+  aws-partitions (1.1282.0) sha256=d6c7c4ad2e4f8cd4ca56445bfbb3958fec0deecd959c1e2bcd3a83c9aa308c18
   aws-sdk-core (3.254.1) sha256=518089e32134c3478cd4ec63d07fb966546a45e9e4cbf5f80d2cf16d5699d29b
   aws-sdk-kms (1.130.0) sha256=a2e83662ca31b77a2a19c9aa2f40a98165a67270c18c718fe1c70d0cbd7cd749
   aws-sdk-s3 (1.229.0) sha256=7dd11a111875b3505d2ec0a0a383a6aab6c1badb3d4e94e7fbb958a24451f596
@@ -274,7 +274,6 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
-  bundler (4.0.16) sha256=d6ca5dd440c24f9abce9844cf44cc8e18c6a553de65a47efb4544137af92c47d
   claide (1.1.0) sha256=6d3c5c089dde904d96aa30e73306d0d4bd444b1accb9b3125ce14a3c0183f82e
   colored (1.2) sha256=9d82b47ac589ce7f6cab64b1f194a2009e9fd00c326a5357321f44afab2c1d2c
   colored2 (3.1.2) sha256=b13c2bd7eeae2cf7356a62501d398e72fde78780bd26aec6a979578293c28b4a
@@ -286,7 +285,7 @@ CHECKSUMS
   dotenv (2.8.1) sha256=c5944793349ae03c432e1780a2ca929d60b88c7d14d52d630db0508c3a8a17d8
   emoji_regex (3.2.3) sha256=ecd8be856b7691406c6bf3bb3a5e55d6ed683ffab98b4aa531bb90e1ddcc564b
   erb (6.0.7) sha256=c5ca6dc25b0ef974a44dc8f59fe847577122483b1968a38dec305c60bf91ee92
-  excon (1.7.0) sha256=b8deec2bf978123b7e4b13a103ffec61557c6feaba34706dbc1ce4a94dec33e0
+  excon (1.7.1) sha256=dd2d870eece1b5ce4e4f9efd938e67a69ccd8c003c3825b638b937e1082eaac2
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-cookie_jar (0.0.8) sha256=0140605823f8cc63c7028fccee486aaed8e54835c360cffc1f7c8c07c4299dbb
   faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
@@ -297,7 +296,7 @@ CHECKSUMS
   fastlane (2.238.0) sha256=78e9252df2224c7e427012638e41051edfa29b133a40fda883fd2f1c13a77b98
   fastlane-sirp (1.1.0) sha256=10bc94f9682efd8e1badfb31452a76dd8981f1f3a33717c765fde6d75b54d847
   gh_inspector (1.1.3) sha256=04cca7171b87164e053aa43147971d3b7f500fcb58177698886b48a9fc4a1939
-  google-apis-androidpublisher_v3 (0.106.0) sha256=b90b5312b70f8f731def88f24a2b8fb791fe1b979a7c2c14a905cb6cae19cf3f
+  google-apis-androidpublisher_v3 (0.107.0) sha256=b8207eecc89e6a9f7ea11aa88a07bccdcae5ca90121330079db4ef4696a2f3ff
   google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
   google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
   google-apis-playcustomapp_v1 (0.18.0) sha256=44b277b9dee4a59ac5e9d98be1485edc5e382d2f9d73c79ae8908a455786a254
@@ -307,7 +306,7 @@ CHECKSUMS
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
   google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
-  googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
+  googleauth (1.17.4) sha256=acc2cac2a6011048f149c922cbc6c9675719e165aa5000c7fa3876c480fe9ae3
   highline (2.0.3) sha256=2ddd5c127d4692721486f91737307236fe005352d12a4202e26c48614f719479
   http-cookie (1.0.8) sha256=b14fe0445cf24bf9ae098633e9b8d42e4c07c3c1f700672b09fbfe32ffd41aa6
   io-console (0.9.2) sha256=efa74f891dd03c0939a931dfc6e74c2813d904763d456ea9762b0525e748db08
@@ -335,7 +334,7 @@ CHECKSUMS
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  rbs (4.1.3) sha256=0c4474a9751cdc14364bfad0b3e53678323bbdc2c31683b0445932867dbab8c4
+  rbs (4.2.0) sha256=51f7b886dcc05bc09e10b901daa6a81829f6adc03101d6ca9ea4aac6103e0674
   rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
   reline (0.7.0) sha256=5b012d8e55dbf9d450f12bde2cf7d15ff546ae80b3f8f3b30e570d431815583d
   representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace

--- a/client/app/ios/Gemfile.lock
+++ b/client/app/ios/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1281.0)
+    aws-partitions (1.1282.0)
     aws-sdk-core (3.254.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -102,7 +102,7 @@ GEM
     ethon (0.18.0)
       ffi (>= 1.15.0)
       logger
-    excon (1.7.0)
+    excon (1.7.1)
       logger
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
@@ -180,7 +180,7 @@ GEM
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    google-apis-androidpublisher_v3 (0.106.0)
+    google-apis-androidpublisher_v3 (0.107.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-core (1.2.5)
       addressable (~> 2.9)
@@ -214,7 +214,7 @@ GEM
       googleauth (~> 1.9)
       mini_mime (~> 1.0)
     google-logging-utils (0.2.0)
-    googleauth (1.17.3)
+    googleauth (1.17.4)
       faraday (>= 1.0, < 3.a)
       google-cloud-env (~> 2.2)
       google-logging-utils (~> 0.1)
@@ -267,7 +267,7 @@ GEM
     pstore (0.2.1)
     public_suffix (4.0.7)
     rake (13.4.2)
-    rbs (4.1.3)
+    rbs (4.2.0)
       logger
       prism (>= 1.6.0)
       tsort
@@ -346,7 +346,7 @@ CHECKSUMS
   artifactory (3.0.17) sha256=3023d5c964c31674090d655a516f38ca75665c15084140c08b7f2841131af263
   atomos (0.1.3) sha256=7d43b22f2454a36bace5532d30785b06de3711399cb1c6bf932573eda536789f
   aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
-  aws-partitions (1.1281.0) sha256=97fcc7d6a068ab790a1efcd8c6587c08fb108b4bed7ff1409cb47e0d642782ec
+  aws-partitions (1.1282.0) sha256=d6c7c4ad2e4f8cd4ca56445bfbb3958fec0deecd959c1e2bcd3a83c9aa308c18
   aws-sdk-core (3.254.1) sha256=518089e32134c3478cd4ec63d07fb966546a45e9e4cbf5f80d2cf16d5699d29b
   aws-sdk-kms (1.130.0) sha256=a2e83662ca31b77a2a19c9aa2f40a98165a67270c18c718fe1c70d0cbd7cd749
   aws-sdk-s3 (1.229.0) sha256=7dd11a111875b3505d2ec0a0a383a6aab6c1badb3d4e94e7fbb958a24451f596
@@ -355,7 +355,6 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
-  bundler (4.0.16) sha256=d6ca5dd440c24f9abce9844cf44cc8e18c6a553de65a47efb4544137af92c47d
   claide (1.1.0) sha256=6d3c5c089dde904d96aa30e73306d0d4bd444b1accb9b3125ce14a3c0183f82e
   cocoapods (1.16.2) sha256=0ff1c860f32df3db8b16df09b58da1a6bb2a12fe55f6d5e8be994a74fadd1e5e
   cocoapods-core (1.16.2) sha256=4bb1b5c420691e60cf36fa227dec6bc48c096c34c97bb7aa512ea7f3246fc12b
@@ -380,7 +379,7 @@ CHECKSUMS
   erb (6.0.7) sha256=c5ca6dc25b0ef974a44dc8f59fe847577122483b1968a38dec305c60bf91ee92
   escape (0.0.4) sha256=e49f44ae2b4f47c6a3abd544ae77fe4157802794e32f19b8e773cbc4dcec4169
   ethon (0.18.0) sha256=b598afc9f30448cb068b850714b7d6948e941476095d04f90a4ac65b8d6efcb2
-  excon (1.7.0) sha256=b8deec2bf978123b7e4b13a103ffec61557c6feaba34706dbc1ce4a94dec33e0
+  excon (1.7.1) sha256=dd2d870eece1b5ce4e4f9efd938e67a69ccd8c003c3825b638b937e1082eaac2
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-cookie_jar (0.0.8) sha256=0140605823f8cc63c7028fccee486aaed8e54835c360cffc1f7c8c07c4299dbb
   faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
@@ -395,7 +394,7 @@ CHECKSUMS
   fourflusher (2.3.1) sha256=1b3de61c7c791b6a4e64f31e3719eb25203d151746bb519a0292bff1065ccaa9
   fuzzy_match (2.0.4) sha256=b5de4f95816589c5b5c3ad13770c0af539b75131c158135b3f3bbba75d0cfca5
   gh_inspector (1.1.3) sha256=04cca7171b87164e053aa43147971d3b7f500fcb58177698886b48a9fc4a1939
-  google-apis-androidpublisher_v3 (0.106.0) sha256=b90b5312b70f8f731def88f24a2b8fb791fe1b979a7c2c14a905cb6cae19cf3f
+  google-apis-androidpublisher_v3 (0.107.0) sha256=b8207eecc89e6a9f7ea11aa88a07bccdcae5ca90121330079db4ef4696a2f3ff
   google-apis-core (1.2.5) sha256=e21562b5627a0fc6a0c3165e429c3afed0f6a628eaa514e83f7204dda1adff69
   google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
   google-apis-playcustomapp_v1 (0.18.0) sha256=44b277b9dee4a59ac5e9d98be1485edc5e382d2f9d73c79ae8908a455786a254
@@ -405,7 +404,7 @@ CHECKSUMS
   google-cloud-errors (1.7.0) sha256=6e682f42d89aae08689f36f28495de629d756da076bafff0003bac7f8042ebb3
   google-cloud-storage (1.62.0) sha256=e2c3c08bf8fd40d50be92304084942203314d4fc0ee52028e99f9359c3ad1330
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
-  googleauth (1.17.3) sha256=9a655455885c0c17a8b70537acd2a992a7c7842c43c06c6612dfb0d93e755d58
+  googleauth (1.17.4) sha256=acc2cac2a6011048f149c922cbc6c9675719e165aa5000c7fa3876c480fe9ae3
   highline (2.0.3) sha256=2ddd5c127d4692721486f91737307236fe005352d12a4202e26c48614f719479
   http-cookie (1.0.8) sha256=b14fe0445cf24bf9ae098633e9b8d42e4c07c3c1f700672b09fbfe32ffd41aa6
   httpclient (2.9.0) sha256=4b645958e494b2f86c2f8a2f304c959baa273a310e77a2931ddb986d83e498c8
@@ -439,7 +438,7 @@ CHECKSUMS
   pstore (0.2.1) sha256=03904d0f2c66579e96d1e6704cdabc0c88df7ea8ed8782d9f3569f6f6c702c1a
   public_suffix (4.0.7) sha256=8be161e2421f8d45b0098c042c06486789731ea93dc3a896d30554ee38b573b8
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  rbs (4.1.3) sha256=0c4474a9751cdc14364bfad0b3e53678323bbdc2c31683b0445932867dbab8c4
+  rbs (4.2.0) sha256=51f7b886dcc05bc09e10b901daa6a81829f6adc03101d6ca9ea4aac6103e0674
   rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
   reline (0.7.0) sha256=5b012d8e55dbf9d450f12bde2cf7d15ff546ae80b3f8f3b30e570d431815583d
   representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace

--- a/client/app/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/client/app/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "33a468adfdb75b53f05a37e7c886ca7c962b5c17",
-        "version" : "12.17.0"
+        "revision" : "346daa9f46316aa372b35b317e18224acc2e9063",
+        "version" : "12.18.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "fceaffa07d22dcd5624d3639fd970351a4a5ad8c",
-        "version" : "12.17.0"
+        "revision" : "f04760d460296cc0fa430935a7be212e5bd67fc5",
+        "version" : "12.18.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "9f183ae842be978784f2963a343682e0c46d8fb3",
-        "version" : "8.1.2"
+        "revision" : "92c8f6dc3ac375d6febdfcb3db68bc3d10633db3",
+        "version" : "8.1.3"
       }
     },
     {

--- a/client/app/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/client/app/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "33a468adfdb75b53f05a37e7c886ca7c962b5c17",
-        "version" : "12.17.0"
+        "revision" : "346daa9f46316aa372b35b317e18224acc2e9063",
+        "version" : "12.18.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "fceaffa07d22dcd5624d3639fd970351a4a5ad8c",
-        "version" : "12.17.0"
+        "revision" : "f04760d460296cc0fa430935a7be212e5bd67fc5",
+        "version" : "12.18.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "9f183ae842be978784f2963a343682e0c46d8fb3",
-        "version" : "8.1.2"
+        "revision" : "92c8f6dc3ac375d6febdfcb3db68bc3d10633db3",
+        "version" : "8.1.3"
       }
     },
     {

--- a/client/app/lib/core/routing/app_router.dart
+++ b/client/app/lib/core/routing/app_router.dart
@@ -41,20 +41,6 @@ const _settingsNotificationsRouteSegment = "notifications";
 const _settingsHarnessesRouteSegment = "harnesses";
 const _settingsProfileRouteSegment = "profile";
 
-// WORKAROUND: go_router only recognizes package:flutter's legacy MaterialApp,
-// so builder routes under material_ui.MaterialApp become NoTransitionPages.
-// Remove this helper and the explicit pageBuilders once
-// https://github.com/flutter/flutter/issues/191132 is fixed.
-MaterialPage<void> _materialPage({required GoRouterState state, required Widget child}) {
-  return MaterialPage<void>(
-    key: state.pageKey,
-    name: state.name ?? state.path,
-    arguments: <String, String>{...state.pathParameters, ...state.uri.queryParameters},
-    restorationId: state.pageKey.value,
-    child: child,
-  );
-}
-
 extension AppRouteToGoRoute on AppRouteDef {
   /// Returns the [GoRoute] for this route definition with an exhaustive
   /// screen switch over decoded [AppRoute] values.
@@ -95,10 +81,7 @@ extension AppRouteToGoRoute on AppRouteDef {
     return GoRoute(
       path: path,
       routes: routes,
-      pageBuilder: (context, state) => _materialPage(
-        state: state,
-        child: _buildScreen(context: context, state: state),
-      ),
+      builder: (context, state) => _buildScreen(context: context, state: state),
     );
   }
 
@@ -261,26 +244,23 @@ List<RouteBase> _buildAppRoutes({
       routes: [
         ShellRoute(
           navigatorKey: sessionShellNavigatorKey,
-          pageBuilder: (context, state, child) {
+          builder: (context, state, child) {
             final projectId = state.pathParameters[projectIdPathParam] ?? "";
             final projectName = state.uri.queryParameters[projectNameQueryParam];
             final selectedSessionId = state.pathParameters[sessionIdPathParam];
             final projectViewingService = getIt<ProjectViewingService>();
 
-            return _materialPage(
-              state: state,
-              child: SessionListCubitProvider(
-                key: ValueKey("session-list-cubit-$projectId"),
-                projectId: projectId,
-                child: SessionSplitShell(
-                  projectViewingService: projectViewingService,
-                  list: _SessionListPane(
-                    projectId: projectId,
-                    projectName: projectName,
-                    selectedSessionId: selectedSessionId,
-                  ),
-                  child: child,
+            return SessionListCubitProvider(
+              key: ValueKey("session-list-cubit-$projectId"),
+              projectId: projectId,
+              child: SessionSplitShell(
+                projectViewingService: projectViewingService,
+                list: _SessionListPane(
+                  projectId: projectId,
+                  projectName: projectName,
+                  selectedSessionId: selectedSessionId,
                 ),
+                child: child,
               ),
             );
           },
@@ -391,10 +371,8 @@ List<RouteBase> _buildAppRoutes({
       routes: [
         GoRoute(
           path: _settingsNotificationsRouteSegment,
-          pageBuilder: (context, state) => _materialPage(
-            state: state,
-            child: AppRouteDef.settingsNotifications._buildScreen(context: context, state: state),
-          ),
+          builder: (context, state) =>
+              AppRouteDef.settingsNotifications._buildScreen(context: context, state: state),
         ),
         GoRoute(
           path: _settingsHarnessesRouteSegment,
@@ -406,8 +384,9 @@ List<RouteBase> _buildAppRoutes({
           //
           // The modal is a CupertinoPage for the same reason settings itself
           // uses one: only the Cupertino route honours `fullscreenDialog` on
-          // Android too. The pushed page is an explicit MaterialPage, so it
-          // keeps the platform's push transition.
+          // Android too. Choosing per presentation requires a pageBuilder, so
+          // the pushed branch spells out the MaterialPage that go_router would
+          // otherwise supply, keeping the platform's push transition.
           pageBuilder: (context, state) {
             final route = AppRouteSettingsHarnesses.fromParams(queryParams: state.uri.queryParameters);
             final child = route.screen;
@@ -417,16 +396,19 @@ List<RouteBase> _buildAppRoutes({
                 fullscreenDialog: true,
                 child: child,
               ),
-              HarnessSettingsPresentation.pushed => _materialPage(state: state, child: child),
+              HarnessSettingsPresentation.pushed => MaterialPage<void>(
+                key: state.pageKey,
+                name: state.name ?? state.path,
+                arguments: <String, String>{...state.pathParameters, ...state.uri.queryParameters},
+                restorationId: state.pageKey.value,
+                child: child,
+              ),
             };
           },
         ),
         GoRoute(
           path: _settingsProfileRouteSegment,
-          pageBuilder: (context, state) => _materialPage(
-            state: state,
-            child: AppRouteDef.settingsProfile._buildScreen(context: context, state: state),
-          ),
+          builder: (context, state) => AppRouteDef.settingsProfile._buildScreen(context: context, state: state),
         ),
       ],
     ),

--- a/client/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/client/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -30,7 +30,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FirebaseAnalyticsPlugin.register(with: registry.registrar(forPlugin: "FirebaseAnalyticsPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
-  FLTFirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCrashlyticsPlugin"))
+  FirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FirebaseCrashlyticsPlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
   FirebaseRemoteConfigPlugin.register(with: registry.registrar(forPlugin: "FirebaseRemoteConfigPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))

--- a/client/app/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/client/app/macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "33a468adfdb75b53f05a37e7c886ca7c962b5c17",
-        "version" : "12.17.0"
+        "revision" : "346daa9f46316aa372b35b317e18224acc2e9063",
+        "version" : "12.18.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "fceaffa07d22dcd5624d3639fd970351a4a5ad8c",
-        "version" : "12.17.0"
+        "revision" : "f04760d460296cc0fa430935a7be212e5bd67fc5",
+        "version" : "12.18.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "9f183ae842be978784f2963a343682e0c46d8fb3",
-        "version" : "8.1.2"
+        "revision" : "92c8f6dc3ac375d6febdfcb3db68bc3d10633db3",
+        "version" : "8.1.3"
       }
     },
     {

--- a/client/app/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/client/app/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "33a468adfdb75b53f05a37e7c886ca7c962b5c17",
-        "version" : "12.17.0"
+        "revision" : "346daa9f46316aa372b35b317e18224acc2e9063",
+        "version" : "12.18.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "fceaffa07d22dcd5624d3639fd970351a4a5ad8c",
-        "version" : "12.17.0"
+        "revision" : "f04760d460296cc0fa430935a7be212e5bd67fc5",
+        "version" : "12.18.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "9f183ae842be978784f2963a343682e0c46d8fb3",
-        "version" : "8.1.2"
+        "revision" : "92c8f6dc3ac375d6febdfcb3db68bc3d10633db3",
+        "version" : "8.1.3"
       }
     },
     {

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -33,19 +33,16 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   intl: any
-  material_ui: ^1.0.1
-  cupertino_ui: ^1.0.0
+  material_ui: ^1.1.0
+  cupertino_ui: ^1.0.1
 
-  liquid_glass_widgets: ^0.30.1
+  liquid_glass_widgets: ^1.1.0
   http: ^1.6.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.12.0
   rxdart: ^0.28.0
   flutter_bloc: ^9.1.1
-  # Before updating go_router, check its release notes for a fix to
-  # https://github.com/flutter/flutter/issues/191132. Once fixed, remove the
-  # explicit MaterialPage workaround in lib/core/routing/app_router.dart.
-  go_router: ^17.5.0
+  go_router: ^18.0.0
   get_it: ^9.2.1
   injectable: ^3.0.0
   flutter_markdown_plus: ^1.0.12
@@ -73,15 +70,15 @@ dependencies:
   path_provider: ^2.1.6
   re_highlight: ^0.0.3
   wakelock_plus: ^1.7.0
-  firebase_core: ^4.13.0
-  firebase_analytics: ^12.4.6
-  firebase_crashlytics: ^5.2.7
-  firebase_messaging: ^16.5.0
-  firebase_remote_config: ^6.5.6
+  firebase_core: ^4.14.0
+  firebase_analytics: ^12.5.0
+  firebase_crashlytics: ^5.3.0
+  firebase_messaging: ^16.6.0
+  firebase_remote_config: ^6.6.0
   singular_flutter_sdk: ^1.9.0
   flutter_local_notifications: ^22.3.0
   flutter_svg: ^2.3.0
-  sign_in_with_apple: ^8.1.0
+  sign_in_with_apple: ^8.2.0
   crypto: ^3.0.7
   vector_graphics: ^1.2.3
   image_picker: ^1.2.3
@@ -97,7 +94,7 @@ dev_dependencies:
     sdk: flutter
   no_slop_linter:
     path: "../../shared/no_slop_linter"
-  freezed: 4.0.0-dev.3
+  freezed: ^4.0.0
   json_serializable: ^6.14.1
   injectable_generator: ^3.1.3
   bloc_test: ^10.0.0

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -19,7 +19,7 @@ resolution: workspace
 # of the product and file versions while build-number is used as the build suffix.
 version: 1.8.2+1
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/client/app/test/core/routing/app_route_test.dart
+++ b/client/app/test/core/routing/app_route_test.dart
@@ -143,9 +143,8 @@ void main() {
 
   group("flat routes", () {
     test("splash route builds SplashScreen", () {
-      final page = AppRouteDef.splash.toGoRoute().pageBuilder!(_FakeBuildContext(), _FakeGoRouterState());
-      expect(page, isA<MaterialPage<void>>());
-      expect((page as MaterialPage<void>).child, isA<SplashScreen>());
+      final widget = AppRouteDef.splash.toGoRoute().builder!(_FakeBuildContext(), _FakeGoRouterState());
+      expect(widget, isA<SplashScreen>());
     });
 
     test("login route builds LoginScreen behind a fade transition page", () {
@@ -159,9 +158,8 @@ void main() {
     });
 
     test("projects route builds ProjectListScreen", () {
-      final page = AppRouteDef.projects.toGoRoute().pageBuilder!(_FakeBuildContext(), _FakeGoRouterState());
-      expect(page, isA<MaterialPage<void>>());
-      expect((page as MaterialPage<void>).child, isA<ProjectListScreen>());
+      final widget = AppRouteDef.projects.toGoRoute().builder!(_FakeBuildContext(), _FakeGoRouterState());
+      expect(widget, isA<ProjectListScreen>());
     });
 
     // A CupertinoPage, so the bottom-up modal slide is the same on Android,
@@ -184,11 +182,8 @@ void main() {
         children.map((route) => route.path),
         equals(["notifications", "harnesses", "profile"]),
       );
-      final notificationsPage = children[0].pageBuilder!(
-        _FakeBuildContext(),
-        _FakeGoRouterState(),
-      ) as MaterialPage<void>;
-      expect(notificationsPage.child, isA<NotificationSettingsScreen>());
+      final notificationsWidget = children[0].builder!(_FakeBuildContext(), _FakeGoRouterState());
+      expect(notificationsWidget, isA<NotificationSettingsScreen>());
       // Harnesses rise as a modal from the new-session harness menu and push
       // in from the settings list, so the route builds its own page per
       // presentation instead of taking the default push for both.
@@ -208,11 +203,8 @@ void main() {
         HarnessSettingsPresentation.pushed,
       );
       expect(children[1].routes, isEmpty);
-      final profilePage = children[2].pageBuilder!(
-        _FakeBuildContext(),
-        _FakeGoRouterState(),
-      ) as MaterialPage<void>;
-      expect(profilePage.child, isA<ProfileScreen>());
+      final profileWidget = children[2].builder!(_FakeBuildContext(), _FakeGoRouterState());
+      expect(profileWidget, isA<ProfileScreen>());
       expect(
         _composeRoutePath(parentPath: AppRouteDef.settings.path, path: children[0].path),
         AppRouteDef.settingsNotifications.path,
@@ -228,11 +220,10 @@ void main() {
     });
 
     test("newSession route builds NewSessionScreen", () {
-      final page = AppRouteDef.newSession.toGoRoute().pageBuilder!(
+      final widget = AppRouteDef.newSession.toGoRoute().builder!(
         _FakeBuildContext(),
         _FakeGoRouterState(pathParameters: {"projectId": "proj-42"}, queryParameters: {"name": "Project One"}),
-      ) as MaterialPage<void>;
-      final widget = page.child;
+      );
       expect(widget, isA<NewSessionScreen>());
       expect((widget as NewSessionScreen).projectId, "proj-42");
       expect(widget.projectName, "Project One");
@@ -240,33 +231,6 @@ void main() {
   });
 
   group("buildAppRoutes", () {
-    test("every route provides an explicit standalone page", () {
-      void expectExplicitPages(List<RouteBase> routes) {
-        for (final route in routes) {
-          switch (route) {
-            case GoRoute(:final pageBuilder, :final routes):
-              expect(
-                pageBuilder,
-                isNotNull,
-                reason: "GoRoute ${route.path} must not rely on go_router's legacy MaterialApp detection",
-              );
-              expectExplicitPages(routes);
-            case ShellRoute(:final pageBuilder, :final routes):
-              expect(
-                pageBuilder,
-                isNotNull,
-                reason: "ShellRoute must not rely on go_router's legacy MaterialApp detection",
-              );
-              expectExplicitPages(routes);
-            default:
-              throw StateError("Unsupported route type ${route.runtimeType}");
-          }
-        }
-      }
-
-      expectExplicitPages(buildAppRoutes());
-    });
-
     test("explicit route table covers every AppRouteDef exactly once", () {
       final routes = buildAppRoutes();
       final registeredPaths = _collectAbsoluteRoutePaths(routes: routes);
@@ -328,15 +292,14 @@ void main() {
       addTearDown(() => getIt.unregister<ProjectViewingService>());
 
       final shell = _sessionShellRoute();
-      final page = shell.pageBuilder!(
+      final widget = shell.builder!(
         _FakeBuildContext(),
         _FakeGoRouterState(
           pathParameters: {"projectId": "proj-42", "sessionId": "ses-99"},
           queryParameters: {"name": "My Project"},
         ),
         const SizedBox(),
-      ) as MaterialPage<void>;
-      final widget = page.child;
+      );
 
       expect(widget, isA<SessionListCubitProvider>());
       final provider = widget as SessionListCubitProvider;

--- a/client/design_catalog/pubspec.yaml
+++ b/client/design_catalog/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   cupertino_icons: ^1.0.9
   flutter:
     sdk: flutter
-  material_ui: ^1.0.1
+  material_ui: ^1.1.0
   theme_prego:
     path: ../module_prego
   widgetbook: 3.25.0

--- a/client/design_catalog/pubspec.yaml
+++ b/client/design_catalog/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
-  flutter: ">=3.47.1 <3.48.0"
+  sdk: ^3.13.2
+  flutter: ">=3.47.2 <3.48.0"
 
 dependencies:
   cupertino_icons: ^1.0.9

--- a/client/desktop/pubspec.yaml
+++ b/client/desktop/pubspec.yaml
@@ -9,7 +9,7 @@ resolution: workspace
 version: 0.1.0
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   device_info_plus: ^13.2.0

--- a/client/desktop/pubspec.yaml
+++ b/client/desktop/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   get_it: ^9.2.1
   http: ^1.6.0
   injectable: ^3.0.0
-  material_ui: ^1.0.1
+  material_ui: ^1.1.0
   package_info_plus: ^10.2.1
   path: ^1.9.1
   path_provider: ^2.1.6

--- a/client/module_auth/pubspec.yaml
+++ b/client/module_auth/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
   no_slop_linter:
     path: "../../shared/no_slop_linter"
   fake_async: ^1.3.3
-  freezed: 4.0.0-dev.3
+  freezed: ^4.0.0
   injectable_generator: ^3.1.3
   json_serializable: ^6.14.1
   mocktail: ^1.0.5

--- a/client/module_auth/pubspec.yaml
+++ b/client/module_auth/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   freezed_annotation: ^3.1.0

--- a/client/module_core/pubspec.yaml
+++ b/client/module_core/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   bloc: ^9.2.1

--- a/client/module_core/pubspec.yaml
+++ b/client/module_core/pubspec.yaml
@@ -32,7 +32,7 @@ dev_dependencies:
     path: "../../shared/no_slop_linter"
   bloc_test: ^10.0.0
   build_runner: ^2.16.0
-  freezed: 4.0.0-dev.3
+  freezed: ^4.0.0
   injectable_generator: ^3.1.3
   json_serializable: ^6.14.1
   test: ^1.31.1

--- a/client/module_desktop_core/pubspec.yaml
+++ b/client/module_desktop_core/pubspec.yaml
@@ -24,7 +24,7 @@ dev_dependencies:
   no_slop_linter:
     path: "../../shared/no_slop_linter"
   build_runner: ^2.16.0
-  freezed: 4.0.0-dev.3
+  freezed: ^4.0.0
   injectable_generator: ^3.1.3
   mocktail: ^1.0.5
   test: ^1.31.1

--- a/client/module_desktop_core/pubspec.yaml
+++ b/client/module_desktop_core/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   bloc: ^9.2.1

--- a/client/module_prego/pubspec.yaml
+++ b/client/module_prego/pubspec.yaml
@@ -5,8 +5,8 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.13.1
-  flutter: ">=3.47.1"
+  sdk: ^3.13.2
+  flutter: ">=3.47.2"
 
 dependencies:
   flutter:

--- a/client/module_prego/pubspec.yaml
+++ b/client/module_prego/pubspec.yaml
@@ -11,13 +11,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  material_ui: ^1.0.1
-  cupertino_ui: ^1.0.0
+  material_ui: ^1.1.0
+  cupertino_ui: ^1.0.1
   sesori_shared:
     path: ../../shared/sesori_shared
   flutter_svg: ^2.3.0
   universal_platform: ^1.1.0
-  liquid_glass_widgets: ^0.30.1
+  liquid_glass_widgets: ^1.1.0
   cue: ^0.3.1
 
 flutter:

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -2,7 +2,7 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages:
   _fe_analyzer_shared:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: _fe_analyzer_shared
       sha256: "1b0e6a07425a3e460666e88bf1c949ccc7bb0116ad562ce94a1eca60fe820725"
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "6727cf2ced9b104abca9daa278380be2eca2b98ce33d4b46f11708e387dc6b4d"
+      sha256: f6966125633a34f82d9be2ee895b755cff3554087b1d00a9eb884e5947f4bca9
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.76"
+    version: "1.3.77"
   accessibility_tools:
     dependency: transitive
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: be169cf6ac481e052c4538715d88841d567150dfe1df38aaec76461a4e7b39f2
+      sha256: ace891da0862b0e4cabbb064ee3fd87b2728b898949fdb366d83fe98342c9f19
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.0"
   args:
     dependency: transitive
     description:
@@ -269,10 +269,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
+      sha256: f141ea4f277af142a0356955707f6556f37b03947d39d55585981a06ca437bd6
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+4"
+    version: "0.3.5+5"
   crypto:
     dependency: transitive
     description:
@@ -317,18 +317,18 @@ packages:
     dependency: transitive
     description:
       name: cupertino_ui
-      sha256: "7ed8ce4159d342eec4c65f4ea6eec57adaf9365404378541f38efc1da20a5b3d"
+      sha256: "2137c0d41f3b62cc4d3d2495e6c354bd6b6133cd21c6bb155736cc31dbd49a11"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "3f88fc9c96c568d631356507355a2d1e983ee000c9ac008bdcb39b5bf53ce777"
+      sha256: "82ade9fc4273f29ed673e33166944465225b4f7fc5d4aaef48605cc751c18fc1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.12"
+    version: "3.1.13"
   dbus:
     dependency: transitive
     description:
@@ -413,34 +413,34 @@ packages:
     dependency: transitive
     description:
       name: file_selector_android
-      sha256: "1d45e9910f68c16eb0c74f0b10097ad81aed516ea28054c027137e8f7d75e840"
+      sha256: "7c76473740e33a11343c8fce88166049230850d2f19cd8a652ea935fcb8c9206"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.2+9"
+    version: "0.5.2+10"
   file_selector_ios:
     dependency: transitive
     description:
       name: file_selector_ios
-      sha256: e2ecf2885c121691ce13b60db3508f53c01f869fb6e8dc5c1cfa771e4c46aeca
+      sha256: "97269e5307a0ab813b1fa2430bada0a96e0afb74848417f8676f64ba5de0051c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.3+5"
+    version: "0.5.3+6"
   file_selector_linux:
     dependency: transitive
     description:
       name: file_selector_linux
-      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
+      sha256: da76400e7872ce7637ffdce12749ec24169c25f6195c28372208e65a24bcd2ab
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.4"
+    version: "0.9.4+1"
   file_selector_macos:
     dependency: transitive
     description:
       name: file_selector_macos
-      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      sha256: d57c62362766b5e7ae739448650b66c6aab7a68ba7ecc65e04018652645ae0f4
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.5"
+    version: "0.9.5+1"
   file_selector_platform_interface:
     dependency: transitive
     description:
@@ -461,122 +461,122 @@ packages:
     dependency: transitive
     description:
       name: file_selector_windows
-      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
+      sha256: fbefc5fb92c6d3cbe8d284a2cd971b593bb07d2cd6da8557b81a862250b4acec
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+5"
+    version: "0.9.3+6"
   firebase_analytics:
     dependency: transitive
     description:
       name: firebase_analytics
-      sha256: a139dd0ada1c6e0ffd77bfdb877ac9061ffdec7c415e3e06113bdf8844db771f
+      sha256: "0bf812fe5fecf395c07b673f40d951929f631749bd7513a31b8bfafa182d9a06"
       url: "https://pub.dev"
     source: hosted
-    version: "12.4.6"
+    version: "12.5.0"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
-      sha256: "448c319ea895da002e43892c7d3f15dccbc3c4c3b81d3e307e37da885ea52bdf"
+      sha256: "5c3ab4b681c837afd71f0abf77c7485f51c7b645d4ae77b96f9ed54779ff4126"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.6"
+    version: "6.0.7"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
-      sha256: "67f287a0df75f27eafdd4a66a41e44f232c3aba713ea4794a1159893665a8bf5"
+      sha256: "09eb4d0ce4c9a16efbc277ac709a90eb197d5512592215a73c6a302ab1ab6c3a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1+12"
+    version: "0.6.1+13"
   firebase_core:
     dependency: transitive
     description:
       name: firebase_core
-      sha256: "9478ca6700c02d315c6aba37e206e612317f98bb4f335bb1cbd6e0ce67dcf764"
+      sha256: "2343710d8a164e3157a5e2fbb00663503c669be4aa06185311df48626760fdf1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.13.0"
+    version: "4.14.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: e28f9afdcb5b0f0a8ea74ea3b322f5a7592c81cb45dd9d189913bdae08a2089a
+      sha256: "9bfbc85faca09346471ac56fbcee00757ebcfd85887c6f602764eff0001902d8"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "8.1.1"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: f471a288b0101a45567548322ac4a5ad31e3ecbf87a576dcc0e424e6a11e04ea
+      sha256: de1e678209a0c974d8aa4cff39f17d61d2dc263aa64993168360f9be4efb8e91
       url: "https://pub.dev"
     source: hosted
-    version: "3.10.0"
+    version: "3.11.0"
   firebase_crashlytics:
     dependency: transitive
     description:
       name: firebase_crashlytics
-      sha256: "96c1d85de9eddc07061d3f7e2fb75596e75a45c9cec9c2e3a7cc9f97e6f3a748"
+      sha256: aca14d94150d50e3f9e0f5090008fa98232d924bc780689481056521d9dc25c9
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.7"
+    version: "5.3.0"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
-      sha256: "47d83b71fd39c580297c696a507a7c2652680ea2045e40c6c4e3c371b0ee7bc6"
+      sha256: "8270dcdb1800db3e5f888ce30a2d5e8f92c379c461f022297c83b2c794aa1792"
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.27"
+    version: "3.9.0"
   firebase_messaging:
     dependency: transitive
     description:
       name: firebase_messaging
-      sha256: "55cf1000dd72d229ebff3ce6a399bd35705a7675275478b31308afd90ac85751"
+      sha256: "31feb5db1fcbdececefd0feb5520013b7cb5d362018008c2889e7ae7e0da4dcb"
       url: "https://pub.dev"
     source: hosted
-    version: "16.5.0"
+    version: "16.6.0"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: e5fbb62bd23a27c983825277877ac91fdfdb6bfb31c6e5399700963ae586e339
+      sha256: f9707e185b8ce1155d58e7e29348245072d99981f899fa8d3214abb2652c4ccb
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.3"
+    version: "4.10.0"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: "663d320e90a41fe57d651ec79df2bc831bf29e051bc0c2cd41faf3106eb412d9"
+      sha256: "311b16c75fc645c7a70c9ade38908abb12310dfce449fc3d3cee1771f196351e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.4"
+    version: "4.2.5"
   firebase_remote_config:
     dependency: transitive
     description:
       name: firebase_remote_config
-      sha256: c661fedafc8acf18eb541f4379b9decaef8bd414f2bede79cc2df4178020813b
+      sha256: b17051e0d8ebd26ec9745a7a6cb8f0762b6e3281d23126dc9ace728e499f3bfd
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.6"
+    version: "6.6.0"
   firebase_remote_config_platform_interface:
     dependency: transitive
     description:
       name: firebase_remote_config_platform_interface
-      sha256: c05980baf7e116689d6f320db5b7e3b2ff19b30eb577f78150fae019057d591e
+      sha256: dc5a9713031f2ca744cb266d96a58609e929db19f3d91a1dd6bb8f8a0d77acad
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   firebase_remote_config_web:
     dependency: transitive
     description:
       name: firebase_remote_config_web
-      sha256: e09d6a4da4ac6223e74e56fdbe14c8f3a58d3a5c0e5061b6a32485a45c1385fd
+      sha256: "500abf695c370c76a486ad7480a6df7caf55d2d35ccc5c66b9fc9c1c47f2bc14"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.13"
+    version: "1.10.14"
   fixnum:
     dependency: transitive
     description:
@@ -795,10 +795,10 @@ packages:
     dependency: transitive
     description:
       name: freezed
-      sha256: "9ec135696554923c59339d46dd50adbaf81099be06ffda0fb9c06f410aea9137"
+      sha256: "27585a6c2b9ac28ffb7b45d87fd1502332af1eb90e1c9f5eb1acb24c71d26e17"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0-dev.3"
+    version: "4.0.0"
   freezed_annotation:
     dependency: transitive
     description:
@@ -843,10 +843,10 @@ packages:
     dependency: transitive
     description:
       name: go_router
-      sha256: d7a3576cb312649eaa51f2356450aed686085fb58fcdebda5b359aa951eef7ea
+      sha256: "2e7fcb9ac4d52ec06cd940552f12e66ee71fccbcadb09a067cb9fe20462b5bf3"
       url: "https://pub.dev"
     source: hosted
-    version: "17.5.0"
+    version: "18.0.0"
   graphs:
     dependency: transitive
     description:
@@ -931,10 +931,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "6f3a1995eafb000333174fae92202622033b0ee7fd917a6cd3730295264df84a"
+      sha256: f71f4f3a9c5dbbe39800b31839cb3b305aac403a7cfbddf8331cf179d813b72a
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.13+19"
+    version: "0.8.13+21"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -947,10 +947,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_ios
-      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
+      sha256: ee3885b6fcd71958fbc79770dd194c63371439d536d69c47b279171a486482ae
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.13+6"
+    version: "0.8.13+7"
   image_picker_linux:
     dependency: transitive
     description:
@@ -1107,10 +1107,10 @@ packages:
     dependency: transitive
     description:
       name: liquid_glass_widgets
-      sha256: "72ca31d9d0dba80a91b16de1cd69e8ab531b8c5603cca1f9486a849841fea578"
+      sha256: "47ab73d189f7a07db47173eeabe78a85707c2432a3a03d46348b4fd7351230d7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.30.1"
+    version: "1.1.0"
   logging:
     dependency: transitive
     description:
@@ -1147,10 +1147,10 @@ packages:
     dependency: transitive
     description:
       name: material_ui
-      sha256: "4f3f38b9953df0a87d6bf5f21880029f77c47048487d5339410c39936be4683b"
+      sha256: "7ba1ca315d50a004791dbab290417c52a61466d56db2822fe3c5c2994903110c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   meta:
     dependency: transitive
     description:
@@ -1530,10 +1530,10 @@ packages:
     dependency: transitive
     description:
       name: sign_in_with_apple
-      sha256: d284f8e235ab0c5be09a1e9146466912bae8f15f0bd5eb3c4cb999b57cd5c3f9
+      sha256: "6d205ad2b30f95b231812d61f19b4a8df836f16ba9cde28735b3ac8ece9113f7"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "8.2.0"
   sign_in_with_apple_platform_interface:
     dependency: transitive
     description:
@@ -1711,34 +1711,34 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
+      sha256: "611e87fb320b70d1dd721dc46af89c98aceccea9b31fde49e084591414e0c610"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.32"
+    version: "6.3.33"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      sha256: "8faa1aab294f1ab4040b43660c887b0418d5fa4f0cffef76a484e6aa1092eb4a"
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.1"
+    version: "6.4.2"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      sha256: "10f86fef4c2c43563fa6c211ff9cf757adf4d3ab762c56bd430664a947d70cd0"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.2"
+    version: "3.2.3"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      sha256: "5e835a3b869c2d70325349c81c5a45c28e20791265b67b2669da6b08c5cd5201"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.5"
+    version: "3.2.6"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1759,10 +1759,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      sha256: "6c5ad3f22cd4c38e089b81963b3cd7bb83b111b2df5dce008bb066162f42e429"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.6"
   uuid:
     dependency: transitive
     description:
@@ -1940,5 +1940,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: ">=3.13.1 <4.0.0"
-  flutter: ">=3.47.1 <3.48.0"
+  dart: ">=3.13.2 <4.0.0"
+  flutter: ">=3.47.2 <3.48.0"

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -2,8 +2,8 @@ name: sesori_client_workspace
 publish_to: none
 
 environment:
-  sdk: ^3.13.1
-  flutter: ">=3.47.1 <3.48.0"
+  sdk: ^3.13.2
+  flutter: ">=3.47.2 <3.48.0"
 
 workspace:
   - app

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -15,10 +15,6 @@ workspace:
   - desktop
 
 dependency_overrides:
-  # TODO(2026-08-13): Remove this override after Freezed and analyzer_buffer
-  # publish analyzer 14 support; then verify pub-get, codegen, and analyze in CI.
-  # lean_builder 1.2.1 changed only its frontend constraints from 1.2.0.
-  _fe_analyzer_shared: 103.0.0
   record_android:
     git:
       url: https://github.com/sesori-ai/record.git

--- a/shared/sesori_shared/pubspec.lock
+++ b/shared/sesori_shared/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "3f88fc9c96c568d631356507355a2d1e983ee000c9ac008bdcb39b5bf53ce777"
+      sha256: "82ade9fc4273f29ed673e33166944465225b4f7fc5d4aaef48605cc751c18fc1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.12"
+    version: "3.1.13"
   ffi:
     dependency: transitive
     description:
@@ -189,10 +189,10 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "9ec135696554923c59339d46dd50adbaf81099be06ffda0fb9c06f410aea9137"
+      sha256: "27585a6c2b9ac28ffb7b45d87fd1502332af1eb90e1c9f5eb1acb24c71d26e17"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0-dev.3"
+    version: "4.0.0"
   freezed_annotation:
     dependency: "direct main"
     description:
@@ -554,4 +554,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.13.1 <4.0.0"
+  dart: ">=3.13.2 <4.0.0"

--- a/shared/sesori_shared/pubspec.yaml
+++ b/shared/sesori_shared/pubspec.yaml
@@ -4,7 +4,7 @@ description: Shared crypto and protocol for Sesori relay. Pure Dart, no Flutter.
 version: 0.3.0
 
 environment:
-  sdk: ^3.13.1
+  sdk: ^3.13.2
 
 dependencies:
   cryptography: ^2.9.0

--- a/shared/sesori_shared/pubspec.yaml
+++ b/shared/sesori_shared/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: any
-  freezed: 4.0.0-dev.3
+  freezed: ^4.0.0
   json_serializable: ^6.14.1
   lints: any
   test: any


### PR DESCRIPTION
## Complexity

Moderate. Mostly mechanical constraint bumps and lockfile regeneration, plus two
major-version upgrades that needed changelog and call-site verification, and the
removal of a routing workaround that one of those upgrades retires.

## What

Weekly dependency update across all three resolution units, plus native and Ruby
dependency graphs.

- **Toolchain**: Flutter 3.47.1 → 3.47.2, Dart 3.13.1 → 3.13.2. Environment
  constraints raised in all 25 in-scope pubspecs (`sdk: ^3.13.2`,
  `flutter: ">=3.47.2"`).
- **Dart**: `freezed` 4.0.0-dev.3 → `^4.0.0` (stable) everywhere;
  `go_router` `^17.5.0` → `^18.0.0`; `liquid_glass_widgets` `^0.30.1` → `^1.1.0`.
- **Constraint minimums** raised to resolved versions: `material_ui` `^1.1.0`,
  `cupertino_ui` `^1.0.1`, `firebase_core` `^4.14.0`, `firebase_analytics`
  `^12.5.0`, `firebase_crashlytics` `^5.3.0`, `firebase_messaging` `^16.6.0`,
  `firebase_remote_config` `^6.6.0`, `sign_in_with_apple` `^8.2.0`.
- **Native (SwiftPM)**: Firebase 12.17.0 → 12.18.0, GoogleUtilities 8.1.2 →
  8.1.3, across all four `Package.resolved` copies.
- **Ruby**: iOS and Android `Gemfile.lock` regenerated. `fastlane` stays at
  2.238.0 — `~> 2.238` is already current.
- **Cleanup enabled by the upgrades**: retired the go_router MaterialApp
  workaround, and dropped the now-redundant `_fe_analyzer_shared` override.

## Why

Routine weekly currency. Two items are worth calling out:

`go_router` 18.0.0 migrates to `material_ui`/`cupertino_ui`. Its `isMaterialApp`
check now resolves `MaterialApp` from `material_ui`, which is what the app
actually builds — so builder routes get real `MaterialPage`s again instead of
`NoTransitionPage`s. That is exactly the condition `app_router.dart` was waiting
on, so the `_materialPage` helper and its explicit `pageBuilder`s are gone.
go_router's own `_buildPlatformAdapterPage` supplies the same `key`, `name`,
`arguments`, and `restorationId` the helper did, so the pages are unchanged.

The `_fe_analyzer_shared: 103.0.0` override no longer does anything: resolution
lands on 103.0.0 without it, because `freezed` 4.0.0 still caps `analyzer` at
`^13.0.0`. Its TODO condition (analyzer 14 support) is still unmet, but keeping a
no-op pin only risks masking the resolution once that support lands.

## Risk and test focus

**User-visible impact**: none intended. The routing change is the only one that
touches runtime behavior, and it is page-for-page equivalent. Worth a manual pass
on push/pop transitions: projects → sessions → session detail, the settings
full-screen modal, and harness settings reached both from the settings list
(pushes) and from the new-session harness menu (rises as a modal).

`liquid_glass_widgets` 1.x removes a number of APIs (`GlassBottomBar`,
`GlassTabBarCollapseConfig`, `enablePeek`, `respectsAccessibility`,
`usesBackdropFilter`, `LiquidGlassScope.stack`, and others). None are referenced
anywhere in `client/`, so the bump is a no-op at the call sites.

**Database impact**: none. No schema, migration, or persisted-shape changes.
`drift` is deliberately unchanged.

## Expected result

Same behavior on a current toolchain and native SDK set, with one workaround and
one redundant override removed.

## Deferred

| Dependency | Current | Latest | Reason |
|---|---|---|---|
| `drift_dev` | 2.34.3 | 2.34.5 | `drift` runtime is still 2.34.3. Both are pinned to the same patch on purpose — skew breaks the Drift schema verifier. |
| `test` (client only) | 1.31.1 | 1.31.2 | `flutter_test` from the SDK pins `test_api` 0.7.12; 1.31.2 needs 0.7.13. Bridge is already on 1.31.2. |
| `analyzer` | 13.3.0 | 14.1.0 | `freezed` 4.0.0 requires `analyzer ^13.0.0`; `analyzer_buffer` 0.3.3 caps at `<14.0.0`. |

## Verification

- `make analyze` — clean in `shared`, `bridge`, `client` (client runs with `--fatal-infos`).
- `make test` — `shared` 208 passed, `bridge` 2798 passed, `client` all members
  passed (`app` 914; one fewer than before, the deleted guard test).
- `make codegen` — clean in all three; only real output change is
  `GeneratedPluginRegistrant.swift`, from the `firebase_crashlytics` 5.3.0 plugin
  class rename.
- SwiftPM project and workspace pins verified identical per platform.
- `bundle exec fastlane --version` reports 2.238.0 for both iOS and Android.

## Skill maintenance

`.ai/skills/update-dependencies/SKILL.md` was stale and is updated:

Three bridge plugins were missing from every per-package step —
`sesori_plugin_copilot`, `sesori_plugin_grok`, `sesori_plugin_deepseek`. The
Phase 0 preflight is what caught them.
