### PR TITLE
🌿 Fix session detail back routing

### DIFF
--- a/client/app/lib/core/routing/imperative_pane_route.dart
+++ b/client/app/lib/core/routing/imperative_pane_route.dart
@@ -25,6 +25,7 @@ class const ImperativePaneRouteScope({
 bool isImperativePaneRoute(BuildContext context) {
   final scoped = ImperativePaneRouteScope.maybeOf(context);
   if (scoped != null) return scoped.isImperative;
+  // ignore: no_slop_linter/avoid_raw_go_router, checks router ancestry without performing navigation
   if (GoRouter.maybeOf(context) == null) return false;
 
   return isImperativePaneState(context: context, state: GoRouterState.of(context));

--- a/client/app/lib/core/routing/imperative_pane_route.dart
+++ b/client/app/lib/core/routing/imperative_pane_route.dart
@@ -25,6 +25,7 @@ class const ImperativePaneRouteScope({
 bool isImperativePaneRoute(BuildContext context) {
   final scoped = ImperativePaneRouteScope.maybeOf(context);
   if (scoped != null) return scoped.isImperative;
+  if (GoRouter.maybeOf(context) == null) return false;
 
   return isImperativePaneState(context: context, state: GoRouterState.of(context));
 }

--- a/client/app/lib/features/session_detail/widgets/session_detail_body.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_body.dart
@@ -1,6 +1,7 @@
 import "dart:async";
 
 import "package:flutter_bloc/flutter_bloc.dart";
+import "package:go_router/go_router.dart";
 import "package:material_ui/material_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -81,7 +82,8 @@ class _SessionDetailBodyState() extends State<SessionDetailBody> {
     final loc = context.loc;
     final state = context.watch<SessionDetailCubit>().state;
     final isSplit = SessionSplitScope.maybeOf(context)?.isSplit ?? false;
-    final showLeading = !isSplit || isImperativePaneRoute(context);
+    final isImperative = isImperativePaneRoute(context);
+    final showLeading = !isSplit || isImperative;
     final isBusy = switch (state) {
       SessionDetailLoaded(:final sessionStatus, :final childStatuses) => hasActiveWork(
         sessionStatus: sessionStatus,
@@ -154,17 +156,20 @@ class _SessionDetailBodyState() extends State<SessionDetailBody> {
       // that starts on the pinned composer overscrolls/bounces the whole page.
       scrollable: false,
       // Toolbar navigation is explicit: unlike Android system back, it must
-      // not be vetoed by the composer's keyboard-dismissal PopScope. Navigate
-      // to the typed parent route rather than asking go_router to derive it
-      // from decoded path parameters, which would turn path-like project IDs
-      // back into literal slashes and make the parent URL unmatchable.
+      // not be vetoed by the composer's keyboard-dismissal PopScope. A pushed
+      // child detail still pops to its parent. The base compact detail uses the
+      // typed parent route rather than asking go_router to derive it from
+      // decoded path parameters, which would turn path-like project IDs back
+      // into literal slashes and make the parent URL unmatchable.
       onBack: showLeading
-          ? () => context.goRoute(
-              AppRoute.sessions(
-                projectId: widget.projectId,
-                projectName: widget.projectName,
-              ),
-            )
+          ? () => isImperative
+                ? context.pop()
+                : context.goRoute(
+                    AppRoute.sessions(
+                      projectId: widget.projectId,
+                      projectName: widget.projectName,
+                    ),
+                  )
           : null,
       automaticallyImplyLeading: showLeading,
       actions: actions.isEmpty ? null : actions,

--- a/client/app/lib/features/session_detail/widgets/session_detail_body.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_body.dart
@@ -1,7 +1,6 @@
 import "dart:async";
 
 import "package:flutter_bloc/flutter_bloc.dart";
-import "package:go_router/go_router.dart";
 import "package:material_ui/material_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -155,8 +154,18 @@ class _SessionDetailBodyState() extends State<SessionDetailBody> {
       // that starts on the pinned composer overscrolls/bounces the whole page.
       scrollable: false,
       // Toolbar navigation is explicit: unlike Android system back, it must
-      // not be vetoed by the composer's keyboard-dismissal PopScope.
-      onBack: showLeading ? () => context.pop() : null,
+      // not be vetoed by the composer's keyboard-dismissal PopScope. Navigate
+      // to the typed parent route rather than asking go_router to derive it
+      // from decoded path parameters, which would turn path-like project IDs
+      // back into literal slashes and make the parent URL unmatchable.
+      onBack: showLeading
+          ? () => context.goRoute(
+              AppRoute.sessions(
+                projectId: widget.projectId,
+                projectName: widget.projectName,
+              ),
+            )
+          : null,
       automaticallyImplyLeading: showLeading,
       actions: actions.isEmpty ? null : actions,
       slivers: [

--- a/client/app/test/core/routing/adaptive_session_route_matrix_test.dart
+++ b/client/app/test/core/routing/adaptive_session_route_matrix_test.dart
@@ -4,6 +4,7 @@ import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/core/widgets/session_split/empty_session_detail_panel.dart";
 import "package:sesori_mobile/features/new_session/new_session_screen.dart";
 import "package:sesori_mobile/features/session_list/session_tile.dart";
+import "package:theme_prego/module_prego.dart";
 
 import "../../helpers/test_helpers.dart";
 import "adaptive_session_router_test_harness.dart";
@@ -172,6 +173,41 @@ void main() {
       }
 
       addTearDown(() => tester.binding.setSurfaceSize(null));
+    });
+
+    testWidgets("detail toolbar back returns path-like project IDs to their sessions route", (tester) async {
+      const projectId = "/Users/example/workspace/project";
+      final detailLocation = const AppRoute.sessionDetail(
+        projectId: projectId,
+        projectName: "Project One",
+        sessionId: "session-1",
+        sessionTitle: "Session One",
+        readOnly: false,
+      ).buildPath();
+      final sessionsLocation = const AppRoute.sessions(
+        projectId: projectId,
+        projectName: "Project One",
+      ).buildPath();
+      final harness = AdaptiveSessionRouterTestHarness();
+      await tester.binding.setSurfaceSize(const Size(390, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      addTearDown(harness.tearDown);
+      await harness.setUp(
+        initialLocation: detailLocation,
+        currentRouteDef: AppRouteDef.sessionDetail,
+        sessionsByProject: {
+          projectId: [adaptiveTestSession(projectId: projectId, id: "session-1", title: "Session One")],
+        },
+      );
+
+      await tester.pumpWidget(harness.buildApp());
+      await _pumpDiffFrames(tester);
+
+      await tester.tap(find.byIcon(TablerRegular.chevron_left));
+      await tester.pumpAndSettle();
+
+      expect(harness.currentLocation, sessionsLocation);
+      expect(find.text("Session One"), findsOneWidget);
     });
 
     testWidgets("shrinking from wide detail to 390 keeps the same full-screen detail route", (tester) async {

--- a/client/app/test/core/routing/imperative_pane_route_test.dart
+++ b/client/app/test/core/routing/imperative_pane_route_test.dart
@@ -6,6 +6,16 @@ import "package:material_ui/material_ui.dart";
 import "package:sesori_mobile/core/routing/imperative_pane_route.dart";
 
 void main() {
+  testWidgets("isImperativePaneRoute is false outside a GoRouter route", (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: _ImperativeProbe()),
+      ),
+    );
+
+    expect(find.text("imperative=false"), findsOneWidget);
+  });
+
   testWidgets("isImperativePaneRoute is false for declarative route matches", (tester) async {
     final router = _router(initialLocation: "/projects/p1/sessions/s1");
 

--- a/docs/regression/navigation-transitions.md
+++ b/docs/regression/navigation-transitions.md
@@ -12,9 +12,10 @@ the intentional login, settings-modal, and split-view transitions distinct.
   Android.
 - Compact session-list, session-detail, new-session, and diff navigation uses
   the same platform transition. Split-view pane changes fade instead of sliding.
-- The compact session-detail toolbar returns to the typed sessions route. This
-  keeps path-like project identifiers percent-encoded and matchable instead of
-  reconstructing the parent URL from decoded route parameters.
+- The base compact session-detail toolbar returns to the typed sessions route.
+  This keeps path-like project identifiers percent-encoded and matchable instead
+  of reconstructing the parent URL from decoded route parameters. A child or
+  background-task detail opened with a push still pops to its parent detail.
 - Settings and modal harness settings rise from the bottom on every platform;
   settings child pages use the standard platform push.
 - Login uses its intentional fade and logo hero motion.
@@ -37,11 +38,13 @@ the intentional login, settings-modal, and split-view transitions distinct.
 - iOS or macOS uses no transition, or Android loses its configured transition.
 - A settings child rises as a modal, or the settings modal slides horizontally.
 - Compact and split session layouts use each other's transition.
-- Returning from a compact session detail produces an unmatchable sessions URL,
-  especially when a project identifier contains filesystem-path separators.
+- Returning from a base compact session detail produces an unmatchable sessions
+  URL, especially when a project identifier contains filesystem-path separators,
+  or a pushed child detail returns to the sessions list instead of its parent.
 
 ## Sources
 
 - `client/app/lib/core/routing/app_router.dart`
 - `client/app/test/core/routing/app_route_test.dart`
 - `client/app/test/core/routing/adaptive_session_route_matrix_test.dart`
+- `client/app/test/features/session_detail/adaptive_session_detail_routing_test.dart`

--- a/docs/regression/navigation-transitions.md
+++ b/docs/regression/navigation-transitions.md
@@ -46,5 +46,6 @@ the intentional login, settings-modal, and split-view transitions distinct.
 
 - `client/app/lib/core/routing/app_router.dart`
 - `client/app/test/core/routing/app_route_test.dart`
+- `client/app/test/core/routing/imperative_pane_route_test.dart`
 - `client/app/test/core/routing/adaptive_session_route_matrix_test.dart`
 - `client/app/test/features/session_detail/adaptive_session_detail_routing_test.dart`

--- a/docs/regression/navigation-transitions.md
+++ b/docs/regression/navigation-transitions.md
@@ -12,6 +12,9 @@ the intentional login, settings-modal, and split-view transitions distinct.
   Android.
 - Compact session-list, session-detail, new-session, and diff navigation uses
   the same platform transition. Split-view pane changes fade instead of sliding.
+- The compact session-detail toolbar returns to the typed sessions route. This
+  keeps path-like project identifiers percent-encoded and matchable instead of
+  reconstructing the parent URL from decoded route parameters.
 - Settings and modal harness settings rise from the bottom on every platform;
   settings child pages use the standard platform push.
 - Login uses its intentional fade and logo hero motion.
@@ -34,8 +37,11 @@ the intentional login, settings-modal, and split-view transitions distinct.
 - iOS or macOS uses no transition, or Android loses its configured transition.
 - A settings child rises as a modal, or the settings modal slides horizontally.
 - Compact and split session layouts use each other's transition.
+- Returning from a compact session detail produces an unmatchable sessions URL,
+  especially when a project identifier contains filesystem-path separators.
 
 ## Sources
 
 - `client/app/lib/core/routing/app_router.dart`
 - `client/app/test/core/routing/app_route_test.dart`
+- `client/app/test/core/routing/adaptive_session_route_matrix_test.dart`


### PR DESCRIPTION
## Complexity

🌿 Straightforward — localized navigation correction with focused regression coverage.

## What

- Navigate the compact session-detail toolbar back button through the typed sessions route.
- Add regression coverage for path-like project identifiers.
- Document the navigation invariant and failure signal.

## Why

`go_router` reconstructed the parent route from already-decoded path parameters when the detail page was popped. Project identifiers containing filesystem separators became literal URL path separators, producing an unmatchable sessions route.

## Risk and test focus

The change only affects compact session-detail toolbar back navigation. The user-visible impact is that returning to the sessions list now succeeds for path-like project IDs. There is no database or wire-protocol impact.

Focus testing on compact navigation from a chat to its sessions list, especially projects whose IDs contain `/`.

## Expected result

Tapping Back on a compact chat returns to the correct sessions list with the project ID still percent-encoded and no `GoRouter could not match route` error.

## Verification

- `flutter test test/core/routing/adaptive_session_route_matrix_test.dart`
- `flutter analyze`
- Dart LSP diagnostics: no issues in the changed Dart files
- iPhone 17 Pro simulator (iOS 26.5): opened and returned from `Tool-Card Test` in `kustos`
- iPhone 17 Pro simulator (iOS 26.5): opened and returned from `Project memory overview` in `sesori_apps_monorepo`
- Simulator logs after both checks contained no `GoRouter could not match` error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session-detail toolbar back routing so base compact details return through the typed sessions route while pushed child details still pop to their parent. Path-like project IDs stay percent-encoded, keeping the parent URL matchable instead of rebuilding it from decoded parameters.

- Makes `isImperativePaneRoute` return `false` outside a `GoRouter` scope instead of crashing.
- Adds regression tests for path-like project IDs and router-scope rendering.
- Documents the navigation invariant and the failure signal in the regression notes.

<sup>Written for commit d48bc2f4c05dba811e468176b7c10259cb7ba6e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

