### PR TITLE
⚙️ [desktop-app] Repair development autostart and hidden boot

### DIFF
--- a/.plan/active/desktop-app/PLAN.md
+++ b/.plan/active/desktop-app/PLAN.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Plan slug:** `desktop-app`
-- **Status:** Active — step 13/22 in progress (desktop relay-client enablement)
+- **Status:** Active — awaiting MT gate B before step 14 (desktop relay client merged)
 - **Plan date:** 2026-08-28
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Current implementation base:** `main`
@@ -434,7 +434,12 @@ root wiring: `ConnectionOverlayCubit` (+ `ConnectionBanner` host) and
 not be silently consumed). **Standing rule for every cockpit slice
 (15–19):** the slice that first renders a screen also wires, at the desktop
 root, every root-level provider/listener that screen watches — a moved
-screen may never land ahead of its root wiring.
+screen may never land ahead of its root wiring. Token-only local restores hand
+connection startup to a desktop auth/connection coordinator rather than the
+projection cubit.
+
+Step 13 merged in PR #1216 on 2026-08-31. The implementation is complete; the
+next implementation step waits for the user-run MT gate B above.
 
 **Step 14 — ⚙️ Create `module_app_ui` + shared foundations.** New Flutter
 package; move `l10n/` (ownership of `l10n.yaml`/codegen) and the

--- a/.plan/active/desktop-app/TRACKER.md
+++ b/.plan/active/desktop-app/TRACKER.md
@@ -21,7 +21,7 @@ user-run checkpoints, not PRs; only the user marks them passed.
 | 11 | 🚧 Logout coordination + offline unregister fallback | done |
 | 12 | 🚧 Supervised E2E suite + dev-harness retirement | done |
 | — | MT gate B: daily driver (user-run) | pending |
-| 13 | ⚙️ Desktop relay-client enablement | in-progress |
+| 13 | ⚙️ Desktop relay-client enablement | done |
 | 14 | ⚙️ Create `module_app_ui` + l10n/extensions/theme move | pending |
 | 15 | 🚧 Settings + harness management slice (desktop onboarding) | pending |
 | 16 | 🚧 Project/session lists slice + desktop offline strategy | pending |
@@ -48,4 +48,7 @@ Step 10 merged in PR #1212 on 2026-08-30. Step 11 merged in PR #1213 on
 2026-08-30. Step 12 merged in PR #1215 on 2026-08-30 with 19/19 CI checks
 passing, including the native supervised E2E on macOS, Windows, and Linux.
 The Step 12 PR also included the post-merge Step 11 stop-mode and token-only
-deletion hardening. Step 13 is now the active successor.
+deletion hardening. Step 13 merged in PR #1216 on 2026-08-31 with 13/13 CI
+checks passing. The desktop relay client and token-only startup handoff are
+complete. MT gate B remains pending; do not begin Step 14 until the user-run
+daily-driver checkpoint is recorded.

--- a/.plan/active/desktop-app/steps/step-13.md
+++ b/.plan/active/desktop-app/steps/step-13.md
@@ -60,13 +60,14 @@ intent before the follow-up push.
   row.
 - Dart LSP diagnostics and `git diff --check` are clean.
 - `asdf exec flutter build macos` completed successfully (`Sesori.app`,
-  55.3 MB). Windows/Linux native build verification remains pending for the
-  Step 13 PR.
+  55.3 MB); the Step 13 PR's 13/13 CI checks also passed the Windows/Linux
+  native build jobs.
 
 ## Handoff
 
-Step 12 merged in PR #1215 on 2026-08-30. After this step merges, Step 14
-creates `module_app_ui`, moves the shared localization/context foundation, and
-replaces the temporary route-less desktop source and shell-owned connection
-banner with the shared adaptive UI/router foundation. MT gate B remains the
-user-run daily-driver checkpoint.
+Step 12 merged in PR #1215 on 2026-08-30, and Step 13 merged in PR #1216 on
+2026-08-31. The desktop relay-client implementation is complete. MT gate B
+remains the user-run daily-driver checkpoint; after its outcome is recorded,
+Step 14 creates `module_app_ui`, moves the shared localization/context
+foundation, and replaces the temporary route-less desktop source and
+shell-owned connection banner with the shared adaptive UI/router foundation.

--- a/client/desktop/lib/core/platform/desktop_bridge_executable_path_resolver.dart
+++ b/client/desktop/lib/core/platform/desktop_bridge_executable_path_resolver.dart
@@ -7,20 +7,24 @@ import "package:sesori_desktop_core/sesori_desktop_core.dart";
 
 /// Development bridge-path policy for the desktop shell.
 ///
-/// An explicit `SESORI_DESKTOP_BRIDGE_PATH` wins. Otherwise `flutter run` from
-/// `client/desktop` resolves the host bundle produced by
-/// `bridge/app/make build-host`. Packaged-layout resolution belongs to the
-/// distribution plan and will replace this repository-relative default.
+/// An explicit `SESORI_DESKTOP_BRIDGE_PATH` wins. Otherwise the repository
+/// host bundle produced by `bridge/app/make build-host` is resolved from the
+/// desktop package location. The executable location is used as a fallback
+/// because launchd starts a LaunchAgent with `/` as its working directory.
+/// Packaged-layout resolution belongs to the distribution plan and will
+/// replace this repository-relative default.
 @LazySingleton(as: BridgeExecutablePathResolver)
 class DesktopBridgeExecutablePathResolver.forTesting({
   required final Map<String, String> _environment,
   required final String _workingDirectory,
+  required final String _resolvedExecutable,
   required final bool _isWindows,
 }) implements BridgeExecutablePathResolver {
   new()
     : this.forTesting(
         environment: Platform.environment,
         workingDirectory: Directory.current.path,
+        resolvedExecutable: Platform.resolvedExecutable,
         isWindows: Platform.isWindows,
       );
 
@@ -38,9 +42,17 @@ class DesktopBridgeExecutablePathResolver.forTesting({
       );
     }
 
+    final String? desktopPackageDirectory = _findDesktopPackageDirectory(startPath: _workingDirectory);
+    final String? executablePackageDirectory = _findDesktopPackageDirectory(startPath: _resolvedExecutable);
+    return _bridgePath(
+      desktopPackageDirectory: desktopPackageDirectory ?? executablePackageDirectory ?? _workingDirectory,
+    );
+  }
+
+  String _bridgePath({required String desktopPackageDirectory}) {
     return path.normalize(
       path.join(
-        _workingDirectory,
+        desktopPackageDirectory,
         "..",
         "..",
         "bridge",
@@ -52,5 +64,23 @@ class DesktopBridgeExecutablePathResolver.forTesting({
         _isWindows ? "bridge.exe" : "bridge",
       ),
     );
+  }
+
+  /// Finds the repository's desktop package by path shape rather than probing
+  /// the filesystem. A missing helper should still produce the expected
+  /// repository path in its startup error, and this keeps resolution usable in
+  /// tests before a host bundle has been built.
+  String? _findDesktopPackageDirectory({required String startPath}) {
+    String current = path.normalize(startPath);
+    while (true) {
+      if (path.basename(current) == "desktop" && path.basename(path.dirname(current)) == "client") {
+        return current;
+      }
+      final String parent = path.dirname(current);
+      if (parent == current) {
+        return null;
+      }
+      current = parent;
+    }
   }
 }

--- a/client/desktop/lib/core/platform/flutter_window_host.dart
+++ b/client/desktop/lib/core/platform/flutter_window_host.dart
@@ -45,7 +45,12 @@ class FlutterWindowHost.forTesting({required final WindowManager _manager}) with
       await _manager.setPreventClose(true);
       await _manager.waitUntilReadyToShow(_options);
       await _manager.setSkipTaskbar(hidden);
-      if (!hidden) {
+      if (hidden) {
+        // Native runners hide the window before the first frame where
+        // possible; keep the state explicit here as a cross-platform
+        // fallback for hosts that initially order the window.
+        await _manager.hide();
+      } else {
         await _manager.show();
         await _manager.focus();
       }

--- a/client/desktop/macos/Runner/MainFlutterWindow.swift
+++ b/client/desktop/macos/Runner/MainFlutterWindow.swift
@@ -1,7 +1,10 @@
 import Cocoa
 import FlutterMacOS
+import window_manager
 
 class MainFlutterWindow: NSWindow {
+  private static let hiddenLaunchArgument = "--hidden"
+
   override func awakeFromNib() {
     let flutterProject = FlutterDartProject()
     // Pass the native process arguments through explicitly so LaunchAgent
@@ -16,5 +19,16 @@ class MainFlutterWindow: NSWindow {
     MacOsLegacyKeychainPlugin.register(binaryMessenger: flutterViewController.engine.binaryMessenger)
 
     super.awakeFromNib()
+  }
+
+  // MainMenu.xib orders the Flutter window before Dart can apply its hidden
+  // startup policy. Use window_manager's native first-order hook so a
+  // LaunchAgent startup never flashes the window; normal launches retain the
+  // existing visible behavior and are shown by FlutterWindowHost.
+  override public func order(_ place: NSWindow.OrderingMode, relativeTo otherWin: Int) {
+    super.order(place, relativeTo: otherWin)
+    if CommandLine.arguments.dropFirst().contains(Self.hiddenLaunchArgument) {
+      hiddenWindowAtLaunch()
+    }
   }
 }

--- a/client/desktop/test/core/platform/desktop_bridge_executable_path_resolver_test.dart
+++ b/client/desktop/test/core/platform/desktop_bridge_executable_path_resolver_test.dart
@@ -9,6 +9,7 @@ void main() {
       final DesktopBridgeExecutablePathResolver resolver = DesktopBridgeExecutablePathResolver.forTesting(
         environment: {DesktopBridgeExecutablePathResolver.environmentVariable: configuredPath},
         workingDirectory: path.absolute(path.join("repo", "client", "desktop")),
+        resolvedExecutable: path.absolute(path.join("repo", "client", "desktop", "build", "Sesori")),
         isWindows: false,
       );
 
@@ -20,6 +21,7 @@ void main() {
       final DesktopBridgeExecutablePathResolver resolver = DesktopBridgeExecutablePathResolver.forTesting(
         environment: const {DesktopBridgeExecutablePathResolver.environmentVariable: "tools/bridge"},
         workingDirectory: workingDirectory,
+        resolvedExecutable: path.join(workingDirectory, "build", "Sesori"),
         isWindows: false,
       );
 
@@ -31,6 +33,55 @@ void main() {
       final DesktopBridgeExecutablePathResolver resolver = DesktopBridgeExecutablePathResolver.forTesting(
         environment: const {},
         workingDirectory: workingDirectory,
+        resolvedExecutable: path.join(workingDirectory, "build", "Sesori"),
+        isWindows: false,
+      );
+
+      expect(
+        resolver.resolve(),
+        path.normalize(
+          path.join(workingDirectory, "..", "..", "bridge", "app", "build", "cli", "bundle", "bin", "bridge"),
+        ),
+      );
+    });
+
+    test("resolves the repository from the executable when launchd changes the working directory", () {
+      final String repositoryRoot = path.absolute("repo");
+      final DesktopBridgeExecutablePathResolver resolver = DesktopBridgeExecutablePathResolver.forTesting(
+        environment: const {},
+        workingDirectory: path.rootPrefix(repositoryRoot),
+        resolvedExecutable: path.join(
+          repositoryRoot,
+          "client",
+          "desktop",
+          "build",
+          "macos",
+          "Build",
+          "Products",
+          "Release",
+          "Sesori.app",
+          "Contents",
+          "MacOS",
+          "Sesori",
+        ),
+        isWindows: false,
+      );
+
+      expect(
+        resolver.resolve(),
+        path.normalize(
+          path.join(repositoryRoot, "bridge", "app", "build", "cli", "bundle", "bin", "bridge"),
+        ),
+      );
+    });
+
+    test("falls back to the launch directory outside the repository", () {
+      final String root = path.rootPrefix(path.absolute("repo"));
+      final String workingDirectory = path.join(root, "tmp", "sesori-desktop");
+      final DesktopBridgeExecutablePathResolver resolver = DesktopBridgeExecutablePathResolver.forTesting(
+        environment: const {},
+        workingDirectory: workingDirectory,
+        resolvedExecutable: path.join(root, "Applications", "Sesori.app", "Contents", "MacOS", "Sesori"),
         isWindows: false,
       );
 
@@ -47,6 +98,7 @@ void main() {
       final DesktopBridgeExecutablePathResolver resolver = DesktopBridgeExecutablePathResolver.forTesting(
         environment: const {},
         workingDirectory: workingDirectory,
+        resolvedExecutable: path.join(workingDirectory, "build", "Sesori.exe"),
         isWindows: true,
       );
 

--- a/client/desktop/test/core/platform/flutter_window_host_test.dart
+++ b/client/desktop/test/core/platform/flutter_window_host_test.dart
@@ -54,7 +54,10 @@ void main() {
 
     await host.initialize(hidden: true);
 
-    verify(() => manager.setSkipTaskbar(true)).called(1);
+    verifyInOrder(<void Function()>[
+      () => manager.setSkipTaskbar(true),
+      () => manager.hide(),
+    ]);
     verifyNever(manager.show);
     verifyNever(manager.focus);
   });

--- a/docs/regression/desktop-bridge-supervision.md
+++ b/docs/regression/desktop-bridge-supervision.md
@@ -21,10 +21,14 @@ and keep native close/quit behavior safe.
   ready; signed-out restore reaches login-required without spawning a helper.
   Launch at login is an idempotent per-user registration that starts the app
   with `--hidden`; disabling it removes the registration rather than merely
-  flipping an in-app flag.
-- A `--hidden` launch stays tray-only when the tray is proven available. If the
-  tray is unavailable or fails to initialize, the window is shown so the app
-  remains reachable.
+  flipping an in-app flag. Development builds resolve the repository helper
+  from the desktop executable path when a login service supplies `/` as the
+  working directory; packaged-layout resolution remains a distribution-plan
+  concern.
+- A `--hidden` launch stays tray-only when the tray is proven available. The
+  macOS runner suppresses the native first ordering and the Flutter window
+  adapter applies the hidden state as a fallback. If the tray is unavailable
+  or fails to initialize, the window is shown so the app remains reachable.
 - On a proven tray host, native close hides the window immediately, including
   during bridge lifecycle work, removes the macOS app from the Dock while it is
   hidden, and Open restores/focuses it and returns it to the Dock. Without a
@@ -82,8 +86,10 @@ at different handshake phases and inspect the status and bounded recent output.
 - Desired Off restores On, last-On never restores, startup bypasses auth gating,
   or bridge restore begins before the control dispatcher owns its event stream.
 - Repeated launch-at-login enables create duplicate registrations, disabling
-  leaves a stale login item, `--hidden` startup hides the app without a usable
-  tray, or a normal manual launch unexpectedly starts hidden.
+  leaves a stale login item, a login-launched development build cannot find its
+  repository helper, `--hidden` startup hides the app without a usable tray,
+  the macOS window flashes or remains visible during hidden startup, or a normal
+  manual launch unexpectedly starts hidden.
 - Close hides the only surface when no tray host exists, ignores a close during
   lifecycle work, Open shows without focusing, native close bypasses teardown,
   or the macOS tray icon has an opaque background/wrong light-dark treatment,
@@ -117,7 +123,9 @@ at different handshake phases and inspect the status and bounded recent output.
   distributed builds belongs to the later desktop-distribution plan.
 - Login registration is owned by the current desktop executable path. A
   development build moved or rebuilt at a different path must be re-enabled;
-  packaged-path migration belongs to the later desktop-distribution plan.
+  the dev resolver can locate the repository helper from an executable inside
+  the checkout even when launchd changes the working directory. Packaged-path
+  migration belongs to the later desktop-distribution plan.
 
 ## Sources
 


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this is a focused desktop-shell follow-up spanning the macOS native window lifecycle, development helper-path resolution, and regression coverage.

## What

- Resolve the development bridge helper from the desktop executable's repository location when a LaunchAgent starts the app with `/` as its working directory.
- Keep `SESORI_DESKTOP_BRIDGE_PATH` as the explicit override for manual or non-repository launches.
- Suppress the macOS native first window ordering for the exact `--hidden` launch argument using the existing `window_manager` integration.
- Apply an explicit Flutter-side hide as a cross-platform fallback while retaining visible manual launches and tray-unavailable fallback behavior.
- Add focused resolver/window-host tests and update desktop supervision regression guidance.
- Carry the merged Step 13 bookkeeping that records MT Gate B as pending before Step 14.

## Why

The LaunchAgent registration itself was correct, but macOS launchd supplied `/` as the process working directory, causing the development resolver to seek the helper at `/bridge/app/...`. Separately, the macOS nib ordered the window before Dart could process `--hidden`, so a login launch showed a window even though the tray was available. Both defects prevented the daily-driver autostart check from passing.

There is no database, relay-protocol, authentication-contract, or shared CLI-state impact. The change is limited to development desktop path discovery and native/window presentation.

## Risk and test focus

The main risks are selecting the wrong repository-relative helper path, hiding a normal manual launch, or hiding the window on a host whose tray is unavailable. Focus on executable-path resolution from a LaunchAgent-style cwd, explicit-path precedence, exact hidden behavior, visible startup, and tray-unavailable recovery. Packaged-layout resolution remains out of scope for the later desktop-distribution plan.

## Expected result

A release development app launched by its LaunchAgent finds the helper from its own checkout path regardless of launchd's working directory. A `--hidden` macOS launch remains tray-only without a visible-window flash; a normal launch remains visible; and a missing tray still exposes the window as a reachable fallback.

## Verification

- `cd client/desktop && asdf exec flutter test` — 59 tests passed.
- `cd client/desktop && asdf exec flutter analyze --fatal-infos` — clean.
- `cd client/desktop && asdf exec flutter build macos` — passed (`Sesori.app`, 55.5 MB).
- Focused resolver and window-host tests — passed.
- Dart LSP diagnostics for all changed Dart files — zero diagnostics.
- `git diff --check` — clean.
- Architecture implementation review — approved with no findings.

## Manual follow-up

Please rebuild this PR branch and rerun Gate B item A through the LaunchAgent: confirm the app starts hidden, the tray is present, the supervised helper reaches `--control-url`, and disabling Launch at Login still removes the plist. Gate B items B, C, and F have been reported passing on the current build; D, E, and G remain user-owned validation/clarification items.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes development autostart for the desktop app so LaunchAgent launches find the bridge helper and `--hidden` boots tray-only without flashing a window. Previously launchd's `/` working directory broke helper resolution and the macOS nib ordered the window before Dart could hide it.

- Resolves the repository helper from the desktop executable path when the working directory is `/`; `SESORI_DESKTOP_BRIDGE_PATH` still wins.
- Hides the native first window ordering for the exact `--hidden` argument and applies an explicit Flutter-side hide as a fallback.
- Keeps normal manual launches visible and shows the window when the tray is unavailable.
- Adds resolver and window-host tests and updates the desktop supervision regression guidance.
- Records Step 13 as merged with MT gate B pending in the plan files.

<sup>Written for commit 9a1e9b9906bb51c352f9d364d833cf8204b30810. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

