### PR TITLE
🌿 Detect dead relay sockets via pings and surface the reconnecting banner

### DIFF
--- a/client/app/lib/core/widgets/connection_banner.dart
+++ b/client/app/lib/core/widgets/connection_banner.dart
@@ -12,27 +12,40 @@ import "../extensions/build_context_x.dart";
 /// dedicated offline design (the project list's full-screen flows) simply
 /// don't pass it while that design is showing.
 ///
-/// Two variants:
+/// Three variants:
 /// - the default [ConnectionBanner] is the *bridge-offline* alert — purely
 ///   informational, because the relay connection stays alive and reconnects on
 ///   its own the moment the bridge is back;
+/// - [ConnectionBanner.reconnecting] is the *relay-interrupted* alert — the
+///   relay socket dropped and auto-reconnect is still running, so it is
+///   informational too;
 /// - [ConnectionBanner.connectionLost] is the *relay-unreachable* alert, whose
 ///   auto-reconnect has stopped, so it carries a Retry action.
 class ConnectionBanner extends StatelessWidget {
   /// The bridge-offline banner: informational only. The relay connection stays
   /// alive and `ConnectionService` reconnects the moment the bridge is back, so
   /// there is no action to offer.
-  const new({super.key}) : _onRetry = null;
+  const new({super.key}) : _onRetry = null, _isReconnecting = false;
+
+  /// The reconnecting banner: the relay socket dropped and auto-reconnect is
+  /// in progress, so there is no action to offer. Only surfaced once the
+  /// reconnect outlasts [ConnectionOverlayCubit]'s grace window.
+  const new reconnecting({super.key}) : _onRetry = null, _isReconnecting = true;
 
   /// The connection-lost banner: the relay itself is unreachable and
   /// auto-reconnect has given up, so this variant carries a Retry action that
   /// re-triggers a relay reconnect via [onRetry].
-  const new connectionLost({super.key, required VoidCallback onRetry}) : _onRetry = onRetry;
+  const new connectionLost({super.key, required VoidCallback onRetry})
+    : _onRetry = onRetry,
+      _isReconnecting = false;
 
   /// Reconnect callback for the connection-lost variant; `null` for the
-  /// bridge-offline variant, which self-heals and offers no action. Its
-  /// nullness selects the variant at [build] time.
+  /// self-healing variants, which offer no action. Its nullness selects the
+  /// variant at [build] time.
   final VoidCallback? _onRetry;
+
+  /// Selects the reconnecting variant among the action-less banners.
+  final bool _isReconnecting;
 
   /// Returns the banner for [PregoGlassScaffold.banner], or `null` when nothing
   /// should be shown. Watches [ConnectionOverlayCubit] (provided app-wide above
@@ -44,8 +57,9 @@ class ConnectionBanner extends StatelessWidget {
     final cubit = context.watch<ConnectionOverlayCubit>();
     return switch (cubit.state) {
       ConnectionOverlayBridgeOffline() => const ConnectionBanner(),
+      ConnectionOverlayReconnecting() => const ConnectionBanner.reconnecting(),
       ConnectionOverlayConnectionLost() => ConnectionBanner.connectionLost(onRetry: cubit.reconnect),
-      ConnectionOverlayHidden() || ConnectionOverlayReconnecting() => null,
+      ConnectionOverlayHidden() => null,
     };
   }
 
@@ -70,8 +84,8 @@ class ConnectionBanner extends StatelessWidget {
       child: onRetry == null
           ? PregoInlineAlertsNotifications(
               type: PregoInlineAlertsNotificationsType.warning,
-              title: context.loc.bridgeDisconnectedTitle,
-              icon: TablerRegular.broadcast_off,
+              title: _isReconnecting ? context.loc.connectionReconnectingTitle : context.loc.bridgeDisconnectedTitle,
+              icon: _isReconnecting ? TablerRegular.cloud_off : TablerRegular.broadcast_off,
             )
           : PregoInlineAlertsNotifications(
               type: PregoInlineAlertsNotificationsType.error,

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -140,6 +140,7 @@
   },
   "connectionLostTitle": "Connection Lost",
   "connectionLostReconnect": "Reconnect",
+  "connectionReconnectingTitle": "Reconnecting…",
   "bridgeDisconnectedTitle": "Bridge disconnected",
   "settingsTitle": "Settings",
   "settingsAccountSignedInWith": "Signed in with {provider}",

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -361,6 +361,12 @@ abstract class AppLocalizations {
   /// **'Reconnect'**
   String get connectionLostReconnect;
 
+  /// No description provided for @connectionReconnectingTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Reconnecting…'**
+  String get connectionReconnectingTitle;
+
   /// No description provided for @bridgeDisconnectedTitle.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -155,6 +155,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get connectionLostReconnect => 'Reconnect';
 
   @override
+  String get connectionReconnectingTitle => 'Reconnecting…';
+
+  @override
   String get bridgeDisconnectedTitle => 'Bridge disconnected';
 
   @override

--- a/client/app/test/core/widgets/connection_banner_test.dart
+++ b/client/app/test/core/widgets/connection_banner_test.dart
@@ -56,9 +56,15 @@ void main() {
       return resolved;
     }
 
-    testWidgets("returns a banner for bridgeOffline and connectionLost, nothing otherwise", (tester) async {
+    testWidgets("returns a banner for bridgeOffline, reconnecting, and connectionLost, nothing otherwise", (
+      tester,
+    ) async {
       expect(
         await resolveFor(tester, const ConnectionOverlayState.bridgeOffline()),
+        isA<ConnectionBanner>(),
+      );
+      expect(
+        await resolveFor(tester, const ConnectionOverlayState.reconnecting()),
         isA<ConnectionBanner>(),
       );
       expect(
@@ -67,7 +73,6 @@ void main() {
       );
       expect(await resolveFor(tester, const ConnectionOverlayState.hidden(connected: true)), isNull);
       expect(await resolveFor(tester, const ConnectionOverlayState.hidden(connected: false)), isNull);
-      expect(await resolveFor(tester, const ConnectionOverlayState.reconnecting()), isNull);
     });
   });
 
@@ -112,6 +117,21 @@ void main() {
     final alert = tester.widget<PregoInlineAlertsNotifications>(find.byType(PregoInlineAlertsNotifications));
     expect(alert.type, PregoInlineAlertsNotificationsType.warning);
     expect(alert.icon, TablerRegular.broadcast_off);
+  });
+
+  testWidgets("renders the warning alert with the reconnecting title", (tester) async {
+    final cubit = StubConnectionOverlayCubit(initialState: const ConnectionOverlayState.reconnecting());
+    addTearDown(cubit.close);
+
+    await tester.pumpWidget(
+      _app(cubit: cubit, home: const Scaffold(body: ConnectionBanner.reconnecting())),
+    );
+
+    expect(find.text("Reconnecting…"), findsOneWidget);
+    final alert = tester.widget<PregoInlineAlertsNotifications>(find.byType(PregoInlineAlertsNotifications));
+    expect(alert.type, PregoInlineAlertsNotificationsType.warning);
+    expect(alert.icon, TablerRegular.cloud_off);
+    expect(alert.primaryAction, isNull);
   });
 
   testWidgets("marks the offline banner as a live region so screen readers announce it", (tester) async {

--- a/client/desktop/lib/core/widgets/desktop_connection_banner.dart
+++ b/client/desktop/lib/core/widgets/desktop_connection_banner.dart
@@ -9,19 +9,27 @@ import "package:theme_prego/module_prego.dart";
 /// desktop router and shared screens exist, the shell owns this equivalent
 /// host so connection state is visible above the auth-gated window.
 class DesktopConnectionBanner extends StatelessWidget {
-  const new({super.key}) : _onRetry = null;
+  const new({super.key}) : _onRetry = null, _isReconnecting = false;
 
-  const new connectionLost({super.key, required VoidCallback onRetry}) : _onRetry = onRetry;
+  const new reconnecting({super.key}) : _onRetry = null, _isReconnecting = true;
+
+  const new connectionLost({super.key, required VoidCallback onRetry})
+    : _onRetry = onRetry,
+      _isReconnecting = false;
 
   final VoidCallback? _onRetry;
+
+  /// Selects the reconnecting variant among the action-less banners.
+  final bool _isReconnecting;
 
   /// Returns the root banner for the states that need one.
   static Widget? maybeFor(BuildContext context) {
     final ConnectionOverlayCubit cubit = context.watch<ConnectionOverlayCubit>();
     return switch (cubit.state) {
       ConnectionOverlayBridgeOffline() => const DesktopConnectionBanner(),
+      ConnectionOverlayReconnecting() => const DesktopConnectionBanner.reconnecting(),
       ConnectionOverlayConnectionLost() => DesktopConnectionBanner.connectionLost(onRetry: cubit.reconnect),
-      ConnectionOverlayHidden() || ConnectionOverlayReconnecting() => null,
+      ConnectionOverlayHidden() => null,
     };
   }
 
@@ -32,10 +40,10 @@ class DesktopConnectionBanner extends StatelessWidget {
       container: true,
       liveRegion: true,
       child: onRetry == null
-          ? const PregoInlineAlertsNotifications(
+          ? PregoInlineAlertsNotifications(
               type: PregoInlineAlertsNotificationsType.warning,
-              title: "Bridge disconnected",
-              icon: TablerRegular.broadcast_off,
+              title: _isReconnecting ? "Reconnecting…" : "Bridge disconnected",
+              icon: _isReconnecting ? TablerRegular.cloud_off : TablerRegular.broadcast_off,
             )
           : PregoInlineAlertsNotifications(
               type: PregoInlineAlertsNotificationsType.error,

--- a/client/desktop/test/core/widgets/desktop_connection_banner_test.dart
+++ b/client/desktop/test/core/widgets/desktop_connection_banner_test.dart
@@ -63,11 +63,25 @@ void main() {
     expect(cubit.reconnectCalls, 1);
   });
 
-  testWidgets("does not render for connected or reconnecting states", (WidgetTester tester) async {
+  testWidgets("renders the reconnecting warning without an action", (WidgetTester tester) async {
+    final _MockConnectionOverlayCubit cubit = _MockConnectionOverlayCubit();
+    addTearDown(cubit.close);
+    whenListen(
+      cubit,
+      const Stream<ConnectionOverlayState>.empty(),
+      initialState: const ConnectionOverlayState.reconnecting(),
+    );
+
+    await pumpBanner(tester: tester, cubit: cubit);
+
+    expect(find.text("Reconnecting…"), findsOneWidget);
+    expect(find.text("Reconnect"), findsNothing);
+  });
+
+  testWidgets("does not render for hidden states", (WidgetTester tester) async {
     for (final ConnectionOverlayState state in <ConnectionOverlayState>[
       const ConnectionOverlayState.hidden(connected: true),
       const ConnectionOverlayState.hidden(connected: false),
-      const ConnectionOverlayState.reconnecting(),
     ]) {
       final _MockConnectionOverlayCubit cubit = _MockConnectionOverlayCubit();
       addTearDown(cubit.close);

--- a/client/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/client/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -5,6 +5,7 @@ import "dart:typed_data";
 import "package:cryptography/cryptography.dart";
 import "package:meta/meta.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:web_socket_channel/io.dart";
 import "package:web_socket_channel/web_socket_channel.dart";
 
 import "../../logging/logging.dart";
@@ -56,6 +57,14 @@ class RelayClient._({
   static const int _messageVersion = 0x01;
   static const Duration _handshakeTimeout = Duration(seconds: 15);
   static const Duration _channelCloseTimeout = Duration(seconds: 3);
+
+  /// Client→relay WebSocket ping cadence, mirroring the bridge's relay client.
+  /// `dart:io` closes the socket locally when no pong arrives within the next
+  /// interval, so a dead network path (Wi-Fi drop, VPN toggle, sleep/wake)
+  /// surfaces as a socket close within ~2× this interval and enters the normal
+  /// reconnect path, instead of lingering undetected until a 30s request
+  /// timeout or the relay reaping the connection from its side.
+  static const Duration _pingInterval = Duration(seconds: 15);
   int? _lastCloseCode;
   int? get lastCloseCode => _lastCloseCode;
 
@@ -69,7 +78,7 @@ class RelayClient._({
          cryptoService: cryptoService,
          roomKeyStorage: roomKeyStorage,
          authToken: authToken,
-         channelConnector: WebSocketChannel.connect,
+         channelConnector: _connectWithPingInterval,
          boundedJsonEncoder: BoundedJsonEncoder(
            chunkSize: BoundedJsonEncoder.defaultChunkSize,
            yieldTurn: BoundedJsonEncoder.eventLoopTurn,
@@ -100,6 +109,9 @@ class RelayClient._({
               ),
           maxPlaintextMessageBytes: maxPlaintextMessageBytes,
         );
+
+  static WebSocketChannel _connectWithPingInterval(Uri uri) =>
+      IOWebSocketChannel.connect(uri, pingInterval: _pingInterval);
 
   RelayClientConnectionState get connectionState => _connectionState;
 

--- a/client/module_core/lib/src/cubits/connection_overlay/connection_overlay_cubit.dart
+++ b/client/module_core/lib/src/cubits/connection_overlay/connection_overlay_cubit.dart
@@ -1,6 +1,7 @@
 import "dart:async";
 
 import "package:bloc/bloc.dart";
+import "package:meta/meta.dart";
 import "package:rxdart/rxdart.dart";
 
 import "../../capabilities/server_connection/connection_service.dart";
@@ -20,9 +21,17 @@ import "connection_overlay_state.dart";
 /// banner whenever either input changes.
 class ConnectionOverlayCubit(
   final ConnectionService _connectionService,
-  RegisteredBridgesService registeredBridgesService,
-) extends Cubit<ConnectionOverlayState> {
+  RegisteredBridgesService registeredBridgesService, {
+  @visibleForTesting final Duration _reconnectingGrace = defaultReconnectingGrace,
+}) extends Cubit<ConnectionOverlayState> {
   late final StreamSubscription<ConnectionOverlayState> _subscription;
+  Timer? _reconnectingGraceTimer;
+
+  /// How long a reconnect must persist before [ConnectionOverlayState.reconnecting]
+  /// is surfaced. Routine fast reconnects (foreground resume, a bridge handover)
+  /// complete within this window, so the banner appears only when the relay link
+  /// is genuinely interrupted; the previous state is retained meanwhile.
+  static const Duration defaultReconnectingGrace = Duration(seconds: 3);
 
   // ignore: no_slop_linter/prefer_required_named_parameters, public cubit constructor API
   this : super(_derive(_connectionService.currentStatus, registeredBridgesService.isRegistered.value)) {
@@ -31,13 +40,26 @@ class ConnectionOverlayCubit(
           _connectionService.status,
           registeredBridgesService.isRegistered,
           _derive,
-        ).listen((derived) {
-          // Guard equality ourselves: the first combineLatest2 emission replays
-          // the same inputs the seeded state was derived from, and bloc does not
-          // dedupe a cubit's very first emit — so without this it would surface
-          // as a redundant (hidden -> hidden) rebuild on startup.
-          if (!isClosed && derived != state) emit(derived);
-        });
+        ).listen(_onDerived);
+  }
+
+  void _onDerived(ConnectionOverlayState derived) {
+    if (isClosed) return;
+    if (derived is ConnectionOverlayReconnecting) {
+      if (state is ConnectionOverlayReconnecting) return;
+      _reconnectingGraceTimer ??= Timer(_reconnectingGrace, () {
+        _reconnectingGraceTimer = null;
+        if (!isClosed) emit(const ConnectionOverlayState.reconnecting());
+      });
+      return;
+    }
+    _reconnectingGraceTimer?.cancel();
+    _reconnectingGraceTimer = null;
+    // Guard equality ourselves: the first combineLatest2 emission replays
+    // the same inputs the seeded state was derived from, and bloc does not
+    // dedupe a cubit's very first emit — so without this it would surface
+    // as a redundant (hidden -> hidden) rebuild on startup.
+    if (derived != state) emit(derived);
   }
 
   // ignore: no_slop_linter/prefer_required_named_parameters, combineLatest2 combiner requires positional parameters
@@ -58,6 +80,8 @@ class ConnectionOverlayCubit(
 
   @override
   Future<void> close() async {
+    _reconnectingGraceTimer?.cancel();
+    _reconnectingGraceTimer = null;
     await _subscription.cancel();
     await super.close();
   }

--- a/client/module_core/lib/src/cubits/connection_overlay/connection_overlay_state.dart
+++ b/client/module_core/lib/src/cubits/connection_overlay/connection_overlay_state.dart
@@ -22,7 +22,9 @@ sealed class ConnectionOverlayState with _$ConnectionOverlayState {
   /// bannerless offline states.
   const factory hidden({required bool connected}) = ConnectionOverlayHidden;
 
-  /// A subtle reconnecting indicator: the relay dropped and is auto-reconnecting.
+  /// The relay dropped and auto-reconnect has been running for longer than the
+  /// cubit's grace window — shown as a warning banner. Reconnects that resolve
+  /// within the grace window never surface this state.
   const factory reconnecting() = ConnectionOverlayReconnecting;
 
   /// The blocking "connection lost" card with Reconnect / Disconnect actions.

--- a/client/module_core/test/cubits/connection_overlay/connection_overlay_cubit_test.dart
+++ b/client/module_core/test/cubits/connection_overlay/connection_overlay_cubit_test.dart
@@ -39,7 +39,13 @@ void main() {
       await registeredStream.close();
     });
 
-    ConnectionOverlayCubit buildCubit() => ConnectionOverlayCubit(mockConnectionService, mockRegisteredBridgesService);
+    ConnectionOverlayCubit buildCubit({
+      Duration reconnectingGrace = ConnectionOverlayCubit.defaultReconnectingGrace,
+    }) => ConnectionOverlayCubit(
+      mockConnectionService,
+      mockRegisteredBridgesService,
+      reconnectingGrace: reconnectingGrace,
+    );
 
     blocTest<ConnectionOverlayCubit, ConnectionOverlayState>(
       "starts hidden and not connected when disconnected and not registered",
@@ -50,13 +56,13 @@ void main() {
     );
 
     blocTest<ConnectionOverlayCubit, ConnectionOverlayState>(
-      "maps connection statuses to overlay states",
-      build: buildCubit,
+      "maps connection statuses to overlay states, surfacing reconnecting after the grace window",
+      build: () => buildCubit(reconnectingGrace: const Duration(milliseconds: 100)),
       act: (_) async {
         statusStream.add(connectionLost);
         await Future<void>.delayed(Duration.zero);
         statusStream.add(reconnecting);
-        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(const Duration(milliseconds: 300));
         statusStream.add(connected);
         await Future<void>.delayed(Duration.zero);
       },
@@ -65,6 +71,22 @@ void main() {
         ConnectionOverlayState.reconnecting(),
         ConnectionOverlayState.hidden(connected: true),
       ],
+    );
+
+    blocTest<ConnectionOverlayCubit, ConnectionOverlayState>(
+      "a reconnect that resolves within the grace window never surfaces the banner",
+      build: () => buildCubit(reconnectingGrace: const Duration(milliseconds: 300)),
+      act: (_) async {
+        statusStream.add(connected);
+        await Future<void>.delayed(Duration.zero);
+        statusStream.add(reconnecting);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        statusStream.add(connected);
+        // Waits past the grace deadline to prove the pending surface was
+        // cancelled, not merely still counting down.
+        await Future<void>.delayed(const Duration(milliseconds: 500));
+      },
+      expect: () => const [ConnectionOverlayState.hidden(connected: true)],
     );
 
     blocTest<ConnectionOverlayCubit, ConnectionOverlayState>(

--- a/docs/regression/bridge-connectivity.md
+++ b/docs/regression/bridge-connectivity.md
@@ -34,6 +34,13 @@ explicit restart, and the connection states the app presents.
   roots the same `ConnectionService` beside the supervised control channel, shows
   its relay-client state separately from helper relay status, and hosts the typed
   connection banner at the window root.
+- The client relay socket pings on an interval, so a silently dead network path
+  (Wi-Fi drop, VPN toggle, sleep/wake) surfaces as a socket close and enters
+  reconnect within roughly two ping intervals instead of waiting on request
+  timeouts or relay-side reaping.
+- A reconnect that outlasts the overlay grace window surfaces the reconnecting
+  banner on all surfaces; reconnects that resolve within the window (foreground
+  resume, bridge handover) stay bannerless.
 - The desktop root constructs `ConnectionOverlayCubit` and `SseToastCubit` outside
   the auth-gated content. Backend `tui.toast.show` events reach the desktop Prego
   popup listener rather than being silently consumed; handled shared failures are
@@ -124,6 +131,8 @@ the bridge starts, how many clients are present, and whether restart is explicit
 - A bridge registering a network-derived numeric hostname as its machine name.
 - A clean shutdown producing reconnects, a cancelled handshake later sending auth, or an
   app stuck reconnecting after the bridge returns.
+- A dead network path leaving the app claiming connected for minutes, or the
+  reconnecting banner flashing on every routine foreground resume.
 - GUI shutdown unregistering the bridge, emitting login-needed, or exiting with the
   auth-required sentinel because teardown cancelled the bootstrap token request.
 - A forced stop leaving a backend alive, targeting only one process-table snapshot,


### PR DESCRIPTION
## Complexity

Straightforward: one socket option on the existing relay client, a debounce timer in the existing overlay cubit, and a third variant for the two existing banner widgets.

## What

- `RelayClient` now connects through `IOWebSocketChannel` with a 15s `pingInterval` (the same cadence the bridge's own relay client already uses). When a pong misses the next interval, `dart:io` closes the socket locally, which feeds the existing socket-closed → reconnect path.
- `ConnectionOverlayCubit` surfaces `ConnectionOverlayReconnecting` only after the reconnect has persisted for a 3s grace window (previous state is retained meanwhile); reconnects that resolve inside the window never surface it.
- The mobile `ConnectionBanner` and `DesktopConnectionBanner` gain a `reconnecting` variant: a warning alert titled "Reconnecting…" with no action, shown from the shared `maybeFor` mapping. New `connectionReconnectingTitle` l10n string; regenerated localizations.
- Updated `docs/regression/bridge-connectivity.md`.

## Why

With no client-side liveness probing, a silently dead network path (Wi-Fi drop, VPN toggle, sleep/wake — especially with bridge and client on the same machine) went undetected until a 30s request timeout fired or the relay reaped the connection from its side, so recovery routinely took close to a minute of stale "connected" UI and piled-up request timeouts. And because the banner mapping returned nothing for the reconnecting state, the entire outage showed no indication at all.

## Risk and test focus

- The ping close surfaces as closeCode 1001 (goingAway), which `RelayCloseCodes.shouldReconnect` treats as reconnectable; pending requests are already failed fast on socket close.
- Grace window trade-off: brief resume/bridge-handover reconnects (~1–2s) stay bannerless; the previous banner state (e.g. bridge-offline) lingers up to 3s before flipping to "Reconnecting…".
- Tests: overlay cubit grace tests (surfaces after the window, cancelled surface never fires), banner variant rendering on both surfaces, existing relay/overlay suites pass.
- No wire-contract change: WebSocket ping/pong is transport-level and answered automatically by the relay; older bridges are unaffected.

## Expected result

After a network drop, the app notices the dead socket within ~15–30s (instead of ~a minute), shows a "Reconnecting…" warning banner on phone and desktop while auto-reconnect runs, and returns to connected without the user waiting through stacked request timeouts. No database impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the client relay detecting silently dead sockets and surfaces a "Reconnecting…" banner while auto-reconnect runs. Previously a dead network path (Wi-Fi drop, VPN toggle, sleep/wake) could leave a stale connected state for close to a minute with no visible indicator; now the socket closes locally within roughly two ping intervals and both mobile and desktop show a warning banner until reconnection resolves.

- `RelayClient` connects via `IOWebSocketChannel` with a 15s `pingInterval`, so a missed pong closes the socket locally and enters the existing reconnect path.
- `ConnectionOverlayCubit` surfaces the reconnecting state only after a 3s grace window, keeping brief reconnects (foreground resume, bridge handover) bannerless.
- The banner adds a reconnecting variant with no action, a new `connectionReconnectingTitle` l10n string, and updated regression docs.
- No wire-contract change; ping/pong is transport-level and answered automatically by the relay, so older bridges are unaffected.

<sup>Written for commit f277702b6c3330f18d3a741dcf2e38a50d87a47f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

