### PR TITLE
🚧 [desktop-app] Harden auth logout and refresh rejection [step 10/22]

### DIFF
--- a/.plan/active/desktop-app/PLAN.md
+++ b/.plan/active/desktop-app/PLAN.md
@@ -562,7 +562,7 @@ provisioning UI on the control channel, and any multi-bridge machinery.
 - Step 5: delete dead control protocol (`provisionProgress`, `restart`,
   `tokenUpdate`, `ControlProvisionNotifier`, mirror DTOs, bridge receiver
   paths, client dispatcher branches).
-- Step 10: delete `AuthGateCubit`'s post-fence re-clear workaround.
+- Step 10: deleted `AuthGateCubit`'s post-fence re-clear workaround.
 - Step 12: delete `bridge/app/tool/dev_control_host.dart`.
 - Steps 14–19: moved code is deleted at origin in the same PR (no dual copies).
 

--- a/.plan/active/desktop-app/TRACKER.md
+++ b/.plan/active/desktop-app/TRACKER.md
@@ -16,8 +16,8 @@ user-run checkpoints, not PRs; only the user marks them passed.
 | 7 | ⚙️ Window + Prego theme + v1 contents | done |
 | — | MT gate A: first real GUI supervision (user-run) | done |
 | 8 | ⚙️ Single instance + last-state restore | done |
-| 9 | ⚙️ Autostart + hidden boot | in-progress |
-| 10 | 🚧 `module_auth` logout/rejection hardening (R1) | pending |
+| 9 | ⚙️ Autostart + hidden boot | done |
+| 10 | 🚧 `module_auth` logout/rejection hardening (R1) | in-progress |
 | 11 | ⚙️ Logout coordination + offline unregister fallback | pending |
 | 12 | ⚙️ Supervised E2E suite + dev-harness retirement | pending |
 | — | MT gate B: daily driver (user-run) | pending |
@@ -44,4 +44,4 @@ work is expected. Phone session round-trip and standalone CLI coexistence were
 not separately re-reported in the final check; the user explicitly accepted
 the available gate coverage as sufficient.
 
-The next plan slice is Step 9 (autostart + hidden boot).
+The next plan slice is Step 10 (`module_auth` logout/rejection hardening).

--- a/.plan/active/desktop-app/steps/step-07.md
+++ b/.plan/active/desktop-app/steps/step-07.md
@@ -19,8 +19,8 @@ Date: 2026-08-28.
 - Added `DesktopLogoutOrchestrator` as the named Layer-4 cross-service owner.
   It marks a Layer-2 logout tracker so all lifecycle surfaces stay locked from
   expected stop through local token clearing, shares concurrent logout calls,
-  and refuses logout when stop fails. `AuthGateCubit` delegates while retaining
-  its temporary in-flight-restore fence until step 10 hardens auth generations.
+  and refuses logout when stop fails. `AuthGateCubit` delegates while
+  `module_auth` owns the generation fence for every in-flight auth result.
 - Added Prego-owned light/dark `ThemeData` assembly and adopted it in desktop.
 - Replaced the signed-in placeholder with account, On/Off, detailed status,
   active sessions, recent crash output, Open Logs, and coordinated sign-out.

--- a/.plan/active/desktop-app/steps/step-10.md
+++ b/.plan/active/desktop-app/steps/step-10.md
@@ -1,0 +1,59 @@
+# Step 10 — `module_auth` logout/rejection hardening
+
+Date: 2026-08-30.
+
+## Delivered
+
+- Added an auth-generation fence owned by `AuthManager`. Local logout,
+  definitive refresh rejection, and each new interactive login advance the
+  generation, so an older restore, refresh, OAuth completion, email login, or
+  Apple login cannot re-save credentials or emit `AuthAuthenticated` after a
+  newer auth decision.
+- Added a private mutation lock around credential/user persistence, OAuth
+  cleanup, and auth-state emission. Every awaited write is followed by a
+  generation/ownership check; a superseded token result clears any tokens it
+  managed to write before it returns.
+- Fenced both `/auth/me` restore paths, including the no-refresh local restore
+  path. A restored user is saved and emitted only while its generation remains
+  current.
+- Distinguished definitive `/auth/refresh` 4xx rejection from transport and
+  server failures. A rejection clears persisted tokens and the cached user
+  before emitting `unauthenticated`; offline/transport and non-definitive
+  server failures remain non-destructive.
+- Removed `AuthGateCubit`'s temporary timeout and unconditional post-fence
+  re-clear workaround. It now delegates sign-out directly to
+  `DesktopLogoutOrchestrator`; auth-generation ownership remains in
+  `module_auth`.
+- Updated account/onboarding regression guidance and retired the obsolete
+  Step 7 note about the temporary gate fence.
+
+No database, relay, or auth wire-contract change. The change hardens local
+credential lifecycle and in-memory state ordering only.
+
+## Architecture implementation review
+
+The Step 10 architecture implementation review approved the changed
+`module_auth` and `module_desktop_core` behavior with no findings. It confirmed
+that `AuthManager` retains ownership of auth state, persistence, generation
+fencing, and mutation serialization, while `AuthGateCubit` remains a consumer
+that delegates coordinated logout.
+
+## Verification
+
+- `client/module_auth`: `dart analyze --fatal-infos` clean; full suite passed
+  (105 tests), including refresh-rejection relaunch and login/restore/refresh
+  race coverage.
+- `client/module_desktop_core`: `dart analyze --fatal-infos` clean; full suite
+  passed (155 tests), including direct sign-out delegation while restore is
+  pending.
+- `client/module_core`: `dart analyze --fatal-infos` clean; full suite passed
+  (1,459 tests).
+- `client/app`: `flutter analyze --fatal-infos` clean; full suite passed (913
+  tests).
+- Dart LSP reported zero diagnostics across all changed Dart files.
+- `git diff --check` clean.
+
+## Remaining
+
+Step 10 is implementation-complete and awaits its plan-series PR review and
+merge. MT gate B remains the user-run daily-driver checkpoint after Step 12.

--- a/.plan/active/desktop-app/steps/step-10.md
+++ b/.plan/active/desktop-app/steps/step-10.md
@@ -12,7 +12,8 @@ Date: 2026-08-30.
 - Added a private mutation lock around credential/user persistence, OAuth
   cleanup, and auth-state emission. Every awaited write is followed by a
   generation/ownership check; a superseded token result clears any tokens it
-  managed to write before it returns.
+  managed to write before it returns. Refresh singleflight is scoped to the
+  auth generation, so a new account is not blocked by a stale pending request.
 - Fenced both `/auth/me` restore paths, including the no-refresh local restore
   path. A restored user is saved and emitted only while its generation remains
   current.
@@ -21,6 +22,9 @@ Date: 2026-08-30.
   rejection clears persisted tokens and the cached user before emitting
   `unauthenticated`; offline, transport, and non-definitive server failures
   remain non-destructive.
+- Terminal OAuth cleanup attempts PKCE, provider, and persisted-session removal
+  independently, while retaining the generation/ownership fence so an older
+  flow cannot clear a newer flow's state.
 - Removed `AuthGateCubit`'s temporary timeout and unconditional post-fence
   re-clear workaround. It now delegates sign-out directly to
   `DesktopLogoutOrchestrator`; auth-generation ownership remains in
@@ -42,8 +46,9 @@ that delegates coordinated logout.
 ## Verification
 
 - `client/module_auth`: `dart analyze --fatal-infos` clean; full suite passed
-  (106 tests), including refresh-rejection relaunch, transient-4xx handling,
-  and login/restore/refresh race coverage.
+  (108 tests), including refresh-rejection relaunch, transient-4xx handling,
+  generation-scoped refresh, OAuth cleanup failure, and
+  login/restore/refresh race coverage.
 - `client/module_desktop_core`: `dart analyze --fatal-infos` clean; full suite
   passed (155 tests), including direct sign-out delegation while restore is
   pending.

--- a/.plan/active/desktop-app/steps/step-10.md
+++ b/.plan/active/desktop-app/steps/step-10.md
@@ -16,10 +16,11 @@ Date: 2026-08-30.
 - Fenced both `/auth/me` restore paths, including the no-refresh local restore
   path. A restored user is saved and emitted only while its generation remains
   current.
-- Distinguished definitive `/auth/refresh` 4xx rejection from transport and
-  server failures. A rejection clears persisted tokens and the cached user
-  before emitting `unauthenticated`; offline/transport and non-definitive
-  server failures remain non-destructive.
+- Distinguished definitive `/auth/refresh` rejection (the auth server's 401
+  invalid/revoked response) from transport and other server failures. A
+  rejection clears persisted tokens and the cached user before emitting
+  `unauthenticated`; offline, transport, and non-definitive server failures
+  remain non-destructive.
 - Removed `AuthGateCubit`'s temporary timeout and unconditional post-fence
   re-clear workaround. It now delegates sign-out directly to
   `DesktopLogoutOrchestrator`; auth-generation ownership remains in
@@ -41,8 +42,8 @@ that delegates coordinated logout.
 ## Verification
 
 - `client/module_auth`: `dart analyze --fatal-infos` clean; full suite passed
-  (105 tests), including refresh-rejection relaunch and login/restore/refresh
-  race coverage.
+  (106 tests), including refresh-rejection relaunch, transient-4xx handling,
+  and login/restore/refresh race coverage.
 - `client/module_desktop_core`: `dart analyze --fatal-infos` clean; full suite
   passed (155 tests), including direct sign-out delegation while restore is
   pending.

--- a/client/module_auth/lib/src/auth_manager.dart
+++ b/client/module_auth/lib/src/auth_manager.dart
@@ -425,17 +425,36 @@ class AuthManager(
         (requireOwnership && !_ownsOAuthSession(generation: generation, sessionToken: sessionToken))) {
       return false;
     }
-    await _oAuthStorage.clearPkceVerifier();
+
+    Object? firstCleanupError;
+    StackTrace? firstCleanupStackTrace;
+
+    Future<void> attemptCleanup({required Future<void> Function() action}) async {
+      try {
+        await action();
+      } catch (error, stackTrace) {
+        firstCleanupError ??= error;
+        firstCleanupStackTrace ??= stackTrace;
+      }
+    }
+
+    await attemptCleanup(action: _oAuthStorage.clearPkceVerifier);
     if (!_isCurrentGeneration(generation: generation) ||
         (requireOwnership && !_ownsOAuthSession(generation: generation, sessionToken: sessionToken))) {
       return false;
     }
-    await _oAuthStorage.clearAuthProvider();
+
+    await attemptCleanup(action: _oAuthStorage.clearAuthProvider);
     if (!_isCurrentGeneration(generation: generation) ||
         (requireOwnership && !_ownsOAuthSession(generation: generation, sessionToken: sessionToken))) {
       return false;
     }
-    await _oAuthStorage.clearOAuthSession();
+
+    await attemptCleanup(action: _oAuthStorage.clearOAuthSession);
+    final Object? cleanupError = firstCleanupError;
+    if (cleanupError != null) {
+      Error.throwWithStackTrace(cleanupError, firstCleanupStackTrace ?? StackTrace.current);
+    }
     return true;
   }
 
@@ -789,9 +808,12 @@ class AuthManager(
       return Future<String?>.value(null);
     }
     final Future<String?>? activeRefresh = _activeRefresh;
-    if (activeRefresh != null) {
-      return _activeRefreshGeneration == generation ? activeRefresh : Future<String?>.value(null);
+    if (activeRefresh != null && _activeRefreshGeneration == generation) {
+      return activeRefresh;
     }
+    // A refresh from an older auth generation may be stuck in an HTTP client
+    // indefinitely. Detach it rather than making a new account wait for an
+    // operation whose result is already fenced from persistence.
 
     late final Future<String?> refresh;
     refresh = _doRefreshAndPersist(generation: generation).whenComplete(() {

--- a/client/module_auth/lib/src/auth_manager.dart
+++ b/client/module_auth/lib/src/auth_manager.dart
@@ -823,7 +823,10 @@ class AuthManager(
       if (!_isCurrentGeneration(generation: generation)) {
         return null;
       }
-      if (response.statusCode >= 400 && response.statusCode < 500) {
+      // The auth server uses 401 for an invalid or revoked refresh token.
+      // Other 4xx responses (for example 408/429 from a gateway) are not
+      // proof that the persisted credentials are invalid.
+      if (response.statusCode == 401) {
         await _handleDefinitiveRefreshRejection(generation: generation);
         return null;
       }

--- a/client/module_auth/lib/src/auth_manager.dart
+++ b/client/module_auth/lib/src/auth_manager.dart
@@ -37,7 +37,10 @@ class AuthManager(
 
   final BehaviorSubject<AuthState> _authState;
   final Future<void> Function(Duration duration) _delay = delay ?? Future<void>.delayed;
+  final _AuthMutationLock _mutationLock = _AuthMutationLock();
   String? _oAuthSessionToken;
+  int? _oAuthSessionGeneration;
+  int _logoutGeneration = 0;
 
   this : _authState = BehaviorSubject.seeded(const AuthState.initial());
 
@@ -62,32 +65,79 @@ class AuthManager(
   @override
   AuthState get currentState => _authState.value;
 
+  bool _isCurrentGeneration({required int generation}) => generation == _logoutGeneration;
+
+  /// Starts a new auth epoch and invalidates results from the prior epoch.
+  ///
+  /// Logout and a new interactive login both use this boundary: a restore or
+  /// refresh that started for the previous account must not overwrite the
+  /// account the user is now establishing.
+  int _beginAuthGeneration() {
+    final int generation = ++_logoutGeneration;
+    _oAuthSessionToken = null;
+    _oAuthSessionGeneration = null;
+    return generation;
+  }
+
+  int _beginLocalLogout() => _beginAuthGeneration();
+
+  int _beginInteractiveLogin() => _beginAuthGeneration();
+
+  void _throwIfGenerationSuperseded({required int generation}) {
+    if (!_isCurrentGeneration(generation: generation)) {
+      throw const _AuthFlowSuperseded();
+    }
+  }
+
   @override
   Future<String?> getFreshAccessToken({
     Duration minTtl = const Duration(seconds: 30),
     bool forceRefresh = false,
+  }) {
+    final int generation = _logoutGeneration;
+    return _getFreshAccessToken(
+      generation: generation,
+      minTtl: minTtl,
+      forceRefresh: forceRefresh,
+    );
+  }
+
+  Future<String?> _getFreshAccessToken({
+    required int generation,
+    required Duration minTtl,
+    required bool forceRefresh,
   }) async {
+    if (!_isCurrentGeneration(generation: generation)) {
+      return null;
+    }
     if (forceRefresh) {
-      return await _refreshAndPersistTokens();
+      final String? token = await _refreshAndPersistTokens(generation: generation);
+      return _isCurrentGeneration(generation: generation) ? token : null;
     }
 
     final tokenAndValidityLeft = await _tokenStorage.getAccessToken();
+    if (!_isCurrentGeneration(generation: generation)) {
+      return null;
+    }
 
     if (tokenAndValidityLeft == null || tokenAndValidityLeft.validityLeft < minTtl) {
-      return await _refreshAndPersistTokens();
+      final String? token = await _refreshAndPersistTokens(generation: generation);
+      return _isCurrentGeneration(generation: generation) ? token : null;
     }
 
     if (tokenAndValidityLeft.validityLeft < const Duration(seconds: 90)) {
-      unawaited(_refreshAndPersistTokens());
+      unawaited(_refreshAndPersistTokens(generation: generation));
     }
 
-    return tokenAndValidityLeft.token;
+    return _isCurrentGeneration(generation: generation) ? tokenAndValidityLeft.token : null;
   }
 
   @override
   Future<AuthInitResponse> startOAuthFlow({required OAuthProvider provider}) async {
-    final sessionToken = _generateSessionToken();
+    final int generation = _beginInteractiveLogin();
+    final String sessionToken = _generateSessionToken();
     _oAuthSessionToken = sessionToken;
+    _oAuthSessionGeneration = generation;
 
     try {
       final descriptor = await _deviceDescriptorProvider.describe();
@@ -101,35 +151,92 @@ class AuthManager(
 
       final initResponse = AuthInitResponse.fromJson(jsonDecodeMap(response.body));
       final expiresAt = DateTime.now().add(Duration(seconds: initResponse.expiresIn));
-      await _oAuthStorage.saveOAuthSession(
-        sessionToken: sessionToken,
-        expiresAt: expiresAt,
+      await _mutationLock.run(
+        action: () async {
+          _throwIfGenerationSuperseded(generation: generation);
+          if (!_ownsOAuthSession(generation: generation, sessionToken: sessionToken)) {
+            throw const _AuthFlowSuperseded();
+          }
+          await _oAuthStorage.saveOAuthSession(
+            sessionToken: sessionToken,
+            expiresAt: expiresAt,
+          );
+          _throwIfGenerationSuperseded(generation: generation);
+          if (!_ownsOAuthSession(generation: generation, sessionToken: sessionToken)) {
+            throw const _AuthFlowSuperseded();
+          }
+        },
       );
+      _throwIfGenerationSuperseded(generation: generation);
+      if (!_ownsOAuthSession(generation: generation, sessionToken: sessionToken)) {
+        throw const _AuthFlowSuperseded();
+      }
       return initResponse;
-    } catch (_) {
-      _oAuthSessionToken = null;
-      await _oAuthStorage.clearOAuthSession();
-      rethrow;
+    } on Object catch (error, stackTrace) {
+      try {
+        await _clearOAuthStateIfOwned(generation: generation, sessionToken: sessionToken);
+      } on Object catch (cleanupError, cleanupStackTrace) {
+        developer.log(
+          "Failed to clear OAuth state after starting the flow failed",
+          error: cleanupError,
+          stackTrace: cleanupStackTrace,
+          name: "sesori_auth",
+        );
+      }
+      if (identical(_oAuthSessionToken, sessionToken)) {
+        _oAuthSessionToken = null;
+        _oAuthSessionGeneration = null;
+      }
+      Error.throwWithStackTrace(error, stackTrace);
     }
   }
 
   @override
   Future<AuthLoginResult> pollForResult() async {
-    final sessionToken = _oAuthSessionToken ?? (await _oAuthStorage.getOAuthSession()).sessionToken;
-    final expiresAt = (await _oAuthStorage.getOAuthSession()).expiresAt;
+    final int observedGeneration = _logoutGeneration;
+    final String? initialSessionToken = _oAuthSessionToken;
+    final int? initialSessionGeneration = _oAuthSessionGeneration;
+    final storedSession = await _oAuthStorage.getOAuthSession();
 
+    _throwIfGenerationSuperseded(generation: observedGeneration);
+    if (_oAuthSessionToken != initialSessionToken || _oAuthSessionGeneration != initialSessionGeneration) {
+      throw const _AuthFlowSuperseded();
+    }
+
+    final String? sessionToken = initialSessionToken ?? storedSession.sessionToken;
+    final DateTime? expiresAt = storedSession.expiresAt;
     if (sessionToken == null || sessionToken.isEmpty) {
       throw StateError("No OAuth flow is active");
     }
+    final int generation;
+    if (initialSessionToken == null) {
+      // A persisted OAuth flow is a new interactive login after a relaunch;
+      // advance the epoch so an older restore or refresh cannot win over it.
+      generation = _beginInteractiveLogin();
+      _oAuthSessionToken = sessionToken;
+      _oAuthSessionGeneration = generation;
+    } else {
+      generation = observedGeneration;
+    }
+    if (!_ownsOAuthSession(generation: generation, sessionToken: sessionToken)) {
+      throw const _AuthFlowSuperseded();
+    }
 
     if (expiresAt != null && DateTime.now().isAfter(expiresAt)) {
-      await _oAuthStorage.clearOAuthSession();
-      _oAuthSessionToken = null;
+      try {
+        await _clearOAuthStateIfOwned(generation: generation, sessionToken: sessionToken);
+      } finally {
+        _releaseOAuthSessionIfOwned(generation: generation, sessionToken: sessionToken);
+      }
       throw TimeoutException("OAuth authorization expired");
     }
 
     try {
       while (expiresAt == null || DateTime.now().isBefore(expiresAt)) {
+        _throwIfGenerationSuperseded(generation: generation);
+        if (!_ownsOAuthSession(generation: generation, sessionToken: sessionToken)) {
+          throw const _AuthFlowSuperseded();
+        }
         final remaining = expiresAt?.difference(DateTime.now()) ?? _pollTimeout;
         final requestTimeout = remaining < _defaultRequestTimeout ? remaining : _defaultRequestTimeout;
         if (requestTimeout <= Duration.zero) break;
@@ -146,9 +253,10 @@ class AuthManager(
             isFinalRequest: isFinalRequest,
           );
         } on TimeoutException {
-          await _oAuthStorage.clearOAuthSession();
+          await _clearOAuthStateIfOwned(generation: generation, sessionToken: sessionToken);
           rethrow;
         }
+        _throwIfGenerationSuperseded(generation: generation);
 
         final status = _parseSessionStatus(response);
         switch (status) {
@@ -164,29 +272,44 @@ class AuthManager(
             :final user,
             :final accountStatus,
           ):
-            await _persistOAuthCompletion(
+            final bool persisted = await _persistAuthenticatedResult(
+              generation: generation,
               accessToken: accessToken,
               refreshToken: refreshToken,
               user: user,
+              clearOAuthState: true,
+              requireOAuthOwnership: true,
+              oauthSessionToken: sessionToken,
             );
+            if (!persisted) {
+              throw const _AuthFlowSuperseded();
+            }
             _ackOAuthCompletion(sessionToken: sessionToken);
             return AuthLoginResult(user: user, accountStatus: accountStatus);
           case AuthSessionStatusResponseDenied():
-            await _oAuthStorage.clearOAuthSession();
+            await _clearOAuthStateIfOwned(generation: generation, sessionToken: sessionToken);
             throw StateError("OAuth authorization was denied");
           case AuthSessionStatusResponseExpired():
-            await _oAuthStorage.clearOAuthSession();
+            await _clearOAuthStateIfOwned(generation: generation, sessionToken: sessionToken);
             throw StateError("OAuth authorization expired");
           case AuthSessionStatusResponseError(:final message):
-            await _oAuthStorage.clearOAuthSession();
+            await _clearOAuthStateIfOwned(generation: generation, sessionToken: sessionToken);
             throw StateError("OAuth authorization failed: $message");
         }
       }
 
-      await _oAuthStorage.clearOAuthSession();
+      await _clearOAuthStateIfOwned(generation: generation, sessionToken: sessionToken);
+      _throwIfGenerationSuperseded(generation: generation);
       throw TimeoutException("OAuth authorization timed out");
     } finally {
+      _releaseOAuthSessionIfOwned(generation: generation, sessionToken: sessionToken);
+    }
+  }
+
+  void _releaseOAuthSessionIfOwned({required int generation, required String sessionToken}) {
+    if (_ownsOAuthSession(generation: generation, sessionToken: sessionToken)) {
       _oAuthSessionToken = null;
+      _oAuthSessionGeneration = null;
     }
   }
 
@@ -216,26 +339,117 @@ class AuthManager(
     }
   }
 
-  Future<void> _persistOAuthCompletion({
+  Future<bool> _persistAuthenticatedResult({
+    required int generation,
     required String accessToken,
     required String refreshToken,
     required AuthUser user,
-  }) async {
-    await _tokenStorage.saveTokens(
-      accessToken: accessToken,
-      refreshToken: refreshToken,
+    required bool clearOAuthState,
+    required bool requireOAuthOwnership,
+    required String? oauthSessionToken,
+  }) {
+    return _mutationLock.run(
+      action: () async {
+        if (!_isCurrentGeneration(generation: generation)) {
+          return false;
+        }
+        if (requireOAuthOwnership && !_ownsOAuthSession(generation: generation, sessionToken: oauthSessionToken)) {
+          return false;
+        }
+
+        await _tokenStorage.saveTokens(
+          accessToken: accessToken,
+          refreshToken: refreshToken,
+        );
+        if (!_isCurrentGeneration(generation: generation) ||
+            (requireOAuthOwnership && !_ownsOAuthSession(generation: generation, sessionToken: oauthSessionToken))) {
+          await _clearTokensAfterSupersededResult();
+          return false;
+        }
+
+        final bool userSaved = await _saveUserBestEffort(
+          user: user,
+          generation: generation,
+        );
+        if (!userSaved ||
+            !_isCurrentGeneration(generation: generation) ||
+            (requireOAuthOwnership && !_ownsOAuthSession(generation: generation, sessionToken: oauthSessionToken))) {
+          await _clearTokensAfterSupersededResult();
+          return false;
+        }
+
+        if (clearOAuthState) {
+          final bool oauthStateCleared = await _clearOAuthStateInMutation(
+            generation: generation,
+            sessionToken: oauthSessionToken,
+            requireOwnership: requireOAuthOwnership,
+          );
+          if (!oauthStateCleared ||
+              !_isCurrentGeneration(generation: generation) ||
+              (requireOAuthOwnership && !_ownsOAuthSession(generation: generation, sessionToken: oauthSessionToken))) {
+            await _clearTokensAfterSupersededResult();
+            return false;
+          }
+        }
+
+        if (!_isCurrentGeneration(generation: generation) ||
+            (requireOAuthOwnership && !_ownsOAuthSession(generation: generation, sessionToken: oauthSessionToken))) {
+          await _clearTokensAfterSupersededResult();
+          return false;
+        }
+        _authState.add(AuthState.authenticated(user: user));
+        return true;
+      },
     );
-    // Best-effort: the tokens above already make this a valid session, so a
-    // local user-cache write failure must not abort a completed login.
-    await _saveUserBestEffort(user);
+  }
 
-    await Future.wait([
-      _oAuthStorage.clearPkceVerifier(),
-      _oAuthStorage.clearAuthProvider(),
-      _oAuthStorage.clearOAuthSession(),
-    ]);
+  bool _ownsOAuthSession({required int generation, required String? sessionToken}) =>
+      sessionToken != null && _oAuthSessionGeneration == generation && _oAuthSessionToken == sessionToken;
 
-    _authState.add(AuthState.authenticated(user: user));
+  Future<void> _clearOAuthStateIfOwned({required int generation, required String? sessionToken}) {
+    return _mutationLock.run(
+      action: () => _clearOAuthStateInMutation(
+        generation: generation,
+        sessionToken: sessionToken,
+        requireOwnership: true,
+      ),
+    );
+  }
+
+  Future<bool> _clearOAuthStateInMutation({
+    required int generation,
+    required String? sessionToken,
+    required bool requireOwnership,
+  }) async {
+    if (!_isCurrentGeneration(generation: generation) ||
+        (requireOwnership && !_ownsOAuthSession(generation: generation, sessionToken: sessionToken))) {
+      return false;
+    }
+    await _oAuthStorage.clearPkceVerifier();
+    if (!_isCurrentGeneration(generation: generation) ||
+        (requireOwnership && !_ownsOAuthSession(generation: generation, sessionToken: sessionToken))) {
+      return false;
+    }
+    await _oAuthStorage.clearAuthProvider();
+    if (!_isCurrentGeneration(generation: generation) ||
+        (requireOwnership && !_ownsOAuthSession(generation: generation, sessionToken: sessionToken))) {
+      return false;
+    }
+    await _oAuthStorage.clearOAuthSession();
+    return true;
+  }
+
+  Future<void> _clearTokensAfterSupersededResult() async {
+    try {
+      await _tokenStorage.clearTokens();
+    } on Object catch (error, stackTrace) {
+      developer.log(
+        "Failed to clear tokens after an authentication result was superseded",
+        error: error,
+        stackTrace: stackTrace,
+        name: "sesori_auth",
+      );
+    }
   }
 
   void _ackOAuthCompletion({required String sessionToken}) {
@@ -266,7 +480,10 @@ class AuthManager(
   /// ([restoreLocalSession]); it is never authoritative. A write failure must
   /// not abort a flow whose tokens are already saved and whose in-memory
   /// session is valid, so callers stay authenticated even if this fails.
-  Future<void> _saveUserBestEffort(AuthUser user) async {
+  Future<bool> _saveUserBestEffort({required AuthUser user, required int generation}) async {
+    if (!_isCurrentGeneration(generation: generation)) {
+      return false;
+    }
     try {
       await _tokenStorage.saveUser(user);
     } catch (error, stackTrace) {
@@ -277,6 +494,7 @@ class AuthManager(
         name: "sesori_auth",
       );
     }
+    return _isCurrentGeneration(generation: generation);
   }
 
   AuthSessionStatusResponse _parseSessionStatus(http.Response response) {
@@ -311,8 +529,9 @@ class AuthManager(
 
   @override
   Future<bool> hasActiveOAuthSession() async {
+    final int generation = _logoutGeneration;
     final session = await _oAuthStorage.getOAuthSession();
-    if (session.sessionToken == null || session.expiresAt == null) {
+    if (!_isCurrentGeneration(generation: generation) || session.sessionToken == null || session.expiresAt == null) {
       return false;
     }
     final expiresAt = session.expiresAt;
@@ -321,10 +540,19 @@ class AuthManager(
   }
 
   @override
-  Future<AuthUser?> getCurrentUser() async {
+  Future<AuthUser?> getCurrentUser() {
+    final int generation = _logoutGeneration;
+    return _getCurrentUser(generation: generation);
+  }
+
+  Future<AuthUser?> _getCurrentUser({required int generation}) async {
     try {
-      final accessToken = await getFreshAccessToken();
-      if (accessToken == null) {
+      final String? accessToken = await _getFreshAccessToken(
+        generation: generation,
+        minTtl: const Duration(seconds: 30),
+        forceRefresh: false,
+      );
+      if (accessToken == null || !_isCurrentGeneration(generation: generation)) {
         return null;
       }
 
@@ -333,10 +561,13 @@ class AuthManager(
         uri,
         headers: _authHeader(accessToken),
       );
+      if (!_isCurrentGeneration(generation: generation)) {
+        return null;
+      }
       _ensureSuccess(response, context: "Failed to fetch current user");
 
       final authMeResponse = AuthMeResponse.fromJson(jsonDecodeMap(response.body));
-      return authMeResponse.user;
+      return _isCurrentGeneration(generation: generation) ? authMeResponse.user : null;
     } on http.ClientException catch (error, stackTrace) {
       developer.log(
         "Failed to fetch current user due to network error",
@@ -372,27 +603,55 @@ class AuthManager(
 
   @override
   Future<bool> restoreSession() async {
-    final user = await getCurrentUser();
-    if (user == null) return false;
+    final int generation = _logoutGeneration;
+    final AuthUser? user = await _getCurrentUser(generation: generation);
+    if (user == null) {
+      return false;
+    }
 
-    // Persist the user for sessions that were authenticated before it was
-    // stored locally; /auth/me is the authoritative source for the value.
-    // Best-effort: a local persistence failure must not block restoring a
-    // session that /auth/me just confirmed.
-    await _saveUserBestEffort(user);
-    _authState.add(AuthState.authenticated(user: user));
-    return true;
+    return await _mutationLock.run(
+      action: () async {
+        if (!_isCurrentGeneration(generation: generation)) {
+          return false;
+        }
+        // Persist the user for sessions that were authenticated before it was
+        // stored locally; /auth/me is the authoritative source for the value.
+        // Best-effort: a local persistence failure must not block restoring a
+        // session that /auth/me just confirmed.
+        final bool userSaved = await _saveUserBestEffort(
+          user: user,
+          generation: generation,
+        );
+        if (!userSaved || !_isCurrentGeneration(generation: generation)) {
+          return false;
+        }
+        _authState.add(AuthState.authenticated(user: user));
+        return true;
+      },
+    );
   }
 
   @override
   Future<bool> restoreLocalSession() async {
+    final int generation = _logoutGeneration;
     try {
-      if (!await _tokenStorage.hasLocallyValidSession()) return false;
-      final user = await _tokenStorage.getUser();
-      if (user == null) return false;
+      if (!await _tokenStorage.hasLocallyValidSession() || !_isCurrentGeneration(generation: generation)) {
+        return false;
+      }
+      final AuthUser? user = await _tokenStorage.getUser();
+      if (user == null || !_isCurrentGeneration(generation: generation)) {
+        return false;
+      }
 
-      _authState.add(AuthState.authenticated(user: user));
-      return true;
+      return await _mutationLock.run(
+        action: () async {
+          if (!_isCurrentGeneration(generation: generation)) {
+            return false;
+          }
+          _authState.add(AuthState.authenticated(user: user));
+          return true;
+        },
+      );
     } catch (error, stackTrace) {
       developer.log(
         "Failed to restore local session",
@@ -406,6 +665,7 @@ class AuthManager(
 
   @override
   Future<AuthLoginResult> loginWithEmail({required String email, required String password}) async {
+    final int generation = _beginInteractiveLogin();
     final uri = Uri.parse("$authBaseUrl/auth/email");
     final response = await _post(
       uri,
@@ -425,26 +685,24 @@ class AuthManager(
       throw Exception("Failed to parse auth response: ${e.toString()}");
     }
 
-    await _tokenStorage.saveTokens(
+    final bool persisted = await _persistAuthenticatedResult(
+      generation: generation,
       accessToken: authResponse.accessToken,
       refreshToken: authResponse.refreshToken,
+      user: authResponse.user,
+      clearOAuthState: true,
+      requireOAuthOwnership: false,
+      oauthSessionToken: null,
     );
-    await _tokenStorage.saveUser(authResponse.user);
-
-    // Clear any stale OAuth temp state so a later deep-link callback
-    // cannot unexpectedly exchange using stale PKCE data.
-    await Future.wait([
-      _oAuthStorage.clearPkceVerifier(),
-      _oAuthStorage.clearAuthProvider(),
-      _oAuthStorage.clearOAuthSession(),
-    ]);
-
-    _authState.add(AuthState.authenticated(user: authResponse.user));
+    if (!persisted) {
+      throw const _AuthFlowSuperseded();
+    }
     return AuthLoginResult(user: authResponse.user, accountStatus: authResponse.accountStatus);
   }
 
   @override
   Future<AuthLoginResult> loginWithApple({required String idToken, required String nonce}) async {
+    final int generation = _beginInteractiveLogin();
     final uri = Uri.parse("$authBaseUrl/auth/apple/native");
     final response = await _post(
       uri,
@@ -461,68 +719,99 @@ class AuthManager(
       throw Exception("Failed to parse auth response: ${e.toString()}");
     }
 
-    await _tokenStorage.saveTokens(
+    final bool persisted = await _persistAuthenticatedResult(
+      generation: generation,
       accessToken: authResponse.accessToken,
       refreshToken: authResponse.refreshToken,
+      user: authResponse.user,
+      clearOAuthState: true,
+      requireOAuthOwnership: false,
+      oauthSessionToken: null,
     );
-    await _tokenStorage.saveUser(authResponse.user);
-
-    // Clear any stale OAuth temp state so a later deep-link callback
-    // cannot unexpectedly exchange using stale PKCE data.
-    await Future.wait([
-      _oAuthStorage.clearPkceVerifier(),
-      _oAuthStorage.clearAuthProvider(),
-      _oAuthStorage.clearOAuthSession(),
-    ]);
-
-    _authState.add(AuthState.authenticated(user: authResponse.user));
+    if (!persisted) {
+      throw const _AuthFlowSuperseded();
+    }
     return AuthLoginResult(user: authResponse.user, accountStatus: authResponse.accountStatus);
   }
 
   @override
   Future<void> invalidateAllSessions() async {
-    final accessToken = await getFreshAccessToken();
+    final int requestGeneration = _logoutGeneration;
+    final String? accessToken = await _getFreshAccessToken(
+      generation: requestGeneration,
+      minTtl: const Duration(seconds: 30),
+      forceRefresh: false,
+    );
+    if (!_isCurrentGeneration(generation: requestGeneration)) {
+      return;
+    }
     if (accessToken != null) {
       final uri = Uri.parse("$authBaseUrl/auth/logout");
       final response = await _post(
         uri,
         headers: _authHeader(accessToken),
       );
+      _throwIfGenerationSuperseded(generation: requestGeneration);
       _ensureSuccess(response, context: "Failed to invalidate all sessions");
     }
 
-    await Future.wait([
-      _tokenStorage.clearTokens(),
-      _oAuthStorage.clearPkceVerifier(),
-      _oAuthStorage.clearAuthProvider(),
-      _oAuthStorage.clearOAuthSession(),
-    ]);
-    _authState.add(const AuthState.unauthenticated());
+    final int generation = _beginLocalLogout();
+    await _clearLocalAuthState(generation: generation);
   }
 
   @override
   Future<void> logoutCurrentDevice() async {
-    await Future.wait([
-      _tokenStorage.clearTokens(),
-      _oAuthStorage.clearPkceVerifier(),
-      _oAuthStorage.clearAuthProvider(),
-      _oAuthStorage.clearOAuthSession(),
-    ]);
-    _authState.add(const AuthState.unauthenticated());
+    final int generation = _beginLocalLogout();
+    await _clearLocalAuthState(generation: generation);
+  }
+
+  Future<void> _clearLocalAuthState({required int generation}) {
+    return _mutationLock.run(
+      action: () async {
+        await Future.wait([
+          _tokenStorage.clearTokens(),
+          _oAuthStorage.clearPkceVerifier(),
+          _oAuthStorage.clearAuthProvider(),
+          _oAuthStorage.clearOAuthSession(),
+        ]);
+        if (_isCurrentGeneration(generation: generation)) {
+          _authState.add(const AuthState.unauthenticated());
+        }
+      },
+    );
   }
 
   Future<String?>? _activeRefresh;
+  int? _activeRefreshGeneration;
 
-  Future<String?> _refreshAndPersistTokens() {
-    return _activeRefresh ??= _doRefreshAndPersist().whenComplete(() {
-      _activeRefresh = null;
+  Future<String?> _refreshAndPersistTokens({required int generation}) {
+    if (!_isCurrentGeneration(generation: generation)) {
+      return Future<String?>.value(null);
+    }
+    final Future<String?>? activeRefresh = _activeRefresh;
+    if (activeRefresh != null) {
+      return _activeRefreshGeneration == generation ? activeRefresh : Future<String?>.value(null);
+    }
+
+    late final Future<String?> refresh;
+    refresh = _doRefreshAndPersist(generation: generation).whenComplete(() {
+      if (identical(_activeRefresh, refresh)) {
+        _activeRefresh = null;
+        _activeRefreshGeneration = null;
+      }
     });
+    _activeRefresh = refresh;
+    _activeRefreshGeneration = generation;
+    return refresh;
   }
 
-  Future<String?> _doRefreshAndPersist() async {
+  Future<String?> _doRefreshAndPersist({required int generation}) async {
     try {
-      final refreshToken = await _tokenStorage.getRefreshToken();
-      if (refreshToken == null || refreshToken.isEmpty) {
+      if (!_isCurrentGeneration(generation: generation)) {
+        return null;
+      }
+      final String? refreshToken = await _tokenStorage.getRefreshToken();
+      if (refreshToken == null || refreshToken.isEmpty || !_isCurrentGeneration(generation: generation)) {
         return null;
       }
 
@@ -531,6 +820,13 @@ class AuthManager(
         uri,
         body: {"refreshToken": refreshToken},
       );
+      if (!_isCurrentGeneration(generation: generation)) {
+        return null;
+      }
+      if (response.statusCode >= 400 && response.statusCode < 500) {
+        await _handleDefinitiveRefreshRejection(generation: generation);
+        return null;
+      }
       _ensureSuccess(response, context: "Token refresh failed");
 
       final decodedBody = jsonDecodeMap(response.body);
@@ -541,12 +837,14 @@ class AuthManager(
         throw Exception("Failed to parse auth response: ${e.toString()}");
       }
 
-      await _tokenStorage.saveTokens(
+      final bool persisted = await _persistRefreshedTokens(
+        generation: generation,
         accessToken: authResponse.accessToken,
         refreshToken: authResponse.refreshToken,
       );
-
-      return authResponse.accessToken;
+      return persisted && _isCurrentGeneration(generation: generation) ? authResponse.accessToken : null;
+    } on _AuthFlowSuperseded {
+      return null;
     } catch (error, stackTrace) {
       developer.log(
         "Token refresh failed",
@@ -556,6 +854,44 @@ class AuthManager(
       );
       return null;
     }
+  }
+
+  Future<bool> _persistRefreshedTokens({
+    required int generation,
+    required String accessToken,
+    required String refreshToken,
+  }) {
+    return _mutationLock.run(
+      action: () async {
+        if (!_isCurrentGeneration(generation: generation)) {
+          return false;
+        }
+        await _tokenStorage.saveTokens(
+          accessToken: accessToken,
+          refreshToken: refreshToken,
+        );
+        if (!_isCurrentGeneration(generation: generation)) {
+          await _clearTokensAfterSupersededResult();
+          return false;
+        }
+        return true;
+      },
+    );
+  }
+
+  Future<void> _handleDefinitiveRefreshRejection({required int generation}) async {
+    if (!_isCurrentGeneration(generation: generation)) {
+      return;
+    }
+    final int rejectionGeneration = _beginAuthGeneration();
+    await _mutationLock.run(
+      action: () async {
+        await _tokenStorage.clearTokens();
+        if (_isCurrentGeneration(generation: rejectionGeneration)) {
+          _authState.add(const AuthState.unauthenticated());
+        }
+      },
+    );
   }
 
   String _generateSessionToken() {
@@ -603,6 +939,27 @@ class AuthManager(
   void _ensureSuccess(http.Response response, {required String context}) {
     if (response.statusCode < 200 || response.statusCode >= 300) {
       throw StateError("$context (HTTP ${response.statusCode})");
+    }
+  }
+}
+
+final class const _AuthFlowSuperseded() implements Exception {
+  @override
+  String toString() => "Authentication operation was superseded";
+}
+
+class _AuthMutationLock() {
+  Future<void> _tail = Future<void>.value();
+
+  Future<T> run<T>({required Future<T> Function() action}) async {
+    final Future<void> previous = _tail;
+    final Completer<void> release = Completer<void>();
+    _tail = release.future;
+    await previous;
+    try {
+      return await action();
+    } finally {
+      release.complete();
     }
   }
 }

--- a/client/module_auth/test/auth_manager_test.dart
+++ b/client/module_auth/test/auth_manager_test.dart
@@ -283,6 +283,85 @@ void main() {
   });
 
   group("refresh fencing", () {
+    test("starts a new refresh when a prior generation refresh is still pending", () async {
+      when(() => mockTokenStorage.getAccessToken()).thenAnswer((_) async => null);
+      when(() => mockTokenStorage.getRefreshToken()).thenAnswer((_) async => "pending-refresh-token");
+      when(mockTokenStorage.clearTokens).thenAnswer((_) async {});
+
+      final Completer<http.Response> staleResponse = Completer<http.Response>();
+      final Completer<http.Response> currentResponse = Completer<http.Response>();
+      var refreshCalls = 0;
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/refresh"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer((_) {
+        refreshCalls += 1;
+        return refreshCalls == 1 ? staleResponse.future : currentResponse.future;
+      });
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/email"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            "accessToken": "new-login-access-token",
+            "refreshToken": "new-login-refresh-token",
+            "user": {
+              "id": user.id,
+              "provider": user.provider.key,
+              "providerUserId": user.providerUserId,
+              "providerUsername": user.providerUsername,
+            },
+            "accountStatus": "existing",
+          }),
+          200,
+        ),
+      );
+      when(
+        () => mockTokenStorage.saveTokens(
+          accessToken: "new-login-access-token",
+          refreshToken: "new-login-refresh-token",
+        ),
+      ).thenAnswer((_) async {});
+
+      final Future<String?> staleRefresh = authManager.getFreshAccessToken();
+      await pumpEventQueue();
+      expect(refreshCalls, 1);
+
+      await authManager.logoutCurrentDevice();
+      expect(
+        (await authManager.loginWithEmail(email: "test@example.com", password: "correct-password")).user,
+        user,
+      );
+
+      final Future<String?> currentRefresh = authManager.getFreshAccessToken(forceRefresh: true);
+      await pumpEventQueue();
+      expect(refreshCalls, 2);
+
+      currentResponse.complete(http.Response("{}", 401));
+      expect(await currentRefresh, isNull);
+
+      // The old request can finish much later, but its result belongs to the
+      // superseded generation and must not affect the new account.
+      staleResponse.complete(http.Response("{}", 200));
+      expect(await staleRefresh, isNull);
+
+      verify(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/refresh"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).called(2);
+      verify(mockTokenStorage.clearTokens).called(2);
+    });
+
     test("clears local credentials before emitting unauthenticated on refresh rejection", () async {
       when(() => mockTokenStorage.getAccessToken()).thenAnswer((_) async => null);
       when(() => mockTokenStorage.getRefreshToken()).thenAnswer((_) async => "revoked-refresh-token");
@@ -1041,6 +1120,41 @@ void main() {
           body: null,
         ),
       ).called(1);
+    });
+
+    test("clears the persisted OAuth session when temporary cleanup fails", () async {
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/google/init"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            "authUrl": "https://accounts.google.com/o/oauth2/v2/auth",
+            "state": "state-cleanup-failure",
+            "userCode": "CLEAN",
+            "expiresIn": 300,
+          }),
+          200,
+        ),
+      );
+      when(
+        () => mockHttpClient.get(
+          Uri.parse("$authBaseUrl/auth/session/status"),
+          headers: any(named: "headers"),
+        ),
+      ).thenAnswer((_) async => http.Response(jsonEncode({"status": "denied"}), 200));
+      when(mockOAuthStorage.clearPkceVerifier).thenThrow(StateError("PKCE cleanup failed"));
+      when(mockOAuthStorage.clearAuthProvider).thenThrow(StateError("provider cleanup failed"));
+
+      await authManager.startOAuthFlow(provider: AuthProvider.google);
+      await expectLater(authManager.pollForResult(), throwsA(isA<StateError>()));
+
+      verify(mockOAuthStorage.clearPkceVerifier).called(1);
+      verify(mockOAuthStorage.clearAuthProvider).called(1);
+      verify(mockOAuthStorage.clearOAuthSession).called(1);
     });
 
     test("pollForResult sends the same session token only in status headers", () async {

--- a/client/module_auth/test/auth_manager_test.dart
+++ b/client/module_auth/test/auth_manager_test.dart
@@ -313,6 +313,22 @@ void main() {
       expect(states.last, const AuthState.unauthenticated());
     });
 
+    test("keeps credentials for a non-definitive refresh 4xx response", () async {
+      when(() => mockTokenStorage.getAccessToken()).thenAnswer((_) async => null);
+      when(() => mockTokenStorage.getRefreshToken()).thenAnswer((_) async => "still-valid-refresh-token");
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/refresh"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer((_) async => http.Response("{}", 429));
+
+      expect(await authManager.getFreshAccessToken(), isNull);
+      verifyNever(mockTokenStorage.clearTokens);
+      expect(authManager.currentState, isA<AuthInitial>());
+    });
+
     test("a rejected refresh cannot be restored by a new manager", () async {
       final _MemorySecureStorage storage = _MemorySecureStorage();
       final TokenStorageService tokenStorage = TokenStorageService(storage);

--- a/client/module_auth/test/auth_manager_test.dart
+++ b/client/module_auth/test/auth_manager_test.dart
@@ -8,6 +8,7 @@ import "package:sesori_auth/src/auth_manager.dart";
 import "package:sesori_auth/src/models/auth_login_result.dart";
 import "package:sesori_auth/src/models/auth_state.dart";
 import "package:sesori_auth/src/platform/oauth_device_descriptor_provider.dart";
+import "package:sesori_auth/src/platform/secure_storage.dart";
 import "package:sesori_auth/src/storage/oauth_storage_service.dart";
 import "package:sesori_auth/src/storage/token_storage_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -63,6 +64,8 @@ void main() {
     when(() => mockOAuthStorage.getOAuthSession()).thenAnswer(
       (_) async => (sessionToken: null, expiresAt: null),
     );
+    when(() => mockOAuthStorage.clearPkceVerifier()).thenAnswer((_) async {});
+    when(() => mockOAuthStorage.clearAuthProvider()).thenAnswer((_) async {});
     when(() => mockOAuthStorage.clearOAuthSession()).thenAnswer((_) async {});
     when(() => mockTokenStorage.saveUser(any())).thenAnswer((_) async {});
     when(
@@ -279,7 +282,379 @@ void main() {
     });
   });
 
+  group("refresh fencing", () {
+    test("clears local credentials before emitting unauthenticated on refresh rejection", () async {
+      when(() => mockTokenStorage.getAccessToken()).thenAnswer((_) async => null);
+      when(() => mockTokenStorage.getRefreshToken()).thenAnswer((_) async => "revoked-refresh-token");
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/refresh"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer((_) async => http.Response("{}", 401));
+
+      final Completer<void> clearTokens = Completer<void>();
+      when(mockTokenStorage.clearTokens).thenAnswer((_) => clearTokens.future);
+      final List<AuthState> states = <AuthState>[];
+      final StreamSubscription<AuthState> subscription = authManager.authStateStream.listen(states.add);
+
+      final Future<String?> refreshed = authManager.getFreshAccessToken();
+      await pumpEventQueue();
+
+      expect(states.whereType<AuthUnauthenticated>(), isEmpty);
+      verify(mockTokenStorage.clearTokens).called(1);
+      clearTokens.complete();
+
+      expect(await refreshed, isNull);
+      await pumpEventQueue();
+      await subscription.cancel();
+      expect(authManager.currentState, const AuthState.unauthenticated());
+      expect(states.last, const AuthState.unauthenticated());
+    });
+
+    test("a rejected refresh cannot be restored by a new manager", () async {
+      final _MemorySecureStorage storage = _MemorySecureStorage();
+      final TokenStorageService tokenStorage = TokenStorageService(storage);
+      final OAuthStorageService oauthStorage = OAuthStorageService(storage);
+      await tokenStorage.saveTokens(
+        accessToken: "old-access-token",
+        refreshToken: "revoked-refresh-token",
+      );
+      await tokenStorage.saveUser(user);
+
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/refresh"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer((_) async => http.Response("{}", 401));
+
+      final AuthManager firstManager = AuthManager(
+        mockHttpClient,
+        tokenStorage,
+        oauthStorage,
+        FakeOAuthDeviceDescriptorProvider(),
+      );
+      expect(await firstManager.getFreshAccessToken(forceRefresh: true), isNull);
+      expect(await storage.read(key: "access_token"), isNull);
+      expect(await storage.read(key: "refresh_token"), isNull);
+      expect(await storage.read(key: "auth_user"), isNull);
+
+      final AuthManager relaunchedManager = AuthManager(
+        MockHttpClient(),
+        TokenStorageService(storage),
+        OAuthStorageService(storage),
+        FakeOAuthDeviceDescriptorProvider(),
+      );
+      expect(await relaunchedManager.hasLocallyValidSession(), isFalse);
+      expect(await relaunchedManager.restoreLocalSession(), isFalse);
+    });
+
+    test("keeps local credentials on a refresh transport failure", () async {
+      when(() => mockTokenStorage.getAccessToken()).thenAnswer((_) async => null);
+      when(() => mockTokenStorage.getRefreshToken()).thenAnswer((_) async => "offline-refresh-token");
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/refresh"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer((_) => Future<http.Response>.error(http.ClientException("offline")));
+
+      expect(await authManager.getFreshAccessToken(), isNull);
+      verifyNever(mockTokenStorage.clearTokens);
+      expect(authManager.currentState, isA<AuthInitial>());
+    });
+
+    test("a stale refresh rejection cannot clear a newer completed login", () async {
+      when(() => mockTokenStorage.getAccessToken()).thenAnswer((_) async => null);
+      when(() => mockTokenStorage.getRefreshToken()).thenAnswer((_) async => "old-refresh-token");
+      final Completer<http.Response> refreshResponse = Completer<http.Response>();
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/refresh"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer((_) => refreshResponse.future);
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/email"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            "accessToken": "new-login-access-token",
+            "refreshToken": "new-login-refresh-token",
+            "user": {
+              "id": user.id,
+              "provider": user.provider.key,
+              "providerUserId": user.providerUserId,
+              "providerUsername": user.providerUsername,
+            },
+            "accountStatus": "existing",
+          }),
+          200,
+        ),
+      );
+      when(
+        () => mockTokenStorage.saveTokens(
+          accessToken: "new-login-access-token",
+          refreshToken: "new-login-refresh-token",
+        ),
+      ).thenAnswer((_) async {});
+      when(mockTokenStorage.clearTokens).thenAnswer((_) async {});
+
+      final Future<String?> refresh = authManager.getFreshAccessToken();
+      await pumpEventQueue();
+      final AuthLoginResult login = await authManager.loginWithEmail(
+        email: "test@example.com",
+        password: "correct-password",
+      );
+      expect(login.user, user);
+
+      refreshResponse.complete(http.Response("{}", 401));
+      expect(await refresh, isNull);
+      await pumpEventQueue();
+
+      verifyNever(mockTokenStorage.clearTokens);
+      expect(authManager.currentState, const AuthState.authenticated(user: user));
+    });
+
+    test("a refresh rejection cannot invalidate a login that is still completing", () async {
+      when(() => mockTokenStorage.getAccessToken()).thenAnswer((_) async => null);
+      when(() => mockTokenStorage.getRefreshToken()).thenAnswer((_) async => "old-refresh-token");
+      final Completer<http.Response> refreshResponse = Completer<http.Response>();
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/refresh"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer((_) => refreshResponse.future);
+      final Completer<http.Response> loginResponse = Completer<http.Response>();
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/email"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer((_) => loginResponse.future);
+      when(
+        () => mockTokenStorage.saveTokens(
+          accessToken: "new-login-access-token",
+          refreshToken: "new-login-refresh-token",
+        ),
+      ).thenAnswer((_) async {});
+      when(mockTokenStorage.clearTokens).thenAnswer((_) async {});
+
+      final Future<String?> refresh = authManager.getFreshAccessToken();
+      await pumpEventQueue();
+      final Future<AuthLoginResult> login = authManager.loginWithEmail(
+        email: "test@example.com",
+        password: "correct-password",
+      );
+
+      refreshResponse.complete(http.Response("{}", 401));
+      expect(await refresh, isNull);
+      verifyNever(mockTokenStorage.clearTokens);
+
+      loginResponse.complete(
+        http.Response(
+          jsonEncode({
+            "accessToken": "new-login-access-token",
+            "refreshToken": "new-login-refresh-token",
+            "user": {
+              "id": user.id,
+              "provider": user.provider.key,
+              "providerUserId": user.providerUserId,
+              "providerUsername": user.providerUsername,
+            },
+            "accountStatus": "existing",
+          }),
+          200,
+        ),
+      );
+
+      expect((await login).user, user);
+      expect(authManager.currentState, const AuthState.authenticated(user: user));
+    });
+
+    test("does not retain a refreshed token when logout races its awaited write", () async {
+      when(() => mockTokenStorage.getAccessToken()).thenAnswer((_) async => null);
+      when(() => mockTokenStorage.getRefreshToken()).thenAnswer((_) async => "race-refresh-token");
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/refresh"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            "accessToken": "race-access-token",
+            "refreshToken": "race-new-refresh-token",
+            "user": {
+              "id": user.id,
+              "provider": user.provider.key,
+              "providerUserId": user.providerUserId,
+              "providerUsername": user.providerUsername,
+            },
+          }),
+          200,
+        ),
+      );
+      final Completer<void> saveTokens = Completer<void>();
+      when(
+        () => mockTokenStorage.saveTokens(
+          accessToken: "race-access-token",
+          refreshToken: "race-new-refresh-token",
+        ),
+      ).thenAnswer((_) => saveTokens.future);
+      when(mockTokenStorage.clearTokens).thenAnswer((_) async {});
+
+      final Future<String?> refreshed = authManager.getFreshAccessToken();
+      await pumpEventQueue();
+      verify(
+        () => mockTokenStorage.saveTokens(
+          accessToken: "race-access-token",
+          refreshToken: "race-new-refresh-token",
+        ),
+      ).called(1);
+
+      final Future<void> logout = authManager.logoutCurrentDevice();
+      saveTokens.complete();
+
+      expect(await refreshed, isNull);
+      await logout;
+      expect(authManager.currentState, const AuthState.unauthenticated());
+      verify(mockTokenStorage.clearTokens).called(2);
+    });
+
+    test("does not write a refresh result that arrives after logout", () async {
+      when(() => mockTokenStorage.getAccessToken()).thenAnswer((_) async => null);
+      when(() => mockTokenStorage.getRefreshToken()).thenAnswer((_) async => "late-refresh-token");
+      final Completer<http.Response> response = Completer<http.Response>();
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/refresh"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer((_) => response.future);
+      when(mockTokenStorage.clearTokens).thenAnswer((_) async {});
+
+      final Future<String?> refreshed = authManager.getFreshAccessToken();
+      await pumpEventQueue();
+      final Future<void> logout = authManager.logoutCurrentDevice();
+      await logout;
+      response.complete(
+        http.Response(
+          jsonEncode({
+            "accessToken": "late-access-token",
+            "refreshToken": "late-new-refresh-token",
+            "user": {
+              "id": user.id,
+              "provider": user.provider.key,
+              "providerUserId": user.providerUserId,
+              "providerUsername": user.providerUsername,
+            },
+          }),
+          200,
+        ),
+      );
+
+      expect(await refreshed, isNull);
+      verifyNever(
+        () => mockTokenStorage.saveTokens(
+          accessToken: "late-access-token",
+          refreshToken: "late-new-refresh-token",
+        ),
+      );
+    });
+  });
+
   group("OAuth flow", () {
+    test("does not emit OAuth completion when logout races token persistence", () async {
+      authManager = AuthManager(
+        mockHttpClient,
+        mockTokenStorage,
+        mockOAuthStorage,
+        FakeOAuthDeviceDescriptorProvider(),
+        pollInterval: Duration.zero,
+        delay: (_) async {},
+      );
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/google/init"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            "authUrl": "https://accounts.google.com/o/oauth2/v2/auth",
+            "state": "state-race",
+            "userCode": "RACE",
+            "expiresIn": 300,
+          }),
+          200,
+        ),
+      );
+      when(
+        () => mockHttpClient.get(
+          Uri.parse("$authBaseUrl/auth/session/status"),
+          headers: any(named: "headers"),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            "status": "complete",
+            "accessToken": "oauth-race-access-token",
+            "refreshToken": "oauth-race-refresh-token",
+            "accountStatus": "created",
+            "user": {
+              "id": user.id,
+              "provider": user.provider.key,
+              "providerUserId": user.providerUserId,
+              "providerUsername": user.providerUsername,
+            },
+          }),
+          200,
+        ),
+      );
+      final Completer<void> saveTokens = Completer<void>();
+      when(
+        () => mockTokenStorage.saveTokens(
+          accessToken: "oauth-race-access-token",
+          refreshToken: "oauth-race-refresh-token",
+        ),
+      ).thenAnswer((_) => saveTokens.future);
+      when(mockTokenStorage.clearTokens).thenAnswer((_) async {});
+
+      await authManager.startOAuthFlow(provider: AuthProvider.google);
+      final Future<AuthLoginResult> poll = authManager.pollForResult();
+      await pumpEventQueue();
+      verify(
+        () => mockTokenStorage.saveTokens(
+          accessToken: "oauth-race-access-token",
+          refreshToken: "oauth-race-refresh-token",
+        ),
+      ).called(1);
+
+      final Future<void> logout = authManager.logoutCurrentDevice();
+      saveTokens.complete();
+
+      await expectLater(poll, throwsA(isA<Exception>()));
+      await logout;
+      expect(authManager.currentState, const AuthState.unauthenticated());
+      verifyNever(() => mockTokenStorage.saveUser(any()));
+    });
+
     test("startOAuthFlow creates header-only session token and sends the device descriptor", () async {
       const authUrl = "https://github.com/login/oauth/authorize?client_id=abc";
       when(
@@ -814,6 +1189,8 @@ void main() {
             expiresAt: any(named: "expiresAt"),
           ),
         ).thenAnswer((_) async {});
+        when(mockOAuthStorage.clearPkceVerifier).thenAnswer((_) async {});
+        when(mockOAuthStorage.clearAuthProvider).thenAnswer((_) async {});
         when(mockOAuthStorage.clearOAuthSession).thenAnswer((_) async {});
         when(mockOAuthStorage.getOAuthSession).thenAnswer(
           (_) async => (sessionToken: null, expiresAt: null),
@@ -1106,6 +1483,59 @@ void main() {
   });
 
   group("loginWithEmail", () {
+    test("does not authenticate an email result when logout races token persistence", () async {
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/email"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            "accessToken": "email-race-access-token",
+            "refreshToken": "email-race-refresh-token",
+            "user": {
+              "id": user.id,
+              "provider": "email",
+              "providerUserId": user.providerUserId,
+              "providerUsername": user.providerUsername,
+            },
+            "accountStatus": "existing",
+          }),
+          200,
+        ),
+      );
+      final Completer<void> saveTokens = Completer<void>();
+      when(
+        () => mockTokenStorage.saveTokens(
+          accessToken: "email-race-access-token",
+          refreshToken: "email-race-refresh-token",
+        ),
+      ).thenAnswer((_) => saveTokens.future);
+      when(mockTokenStorage.clearTokens).thenAnswer((_) async {});
+
+      final Future<AuthLoginResult> login = authManager.loginWithEmail(
+        email: "test@example.com",
+        password: "correct-password",
+      );
+      await pumpEventQueue();
+      verify(
+        () => mockTokenStorage.saveTokens(
+          accessToken: "email-race-access-token",
+          refreshToken: "email-race-refresh-token",
+        ),
+      ).called(1);
+
+      final Future<void> logout = authManager.logoutCurrentDevice();
+      saveTokens.complete();
+
+      await expectLater(login, throwsA(isA<Exception>()));
+      await logout;
+      verifyNever(() => mockTokenStorage.saveUser(any()));
+      expect(authManager.currentState, const AuthState.unauthenticated());
+    });
+
     test("posts to /auth/email and stores tokens and username on success", () async {
       when(
         () => mockHttpClient.post(
@@ -1174,6 +1604,180 @@ void main() {
   });
 
   group("restoreSession", () {
+    test("does not overwrite a newer login when /auth/me completes later", () async {
+      when(() => mockTokenStorage.getAccessToken()).thenAnswer(
+        (_) async => (token: "restore-access-token", validityLeft: const Duration(minutes: 5)),
+      );
+      final Completer<http.Response> restoreResponse = Completer<http.Response>();
+      when(
+        () => mockHttpClient.get(
+          Uri.parse("$authBaseUrl/auth/me"),
+          headers: any(named: "headers"),
+        ),
+      ).thenAnswer((_) => restoreResponse.future);
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/email"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            "accessToken": "login-access-token",
+            "refreshToken": "login-refresh-token",
+            "user": {
+              "id": user.id,
+              "provider": user.provider.key,
+              "providerUserId": user.providerUserId,
+              "providerUsername": user.providerUsername,
+            },
+            "accountStatus": "existing",
+          }),
+          200,
+        ),
+      );
+      when(
+        () => mockTokenStorage.saveTokens(
+          accessToken: "login-access-token",
+          refreshToken: "login-refresh-token",
+        ),
+      ).thenAnswer((_) async {});
+
+      final Future<bool> restored = authManager.restoreSession();
+      await pumpEventQueue();
+      final AuthLoginResult login = await authManager.loginWithEmail(
+        email: "test@example.com",
+        password: "correct-password",
+      );
+      expect(login.user, user);
+
+      restoreResponse.complete(
+        http.Response(
+          jsonEncode({
+            "user": {
+              "id": "restored-user",
+              "provider": user.provider.key,
+              "providerUserId": "restored-provider-id",
+              "providerUsername": "restored-user",
+            },
+          }),
+          200,
+        ),
+      );
+
+      expect(await restored, isFalse);
+      expect(authManager.currentState, const AuthState.authenticated(user: user));
+      verify(() => mockTokenStorage.saveUser(user)).called(1);
+    });
+
+    test("does not emit or save a user when logout supersedes /auth/me", () async {
+      when(() => mockTokenStorage.getAccessToken()).thenAnswer(
+        (_) async => (token: "valid-access-token", validityLeft: const Duration(minutes: 5)),
+      );
+      final Completer<http.Response> response = Completer<http.Response>();
+      when(
+        () => mockHttpClient.get(
+          Uri.parse("$authBaseUrl/auth/me"),
+          headers: any(named: "headers"),
+        ),
+      ).thenAnswer((_) => response.future);
+      when(mockTokenStorage.clearTokens).thenAnswer((_) async {});
+
+      final Future<bool> restored = authManager.restoreSession();
+      await pumpEventQueue();
+      final Future<void> logout = authManager.logoutCurrentDevice();
+      await logout;
+      response.complete(
+        http.Response(
+          jsonEncode({
+            "user": {
+              "id": user.id,
+              "provider": user.provider.key,
+              "providerUserId": user.providerUserId,
+              "providerUsername": user.providerUsername,
+            },
+          }),
+          200,
+        ),
+      );
+
+      expect(await restored, isFalse);
+      verifyNever(() => mockTokenStorage.saveUser(any()));
+      expect(authManager.currentState, const AuthState.unauthenticated());
+    });
+
+    test("does not emit a restored user when logout races its user-cache write", () async {
+      when(() => mockTokenStorage.getAccessToken()).thenAnswer(
+        (_) async => (token: "valid-access-token", validityLeft: const Duration(minutes: 5)),
+      );
+      when(
+        () => mockHttpClient.get(
+          Uri.parse("$authBaseUrl/auth/me"),
+          headers: any(named: "headers"),
+        ),
+      ).thenAnswer(
+        (_) async => http.Response(
+          jsonEncode({
+            "user": {
+              "id": user.id,
+              "provider": user.provider.key,
+              "providerUserId": user.providerUserId,
+              "providerUsername": user.providerUsername,
+            },
+          }),
+          200,
+        ),
+      );
+      final Completer<void> saveUser = Completer<void>();
+      when(() => mockTokenStorage.saveUser(user)).thenAnswer((_) => saveUser.future);
+      when(mockTokenStorage.clearTokens).thenAnswer((_) async {});
+
+      final Future<bool> restored = authManager.restoreSession();
+      await pumpEventQueue();
+      verify(() => mockTokenStorage.saveUser(user)).called(1);
+
+      final Future<void> logout = authManager.logoutCurrentDevice();
+      saveUser.complete();
+
+      expect(await restored, isFalse);
+      await logout;
+      expect(authManager.currentState, const AuthState.unauthenticated());
+    });
+
+    test("does not restore a local session when logout races the token read", () async {
+      final Completer<bool> hasSession = Completer<bool>();
+      when(() => mockTokenStorage.hasLocallyValidSession()).thenAnswer((_) => hasSession.future);
+      when(mockTokenStorage.clearTokens).thenAnswer((_) async {});
+
+      final Future<bool> restored = authManager.restoreLocalSession();
+      await pumpEventQueue();
+      final Future<void> logout = authManager.logoutCurrentDevice();
+      hasSession.complete(true);
+
+      expect(await restored, isFalse);
+      await logout;
+      verifyNever(() => mockTokenStorage.getUser());
+      expect(authManager.currentState, const AuthState.unauthenticated());
+    });
+
+    test("does not emit a local user when logout races the final restore read", () async {
+      when(() => mockTokenStorage.hasLocallyValidSession()).thenAnswer((_) async => true);
+      final Completer<AuthUser?> userRead = Completer<AuthUser?>();
+      when(() => mockTokenStorage.getUser()).thenAnswer((_) => userRead.future);
+      when(mockTokenStorage.clearTokens).thenAnswer((_) async {});
+
+      final Future<bool> restored = authManager.restoreLocalSession();
+      await pumpEventQueue();
+      verify(() => mockTokenStorage.getUser()).called(1);
+      final Future<void> logout = authManager.logoutCurrentDevice();
+      userRead.complete(user);
+
+      expect(await restored, isFalse);
+      await logout;
+      expect(authManager.currentState, const AuthState.unauthenticated());
+    });
+
     test("persists the username after restoring from /auth/me", () async {
       when(() => mockTokenStorage.getAccessToken()).thenAnswer(
         (_) async => (token: "valid-access-token", validityLeft: const Duration(minutes: 5)),
@@ -1281,4 +1885,21 @@ void main() {
       expect(authManager.currentState, isA<AuthInitial>());
     });
   });
+}
+
+class _MemorySecureStorage() implements SecureStorage {
+  final Map<String, String> _values = <String, String>{};
+
+  @override
+  Future<String?> read({required String key}) async => _values[key];
+
+  @override
+  Future<void> write({required String key, required String value}) async {
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> delete({required String key}) async {
+    _values.remove(key);
+  }
 }

--- a/client/module_desktop_core/lib/src/cubits/auth_gate/auth_gate_cubit.dart
+++ b/client/module_desktop_core/lib/src/cubits/auth_gate/auth_gate_cubit.dart
@@ -1,7 +1,6 @@
 import "dart:async";
 
 import "package:bloc/bloc.dart";
-import "package:meta/meta.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 
 import "../../orchestration/desktop_logout_orchestrator.dart";
@@ -17,16 +16,13 @@ import "auth_gate_state.dart";
 class AuthGateCubit._create({
   required final AuthSession _authSession,
   required final DesktopLogoutOrchestrator _logoutOrchestrator,
-  @visibleForTesting required final Duration _signOutRestoreFence,
 }) extends Cubit<AuthGateState> {
   new({
     required AuthSession authSession,
     required DesktopLogoutOrchestrator logoutOrchestrator,
-    @visibleForTesting Duration signOutRestoreFence = const Duration(seconds: 5),
   }) : this._create(
          authSession: authSession,
          logoutOrchestrator: logoutOrchestrator,
-         signOutRestoreFence: signOutRestoreFence,
        );
 
   this : super(const AuthGateState.checking()) {
@@ -34,7 +30,6 @@ class AuthGateCubit._create({
   }
 
   StreamSubscription<AuthState>? _subscription;
-  Future<void>? _backgroundRestore;
 
   Future<void> _restoreAndSubscribe() async {
     bool hasLocalSession = false;
@@ -72,12 +67,9 @@ class AuthGateCubit._create({
     }
 
     // Recover the account details in the background; the auth stream upgrades
-    // the state to a full signedIn(user) when it completes. The future is
-    // kept so signOut() can fence on it.
-    final Future<void> restore = _recoverUserInBackground();
-    _backgroundRestore = restore;
-    await restore;
-    _backgroundRestore = null;
+    // the state to a full signedIn(user) when it completes. AuthManager owns
+    // the logout generation that prevents a late result from re-authenticating.
+    await _recoverUserInBackground();
   }
 
   Future<void> _recoverUserInBackground() async {
@@ -99,30 +91,8 @@ class AuthGateCubit._create({
 
   /// Coordinated device-local sign-out. The logout owner stops the supervised
   /// helper before clearing local tokens; step 11 extends that same owner with
-  /// unregister handling.
+  /// unregister handling. AuthManager fences every in-flight auth result.
   Future<void> signOut() async {
-    // Fence on the startup user recovery: its /auth/me completion re-emits
-    // authenticated, which must land BEFORE logout's unauthenticated — never
-    // after, or a signed-out user would be flipped back to signed in.
-    final Future<void>? pending = _backgroundRestore;
-    if (pending != null) {
-      try {
-        await pending.timeout(_signOutRestoreFence);
-      } on TimeoutException {
-        // Pathologically slow restore: proceed with the sign-out rather than
-        // blocking the user — but the hung restore can still re-emit
-        // authenticated when it finally lands, so re-run coordinated logout
-        // after it settles: sign-out always wins eventually.
-        logw("Background session restore still pending at sign-out; retrying logout when it settles");
-        // Deliberately UNCONDITIONAL: the settling restore's own token
-        // refresh can re-persist tokens after the logout, and the auth layer
-        // has no logout generation, so no local check can distinguish them
-        // from a fresh sign-in. A fresh sign-in completing inside this
-        // pathological window is bounced once — visible and recoverable —
-        // which beats a silently undone sign-out.
-        unawaited(pending.whenComplete(_logoutBestEffort));
-      }
-    }
     await _logoutBestEffort();
   }
 

--- a/client/module_desktop_core/test/cubits/auth_gate/auth_gate_cubit_test.dart
+++ b/client/module_desktop_core/test/cubits/auth_gate/auth_gate_cubit_test.dart
@@ -120,21 +120,15 @@ void main() {
     verify(() => authSession.restoreSession()).called(1);
   });
 
-  test("signing out during token-only recovery cannot be undone by the in-flight restore", () async {
+  test("sign out delegates immediately while background restore is pending", () async {
     when(() => authSession.hasLocallyValidSession()).thenAnswer((_) async => true);
     when(() => authSession.restoreLocalSession()).thenAnswer((_) async => false);
     final Completer<bool> restore = Completer<bool>();
-    when(() => authSession.restoreSession()).thenAnswer(
-      (_) => restore.future.then((confirmed) {
-        if (confirmed) {
-          authStates.add(const AuthState.authenticated(user: _user));
-        }
-        return confirmed;
-      }),
-    );
+    when(() => authSession.restoreSession()).thenAnswer((_) => restore.future);
     when(() => authSession.logoutCurrentDevice()).thenAnswer((_) async {
       authStates.add(const AuthState.unauthenticated());
     });
+
     final AuthGateCubit cubit = AuthGateCubit(
       authSession: authSession,
       logoutOrchestrator: logoutOrchestrator,
@@ -143,87 +137,13 @@ void main() {
     await pumpEventQueue();
     expect(cubit.state, const AuthGateState.signedIn(user: null));
 
-    final Future<void> signOut = cubit.signOut();
-    // The /auth/me confirmation lands only AFTER the user clicked sign out.
-    restore.complete(true);
-    await signOut;
-    await pumpEventQueue();
-
-    expect(cubit.state, const AuthGateState.signedOut());
-  });
-
-  test("a restore outliving the sign-out fence is re-cleared when it settles", () async {
-    bool tokensStored = true;
-    when(() => authSession.hasLocallyValidSession()).thenAnswer((_) async => tokensStored);
-    when(() => authSession.restoreLocalSession()).thenAnswer((_) async => false);
-    final Completer<bool> hungRestore = Completer<bool>();
-    when(() => authSession.restoreSession()).thenAnswer(
-      (_) => hungRestore.future.then((confirmed) {
-        if (confirmed) {
-          authStates.add(const AuthState.authenticated(user: _user));
-        }
-        return confirmed;
-      }),
-    );
-    when(() => authSession.logoutCurrentDevice()).thenAnswer((_) async {
-      tokensStored = false;
-      authStates.add(const AuthState.unauthenticated());
-    });
-    final AuthGateCubit cubit = AuthGateCubit(
-      authSession: authSession,
-      logoutOrchestrator: logoutOrchestrator,
-      signOutRestoreFence: const Duration(milliseconds: 20),
-    );
-    addTearDown(cubit.close);
-    await pumpEventQueue();
-
-    // The fence times out on the hung restore and the sign-out proceeds.
     await cubit.signOut();
-    expect(cubit.state, const AuthGateState.signedOut());
-
-    // The hung /auth/me finally lands and re-emits authenticated — the
-    // chained re-clear must flip it back to signed out (no fresh tokens
-    // exist, so this is the stale session).
-    hungRestore.complete(true);
-    await pumpEventQueue();
 
     expect(cubit.state, const AuthGateState.signedOut());
-    verify(() => authSession.logoutCurrentDevice()).called(2);
-  });
+    verify(() => authSession.logoutCurrentDevice()).called(1);
 
-  test("the delayed re-clear is unconditional — a sign-in inside the window is bounced once", () async {
-    // Deliberate correctness-first trade: the stale restore's own token
-    // refresh can re-persist tokens post-logout, so no local check can tell
-    // it apart from a fresh sign-in. The re-clear
-    // therefore always runs; a fresh sign-in completing inside this
-    // pathological window is signed out once more (visible, recoverable)
-    // instead of ever leaving a sign-out silently undone.
-    when(() => authSession.hasLocallyValidSession()).thenAnswer((_) async => true);
-    when(() => authSession.restoreLocalSession()).thenAnswer((_) async => false);
-    final Completer<bool> hungRestore = Completer<bool>();
-    when(() => authSession.restoreSession()).thenAnswer((_) => hungRestore.future);
-    when(() => authSession.logoutCurrentDevice()).thenAnswer((_) async {
-      authStates.add(const AuthState.unauthenticated());
-    });
-    final AuthGateCubit cubit = AuthGateCubit(
-      authSession: authSession,
-      logoutOrchestrator: logoutOrchestrator,
-      signOutRestoreFence: const Duration(milliseconds: 20),
-    );
-    addTearDown(cubit.close);
+    restore.complete(false);
     await pumpEventQueue();
-    await cubit.signOut();
-    expect(cubit.state, const AuthGateState.signedOut());
-
-    // The user signs back in BEFORE the hung restore settles…
-    authStates.add(const AuthState.authenticated(user: _user));
-    await pumpEventQueue();
-    hungRestore.complete(false);
-    await pumpEventQueue();
-
-    // …and is bounced once by the unconditional re-clear.
-    expect(cubit.state, const AuthGateState.signedOut());
-    verify(() => authSession.logoutCurrentDevice()).called(2);
   });
 
   test("an unconfirmed background restore stays provisionally signed in", () async {

--- a/docs/regression/account-and-onboarding.md
+++ b/docs/regression/account-and-onboarding.md
@@ -14,11 +14,15 @@ participates.
 - Startup routing uses local session state only, with no network work at splash.
 - Tokens live in secure storage with one writer, refresh before expiry, and are
   cleared on logout; the connection follows logout. Startup reads stored tokens
-  once before deciding whether validation or a fresh login is needed. Standalone
-  bridge logout remains clean and idempotent when tokens are already absent or
-  the saved authentication session has expired. Non-sandboxed macOS desktop
-  builds use the classic default Keychain without requiring a provisioned
-  Data Protection Keychain access group.
+  once before deciding whether validation or a fresh login is needed. Logout
+  fences in-flight login, refresh, and restore results, so none can re-save
+  credentials or emit authenticated after local sign-out. A definitive
+  `/auth/refresh` 4xx rejection clears persisted tokens and user data before
+  emitting unauthenticated, while transport/server failures leave credentials
+  intact. Standalone bridge logout remains clean and idempotent when tokens are
+  already absent or the saved authentication session has expired. Non-sandboxed
+  macOS desktop builds use the classic default Keychain without requiring a
+  provisioned Data Protection Keychain access group.
 - Auth-server URLs behave identically with or without trailing slashes, and
   deadline expiry actively aborts registration and token-refresh transport,
   including response-body consumption.
@@ -37,9 +41,9 @@ participates.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Signed-in launch restores the local session and reaches Projects with no network work at splash; the macOS desktop adapter routes secure storage through its classic-Keychain client; a bridge start reaches readiness. Client end to end plus headless bridge; no plugin. |
-| L2 Routine | One provider through sign-in and logout on the release-target client platform, plus the prompt decision for marker-present, already-registered, and absent accounts. Client end to end plus headless bridge; no plugin. |
+| L2 Routine | One provider through sign-in and logout on the release-target client platform, including an in-flight restore/refresh race and definitive refresh rejection, plus the prompt decision for marker-present, already-registered, and absent accounts. Client end to end plus headless bridge; no plugin. |
 | L3 Release | Every sign-in option on the release-target client platform, both empty-Projects states, and prompt ordering proved by a real client joining, completing key exchange, and issuing a request while the prompt shows. Client end to end plus relay integration; no plugin. |
-| L4 Extended | Background/resume mid sign-in, unreachable or rejecting auth server, expiry refresh, logout while connected, withheld push registration, delayed status check, second mobile platform. Client end to end where the app observes it, headless where the bridge owns it. |
+| L4 Extended | Background/resume mid sign-in, unreachable or rejecting auth server, expiry refresh, logout while connected, logout during restore/login persistence, refresh rejection followed by relaunch, withheld push registration, delayed status check, second mobile platform. Client end to end where the app observes it, headless where the bridge owns it. |
 | L5 Full | Store builds: native Apple sign-in on a real device, email flow, legal and analytics-preference surfaces, marker rewrite after a fresh install, and the status-endpoint-unavailable path against an older auth deployment. Packaged or external; no plugin. |
 
 ## Exploration Guidance
@@ -53,8 +57,10 @@ the prompt and a reused one when testing suppression.
 
 - Splash doing network work, or routing a valid session to sign-in.
 - A recoverable interruption surfacing as terminal, or a real failure as silent.
-- Tokens surviving logout, a logged-out app holding a live connection, or macOS
-  OAuth completion failing with a missing Keychain entitlement (`-34018`).
+- Tokens surviving logout, an in-flight login/refresh/restore re-saving tokens or
+  emitting authenticated after logout, a rejected refresh leaving credentials
+  restorable after relaunch, a transport failure clearing a usable session, or
+  macOS OAuth completion failing with a missing Keychain entitlement (`-34018`).
 - The prompt appearing before readiness, after a failed start, on an account that
   already has the app, or driving repeated status requests.
 - Relay availability or key exchange waiting on push registration or the check.


### PR DESCRIPTION
## Complexity

🚧 Complex — this hardens concurrent authentication, logout, restore, and refresh lifecycles across shared auth and desktop logout surfaces.

## What

- Add `AuthManager` auth-generation fencing and a private mutation lock around token/user persistence, OAuth cleanup, and auth-state emission.
- Prevent stale restore, refresh, OAuth, email, and Apple results from re-authenticating or overwriting a newer auth decision.
- Treat definitive `/auth/refresh` 4xx responses as credential rejection: clear persisted tokens/user data before emitting `unauthenticated`; keep transport and non-definitive server failures non-destructive.
- Remove `AuthGateCubit`'s temporary timeout/re-clear workaround so it delegates directly to `DesktopLogoutOrchestrator`.
- Add race, rejection, transport, and relaunch regression coverage and update auth/plan regression documentation.

## Why

An async restore or refresh could finish after local sign-out or a newer login, re-save credentials, or emit an authenticated state for the wrong account. A revoked refresh token could also leave credentials restorable after relaunch. The auth owner now makes those outcomes ordered and observable at the persistence/state boundary.

## Risk and test focus

Medium-high security and lifecycle risk, limited to shared local auth state and desktop sign-out coordination; no relay or database changes. Focus on logout during awaited token/user writes, restore/login and refresh/login ordering, definitive refresh rejection versus offline transport failure, and relaunch after credential rejection.

## Expected result

- Local logout remains authoritative even when auth work is already in flight.
- A newer interactive login cannot be overwritten by an older restore or refresh rejection.
- Revoked credentials and cached user data are removed before the signed-out state is emitted; offline failures do not sign users out.
- No database, relay, or wire-contract impact. The desktop gate no longer owns a second auth-clear workaround.

## Verification

- `module_auth`: `dart analyze --fatal-infos`; 105 tests passed.
- `module_desktop_core`: `dart analyze --fatal-infos`; 155 tests passed.
- `module_core`: `dart analyze --fatal-infos`; 1,459 tests passed.
- `client/app`: `flutter analyze --fatal-infos`; 913 tests passed.
- `client/desktop`: `flutter analyze --fatal-infos`; 49 tests passed.
- Dart LSP: zero diagnostics across changed Dart files.
- Architecture implementation review: approved with no findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale restore, refresh, or login results from re-authenticating the wrong account after local sign-out or a newer login, and makes a definitive refresh rejection (auth-server 401) clear credentials before the signed-out state is emitted.

- `AuthManager` advances an auth generation on logout, interactive login, and refresh rejection, so older in-flight restore, refresh, OAuth, email, and Apple results can't re-save tokens or emit `authenticated`.
- A private mutation lock serializes credential/user persistence, OAuth cleanup, and auth-state emission; a superseded write clears any tokens it managed to store.
- Only auth-server 401 responses clear persisted tokens and user data before emitting `unauthenticated`; transport, gateway 4xx, and other server failures keep credentials intact.
- Removed `AuthGateCubit`'s temporary timeout/re-clear workaround; it now delegates sign-out directly to `DesktopLogoutOrchestrator`.
- No database, relay, or auth wire-contract changes.

<sup>Written for commit 2601b8a9fe1cbff00f9c3ed9f7d1f7f82bac3af4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

