### PR TITLE
🚧 [desktop-app] Coordinate logout and offline unregister [step 11/22]

### DIFF
--- a/.plan/active/desktop-app/PLAN.md
+++ b/.plan/active/desktop-app/PLAN.md
@@ -356,7 +356,7 @@ refresh / logout regression is this step's test focus. Ordered **before** the
 logout orchestrator so step 11 can call `logoutCurrentDevice()` directly
 without re-creating the cubit's fence.
 
-**Step 11 — ⚙️ Logout coordination + offline unregister fallback.** Add
+**Step 11 — 🚧 Logout coordination + offline unregister fallback.** Add
 `deleteBridge(id)` to `module_core` `BridgeApi`/`BridgeRepository`
 (`DELETE /auth/bridges/:bridgeId`; 404 = success) — mobile-shared, mobile
 stays green. **Establish GUI-side `bridgeId` persistence (C8):** a Layer-1

--- a/.plan/active/desktop-app/PLAN.md
+++ b/.plan/active/desktop-app/PLAN.md
@@ -363,15 +363,17 @@ stays green. **Establish GUI-side `bridgeId` persistence (C8):** a Layer-1
 desktop-owned `BridgeIdStorage` (step-2 storage pattern) written by
 `BridgeStatusTracker` on the `registered` event down the existing
 dispatcher→tracker path, seeded from disk at startup so a GUI relaunch with a
-dead helper still knows what to delete. **`DesktopLogoutOrchestrator`**
-(extending the step-7 orchestrator) composes `ControlCommandService`
-(`unregister_and_exit` send), `BridgeProcessService` (bounded wait → kill if
-needed), `BridgeRepository.deleteBridge` — attempted **always**, not only for
-a dead helper: the helper's own unregister failure is swallowed by design and
-unacknowledged, so the idempotent persisted-id deletion (404 = success) is
-what actually guarantees no leaked registration — and
-`AuthSession.logoutCurrentDevice()` (safe against late restores per step 10).
-Every network step is best-effort with a bounded timeout; logout always
+dead helper still knows what to delete. Persist the owning account together
+with the id; a later account must never submit or clear an earlier account's
+offline retry handle. **`DesktopLogoutOrchestrator`** (extending the step-7
+orchestrator) composes `ControlCommandService` (`unregister_and_exit` send),
+`BridgeProcessService`'s expected-stop-after-command path (bounded wait → kill
+if needed, without a competing shutdown), `BridgeRepository.deleteBridge` —
+attempted **always**, not only for a dead helper: the helper's own unregister
+failure is swallowed by design and unacknowledged, so the idempotent persisted
+delete (404 = success) is what actually guarantees no leaked registration —
+and `AuthSession.logoutCurrentDevice()` (safe against late restores per step
+10). Every network step is best-effort with a bounded timeout; logout always
 completes offline, then clears local tokens only (never account-wide).
 
 **Step 12 — ⚙️ Supervised E2E + harness retirement.** Automated integration:

--- a/.plan/active/desktop-app/TRACKER.md
+++ b/.plan/active/desktop-app/TRACKER.md
@@ -17,8 +17,8 @@ user-run checkpoints, not PRs; only the user marks them passed.
 | — | MT gate A: first real GUI supervision (user-run) | done |
 | 8 | ⚙️ Single instance + last-state restore | done |
 | 9 | ⚙️ Autostart + hidden boot | done |
-| 10 | 🚧 `module_auth` logout/rejection hardening (R1) | in-progress |
-| 11 | ⚙️ Logout coordination + offline unregister fallback | pending |
+| 10 | 🚧 `module_auth` logout/rejection hardening (R1) | done |
+| 11 | ⚙️ Logout coordination + offline unregister fallback | in-progress |
 | 12 | ⚙️ Supervised E2E suite + dev-harness retirement | pending |
 | — | MT gate B: daily driver (user-run) | pending |
 | 13 | ⚙️ Desktop relay-client enablement | pending |
@@ -44,4 +44,6 @@ work is expected. Phone session round-trip and standalone CLI coexistence were
 not separately re-reported in the final check; the user explicitly accepted
 the available gate coverage as sufficient.
 
-The next plan slice is Step 10 (`module_auth` logout/rejection hardening).
+Step 10 merged in PR #1212 on 2026-08-30. Step 11 is now the active
+implementation slice; its successor branch was prepared locally while Step 10
+was under review.

--- a/.plan/active/desktop-app/TRACKER.md
+++ b/.plan/active/desktop-app/TRACKER.md
@@ -18,7 +18,7 @@ user-run checkpoints, not PRs; only the user marks them passed.
 | 8 | ⚙️ Single instance + last-state restore | done |
 | 9 | ⚙️ Autostart + hidden boot | done |
 | 10 | 🚧 `module_auth` logout/rejection hardening (R1) | done |
-| 11 | ⚙️ Logout coordination + offline unregister fallback | in-progress |
+| 11 | 🚧 Logout coordination + offline unregister fallback | in-progress |
 | 12 | ⚙️ Supervised E2E suite + dev-harness retirement | pending |
 | — | MT gate B: daily driver (user-run) | pending |
 | 13 | ⚙️ Desktop relay-client enablement | pending |

--- a/.plan/active/desktop-app/steps/step-10.md
+++ b/.plan/active/desktop-app/steps/step-10.md
@@ -59,7 +59,7 @@ that delegates coordinated logout.
 - Dart LSP reported zero diagnostics across all changed Dart files.
 - `git diff --check` clean.
 
-## Remaining
+## Completed handoff
 
-Step 10 is implementation-complete and awaits its plan-series PR review and
-merge. MT gate B remains the user-run daily-driver checkpoint after Step 12.
+Step 10 merged in PR #1212 on 2026-08-30. MT gate B remains the user-run
+daily-driver checkpoint after Step 12.

--- a/.plan/active/desktop-app/steps/step-11.md
+++ b/.plan/active/desktop-app/steps/step-11.md
@@ -1,4 +1,4 @@
-# Step 11 — Logout coordination + offline unregister fallback
+# Step 11 — 🚧 Logout coordination + offline unregister fallback
 
 Date: 2026-08-30.
 

--- a/.plan/active/desktop-app/steps/step-11.md
+++ b/.plan/active/desktop-app/steps/step-11.md
@@ -30,9 +30,8 @@ findings. It confirmed the API → repository → service boundaries, focused
 - `dart run build_runner build` completed successfully for `module_desktop_core` and regenerated its DI config.
 - `git diff --check` clean.
 
-## Remaining
+## Handoff
 
-Step 11 is implementation-complete on the local successor branch and awaits
-Step 10's PR merge before it can be rebased, pushed, and opened as the next
-plan-series PR. MT gate B remains the user-run daily-driver checkpoint after
-this step's successor work.
+Step 10 merged in PR #1212. The successor branch is rebased onto the merged
+`origin/main` and is ready to publish as the next plan-series PR. MT gate B
+remains the user-run daily-driver checkpoint after Step 12.

--- a/.plan/active/desktop-app/steps/step-11.md
+++ b/.plan/active/desktop-app/steps/step-11.md
@@ -16,22 +16,22 @@ and local logout sequencing.
 
 ## Architecture implementation review
 
-The Step 11 architecture implementation review approved the changes with no
-findings. It confirmed the API → repository → service boundaries, focused
-`BridgeIdStorage` ownership, dispatcher-before-restore startup ordering, and
-`DesktopLogoutOrchestrator` lifecycle ownership.
+The initial Step 11 architecture implementation review approved the original
+implementation with no findings. A second review after the Codex follow-up
+also approved the account-bound persistence record, owner-checked deletion,
+and expected-stop-after-command path with no findings.
 
 ## Verification
 
 - `client/module_core`: `dart analyze --fatal-infos` clean; full suite passed (1,463 tests), including bridge deletion and 404-idempotence coverage.
-- `client/module_desktop_core`: `dart analyze --fatal-infos` clean; full suite passed (165 tests), including account-bound persisted registration, dispatcher startup, command routing, expected-stop teardown, and logout ordering/fallback coverage.
+- `client/module_desktop_core`: `dart analyze --fatal-infos` clean; full suite passed (171 tests), including account-bound persisted registration, dispatcher startup, command routing, expected-stop teardown, and logout ordering/fallback coverage.
 - `client/desktop`: `flutter analyze --fatal-infos` clean; full suite passed (49 tests).
 - `client/app`: `flutter analyze --fatal-infos` clean; full suite passed (913 tests), confirming the shared module-core extension leaves mobile green.
-- `dart run build_runner build` completed successfully for `module_desktop_core` and regenerated its DI config.
+- `dart pub get` and `dart run build_runner build` completed successfully for `module_desktop_core`; the typed persisted-registration model and DI config were regenerated.
 - `git diff --check` clean.
 
 ## Handoff
 
 Step 10 merged in PR #1212. The successor branch is rebased onto the merged
-`origin/main` and is ready to publish as the next plan-series PR. MT gate B
-remains the user-run daily-driver checkpoint after Step 12.
+`origin/main`, and the implementation plus both architecture reviews are
+complete. MT gate B remains the user-run daily-driver checkpoint after Step 12.

--- a/.plan/active/desktop-app/steps/step-11.md
+++ b/.plan/active/desktop-app/steps/step-11.md
@@ -1,0 +1,31 @@
+# Step 11 — Logout coordination + offline unregister fallback
+
+Date: 2026-08-30.
+
+## Delivered
+
+- Added the authenticated `BridgeApi.deleteBridge()` / `BridgeRepository.deleteBridge()` path for `DELETE /auth/bridges/:bridgeId`. Bridge IDs are URL-encoded and an already-absent registration (`404`) maps to idempotent success.
+- Added desktop-owned `BridgeIdStorage` under the existing `desktop-instance` application-data directory. `BridgeStatusTracker` persists each `registered` event, serializes ID mutations, restores the ID during dispatcher startup, and clears it only after confirmed server deletion.
+- Added the typed `unregister_and_exit` command through `ControlCommandRepository` and `ControlCommandService`.
+- Extended `DesktopLogoutOrchestrator` to persist durable Off, request helper-side unregister, bounded-stop the helper through `BridgeProcessService`, independently attempt GUI-side idempotent deletion, and then call `AuthSession.logoutCurrentDevice()` only after a successful helper stop. Deletion and helper-command failures remain observable but do not block offline local logout; a failed process stop retains authentication under the existing safety boundary.
+- Updated desktop DI, startup ordering, regression documentation, and focused tests.
+
+No database or new wire-contract change; the auth deletion endpoint and
+`unregister_and_exit` protocol already existed. The change adds GUI persistence
+and local logout sequencing.
+
+## Verification
+
+- `client/module_core`: `dart analyze --fatal-infos` clean; full suite passed (1,463 tests), including bridge deletion and 404-idempotence coverage.
+- `client/module_desktop_core`: `dart analyze --fatal-infos` clean; full suite passed (165 tests), including persisted-id storage, dispatcher startup, command routing, and logout ordering/fallback coverage.
+- `client/desktop`: `flutter analyze --fatal-infos` clean; full suite passed (49 tests).
+- `client/app`: `flutter analyze --fatal-infos` clean; full suite passed (913 tests), confirming the shared module-core extension leaves mobile green.
+- `dart run build_runner build` completed successfully for `module_desktop_core` and regenerated its DI config.
+- `git diff --check` clean.
+
+## Remaining
+
+Step 11 is implementation-complete on the local successor branch and awaits
+Step 10's PR merge before it can be rebased, pushed, and opened as the next
+plan-series PR. MT gate B remains the user-run daily-driver checkpoint after
+this step's successor work.

--- a/.plan/active/desktop-app/steps/step-11.md
+++ b/.plan/active/desktop-app/steps/step-11.md
@@ -14,6 +14,13 @@ No database or new wire-contract change; the auth deletion endpoint and
 `unregister_and_exit` protocol already existed. The change adds GUI persistence
 and local logout sequencing.
 
+## Architecture implementation review
+
+The Step 11 architecture implementation review approved the changes with no
+findings. It confirmed the API → repository → service boundaries, focused
+`BridgeIdStorage` ownership, dispatcher-before-restore startup ordering, and
+`DesktopLogoutOrchestrator` lifecycle ownership.
+
 ## Verification
 
 - `client/module_core`: `dart analyze --fatal-infos` clean; full suite passed (1,463 tests), including bridge deletion and 404-idempotence coverage.

--- a/.plan/active/desktop-app/steps/step-11.md
+++ b/.plan/active/desktop-app/steps/step-11.md
@@ -5,9 +5,9 @@ Date: 2026-08-30.
 ## Delivered
 
 - Added the authenticated `BridgeApi.deleteBridge()` / `BridgeRepository.deleteBridge()` path for `DELETE /auth/bridges/:bridgeId`. Bridge IDs are URL-encoded and an already-absent registration (`404`) maps to idempotent success.
-- Added desktop-owned `BridgeIdStorage` under the existing `desktop-instance` application-data directory. `BridgeStatusTracker` persists each `registered` event, serializes ID mutations, restores the ID during dispatcher startup, and clears it only after confirmed server deletion.
+- Added desktop-owned `BridgeIdStorage` under the existing `desktop-instance` application-data directory. `BridgeStatusTracker` persists each `registered` event with its owning account, serializes registration mutations, restores the record during dispatcher startup, and clears it only after confirmed server deletion for the currently authenticated owner.
 - Added the typed `unregister_and_exit` command through `ControlCommandRepository` and `ControlCommandService`.
-- Extended `DesktopLogoutOrchestrator` to persist durable Off, request helper-side unregister, bounded-stop the helper through `BridgeProcessService`, independently attempt GUI-side idempotent deletion, and then call `AuthSession.logoutCurrentDevice()` only after a successful helper stop. Deletion and helper-command failures remain observable but do not block offline local logout; a failed process stop retains authentication under the existing safety boundary.
+- Extended `DesktopLogoutOrchestrator` to persist durable Off, request helper-side unregister, wait through the expected-stop-after-command path without a competing shutdown, independently attempt GUI-side idempotent deletion only for the current account owner, and then call `AuthSession.logoutCurrentDevice()` only after a successful helper stop. Deletion and helper-command failures remain observable but do not block offline local logout; a failed process stop retains authentication under the existing safety boundary.
 - Updated desktop DI, startup ordering, regression documentation, and focused tests.
 
 No database or new wire-contract change; the auth deletion endpoint and
@@ -24,7 +24,7 @@ findings. It confirmed the API → repository → service boundaries, focused
 ## Verification
 
 - `client/module_core`: `dart analyze --fatal-infos` clean; full suite passed (1,463 tests), including bridge deletion and 404-idempotence coverage.
-- `client/module_desktop_core`: `dart analyze --fatal-infos` clean; full suite passed (165 tests), including persisted-id storage, dispatcher startup, command routing, and logout ordering/fallback coverage.
+- `client/module_desktop_core`: `dart analyze --fatal-infos` clean; full suite passed (165 tests), including account-bound persisted registration, dispatcher startup, command routing, expected-stop teardown, and logout ordering/fallback coverage.
 - `client/desktop`: `flutter analyze --fatal-infos` clean; full suite passed (49 tests).
 - `client/app`: `flutter analyze --fatal-infos` clean; full suite passed (913 tests), confirming the shared module-core extension leaves mobile green.
 - `dart run build_runner build` completed successfully for `module_desktop_core` and regenerated its DI config.

--- a/client/app/test/core/routing/adaptive_session_router_test_harness.dart
+++ b/client/app/test/core/routing/adaptive_session_router_test_harness.dart
@@ -8,7 +8,6 @@ import "package:mocktail/mocktail.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/models/sse_event.dart";
-import "package:sesori_dart_core/src/repositories/bridge_repository.dart";
 import "package:sesori_dart_core/src/repositories/models/plugin_discovery_snapshot.dart";
 import "package:sesori_dart_core/src/repositories/plugin_preference_repository.dart";
 import "package:sesori_mobile/core/routing/app_router.dart";

--- a/client/desktop/lib/main.dart
+++ b/client/desktop/lib/main.dart
@@ -29,7 +29,7 @@ Future<void> main(List<String> arguments) async {
   }
   // The dispatcher must own the control event stream before any service can
   // spawn a helper, or its first bootstrap token request could go unread.
-  getIt<ControlMessageDispatcher>().start();
+  await getIt<ControlMessageDispatcher>().start();
   runApp(SesoriDesktopApp(hiddenLaunch: hiddenLaunch));
   unawaited(startupOrchestrator.restoreBridgeDesiredState());
 }

--- a/client/module_core/lib/sesori_dart_core.dart
+++ b/client/module_core/lib/sesori_dart_core.dart
@@ -35,6 +35,7 @@ export "package:sesori_shared/sesori_shared.dart" show AccountStatus, AuthProvid
 export "src/api/analytics_api.dart";
 export "src/api/analytics_release_cutoff_api.dart";
 export "src/api/attribution_api.dart";
+export "src/api/bridge_api.dart";
 export "src/api/bridge_settings_api.dart";
 export "src/api/client/relay_http_client.dart";
 export "src/api/filesystem_api.dart";
@@ -134,6 +135,7 @@ export "src/repositories/analytics_release_cutoff_repository.dart";
 export "src/repositories/analytics_repository.dart";
 export "src/repositories/appearance_store.dart";
 export "src/repositories/attribution_repository.dart";
+export "src/repositories/bridge_repository.dart";
 export "src/repositories/bridge_settings_repository.dart";
 export "src/repositories/chat_input_mode_store.dart";
 export "src/repositories/composer_draft_repository.dart";

--- a/client/module_core/lib/src/api/bridge_api.dart
+++ b/client/module_core/lib/src/api/bridge_api.dart
@@ -14,6 +14,15 @@ class BridgeApi({required final AuthenticatedHttpApiClient _client}) {
     );
   }
 
+  /// Revokes one bridge registration. The repository maps an already-revoked
+  /// bridge (404) to the idempotent success expected by logout.
+  Future<ApiResponse<void>> deleteBridge({required String bridgeId}) {
+    return _client.delete(
+      Uri.parse("$authBaseUrl/auth/bridges/${Uri.encodeComponent(bridgeId)}"),
+      fromJson: (_) {},
+    );
+  }
+
   // ignore: no_slop_linter/prefer_specific_type, JSON parser callback signature requires dynamic input
   static BridgesListResponse _parseBridges(dynamic json) {
     // ignore: no_slop_linter/prefer_specific_type, JSON parsing requires dynamic

--- a/client/module_core/lib/src/repositories/bridge_repository.dart
+++ b/client/module_core/lib/src/repositories/bridge_repository.dart
@@ -17,4 +17,15 @@ class BridgeRepository({required final BridgeApi _api}) {
       ErrorResponse(:final error) => ApiResponse.error(error),
     };
   }
+
+  /// Revokes one bridge registration. The server's 404 means the registration
+  /// is already absent, which is the desired end state for device logout.
+  Future<ApiResponse<void>> deleteBridge({required String bridgeId}) async {
+    final response = await _api.deleteBridge(bridgeId: bridgeId);
+    return switch (response) {
+      SuccessResponse() => response,
+      ErrorResponse(error: NonSuccessCodeError(errorCode: 404)) => ApiResponse.success(null),
+      ErrorResponse(:final error) => ApiResponse.error(error),
+    };
+  }
 }

--- a/client/module_core/test/api/bridge_api_test.dart
+++ b/client/module_core/test/api/bridge_api_test.dart
@@ -85,5 +85,30 @@ void main() {
         isA<ErrorResponse<BridgesListResponse>>().having((r) => r.error, "error", isA<NonSuccessCodeError>()),
       );
     });
+
+    test("deleteBridge DELETEs an encoded bridge path", () async {
+      when(
+        () => mockClient.delete<void>(
+          any(),
+          fromJson: any(named: "fromJson"),
+          headers: any(named: "headers"),
+          contentType: any(named: "contentType"),
+          logBody: any(named: "logBody"),
+        ),
+      ).thenAnswer((_) async => ApiResponse.success(null));
+
+      final response = await api.deleteBridge(bridgeId: "br weird/../id?x=1");
+
+      expect(response, isA<SuccessResponse<void>>());
+      verify(
+        () => mockClient.delete<void>(
+          Uri.parse("$authBaseUrl/auth/bridges/br%20weird%2F..%2Fid%3Fx%3D1"),
+          fromJson: any(named: "fromJson"),
+          headers: any(named: "headers"),
+          contentType: any(named: "contentType"),
+          logBody: any(named: "logBody"),
+        ),
+      ).called(1);
+    });
   });
 }

--- a/client/module_core/test/repositories/bridge_repository_test.dart
+++ b/client/module_core/test/repositories/bridge_repository_test.dart
@@ -58,5 +58,39 @@ void main() {
         isA<ErrorResponse<List<BridgeSummary>>>().having((r) => r.error, "error", isA<GenericError>()),
       );
     });
+
+    test("deleteBridge passes a successful deletion through", () async {
+      when(() => mockApi.deleteBridge(bridgeId: "br_1")).thenAnswer((_) async => ApiResponse.success(null));
+
+      final response = await repository.deleteBridge(bridgeId: "br_1");
+
+      expect(response, isA<SuccessResponse<void>>());
+      verify(() => mockApi.deleteBridge(bridgeId: "br_1")).called(1);
+    });
+
+    test("deleteBridge treats an already-missing bridge as success", () async {
+      when(() => mockApi.deleteBridge(bridgeId: "br_missing")).thenAnswer(
+        (_) async => ApiResponse.error(
+          ApiError.nonSuccessCode(errorCode: 404, rawErrorString: "bridge not found"),
+        ),
+      );
+
+      final response = await repository.deleteBridge(bridgeId: "br_missing");
+
+      expect(response, isA<SuccessResponse<void>>());
+    });
+
+    test("deleteBridge passes non-404 errors through", () async {
+      when(() => mockApi.deleteBridge(bridgeId: "br_1")).thenAnswer(
+        (_) async => ApiResponse.error(ApiError.nonSuccessCode(errorCode: 503, rawErrorString: "offline")),
+      );
+
+      final response = await repository.deleteBridge(bridgeId: "br_1");
+
+      expect(
+        response,
+        isA<ErrorResponse<void>>().having((r) => r.error, "error", isA<NonSuccessCodeError>()),
+      );
+    });
   });
 }

--- a/client/module_desktop_core/lib/sesori_desktop_core.dart
+++ b/client/module_desktop_core/lib/sesori_desktop_core.dart
@@ -6,6 +6,7 @@ library;
 // so shell consumers don't need a direct sesori_shared import for it).
 export "package:sesori_shared/sesori_shared.dart" show AuthUser, BridgeSupervisedExitCode;
 
+export "src/api/bridge_id_storage.dart";
 export "src/api/bridge_process_api.dart";
 export "src/api/bridge_process_log_storage.dart";
 export "src/api/control_channel_api.dart";

--- a/client/module_desktop_core/lib/sesori_desktop_core.dart
+++ b/client/module_desktop_core/lib/sesori_desktop_core.dart
@@ -9,6 +9,7 @@ export "package:sesori_shared/sesori_shared.dart" show AuthUser, BridgeSupervise
 export "src/api/bridge_id_storage.dart";
 export "src/api/bridge_process_api.dart";
 export "src/api/bridge_process_log_storage.dart";
+export "src/api/bridge_registration_record.dart";
 export "src/api/control_channel_api.dart";
 export "src/api/desktop_instance_api.dart";
 export "src/api/desktop_instance_storage.dart";

--- a/client/module_desktop_core/lib/src/api/bridge_id_storage.dart
+++ b/client/module_desktop_core/lib/src/api/bridge_id_storage.dart
@@ -1,0 +1,48 @@
+import "dart:io";
+
+import "package:injectable/injectable.dart";
+import "package:path/path.dart" as path;
+
+import "../foundation/platform/desktop_application_support_directory.dart";
+
+/// Layer-1 persistence for the desktop GUI's last known bridge registration id.
+///
+/// The id is intentionally kept in desktop-owned application data rather than
+/// the bridge CLI's state directory: the GUI must still be able to issue the
+/// idempotent unregister request after the supervised helper has died.
+@lazySingleton
+class BridgeIdStorage({required DesktopApplicationSupportDirectory applicationSupportDirectory}) {
+  final DesktopApplicationSupportDirectory _applicationSupportDirectory = applicationSupportDirectory;
+
+  static const String _directoryName = "desktop-instance";
+  static const String _bridgeIdFileName = "bridge-id";
+
+  Future<String?> read() async {
+    final File file = await _bridgeIdFile();
+    // ignore: avoid_slow_async_io, one startup read must not block the UI isolate
+    if (!await file.exists()) {
+      return null;
+    }
+    final String bridgeId = (await file.readAsString()).trim();
+    return bridgeId.isEmpty ? null : bridgeId;
+  }
+
+  Future<void> write({required String bridgeId}) async {
+    final File file = await _bridgeIdFile();
+    await file.parent.create(recursive: true);
+    await file.writeAsString(bridgeId, flush: true);
+  }
+
+  Future<void> clear() async {
+    final File file = await _bridgeIdFile();
+    // ignore: avoid_slow_async_io, logout cleanup is already asynchronous
+    if (await file.exists()) {
+      await file.delete();
+    }
+  }
+
+  Future<File> _bridgeIdFile() async {
+    final Directory root = await _applicationSupportDirectory.resolve();
+    return File(path.join(root.path, _directoryName, _bridgeIdFileName));
+  }
+}

--- a/client/module_desktop_core/lib/src/api/bridge_id_storage.dart
+++ b/client/module_desktop_core/lib/src/api/bridge_id_storage.dart
@@ -1,15 +1,20 @@
+import "dart:convert";
 import "dart:io";
 
 import "package:injectable/injectable.dart";
 import "package:path/path.dart" as path;
+import "package:sesori_shared/sesori_shared.dart" show jsonDecodeMap;
 
 import "../foundation/platform/desktop_application_support_directory.dart";
+import "bridge_registration_record.dart";
 
-/// Layer-1 persistence for the desktop GUI's last known bridge registration id.
+/// Layer-1 persistence for the desktop GUI's last known bridge registration.
 ///
-/// The id is intentionally kept in desktop-owned application data rather than
-/// the bridge CLI's state directory: the GUI must still be able to issue the
-/// idempotent unregister request after the supervised helper has died.
+/// The registration and its owning account are intentionally kept in
+/// desktop-owned application data rather than the bridge CLI's state directory:
+/// the GUI must still be able to issue the idempotent unregister request after
+/// the supervised helper has died, without submitting one account's id with a
+/// different account's bearer token.
 @lazySingleton
 class BridgeIdStorage({required DesktopApplicationSupportDirectory applicationSupportDirectory}) {
   final DesktopApplicationSupportDirectory _applicationSupportDirectory = applicationSupportDirectory;
@@ -17,20 +22,23 @@ class BridgeIdStorage({required DesktopApplicationSupportDirectory applicationSu
   static const String _directoryName = "desktop-instance";
   static const String _bridgeIdFileName = "bridge-id";
 
-  Future<String?> read() async {
+  Future<BridgeRegistrationRecord?> read() async {
     final File file = await _bridgeIdFile();
     // ignore: avoid_slow_async_io, one startup read must not block the UI isolate
     if (!await file.exists()) {
       return null;
     }
-    final String bridgeId = (await file.readAsString()).trim();
-    return bridgeId.isEmpty ? null : bridgeId;
+    final String contents = (await file.readAsString()).trim();
+    if (contents.isEmpty) {
+      return null;
+    }
+    return BridgeRegistrationRecord.fromJson(jsonDecodeMap(contents));
   }
 
-  Future<void> write({required String bridgeId}) async {
+  Future<void> write({required BridgeRegistrationRecord registration}) async {
     final File file = await _bridgeIdFile();
     await file.parent.create(recursive: true);
-    await file.writeAsString(bridgeId, flush: true);
+    await file.writeAsString(jsonEncode(registration.toJson()), flush: true);
   }
 
   Future<void> clear() async {

--- a/client/module_desktop_core/lib/src/api/bridge_registration_record.dart
+++ b/client/module_desktop_core/lib/src/api/bridge_registration_record.dart
@@ -1,0 +1,17 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "bridge_registration_record.freezed.dart";
+part "bridge_registration_record.g.dart";
+
+/// The desktop's persisted bridge registration together with its owning
+/// account. The owner prevents a later account on the same machine from
+/// treating an earlier account's offline-unregister handle as its own.
+@Freezed(fromJson: true, toJson: true)
+sealed class BridgeRegistrationRecord with _$BridgeRegistrationRecord {
+  const factory({
+    required String bridgeId,
+    required String accountId,
+  }) = _BridgeRegistrationRecord;
+
+  factory fromJson(Map<String, dynamic> json) => _$BridgeRegistrationRecordFromJson(json);
+}

--- a/client/module_desktop_core/lib/src/api/bridge_registration_record.freezed.dart
+++ b/client/module_desktop_core/lib/src/api/bridge_registration_record.freezed.dart
@@ -1,0 +1,152 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint, type=warning, deprecated_member_use, deprecated_member_use_from_same_package
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'bridge_registration_record.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$BridgeRegistrationRecord {
+
+ String get bridgeId; String get accountId;
+/// Create a copy of BridgeRegistrationRecord
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$BridgeRegistrationRecordCopyWith<BridgeRegistrationRecord> get copyWith => _$BridgeRegistrationRecordCopyWithImpl<BridgeRegistrationRecord>(this as BridgeRegistrationRecord, _$identity);
+
+  /// Serializes this BridgeRegistrationRecord to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is BridgeRegistrationRecord&&(identical(other.bridgeId, bridgeId) || other.bridgeId == bridgeId)&&(identical(other.accountId, accountId) || other.accountId == accountId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,bridgeId,accountId);
+
+@override
+String toString() {
+  return 'BridgeRegistrationRecord(bridgeId: $bridgeId, accountId: $accountId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $BridgeRegistrationRecordCopyWith<$Res>  {
+  factory $BridgeRegistrationRecordCopyWith(BridgeRegistrationRecord value, $Res Function(BridgeRegistrationRecord) _then) = _$BridgeRegistrationRecordCopyWithImpl;
+@useResult
+$Res call({
+ String bridgeId, String accountId
+});
+
+
+
+
+}
+/// @nodoc
+class _$BridgeRegistrationRecordCopyWithImpl<$Res>
+    implements $BridgeRegistrationRecordCopyWith<$Res> {
+  _$BridgeRegistrationRecordCopyWithImpl(this._self, this._then);
+
+  final BridgeRegistrationRecord _self;
+  final $Res Function(BridgeRegistrationRecord) _then;
+
+/// Create a copy of BridgeRegistrationRecord
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? bridgeId = null,Object? accountId = null,}) {
+  return _then(BridgeRegistrationRecord(
+bridgeId: null == bridgeId ? _self.bridgeId : bridgeId // ignore: cast_nullable_to_non_nullable
+as String,accountId: null == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _BridgeRegistrationRecord implements BridgeRegistrationRecord {
+  const _BridgeRegistrationRecord({required this.bridgeId, required this.accountId});
+  factory _BridgeRegistrationRecord.fromJson(Map<String, dynamic> json) => _$BridgeRegistrationRecordFromJson(json);
+
+@override final  String bridgeId;
+@override final  String accountId;
+
+/// Create a copy of BridgeRegistrationRecord
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$BridgeRegistrationRecordCopyWith<_BridgeRegistrationRecord> get copyWith => __$BridgeRegistrationRecordCopyWithImpl<_BridgeRegistrationRecord>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$BridgeRegistrationRecordToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _BridgeRegistrationRecord&&(identical(other.bridgeId, bridgeId) || other.bridgeId == bridgeId)&&(identical(other.accountId, accountId) || other.accountId == accountId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,bridgeId,accountId);
+
+@override
+String toString() {
+  return 'BridgeRegistrationRecord(bridgeId: $bridgeId, accountId: $accountId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$BridgeRegistrationRecordCopyWith<$Res> implements $BridgeRegistrationRecordCopyWith<$Res> {
+  factory _$BridgeRegistrationRecordCopyWith(_BridgeRegistrationRecord value, $Res Function(_BridgeRegistrationRecord) _then) = __$BridgeRegistrationRecordCopyWithImpl;
+@override @useResult
+$Res call({
+ String bridgeId, String accountId
+});
+
+
+
+
+}
+/// @nodoc
+class __$BridgeRegistrationRecordCopyWithImpl<$Res>
+    implements _$BridgeRegistrationRecordCopyWith<$Res> {
+  __$BridgeRegistrationRecordCopyWithImpl(this._self, this._then);
+
+  final _BridgeRegistrationRecord _self;
+  final $Res Function(_BridgeRegistrationRecord) _then;
+
+/// Create a copy of BridgeRegistrationRecord
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? bridgeId = null,Object? accountId = null,}) {
+  return _then(_BridgeRegistrationRecord(
+bridgeId: null == bridgeId ? _self.bridgeId : bridgeId // ignore: cast_nullable_to_non_nullable
+as String,accountId: null == accountId ? _self.accountId : accountId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/client/module_desktop_core/lib/src/api/bridge_registration_record.g.dart
+++ b/client/module_desktop_core/lib/src/api/bridge_registration_record.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'bridge_registration_record.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_BridgeRegistrationRecord _$BridgeRegistrationRecordFromJson(
+  Map<String, dynamic> json,
+) => _BridgeRegistrationRecord(
+  bridgeId: json['bridgeId'] as String,
+  accountId: json['accountId'] as String,
+);
+
+Map<String, dynamic> _$BridgeRegistrationRecordToJson(
+  _BridgeRegistrationRecord instance,
+) => <String, dynamic>{
+  'bridgeId': instance.bridgeId,
+  'accountId': instance.accountId,
+};

--- a/client/module_desktop_core/lib/src/control/control_message_dispatcher.dart
+++ b/client/module_desktop_core/lib/src/control/control_message_dispatcher.dart
@@ -12,13 +12,14 @@ import "../trackers/bridge_status_tracker.dart";
 /// Single inbound consumer of helper→GUI control messages.
 ///
 /// Decodes each frame once and writes strictly DOWNWARD: token requests are
-/// answered from the auth seam, status/registered land in the status tracker,
-/// prompts land in the prompt tracker. It never touches cubits or UI — those
-/// read the same trackers.
+/// answered from the auth seam, status/registered land in the status tracker
+/// (with the current account owner), prompts land in the prompt tracker. It
+/// never touches cubits or UI — those read the same trackers.
 @lazySingleton
 class ControlMessageDispatcher({
   required final ControlChannelServer _server,
   required final AuthTokenProvider _tokenProvider,
+  required final AuthSession _authSession,
   required final BridgeStatusTracker _statusTracker,
   required final BridgePromptTracker _promptTracker,
 }) {
@@ -73,7 +74,15 @@ class ControlMessageDispatcher({
       case ControlStatus():
         _statusTracker.applyStatus(status: message);
       case ControlRegistered(:final bridgeId):
-        _statusTracker.handleRegistered(bridgeId: bridgeId);
+        final AuthState authState = _authSession.currentState;
+        if (authState is AuthAuthenticated) {
+          _statusTracker.handleRegistered(
+            bridgeId: bridgeId,
+            accountId: authState.user.id,
+          );
+        } else {
+          logw("Ignoring a bridge registration received without an authenticated account");
+        }
       case ControlPromptRequest():
         _promptTracker.addPrompt(prompt: message);
       case ControlTokenResponse() || ControlPromptResponse() || ControlShutdown() || ControlUnregisterAndExit():

--- a/client/module_desktop_core/lib/src/control/control_message_dispatcher.dart
+++ b/client/module_desktop_core/lib/src/control/control_message_dispatcher.dart
@@ -28,10 +28,14 @@ class ControlMessageDispatcher({
   /// connection its request arrived on and dropped when that changes.
   int _connectionEpoch = 0;
 
-  void start() {
+  Future<void> start() async {
     if (_eventSubscription != null) {
       throw StateError("ControlMessageDispatcher is already started");
     }
+    // Seed persisted bridge identity before any helper can be spawned. The
+    // server is newly created for this desktop process, so no live frame can
+    // arrive during this startup read.
+    await _statusTracker.initialize();
     // ONE ordered stream for lifecycle + frames: a status frame can never be
     // processed on the wrong side of the connect/disconnect it belongs to.
     _eventSubscription = _server.events.listen(_onEvent);

--- a/client/module_desktop_core/lib/src/di/injection.config.dart
+++ b/client/module_desktop_core/lib/src/di/injection.config.dart
@@ -125,6 +125,16 @@ extension GetItInjectableX on _i174.GetIt {
         storage: gh<_i155.DesktopInstanceStorage>(),
       ),
     );
+    gh.lazySingleton<_i21.ControlMessageDispatcher>(
+      () => _i21.ControlMessageDispatcher(
+        server: gh<_i464.ControlChannelServer>(),
+        tokenProvider: gh<_i948.AuthTokenProvider>(),
+        authSession: gh<_i948.AuthSession>(),
+        statusTracker: gh<_i227.BridgeStatusTracker>(),
+        promptTracker: gh<_i686.BridgePromptTracker>(),
+      ),
+      dispose: (i) => i.dispose(),
+    );
     gh.lazySingleton<_i171.ControlCommandRepository>(
       () => _i171.ControlCommandRepository(api: gh<_i639.ControlChannelApi>()),
     );
@@ -143,15 +153,6 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i494.DesktopInstanceService(
         repository: gh<_i210.DesktopInstanceRepository>(),
       ),
-    );
-    gh.lazySingleton<_i21.ControlMessageDispatcher>(
-      () => _i21.ControlMessageDispatcher(
-        server: gh<_i464.ControlChannelServer>(),
-        tokenProvider: gh<_i948.AuthTokenProvider>(),
-        statusTracker: gh<_i227.BridgeStatusTracker>(),
-        promptTracker: gh<_i686.BridgePromptTracker>(),
-      ),
-      dispose: (i) => i.dispose(),
     );
     gh.lazySingleton<_i175.ControlCommandService>(
       () => _i175.ControlCommandService(

--- a/client/module_desktop_core/lib/src/di/injection.config.dart
+++ b/client/module_desktop_core/lib/src/di/injection.config.dart
@@ -13,6 +13,7 @@
 import 'package:get_it/get_it.dart' as _i174;
 import 'package:injectable/injectable.dart' as _i526;
 import 'package:sesori_dart_core/sesori_dart_core.dart' as _i948;
+import 'package:sesori_desktop_core/src/api/bridge_id_storage.dart' as _i73;
 import 'package:sesori_desktop_core/src/api/bridge_process_api.dart' as _i874;
 import 'package:sesori_desktop_core/src/api/bridge_process_log_storage.dart'
     as _i570;
@@ -73,13 +74,15 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i686.BridgePromptTracker(),
       dispose: (i) => i.dispose(),
     );
-    gh.lazySingleton<_i227.BridgeStatusTracker>(
-      () => _i227.BridgeStatusTracker(),
-      dispose: (i) => i.dispose(),
-    );
     gh.lazySingleton<_i786.DesktopLogoutTracker>(
       () => _i786.DesktopLogoutTracker(),
       dispose: (i) => i.dispose(),
+    );
+    gh.lazySingleton<_i73.BridgeIdStorage>(
+      () => _i73.BridgeIdStorage(
+        applicationSupportDirectory:
+            gh<_i695.DesktopApplicationSupportDirectory>(),
+      ),
     );
     gh.lazySingleton<_i570.BridgeProcessLogStorage>(
       () => _i570.BridgeProcessLogStorage(
@@ -100,12 +103,9 @@ extension GetItInjectableX on _i174.GetIt {
             gh<_i695.DesktopApplicationSupportDirectory>(),
       ),
     );
-    gh.lazySingleton<_i21.ControlMessageDispatcher>(
-      () => _i21.ControlMessageDispatcher(
-        server: gh<_i464.ControlChannelServer>(),
-        tokenProvider: gh<_i948.AuthTokenProvider>(),
-        statusTracker: gh<_i227.BridgeStatusTracker>(),
-        promptTracker: gh<_i686.BridgePromptTracker>(),
+    gh.lazySingleton<_i227.BridgeStatusTracker>(
+      () => _i227.BridgeStatusTracker(
+        bridgeIdStorage: gh<_i73.BridgeIdStorage>(),
       ),
       dispose: (i) => i.dispose(),
     );
@@ -144,6 +144,15 @@ extension GetItInjectableX on _i174.GetIt {
         repository: gh<_i210.DesktopInstanceRepository>(),
       ),
     );
+    gh.lazySingleton<_i21.ControlMessageDispatcher>(
+      () => _i21.ControlMessageDispatcher(
+        server: gh<_i464.ControlChannelServer>(),
+        tokenProvider: gh<_i948.AuthTokenProvider>(),
+        statusTracker: gh<_i227.BridgeStatusTracker>(),
+        promptTracker: gh<_i686.BridgePromptTracker>(),
+      ),
+      dispose: (i) => i.dispose(),
+    );
     gh.lazySingleton<_i175.ControlCommandService>(
       () => _i175.ControlCommandService(
         repository: gh<_i171.ControlCommandRepository>(),
@@ -164,7 +173,10 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i165.DesktopLogoutOrchestrator>(
       () => _i165.DesktopLogoutOrchestrator(
         processService: gh<_i765.BridgeProcessService>(),
+        controlCommandService: gh<_i175.ControlCommandService>(),
         instanceService: gh<_i494.DesktopInstanceService>(),
+        bridgeRepository: gh<_i948.BridgeRepository>(),
+        statusTracker: gh<_i227.BridgeStatusTracker>(),
         logoutTracker: gh<_i786.DesktopLogoutTracker>(),
         authSession: gh<_i948.AuthSession>(),
       ),

--- a/client/module_desktop_core/lib/src/di/injection.dart
+++ b/client/module_desktop_core/lib/src/di/injection.dart
@@ -1,9 +1,10 @@
 import "package:get_it/get_it.dart";
 import "package:injectable/injectable.dart";
-import "package:sesori_dart_core/sesori_dart_core.dart" show AuthSession, AuthTokenProvider;
+import "package:sesori_dart_core/sesori_dart_core.dart" show AuthSession, AuthTokenProvider, BridgeRepository;
 
 import "../foundation/platform/bridge_executable_path_resolver.dart";
 import "../foundation/platform/desktop_application_support_directory.dart";
+import "../foundation/platform/desktop_application_terminator.dart";
 import "injection.config.dart";
 
 // Phase 4 of the desktop 4-phase DI init (see client/AGENTS.md):
@@ -19,7 +20,9 @@ import "injection.config.dart";
     AuthSession,
     AuthTokenProvider,
     BridgeExecutablePathResolver,
+    BridgeRepository,
     DesktopApplicationSupportDirectory,
+    DesktopApplicationTerminator,
   ],
 )
 void configureDesktopCoreDependencies(GetIt getIt) => getIt.init();

--- a/client/module_desktop_core/lib/src/orchestration/desktop_logout_orchestrator.dart
+++ b/client/module_desktop_core/lib/src/orchestration/desktop_logout_orchestrator.dart
@@ -3,6 +3,7 @@ import "dart:async";
 import "package:injectable/injectable.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 
+import "../api/bridge_registration_record.dart";
 import "../foundation/bridge_process_desired_state.dart";
 import "../foundation/control_channel_server.dart";
 import "../services/bridge_process_service.dart";
@@ -23,8 +24,8 @@ enum DesktopLogoutOutcome() {
 ///
 /// The supervised helper must unregister/stop while the GUI still has an
 /// authenticated session. The GUI then retries deletion using its persisted
-/// bridge id before clearing local credentials; callers remain unaware of the
-/// sequence.
+/// account-bound bridge registration before clearing local credentials; callers
+/// remain unaware of the sequence.
 @lazySingleton
 class DesktopLogoutOrchestrator({
   required final BridgeProcessService processService,
@@ -75,6 +76,20 @@ class DesktopLogoutOrchestrator({
 
     bool bridgeStopped = false;
     try {
+      // Mark the child as expected and begin waiting before sending the
+      // unregister command. The process-service path deliberately sends no
+      // competing shutdown frame, so the helper's token service stays alive
+      // until its authenticated unregister attempt has finished.
+      Future<void>? bridgeStop;
+      AsyncError? bridgeStopError;
+      try {
+        bridgeStop = _processService.stopAfterUnregister();
+      } on Object catch (error, stackTrace) {
+        // Still attempt the helper command when the local stop operation could
+        // not be started; the GUI deletion below remains the fallback.
+        bridgeStopError = AsyncError(error, stackTrace);
+      }
+
       // The helper's own unregister path is deliberately unacknowledged and
       // best-effort. A missing socket is expected when the helper is already
       // dead; the GUI deletion below is the durable fallback in either case.
@@ -86,7 +101,14 @@ class DesktopLogoutOrchestrator({
         logw("Failed to send the supervised bridge unregister command", error, stackTrace);
       }
 
-      await _processService.stop();
+      if (bridgeStopError case final AsyncError failure) {
+        Error.throwWithStackTrace(failure.error, failure.stackTrace);
+      }
+      if (bridgeStop case final Future<void> operation) {
+        await operation;
+      } else {
+        throw StateError("Desktop bridge stop operation was not created");
+      }
       bridgeStopped = true;
     } on Object catch (error, stackTrace) {
       logw("Desktop logout stopped because the supervised bridge could not stop", error, stackTrace);
@@ -113,14 +135,23 @@ class DesktopLogoutOrchestrator({
   }
 
   Future<void> _deleteRegisteredBridge() async {
-    final String? bridgeId = _statusTracker.status.bridgeId;
-    if (bridgeId == null) {
+    final BridgeRegistrationRecord? registration = _statusTracker.registeredBridge;
+    if (registration == null) {
+      return;
+    }
+
+    final AuthState authState = _authSession.currentState;
+    if (authState is! AuthAuthenticated || authState.user.id != registration.accountId) {
+      // The record may belong to an earlier account that logged out while
+      // offline. Never submit its id with the current account's bearer token,
+      // and retain it so the owning account can retry later.
+      logd("Skipping desktop bridge deletion because its owner is not signed in");
       return;
     }
 
     final ApiResponse<void> response;
     try {
-      response = await _bridgeRepository.deleteBridge(bridgeId: bridgeId).timeout(_bridgeDeletionTimeout);
+      response = await _bridgeRepository.deleteBridge(bridgeId: registration.bridgeId).timeout(_bridgeDeletionTimeout);
     } on Object catch (error, stackTrace) {
       logw("Failed to unregister the desktop bridge; continuing local logout", error, stackTrace);
       return;
@@ -129,7 +160,7 @@ class DesktopLogoutOrchestrator({
     switch (response) {
       case SuccessResponse():
         try {
-          await _statusTracker.clearBridgeId(bridgeId: bridgeId);
+          await _statusTracker.clearBridgeId(registration: registration);
         } on Object catch (error, stackTrace) {
           // The server-side registration is already gone. Retain the local id
           // for a future retry if its cleanup cannot be persisted now.

--- a/client/module_desktop_core/lib/src/orchestration/desktop_logout_orchestrator.dart
+++ b/client/module_desktop_core/lib/src/orchestration/desktop_logout_orchestrator.dart
@@ -1,9 +1,14 @@
+import "dart:async";
+
 import "package:injectable/injectable.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 
 import "../foundation/bridge_process_desired_state.dart";
+import "../foundation/control_channel_server.dart";
 import "../services/bridge_process_service.dart";
+import "../services/control_command_service.dart";
 import "../services/desktop_instance_service.dart";
+import "../trackers/bridge_status_tracker.dart";
 import "../trackers/desktop_logout_tracker.dart";
 
 /// Result of the interim device-local desktop logout sequence.
@@ -16,18 +21,27 @@ enum DesktopLogoutOutcome() {
 
 /// Layer-4 owner of cross-service desktop logout ordering.
 ///
-/// The supervised helper must stop while the GUI still has an authenticated
-/// session. Step 11 extends this owner with unregister coordination; callers
-/// remain unaware of the sequence.
+/// The supervised helper must unregister/stop while the GUI still has an
+/// authenticated session. The GUI then retries deletion using its persisted
+/// bridge id before clearing local credentials; callers remain unaware of the
+/// sequence.
 @lazySingleton
 class DesktopLogoutOrchestrator({
   required final BridgeProcessService processService,
+  required final ControlCommandService controlCommandService,
   required final DesktopInstanceService instanceService,
+  required final BridgeRepository bridgeRepository,
+  required final BridgeStatusTracker statusTracker,
   required final DesktopLogoutTracker logoutTracker,
   required final AuthSession authSession,
 }) {
+  static const Duration _bridgeDeletionTimeout = Duration(seconds: 10);
+
   final BridgeProcessService _processService = processService;
+  final ControlCommandService _controlCommandService = controlCommandService;
   final DesktopInstanceService _instanceService = instanceService;
+  final BridgeRepository _bridgeRepository = bridgeRepository;
+  final BridgeStatusTracker _statusTracker = statusTracker;
   final DesktopLogoutTracker _logoutTracker = logoutTracker;
   final AuthSession _authSession = authSession;
   Future<DesktopLogoutOutcome>? _activeLogout;
@@ -59,10 +73,33 @@ class DesktopLogoutOrchestrator({
       return DesktopLogoutOutcome.desiredStatePersistenceFailed;
     }
 
+    bool bridgeStopped = false;
     try {
+      // The helper's own unregister path is deliberately unacknowledged and
+      // best-effort. A missing socket is expected when the helper is already
+      // dead; the GUI deletion below is the durable fallback in either case.
+      try {
+        _controlCommandService.unregisterAndExit();
+      } on ControlHelperNotConnectedException catch (error, stackTrace) {
+        logd("Supervised bridge is not connected for unregister; using GUI fallback", error, stackTrace);
+      } on Object catch (error, stackTrace) {
+        logw("Failed to send the supervised bridge unregister command", error, stackTrace);
+      }
+
       await _processService.stop();
+      bridgeStopped = true;
     } on Object catch (error, stackTrace) {
       logw("Desktop logout stopped because the supervised bridge could not stop", error, stackTrace);
+    }
+
+    // This attempt is intentionally independent of both the control command
+    // and process teardown. The persisted id is what covers a dead helper and
+    // a helper whose own network unregister timed out.
+    await _deleteRegisteredBridge();
+
+    if (!bridgeStopped) {
+      // Preserve the pre-existing safety boundary: when a helper may still be
+      // alive, do not clear the GUI's credentials out from under it.
       return DesktopLogoutOutcome.bridgeStopFailed;
     }
 
@@ -72,6 +109,34 @@ class DesktopLogoutOrchestrator({
     } on Object catch (error, stackTrace) {
       logw("Device-local sign-out failed", error, stackTrace);
       return DesktopLogoutOutcome.localSessionClearFailed;
+    }
+  }
+
+  Future<void> _deleteRegisteredBridge() async {
+    final String? bridgeId = _statusTracker.status.bridgeId;
+    if (bridgeId == null) {
+      return;
+    }
+
+    final ApiResponse<void> response;
+    try {
+      response = await _bridgeRepository.deleteBridge(bridgeId: bridgeId).timeout(_bridgeDeletionTimeout);
+    } on Object catch (error, stackTrace) {
+      logw("Failed to unregister the desktop bridge; continuing local logout", error, stackTrace);
+      return;
+    }
+
+    switch (response) {
+      case SuccessResponse():
+        try {
+          await _statusTracker.clearBridgeId(bridgeId: bridgeId);
+        } on Object catch (error, stackTrace) {
+          // The server-side registration is already gone. Retain the local id
+          // for a future retry if its cleanup cannot be persisted now.
+          logw("Failed to clear the persisted desktop bridge id", error, stackTrace);
+        }
+      case ErrorResponse(:final error):
+        logw("Failed to unregister the desktop bridge; continuing local logout", error);
     }
   }
 }

--- a/client/module_desktop_core/lib/src/repositories/bridge_process_repository.dart
+++ b/client/module_desktop_core/lib/src/repositories/bridge_process_repository.dart
@@ -125,12 +125,39 @@ class BridgeProcessRepository.forTesting({
     return active.stopFuture ??= _runStopExpected(active: active);
   }
 
+  /// Marks the current child as expected and waits for a shutdown command that
+  /// was already sent by another owner, without sending a competing shutdown.
+  ///
+  /// The unregister-and-exit logout command owns the helper's graceful request.
+  /// This path keeps the token service alive until that command's unregister
+  /// request has completed, while retaining the same bounded force-kill
+  /// fallback if the helper does not exit.
+  Future<void> stopExpectedAfterCommand() {
+    final _ActiveBridgeProcess? active = _active;
+    if (active == null) {
+      return Future<void>.value();
+    }
+    return active.stopFuture ??= _runStopExpectedAfterCommand(active: active);
+  }
+
   Future<void> _runStopExpected({required _ActiveBridgeProcess active}) async {
     try {
       await _stopExpected(active: active);
     } on Object {
       // Keep concurrent callers on one atomic stop attempt, but do not let one
       // failed platform command permanently poison future Off/Quit retries.
+      if (identical(_active, active)) {
+        active.stopFuture = null;
+      }
+      rethrow;
+    }
+  }
+
+  Future<void> _runStopExpectedAfterCommand({required _ActiveBridgeProcess active}) async {
+    try {
+      active.expected = true;
+      await _waitForExitOrForceKill(active: active);
+    } on Object {
       if (identical(_active, active)) {
         active.stopFuture = null;
       }
@@ -160,6 +187,10 @@ class BridgeProcessRepository.forTesting({
       return;
     }
 
+    await _waitForExitOrForceKill(active: active);
+  }
+
+  Future<void> _waitForExitOrForceKill({required _ActiveBridgeProcess active}) async {
     try {
       await active.handle.exitCode.timeout(_gracefulShutdownTimeout);
     } on TimeoutException {

--- a/client/module_desktop_core/lib/src/repositories/control_command_repository.dart
+++ b/client/module_desktop_core/lib/src/repositories/control_command_repository.dart
@@ -3,16 +3,21 @@ import "package:sesori_shared/sesori_shared.dart";
 
 import "../api/control_channel_api.dart";
 
-/// Layer-2 owner of outbound conversational control commands.
+/// Layer-2 owner of outbound desktop-to-helper control commands.
 ///
 /// Expected process shutdown remains the bridge-process repository's atomic
-/// operation. This repository exposes only commands initiated by the desktop
-/// conversation flow.
+/// operation. This repository exposes prompt answers and the logout-specific
+/// unregister request.
 @lazySingleton
 class ControlCommandRepository({required final ControlChannelApi _api}) {
   void answerPrompt({required String id, required bool accepted}) {
     _api.send(
       message: ControlMessage.promptResponse(id: id, accepted: accepted),
     );
+  }
+
+  /// Requests the supervised helper to unregister and then exit.
+  void unregisterAndExit() {
+    _api.send(message: const ControlMessage.unregisterAndExit());
   }
 }

--- a/client/module_desktop_core/lib/src/services/bridge_process_service.dart
+++ b/client/module_desktop_core/lib/src/services/bridge_process_service.dart
@@ -139,7 +139,17 @@ class BridgeProcessService.forTesting({
   Future<void> stop() {
     _ensureNotDisposed();
     _beginManualAction(desiredState: BridgeProcessDesiredState.off);
-    return _requestStop();
+    return _requestStop(requestShutdown: true);
+  }
+
+  /// Requests Off and waits for an already-sent helper command to terminate
+  /// the child. Unlike [stop], this never sends a competing shutdown frame.
+  /// Logout uses it after sending `unregister_and_exit`, so the helper can
+  /// finish its authenticated unregister before its token service is disposed.
+  Future<void> stopAfterUnregister() {
+    _ensureNotDisposed();
+    _beginManualAction(desiredState: BridgeProcessDesiredState.off);
+    return _requestStop(requestShutdown: false);
   }
 
   void _beginManualAction({required BridgeProcessDesiredState desiredState}) {
@@ -296,12 +306,12 @@ class BridgeProcessService.forTesting({
     }
   }
 
-  Future<void> _requestStop() {
+  Future<void> _requestStop({required bool requestShutdown}) {
     final Future<void>? existing = _stopFuture;
     if (existing != null) {
       return existing;
     }
-    final Future<void> operation = _stop();
+    final Future<void> operation = _stop(requestShutdown: requestShutdown);
     _stopFuture = operation;
     unawaited(_clearStopWhenComplete(operation: operation));
     return operation;
@@ -320,7 +330,7 @@ class BridgeProcessService.forTesting({
     }
   }
 
-  Future<void> _stop() async {
+  Future<void> _stop({required bool requestShutdown}) async {
     final Future<void>? pendingStart = _startFuture;
     if (pendingStart != null) {
       try {
@@ -336,7 +346,11 @@ class BridgeProcessService.forTesting({
       _publish(BridgeProcessStopping(pid: pid));
     }
     try {
-      await _repository.stopExpected();
+      if (requestShutdown) {
+        await _repository.stopExpected();
+      } else {
+        await _repository.stopExpectedAfterCommand();
+      }
     } on Object {
       if (_repository.isRunning) {
         final int? recoveredPid = _repository.activePid ?? pid;

--- a/client/module_desktop_core/lib/src/services/control_command_service.dart
+++ b/client/module_desktop_core/lib/src/services/control_command_service.dart
@@ -33,4 +33,14 @@ class ControlCommandService({
     _repository.answerPrompt(id: prompt.id, accepted: accepted);
     _promptTracker.removePrompt(id: prompt.id);
   }
+
+  /// Asks the live helper to unregister its server-side bridge and exit.
+  ///
+  /// The helper owns its own bounded unregister attempt; callers still stop
+  /// the process through the process-service boundary because the control
+  /// channel may be unavailable or the helper may disappear before handling
+  /// this.
+  void unregisterAndExit() {
+    _repository.unregisterAndExit();
+  }
 }

--- a/client/module_desktop_core/lib/src/trackers/bridge_status_tracker.dart
+++ b/client/module_desktop_core/lib/src/trackers/bridge_status_tracker.dart
@@ -6,6 +6,7 @@ import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../api/bridge_id_storage.dart";
+import "../api/bridge_registration_record.dart";
 import "bridge_control_status.dart";
 
 /// Holds the supervised bridge's status as stream + snapshot.
@@ -20,12 +21,18 @@ class BridgeStatusTracker({required BridgeIdStorage bridgeIdStorage}) {
   final BehaviorSubject<BridgeControlStatus> _status = BehaviorSubject.seeded(BridgeControlStatus.offline);
   Future<void>? _initialization;
   Future<void> _bridgeIdMutationTail = Future<void>.value();
+  BridgeRegistrationRecord? _registeredBridge;
 
   ValueStream<BridgeControlStatus> get statusStream => _status.stream;
 
   BridgeControlStatus get status => _status.value;
 
-  /// Loads the last registration id before helper lifecycle work begins.
+  /// The last bridge registration observed by this desktop, including the
+  /// account that owns the server-side record. It is retained while offline so
+  /// logout can safely decide whether the current account may delete it.
+  BridgeRegistrationRecord? get registeredBridge => _registeredBridge;
+
+  /// Loads the last registration and owner before helper lifecycle work begins.
   /// Repeated callers share the same startup read.
   Future<void> initialize() {
     final Future<void>? existing = _initialization;
@@ -39,9 +46,10 @@ class BridgeStatusTracker({required BridgeIdStorage bridgeIdStorage}) {
 
   Future<void> _loadPersistedBridgeId() async {
     try {
-      final String? bridgeId = await _bridgeIdStorage.read();
-      if (bridgeId != null && !_status.isClosed && status.bridgeId == null) {
-        _status.add(status.copyWith(bridgeId: bridgeId));
+      final BridgeRegistrationRecord? registration = await _bridgeIdStorage.read();
+      if (registration != null && !_status.isClosed && status.bridgeId == null) {
+        _registeredBridge = registration;
+        _status.add(status.copyWith(bridgeId: registration.bridgeId));
       }
     } on Object catch (error, stackTrace) {
       logw("Failed to restore the desktop bridge registration id", error, stackTrace);
@@ -91,44 +99,70 @@ class BridgeStatusTracker({required BridgeIdStorage bridgeIdStorage}) {
   ///
   /// Deliberately NOT gated on `helperOnline`: the id is retained across
   /// disconnects anyway, and a late-processed `registered` frame carries
-  /// exactly the value worth keeping. Writes are serialized so a rapid
-  /// re-registration cannot leave an older id on disk after a newer event.
-  void handleRegistered({required String bridgeId}) {
+  /// exactly the value worth keeping. The dispatcher supplies the currently
+  /// authenticated account so an offline retry handle cannot be reused by a
+  /// different account. Writes are serialized so a rapid re-registration
+  /// cannot leave an older record on disk after a newer event.
+  void handleRegistered({required String bridgeId, required String accountId}) {
     if (_status.isClosed) {
       return;
     }
+    final BridgeRegistrationRecord registration = BridgeRegistrationRecord(
+      bridgeId: bridgeId,
+      accountId: accountId,
+    );
+    _registeredBridge = registration;
     _status.add(status.copyWith(bridgeId: bridgeId));
-    unawaited(_queueBridgeIdMutation(action: () => _bridgeIdStorage.write(bridgeId: bridgeId)));
-  }
-
-  /// Removes the persisted id after the server confirms deletion. If a newer
-  /// registration arrived while the delete was in flight, its id is left
-  /// untouched.
-  Future<void> clearBridgeId({required String bridgeId}) {
-    return _queueBridgeIdMutation(
-      action: () async {
-        if (_status.isClosed || status.bridgeId != bridgeId) {
-          return;
-        }
-        await _bridgeIdStorage.clear();
-        if (!_status.isClosed && status.bridgeId == bridgeId) {
-          _status.add(status.copyWith(bridgeId: null));
-        }
-      },
+    unawaited(
+      _queueBridgeIdMutation(
+        action: () => _bridgeIdStorage.write(registration: registration),
+        reportFailure: true,
+      ),
     );
   }
 
-  Future<void> _queueBridgeIdMutation({required Future<void> Function() action}) {
+  /// Removes the persisted record after the server confirms deletion. If a
+  /// newer registration arrived while the delete was in flight, its record is
+  /// left untouched. The caller supplies the full record so an account mismatch
+  /// cannot clear another account's retry handle.
+  Future<void> clearBridgeId({required BridgeRegistrationRecord registration}) {
+    return _queueBridgeIdMutation(
+      action: () async {
+        if (_status.isClosed || _registeredBridge != registration) {
+          return;
+        }
+        await _bridgeIdStorage.clear();
+        if (!_status.isClosed && _registeredBridge == registration) {
+          _registeredBridge = null;
+          _status.add(status.copyWith(bridgeId: null));
+        }
+      },
+      reportFailure: false,
+    );
+  }
+
+  Future<void> _queueBridgeIdMutation({
+    required Future<void> Function() action,
+    required bool reportFailure,
+  }) {
     final Future<void> operation = _bridgeIdMutationTail.then((_) => action());
-    _bridgeIdMutationTail = _observeBridgeIdMutation(operation: operation);
+    _bridgeIdMutationTail = _observeBridgeIdMutation(
+      operation: operation,
+      reportFailure: reportFailure,
+    );
     return operation;
   }
 
-  Future<void> _observeBridgeIdMutation({required Future<void> operation}) async {
+  Future<void> _observeBridgeIdMutation({
+    required Future<void> operation,
+    required bool reportFailure,
+  }) async {
     try {
       await operation;
     } on Object catch (error, stackTrace) {
-      logw("Failed to persist the desktop bridge registration id", error, stackTrace);
+      if (reportFailure) {
+        logw("Failed to persist the desktop bridge registration id", error, stackTrace);
+      }
     }
   }
 

--- a/client/module_desktop_core/lib/src/trackers/bridge_status_tracker.dart
+++ b/client/module_desktop_core/lib/src/trackers/bridge_status_tracker.dart
@@ -1,7 +1,11 @@
+import "dart:async";
+
 import "package:injectable/injectable.dart";
 import "package:rxdart/rxdart.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../api/bridge_id_storage.dart";
 import "bridge_control_status.dart";
 
 /// Holds the supervised bridge's status as stream + snapshot.
@@ -11,12 +15,38 @@ import "bridge_control_status.dart";
 /// the offline baseline before any helper connects, so the v1 UI can render
 /// "bridge off" without a control channel.
 @lazySingleton
-class BridgeStatusTracker() {
+class BridgeStatusTracker({required BridgeIdStorage bridgeIdStorage}) {
+  final BridgeIdStorage _bridgeIdStorage = bridgeIdStorage;
   final BehaviorSubject<BridgeControlStatus> _status = BehaviorSubject.seeded(BridgeControlStatus.offline);
+  Future<void>? _initialization;
+  Future<void> _bridgeIdMutationTail = Future<void>.value();
 
   ValueStream<BridgeControlStatus> get statusStream => _status.stream;
 
   BridgeControlStatus get status => _status.value;
+
+  /// Loads the last registration id before helper lifecycle work begins.
+  /// Repeated callers share the same startup read.
+  Future<void> initialize() {
+    final Future<void>? existing = _initialization;
+    if (existing != null) {
+      return existing;
+    }
+    final Future<void> operation = _loadPersistedBridgeId();
+    _initialization = operation;
+    return operation;
+  }
+
+  Future<void> _loadPersistedBridgeId() async {
+    try {
+      final String? bridgeId = await _bridgeIdStorage.read();
+      if (bridgeId != null && !_status.isClosed && status.bridgeId == null) {
+        _status.add(status.copyWith(bridgeId: bridgeId));
+      }
+    } on Object catch (error, stackTrace) {
+      logw("Failed to restore the desktop bridge registration id", error, stackTrace);
+    }
+  }
 
   /// A helper completed the control-channel handshake. Health/relay fields
   /// keep their current values until the helper's first `status` push lands.
@@ -61,16 +91,49 @@ class BridgeStatusTracker() {
   ///
   /// Deliberately NOT gated on `helperOnline`: the id is retained across
   /// disconnects anyway, and a late-processed `registered` frame carries
-  /// exactly the value worth keeping.
+  /// exactly the value worth keeping. Writes are serialized so a rapid
+  /// re-registration cannot leave an older id on disk after a newer event.
   void handleRegistered({required String bridgeId}) {
     if (_status.isClosed) {
       return;
     }
     _status.add(status.copyWith(bridgeId: bridgeId));
+    unawaited(_queueBridgeIdMutation(action: () => _bridgeIdStorage.write(bridgeId: bridgeId)));
+  }
+
+  /// Removes the persisted id after the server confirms deletion. If a newer
+  /// registration arrived while the delete was in flight, its id is left
+  /// untouched.
+  Future<void> clearBridgeId({required String bridgeId}) {
+    return _queueBridgeIdMutation(
+      action: () async {
+        if (_status.isClosed || status.bridgeId != bridgeId) {
+          return;
+        }
+        await _bridgeIdStorage.clear();
+        if (!_status.isClosed && status.bridgeId == bridgeId) {
+          _status.add(status.copyWith(bridgeId: null));
+        }
+      },
+    );
+  }
+
+  Future<void> _queueBridgeIdMutation({required Future<void> Function() action}) {
+    final Future<void> operation = _bridgeIdMutationTail.then((_) => action());
+    _bridgeIdMutationTail = _observeBridgeIdMutation(operation: operation);
+    return operation;
+  }
+
+  Future<void> _observeBridgeIdMutation({required Future<void> operation}) async {
+    try {
+      await operation;
+    } on Object catch (error, stackTrace) {
+      logw("Failed to persist the desktop bridge registration id", error, stackTrace);
+    }
   }
 
   @disposeMethod
-  void dispose() {
-    _status.close();
+  Future<void> dispose() async {
+    await _status.close();
   }
 }

--- a/client/module_desktop_core/pubspec.yaml
+++ b/client/module_desktop_core/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   freezed_annotation: ^3.1.0
   get_it: ^9.2.1
   injectable: ^3.0.0
+  json_annotation: ^4.12.0
   meta: ^1.19.0
   path: ^1.9.1
   rxdart: ^0.28.0
@@ -25,6 +26,7 @@ dev_dependencies:
     path: "../../shared/no_slop_linter"
   build_runner: ^2.16.0
   freezed: ^4.0.0
+  json_serializable: ^6.14.1
   injectable_generator: ^3.1.3
   mocktail: ^1.0.5
   test: ^1.31.1

--- a/client/module_desktop_core/test/api/bridge_id_storage_test.dart
+++ b/client/module_desktop_core/test/api/bridge_id_storage_test.dart
@@ -1,0 +1,60 @@
+import "dart:io";
+
+import "package:path/path.dart" as path;
+import "package:sesori_desktop_core/sesori_desktop_core.dart";
+import "package:test/test.dart";
+
+void main() {
+  late Directory root;
+  late BridgeIdStorage storage;
+
+  setUp(() {
+    root = Directory.systemTemp.createTempSync("sesori_bridge_id_");
+    storage = BridgeIdStorage(
+      applicationSupportDirectory: _FixedApplicationSupportDirectory(directory: root),
+    );
+  });
+
+  tearDown(() {
+    if (root.existsSync()) {
+      root.deleteSync(recursive: true);
+    }
+  });
+
+  test("missing bridge id reads as null", () async {
+    expect(await storage.read(), isNull);
+  });
+
+  test("persists the bridge id under desktop-owned application data", () async {
+    await storage.write(bridgeId: "br_abc123");
+
+    expect(await storage.read(), "br_abc123");
+    expect(
+      File(path.join(root.path, "desktop-instance", "bridge-id")).readAsStringSync(),
+      "br_abc123",
+    );
+  });
+
+  test("blank persisted content reads as null", () async {
+    final File file = File(path.join(root.path, "desktop-instance", "bridge-id"));
+    file.createSync(recursive: true);
+    file.writeAsStringSync("  \n");
+
+    expect(await storage.read(), isNull);
+  });
+
+  test("clear is idempotent", () async {
+    await storage.clear();
+    await storage.write(bridgeId: "br_to_clear");
+    await storage.clear();
+    await storage.clear();
+
+    expect(await storage.read(), isNull);
+  });
+}
+
+class _FixedApplicationSupportDirectory({required final Directory directory})
+    implements DesktopApplicationSupportDirectory {
+  @override
+  Future<Directory> resolve() async => directory;
+}

--- a/client/module_desktop_core/test/api/bridge_id_storage_test.dart
+++ b/client/module_desktop_core/test/api/bridge_id_storage_test.dart
@@ -1,3 +1,4 @@
+import "dart:convert";
 import "dart:io";
 
 import "package:path/path.dart" as path;
@@ -25,13 +26,17 @@ void main() {
     expect(await storage.read(), isNull);
   });
 
-  test("persists the bridge id under desktop-owned application data", () async {
-    await storage.write(bridgeId: "br_abc123");
+  test("persists the bridge id and owning account under desktop-owned application data", () async {
+    const BridgeRegistrationRecord registration = BridgeRegistrationRecord(
+      bridgeId: "br_abc123",
+      accountId: "account-a",
+    );
+    await storage.write(registration: registration);
 
-    expect(await storage.read(), "br_abc123");
+    expect(await storage.read(), registration);
     expect(
-      File(path.join(root.path, "desktop-instance", "bridge-id")).readAsStringSync(),
-      "br_abc123",
+      jsonDecode(File(path.join(root.path, "desktop-instance", "bridge-id")).readAsStringSync()),
+      <String, String>{"bridgeId": "br_abc123", "accountId": "account-a"},
     );
   });
 
@@ -45,7 +50,12 @@ void main() {
 
   test("clear is idempotent", () async {
     await storage.clear();
-    await storage.write(bridgeId: "br_to_clear");
+    await storage.write(
+      registration: const BridgeRegistrationRecord(
+        bridgeId: "br_to_clear",
+        accountId: "account-a",
+      ),
+    );
     await storage.clear();
     await storage.clear();
 

--- a/client/module_desktop_core/test/control/control_message_dispatcher_test.dart
+++ b/client/module_desktop_core/test/control/control_message_dispatcher_test.dart
@@ -12,9 +12,19 @@ import "../support/bridge_id_storage.dart";
 
 class _MockAuthTokenProvider() extends Mock implements AuthTokenProvider;
 
+class _MockAuthSession() extends Mock implements AuthSession;
+
+const AuthUser _user = AuthUser(
+  id: "account-a",
+  provider: AuthProvider.github,
+  providerUserId: "github-a",
+  providerUsername: "account-a",
+);
+
 void main() {
   late ControlChannelServer server;
   late _MockAuthTokenProvider tokenProvider;
+  late _MockAuthSession authSession;
   late MemoryBridgeIdStorage bridgeIdStorage;
   late BridgeStatusTracker statusTracker;
   late BridgePromptTracker promptTracker;
@@ -24,12 +34,15 @@ void main() {
     server = ControlChannelServer();
     await server.start();
     tokenProvider = _MockAuthTokenProvider();
+    authSession = _MockAuthSession();
+    when(() => authSession.currentState).thenReturn(const AuthState.authenticated(user: _user));
     bridgeIdStorage = MemoryBridgeIdStorage();
     statusTracker = BridgeStatusTracker(bridgeIdStorage: bridgeIdStorage);
     promptTracker = BridgePromptTracker();
     dispatcher = ControlMessageDispatcher(
       server: server,
       tokenProvider: tokenProvider,
+      authSession: authSession,
       statusTracker: statusTracker,
       promptTracker: promptTracker,
     );
@@ -128,7 +141,20 @@ void main() {
     await pumpEventQueue();
 
     expect(statusTracker.status.bridgeId, "bridge-9");
-    expect(bridgeIdStorage.bridgeId, "bridge-9");
+    expect(bridgeIdStorage.registration?.bridgeId, "bridge-9");
+    expect(bridgeIdStorage.registration?.accountId, "account-a");
+    expect(statusTracker.registeredBridge?.accountId, "account-a");
+  });
+
+  test("does not persist a registration when no account is authenticated", () async {
+    when(() => authSession.currentState).thenReturn(const AuthState.unauthenticated());
+    final WebSocket helper = await connectHelper();
+
+    sendFromHelper(helper, const ControlMessage.registered(bridgeId: "unowned-bridge"));
+    await pumpEventQueue(times: 2);
+
+    expect(statusTracker.status.bridgeId, isNull);
+    expect(bridgeIdStorage.registration, isNull);
   });
 
   test("prompt requests land in the prompt tracker", () async {

--- a/client/module_desktop_core/test/control/control_message_dispatcher_test.dart
+++ b/client/module_desktop_core/test/control/control_message_dispatcher_test.dart
@@ -8,11 +8,14 @@ import "package:sesori_desktop_core/sesori_desktop_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../support/bridge_id_storage.dart";
+
 class _MockAuthTokenProvider() extends Mock implements AuthTokenProvider;
 
 void main() {
   late ControlChannelServer server;
   late _MockAuthTokenProvider tokenProvider;
+  late MemoryBridgeIdStorage bridgeIdStorage;
   late BridgeStatusTracker statusTracker;
   late BridgePromptTracker promptTracker;
   late ControlMessageDispatcher dispatcher;
@@ -21,7 +24,8 @@ void main() {
     server = ControlChannelServer();
     await server.start();
     tokenProvider = _MockAuthTokenProvider();
-    statusTracker = BridgeStatusTracker();
+    bridgeIdStorage = MemoryBridgeIdStorage();
+    statusTracker = BridgeStatusTracker(bridgeIdStorage: bridgeIdStorage);
     promptTracker = BridgePromptTracker();
     dispatcher = ControlMessageDispatcher(
       server: server,
@@ -29,11 +33,11 @@ void main() {
       statusTracker: statusTracker,
       promptTracker: promptTracker,
     );
-    dispatcher.start();
+    await dispatcher.start();
     addTearDown(() async {
       await dispatcher.dispose();
       await server.dispose();
-      statusTracker.dispose();
+      await statusTracker.dispose();
       promptTracker.dispose();
     });
   });
@@ -121,8 +125,10 @@ void main() {
 
     sendFromHelper(helper, const ControlMessage.registered(bridgeId: "bridge-9"));
     await statusTracker.statusStream.firstWhere((status) => status.bridgeId != null);
+    await pumpEventQueue();
 
     expect(statusTracker.status.bridgeId, "bridge-9");
+    expect(bridgeIdStorage.bridgeId, "bridge-9");
   });
 
   test("prompt requests land in the prompt tracker", () async {

--- a/client/module_desktop_core/test/cubits/bridge_control/bridge_control_cubit_test.dart
+++ b/client/module_desktop_core/test/cubits/bridge_control/bridge_control_cubit_test.dart
@@ -6,6 +6,8 @@ import "package:sesori_desktop_core/sesori_desktop_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../support/bridge_id_storage.dart";
+
 void main() {
   group("BridgeControlCubit", () {
     late _FakeBridgeProcessService processService;
@@ -22,7 +24,7 @@ void main() {
 
     setUp(() {
       processService = _FakeBridgeProcessService();
-      statusTracker = BridgeStatusTracker();
+      statusTracker = BridgeStatusTracker(bridgeIdStorage: MemoryBridgeIdStorage());
       systemTray = _FakeSystemTray();
       windowHost = _FakeWindowHost();
       applicationTerminator = _FakeDesktopApplicationTerminator();
@@ -49,7 +51,7 @@ void main() {
     tearDown(() async {
       await cubit.close();
       await processService.disposeFake();
-      statusTracker.dispose();
+      await statusTracker.dispose();
       await systemTray.disposeFake();
       await windowHost.disposeFake();
       await instanceService.disposeFake();

--- a/client/module_desktop_core/test/di/injection_test.dart
+++ b/client/module_desktop_core/test/di/injection_test.dart
@@ -7,6 +7,7 @@ void main() {
     final GetIt getIt = GetIt.asNewInstance();
 
     expect(() => configureDesktopCoreDependencies(getIt), returnsNormally);
+    expect(getIt.isRegistered<BridgeIdStorage>(), isTrue);
     expect(getIt.isRegistered<BridgeProcessApi>(), isTrue);
     expect(getIt.isRegistered<BridgeProcessRepository>(), isTrue);
     expect(getIt.isRegistered<BridgeProcessLogStorage>(), isTrue);
@@ -20,5 +21,6 @@ void main() {
     expect(getIt.isRegistered<DesktopInstanceRepository>(), isTrue);
     expect(getIt.isRegistered<DesktopInstanceService>(), isTrue);
     expect(getIt.isRegistered<DesktopStartupOrchestrator>(), isTrue);
+    expect(getIt.isRegistered<DesktopLogoutOrchestrator>(), isTrue);
   });
 }

--- a/client/module_desktop_core/test/orchestration/desktop_logout_orchestrator_test.dart
+++ b/client/module_desktop_core/test/orchestration/desktop_logout_orchestrator_test.dart
@@ -23,6 +23,7 @@ void main() {
     controlCommandService = _MockControlCommandService();
     bridgeRepository = _MockBridgeRepository();
     authSession = _MockAuthSession();
+    when(() => authSession.currentState).thenReturn(const AuthState.authenticated(user: _userA));
     instanceService = _MockDesktopInstanceService();
     bridgeIdStorage = MemoryBridgeIdStorage();
     statusTracker = BridgeStatusTracker(bridgeIdStorage: bridgeIdStorage);
@@ -50,7 +51,7 @@ void main() {
     final List<String> operations = <String>[];
     when(() => instanceService.cancelPendingBridgeRestore()).thenAnswer((_) => operations.add("cancel"));
     when(() => controlCommandService.unregisterAndExit()).thenAnswer((_) => operations.add("unregister"));
-    when(() => processService.stop()).thenAnswer((_) async => operations.add("stop"));
+    when(() => processService.stopAfterUnregister()).thenAnswer((_) async => operations.add("stop"));
     when(
       () => instanceService.writeBridgeDesiredState(state: BridgeProcessDesiredState.off),
     ).thenAnswer((_) async => operations.add("persist"));
@@ -59,15 +60,15 @@ void main() {
     final DesktopLogoutOutcome outcome = await orchestrator.logoutCurrentDevice();
 
     expect(outcome, DesktopLogoutOutcome.completed);
-    expect(operations, <String>["cancel", "persist", "unregister", "stop", "logout"]);
+    expect(operations, <String>["cancel", "persist", "stop", "unregister", "logout"]);
   });
 
   test("unregisters through the helper, then confirms deletion before local logout", () async {
     final List<String> operations = <String>[];
-    statusTracker.handleRegistered(bridgeId: "bridge-1");
+    statusTracker.handleRegistered(bridgeId: "bridge-1", accountId: _userA.id);
     await pumpEventQueue();
     when(() => controlCommandService.unregisterAndExit()).thenAnswer((_) => operations.add("unregister"));
-    when(() => processService.stop()).thenAnswer((_) async => operations.add("stop"));
+    when(() => processService.stopAfterUnregister()).thenAnswer((_) async => operations.add("stop"));
     when(() => bridgeRepository.deleteBridge(bridgeId: "bridge-1")).thenAnswer((_) async {
       operations.add("delete");
       return ApiResponse.success(null);
@@ -77,16 +78,16 @@ void main() {
     final DesktopLogoutOutcome outcome = await orchestrator.logoutCurrentDevice();
 
     expect(outcome, DesktopLogoutOutcome.completed);
-    expect(operations, <String>["unregister", "stop", "delete", "logout"]);
+    expect(operations, <String>["stop", "unregister", "delete", "logout"]);
     expect(bridgeIdStorage.bridgeId, isNull);
     expect(statusTracker.status.bridgeId, isNull);
   });
 
   test("attempts GUI deletion even when the helper stop fails", () async {
-    statusTracker.handleRegistered(bridgeId: "bridge-stuck");
+    statusTracker.handleRegistered(bridgeId: "bridge-stuck", accountId: _userA.id);
     await pumpEventQueue();
     when(() => controlCommandService.unregisterAndExit()).thenThrow(const ControlHelperNotConnectedException());
-    when(() => processService.stop()).thenThrow(StateError("helper remained alive"));
+    when(() => processService.stopAfterUnregister()).thenThrow(StateError("helper remained alive"));
     when(() => bridgeRepository.deleteBridge(bridgeId: "bridge-stuck")).thenAnswer((_) async {
       return ApiResponse.success(null);
     });
@@ -100,10 +101,10 @@ void main() {
   });
 
   test("continues local logout when GUI deletion is offline", () async {
-    statusTracker.handleRegistered(bridgeId: "bridge-offline");
+    statusTracker.handleRegistered(bridgeId: "bridge-offline", accountId: _userA.id);
     await pumpEventQueue();
     when(() => controlCommandService.unregisterAndExit()).thenAnswer((_) {});
-    when(() => processService.stop()).thenAnswer((_) async {});
+    when(() => processService.stopAfterUnregister()).thenAnswer((_) async {});
     when(() => bridgeRepository.deleteBridge(bridgeId: "bridge-offline")).thenAnswer(
       (_) async => ApiResponse.error(ApiError.generic()),
     );
@@ -119,9 +120,26 @@ void main() {
     expect(bridgeIdStorage.bridgeId, "bridge-offline");
   });
 
+  test("does not submit or clear a persisted registration owned by another account", () async {
+    statusTracker.handleRegistered(bridgeId: "bridge-account-a", accountId: _userA.id);
+    await pumpEventQueue();
+    when(() => authSession.currentState).thenReturn(const AuthState.authenticated(user: _userB));
+    when(() => controlCommandService.unregisterAndExit()).thenAnswer((_) {});
+    when(() => processService.stopAfterUnregister()).thenAnswer((_) async {});
+    when(() => authSession.logoutCurrentDevice()).thenAnswer((_) async {});
+
+    final DesktopLogoutOutcome outcome = await orchestrator.logoutCurrentDevice();
+
+    expect(outcome, DesktopLogoutOutcome.completed);
+    verifyNever(() => bridgeRepository.deleteBridge(bridgeId: "bridge-account-a"));
+    verify(() => authSession.logoutCurrentDevice()).called(1);
+    expect(bridgeIdStorage.registration?.bridgeId, "bridge-account-a");
+    expect(bridgeIdStorage.registration?.accountId, _userA.id);
+  });
+
   test("keeps controls locked through token clearing and shares concurrent logout", () async {
     final Completer<void> tokenClear = Completer<void>();
-    when(() => processService.stop()).thenAnswer((_) async {});
+    when(() => processService.stopAfterUnregister()).thenAnswer((_) async {});
     when(() => authSession.logoutCurrentDevice()).thenAnswer((_) => tokenClear.future);
 
     final Future<DesktopLogoutOutcome> first = orchestrator.logoutCurrentDevice();
@@ -130,7 +148,7 @@ void main() {
 
     expect(identical(first, second), isTrue);
     expect(logoutTracker.status, DesktopLogoutStatus.inProgress);
-    verify(() => processService.stop()).called(1);
+    verify(() => processService.stopAfterUnregister()).called(1);
 
     tokenClear.complete();
     expect(await first, DesktopLogoutOutcome.completed);
@@ -145,13 +163,13 @@ void main() {
     final DesktopLogoutOutcome outcome = await orchestrator.logoutCurrentDevice();
 
     expect(outcome, DesktopLogoutOutcome.desiredStatePersistenceFailed);
-    verifyNever(() => processService.stop());
+    verifyNever(() => processService.stopAfterUnregister());
     verifyNever(() => authSession.logoutCurrentDevice());
   });
 
   test("does not clear authentication when the helper cannot stop", () async {
     when(() => controlCommandService.unregisterAndExit()).thenAnswer((_) {});
-    when(() => processService.stop()).thenThrow(StateError("helper remained alive"));
+    when(() => processService.stopAfterUnregister()).thenThrow(StateError("helper remained alive"));
 
     final DesktopLogoutOutcome outcome = await orchestrator.logoutCurrentDevice();
 
@@ -163,13 +181,13 @@ void main() {
   });
 
   test("reports a local-session failure after a successful helper stop", () async {
-    when(() => processService.stop()).thenAnswer((_) async {});
+    when(() => processService.stopAfterUnregister()).thenAnswer((_) async {});
     when(() => authSession.logoutCurrentDevice()).thenThrow(StateError("secure storage unavailable"));
 
     final DesktopLogoutOutcome outcome = await orchestrator.logoutCurrentDevice();
 
     expect(outcome, DesktopLogoutOutcome.localSessionClearFailed);
-    verify(() => processService.stop()).called(1);
+    verify(() => processService.stopAfterUnregister()).called(1);
   });
 }
 
@@ -182,3 +200,17 @@ class _MockBridgeRepository() extends Mock implements BridgeRepository;
 class _MockAuthSession() extends Mock implements AuthSession;
 
 class _MockDesktopInstanceService() extends Mock implements DesktopInstanceService;
+
+const AuthUser _userA = AuthUser(
+  id: "account-a",
+  provider: AuthProvider.github,
+  providerUserId: "github-a",
+  providerUsername: "account-a",
+);
+
+const AuthUser _userB = AuthUser(
+  id: "account-b",
+  provider: AuthProvider.github,
+  providerUserId: "github-b",
+  providerUsername: "account-b",
+);

--- a/client/module_desktop_core/test/orchestration/desktop_logout_orchestrator_test.dart
+++ b/client/module_desktop_core/test/orchestration/desktop_logout_orchestrator_test.dart
@@ -5,36 +5,51 @@ import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_desktop_core/sesori_desktop_core.dart";
 import "package:test/test.dart";
 
+import "../support/bridge_id_storage.dart";
+
 void main() {
   late _MockBridgeProcessService processService;
+  late _MockControlCommandService controlCommandService;
+  late _MockBridgeRepository bridgeRepository;
   late _MockAuthSession authSession;
   late _MockDesktopInstanceService instanceService;
+  late MemoryBridgeIdStorage bridgeIdStorage;
+  late BridgeStatusTracker statusTracker;
   late DesktopLogoutTracker logoutTracker;
   late DesktopLogoutOrchestrator orchestrator;
 
   setUp(() {
     processService = _MockBridgeProcessService();
+    controlCommandService = _MockControlCommandService();
+    bridgeRepository = _MockBridgeRepository();
     authSession = _MockAuthSession();
     instanceService = _MockDesktopInstanceService();
+    bridgeIdStorage = MemoryBridgeIdStorage();
+    statusTracker = BridgeStatusTracker(bridgeIdStorage: bridgeIdStorage);
     logoutTracker = DesktopLogoutTracker();
     when(
       () => instanceService.writeBridgeDesiredState(state: BridgeProcessDesiredState.off),
     ).thenAnswer((_) async {});
     orchestrator = DesktopLogoutOrchestrator(
       processService: processService,
+      controlCommandService: controlCommandService,
       instanceService: instanceService,
+      bridgeRepository: bridgeRepository,
+      statusTracker: statusTracker,
       logoutTracker: logoutTracker,
       authSession: authSession,
     );
   });
 
   tearDown(() async {
+    await statusTracker.dispose();
     await logoutTracker.dispose();
   });
 
   test("cancels startup restore before stopping the helper and clearing the local session", () async {
     final List<String> operations = <String>[];
     when(() => instanceService.cancelPendingBridgeRestore()).thenAnswer((_) => operations.add("cancel"));
+    when(() => controlCommandService.unregisterAndExit()).thenAnswer((_) => operations.add("unregister"));
     when(() => processService.stop()).thenAnswer((_) async => operations.add("stop"));
     when(
       () => instanceService.writeBridgeDesiredState(state: BridgeProcessDesiredState.off),
@@ -44,7 +59,64 @@ void main() {
     final DesktopLogoutOutcome outcome = await orchestrator.logoutCurrentDevice();
 
     expect(outcome, DesktopLogoutOutcome.completed);
-    expect(operations, <String>["cancel", "persist", "stop", "logout"]);
+    expect(operations, <String>["cancel", "persist", "unregister", "stop", "logout"]);
+  });
+
+  test("unregisters through the helper, then confirms deletion before local logout", () async {
+    final List<String> operations = <String>[];
+    statusTracker.handleRegistered(bridgeId: "bridge-1");
+    await pumpEventQueue();
+    when(() => controlCommandService.unregisterAndExit()).thenAnswer((_) => operations.add("unregister"));
+    when(() => processService.stop()).thenAnswer((_) async => operations.add("stop"));
+    when(() => bridgeRepository.deleteBridge(bridgeId: "bridge-1")).thenAnswer((_) async {
+      operations.add("delete");
+      return ApiResponse.success(null);
+    });
+    when(() => authSession.logoutCurrentDevice()).thenAnswer((_) async => operations.add("logout"));
+
+    final DesktopLogoutOutcome outcome = await orchestrator.logoutCurrentDevice();
+
+    expect(outcome, DesktopLogoutOutcome.completed);
+    expect(operations, <String>["unregister", "stop", "delete", "logout"]);
+    expect(bridgeIdStorage.bridgeId, isNull);
+    expect(statusTracker.status.bridgeId, isNull);
+  });
+
+  test("attempts GUI deletion even when the helper stop fails", () async {
+    statusTracker.handleRegistered(bridgeId: "bridge-stuck");
+    await pumpEventQueue();
+    when(() => controlCommandService.unregisterAndExit()).thenThrow(const ControlHelperNotConnectedException());
+    when(() => processService.stop()).thenThrow(StateError("helper remained alive"));
+    when(() => bridgeRepository.deleteBridge(bridgeId: "bridge-stuck")).thenAnswer((_) async {
+      return ApiResponse.success(null);
+    });
+
+    final DesktopLogoutOutcome outcome = await orchestrator.logoutCurrentDevice();
+
+    expect(outcome, DesktopLogoutOutcome.bridgeStopFailed);
+    verify(() => bridgeRepository.deleteBridge(bridgeId: "bridge-stuck")).called(1);
+    verifyNever(() => authSession.logoutCurrentDevice());
+    expect(bridgeIdStorage.bridgeId, isNull);
+  });
+
+  test("continues local logout when GUI deletion is offline", () async {
+    statusTracker.handleRegistered(bridgeId: "bridge-offline");
+    await pumpEventQueue();
+    when(() => controlCommandService.unregisterAndExit()).thenAnswer((_) {});
+    when(() => processService.stop()).thenAnswer((_) async {});
+    when(() => bridgeRepository.deleteBridge(bridgeId: "bridge-offline")).thenAnswer(
+      (_) async => ApiResponse.error(ApiError.generic()),
+    );
+    when(() => authSession.logoutCurrentDevice()).thenAnswer((_) async {});
+
+    final DesktopLogoutOutcome outcome = await orchestrator.logoutCurrentDevice();
+
+    expect(outcome, DesktopLogoutOutcome.completed);
+    verify(() => bridgeRepository.deleteBridge(bridgeId: "bridge-offline")).called(1);
+    verify(() => authSession.logoutCurrentDevice()).called(1);
+    // Retain the id when the server could not confirm deletion, so a later
+    // explicitly-triggered logout can retry the fallback.
+    expect(bridgeIdStorage.bridgeId, "bridge-offline");
   });
 
   test("keeps controls locked through token clearing and shares concurrent logout", () async {
@@ -78,6 +150,7 @@ void main() {
   });
 
   test("does not clear authentication when the helper cannot stop", () async {
+    when(() => controlCommandService.unregisterAndExit()).thenAnswer((_) {});
     when(() => processService.stop()).thenThrow(StateError("helper remained alive"));
 
     final DesktopLogoutOutcome outcome = await orchestrator.logoutCurrentDevice();
@@ -85,6 +158,7 @@ void main() {
     expect(outcome, DesktopLogoutOutcome.bridgeStopFailed);
     verify(() => instanceService.cancelPendingBridgeRestore()).called(1);
     verify(() => instanceService.writeBridgeDesiredState(state: BridgeProcessDesiredState.off)).called(1);
+    verify(() => controlCommandService.unregisterAndExit()).called(1);
     verifyNever(() => authSession.logoutCurrentDevice());
   });
 
@@ -100,6 +174,10 @@ void main() {
 }
 
 class _MockBridgeProcessService() extends Mock implements BridgeProcessService;
+
+class _MockControlCommandService() extends Mock implements ControlCommandService;
+
+class _MockBridgeRepository() extends Mock implements BridgeRepository;
 
 class _MockAuthSession() extends Mock implements AuthSession;
 

--- a/client/module_desktop_core/test/repositories/bridge_process_repository_test.dart
+++ b/client/module_desktop_core/test/repositories/bridge_process_repository_test.dart
@@ -68,6 +68,36 @@ void main() {
       expect(processApi.killedTreePids, isEmpty);
     });
 
+    test("waits for an external shutdown command without sending another frame", () async {
+      await _spawn(repository);
+      final Future<BridgeProcessExit> exit = repository.exits.first;
+
+      final Future<void> stopping = repository.stopExpectedAfterCommand();
+
+      expect(controlServer.sentFrames, isEmpty);
+      fixture.exitCode.complete(0);
+      await stopping;
+
+      expect(await exit, const BridgeProcessExit(pid: 123, exitCode: 0, expected: true));
+      expect(processApi.gracefulSignalPids, isEmpty);
+      expect(processApi.killedTreePids, isEmpty);
+    });
+
+    test("external shutdown command is force-killed after the graceful deadline", () async {
+      await _spawn(repository);
+      final Future<BridgeProcessExit> exit = repository.exits.first;
+      processApi.onKill = () {
+        fixture.exitCode.complete(-9);
+      };
+
+      await repository.stopExpectedAfterCommand();
+
+      expect(controlServer.sentFrames, isEmpty);
+      expect(processApi.gracefulSignalPids, isEmpty);
+      expect(processApi.killedTreePids, [123]);
+      expect(await exit, const BridgeProcessExit(pid: 123, exitCode: -9, expected: true));
+    });
+
     test("channel loss falls back to POSIX graceful signal", () async {
       await _spawn(repository);
       final Future<BridgeProcessExit> exit = repository.exits.first;

--- a/client/module_desktop_core/test/services/bridge_process_service_test.dart
+++ b/client/module_desktop_core/test/services/bridge_process_service_test.dart
@@ -28,9 +28,9 @@ void main() {
       streams = _ProcessStreamsFixture(pid: 42);
       repository = _FakeBridgeProcessRepository(streams: streams.value);
       logTracker = _FakeBridgeProcessLogTracker();
-      statusTracker = BridgeStatusTracker(bridgeIdStorage: MemoryBridgeIdStorage());
       controlServer = _FakeControlChannelServer();
       authSession = _FakeAuthSession(initialState: const AuthState.unauthenticated());
+      statusTracker = BridgeStatusTracker(bridgeIdStorage: MemoryBridgeIdStorage());
       executablePathResolver = _FakeBridgeExecutablePathResolver(path: "/repo/bridge");
       now = DateTime.utc(2026, 8, 28);
       warnings = <String>[];
@@ -121,6 +121,19 @@ void main() {
 
       expect(repository.stopCalls, 1);
       expect(controlServer.stopCalls, 1);
+      expect(service.state, isA<BridgeProcessStopped>());
+    });
+
+    test("unregister stop waits without sending a competing repository shutdown", () async {
+      authSession.state = _authenticatedState;
+      await service.start();
+      repository.emitExpectedExitOnStop = true;
+
+      await service.stopAfterUnregister();
+
+      expect(repository.stopAfterCommandCalls, 1);
+      expect(repository.stopCalls, 0);
+      expect(controlServer.stopCalls, greaterThanOrEqualTo(1));
       expect(service.state, isA<BridgeProcessStopped>());
     });
 
@@ -646,6 +659,7 @@ void main() {
     final _FakeBridgeProcessRepository repository = _FakeBridgeProcessRepository(streams: streams.value);
     final _FakeBridgeProcessLogTracker logTracker = _FakeBridgeProcessLogTracker();
     final ControlChannelServer server = ControlChannelServer();
+    final _FakeAuthSession authSession = _FakeAuthSession(initialState: _authenticatedState);
     final BridgeStatusTracker statusTracker = BridgeStatusTracker(
       bridgeIdStorage: MemoryBridgeIdStorage(),
     );
@@ -653,10 +667,10 @@ void main() {
     final ControlMessageDispatcher dispatcher = ControlMessageDispatcher(
       server: server,
       tokenProvider: _FakeAuthTokenProvider(),
+      authSession: authSession,
       statusTracker: statusTracker,
       promptTracker: promptTracker,
     );
-    final _FakeAuthSession authSession = _FakeAuthSession(initialState: _authenticatedState);
     final BridgeProcessService service = BridgeProcessService.forTesting(
       repository: repository,
       logTracker: logTracker,
@@ -744,6 +758,7 @@ class _FakeBridgeProcessRepository({required final BridgeProcessStreams streams}
   final StreamController<BridgeProcessExit> _exits = StreamController<BridgeProcessExit>.broadcast(sync: true);
   int spawnCalls = 0;
   int stopCalls = 0;
+  int stopAfterCommandCalls = 0;
   String? executable;
   List<String>? arguments;
   Object? spawnError;
@@ -785,6 +800,24 @@ class _FakeBridgeProcessRepository({required final BridgeProcessStreams streams}
   @override
   Future<void> stopExpected() async {
     stopCalls++;
+    final Object? failure = stopError;
+    if (failure != null) {
+      throw failure;
+    }
+    if (emitExpectedExitOnStop) {
+      emitExit(exitCode: 0, expected: true);
+      return;
+    }
+    _isRunning = false;
+    _activePid = null;
+  }
+
+  @override
+  Future<void> stopExpectedAfterCommand() async {
+    if (!_isRunning) {
+      return;
+    }
+    stopAfterCommandCalls++;
     final Object? failure = stopError;
     if (failure != null) {
       throw failure;

--- a/client/module_desktop_core/test/services/bridge_process_service_test.dart
+++ b/client/module_desktop_core/test/services/bridge_process_service_test.dart
@@ -9,6 +9,8 @@ import "package:sesori_desktop_core/sesori_desktop_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../support/bridge_id_storage.dart";
+
 void main() {
   group("BridgeProcessService", () {
     late _ProcessStreamsFixture streams;
@@ -26,7 +28,7 @@ void main() {
       streams = _ProcessStreamsFixture(pid: 42);
       repository = _FakeBridgeProcessRepository(streams: streams.value);
       logTracker = _FakeBridgeProcessLogTracker();
-      statusTracker = BridgeStatusTracker();
+      statusTracker = BridgeStatusTracker(bridgeIdStorage: MemoryBridgeIdStorage());
       controlServer = _FakeControlChannelServer();
       authSession = _FakeAuthSession(initialState: const AuthState.unauthenticated());
       executablePathResolver = _FakeBridgeExecutablePathResolver(path: "/repo/bridge");
@@ -80,7 +82,7 @@ void main() {
       await service.dispose();
       await repository.disposeFake();
       await authSession.disposeFake();
-      statusTracker.dispose();
+      await statusTracker.dispose();
     });
 
     test("signed-out start enters login-required without starting infrastructure", () async {
@@ -644,7 +646,9 @@ void main() {
     final _FakeBridgeProcessRepository repository = _FakeBridgeProcessRepository(streams: streams.value);
     final _FakeBridgeProcessLogTracker logTracker = _FakeBridgeProcessLogTracker();
     final ControlChannelServer server = ControlChannelServer();
-    final BridgeStatusTracker statusTracker = BridgeStatusTracker();
+    final BridgeStatusTracker statusTracker = BridgeStatusTracker(
+      bridgeIdStorage: MemoryBridgeIdStorage(),
+    );
     final BridgePromptTracker promptTracker = BridgePromptTracker();
     final ControlMessageDispatcher dispatcher = ControlMessageDispatcher(
       server: server,
@@ -672,13 +676,13 @@ void main() {
       await service.dispose();
       await dispatcher.dispose();
       await server.dispose();
-      statusTracker.dispose();
+      await statusTracker.dispose();
       promptTracker.dispose();
       await repository.disposeFake();
       await authSession.disposeFake();
     });
 
-    dispatcher.start();
+    await dispatcher.start();
     await service.start();
     socket = await WebSocket.connect(
       server.url.toString(),

--- a/client/module_desktop_core/test/services/control_command_service_test.dart
+++ b/client/module_desktop_core/test/services/control_command_service_test.dart
@@ -31,6 +31,15 @@ void main() {
       expect(promptTracker.prompts, isEmpty);
     });
 
+    test("sends unregister_and_exit without requiring a pending prompt", () {
+      service.unregisterAndExit();
+
+      expect(
+        api.sentMessages,
+        <ControlMessage>[const ControlMessage.unregisterAndExit()],
+      );
+    });
+
     test("retains the prompt when the connected helper cannot accept the frame", () {
       promptTracker.addPrompt(prompt: _prompt);
       const ControlHelperNotConnectedException sendError = ControlHelperNotConnectedException();

--- a/client/module_desktop_core/test/support/bridge_id_storage.dart
+++ b/client/module_desktop_core/test/support/bridge_id_storage.dart
@@ -1,0 +1,34 @@
+import "dart:io";
+
+import "package:sesori_desktop_core/sesori_desktop_core.dart";
+
+/// In-memory bridge-id storage for pure-Dart tracker/service tests.
+class MemoryBridgeIdStorage extends BridgeIdStorage {
+  // ignore: use_primary_constructors, unnecessary_type_name_in_constructor, the test double needs a fixed super argument
+  MemoryBridgeIdStorage({String? initialBridgeId})
+    : bridgeId = initialBridgeId,
+      super(
+        applicationSupportDirectory: _UnusedApplicationSupportDirectory(),
+      );
+
+  String? bridgeId;
+
+  @override
+  Future<String?> read() async => bridgeId;
+
+  @override
+  Future<void> write({required String bridgeId}) async {
+    this.bridgeId = bridgeId;
+  }
+
+  @override
+  Future<void> clear() async {
+    bridgeId = null;
+  }
+}
+
+// ignore: use_primary_constructors, this test-only implementation has no constructor state
+class _UnusedApplicationSupportDirectory implements DesktopApplicationSupportDirectory {
+  @override
+  Future<Directory> resolve() async => Directory.systemTemp;
+}

--- a/client/module_desktop_core/test/support/bridge_id_storage.dart
+++ b/client/module_desktop_core/test/support/bridge_id_storage.dart
@@ -5,25 +5,36 @@ import "package:sesori_desktop_core/sesori_desktop_core.dart";
 /// In-memory bridge-id storage for pure-Dart tracker/service tests.
 class MemoryBridgeIdStorage extends BridgeIdStorage {
   // ignore: use_primary_constructors, unnecessary_type_name_in_constructor, the test double needs a fixed super argument
-  MemoryBridgeIdStorage({String? initialBridgeId})
-    : bridgeId = initialBridgeId,
+  MemoryBridgeIdStorage({BridgeRegistrationRecord? initialRegistration})
+    : registration = initialRegistration,
       super(
         applicationSupportDirectory: _UnusedApplicationSupportDirectory(),
       );
 
-  String? bridgeId;
+  BridgeRegistrationRecord? registration;
+
+  String? get bridgeId => registration?.bridgeId;
+
+  set bridgeId(String? value) {
+    registration = value == null
+        ? null
+        : BridgeRegistrationRecord(
+            bridgeId: value,
+            accountId: "account-a",
+          );
+  }
 
   @override
-  Future<String?> read() async => bridgeId;
+  Future<BridgeRegistrationRecord?> read() async => registration;
 
   @override
-  Future<void> write({required String bridgeId}) async {
-    this.bridgeId = bridgeId;
+  Future<void> write({required BridgeRegistrationRecord registration}) async {
+    this.registration = registration;
   }
 
   @override
   Future<void> clear() async {
-    bridgeId = null;
+    registration = null;
   }
 }
 

--- a/client/module_desktop_core/test/trackers/bridge_status_tracker_test.dart
+++ b/client/module_desktop_core/test/trackers/bridge_status_tracker_test.dart
@@ -2,11 +2,15 @@ import "package:sesori_desktop_core/sesori_desktop_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../support/bridge_id_storage.dart";
+
 void main() {
   late BridgeStatusTracker tracker;
+  late MemoryBridgeIdStorage storage;
 
   setUp(() {
-    tracker = BridgeStatusTracker();
+    storage = MemoryBridgeIdStorage();
+    tracker = BridgeStatusTracker(bridgeIdStorage: storage);
     addTearDown(tracker.dispose);
   });
 
@@ -32,9 +36,10 @@ void main() {
     expect(tracker.status.activeSessionCount, 3);
   });
 
-  test("disconnect resets status to the baseline but retains bridgeId", () {
+  test("disconnect resets status to the baseline but retains bridgeId", () async {
     tracker.markHelperConnected();
     tracker.handleRegistered(bridgeId: "bridge-1");
+    await pumpEventQueue();
     tracker.applyStatus(
       status: const ControlStatus(
         relay: ControlRelayConnectionState.connected,
@@ -83,14 +88,39 @@ void main() {
     expect(tracker.status.activeSessionCount, 0);
   });
 
-  test("a late registered frame is still recorded while offline", () {
+  test("a late registered frame is still recorded while offline", () async {
     tracker.handleRegistered(bridgeId: "bridge-late");
+    await pumpEventQueue();
 
     expect(tracker.status.bridgeId, "bridge-late");
+    expect(storage.bridgeId, "bridge-late");
   });
 
-  test("writes after dispose are ignored instead of throwing", () {
-    final BridgeStatusTracker disposed = BridgeStatusTracker()..dispose();
+  test("initializes its bridge id from persisted storage", () async {
+    storage.bridgeId = "bridge-persisted";
+    await tracker.initialize();
+
+    expect(tracker.status.bridgeId, "bridge-persisted");
+  });
+
+  test("clears only the bridge id it deleted", () async {
+    tracker.handleRegistered(bridgeId: "bridge-current");
+    await pumpEventQueue();
+
+    await tracker.clearBridgeId(bridgeId: "bridge-other");
+    expect(storage.bridgeId, "bridge-current");
+    expect(tracker.status.bridgeId, "bridge-current");
+
+    await tracker.clearBridgeId(bridgeId: "bridge-current");
+    expect(storage.bridgeId, isNull);
+    expect(tracker.status.bridgeId, isNull);
+  });
+
+  test("writes after dispose are ignored instead of throwing", () async {
+    final BridgeStatusTracker disposed = BridgeStatusTracker(
+      bridgeIdStorage: MemoryBridgeIdStorage(),
+    );
+    await disposed.dispose();
 
     expect(disposed.markHelperConnected, returnsNormally);
     expect(disposed.markHelperDisconnected, returnsNormally);

--- a/client/module_desktop_core/test/trackers/bridge_status_tracker_test.dart
+++ b/client/module_desktop_core/test/trackers/bridge_status_tracker_test.dart
@@ -38,7 +38,7 @@ void main() {
 
   test("disconnect resets status to the baseline but retains bridgeId", () async {
     tracker.markHelperConnected();
-    tracker.handleRegistered(bridgeId: "bridge-1");
+    tracker.handleRegistered(bridgeId: "bridge-1", accountId: "account-a");
     await pumpEventQueue();
     tracker.applyStatus(
       status: const ControlStatus(
@@ -89,31 +89,62 @@ void main() {
   });
 
   test("a late registered frame is still recorded while offline", () async {
-    tracker.handleRegistered(bridgeId: "bridge-late");
+    tracker.handleRegistered(bridgeId: "bridge-late", accountId: "account-a");
     await pumpEventQueue();
 
     expect(tracker.status.bridgeId, "bridge-late");
     expect(storage.bridgeId, "bridge-late");
   });
 
-  test("initializes its bridge id from persisted storage", () async {
-    storage.bridgeId = "bridge-persisted";
+  test("initializes its bridge id and owner from persisted storage", () async {
+    const BridgeRegistrationRecord registration = BridgeRegistrationRecord(
+      bridgeId: "bridge-persisted",
+      accountId: "account-a",
+    );
+    storage.registration = registration;
     await tracker.initialize();
 
     expect(tracker.status.bridgeId, "bridge-persisted");
+    expect(tracker.registeredBridge, registration);
   });
 
   test("clears only the bridge id it deleted", () async {
-    tracker.handleRegistered(bridgeId: "bridge-current");
+    tracker.handleRegistered(bridgeId: "bridge-current", accountId: "account-a");
     await pumpEventQueue();
 
-    await tracker.clearBridgeId(bridgeId: "bridge-other");
+    await tracker.clearBridgeId(
+      registration: const BridgeRegistrationRecord(
+        bridgeId: "bridge-other",
+        accountId: "account-a",
+      ),
+    );
     expect(storage.bridgeId, "bridge-current");
     expect(tracker.status.bridgeId, "bridge-current");
 
-    await tracker.clearBridgeId(bridgeId: "bridge-current");
+    await tracker.clearBridgeId(
+      registration: const BridgeRegistrationRecord(
+        bridgeId: "bridge-current",
+        accountId: "account-a",
+      ),
+    );
     expect(storage.bridgeId, isNull);
     expect(tracker.status.bridgeId, isNull);
+  });
+
+  test("does not clear a record with a different owning account", () async {
+    tracker.handleRegistered(bridgeId: "bridge-owned", accountId: "account-a");
+    await pumpEventQueue();
+
+    await tracker.clearBridgeId(
+      registration: const BridgeRegistrationRecord(
+        bridgeId: "bridge-owned",
+        accountId: "account-b",
+      ),
+    );
+
+    expect(storage.registration?.bridgeId, "bridge-owned");
+    expect(storage.registration?.accountId, "account-a");
+    expect(tracker.registeredBridge?.accountId, "account-a");
   });
 
   test("writes after dispose are ignored instead of throwing", () async {
@@ -134,7 +165,10 @@ void main() {
       ),
       returnsNormally,
     );
-    expect(() => disposed.handleRegistered(bridgeId: "x"), returnsNormally);
+    expect(
+      () => disposed.handleRegistered(bridgeId: "x", accountId: "account-a"),
+      returnsNormally,
+    );
   });
 
   test("the stream pushes every write to subscribers", () async {

--- a/docs/regression/account-and-onboarding.md
+++ b/docs/regression/account-and-onboarding.md
@@ -16,10 +16,11 @@ participates.
   cleared on logout; the connection follows logout. Startup reads stored tokens
   once before deciding whether validation or a fresh login is needed. Logout
   fences in-flight login, refresh, and restore results, so none can re-save
-  credentials or emit authenticated after local sign-out. A definitive
-  `/auth/refresh` 4xx rejection clears persisted tokens and user data before
-  emitting unauthenticated, while transport/server failures leave credentials
-  intact. Standalone bridge logout remains clean and idempotent when tokens are
+  credentials or emit authenticated after local sign-out. The auth server's
+  definitive `/auth/refresh` 401 invalid/revoked response clears persisted
+  tokens and user data before emitting unauthenticated; non-definitive 4xx,
+  transport, and other server failures leave credentials intact. Standalone
+  bridge logout remains clean and idempotent when tokens are
   already absent or the saved authentication session has expired. Non-sandboxed
   macOS desktop builds use the classic default Keychain without requiring a
   provisioned Data Protection Keychain access group.

--- a/docs/regression/desktop-bridge-supervision.md
+++ b/docs/regression/desktop-bridge-supervision.md
@@ -46,9 +46,13 @@ and keep native close/quit behavior safe.
 - Open Logs prepares the owner-only active log through Layer-1 storage, then
   resolves it through the desktop log repository and delegates it to the system
   default application, including before the helper emits its first line.
-- Device-local sign-out locks every bridge lifecycle surface, expected-stops the
-  helper, and keeps controls locked until local tokens finish clearing. If
-  helper stop fails, authentication remains intact; other devices are never
+- Device-local sign-out locks every bridge lifecycle surface, asks the live
+  helper to `unregister_and_exit`, expected-stops it, and independently
+  deletes the GUI's persisted bridge registration id (404 is already success).
+  The delete attempt has a bounded timeout and is best-effort offline; a
+  confirmed deletion clears the local id, while an unconfirmed deletion keeps
+  it for a later retry. Local tokens are cleared only after a successful helper
+  stop; if stop fails, authentication remains intact. Other devices are never
   logged out.
 
 ## Regression Levels
@@ -56,7 +60,7 @@ and keep native close/quit behavior safe.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Automated desktop startup proves eager tray initialization, Prego theme assembly, signed-out login rendering, and signed-in supervision rendering. No plugin. |
-| L2 Routine | Automated cubit/adapter coverage for Open/focus, close-to-hide, no-tray close-to-Quit, ordered Quit, failed-stop/persistence refusal to exit, On/Off recovery, diagnostics launch, and durable-Off-before-local-logout; cross-process lock/activation, killed-owner recovery, persisted desired state, and auth-gated startup restoration. No plugin. |
+| L2 Routine | Automated cubit/adapter coverage for Open/focus, close-to-hide, no-tray close-to-Quit, ordered Quit, failed-stop/persistence refusal to exit, On/Off recovery, diagnostics launch, durable-Off-before-local-logout, helper unregister command, persisted bridge-id restart, 404-idempotent deletion, and offline deletion failure; cross-process lock/activation, killed-owner recovery, persisted desired state, and auth-gated startup restoration. No plugin. |
 | L3 Release | Client end to end on macOS with a dev-built helper and representative live plugin: browser login/relaunch restore, healthy handshake, phone session round-trip, helper crash/backoff, exit-86 restart, login-required behavior, Off/close/Quit orphan checks, and standalone CLI coexistence. |
 | L4 Extended | Client end to end on Windows and Linux, including a Linux StatusNotifier host and a no-host windowed fallback; vary helper startup/stop failures, relay takeover, crash give-up output, and default log-file application availability. |
 | L5 Full | Packaged desktop artifacts on every release target, including native tray/window appearance, signing/install behavior, and long-running supervision through repeated sleep, reconnect, restart, hide/show, and relaunch cycles. |
@@ -85,6 +89,10 @@ at different handshake phases and inspect the status and bounded recent output.
   the Dock still shows a hidden window, or secondary tray clicks do nothing.
 - Quit or sign-out clears auth or exits while a supervised helper remains alive,
   or an On command can race between logout's helper stop and token clearing.
+- Sign-out fails to send the helper unregister command, skips the persisted-id
+  fallback, loses the id across a GUI relaunch, blocks indefinitely on an
+  offline auth server, or clears the id/auth state before deletion/teardown is
+  ordered.
 - A failed On/Off action presents or executes the opposite operation instead of
   retrying the failed action.
 - Window and tray disagree on desired state, status, or active-session count.
@@ -94,9 +102,11 @@ at different handshake phases and inspect the status and bounded recent output.
 
 ## Known Limitations
 
-- Device-local sign-out stops the helper but does not yet perform persisted
-  bridge-registration deletion; coordinated unregister/offline fallback remains
-  a later plan slice.
+- A registration deletion that times out or otherwise fails is retained for a
+  later explicitly-triggered logout retry; there is no background retry job.
+- The helper's `unregister_and_exit` command has no acknowledgement. The GUI
+  therefore always performs its own idempotent deletion attempt after bounded
+  process teardown.
 - Real Linux StatusNotifier and Windows tray/window appearance require host
   smoke coverage; automated tests prove translation and fallback behavior.
 - Non-provisioned/ad-hoc macOS development builds may show one Keychain
@@ -111,6 +121,9 @@ at different handshake phases and inspect the status and bounded recent output.
 
 - `client/module_desktop_core/lib/src/cubits/bridge_control/`
 - `client/module_desktop_core/lib/src/orchestration/desktop_logout_orchestrator.dart`
+- `client/module_desktop_core/lib/src/api/bridge_id_storage.dart`
+- `client/module_core/lib/src/api/bridge_api.dart`
+- `client/module_core/lib/src/repositories/bridge_repository.dart`
 - `client/desktop/lib/core/platform/flutter_window_host.dart`
 - `client/desktop/lib/features/home/desktop_home.dart`
 - `.plan/active/desktop-app/PLAN.md`

--- a/docs/regression/desktop-bridge-supervision.md
+++ b/docs/regression/desktop-bridge-supervision.md
@@ -47,20 +47,21 @@ and keep native close/quit behavior safe.
   resolves it through the desktop log repository and delegates it to the system
   default application, including before the helper emits its first line.
 - Device-local sign-out locks every bridge lifecycle surface, asks the live
-  helper to `unregister_and_exit`, expected-stops it, and independently
-  deletes the GUI's persisted bridge registration id (404 is already success).
-  The delete attempt has a bounded timeout and is best-effort offline; a
-  confirmed deletion clears the local id, while an unconfirmed deletion keeps
-  it for a later retry. Local tokens are cleared only after a successful helper
-  stop; if stop fails, authentication remains intact. Other devices are never
-  logged out.
+  helper to `unregister_and_exit`, waits for that command's expected exit
+  without sending a competing shutdown, and independently deletes the GUI's
+  persisted account-bound bridge registration (404 is already success). The
+  delete attempt has a bounded timeout and is best-effort offline; a confirmed
+  deletion clears the local record, while an unconfirmed deletion keeps it for
+  a later retry. A different account never submits or clears the record. Local
+  tokens are cleared only after a successful helper stop; if stop fails,
+  authentication remains intact. Other devices are never logged out.
 
 ## Regression Levels
 
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Automated desktop startup proves eager tray initialization, Prego theme assembly, signed-out login rendering, and signed-in supervision rendering. No plugin. |
-| L2 Routine | Automated cubit/adapter coverage for Open/focus, close-to-hide, no-tray close-to-Quit, ordered Quit, failed-stop/persistence refusal to exit, On/Off recovery, diagnostics launch, durable-Off-before-local-logout, helper unregister command, persisted bridge-id restart, 404-idempotent deletion, and offline deletion failure; cross-process lock/activation, killed-owner recovery, persisted desired state, and auth-gated startup restoration. No plugin. |
+| L2 Routine | Automated cubit/adapter coverage for Open/focus, close-to-hide, no-tray close-to-Quit, ordered Quit, failed-stop/persistence refusal to exit, On/Off recovery, diagnostics launch, durable-Off-before-local-logout, helper unregister command, no-competing-shutdown expected stop, account-bound persisted bridge-id restart, owner-mismatch protection, 404-idempotent deletion, and offline deletion failure; cross-process lock/activation, killed-owner recovery, persisted desired state, and auth-gated startup restoration. No plugin. |
 | L3 Release | Client end to end on macOS with a dev-built helper and representative live plugin: browser login/relaunch restore, healthy handshake, phone session round-trip, helper crash/backoff, exit-86 restart, login-required behavior, Off/close/Quit orphan checks, and standalone CLI coexistence. |
 | L4 Extended | Client end to end on Windows and Linux, including a Linux StatusNotifier host and a no-host windowed fallback; vary helper startup/stop failures, relay takeover, crash give-up output, and default log-file application availability. |
 | L5 Full | Packaged desktop artifacts on every release target, including native tray/window appearance, signing/install behavior, and long-running supervision through repeated sleep, reconnect, restart, hide/show, and relaunch cycles. |
@@ -89,10 +90,11 @@ at different handshake phases and inspect the status and bounded recent output.
   the Dock still shows a hidden window, or secondary tray clicks do nothing.
 - Quit or sign-out clears auth or exits while a supervised helper remains alive,
   or an On command can race between logout's helper stop and token clearing.
-- Sign-out fails to send the helper unregister command, skips the persisted-id
-  fallback, loses the id across a GUI relaunch, blocks indefinitely on an
-  offline auth server, or clears the id/auth state before deletion/teardown is
-  ordered.
+- Sign-out fails to send the helper unregister command, pre-empts it with a
+  competing shutdown, skips the persisted-id fallback, loses the account-bound
+  record across a GUI relaunch, submits one account's id with another
+  account's token, blocks indefinitely on an offline auth server, or clears
+  the record/auth state before deletion/teardown is ordered.
 - A failed On/Off action presents or executes the opposite operation instead of
   retrying the failed action.
 - Window and tray disagree on desired state, status, or active-session count.


### PR DESCRIPTION
## Complexity

🚧 Complex — this coordinates authenticated API deletion, account-bound desktop persistence, helper lifecycle teardown, and offline-safe logout ordering across shared and desktop layers.

## What

- Add authenticated `BridgeApi`/`BridgeRepository` bridge deletion with URL-safe IDs and idempotent 404 handling.
- Persist the registered bridge ID together with its owning account in desktop-owned application data, restore it before helper startup, and update it from the existing registration-status path.
- Route the typed `unregister_and_exit` command through the desktop control layers.
- Add an expected-stop-after-command path that waits for helper unregister without sending a competing `ControlShutdown`, retaining bounded force-kill fallback.
- Coordinate unregister, teardown, GUI-side deletion, and device-local auth logout in `DesktopLogoutOrchestrator`.
- Add focused regression coverage and update the desktop/account behavior documents.

## Why

Desktop logout must remove the bridge registration even when the helper is unavailable or its own unregister attempt cannot be acknowledged, without turning an offline condition into account-wide logout, losing the retry handle, or allowing one account to act on another account's registration.

## Risk and test focus

Risk is moderate-to-high around logout ordering, account-bound persisted identity, helper shutdown, authenticated deletion, and retry behavior. Focus on 404 idempotence, startup restoration, registration persistence, owner mismatch protection, command routing, no-competing-shutdown teardown, bounded force-kill fallback, deletion failure/offline behavior, and preserving local auth when helper stop fails.

## Expected result

Logging out from desktop unregisters the helper when reachable, removes the saved bridge registration when the auth service is reachable and the current account owns it, and completes device-local logout offline when safe teardown succeeds. A failed helper stop retains authentication and the account-bound retry record. A different account never submits or clears the record. No database schema or new wire-contract change; only desktop-owned local registration persistence is added.

## Verification

- `client/module_core`: `asdf exec dart analyze --fatal-infos`; `asdf exec dart test` (1,463 passed).
- `client/module_desktop_core`: `asdf exec dart analyze --fatal-infos`; `asdf exec dart test` (171 passed).
- `client/desktop`: `asdf exec flutter analyze --fatal-infos`; `asdf exec flutter test` (49 passed).
- `client/app`: `asdf exec flutter analyze --fatal-infos`; `asdf exec flutter test` (913 passed).
- `dart pub get` and `dart run build_runner build` completed for desktop-core; generated model and DI config are committed. LSP diagnostics and `git diff --check` are clean.
- Step 11 architecture implementation review (including the follow-up review): approved with no findings.
