### PR TITLE
🌿 Fix registered-bridge state leaking across logout

### DIFF
--- a/client/module_core/lib/src/repositories/registered_bridges_store.dart
+++ b/client/module_core/lib/src/repositories/registered_bridges_store.dart
@@ -43,11 +43,18 @@ class RegisteredBridgesStore({
   /// registered bridge; `false` means "not yet known" — never "no bridges".
   bool _knownRegistered = false;
 
+  /// Bumped on logout so a storage read started for the previous account
+  /// cannot repopulate this cache after the account changes.
+  int _authGeneration = 0;
+
   this {
     _authSubscription = authSession.authStateStream.listen((state) {
       // Logout: drop the latch so the next account starts from scratch.
       // clear() handles its own errors, so this stays fire-and-forget.
-      if (state is AuthUnauthenticated) unawaited(clear());
+      if (state is AuthUnauthenticated) {
+        _authGeneration++;
+        unawaited(clear());
+      }
     });
   }
 
@@ -56,14 +63,15 @@ class RegisteredBridgesStore({
   /// run for the positive answer; the in-memory flag short-circuits after that.
   Future<bool> hasRegisteredBridges() async {
     if (_knownRegistered) return true;
+    final generation = _authGeneration;
     try {
       if (await _storage.read(key: _storageKey) == _storedValue) {
-        _knownRegistered = true;
+        if (generation == _authGeneration) _knownRegistered = true;
       }
     } catch (error, stackTrace) {
       loge("Failed to read registered-bridges latch", error, stackTrace);
     }
-    return _knownRegistered;
+    return generation == _authGeneration && _knownRegistered;
   }
 
   /// Latches the positive answer in memory and in persistent storage. A no-op

--- a/client/module_core/lib/src/services/registered_bridges_service.dart
+++ b/client/module_core/lib/src/services/registered_bridges_service.dart
@@ -64,12 +64,12 @@ class RegisteredBridgesService({
   /// Last successful bridge-list result, sorted in display order.
   List<BridgeSummary>? _cachedBridges;
 
-  /// Auth generation, bumped on every logout. A lookup or connection-driven
-  /// latch captures this when it starts; if a logout bumps it while the
-  /// operation is in flight, the operation must not write the old account's
-  /// answer to the store or the stream — otherwise the next account signing in
-  /// on this device would inherit the latch and see a spurious bridge-offline
-  /// flow.
+  /// Auth generation, bumped on every logout. An asynchronous read, lookup, or
+  /// connection-driven latch captures this when it starts; if a logout bumps
+  /// it while the operation is in flight, the operation must not write the old
+  /// account's answer to the store or the stream — otherwise the next account
+  /// signing in on this device would inherit the latch and see a spurious
+  /// bridge-offline flow.
   int _authGeneration = 0;
 
   StreamSubscription<ConnectionStatus>? _statusSubscription;
@@ -106,17 +106,21 @@ class RegisteredBridgesService({
   }
 
   Future<void> _seedFromStore() async {
-    if (await _store.hasRegisteredBridges()) _latchEmit();
+    final generation = _authGeneration;
+    if (await _store.hasRegisteredBridges() && generation == _authGeneration) _latchEmit();
   }
 
   Future<bool> _resolve() async {
+    final generation = _authGeneration;
     // Tiers 1 & 2: the in-process latch, then the store's in-memory / persisted
     // latch. A known-positive answer never reverts, so don't touch the network.
     if (_isRegistered.value) return true;
     if (await _store.hasRegisteredBridges()) {
+      if (generation != _authGeneration) return false;
       _latchEmit();
       return true;
     }
+    if (generation != _authGeneration) return false;
     // Tier 3: ask the auth server, latching a positive answer for next time.
     return await _lookup();
   }

--- a/client/module_core/test/repositories/registered_bridges_store_test.dart
+++ b/client/module_core/test/repositories/registered_bridges_store_test.dart
@@ -18,11 +18,14 @@ class _InMemorySecureStorage() implements SecureStorage {
   bool throwOnRead = false;
   bool throwOnWrite = false;
   bool throwOnDelete = false;
+  Completer<String?>? readGate;
 
   @override
   Future<String?> read({required String key}) async {
     reads++;
     if (throwOnRead) throw Exception("read failed");
+    final gate = readGate;
+    if (gate != null) return await gate.future;
     return _data[key];
   }
 
@@ -123,6 +126,23 @@ void main() {
 
     expect(storage._data.containsKey("has_registered_bridges"), isFalse);
     expect(storage.deletes, greaterThanOrEqualTo(1));
+    expect(await store.hasRegisteredBridges(), isFalse);
+  });
+
+  test("a storage read completing after logout does not restore the cache", () async {
+    storage._data["has_registered_bridges"] = "true";
+    final readGate = storage.readGate = Completer<String?>();
+    final store = buildStore();
+    final pending = store.hasRegisteredBridges();
+    await _settle();
+
+    authState.add(const AuthState.unauthenticated());
+    await _settle();
+    storage.readGate = null;
+    readGate.complete("true");
+    await _settle();
+
+    expect(await pending, isFalse);
     expect(await store.hasRegisteredBridges(), isFalse);
   });
 

--- a/client/module_core/test/services/registered_bridges_service_test.dart
+++ b/client/module_core/test/services/registered_bridges_service_test.dart
@@ -426,6 +426,36 @@ void main() {
       expect(service.isRegistered.value, isFalse);
     });
 
+    test("a logout while the startup store seed is in flight discards the stale latch", () async {
+      final seedGate = Completer<bool>();
+      when(() => store.hasRegisteredBridges()).thenAnswer((_) => seedGate.future);
+      final service = build();
+      await _settle();
+
+      authSubject.add(const AuthState.unauthenticated());
+      await _settle();
+      seedGate.complete(true);
+      await _settle();
+
+      expect(service.isRegistered.value, isFalse);
+    });
+
+    test("a logout while store resolution is in flight discards the stale latch", () async {
+      final service = build();
+      await _settle();
+      final resolutionGate = Completer<bool>();
+      when(() => store.hasRegisteredBridges()).thenAnswer((_) => resolutionGate.future);
+
+      final pending = service.hasRegisteredBridges();
+      await _settle();
+      authSubject.add(const AuthState.unauthenticated());
+      await _settle();
+      resolutionGate.complete(true);
+
+      expect(await pending, isFalse);
+      expect(service.isRegistered.value, isFalse);
+    });
+
     test("a stale latch completing after a new account latched does not wipe the new latch", () async {
       var markCalls = 0;
       final firstMarkGate = Completer<void>();

--- a/docs/regression/account-and-onboarding.md
+++ b/docs/regression/account-and-onboarding.md
@@ -32,6 +32,8 @@ participates.
   projects shows the add-project call to action instead.
 - An account that never registered a bridge parks offline silently; the
   bridge-offline banner is reserved for accounts that have one.
+- A persisted registered-bridge read that completes after logout cannot restore
+  the signed-out account's latch or leak it to the next account.
 - The bridge prompt appears only once the bridge is locally ready to serve, never
   after a failed or cancelled start, and never for an account known to have the app.
 - The prompt costs one immediate registration check and never polls; push
@@ -62,6 +64,8 @@ the prompt and a reused one when testing suppression.
   emitting authenticated after logout, a rejected refresh leaving credentials
   restorable after relaunch, a transport failure clearing a usable session, or
   macOS OAuth completion failing with a missing Keychain entitlement (`-34018`).
+- A delayed persisted registered-bridge read restoring the previous account's
+  offline banner or recovery flow after logout.
 - The prompt appearing before readiness, after a failed start, on an account that
   already has the app, or driving repeated status requests.
 - Relay availability or key exchange waiting on push registration or the check.


### PR DESCRIPTION
## Complexity

🌿 Straightforward: add auth-generation fences to existing asynchronous latch reads and regression coverage.

## What

- Fence the reactive startup seed and store-backed resolution so results started before logout cannot update the service.
- Fence the persisted store cache so a delayed read cannot rehydrate the previous account's latch.
- Add deterministic logout-race tests for the service and store.
- Document the logout invariant in the account and onboarding regression contract.

## Why

The registered-bridge service starts a persisted-latch read from its app-wide builder. If logout completes while that read is pending, the old implementation emitted `true` afterward, allowing the signed-out or next account to enter the bridge-offline recovery flow. The store could also retain the delayed result in its in-memory cache.

## Risk and test focus

There is no wire-contract, database-schema, or migration impact. The change only discards asynchronous registered-bridge results whose auth generation is no longer current. Focus is on logout ordering, persisted-latch reads, cache state, and preserving existing positive-latch behavior.

## Expected result

Logging out while a registered-bridge read is in flight leaves the service and store unlatched for the next account. Reads completed within the current auth generation retain their existing behavior.

## Verification

- The new startup-race test failed before the fix with `Expected: false; Actual: true` and passes afterward.
- `dart test` from `client/module_core`: 1,466 tests passed.
- `dart analyze` from `client/module_core`: passed.
- `flutter test` from `client/app`: 913 tests passed.
- `flutter analyze` from `client/app`: passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a logout race where a registered-bridge read that finishes after logout could restore the previous account's latch, causing the signed-out or next account to enter the bridge-offline recovery flow.

- Discards persisted-latch reads started before logout in the service and store.
- Adds regression tests for the service and store logout races.
- Documents the logout invariant in the account and onboarding regression contract.

<sup>Written for commit 82f7cb715c9d15994e32c9698faefe6acbad56b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

