### PR TITLE
🌱 Fix Pi harness audit command guards

### DIFF
--- a/.agents/skills/update-pi-harness/SKILL.md
+++ b/.agents/skills/update-pi-harness/SKILL.md
@@ -120,8 +120,22 @@ both public tags still resolve to those exact commits before using any diff:
 ```bash
 old_commit_sha="<recorded full 40-hex old-release commit>"
 new_commit_sha="<recorded full 40-hex new-release commit>"
-test "$(gh api repos/earendil-works/pi/commits/v<old> --jq .sha)" = "$old_commit_sha"
-test "$(gh api repos/earendil-works/pi/commits/v<new> --jq .sha)" = "$new_commit_sha"
+resolved_old_sha="$(gh api repos/earendil-works/pi/commits/v<old> --jq .sha)" || {
+  echo "ERROR: could not resolve v<old>; restart the audit" >&2
+  exit 1
+}
+if [ "$resolved_old_sha" != "$old_commit_sha" ]; then
+  echo "ERROR: v<old> no longer resolves to $old_commit_sha; restart the audit" >&2
+  exit 1
+fi
+resolved_new_sha="$(gh api repos/earendil-works/pi/commits/v<new> --jq .sha)" || {
+  echo "ERROR: could not resolve v<new>; restart the audit" >&2
+  exit 1
+}
+if [ "$resolved_new_sha" != "$new_commit_sha" ]; then
+  echo "ERROR: v<new> no longer resolves to $new_commit_sha; restart the audit" >&2
+  exit 1
+fi
 gh api "repos/earendil-works/pi/compare/${old_commit_sha}...${new_commit_sha}"
 ```
 
@@ -141,8 +155,22 @@ git clone --filter=blob:none --no-checkout --quiet \
   https://github.com/earendil-works/pi.git "$tmp_repo/pi"
 git -C "$tmp_repo/pi" fetch --quiet --no-tags origin \
   refs/tags/v<old>:refs/tags/v<old> refs/tags/v<new>:refs/tags/v<new>
-test "$(git -C "$tmp_repo/pi" rev-parse "refs/tags/v<old>^{commit}")" = "$old_commit_sha"
-test "$(git -C "$tmp_repo/pi" rev-parse "refs/tags/v<new>^{commit}")" = "$new_commit_sha"
+resolved_old_sha="$(git -C "$tmp_repo/pi" rev-parse "refs/tags/v<old>^{commit}")" || {
+  echo "ERROR: local v<old> tag cannot be resolved; restart the audit" >&2
+  exit 1
+}
+if [ "$resolved_old_sha" != "$old_commit_sha" ]; then
+  echo "ERROR: local v<old> tag moved from $old_commit_sha; restart the audit" >&2
+  exit 1
+fi
+resolved_new_sha="$(git -C "$tmp_repo/pi" rev-parse "refs/tags/v<new>^{commit}")" || {
+  echo "ERROR: local v<new> tag cannot be resolved; restart the audit" >&2
+  exit 1
+}
+if [ "$resolved_new_sha" != "$new_commit_sha" ]; then
+  echo "ERROR: local v<new> tag moved from $new_commit_sha; restart the audit" >&2
+  exit 1
+fi
 git -C "$tmp_repo/pi" diff --name-status "$old_commit_sha" "$new_commit_sha"
 git -C "$tmp_repo/pi" diff --stat "$old_commit_sha" "$new_commit_sha"
 git -C "$tmp_repo/pi" diff --no-ext-diff --no-textconv "$old_commit_sha" "$new_commit_sha" -- \
@@ -451,11 +479,31 @@ Run focused verification for the changed package and inspect the diff:
 git status --short
 git diff HEAD --check
 git diff HEAD -- bridge/sesori_plugin_pi
-# Explicitly inspect every untracked production file too. --no-index returns 1
-# for a content difference, which is expected; any other status is an error.
+# Explicitly inspect every untracked production file too. A --no-index
+# difference returns 1, which is expected; preserve and inspect each status.
 while IFS= read -r path; do
-  git diff --no-index --check -- /dev/null "$path" || test "$?" -eq 1
-  git diff --no-index -- /dev/null "$path" || test "$?" -eq 1
+  if git diff --no-index --check -- /dev/null "$path"; then
+    check_status=0
+  else
+    check_status=$?
+  fi
+  case "$check_status" in
+    0|1) ;;
+    *)
+      echo "ERROR: whitespace/check failure in untracked file: $path" >&2
+      exit 1
+      ;;
+  esac
+
+  if git diff --no-index -- /dev/null "$path"; then
+    diff_status=0
+  else
+    diff_status=$?
+  fi
+  if test "$diff_status" -ne 0 && test "$diff_status" -ne 1; then
+    echo "ERROR: could not inspect untracked file: $path" >&2
+    exit 1
+  fi
 done < <(git ls-files --others --exclude-standard -- bridge/sesori_plugin_pi)
 git diff HEAD -- .agents/skills/update-pi-harness/SKILL.md
 ```
@@ -476,8 +524,13 @@ multiline PR body with these sections:
 - `## Verification`
 
 Use the repository's implementation-complexity emoji prefix, commit and push
-when the task is ready for review, open the PR, and start the PR monitor
-immediately. Never enable auto-merge; the user merges.
+when the task is ready for review, open the PR, and, when `pr_monitor` is
+available, load the `monitor-pr` skill and start it immediately. Never enable
+auto-merge; the user merges. If `pr_monitor` is unavailable in the current
+agent interface, do not invent a substitute or create sleeps/polling loops:
+leave the PR open, report that automated monitoring/readiness is unavailable,
+and wait for an explicit host or user notification before handling follow-up
+feedback.
 
 The final implementation report must state the old/new target, unchanged
 minimum, six digest status, adopted/deferred findings, probe result, tests,


### PR DESCRIPTION
## Complexity

🌱 Trivial documentation and command-safety correction.

## What

- Add explicit failure guards when recorded upstream release tags no longer resolve to their audited commit SHAs.
- Preserve and inspect verification statuses for untracked production files so whitespace/check failures cannot be swallowed.
- Make PR monitoring conditional on `pr_monitor` availability, with a non-polling fallback when the tool is unavailable.

## Why

The reusable Pi harness skill was merged in #1223, but post-merge review identified two shell-status paths that could continue after a safety check failed and a delivery instruction that assumed every agent interface exposes `pr_monitor`.

## Risk and test focus

This is documentation-only with no runtime, database, wire-contract, or user-visible product impact. Review the guarded shell examples for correct non-zero handling and ensure the unavailable-monitor path does not introduce polling or sleeps.

## Expected result

Future Pi harness audits stop on tag movement, surface untracked-file whitespace/check failures, and remain usable in agent interfaces without the PR-monitor tool.

## Verification

- `git diff --check`
- Manual review of the complete skill diff against the merged implementation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Pi harness audit skill so failed safety checks abort the audit instead of continuing, and untracked-file verification failures are no longer swallowed.

- Records tag resolution failures with explicit `exit 1` guards instead of silently continuing when upstream tags move.
- Preserves and inspects `git diff --no-index` exit statuses so whitespace/check failures in untracked production files surface as errors.
- Makes PR monitoring conditional on `pr_monitor` availability, with a non-polling fallback that reports unavailability and waits for explicit notification.

This is documentation-only with no runtime, database, or user-visible product impact.

<sup>Written for commit 3e43c6831b8a008d9bcf6a4d59216c711371346d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

