### PR TITLE
🌱 Paint app background beneath iOS keyboard

### DIFF
--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -501,7 +501,10 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
 
     // Remove this wrapper once liquid_glass_widgets migrates from the Flutter SDK Material and Cupertino libraries to material_ui and cupertino_ui.
     return Scaffold(
-      backgroundColor: Colors.transparent,
+      // Keep the page surface painted through the keyboard inset. The inner
+      // GlassScaffold is resized above the keyboard, but iOS 26's rounded,
+      // translucent keyboard exposes the area behind it around the corners.
+      backgroundColor: backgroundColor,
       floatingActionButton: _floatingActionButton,
       body: top_bar.PregoTopBarInsetScope(
         baseInset: topPad + PregoTopNavigation.barHeight,

--- a/client/module_prego/test/components/prego_glass_scaffold_background_test.dart
+++ b/client/module_prego/test/components/prego_glass_scaffold_background_test.dart
@@ -1,0 +1,34 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:material_ui/material_ui.dart";
+import "package:theme_prego/module_prego.dart";
+
+void main() {
+  testWidgets("page background remains painted behind the keyboard", (tester) async {
+    const keyboardInset = 180.0;
+    const pageBackground = Color(0xFF123456);
+    final devicePixelRatio = tester.view.devicePixelRatio;
+    tester.view.viewInsets = FakeViewPadding(bottom: keyboardInset * devicePixelRatio);
+    addTearDown(tester.view.resetViewInsets);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(extensions: [PregoDesignSystem.light]),
+        home: const PregoGlassScaffold(
+          title: "Title",
+          automaticallyImplyLeading: false,
+          backgroundColor: pageBackground,
+          slivers: [SliverFillRemaining(child: SizedBox.expand())],
+        ),
+      ),
+    );
+
+    // The outer Material scaffold owns keyboard avoidance but still fills the
+    // window, so its surface is what iOS reveals around the translucent
+    // keyboard after the inner GlassScaffold resizes above it.
+    final scaffoldFinder = find.byType(Scaffold);
+    final scaffold = tester.widget<Scaffold>(scaffoldFinder);
+    final logicalHeight = tester.view.physicalSize.height / devicePixelRatio;
+    expect(tester.getSize(scaffoldFinder).height, logicalHeight);
+    expect(scaffold.backgroundColor, pageBackground);
+  });
+}

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -252,6 +252,9 @@ defaults and queued client sends coherent.
 - Transcript content scrolling behind the top navigation or floating composer
   dissolves into a strong surface-colour fade, keeping the title and controls
   visually separate and screenshot-readable without text collisions.
+- When the software keyboard opens, interactive content resizes above it while
+  the page surface remains painted underneath it. Rounded or translucent iOS
+  keyboards never reveal a black route or platform background around their edges.
 - Transcript rows render in a plain reversed list with newest content at the
   bottom. Following stays pinned through appends and streaming growth; scrolling
   away freezes live row content until reattachment. Sending, queued, retry,
@@ -356,8 +359,9 @@ provider failure, early and late abort, busy stop-and-send, and two sessions.
 - Scrolled transcript text remains clearly visible through the fade and collides
   with the navigation title or floating composer controls.
 - A live append or streaming update moves a detached viewport, an outgoing
-  prompt blanks or duplicates during its sending-to-sent transition, or keyboard
-  and composer insets obscure newest content.
+  prompt blanks or duplicates during its sending-to-sent transition, keyboard
+  and composer insets obscure newest content, or the keyboard reveals a black
+  background around its rounded or translucent edges.
 - A timestamp peek responds from a reserved system-back edge, detaches or
   vertically scrolls the transcript, captures a mouse selection drag, or moves
   while a fenced code block is handling the horizontal drag.


### PR DESCRIPTION
## Complexity

🌱 Trivial — one shared scaffold paint change with focused regression coverage.

## What

- Paint the outer `PregoGlassScaffold` surface with the resolved page background instead of transparency.
- Add a widget regression test with a simulated keyboard inset.
- Document keyboard backdrop behavior and its regression signal.

## Why

The inner glass scaffold resizes above the software keyboard. On iOS 26, the rounded translucent keyboard exposes the area behind it, so the transparent outer scaffold revealed a black route or platform background around the keyboard edges.

## Risk and test focus

Low risk. Keyboard avoidance and composer positioning are unchanged; only the previously transparent outer surface now matches the page background. There is no database impact. The user-visible impact is limited to removing the black area around rounded or translucent keyboards.

## Expected result

When the software keyboard is visible, interactive content continues to stay above it while the page background remains painted beneath the keyboard across light, dark, and explicit page colors.

## Verification

- `cd client && dart pub get`
- `cd client/module_prego && flutter test test/components/prego_glass_scaffold_*_test.dart`
- `cd client/module_prego && flutter test test/components/prego_glass_scaffold_background_test.dart`
- `cd client/module_prego && dart analyze`
- `cd client/app && dart analyze`
- `cd client/desktop && dart analyze`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS 26 keyboard backdrop where the rounded translucent keyboard exposed a black area behind it. The outer scaffold now paints the page background instead of transparency, so the area under the keyboard matches the page without changing keyboard avoidance or composer positioning.

Added a widget regression test for the keyboard inset and updated the regression documentation to cover this behavior.

<sup>Written for commit f674bc7e493540d6f7e9ccadbf1af47225266189. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

