### PR TITLE
⚙️ [desktop-app] Enable desktop relay client [step 13/22]

### DIFF
--- a/.plan/active/desktop-app/PLAN.md
+++ b/.plan/active/desktop-app/PLAN.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Plan slug:** `desktop-app`
-- **Status:** Active — step 12/22 in progress (supervised E2E + harness retirement)
+- **Status:** Active — step 13/22 in progress (desktop relay-client enablement)
 - **Plan date:** 2026-08-28
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Current implementation base:** `main`
@@ -398,9 +398,12 @@ than reviving a removed control message. CI runs the native bundle and test on
 macOS, Windows, and Linux; failure diagnostics are uploaded without bearer
 credentials or control secrets.
 
-The first Step 12 commit also carries the post-merge Step 11 lifecycle fixes:
-logout stop-mode ownership, immediate ordinary-shutdown fallback when unregister
-cannot be delivered, and `/auth/me` verification for token-only local sessions.
+Step 12 merged in PR #1215 on 2026-08-30. Its native supervised E2E
+verification passed on macOS, Windows, and Linux; the obsolete interactive
+control harness was retired. The PR also carried the post-merge Step 11
+lifecycle fixes: logout stop-mode ownership, immediate ordinary-shutdown
+fallback when unregister cannot be delivered, and `/auth/me` verification for
+token-only local sessions.
 
 > **MT gate B — daily driver (user-run, after step 12).** macOS primary
 > (Windows/Linux dev-build smoke as machines allow): autostart reboot →

--- a/.plan/active/desktop-app/TRACKER.md
+++ b/.plan/active/desktop-app/TRACKER.md
@@ -19,9 +19,9 @@ user-run checkpoints, not PRs; only the user marks them passed.
 | 9 | ⚙️ Autostart + hidden boot | done |
 | 10 | 🚧 `module_auth` logout/rejection hardening (R1) | done |
 | 11 | 🚧 Logout coordination + offline unregister fallback | done |
-| 12 | 🚧 Supervised E2E suite + dev-harness retirement | in-progress |
+| 12 | 🚧 Supervised E2E suite + dev-harness retirement | done |
 | — | MT gate B: daily driver (user-run) | pending |
-| 13 | ⚙️ Desktop relay-client enablement | pending |
+| 13 | ⚙️ Desktop relay-client enablement | in-progress |
 | 14 | ⚙️ Create `module_app_ui` + l10n/extensions/theme move | pending |
 | 15 | 🚧 Settings + harness management slice (desktop onboarding) | pending |
 | 16 | 🚧 Project/session lists slice + desktop offline strategy | pending |
@@ -45,5 +45,7 @@ not separately re-reported in the final check; the user explicitly accepted
 the available gate coverage as sufficient.
 
 Step 10 merged in PR #1212 on 2026-08-30. Step 11 merged in PR #1213 on
-2026-08-30. Its post-merge stop-mode and token-only deletion hardening is being
-carried into the Step 12 branch alongside the real supervised E2E coverage.
+2026-08-30. Step 12 merged in PR #1215 on 2026-08-30 with 19/19 CI checks
+passing, including the native supervised E2E on macOS, Windows, and Linux.
+The Step 12 PR also included the post-merge Step 11 stop-mode and token-only
+deletion hardening. Step 13 is now the active successor.

--- a/.plan/active/desktop-app/steps/step-12.md
+++ b/.plan/active/desktop-app/steps/step-12.md
@@ -55,10 +55,10 @@ runner; the terminal `status` aggregator includes the new job.
   tests).
 - `actionlint .github/workflows/desktop-ci.yml` and Dart LSP diagnostics for
   changed source/test files are clean; `git diff --check` is clean.
-- Native three-OS CI verification remains pending until the Step 12 PR runs.
+- Native three-OS CI passed in the merged Step 12 PR (#1215), with 19/19 CI
+  checks green, including the real supervised E2E on macOS, Windows, and Linux.
 
 ## Handoff
 
-The Step 12 implementation is ready for its PR. After it is merged, the
-user-run MT gate B daily-driver matrix is the next checkpoint. The plan remains
-active until that gate is recorded.
+Step 12 merged in PR #1215 on 2026-08-30. The user-run MT gate B daily-driver
+matrix is the next manual checkpoint while Step 13 proceeds locally.

--- a/.plan/active/desktop-app/steps/step-13.md
+++ b/.plan/active/desktop-app/steps/step-13.md
@@ -1,0 +1,58 @@
+# Step 13 — ⚙️ Desktop becomes a relay client
+
+Date: 2026-08-30.
+
+## Delivered
+
+- Registered the desktop shell's missing shared relay prerequisites: a
+  singleton `RelayCryptoService`, a local log-backed `FailureReporter`, and a
+  route-source boundary for the pre-router shell.
+- `DesktopFailureReporter` keeps handled failures observable through the
+  existing application logger. It retains the original error and stack trace,
+  bounded operation/event context, and fatal/reason metadata while reducing
+  opaque information arguments to type/shape metadata so SSE properties cannot
+  put prompt, transcript, or source content into a future crash-report seam.
+- Rooted the existing shared `ConnectionService` before the desktop widget tree
+  and let its auth-state listener own relay connect/reconnect behavior. No
+  second reconnect driver was added.
+- Constructed `ConnectionOverlayCubit` and `SseToastCubit` at the desktop root,
+  added a root connection-banner host, and added a navigator-overlay Prego toast
+  listener for backend `tui.toast.show` events. The desktop home now shows the
+  desktop relay-client state separately from the supervised helper's relay
+  status.
+- Added the route-less desktop source required by `SseToastCubit`. Until the
+  Step 14 router exists, app-wide toasts remain visible and session-attributed
+  toasts are withheld without inventing a session identity. Push/local
+  notification-open capabilities remain unbound because the current desktop
+  shell has no notification surface.
+- Added focused DI, reporter, route-source, banner, toast-listener, home, auth
+  gate, and startup smoke coverage.
+
+No database schema, persisted-data format, or wire-contract change. The desktop
+shell now activates the already-shared relay transport and root event surfaces.
+
+## Architecture implementation review
+
+Pending the required implementation review for the new desktop DI/platform
+boundary and root relay-client composition.
+
+## Verification
+
+- `client/desktop`: `dart analyze --fatal-infos` clean; full `flutter test`
+  passed (56 tests).
+- Desktop DI resolves `RelayCryptoService`, `FailureReporter`, `RouteSource`,
+  `ConnectionService`, and `RegisteredBridgesService`; cubits remain
+  shell-constructed rather than DI-registered.
+- Focused widget coverage verifies bridge-offline and relay-lost banners,
+  retry delegation, backend toast presentation on the navigator overlay, and
+  the separate desktop relay-client status row.
+- Dart LSP diagnostics and `git diff --check` are clean.
+- Native desktop build/CI verification remains pending for the Step 13 PR.
+
+## Handoff
+
+Step 12 merged in PR #1215 on 2026-08-30. After this step merges, Step 14
+creates `module_app_ui`, moves the shared localization/context foundation, and
+replaces the temporary route-less desktop source and shell-owned connection
+banner with the shared adaptive UI/router foundation. MT gate B remains the
+user-run daily-driver checkpoint.

--- a/.plan/active/desktop-app/steps/step-13.md
+++ b/.plan/active/desktop-app/steps/step-13.md
@@ -14,9 +14,10 @@ Date: 2026-08-30.
   put prompt, transcript, or source content into a future crash-report seam.
 - Rooted the existing shared `ConnectionService` before the desktop widget tree
   and let its auth-state listener own relay connect/reconnect behavior. The
-  signed-in destination also issues one idempotent auth-backed connect trigger
-  for token-only local restores that intentionally remain `AuthInitial`; no
-  second reconnect driver was added.
+  signed-in destination signals `DesktopRelayConnectionService` through the
+  auth-gate intent for token-only local restores that intentionally remain
+  `AuthInitial`; the connection overlay remains stream-derived and issues no
+  transport commands.
 - Constructed `ConnectionOverlayCubit` and `SseToastCubit` at the desktop root,
   added a root connection-banner host, and added a navigator-overlay Prego toast
   listener for backend `tui.toast.show` events. The desktop home now shows the
@@ -38,19 +39,25 @@ shell now activates the already-shared relay transport and root event surfaces.
 Approved with no blocking findings. The review covered the desktop DI/platform
 boundary, root relay-client composition, shell-owned cubits and presentation,
 route-less behavior, privacy-preserving failure reporting, client layering, and
-Step 13 scope. The reviewer returned `Merge verdict: OK`.
+Step 13 scope. The reviewer returned `Merge verdict: OK`. A follow-up Codex P1
+found that the token-only trigger had been placed on the projection cubit; it
+was moved to the desktop auth/connection coordination service and auth-gate
+intent before the follow-up push.
 
 ## Verification
 
 - `client/desktop`: `dart analyze --fatal-infos` clean; full `flutter test`
-  passed (56 tests).
+  passed (57 tests).
+- `client/module_desktop_core`: `dart analyze --fatal-infos` clean; full
+  `dart test` passed (183 tests).
 - Desktop DI resolves `RelayCryptoService`, `FailureReporter`, `RouteSource`,
   `ConnectionService`, and `RegisteredBridgesService`; cubits remain
   shell-constructed rather than DI-registered.
-- Focused widget coverage verifies bridge-offline and relay-lost banners,
-  retry delegation, backend toast presentation on the navigator overlay, the
-  token-only signed-in destination connection trigger, and the separate desktop
-  relay-client status row.
+- Focused coverage verifies bridge-offline and relay-lost banners, retry
+  delegation, backend toast presentation on the navigator overlay, the
+  token-only signed-in destination handoff through the auth/connection
+  coordinator, DI registration, and the separate desktop relay-client status
+  row.
 - Dart LSP diagnostics and `git diff --check` are clean.
 - `asdf exec flutter build macos` completed successfully (`Sesori.app`,
   55.3 MB). Windows/Linux native build verification remains pending for the

--- a/.plan/active/desktop-app/steps/step-13.md
+++ b/.plan/active/desktop-app/steps/step-13.md
@@ -13,7 +13,9 @@ Date: 2026-08-30.
   opaque information arguments to type/shape metadata so SSE properties cannot
   put prompt, transcript, or source content into a future crash-report seam.
 - Rooted the existing shared `ConnectionService` before the desktop widget tree
-  and let its auth-state listener own relay connect/reconnect behavior. No
+  and let its auth-state listener own relay connect/reconnect behavior. The
+  signed-in destination also issues one idempotent auth-backed connect trigger
+  for token-only local restores that intentionally remain `AuthInitial`; no
   second reconnect driver was added.
 - Constructed `ConnectionOverlayCubit` and `SseToastCubit` at the desktop root,
   added a root connection-banner host, and added a navigator-overlay Prego toast
@@ -46,8 +48,9 @@ Step 13 scope. The reviewer returned `Merge verdict: OK`.
   `ConnectionService`, and `RegisteredBridgesService`; cubits remain
   shell-constructed rather than DI-registered.
 - Focused widget coverage verifies bridge-offline and relay-lost banners,
-  retry delegation, backend toast presentation on the navigator overlay, and
-  the separate desktop relay-client status row.
+  retry delegation, backend toast presentation on the navigator overlay, the
+  token-only signed-in destination connection trigger, and the separate desktop
+  relay-client status row.
 - Dart LSP diagnostics and `git diff --check` are clean.
 - `asdf exec flutter build macos` completed successfully (`Sesori.app`,
   55.3 MB). Windows/Linux native build verification remains pending for the

--- a/.plan/active/desktop-app/steps/step-13.md
+++ b/.plan/active/desktop-app/steps/step-13.md
@@ -33,8 +33,10 @@ shell now activates the already-shared relay transport and root event surfaces.
 
 ## Architecture implementation review
 
-Pending the required implementation review for the new desktop DI/platform
-boundary and root relay-client composition.
+Approved with no blocking findings. The review covered the desktop DI/platform
+boundary, root relay-client composition, shell-owned cubits and presentation,
+route-less behavior, privacy-preserving failure reporting, client layering, and
+Step 13 scope. The reviewer returned `Merge verdict: OK`.
 
 ## Verification
 
@@ -47,7 +49,9 @@ boundary and root relay-client composition.
   retry delegation, backend toast presentation on the navigator overlay, and
   the separate desktop relay-client status row.
 - Dart LSP diagnostics and `git diff --check` are clean.
-- Native desktop build/CI verification remains pending for the Step 13 PR.
+- `asdf exec flutter build macos` completed successfully (`Sesori.app`,
+  55.3 MB). Windows/Linux native build verification remains pending for the
+  Step 13 PR.
 
 ## Handoff
 

--- a/client/app/test/helpers/test_helpers.dart
+++ b/client/app/test/helpers/test_helpers.dart
@@ -37,9 +37,6 @@ class StubConnectionOverlayCubit({
   this : super(initialState);
 
   @override
-  Future<void> ensureConnected() async {}
-
-  @override
   void reconnect() {}
 }
 

--- a/client/app/test/helpers/test_helpers.dart
+++ b/client/app/test/helpers/test_helpers.dart
@@ -37,6 +37,9 @@ class StubConnectionOverlayCubit({
   this : super(initialState);
 
   @override
+  Future<void> ensureConnected() async {}
+
+  @override
   void reconnect() {}
 }
 

--- a/client/desktop/lib/app.dart
+++ b/client/desktop/lib/app.dart
@@ -2,46 +2,91 @@ import "dart:async";
 
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:material_ui/material_ui.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_desktop_core/sesori_desktop_core.dart";
 import "package:theme_prego/module_prego.dart";
 
 import "core/di/injection.dart";
+import "core/widgets/desktop_connection_banner.dart";
+import "core/widgets/desktop_sse_toast_listener.dart";
 import "features/auth_gate/auth_gate.dart";
+
+final GlobalKey<NavigatorState> _desktopNavigatorKey = GlobalKey<NavigatorState>();
 
 /// Root widget of the Sesori desktop app.
 ///
-/// Owns the eager desktop bridge controller, Prego themes, and sign-in gate.
+/// Owns the eager desktop bridge controller, relay-client connection effects,
+/// Prego themes, and sign-in gate.
 class const SesoriDesktopApp({required final bool hiddenLaunch, super.key}) extends StatelessWidget {
   static const String _appTitle = "Sesori";
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider<BridgeControlCubit>(
-      lazy: false,
-      create: (_) {
-        final BridgeControlCubit cubit = BridgeControlCubit(
-          processService: getIt(),
-          statusTracker: getIt(),
-          systemTray: getIt(),
-          windowHost: getIt(),
-          applicationTerminator: getIt(),
-          logRepository: getIt(),
-          instanceService: getIt(),
-          logoutTracker: getIt(),
-          urlLauncher: getIt(),
-          launchAtLogin: getIt(),
-          hiddenLaunch: hiddenLaunch,
-        );
-        unawaited(cubit.initialize());
-        return cubit;
-      },
+    return MultiBlocProvider(
+      providers: <BlocProvider<dynamic>>[
+        BlocProvider<ConnectionOverlayCubit>(
+          lazy: false,
+          create: (_) => ConnectionOverlayCubit(
+            getIt<ConnectionService>(),
+            getIt<RegisteredBridgesService>(),
+          ),
+        ),
+        BlocProvider<SseToastCubit>(
+          lazy: false,
+          create: (_) => SseToastCubit(
+            connectionService: getIt<ConnectionService>(),
+            routeSource: getIt<RouteSource>(),
+          ),
+        ),
+        BlocProvider<BridgeControlCubit>(
+          lazy: false,
+          create: (_) {
+            final BridgeControlCubit cubit = BridgeControlCubit(
+              processService: getIt(),
+              statusTracker: getIt(),
+              systemTray: getIt(),
+              windowHost: getIt(),
+              applicationTerminator: getIt(),
+              logRepository: getIt(),
+              instanceService: getIt(),
+              logoutTracker: getIt(),
+              urlLauncher: getIt(),
+              launchAtLogin: getIt(),
+              hiddenLaunch: hiddenLaunch,
+            );
+            unawaited(cubit.initialize());
+            return cubit;
+          },
+        ),
+      ],
       child: MaterialApp(
         title: _appTitle,
         debugShowCheckedModeBanner: false,
+        navigatorKey: _desktopNavigatorKey,
         theme: buildPregoThemeData(brightness: Brightness.light),
         darkTheme: buildPregoThemeData(brightness: Brightness.dark),
         themeMode: ThemeMode.system,
         home: const AuthGate(),
+        builder: (context, child) => _DesktopRootEffects(
+          navigatorKey: _desktopNavigatorKey,
+          child: child ?? const SizedBox.shrink(),
+        ),
+      ),
+    );
+  }
+}
+
+class const _DesktopRootEffects({required final Widget child, required final GlobalKey<NavigatorState> navigatorKey})
+    extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return DesktopSseToastListener(
+      navigatorKey: navigatorKey,
+      child: Column(
+        children: <Widget>[
+          DesktopConnectionBanner.maybeFor(context) ?? const SizedBox.shrink(),
+          Expanded(child: child),
+        ],
       ),
     );
   }

--- a/client/desktop/lib/core/di/injection.config.dart
+++ b/client/desktop/lib/core/di/injection.config.dart
@@ -19,10 +19,14 @@ import 'package:sesori_dart_core/sesori_dart_core.dart' as _i948;
 import 'package:sesori_desktop/core/di/register_module.dart' as _i893;
 import 'package:sesori_desktop/core/platform/desktop_bridge_executable_path_resolver.dart'
     as _i964;
+import 'package:sesori_desktop/core/platform/desktop_failure_reporter.dart'
+    as _i227;
 import 'package:sesori_desktop/core/platform/desktop_lifecycle_observer.dart'
     as _i670;
 import 'package:sesori_desktop/core/platform/desktop_oauth_device_descriptor_provider.dart'
     as _i20;
+import 'package:sesori_desktop/core/platform/desktop_route_source.dart'
+    as _i911;
 import 'package:sesori_desktop/core/platform/desktop_secure_storage_adapter.dart'
     as _i757;
 import 'package:sesori_desktop/core/platform/desktop_url_launcher.dart'
@@ -41,6 +45,7 @@ import 'package:sesori_desktop/core/platform/no_op_analytics_client.dart'
 import 'package:sesori_desktop/core/platform/no_op_attribution_client.dart'
     as _i91;
 import 'package:sesori_desktop_core/sesori_desktop_core.dart' as _i316;
+import 'package:sesori_shared/sesori_shared.dart' as _i553;
 
 extension GetItInjectableX on _i174.GetIt {
   // initializes the registration of main-scope dependencies inside of GetIt
@@ -53,6 +58,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i519.Client>(() => registerModule.httpClient);
     gh.lazySingleton<_i833.DeviceInfoPlugin>(
       () => registerModule.deviceInfoPlugin,
+    );
+    gh.lazySingleton<_i553.RelayCryptoService>(
+      () => registerModule.relayCryptoService,
     );
     gh.lazySingleton<_i558.FlutterSecureStorage>(
       () => registerModule.secureStorage,
@@ -83,11 +91,15 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i948.AttributionClient>(
       () => _i91.NoOpAttributionClient(),
     );
+    gh.lazySingleton<_i553.FailureReporter>(
+      () => _i227.DesktopFailureReporter(),
+    );
     gh.lazySingleton<_i948.UrlLauncher>(() => _i137.DesktopUrlLauncher());
     gh.lazySingleton<_i316.WindowHost>(
       () => _i789.FlutterWindowHost(),
       dispose: (i) => i.dispose(),
     );
+    gh.singleton<_i948.RouteSource>(() => _i911.DesktopRouteSource());
     gh.lazySingleton<_i948.AnalyticsClient>(() => _i262.NoOpAnalyticsClient());
     gh.lazySingleton<_i948.SecureStorage>(
       () => _i757.DesktopSecureStorageAdapter(

--- a/client/desktop/lib/core/di/register_module.dart
+++ b/client/desktop/lib/core/di/register_module.dart
@@ -2,6 +2,7 @@ import "package:device_info_plus/device_info_plus.dart";
 import "package:flutter_secure_storage/flutter_secure_storage.dart";
 import "package:http/http.dart" as http;
 import "package:injectable/injectable.dart";
+import "package:sesori_shared/sesori_shared.dart";
 
 @module
 abstract class RegisterModule() {
@@ -10,6 +11,9 @@ abstract class RegisterModule() {
 
   @lazySingleton
   DeviceInfoPlugin get deviceInfoPlugin => DeviceInfoPlugin();
+
+  @lazySingleton
+  RelayCryptoService get relayCryptoService => RelayCryptoService();
 
   // Used by Windows and Linux. The desktop storage adapter routes macOS to the
   // dedicated classic-Keychain channel required by non-provisioned builds.

--- a/client/desktop/lib/core/platform/desktop_failure_reporter.dart
+++ b/client/desktop/lib/core/platform/desktop_failure_reporter.dart
@@ -1,0 +1,85 @@
+import "package:flutter/foundation.dart" show visibleForTesting;
+import "package:injectable/injectable.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+/// Test seam for the desktop application's log-backed failure reporter.
+@visibleForTesting
+typedef DesktopFailureLogSink = void Function({
+  required String message,
+  required Object? error,
+  required StackTrace? stackTrace,
+});
+
+/// Keeps shared handled failures observable on desktop without forwarding
+/// payload-bearing context to a remote crash service.
+///
+/// The shared module supplies [FailureReporter] to recoverable event handlers.
+/// Mobile binds that seam to Crashlytics, but the desktop shell intentionally
+/// has no remote crash-reporting dependency yet. This implementation preserves
+/// the useful error, stack, operation identifier, and event-type context in the
+/// local application log while reducing [information] to type/shape metadata.
+@LazySingleton(as: FailureReporter)
+class DesktopFailureReporter.forTesting({required final DesktopFailureLogSink _logSink}) implements FailureReporter {
+  new()
+    : this.forTesting(
+        logSink: ({required String message, required Object? error, required StackTrace? stackTrace}) =>
+            loge(message, error, stackTrace),
+      );
+
+  @override
+  void setGlobalKey({required String key, required Object value}) {
+    _logSink(
+      message:
+          "Failure reporter context updated: key=${_sanitizeContext(key)} valueType=${value.runtimeType.toString()}",
+      error: null,
+      stackTrace: null,
+    );
+  }
+
+  @override
+  void log({required String message}) {
+    _logSink(
+      message: "Failure reporter log: ${_sanitizeContext(message)}",
+      error: null,
+      stackTrace: null,
+    );
+  }
+
+  @override
+  Future<void> recordFailure({
+    required Object error,
+    required StackTrace stackTrace,
+    required String uniqueIdentifier,
+    required bool fatal,
+    required String? reason,
+    required Iterable<Object> information,
+  }) async {
+    final String informationShape = information.map(_describeInformation).join(", ");
+    _logSink(
+      message:
+          "Handled failure: identifier=${_sanitizeContext(uniqueIdentifier)} "
+          "fatal=$fatal reason=${reason == null ? "<none>" : _sanitizeContext(reason)} "
+          "information=[$informationShape]",
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
+
+  // ignore: no_slop_linter/prefer_specific_type, FailureReporter information is intentionally opaque at this boundary.
+  static String _describeInformation(Object value) {
+    if (value is String) {
+      return "String(length=${value.length})";
+    }
+    return value.runtimeType.toString();
+  }
+
+  /// Keeps operation/event labels readable while preventing arbitrary values
+  /// from becoming multiline or unbounded log records.
+  static String _sanitizeContext(String value) {
+    final String normalized = value.replaceAll(RegExp(r"\s+"), " ").trim();
+    final String safe = normalized.replaceAll(RegExp("[^A-Za-z0-9_.:/=-]"), "_");
+    if (safe.length <= 160) return safe;
+    return "${safe.substring(0, 160)}…";
+  }
+}

--- a/client/desktop/lib/core/platform/desktop_route_source.dart
+++ b/client/desktop/lib/core/platform/desktop_route_source.dart
@@ -1,0 +1,25 @@
+import "package:injectable/injectable.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+
+/// Route boundary for the pre-router desktop shell.
+///
+/// Desktop currently composes the auth gate directly rather than using the
+/// shared router. Keeping a real [RouteSource] in the shell lets the shared
+/// SSE toast and connection services start now; session-attributed toasts are
+/// correctly withheld until Step 14 supplies a route identity, while
+/// unattributed app-wide toasts remain available.
+@Singleton(as: RouteSource)
+class DesktopRouteSource() implements RouteSource {
+  final BehaviorSubject<AppRouteDef?> _currentRoute = BehaviorSubject.seeded(null);
+
+  @override
+  ValueStream<AppRouteDef?> get currentRouteStream => _currentRoute.stream;
+
+  @override
+  String? get currentLocation => null;
+
+  /// Closes the stream when a test or shell explicitly tears down the source.
+  /// The desktop process owns this singleton for its whole lifetime.
+  Future<void> dispose() => _currentRoute.close();
+}

--- a/client/desktop/lib/core/widgets/desktop_connection_banner.dart
+++ b/client/desktop/lib/core/widgets/desktop_connection_banner.dart
@@ -1,0 +1,52 @@
+import "package:flutter_bloc/flutter_bloc.dart";
+import "package:material_ui/material_ui.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:theme_prego/module_prego.dart";
+
+/// Root-level desktop presentation for relay/bridge connection interruptions.
+///
+/// The shared mobile banner will move to `module_app_ui` in Step 14. Until the
+/// desktop router and shared screens exist, the shell owns this equivalent
+/// host so connection state is visible above the auth-gated window.
+class DesktopConnectionBanner extends StatelessWidget {
+  const new({super.key}) : _onRetry = null;
+
+  const new connectionLost({super.key, required VoidCallback onRetry}) : _onRetry = onRetry;
+
+  final VoidCallback? _onRetry;
+
+  /// Returns the root banner for the states that need one.
+  static Widget? maybeFor(BuildContext context) {
+    final ConnectionOverlayCubit cubit = context.watch<ConnectionOverlayCubit>();
+    return switch (cubit.state) {
+      ConnectionOverlayBridgeOffline() => const DesktopConnectionBanner(),
+      ConnectionOverlayConnectionLost() => DesktopConnectionBanner.connectionLost(onRetry: cubit.reconnect),
+      ConnectionOverlayHidden() || ConnectionOverlayReconnecting() => null,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final VoidCallback? onRetry = _onRetry;
+    return Semantics(
+      container: true,
+      liveRegion: true,
+      child: onRetry == null
+          ? const PregoInlineAlertsNotifications(
+              type: PregoInlineAlertsNotificationsType.warning,
+              title: "Bridge disconnected",
+              icon: TablerRegular.broadcast_off,
+            )
+          : PregoInlineAlertsNotifications(
+              type: PregoInlineAlertsNotificationsType.error,
+              title: "Connection lost",
+              icon: TablerRegular.cloud_off,
+              primaryAction: PregoInlineAlertsNotificationsAction(
+                label: "Reconnect",
+                icon: TablerRegular.rotate_clockwise,
+                onPressed: onRetry,
+              ),
+            ),
+    );
+  }
+}

--- a/client/desktop/lib/core/widgets/desktop_sse_toast_listener.dart
+++ b/client/desktop/lib/core/widgets/desktop_sse_toast_listener.dart
@@ -1,0 +1,45 @@
+import "package:flutter_bloc/flutter_bloc.dart";
+import "package:material_ui/material_ui.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:theme_prego/module_prego.dart";
+
+/// Presents backend `tui.toast.show` events on the desktop root overlay.
+///
+/// The cubit remains responsible only for filtering and typing SSE events;
+/// presentation stays in the Flutter shell, where the navigator overlay and
+/// Prego popup presenter are available.
+class const DesktopSseToastListener({
+  required final GlobalKey<NavigatorState> navigatorKey,
+  required final Widget child,
+  super.key,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<SseToastCubit, SseToastState>(
+      listener: (context, state) {
+        if (state case SseToastShow(:final title, :final message, :final variant)) {
+          final OverlayState? overlay = navigatorKey.currentState?.overlay;
+          if (overlay == null) {
+            logw("Cannot present an SSE toast before the desktop navigator overlay is ready");
+            return;
+          }
+          PregoPopupAlertPresenter.fromOverlayState(overlay).show(
+            title: title ?? message,
+            content: title == null ? const PregoPopupAlertContent() : PregoPopupAlertContent(message: message),
+            variant: switch (variant) {
+              SseToastVariant.info => PregoPopupAlertsNotificationsVariant.info,
+              SseToastVariant.success => PregoPopupAlertsNotificationsVariant.success,
+              SseToastVariant.warning => PregoPopupAlertsNotificationsVariant.warning,
+              SseToastVariant.error => PregoPopupAlertsNotificationsVariant.error,
+            },
+            duration: switch (variant) {
+              SseToastVariant.error || SseToastVariant.warning => const Duration(seconds: 8),
+              SseToastVariant.info || SseToastVariant.success => const Duration(seconds: 4),
+            },
+          );
+        }
+      },
+      child: child,
+    );
+  }
+}

--- a/client/desktop/lib/features/auth_gate/auth_gate.dart
+++ b/client/desktop/lib/features/auth_gate/auth_gate.dart
@@ -2,7 +2,6 @@ import "dart:async";
 
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:material_ui/material_ui.dart";
-import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_desktop_core/sesori_desktop_core.dart";
 import "package:theme_prego/module_prego.dart";
 
@@ -16,7 +15,11 @@ class const AuthGate({super.key}) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider<AuthGateCubit>(
-      create: (_) => AuthGateCubit(authSession: getIt(), logoutOrchestrator: getIt()),
+      create: (_) => AuthGateCubit(
+        authSession: getIt(),
+        logoutOrchestrator: getIt(),
+        relayConnectionService: getIt(),
+      ),
       child: const AuthGateView(),
     );
   }
@@ -34,7 +37,7 @@ class const AuthGateView({super.key}) extends StatelessWidget {
         // The auth gate itself stays local-only. Once the signed-in
         // destination is entered, explicitly start the relay for token-only
         // restores that intentionally remain AuthInitial.
-        unawaited(context.read<ConnectionOverlayCubit>().ensureConnected());
+        unawaited(context.read<AuthGateCubit>().onSignedInDestinationReady());
       },
       child: switch (state) {
         AuthGateChecking() => Scaffold(

--- a/client/desktop/lib/features/auth_gate/auth_gate.dart
+++ b/client/desktop/lib/features/auth_gate/auth_gate.dart
@@ -1,5 +1,8 @@
+import "dart:async";
+
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:material_ui/material_ui.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_desktop_core/sesori_desktop_core.dart";
 import "package:theme_prego/module_prego.dart";
 
@@ -25,12 +28,21 @@ class const AuthGateView({super.key}) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final AuthGateState state = context.watch<AuthGateCubit>().state;
-    return switch (state) {
-      AuthGateChecking() => Scaffold(
-        body: Center(child: PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary)),
-      ),
-      AuthGateSignedOut() => const LoginScreen(),
-      AuthGateSignedIn(:final user) => DesktopHome(user: user),
-    };
+    return BlocListener<AuthGateCubit, AuthGateState>(
+      listenWhen: (previous, current) => previous is! AuthGateSignedIn && current is AuthGateSignedIn,
+      listener: (context, _) {
+        // The auth gate itself stays local-only. Once the signed-in
+        // destination is entered, explicitly start the relay for token-only
+        // restores that intentionally remain AuthInitial.
+        unawaited(context.read<ConnectionOverlayCubit>().ensureConnected());
+      },
+      child: switch (state) {
+        AuthGateChecking() => Scaffold(
+          body: Center(child: PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary)),
+        ),
+        AuthGateSignedOut() => const LoginScreen(),
+        AuthGateSignedIn(:final user) => DesktopHome(user: user),
+      },
+    );
   }
 }

--- a/client/desktop/lib/features/home/desktop_home.dart
+++ b/client/desktop/lib/features/home/desktop_home.dart
@@ -2,6 +2,7 @@ import "dart:async";
 
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:material_ui/material_ui.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_desktop_core/sesori_desktop_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
@@ -20,6 +21,7 @@ class const DesktopHome({required final AuthUser? user, super.key}) extends Stat
   Widget build(BuildContext context) {
     final BridgeControlState state = context.watch<BridgeControlCubit>().state;
     final BridgeControlCubit controls = context.read<BridgeControlCubit>();
+    final ConnectionOverlayState relayConnection = context.watch<ConnectionOverlayCubit>().state;
     final List<BridgeProcessLogEntry> crashLogs = switch (state.processState) {
       BridgeProcessCrashGiveUp(:final recentLogs) => recentLogs,
       BridgeProcessStopped() ||
@@ -60,7 +62,8 @@ class const DesktopHome({required final AuthUser? user, super.key}) extends Stat
                           label: "Registration",
                           value: state.controlStatus.bridgeId == null ? "Not registered" : "Registered",
                         ),
-                        _StatusRow(label: "Relay", value: _relayLabel(state.controlStatus.relay)),
+                        _StatusRow(label: "Supervised relay", value: _relayLabel(state.controlStatus.relay)),
+                        _StatusRow(label: "Desktop relay client", value: _connectionLabel(relayConnection)),
                         _StatusRow(label: "Plugin health", value: _pluginLabel(state.controlStatus.plugin)),
                         _StatusRow(
                           label: "Active sessions",
@@ -124,6 +127,13 @@ class const DesktopHome({required final AuthUser? user, super.key}) extends Stat
     ControlRelayConnectionState.disconnected => "Disconnected",
     ControlRelayConnectionState.takenOver => "Taken over",
     ControlRelayConnectionState.unknown => "Unknown",
+  };
+
+  static String _connectionLabel(ConnectionOverlayState state) => switch (state) {
+    ConnectionOverlayHidden(:final connected) => connected ? "Connected" : "Disconnected",
+    ConnectionOverlayReconnecting() => "Reconnecting",
+    ConnectionOverlayConnectionLost() => "Connection lost",
+    ConnectionOverlayBridgeOffline() => "Bridge offline",
   };
 
   static String _pluginLabel(ControlPluginHealthState state) => switch (state) {

--- a/client/desktop/lib/main.dart
+++ b/client/desktop/lib/main.dart
@@ -30,6 +30,10 @@ Future<void> main(List<String> arguments) async {
   // The dispatcher must own the control event stream before any service can
   // spawn a helper, or its first bootstrap token request could go unread.
   await getIt<ControlMessageDispatcher>().start();
+  // Root the shared relay client before the UI builds. Its auth-state listener
+  // connects automatically when AuthGate restores or completes a login, and
+  // no second reconnect driver is introduced in the desktop shell.
+  getIt<ConnectionService>();
   runApp(SesoriDesktopApp(hiddenLaunch: hiddenLaunch));
   unawaited(startupOrchestrator.restoreBridgeDesiredState());
 }

--- a/client/desktop/test/core/di/injection_test.dart
+++ b/client/desktop/test/core/di/injection_test.dart
@@ -65,6 +65,7 @@ void main() {
     final ConnectionService connectionService = getIt<ConnectionService>();
     expect(connectionService.currentStatus, isA<ConnectionDisconnected>());
     expect(getIt<RegisteredBridgesService>(), isA<RegisteredBridgesService>());
+    expect(getIt<DesktopRelayConnectionService>(), isA<DesktopRelayConnectionService>());
     expect(getIt.isRegistered<DesktopInstanceService>(), isTrue);
     expect(getIt.isRegistered<BridgeControlCubit>(), isFalse);
     expect(getIt<BridgeProcessService>().state, isA<BridgeProcessStopped>());

--- a/client/desktop/test/core/di/injection_test.dart
+++ b/client/desktop/test/core/di/injection_test.dart
@@ -1,8 +1,24 @@
 import "package:flutter_test/flutter_test.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_desktop/core/di/injection.dart";
+import "package:sesori_desktop/core/platform/desktop_failure_reporter.dart";
+import "package:sesori_desktop/core/platform/desktop_route_source.dart";
 import "package:sesori_desktop/core/platform/no_op_analytics_client.dart";
 import "package:sesori_desktop_core/sesori_desktop_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+class _InMemorySecureStorage() implements SecureStorage {
+  final Map<String, String> _values = <String, String>{};
+
+  @override
+  Future<String?> read({required String key}) async => _values[key];
+
+  @override
+  Future<void> write({required String key, required String value}) async => _values[key] = value;
+
+  @override
+  Future<void> delete({required String key}) async => _values.remove(key);
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -13,6 +29,8 @@ void main() {
 
   test("4-phase DI bootstrap lets LoginCubit be constructed with no missing registrations", () async {
     configureDesktopDependencies();
+    getIt.unregister<SecureStorage>();
+    getIt.registerLazySingleton<SecureStorage>(_InMemorySecureStorage.new);
 
     // Acceptance for the platform-adapter slice: every LoginCubit dependency
     // resolves through getIt, while the cubit itself stays out of DI.
@@ -41,6 +59,12 @@ void main() {
     expect(getIt.isRegistered<BridgeProcessLogRepository>(), isTrue);
     expect(getIt.isRegistered<DesktopLogoutOrchestrator>(), isTrue);
     expect(getIt.isRegistered<DesktopStartupOrchestrator>(), isTrue);
+    expect(getIt<RelayCryptoService>(), isA<RelayCryptoService>());
+    expect(getIt<FailureReporter>(), isA<DesktopFailureReporter>());
+    expect(getIt<RouteSource>(), isA<DesktopRouteSource>());
+    final ConnectionService connectionService = getIt<ConnectionService>();
+    expect(connectionService.currentStatus, isA<ConnectionDisconnected>());
+    expect(getIt<RegisteredBridgesService>(), isA<RegisteredBridgesService>());
     expect(getIt.isRegistered<DesktopInstanceService>(), isTrue);
     expect(getIt.isRegistered<BridgeControlCubit>(), isFalse);
     expect(getIt<BridgeProcessService>().state, isA<BridgeProcessStopped>());

--- a/client/desktop/test/core/platform/desktop_failure_reporter_test.dart
+++ b/client/desktop/test/core/platform/desktop_failure_reporter_test.dart
@@ -1,0 +1,48 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:sesori_desktop/core/platform/desktop_failure_reporter.dart";
+
+void main() {
+  test("keeps failure context and error details while redacting information values", () async {
+    String? loggedMessage;
+    Object? loggedError;
+    StackTrace? loggedStackTrace;
+    final StackTrace stackTrace = StackTrace.current;
+    final StateError error = StateError("transport failed");
+    final reporter = DesktopFailureReporter.forTesting(
+      logSink: ({required String message, required Object? error, required StackTrace? stackTrace}) {
+        loggedMessage = message;
+        loggedError = error;
+        loggedStackTrace = stackTrace;
+      },
+    );
+
+    await reporter.recordFailure(
+      error: error,
+      stackTrace: stackTrace,
+      uniqueIdentifier: "sse_parse_failure:SesoriSessionUpdated",
+      fatal: false,
+      reason: "Failed to parse event",
+      information: const <Object>["prompt text must not be logged", "project-id"],
+    );
+
+    expect(loggedMessage, contains("sse_parse_failure:SesoriSessionUpdated"));
+    expect(loggedMessage, contains("String(length=30)"));
+    expect(loggedMessage, isNot(contains("prompt text must not be logged")));
+    expect(loggedMessage, isNot(contains("project-id")));
+    expect(loggedError, same(error));
+    expect(loggedStackTrace, same(stackTrace));
+  });
+
+  test("bounds and sanitizes free-form context", () async {
+    String? loggedMessage;
+    final reporter = DesktopFailureReporter.forTesting(
+      logSink: ({required String message, required Object? error, required StackTrace? stackTrace}) {
+        loggedMessage = message;
+      },
+    );
+
+    reporter.log(message: "line one\nline two");
+
+    expect(loggedMessage, "Failure reporter log: line_one_line_two");
+  });
+}

--- a/client/desktop/test/core/platform/desktop_route_source_test.dart
+++ b/client/desktop/test/core/platform/desktop_route_source_test.dart
@@ -1,0 +1,12 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:sesori_desktop/core/platform/desktop_route_source.dart";
+
+void main() {
+  test("starts without a route until the desktop router is installed", () async {
+    final DesktopRouteSource source = DesktopRouteSource();
+    addTearDown(source.dispose);
+
+    expect(source.currentRouteStream.value, isNull);
+    expect(source.currentLocation, isNull);
+  });
+}

--- a/client/desktop/test/core/widgets/desktop_connection_banner_test.dart
+++ b/client/desktop/test/core/widgets/desktop_connection_banner_test.dart
@@ -1,0 +1,79 @@
+import "package:bloc_test/bloc_test.dart";
+import "package:flutter_bloc/flutter_bloc.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:material_ui/material_ui.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_desktop/core/widgets/desktop_connection_banner.dart";
+import "package:theme_prego/module_prego.dart";
+
+class _MockConnectionOverlayCubit() extends MockCubit<ConnectionOverlayState> implements ConnectionOverlayCubit {
+  int reconnectCalls = 0;
+
+  @override
+  void reconnect() => reconnectCalls++;
+}
+
+void main() {
+  Future<void> pumpBanner({required WidgetTester tester, required _MockConnectionOverlayCubit cubit}) async {
+    await tester.pumpWidget(
+      BlocProvider<ConnectionOverlayCubit>.value(
+        value: cubit,
+        child: MaterialApp(
+          theme: buildPregoThemeData(brightness: Brightness.light),
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: DesktopConnectionBanner.maybeFor(context) ?? const SizedBox.shrink(),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets("renders bridge-offline warning", (WidgetTester tester) async {
+    final _MockConnectionOverlayCubit cubit = _MockConnectionOverlayCubit();
+    addTearDown(cubit.close);
+    whenListen(
+      cubit,
+      const Stream<ConnectionOverlayState>.empty(),
+      initialState: const ConnectionOverlayState.bridgeOffline(),
+    );
+
+    await pumpBanner(tester: tester, cubit: cubit);
+
+    expect(find.text("Bridge disconnected"), findsOneWidget);
+    expect(find.byType(PregoInlineAlertsNotifications), findsOneWidget);
+  });
+
+  testWidgets("renders connection-lost retry and delegates to the cubit", (WidgetTester tester) async {
+    final _MockConnectionOverlayCubit cubit = _MockConnectionOverlayCubit();
+    addTearDown(cubit.close);
+    whenListen(
+      cubit,
+      const Stream<ConnectionOverlayState>.empty(),
+      initialState: const ConnectionOverlayState.connectionLost(),
+    );
+
+    await pumpBanner(tester: tester, cubit: cubit);
+
+    expect(find.text("Connection lost"), findsOneWidget);
+    expect(find.text("Reconnect"), findsOneWidget);
+    await tester.tap(find.text("Reconnect"));
+    expect(cubit.reconnectCalls, 1);
+  });
+
+  testWidgets("does not render for connected or reconnecting states", (WidgetTester tester) async {
+    for (final ConnectionOverlayState state in <ConnectionOverlayState>[
+      const ConnectionOverlayState.hidden(connected: true),
+      const ConnectionOverlayState.hidden(connected: false),
+      const ConnectionOverlayState.reconnecting(),
+    ]) {
+      final _MockConnectionOverlayCubit cubit = _MockConnectionOverlayCubit();
+      addTearDown(cubit.close);
+      whenListen(cubit, const Stream<ConnectionOverlayState>.empty(), initialState: state);
+      await pumpBanner(tester: tester, cubit: cubit);
+      expect(find.byType(DesktopConnectionBanner), findsNothing);
+    }
+  });
+}

--- a/client/desktop/test/core/widgets/desktop_sse_toast_listener_test.dart
+++ b/client/desktop/test/core/widgets/desktop_sse_toast_listener_test.dart
@@ -1,0 +1,67 @@
+import "package:flutter_bloc/flutter_bloc.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:material_ui/material_ui.dart";
+import "package:mocktail/mocktail.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_desktop/core/widgets/desktop_sse_toast_listener.dart";
+import "package:theme_prego/module_prego.dart";
+
+class _MockConnectionService() extends Mock implements ConnectionService;
+
+class _EmptyRouteSource() implements RouteSource {
+  final BehaviorSubject<AppRouteDef?> _route = BehaviorSubject.seeded(null);
+
+  @override
+  ValueStream<AppRouteDef?> get currentRouteStream => _route.stream;
+
+  @override
+  String? get currentLocation => null;
+
+  Future<void> dispose() => _route.close();
+}
+
+void main() {
+  testWidgets("presents a backend toast on the desktop navigator overlay", (WidgetTester tester) async {
+    final _MockConnectionService connectionService = _MockConnectionService();
+    when(() => connectionService.events).thenAnswer((_) => const Stream.empty());
+    final _EmptyRouteSource routeSource = _EmptyRouteSource();
+    final SseToastCubit cubit = SseToastCubit(
+      connectionService: connectionService,
+      routeSource: routeSource,
+    );
+    addTearDown(cubit.close);
+    addTearDown(routeSource.dispose);
+    final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+
+    await tester.pumpWidget(
+      BlocProvider<SseToastCubit>.value(
+        value: cubit,
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          theme: buildPregoThemeData(brightness: Brightness.light),
+          home: DesktopSseToastListener(
+            navigatorKey: navigatorKey,
+            child: const Scaffold(body: SizedBox.shrink()),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    cubit.emit(
+      const SseToastState.show(
+        sequence: 1,
+        title: "Backend notice",
+        message: "A bridge event arrived",
+        variant: SseToastVariant.info,
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(navigatorKey.currentState, isNotNull);
+    expect(navigatorKey.currentState?.overlay, isNotNull);
+    expect(find.text("Backend notice"), findsOneWidget);
+    expect(find.text("A bridge event arrived"), findsOneWidget);
+  });
+}

--- a/client/desktop/test/features/auth_gate/auth_gate_view_test.dart
+++ b/client/desktop/test/features/auth_gate/auth_gate_view_test.dart
@@ -52,7 +52,7 @@ void main() {
       const Stream<ConnectionOverlayState>.empty(),
       initialState: const ConnectionOverlayState.hidden(connected: false),
     );
-    when(() => connectionOverlayCubit.ensureConnected()).thenAnswer((_) async {});
+    when(() => cubit.onSignedInDestinationReady()).thenAnswer((_) async {});
   });
 
   Future<void> pumpGate(WidgetTester tester) {
@@ -98,7 +98,7 @@ void main() {
     await pumpGate(tester);
     await tester.pump();
 
-    verify(() => connectionOverlayCubit.ensureConnected()).called(1);
+    verify(() => cubit.onSignedInDestinationReady()).called(1);
   });
 
   testWidgets("sign out button delegates to the cubit", (WidgetTester tester) async {

--- a/client/desktop/test/features/auth_gate/auth_gate_view_test.dart
+++ b/client/desktop/test/features/auth_gate/auth_gate_view_test.dart
@@ -52,6 +52,7 @@ void main() {
       const Stream<ConnectionOverlayState>.empty(),
       initialState: const ConnectionOverlayState.hidden(connected: false),
     );
+    when(() => connectionOverlayCubit.ensureConnected()).thenAnswer((_) async {});
   });
 
   Future<void> pumpGate(WidgetTester tester) {
@@ -85,6 +86,19 @@ void main() {
 
     expect(find.byType(DesktopHome), findsOneWidget);
     expect(find.textContaining("alex"), findsOneWidget);
+  });
+
+  testWidgets("signed-in destination starts relay for a token-only restore", (WidgetTester tester) async {
+    whenListen(
+      cubit,
+      Stream<AuthGateState>.value(const AuthGateState.signedIn(user: null)),
+      initialState: const AuthGateState.checking(),
+    );
+
+    await pumpGate(tester);
+    await tester.pump();
+
+    verify(() => connectionOverlayCubit.ensureConnected()).called(1);
   });
 
   testWidgets("sign out button delegates to the cubit", (WidgetTester tester) async {

--- a/client/desktop/test/features/auth_gate/auth_gate_view_test.dart
+++ b/client/desktop/test/features/auth_gate/auth_gate_view_test.dart
@@ -3,6 +3,7 @@ import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:material_ui/material_ui.dart";
 import "package:mocktail/mocktail.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_desktop/features/auth_gate/auth_gate.dart";
 import "package:sesori_desktop/features/home/desktop_home.dart";
 import "package:sesori_desktop_core/sesori_desktop_core.dart";
@@ -12,6 +13,8 @@ import "package:theme_prego/module_prego.dart";
 class _MockAuthGateCubit() extends MockCubit<AuthGateState> implements AuthGateCubit;
 
 class _MockBridgeControlCubit() extends MockCubit<BridgeControlState> implements BridgeControlCubit;
+
+class _MockConnectionOverlayCubit() extends MockCubit<ConnectionOverlayState> implements ConnectionOverlayCubit;
 
 const AuthUser _user = AuthUser(
   id: "user-1",
@@ -23,10 +26,12 @@ const AuthUser _user = AuthUser(
 void main() {
   late _MockAuthGateCubit cubit;
   late _MockBridgeControlCubit bridgeControlCubit;
+  late _MockConnectionOverlayCubit connectionOverlayCubit;
 
   setUp(() {
     cubit = _MockAuthGateCubit();
     bridgeControlCubit = _MockBridgeControlCubit();
+    connectionOverlayCubit = _MockConnectionOverlayCubit();
     whenListen(
       bridgeControlCubit,
       const Stream<BridgeControlState>.empty(),
@@ -42,6 +47,11 @@ void main() {
         controlStatus: BridgeControlStatus.offline,
       ),
     );
+    whenListen(
+      connectionOverlayCubit,
+      const Stream<ConnectionOverlayState>.empty(),
+      initialState: const ConnectionOverlayState.hidden(connected: false),
+    );
   });
 
   Future<void> pumpGate(WidgetTester tester) {
@@ -52,6 +62,7 @@ void main() {
           providers: [
             BlocProvider<AuthGateCubit>.value(value: cubit),
             BlocProvider<BridgeControlCubit>.value(value: bridgeControlCubit),
+            BlocProvider<ConnectionOverlayCubit>.value(value: connectionOverlayCubit),
           ],
           child: const AuthGateView(),
         ),

--- a/client/desktop/test/features/home/desktop_home_test.dart
+++ b/client/desktop/test/features/home/desktop_home_test.dart
@@ -3,6 +3,7 @@ import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:material_ui/material_ui.dart";
 import "package:mocktail/mocktail.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_desktop/features/home/desktop_home.dart";
 import "package:sesori_desktop_core/sesori_desktop_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -18,10 +19,12 @@ const AuthUser _user = AuthUser(
 void main() {
   late _MockBridgeControlCubit bridgeControlCubit;
   late _MockAuthGateCubit authGateCubit;
+  late _MockConnectionOverlayCubit connectionOverlayCubit;
 
   setUp(() {
     bridgeControlCubit = _MockBridgeControlCubit();
     authGateCubit = _MockAuthGateCubit();
+    connectionOverlayCubit = _MockConnectionOverlayCubit();
     when(() => bridgeControlCubit.toggleBridge()).thenAnswer((_) async {});
     when(() => bridgeControlCubit.toggleLaunchAtLogin()).thenAnswer((_) async {});
     when(() => bridgeControlCubit.openLogs()).thenAnswer((_) async {});
@@ -35,6 +38,11 @@ void main() {
       const Stream<AuthGateState>.empty(),
       initialState: const AuthGateState.signedIn(user: _user),
     );
+    whenListen(
+      connectionOverlayCubit,
+      const Stream<ConnectionOverlayState>.empty(),
+      initialState: const ConnectionOverlayState.hidden(connected: true),
+    );
     return tester.pumpWidget(
       MaterialApp(
         theme: buildPregoThemeData(brightness: Brightness.light),
@@ -42,6 +50,7 @@ void main() {
           providers: [
             BlocProvider<BridgeControlCubit>.value(value: bridgeControlCubit),
             BlocProvider<AuthGateCubit>.value(value: authGateCubit),
+            BlocProvider<ConnectionOverlayCubit>.value(value: connectionOverlayCubit),
           ],
           child: const DesktopHome(user: _user),
         ),
@@ -69,7 +78,8 @@ void main() {
     expect(find.text("Signed in as alex (GitHub)"), findsOneWidget);
     expect(find.text("Bridge: Connected"), findsOneWidget);
     expect(find.text("Registered"), findsOneWidget);
-    expect(find.text("Connected"), findsOneWidget);
+    expect(find.text("Desktop relay client"), findsOneWidget);
+    expect(find.text("Connected"), findsNWidgets(2));
     expect(find.text("Healthy"), findsOneWidget);
     expect(find.text("2"), findsOneWidget);
     expect(find.text("Turn Bridge Off"), findsOneWidget);
@@ -135,3 +145,5 @@ BridgeControlState _state({
 class _MockBridgeControlCubit() extends MockCubit<BridgeControlState> implements BridgeControlCubit;
 
 class _MockAuthGateCubit() extends MockCubit<AuthGateState> implements AuthGateCubit;
+
+class _MockConnectionOverlayCubit() extends MockCubit<ConnectionOverlayState> implements ConnectionOverlayCubit;

--- a/client/module_core/lib/src/cubits/connection_overlay/connection_overlay_cubit.dart
+++ b/client/module_core/lib/src/cubits/connection_overlay/connection_overlay_cubit.dart
@@ -54,17 +54,6 @@ class ConnectionOverlayCubit(
     };
   }
 
-  /// Starts a fresh auth-backed connection for a signed-in destination.
-  ///
-  /// The root cubit is created before auth restoration, so its connection
-  /// service normally starts from an [AuthAuthenticated] stream emission. A
-  /// token-only local restore intentionally keeps [AuthInitial] while the
-  /// destination is already visible; that destination uses this one-shot
-  /// trigger to avoid leaving a valid local session disconnected.
-  Future<void> ensureConnected() async {
-    await _connectionService.connectWithFreshAuthToken();
-  }
-
   void reconnect() => _connectionService.reconnect();
 
   @override

--- a/client/module_core/lib/src/cubits/connection_overlay/connection_overlay_cubit.dart
+++ b/client/module_core/lib/src/cubits/connection_overlay/connection_overlay_cubit.dart
@@ -54,6 +54,17 @@ class ConnectionOverlayCubit(
     };
   }
 
+  /// Starts a fresh auth-backed connection for a signed-in destination.
+  ///
+  /// The root cubit is created before auth restoration, so its connection
+  /// service normally starts from an [AuthAuthenticated] stream emission. A
+  /// token-only local restore intentionally keeps [AuthInitial] while the
+  /// destination is already visible; that destination uses this one-shot
+  /// trigger to avoid leaving a valid local session disconnected.
+  Future<void> ensureConnected() async {
+    await _connectionService.connectWithFreshAuthToken();
+  }
+
   void reconnect() => _connectionService.reconnect();
 
   @override

--- a/client/module_core/test/cubits/connection_overlay/connection_overlay_cubit_test.dart
+++ b/client/module_core/test/cubits/connection_overlay/connection_overlay_cubit_test.dart
@@ -125,16 +125,6 @@ void main() {
       expect: () => const [ConnectionOverlayState.bridgeOffline()],
     );
 
-    test("ensureConnected() delegates to an auth-backed connection", () async {
-      when(() => mockConnectionService.connectWithFreshAuthToken()).thenAnswer((_) async => true);
-      final ConnectionOverlayCubit cubit = buildCubit();
-      addTearDown(cubit.close);
-
-      await cubit.ensureConnected();
-
-      verify(() => mockConnectionService.connectWithFreshAuthToken()).called(1);
-    });
-
     blocTest<ConnectionOverlayCubit, ConnectionOverlayState>(
       "reconnect() delegates to connectionService.reconnect()",
       build: buildCubit,

--- a/client/module_core/test/cubits/connection_overlay/connection_overlay_cubit_test.dart
+++ b/client/module_core/test/cubits/connection_overlay/connection_overlay_cubit_test.dart
@@ -125,6 +125,16 @@ void main() {
       expect: () => const [ConnectionOverlayState.bridgeOffline()],
     );
 
+    test("ensureConnected() delegates to an auth-backed connection", () async {
+      when(() => mockConnectionService.connectWithFreshAuthToken()).thenAnswer((_) async => true);
+      final ConnectionOverlayCubit cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      await cubit.ensureConnected();
+
+      verify(() => mockConnectionService.connectWithFreshAuthToken()).called(1);
+    });
+
     blocTest<ConnectionOverlayCubit, ConnectionOverlayState>(
       "reconnect() delegates to connectionService.reconnect()",
       build: buildCubit,

--- a/client/module_desktop_core/lib/sesori_desktop_core.dart
+++ b/client/module_desktop_core/lib/sesori_desktop_core.dart
@@ -37,6 +37,7 @@ export "src/services/bridge_process_service.dart";
 export "src/services/bridge_process_state.dart";
 export "src/services/control_command_service.dart";
 export "src/services/desktop_instance_service.dart";
+export "src/services/desktop_relay_connection_service.dart";
 export "src/trackers/bridge_control_status.dart";
 export "src/trackers/bridge_process_log_tracker.dart";
 export "src/trackers/bridge_prompt_tracker.dart";

--- a/client/module_desktop_core/lib/src/cubits/auth_gate/auth_gate_cubit.dart
+++ b/client/module_desktop_core/lib/src/cubits/auth_gate/auth_gate_cubit.dart
@@ -4,6 +4,7 @@ import "package:bloc/bloc.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 
 import "../../orchestration/desktop_logout_orchestrator.dart";
+import "../../services/desktop_relay_connection_service.dart";
 import "auth_gate_state.dart";
 
 /// Desktop sign-in gate: maps the auth session's state stream into the
@@ -16,13 +17,16 @@ import "auth_gate_state.dart";
 class AuthGateCubit._create({
   required final AuthSession _authSession,
   required final DesktopLogoutOrchestrator _logoutOrchestrator,
+  required final DesktopRelayConnectionService _relayConnectionService,
 }) extends Cubit<AuthGateState> {
   new({
     required AuthSession authSession,
     required DesktopLogoutOrchestrator logoutOrchestrator,
+    required DesktopRelayConnectionService relayConnectionService,
   }) : this._create(
          authSession: authSession,
          logoutOrchestrator: logoutOrchestrator,
+         relayConnectionService: relayConnectionService,
        );
 
   this : super(const AuthGateState.checking()) {
@@ -87,6 +91,14 @@ class AuthGateCubit._create({
       // Same posture as the unconfirmed case above.
       logw("Background session restore failed", error, stackTrace);
     }
+  }
+
+  /// Starts the relay once the signed-in destination is visible.
+  ///
+  /// This is deliberately separate from local startup restoration: the gate
+  /// remains local-only and the relay coordinator owns the transport command.
+  Future<void> onSignedInDestinationReady() {
+    return _relayConnectionService.connectForAuthenticatedDestination();
   }
 
   /// Coordinated device-local sign-out. The logout owner stops the supervised

--- a/client/module_desktop_core/lib/src/di/injection.config.dart
+++ b/client/module_desktop_core/lib/src/di/injection.config.dart
@@ -49,6 +49,8 @@ import 'package:sesori_desktop_core/src/services/control_command_service.dart'
     as _i175;
 import 'package:sesori_desktop_core/src/services/desktop_instance_service.dart'
     as _i494;
+import 'package:sesori_desktop_core/src/services/desktop_relay_connection_service.dart'
+    as _i314;
 import 'package:sesori_desktop_core/src/trackers/bridge_process_log_tracker.dart'
     as _i866;
 import 'package:sesori_desktop_core/src/trackers/bridge_prompt_tracker.dart'
@@ -123,6 +125,12 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i210.DesktopInstanceRepository(
         api: gh<_i828.DesktopInstanceApi>(),
         storage: gh<_i155.DesktopInstanceStorage>(),
+      ),
+    );
+    gh.lazySingleton<_i314.DesktopRelayConnectionService>(
+      () => _i314.DesktopRelayConnectionService(
+        authSession: gh<_i948.AuthSession>(),
+        connectionService: gh<_i948.ConnectionService>(),
       ),
     );
     gh.lazySingleton<_i21.ControlMessageDispatcher>(

--- a/client/module_desktop_core/lib/src/di/injection.dart
+++ b/client/module_desktop_core/lib/src/di/injection.dart
@@ -1,6 +1,7 @@
 import "package:get_it/get_it.dart";
 import "package:injectable/injectable.dart";
-import "package:sesori_dart_core/sesori_dart_core.dart" show AuthSession, AuthTokenProvider, BridgeRepository;
+import "package:sesori_dart_core/sesori_dart_core.dart"
+    show AuthSession, AuthTokenProvider, BridgeRepository, ConnectionService;
 
 import "../foundation/platform/bridge_executable_path_resolver.dart";
 import "../foundation/platform/desktop_application_support_directory.dart";
@@ -19,6 +20,7 @@ import "injection.config.dart";
   ignoreUnregisteredTypes: [
     AuthSession,
     AuthTokenProvider,
+    ConnectionService,
     BridgeExecutablePathResolver,
     BridgeRepository,
     DesktopApplicationSupportDirectory,

--- a/client/module_desktop_core/lib/src/services/desktop_relay_connection_service.dart
+++ b/client/module_desktop_core/lib/src/services/desktop_relay_connection_service.dart
@@ -1,0 +1,46 @@
+import "package:injectable/injectable.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+
+/// Layer-3 owner of the desktop destination's auth-to-relay startup handoff.
+///
+/// [ConnectionService] normally starts from an `AuthAuthenticated` emission.
+/// A token-only local restore deliberately keeps the auth session in
+/// `AuthInitial` while the desktop gate is already provisionally signed in, so
+/// the signed-in destination needs an explicit lifecycle handoff. Keeping that
+/// policy here prevents the presentation-only connection overlay cubit from
+/// issuing transport commands.
+@lazySingleton
+class DesktopRelayConnectionService({
+  required AuthSession authSession,
+  required ConnectionService connectionService,
+}) {
+  final AuthSession _authSession = authSession;
+  final ConnectionService _connectionService = connectionService;
+
+  /// Starts the relay connection once the signed-in desktop destination is
+  /// visible. The auth-state check makes a destination transition racing a
+  /// logout harmless, while allowing the provisional token-only state.
+  Future<void> connectForAuthenticatedDestination() async {
+    switch (_authSession.currentState) {
+      case AuthAuthenticated():
+        await _connectionService.connectWithFreshAuthToken();
+      case AuthInitial():
+        final bool hasLocalSession;
+        try {
+          hasLocalSession = await _authSession.hasLocallyValidSession();
+        } on Object catch (error, stackTrace) {
+          logw("Failed to verify the provisional desktop session before relay startup", error, stackTrace);
+          return;
+        }
+        if (!hasLocalSession) return;
+        switch (_authSession.currentState) {
+          case AuthInitial() || AuthAuthenticated():
+            await _connectionService.connectWithFreshAuthToken();
+          case AuthUnauthenticated() || AuthAuthenticating() || AuthFailed():
+            return;
+        }
+      case AuthUnauthenticated() || AuthAuthenticating() || AuthFailed():
+        return;
+    }
+  }
+}

--- a/client/module_desktop_core/test/cubits/auth_gate/auth_gate_cubit_test.dart
+++ b/client/module_desktop_core/test/cubits/auth_gate/auth_gate_cubit_test.dart
@@ -11,6 +11,8 @@ class _MockAuthSession() extends Mock implements AuthSession;
 
 class _MockDesktopLogoutOrchestrator() extends Mock implements DesktopLogoutOrchestrator;
 
+class _MockDesktopRelayConnectionService() extends Mock implements DesktopRelayConnectionService;
+
 const AuthUser _user = AuthUser(
   id: "user-1",
   provider: AuthProvider.github,
@@ -21,16 +23,19 @@ const AuthUser _user = AuthUser(
 void main() {
   late _MockAuthSession authSession;
   late _MockDesktopLogoutOrchestrator logoutOrchestrator;
+  late _MockDesktopRelayConnectionService relayConnectionService;
   late BehaviorSubject<AuthState> authStates;
 
   setUp(() {
     authSession = _MockAuthSession();
     logoutOrchestrator = _MockDesktopLogoutOrchestrator();
+    relayConnectionService = _MockDesktopRelayConnectionService();
     authStates = BehaviorSubject<AuthState>.seeded(const AuthState.initial());
     when(() => authSession.authStateStream).thenAnswer((_) => authStates.stream);
     when(() => authSession.currentState).thenAnswer((_) => authStates.value);
     when(() => authSession.hasLocallyValidSession()).thenAnswer((_) async => false);
     when(() => authSession.restoreLocalSession()).thenAnswer((_) async => false);
+    when(() => relayConnectionService.connectForAuthenticatedDestination()).thenAnswer((_) async {});
     when(() => logoutOrchestrator.logoutCurrentDevice()).thenAnswer((_) async {
       try {
         await authSession.logoutCurrentDevice();
@@ -49,6 +54,7 @@ void main() {
     final AuthGateCubit cubit = AuthGateCubit(
       authSession: authSession,
       logoutOrchestrator: logoutOrchestrator,
+      relayConnectionService: relayConnectionService,
     );
     addTearDown(cubit.close);
     // Let the async restore-and-subscribe bootstrap settle.
@@ -107,6 +113,7 @@ void main() {
     final AuthGateCubit cubit = AuthGateCubit(
       authSession: authSession,
       logoutOrchestrator: logoutOrchestrator,
+      relayConnectionService: relayConnectionService,
     );
     addTearDown(cubit.close);
     final List<AuthGateState> emitted = <AuthGateState>[];
@@ -132,6 +139,7 @@ void main() {
     final AuthGateCubit cubit = AuthGateCubit(
       authSession: authSession,
       logoutOrchestrator: logoutOrchestrator,
+      relayConnectionService: relayConnectionService,
     );
     addTearDown(cubit.close);
     await pumpEventQueue();
@@ -172,6 +180,14 @@ void main() {
     final AuthGateCubit cubit = await pumpCubit();
 
     expect(cubit.state, const AuthGateState.signedOut());
+  });
+
+  test("signed-in destination delegates relay startup", () async {
+    final AuthGateCubit cubit = await pumpCubit();
+
+    await cubit.onSignedInDestinationReady();
+
+    verify(() => relayConnectionService.connectForAuthenticatedDestination()).called(1);
   });
 
   test("signOut delegates to the device-local logout", () async {

--- a/client/module_desktop_core/test/di/injection_test.dart
+++ b/client/module_desktop_core/test/di/injection_test.dart
@@ -20,6 +20,7 @@ void main() {
     expect(getIt.isRegistered<DesktopInstanceStorage>(), isTrue);
     expect(getIt.isRegistered<DesktopInstanceRepository>(), isTrue);
     expect(getIt.isRegistered<DesktopInstanceService>(), isTrue);
+    expect(getIt.isRegistered<DesktopRelayConnectionService>(), isTrue);
     expect(getIt.isRegistered<DesktopStartupOrchestrator>(), isTrue);
     expect(getIt.isRegistered<DesktopLogoutOrchestrator>(), isTrue);
   });

--- a/client/module_desktop_core/test/services/desktop_relay_connection_service_test.dart
+++ b/client/module_desktop_core/test/services/desktop_relay_connection_service_test.dart
@@ -1,0 +1,82 @@
+import "package:mocktail/mocktail.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_desktop_core/sesori_desktop_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+class _MockAuthSession() extends Mock implements AuthSession;
+
+class _MockConnectionService() extends Mock implements ConnectionService;
+
+const AuthUser _user = AuthUser(
+  id: "user-1",
+  provider: AuthProvider.github,
+  providerUserId: "gh-1",
+  providerUsername: "alex",
+);
+
+void main() {
+  late _MockAuthSession authSession;
+  late _MockConnectionService connectionService;
+  late DesktopRelayConnectionService service;
+
+  setUp(() {
+    authSession = _MockAuthSession();
+    connectionService = _MockConnectionService();
+    service = DesktopRelayConnectionService(
+      authSession: authSession,
+      connectionService: connectionService,
+    );
+    when(() => connectionService.connectWithFreshAuthToken()).thenAnswer((_) async => true);
+  });
+
+  test("connects for a fully authenticated destination", () async {
+    when(() => authSession.currentState).thenReturn(const AuthState.authenticated(user: _user));
+
+    await service.connectForAuthenticatedDestination();
+
+    verify(() => connectionService.connectWithFreshAuthToken()).called(1);
+    verifyNever(() => authSession.hasLocallyValidSession());
+  });
+
+  test("connects for a token-only destination with locally valid tokens", () async {
+    when(() => authSession.currentState).thenReturn(const AuthState.initial());
+    when(() => authSession.hasLocallyValidSession()).thenAnswer((_) async => true);
+
+    await service.connectForAuthenticatedDestination();
+
+    verify(() => authSession.hasLocallyValidSession()).called(1);
+    verify(() => connectionService.connectWithFreshAuthToken()).called(1);
+  });
+
+  test("does not connect for an initial state without locally valid tokens", () async {
+    when(() => authSession.currentState).thenReturn(const AuthState.initial());
+    when(() => authSession.hasLocallyValidSession()).thenAnswer((_) async => false);
+
+    await service.connectForAuthenticatedDestination();
+
+    verifyNever(() => connectionService.connectWithFreshAuthToken());
+  });
+
+  test("a failed provisional-session check stays disconnected", () async {
+    when(() => authSession.currentState).thenReturn(const AuthState.initial());
+    when(() => authSession.hasLocallyValidSession()).thenThrow(StateError("storage unavailable"));
+
+    await service.connectForAuthenticatedDestination();
+
+    verifyNever(() => connectionService.connectWithFreshAuthToken());
+  });
+
+  test("does not connect after the auth session becomes unauthenticated", () async {
+    when(() => authSession.hasLocallyValidSession()).thenAnswer((_) async => true);
+    var stateReads = 0;
+    when(() => authSession.currentState).thenAnswer((_) {
+      stateReads++;
+      return stateReads == 1 ? const AuthState.initial() : const AuthState.unauthenticated();
+    });
+
+    await service.connectForAuthenticatedDestination();
+
+    verifyNever(() => connectionService.connectWithFreshAuthToken());
+  });
+}

--- a/docs/regression/bridge-connectivity.md
+++ b/docs/regression/bridge-connectivity.md
@@ -30,7 +30,16 @@ explicit restart, and the connection states the app presents.
 - Bridge registration uses a stable machine name. On macOS, transient
   network-derived numeric hostnames must not replace the machine's LocalHostName.
 - The client distinguishes connected, reconnecting, connection lost, bridge offline, and
-  disconnected, and returns to connected when the bridge is back.
+  disconnected, and returns to connected when the bridge is back. The desktop shell
+  roots the same `ConnectionService` beside the supervised control channel, shows
+  its relay-client state separately from helper relay status, and hosts the typed
+  connection banner at the window root.
+- The desktop root constructs `ConnectionOverlayCubit` and `SseToastCubit` outside
+  the auth-gated content. Backend `tui.toast.show` events reach the desktop Prego
+  popup listener rather than being silently consumed; handled shared failures are
+  retained in local logs through a privacy-safe reporter that records error/stack
+  and operation/event context while reducing payload-bearing information to shape
+  metadata.
 - Fresh connections require the typed health body, including explicit filesystem-access
   degradation state; missing or malformed fields fail the connection rather than being
   treated as healthy. Resumed connections retain the last validated health state.
@@ -146,6 +155,11 @@ the bridge starts, how many clients are present, and whether restart is explicit
 - The real supervised helper E2E suite uses fake loopback auth/relay/control services;
   it validates outbound relay authentication and local control sequencing, but does
   not claim production-service or server-side JWT coverage.
+- Until the shared router lands in Step 14, the desktop route source is intentionally
+  route-less: app-wide SSE toasts render, while session-attributed toast events are
+  withheld because no desktop session identity exists yet. The desktop notification-
+  open stack remains unbound until the shell has a real route and notification
+  capability.
 - Relay capacity and provider outages are out of scope.
 
 ## Sources

--- a/docs/regression/bridge-connectivity.md
+++ b/docs/regression/bridge-connectivity.md
@@ -40,8 +40,9 @@ explicit restart, and the connection states the app presents.
   retained in local logs through a privacy-safe reporter that records error/stack
   and operation/event context while reducing payload-bearing information to shape
   metadata. A token-only local restore entering the signed-in desktop destination
-  triggers one fresh auth-backed connection even while the auth session remains
-  provisionally `AuthInitial`.
+  hands off one fresh auth-backed connection to the desktop auth/connection
+  coordinator even while the auth session remains provisionally `AuthInitial`;
+  the overlay cubit remains stream-derived.
 - Fresh connections require the typed health body, including explicit filesystem-access
   degradation state; missing or malformed fields fail the connection rather than being
   treated as healthy. Resumed connections retain the last validated health state.

--- a/docs/regression/bridge-connectivity.md
+++ b/docs/regression/bridge-connectivity.md
@@ -39,7 +39,9 @@ explicit restart, and the connection states the app presents.
   popup listener rather than being silently consumed; handled shared failures are
   retained in local logs through a privacy-safe reporter that records error/stack
   and operation/event context while reducing payload-bearing information to shape
-  metadata.
+  metadata. A token-only local restore entering the signed-in desktop destination
+  triggers one fresh auth-backed connection even while the auth session remains
+  provisionally `AuthInitial`.
 - Fresh connections require the typed health body, including explicit filesystem-access
   degradation state; missing or malformed fields fail the connection rather than being
   treated as healthy. Resumed connections retain the last validated health state.


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this wires the desktop shell into the existing shared relay lifecycle across DI, authenticated startup, root state, and presentation boundaries without changing transport contracts.

## What

- Register the desktop relay crypto, failure-reporting, and route-source adapters.
- Root `ConnectionService` before the desktop widget tree so authenticated state owns relay connect/reconnect behavior.
- Construct `ConnectionOverlayCubit` and `SseToastCubit` in shell-owned `BlocProvider`s.
- Add desktop connection-banner and navigator-overlay Prego toast presentation.
- Show desktop relay-client status separately from supervised-helper relay status.
- Route token-only local-restore startup through `DesktopRelayConnectionService` and the signed-in auth-gate destination intent; keep `ConnectionOverlayCubit` stream-derived and transport-command-free.
- Add focused DI, platform, widget, auth-gate, coordinator, and shared-cubit coverage.
- Document the desktop relay behavior and the intentional route-less pre-router behavior.

## Why

The desktop app is both supervisor and cockpit. Step 13 activates the already-shared encrypted relay client while keeping supervision state on the control channel, preserving the shell/module boundaries, and avoiding a premature `module_app_ui` dependency before Step 14. The destination handoff ensures valid locally restored credentials are usable even when no cached user record exists and auth remains provisional during an unavailable `/auth/me` check, without making the presentation-only overlay cubit a transport owner.

## Risk and test focus

Medium risk: authenticated startup/logout lifecycle, relay reconnect state, root overlay presentation, token-only restore behavior, auth/connection ownership, and privacy-safe handled-failure logging. Verify that desktop DI resolves all shared connection prerequisites, that cubits remain shell-constructed, that helper relay status is not conflated with desktop-client status, and that route-less session toasts are withheld rather than assigned a false session.

## Expected result

Authenticated desktop sessions connect through the existing E2E-encrypted relay `ConnectionService`; token-only local restores also initiate one connection from the signed-in destination through the desktop auth/connection coordinator. Connection interruptions and backend toasts are visible in the desktop shell. The supervised helper continues to use its existing control-channel lifecycle. There is no database schema, persisted-data format, or wire-contract change. Windows/Linux native build coverage remains in CI, and MT gate B remains user-run.

## Verification

- `asdf exec dart analyze --fatal-infos` — passed for `client/module_core`, `client/module_desktop_core`, `client/desktop`, and `client/app`.
- Full `client/module_core` Dart suite — passed (1,464 tests).
- Full `client/module_desktop_core` Dart suite — passed (183 tests).
- Full `client/desktop` Flutter suite — passed (57 tests).
- Full `client/app` Flutter suite — passed (913 tests).
- `asdf exec flutter build macos` — passed (`Sesori.app`, 55.3 MB).
- Dart LSP diagnostics — clean.
- `git diff --check` — clean.
- Architecture implementation review — approved with no blocking findings (`Merge verdict: OK`) for the original Step 13 composition; the follow-up Codex P1 boundary finding was addressed by the coordinator move.
