### PR TITLE
⚙️ Add native Pi manual compaction

### DIFF
--- a/bridge/sesori_plugin_pi/lib/src/models/pi_rpc_command.dart
+++ b/bridge/sesori_plugin_pi/lib/src/models/pi_rpc_command.dart
@@ -2,6 +2,7 @@
 enum PiRpcCommand(final String wireValue) {
   prompt("prompt"),
   abort("abort"),
+  compact("compact"),
   getState("get_state"),
   setModel("set_model"),
   getAvailableModels("get_available_models"),

--- a/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
+++ b/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
@@ -357,13 +357,12 @@ final class PiPlugin._({
       staleOptions: true,
     );
     final options = await _catalogService.requireOptions(projectId: session.directory);
-    if (command.trim() != command ||
-        command.isEmpty ||
-        !options.commands.any((candidate) => candidate.name == command)) {
+    final catalogCommand = options.commands.where((candidate) => candidate.name == command).firstOrNull;
+    if (command.trim() != command || command.isEmpty || catalogCommand == null) {
       throw const PluginOperationException("sendCommand", statusCode: 400, message: "Unsupported Pi command.");
     }
     try {
-      final dispatch = command == PiCatalogService.compactionCommandName
+      final dispatch = _catalogService.isNativeCompactionCommand(command: catalogCommand)
           ? _sessionService.compact(
               sessionId: sessionId,
               promptId: promptId,

--- a/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
+++ b/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
@@ -363,16 +363,28 @@ final class PiPlugin._({
       throw const PluginOperationException("sendCommand", statusCode: 400, message: "Unsupported Pi command.");
     }
     try {
-      await _sessionService.sendCommand(
-        sessionId: sessionId,
-        promptId: promptId,
-        directory: session.directory,
-        command: command,
-        arguments: arguments,
-        userVisibleArguments: userVisibleArguments,
-        variant: variant,
-        model: model,
-      );
+      final dispatch = command == PiCatalogService.compactionCommandName
+          ? _sessionService.compact(
+              sessionId: sessionId,
+              promptId: promptId,
+              directory: session.directory,
+              command: command,
+              arguments: arguments,
+              userVisibleArguments: userVisibleArguments,
+              variant: variant,
+              model: model,
+            )
+          : _sessionService.sendCommand(
+              sessionId: sessionId,
+              promptId: promptId,
+              directory: session.directory,
+              command: command,
+              arguments: arguments,
+              userVisibleArguments: userVisibleArguments,
+              variant: variant,
+              model: model,
+            );
+      await dispatch;
     } on PluginOperationException {
       rethrow;
     } on Object catch (error, stackTrace) {

--- a/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/pi_session_process_repository.dart
@@ -402,6 +402,17 @@ final class PiSessionProcessRepository({
     );
   }
 
+  Future<void> dispatchCompaction({
+    required PiSessionConnection connection,
+    required String? customInstructions,
+  }) async {
+    await _requiredResident(connection).client.send(
+      command: PiRpcCommand.compact,
+      arguments: {"customInstructions": ?customInstructions},
+      timeout: _promptRpcTimeout,
+    );
+  }
+
   Future<PiAgentState> getState({required PiSessionConnection connection}) async {
     final data = (await _requiredResident(connection).client.send(
       command: PiRpcCommand.getState,

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_catalog_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_catalog_service.dart
@@ -13,6 +13,10 @@ class PiCatalogService({
     if (_totalTimeout <= Duration.zero) throw ArgumentError.value(_totalTimeout, "totalTimeout", "must be positive");
   }
 
+  static const String compactionCommandName = "compact";
+
+  static final PluginCommand _compactionCommand = PluginCommand.compaction(name: compactionCommandName);
+
   final Map<String, Future<_PiCatalogProbeOutcome>> _inFlight = {};
 
   Future<bool> healthCheck() => _repository.healthCheck();
@@ -65,7 +69,7 @@ class PiCatalogService({
       final snapshot = PluginSessionOptions(
         agents: probe.agents,
         providers: probe.providers,
-        commands: probe.commands,
+        commands: _withCompaction(probe.commands),
         completeness: probe.complete
             ? PluginSessionOptionsCompleteness.complete
             : PluginSessionOptionsCompleteness.partial,
@@ -84,6 +88,11 @@ class PiCatalogService({
         stackTrace: stack,
       );
     }
+  }
+
+  List<PluginCommand> _withCompaction(List<PluginCommand> commands) {
+    if (commands.any((command) => command.name == compactionCommandName)) return commands;
+    return [...commands, _compactionCommand];
   }
 
   Never _throwDiscoveryFailure({required _PiCatalogProbeOutcome outcome}) {

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_catalog_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_catalog_service.dart
@@ -24,6 +24,8 @@ class PiCatalogService({
   Future<List<PluginCommand>> getCommands({required String projectId}) async =>
       (await requireOptions(projectId: projectId)).commands;
 
+  bool isNativeCompactionCommand({required PluginCommand command}) => identical(command, _compactionCommand);
+
   Future<PluginSessionOptions> requireOptions({required String projectId}) async {
     final normalized = normalizeProjectDirectory(directory: projectId);
     final tracked = _tracker.snapshotFor(projectId: normalized);

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -400,7 +400,7 @@ final class PiSessionService({
     required PluginSessionVariant? variant,
     required ({String providerID, String modelID})? model,
   }) {
-    final (:execution, :visible) = _commandText(
+    final commandText = _commandText(
       command: command,
       arguments: arguments,
       userVisibleArguments: userVisibleArguments,
@@ -411,10 +411,10 @@ final class PiSessionService({
       directory: directory,
       turn: _PiCompactionTurn(
         promptId: promptId,
-        payload: PiPromptPayload(message: execution, images: const []),
+        payload: PiPromptPayload(message: commandText.visible, images: const []),
         model: model,
         variant: variant,
-        userVisibleText: visible,
+        userVisibleText: commandText.visible,
         acceptance: acceptance,
         customInstructions: arguments.isEmpty ? null : arguments,
       ),
@@ -924,6 +924,7 @@ final class PiSessionService({
         StackTrace.current,
       );
     }
+    if (failed && turn is _PiCompactionTurn) _clearCompaction(sessionId: sessionId);
     if (!failed && turn.promptDispatched && !turn.userMessageEmitted) {
       _emitMissingUserMessage(sessionId: sessionId, turn: turn);
     } else if (!turn.userMessageEmitted) {

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -119,7 +119,7 @@ final class _PiQueuedPromptTurn({
   _PiQueueState queueState = _PiQueueState.visible;
 }
 
-final class _PiCommandTurn({
+sealed class _PiCommandTurn({
   required super.promptId,
   required super.payload,
   required super.model,
@@ -127,6 +127,25 @@ final class _PiCommandTurn({
   required super.userVisibleText,
   required final Completer<void> acceptance,
 }) extends _PiTurn;
+
+final class _PiSlashCommandTurn({
+  required super.promptId,
+  required super.payload,
+  required super.model,
+  required super.variant,
+  required super.userVisibleText,
+  required super.acceptance,
+}) extends _PiCommandTurn;
+
+final class _PiCompactionTurn({
+  required super.promptId,
+  required super.payload,
+  required super.model,
+  required super.variant,
+  required super.userVisibleText,
+  required super.acceptance,
+  required final String? customInstructions,
+}) extends _PiCommandTurn;
 
 final class PiSessionService({
   required final PiSessionProcessRepository processRepository,
@@ -351,32 +370,83 @@ final class PiSessionService({
     required PluginSessionVariant? variant,
     required ({String providerID, String modelID})? model,
   }) {
-    if (_disposed) return Future.error(const PiRpcDisposedException());
-    final state = _sessions[sessionId];
-    if (state != null && state.isAdmitted(promptId: promptId)) return Future.value();
-    if (state?.hasWork ?? false) {
-      return Future.error(PiSessionBusyException(sessionId: sessionId));
-    }
-    final execution = arguments.isEmpty ? "/$command" : "/$command $arguments";
-    final visibleArguments = userVisibleArguments?.trim();
-    final visible = visibleArguments == null || visibleArguments.isEmpty
-        ? "/$command"
-        : "/$command $userVisibleArguments";
+    final (:execution, :visible) = _commandText(
+      command: command,
+      arguments: arguments,
+      userVisibleArguments: userVisibleArguments,
+    );
     final acceptance = Completer<void>();
-    final payload = PiPromptPayload(message: execution, images: const []);
-    _admit(
+    return _admitCommandTurn(
       sessionId: sessionId,
       directory: directory,
-      turn: _PiCommandTurn(
+      turn: _PiSlashCommandTurn(
         promptId: promptId,
-        payload: payload,
+        payload: PiPromptPayload(message: execution, images: const []),
         model: model,
         variant: variant,
         userVisibleText: visible,
         acceptance: acceptance,
       ),
     );
-    return acceptance.future;
+  }
+
+  Future<void> compact({
+    required String sessionId,
+    required String promptId,
+    required String directory,
+    required String command,
+    required String arguments,
+    required String? userVisibleArguments,
+    required PluginSessionVariant? variant,
+    required ({String providerID, String modelID})? model,
+  }) {
+    final (:execution, :visible) = _commandText(
+      command: command,
+      arguments: arguments,
+      userVisibleArguments: userVisibleArguments,
+    );
+    final acceptance = Completer<void>();
+    return _admitCommandTurn(
+      sessionId: sessionId,
+      directory: directory,
+      turn: _PiCompactionTurn(
+        promptId: promptId,
+        payload: PiPromptPayload(message: execution, images: const []),
+        model: model,
+        variant: variant,
+        userVisibleText: visible,
+        acceptance: acceptance,
+        customInstructions: arguments.isEmpty ? null : arguments,
+      ),
+    );
+  }
+
+  Future<void> _admitCommandTurn({
+    required String sessionId,
+    required String directory,
+    required _PiCommandTurn turn,
+  }) {
+    if (_disposed) return Future.error(const PiRpcDisposedException());
+    final state = _sessions[sessionId];
+    if (state != null && state.isAdmitted(promptId: turn.promptId)) return Future.value();
+    if (state?.hasWork ?? false) {
+      return Future.error(PiSessionBusyException(sessionId: sessionId));
+    }
+    _admit(sessionId: sessionId, directory: directory, turn: turn);
+    return turn.acceptance.future;
+  }
+
+  ({String execution, String visible}) _commandText({
+    required String command,
+    required String arguments,
+    required String? userVisibleArguments,
+  }) {
+    final execution = arguments.isEmpty ? "/$command" : "/$command $arguments";
+    final visibleArguments = userVisibleArguments?.trim();
+    final visible = visibleArguments == null || visibleArguments.isEmpty
+        ? "/$command"
+        : "/$command $userVisibleArguments";
+    return (execution: execution, visible: visible);
   }
 
   void _admit({required String sessionId, required String directory, required _PiTurn turn}) {
@@ -476,11 +546,22 @@ final class PiSessionService({
       turn
         ..promptDispatched = true
         ..agentStarted = state.agentRunning;
-      await _processes.dispatchPrompt(connection: connection, payload: turn.payload);
+      if (turn case _PiCompactionTurn(:final customInstructions)) {
+        await _processes.dispatchCompaction(
+          connection: connection,
+          customInstructions: customInstructions,
+        );
+      } else {
+        await _processes.dispatchPrompt(connection: connection, payload: turn.payload);
+      }
       if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
       turn.responseSucceeded = true;
       if (turn is _PiCommandTurn && !turn.acceptance.isCompleted) {
         turn.acceptance.complete();
+      }
+      if (turn is _PiCompactionTurn) {
+        _finish(sessionId: sessionId, state: state, turn: turn, failed: false, failure: null);
+        return;
       }
       await Future<void>.delayed(Duration.zero);
       if (!_isCurrent(sessionId: sessionId, state: state, turn: turn, generation: generation)) return;
@@ -619,6 +700,11 @@ final class PiSessionService({
             } else {
               turn.settlementObservedBeforeAcceptance = true;
             }
+          }
+        }
+        if (event is PiCompactionStartEvent) {
+          for (final turn in generationTurns.whereType<_PiCompactionTurn>()) {
+            if (turn.promptDispatched && !turn.acceptance.isCompleted) turn.acceptance.complete();
           }
         }
         final now = _clock.now();

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -704,7 +704,11 @@ final class PiSessionService({
         }
         if (event is PiCompactionStartEvent) {
           for (final turn in generationTurns.whereType<_PiCompactionTurn>()) {
-            if (turn.promptDispatched && !turn.acceptance.isCompleted) turn.acceptance.complete();
+            if (!turn.promptDispatched) continue;
+            if (!turn.userMessageEmitted) {
+              _emitMissingUserMessage(sessionId: processFrame.sessionId, turn: turn);
+            }
+            if (!turn.acceptance.isCompleted) turn.acceptance.complete();
           }
         }
         final now = _clock.now();

--- a/bridge/sesori_plugin_pi/test/pi_catalog_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_catalog_service_test.dart
@@ -33,6 +33,7 @@ void main() {
     final compaction = observedOptions.commands.last;
     expect(compaction.description, "Summarize the conversation so far to free up the context window");
     expect(compaction.source, PluginCommandSource.command);
+    expect(service.isNativeCompactionCommand(command: compaction), isTrue);
     expect((reused as PluginSessionOptionsDiscoveryObserved).options, same(observedOptions));
     expect(refreshOptions.commands.map((command) => command.name), [
       "refreshed",
@@ -60,6 +61,7 @@ void main() {
 
     expect(options.commands, hasLength(1));
     expect(options.commands.single.name, PiCatalogService.compactionCommandName);
+    expect(service.isNativeCompactionCommand(command: options.commands.single), isFalse);
   });
 
   test("coalesces same-project probes while different projects probe concurrently", () async {

--- a/bridge/sesori_plugin_pi/test/pi_catalog_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_catalog_service_test.dart
@@ -29,12 +29,37 @@ void main() {
 
     final observedOptions = (observed as PluginSessionOptionsDiscoveryObserved).options;
     final refreshOptions = (refresh as PluginSessionOptionsDiscoveryObserved).options;
-    expect(observedOptions.commands.single.name, "first");
+    expect(observedOptions.commands.map((command) => command.name), ["first", PiCatalogService.compactionCommandName]);
+    final compaction = observedOptions.commands.last;
+    expect(compaction.description, "Summarize the conversation so far to free up the context window");
+    expect(compaction.source, PluginCommandSource.command);
     expect((reused as PluginSessionOptionsDiscoveryObserved).options, same(observedOptions));
-    expect(refreshOptions.commands.single.name, "refreshed");
+    expect(refreshOptions.commands.map((command) => command.name), [
+      "refreshed",
+      PiCatalogService.compactionCommandName,
+    ]);
     expect(refreshOptions.completeness, PluginSessionOptionsCompleteness.partial);
     expect(repository.projects, [path.normalize(project), path.normalize(project)]);
     expect(tracker.snapshotFor(projectId: project), same(refreshOptions));
+  });
+
+  test("does not duplicate a compact command returned by Pi", () async {
+    final service = _service(
+      repository: _FakeCatalogRepository(
+        results: [
+          _options(
+            command: PiCatalogService.compactionCommandName,
+            completeness: PluginSessionOptionsCompleteness.complete,
+          ),
+        ],
+      ),
+      tracker: PiCatalogTracker(),
+    );
+
+    final options = await service.requireOptions(projectId: path.absolute("project"));
+
+    expect(options.commands, hasLength(1));
+    expect(options.commands.single.name, PiCatalogService.compactionCommandName);
   });
 
   test("coalesces same-project probes while different projects probe concurrently", () async {

--- a/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
@@ -91,7 +91,10 @@ void main() {
     test("exposes one coherent project catalog and validates selections and commands", () async {
       expect((await harness.plugin.getAgents(projectId: harness.project.path)).single.name, "pi");
       expect((await harness.plugin.getProviders(projectId: harness.project.path)).providers.single.id, "provider");
-      expect((await harness.plugin.getCommands(projectId: harness.project.path)).single.name, "review");
+      expect((await harness.plugin.getCommands(projectId: harness.project.path)).map((command) => command.name), [
+        "review",
+        PiCatalogService.compactionCommandName,
+      ]);
       final options = await harness.plugin.getSessionOptions(
         projectId: harness.project.path,
         discoveryMode: PluginSessionOptionsDiscoveryMode.reuse,
@@ -160,6 +163,55 @@ void main() {
         harness.processes.where((entry) => entry.spec.launch is! PiNoSession),
         hasLength(1),
       );
+    });
+
+    test("exposes and dispatches native manual compaction", () async {
+      final commands = await harness.plugin.getCommands(projectId: harness.project.path);
+      final compaction = commands.singleWhere(
+        (command) => command.name == PiCatalogService.compactionCommandName,
+      );
+      expect(compaction.description, isNotNull);
+      final session = await harness.plugin.createSession(
+        directory: harness.project.path,
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final events = <BridgeSseEvent>[];
+      final subscription = harness.plugin.events.listen(events.add);
+      addTearDown(subscription.cancel);
+
+      final accepted = harness.plugin.sendCommand(
+        sessionId: session.id,
+        promptId: "prompt-compact",
+        command: PiCatalogService.compactionCommandName,
+        arguments: "Keep architecture decisions",
+        userVisibleArguments: "Keep architecture decisions",
+        variant: null,
+        agent: "pi",
+        model: null,
+      );
+      var completed = false;
+      unawaited(accepted.then((_) => completed = true));
+      final process = await harness.nextSessionProcess();
+      final request = await waitForCommand(process: process, type: "compact");
+      expect(request["customInstructions"], "Keep architecture decisions");
+      expect(process.written.where((frame) => frame["type"] == "prompt"), isEmpty);
+      expect(completed, isFalse);
+
+      process.emit(frame: {"type": "compaction_start", "reason": "manual"});
+      await accepted;
+      expect(completed, isTrue);
+
+      final idle = harness.plugin.events.firstWhere((event) => event is BridgeSseSessionIdle);
+      process.emit(frame: {"type": "compaction_end", "reason": "manual", "aborted": false, "willRetry": false});
+      process.emitResponse(id: request["id"]! as String, command: "compact", data: const {});
+      await idle;
+
+      expect(events.whereType<BridgeSseSessionCompacted>(), hasLength(1));
     });
 
     test("wrapped command failures retain the backend stack", () async {

--- a/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
@@ -212,6 +212,7 @@ void main() {
       await idle;
 
       expect(events.whereType<BridgeSseSessionCompacted>(), hasLength(1));
+      expect(events.whereType<BridgeSseMessageUpdated>().first.info["promptId"], "prompt-compact");
       final visibleText = events
           .whereType<BridgeSseMessagePartUpdated>()
           .where((event) => event.part.type == PluginMessagePartType.text)

--- a/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
@@ -188,8 +188,8 @@ void main() {
         sessionId: session.id,
         promptId: "prompt-compact",
         command: PiCatalogService.compactionCommandName,
-        arguments: "Keep architecture decisions",
-        userVisibleArguments: "Keep architecture decisions",
+        arguments: "secret-instructions",
+        userVisibleArguments: "architecture decisions",
         variant: null,
         agent: "pi",
         model: null,
@@ -198,7 +198,7 @@ void main() {
       unawaited(accepted.then((_) => completed = true));
       final process = await harness.nextSessionProcess();
       final request = await waitForCommand(process: process, type: "compact");
-      expect(request["customInstructions"], "Keep architecture decisions");
+      expect(request["customInstructions"], "secret-instructions");
       expect(process.written.where((frame) => frame["type"] == "prompt"), isEmpty);
       expect(completed, isFalse);
 
@@ -212,6 +212,91 @@ void main() {
       await idle;
 
       expect(events.whereType<BridgeSseSessionCompacted>(), hasLength(1));
+      final visibleText = events
+          .whereType<BridgeSseMessagePartUpdated>()
+          .where((event) => event.part.type == PluginMessagePartType.text)
+          .map((event) => event.part.text);
+      expect(visibleText, contains("/compact architecture decisions"));
+      expect(visibleText, everyElement(isNot(contains("secret-instructions"))));
+    });
+
+    test("native compaction failure removes its running card", () async {
+      await harness.plugin.getCommands(projectId: harness.project.path);
+      final session = await harness.plugin.createSession(
+        directory: harness.project.path,
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final accepted = harness.plugin.sendCommand(
+        sessionId: session.id,
+        promptId: "prompt-failed-compact",
+        command: PiCatalogService.compactionCommandName,
+        arguments: "",
+        userVisibleArguments: null,
+        variant: null,
+        agent: "pi",
+        model: null,
+      );
+      final process = await harness.nextSessionProcess();
+      final request = await waitForCommand(process: process, type: "compact");
+      final runningUpdate = harness.plugin.events.firstWhere((event) => event is BridgeSseMessageUpdated);
+      process.emit(frame: {"type": "compaction_start", "reason": "manual"});
+      await accepted;
+      final runningEvent = await runningUpdate;
+      final running = runningEvent as BridgeSseMessageUpdated;
+      final removed = harness.plugin.events.firstWhere((event) => event is BridgeSseMessageRemoved);
+      final failed = harness.plugin.events.firstWhere((event) => event is BridgeSseSessionError);
+      final idle = harness.plugin.events.firstWhere((event) => event is BridgeSseSessionIdle);
+      process.emitFailure(id: request["id"]! as String, command: "compact", error: "compaction failed");
+
+      final removedEvent = await removed;
+      expect((removedEvent as BridgeSseMessageRemoved).messageID, running.info["id"]);
+      await Future.wait([failed, idle]);
+      expect(harness.plugin.getActiveSessionsSummary(), isEmpty);
+    });
+
+    test("an upstream compact command remains an ordinary slash command", () async {
+      final custom = _Harness(catalogCommand: PiCatalogService.compactionCommandName);
+      addTearDown(custom.dispose);
+      final commands = await custom.plugin.getCommands(projectId: custom.project.path);
+      expect(commands, hasLength(1));
+      expect(commands.single.description, isNull);
+      final session = await custom.plugin.createSession(
+        directory: custom.project.path,
+        parentSessionId: null,
+        parts: const [],
+        userVisibleText: null,
+        variant: null,
+        agent: null,
+        model: null,
+      );
+
+      final accepted = custom.plugin.sendCommand(
+        sessionId: session.id,
+        promptId: "prompt-custom-compact",
+        command: PiCatalogService.compactionCommandName,
+        arguments: "custom",
+        userVisibleArguments: "custom",
+        variant: null,
+        agent: "pi",
+        model: null,
+      );
+      final process = await custom.nextSessionProcess();
+      final prompt = await waitForCommand(process: process, type: "prompt");
+      expect(prompt["message"], "/compact custom");
+      expect(process.written.where((frame) => frame["type"] == "compact"), isEmpty);
+      process.emitResponse(id: prompt["id"]! as String, command: "prompt");
+      final state = await waitForCommand(process: process, type: "get_state");
+      process.emitResponse(
+        id: state["id"]! as String,
+        command: "get_state",
+        data: const {"isStreaming": false, "pendingMessageCount": 0},
+      );
+      await accepted;
     });
 
     test("wrapped command failures retain the backend stack", () async {
@@ -447,7 +532,7 @@ void main() {
   });
 }
 
-final class _Harness({bool stdinCloseCompletes = true}) {
+final class _Harness({bool stdinCloseCompletes = true, String catalogCommand = "review"}) {
   this {
     root = Directory.systemTemp.createTempSync("pi-plugin-");
     project = Directory("${root.path}/project")..createSync();
@@ -460,7 +545,7 @@ final class _Harness({bool stdinCloseCompletes = true}) {
       processFactory: ({required spec}) async {
         final process = FakePiProcess(stdinCloseCompletes: stdinCloseCompletes);
         processes.add((spec: spec, process: process));
-        unawaited(_answerProcess(process: process, spec: spec));
+        unawaited(_answerProcess(process: process, spec: spec, catalogCommand: catalogCommand));
         return process;
       },
       commandExecutor: commands,
@@ -515,7 +600,11 @@ final class _Harness({bool stdinCloseCompletes = true}) {
   }
 }
 
-Future<void> _answerProcess({required FakePiProcess process, required PiLaunchSpec spec}) async {
+Future<void> _answerProcess({
+  required FakePiProcess process,
+  required PiLaunchSpec spec,
+  required String catalogCommand,
+}) async {
   final answered = <String>{};
   while (!process.killed && !process.stdinClosed) {
     for (final command in process.written.toList()) {
@@ -561,9 +650,9 @@ Future<void> _answerProcess({required FakePiProcess process, required PiLaunchSp
           process.emitResponse(
             id: id,
             command: type,
-            data: const {
+            data: {
               "commands": [
-                {"name": "review", "source": "extension"},
+                {"name": catalogCommand, "source": "extension"},
               ],
             },
           );

--- a/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
@@ -244,7 +244,9 @@ void main() {
       );
       final process = await harness.nextSessionProcess();
       final request = await waitForCommand(process: process, type: "compact");
-      final runningUpdate = harness.plugin.events.firstWhere((event) => event is BridgeSseMessageUpdated);
+      final runningUpdate = harness.plugin.events.firstWhere(
+        (event) => event is BridgeSseMessageUpdated && event.info["promptId"] == null,
+      );
       process.emit(frame: {"type": "compaction_start", "reason": "manual"});
       await accepted;
       final runningEvent = await runningUpdate;

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -102,7 +102,8 @@ defaults and queued client sends coherent.
 - Pi slash commands are accepted by their correlated response or a matching
   extension dialog and remain in the request's sending state until then rather
   than exposing a cancellable bridge-queue entry. The bridge-synthesized
-  `compact` command instead accepts on Pi's `compaction_start`, then keeps the
+  `compact` command instead publishes its visible command marker before the
+  running compaction card, accepts on Pi's `compaction_start`, then keeps the
   resident busy until the native RPC finishes. A rejected native compaction clears
   its running card. Commands reject while that session is busy, and a successful
   ordinary command with no agent run crosses `get_state`

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -103,8 +103,9 @@ defaults and queued client sends coherent.
   extension dialog and remain in the request's sending state until then rather
   than exposing a cancellable bridge-queue entry. The bridge-synthesized
   `compact` command instead accepts on Pi's `compaction_start`, then keeps the
-  resident busy until the native RPC finishes. Commands reject while that session
-  is busy, and a successful ordinary command with no agent run crosses `get_state`
+  resident busy until the native RPC finishes. A rejected native compaction clears
+  its running card. Commands reject while that session is busy, and a successful
+  ordinary command with no agent run crosses `get_state`
   before returning the lane idle.
   Abort rejects queued work and replaces the process so hidden steering or
   follow-up input cannot leak into the next turn. Its control acknowledgement
@@ -119,7 +120,10 @@ defaults and queued client sends coherent.
   project directories. Because Pi omits built-in TUI commands from `get_commands`,
   the plugin appends one `compact` command and dispatches it through Pi's native
   `compact` RPC with optional user instructions rather than sending `/compact` as
-  a prompt. Reuse is project-local, refresh always probes, concurrent
+  a prompt. If an upstream command already owns that name, it remains an ordinary
+  slash command and the native action is not synthesized. Private instructions
+  remain confined to the RPC while the synthetic user marker uses only the
+  user-visible command text. Reuse is project-local, refresh always probes, concurrent
   requests for one project coalesce, and a failed refresh never replaces the
   last coherent snapshot. Dialogs raised during probes are cancelled and never
   enter session UI state. Empty Pi sessions remain lazy until their first prompt

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -101,8 +101,10 @@ defaults and queued client sends coherent.
   sender field and retains its prior assistant styling.
 - Pi slash commands are accepted by their correlated response or a matching
   extension dialog and remain in the request's sending state until then rather
-  than exposing a cancellable bridge-queue entry. Commands reject while that
-  session is busy, and a successful command with no agent run crosses `get_state`
+  than exposing a cancellable bridge-queue entry. The bridge-synthesized
+  `compact` command instead accepts on Pi's `compaction_start`, then keeps the
+  resident busy until the native RPC finishes. Commands reject while that session
+  is busy, and a successful ordinary command with no agent run crosses `get_state`
   before returning the lane idle.
   Abort rejects queued work and replaces the process so hidden steering or
   follow-up input cannot leak into the next turn. Its control acknowledgement
@@ -114,7 +116,10 @@ defaults and queued client sends coherent.
   before admission and are never fetched, stringified, or silently omitted.
 - Pi discovers models, thinking levels, and extension, prompt-template, prompt,
   and skill commands through bounded approved no-session probes in normalized
-  project directories. Reuse is project-local, refresh always probes, concurrent
+  project directories. Because Pi omits built-in TUI commands from `get_commands`,
+  the plugin appends one `compact` command and dispatches it through Pi's native
+  `compact` RPC with optional user instructions rather than sending `/compact` as
+  a prompt. Reuse is project-local, refresh always probes, concurrent
   requests for one project coalesce, and a failed refresh never replaces the
   last coherent snapshot. Dialogs raised during probes are cancelled and never
   enter session UI state. Empty Pi sessions remain lazy until their first prompt


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this threads a built-in Pi action through command discovery, session lifecycle handling, and native RPC dispatch.

## What

- Add one synthetic `compact` command when Pi omits it from `get_commands`, without duplicating an upstream command.
- Dispatch manual compaction through Pi's native `compact` RPC with optional custom instructions instead of sending `/compact` as a prompt.
- Accept the command on `compaction_start` or RPC completion while keeping the session lane busy until the RPC finishes.
- Cover catalog metadata, deduplication, native wire arguments, lifecycle timing, and `SessionCompacted` emission.
- Document the supported Pi session-turn behavior.

## Why

Pi does not return built-in TUI commands from `get_commands`, so Sesori clients could not discover or manually trigger context compaction. Sending `/compact` as an ordinary prompt would also bypass Pi's native compaction path.

## Risk and test focus

User-visible impact: Pi sessions now list and execute a manual `compact` command. Database impact: none.

The main risk is command/session lifecycle drift, especially accepting too early, releasing the busy lane before compaction completes, or accidentally writing a prompt frame. Tests focus on those boundaries and command deduplication.

## Expected result

Users can manually compact a Pi session from Sesori, optionally provide compaction instructions, see the compaction lifecycle event, and continue only after Pi's native compaction request completes.

## Verification

- `dart test` — 289 tests passed
- `dart analyze --fatal-infos` — no issues
- Architecture implementation review — approved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a synthetic `compact` command to Pi sessions so users can manually trigger context compaction. Previously Pi omitted its built-in TUI commands from `get_commands` and `/compact` was sent as a prompt, bypassing the native compaction path. Now the command dispatches through Pi's native `compact` RPC and keeps the session busy until the RPC finishes.

**New Features**

- Appends `compact` to catalog commands only when Pi does not already provide one.
- Accepts the command when Pi emits `compaction_start` or when the native RPC completes.
- Passes optional user-provided compaction instructions as `customInstructions` instead of writing a prompt frame.
- Emits the visible command marker before the running compaction card so the transcript reads in order.
- Clears the compaction card when the native RPC fails.

<sup>Written for commit 38cf614c1aa7e264d4958824217fea452dc9b6f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

