### PR TITLE
🌱 Stop copied chat spacing from adding blank lines

### DIFF
--- a/client/module_prego/lib/components/prego_readable_selection_area.dart
+++ b/client/module_prego/lib/components/prego_readable_selection_area.dart
@@ -1,7 +1,7 @@
 import "package:flutter/rendering.dart";
 import "package:material_ui/material_ui.dart";
 
-/// A selection area that preserves the visual separation between text widgets
+/// A selection area that preserves structural boundaries between text widgets
 /// when copying across them.
 class const PregoReadableSelectionArea({super.key, required final Widget child}) extends StatefulWidget {
   @override
@@ -30,7 +30,6 @@ class _PregoReadableSelectionAreaState() extends State<PregoReadableSelectionAre
 
 class _ReadableSelectionContainerDelegate() extends StaticSelectionContainerDelegate {
   static const _sameLineTolerance = 3.0;
-  static const _blankLineGap = 4.0;
 
   @override
   SelectedContent? getSelectedContent() {
@@ -80,7 +79,7 @@ class _ReadableSelectionContainerDelegate() extends StaticSelectionContainerDele
     final verticalGap = currentBounds.top - previousBounds.bottom;
     if (verticalGap >= -_sameLineTolerance) {
       if (previousText.endsWith("\n") || currentText.startsWith("\n")) return "";
-      return verticalGap > _blankLineGap ? "\n\n" : "\n";
+      return "\n";
     }
     if (currentBounds.left > previousBounds.right - 1 &&
         !_endsWithInlineWhitespace(text: previousText) &&

--- a/client/module_prego/test/components/prego_readable_selection_area_test.dart
+++ b/client/module_prego/test/components/prego_readable_selection_area_test.dart
@@ -7,7 +7,7 @@ import "package:material_ui/material_ui.dart";
 import "package:theme_prego/module_prego.dart";
 
 void main() {
-  testWidgets("copy preserves block and list boundaries", (tester) async {
+  testWidgets("copy uses one newline regardless of visual block spacing", (tester) async {
     await tester.pumpWidget(
       const MaterialApp(
         home: Scaffold(
@@ -33,7 +33,7 @@ void main() {
                 ),
                 SizedBox(height: 8),
                 Row(mainAxisSize: MainAxisSize.min, children: [Text("•"), SizedBox(width: 8), Text("item one")]),
-                SizedBox(height: 8),
+                SizedBox(height: 32),
                 Row(mainAxisSize: MainAxisSize.min, children: [Text("•"), SizedBox(width: 8), Text("item two")]),
               ],
             ),
@@ -45,7 +45,7 @@ void main() {
 
     expect(
       await _copyAll(tester: tester),
-      "Heading\n\nFirst paragraph.\n\nSecond bold paragraph.\n\n• item one\n\n• item two",
+      "Heading\nFirst paragraph.\nSecond bold paragraph.\n• item one\n• item two",
     );
   });
 
@@ -101,7 +101,7 @@ void main() {
     await gesture.up();
     await tester.pump();
 
-    expect(await _copySelection(tester: tester), "paragraph.\n\nSecond");
+    expect(await _copySelection(tester: tester), "paragraph.\nSecond");
   });
 }
 

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -234,10 +234,11 @@ defaults and queued client sends coherent.
   markup as a literal code block, so a pasted page or error body stays visible
   and copyable instead of being swallowed by the Markdown renderer.
 - Selecting across user, assistant, or reasoning text copies the rendered
-  content with readable structure: visually separated Markdown blocks retain
-  line breaks, and same-line fragments such as a list bullet and its text retain
-  a separating space. Partial selections spanning blocks preserve the same
-  boundaries instead of running adjacent paragraphs together.
+  content with readable structure: each transition between vertically stacked
+  Markdown blocks contributes exactly one line break regardless of their visual
+  spacing, while same-line fragments such as a list bullet and its text retain a
+  separating space. Partial selections spanning blocks preserve the same
+  boundary instead of joining paragraphs or adding empty lines.
 - Live message envelopes render in transcript timestamp order even when events
   arrive out of order; late envelopes append after existing envelopes with the
   same timestamp rather than reordering an established turn. Finalized parts
@@ -324,8 +325,8 @@ provider failure, early and late abort, busy stop-and-send, and two sessions.
   without a bound, or leaves a corrected selection on a variant the picker does
   not display.
 - Copied chat text runs headings, paragraphs, list bullets, table cells, or
-  separate message parts together without whitespace matching their visual
-  separation.
+  separate message parts together, or inserts empty lines based on their visual
+  spacing instead of one structural line break.
 - A cold Pi process exposes a stale default model or thinking level to startup
   extensions instead of the pending turn's selection, or a cold follow-up wakes
   the process but times out in pre-prompt automatic compaction before reaching
@@ -358,8 +359,9 @@ provider failure, early and late abort, busy stop-and-send, and two sessions.
 ## Known Limitations
 
 - Flutter's selection and clipboard APIs expose selected content as plain text
-  only, so chat copy preserves document structure but not Markdown styling such
-  as bold or italics (`flutter/flutter#104206`).
+  only, so chat copy preserves document structure but not Markdown styling or
+  metadata such as bold, italics, and hyperlink destinations
+  (`flutter/flutter#104206`).
 - L3 and above need live backends; an omitted plugin is partial coverage, and
   client end-to-end coverage is phone-only.
 - Session-detail refresh behavior is under active investigation, so refresh


### PR DESCRIPTION
## Complexity

🌱 Trivial: this removes one visual-gap branch from the shared selection separator and updates focused expectations.

## What

- Separate vertically stacked selected blocks with one newline regardless of rendered spacing.
- Keep the existing same-line separator behavior for fragments such as bullets and their text.
- Cover large visual gaps and partial cross-block selections in the focused widget tests.
- Record the exact copy invariant and Flutter's rich-clipboard limitation in regression documentation.

## Why

The readable selection wrapper treated visual gaps over four pixels as semantic blank lines. Normal Markdown margins therefore inserted empty lines between every copied paragraph and list item even though spacing is presentation, not text content.

## Risk and test focus

The user-visible impact is limited to copied chat text: generated empty lines are removed. Same-line spacing and existing selected newline content remain unchanged. There is no database, wire-contract, or backend impact.

## Expected result

Copying headings, paragraphs, and bullets produces one line break at each vertical block boundary, even when the widgets have large visual margins.

## Verification

- `dart analyze` in `client/module_prego`
- `flutter test test/components/prego_readable_selection_area_test.dart` in `client/module_prego`
- `dart analyze` in `client/app`
- `flutter test test/features/session_detail/widgets/assistant_message_card_test.dart test/features/session_detail/widgets/reasoning_modal_test.dart test/features/session_detail/widgets/session_detail_body_test.dart` in `client/app` (116 tests)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops copied chat text from adding blank lines between Markdown blocks that merely have large visual spacing. Previously, any vertical gap over four pixels became a double newline; now every vertically stacked block boundary contributes exactly one newline, while same-line fragments like bullets and their text keep their existing separator.

<sup>Written for commit b8d977409c53adf2f788c704d83e43303f61d895. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

