### PR TITLE
🌱 Stop replaying Pi backend error payloads into the bridge log

### DIFF
--- a/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_history_mapper.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_history_mapper.dart
@@ -141,9 +141,6 @@ final class PiHistoryMapper({
     required String? variant,
     required Set<_PiHistoryWarning> warnings,
   }) {
-    if (message.stopReason == PiAssistantStopReason.error && message.errorMessage != null) {
-      Log.w("[pi] assistant response failed", _PiAssistantFailureDiagnostic(detail: message.errorMessage!));
-    }
     final parts = <PluginMessagePart>[];
     for (var index = 0; index < message.content.length; index++) {
       switch (message.content[index]) {
@@ -776,11 +773,6 @@ final class _MappedToolResult({
 final class _ImageBudget() {
   int candidates = 0;
   int decodedBytes = 0;
-}
-
-final class const _PiAssistantFailureDiagnostic({required final String detail}) implements Exception {
-  @override
-  String toString() => "Pi assistant response failed: $detail";
 }
 
 enum _PiHistoryWarning(final String message) {

--- a/bridge/sesori_plugin_pi/test/pi_history_mapper_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_history_mapper_test.dart
@@ -288,7 +288,7 @@ void main() {
       expect(messages.toString(), isNot(contains(privateSummary)));
     });
 
-    test("logs assistant failure locally and forwards it unchanged", () async {
+    test("forwards assistant failure unchanged and keeps its detail out of the log", () async {
       const backendError = "provider overload detail";
       late List<PluginMessageWithParts> messages;
       final warnings = await _captureWarnings(() async {
@@ -356,7 +356,10 @@ void main() {
       expect(aborted.state.status, PluginToolStatus.error);
       expect(aborted.state.error, "Pi tool call did not complete.");
       expect(messages.toString(), isNot(contains("private reasoning")));
-      expect(warnings, contains(backendError));
+      // The error message reaches the client verbatim, so re-logging it locally
+      // only replays backend payloads — a whole HTML error page, in practice —
+      // on every history mapping pass.
+      expect(warnings, isNot(contains(backendError)));
     });
 
     test("enforces image candidate count", () {


### PR DESCRIPTION
## Complexity

Trivial. One redundant log call and its private diagnostic type removed; one
existing test assertion flipped to pin the new behavior.

## What

`PiHistoryMapper._mapAssistantMessage` warned with the raw backend
`errorMessage` whenever an assistant message stopped with
`PiAssistantStopReason.error`. That call and the `_PiAssistantFailureDiagnostic`
wrapper it used are removed.

No user-visible impact: the same error text still reaches the client verbatim
through `PluginMessage.error`, which the dispatcher emits as
`BridgeSseMessageUpdated`. No database impact.

## Why

The log duplicated a failure that is already returned as an explicit failure,
which `AGENTS.md` calls out as a redundant log. The exception it built carried
only `message.errorMessage` — no stack, no session or message id, no operation
context — so the local log retained nothing the forwarded error lacks.

Two consequences made it actively harmful rather than merely redundant:

- The detail is an unbounded backend payload. A provider 520 answered by a
  Cloudflare HTML error page wrote several kilobytes of markup, inline CSS, and
  SVG path data into the bridge log as a single warning.
- `map()` walks the whole active branch, so every history mapping pass re-logged
  every historical failure on that branch. A long-lived session replayed the
  same warning repeatedly, which also reads as a fresh failure each time.

## Risk and test focus

Low. The change only removes a log; no mapping, part, status, or event output
moves. The risk worth checking is that the failure stays observable — it does,
via the `PluginMessageError` the mapper still returns and the dispatcher still
emits.

Test focus: `bridge/sesori_plugin_pi/test/pi_history_mapper_test.dart`, which
already asserted that the backend error is forwarded unchanged. Its log
assertion is inverted, so re-adding the warning fails the suite.

## Expected result

A Pi assistant failure still surfaces in the app as an error message with the
backend's text. The bridge log no longer contains
`[pi] assistant response failed` or the backend payload behind it.

## Verification

- `dart analyze` in `bridge/sesori_plugin_pi` — no issues found.
- `dart test` in `bridge/sesori_plugin_pi` — 281 tests, all passing.

Run with the pinned toolchain (Flutter 3.47.2-stable / Dart 3.13.2); the SDK on
PATH locally is 3.47.1 and cannot resolve the workspace constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops replaying Pi backend error payloads into the bridge log. Failed assistant messages previously logged the raw `errorMessage`; the error still reaches the client verbatim through `PluginMessage.error`, so there is no user-visible change.

**Why**
- The log carried no extra context beyond the forwarded error — no stack, session, or message id.
- A provider 520 answered with an HTML error page wrote several kilobytes of markup into the log as a single warning.
- Every history mapping pass re-logged every historical failure, so long-lived sessions replayed the same warning repeatedly.

**Test focus**
- The log assertion in `pi_history_mapper_test.dart` is inverted, so re-adding the warning fails the suite.

<sup>Written for commit e3464ebb1b3a853c4e42ae4fc9e1701a6832bf86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

