### PR TITLE
🌿 Redesign project picker hierarchy navigation

### DIFF
--- a/client/app/lib/features/project_list/add_project_dialog.dart
+++ b/client/app/lib/features/project_list/add_project_dialog.dart
@@ -14,8 +14,8 @@ import "new_folder_dialog.dart";
 /// Shows the Add Project modal bottom sheet.
 ///
 /// Presented directly rather than through `showPregoBottomSheet` because the
-/// header is not fixed: its title, path subtitle, and back button all follow
-/// the folder the browser is showing.
+/// header is not fixed: its title and path subtitle follow the folder the
+/// browser is showing.
 ///
 /// The [cubit] is passed explicitly so the dialog can call `discoverProject` /
 /// `createDirectory` without relying on the widget tree's BlocProvider (which
@@ -44,6 +44,7 @@ Future<void> showAddProjectDialog(BuildContext context, ProjectListCubit cubit) 
 @visibleForTesting
 class const AddProjectDialog({
   required final ProjectListCubit cubit,
+
   /// The status-bar inset captured from the presenting context — the modal
   /// route strips it from the sheet's own MediaQuery.
   required final double topInset,
@@ -73,7 +74,7 @@ class _AddProjectDialogState() extends State<AddProjectDialog> {
 
   bool get _isAtStartingPath => _currentPath.isNotEmpty && _currentPath == _startingPath;
 
-  bool get _canNavigateUp => _currentPath.isNotEmpty && widget.cubit.parentHostPath(path: _currentPath) != null;
+  String? get _parentPath => _currentPath.isEmpty ? null : widget.cubit.parentHostPath(path: _currentPath);
 
   @override
   void initState() {
@@ -134,7 +135,7 @@ class _AddProjectDialogState() extends State<AddProjectDialog> {
   }
 
   void _navigateUp() {
-    final parent = widget.cubit.parentHostPath(path: _currentPath);
+    final parent = _parentPath;
     if (parent == null) return;
     setState(() => _currentPath = parent);
     _fetchEntries();
@@ -327,7 +328,6 @@ class _AddProjectDialogState() extends State<AddProjectDialog> {
       // for the sheet — so the leading-aligned title/path variant.
       alignment: PregoSheetTitleAlignment.start,
       topInset: widget.topInset,
-      onBack: _canNavigateUp ? _navigateUp : null,
       onClose: _dismissDialog,
       // Full-bleed body; the banner, rows, and action menu pad themselves.
       contentPadding: EdgeInsetsDirectional.zero,
@@ -381,19 +381,33 @@ class _AddProjectDialogState() extends State<AddProjectDialog> {
   /// content pads past it so the last folder clears the buttons, and the states
   /// that centre their content centre in what is left above them.
   Widget _buildListing({required AppLocalizations loc, required double bottomInset}) {
+    final parentPath = _parentPath;
     if (_loading) {
-      return _FolderListSkeleton(semanticLabel: loc.addProject);
-    }
-    if (_hasError) {
-      return Padding(
+      return ListView(
         padding: EdgeInsetsDirectional.only(bottom: bottomInset),
-        child: _BrowseError(
-          permissionDenied: _permissionDenied,
-          onRetry: _fetchEntries,
-        ),
+        children: [
+          if (parentPath != null) _buildParentEntry(path: parentPath),
+          _FolderListSkeleton(semanticLabel: loc.addProject),
+        ],
       );
     }
-    if (_entries.isEmpty) {
+    if (_hasError) {
+      return Column(
+        children: [
+          if (parentPath != null) _buildParentEntry(path: parentPath),
+          Expanded(
+            child: Padding(
+              padding: EdgeInsetsDirectional.only(bottom: bottomInset),
+              child: _BrowseError(
+                permissionDenied: _permissionDenied,
+                onRetry: _fetchEntries,
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+    if (_entries.isEmpty && parentPath == null) {
       return Padding(
         padding: EdgeInsetsDirectional.only(bottom: bottomInset),
         child: Center(
@@ -408,14 +422,24 @@ class _AddProjectDialogState() extends State<AddProjectDialog> {
     }
     return ListView.builder(
       padding: EdgeInsetsDirectional.only(bottom: bottomInset),
-      itemCount: _entries.length,
+      itemCount: _entries.length + (parentPath == null ? 0 : 1),
       itemBuilder: (context, index) {
-        final entry = _entries[index];
+        if (parentPath != null && index == 0) {
+          return _buildParentEntry(path: parentPath);
+        }
+        final entry = _entries[index - (parentPath == null ? 0 : 1)];
         return _FolderTile(
           entry: entry,
           onTap: () => _navigateInto(path: entry.path),
         );
       },
+    );
+  }
+
+  Widget _buildParentEntry({required String path}) {
+    return _FolderTile(
+      entry: FilesystemSuggestion(path: path, name: "..", isGitRepo: false),
+      onTap: _navigateUp,
     );
   }
 }
@@ -426,7 +450,8 @@ class _AddProjectDialogState() extends State<AddProjectDialog> {
 
 /// One folder in the browser: its name, a tag when it already holds a git
 /// repository, and a chevron into it.
-class const _FolderTile({required final FilesystemSuggestion entry, required final VoidCallback onTap}) extends StatelessWidget {
+class const _FolderTile({required final FilesystemSuggestion entry, required final VoidCallback onTap})
+    extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
@@ -545,7 +570,8 @@ class const _FolderListSkeleton({required final String semanticLabel}) extends S
 
 /// The listing's failure state — the folder could not be read, either because
 /// the host denied access or because the bridge could not list it.
-class const _BrowseError({required final bool permissionDenied, required final VoidCallback onRetry}) extends StatelessWidget {
+class const _BrowseError({required final bool permissionDenied, required final VoidCallback onRetry})
+    extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
@@ -593,14 +619,16 @@ class const _BrowseError({required final bool permissionDenied, required final V
 /// uses (`PromptInput`), and the mirror of the scroll-edge fade the sheet header
 /// paints at the top.
 class const _ActionMenu({
-    /// Null while an action is in flight or before the browser knows its folder.
+  /// Null while an action is in flight or before the browser knows its folder.
   required final VoidCallback? onAdd,
-    /// Null while an action is in flight or before the browser knows its folder.
+
+  /// Null while an action is in flight or before the browser knows its folder.
   required final VoidCallback? onCreateFolder,
-    /// Which action is waiting on the bridge, so that button — and only that one
+
+  /// Which action is waiting on the bridge, so that button — and only that one
   /// — spins.
   required final _AddProjectAction? inFlight,
-  }) extends StatelessWidget {
+}) extends StatelessWidget {
   /// Clear space above the buttons, where the fade starts.
   static const double _fadeExtent = PregoSpacing.x5l;
 
@@ -717,7 +745,10 @@ class const _FilesystemAccessBanner() extends StatelessWidget {
 
 /// The sheet's two bridge-bound actions, so the one that is running can be told
 /// apart from the one that is merely blocked while it runs.
-enum _AddProjectAction() { add, createFolder }
+enum _AddProjectAction() {
+  add,
+  createFolder,
+}
 
 const double _folderIconSize = 16;
 const double _chevronSize = 16;

--- a/client/app/lib/features/project_list/add_project_dialog.dart
+++ b/client/app/lib/features/project_list/add_project_dialog.dart
@@ -1,7 +1,6 @@
 import "package:get_it/get_it.dart";
 import "package:go_router/go_router.dart";
 import "package:material_ui/material_ui.dart";
-import "package:path/path.dart" as p;
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
@@ -55,9 +54,12 @@ class const AddProjectDialog({
 }
 
 class _AddProjectDialogState() extends State<AddProjectDialog> {
-  /// The folder the bridge started us in, used to present that full host path
-  /// as the header title. It is a starting location, not a navigation boundary.
+  /// The folder the bridge started us in. The bridge's default is the host
+  /// user's home directory, so this is also the Home shortcut target.
   String? _startingPath;
+
+  /// The host filesystem root resolved from [_startingPath].
+  String? _rootPath;
 
   /// The folder being listed. Empty until the first fetch resolves the start.
   String _currentPath = "";
@@ -71,8 +73,6 @@ class _AddProjectDialogState() extends State<AddProjectDialog> {
   /// same folder, so one at a time — and the button that is working is the one
   /// that shows it.
   _AddProjectAction? _inFlight;
-
-  bool get _isAtStartingPath => _currentPath.isNotEmpty && _currentPath == _startingPath;
 
   String? get _parentPath => _currentPath.isEmpty ? null : widget.cubit.parentHostPath(path: _currentPath);
 
@@ -108,11 +108,12 @@ class _AddProjectDialogState() extends State<AddProjectDialog> {
       switch (outcome) {
         case FilesystemSuggestionsSuccess(:final suggestions):
           final resolvedPath = suggestions.path;
-          // The first fetch has no prefix, so the bridge names the folder it
-          // chose. Keep it for presentation while allowing navigation above it.
+          // The first fetch has no prefix, so the bridge names the host user's
+          // home folder. Keep both shortcut targets for this browsing session.
           if (_currentPath.isEmpty && resolvedPath != null && resolvedPath.isNotEmpty) {
             _currentPath = resolvedPath;
             _startingPath = resolvedPath;
+            _rootPath = _resolveRootPath(path: resolvedPath);
           }
           _entries = suggestions.data;
           _hasError = false;
@@ -137,33 +138,17 @@ class _AddProjectDialogState() extends State<AddProjectDialog> {
   void _navigateUp() {
     final parent = _parentPath;
     if (parent == null) return;
-    setState(() => _currentPath = parent);
-    _fetchEntries();
+    _navigateInto(path: parent);
   }
 
-  // ---------------------------------------------------------------------------
-  // Header labelling
-  // ---------------------------------------------------------------------------
-
-  /// The bar's title: the bridge-returned host path at the starting folder, or
-  /// the current folder name after navigating away from it.
-  String _title({required AppLocalizations loc}) {
-    if (_currentPath.isEmpty) return loc.addProject;
-    if (_isAtStartingPath) return _currentPath;
-    return _hostBasename(_currentPath);
+  String _resolveRootPath({required String path}) {
+    var root = path;
+    while (true) {
+      final parent = widget.cubit.parentHostPath(path: root);
+      if (parent == null) return root;
+      root = parent;
+    }
   }
-
-  /// The bar's second line is the full host path after navigating away from the
-  /// starting folder. Null there, where the title already shows that path.
-  String? _subtitle() {
-    if (_isAtStartingPath || _currentPath.isEmpty) return null;
-    return _currentPath;
-  }
-
-  /// The last segment of a host path. The path comes from the bridge's host,
-  /// not the phone's, so both separator styles have to parse — the
-  /// platform-local basename would return a Windows path unchanged.
-  static String _hostBasename(String path) => p.posix.basename(path.replaceAll(r"\", "/"));
 
   // ---------------------------------------------------------------------------
   // Actions
@@ -315,6 +300,8 @@ class _AddProjectDialogState() extends State<AddProjectDialog> {
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
+    final startingPath = _startingPath;
+    final rootPath = _rootPath;
     // The listing scrolls inside the body, so the body needs a bounded height.
     // Take the whole sheet: the browser keeps one height while folders of
     // different lengths come and go, instead of the sheet resizing under the
@@ -322,11 +309,9 @@ class _AddProjectDialogState() extends State<AddProjectDialog> {
     final bodyHeight = MediaQuery.heightOf(context) - widget.topInset - PregoBottomSheet.contentTopInset;
 
     return PregoBottomSheet(
-      title: _title(loc: loc),
-      subtitle: _subtitle(),
-      // The header is a nav bar for the folder being browsed, not a headline
-      // for the sheet — so the leading-aligned title/path variant.
-      alignment: PregoSheetTitleAlignment.start,
+      // Navigation lives in the browser body; the sheet header only owns its
+      // close affordance and drag handle.
+      title: "",
       topInset: widget.topInset,
       onClose: _dismissDialog,
       // Full-bleed body; the banner, rows, and action menu pad themselves.
@@ -344,6 +329,17 @@ class _AddProjectDialogState() extends State<AddProjectDialog> {
             child: Column(
               children: [
                 const _FilesystemAccessBanner(),
+                if (_currentPath.isNotEmpty)
+                  _DirectoryNavigation(
+                    currentPath: _currentPath,
+                    onNavigateUp: _parentPath == null ? null : _navigateUp,
+                    onNavigateHome: startingPath == null || _currentPath == startingPath
+                        ? null
+                        : () => _navigateInto(path: startingPath),
+                    onNavigateRoot: rootPath == null || _currentPath == rootPath
+                        ? null
+                        : () => _navigateInto(path: rootPath),
+                  ),
                 Expanded(
                   // The listing runs to the bottom edge and the actions float
                   // over it, so folders scroll behind them and dissolve into
@@ -381,33 +377,22 @@ class _AddProjectDialogState() extends State<AddProjectDialog> {
   /// content pads past it so the last folder clears the buttons, and the states
   /// that centre their content centre in what is left above them.
   Widget _buildListing({required AppLocalizations loc, required double bottomInset}) {
-    final parentPath = _parentPath;
     if (_loading) {
       return ListView(
         padding: EdgeInsetsDirectional.only(bottom: bottomInset),
-        children: [
-          if (parentPath != null) _buildParentEntry(path: parentPath),
-          _FolderListSkeleton(semanticLabel: loc.addProject),
-        ],
+        children: [_FolderListSkeleton(semanticLabel: loc.addProject)],
       );
     }
     if (_hasError) {
-      return Column(
-        children: [
-          if (parentPath != null) _buildParentEntry(path: parentPath),
-          Expanded(
-            child: Padding(
-              padding: EdgeInsetsDirectional.only(bottom: bottomInset),
-              child: _BrowseError(
-                permissionDenied: _permissionDenied,
-                onRetry: _fetchEntries,
-              ),
-            ),
-          ),
-        ],
+      return Padding(
+        padding: EdgeInsetsDirectional.only(bottom: bottomInset),
+        child: _BrowseError(
+          permissionDenied: _permissionDenied,
+          onRetry: _fetchEntries,
+        ),
       );
     }
-    if (_entries.isEmpty && parentPath == null) {
+    if (_entries.isEmpty) {
       return Padding(
         padding: EdgeInsetsDirectional.only(bottom: bottomInset),
         child: Center(
@@ -422,39 +407,93 @@ class _AddProjectDialogState() extends State<AddProjectDialog> {
     }
     return ListView.builder(
       padding: EdgeInsetsDirectional.only(bottom: bottomInset),
-      itemCount: _entries.length + (parentPath == null ? 0 : 1),
+      itemCount: _entries.length,
       itemBuilder: (context, index) {
-        if (parentPath != null && index == 0) {
-          return _buildParentEntry(path: parentPath);
-        }
-        final entry = _entries[index - (parentPath == null ? 0 : 1)];
+        final entry = _entries[index];
         return _FolderTile(
           entry: entry,
-          semanticLabel: null,
           onTap: () => _navigateInto(path: entry.path),
         );
       },
     );
   }
-
-  Widget _buildParentEntry({required String path}) {
-    return _FolderTile(
-      entry: FilesystemSuggestion(path: path, name: "..", isGitRepo: false),
-      semanticLabel: context.loc.parentDirectory,
-      onTap: _navigateUp,
-    );
-  }
 }
 
 // ---------------------------------------------------------------------------
-// Folder rows
+// Folder navigation and rows
 // ---------------------------------------------------------------------------
+
+class const _DirectoryNavigation({
+  required final String currentPath,
+  required final VoidCallback? onNavigateUp,
+  required final VoidCallback? onNavigateHome,
+  required final VoidCallback? onNavigateRoot,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final loc = context.loc;
+    final prego = context.prego;
+
+    return Padding(
+      padding: const EdgeInsetsDirectional.fromSTEB(
+        PregoSpacing.xl,
+        0,
+        PregoSpacing.xl,
+        PregoSpacing.lg,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            spacing: PregoSpacing.md,
+            children: [
+              PregoButtonsSolid(
+                label: loc.folderPickerHome,
+                hierarchy: PregoButtonsSolidHierarchy.secondary,
+                size: PregoButtonsSolidSize.sm,
+                onPressed: onNavigateHome,
+              ),
+              PregoButtonsSolid(
+                label: loc.folderPickerRoot,
+                hierarchy: PregoButtonsSolidHierarchy.secondary,
+                size: PregoButtonsSolidSize.sm,
+                onPressed: onNavigateRoot,
+              ),
+            ],
+          ),
+          const SizedBox(height: PregoSpacing.xl),
+          Row(
+            children: [
+              Semantics(
+                label: loc.parentDirectory,
+                child: PregoButtonsSolid.iconOnly(
+                  leadingIcon: TablerRegular.arrow_up,
+                  hierarchy: PregoButtonsSolidHierarchy.secondary,
+                  size: PregoButtonsSolidSize.lg,
+                  onPressed: onNavigateUp,
+                ),
+              ),
+              const SizedBox(width: PregoSpacing.lg),
+              Expanded(
+                child: Text(
+                  "..$currentPath",
+                  style: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textPrimary),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
 
 /// One folder in the browser: its name, a tag when it already holds a git
 /// repository, and a chevron into it.
 class const _FolderTile({
   required final FilesystemSuggestion entry,
-  required final String? semanticLabel,
   required final VoidCallback onTap,
 }) extends StatelessWidget {
   @override
@@ -464,7 +503,6 @@ class const _FolderTile({
 
     return MergeSemantics(
       child: Semantics(
-        label: semanticLabel,
         button: true,
         child: InkWell(
           onTap: onTap,
@@ -496,14 +534,11 @@ class const _FolderTile({
                         // Yields to the tag, so a long folder name ellipsizes
                         // instead of pushing the tag off the row.
                         Flexible(
-                          child: ExcludeSemantics(
-                            excluding: semanticLabel != null,
-                            child: Text(
-                              entry.name,
-                              style: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textPrimary),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            ),
+                          child: Text(
+                            entry.name,
+                            style: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textPrimary),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
                           ),
                         ),
                         if (entry.isGitRepo) ...[

--- a/client/app/lib/features/project_list/add_project_dialog.dart
+++ b/client/app/lib/features/project_list/add_project_dialog.dart
@@ -430,6 +430,7 @@ class _AddProjectDialogState() extends State<AddProjectDialog> {
         final entry = _entries[index - (parentPath == null ? 0 : 1)];
         return _FolderTile(
           entry: entry,
+          semanticLabel: null,
           onTap: () => _navigateInto(path: entry.path),
         );
       },
@@ -439,6 +440,7 @@ class _AddProjectDialogState() extends State<AddProjectDialog> {
   Widget _buildParentEntry({required String path}) {
     return _FolderTile(
       entry: FilesystemSuggestion(path: path, name: "..", isGitRepo: false),
+      semanticLabel: context.loc.parentDirectory,
       onTap: _navigateUp,
     );
   }
@@ -450,8 +452,11 @@ class _AddProjectDialogState() extends State<AddProjectDialog> {
 
 /// One folder in the browser: its name, a tag when it already holds a git
 /// repository, and a chevron into it.
-class const _FolderTile({required final FilesystemSuggestion entry, required final VoidCallback onTap})
-    extends StatelessWidget {
+class const _FolderTile({
+  required final FilesystemSuggestion entry,
+  required final String? semanticLabel,
+  required final VoidCallback onTap,
+}) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
@@ -459,6 +464,7 @@ class const _FolderTile({required final FilesystemSuggestion entry, required fin
 
     return MergeSemantics(
       child: Semantics(
+        label: semanticLabel,
         button: true,
         child: InkWell(
           onTap: onTap,
@@ -490,11 +496,14 @@ class const _FolderTile({required final FilesystemSuggestion entry, required fin
                         // Yields to the tag, so a long folder name ellipsizes
                         // instead of pushing the tag off the row.
                         Flexible(
-                          child: Text(
-                            entry.name,
-                            style: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textPrimary),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
+                          child: ExcludeSemantics(
+                            excluding: semanticLabel != null,
+                            child: Text(
+                              entry.name,
+                              style: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textPrimary),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
                           ),
                         ),
                         if (entry.isGitRepo) ...[

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -766,7 +766,15 @@
   "emptyDirectory": "This directory is empty",
   "parentDirectory": "Parent directory",
   "@parentDirectory": {
-    "description": "Accessibility label for the '..' row that navigates to the parent folder in the add-project browser."
+    "description": "Accessibility label for the arrow button that navigates to the parent folder in the add-project browser."
+  },
+  "folderPickerHome": "~ Home",
+  "@folderPickerHome": {
+    "description": "Shortcut button that jumps to the host user's home directory in the add-project browser."
+  },
+  "folderPickerRoot": "/ Root",
+  "@folderPickerRoot": {
+    "description": "Shortcut button that jumps to the host filesystem root in the add-project browser."
   },
   "fetchDirectoryFailed": "Could not load directory contents",
   "fetchDirectoryRetry": "Retry",

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -764,6 +764,10 @@
   "newFolderFailed": "Could not create the folder",
   "newFolderUnsupported": "Update Sesori Bridge on your computer to create folders from here.",
   "emptyDirectory": "This directory is empty",
+  "parentDirectory": "Parent directory",
+  "@parentDirectory": {
+    "description": "Accessibility label for the '..' row that navigates to the parent folder in the add-project browser."
+  },
   "fetchDirectoryFailed": "Could not load directory contents",
   "fetchDirectoryRetry": "Retry",
   "gitRepoBadge": "Git",

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -2491,11 +2491,23 @@ abstract class AppLocalizations {
   /// **'This directory is empty'**
   String get emptyDirectory;
 
-  /// Accessibility label for the '..' row that navigates to the parent folder in the add-project browser.
+  /// Accessibility label for the arrow button that navigates to the parent folder in the add-project browser.
   ///
   /// In en, this message translates to:
   /// **'Parent directory'**
   String get parentDirectory;
+
+  /// Shortcut button that jumps to the host user's home directory in the add-project browser.
+  ///
+  /// In en, this message translates to:
+  /// **'~ Home'**
+  String get folderPickerHome;
+
+  /// Shortcut button that jumps to the host filesystem root in the add-project browser.
+  ///
+  /// In en, this message translates to:
+  /// **'/ Root'**
+  String get folderPickerRoot;
 
   /// No description provided for @fetchDirectoryFailed.
   ///

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -2491,6 +2491,12 @@ abstract class AppLocalizations {
   /// **'This directory is empty'**
   String get emptyDirectory;
 
+  /// Accessibility label for the '..' row that navigates to the parent folder in the add-project browser.
+  ///
+  /// In en, this message translates to:
+  /// **'Parent directory'**
+  String get parentDirectory;
+
   /// No description provided for @fetchDirectoryFailed.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -1313,6 +1313,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get parentDirectory => 'Parent directory';
 
   @override
+  String get folderPickerHome => '~ Home';
+
+  @override
+  String get folderPickerRoot => '/ Root';
+
+  @override
   String get fetchDirectoryFailed => 'Could not load directory contents';
 
   @override

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -1310,6 +1310,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get emptyDirectory => 'This directory is empty';
 
   @override
+  String get parentDirectory => 'Parent directory';
+
+  @override
   String get fetchDirectoryFailed => 'Could not load directory contents';
 
   @override

--- a/client/app/test/features/project_list/add_project_dialog_test.dart
+++ b/client/app/test/features/project_list/add_project_dialog_test.dart
@@ -163,6 +163,9 @@ final Finder _addButton = find.widgetWithText(PregoButtonsSolid, "Add as new pro
 /// glyph that carries it.
 final Finder _createFolderButton = find.widgetWithIcon(PregoButtonsSolid, TablerRegular.folder_plus);
 
+/// The hierarchy control that navigates to the parent directory.
+final Finder _navigateUpButton = find.widgetWithIcon(PregoButtonsSolid, TablerRegular.arrow_up);
+
 /// The action-menu button [finder] resolves to, for asserting on its enabled
 /// state.
 PregoButtonsSolid _button(WidgetTester tester, Finder finder) => tester.widget<PregoButtonsSolid>(finder);
@@ -246,7 +249,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Single view — the bridge-returned host path heads the listing.
-      expect(find.text(_homePath), findsOneWidget);
+      expect(find.text("..$_homePath"), findsOneWidget);
       expect(find.text("projects"), findsOneWidget);
       expect(find.text("Add as new project"), findsOneWidget);
     });
@@ -381,7 +384,7 @@ void main() {
       expect(_createFolderButton, findsOneWidget);
     });
 
-    testWidgets("starting folder uses its host path and remains navigable and writable", (tester) async {
+    testWidgets("starting folder shows hierarchy shortcuts and remains navigable and writable", (tester) async {
       _stubSuggestionsPerPrefix(
         mockCubit,
         byPrefix: {
@@ -409,14 +412,16 @@ void main() {
 
       // The path comes from the bridge response, so it is bound to the host
       // serving the filesystem request.
-      expect(find.text(_homePath), findsOneWidget);
+      expect(find.text("..$_homePath"), findsOneWidget);
       expect(find.byIcon(TablerRegular.arrow_left), findsNothing);
-      expect(find.text(".."), findsOneWidget);
+      expect(_navigateUpButton, findsOneWidget);
+      expect(find.widgetWithText(PregoButtonsSolid, "~ Home"), findsOneWidget);
+      expect(find.widgetWithText(PregoButtonsSolid, "/ Root"), findsOneWidget);
 
       expect(_button(tester, _addButton).onPressed, isNotNull);
       expect(_button(tester, _createFolderButton).onPressed, isNotNull);
 
-      await tester.tap(find.text(".."));
+      await tester.tap(_navigateUpButton);
       await tester.pumpAndSettle();
 
       verify(() => mockCubit.fetchFilesystemSuggestions(prefix: "/home")).called(1);
@@ -456,21 +461,18 @@ void main() {
       expect(find.text("app-one"), findsOneWidget);
       expect(find.text("lib-two"), findsOneWidget);
       expect(find.text("work"), findsNothing);
-      // The bar follows the browser: the folder heads it, with the full host
-      // path below.
-      expect(find.text("projects"), findsOneWidget);
-      expect(find.text("/home/user/projects"), findsOneWidget);
+      expect(find.text("../home/user/projects"), findsOneWidget);
       expect(find.byIcon(TablerRegular.arrow_left), findsNothing);
-      expect(find.text(".."), findsOneWidget);
-      expect(tester.getSemantics(find.text("..")).label, "Parent directory");
+      expect(_navigateUpButton, findsOneWidget);
+      expect(tester.getSemantics(find.byIcon(TablerRegular.arrow_up)).label, contains("Parent directory"));
       expect(
-        tester.getTopLeft(find.text("..")).dy,
+        tester.getTopLeft(_navigateUpButton).dy,
         lessThan(tester.getTopLeft(find.text("app-one")).dy),
       );
       semantics.dispose();
     });
 
-    testWidgets("parent directory entry navigates up one directory level", (tester) async {
+    testWidgets("up arrow navigates up one directory level", (tester) async {
       _stubSuggestionsPerPrefix(
         mockCubit,
         byPrefix: {
@@ -505,15 +507,68 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text("app-one"), findsOneWidget);
 
-      await tester.tap(find.text(".."));
+      await tester.tap(_navigateUpButton);
       await tester.pumpAndSettle();
 
       expect(find.text("projects"), findsOneWidget);
       expect(find.text("work"), findsOneWidget);
       // The starting folder is only the initial location; its parent remains
-      // reachable through the first list row.
-      expect(find.text(".."), findsOneWidget);
+      // reachable through the hierarchy control.
+      expect(_navigateUpButton, findsOneWidget);
       expect(find.byIcon(TablerRegular.arrow_left), findsNothing);
+    });
+
+    testWidgets("Home and Root pills jump to their host directories", (tester) async {
+      const rootEntries = [
+        FilesystemSuggestion(path: "/home", name: "home", isGitRepo: false),
+      ];
+      _stubSuggestionsPerPrefix(
+        mockCubit,
+        byPrefix: {
+          "": _homeDirEntries,
+          "/home/user/projects": _projectsDirEntries,
+          _homePath: _homeDirEntries,
+          "/": rootEntries,
+        },
+      );
+      when(() => mockCubit.parentHostPath(path: "/home/user/projects")).thenReturn(_homePath);
+      when(() => mockCubit.parentHostPath(path: _homePath)).thenReturn("/home");
+      when(() => mockCubit.parentHostPath(path: "/home")).thenReturn("/");
+      when(() => mockCubit.parentHostPath(path: "/")).thenReturn(null);
+
+      await tester.pumpWidget(
+        _buildApp(
+          cubit: mockCubit,
+          child: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => showAddProjectDialog(context, mockCubit),
+                child: const Text("Open"),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text("Open"));
+      await tester.pumpAndSettle();
+
+      final homeButton = find.widgetWithText(PregoButtonsSolid, "~ Home");
+      final rootButton = find.widgetWithText(PregoButtonsSolid, "/ Root");
+      expect(tester.getTopLeft(homeButton).dy, lessThan(tester.getTopLeft(_navigateUpButton).dy));
+
+      await tester.tap(find.text("projects"));
+      await tester.pumpAndSettle();
+      expect(_button(tester, homeButton).onPressed, isNotNull);
+
+      await tester.tap(homeButton);
+      await tester.pumpAndSettle();
+      expect(find.text("..$_homePath"), findsOneWidget);
+
+      await tester.tap(rootButton);
+      await tester.pumpAndSettle();
+      expect(find.text("home"), findsOneWidget);
+      expect(find.text("../"), findsOneWidget);
+      expect(_button(tester, rootButton).onPressed, isNull);
     });
 
     testWidgets("a listing that lands after stepping back out is ignored", (tester) async {
@@ -550,7 +605,7 @@ void main() {
 
       await tester.tap(find.text("projects"));
       await tester.pump();
-      await tester.tap(find.text(".."));
+      await tester.tap(_navigateUpButton);
       await tester.pumpAndSettle();
 
       projectsListing.complete(
@@ -562,7 +617,7 @@ void main() {
 
       expect(find.text("app-one"), findsNothing);
       expect(find.text("work"), findsOneWidget);
-      expect(find.text(_homePath), findsOneWidget);
+      expect(find.text("..$_homePath"), findsOneWidget);
     });
 
     testWidgets("Add as new project calls discoverProject with browsed path", (tester) async {
@@ -842,8 +897,7 @@ void main() {
           gitAction: any(named: "gitAction"),
         ),
       );
-      expect(find.text("new-app"), findsOneWidget);
-      expect(find.text(newFolderPath), findsOneWidget);
+      expect(find.text("..$newFolderPath"), findsOneWidget);
       expect(find.text("This directory is empty"), findsOneWidget);
     });
 

--- a/client/app/test/features/project_list/add_project_dialog_test.dart
+++ b/client/app/test/features/project_list/add_project_dialog_test.dart
@@ -423,6 +423,7 @@ void main() {
     });
 
     testWidgets("tapping a directory entry navigates into it", (tester) async {
+      final semantics = tester.ensureSemantics();
       _stubSuggestionsPerPrefix(
         mockCubit,
         byPrefix: {
@@ -461,10 +462,12 @@ void main() {
       expect(find.text("/home/user/projects"), findsOneWidget);
       expect(find.byIcon(TablerRegular.arrow_left), findsNothing);
       expect(find.text(".."), findsOneWidget);
+      expect(tester.getSemantics(find.text("..")).label, "Parent directory");
       expect(
         tester.getTopLeft(find.text("..")).dy,
         lessThan(tester.getTopLeft(find.text("app-one")).dy),
       );
+      semantics.dispose();
     });
 
     testWidgets("parent directory entry navigates up one directory level", (tester) async {

--- a/client/app/test/features/project_list/add_project_dialog_test.dart
+++ b/client/app/test/features/project_list/add_project_dialog_test.dart
@@ -410,12 +410,13 @@ void main() {
       // The path comes from the bridge response, so it is bound to the host
       // serving the filesystem request.
       expect(find.text(_homePath), findsOneWidget);
-      expect(find.byIcon(TablerRegular.arrow_left), findsOneWidget);
+      expect(find.byIcon(TablerRegular.arrow_left), findsNothing);
+      expect(find.text(".."), findsOneWidget);
 
       expect(_button(tester, _addButton).onPressed, isNotNull);
       expect(_button(tester, _createFolderButton).onPressed, isNotNull);
 
-      await tester.tap(find.byIcon(TablerRegular.arrow_left));
+      await tester.tap(find.text(".."));
       await tester.pumpAndSettle();
 
       verify(() => mockCubit.fetchFilesystemSuggestions(prefix: "/home")).called(1);
@@ -458,10 +459,15 @@ void main() {
       // path below.
       expect(find.text("projects"), findsOneWidget);
       expect(find.text("/home/user/projects"), findsOneWidget);
-      expect(find.byIcon(TablerRegular.arrow_left), findsOneWidget);
+      expect(find.byIcon(TablerRegular.arrow_left), findsNothing);
+      expect(find.text(".."), findsOneWidget);
+      expect(
+        tester.getTopLeft(find.text("..")).dy,
+        lessThan(tester.getTopLeft(find.text("app-one")).dy),
+      );
     });
 
-    testWidgets("back button navigates up one directory level", (tester) async {
+    testWidgets("parent directory entry navigates up one directory level", (tester) async {
       _stubSuggestionsPerPrefix(
         mockCubit,
         byPrefix: {
@@ -496,14 +502,15 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text("app-one"), findsOneWidget);
 
-      await tester.tap(find.byIcon(TablerRegular.arrow_left));
+      await tester.tap(find.text(".."));
       await tester.pumpAndSettle();
 
       expect(find.text("projects"), findsOneWidget);
       expect(find.text("work"), findsOneWidget);
       // The starting folder is only the initial location; its parent remains
-      // reachable.
-      expect(find.byIcon(TablerRegular.arrow_left), findsOneWidget);
+      // reachable through the first list row.
+      expect(find.text(".."), findsOneWidget);
+      expect(find.byIcon(TablerRegular.arrow_left), findsNothing);
     });
 
     testWidgets("a listing that lands after stepping back out is ignored", (tester) async {
@@ -539,8 +546,8 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.tap(find.text("projects"));
-      await tester.pumpAndSettle();
-      await tester.tap(find.byIcon(TablerRegular.arrow_left));
+      await tester.pump();
+      await tester.tap(find.text(".."));
       await tester.pumpAndSettle();
 
       projectsListing.complete(

--- a/client/app/test/features/project_list/connected_empty_view_test.dart
+++ b/client/app/test/features/project_list/connected_empty_view_test.dart
@@ -156,6 +156,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(AddProjectDialog), findsOneWidget);
-    expect(find.text("Add Project"), findsOneWidget);
+    expect(find.text("This directory is empty"), findsOneWidget);
+    expect(find.text("Add Project"), findsNothing);
   });
 }

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -23,9 +23,13 @@ child sessions with titles, activity, statuses, and unseen state.
   existing binding applies; discovery after a move therefore creates a new project
   rather than mutating the old one. An unknown catalog identifier is never
   interpreted as a path.
-- Opening validates the path and surfaces the git-initialization choice. Hiding
-  delists without destroying sessions or history. Import is explicit, per
-  plugin, atomic, non-destructive, cancellable, and attributes progress.
+- Opening validates the path and surfaces the git-initialization choice. The
+  add-project folder browser keeps hierarchy controls above the folder rows: an
+  up arrow moves to the parent, while Home and Root shortcuts jump to the host
+  user's home directory and filesystem root. Those controls remain available
+  while a navigated directory loads or reports an access failure. Hiding delists
+  without destroying sessions or history. Import is explicit, per plugin,
+  atomic, non-destructive, cancellable, and attributes progress.
 - A completed import reports both the totals it published and, separately, how
   much of that was new. The two are not interchangeable: a re-import of an
   unchanged catalog still publishes every row, so the totals stay at the full
@@ -321,6 +325,7 @@ leave the surface that started one. Restore harness eligibility afterwards.
   `client/module_prego/test/components/prego_sliver_refresh_control_test.dart`,
   `client/app/test/core/extensions/build_context_x_test.dart`,
   `client/app/test/core/widgets/catalog_scan_row_test.dart`,
+  `client/app/test/features/project_list/add_project_dialog_test.dart`,
   `client/app/test/features/project_list/project_list_catalog_scan_test.dart`,
   `client/app/test/features/session_list/session_list_bar_test.dart`, and
   `client/app/test/features/session_list/session_list_panel_test.dart`


### PR DESCRIPTION
## Complexity

🌿 Straightforward — localized project-picker navigation, styling, and widget-test updates.

## What

- Removed the picker header back button and title.
- Added hierarchy controls above the folder list: an up-arrow button, `~ Home`, and `/ Root` shortcuts.
- Kept hierarchy controls available while a directory is loading or showing an access error.
- Added localized labels, regression documentation, and focused widget coverage.

## Why

Folder navigation should match the updated Figma design and provide direct access to the host user's home directory and filesystem root.

## Risk and test focus

Low UI-navigation risk. Focused tests cover entering folders, navigating upward, Home/Root jumps, stale in-flight listings, shortcut ordering, and accessibility. The design was also exercised on an iPhone 15 Pro Max against a connected macOS bridge. There is no database impact.

## Expected result

Users navigate upward with the hierarchy arrow or jump directly to Home or Root using the pills above the folder list. The picker no longer displays a header back button or a synthetic `..` folder row.

## Verification

- `flutter test test/features/project_list/add_project_dialog_test.dart`
- `dart analyze lib/features/project_list/add_project_dialog.dart test/features/project_list/add_project_dialog_test.dart`
- Mobile MCP on iPhone 15 Pro Max: opened the picker, navigated up, jumped to `/`, and returned to `/Users/habibi`
