### PR TITLE
🌱 Use official flutter_keyboard_visibility release

### DIFF
--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -82,11 +82,7 @@ dependencies:
   crypto: ^3.0.7
   vector_graphics: ^1.2.3
   image_picker: ^1.2.3
-  flutter_keyboard_visibility:
-    git:
-      url: https://github.com/vespr-wallet/flutter_keyboard_visibility.git
-      ref: a640afe883868faf2709c41daa391e2cd6f1fc7b
-      path: flutter_keyboard_visibility
+  flutter_keyboard_visibility: ^7.0.1
 
 dev_dependencies:
   cryptography: ^2.9.0

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -601,53 +601,51 @@ packages:
   flutter_keyboard_visibility:
     dependency: transitive
     description:
-      path: flutter_keyboard_visibility
-      ref: a640afe883868faf2709c41daa391e2cd6f1fc7b
-      resolved-ref: a640afe883868faf2709c41daa391e2cd6f1fc7b
-      url: "https://github.com/vespr-wallet/flutter_keyboard_visibility.git"
-    source: git
-    version: "6.0.2"
+      name: flutter_keyboard_visibility
+      sha256: dabc6c146897b2d07794b096e3e696212c08ac1500b4344ba84f0bd6878b9a51
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter_keyboard_visibility_linux:
     dependency: transitive
     description:
       name: flutter_keyboard_visibility_linux
-      sha256: "6fba7cd9bb033b6ddd8c2beb4c99ad02d728f1e6e6d9b9446667398b2ac39f08"
+      sha256: "478ccab140efbf8e0725063da5522a6c512a6ed33b9687161855a1eb6a668abe"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "2.0.0"
   flutter_keyboard_visibility_macos:
     dependency: transitive
     description:
       name: flutter_keyboard_visibility_macos
-      sha256: c5c49b16fff453dfdafdc16f26bdd8fb8d55812a1d50b0ce25fc8d9f2e53d086
+      sha256: "7bee81be3c5aa06950b11e68cc947b4b567079456ab66a261c3fee01a5194fc0"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "2.0.0"
   flutter_keyboard_visibility_platform_interface:
     dependency: transitive
     description:
       name: flutter_keyboard_visibility_platform_interface
-      sha256: e43a89845873f7be10cb3884345ceb9aebf00a659f479d1c8f4293fcb37022a4
+      sha256: c16de89f36e655562baed76d8e05a9f19c884707e569b3ae6c121e0f41adfabe
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   flutter_keyboard_visibility_web:
     dependency: transitive
     description:
-      path: flutter_keyboard_visibility_web
-      ref: "4303f02862cf94bd196f3740cea7671d243b7239"
-      resolved-ref: "4303f02862cf94bd196f3740cea7671d243b7239"
-      url: "https://github.com/vespr-wallet/flutter_keyboard_visibility.git"
-    source: git
-    version: "2.0.1"
+      name: flutter_keyboard_visibility_web
+      sha256: "2200cc44d1d743b83176bd078a341780bd054a0217ec35a08679387c0989fb35"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   flutter_keyboard_visibility_windows:
     dependency: transitive
     description:
       name: flutter_keyboard_visibility_windows
-      sha256: fc4b0f0b6be9b93ae527f3d527fb56ee2d918cd88bbca438c478af7bcfd0ef73
+      sha256: fde7b3fd757bcd31474e6575d0e12ccb3d244841e97645b6d78df7bf86a9e341
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "2.0.0"
   flutter_lints:
     dependency: transitive
     description:


### PR DESCRIPTION
## Complexity

Trivial dependency source update.

## What

- Replace the Vespr Wallet git fork of `flutter_keyboard_visibility` 6.0.2 with the official pub.dev 7.0.1 release.
- Refresh the package's federated platform dependencies in the client lockfile.

## Why

The official package now includes the capabilities that required the fork: Android API 24 compatibility through Flutter's minimum SDK, current Android tooling, Swift Package Manager support, and `package:web`/Wasm compatibility. Returning to the official release removes fork maintenance while retaining the APIs Sesori uses.

## Risk and test focus

Low risk, but this updates native Android and iOS implementations. Android 11 and later now use the official `WindowInsets` keyboard detection path; older Android versions retain the existing fallback. Test focus is Android API 24 manifest compatibility, system-back keyboard behavior, and iOS Swift Package Manager integration.

No database impact and no intended user-visible behavior change.

## Expected result

Sesori keeps its existing keyboard-aware navigation behavior while consuming the maintained, checksummed pub.dev package instead of the git fork.

## Verification

- `dart pub get` from `client/`
- `dart analyze` from `client/app`
- `flutter test test/features/new_session/new_session_screen_test.dart test/features/session_detail/widgets/session_detail_body_test.dart` from `client/app`
- `flutter build appbundle --debug` from `client/app`
- `flutter build ios --simulator --debug` from `client/app`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the Vespr Wallet git fork of `flutter_keyboard_visibility` with the official pub.dev `7.0.1` release, keeping existing keyboard-aware navigation behavior while dropping fork maintenance.

**Risk and test focus**
- The official package now covers everything the fork provided: Android API 24 compatibility, current Android tooling, Swift Package Manager, and `package:web`/Wasm support.
- Android 11 and later switch to the official `WindowInsets` detection path; older Android keeps the existing fallback.
- No database impact and no intended user-visible behavior change; verify Android API 24 manifest compatibility, system-back keyboard behavior, and iOS Swift Package Manager integration.

<sup>Written for commit 0ef8f1f7d612464026fa2cdf5ce47bf8ac242769. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

