### PR TITLE
🌿 Make ACP stop-and-send the shared default

### DIFF
--- a/bridge/sesori_plugin_acp/lib/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/acp_plugin.dart
@@ -9,8 +9,11 @@
 // Adding an ACP harness:
 //  1. An `XxxBinary` with the launch spec (binary + `acp` args) and any fixed
 //     handshake policy (auth method id, capability meta).
-//  2. A subclass of AcpPlugin. Every policy and hook has a stock-ACP default;
+//  2. A subclass of AcpPlugin. Every policy and hook has a bridge-safe default;
 //     override only what the agent does differently (see the AcpPlugin doc).
+//     Busy-session follow-ups default to stop-and-send because ACP has no
+//     standard steering method. Never disable that fallback unless the concrete
+//     plugin supplies another immediate active-turn delivery path.
 //     The composer builds one AcpSessionConfigurationTracker + AcpCommandTracker
 //     and shares them between the AcpEventMapper (subclass the mapper only for
 //     `xxx/*` notification extensions), the neutral AcpSessionOptionsService,

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -25,7 +25,7 @@ import "repositories/acp_session_config_repository.dart";
 /// so the bridge derives the project list from [listAllSessions] and owns all
 /// project/session persistence itself; the plugin stores nothing on disk.
 ///
-/// Every policy and behavior hook has a stock-ACP default, so a compliant agent
+/// Every policy and behavior hook has a bridge-safe default, so a compliant agent
 /// needs only identity, launch spec, and trackers. A harness overrides what
 /// differs: protocol policies ([authMethodId], [authMethodAllowlist], [initializeCapabilityMeta],
 /// [supportsFormElicitation], [serializesPromptsProcessWide],
@@ -188,7 +188,7 @@ abstract class AcpPlugin({
   /// enumeration; reset on respawn since a replacement process may comply.
   bool _bareSessionListUnsupported = false;
 
-  // --- Protocol policies (stock-ACP defaults; override what differs) ---
+  // --- Protocol policies (bridge-safe defaults; override what differs) ---
 
   /// Auth method id to call if the agent reports it requires auth. `null`
   /// picks the first advertised non-terminal method — the headless bridge can
@@ -213,10 +213,14 @@ abstract class AcpPlugin({
 
   /// Whether accepting another input should cancel this session's active turn.
   ///
-  /// Harnesses use this for stop-and-send behavior when they cannot steer an
-  /// active turn. The shared adapter queues the new input, sends the standard
-  /// ACP cancel, and dispatches the input only after cancellation settles.
-  bool get cancelsActiveTurnForQueuedInput => false;
+  /// Every production harness must deliver busy-session follow-ups immediately,
+  /// either through native steering or this stop-and-send fallback. ACP v1 has
+  /// no standard steering method, so the shared default queues the new input,
+  /// sends the standard ACP cancel, and dispatches only after cancellation
+  /// settles. Override with `false` only when the concrete plugin supplies a
+  /// different immediate active-turn delivery path; inheriting the turn queue
+  /// while returning `false` is not valid production behavior.
+  bool get cancelsActiveTurnForQueuedInput => true;
 
   /// Whether a turn must stop when its requested selection cannot be applied.
   /// Fail closed by default: a prompt should not silently run on a model/mode

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -759,7 +759,7 @@ void main() {
       expect(emitted.whereType<BridgeSseSessionError>(), hasLength(1));
     });
 
-    test("a second prompt on one session dispatches only after the first turn completes", () async {
+    test("active-turn follow-ups cancel before replacement dispatch", () async {
       await connect();
       final sessionId = await createSession(cwd, "s1");
 
@@ -768,13 +768,15 @@ void main() {
       expect(busyCount(), 1);
 
       final secondPromptId = await sendPrompt(sessionId, "second");
+      final cancel = await waitForFrame("session/cancel");
+      expect(cancel["params"], {"sessionId": sessionId});
       for (var i = 0; i < 10; i++) {
         await pump();
       }
       expect(
         frames("session/prompt"),
         hasLength(1),
-        reason: "the second prompt must wait for the first turn to complete",
+        reason: "the second prompt must wait for cancellation to settle",
       );
       expect((await plugin.getQueuedPrompts(sessionId: sessionId)).single.id, secondPromptId);
       expect(
@@ -785,7 +787,7 @@ void main() {
       expect(busyCount(), 1, reason: "queued turn keeps the one busy signal");
       expect(idleCount(), 0);
 
-      respondTo(firstPrompt, {"stopReason": "end_turn"});
+      respondTo(firstPrompt, {"stopReason": "cancelled"});
       final secondPrompt = await waitForFrameCount("session/prompt", 2);
       expect((secondPrompt["params"] as Map)["sessionId"], sessionId);
       await pump();
@@ -926,7 +928,11 @@ void main() {
       await sendPrompt(sessionId, "queued");
 
       await plugin.abortSession(sessionId: sessionId);
-      expect(frames("session/cancel"), hasLength(1));
+      expect(
+        frames("session/cancel"),
+        hasLength(2),
+        reason: "the queued follow-up and explicit abort each cancel the active turn",
+      );
 
       // The agent honours the cancel by ending the in-flight turn.
       respondTo(firstPrompt, {"stopReason": "cancelled"});

--- a/bridge/sesori_plugin_copilot/lib/src/copilot_plugin_impl.dart
+++ b/bridge/sesori_plugin_copilot/lib/src/copilot_plugin_impl.dart
@@ -84,9 +84,6 @@ class CopilotPlugin._({
       super.authenticationFailureActionHint == null ? null : CopilotBinary.loginActionHint;
 
   @override
-  bool get cancelsActiveTurnForQueuedInput => true;
-
-  @override
   void captureSessionConfig(
     AcpNewSessionResult result, {
     required String? sessionId,

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
@@ -137,9 +137,6 @@ class CursorPlugin._({
   Map<String, dynamic>? get initializeCapabilityMeta => CursorBinary.acpCapabilityMeta;
 
   @override
-  bool get cancelsActiveTurnForQueuedInput => true;
-
-  @override
   AcpApprovalRegistry buildApprovalRegistry(AcpStdioClient client) {
     return CursorApprovalRegistry(
       client: client,

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
@@ -28,9 +28,6 @@ class DeepSeekPlugin({
       );
 
   @override
-  bool get cancelsActiveTurnForQueuedInput => true;
-
-  @override
   AcpApprovalRegistry buildApprovalRegistry(AcpStdioClient client) => DeepSeekApprovalRegistry(
     client: client,
     emit: emitActivityEvent,

--- a/bridge/sesori_plugin_grok/lib/src/grok_plugin_impl.dart
+++ b/bridge/sesori_plugin_grok/lib/src/grok_plugin_impl.dart
@@ -84,9 +84,6 @@ class GrokPlugin._({
       : "Run `grok login` or configure a headless Grok credential locally, then retry.";
 
   @override
-  bool get cancelsActiveTurnForQueuedInput => true;
-
-  @override
   void validateInitializeResult(AcpInitializeResult result) =>
       _grokSessionOptionsService.validateInitializeResult(result: result);
 

--- a/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
+++ b/bridge/sesori_plugin_hermes/lib/src/hermes_plugin_impl.dart
@@ -31,9 +31,6 @@ class HermesPlugin({
       );
 
   @override
-  bool get cancelsActiveTurnForQueuedInput => true;
-
-  @override
   void captureSessionConfig(
     AcpNewSessionResult result, {
     required String? sessionId,

--- a/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
+++ b/bridge/sesori_plugin_omp/lib/src/omp_plugin_impl.dart
@@ -115,9 +115,6 @@ class OmpPlugin._({
   bool get supportsFormElicitation => true;
 
   @override
-  bool get cancelsActiveTurnForQueuedInput => true;
-
-  @override
   void captureSessionConfig(
     AcpNewSessionResult result, {
     required String? sessionId,

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -148,10 +148,13 @@ defaults and queued client sends coherent.
   turn, declared process-wide lane, resume, or selection blocks their
   `session/prompt` frame. ACP v1 has no standard steering operation, so Sesori
   never sends overlapping prompt requests. It does define `session/cancel`:
-  Cursor, Hermes, DeepSeek, Copilot, and Grok therefore implement active-turn
-  follow-ups as stop-and-send, immediately cancelling the active turn and
+  the shared ACP plugin therefore defaults every harness to active-turn
+  stop-and-send, immediately cancelling the active turn and
   dispatching the queued input after cancellation settles. Further already-queued
-  inputs retain FIFO order. Their
+  inputs retain FIFO order. A concrete plugin may disable that fallback only when
+  it supplies another immediate active-turn delivery path; natural-completion
+  queueing is not valid production behavior. Cursor, Hermes, DeepSeek, Copilot,
+  Grok, and OMP use the shared fallback. Their
   synthetic user transcript message is published only after its frame flushes
   successfully to the agent's stdin. A prompt rejected after that dispatch
   renders a durable inline error, preserving the agent's diagnostic detail
@@ -160,8 +163,7 @@ defaults and queued client sends coherent.
   attachment-only prompts. Initial projection contains only normalized
   user-visible text plus those images; injected context, local paths, and URLs
   remain absent. OMP runs different sessions concurrently because its permission
-  and form requests carry explicit session IDs. OMP uses the same stop-and-send
-  sequence for its ACP server's replacement semantics.
+  and form requests carry explicit session IDs.
 - DeepSeek maps text, reasoning, tools, plans, title/config updates, compaction
   completion, and bounded warning errors through standard ACP plus its narrow
   status extension. Retry and compaction-start notifications are validated but


### PR DESCRIPTION
## Complexity

🌿 Straightforward: one shared ACP policy default plus removal of redundant concrete overrides.

## What

- Default busy-session ACP follow-ups to stop-and-send in `AcpPlugin`.
- Remove identical `true` overrides from Cursor, OMP, Hermes, DeepSeek, Copilot, and Grok.
- Update shared turn-serialization coverage and regression documentation.

## Why

ACP v1 has no standard steering method. Making stop-and-send the bridge-safe base behavior prevents a new ACP harness from silently queueing follow-ups until natural turn completion when it omits an override.

## Risk and test focus

Existing production harness behavior is unchanged because every concrete ACP plugin already selected this policy. The main risk is changing behavior for subclasses that relied on the former queue-until-completion default; shared tests now pin cancellation before replacement dispatch. There is no database impact and no current user-visible behavior change.

## Expected result

Every ACP harness immediately handles busy-session follow-ups through the shared stop-and-send fallback unless it explicitly supplies another immediate active-turn delivery path.

## Verification

- `dart test` and `dart analyze --fatal-infos` in `bridge/sesori_plugin_acp`
- `dart test` and `dart analyze --fatal-infos` in all six downstream ACP plugin packages
- Architecture implementation review approved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes stop-and-send the shared default for busy-session ACP follow-ups. Previously the default queued new input until the active turn completed; now the plugin cancels the active turn and dispatches after cancellation settles. No existing harness changes behavior because Cursor, OMP, Hermes, DeepSeek, Copilot, and Grok all already overrode this to `true`, so those overrides were removed.

**Subclass behavior change**
- Subclasses relying on queue-until-completion now cancel active turns; shared tests pin cancellation before replacement dispatch.
- No database impact or user-visible behavior change.

<sup>Written for commit 522538164df6945d11f6920bd19b92898d97a8c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

