### PR TITLE
⚙️ Update Pi runtime to v0.84.4 with early tool visibility

### DIFF
--- a/bridge/sesori_plugin_pi/lib/src/api/models/pi_assistant_delta.dart
+++ b/bridge/sesori_plugin_pi/lib/src/api/models/pi_assistant_delta.dart
@@ -3,12 +3,14 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "../../models/pi_assistant_stop_reason.dart";
 import "pi_frame_fields.dart";
 
-/// One `message_update.assistantMessageEvent` from Pi v0.84.1.
+/// One `message_update.assistantMessageEvent` from Pi v0.84.4.
 ///
-/// Pi strips the cumulative `partial` snapshot from these events before writing
-/// them to stdout, so a delta carries only its own increment. The full tool
-/// call is guaranteed at [PiToolCallEndDelta]; `message_end` stays the final
-/// authority for the whole message.
+/// Pi strips cumulative `partial` snapshots from these events before writing
+/// them to stdout, so a delta carries only its own increment. Since v0.84.3,
+/// `toolcall_start` also carries the tool id and name; the nullable fields keep
+/// the supported v0.84.1 floor working when an older binary omits them. The
+/// full tool call is guaranteed at [PiToolCallEndDelta]; `message_end` stays
+/// the final authority for the whole message.
 ///
 /// Wire scalars are nullable throughout: stdout is foreign input, and a frame
 /// that omits or mistypes one field must not take down the surrounding turn.
@@ -29,7 +31,12 @@ sealed class const PiAssistantDelta({
       "thinking_start" => PiThinkingStartDelta(contentIndex: index, raw: json),
       "thinking_delta" => PiThinkingDelta(contentIndex: index, delta: stringOrNull(json["delta"]), raw: json),
       "thinking_end" => PiThinkingEndDelta(contentIndex: index, content: stringOrNull(json["content"]), raw: json),
-      "toolcall_start" => PiToolCallStartDelta(contentIndex: index, raw: json),
+      "toolcall_start" => PiToolCallStartDelta(
+        contentIndex: index,
+        id: stringOrNull(json["id"]),
+        toolName: stringOrNull(json["toolName"]),
+        raw: json,
+      ),
       "toolcall_delta" => PiToolCallDelta(contentIndex: index, delta: stringOrNull(json["delta"]), raw: json),
       "toolcall_end" => PiToolCallEndDelta(
         contentIndex: index,
@@ -84,7 +91,14 @@ final class const PiThinkingDelta({required super.contentIndex, required final S
 final class const PiThinkingEndDelta({required super.contentIndex, required final String? content, required super.raw})
     extends PiIndexedDelta;
 
-final class const PiToolCallStartDelta({required super.contentIndex, required super.raw}) extends PiIndexedDelta;
+final class const PiToolCallStartDelta({
+  required super.contentIndex,
+
+  /// Pi v0.84.3+ sends stable metadata here without the cumulative snapshot.
+  required final String? id,
+  required final String? toolName,
+  required super.raw,
+}) extends PiIndexedDelta;
 
 /// A fragment of tool-call arguments. The complete call is only guaranteed at
 /// [PiToolCallEndDelta].

--- a/bridge/sesori_plugin_pi/lib/src/api/models/pi_assistant_delta.dart
+++ b/bridge/sesori_plugin_pi/lib/src/api/models/pi_assistant_delta.dart
@@ -2,6 +2,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 import "../../models/pi_assistant_stop_reason.dart";
 import "pi_frame_fields.dart";
+import "pi_tool_call_start_dto.dart";
 
 /// One `message_update.assistantMessageEvent` from Pi v0.84.4.
 ///
@@ -31,12 +32,7 @@ sealed class const PiAssistantDelta({
       "thinking_start" => PiThinkingStartDelta(contentIndex: index, raw: json),
       "thinking_delta" => PiThinkingDelta(contentIndex: index, delta: stringOrNull(json["delta"]), raw: json),
       "thinking_end" => PiThinkingEndDelta(contentIndex: index, content: stringOrNull(json["content"]), raw: json),
-      "toolcall_start" => PiToolCallStartDelta(
-        contentIndex: index,
-        id: stringOrNull(json["id"]),
-        toolName: stringOrNull(json["toolName"]),
-        raw: json,
-      ),
+      "toolcall_start" => _toolCallStartDelta(json: json),
       "toolcall_delta" => PiToolCallDelta(contentIndex: index, delta: stringOrNull(json["delta"]), raw: json),
       "toolcall_end" => PiToolCallEndDelta(
         contentIndex: index,
@@ -56,6 +52,16 @@ sealed class const PiAssistantDelta({
       _ => _unknownDelta(json),
     };
   }
+}
+
+PiToolCallStartDelta _toolCallStartDelta({required Map<String, Object?> json}) {
+  final decoded = PiToolCallStartDto.fromJson(json.cast<String, dynamic>());
+  return PiToolCallStartDelta(
+    contentIndex: decoded.contentIndex,
+    id: decoded.id,
+    toolName: decoded.toolName,
+    raw: json,
+  );
 }
 
 PiAssistantStopReason? _stopReason(String? value) {

--- a/bridge/sesori_plugin_pi/lib/src/api/models/pi_event.dart
+++ b/bridge/sesori_plugin_pi/lib/src/api/models/pi_event.dart
@@ -6,11 +6,12 @@ import "../../models/pi_thinking_level.dart";
 import "pi_assistant_delta.dart";
 import "pi_frame_fields.dart";
 
-/// One agent event from Pi v0.84.1's stdout event stream.
+/// One agent event from Pi v0.84.4's stdout event stream.
 ///
 /// Every known top-level event type is routed to a variant so no event silently
 /// becomes anonymous data; unknown types survive as [PiUnknownEvent] because Pi
 /// gains events between releases and a strict parser would drop a whole turn.
+/// The parser remains tolerant of the supported v0.84.1 PATH floor.
 ///
 /// Only Pi's own scalars are typed here. Message, entry, tool, and result
 /// payloads stay raw maps until the step that consumes them adds their DTOs.
@@ -161,8 +162,7 @@ final class const PiMessageStartEvent({required final Map<String, Object?> messa
 final class const PiMessageUpdateEvent({required final PiAssistantDelta delta, required super.raw}) extends PiEvent;
 
 /// The final authority for one message.
-final class const PiMessageEndEvent({required final Map<String, Object?> message, required super.raw})
-    extends PiEvent;
+final class const PiMessageEndEvent({required final Map<String, Object?> message, required super.raw}) extends PiEvent;
 
 final class const PiToolExecutionStartEvent({
   required final String? toolCallId,
@@ -215,8 +215,7 @@ final class const PiCompactionEndEvent({
 }) extends PiEvent;
 
 /// A session entry was persisted. The entry stays raw until history mapping.
-final class const PiEntryAppendedEvent({required final Map<String, Object?> entry, required super.raw})
-    extends PiEvent;
+final class const PiEntryAppendedEvent({required final Map<String, Object?> entry, required super.raw}) extends PiEvent;
 
 /// The explicit session name changed. Null means the name was cleared.
 final class const PiSessionInfoChangedEvent({required final String? name, required super.raw}) extends PiEvent;

--- a/bridge/sesori_plugin_pi/lib/src/api/models/pi_tool_call_start_dto.dart
+++ b/bridge/sesori_plugin_pi/lib/src/api/models/pi_tool_call_start_dto.dart
@@ -1,0 +1,22 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+import "pi_frame_fields.dart";
+
+part "pi_tool_call_start_dto.freezed.dart";
+part "pi_tool_call_start_dto.g.dart";
+
+/// The typed wire shape introduced for Pi's `toolcall_start` delta.
+///
+/// The converters retain the transport boundary's tolerant behavior: Pi is a
+/// foreign process, so malformed optional scalars become null instead of
+/// aborting the surrounding turn.
+@Freezed(fromJson: true, toJson: false, toStringOverride: false)
+sealed class PiToolCallStartDto with _$PiToolCallStartDto {
+  const factory({
+    @JsonKey(fromJson: intOrNull) required int? contentIndex,
+    @JsonKey(fromJson: stringOrNull) required String? id,
+    @JsonKey(fromJson: stringOrNull) required String? toolName,
+  }) = _PiToolCallStartDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$PiToolCallStartDtoFromJson(json);
+}

--- a/bridge/sesori_plugin_pi/lib/src/api/models/pi_tool_call_start_dto.freezed.dart
+++ b/bridge/sesori_plugin_pi/lib/src/api/models/pi_tool_call_start_dto.freezed.dart
@@ -1,0 +1,142 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint, type=warning, deprecated_member_use, deprecated_member_use_from_same_package
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'pi_tool_call_start_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PiToolCallStartDto {
+
+@JsonKey(fromJson: intOrNull) int? get contentIndex;@JsonKey(fromJson: stringOrNull) String? get id;@JsonKey(fromJson: stringOrNull) String? get toolName;
+/// Create a copy of PiToolCallStartDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PiToolCallStartDtoCopyWith<PiToolCallStartDto> get copyWith => _$PiToolCallStartDtoCopyWithImpl<PiToolCallStartDto>(this as PiToolCallStartDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PiToolCallStartDto&&(identical(other.contentIndex, contentIndex) || other.contentIndex == contentIndex)&&(identical(other.id, id) || other.id == id)&&(identical(other.toolName, toolName) || other.toolName == toolName));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,contentIndex,id,toolName);
+
+
+
+}
+
+/// @nodoc
+abstract mixin class $PiToolCallStartDtoCopyWith<$Res>  {
+  factory $PiToolCallStartDtoCopyWith(PiToolCallStartDto value, $Res Function(PiToolCallStartDto) _then) = _$PiToolCallStartDtoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(fromJson: intOrNull) int? contentIndex,@JsonKey(fromJson: stringOrNull) String? id,@JsonKey(fromJson: stringOrNull) String? toolName
+});
+
+
+
+
+}
+/// @nodoc
+class _$PiToolCallStartDtoCopyWithImpl<$Res>
+    implements $PiToolCallStartDtoCopyWith<$Res> {
+  _$PiToolCallStartDtoCopyWithImpl(this._self, this._then);
+
+  final PiToolCallStartDto _self;
+  final $Res Function(PiToolCallStartDto) _then;
+
+/// Create a copy of PiToolCallStartDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? contentIndex = freezed,Object? id = freezed,Object? toolName = freezed,}) {
+  return _then(PiToolCallStartDto(
+contentIndex: freezed == contentIndex ? _self.contentIndex : contentIndex // ignore: cast_nullable_to_non_nullable
+as int?,id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,toolName: freezed == toolName ? _self.toolName : toolName // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _PiToolCallStartDto implements PiToolCallStartDto {
+  const _PiToolCallStartDto({@JsonKey(fromJson: intOrNull) required this.contentIndex, @JsonKey(fromJson: stringOrNull) required this.id, @JsonKey(fromJson: stringOrNull) required this.toolName});
+  factory _PiToolCallStartDto.fromJson(Map<String, dynamic> json) => _$PiToolCallStartDtoFromJson(json);
+
+@override@JsonKey(fromJson: intOrNull) final  int? contentIndex;
+@override@JsonKey(fromJson: stringOrNull) final  String? id;
+@override@JsonKey(fromJson: stringOrNull) final  String? toolName;
+
+/// Create a copy of PiToolCallStartDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PiToolCallStartDtoCopyWith<_PiToolCallStartDto> get copyWith => __$PiToolCallStartDtoCopyWithImpl<_PiToolCallStartDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PiToolCallStartDto&&(identical(other.contentIndex, contentIndex) || other.contentIndex == contentIndex)&&(identical(other.id, id) || other.id == id)&&(identical(other.toolName, toolName) || other.toolName == toolName));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,contentIndex,id,toolName);
+
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PiToolCallStartDtoCopyWith<$Res> implements $PiToolCallStartDtoCopyWith<$Res> {
+  factory _$PiToolCallStartDtoCopyWith(_PiToolCallStartDto value, $Res Function(_PiToolCallStartDto) _then) = __$PiToolCallStartDtoCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(fromJson: intOrNull) int? contentIndex,@JsonKey(fromJson: stringOrNull) String? id,@JsonKey(fromJson: stringOrNull) String? toolName
+});
+
+
+
+
+}
+/// @nodoc
+class __$PiToolCallStartDtoCopyWithImpl<$Res>
+    implements _$PiToolCallStartDtoCopyWith<$Res> {
+  __$PiToolCallStartDtoCopyWithImpl(this._self, this._then);
+
+  final _PiToolCallStartDto _self;
+  final $Res Function(_PiToolCallStartDto) _then;
+
+/// Create a copy of PiToolCallStartDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? contentIndex = freezed,Object? id = freezed,Object? toolName = freezed,}) {
+  return _then(_PiToolCallStartDto(
+contentIndex: freezed == contentIndex ? _self.contentIndex : contentIndex // ignore: cast_nullable_to_non_nullable
+as int?,id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,toolName: freezed == toolName ? _self.toolName : toolName // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/sesori_plugin_pi/lib/src/api/models/pi_tool_call_start_dto.g.dart
+++ b/bridge/sesori_plugin_pi/lib/src/api/models/pi_tool_call_start_dto.g.dart
@@ -1,0 +1,14 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pi_tool_call_start_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PiToolCallStartDto _$PiToolCallStartDtoFromJson(Map json) =>
+    _PiToolCallStartDto(
+      contentIndex: intOrNull(json['contentIndex']),
+      id: stringOrNull(json['id']),
+      toolName: stringOrNull(json['toolName']),
+    );

--- a/bridge/sesori_plugin_pi/lib/src/runtime/pi_runtime_manifest.dart
+++ b/bridge/sesori_plugin_pi/lib/src/runtime/pi_runtime_manifest.dart
@@ -10,7 +10,7 @@ class const PiRuntimeManifest() extends RuntimeManifest {
   static final SemanticRuntimeVersion _minPathVersion = SemanticRuntimeVersion.parse(value: "0.84.1");
 
   /// The latest stable Pi release targeted by this plugin.
-  static const String targetVersion = "0.84.2";
+  static const String targetVersion = "0.84.4";
 
   static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: targetVersion);
 
@@ -19,14 +19,14 @@ class const PiRuntimeManifest() extends RuntimeManifest {
       PlatformArch.arm64: ArchiveRuntimeAsset(
         assetName: "pi-darwin-arm64.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "c996e888b7f7dce44bcf24f69176ac646c44139d3916bd49a6b28e5a8c5e3a65",
+        sha256: "c68e3ac4d05b4e282aaab2e6c76f161d3e9e68f19a22e38913cbfaadb6c800f0",
         archiveBinaryName: "pi",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
         assetName: "pi-darwin-x64.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "808cf02a93cd601d3ea05d47dc15c45074b120ac81decc8644cd3e40a35824e6",
+        sha256: "7a042d6413065421387001a4986190a1a03186c95a695f4dee0bdc76e60de8f7",
         archiveBinaryName: "pi",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
@@ -35,14 +35,14 @@ class const PiRuntimeManifest() extends RuntimeManifest {
       PlatformArch.arm64: ArchiveRuntimeAsset(
         assetName: "pi-linux-arm64.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "d15372da9e4b4c5fef9fd15bed76d7f5f1720dd39fe7cde0ec62e5b65ad63ef1",
+        sha256: "135580f6b942151646e67b8b866d987d28ce3cff5a497030775ddd29659f943d",
         archiveBinaryName: "pi",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
         assetName: "pi-linux-x64.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "906fbe787fd225c4ac624fe7ebd5b1d55a60e0f5c7ef51795d231564f9ee1c13",
+        sha256: "c2f3c3e6a1850bd87654cc3ca8811013272397c3d042a4e2a64c43ee1b423972",
         archiveBinaryName: "pi",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
@@ -51,14 +51,14 @@ class const PiRuntimeManifest() extends RuntimeManifest {
       PlatformArch.arm64: ArchiveRuntimeAsset(
         assetName: "pi-windows-arm64.zip",
         format: ArchiveFormat.zip,
-        sha256: "092e2b276e0066efcb3d860465591c2e32ea48ee90395d34ceda0d84d8ff4470",
+        sha256: "6b2726efc34a9158ab06bf7b981f7bcccf15de9ea236a3f4ef7a894a78aa386e",
         archiveBinaryName: "pi.exe",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
         assetName: "pi-windows-x64.zip",
         format: ArchiveFormat.zip,
-        sha256: "741fc1ae1afecb573ac2888e011188ff446b3940f4aabe1583f60bf55be8a3d0",
+        sha256: "03b2318774f18721e959d9f8f3340a9f942e7aa516fb7030d3007a12a40a4a97",
         archiveBinaryName: "pi.exe",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
@@ -220,6 +220,13 @@ final class PiEventDispatcher({
         content: content,
         type: PluginMessagePartType.reasoning,
       ),
+      PiToolCallStartDelta(:final contentIndex, :final id, :final toolName) => _toolCallStart(
+        sessionId: sessionId,
+        state: state,
+        contentIndex: contentIndex,
+        toolId: id,
+        toolName: toolName,
+      ),
       PiToolCallEndDelta(:final contentIndex, :final toolCall) => _toolCall(
         sessionId: sessionId,
         state: state,
@@ -227,7 +234,6 @@ final class PiEventDispatcher({
         toolCall: toolCall,
       ),
       PiMessageStartDelta() ||
-      PiToolCallStartDelta() ||
       PiToolCallDelta() ||
       PiAssistantDoneDelta() ||
       PiAssistantErrorDelta() ||
@@ -456,6 +462,29 @@ final class PiEventDispatcher({
     ];
   }
 
+  List<BridgeSseEvent> _toolCallStart({
+    required String sessionId,
+    required _SessionState state,
+    required int? contentIndex,
+    required String? toolId,
+    required String? toolName,
+  }) {
+    if (contentIndex == null || contentIndex < 0) return const [];
+    if (state.messageId == null) return const [];
+    if (toolId == null || toolName == null || toolId.isEmpty || toolName.isEmpty) {
+      // COMPATIBILITY 2026-08-31 (v1.8.3): Pi <= 0.84.2 omits toolcall_start
+      // metadata; keep waiting for toolcall_end. Remove this fallback when
+      // PiRuntimeManifest.minPathVersion is raised to 0.84.3.
+      return const [];
+    }
+    return _emitToolCall(
+      sessionId: sessionId,
+      state: state,
+      toolId: toolId,
+      toolName: toolName,
+    );
+  }
+
   List<BridgeSseEvent> _toolCall({
     required String sessionId,
     required _SessionState state,
@@ -463,24 +492,40 @@ final class PiEventDispatcher({
     required Map<String, Object?> toolCall,
   }) {
     if (contentIndex == null || contentIndex < 0) return const [];
-    final messageId = state.messageId;
+    if (state.messageId == null) return const [];
     final decoded = _historyMapper.decodeToolCall(raw: toolCall);
-    if (messageId == null || decoded == null) return const [];
+    if (decoded == null) return const [];
+    return _emitToolCall(
+      sessionId: sessionId,
+      state: state,
+      toolId: decoded.id,
+      toolName: decoded.name,
+    );
+  }
+
+  List<BridgeSseEvent> _emitToolCall({
+    required String sessionId,
+    required _SessionState state,
+    required String toolId,
+    required String toolName,
+  }) {
+    final messageId = state.messageId;
+    if (messageId == null) return const [];
     final tool = _tools.pending(
       sessionId: sessionId,
       messageId: messageId,
-      toolId: decoded.id,
-      name: decoded.name,
+      toolId: toolId,
+      name: toolName,
     );
-    if (tool != null) state.emittedPartIds.add(tool.id);
-    return tool == null
-        ? const []
-        : [
-            ..._announce(sessionId: sessionId, state: state),
-            BridgeSseMessagePartUpdated(
-              part: _toolPart(sessionId: sessionId, tool: tool),
-            ),
-          ];
+    // The start event already announced this part; the terminal delta adds no
+    // new display state. `message_end` remains authoritative and reconciles it.
+    if (tool == null || !state.emittedPartIds.add(tool.id)) return const [];
+    return [
+      ..._announce(sessionId: sessionId, state: state),
+      BridgeSseMessagePartUpdated(
+        part: _toolPart(sessionId: sessionId, tool: tool),
+      ),
+    ];
   }
 
   List<BridgeSseEvent> _toolRunning({

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
@@ -478,6 +478,7 @@ final class PiEventDispatcher({
     return _emitToolCall(
       sessionId: sessionId,
       state: state,
+      contentIndex: contentIndex,
       toolId: toolId,
       toolName: toolName,
     );
@@ -496,6 +497,7 @@ final class PiEventDispatcher({
     return _emitToolCall(
       sessionId: sessionId,
       state: state,
+      contentIndex: contentIndex,
       toolId: decoded.id,
       toolName: decoded.name,
     );
@@ -504,11 +506,16 @@ final class PiEventDispatcher({
   List<BridgeSseEvent> _emitToolCall({
     required String sessionId,
     required _SessionState state,
+    required int contentIndex,
     required String toolId,
     required String toolName,
   }) {
     final messageId = state.messageId;
     if (messageId == null) return const [];
+    // The content index identifies the streamed block. Prefer it over the
+    // decoded ids because start metadata and the cumulative end payload must
+    // not produce two visible cards if an upstream id is normalized differently.
+    if (!state.emittedToolContentIndexes.add(contentIndex)) return const [];
     final tool = _tools.pending(
       sessionId: sessionId,
       messageId: messageId,
@@ -517,7 +524,11 @@ final class PiEventDispatcher({
     );
     // The start event already announced this part; the terminal delta adds no
     // new display state. `message_end` remains authoritative and reconciles it.
-    if (tool == null || !state.emittedPartIds.add(tool.id)) return const [];
+    if (tool == null) {
+      state.emittedToolContentIndexes.remove(contentIndex);
+      return const [];
+    }
+    state.emittedPartIds.add(tool.id);
     return [
       ..._announce(sessionId: sessionId, state: state),
       BridgeSseMessagePartUpdated(
@@ -731,6 +742,7 @@ final class _SessionState({required final PiMessageIdentityBuilder identities}) 
   bool announced = false;
   final Set<({int contentIndex, PluginMessagePartType type})> startedParts = {};
   final Set<String> emittedPartIds = {};
+  final Set<int> emittedToolContentIndexes = {};
   String? compactionMessageId;
 
   void clearMessage() {
@@ -739,6 +751,7 @@ final class _SessionState({required final PiMessageIdentityBuilder identities}) 
     announced = false;
     startedParts.clear();
     emittedPartIds.clear();
+    emittedToolContentIndexes.clear();
   }
 }
 

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
@@ -471,12 +471,10 @@ final class PiEventDispatcher({
   }) {
     if (contentIndex == null || contentIndex < 0) return const [];
     if (state.messageId == null) return const [];
-    if (toolId == null || toolName == null || toolId.isEmpty || toolName.isEmpty) {
-      // COMPATIBILITY 2026-08-31 (v1.8.3): Pi <= 0.84.2 omits toolcall_start
-      // metadata; keep waiting for toolcall_end. Remove this fallback when
-      // PiRuntimeManifest.minPathVersion is raised to 0.84.3.
-      return const [];
-    }
+    // COMPATIBILITY 2026-08-31 (v1.8.3): Pi <= 0.84.2 omits toolcall_start
+    // metadata; keep waiting for toolcall_end. Remove this fallback when
+    // PiRuntimeManifest.minPathVersion is raised to 0.84.3.
+    if (toolId == null || toolName == null || toolId.isEmpty || toolName.isEmpty) return const [];
     return _emitToolCall(
       sessionId: sessionId,
       state: state,

--- a/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
@@ -126,6 +126,38 @@ void main() {
     expect(ended, isEmpty);
   });
 
+  test("correlates early and terminal tool visibility by content index", () {
+    dispatcher.map(
+      sessionId: sessionId,
+      event: _event("message_start", {"message": _assistant(content: const [], timestamp: 103)}),
+    );
+
+    final started = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("message_update", {
+        "assistantMessageEvent": {
+          "type": "toolcall_start",
+          "contentIndex": 0,
+          "id": "normalized-at-start",
+          "toolName": "write",
+        },
+      }),
+    );
+    expect(started.whereType<BridgeSseMessagePartUpdated>().single.part.id, "normalized-at-start");
+
+    final ended = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("message_update", {
+        "assistantMessageEvent": {
+          "type": "toolcall_end",
+          "contentIndex": 0,
+          "toolCall": {"id": "normalized-at-end", "name": "write", "arguments": <String, Object?>{}},
+        },
+      }),
+    );
+    expect(ended, isEmpty);
+  });
+
   test("legacy toolcall_start waits for toolcall_end metadata", () {
     dispatcher.map(
       sessionId: sessionId,

--- a/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
@@ -90,6 +90,71 @@ void main() {
     expect(finalEvents.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part), replay.parts);
   });
 
+  test("announces a pending tool at toolcall_start and avoids a duplicate at toolcall_end", () {
+    dispatcher.map(
+      sessionId: sessionId,
+      event: _event("message_start", {"message": _assistant(content: const [], timestamp: 101)}),
+    );
+
+    final started = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("message_update", {
+        "assistantMessageEvent": {
+          "type": "toolcall_start",
+          "contentIndex": 0,
+          "id": "call-start",
+          "toolName": "write",
+        },
+      }),
+    );
+    final part = started.whereType<BridgeSseMessagePartUpdated>().single.part;
+    expect(started.whereType<BridgeSseMessageUpdated>(), hasLength(1));
+    expect(part.id, "call-start");
+    expect(part.tool, "write");
+    expect(part.state.status, PluginToolStatus.pending);
+
+    final ended = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("message_update", {
+        "assistantMessageEvent": {
+          "type": "toolcall_end",
+          "contentIndex": 0,
+          "toolCall": {"id": "call-start", "name": "write", "arguments": <String, Object?>{}},
+        },
+      }),
+    );
+    expect(ended, isEmpty);
+  });
+
+  test("legacy toolcall_start waits for toolcall_end metadata", () {
+    dispatcher.map(
+      sessionId: sessionId,
+      event: _event("message_start", {"message": _assistant(content: const [], timestamp: 102)}),
+    );
+
+    expect(
+      dispatcher.map(
+        sessionId: sessionId,
+        event: _event("message_update", {
+          "assistantMessageEvent": {"type": "toolcall_start", "contentIndex": 0},
+        }),
+      ),
+      isEmpty,
+    );
+
+    final ended = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("message_update", {
+        "assistantMessageEvent": {
+          "type": "toolcall_end",
+          "contentIndex": 0,
+          "toolCall": {"id": "call-legacy", "name": "write", "arguments": <String, Object?>{}},
+        },
+      }),
+    );
+    expect(ended.whereType<BridgeSseMessagePartUpdated>().single.part.tool, "write");
+  });
+
   test("registering a steering prompt preserves the active assistant stream and prompt order", () {
     dispatcher.registerPrompt(
       sessionId: sessionId,

--- a/bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart
@@ -39,13 +39,13 @@ void main() {
       final processes = _Processes(
         outputs: const [
           _Output(stdout: "0.84.0\n", exitCode: 0),
-          _Output(stdout: "0.84.2\n", exitCode: 0),
+          _Output(stdout: "0.84.4\n", exitCode: 0),
         ],
       );
       final events = await PiPluginDescriptor.production().ensureRuntime(host: _Host(processes: processes)).toList();
 
-      expect((events.last as ProvisionReady).binaryPath, contains("/state/pi/0.84.2/pi"));
-      expect(processes.executables, ["pi", contains("/state/pi/0.84.2/pi")]);
+      expect((events.last as ProvisionReady).binaryPath, contains("/state/pi/0.84.4/pi"));
+      expect(processes.executables, ["pi", contains("/state/pi/0.84.4/pi")]);
     });
 
     test("inspectSetup checks only version and preserves the environment", () async {

--- a/bridge/sesori_plugin_pi/test/pi_rpc_frame_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_rpc_frame_test.dart
@@ -234,6 +234,32 @@ void main() {
       expect(routed.map((delta) => delta.runtimeType).toSet(), hasLength(routed.length));
     });
 
+    test("carries tool-call identity at toolcall_start", () {
+      final delta = parseDelta({
+        "type": "toolcall_start",
+        "contentIndex": 2,
+        "id": "call-1",
+        "toolName": "bash",
+      });
+
+      final start = delta as PiToolCallStartDelta;
+      expect(start.contentIndex, 2);
+      expect(start.id, "call-1");
+      expect(start.toolName, "bash");
+    });
+
+    test("keeps the legacy toolcall_start shape available for the compatibility fallback", () {
+      final delta = parseDelta({
+        "type": "toolcall_start",
+        "contentIndex": 2,
+      });
+
+      final start = delta as PiToolCallStartDelta;
+      expect(start.contentIndex, 2);
+      expect(start.id, isNull);
+      expect(start.toolName, isNull);
+    });
+
     test("carries the content index and the complete tool call at toolcall_end", () {
       final delta = parseDelta({
         "type": "toolcall_end",

--- a/bridge/sesori_plugin_pi/test/pi_rpc_frame_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_rpc_frame_test.dart
@@ -260,6 +260,20 @@ void main() {
       expect(start.toolName, isNull);
     });
 
+    test("tolerates malformed optional toolcall_start metadata", () {
+      final delta = parseDelta({
+        "type": "toolcall_start",
+        "contentIndex": "not-an-index",
+        "id": 42,
+        "toolName": false,
+      });
+
+      final start = delta as PiToolCallStartDelta;
+      expect(start.contentIndex, isNull);
+      expect(start.id, isNull);
+      expect(start.toolName, isNull);
+    });
+
     test("carries the content index and the complete tool call at toolcall_end", () {
       final delta = parseDelta({
         "type": "toolcall_end",

--- a/bridge/sesori_plugin_pi/test/pi_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_runtime_manifest_test.dart
@@ -8,14 +8,14 @@ import "package:test/test.dart";
 void main() {
   const manifest = PiRuntimeManifest();
 
-  test("keeps the verified PATH floor and pins managed Pi v0.84.2", () {
+  test("keeps the verified PATH floor and pins managed Pi v0.84.4", () {
     expect(manifest.runtimeId, "pi");
     expect(manifest.pathExecutableName, "pi");
     expect(manifest.binaryFileName, Platform.isWindows ? "pi.exe" : "pi");
     expect(manifest.minPathVersion.raw, "0.84.1");
-    expect(PiRuntimeManifest.targetVersion, "0.84.2");
+    expect(PiRuntimeManifest.targetVersion, "0.84.4");
     expect(manifest.bundledVersion.raw, PiRuntimeManifest.targetVersion);
-    expect(manifest.parseVersion(value: "0.84.2")?.raw, "0.84.2");
+    expect(manifest.parseVersion(value: "0.84.4")?.raw, "0.84.4");
     expect(manifest.parseVersion(value: "pi/0.84.2"), isNull);
   });
 
@@ -46,12 +46,17 @@ void main() {
         predicate<ArchiveRuntimeAsset>((asset) => asset.layout == RuntimeArchiveLayout.packageDirectory),
       ),
     );
-    expect(assets.map((asset) => asset.sha256).toSet(), hasLength(6));
+    const expectedSha256 = {
+      "pi-darwin-arm64.tar.gz": "c68e3ac4d05b4e282aaab2e6c76f161d3e9e68f19a22e38913cbfaadb6c800f0",
+      "pi-darwin-x64.tar.gz": "7a042d6413065421387001a4986190a1a03186c95a695f4dee0bdc76e60de8f7",
+      "pi-linux-arm64.tar.gz": "135580f6b942151646e67b8b866d987d28ce3cff5a497030775ddd29659f943d",
+      "pi-linux-x64.tar.gz": "c2f3c3e6a1850bd87654cc3ca8811013272397c3d042a4e2a64c43ee1b423972",
+      "pi-windows-arm64.zip": "6b2726efc34a9158ab06bf7b981f7bcccf15de9ea236a3f4ef7a894a78aa386e",
+      "pi-windows-x64.zip": "03b2318774f18721e959d9f8f3340a9f942e7aa516fb7030d3007a12a40a4a97",
+    };
     expect(
-      assets,
-      everyElement(
-        predicate<ArchiveRuntimeAsset>((asset) => RegExp(r"^[0-9a-f]{64}$").hasMatch(asset.sha256)),
-      ),
+      {for (final asset in assets) asset.assetName: asset.sha256},
+      expectedSha256,
     );
     expect(
       assets.take(4),
@@ -69,7 +74,7 @@ void main() {
     )!;
     expect(
       manifest.downloadUrlFor(asset: asset),
-      "https://github.com/earendil-works/pi/releases/download/v0.84.2/pi-darwin-arm64.tar.gz",
+      "https://github.com/earendil-works/pi/releases/download/v0.84.4/pi-darwin-arm64.tar.gz",
     );
   });
 }

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -101,15 +101,18 @@ reconnect or restart.
 - Pi live assistant finals use the same message identities, parts, bounded tool
   results, terminal failures, and visible compaction card as cold replay.
   Streaming text and reasoning follow their content indices, tool progress
-  replaces cumulative output, edit/write completion invalidates the diff once,
-  and only `agent_settled` marks the session idle.
+  replaces cumulative output, and Pi v0.84.3+ `toolcall_start` metadata
+  announces a pending tool before execution begins without duplicating it at
+  `toolcall_end`; older Pi output waits for the terminal tool-call metadata.
+  `message_end` remains authoritative, edit/write completion invalidates the
+  diff once, and only `agent_settled` marks the session idle.
 
 ## Regression Levels
 
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Headless bridge, one representative plugin: a previously synced session's transcript is served with every backend stopped. |
-| L2 Routine | Live plugin, representative: first backfill, replayed prompt-default persistence and response precedence, live capture that becomes immediately queryable, semantic identity reconciliation with ordered-context and multiplicity preservation (including normalized attachments), stale re-read ordering for retained live-only rows, and paging older messages on a transcript longer than one page. Automated OpenCode, Codex, Claude, and Pi coverage preserves available historical effort or thinking-level variants from assistant/error messages; Pi covers active-branch attribution and file fallback. Automated Pi coverage also includes v1-v3 fallback migration, compaction visibility, hidden-context decoding, bounded tool/image mapping, content-index streaming, cumulative tool updates, and live/replay final parity. |
+| L2 Routine | Live plugin, representative: first backfill, replayed prompt-default persistence and response precedence, live capture that becomes immediately queryable, semantic identity reconciliation with ordered-context and multiplicity preservation (including normalized attachments), stale re-read ordering for retained live-only rows, and paging older messages on a transcript longer than one page. Automated OpenCode, Codex, Claude, and Pi coverage preserves available historical effort or thinking-level variants from assistant/error messages; Pi covers active-branch attribution and file fallback. Automated Pi coverage also includes v1-v3 fallback migration, compaction visibility, hidden-context decoding, bounded tool/image mapping, content-index streaming, early tool-call metadata with the pre-0.84.3 fallback, duplicate terminal suppression, cumulative tool updates, and live/replay final parity. |
 | L3 Release | Client end to end on the release-target client platform, every supporting production plugin: open a long session, page back, continue a live turn, reopen cold, and confirm live and replayed content converge including tool parts and image parts where declared. Grok additionally retains its exact loaded model/effort attribution across first load, cold reopen, plugin restart, and bridge restart. |
 | L4 Extended | Relay integration plus owning client automated coverage, every supporting production plugin: session advanced through the backend's own CLI, plugin restart and event-stream-gap invalidation, bridge restart, client reconnect inside and outside the replay window without refresh losing concurrently finalized content, two clients on one session, a slow request beside unrelated traffic. Copilot and Grok additionally replace their ACP process, reload the same session, and converge standard replay with the bridge transcript without duplicate live delivery. |
 | L5 Full | Automated and headless bridge for unreadable or partial store artifacts, interrupted backfill, and startup reconciliation; packaged or external for pagination's released-client shape; live plugin for very large transcripts. Every supporting production plugin. |
@@ -152,9 +155,10 @@ rules where supported.
 - Pi falls back after an arbitrary RPC failure, shows an abandoned branch or
   summary payload, exposes a private persisted path or hidden prompt prefix, or
   rewrites backend-provided error text in mapped history.
-- A Pi streamed part changes identity when finalized, cumulative tool output is
-  appended, a duplicate terminal tool event repeats a diff invalidation, or
-  `agent_end` marks the session idle before `agent_settled`.
+- A Pi streamed part changes identity when finalized, a tool remains invisible
+  until execution ends despite valid start metadata, a duplicate terminal tool
+  event repeats the pending card or a diff invalidation, or `agent_end` marks
+  the session idle before `agent_settled`.
 - Buffered events are lost after a reconnect inside the replay window, or a slow
   request stalls other requests, plugins, or reconnects.
 - A Copilot restart prompts before `session/load`, duplicates replay as new live


### PR DESCRIPTION
## Complexity

Moderate: this combines a managed Pi artifact refresh with a small, backward-tolerant RPC event mapping change.

## What

- Pins the Pi managed runtime to stable `v0.84.4` and updates all six verified official asset digests.
- Preserves the `0.84.1` PATH minimum and complete package-directory archive layout.
- Parses nullable `toolcall_start` `id`/`toolName` metadata and publishes a pending tool before execution for Pi `v0.84.3+`.
- Suppresses the duplicate terminal tool announcement while retaining `message_end` as final authority.
- Keeps the legacy `toolcall_end` path for Pi `<= 0.84.2` and documents its retirement condition.
- Updates Pi regression coverage and records the early-tool behavior in the session-history regression document.

## Why

Pi now exposes stable tool identity at the start of an assistant tool call. Using it removes the visible delay before tool execution while one tolerant implementation continues to support the existing PATH floor. There is no database or relay protocol change.

## Risk and test focus

The main risks are an incorrect release digest, package-layout regression, malformed foreign metadata, duplicate tool cards, or divergence between streamed and authoritative final state. The implementation ignores incomplete start metadata, falls back to terminal metadata on older Pi versions, and continues to use the existing tracker and final reconciliation path.

## Expected result

Managed installs use Pi `v0.84.4` on all six supported targets. Users see a pending tool as soon as supported Pi emits `toolcall_start`; older Pi versions retain their previous behavior, and final replay remains authoritative.

## Verification

- Verified all six official `v0.84.4` assets and SHA-256 digests; macOS arm64 archive/package layout and credential-free JSONL RPC probing passed.
- `cd bridge && dart test sesori_plugin_pi` — passed (285 tests).
- `cd bridge/sesori_plugin_pi && dart analyze --fatal-infos` — passed.
- `git diff HEAD --check` — passed.
- Architecture implementation review — accepted with no architecture-scope findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the managed Pi runtime to v0.84.4 and shows a pending tool card as soon as Pi v0.84.3+ emits `toolcall_start`, so users see the tool start immediately instead of waiting for `toolcall_end`.

- Pins the managed Pi artifact to `v0.84.4` with verified digests for all six supported targets; the `0.84.1` PATH minimum and package-directory archive layout are unchanged.
- Publishes a pending tool from the nullable `toolcall_start` `id` and `toolName`, and suppresses the duplicate announcement at `toolcall_end`.
- Correlates early and terminal tool visibility by content index, so the pending card still wins if the end metadata normalizes the tool id differently.
- Pi `<= 0.84.2`, or malformed start metadata, still waits for `toolcall_end`, keeping existing behavior for older installs.

<sup>Written for commit 0bfb80a81b1cac4f2e00d18942c76737ebba9795. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

