### PR TITLE
⚙️ Render the activity indicator natively on Android and macOS

### DIFF
--- a/client/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/client/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -21,6 +21,7 @@ import pasteboard
 import record_macos
 import share_plus
 import sign_in_with_apple
+import theme_prego
 import url_launcher_macos
 import wakelock_plus
 
@@ -41,6 +42,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SignInWithApplePlugin.register(with: registry.registrar(forPlugin: "SignInWithApplePlugin"))
+  ThemePregoPlugin.register(with: registry.registrar(forPlugin: "ThemePregoPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
 }

--- a/client/app/test/flutter_test_config.dart
+++ b/client/app/test/flutter_test_config.dart
@@ -1,19 +1,29 @@
 import "dart:async";
 
+import "package:flutter/foundation.dart";
 import "package:flutter/services.dart";
 import "package:flutter_test/flutter_test.dart";
 
 /// Global harness for every test in this package.
 ///
-/// The test binding has no handler for the platform-views channel, so any
-/// widget rendering a native view — such as `PregoActivityIndicator` on
-/// Android, iOS, and macOS — would fail its create call with a
-/// `MissingPluginException`. A null reply satisfies every method this suite's
-/// platform views send.
+/// Widget tests render `PregoActivityIndicator`'s native platform views since
+/// the Android/macOS branches landed; without a channel handler the create
+/// call fails with a `MissingPluginException` in every loading-state test. A
+/// null reply satisfies every method this suite's platform views send.
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
-  TestWidgetsFlutterBinding.ensureInitialized();
   setUp(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+    // Only widget-test suites have a test binding (`testWidgets` initializes
+    // it at declaration time, before setUp runs). Plain test() suites must not
+    // get one forced on them: TestWidgetsFlutterBinding installs HttpOverrides
+    // that answer every real HttpClient request with a 400, which breaks
+    // suites exercising a local HTTP server.
+    final TestWidgetsFlutterBinding binding;
+    try {
+      binding = TestWidgetsFlutterBinding.instance;
+    } on FlutterError {
+      return;
+    }
+    binding.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform_views, (call) async => null);
   });
   await testMain();

--- a/client/app/test/flutter_test_config.dart
+++ b/client/app/test/flutter_test_config.dart
@@ -1,0 +1,20 @@
+import "dart:async";
+
+import "package:flutter/services.dart";
+import "package:flutter_test/flutter_test.dart";
+
+/// Global harness for every test in this package.
+///
+/// The test binding has no handler for the platform-views channel, so any
+/// widget rendering a native view — such as `PregoActivityIndicator` on
+/// Android, iOS, and macOS — would fail its create call with a
+/// `MissingPluginException`. A null reply satisfies every method this suite's
+/// platform views send.
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform_views, (call) async => null);
+  });
+  await testMain();
+}

--- a/client/app/test/flutter_test_config.dart
+++ b/client/app/test/flutter_test_config.dart
@@ -12,18 +12,13 @@ import "package:flutter_test/flutter_test.dart";
 /// null reply satisfies every method this suite's platform views send.
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   setUp(() {
-    // Only widget-test suites have a test binding (`testWidgets` initializes
-    // it at declaration time, before setUp runs). Plain test() suites must not
-    // get one forced on them: TestWidgetsFlutterBinding installs HttpOverrides
+    // Only widget-test suites have a binding (`testWidgets` initializes it at
+    // declaration time, before setUp runs). Plain test() suites must not get
+    // one forced on them: TestWidgetsFlutterBinding installs HttpOverrides
     // that answer every real HttpClient request with a 400, which breaks
     // suites exercising a local HTTP server.
-    final TestWidgetsFlutterBinding binding;
-    try {
-      binding = TestWidgetsFlutterBinding.instance;
-    } on FlutterError {
-      return;
-    }
-    binding.defaultBinaryMessenger
+    if (BindingBase.debugBindingType() == null) return;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform_views, (call) async => null);
   });
   await testMain();

--- a/client/desktop/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/client/desktop/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import device_info_plus
 import flutter_secure_storage_darwin
 import package_info_plus
 import screen_retriever_macos
+import theme_prego
 import tray_manager
 import url_launcher_macos
 import window_manager
@@ -18,6 +19,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
+  ThemePregoPlugin.register(with: registry.registrar(forPlugin: "ThemePregoPlugin"))
   TrayManagerPlugin.register(with: registry.registrar(forPlugin: "TrayManagerPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))

--- a/client/desktop/test/flutter_test_config.dart
+++ b/client/desktop/test/flutter_test_config.dart
@@ -1,19 +1,29 @@
 import "dart:async";
 
+import "package:flutter/foundation.dart";
 import "package:flutter/services.dart";
 import "package:flutter_test/flutter_test.dart";
 
 /// Global harness for every test in this package.
 ///
-/// The test binding has no handler for the platform-views channel, so any
-/// widget rendering a native view — such as `PregoActivityIndicator` on
-/// Android, iOS, and macOS — would fail its create call with a
-/// `MissingPluginException`. A null reply satisfies every method this suite's
-/// platform views send.
+/// Widget tests render `PregoActivityIndicator`'s native platform views since
+/// the Android/macOS branches landed; without a channel handler the create
+/// call fails with a `MissingPluginException` in every loading-state test. A
+/// null reply satisfies every method this suite's platform views send.
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
-  TestWidgetsFlutterBinding.ensureInitialized();
   setUp(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+    // Only widget-test suites have a test binding (`testWidgets` initializes
+    // it at declaration time, before setUp runs). Plain test() suites must not
+    // get one forced on them: TestWidgetsFlutterBinding installs HttpOverrides
+    // that answer every real HttpClient request with a 400, which breaks
+    // suites exercising a local HTTP server.
+    final TestWidgetsFlutterBinding binding;
+    try {
+      binding = TestWidgetsFlutterBinding.instance;
+    } on FlutterError {
+      return;
+    }
+    binding.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform_views, (call) async => null);
   });
   await testMain();

--- a/client/desktop/test/flutter_test_config.dart
+++ b/client/desktop/test/flutter_test_config.dart
@@ -1,0 +1,20 @@
+import "dart:async";
+
+import "package:flutter/services.dart";
+import "package:flutter_test/flutter_test.dart";
+
+/// Global harness for every test in this package.
+///
+/// The test binding has no handler for the platform-views channel, so any
+/// widget rendering a native view — such as `PregoActivityIndicator` on
+/// Android, iOS, and macOS — would fail its create call with a
+/// `MissingPluginException`. A null reply satisfies every method this suite's
+/// platform views send.
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform_views, (call) async => null);
+  });
+  await testMain();
+}

--- a/client/desktop/test/flutter_test_config.dart
+++ b/client/desktop/test/flutter_test_config.dart
@@ -12,18 +12,13 @@ import "package:flutter_test/flutter_test.dart";
 /// null reply satisfies every method this suite's platform views send.
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   setUp(() {
-    // Only widget-test suites have a test binding (`testWidgets` initializes
-    // it at declaration time, before setUp runs). Plain test() suites must not
-    // get one forced on them: TestWidgetsFlutterBinding installs HttpOverrides
+    // Only widget-test suites have a binding (`testWidgets` initializes it at
+    // declaration time, before setUp runs). Plain test() suites must not get
+    // one forced on them: TestWidgetsFlutterBinding installs HttpOverrides
     // that answer every real HttpClient request with a 400, which breaks
     // suites exercising a local HTTP server.
-    final TestWidgetsFlutterBinding binding;
-    try {
-      binding = TestWidgetsFlutterBinding.instance;
-    } on FlutterError {
-      return;
-    }
-    binding.defaultBinaryMessenger
+    if (BindingBase.debugBindingType() == null) return;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform_views, (call) async => null);
   });
   await testMain();

--- a/client/module_prego/android/.gitignore
+++ b/client/module_prego/android/.gitignore
@@ -1,0 +1,6 @@
+*.iml
+.gradle
+/local.properties
+.DS_Store
+/build
+.cxx

--- a/client/module_prego/android/build.gradle.kts
+++ b/client/module_prego/android/build.gradle.kts
@@ -1,0 +1,53 @@
+group = "com.sesori.theme_prego"
+version = "0.1.0"
+
+buildscript {
+    val kotlinVersion = "2.3.20"
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath("com.android.tools.build:gradle:9.1.1")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+plugins {
+    id("com.android.library")
+}
+
+android {
+    namespace = "com.sesori.theme_prego"
+
+    compileSdk = 36
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    sourceSets {
+        getByName("main") {
+            java.srcDirs("src/main/kotlin")
+        }
+    }
+
+    defaultConfig {
+        minSdk = 24
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}

--- a/client/module_prego/android/settings.gradle.kts
+++ b/client/module_prego/android/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "theme_prego"

--- a/client/module_prego/android/src/main/AndroidManifest.xml
+++ b/client/module_prego/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/client/module_prego/android/src/main/kotlin/com/sesori/theme_prego/ThemePregoPlugin.kt
+++ b/client/module_prego/android/src/main/kotlin/com/sesori/theme_prego/ThemePregoPlugin.kt
@@ -1,0 +1,53 @@
+package com.sesori.theme_prego
+
+import android.content.Context
+import android.content.res.ColorStateList
+import android.view.View
+import android.widget.ProgressBar
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.StandardMessageCodec
+import io.flutter.plugin.platform.PlatformView
+import io.flutter.plugin.platform.PlatformViewFactory
+
+class ThemePregoPlugin : FlutterPlugin {
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        binding.platformViewRegistry.registerViewFactory(
+            NativeActivityIndicatorPlatformViewFactory.VIEW_TYPE,
+            NativeActivityIndicatorPlatformViewFactory(),
+        )
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {}
+}
+
+private class NativeActivityIndicatorPlatformViewFactory :
+    PlatformViewFactory(StandardMessageCodec.INSTANCE) {
+
+    companion object {
+        const val VIEW_TYPE = "sesori/native-activity-indicator"
+    }
+
+    override fun create(context: Context, viewId: Int, args: Any?): PlatformView {
+        val argb = args as? Number
+            ?: error("Invalid native activity indicator creation arguments")
+        return NativeActivityIndicatorPlatformView(
+            context = context,
+            color = argb.toLong().toInt(),
+        )
+    }
+}
+
+private class NativeActivityIndicatorPlatformView(context: Context, color: Int) : PlatformView {
+    // The default ProgressBar style is the indeterminate circular spinner; its
+    // AnimatedVectorDrawable animates on RenderThread, outside Flutter's frame
+    // pipeline. The Flutter widget owns semantics, so the view is hidden from
+    // accessibility like its iOS counterpart.
+    private val indicator = ProgressBar(context).apply {
+        indeterminateTintList = ColorStateList.valueOf(color)
+        importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+    }
+
+    override fun getView(): View = indicator
+
+    override fun dispose() {}
+}

--- a/client/module_prego/darwin/theme_prego.podspec
+++ b/client/module_prego/darwin/theme_prego.podspec
@@ -1,8 +1,8 @@
 Pod::Spec.new do |s|
   s.name = 'theme_prego'
   s.version = '0.1.0'
-  s.summary = 'Native iOS renderer for the Prego design system.'
-  s.description = 'Native iOS renderer used by Prego Flutter components.'
+  s.summary = 'Native Apple-platform renderer for the Prego design system.'
+  s.description = 'Native iOS and macOS renderer used by Prego Flutter components.'
   s.homepage = 'https://github.com/sesori-ai/sesori_apps_monorepo'
   s.license = { :type => 'Proprietary' }
   s.author = { 'Sesori' => 'hello@sesori.ai' }
@@ -10,6 +10,8 @@ Pod::Spec.new do |s|
   s.source_files = 'theme_prego/Sources/theme_prego/**/*.swift'
   s.ios.dependency 'Flutter'
   s.ios.deployment_target = '13.0'
+  s.osx.dependency 'FlutterMacOS'
+  s.osx.deployment_target = '12.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'
 end

--- a/client/module_prego/darwin/theme_prego/Package.swift
+++ b/client/module_prego/darwin/theme_prego/Package.swift
@@ -5,7 +5,8 @@ import PackageDescription
 let package = Package(
   name: "theme_prego",
   platforms: [
-    .iOS("13.0")
+    .iOS("13.0"),
+    .macOS("12.0"),
   ],
   products: [
     .library(name: "theme-prego", targets: ["theme_prego"])

--- a/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
+++ b/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
@@ -1,6 +1,13 @@
-import Flutter
 import Foundation
-import UIKit
+
+#if os(iOS)
+  import Flutter
+  import UIKit
+#elseif os(macOS)
+  import AppKit
+  import CoreImage
+  import FlutterMacOS
+#endif
 
 public final class ThemePregoPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
@@ -11,122 +18,210 @@ public final class ThemePregoPlugin: NSObject, FlutterPlugin {
   }
 }
 
-private final class NativeActivityIndicatorPlatformViewFactory: NSObject,
-  FlutterPlatformViewFactory
-{
-  static let viewType = "sesori/native-activity-indicator"
-
-  func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
-    FlutterStandardMessageCodec.sharedInstance()
-  }
-
-  func create(
-    withFrame frame: CGRect,
-    viewIdentifier viewId: Int64,
-    arguments args: Any?
-  ) -> FlutterPlatformView {
-    guard let color = args as? NSNumber else {
-      preconditionFailure("Invalid native activity indicator creation arguments")
-    }
-    return NativeActivityIndicatorPlatformView(
-      frame: frame,
-      color: Self.nativeColor(fromARGB: color.int64Value)
-    )
-  }
-
-  private static func nativeColor(fromARGB value: Int64) -> UIColor {
-    let components = colorComponents(fromARGB: value)
-    return UIColor(
-      red: components.red,
-      green: components.green,
-      blue: components.blue,
-      alpha: components.alpha
-    )
-  }
-
-  private static func colorComponents(fromARGB value: Int64) -> ColorComponents {
-    let argb = UInt32(truncatingIfNeeded: value)
-    return ColorComponents(
-      red: CGFloat((argb >> 16) & 0xff) / 255,
-      green: CGFloat((argb >> 8) & 0xff) / 255,
-      blue: CGFloat(argb & 0xff) / 255,
-      alpha: CGFloat((argb >> 24) & 0xff) / 255
-    )
-  }
-}
-
 private struct ColorComponents {
   let red: CGFloat
   let green: CGFloat
   let blue: CGFloat
   let alpha: CGFloat
+
+  init(fromARGB value: Int64) {
+    let argb = UInt32(truncatingIfNeeded: value)
+    red = CGFloat((argb >> 16) & 0xff) / 255
+    green = CGFloat((argb >> 8) & 0xff) / 255
+    blue = CGFloat(argb & 0xff) / 255
+    alpha = CGFloat((argb >> 24) & 0xff) / 255
+  }
 }
 
-private final class NativeActivityIndicatorPlatformView: UIView, FlutterPlatformView {
-  private let indicator = UIActivityIndicatorView(style: .medium)
+#if os(iOS)
 
-  init(frame: CGRect, color: UIColor) {
-    super.init(frame: frame)
+  private final class NativeActivityIndicatorPlatformViewFactory: NSObject,
+    FlutterPlatformViewFactory
+  {
+    static let viewType = "sesori/native-activity-indicator"
 
-    isAccessibilityElement = false
-    accessibilityElementsHidden = true
-    indicator.color = color
-    indicator.hidesWhenStopped = false
-    indicator.translatesAutoresizingMaskIntoConstraints = false
-    addSubview(indicator)
-    NSLayoutConstraint.activate([
-      indicator.centerXAnchor.constraint(equalTo: centerXAnchor),
-      indicator.centerYAnchor.constraint(equalTo: centerYAnchor),
-    ])
+    func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
+      FlutterStandardMessageCodec.sharedInstance()
+    }
 
-    NotificationCenter.default.addObserver(
-      self,
-      selector: #selector(reduceMotionStatusDidChange),
-      name: UIAccessibility.reduceMotionStatusDidChangeNotification,
-      object: nil
-    )
-    updateAnimationState()
-  }
-
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-
-  deinit {
-    NotificationCenter.default.removeObserver(
-      self,
-      name: UIAccessibility.reduceMotionStatusDidChangeNotification,
-      object: nil
-    )
-  }
-
-  func view() -> UIView {
-    self
-  }
-
-  override func layoutSubviews() {
-    super.layoutSubviews()
-    let diameter = indicator.intrinsicContentSize.width
-    let minDimension = min(bounds.width, bounds.height)
-    guard diameter > 0, minDimension > 0 else { return }
-    let scale = minDimension / diameter
-    indicator.transform = CGAffineTransform(scaleX: scale, y: scale)
-  }
-
-  override func didMoveToWindow() {
-    super.didMoveToWindow()
-    updateAnimationState()
-  }
-
-  @objc private func reduceMotionStatusDidChange() {
-    updateAnimationState()
-  }
-
-  private func updateAnimationState() {
-    if window != nil && !UIAccessibility.isReduceMotionEnabled {
-      indicator.startAnimating()
-    } else {
-      indicator.stopAnimating()
+    func create(
+      withFrame frame: CGRect,
+      viewIdentifier viewId: Int64,
+      arguments args: Any?
+    ) -> FlutterPlatformView {
+      guard let color = args as? NSNumber else {
+        preconditionFailure("Invalid native activity indicator creation arguments")
+      }
+      let components = ColorComponents(fromARGB: color.int64Value)
+      return NativeActivityIndicatorPlatformView(
+        frame: frame,
+        color: UIColor(
+          red: components.red,
+          green: components.green,
+          blue: components.blue,
+          alpha: components.alpha
+        )
+      )
     }
   }
-}
+
+  private final class NativeActivityIndicatorPlatformView: UIView, FlutterPlatformView {
+    private let indicator = UIActivityIndicatorView(style: .medium)
+
+    init(frame: CGRect, color: UIColor) {
+      super.init(frame: frame)
+
+      isAccessibilityElement = false
+      accessibilityElementsHidden = true
+      indicator.color = color
+      indicator.hidesWhenStopped = false
+      indicator.translatesAutoresizingMaskIntoConstraints = false
+      addSubview(indicator)
+      NSLayoutConstraint.activate([
+        indicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+        indicator.centerYAnchor.constraint(equalTo: centerYAnchor),
+      ])
+
+      NotificationCenter.default.addObserver(
+        self,
+        selector: #selector(reduceMotionStatusDidChange),
+        name: UIAccessibility.reduceMotionStatusDidChangeNotification,
+        object: nil
+      )
+      updateAnimationState()
+    }
+
+    required init?(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+      NotificationCenter.default.removeObserver(
+        self,
+        name: UIAccessibility.reduceMotionStatusDidChangeNotification,
+        object: nil
+      )
+    }
+
+    func view() -> UIView {
+      self
+    }
+
+    override func layoutSubviews() {
+      super.layoutSubviews()
+      let diameter = indicator.intrinsicContentSize.width
+      let minDimension = min(bounds.width, bounds.height)
+      guard diameter > 0, minDimension > 0 else { return }
+      let scale = minDimension / diameter
+      indicator.transform = CGAffineTransform(scaleX: scale, y: scale)
+    }
+
+    override func didMoveToWindow() {
+      super.didMoveToWindow()
+      updateAnimationState()
+    }
+
+    @objc private func reduceMotionStatusDidChange() {
+      updateAnimationState()
+    }
+
+    private func updateAnimationState() {
+      if window != nil && !UIAccessibility.isReduceMotionEnabled {
+        indicator.startAnimating()
+      } else {
+        indicator.stopAnimating()
+      }
+    }
+  }
+
+#elseif os(macOS)
+
+  private final class NativeActivityIndicatorPlatformViewFactory: NSObject,
+    FlutterPlatformViewFactory
+  {
+    static let viewType = "sesori/native-activity-indicator"
+
+    func createArgsCodec() -> (FlutterMessageCodec & NSObjectProtocol)? {
+      FlutterStandardMessageCodec.sharedInstance()
+    }
+
+    func create(withViewIdentifier viewId: Int64, arguments args: Any?) -> NSView {
+      guard let color = args as? NSNumber else {
+        preconditionFailure("Invalid native activity indicator creation arguments")
+      }
+      let components = ColorComponents(fromARGB: color.int64Value)
+      return NativeActivityIndicatorView(
+        color: NSColor(
+          red: components.red,
+          green: components.green,
+          blue: components.blue,
+          alpha: components.alpha
+        )
+      )
+    }
+  }
+
+  private final class NativeActivityIndicatorView: NSView {
+    private let indicator = NSProgressIndicator()
+
+    init(color: NSColor) {
+      super.init(frame: .zero)
+
+      setAccessibilityElement(false)
+      indicator.style = .spinning
+      indicator.isIndeterminate = true
+      indicator.isDisplayedWhenStopped = true
+      indicator.translatesAutoresizingMaskIntoConstraints = false
+      // NSProgressIndicator has no tint API; a monochrome content filter
+      // recolours the spinner to the requested colour.
+      if let filter = CIFilter(name: "CIColorMonochrome"), let ciColor = CIColor(color: color) {
+        filter.setValue(ciColor, forKey: "inputColor")
+        filter.setValue(1.0, forKey: "inputIntensity")
+        indicator.contentFilters = [filter]
+      }
+      addSubview(indicator)
+      NSLayoutConstraint.activate([
+        indicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+        indicator.centerYAnchor.constraint(equalTo: centerYAnchor),
+      ])
+
+      NSWorkspace.shared.notificationCenter.addObserver(
+        self,
+        selector: #selector(accessibilityDisplayOptionsDidChange),
+        name: NSWorkspace.accessibilityDisplayOptionsDidChangeNotification,
+        object: nil
+      )
+      updateAnimationState()
+    }
+
+    required init?(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+      NSWorkspace.shared.notificationCenter.removeObserver(
+        self,
+        name: NSWorkspace.accessibilityDisplayOptionsDidChangeNotification,
+        object: nil
+      )
+    }
+
+    override func viewDidMoveToWindow() {
+      super.viewDidMoveToWindow()
+      updateAnimationState()
+    }
+
+    @objc private func accessibilityDisplayOptionsDidChange() {
+      updateAnimationState()
+    }
+
+    private func updateAnimationState() {
+      if window != nil && !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion {
+        indicator.startAnimation(nil)
+      } else {
+        indicator.stopAnimation(nil)
+      }
+    }
+  }
+
+#endif

--- a/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
+++ b/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
@@ -167,11 +167,16 @@ private struct ColorComponents {
     init(color: NSColor) {
       super.init(frame: .zero)
 
+      // The Flutter wrapper owns the loading-spinner semantics; hide both the
+      // container and the native indicator from VoiceOver.
       setAccessibilityElement(false)
+      indicator.setAccessibilityElement(false)
       indicator.style = .spinning
       indicator.isIndeterminate = true
       indicator.isDisplayedWhenStopped = true
       indicator.translatesAutoresizingMaskIntoConstraints = false
+      // Content filters only apply to a layer-backed view.
+      indicator.wantsLayer = true
       // NSProgressIndicator has no tint API; a monochrome content filter
       // recolours the spinner to the requested colour.
       if let filter = CIFilter(name: "CIColorMonochrome"), let ciColor = CIColor(color: color) {
@@ -204,6 +209,20 @@ private struct ColorComponents {
         name: NSWorkspace.accessibilityDisplayOptionsDidChangeNotification,
         object: nil
       )
+    }
+
+    override func layout() {
+      super.layout()
+      let minDimension = min(bounds.width, bounds.height)
+      guard minDimension > 0 else { return }
+      // A spinning NSProgressIndicator draws at its control size rather than
+      // its frame; pick the largest size that fits so small consumers (16px
+      // inline rows and buttons) neither clip nor overflow.
+      let fitting: NSControl.ControlSize =
+        minDimension >= 32 ? .regular : minDimension >= 16 ? .small : .mini
+      if indicator.controlSize != fitting {
+        indicator.controlSize = fitting
+      }
     }
 
     override func viewDidMoveToWindow() {

--- a/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
+++ b/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
@@ -93,7 +93,8 @@ class const PregoActivityIndicator({
   }
 
   Widget _indicator({required double? value}) {
-    // The approved wrapper owns the Flutter fallback on non-iOS platforms.
+    // The approved wrapper owns the Flutter fallback for platforms without a
+    // native renderer and for static reduced-motion states.
     // ignore: no_slop_linter/avoid_flutter_spinners
     return CircularProgressIndicator(
       value: value,

--- a/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
+++ b/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
@@ -54,7 +54,12 @@ class const PregoActivityIndicator({
       TargetPlatform.fuchsia || TargetPlatform.linux || TargetPlatform.windows => null,
     };
 
-    return nativeView ?? _indicator(value: null);
+    if (nativeView == null) {
+      return _indicator(value: null);
+    }
+    // Native views consume creationParams only at creation, so a colour change
+    // (a theme switch while a spinner is visible) must recreate the view.
+    return KeyedSubtree(key: ValueKey(color.toARGB32()), child: nativeView);
   }
 
   /// Forced hybrid composition, not the default texture-layer mode: a texture
@@ -62,32 +67,35 @@ class const PregoActivityIndicator({
   /// the whole raster pipeline hot, while a real Android view animates on
   /// RenderThread and lets an otherwise-static Flutter scene schedule nothing.
   Widget _androidIndicator() {
-    // PlatformViewLink calls onCreatePlatformView before surfaceFactory, so the
-    // typed controller can be captured instead of downcasting the surface
-    // callback's PlatformViewController parameter.
-    late final ExpensiveAndroidViewController viewController;
     return PlatformViewLink(
       viewType: _nativeViewType,
+      // The surface must derive the controller from its parameter: the link's
+      // state calls surfaceFactory on every rebuild with the one controller
+      // onCreatePlatformView returned, so a captured local would be a fresh
+      // uninitialized closure variable after any rebuild.
       surfaceFactory: (context, controller) {
-        return AndroidViewSurface(
-          controller: viewController,
-          gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
-          hitTestBehavior: PlatformViewHitTestBehavior.transparent,
+        if (controller case final AndroidViewController androidViewController) {
+          return AndroidViewSurface(
+            controller: androidViewController,
+            gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+            hitTestBehavior: PlatformViewHitTestBehavior.transparent,
+          );
+        }
+        throw StateError(
+          "Android platform view controller of unexpected type: ${controller.runtimeType.toString()}",
         );
       },
       onCreatePlatformView: (params) {
-        viewController = PlatformViewsService.initExpensiveAndroidView(
+        return PlatformViewsService.initExpensiveAndroidView(
           id: params.id,
           viewType: params.viewType,
           layoutDirection: TextDirection.ltr,
           creationParams: color.toARGB32(),
           creationParamsCodec: const StandardMessageCodec(),
           onFocus: () => params.onFocusChanged(true),
-        );
-        viewController
+        )
           ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
           ..create();
-        return viewController;
       },
     );
   }

--- a/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
+++ b/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
@@ -1,4 +1,5 @@
 import "package:flutter/foundation.dart";
+import "package:flutter/gestures.dart";
 import "package:flutter/rendering.dart";
 import "package:flutter/services.dart";
 import "package:material_ui/material_ui.dart";
@@ -43,14 +44,52 @@ class const PregoActivityIndicator({
         creationParamsCodec: const StandardMessageCodec(),
         hitTestBehavior: PlatformViewHitTestBehavior.transparent,
       ),
-      TargetPlatform.android ||
-      TargetPlatform.fuchsia ||
-      TargetPlatform.linux ||
-      TargetPlatform.macOS ||
-      TargetPlatform.windows => null,
+      TargetPlatform.macOS => AppKitView(
+        viewType: _nativeViewType,
+        creationParams: color.toARGB32(),
+        creationParamsCodec: const StandardMessageCodec(),
+        hitTestBehavior: PlatformViewHitTestBehavior.transparent,
+      ),
+      TargetPlatform.android => _androidIndicator(),
+      TargetPlatform.fuchsia || TargetPlatform.linux || TargetPlatform.windows => null,
     };
 
     return nativeView ?? _indicator(value: null);
+  }
+
+  /// Forced hybrid composition, not the default texture-layer mode: a texture
+  /// layer schedules a Flutter frame for every native spinner frame, keeping
+  /// the whole raster pipeline hot, while a real Android view animates on
+  /// RenderThread and lets an otherwise-static Flutter scene schedule nothing.
+  Widget _androidIndicator() {
+    // PlatformViewLink calls onCreatePlatformView before surfaceFactory, so the
+    // typed controller can be captured instead of downcasting the surface
+    // callback's PlatformViewController parameter.
+    late final ExpensiveAndroidViewController viewController;
+    return PlatformViewLink(
+      viewType: _nativeViewType,
+      surfaceFactory: (context, controller) {
+        return AndroidViewSurface(
+          controller: viewController,
+          gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+          hitTestBehavior: PlatformViewHitTestBehavior.transparent,
+        );
+      },
+      onCreatePlatformView: (params) {
+        viewController = PlatformViewsService.initExpensiveAndroidView(
+          id: params.id,
+          viewType: params.viewType,
+          layoutDirection: TextDirection.ltr,
+          creationParams: color.toARGB32(),
+          creationParamsCodec: const StandardMessageCodec(),
+          onFocus: () => params.onFocusChanged(true),
+        );
+        viewController
+          ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
+          ..create();
+        return viewController;
+      },
+    );
   }
 
   Widget _indicator({required double? value}) {

--- a/client/module_prego/pubspec.yaml
+++ b/client/module_prego/pubspec.yaml
@@ -23,7 +23,13 @@ dependencies:
 flutter:
   plugin:
     platforms:
+      android:
+        package: com.sesori.theme_prego
+        pluginClass: ThemePregoPlugin
       ios:
+        pluginClass: ThemePregoPlugin
+        sharedDarwinSource: true
+      macos:
         pluginClass: ThemePregoPlugin
         sharedDarwinSource: true
   assets:

--- a/client/module_prego/test/components/prego_activity_indicator_test.dart
+++ b/client/module_prego/test/components/prego_activity_indicator_test.dart
@@ -1,5 +1,6 @@
 import "package:flutter/foundation.dart";
 import "package:flutter/rendering.dart";
+import "package:flutter/services.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:material_ui/material_ui.dart";
 import "package:theme_prego/module_prego.dart";
@@ -75,6 +76,78 @@ void main() {
     expect(platformView.hitTestBehavior, PlatformViewHitTestBehavior.transparent);
     expect(find.byType(CircularProgressIndicator), findsNothing);
     expect(tester.hasRunningAnimations, isFalse);
+
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets("creates the Android platform view with the requested colour", (tester) async {
+    usePlatform(TargetPlatform.android);
+    final creates = <MethodCall>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform_views,
+      (call) async {
+        if (call.method == "create") creates.add(call);
+        return null;
+      },
+    );
+    await tester.pumpWidget(
+      wrap(const PregoActivityIndicator(color: color)),
+    );
+    await tester.pump();
+
+    expect(creates, hasLength(1));
+    final arguments = creates.single.arguments;
+    if (arguments is! Map) {
+      fail("create arguments were not a map: $arguments");
+    }
+    expect(arguments["viewType"], "sesori/native-activity-indicator");
+    expect(arguments["hybrid"], isTrue);
+    final params = arguments["params"];
+    if (params is! Uint8List) {
+      fail("creation params were not encoded bytes: $params");
+    }
+    expect(
+      const StandardMessageCodec().decodeMessage(ByteData.sublistView(params)),
+      color.toARGB32(),
+    );
+
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets("Android indicator survives a rebuild with an unchanged colour", (tester) async {
+    usePlatform(TargetPlatform.android);
+    await tester.pumpWidget(
+      wrap(const PregoActivityIndicator(color: color)),
+    );
+    // The link's state re-invokes surfaceFactory with its original controller;
+    // a second identical pump must not crash the surface build.
+    await tester.pumpWidget(
+      wrap(const PregoActivityIndicator(color: color)),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(PlatformViewLink), findsOneWidget);
+
+    debugDefaultTargetPlatformOverride = null;
+  });
+
+  testWidgets("recreates the native view when the colour changes", (tester) async {
+    usePlatform(TargetPlatform.iOS);
+    const other = Color(0xFF654321);
+    await tester.pumpWidget(
+      wrap(const PregoActivityIndicator(color: color)),
+    );
+    expect(find.byKey(ValueKey(color.toARGB32())), findsOneWidget);
+
+    await tester.pumpWidget(
+      wrap(const PregoActivityIndicator(color: other)),
+    );
+    expect(find.byKey(ValueKey(color.toARGB32())), findsNothing);
+    expect(find.byKey(ValueKey(other.toARGB32())), findsOneWidget);
+    expect(
+      tester.widget<UiKitView>(find.byType(UiKitView)).creationParams,
+      other.toARGB32(),
+    );
 
     debugDefaultTargetPlatformOverride = null;
   });

--- a/client/module_prego/test/components/prego_activity_indicator_test.dart
+++ b/client/module_prego/test/components/prego_activity_indicator_test.dart
@@ -22,7 +22,7 @@ void main() {
     debugDefaultTargetPlatformOverride = platform;
   }
 
-  testWidgets("uses the Flutter Android spinner without a platform view", (tester) async {
+  testWidgets("uses the native Android spinner without scheduling Flutter animation", (tester) async {
     usePlatform(TargetPlatform.android);
     final handle = tester.ensureSemantics();
     await tester.pumpWidget(
@@ -36,13 +36,9 @@ void main() {
       ),
       findsOneWidget,
     );
-    expect(
-      tester.widget<CircularProgressIndicator>(find.byType(CircularProgressIndicator)).value,
-      isNull,
-    );
-    expect(find.byType(AndroidView), findsNothing);
-    expect(find.byType(PlatformViewLink), findsNothing);
-    expect(tester.hasRunningAnimations, isTrue);
+    expect(find.byType(PlatformViewLink), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(tester.hasRunningAnimations, isFalse);
 
     final data = tester.getSemantics(find.byType(PregoActivityIndicator)).getSemanticsData();
     expect(data.role, SemanticsRole.loadingSpinner);
@@ -67,24 +63,24 @@ void main() {
     debugDefaultTargetPlatformOverride = null;
   });
 
-  testWidgets("uses the Flutter macOS spinner without a platform view", (tester) async {
+  testWidgets("uses the native macOS spinner without scheduling Flutter animation", (tester) async {
     usePlatform(TargetPlatform.macOS);
     await tester.pumpWidget(
       wrap(const PregoActivityIndicator(color: color)),
     );
 
-    expect(
-      tester.widget<CircularProgressIndicator>(find.byType(CircularProgressIndicator)).value,
-      isNull,
-    );
-    expect(find.byType(AppKitView), findsNothing);
-    expect(tester.hasRunningAnimations, isTrue);
+    final platformView = tester.widget<AppKitView>(find.byType(AppKitView));
+    expect(platformView.viewType, "sesori/native-activity-indicator");
+    expect(platformView.creationParams, color.toARGB32());
+    expect(platformView.hitTestBehavior, PlatformViewHitTestBehavior.transparent);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(tester.hasRunningAnimations, isFalse);
 
     debugDefaultTargetPlatformOverride = null;
   });
 
   testWidgets("gives a loosely constrained Flutter spinner a 36 pixel square", (tester) async {
-    usePlatform(TargetPlatform.android);
+    usePlatform(TargetPlatform.linux);
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(

--- a/client/module_prego/test/flutter_test_config.dart
+++ b/client/module_prego/test/flutter_test_config.dart
@@ -1,19 +1,29 @@
 import "dart:async";
 
+import "package:flutter/foundation.dart";
 import "package:flutter/services.dart";
 import "package:flutter_test/flutter_test.dart";
 
 /// Global harness for every test in this package.
 ///
-/// The test binding has no handler for the platform-views channel, so any
-/// widget rendering a native view — such as `PregoActivityIndicator` on
-/// Android, iOS, and macOS — would fail its create call with a
-/// `MissingPluginException`. A null reply satisfies every method this suite's
-/// platform views send.
+/// Widget tests render `PregoActivityIndicator`'s native platform views since
+/// the Android/macOS branches landed; without a channel handler the create
+/// call fails with a `MissingPluginException` in every loading-state test. A
+/// null reply satisfies every method this suite's platform views send.
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
-  TestWidgetsFlutterBinding.ensureInitialized();
   setUp(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+    // Only widget-test suites have a test binding (`testWidgets` initializes
+    // it at declaration time, before setUp runs). Plain test() suites must not
+    // get one forced on them: TestWidgetsFlutterBinding installs HttpOverrides
+    // that answer every real HttpClient request with a 400, which breaks
+    // suites exercising a local HTTP server.
+    final TestWidgetsFlutterBinding binding;
+    try {
+      binding = TestWidgetsFlutterBinding.instance;
+    } on FlutterError {
+      return;
+    }
+    binding.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform_views, (call) async => null);
   });
   await testMain();

--- a/client/module_prego/test/flutter_test_config.dart
+++ b/client/module_prego/test/flutter_test_config.dart
@@ -1,0 +1,20 @@
+import "dart:async";
+
+import "package:flutter/services.dart";
+import "package:flutter_test/flutter_test.dart";
+
+/// Global harness for every test in this package.
+///
+/// The test binding has no handler for the platform-views channel, so any
+/// widget rendering a native view — such as `PregoActivityIndicator` on
+/// Android, iOS, and macOS — would fail its create call with a
+/// `MissingPluginException`. A null reply satisfies every method this suite's
+/// platform views send.
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUp(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform_views, (call) async => null);
+  });
+  await testMain();
+}

--- a/client/module_prego/test/flutter_test_config.dart
+++ b/client/module_prego/test/flutter_test_config.dart
@@ -12,18 +12,13 @@ import "package:flutter_test/flutter_test.dart";
 /// null reply satisfies every method this suite's platform views send.
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   setUp(() {
-    // Only widget-test suites have a test binding (`testWidgets` initializes
-    // it at declaration time, before setUp runs). Plain test() suites must not
-    // get one forced on them: TestWidgetsFlutterBinding installs HttpOverrides
+    // Only widget-test suites have a binding (`testWidgets` initializes it at
+    // declaration time, before setUp runs). Plain test() suites must not get
+    // one forced on them: TestWidgetsFlutterBinding installs HttpOverrides
     // that answer every real HttpClient request with a 400, which breaks
     // suites exercising a local HTTP server.
-    final TestWidgetsFlutterBinding binding;
-    try {
-      binding = TestWidgetsFlutterBinding.instance;
-    } on FlutterError {
-      return;
-    }
-    binding.defaultBinaryMessenger
+    if (BindingBase.debugBindingType() == null) return;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(SystemChannels.platform_views, (call) async => null);
   });
   await testMain();

--- a/docs/regression/README.md
+++ b/docs/regression/README.md
@@ -153,6 +153,7 @@ failed, or unexecuted required coverage keeps the plan active.
 - [Design catalog](design-catalog.md)
 - [Desktop bridge supervision](desktop-bridge-supervision.md)
 - [Diffs and source control](diffs-and-source-control.md)
+- [Native activity indicators](native-activity-indicators.md)
 - [Navigation transitions](navigation-transitions.md)
 - [Notifications](notifications.md)
 - [Permission auto-approval](permission-auto-approval.md)

--- a/docs/regression/native-activity-indicators.md
+++ b/docs/regression/native-activity-indicators.md
@@ -1,0 +1,43 @@
+# Native Activity Indicators
+
+`PregoActivityIndicator` renders the shared busy spinner. On iOS, macOS, and
+Android it renders through a `theme_prego` platform view so the animation runs
+outside Flutter's frame pipeline — Core Animation on Apple platforms,
+RenderThread on Android via forced hybrid composition — and an otherwise-static
+screen schedules no Flutter frames while it spins. Web and the remaining
+desktop platforms use the animated Flutter fallback arc. Reduced motion and
+disabled tickers replace the native view with a static Flutter arc, and the
+widget owns loading-spinner semantics on every platform.
+
+Material failure signals: a native-platform spinner driving continuous Flutter
+frame production again; crashes, frozen or corrupted scene rendering, or leaked
+native views when a spinner scrolls out of view, is inserted and removed
+repeatedly, or composes with glass and blur; a spinner ignoring its requested
+colour; reduce motion still animating.
+
+## Regression Levels
+
+| Level | Additional coverage |
+|---|---|
+| L1 Smoke | Automated: the owning widget test suite proves per-platform widget selection, creation parameters, semantics role, and the reduced-motion and disabled-ticker fallbacks. |
+| L2 Routine | Client end to end (release-target client platform): a screen with a spinning indicator renders correctly while the app shows no continuous Flutter UI/raster work attributable to the spinner. |
+| L3 Release | Client end to end: repeat on the alternate mobile platform and macOS desktop; scroll an indicator through a list, insert and remove it repeatedly, and overlap it with glass/blur without crashes or scene corruption. |
+| L4 Extended | Client end to end: toggle system reduce motion mid-spin; background and foreground the app while an indicator is animating. |
+| L5 Full | No additional coverage. |
+
+## Exploration Guidance
+
+- Prefer real loading states (session list refresh, solid-button loading,
+  session detail) over synthetic screens.
+- Judge the power invariant by per-thread CPU, not visual smoothness: an idle
+  screen with a native spinner must produce no continuous Flutter frames.
+- On Android verify the forced hybrid-composition path specifically; the
+  default texture-layer platform-view mode recreates the frame-pipeline drain
+  this capability exists to remove.
+
+## Maintenance Sources
+
+- `client/module_prego/lib/components/loaders/prego_activity_indicator.dart`
+- `client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift`
+- `client/module_prego/android/src/main/kotlin/com/sesori/theme_prego/ThemePregoPlugin.kt`
+- `client/module_prego/test/components/prego_activity_indicator_test.dart`


### PR DESCRIPTION
## Complexity
⚙️ Moderate — mirrors the established iOS native-spinner pattern on two more platforms; new native code on each, but no new architecture (approved by architecture implementation review).

## What
Extends the `theme_prego` native activity indicator beyond iOS:

- **Android**: an indeterminate `ProgressBar` platform view via **forced hybrid composition** (`initExpensiveAndroidView`), so the AnimatedVectorDrawable animates on RenderThread. The default texture-layer mode is deliberately avoided: it schedules a Flutter frame for every native frame, keeping the raster pipeline hot (measured strictly worse than a Flutter spinner).
- **macOS**: an `NSProgressIndicator` behind `AppKitView`, added to the shared darwin source with an `#if os()` split, tinted via a monochrome content filter, honoring reduce motion and window detach.
- Plugin metadata (`pubspec.yaml`), podspec, and `Package.swift` declare the new platforms; registration stays automatic through plugin metadata — no shell wiring.
- Widget tests now assert the per-platform platform views; new `docs/regression/native-activity-indicators.md` captures the capability.

## Why
An idle screen with a spinner kept Flutter's whole frame pipeline running (Dart tick + full raster at refresh rate) — the main driver of the loading-state battery drain. Native platform views animate on the OS side while Flutter schedules zero frames.

Measured with release builds of a standalone harness running this exact plugin code (app CPU, % of one core):

| Scenario | Native | Flutter spinner |
|---|---|---|
| Android idle (emulator) | 3.7% | 10.4% |
| Android 1→10 spinners (steady state) | 2.4–3.0% (flat) | ~11% (TLHC: 9.3→14.9%) |
| macOS idle (real hardware) | **0.1%** | **19.0%** |
| macOS scroll with spinner in list | 24.9% | 27.4% |

Full lifecycle gauntlet on both platforms — scrolling in/out of a list, insert/remove churn every 400ms, blur/glass overlap: no crashes, no scene corruption, zero error logs on Flutter 3.47.2.

## Risk and test focus
- **Android scroll cost**: hybrid composition is pricier while Flutter itself animates — ~2× a Flutter spinner during continuous scroll (24.3% vs 12.5% on the emulator). Idle dominates real spinner usage, but verify scroll smoothness with visible spinners on a real device.
- **macOS stability**: earlier native attempts crashed when scrolling the spinner offscreen in a list; that exact scenario passed the stress test on 3.47.2. The tint filter was not visually verified (no screen-recording permission in the test environment) — eyeball the spinner colour when next running the desktop app.
- iOS behavior is unchanged: the same implementation relocated behind `#if os(iOS)`.
- No user-visible layout change (same 36px box), no database impact, no wire-contract change — the view-type string is internal to the package.

## Expected result
Spinners on Android and macOS render as native platform views with the same placement and colour as today, while an otherwise-static screen schedules no Flutter frames — matching the existing iOS behavior. Web/Linux/Windows keep the animated Flutter fallback; reduced motion still shows the static arc.

## Verification
- `module_prego` loader widget tests: 7/7 pass; `dart analyze` clean on touched files.
- Real `client/app` Android APK and `client/desktop` macOS app both build with the plugin (AGP 9.1.1 / SwiftPM).
- Runtime stress + CPU measurements above executed against this plugin code on an API 36 emulator and macOS hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders the `PregoActivityIndicator` spinner natively on Android and macOS so an otherwise-static screen with a spinner stops scheduling Flutter frames. The spinner previously used a Flutter `CircularProgressIndicator` on those platforms.

**Notes**
- Android uses a `ProgressBar` via forced hybrid composition; macOS uses an `NSProgressIndicator` behind `AppKitView`, both at the same 36px size, color, and semantics.
- iOS behavior is unchanged; the shared Darwin implementation now splits with `#if os()`.
- Web, Linux, and Windows keep the animated Flutter fallback; reduced motion still shows a static arc.
- Native views recreate when the spinner color changes (e.g., theme switch), which also closes the same pre-existing iOS gap.
- On macOS the spinner hides from VoiceOver (the Flutter wrapper owns semantics) and scales its control size to fit 14–16px consumers.
- Android hybrid composition costs ~2x a Flutter spinner during continuous scroll, but stationary spinners idle at ~3% CPU versus ~10% before; macOS idle drops to ~0.1% CPU.
- The macOS tint uses a `CIColorMonochrome` filter that hasn't been visually verified.
- Widget test harnesses now mock the platform-views channel so tests rendering native views pass instead of throwing `MissingPluginException`.
- No user-visible layout change, no database impact, no wire-contract change.

<sup>Written for commit c759c53cd16ebaa703b031e351fee5985c1f03a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

