### PR TITLE
🌿 Render raw HTML blocks in message text instead of dropping them

### DIFF
--- a/client/app/lib/core/widgets/markdown_styles.dart
+++ b/client/app/lib/core/widgets/markdown_styles.dart
@@ -1,6 +1,7 @@
 import "dart:async";
 
 import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
+import "package:markdown/markdown.dart" as md;
 import "package:material_ui/material_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:theme_prego/module_prego.dart";
@@ -93,6 +94,21 @@ Map<String, MarkdownElementBuilder> buildSessionMarkdownBuilders({
     ),
   };
 }
+
+/// Renders a raw HTML block as a code block instead of dropping it.
+///
+/// The default [md.HtmlBlockSyntax] emits a bare text node under the document
+/// root, and the Markdown widget skips text directly under the root, so a
+/// pasted HTML page or error body silently disappears from the message. Chat
+/// text is never trusted markup anyway, so showing the source is the honest
+/// rendering, and a code block keeps its whitespace and stays copyable.
+class const _LiteralHtmlBlockSyntax() extends md.HtmlBlockSyntax {
+  @override
+  md.Node parse(md.BlockParser parser) => md.Element("pre", [md.Text(super.parse(parser).textContent.trim())]);
+}
+
+/// Custom [MarkdownBody.blockSyntaxes] for session chat markdown.
+const sessionMarkdownBlockSyntaxes = <md.BlockSyntax>[_LiteralHtmlBlockSyntax()];
 
 /// Style sheet for the legal documents (terms, privacy) the backend serves as
 /// markdown: a long-form reading layout with headings, numbered clauses and the

--- a/client/app/lib/features/session_detail/widgets/text_part_widget.dart
+++ b/client/app/lib/features/session_detail/widgets/text_part_widget.dart
@@ -30,6 +30,7 @@ class const TextPartWidget({
           semanticLabel: alt,
         ),
         styleSheet: buildSessionMarkdownStyleSheet(prego: context.prego),
+        blockSyntaxes: sessionMarkdownBlockSyntaxes,
         builders: buildSessionMarkdownBuilders(
           highlightEnabled: !isStreaming,
           copyTooltip: context.loc.sessionDetailCopy,

--- a/client/app/lib/features/session_detail/widgets/user_message_card.dart
+++ b/client/app/lib/features/session_detail/widgets/user_message_card.dart
@@ -89,6 +89,7 @@ class const UserMessageBubble({
                     semanticLabel: alt,
                   ),
                   styleSheet: buildUserMessageMarkdownStyleSheet(prego: prego),
+                  blockSyntaxes: sessionMarkdownBlockSyntaxes,
                   builders: buildSessionMarkdownBuilders(
                     highlightEnabled: true,
                     copyTooltip: context.loc.sessionDetailCopy,

--- a/client/app/test/core/widgets/markdown_styles_test.dart
+++ b/client/app/test/core/widgets/markdown_styles_test.dart
@@ -1,5 +1,8 @@
+import "dart:convert";
+
 import "package:flutter_test/flutter_test.dart";
 import "package:get_it/get_it.dart";
+import "package:markdown/markdown.dart" as md;
 import "package:material_ui/material_ui.dart";
 import "package:mocktail/mocktail.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
@@ -46,6 +49,26 @@ void main() {
     expect(styleSheet.strong?.color, prego.colors.textBrandPrimary);
     expect(styleSheet.listBullet?.color, prego.colors.textBrandPrimary);
     expect(styleSheet.code?.color, prego.colors.textBrandPrimary);
+  });
+
+  test("sessionMarkdownBlockSyntaxes keeps raw HTML visible as a code block", () {
+    const message = "Pi assistant response failed: <html>\n"
+        "  <head>\n"
+        "    <style>body{font-family:Arial}</style>\n"
+        "  </head>\n"
+        "  <body><p>Error 520</p></body>\n"
+        "</html>";
+
+    final nodes = md.Document(
+      blockSyntaxes: sessionMarkdownBlockSyntaxes,
+      extensionSet: md.ExtensionSet.gitHubFlavored,
+      encodeHtml: false,
+    ).parseLines(const LineSplitter().convert(message));
+
+    final html = nodes.whereType<md.Element>().where((node) => node.tag == "pre").single;
+    expect(html.textContent, contains("<head>"));
+    expect(html.textContent, contains("Error 520"));
+    expect(html.textContent, contains("</html>"));
   });
 
   test("Markdown links launch absolute web and email URLs", () async {

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -230,6 +230,9 @@ defaults and queued client sends coherent.
   rail and subtle queued outline carry the transient state, with the outline
   change animated when reduced motion is not requested. A turn started on one
   client is visible to every other client of that bridge.
+- User and assistant message text containing a raw HTML block renders that
+  markup as a literal code block, so a pasted page or error body stays visible
+  and copyable instead of being swallowed by the Markdown renderer.
 - Live message envelopes render in transcript timestamp order even when events
   arrive out of order; late envelopes append after existing envelopes with the
   same timestamp rather than reordering an established turn. Finalized parts
@@ -308,7 +311,8 @@ provider failure, early and late abort, busy stop-and-send, and two sessions.
   queued bubble and its dispatched message render simultaneously. Submitted text disappears while
   bridge acceptance or backend startup is still pending, or queued feedback
   uses a visually unrelated or composer-pinned surface, or renders authored
-  Markdown as literal syntax.
+  Markdown as literal syntax. Message text that embeds a raw HTML block loses
+  everything from the first block-level tag onward.
 - A stale-option rejection retains the rejected cache row, waits on an
   unrelated options discovery before answering, remains silent, drops the
   staged prompt, changes FIFO order or prompt identity, refreshes and retries


### PR DESCRIPTION
## Complexity

Straightforward: one custom Markdown block syntax plus two call sites.

## What

Session chat Markdown now parses a raw HTML block into a `pre` element, so
`MarkdownBody` renders the markup as a literal code block. Wired into the user
bubble and the assistant text part.

## Why

`markdown`'s `HtmlBlockSyntax` emits a bare text node directly under the
document root, and `flutter_markdown` explicitly skips text under the root. A
message containing an HTML page — for example a Cloudflare 520 error body
surfaced by a backend failure — lost everything from the first block-level tag
onward. Only `Pi assistant response failed: <html>` survived on screen; the
rest of the paragraph and the whole document silently disappeared.

## Risk and test focus

No database impact. User-visible impact is limited to message text containing
raw HTML: it now shows as a monospace, copyable code block instead of being
dropped. Text without HTML blocks parses exactly as before — the shadowed
syntax matches the same pattern the default one did.

Test focus: existing Markdown rendering in the transcript (fenced code blocks,
inline HTML such as `<b>` inside a paragraph, images) stays unchanged.

## Expected result

Pasting or receiving an HTML document in a message shows the markup in full.

## Verification

- `flutter test test/core/widgets/markdown_styles_test.dart` — passes, includes
  a new parse-level check on the reported HTML sample.
- `flutter test test/features/session_detail/widgets/session_detail_body_test.dart` — passes.
- `flutter analyze` on the changed lib files — no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat messages containing raw HTML so the markup renders as a literal code block instead of silently dropping everything from the first block-level tag onward.

- Wires a custom Markdown block syntax into both the user bubble and assistant text part.
- Messages without HTML blocks parse exactly as before.
- No database impact; the markup stays visible, whitespace-preserving, and copyable.

<sup>Written for commit 3160fe60caf58c5a33ee6be0e561461a60c40c84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

