### PR TITLE
🌱 Record desktop MT Gate B acceptance

### DIFF
--- a/.plan/active/desktop-app/PLAN.md
+++ b/.plan/active/desktop-app/PLAN.md
@@ -415,6 +415,13 @@ token-only local sessions.
 > takeover state + Take-over works. Gate outcome: the desktop app replaces
 > the terminal bridge for daily use.
 
+**MT gate B accepted — 2026-09-01.** The user reported the full macOS-primary
+daily-driver matrix passed on the final merged build after PRs #1222 and #1230:
+autostart/hidden last-On restoration and sticky disable, second-instance focus,
+GUI-crash helper teardown and restoration, live/dead-helper logout, 10+ minute
+sleep/wake recovery, and explicit cross-machine takeover without a restart war.
+The desktop app is accepted as the terminal bridge replacement for daily use.
+
 ### M4 — Cockpit
 
 **Step 13 — ⚙️ Desktop becomes a relay client.** Register the missing
@@ -438,14 +445,15 @@ screen may never land ahead of its root wiring. Token-only local restores hand
 connection startup to a desktop auth/connection coordinator rather than the
 projection cubit.
 
-Step 13 merged in PR #1216 on 2026-08-31. The implementation is complete; the
-next implementation step waits for the user-run MT gate B above.
+Step 13 merged in PR #1216 on 2026-08-31. The implementation is complete, and
+MT gate B was accepted on 2026-09-01. Step 14 remains pending until the user
+explicitly authorizes it.
 
 ### Plan divergence — post-Step 13 Gate B findings (2026-08-31)
 
 The first daily-driver checks exposed three gaps that were not represented at
-the Step 13/14 boundary. This is pre-Gate-B hardening, not Step 14; the
-cockpit extraction remains blocked until the user accepts MT Gate B.
+the Step 13/14 boundary. This was pre-Gate-B hardening, not Step 14; both
+follow-ups merged before the user accepted MT Gate B.
 
 | Finding | Evidence | Revised plan |
 |---|---|---|
@@ -467,11 +475,12 @@ two-PR pre-gate follow-up:
    coverage (PR #1222, merged).
 2. `🚧 [desktop-app] Preserve bridge intent and add Take Over [step 2/2]` —
    quit semantics, takeover orchestration, shell controls, and lifecycle
-   coverage (PR #1230, open).
+   coverage (PR #1230, merged).
 
-The series does not change the original 22-step numbering or mark Gate B done;
-Step 14 must not begin until the user records the gate outcome and explicitly
-authorizes it.
+The series does not change the original 22-step numbering. Its merge did not
+itself mark Gate B done; the user accepted the gate after running the final
+matrix on 2026-09-01. Step 14 is no longer gate-blocked but remains pending
+until the user explicitly authorizes it.
 
 **Step 14 — ⚙️ Create `module_app_ui` + shared foundations.** New Flutter
 package; move `l10n/` (ownership of `l10n.yaml`/codegen) and the

--- a/.plan/active/desktop-app/TRACKER.md
+++ b/.plan/active/desktop-app/TRACKER.md
@@ -20,7 +20,7 @@ user-run checkpoints, not PRs; only the user marks them passed.
 | 10 | 🚧 `module_auth` logout/rejection hardening (R1) | done |
 | 11 | 🚧 Logout coordination + offline unregister fallback | done |
 | 12 | 🚧 Supervised E2E suite + dev-harness retirement | done |
-| — | MT gate B: daily driver (user-run) | pending |
+| — | MT gate B: daily driver (user-run) | done |
 | 13 | ⚙️ Desktop relay-client enablement | done |
 | 14 | ⚙️ Create `module_app_ui` + l10n/extensions/theme move | pending |
 | 15 | 🚧 Settings + harness management slice (desktop onboarding) | pending |
@@ -50,8 +50,22 @@ passing, including the native supervised E2E on macOS, Windows, and Linux.
 The Step 12 PR also included the post-merge Step 11 stop-mode and token-only
 deletion hardening. Step 13 merged in PR #1216 on 2026-08-31 with 13/13 CI
 checks passing. The desktop relay client and token-only startup handoff are
-complete. MT gate B remains pending; do not begin Step 14 until the user-run
-daily-driver checkpoint is recorded.
+complete. MT gate B was later accepted below.
+
+## MT Gate B — accepted 2026-09-01
+
+The user reported every macOS-primary daily-driver check passed on the final
+merged build after PRs #1222 and #1230: autostart reboot restored a hidden
+last-On bridge and disabling autostart stuck; a second launch focused the first
+instance; GUI `kill -9` led to bounded helper teardown and last-On restoration;
+live- and dead-helper logout removed the active bridge while preserving the
+phone session and clearing local tokens; 10+ minute sleep/wake recovered
+without a duplicate helper; and explicit cross-machine Take Over reclaimed
+ownership without a flip-flop restart war. The user accepted the desktop app as
+the terminal bridge replacement for daily use.
+
+Gate B acceptance removes the gate blocker but does not start Step 14. Step 14
+remains pending until the user explicitly authorizes further work.
 
 ## Plan divergence — post-Step 13 Gate B findings (2026-08-31)
 
@@ -75,9 +89,9 @@ PRs:
 | Follow-up | Status | Scope |
 |---|---|---|
 | `🌿 [desktop-app] Restore supervised harness discovery [step 1/2]` | done | PR #1222 merged: macOS-only PATH enrichment at the supervised process boundary, setup diagnostics, and regression coverage |
-| `🚧 [desktop-app] Preserve bridge intent and add Take Over [step 2/2]` | in-progress | PR #1230 open: Quit intent semantics, explicit takeover orchestration/UI, and lifecycle coverage |
+| `🚧 [desktop-app] Preserve bridge intent and add Take Over [step 2/2]` | done | PR #1230 merged: Quit intent semantics, explicit takeover orchestration/UI, and lifecycle coverage |
 
 The helper receives only a login-shell-derived PATH, merged with its inherited
 environment; shell variables, secrets, permissions, and entitlements are not
-copied. Gate B stays user-owned and Step 14 stays blocked until the user
-records the documented gate outcome and explicitly authorizes progression.
+copied. The user accepted Gate B on 2026-09-01. Step 14 remains pending until
+the user explicitly authorizes progression.


### PR DESCRIPTION
## Complexity

🌱 Trivial — this is a documentation-only update to the existing desktop plan and tracker.

## What

- Mark MT Gate B as accepted on 2026-09-01.
- Record the user-confirmed passing macOS-primary daily-driver matrix.
- Mark both pre-Gate-B hardening PRs, #1222 and #1230, as merged and complete.
- Keep Step 14 pending until the user explicitly authorizes further work.

## Why

The user completed the final manual Gate B checks on the merged desktop build and explicitly reported that all checks passed. The durable plan and tracker should now reflect that accepted checkpoint rather than leaving the cockpit work gate-blocked.

## Risk and test focus

Low risk. Review should confirm that the recorded gate evidence matches the user-owned matrix and that accepting Gate B does not incorrectly mark Step 14 as started or authorized.

No user-visible behavior, production code, database, persisted-data, or protocol changes.

## Expected result

The desktop plan and tracker identify MT Gate B as done, retain its acceptance evidence, and show Step 14 as pending explicit authorization.

## Verification

- `git diff --check` — clean.
- Confirmed no stale `MT gate B remains pending`, `PR #1230 open`, or pre-acceptance blocker wording remains in `.plan/active/desktop-app/`.
- No Dart or Flutter suites run because this PR changes documentation only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the user-confirmed MT Gate B acceptance in the desktop plan and tracker, marking the daily-driver checkpoint as done and both pre-gate hardening PRs (#1222, #1230) as merged while leaving Step 14 pending explicit user authorization. Documentation-only change; no production code, behavior, or data impacts.

<sup>Written for commit d678dabe3df93b1fd8a615a7df3778d1acf79f6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

