### PR TITLE
⚙️ Fix desktop macOS secure storage

### DIFF
--- a/client/desktop/lib/core/di/injection.config.dart
+++ b/client/desktop/lib/core/di/injection.config.dart
@@ -33,6 +33,8 @@ import 'package:sesori_desktop/core/platform/flutter_system_tray.dart' as _i81;
 import 'package:sesori_desktop/core/platform/flutter_window_host.dart' as _i789;
 import 'package:sesori_desktop/core/platform/io_desktop_application_terminator.dart'
     as _i665;
+import 'package:sesori_desktop/core/platform/macos_legacy_keychain_client.dart'
+    as _i435;
 import 'package:sesori_desktop/core/platform/no_op_analytics_client.dart'
     as _i262;
 import 'package:sesori_desktop/core/platform/no_op_attribution_client.dart'
@@ -54,6 +56,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i558.FlutterSecureStorage>(
       () => registerModule.secureStorage,
     );
+    gh.lazySingleton<_i435.MacOsLegacyKeychainClient>(
+      () => _i435.MacOsLegacyKeychainClient(),
+    );
     gh.lazySingleton<_i316.DesktopApplicationSupportDirectory>(
       () => _i11.FlutterDesktopApplicationSupportDirectory(),
     );
@@ -63,9 +68,6 @@ extension GetItInjectableX on _i174.GetIt {
       ),
     );
     gh.singleton<_i948.LifecycleSource>(() => _i670.DesktopLifecycleObserver());
-    gh.lazySingleton<_i948.SecureStorage>(
-      () => _i757.DesktopSecureStorageAdapter(gh<_i558.FlutterSecureStorage>()),
-    );
     gh.lazySingleton<_i316.BridgeExecutablePathResolver>(
       () => _i964.DesktopBridgeExecutablePathResolver(),
     );
@@ -85,6 +87,12 @@ extension GetItInjectableX on _i174.GetIt {
       dispose: (i) => i.dispose(),
     );
     gh.lazySingleton<_i948.AnalyticsClient>(() => _i262.NoOpAnalyticsClient());
+    gh.lazySingleton<_i948.SecureStorage>(
+      () => _i757.DesktopSecureStorageAdapter(
+        storage: gh<_i558.FlutterSecureStorage>(),
+        macOsKeychainClient: gh<_i435.MacOsLegacyKeychainClient>(),
+      ),
+    );
     return this;
   }
 }

--- a/client/desktop/lib/core/di/register_module.dart
+++ b/client/desktop/lib/core/di/register_module.dart
@@ -11,17 +11,8 @@ abstract class RegisterModule() {
   @lazySingleton
   DeviceInfoPlugin get deviceInfoPlugin => DeviceInfoPlugin();
 
-  // Same "Sesori" keychain service label as the mobile app; the differing
-  // bundle ids (com.sesori.desktop vs com.sesori.app) keep the two products'
-  // keychain items isolated on macOS.
-  //
-  // usesDataProtectionKeychain is OFF: the data-protection keychain requires a
-  // provisioned keychain-access-group entitlement, which this non-sandboxed
-  // Developer-ID-style app (and every unsigned dev build) does not carry — the
-  // first token write would fail with errSecMissingEntitlement. The legacy
-  // login keychain works for both. Revisit with the final signing setup.
+  // Used by Windows and Linux. The desktop storage adapter routes macOS to the
+  // dedicated classic-Keychain channel required by non-provisioned builds.
   @lazySingleton
-  FlutterSecureStorage get secureStorage => const FlutterSecureStorage(
-    mOptions: MacOsOptions(accountName: "Sesori", usesDataProtectionKeychain: false),
-  );
+  FlutterSecureStorage get secureStorage => const FlutterSecureStorage();
 }

--- a/client/desktop/lib/core/platform/desktop_secure_storage_adapter.dart
+++ b/client/desktop/lib/core/platform/desktop_secure_storage_adapter.dart
@@ -1,17 +1,41 @@
+import "dart:io";
+
+import "package:flutter/foundation.dart" show visibleForTesting;
 import "package:flutter_secure_storage/flutter_secure_storage.dart";
 import "package:injectable/injectable.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 
+import "macos_legacy_keychain_client.dart";
+
 /// Desktop [SecureStorage] backed by the OS credential store
 /// (macOS Keychain, Windows Credential Manager/DPAPI, Linux libsecret).
 @LazySingleton(as: SecureStorage)
-class DesktopSecureStorageAdapter(final FlutterSecureStorage _storage) implements SecureStorage {
-  @override
-  Future<String?> read({required String key}) => _storage.read(key: key);
+class DesktopSecureStorageAdapter.forTesting({
+  required final FlutterSecureStorage _storage,
+  required final MacOsLegacyKeychainClient _macOsKeychainClient,
+  required final bool _isMacOS,
+}) implements SecureStorage {
+  new({
+    required FlutterSecureStorage storage,
+    required MacOsLegacyKeychainClient macOsKeychainClient,
+  }) : this.forTesting(
+         storage: storage,
+         macOsKeychainClient: macOsKeychainClient,
+         isMacOS: Platform.isMacOS,
+       );
+
+  @visibleForTesting
+  this;
 
   @override
-  Future<void> write({required String key, required String value}) => _storage.write(key: key, value: value);
+  Future<String?> read({required String key}) =>
+      _isMacOS ? _macOsKeychainClient.read(key: key) : _storage.read(key: key);
 
   @override
-  Future<void> delete({required String key}) => _storage.delete(key: key);
+  Future<void> write({required String key, required String value}) =>
+      _isMacOS ? _macOsKeychainClient.write(key: key, value: value) : _storage.write(key: key, value: value);
+
+  @override
+  Future<void> delete({required String key}) =>
+      _isMacOS ? _macOsKeychainClient.delete(key: key) : _storage.delete(key: key);
 }

--- a/client/desktop/lib/core/platform/macos_legacy_keychain_client.dart
+++ b/client/desktop/lib/core/platform/macos_legacy_keychain_client.dart
@@ -1,0 +1,27 @@
+import "package:flutter/foundation.dart" show visibleForTesting;
+import "package:flutter/services.dart";
+import "package:injectable/injectable.dart";
+
+/// Thin MethodChannel client for the non-sandboxed macOS default Keychain.
+///
+/// WORKAROUND: `flutter_secure_storage_darwin` 0.4.0 still sends attributes
+/// that select the Data Protection Keychain when its data-protection option is
+/// disabled, causing unsigned and Developer ID builds to fail with
+/// `errSecMissingEntitlement` (-34018). Remove this client once the upstream
+/// legacy path omits those attributes and passes the desktop runtime probe.
+@lazySingleton
+class MacOsLegacyKeychainClient.forTesting({required final MethodChannel _channel}) {
+  new() : this.forTesting(channel: const MethodChannel(_channelName));
+
+  @visibleForTesting
+  this;
+
+  static const String _channelName = "com.sesori.desktop/legacy-keychain";
+
+  Future<String?> read({required String key}) => _channel.invokeMethod<String>("read", <String, String>{"key": key});
+
+  Future<void> write({required String key, required String value}) =>
+      _channel.invokeMethod<void>("write", <String, String>{"key": key, "value": value});
+
+  Future<void> delete({required String key}) => _channel.invokeMethod<void>("delete", <String, String>{"key": key});
+}

--- a/client/desktop/macos/Runner.xcodeproj/project.pbxproj
+++ b/client/desktop/macos/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		A1C900022F00000000000001 /* MacOsLegacyKeychainPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C900012F00000000000001 /* MacOsLegacyKeychainPlugin.swift */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
 
@@ -71,6 +72,7 @@
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		33CC10F72044A3C60003C045 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Runner/Info.plist; sourceTree = "<group>"; };
 		33CC11122044BFA00003C045 /* MainFlutterWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainFlutterWindow.swift; sourceTree = "<group>"; };
+		A1C900012F00000000000001 /* MacOsLegacyKeychainPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacOsLegacyKeychainPlugin.swift; sourceTree = "<group>"; };
 		33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Flutter-Debug.xcconfig"; sourceTree = "<group>"; };
 		33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Flutter-Release.xcconfig"; sourceTree = "<group>"; };
 		33CEB47722A0578A004F2AC0 /* Flutter-Generated.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "Flutter-Generated.xcconfig"; path = "ephemeral/Flutter-Generated.xcconfig"; sourceTree = "<group>"; };
@@ -168,6 +170,7 @@
 			children = (
 				33CC10F02044A3C60003C045 /* AppDelegate.swift */,
 				33CC11122044BFA00003C045 /* MainFlutterWindow.swift */,
+				A1C900012F00000000000001 /* MacOsLegacyKeychainPlugin.swift */,
 				33E51913231747F40026EE4D /* DebugProfile.entitlements */,
 				33E51914231749380026EE4D /* Release.entitlements */,
 				33CC11242044D66E0003C045 /* Resources */,
@@ -355,6 +358,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */,
+				A1C900022F00000000000001 /* MacOsLegacyKeychainPlugin.swift in Sources */,
 				33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */,
 				335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */,
 			);

--- a/client/desktop/macos/Runner/MacOsLegacyKeychainPlugin.swift
+++ b/client/desktop/macos/Runner/MacOsLegacyKeychainPlugin.swift
@@ -1,0 +1,202 @@
+import FlutterMacOS
+import Security
+
+/// Classic default-Keychain storage for non-provisioned desktop builds.
+///
+/// The query deliberately omits Data Protection, accessibility, and
+/// synchronizable attributes because those require a provisioned
+/// keychain-access-group entitlement on macOS.
+final class MacOsLegacyKeychainPlugin {
+  private static let channelName = "com.sesori.desktop/legacy-keychain"
+  private static let service = "com.sesori.desktop"
+  private static let operationQueue = DispatchQueue(
+    label: "com.sesori.desktop.legacy-keychain",
+    qos: .userInitiated
+  )
+  private static var channel: FlutterMethodChannel?
+
+  static func register(binaryMessenger: FlutterBinaryMessenger) {
+    let channel = FlutterMethodChannel(name: channelName, binaryMessenger: binaryMessenger)
+    channel.setMethodCallHandler { call, result in
+      guard ["read", "write", "delete"].contains(call.method) else {
+        result(FlutterMethodNotImplemented)
+        return
+      }
+      guard
+        let arguments = call.arguments as? [String: Any],
+        let key = arguments["key"] as? String,
+        !key.isEmpty
+      else {
+        result(
+          FlutterError(
+            code: "invalid_arguments",
+            message: "A non-empty Keychain key is required",
+            details: nil
+          )
+        )
+        return
+      }
+
+      operationQueue.async {
+        do {
+          let value = try execute(method: call.method, key: key, arguments: arguments)
+          DispatchQueue.main.async {
+            result(value)
+          }
+        } catch let error as KeychainOperationError {
+          DispatchQueue.main.async {
+            result(error.flutterError)
+          }
+        } catch {
+          DispatchQueue.main.async {
+            result(
+              FlutterError(
+                code: "keychain_error",
+                message: "Unexpected macOS Keychain failure",
+                details: nil
+              )
+            )
+          }
+        }
+      }
+    }
+    self.channel = channel
+  }
+
+  private static func execute(
+    method: String,
+    key: String,
+    arguments: [String: Any]
+  ) throws -> Any? {
+    switch method {
+    case "read":
+      return try read(key: key)
+    case "write":
+      guard let value = arguments["value"] as? String else {
+        throw KeychainOperationError.invalidValue
+      }
+      try write(key: key, value: value)
+      return nil
+    case "delete":
+      try delete(key: key)
+      return nil
+    default:
+      return nil
+    }
+  }
+
+  private static func read(key: String) throws -> String? {
+    let keychain = try defaultKeychain()
+    var result: CFTypeRef?
+    var query = matchingQuery(key: key, keychain: keychain)
+    query[kSecReturnData] = true
+    query[kSecMatchLimit] = kSecMatchLimitOne
+    let status = SecItemCopyMatching(query as CFDictionary, &result)
+    if status == errSecItemNotFound {
+      return nil
+    }
+    try requireSuccess(status: status)
+    guard
+      let data = result as? Data,
+      let value = String(data: data, encoding: .utf8)
+    else {
+      throw KeychainOperationError.invalidData
+    }
+    return value
+  }
+
+  private static func write(key: String, value: String) throws {
+    let keychain = try defaultKeychain()
+    let data = Data(value.utf8)
+    let query = matchingQuery(key: key, keychain: keychain)
+    let attributes = [kSecValueData: data] as CFDictionary
+    let updateStatus = SecItemUpdate(query as CFDictionary, attributes)
+    if updateStatus == errSecItemNotFound {
+      var newItem = baseQuery(key: key)
+      newItem[kSecUseKeychain] = keychain
+      newItem[kSecValueData] = data
+      let addStatus = SecItemAdd(newItem as CFDictionary, nil)
+      if addStatus == errSecDuplicateItem {
+        try requireSuccess(status: SecItemUpdate(query as CFDictionary, attributes))
+      } else {
+        try requireSuccess(status: addStatus)
+      }
+      return
+    }
+    try requireSuccess(status: updateStatus)
+  }
+
+  private static func delete(key: String) throws {
+    let keychain = try defaultKeychain()
+    let status = SecItemDelete(matchingQuery(key: key, keychain: keychain) as CFDictionary)
+    if status != errSecItemNotFound {
+      try requireSuccess(status: status)
+    }
+  }
+
+  private static func baseQuery(key: String) -> [CFString: Any] {
+    [
+      kSecClass: kSecClassGenericPassword,
+      kSecAttrService: service,
+      kSecAttrAccount: key,
+    ]
+  }
+
+  private static func matchingQuery(key: String, keychain: SecKeychain) -> [CFString: Any] {
+    var query = baseQuery(key: key)
+    query[kSecMatchSearchList] = [keychain]
+    return query
+  }
+
+  private static func defaultKeychain() throws -> SecKeychain {
+    var keychain: SecKeychain?
+    try requireSuccess(status: SecKeychainCopyDefault(&keychain))
+    guard let keychain else {
+      throw KeychainOperationError.defaultKeychainUnavailable
+    }
+    return keychain
+  }
+
+  private static func requireSuccess(status: OSStatus) throws {
+    if status != errSecSuccess {
+      throw KeychainOperationError.status(status)
+    }
+  }
+}
+
+private enum KeychainOperationError: Error {
+  case invalidValue
+  case invalidData
+  case defaultKeychainUnavailable
+  case status(OSStatus)
+
+  var flutterError: FlutterError {
+    switch self {
+    case .invalidValue:
+      return FlutterError(
+        code: "invalid_arguments",
+        message: "A Keychain value is required",
+        details: nil
+      )
+    case .invalidData:
+      return FlutterError(
+        code: "invalid_keychain_data",
+        message: "The Keychain value is not valid UTF-8",
+        details: nil
+      )
+    case .defaultKeychainUnavailable:
+      return FlutterError(
+        code: "keychain_unavailable",
+        message: "The default macOS Keychain is unavailable",
+        details: nil
+      )
+    case .status(let status):
+      return FlutterError(
+        code: "keychain_error",
+        message: SecCopyErrorMessageString(status, nil) as String?
+          ?? "Unexpected macOS Keychain status",
+        details: Int(status)
+      )
+    }
+  }
+}

--- a/client/desktop/macos/Runner/MainFlutterWindow.swift
+++ b/client/desktop/macos/Runner/MainFlutterWindow.swift
@@ -9,6 +9,7 @@ class MainFlutterWindow: NSWindow {
     self.setFrame(windowFrame, display: true)
 
     RegisterGeneratedPlugins(registry: flutterViewController)
+    MacOsLegacyKeychainPlugin.register(binaryMessenger: flutterViewController.engine.binaryMessenger)
 
     super.awakeFromNib()
   }

--- a/client/desktop/test/core/platform/desktop_secure_storage_adapter_test.dart
+++ b/client/desktop/test/core/platform/desktop_secure_storage_adapter_test.dart
@@ -1,0 +1,68 @@
+import "package:flutter_secure_storage/flutter_secure_storage.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:mocktail/mocktail.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_desktop/core/platform/desktop_secure_storage_adapter.dart";
+import "package:sesori_desktop/core/platform/macos_legacy_keychain_client.dart";
+
+void main() {
+  late _MockFlutterSecureStorage storage;
+  late _MockMacOsLegacyKeychainClient macOsKeychainClient;
+
+  setUp(() {
+    storage = _MockFlutterSecureStorage();
+    macOsKeychainClient = _MockMacOsLegacyKeychainClient();
+  });
+
+  test("routes macOS operations through the classic login-Keychain client", () async {
+    when(() => macOsKeychainClient.read(key: "token")).thenAnswer((_) async => "stored");
+    when(() => macOsKeychainClient.write(key: "token", value: "fresh")).thenAnswer((_) async {});
+    when(() => macOsKeychainClient.delete(key: "token")).thenAnswer((_) async {});
+    final SecureStorage adapter = DesktopSecureStorageAdapter.forTesting(
+      storage: storage,
+      macOsKeychainClient: macOsKeychainClient,
+      isMacOS: true,
+    );
+
+    expect(await adapter.read(key: "token"), "stored");
+    await adapter.write(key: "token", value: "fresh");
+    await adapter.delete(key: "token");
+
+    verifyNever(() => storage.read(key: any(named: "key")));
+    verifyNever(
+      () => storage.write(
+        key: any(named: "key"),
+        value: any(named: "value"),
+      ),
+    );
+    verifyNever(() => storage.delete(key: any(named: "key")));
+  });
+
+  test("keeps flutter_secure_storage for Windows and Linux", () async {
+    when(() => storage.read(key: "token")).thenAnswer((_) async => "stored");
+    when(() => storage.write(key: "token", value: "fresh")).thenAnswer((_) async {});
+    when(() => storage.delete(key: "token")).thenAnswer((_) async {});
+    final SecureStorage adapter = DesktopSecureStorageAdapter.forTesting(
+      storage: storage,
+      macOsKeychainClient: macOsKeychainClient,
+      isMacOS: false,
+    );
+
+    expect(await adapter.read(key: "token"), "stored");
+    await adapter.write(key: "token", value: "fresh");
+    await adapter.delete(key: "token");
+
+    verifyNever(() => macOsKeychainClient.read(key: any(named: "key")));
+    verifyNever(
+      () => macOsKeychainClient.write(
+        key: any(named: "key"),
+        value: any(named: "value"),
+      ),
+    );
+    verifyNever(() => macOsKeychainClient.delete(key: any(named: "key")));
+  });
+}
+
+class _MockFlutterSecureStorage() extends Mock implements FlutterSecureStorage;
+
+class _MockMacOsLegacyKeychainClient() extends Mock implements MacOsLegacyKeychainClient;

--- a/client/desktop/test/core/platform/macos_legacy_keychain_client_test.dart
+++ b/client/desktop/test/core/platform/macos_legacy_keychain_client_test.dart
@@ -1,0 +1,40 @@
+import "package:flutter/services.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:sesori_desktop/core/platform/macos_legacy_keychain_client.dart";
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const MethodChannel channel = MethodChannel("test/legacy-keychain");
+  late List<MethodCall> calls;
+
+  setUp(() {
+    calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      channel,
+      (MethodCall call) async {
+        calls.add(call);
+        return call.method == "read" ? "stored-value" : null;
+      },
+    );
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      channel,
+      null,
+    );
+  });
+
+  test("translates typed storage operations to the native channel", () async {
+    final MacOsLegacyKeychainClient client = MacOsLegacyKeychainClient.forTesting(channel: channel);
+
+    expect(await client.read(key: "access_token"), "stored-value");
+    await client.write(key: "refresh_token", value: "secret");
+    await client.delete(key: "pkce_verifier");
+
+    expect(calls.map((MethodCall call) => call.method), <String>["read", "write", "delete"]);
+    expect(calls[0].arguments, <String, String>{"key": "access_token"});
+    expect(calls[1].arguments, <String, String>{"key": "refresh_token", "value": "secret"});
+    expect(calls[2].arguments, <String, String>{"key": "pkce_verifier"});
+  });
+}

--- a/docs/regression/account-and-onboarding.md
+++ b/docs/regression/account-and-onboarding.md
@@ -16,7 +16,9 @@ participates.
   cleared on logout; the connection follows logout. Startup reads stored tokens
   once before deciding whether validation or a fresh login is needed. Standalone
   bridge logout remains clean and idempotent when tokens are already absent or
-  the saved authentication session has expired.
+  the saved authentication session has expired. Non-sandboxed macOS desktop
+  builds use the classic default Keychain without requiring a provisioned
+  Data Protection Keychain access group.
 - Auth-server URLs behave identically with or without trailing slashes, and
   deadline expiry actively aborts registration and token-refresh transport,
   including response-body consumption.
@@ -34,7 +36,7 @@ participates.
 
 | Level | Additional coverage |
 |---|---|
-| L1 Smoke | Signed-in launch restores the local session and reaches Projects with no network work at splash; a bridge start reaches readiness. Client end to end plus headless bridge; no plugin. |
+| L1 Smoke | Signed-in launch restores the local session and reaches Projects with no network work at splash; the macOS desktop adapter routes secure storage through its classic-Keychain client; a bridge start reaches readiness. Client end to end plus headless bridge; no plugin. |
 | L2 Routine | One provider through sign-in and logout on the release-target client platform, plus the prompt decision for marker-present, already-registered, and absent accounts. Client end to end plus headless bridge; no plugin. |
 | L3 Release | Every sign-in option on the release-target client platform, both empty-Projects states, and prompt ordering proved by a real client joining, completing key exchange, and issuing a request while the prompt shows. Client end to end plus relay integration; no plugin. |
 | L4 Extended | Background/resume mid sign-in, unreachable or rejecting auth server, expiry refresh, logout while connected, withheld push registration, delayed status check, second mobile platform. Client end to end where the app observes it, headless where the bridge owns it. |
@@ -51,7 +53,8 @@ the prompt and a reused one when testing suppression.
 
 - Splash doing network work, or routing a valid session to sign-in.
 - A recoverable interruption surfacing as terminal, or a real failure as silent.
-- Tokens surviving logout, or a logged-out app holding a live connection.
+- Tokens surviving logout, a logged-out app holding a live connection, or macOS
+  OAuth completion failing with a missing Keychain entitlement (`-34018`).
 - The prompt appearing before readiness, after a failed start, on an account that
   already has the app, or driving repeated status requests.
 - Relay availability or key exchange waiting on push registration or the check.


### PR DESCRIPTION
## Complexity

⚙️ Moderate — a focused native Security.framework boundary replaces a broken third-party macOS Keychain path while preserving the existing cross-platform storage contract.

## What

- Route macOS desktop secure-storage operations through a typed MethodChannel client and native classic default-Keychain handler.
- Scope every lookup/update/delete to the resolved default Keychain and every add to that same Keychain.
- Serialize native operations and recover an add race by retrying the scoped update after `errSecDuplicateItem`.
- Keep `flutter_secure_storage` unchanged for Windows and Linux.
- Add MethodChannel, adapter-routing, and DI coverage plus authentication regression documentation.

## Why

The first real desktop login gate failed after browser OAuth with `errSecMissingEntitlement` (`-34018`). `flutter_secure_storage_darwin` 0.4.0 still selects Data Protection Keychain attributes even when its legacy option is disabled, while adding Keychain Sharing would make local/ad-hoc builds require a provisioning profile. The desktop app is non-sandboxed and Developer-ID-oriented, so a narrowly scoped classic Keychain implementation restores secure local token storage without provisioning-only entitlements.

## Risk and test focus

Focus review on OAuth-secret handling, default-Keychain scoping, classic Keychain ACL/code-sign behavior, serial operation ordering, UTF-8 round trips, native error propagation, MethodChannel validation, and ensuring Windows/Linux remain on their existing plugin path.

There is no database or transport impact. Persisted impact is limited to unpublished desktop credentials moving to the `com.sesori.desktop` classic-Keychain service; no production migration is required.

## Expected result

Desktop GitHub OAuth completes on a normal macOS development build without `-34018`; tokens persist and clear through the existing `SecureStorage` contract, and subsequent Gate A supervision testing can continue.

## Verification

- `client/desktop`: analyzer clean; all 35 tests passed.
- macOS debug and release builds passed.
- Compiled runtime probe passed fresh write/read, 20 ordered concurrent first writes, Unicode update/read, delete/read-null, and emitted no `-34018`.
- Dart LSP: 0 diagnostics across all affected Dart files.
- B-Client architecture implementation review approved with no findings.
- Security review approved after default-Keychain scoping and serial-upsert fixes.
- `git diff --check` passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS desktop secure storage so GitHub OAuth no longer fails on the first token write with `errSecMissingEntitlement` (-34018).

**MacOS Keychain path**
- Routes macOS secure-storage operations through a typed MethodChannel client and a native Swift classic default-Keychain handler.
- All lookups, updates, and deletes are scoped to the resolved default Keychain; adds retry after `errSecDuplicateItem`.
- Windows and Linux keep using `flutter_secure_storage` unchanged; `flutter_secure_storage_darwin` 0.4.0 still selects Data Protection Keychain attributes even when its option is disabled, which demands a provisioning profile this non-sandboxed build lacks.
- No production migration is required; impact is limited to unpublished desktop credentials moving to the `com.sesori.desktop` classic-Keychain service.

<sup>Written for commit 79ec41f80fb2e314e3434a8aff8f0ac126cfbade. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

