### PR TITLE
🌿 Fix DeepSeek active-turn follow-ups

### DIFF
--- a/bridge/sesori_plugin_copilot/test/copilot_plugin_test.dart
+++ b/bridge/sesori_plugin_copilot/test/copilot_plugin_test.dart
@@ -130,6 +130,7 @@ void main() {
       expect(CopilotPluginIdentity.id, "copilot");
       expect(CopilotPluginIdentity.displayName, "GitHub Copilot");
       expect(plugin.id, CopilotPluginIdentity.id);
+      expect(plugin.cancelsActiveTurnForQueuedInput, isTrue);
       expect(plugin.launchSpec.command, "/opt/copilot");
       expect(plugin.launchSpec.args, ["--no-auto-update", "--acp"]);
       expect(plugin.launchSpec.cwd, "/repo");
@@ -302,6 +303,66 @@ void main() {
           ),
         ),
       );
+    });
+
+    test("a busy follow-up cancels before replacement prompt dispatch", () async {
+      final connecting = plugin.ensureConnected();
+      await completeHandshake(process: fake);
+      expect(await connecting, isTrue);
+
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final sessionNew = await waitForFrame(process: fake, method: "session/new");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": sessionNew["id"],
+        "result": {"sessionId": "session-1"},
+      });
+      await creating;
+
+      await plugin.sendPrompt(
+        sessionId: "session-1",
+        promptId: "prompt-1",
+        parts: const [PluginPromptPart.text(text: "first")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final first = await waitForFrame(process: fake, method: "session/prompt");
+      await plugin.sendPrompt(
+        sessionId: "session-1",
+        promptId: "prompt-2",
+        parts: const [PluginPromptPart.text(text: "replacement")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final cancel = await waitForFrame(process: fake, method: "session/cancel");
+      expect(cancel["params"], {"sessionId": "session-1"});
+      expect(fake.written.where((frame) => frame["method"] == "session/prompt"), hasLength(1));
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": first["id"],
+        "result": {"stopReason": "cancelled"},
+      });
+      final replacement = await waitForFrame(process: fake, method: "session/prompt");
+      expect(((replacement["params"] as Map)["prompt"] as List).single, {
+        "type": "text",
+        "text": "replacement",
+      });
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": replacement["id"],
+        "result": {"stopReason": "end_turn"},
+      });
     });
   });
 }

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
@@ -28,6 +28,9 @@ class DeepSeekPlugin({
       );
 
   @override
+  bool get cancelsActiveTurnForQueuedInput => true;
+
+  @override
   AcpApprovalRegistry buildApprovalRegistry(AcpStdioClient client) => DeepSeekApprovalRegistry(
     client: client,
     emit: emitActivityEvent,

--- a/bridge/sesori_plugin_deepseek/test/deepseek_plugin_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_plugin_test.dart
@@ -1,0 +1,153 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:deepseek_plugin/deepseek_plugin.dart";
+import "package:deepseek_plugin/deepseek_testing.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("a busy follow-up cancels before replacement prompt dispatch", () async {
+    final fake = FakeAcpProcess();
+    final plugin = _buildPlugin(fake);
+    final handledFrames = <Map<String, dynamic>>{};
+
+    Future<Map<String, dynamic>> waitForFrame({required String method}) async {
+      for (var attempt = 0; attempt < 200; attempt++) {
+        final matches = fake.written.where(
+          (frame) => frame["method"] == method && !handledFrames.contains(frame),
+        );
+        if (matches.isNotEmpty) {
+          final frame = matches.first;
+          handledFrames.add(frame);
+          return frame;
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+      throw StateError("DeepSeek never wrote '$method'");
+    }
+
+    try {
+      expect(plugin.cancelsActiveTurnForQueuedInput, isTrue);
+      final connecting = plugin.ensureConnected();
+      final initialize = await waitForFrame(method: AcpMethods.initialize);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": initialize["id"],
+        "result": {
+          "protocolVersion": 1,
+          "agentCapabilities": <String, dynamic>{},
+          "authMethods": <Object?>[],
+          "_meta": {
+            "sesori.ai/deepseek": {
+              "extensionProtocolVersion": 1,
+              "adapterVersion": DeepSeekPluginDescriptor.targetVersion,
+              "harnessVersion": "0.1.1-rc.2",
+              "persistenceOwner": "sesori",
+            },
+          },
+        },
+      });
+      expect(await connecting, isTrue);
+
+      final creating = plugin.createSession(
+        directory: "/repo",
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final sessionNew = await waitForFrame(method: AcpMethods.sessionNew);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": sessionNew["id"],
+        "result": {"sessionId": "session-1"},
+      });
+      await creating;
+
+      await plugin.sendPrompt(
+        sessionId: "session-1",
+        promptId: "prompt-1",
+        parts: const [PluginPromptPart.text(text: "first")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final first = await waitForFrame(method: AcpMethods.sessionPrompt);
+
+      await plugin.sendPrompt(
+        sessionId: "session-1",
+        promptId: "prompt-2",
+        parts: const [PluginPromptPart.text(text: "replacement")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final cancel = await waitForFrame(method: AcpMethods.sessionCancel);
+      expect(cancel["params"], {"sessionId": "session-1"});
+      expect(fake.written.where((frame) => frame["method"] == AcpMethods.sessionPrompt), hasLength(1));
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": first["id"],
+        "result": {"stopReason": "cancelled"},
+      });
+      final replacement = await waitForFrame(method: AcpMethods.sessionPrompt);
+      expect(((replacement["params"] as Map)["prompt"] as List).single, {
+        "type": "text",
+        "text": "replacement",
+      });
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": replacement["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+    } finally {
+      await plugin.dispose();
+      await fake.close();
+    }
+  });
+}
+
+DeepSeekPlugin _buildPlugin(FakeAcpProcess fake) {
+  final configurationTracker = AcpSessionConfigurationTracker();
+  final commandTracker = AcpCommandTracker();
+  const api = DeepSeekAcpApi(pluginId: DeepSeekIdentity.id);
+  final mapper = DeepSeekEventMapper(
+    launchDirectory: "/repo",
+    pluginId: DeepSeekIdentity.id,
+    configurationTracker: configurationTracker,
+    api: api,
+    messageTimeParser: const DeepSeekMessageTimeParser(),
+  );
+  return DeepSeekPlugin(
+    launchSpec: const AcpLaunchSpec(command: "deepseek", args: [], cwd: "/repo", environment: {}),
+    launchDirectory: "/repo",
+    mapper: mapper,
+    api: api,
+    historyRepository: DeepSeekHistoryRepository(
+      api: api,
+      eventMapper: mapper,
+      pluginId: DeepSeekIdentity.id,
+      messageTimeParser: const DeepSeekMessageTimeParser(),
+    ),
+    deepSeekSessionService: const DeepSeekSessionService(
+      repository: DeepSeekSessionRepository(api: api),
+    ),
+    deepSeekSessionOptionsService: DeepSeekSessionOptionsService(
+      repository: const DeepSeekCatalogRepository(api: api, mapper: DeepSeekCatalogMapper()),
+      configurationTracker: configurationTracker,
+      pluginId: DeepSeekIdentity.id,
+      discoveryTimeout: const Duration(seconds: 30),
+    ),
+    commandTracker: commandTracker,
+    sessionOptionsService: AcpSessionOptionsService(
+      configurationTracker: configurationTracker,
+      commandTracker: commandTracker,
+      pluginId: DeepSeekIdentity.id,
+      agentDisplayName: DeepSeekIdentity.displayName,
+    ),
+    processFactory: (_) async => fake,
+  );
+}

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -19,8 +19,10 @@ defaults and queued client sends coherent.
   plugin enqueues and returns while the adapter's `session/prompt` response
   remains pending through owned work, projected output, and durability quiesce.
   The plugin keeps only one prompt in flight per DeepSeek session while allowing
-  different sessions to run concurrently. Exact advertised slash commands
-  dispatch as commands; unknown slash prefixes remain prose.
+  different sessions to run concurrently. A follow-up accepted during an active
+  turn immediately cancels that turn, then dispatches after cancellation and
+  durability settlement. Exact advertised slash commands dispatch as commands;
+  unknown slash prefixes remain prose.
 - Every send carries a client-generated prompt id, stable across retries. A
   queue-owning plugin refuses a duplicate id (already queued or within its
   bounded recently-dispatched window) as an idempotent success, so a retry of
@@ -146,9 +148,10 @@ defaults and queued client sends coherent.
   turn, declared process-wide lane, resume, or selection blocks their
   `session/prompt` frame. ACP v1 has no standard steering operation, so Sesori
   never sends overlapping prompt requests. It does define `session/cancel`:
-  Cursor, Hermes, Copilot, and Grok therefore implement active-turn follow-ups
-  as stop-and-send, immediately cancelling the active turn and dispatching the queued input after
-  cancellation settles. Further already-queued inputs retain FIFO order. Their
+  Cursor, Hermes, DeepSeek, Copilot, and Grok therefore implement active-turn
+  follow-ups as stop-and-send, immediately cancelling the active turn and
+  dispatching the queued input after cancellation settles. Further already-queued
+  inputs retain FIFO order. Their
   synthetic user transcript message is published only after its frame flushes
   successfully to the agent's stdin. A prompt rejected after that dispatch
   renders a durable inline error, preserving the agent's diagnostic detail
@@ -263,7 +266,7 @@ defaults and queued client sends coherent.
 |---|---|
 | L1 Smoke | Live plugin, representative: a prompt streams assistant output and returns the session to idle. |
 | L2 Routine | Live plugin, representative: slash command returns on acceptance; prompt defaults update; first and stale transcript replay reconciles prompt defaults before the opening snapshot is applied; abort stops a turn and reports its outcome; finalized messages are immediately readable from history; a recognized stale option returns the typed rejection only after cache invalidation. Automated Pi coverage keeps visible custom messages system-attributed across live and replay without changing agent defaults or completion text. |
-| L3 Release | Client end to end (phone), every supporting production plugin: text, reasoning, tool, and status events stream with consistent normalization and the shared output bound; agent, model, and variant apply per send; streaming, composer, sending/queued feedback, and abort render; a stale selection refreshes, warns, and retries once without losing the queued prompt. Copilot additionally covers an exact advertised slash command and reasoning only when its selected model emits it. Grok covers exact model/effort application, accepted-send timing, abort, busy stop-and-send, visible failure, and idle completion without claiming image input. A Pi custom message renders as labelled automation rather than agent output. |
+| L3 Release | Client end to end (phone), every supporting production plugin: text, reasoning, tool, and status events stream with consistent normalization and the shared output bound; agent, model, and variant apply per send; streaming, composer, sending/queued feedback, and abort render; a stale selection refreshes, warns, and retries once without losing the queued prompt. DeepSeek, Copilot, and Grok cover busy stop-and-send. Copilot additionally covers an exact advertised slash command and reasoning only when its selected model emits it. Grok covers exact model/effort application, accepted-send timing, abort, visible failure, and idle completion without claiming image input. A Pi custom message renders as labelled automation rather than agent output. |
 | L4 Extended | Relay integration, every supporting production plugin: a slow or unresponsive plugin leaves other sessions, plugins, and the relay responsive; archived sends and queued-prompt cancels are refused without racing archiving; disconnect and reconnect mid-turn resumes without lost or duplicated parts; bridge-owned prompts survive leaving and reopening in order and appear on a second client; a prompt waiting at a dispatch boundary can be cancelled; a permission reply lands while a command or selection-changing prompt waits behind the running turn; a second client observes the same turn and steering prompt. Two Copilot sessions and two Grok sessions run concurrently while each preserves its own ordering and selection. |
 | L5 Full | Client end to end, every supporting production plugin: retry status surfaces with attempt and timing; concurrent sends across sessions and plugins interleave without ordering damage; background and resume mid-turn recovers live state; an aborted turn triggers no completion notification. |
 
@@ -275,7 +278,8 @@ boundary where supported or stop-and-send over ACP, sending a command or
 selection change that must wait, cancelling before dispatch, leaving and
 reopening while an entry is visible, turn length, and client count. For Hermes,
 include text and image prompts, tool updates, a permission decision, cold history
-replay, and abort after output has started. For Copilot, include prose, an
+replay, and abort after output has started. For DeepSeek, include busy
+stop-and-send around tool use or pending input. For Copilot, include prose, an
 advertised command, tool use, a selected-option change, a queued follow-up
 cancellation, abort, and two independent sessions. For Grok, include text,
 reasoning and tool updates, default and changed model/effort, stale selection,
@@ -335,7 +339,7 @@ provider failure, early and late abort, busy stop-and-send, and two sessions.
   instead of updated when compaction ends, or survives an abort or process
   exit.
 - An abort, permission reply, or question reply stalls behind a send to a
-  busy session on the same session lane, or a Cursor/Hermes/Grok follow-up waits
+  busy session on the same session lane, or a stop-and-send ACP follow-up waits
   for the active turn to finish naturally instead of cancelling it before dispatch.
   A Pi abort waits for the general history/control timeout, lets hidden steering
   resume after Stop, or leaves later sends stuck in their sending state.
@@ -400,6 +404,7 @@ provider failure, early and late abort, busy stop-and-send, and two sessions.
   `shared/sesori_shared/lib/src/models/sesori/send_prompt_error_response.dart`;
   `shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart`
 - Hermes: `bridge/sesori_plugin_hermes/` and the shared ACP plugin implementation
+- DeepSeek: `bridge/sesori_plugin_deepseek/` and the shared ACP plugin implementation
 - Copilot: `bridge/sesori_plugin_copilot/` and the shared ACP plugin implementation
 - Grok: `bridge/sesori_plugin_grok/` and the shared ACP plugin implementation
 - Client: `client/module_core/lib/src/cubits/session_detail/`,


### PR DESCRIPTION
## Complexity

🌿 Straightforward. One DeepSeek ACP policy override activates existing shared stop-and-send behavior; focused harness tests and regression documentation make the behavior explicit.

## What

- Make DeepSeek cancel an active same-session turn when a follow-up prompt is accepted, then dispatch the replacement after cancellation settles.
- Prove DeepSeek and GitHub Copilot emit `session/cancel` without overlapping `session/prompt` requests.
- Re-run the equivalent existing Grok coverage and align the session-turn regression contract across all three harnesses introduced in v1.8.2.

## Why

DeepSeek inherited the stock ACP queue policy, so a message sent during an active turn waited for that turn to finish naturally. Copilot and Grok already selected the intended stop-and-send policy. The released DeepSeek adapter exposes standard ACP cancellation but no native ACP steering method, so the shared cancel-then-dispatch path is the smallest supported correction.

## Risk and test focus

Risk is low and limited to DeepSeek active-turn follow-ups, including cancellation settlement, pending permission/question cleanup, and FIFO replacement dispatch. Review should confirm the replacement cannot overlap the cancelled prompt and that different sessions remain independently concurrent.

The user-visible change is that a DeepSeek follow-up interrupts the active turn instead of waiting for natural completion. There is no database, persisted-state, wire-contract, runtime-version, or analytics impact.

## Expected result

DeepSeek, GitHub Copilot, and Grok Build all accept a follow-up promptly while busy and use ACP stop-and-send by default: cancel the active turn immediately, wait for its response to settle, then dispatch the replacement without overlapping prompts.

## Verification

- DeepSeek: analyzer clean; all 42 tests pass
- GitHub Copilot: analyzer clean; all 14 tests pass
- Grok Build: analyzer clean; all 52 tests pass
- Focused DeepSeek and Copilot busy-follow-up tests pass independently
- Final correctness review: no findings
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DeepSeek active-turn follow-ups so a follow-up prompt now cancels the active turn and dispatches the replacement after cancellation settles, instead of waiting for the active turn to finish naturally.

- Adds a `cancelsActiveTurnForQueuedInput` override to opt into the shared stop-and-send behavior already used by Copilot and Grok.
- Adds busy follow-up tests for DeepSeek and Copilot and updates the session-turn regression docs.
- No database, persisted-state, wire-contract, runtime-version, or analytics impact.

<sup>Written for commit 71ed7d23911b3c78168920f320f704b9cacfb2e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

