### PR TITLE
🌿 Add macOS desktop QA harness

### DIFF
--- a/.agents/skills/macos-desktop-qa/SKILL.md
+++ b/.agents/skills/macos-desktop-qa/SKILL.md
@@ -25,8 +25,10 @@ Combine semantic app automation with visual/native-system inspection:
 Both automation servers are declared in `.mcp.json`. Their shared launcher
 refuses to start versions other than Peekaboo 4.2.2 and agent-device 0.20.10.
 Pi accesses them lazily through `pi-mcp-adapter`; use its `mcp` proxy to
-search/describe a tool before calling it. Other supported hosts can load the
-same servers directly.
+search/describe a tool before calling it. The shared `.mcp.json` command is
+repository-relative, so other hosts must launch it with the repository root as
+their working directory. If a host does not guarantee that working directory,
+point its host-specific configuration at the launcher's absolute path instead.
 
 The reviewed host setup for this workflow is:
 

--- a/.agents/skills/macos-desktop-qa/SKILL.md
+++ b/.agents/skills/macos-desktop-qa/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: macos-desktop-qa
+description: >-
+  Build, launch, inspect, and exercise the Sesori macOS desktop app as a real
+  QA target. Use for macOS desktop smoke, exploratory, regression, lifecycle,
+  tray/menu-bar, evidence, performance, or end-to-end verification.
+metadata:
+  audience: maintainers
+  workflow: local-macos-qa
+---
+
+# Sesori macOS Desktop QA
+
+Use the real macOS app, native helper, relay path, and representative plugin.
+Combine semantic app automation with visual/native-system inspection:
+
+- **agent-device** owns repeatable app sessions, accessibility snapshots,
+  assertions, logs, screenshots, recordings, network evidence, and replay.
+- **Peekaboo** owns macOS-wide visual inspection and native window, menu-bar,
+  tray, Dock, browser, dialog, and permission interaction.
+- **Flutter/Xcode/Dart CLI tools** own compilation, tests, signing inspection,
+  crash diagnostics, and profiling. Do not add an MCP when a first-party CLI is
+  clearer and more reliable.
+
+Both automation servers are declared in `.mcp.json`. Pi accesses them lazily
+through `pi-mcp-adapter`; use its `mcp` proxy to search/describe a tool before
+calling it. Other supported hosts can load the same servers directly.
+
+The reviewed host setup for this workflow is:
+
+```bash
+brew tap steipete/tap
+brew trust --formula steipete/tap/peekaboo
+brew install steipete/tap/peekaboo
+brew pin peekaboo
+npm install --global --ignore-scripts agent-device@0.20.10
+pi install npm:pi-mcp-adapter@2.31.0
+```
+
+Restart Pi after installing the adapter. Treat version changes as executable
+third-party dependency updates: inspect their source/release integrity and
+repeat the MCP handshake plus host preflight before adopting them.
+
+## Safety first
+
+This app uses real account credentials and can supervise a real bridge. Before
+launching, inspect live processes:
+
+```bash
+ps ax -o pid=,ppid=,etime=,command= | \
+  rg '[s]esori-bridge|/[S]esori\.app/Contents/MacOS/' || true
+```
+
+If a standalone bridge or another desktop build is active, do not kill it,
+take over, turn Bridge Off, sign out, clear state, or replace its helper without
+explicit user approval. A normal launch may restore a persisted **On** intent,
+so the process check is required even for a smoke run. Never automate a macOS
+login password, OAuth credentials, MFA, a destructive account action, or an
+externally visible prompt/send action without the user's explicit direction.
+
+Screenshots, logs, recordings, traces, replay files, and network dumps can
+contain account data, prompts, transcripts, source code, paths, and tokens.
+Keep artifacts in a private temporary directory, inspect before sharing, and do
+not commit them.
+
+## Host preflight
+
+Run these once per machine/toolchain change:
+
+```bash
+flutter doctor -v
+peekaboo --version
+peekaboo permissions --json --no-remote
+agent-device --version
+agent-device doctor --platform macos --json
+agent-device capabilities --platform macos --json
+```
+
+Required state:
+
+- the repository-pinned Flutter/Dart SDK is active;
+- Xcode and its macOS SDK are selected;
+- Peekaboo reports Screen Recording, Accessibility, and event synthesis granted;
+- agent-device reports the local macOS target and macOS commands.
+
+The active GUI session must be unlocked. If agent-device reports `Timed out
+while enabling automation mode` and Peekaboo identifies `loginwindow` as the
+frontmost application, ask the user to unlock the Mac and retry. Do not infer a
+broken runner and do not attempt to type the password. Once unlocked, warm the
+runner:
+
+```bash
+agent-device prepare ios-runner --platform macos --timeout 600000 --json
+```
+
+Use `caffeinate` around a long attended run when sleep itself is not under test.
+Do not leave a permanent keep-awake process behind.
+
+## Build and automated baseline
+
+Build the repository helper before launching the desktop app; development
+builds resolve this exact host bundle:
+
+```bash
+(cd bridge && dart pub get)
+(cd bridge/app && make build-host)
+(cd client && dart pub get)
+(cd client/module_desktop_core && dart analyze --fatal-infos && dart test)
+(cd client/desktop && dart analyze --fatal-infos && flutter test)
+(cd client/desktop && flutter build macos --debug)
+```
+
+Use `flutter build macos --release` when validating release-mode behavior. A
+successful build is not GUI evidence. Locate and inspect the actual product:
+
+```bash
+app="$PWD/client/desktop/build/macos/Build/Products/Debug/Sesori.app"
+test -d "$app"
+codesign --verify --deep --strict --verbose=2 "$app"
+codesign -d --entitlements :- "$app" 2>/dev/null
+```
+
+Run the deterministic native supervised-helper suite when bridge/control/auth
+or supervision behavior is in scope:
+
+```bash
+(cd bridge/app && \
+  SESORI_E2E_REQUIRED=1 \
+  SESORI_E2E_ARTIFACT_DIR="$(mktemp -d)/sesori-supervised-e2e" \
+  dart test test/integration/supervised_e2e_test.dart)
+```
+
+## Real app loop
+
+Create a private artifact root:
+
+```bash
+artifact_root="$(mktemp -d)/sesori-macos-qa"
+mkdir -p "$artifact_root"
+```
+
+After the process-safety check and any required approval, launch the built app
+and bind an app session:
+
+```bash
+app="$PWD/client/desktop/build/macos/Build/Products/Debug/Sesori.app"
+open -na "$app"
+agent-device open Sesori --platform macos --surface app --foreground
+agent-device snapshot -i
+agent-device screenshot "$artifact_root/launch.png"
+```
+
+Use `snapshot -i`, selectors, and current `@ref` values to inspect and act.
+Refs are invalid after state changes unless the command's settled diff returns
+new ones. Prefer `press`, `fill`, `find`, `wait`, and `is` over coordinates.
+Use `--settle` on actions when available and verify the resulting state before
+continuing.
+
+Use Peekaboo when visual layout or macOS chrome matters:
+
+```bash
+peekaboo see --app Sesori --annotate \
+  --path "$artifact_root/sesori-annotated.png" --json --no-remote
+peekaboo window list --app Sesori --json --no-remote
+peekaboo menubar --help
+```
+
+Read captured images with the agent's image-capable file reader. Use Peekaboo
+for tray primary/secondary clicks, context-menu appearance, close-to-hide,
+Dock presence, Open/focus, native dialogs, and browser OAuth. Refresh the
+accessibility/visual snapshot after every mutation. Do not silently enable
+Chrome remote debugging on the user's primary browser profile; native
+Peekaboo interaction is sufficient unless the user approves a dedicated
+debuggable QA profile.
+
+For repeatable evidence, arm agent-device recording on `open` with
+`--save-script <private-path>`, close cleanly, and replay only after reviewing
+the generated script for secrets and destructive actions. End every session:
+
+```bash
+agent-device close --json
+```
+
+Then verify no unintended GUI-owned helper/backend process remains. Preserve a
+helper only when that is the expected persisted-On outcome of the test.
+
+## Regression coverage
+
+Treat `docs/regression/desktop-bridge-supervision.md` as the authoritative
+supervision matrix and failure-signal list. For release confidence, cover its
+L3 macOS journey with a dev-built helper and representative live plugin:
+
+1. browser login and relaunch restore;
+2. healthy control handshake, relay state, and plugin health;
+3. phone-to-desktop-helper session round trip;
+4. helper crash/backoff and exit-86 immediate restart;
+5. login-required behavior;
+6. Bridge Off, window close, tray Open, and Quit orphan checks;
+7. standalone CLI coexistence and explicit takeover behavior.
+
+Also vary light/dark appearance, reduced motion, window sizes, menu-bar
+primary/secondary clicks, network loss/recovery, sleep/wake, second launch,
+and accessibility keyboard navigation when relevant to the changed feature.
+Do not claim screens that the active desktop plan has not implemented yet.
+
+## Report
+
+Report:
+
+- exact app commit/build mode and macOS/Xcode/Flutter versions;
+- whether a real or fake auth/relay/plugin path was used;
+- scenarios passed, failed, blocked, and intentionally not run;
+- process/orphan checks and any persistent state changed;
+- artifact paths and whether they contain sensitive data;
+- concrete reproduction steps, expected versus actual behavior, logs, and the
+  smallest useful screenshot/trace for every failure.
+
+A visual pass does not replace process, log, lifecycle, or transport evidence.
+A deterministic headless pass does not replace real tray/window/system QA.

--- a/.agents/skills/macos-desktop-qa/SKILL.md
+++ b/.agents/skills/macos-desktop-qa/SKILL.md
@@ -22,9 +22,11 @@ Combine semantic app automation with visual/native-system inspection:
   crash diagnostics, and profiling. Do not add an MCP when a first-party CLI is
   clearer and more reliable.
 
-Both automation servers are declared in `.mcp.json`. Pi accesses them lazily
-through `pi-mcp-adapter`; use its `mcp` proxy to search/describe a tool before
-calling it. Other supported hosts can load the same servers directly.
+Both automation servers are declared in `.mcp.json`. Their shared launcher
+refuses to start versions other than Peekaboo 4.2.2 and agent-device 0.20.10.
+Pi accesses them lazily through `pi-mcp-adapter`; use its `mcp` proxy to
+search/describe a tool before calling it. Other supported hosts can load the
+same servers directly.
 
 The reviewed host setup for this workflow is:
 
@@ -35,11 +37,16 @@ brew install steipete/tap/peekaboo
 brew pin peekaboo
 npm install --global --ignore-scripts agent-device@0.20.10
 pi install npm:pi-mcp-adapter@2.31.0
+./.agents/skills/macos-desktop-qa/scripts/mcp-server.sh check
 ```
 
-Restart Pi after installing the adapter. Treat version changes as executable
-third-party dependency updates: inspect their source/release integrity and
-repeat the MCP handshake plus host preflight before adopting them.
+The Homebrew tap may advance before a fresh install. The final check must report
+exactly Peekaboo 4.2.2 and agent-device 0.20.10; if it does not, stop and install
+the reviewed formula/package revision rather than changing the expected
+version. Restart Pi after installing the adapter. Treat version changes as
+executable third-party dependency updates: inspect their source/release
+integrity and repeat the MCP handshake plus host preflight before adopting
+them.
 
 ## Safety first
 
@@ -48,7 +55,7 @@ launching, inspect live processes:
 
 ```bash
 ps ax -o pid=,ppid=,etime=,command= | \
-  rg '[s]esori-bridge|/[S]esori\.app/Contents/MacOS/' || true
+  rg '[s]esori-bridge|/[b]ridge/app/build/cli/bundle/bin/bridge|/[S]esori\.app/Contents/MacOS/' || true
 ```
 
 If a standalone bridge or another desktop build is active, do not kill it,
@@ -69,7 +76,7 @@ Run these once per machine/toolchain change:
 
 ```bash
 flutter doctor -v
-peekaboo --version
+./.agents/skills/macos-desktop-qa/scripts/mcp-server.sh check
 peekaboo permissions --json --no-remote
 agent-device --version
 agent-device doctor --platform macos --json

--- a/.agents/skills/macos-desktop-qa/scripts/mcp-server.sh
+++ b/.agents/skills/macos-desktop-qa/scripts/mcp-server.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly peekaboo_expected_version="4.2.2"
+readonly agent_device_expected_version="0.20.10"
+
+fail() {
+  printf 'macOS QA MCP setup error: %s\n' "$1" >&2
+  exit 64
+}
+
+require_command() {
+  local command_name="$1"
+  command -v "$command_name" >/dev/null 2>&1 || fail "${command_name} is not installed or not on PATH"
+}
+
+peekaboo_version() {
+  local output
+  local product
+  local version
+  output="$(peekaboo --version)"
+  read -r product version _ <<<"$output"
+  [[ "$product" == "Peekaboo" && -n "$version" ]] || fail "could not parse Peekaboo version from: $output"
+  printf '%s\n' "$version"
+}
+
+agent_device_version() {
+  local output
+  local version
+  output="$(agent-device --version)"
+  read -r version _ <<<"$output"
+  [[ -n "$version" ]] || fail "could not parse agent-device version"
+  printf '%s\n' "$version"
+}
+
+verify_peekaboo() {
+  local actual_version
+  require_command peekaboo
+  actual_version="$(peekaboo_version)"
+  [[ "$actual_version" == "$peekaboo_expected_version" ]] || \
+    fail "expected Peekaboo ${peekaboo_expected_version}, found ${actual_version}"
+}
+
+verify_agent_device() {
+  local actual_version
+  require_command agent-device
+  actual_version="$(agent_device_version)"
+  [[ "$actual_version" == "$agent_device_expected_version" ]] || \
+    fail "expected agent-device ${agent_device_expected_version}, found ${actual_version}"
+}
+
+case "${1:-}" in
+  check)
+    verify_peekaboo
+    verify_agent_device
+    printf 'Peekaboo %s\nagent-device %s\n' \
+      "$peekaboo_expected_version" \
+      "$agent_device_expected_version"
+    ;;
+  peekaboo)
+    verify_peekaboo
+    exec peekaboo mcp --no-remote
+    ;;
+  agent-device)
+    verify_agent_device
+    export AGENT_DEVICE_NO_UPDATE_NOTIFIER=1
+    exec agent-device mcp
+    ;;
+  *)
+    printf 'Usage: %s check|peekaboo|agent-device\n' "$0" >&2
+    exit 64
+    ;;
+esac

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,15 @@
     "mobile-mcp": {
       "command": "npx",
       "args": ["-y", "@mobilenext/mobile-mcp@1.0.2"]
+    },
+    "peekaboo": {
+      "command": "peekaboo",
+      "args": ["mcp", "--no-remote"]
+    },
+    "agent-device": {
+      "command": "agent-device",
+      "args": ["mcp"],
+      "env": {"AGENT_DEVICE_NO_UPDATE_NOTIFIER": "1"}
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -9,13 +9,12 @@
       "args": ["-y", "@mobilenext/mobile-mcp@1.0.2"]
     },
     "peekaboo": {
-      "command": "peekaboo",
-      "args": ["mcp", "--no-remote"]
+      "command": "./.agents/skills/macos-desktop-qa/scripts/mcp-server.sh",
+      "args": ["peekaboo"]
     },
     "agent-device": {
-      "command": "agent-device",
-      "args": ["mcp"],
-      "env": {"AGENT_DEVICE_NO_UPDATE_NOTIFIER": "1"}
+      "command": "./.agents/skills/macos-desktop-qa/scripts/mcp-server.sh",
+      "args": ["agent-device"]
     }
   }
 }

--- a/opencode.json
+++ b/opencode.json
@@ -9,13 +9,12 @@
     },
     "peekaboo": {
       "type": "local",
-      "command": ["peekaboo", "mcp", "--no-remote"],
+      "command": ["./.agents/skills/macos-desktop-qa/scripts/mcp-server.sh", "peekaboo"],
       "enabled": true
     },
     "agent-device": {
       "type": "local",
-      "command": ["agent-device", "mcp"],
-      "environment": {"AGENT_DEVICE_NO_UPDATE_NOTIFIER": "1"},
+      "command": ["./.agents/skills/macos-desktop-qa/scripts/mcp-server.sh", "agent-device"],
       "enabled": true
     },
     "figma": {

--- a/opencode.json
+++ b/opencode.json
@@ -4,7 +4,18 @@
   "mcp": {
     "mobile-mcp": {
       "type": "local",
-      "command": ["npx", "@mobilenext/mobile-mcp@latest"],
+      "command": ["npx", "-y", "@mobilenext/mobile-mcp@1.0.2"],
+      "enabled": true
+    },
+    "peekaboo": {
+      "type": "local",
+      "command": ["peekaboo", "mcp", "--no-remote"],
+      "enabled": true
+    },
+    "agent-device": {
+      "type": "local",
+      "command": ["agent-device", "mcp"],
+      "environment": {"AGENT_DEVICE_NO_UPDATE_NOTIFIER": "1"},
       "enabled": true
     },
     "figma": {


### PR DESCRIPTION
## Complexity

🌿 Straightforward — this adds project-local MCP wiring and a documented QA workflow without changing product runtime code.

## What

- Add Peekaboo and agent-device to the shared project MCP config and OpenCode config.
- Pin the existing mobile MCP package instead of resolving `latest`.
- Add a committed launcher that refuses to start anything other than Peekaboo 4.2.2 and agent-device 0.20.10.
- Add a `macos-desktop-qa` skill covering safety checks, host setup, builds, semantic and visual automation, regression coverage, evidence handling, and teardown.
- Detect both installed `sesori-bridge` processes and the repository-built desktop helper before GUI QA begins.
- Document the reviewed tool versions: Peekaboo 4.2.2, agent-device 0.20.10, and pi-mcp-adapter 2.31.0.

## Why

Desktop QA needs both semantic XCTest/accessibility automation and macOS-wide visual/system interaction. Keeping those tools behind the shared MCP seam makes the workflow available to Pi and other supported hosts without embedding backend-specific test logic in the app. Enforcing reviewed versions at server startup prevents a PATH or Homebrew/npm update from silently changing the QA harness.

## Risk and test focus

The change has no user-visible product or database impact. The main risk is local developer-machine access: these MCPs can inspect and interact with macOS UI, so the workflow requires project trust, process checks, explicit approval around live bridge/account state, private evidence storage, local-only Peekaboo operation, and exact executable-version checks.

No password entry, Sesori app launch, bridge takeover, sign-out, or helper shutdown was attempted. A standalone `sesori-bridge` was left untouched. The unlocked-host verification used Calculator as a disposable, non-sensitive automation target and removed its temporary screenshot afterward.

## Expected result

A maintainer can invoke the project skill, build the real desktop bundle and helper, and use the reviewed Peekaboo and agent-device versions through MCP for repeatable macOS smoke, exploratory, lifecycle, tray, and end-to-end QA. A missing or mismatched automation binary fails before the MCP server starts.

## Verification

- Parsed `.mcp.json` and `opencode.json`; `git diff --check` passed.
- The launcher accepts the reviewed installed versions and rejects a fake Peekaboo 4.2.3 with a clear version-mismatch failure.
- Direct MCP handshakes through the launcher expose Peekaboo 4.2.2 with 26 tools and agent-device 0.20.10 with 57 tools.
- A fresh Pi RPC session successfully proxied live non-mutating calls through both version-gated servers.
- OpenCode connected to mobile-mcp, Peekaboo, and agent-device through the committed launcher; the unrelated local Figma server was not running.
- Pi discovered `skill:macos-desktop-qa` and the pinned adapter package.
- Peekaboo reports Screen Recording, Accessibility, and Event Synthesizing granted.
- `agent-device doctor --platform macos` reports no blockers and the macOS XCTest runner prepare/health check passes from the exact cached artifact.
- Current-session MCP verification launched Calculator, returned a healthy XCTest accessibility tree, captured and inspected an annotated 230×408 screenshot, listed its window through Peekaboo, then closed the app with zero active agent-device sessions remaining.
- Built the bridge host helper and debug/release `Sesori.app` bundles; strict codesign verification passed (local release bundle is ad-hoc signed).
- Passed desktop core/desktop analysis and tests plus the required supervised-helper E2E test.
