### PR TITLE
⚙️ [desktop-app] Add autostart and hidden boot [step 9/22]

### DIFF
--- a/.plan/active/desktop-app/PLAN.md
+++ b/.plan/active/desktop-app/PLAN.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Plan slug:** `desktop-app`
-- **Status:** Active — MT gate A accepted; step 9/22 next (autostart + hidden boot)
+- **Status:** Active — step 9/22 in progress (autostart + hidden boot)
 - **Plan date:** 2026-08-28
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Current implementation base:** `main`

--- a/.plan/active/desktop-app/TRACKER.md
+++ b/.plan/active/desktop-app/TRACKER.md
@@ -16,7 +16,7 @@ user-run checkpoints, not PRs; only the user marks them passed.
 | 7 | ⚙️ Window + Prego theme + v1 contents | done |
 | — | MT gate A: first real GUI supervision (user-run) | done |
 | 8 | ⚙️ Single instance + last-state restore | done |
-| 9 | ⚙️ Autostart + hidden boot | pending |
+| 9 | ⚙️ Autostart + hidden boot | in-progress |
 | 10 | 🚧 `module_auth` logout/rejection hardening (R1) | pending |
 | 11 | ⚙️ Logout coordination + offline unregister fallback | pending |
 | 12 | ⚙️ Supervised E2E suite + dev-harness retirement | pending |

--- a/.plan/active/desktop-app/steps/step-09.md
+++ b/.plan/active/desktop-app/steps/step-09.md
@@ -1,0 +1,49 @@
+# Step 9 — Autostart + hidden boot
+
+Date: 2026-08-30.
+
+## Delivered
+
+- Added the pure-Dart Layer-0 `LaunchAtLogin` capability and a desktop shell
+  adapter. macOS writes/removes a single per-user LaunchAgent plist, Linux
+  writes/removes a single XDG autostart desktop entry, and Windows owns one
+  `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run` value. Each
+  registration launches the current desktop executable with `--hidden`; repeat
+  enable operations are idempotent and disable removes stale registrations.
+  The adapter owns these small OS registrations directly because the available
+  `launch_at_startup` macOS backend does not forward launch arguments and would
+  add an extra Swift package integration for this dev-build step.
+- Added the tray/window launch-at-login control. The cubit reads the OS-backed
+  state, exposes an On/Off status and command in the tray and window, serializes
+  registration changes with the other lifecycle actions, and leaves the state
+  retryable after a failed operation.
+- Added exact `--hidden` argument parsing. Hidden startup initializes the native
+  window without showing it, keeps it tray-only when the tray is available, and
+  shows it when tray initialization is unavailable or fails. Normal launches
+  remain visible.
+- Extended the native window capability with an explicit initial visibility
+  parameter and regenerated desktop Injectable output.
+
+No database or relay/control-wire impact. Login registration is per-user OS
+state and is separate from the desktop-owned bridge desired-state file.
+
+## Architecture implementation review
+
+The implementation review approved the Step 9 working tree with no findings.
+It confirmed Layer-0 `LaunchAtLogin` ownership, independent desktop platform
+registration, `WindowHost`/`BridgeControlCubit` lifecycle direction, hidden-boot
+fallback ownership, and DI boundaries.
+
+## Verification
+
+- `client/desktop`: `flutter analyze --fatal-infos` clean; full Flutter suite
+  passed (45 tests).
+- `client/module_desktop_core`: `dart analyze --fatal-infos` clean; full pure
+  Dart suite passed (157 tests).
+- Adapter tests cover macOS plist content/hidden argument, loaded-agent
+  unloading, Linux XDG content/idempotence, stale registrations, and Windows
+  registry command behavior; launch-argument parsing and hidden-window fallback
+  are covered separately.
+- Clean macOS application build passed.
+- Manual reboot/login Gate B coverage remains pending; the user-run gate will
+  verify hidden tray startup, disable persistence, and no-tray visible fallback.

--- a/.plan/active/desktop-app/steps/step-09.md
+++ b/.plan/active/desktop-app/steps/step-09.md
@@ -13,7 +13,9 @@ Date: 2026-08-30.
   enable operations are idempotent and disable removes stale registrations.
   macOS disable removes the plist without booting out the currently running
   app, so disabling autostart cannot terminate the app before coordinated
-  bridge shutdown completes.
+  bridge shutdown completes. Windows reads the owned value through the native
+  registry API so missing-value handling is independent of localized
+  `reg.exe` diagnostics, and Linux escapes desktop-entry percent field codes.
   The adapter owns these small OS registrations directly because the available
   `launch_at_startup` macOS backend does not forward launch arguments and would
   add an extra Swift package integration for this dev-build step.
@@ -45,9 +47,10 @@ fallback ownership, and DI boundaries.
 - `client/module_desktop_core`: `dart analyze --fatal-infos` clean; full pure
   Dart suite passed (157 tests).
 - Adapter tests cover macOS plist content/hidden argument and safe removal,
-  Linux XDG content/idempotence and `XDG_CONFIG_HOME`, stale registrations,
-  and Windows registry command/error behavior; launch-argument parsing and
-  hidden-window fallback are covered separately.
-- Clean macOS application build passed.
+  Linux XDG content/idempotence, `XDG_CONFIG_HOME`, and percent field-code
+  escaping, stale registrations, and Windows registry value/error behavior;
+  launch-argument parsing and hidden-window fallback are covered separately.
+- The full desktop Flutter suite passed (48 tests), and a clean macOS
+  application build passed, including explicit LaunchAgent argument forwarding.
 - Manual reboot/login Gate B coverage remains pending; the user-run gate will
   verify hidden tray startup, disable persistence, and no-tray visible fallback.

--- a/.plan/active/desktop-app/steps/step-09.md
+++ b/.plan/active/desktop-app/steps/step-09.md
@@ -6,10 +6,14 @@ Date: 2026-08-30.
 
 - Added the pure-Dart Layer-0 `LaunchAtLogin` capability and a desktop shell
   adapter. macOS writes/removes a single per-user LaunchAgent plist, Linux
-  writes/removes a single XDG autostart desktop entry, and Windows owns one
+  writes/removes a single XDG autostart desktop entry (honoring
+  `XDG_CONFIG_HOME`), and Windows owns one
   `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run` value. Each
   registration launches the current desktop executable with `--hidden`; repeat
   enable operations are idempotent and disable removes stale registrations.
+  macOS disable removes the plist without booting out the currently running
+  app, so disabling autostart cannot terminate the app before coordinated
+  bridge shutdown completes.
   The adapter owns these small OS registrations directly because the available
   `launch_at_startup` macOS backend does not forward launch arguments and would
   add an extra Swift package integration for this dev-build step.
@@ -40,10 +44,10 @@ fallback ownership, and DI boundaries.
   passed (45 tests).
 - `client/module_desktop_core`: `dart analyze --fatal-infos` clean; full pure
   Dart suite passed (157 tests).
-- Adapter tests cover macOS plist content/hidden argument, loaded-agent
-  unloading, Linux XDG content/idempotence, stale registrations, and Windows
-  registry command behavior; launch-argument parsing and hidden-window fallback
-  are covered separately.
+- Adapter tests cover macOS plist content/hidden argument and safe removal,
+  Linux XDG content/idempotence and `XDG_CONFIG_HOME`, stale registrations,
+  and Windows registry command/error behavior; launch-argument parsing and
+  hidden-window fallback are covered separately.
 - Clean macOS application build passed.
 - Manual reboot/login Gate B coverage remains pending; the user-run gate will
   verify hidden tray startup, disable persistence, and no-tray visible fallback.

--- a/.plan/active/desktop-app/steps/step-09.md
+++ b/.plan/active/desktop-app/steps/step-09.md
@@ -28,7 +28,10 @@ Date: 2026-08-30.
   shows it when tray initialization is unavailable or fails. Normal launches
   remain visible.
 - Extended the native window capability with an explicit initial visibility
-  parameter and regenerated desktop Injectable output.
+  parameter and regenerated desktop Injectable output. The macOS, Linux, and
+  Windows native runners now preserve the hidden launch through their first
+  Flutter frame instead of revealing the window before Dart can apply the
+  tray-only policy.
 
 No database or relay/control-wire impact. Login registration is per-user OS
 state and is separate from the desktop-owned bridge desired-state file.
@@ -43,14 +46,15 @@ fallback ownership, and DI boundaries.
 ## Verification
 
 - `client/desktop`: `flutter analyze --fatal-infos` clean; full Flutter suite
-  passed (45 tests).
+  passed (49 tests).
 - `client/module_desktop_core`: `dart analyze --fatal-infos` clean; full pure
   Dart suite passed (157 tests).
 - Adapter tests cover macOS plist content/hidden argument and safe removal,
   Linux XDG content/idempotence, `XDG_CONFIG_HOME`, and percent field-code
   escaping, stale registrations, and Windows registry value/error behavior;
   launch-argument parsing and hidden-window fallback are covered separately.
-- The full desktop Flutter suite passed (48 tests), and a clean macOS
-  application build passed, including explicit LaunchAgent argument forwarding.
+- A clean macOS application build passed, including explicit LaunchAgent
+  argument forwarding. Linux/Windows native-runner compilation is covered by
+  the desktop CI matrix on their respective hosts.
 - Manual reboot/login Gate B coverage remains pending; the user-run gate will
   verify hidden tray startup, disable persistence, and no-tray visible fallback.

--- a/client/desktop/lib/app.dart
+++ b/client/desktop/lib/app.dart
@@ -11,7 +11,7 @@ import "features/auth_gate/auth_gate.dart";
 /// Root widget of the Sesori desktop app.
 ///
 /// Owns the eager desktop bridge controller, Prego themes, and sign-in gate.
-class const SesoriDesktopApp({super.key}) extends StatelessWidget {
+class const SesoriDesktopApp({required final bool hiddenLaunch, super.key}) extends StatelessWidget {
   static const String _appTitle = "Sesori";
 
   @override
@@ -29,6 +29,8 @@ class const SesoriDesktopApp({super.key}) extends StatelessWidget {
           instanceService: getIt(),
           logoutTracker: getIt(),
           urlLauncher: getIt(),
+          launchAtLogin: getIt(),
+          hiddenLaunch: hiddenLaunch,
         );
         unawaited(cubit.initialize());
         return cubit;

--- a/client/desktop/lib/core/di/injection.config.dart
+++ b/client/desktop/lib/core/di/injection.config.dart
@@ -33,6 +33,7 @@ import 'package:sesori_desktop/core/platform/flutter_system_tray.dart' as _i81;
 import 'package:sesori_desktop/core/platform/flutter_window_host.dart' as _i789;
 import 'package:sesori_desktop/core/platform/io_desktop_application_terminator.dart'
     as _i665;
+import 'package:sesori_desktop/core/platform/io_launch_at_login.dart' as _i122;
 import 'package:sesori_desktop/core/platform/macos_legacy_keychain_client.dart'
     as _i435;
 import 'package:sesori_desktop/core/platform/no_op_analytics_client.dart'
@@ -71,6 +72,7 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i316.BridgeExecutablePathResolver>(
       () => _i964.DesktopBridgeExecutablePathResolver(),
     );
+    gh.lazySingleton<_i316.LaunchAtLogin>(() => _i122.IoLaunchAtLogin());
     gh.lazySingleton<_i316.SystemTray>(
       () => _i81.FlutterSystemTray(),
       dispose: (i) => i.dispose(),

--- a/client/desktop/lib/core/platform/desktop_launch_arguments.dart
+++ b/client/desktop/lib/core/platform/desktop_launch_arguments.dart
@@ -1,0 +1,10 @@
+/// The argument used by the per-user login registration to request a hidden
+/// tray-only startup.
+const String desktopHiddenLaunchArgument = "--hidden";
+
+/// Whether the desktop was launched by the login registration rather than by a
+/// user opening the app directly.
+///
+/// The parser intentionally accepts only the exact flag; unrelated arguments
+/// must not change the normal visible-launch behavior.
+bool isDesktopHiddenLaunch({required List<String> arguments}) => arguments.contains(desktopHiddenLaunchArgument);

--- a/client/desktop/lib/core/platform/flutter_window_host.dart
+++ b/client/desktop/lib/core/platform/flutter_window_host.dart
@@ -32,7 +32,7 @@ class FlutterWindowHost.forTesting({required final WindowManager _manager}) with
   Stream<WindowHostEvent> get events => _events.stream;
 
   @override
-  Future<void> initialize() async {
+  Future<void> initialize({required bool hidden}) async {
     _ensureNotDisposed();
     if (_initialized) {
       throw StateError("WindowHost is already initialized");
@@ -44,8 +44,11 @@ class FlutterWindowHost.forTesting({required final WindowManager _manager}) with
     try {
       await _manager.setPreventClose(true);
       await _manager.waitUntilReadyToShow(_options);
-      await _manager.show();
-      await _manager.focus();
+      await _manager.setSkipTaskbar(hidden);
+      if (!hidden) {
+        await _manager.show();
+        await _manager.focus();
+      }
       _initialized = true;
     } on Object {
       _manager.removeListener(this);
@@ -54,6 +57,11 @@ class FlutterWindowHost.forTesting({required final WindowManager _manager}) with
         await _manager.setPreventClose(false);
       } on Object catch (error, stackTrace) {
         logw("Failed to restore native close behavior after window initialization failed", error, stackTrace);
+      }
+      try {
+        await _manager.setSkipTaskbar(false);
+      } on Object catch (error, stackTrace) {
+        logw("Failed to restore Dock/taskbar visibility after window initialization failed", error, stackTrace);
       }
       rethrow;
     }

--- a/client/desktop/lib/core/platform/io_launch_at_login.dart
+++ b/client/desktop/lib/core/platform/io_launch_at_login.dart
@@ -4,6 +4,7 @@ import "package:flutter/foundation.dart" show visibleForTesting;
 import "package:injectable/injectable.dart";
 import "package:path/path.dart" as path;
 import "package:sesori_desktop_core/sesori_desktop_core.dart";
+import "package:win32_registry/win32_registry.dart";
 
 import "desktop_launch_arguments.dart";
 
@@ -12,6 +13,9 @@ typedef LaunchAtLoginProcessRunner = Future<ProcessResult> Function({
   required String executable,
   required List<String> arguments,
 });
+
+@visibleForTesting
+typedef LaunchAtLoginWindowsValueReader = String? Function();
 
 /// Per-user login registration for the three desktop platforms.
 ///
@@ -27,6 +31,7 @@ class IoLaunchAtLogin.forTesting({
   required final String _homeDirectory,
   required final String? _xdgConfigHome,
   required final String _executablePath,
+  required final LaunchAtLoginWindowsValueReader _windowsValueReader,
   required final LaunchAtLoginProcessRunner _runProcess,
 }) implements LaunchAtLogin {
   new()
@@ -37,6 +42,7 @@ class IoLaunchAtLogin.forTesting({
         homeDirectory: _resolveUserHomeDirectory(),
         xdgConfigHome: Platform.environment["XDG_CONFIG_HOME"]?.trim(),
         executablePath: Platform.resolvedExecutable,
+        windowsValueReader: _readWindowsRegistryValue,
         runProcess: ({required String executable, required List<String> arguments}) =>
             Process.run(executable, arguments),
       );
@@ -47,6 +53,7 @@ class IoLaunchAtLogin.forTesting({
   static const String _appName = "Sesori";
   static const String _registrationId = "com.sesori.desktop";
   static const String _windowsRunKey = r"HKCU\Software\Microsoft\Windows\CurrentVersion\Run";
+  static const String _windowsRunSubKey = r"Software\Microsoft\Windows\CurrentVersion\Run";
 
   File get _macOsRegistration => File(path.join(_homeDirectory, "Library", "LaunchAgents", "$_registrationId.plist"));
 
@@ -160,38 +167,9 @@ class IoLaunchAtLogin.forTesting({
     }
   }
 
-  Future<ProcessResult> _queryWindows() =>
-      _runProcess(executable: "reg.exe", arguments: <String>["QUERY", _windowsRunKey, "/v", _appName]);
+  Future<bool> _isWindowsEnabled() async => _windowsValueReader() == _windowsCommand;
 
-  Future<bool> _isWindowsEnabled() async {
-    final ProcessResult result = await _queryWindows();
-    if (result.exitCode != 0) {
-      if (_isMissingWindowsValue(result: result)) {
-        return false;
-      }
-      _requireSuccess(
-        executable: "reg.exe",
-        arguments: <String>["QUERY", _windowsRunKey, "/v", _appName],
-        result: result,
-      );
-    }
-    return result.stdout.toString().contains(_windowsCommand);
-  }
-
-  Future<bool> _windowsValueExists() async {
-    final ProcessResult result = await _queryWindows();
-    if (result.exitCode != 0) {
-      if (_isMissingWindowsValue(result: result)) {
-        return false;
-      }
-      _requireSuccess(
-        executable: "reg.exe",
-        arguments: <String>["QUERY", _windowsRunKey, "/v", _appName],
-        result: result,
-      );
-    }
-    return true;
-  }
+  Future<bool> _windowsValueExists() async => _windowsValueReader() != null;
 
   Future<void> _enableWindows() async {
     if (await _isWindowsEnabled()) {
@@ -221,15 +199,6 @@ class IoLaunchAtLogin.forTesting({
     _requireSuccess(executable: "reg.exe", arguments: arguments, result: result);
   }
 
-  static bool _isMissingWindowsValue({required ProcessResult result}) {
-    if (result.exitCode != 1) {
-      return false;
-    }
-    final String output = "${result.stdout}\n${result.stderr}".toLowerCase();
-    return output.contains("unable to find the specified registry") ||
-        output.contains("cannot find the file specified");
-  }
-
   void _requireSuccess({
     required String executable,
     required List<String> arguments,
@@ -247,6 +216,10 @@ class IoLaunchAtLogin.forTesting({
       result.exitCode,
     );
   }
+
+  // Use the native API so missing values are identified by stable status codes,
+  // rather than localized reg.exe diagnostics.
+  static String? _readWindowsRegistryValue() => CURRENT_USER.getString(_appName, path: _windowsRunSubKey);
 
   static String _resolveUserHomeDirectory() {
     final List<String> keys = Platform.isWindows
@@ -269,5 +242,5 @@ class IoLaunchAtLogin.forTesting({
       .replaceAll("'", "&apos;");
 
   static String _desktopEntryQuote(String value) =>
-      '"${value.replaceAll(r"\", r"\\").replaceAll('"', r'\"').replaceAll(r"$", r"\$").replaceAll("`", r"\`")}"';
+      '"${value.replaceAll(r"\", r"\\").replaceAll('"', r'\"').replaceAll(r"$", r"\$").replaceAll("`", r"\`").replaceAll("%", "%%")}"';
 }

--- a/client/desktop/lib/core/platform/io_launch_at_login.dart
+++ b/client/desktop/lib/core/platform/io_launch_at_login.dart
@@ -25,8 +25,8 @@ class IoLaunchAtLogin.forTesting({
   required final bool _isWindows,
   required final bool _isLinux,
   required final String _homeDirectory,
+  required final String? _xdgConfigHome,
   required final String _executablePath,
-  required final String _userId,
   required final LaunchAtLoginProcessRunner _runProcess,
 }) implements LaunchAtLogin {
   new()
@@ -35,8 +35,8 @@ class IoLaunchAtLogin.forTesting({
         isWindows: Platform.isWindows,
         isLinux: Platform.isLinux,
         homeDirectory: _resolveUserHomeDirectory(),
+        xdgConfigHome: Platform.environment["XDG_CONFIG_HOME"]?.trim(),
         executablePath: Platform.resolvedExecutable,
-        userId: Platform.isMacOS ? _resolveUserId() : "",
         runProcess: ({required String executable, required List<String> arguments}) =>
             Process.run(executable, arguments),
       );
@@ -50,7 +50,9 @@ class IoLaunchAtLogin.forTesting({
 
   File get _macOsRegistration => File(path.join(_homeDirectory, "Library", "LaunchAgents", "$_registrationId.plist"));
 
-  File get _linuxRegistration => File(path.join(_homeDirectory, ".config", "autostart", "$_registrationId.desktop"));
+  File get _linuxRegistration => File(
+    path.join(_xdgConfigHome ?? path.join(_homeDirectory, ".config"), "autostart", "$_registrationId.desktop"),
+  );
 
   @override
   Future<bool> isEnabled() async {
@@ -86,7 +88,7 @@ class IoLaunchAtLogin.forTesting({
   @override
   Future<void> disable() async {
     if (_isMacOS) {
-      await _disableMacOS();
+      _deleteRegistration(file: _macOsRegistration);
       return;
     }
     if (_isLinux) {
@@ -163,12 +165,32 @@ class IoLaunchAtLogin.forTesting({
 
   Future<bool> _isWindowsEnabled() async {
     final ProcessResult result = await _queryWindows();
-    return result.exitCode == 0 && result.stdout.toString().contains(_windowsCommand);
+    if (result.exitCode != 0) {
+      if (_isMissingWindowsValue(result: result)) {
+        return false;
+      }
+      _requireSuccess(
+        executable: "reg.exe",
+        arguments: <String>["QUERY", _windowsRunKey, "/v", _appName],
+        result: result,
+      );
+    }
+    return result.stdout.toString().contains(_windowsCommand);
   }
 
   Future<bool> _windowsValueExists() async {
     final ProcessResult result = await _queryWindows();
-    return result.exitCode == 0;
+    if (result.exitCode != 0) {
+      if (_isMissingWindowsValue(result: result)) {
+        return false;
+      }
+      _requireSuccess(
+        executable: "reg.exe",
+        arguments: <String>["QUERY", _windowsRunKey, "/v", _appName],
+        result: result,
+      );
+    }
+    return true;
   }
 
   Future<void> _enableWindows() async {
@@ -199,30 +221,13 @@ class IoLaunchAtLogin.forTesting({
     _requireSuccess(executable: "reg.exe", arguments: arguments, result: result);
   }
 
-  Future<void> _disableMacOS() async {
-    final File registration = _macOsRegistration;
-    if (!registration.existsSync()) {
-      return;
-    }
-    if (await _isMacOSLoaded()) {
-      final List<String> arguments = <String>["bootout", "gui/$_userId/$_registrationId"];
-      final ProcessResult result = await _runProcess(executable: "launchctl", arguments: arguments);
-      _requireSuccess(executable: "launchctl", arguments: arguments, result: result);
-    }
-    _deleteRegistration(file: registration);
-  }
-
-  Future<bool> _isMacOSLoaded() async {
-    final List<String> arguments = <String>["print", "gui/$_userId/$_registrationId"];
-    final ProcessResult result = await _runProcess(executable: "launchctl", arguments: arguments);
-    if (result.exitCode == 0) {
-      return true;
-    }
-    if (result.exitCode == 113 || result.stderr.toString().contains("Could not find service")) {
+  static bool _isMissingWindowsValue({required ProcessResult result}) {
+    if (result.exitCode != 1) {
       return false;
     }
-    _requireSuccess(executable: "launchctl", arguments: arguments, result: result);
-    return false;
+    final String output = "${result.stdout}\n${result.stderr}".toLowerCase();
+    return output.contains("unable to find the specified registry") ||
+        output.contains("cannot find the file specified");
   }
 
   void _requireSuccess({
@@ -241,18 +246,6 @@ class IoLaunchAtLogin.forTesting({
       stderr.isNotEmpty ? stderr : stdout,
       result.exitCode,
     );
-  }
-
-  static String _resolveUserId() {
-    final ProcessResult result = Process.runSync("id", <String>["-u"]);
-    if (result.exitCode != 0) {
-      throw ProcessException("id", const <String>["-u"], result.stderr.toString(), result.exitCode);
-    }
-    final String userId = result.stdout.toString().trim();
-    if (userId.isEmpty) {
-      throw StateError("Cannot register launch at login because the user id is unavailable");
-    }
-    return userId;
   }
 
   static String _resolveUserHomeDirectory() {

--- a/client/desktop/lib/core/platform/io_launch_at_login.dart
+++ b/client/desktop/lib/core/platform/io_launch_at_login.dart
@@ -1,0 +1,280 @@
+import "dart:io";
+
+import "package:flutter/foundation.dart" show visibleForTesting;
+import "package:injectable/injectable.dart";
+import "package:path/path.dart" as path;
+import "package:sesori_desktop_core/sesori_desktop_core.dart";
+
+import "desktop_launch_arguments.dart";
+
+@visibleForTesting
+typedef LaunchAtLoginProcessRunner = Future<ProcessResult> Function({
+  required String executable,
+  required List<String> arguments,
+});
+
+/// Per-user login registration for the three desktop platforms.
+///
+/// macOS and Linux use one fixed registration file; Windows uses one fixed
+/// value under the current user's Run key. Re-enabling therefore replaces the
+/// same registration instead of accumulating duplicates. Every registration
+/// launches this exact executable with [desktopHiddenLaunchArgument].
+@LazySingleton(as: LaunchAtLogin)
+class IoLaunchAtLogin.forTesting({
+  required final bool _isMacOS,
+  required final bool _isWindows,
+  required final bool _isLinux,
+  required final String _homeDirectory,
+  required final String _executablePath,
+  required final String _userId,
+  required final LaunchAtLoginProcessRunner _runProcess,
+}) implements LaunchAtLogin {
+  new()
+    : this.forTesting(
+        isMacOS: Platform.isMacOS,
+        isWindows: Platform.isWindows,
+        isLinux: Platform.isLinux,
+        homeDirectory: _resolveUserHomeDirectory(),
+        executablePath: Platform.resolvedExecutable,
+        userId: Platform.isMacOS ? _resolveUserId() : "",
+        runProcess: ({required String executable, required List<String> arguments}) =>
+            Process.run(executable, arguments),
+      );
+
+  @visibleForTesting
+  this;
+
+  static const String _appName = "Sesori";
+  static const String _registrationId = "com.sesori.desktop";
+  static const String _windowsRunKey = r"HKCU\Software\Microsoft\Windows\CurrentVersion\Run";
+
+  File get _macOsRegistration => File(path.join(_homeDirectory, "Library", "LaunchAgents", "$_registrationId.plist"));
+
+  File get _linuxRegistration => File(path.join(_homeDirectory, ".config", "autostart", "$_registrationId.desktop"));
+
+  @override
+  Future<bool> isEnabled() async {
+    if (_isMacOS) {
+      return _fileMatches(file: _macOsRegistration, expectedContents: _macOsContents);
+    }
+    if (_isLinux) {
+      return _fileMatches(file: _linuxRegistration, expectedContents: _linuxContents);
+    }
+    if (_isWindows) {
+      return await _isWindowsEnabled();
+    }
+    throw UnsupportedError("Launch at login is unsupported on this platform");
+  }
+
+  @override
+  Future<void> enable() async {
+    if (_isMacOS) {
+      _writeRegistration(file: _macOsRegistration, contents: _macOsContents);
+      return;
+    }
+    if (_isLinux) {
+      _writeRegistration(file: _linuxRegistration, contents: _linuxContents);
+      return;
+    }
+    if (_isWindows) {
+      await _enableWindows();
+      return;
+    }
+    throw UnsupportedError("Launch at login is unsupported on this platform");
+  }
+
+  @override
+  Future<void> disable() async {
+    if (_isMacOS) {
+      await _disableMacOS();
+      return;
+    }
+    if (_isLinux) {
+      _deleteRegistration(file: _linuxRegistration);
+      return;
+    }
+    if (_isWindows) {
+      await _disableWindows();
+      return;
+    }
+    throw UnsupportedError("Launch at login is unsupported on this platform");
+  }
+
+  String get _macOsContents => <String>[
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+    '<plist version="1.0">',
+    '<dict>',
+    '  <key>Label</key>',
+    '  <string>$_registrationId</string>',
+    '  <key>ProgramArguments</key>',
+    '  <array>',
+    '    <string>${_xmlEscape(_executablePath)}</string>',
+    '    <string>$desktopHiddenLaunchArgument</string>',
+    '  </array>',
+    '  <key>RunAtLoad</key>',
+    '  <true/>',
+    '  <key>ProcessType</key>',
+    '  <string>Interactive</string>',
+    '  <key>LimitLoadToSessionType</key>',
+    '  <string>Aqua</string>',
+    '</dict>',
+    '</plist>',
+    '',
+  ].join("\n");
+
+  String get _linuxContents => <String>[
+    "[Desktop Entry]",
+    "Type=Application",
+    "Version=1.0",
+    "Name=$_appName",
+    "Exec=${_desktopEntryQuote(_executablePath)} ${_desktopEntryQuote(desktopHiddenLaunchArgument)}",
+    "Terminal=false",
+    "StartupNotify=false",
+    "X-GNOME-Autostart-enabled=true",
+    "",
+  ].join("\n");
+
+  String get _windowsCommand => '"${_executablePath.replaceAll('"', r'\"')}" $desktopHiddenLaunchArgument';
+
+  bool _fileMatches({required File file, required String expectedContents}) {
+    if (!file.existsSync()) {
+      return false;
+    }
+    return file.readAsStringSync() == expectedContents;
+  }
+
+  void _writeRegistration({required File file, required String contents}) {
+    if (_fileMatches(file: file, expectedContents: contents)) {
+      return;
+    }
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(contents, flush: true);
+  }
+
+  void _deleteRegistration({required File file}) {
+    if (file.existsSync()) {
+      file.deleteSync();
+    }
+  }
+
+  Future<ProcessResult> _queryWindows() =>
+      _runProcess(executable: "reg.exe", arguments: <String>["QUERY", _windowsRunKey, "/v", _appName]);
+
+  Future<bool> _isWindowsEnabled() async {
+    final ProcessResult result = await _queryWindows();
+    return result.exitCode == 0 && result.stdout.toString().contains(_windowsCommand);
+  }
+
+  Future<bool> _windowsValueExists() async {
+    final ProcessResult result = await _queryWindows();
+    return result.exitCode == 0;
+  }
+
+  Future<void> _enableWindows() async {
+    if (await _isWindowsEnabled()) {
+      return;
+    }
+    final List<String> arguments = <String>[
+      "ADD",
+      _windowsRunKey,
+      "/v",
+      _appName,
+      "/t",
+      "REG_SZ",
+      "/d",
+      _windowsCommand,
+      "/f",
+    ];
+    final ProcessResult result = await _runProcess(executable: "reg.exe", arguments: arguments);
+    _requireSuccess(executable: "reg.exe", arguments: arguments, result: result);
+  }
+
+  Future<void> _disableWindows() async {
+    if (!await _windowsValueExists()) {
+      return;
+    }
+    final List<String> arguments = <String>["DELETE", _windowsRunKey, "/v", _appName, "/f"];
+    final ProcessResult result = await _runProcess(executable: "reg.exe", arguments: arguments);
+    _requireSuccess(executable: "reg.exe", arguments: arguments, result: result);
+  }
+
+  Future<void> _disableMacOS() async {
+    final File registration = _macOsRegistration;
+    if (!registration.existsSync()) {
+      return;
+    }
+    if (await _isMacOSLoaded()) {
+      final List<String> arguments = <String>["bootout", "gui/$_userId/$_registrationId"];
+      final ProcessResult result = await _runProcess(executable: "launchctl", arguments: arguments);
+      _requireSuccess(executable: "launchctl", arguments: arguments, result: result);
+    }
+    _deleteRegistration(file: registration);
+  }
+
+  Future<bool> _isMacOSLoaded() async {
+    final List<String> arguments = <String>["print", "gui/$_userId/$_registrationId"];
+    final ProcessResult result = await _runProcess(executable: "launchctl", arguments: arguments);
+    if (result.exitCode == 0) {
+      return true;
+    }
+    if (result.exitCode == 113 || result.stderr.toString().contains("Could not find service")) {
+      return false;
+    }
+    _requireSuccess(executable: "launchctl", arguments: arguments, result: result);
+    return false;
+  }
+
+  void _requireSuccess({
+    required String executable,
+    required List<String> arguments,
+    required ProcessResult result,
+  }) {
+    if (result.exitCode == 0) {
+      return;
+    }
+    final String stderr = result.stderr.toString().trim();
+    final String stdout = result.stdout.toString().trim();
+    throw ProcessException(
+      executable,
+      arguments,
+      stderr.isNotEmpty ? stderr : stdout,
+      result.exitCode,
+    );
+  }
+
+  static String _resolveUserId() {
+    final ProcessResult result = Process.runSync("id", <String>["-u"]);
+    if (result.exitCode != 0) {
+      throw ProcessException("id", const <String>["-u"], result.stderr.toString(), result.exitCode);
+    }
+    final String userId = result.stdout.toString().trim();
+    if (userId.isEmpty) {
+      throw StateError("Cannot register launch at login because the user id is unavailable");
+    }
+    return userId;
+  }
+
+  static String _resolveUserHomeDirectory() {
+    final List<String> keys = Platform.isWindows
+        ? const <String>["USERPROFILE", "HOME"]
+        : const <String>["HOME", "USERPROFILE"];
+    for (final String key in keys) {
+      final String? value = Platform.environment[key]?.trim();
+      if (value != null && value.isNotEmpty) {
+        return value;
+      }
+    }
+    throw StateError("Cannot register launch at login because the user home directory is unavailable");
+  }
+
+  static String _xmlEscape(String value) => value
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&apos;");
+
+  static String _desktopEntryQuote(String value) =>
+      '"${value.replaceAll(r"\", r"\\").replaceAll('"', r'\"').replaceAll(r"$", r"\$").replaceAll("`", r"\`")}"';
+}

--- a/client/desktop/lib/core/platform/io_launch_at_login.dart
+++ b/client/desktop/lib/core/platform/io_launch_at_login.dart
@@ -58,8 +58,13 @@ class IoLaunchAtLogin.forTesting({
   File get _macOsRegistration => File(path.join(_homeDirectory, "Library", "LaunchAgents", "$_registrationId.plist"));
 
   File get _linuxRegistration => File(
-    path.join(_xdgConfigHome ?? path.join(_homeDirectory, ".config"), "autostart", "$_registrationId.desktop"),
+    path.join(_linuxConfigHome, "autostart", "$_registrationId.desktop"),
   );
+
+  String get _linuxConfigHome {
+    final String? configuredHome = _xdgConfigHome?.trim();
+    return configuredHome == null || configuredHome.isEmpty ? path.join(_homeDirectory, ".config") : configuredHome;
+  }
 
   @override
   Future<bool> isEnabled() async {

--- a/client/desktop/lib/features/home/desktop_home.dart
+++ b/client/desktop/lib/features/home/desktop_home.dart
@@ -66,6 +66,10 @@ class const DesktopHome({required final AuthUser? user, super.key}) extends Stat
                           label: "Active sessions",
                           value: state.controlStatus.activeSessionCount.toString(),
                         ),
+                        _StatusRow(
+                          label: "Launch at login",
+                          value: state.launchAtLoginEnabled ? "On" : "Off",
+                        ),
                         SizedBox(height: context.prego.spacing.xl),
                         Wrap(
                           spacing: context.prego.spacing.md,
@@ -77,6 +81,14 @@ class const DesktopHome({required final AuthUser? user, super.key}) extends Stat
                                 state.toggleTarget == BridgeProcessDesiredState.off
                                     ? "Turn Bridge Off"
                                     : "Turn Bridge On",
+                              ),
+                            ),
+                            OutlinedButton(
+                              onPressed: state.activity.locksCommands
+                                  ? null
+                                  : () => unawaited(controls.toggleLaunchAtLogin()),
+                              child: Text(
+                                state.launchAtLoginEnabled ? "Disable Launch at Login" : "Enable Launch at Login",
                               ),
                             ),
                             OutlinedButton(

--- a/client/desktop/lib/main.dart
+++ b/client/desktop/lib/main.dart
@@ -6,8 +6,10 @@ import "package:sesori_desktop_core/sesori_desktop_core.dart";
 
 import "app.dart";
 import "core/di/injection.dart";
+import "core/platform/desktop_launch_arguments.dart";
 
-Future<void> main() async {
+Future<void> main(List<String> arguments) async {
+  final bool hiddenLaunch = isDesktopHiddenLaunch(arguments: arguments);
   WidgetsFlutterBinding.ensureInitialized();
   configureDesktopDependencies();
   final DesktopStartupOrchestrator startupOrchestrator = getIt();
@@ -16,7 +18,7 @@ Future<void> main() async {
   }
 
   try {
-    await getIt<WindowHost>().initialize();
+    await getIt<WindowHost>().initialize(hidden: hiddenLaunch);
   } on Object catch (error, stackTrace) {
     try {
       await getIt.reset();
@@ -28,6 +30,6 @@ Future<void> main() async {
   // The dispatcher must own the control event stream before any service can
   // spawn a helper, or its first bootstrap token request could go unread.
   getIt<ControlMessageDispatcher>().start();
-  runApp(const SesoriDesktopApp());
+  runApp(SesoriDesktopApp(hiddenLaunch: hiddenLaunch));
   unawaited(startupOrchestrator.restoreBridgeDesiredState());
 }

--- a/client/desktop/linux/runner/my_application.cc
+++ b/client/desktop/linux/runner/my_application.cc
@@ -10,13 +10,28 @@
 struct _MyApplication {
   GtkApplication parent_instance;
   char** dart_entrypoint_arguments;
+  gboolean hidden_launch;
 };
 
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
 
+static constexpr char kHiddenLaunchArgument[] = "--hidden";
+
+static gboolean has_hidden_launch_argument(char** arguments) {
+  for (char** argument = arguments; argument != nullptr && *argument != nullptr;
+       ++argument) {
+    if (g_strcmp0(*argument, kHiddenLaunchArgument) == 0) {
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
 // Called when first Flutter frame received.
 static void first_frame_cb(MyApplication* self, FlView* view) {
-  gtk_widget_show(gtk_widget_get_toplevel(GTK_WIDGET(view)));
+  if (!self->hidden_launch) {
+    gtk_widget_show(gtk_widget_get_toplevel(GTK_WIDGET(view)));
+  }
 }
 
 // Implements GApplication::activate.
@@ -67,7 +82,7 @@ static void my_application_activate(GApplication* application) {
   gtk_widget_show(GTK_WIDGET(view));
   gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
 
-  // Show the window when Flutter renders.
+  // Show the window when Flutter renders unless this is a hidden login launch.
   // Requires the view to be realized so we can start rendering.
   g_signal_connect_swapped(view, "first-frame", G_CALLBACK(first_frame_cb),
                            self);
@@ -85,6 +100,7 @@ static gboolean my_application_local_command_line(GApplication* application,
   MyApplication* self = MY_APPLICATION(application);
   // Strip out the first argument as it is the binary name.
   self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
+  self->hidden_launch = has_hidden_launch_argument(self->dart_entrypoint_arguments);
 
   g_autoptr(GError) error = nullptr;
   if (!g_application_register(application, nullptr, &error)) {
@@ -133,7 +149,9 @@ static void my_application_class_init(MyApplicationClass* klass) {
   G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
 }
 
-static void my_application_init(MyApplication* self) {}
+static void my_application_init(MyApplication* self) {
+  self->hidden_launch = FALSE;
+}
 
 MyApplication* my_application_new() {
   // Set the program name to the application ID, which helps various systems
@@ -142,7 +160,7 @@ MyApplication* my_application_new() {
   // the application to be recognized beyond its binary name.
   g_set_prgname(APPLICATION_ID);
 
-  return MY_APPLICATION(g_object_new(my_application_get_type(),
-                                     "application-id", APPLICATION_ID, "flags",
-                                     G_APPLICATION_NON_UNIQUE, nullptr));
+  return MY_APPLICATION(g_object_new(
+      my_application_get_type(), "application-id", APPLICATION_ID, "flags",
+      G_APPLICATION_NON_UNIQUE, nullptr));
 }

--- a/client/desktop/macos/Runner/MainFlutterWindow.swift
+++ b/client/desktop/macos/Runner/MainFlutterWindow.swift
@@ -3,7 +3,11 @@ import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    let flutterViewController = FlutterViewController()
+    let flutterProject = FlutterDartProject()
+    // Pass the native process arguments through explicitly so LaunchAgent
+    // startup reaches Dart with --hidden on macOS as it does on other hosts.
+    flutterProject.dartEntrypointArguments = Array(CommandLine.arguments.dropFirst())
+    let flutterViewController = FlutterViewController(project: flutterProject)
     let windowFrame = self.frame
     self.contentViewController = flutterViewController
     self.setFrame(windowFrame, display: true)

--- a/client/desktop/pubspec.yaml
+++ b/client/desktop/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
     path: ../module_prego
   tray_manager: ^0.5.3
   url_launcher: ^6.3.2
+  win32_registry: ^3.0.3
   window_manager: ^0.5.2
 
 dev_dependencies:

--- a/client/desktop/test/app_smoke_test.dart
+++ b/client/desktop/test/app_smoke_test.dart
@@ -37,8 +37,10 @@ void main() {
     getIt.registerLazySingleton<DesktopApplicationTerminator>(_FakeApplicationTerminator.new);
     getIt.unregister<WindowHost>();
     getIt.registerLazySingleton<WindowHost>(_FakeWindowHost.new);
+    getIt.unregister<LaunchAtLogin>();
+    getIt.registerLazySingleton<LaunchAtLogin>(_FakeLaunchAtLogin.new);
 
-    await tester.pumpWidget(const SesoriDesktopApp());
+    await tester.pumpWidget(const SesoriDesktopApp(hiddenLaunch: false));
     await tester.pump();
     await tester.pump();
 
@@ -72,7 +74,7 @@ class _FakeWindowHost() implements WindowHost {
   Stream<WindowHostEvent> get events => const Stream<WindowHostEvent>.empty();
 
   @override
-  Future<void> initialize() async {}
+  Future<void> initialize({required bool hidden}) async {}
 
   @override
   Future<void> show() async {}
@@ -87,4 +89,15 @@ class _FakeWindowHost() implements WindowHost {
 class _FakeApplicationTerminator() implements DesktopApplicationTerminator {
   @override
   void terminate({required int exitCode}) {}
+}
+
+class _FakeLaunchAtLogin() implements LaunchAtLogin {
+  @override
+  Future<bool> isEnabled() async => false;
+
+  @override
+  Future<void> enable() async {}
+
+  @override
+  Future<void> disable() async {}
 }

--- a/client/desktop/test/core/di/injection_test.dart
+++ b/client/desktop/test/core/di/injection_test.dart
@@ -35,6 +35,7 @@ void main() {
     expect(getIt.isRegistered<BridgeProcessService>(), isTrue);
     expect(getIt.isRegistered<ControlCommandService>(), isTrue);
     expect(getIt.isRegistered<SystemTray>(), isTrue);
+    expect(getIt.isRegistered<LaunchAtLogin>(), isTrue);
     expect(getIt.isRegistered<WindowHost>(), isTrue);
     expect(getIt.isRegistered<DesktopApplicationTerminator>(), isTrue);
     expect(getIt.isRegistered<BridgeProcessLogRepository>(), isTrue);

--- a/client/desktop/test/core/platform/desktop_launch_arguments_test.dart
+++ b/client/desktop/test/core/platform/desktop_launch_arguments_test.dart
@@ -1,0 +1,14 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:sesori_desktop/core/platform/desktop_launch_arguments.dart";
+
+void main() {
+  test("recognizes only the exact hidden launch argument", () {
+    expect(isDesktopHiddenLaunch(arguments: const <String>[]), isFalse);
+    expect(isDesktopHiddenLaunch(arguments: const <String>["hidden"]), isFalse);
+    expect(isDesktopHiddenLaunch(arguments: const <String>["--hidden=true"]), isFalse);
+    expect(
+      isDesktopHiddenLaunch(arguments: const <String>["--other", desktopHiddenLaunchArgument]),
+      isTrue,
+    );
+  });
+}

--- a/client/desktop/test/core/platform/flutter_window_host_test.dart
+++ b/client/desktop/test/core/platform/flutter_window_host_test.dart
@@ -28,7 +28,7 @@ void main() {
     final FlutterWindowHost host = FlutterWindowHost.forTesting(manager: manager);
     addTearDown(host.dispose);
 
-    await host.initialize();
+    await host.initialize(hidden: false);
     final WindowOptions options =
         verify(() => manager.waitUntilReadyToShow(captureAny())).captured.single as WindowOptions;
     final Future<WindowHostEvent> event = host.events.first;
@@ -38,6 +38,7 @@ void main() {
       () => manager.ensureInitialized(),
       () => manager.addListener(host),
       () => manager.setPreventClose(true),
+      () => manager.setSkipTaskbar(false),
       () => manager.show(),
       () => manager.focus(),
     ]);
@@ -47,10 +48,21 @@ void main() {
     expect(await event, WindowHostEvent.closeRequested);
   });
 
+  test("hidden initialization never shows or focuses the window", () async {
+    final FlutterWindowHost host = FlutterWindowHost.forTesting(manager: manager);
+    addTearDown(host.dispose);
+
+    await host.initialize(hidden: true);
+
+    verify(() => manager.setSkipTaskbar(true)).called(1);
+    verifyNever(manager.show);
+    verifyNever(manager.focus);
+  });
+
   test("show focuses the restored window and hide delegates to the plugin", () async {
     final FlutterWindowHost host = FlutterWindowHost.forTesting(manager: manager);
     addTearDown(host.dispose);
-    await host.initialize();
+    await host.initialize(hidden: false);
     clearInteractions(manager);
     when(manager.show).thenAnswer((_) async {});
     when(manager.focus).thenAnswer((_) async {});
@@ -72,7 +84,7 @@ void main() {
     final FlutterWindowHost host = FlutterWindowHost.forTesting(manager: manager);
     when(() => manager.waitUntilReadyToShow(any())).thenThrow(StateError("native window unavailable"));
 
-    await expectLater(host.initialize(), throwsStateError);
+    await expectLater(host.initialize(hidden: false), throwsStateError);
 
     verify(() => manager.removeListener(host)).called(1);
     verify(() => manager.setPreventClose(false)).called(1);
@@ -81,7 +93,7 @@ void main() {
 
   test("dispose removes its listener and restores native close behavior", () async {
     final FlutterWindowHost host = FlutterWindowHost.forTesting(manager: manager);
-    await host.initialize();
+    await host.initialize(hidden: false);
 
     await host.dispose();
 

--- a/client/desktop/test/core/platform/io_launch_at_login_test.dart
+++ b/client/desktop/test/core/platform/io_launch_at_login_test.dart
@@ -17,15 +17,14 @@ void main() {
     });
 
     test("macOS writes one launch agent with the hidden argument and removes it", () async {
-      final _FakeMacOSLaunchctl launchctl = _FakeMacOSLaunchctl(loaded: false);
       final IoLaunchAtLogin launchAtLogin = IoLaunchAtLogin.forTesting(
         isMacOS: true,
         isWindows: false,
         isLinux: false,
         homeDirectory: temporaryDirectory.path,
+        xdgConfigHome: null,
         executablePath: "${temporaryDirectory.path}/Sesori & Tools.app/Contents/MacOS/Sesori",
-        userId: "501",
-        runProcess: launchctl.run,
+        runProcess: _unusedProcessRunner,
       );
 
       await launchAtLogin.enable();
@@ -44,25 +43,20 @@ void main() {
       expect(await launchAtLogin.isEnabled(), isFalse);
     });
 
-    test("macOS unloads a loaded launch agent before deleting its registration", () async {
-      final _FakeMacOSLaunchctl launchctl = _FakeMacOSLaunchctl(loaded: true);
+    test("macOS disables login without booting out the current app", () async {
       final IoLaunchAtLogin launchAtLogin = IoLaunchAtLogin.forTesting(
         isMacOS: true,
         isWindows: false,
         isLinux: false,
         homeDirectory: temporaryDirectory.path,
+        xdgConfigHome: null,
         executablePath: "${temporaryDirectory.path}/Sesori",
-        userId: "501",
-        runProcess: launchctl.run,
+        runProcess: _unusedProcessRunner,
       );
 
       await launchAtLogin.enable();
       await launchAtLogin.disable();
 
-      expect(launchctl.commands, <List<String>>[
-        <String>["print", "gui/501/com.sesori.desktop"],
-        <String>["bootout", "gui/501/com.sesori.desktop"],
-      ]);
       expect(await launchAtLogin.isEnabled(), isFalse);
     });
 
@@ -72,8 +66,8 @@ void main() {
         isWindows: false,
         isLinux: true,
         homeDirectory: temporaryDirectory.path,
+        xdgConfigHome: null,
         executablePath: "${temporaryDirectory.path}/Sesori Desktop",
-        userId: "501",
         runProcess: _unusedProcessRunner,
       );
 
@@ -92,6 +86,30 @@ void main() {
       expect(await launchAtLogin.isEnabled(), isFalse);
     });
 
+    test("Linux honors XDG_CONFIG_HOME for autostart registration", () async {
+      final String xdgConfigHome = "${temporaryDirectory.path}/xdg-config";
+      final IoLaunchAtLogin launchAtLogin = IoLaunchAtLogin.forTesting(
+        isMacOS: false,
+        isWindows: false,
+        isLinux: true,
+        homeDirectory: temporaryDirectory.path,
+        xdgConfigHome: xdgConfigHome,
+        executablePath: "${temporaryDirectory.path}/Sesori",
+        runProcess: _unusedProcessRunner,
+      );
+
+      await launchAtLogin.enable();
+
+      expect(
+        File("$xdgConfigHome/autostart/com.sesori.desktop.desktop").existsSync(),
+        isTrue,
+      );
+      expect(
+        File("${temporaryDirectory.path}/.config/autostart/com.sesori.desktop.desktop").existsSync(),
+        isFalse,
+      );
+    });
+
     test("a stale file is disabled until enable replaces its executable", () async {
       final File registration = File(
         "${temporaryDirectory.path}/.config/autostart/com.sesori.desktop.desktop",
@@ -103,8 +121,8 @@ void main() {
         isWindows: false,
         isLinux: true,
         homeDirectory: temporaryDirectory.path,
+        xdgConfigHome: null,
         executablePath: "${temporaryDirectory.path}/Sesori",
-        userId: "501",
         runProcess: _unusedProcessRunner,
       );
 
@@ -121,8 +139,8 @@ void main() {
         isWindows: true,
         isLinux: false,
         homeDirectory: temporaryDirectory.path,
+        xdgConfigHome: null,
         executablePath: r"C:\Program Files\Sesori\Sesori.exe",
-        userId: "501",
         runProcess: registry.run,
       );
 
@@ -132,6 +150,23 @@ void main() {
       expect(registry.deleteCalls, 1);
     });
 
+    test("Windows surfaces registry query failures", () async {
+      final _FakeWindowsRegistry registry = _FakeWindowsRegistry(queryError: true);
+      final IoLaunchAtLogin launchAtLogin = IoLaunchAtLogin.forTesting(
+        isMacOS: false,
+        isWindows: true,
+        isLinux: false,
+        homeDirectory: temporaryDirectory.path,
+        xdgConfigHome: null,
+        executablePath: r"C:\Program Files\Sesori\Sesori.exe",
+        runProcess: registry.run,
+      );
+
+      await expectLater(launchAtLogin.isEnabled(), throwsA(isA<ProcessException>()));
+      await expectLater(launchAtLogin.disable(), throwsA(isA<ProcessException>()));
+      expect(registry.deleteCalls, 0);
+    });
+
     test("Windows owns one Run value containing the hidden argument", () async {
       final _FakeWindowsRegistry registry = _FakeWindowsRegistry();
       final IoLaunchAtLogin launchAtLogin = IoLaunchAtLogin.forTesting(
@@ -139,8 +174,8 @@ void main() {
         isWindows: true,
         isLinux: false,
         homeDirectory: temporaryDirectory.path,
+        xdgConfigHome: null,
         executablePath: r"C:\Program Files\Sesori\Sesori.exe",
-        userId: "501",
         runProcess: registry.run,
       );
 
@@ -163,20 +198,7 @@ void main() {
 Future<ProcessResult> _unusedProcessRunner({required String executable, required List<String> arguments}) =>
     throw StateError("The process runner must not be used");
 
-class _FakeMacOSLaunchctl({required final bool loaded}) {
-  final List<List<String>> commands = <List<String>>[];
-
-  Future<ProcessResult> run({required String executable, required List<String> arguments}) async {
-    expect(executable, "launchctl");
-    commands.add(arguments);
-    if (arguments.first == "print") {
-      return ProcessResult(1, loaded ? 0 : 113, "", loaded ? "" : "Could not find service");
-    }
-    return ProcessResult(1, 0, "", "");
-  }
-}
-
-class _FakeWindowsRegistry() {
+class _FakeWindowsRegistry({final bool queryError = false}) {
   String? value;
   int addCalls = 0;
   int deleteCalls = 0;
@@ -185,8 +207,16 @@ class _FakeWindowsRegistry() {
     expect(executable, "reg.exe");
     switch (arguments.first) {
       case "QUERY":
+        if (queryError) {
+          return ProcessResult(1, 1, "", "ERROR: Access is denied.");
+        }
         final String? stored = value;
-        return ProcessResult(1, stored == null ? 1 : 0, stored == null ? "" : "REG_SZ    $stored", "");
+        return ProcessResult(
+          1,
+          stored == null ? 1 : 0,
+          stored == null ? "" : "REG_SZ    $stored",
+          stored == null ? "ERROR: The system was unable to find the specified registry key or value." : "",
+        );
       case "ADD":
         addCalls++;
         value = arguments[arguments.indexOf("/d") + 1];

--- a/client/desktop/test/core/platform/io_launch_at_login_test.dart
+++ b/client/desktop/test/core/platform/io_launch_at_login_test.dart
@@ -114,6 +114,26 @@ void main() {
       );
     });
 
+    test("Linux treats an empty XDG_CONFIG_HOME as unset", () async {
+      final IoLaunchAtLogin launchAtLogin = IoLaunchAtLogin.forTesting(
+        isMacOS: false,
+        isWindows: false,
+        isLinux: true,
+        homeDirectory: temporaryDirectory.path,
+        xdgConfigHome: "  ",
+        executablePath: "${temporaryDirectory.path}/Sesori",
+        windowsValueReader: _unusedWindowsValueReader,
+        runProcess: _unusedProcessRunner,
+      );
+
+      await launchAtLogin.enable();
+
+      expect(
+        File("${temporaryDirectory.path}/.config/autostart/com.sesori.desktop.desktop").existsSync(),
+        isTrue,
+      );
+    });
+
     test("Linux escapes percent field codes in autostart paths", () async {
       final String executablePath = "${temporaryDirectory.path}/Sesori %f";
       final IoLaunchAtLogin launchAtLogin = IoLaunchAtLogin.forTesting(

--- a/client/desktop/test/core/platform/io_launch_at_login_test.dart
+++ b/client/desktop/test/core/platform/io_launch_at_login_test.dart
@@ -24,6 +24,7 @@ void main() {
         homeDirectory: temporaryDirectory.path,
         xdgConfigHome: null,
         executablePath: "${temporaryDirectory.path}/Sesori & Tools.app/Contents/MacOS/Sesori",
+        windowsValueReader: _unusedWindowsValueReader,
         runProcess: _unusedProcessRunner,
       );
 
@@ -51,6 +52,7 @@ void main() {
         homeDirectory: temporaryDirectory.path,
         xdgConfigHome: null,
         executablePath: "${temporaryDirectory.path}/Sesori",
+        windowsValueReader: _unusedWindowsValueReader,
         runProcess: _unusedProcessRunner,
       );
 
@@ -68,6 +70,7 @@ void main() {
         homeDirectory: temporaryDirectory.path,
         xdgConfigHome: null,
         executablePath: "${temporaryDirectory.path}/Sesori Desktop",
+        windowsValueReader: _unusedWindowsValueReader,
         runProcess: _unusedProcessRunner,
       );
 
@@ -95,6 +98,7 @@ void main() {
         homeDirectory: temporaryDirectory.path,
         xdgConfigHome: xdgConfigHome,
         executablePath: "${temporaryDirectory.path}/Sesori",
+        windowsValueReader: _unusedWindowsValueReader,
         runProcess: _unusedProcessRunner,
       );
 
@@ -110,6 +114,27 @@ void main() {
       );
     });
 
+    test("Linux escapes percent field codes in autostart paths", () async {
+      final String executablePath = "${temporaryDirectory.path}/Sesori %f";
+      final IoLaunchAtLogin launchAtLogin = IoLaunchAtLogin.forTesting(
+        isMacOS: false,
+        isWindows: false,
+        isLinux: true,
+        homeDirectory: temporaryDirectory.path,
+        xdgConfigHome: null,
+        executablePath: executablePath,
+        windowsValueReader: _unusedWindowsValueReader,
+        runProcess: _unusedProcessRunner,
+      );
+
+      await launchAtLogin.enable();
+
+      final File registration = File(
+        "${temporaryDirectory.path}/.config/autostart/com.sesori.desktop.desktop",
+      );
+      expect(await registration.readAsString(), contains('Exec="${temporaryDirectory.path}/Sesori %%f" "--hidden"'));
+    });
+
     test("a stale file is disabled until enable replaces its executable", () async {
       final File registration = File(
         "${temporaryDirectory.path}/.config/autostart/com.sesori.desktop.desktop",
@@ -123,6 +148,7 @@ void main() {
         homeDirectory: temporaryDirectory.path,
         xdgConfigHome: null,
         executablePath: "${temporaryDirectory.path}/Sesori",
+        windowsValueReader: _unusedWindowsValueReader,
         runProcess: _unusedProcessRunner,
       );
 
@@ -141,6 +167,7 @@ void main() {
         homeDirectory: temporaryDirectory.path,
         xdgConfigHome: null,
         executablePath: r"C:\Program Files\Sesori\Sesori.exe",
+        windowsValueReader: registry.readValue,
         runProcess: registry.run,
       );
 
@@ -151,7 +178,7 @@ void main() {
     });
 
     test("Windows surfaces registry query failures", () async {
-      final _FakeWindowsRegistry registry = _FakeWindowsRegistry(queryError: true);
+      final _FakeWindowsRegistry registry = _FakeWindowsRegistry();
       final IoLaunchAtLogin launchAtLogin = IoLaunchAtLogin.forTesting(
         isMacOS: false,
         isWindows: true,
@@ -159,11 +186,12 @@ void main() {
         homeDirectory: temporaryDirectory.path,
         xdgConfigHome: null,
         executablePath: r"C:\Program Files\Sesori\Sesori.exe",
+        windowsValueReader: _throwingWindowsValueReader,
         runProcess: registry.run,
       );
 
-      await expectLater(launchAtLogin.isEnabled(), throwsA(isA<ProcessException>()));
-      await expectLater(launchAtLogin.disable(), throwsA(isA<ProcessException>()));
+      await expectLater(launchAtLogin.isEnabled(), throwsA(isA<StateError>()));
+      await expectLater(launchAtLogin.disable(), throwsA(isA<StateError>()));
       expect(registry.deleteCalls, 0);
     });
 
@@ -176,6 +204,7 @@ void main() {
         homeDirectory: temporaryDirectory.path,
         xdgConfigHome: null,
         executablePath: r"C:\Program Files\Sesori\Sesori.exe",
+        windowsValueReader: registry.readValue,
         runProcess: registry.run,
       );
 
@@ -198,25 +227,20 @@ void main() {
 Future<ProcessResult> _unusedProcessRunner({required String executable, required List<String> arguments}) =>
     throw StateError("The process runner must not be used");
 
-class _FakeWindowsRegistry({final bool queryError = false}) {
+String? _unusedWindowsValueReader() => throw StateError("The Windows registry reader must not be used");
+
+String? _throwingWindowsValueReader() => throw StateError("The Windows registry query failed");
+
+class _FakeWindowsRegistry() {
   String? value;
   int addCalls = 0;
   int deleteCalls = 0;
 
+  String? readValue() => value;
+
   Future<ProcessResult> run({required String executable, required List<String> arguments}) async {
     expect(executable, "reg.exe");
     switch (arguments.first) {
-      case "QUERY":
-        if (queryError) {
-          return ProcessResult(1, 1, "", "ERROR: Access is denied.");
-        }
-        final String? stored = value;
-        return ProcessResult(
-          1,
-          stored == null ? 1 : 0,
-          stored == null ? "" : "REG_SZ    $stored",
-          stored == null ? "ERROR: The system was unable to find the specified registry key or value." : "",
-        );
       case "ADD":
         addCalls++;
         value = arguments[arguments.indexOf("/d") + 1];

--- a/client/desktop/test/core/platform/io_launch_at_login_test.dart
+++ b/client/desktop/test/core/platform/io_launch_at_login_test.dart
@@ -1,0 +1,201 @@
+import "dart:io";
+
+import "package:flutter_test/flutter_test.dart";
+import "package:sesori_desktop/core/platform/desktop_launch_arguments.dart";
+import "package:sesori_desktop/core/platform/io_launch_at_login.dart";
+
+void main() {
+  group("IoLaunchAtLogin", () {
+    late Directory temporaryDirectory;
+
+    setUp(() async {
+      temporaryDirectory = await Directory.systemTemp.createTemp("sesori-launch-at-login-");
+    });
+
+    tearDown(() async {
+      await temporaryDirectory.delete(recursive: true);
+    });
+
+    test("macOS writes one launch agent with the hidden argument and removes it", () async {
+      final _FakeMacOSLaunchctl launchctl = _FakeMacOSLaunchctl(loaded: false);
+      final IoLaunchAtLogin launchAtLogin = IoLaunchAtLogin.forTesting(
+        isMacOS: true,
+        isWindows: false,
+        isLinux: false,
+        homeDirectory: temporaryDirectory.path,
+        executablePath: "${temporaryDirectory.path}/Sesori & Tools.app/Contents/MacOS/Sesori",
+        userId: "501",
+        runProcess: launchctl.run,
+      );
+
+      await launchAtLogin.enable();
+      await launchAtLogin.enable();
+
+      final File registration = File(
+        "${temporaryDirectory.path}/Library/LaunchAgents/com.sesori.desktop.plist",
+      );
+      final String contents = await registration.readAsString();
+      expect(await launchAtLogin.isEnabled(), isTrue);
+      expect(contents, contains("<string>--hidden</string>"));
+      expect(contents, contains("Sesori &amp; Tools.app"));
+      expect(registration.parent.listSync().whereType<File>(), hasLength(1));
+
+      await launchAtLogin.disable();
+      expect(await launchAtLogin.isEnabled(), isFalse);
+    });
+
+    test("macOS unloads a loaded launch agent before deleting its registration", () async {
+      final _FakeMacOSLaunchctl launchctl = _FakeMacOSLaunchctl(loaded: true);
+      final IoLaunchAtLogin launchAtLogin = IoLaunchAtLogin.forTesting(
+        isMacOS: true,
+        isWindows: false,
+        isLinux: false,
+        homeDirectory: temporaryDirectory.path,
+        executablePath: "${temporaryDirectory.path}/Sesori",
+        userId: "501",
+        runProcess: launchctl.run,
+      );
+
+      await launchAtLogin.enable();
+      await launchAtLogin.disable();
+
+      expect(launchctl.commands, <List<String>>[
+        <String>["print", "gui/501/com.sesori.desktop"],
+        <String>["bootout", "gui/501/com.sesori.desktop"],
+      ]);
+      expect(await launchAtLogin.isEnabled(), isFalse);
+    });
+
+    test("Linux writes one quoted XDG autostart entry and removes it", () async {
+      final IoLaunchAtLogin launchAtLogin = IoLaunchAtLogin.forTesting(
+        isMacOS: false,
+        isWindows: false,
+        isLinux: true,
+        homeDirectory: temporaryDirectory.path,
+        executablePath: "${temporaryDirectory.path}/Sesori Desktop",
+        userId: "501",
+        runProcess: _unusedProcessRunner,
+      );
+
+      await launchAtLogin.enable();
+      await launchAtLogin.enable();
+
+      final File registration = File(
+        "${temporaryDirectory.path}/.config/autostart/com.sesori.desktop.desktop",
+      );
+      final String contents = await registration.readAsString();
+      expect(await launchAtLogin.isEnabled(), isTrue);
+      expect(contents, contains('Exec="${temporaryDirectory.path}/Sesori Desktop" "--hidden"'));
+      expect(registration.parent.listSync().whereType<File>(), hasLength(1));
+
+      await launchAtLogin.disable();
+      expect(await launchAtLogin.isEnabled(), isFalse);
+    });
+
+    test("a stale file is disabled until enable replaces its executable", () async {
+      final File registration = File(
+        "${temporaryDirectory.path}/.config/autostart/com.sesori.desktop.desktop",
+      );
+      await registration.parent.create(recursive: true);
+      await registration.writeAsString("stale registration");
+      final IoLaunchAtLogin launchAtLogin = IoLaunchAtLogin.forTesting(
+        isMacOS: false,
+        isWindows: false,
+        isLinux: true,
+        homeDirectory: temporaryDirectory.path,
+        executablePath: "${temporaryDirectory.path}/Sesori",
+        userId: "501",
+        runProcess: _unusedProcessRunner,
+      );
+
+      expect(await launchAtLogin.isEnabled(), isFalse);
+      await launchAtLogin.enable();
+      expect(await launchAtLogin.isEnabled(), isTrue);
+      expect(await registration.readAsString(), contains(desktopHiddenLaunchArgument));
+    });
+
+    test("disabling Windows removes a stale Run value", () async {
+      final _FakeWindowsRegistry registry = _FakeWindowsRegistry()..value = r'"C:\old\Sesori.exe" --hidden';
+      final IoLaunchAtLogin launchAtLogin = IoLaunchAtLogin.forTesting(
+        isMacOS: false,
+        isWindows: true,
+        isLinux: false,
+        homeDirectory: temporaryDirectory.path,
+        executablePath: r"C:\Program Files\Sesori\Sesori.exe",
+        userId: "501",
+        runProcess: registry.run,
+      );
+
+      await launchAtLogin.disable();
+
+      expect(registry.value, isNull);
+      expect(registry.deleteCalls, 1);
+    });
+
+    test("Windows owns one Run value containing the hidden argument", () async {
+      final _FakeWindowsRegistry registry = _FakeWindowsRegistry();
+      final IoLaunchAtLogin launchAtLogin = IoLaunchAtLogin.forTesting(
+        isMacOS: false,
+        isWindows: true,
+        isLinux: false,
+        homeDirectory: temporaryDirectory.path,
+        executablePath: r"C:\Program Files\Sesori\Sesori.exe",
+        userId: "501",
+        runProcess: registry.run,
+      );
+
+      expect(await launchAtLogin.isEnabled(), isFalse);
+      await launchAtLogin.enable();
+      await launchAtLogin.enable();
+
+      expect(await launchAtLogin.isEnabled(), isTrue);
+      expect(registry.value, r'"C:\Program Files\Sesori\Sesori.exe" --hidden');
+      expect(registry.addCalls, 1);
+
+      await launchAtLogin.disable();
+      await launchAtLogin.disable();
+      expect(await launchAtLogin.isEnabled(), isFalse);
+      expect(registry.deleteCalls, 1);
+    });
+  });
+}
+
+Future<ProcessResult> _unusedProcessRunner({required String executable, required List<String> arguments}) =>
+    throw StateError("The process runner must not be used");
+
+class _FakeMacOSLaunchctl({required final bool loaded}) {
+  final List<List<String>> commands = <List<String>>[];
+
+  Future<ProcessResult> run({required String executable, required List<String> arguments}) async {
+    expect(executable, "launchctl");
+    commands.add(arguments);
+    if (arguments.first == "print") {
+      return ProcessResult(1, loaded ? 0 : 113, "", loaded ? "" : "Could not find service");
+    }
+    return ProcessResult(1, 0, "", "");
+  }
+}
+
+class _FakeWindowsRegistry() {
+  String? value;
+  int addCalls = 0;
+  int deleteCalls = 0;
+
+  Future<ProcessResult> run({required String executable, required List<String> arguments}) async {
+    expect(executable, "reg.exe");
+    switch (arguments.first) {
+      case "QUERY":
+        final String? stored = value;
+        return ProcessResult(1, stored == null ? 1 : 0, stored == null ? "" : "REG_SZ    $stored", "");
+      case "ADD":
+        addCalls++;
+        value = arguments[arguments.indexOf("/d") + 1];
+        return ProcessResult(1, 0, "", "");
+      case "DELETE":
+        deleteCalls++;
+        value = null;
+        return ProcessResult(1, 0, "", "");
+    }
+    throw StateError("Unexpected registry command: ${arguments.first}");
+  }
+}

--- a/client/desktop/test/features/auth_gate/auth_gate_view_test.dart
+++ b/client/desktop/test/features/auth_gate/auth_gate_view_test.dart
@@ -38,6 +38,7 @@ void main() {
         processState: const BridgeProcessStopped(),
         desiredState: BridgeProcessDesiredState.off,
         toggleTarget: BridgeProcessDesiredState.on,
+        launchAtLoginEnabled: false,
         controlStatus: BridgeControlStatus.offline,
       ),
     );

--- a/client/desktop/test/features/home/desktop_home_test.dart
+++ b/client/desktop/test/features/home/desktop_home_test.dart
@@ -23,6 +23,7 @@ void main() {
     bridgeControlCubit = _MockBridgeControlCubit();
     authGateCubit = _MockAuthGateCubit();
     when(() => bridgeControlCubit.toggleBridge()).thenAnswer((_) async {});
+    when(() => bridgeControlCubit.toggleLaunchAtLogin()).thenAnswer((_) async {});
     when(() => bridgeControlCubit.openLogs()).thenAnswer((_) async {});
     when(() => authGateCubit.signOut()).thenAnswer((_) async {});
   });
@@ -72,12 +73,16 @@ void main() {
     expect(find.text("Healthy"), findsOneWidget);
     expect(find.text("2"), findsOneWidget);
     expect(find.text("Turn Bridge Off"), findsOneWidget);
+    expect(find.text("Launch at login"), findsOneWidget);
+    expect(find.text("Enable Launch at Login"), findsOneWidget);
 
     await tester.tap(find.text("Turn Bridge Off"));
+    await tester.tap(find.text("Enable Launch at Login"));
     await tester.tap(find.text("Open Logs"));
     await tester.tap(find.text("Sign out"));
 
     verify(() => bridgeControlCubit.toggleBridge()).called(1);
+    verify(() => bridgeControlCubit.toggleLaunchAtLogin()).called(1);
     verify(() => bridgeControlCubit.openLogs()).called(1);
     verify(() => authGateCubit.signOut()).called(1);
   });
@@ -123,6 +128,7 @@ BridgeControlState _state({
   toggleTarget: desiredState == BridgeProcessDesiredState.on
       ? BridgeProcessDesiredState.off
       : BridgeProcessDesiredState.on,
+  launchAtLoginEnabled: false,
   controlStatus: status,
 );
 

--- a/client/desktop/windows/runner/flutter_window.cpp
+++ b/client/desktop/windows/runner/flutter_window.cpp
@@ -4,8 +4,9 @@
 
 #include "flutter/generated_plugin_registrant.h"
 
-FlutterWindow::FlutterWindow(const flutter::DartProject& project)
-    : project_(project) {}
+FlutterWindow::FlutterWindow(const flutter::DartProject& project,
+                             bool hidden_launch)
+    : project_(project), hidden_launch_(hidden_launch) {}
 
 FlutterWindow::~FlutterWindow() {}
 
@@ -27,13 +28,15 @@ bool FlutterWindow::OnCreate() {
   RegisterPlugins(flutter_controller_->engine());
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
 
-  flutter_controller_->engine()->SetNextFrameCallback([&]() {
-    this->Show();
+  flutter_controller_->engine()->SetNextFrameCallback([this]() {
+    if (!hidden_launch_) {
+      Show();
+    }
   });
 
-  // Flutter can complete the first frame before the "show window" callback is
-  // registered. The following call ensures a frame is pending to ensure the
-  // window is shown. It is a no-op if the first frame hasn't completed yet.
+  // Flutter can complete the first frame before the callback is registered.
+  // The following call ensures a frame is pending so visible launches are
+  // shown. It is a no-op if the first frame hasn't completed yet.
   flutter_controller_->ForceRedraw();
 
   return true;

--- a/client/desktop/windows/runner/flutter_window.h
+++ b/client/desktop/windows/runner/flutter_window.h
@@ -12,7 +12,7 @@
 class FlutterWindow : public Win32Window {
  public:
   // Creates a new FlutterWindow hosting a Flutter view running |project|.
-  explicit FlutterWindow(const flutter::DartProject& project);
+  explicit FlutterWindow(const flutter::DartProject& project, bool hidden_launch);
   virtual ~FlutterWindow();
 
  protected:
@@ -25,6 +25,9 @@ class FlutterWindow : public Win32Window {
  private:
   // The project to run.
   flutter::DartProject project_;
+
+  // Whether the process was started by the hidden login registration.
+  bool hidden_launch_;
 
   // The Flutter instance hosted by this window.
   std::unique_ptr<flutter::FlutterViewController> flutter_controller_;

--- a/client/desktop/windows/runner/main.cpp
+++ b/client/desktop/windows/runner/main.cpp
@@ -5,6 +5,21 @@
 #include "flutter_window.h"
 #include "utils.h"
 
+namespace {
+
+constexpr char kHiddenLaunchArgument[] = "--hidden";
+
+bool HasHiddenLaunchArgument(const std::vector<std::string>& arguments) {
+  for (const std::string& argument : arguments) {
+    if (argument == kHiddenLaunchArgument) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command) {
   // Attach to console when present (e.g., 'flutter run') or create a
@@ -22,9 +37,10 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   std::vector<std::string> command_line_arguments =
       GetCommandLineArguments();
 
+  const bool hidden_launch = HasHiddenLaunchArgument(command_line_arguments);
   project.set_dart_entrypoint_arguments(std::move(command_line_arguments));
 
-  FlutterWindow window(project);
+  FlutterWindow window(project, hidden_launch);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
   if (!window.Create(L"Sesori", origin, size)) {

--- a/client/module_desktop_core/lib/sesori_desktop_core.dart
+++ b/client/module_desktop_core/lib/sesori_desktop_core.dart
@@ -22,6 +22,7 @@ export "src/foundation/control_channel_server.dart";
 export "src/foundation/platform/bridge_executable_path_resolver.dart";
 export "src/foundation/platform/desktop_application_support_directory.dart";
 export "src/foundation/platform/desktop_application_terminator.dart";
+export "src/foundation/platform/launch_at_login.dart";
 export "src/foundation/platform/system_tray.dart";
 export "src/foundation/platform/window_host.dart";
 export "src/orchestration/desktop_logout_orchestrator.dart";

--- a/client/module_desktop_core/lib/src/cubits/bridge_control/bridge_control_cubit.dart
+++ b/client/module_desktop_core/lib/src/cubits/bridge_control/bridge_control_cubit.dart
@@ -6,6 +6,7 @@ import "package:sesori_shared/sesori_shared.dart";
 
 import "../../foundation/bridge_process_desired_state.dart";
 import "../../foundation/platform/desktop_application_terminator.dart";
+import "../../foundation/platform/launch_at_login.dart";
 import "../../foundation/platform/system_tray.dart";
 import "../../foundation/platform/window_host.dart";
 import "../../repositories/bridge_process_log_repository.dart";
@@ -21,8 +22,9 @@ import "bridge_control_state.dart";
 ///
 /// Platform adapters only render [SystemTrayMenu], emit typed events, and
 /// perform native window operations. This cubit derives presentation from
-/// Layer-2/3 snapshots, sequences On/Off, and exits only after expected bridge
-/// teardown succeeds.
+/// Layer-2/3 snapshots, sequences bridge and launch-at-login actions, applies
+/// hidden-startup tray fallback, and exits only after expected bridge teardown
+/// succeeds.
 class BridgeControlCubit._create({
   required final BridgeProcessService _processService,
   required final BridgeStatusTracker _statusTracker,
@@ -33,6 +35,8 @@ class BridgeControlCubit._create({
   required final DesktopInstanceService _instanceService,
   required final DesktopLogoutTracker _logoutTracker,
   required final UrlLauncher _urlLauncher,
+  required final LaunchAtLogin _launchAtLogin,
+  required final bool _hiddenLaunch,
 }) extends Cubit<BridgeControlState> {
   new({
     required BridgeProcessService processService,
@@ -44,6 +48,8 @@ class BridgeControlCubit._create({
     required DesktopInstanceService instanceService,
     required DesktopLogoutTracker logoutTracker,
     required UrlLauncher urlLauncher,
+    required LaunchAtLogin launchAtLogin,
+    required bool hiddenLaunch,
   }) : this._create(
          processService: processService,
          statusTracker: statusTracker,
@@ -54,6 +60,8 @@ class BridgeControlCubit._create({
          instanceService: instanceService,
          logoutTracker: logoutTracker,
          urlLauncher: urlLauncher,
+         launchAtLogin: launchAtLogin,
+         hiddenLaunch: hiddenLaunch,
        );
 
   this
@@ -67,6 +75,7 @@ class BridgeControlCubit._create({
             activity: _logoutTracker.status.locksBridgeControls
                 ? BridgeControlActivity.signingOut
                 : BridgeControlActivity.idle,
+            launchAtLoginEnabled: false,
           ),
           activity: _logoutTracker.status.locksBridgeControls
               ? BridgeControlActivity.signingOut
@@ -78,6 +87,7 @@ class BridgeControlCubit._create({
             processState: _processService.state,
             desiredState: _processService.desiredState,
           ),
+          launchAtLoginEnabled: false,
           controlStatus: _statusTracker.status,
         ),
       );
@@ -92,6 +102,7 @@ class BridgeControlCubit._create({
   BridgeControlActivity _activity = BridgeControlActivity.idle;
   DesktopLogoutStatus _logoutStatus = DesktopLogoutStatus.idle;
   bool _quitAfterActivity = false;
+  bool _launchAtLoginEnabled = false;
   bool _initialized = false;
 
   Future<void> initialize() async {
@@ -106,6 +117,8 @@ class BridgeControlCubit._create({
     _logoutSubscription = _logoutTracker.statuses.listen(_onLogoutStatus);
     _focusRequestSubscription = _instanceService.focusRequests.listen((_) => unawaited(showWindow()));
 
+    await _loadLaunchAtLoginState();
+
     final SystemTrayAvailability availability;
     try {
       availability = await _systemTray.initialize(menu: state.menu);
@@ -114,6 +127,7 @@ class BridgeControlCubit._create({
       if (!isClosed) {
         _trayAvailability = SystemTrayAvailability.unavailable;
         _rebuildMenu(syncTray: false);
+        await _showWindowForUnavailableHiddenLaunch();
       }
       return;
     }
@@ -126,6 +140,9 @@ class BridgeControlCubit._create({
       logw("System tray host is unavailable; keeping the desktop window visible");
     }
     _rebuildMenu(syncTray: false);
+    if (!availability.isAvailable) {
+      await _showWindowForUnavailableHiddenLaunch();
+    }
     if (availability.isAvailable) {
       await _setMenu(menu: state.menu);
     }
@@ -138,6 +155,10 @@ class BridgeControlCubit._create({
       case SystemTrayCommand.toggleBridge:
         if (!_controlsLocked) {
           unawaited(toggleBridge());
+        }
+      case SystemTrayCommand.toggleLaunchAtLogin:
+        if (!_controlsLocked) {
+          unawaited(toggleLaunchAtLogin());
         }
       case SystemTrayCommand.quit:
         if (!_controlsLocked) {
@@ -164,6 +185,8 @@ class BridgeControlCubit._create({
             _quitAfterActivity = true;
           case BridgeControlActivity.signingOut:
             _quitAfterActivity = true;
+          case BridgeControlActivity.configuringLaunchAtLogin:
+            _quitAfterActivity = true;
           case BridgeControlActivity.quitting:
             return;
         }
@@ -180,6 +203,23 @@ class BridgeControlCubit._create({
   }
 
   bool get _controlsLocked => _activity.locksCommands || _logoutTracker.status.locksBridgeControls;
+
+  Future<void> _loadLaunchAtLoginState() async {
+    try {
+      _launchAtLoginEnabled = await _launchAtLogin.isEnabled();
+    } on Object catch (error, stackTrace) {
+      logw("Failed to read the desktop launch-at-login state", error, stackTrace);
+    }
+    if (!isClosed) {
+      _rebuildMenu(syncTray: false);
+    }
+  }
+
+  Future<void> _showWindowForUnavailableHiddenLaunch() async {
+    if (_hiddenLaunch) {
+      await showWindow();
+    }
+  }
 
   BridgeControlActivity get _presentationActivity =>
       _logoutStatus.locksBridgeControls ? BridgeControlActivity.signingOut : _activity;
@@ -227,6 +267,34 @@ class BridgeControlCubit._create({
       await _windowHost.hide();
     } on Object catch (error, stackTrace) {
       logw("Failed to hide the desktop window", error, stackTrace);
+    }
+  }
+
+  Future<void> toggleLaunchAtLogin() async {
+    if (_controlsLocked) {
+      return;
+    }
+    _activity = BridgeControlActivity.configuringLaunchAtLogin;
+    _rebuildMenu();
+    final bool target = !_launchAtLoginEnabled;
+    try {
+      if (target) {
+        await _launchAtLogin.enable();
+      } else {
+        await _launchAtLogin.disable();
+      }
+      _launchAtLoginEnabled = target;
+    } on Object catch (error, stackTrace) {
+      logw("Launch-at-login command failed", error, stackTrace);
+    } finally {
+      if (!isClosed) {
+        _activity = BridgeControlActivity.idle;
+        _rebuildMenu();
+        if (_quitAfterActivity) {
+          _quitAfterActivity = false;
+          _onWindowEvent(event: WindowHostEvent.closeRequested);
+        }
+      }
     }
   }
 
@@ -297,6 +365,7 @@ class BridgeControlCubit._create({
       desiredState: desiredState,
       status: controlStatus,
       activity: activity,
+      launchAtLoginEnabled: _launchAtLoginEnabled,
     );
     emit(
       BridgeControlState(
@@ -307,6 +376,7 @@ class BridgeControlCubit._create({
         processState: processState,
         desiredState: desiredState,
         toggleTarget: _toggleTarget(processState: processState, desiredState: desiredState),
+        launchAtLoginEnabled: _launchAtLoginEnabled,
         controlStatus: controlStatus,
       ),
     );
@@ -328,6 +398,7 @@ class BridgeControlCubit._create({
     required BridgeProcessDesiredState desiredState,
     required BridgeControlStatus status,
     required BridgeControlActivity activity,
+    required bool launchAtLoginEnabled,
   }) {
     final BridgeProcessDesiredState toggleTarget = _toggleTarget(
       processState: processState,
@@ -349,6 +420,13 @@ class BridgeControlCubit._create({
         SystemTrayCommandItem(
           command: SystemTrayCommand.toggleBridge,
           label: toggleTarget == BridgeProcessDesiredState.off ? "Turn Bridge Off" : "Turn Bridge On",
+          enabled: !activity.locksCommands,
+        ),
+        const SystemTraySeparator(),
+        SystemTrayTextItem(label: "Launch at login: ${launchAtLoginEnabled ? "On" : "Off"}"),
+        SystemTrayCommandItem(
+          command: SystemTrayCommand.toggleLaunchAtLogin,
+          label: launchAtLoginEnabled ? "Disable Launch at Login" : "Enable Launch at Login",
           enabled: !activity.locksCommands,
         ),
         const SystemTraySeparator(),

--- a/client/module_desktop_core/lib/src/cubits/bridge_control/bridge_control_state.dart
+++ b/client/module_desktop_core/lib/src/cubits/bridge_control/bridge_control_state.dart
@@ -8,10 +8,12 @@ enum BridgeControlActivity({required final bool locksCommands}) {
   idle(locksCommands: false),
   toggling(locksCommands: true),
   signingOut(locksCommands: true),
+  configuringLaunchAtLogin(locksCommands: true),
   quitting(locksCommands: true),
 }
 
-/// Current tray and window presentation state for bridge supervision.
+/// Current tray, launch-at-login, and window presentation state for bridge
+/// supervision.
 class const BridgeControlState({
   required final SystemTrayAvailability trayAvailability,
   required final SystemTrayMenu menu,
@@ -20,5 +22,6 @@ class const BridgeControlState({
   required final BridgeProcessState processState,
   required final BridgeProcessDesiredState desiredState,
   required final BridgeProcessDesiredState toggleTarget,
+  required final bool launchAtLoginEnabled,
   required final BridgeControlStatus controlStatus,
 });

--- a/client/module_desktop_core/lib/src/foundation/platform/launch_at_login.dart
+++ b/client/module_desktop_core/lib/src/foundation/platform/launch_at_login.dart
@@ -1,0 +1,9 @@
+/// Layer-0 capability for registering the desktop application to launch at
+/// the current user's next login.
+abstract interface class LaunchAtLogin() {
+  Future<bool> isEnabled();
+
+  Future<void> enable();
+
+  Future<void> disable();
+}

--- a/client/module_desktop_core/lib/src/foundation/platform/system_tray.dart
+++ b/client/module_desktop_core/lib/src/foundation/platform/system_tray.dart
@@ -9,6 +9,7 @@ enum SystemTrayAvailability({required final bool isAvailable}) {
 enum SystemTrayCommand({required final String key}) {
   openWindow(key: "open_window"),
   toggleBridge(key: "toggle_bridge"),
+  toggleLaunchAtLogin(key: "toggle_launch_at_login"),
   quit(key: "quit");
 
   static SystemTrayCommand? fromKey({required String? key}) {

--- a/client/module_desktop_core/lib/src/foundation/platform/window_host.dart
+++ b/client/module_desktop_core/lib/src/foundation/platform/window_host.dart
@@ -12,7 +12,11 @@ abstract interface class WindowHost() {
   Stream<WindowHostEvent> get events;
 
   /// Prepares the native window before the Flutter application is rendered.
-  Future<void> initialize();
+  ///
+  /// A hidden launch keeps the native surface out of sight until the tray
+  /// availability decision is known; the owning cubit shows it when no usable
+  /// tray exists.
+  Future<void> initialize({required bool hidden});
 
   Future<void> show();
 

--- a/client/module_desktop_core/test/cubits/bridge_control/bridge_control_cubit_test.dart
+++ b/client/module_desktop_core/test/cubits/bridge_control/bridge_control_cubit_test.dart
@@ -17,6 +17,7 @@ void main() {
     late _FakeDesktopInstanceService instanceService;
     late DesktopLogoutTracker logoutTracker;
     late _FakeUrlLauncher urlLauncher;
+    late _FakeLaunchAtLogin launchAtLogin;
     late BridgeControlCubit cubit;
 
     setUp(() {
@@ -29,6 +30,7 @@ void main() {
       instanceService = _FakeDesktopInstanceService();
       logoutTracker = DesktopLogoutTracker();
       urlLauncher = _FakeUrlLauncher();
+      launchAtLogin = _FakeLaunchAtLogin();
       cubit = BridgeControlCubit(
         processService: processService,
         statusTracker: statusTracker,
@@ -39,6 +41,8 @@ void main() {
         instanceService: instanceService,
         logoutTracker: logoutTracker,
         urlLauncher: urlLauncher,
+        launchAtLogin: launchAtLogin,
+        hiddenLaunch: false,
       );
     });
 
@@ -59,6 +63,11 @@ void main() {
       expect(_textLabels(menu: systemTray.menus.last), containsAll(<String>["Bridge: Off", "Active sessions: 0"]));
       expect(_command(menu: systemTray.menus.last, command: SystemTrayCommand.openWindow).label, "Open Sesori");
       expect(_command(menu: systemTray.menus.last, command: SystemTrayCommand.toggleBridge).label, "Turn Bridge On");
+      expect(cubit.state.launchAtLoginEnabled, isFalse);
+      expect(
+        _command(menu: systemTray.menus.last, command: SystemTrayCommand.toggleLaunchAtLogin).label,
+        "Enable Launch at Login",
+      );
 
       statusTracker.markHelperConnected();
       statusTracker.applyStatus(
@@ -79,6 +88,65 @@ void main() {
         containsAll(<String>["Bridge: Degraded", "Active sessions: 3"]),
       );
       expect(_command(menu: systemTray.menus.last, command: SystemTrayCommand.toggleBridge).label, "Turn Bridge Off");
+    });
+
+    test("toggle launch-at-login updates the menu only after registration succeeds", () async {
+      await cubit.initialize();
+
+      systemTray.emit(command: SystemTrayCommand.toggleLaunchAtLogin);
+      await pumpEventQueue(times: 2);
+
+      expect(launchAtLogin.enableCalls, 1);
+      expect(launchAtLogin.disableCalls, 0);
+      expect(cubit.state.launchAtLoginEnabled, isTrue);
+      expect(
+        _command(menu: systemTray.menus.last, command: SystemTrayCommand.toggleLaunchAtLogin).label,
+        "Disable Launch at Login",
+      );
+
+      systemTray.emit(command: SystemTrayCommand.toggleLaunchAtLogin);
+      await pumpEventQueue(times: 2);
+      expect(launchAtLogin.disableCalls, 1);
+      expect(cubit.state.launchAtLoginEnabled, isFalse);
+    });
+
+    test("failed launch-at-login registration remains retryable", () async {
+      launchAtLogin.enableError = StateError("login item unavailable");
+      await cubit.initialize();
+
+      systemTray.emit(command: SystemTrayCommand.toggleLaunchAtLogin);
+      await pumpEventQueue(times: 2);
+
+      expect(launchAtLogin.enableCalls, 1);
+      expect(cubit.state.launchAtLoginEnabled, isFalse);
+      expect(
+        _command(menu: systemTray.menus.last, command: SystemTrayCommand.toggleLaunchAtLogin).label,
+        "Enable Launch at Login",
+      );
+    });
+
+    test("hidden launch shows the window when tray availability is unavailable", () async {
+      await cubit.close();
+      systemTray.availability = SystemTrayAvailability.unavailable;
+      final BridgeControlCubit hiddenCubit = BridgeControlCubit(
+        processService: processService,
+        statusTracker: statusTracker,
+        systemTray: systemTray,
+        windowHost: windowHost,
+        applicationTerminator: applicationTerminator,
+        logRepository: logRepository,
+        instanceService: instanceService,
+        logoutTracker: logoutTracker,
+        urlLauncher: urlLauncher,
+        launchAtLogin: launchAtLogin,
+        hiddenLaunch: true,
+      );
+      addTearDown(hiddenCubit.close);
+
+      await hiddenCubit.initialize();
+
+      expect(windowHost.showCalls, 1);
+      expect(hiddenCubit.state.trayAvailability, SystemTrayAvailability.unavailable);
     });
 
     test("reports window-only fallback when no usable tray host exists", () async {
@@ -454,7 +522,7 @@ class _FakeWindowHost() implements WindowHost {
   Stream<WindowHostEvent> get events => _events.stream;
 
   @override
-  Future<void> initialize() async {}
+  Future<void> initialize({required bool hidden}) async {}
 
   @override
   Future<void> show() async {
@@ -532,5 +600,36 @@ class _FakeDesktopApplicationTerminator() implements DesktopApplicationTerminato
   @override
   void terminate({required int exitCode}) {
     exitCodes.add(exitCode);
+  }
+}
+
+class _FakeLaunchAtLogin() implements LaunchAtLogin {
+  bool enabled = false;
+  int enableCalls = 0;
+  int disableCalls = 0;
+  Object? enableError;
+  Object? disableError;
+
+  @override
+  Future<bool> isEnabled() async => enabled;
+
+  @override
+  Future<void> enable() async {
+    enableCalls++;
+    final Object? error = enableError;
+    if (error != null) {
+      throw error;
+    }
+    enabled = true;
+  }
+
+  @override
+  Future<void> disable() async {
+    disableCalls++;
+    final Object? error = disableError;
+    if (error != null) {
+      throw error;
+    }
+    enabled = false;
   }
 }

--- a/docs/regression/desktop-bridge-supervision.md
+++ b/docs/regression/desktop-bridge-supervision.md
@@ -19,6 +19,12 @@ and keep native close/quit behavior safe.
 - Desired bridge On/Off state persists under desktop-owned application data.
   Startup restores last-On through the process service after the dispatcher is
   ready; signed-out restore reaches login-required without spawning a helper.
+  Launch at login is an idempotent per-user registration that starts the app
+  with `--hidden`; disabling it removes the registration rather than merely
+  flipping an in-app flag.
+- A `--hidden` launch stays tray-only when the tray is proven available. If the
+  tray is unavailable or fails to initialize, the window is shown so the app
+  remains reachable.
 - On a proven tray host, native close hides the window immediately, including
   during bridge lifecycle work, removes the macOS app from the Dock while it is
   hidden, and Open restores/focuses it and returns it to the Dock. Without a
@@ -70,6 +76,9 @@ at different handshake phases and inspect the status and bounded recent output.
   killed owner leaves a lock that bricks future launches.
 - Desired Off restores On, last-On never restores, startup bypasses auth gating,
   or bridge restore begins before the control dispatcher owns its event stream.
+- Repeated launch-at-login enables create duplicate registrations, disabling
+  leaves a stale login item, `--hidden` startup hides the app without a usable
+  tray, or a normal manual launch unexpectedly starts hidden.
 - Close hides the only surface when no tray host exists, ignores a close during
   lifecycle work, Open shows without focusing, native close bypasses teardown,
   or the macOS tray icon has an opaque background/wrong light-dark treatment,
@@ -97,6 +106,9 @@ at different handshake phases and inspect the status and bounded recent output.
   authorization prompt per existing credential item; this is macOS item ACL
   behavior and is separate from the entitlement workaround. Stable signing for
   distributed builds belongs to the later desktop-distribution plan.
+- Login registration is owned by the current desktop executable path. A
+  development build moved or rebuilt at a different path must be re-enabled;
+  packaged-path migration belongs to the later desktop-distribution plan.
 
 ## Sources
 

--- a/docs/regression/desktop-bridge-supervision.md
+++ b/docs/regression/desktop-bridge-supervision.md
@@ -94,9 +94,6 @@ at different handshake phases and inspect the status and bounded recent output.
 
 ## Known Limitations
 
-- The current development shell still starts visible; hidden login startup is a
-  later plan slice. Single-instance activation already focuses a hidden owner
-  once hidden startup is introduced.
 - Device-local sign-out stops the helper but does not yet perform persisted
   bridge-registration deletion; coordinated unregister/offline fallback remains
   a later plan slice.


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this adds one desktop platform capability, three OS-specific per-user registrations, and a startup visibility path across the existing shell/core boundary.

## What

- Add the pure-Dart `LaunchAtLogin` capability and register the desktop adapter through Injectable.
- Implement idempotent per-user login registration:
  - macOS `~/Library/LaunchAgents/com.sesori.desktop.plist`
  - Linux `~/.config/autostart/com.sesori.desktop.desktop`
  - Windows `HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run`
- Register the current desktop executable with the `--hidden` argument; remove stale registrations on disable.
- Add launch-at-login status and toggle controls to the tray and supervision window.
- Add exact hidden-launch parsing and initialize the native window hidden before tray availability is known.
- Keep hidden startup tray-only when a usable tray exists; show the window when tray initialization is unavailable or fails.
- Preserve normal visible launches and existing single-instance/last-state behavior.
- Update regression documentation and Step 9 execution evidence.

## Why

Step 9 makes the desktop supervisor usable as a login-started background tray app without introducing an invisible process on systems that cannot display a tray icon. The direct OS registrations preserve the required `--hidden` argument on all supported desktop platforms; the available `launch_at_startup` macOS backend does not forward launch arguments and would require an additional Swift package integration.

## Risk and test focus

Risk is moderate and limited to per-user startup registration, native window visibility, tray controls, and the existing bridge startup sequence. There is no database, relay protocol, authentication-token, or shared CLI-state impact. Focus on registration idempotence/removal, hidden startup with and without a tray, normal visible launch, single-instance activation, and last-On bridge restoration.

## Expected result

Enabling Launch at Login creates exactly one registration that starts the current desktop executable with `--hidden`. A hidden login launch keeps the app and last-On supervisor alive behind the tray; if no usable tray exists, the window is shown. Disabling removes the OS registration and remains disabled across later launches. Manual launches remain visible.

## Verification

- `asdf exec flutter analyze --fatal-infos` from `client/desktop` — clean
- `asdf exec dart analyze --fatal-infos` from `client/module_desktop_core` — clean
- `asdf exec flutter test` from `client/desktop` — 45 tests passed
- `asdf exec dart test` from `client/module_desktop_core` — 157 tests passed
- Clean `asdf exec flutter build macos` — passed
- Launch registration tests cover macOS plist/`launchctl` behavior, Linux XDG entries, stale registrations, Windows registry values, idempotence, and `--hidden` parsing
- Architecture implementation review — approved with no findings

## Manual follow-up

Manual Gate B remains user-run after the later supervision hardening steps. The most valuable checks for this slice are: enable the setting, log out/restart, confirm the app returns tray-only and restores last-On; disable it and confirm it stays absent; launch normally and confirm the window is visible; and verify a no-tray host falls back to a visible window.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds launch-at-login registration and exact `--hidden` boot handling so the desktop supervisor can start as a login background tray app. Enabling creates one per-user OS registration that starts the current executable with `--hidden`; disabling removes it, and manual launches remain visible.

**Launch at login**
- Registers per user via macOS LaunchAgent plist, Linux XDG autostart entry, or Windows `HKCU` Run value.
- Repeated enables are idempotent; disable removes the registration even if stale.
- On macOS, disabling only removes the plist and never terminates the running app.
- Registration targets the current executable path, so moved or rebuilt dev builds must be re-enabled.
- Uses direct OS registrations instead of the `launch_at_startup` macOS backend, which does not forward launch arguments.
- Hardens cross-platform handling: Windows reads the registry via the native API, and Linux desktop entries escape percent field codes.

**Hidden boot**
- `--hidden` starts tray-only when a tray is available and shows the window when tray initialization is unavailable or fails.
- Adds Launch at Login status and toggle to the tray and supervision window; failed toggles leave the state unchanged and retryable.
- Only the exact `--hidden` flag triggers hidden startup; other arguments keep normal visible behavior.

<sup>Written for commit 8f70c2bc8fab0d6873c5662720f18106cb19d008. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

