### PR TITLE
🌿 [desktop-app] Review plan after step 15: attention alerts, window bounds, series collisions

### DIFF
--- a/.plan/active/desktop-app/PLAN.md
+++ b/.plan/active/desktop-app/PLAN.md
@@ -13,6 +13,11 @@
   six findings applied to this document (process-repository boundary, bridgeId
   persistence, named send/logout owners, `tokenUpdate` deletion, instance
   Layer-1 storage, theme-assembly ownership)
+- **Plan review 2026-09-01 (after step 15):** added D6 (desktop is never a
+  push device; attention alerts derive locally from SSE), folded attention
+  notifications + window-bounds restore into step 20, named the
+  `instant-session-launch` series as a second extraction collision, and
+  completed the step 21 regression-doc list.
 - **Supersedes:** the paused desktop plan formerly in `docs/desktop/`
   (PLAN.md + phase docs), deleted by step 1. Git history preserves it; the
   still-valid decisions are carried into this document.
@@ -89,6 +94,7 @@ change in this plan is step 5 (status semantics + dead-protocol removal).
 | D3 | Window data path = **relay**, exactly like the phone (E2E encrypted; internet required even for a same-machine bridge — accepted). A loopback local data path stays a recorded future consideration in `docs/ROADMAP.md` (the bridge `DebugServer` is the precedent), not work in this plan. |
 | D4 | The control channel stays a **supervision umbilical only**: token authority, supervision prompts, status (relay/registration/aggregate plugin health/session count), lifecycle sentinels. Product data and per-plugin detail never enter it — that is the relay management API's job. |
 | D5 | The old plan is canceled: `docs/desktop/` deleted, pointers repointed, still-valid content carried here. |
+| D6 | The desktop is **never a push device**: it registers no FCM/APNs token, never runs `NotificationRegistrationService`, and omits the notification-preferences surface (step 15 already does). Out-of-window attention (permission asked, question asked) is derived **locally from the relay SSE stream the cockpit already receives** and rendered through a Layer-0 OS-notification adapter (step 20). The phone stays the sole push surface, so one bridge event never notifies twice on one machine. |
 
 ### Carried architecture decisions (from the superseded plan, still valid)
 
@@ -512,11 +518,15 @@ persisted startup read). **This delivers desktop onboarding.** Mobile
 behavior unchanged.
 
 **Step 16 — 🚧 Project list + session list slice + desktop offline strategy.**
-Decouple and move both lists (incl. `session_split`). Bridge-offline /
-never-registered states act through an injected strategy: mobile keeps CLI
-install copy + `reconnectBridge()`; desktop offers **Start the bridge** (drives
-`BridgeProcessService`) — never CLI-install copy (refactor R3's in-plan half;
-"get the desktop app" phone copy belongs to the distribution plan).
+Decouple and move both lists (incl. `session_split`, the session
+archive/delete/force dialogs, the PR-status row, and the project-list first-run
+onboarding view + "why a bridge" sheet — they travel with the lists, not
+later). Bridge-offline / never-registered states **and the first-run
+onboarding view** act through an injected strategy: mobile keeps CLI install
+copy + `reconnectBridge()`; desktop offers **Start the bridge** (drives
+`BridgeProcessService`) — never CLI-install or "connect your computer" copy
+(refactor R3's in-plan half; "get the desktop app" phone copy belongs to the
+distribution plan).
 
 **Step 17 — 🚧 Session detail: transcript slice.** Move the
 transcript/rendering half (streaming messages, markdown/code, tool parts,
@@ -525,9 +535,10 @@ decoupling as in step 15. The desktop shell registers the image-action seams
 this slice resolves (`ImageSaver`/`ImageClipboard`/`ImageSharer` — the mobile
 shell already has desktop-aware `ImageSaver` selection to reuse), or the
 affected actions hide behind explicit capabilities — no dead controls, no
-missing-registration crashes. Coordinate with the in-flight `claude-inline-subtasks`
-series (rebase order agreed at implementation time). *Overage: mechanical move
-churn.*
+missing-registration crashes. Coordinate with the in-flight
+`claude-inline-subtasks` **and `instant-session-launch`** series (both touch
+`session_detail` widgets; rebase order agreed at implementation time). *Overage:
+mechanical move churn.*
 
 **Step 18 — 🚧 Composer slice + voice/media seams (approved refactor R2's
 heavy part).** Relocate voice lifecycle behind `module_core` service seams and
@@ -544,21 +555,44 @@ concern; then move the composer (attachments, pickers, queued prompts). Voice
 on mobile must be regression-clean. *Overage: move churn.*
 
 **Step 19 — ⚙️ Diffs + new-session slice.** Decouple and move
-`session_diffs` + `new_session` (worktree options included).
+`session_diffs` + `new_session` (worktree options included). The
+`instant-session-launch` series rewrites `new_session_screen` and the queued
+submission model; check its tracker before moving and rebase on whichever
+side lands first.
 
-**Step 20 — ⚙️ Desktop cockpit composition.** Final composition over the
-slice-built router (the skeleton landed in step 14): window
-navigation (sidebar/split composition from the adaptive screens), keyboard
-basics (Enter-to-send vs newline, Esc dismissal, text selection), and the
-supervision surfaces (login-required, crash give-up, takeover) integrated
-around the cockpit.
+**Step 20 — 🚧 Desktop cockpit composition + attention notifications.** Final
+composition over the slice-built router (the skeleton landed in step 14):
+window navigation (sidebar/split composition from the adaptive screens),
+keyboard basics (Enter-to-send vs newline, Esc dismissal, text selection), and
+the supervision surfaces (login-required, crash give-up, takeover) integrated
+around the cockpit. **Window bounds restore:** persist size/position in
+desktop-owned Layer-1 storage (step-8 storage pattern) and restore on show,
+clamped to the current display — the fixed 720×620 default is not a daily
+driver. **Attention notifications (D6):** a Layer-0 `DesktopNotifier` adapter
+in `module_desktop_core` (dumb: show a titled notification, emit a click) with
+a shell implementation; a Layer-4 cubit derives "permission asked" and
+"question asked" from the SSE tracker the cockpit already runs, shows an OS
+notification **only while the window is hidden or unfocused**, and on click
+focuses the window and routes to the session. Content is category-level copy
+plus the session title — never prompt, transcript, or tool payload (same
+privacy line as the bridge's push content builder). Auto-dismiss when the
+request resolves, mirroring the in-app `pending_request_auto_dismiss`. No
+new preferences: a single on/off in desktop settings, persisted
+desktop-namespaced (C11). Without this a tray-resident cockpit cannot tell the
+user a session is blocked — the phone gets push, the desktop got nothing.
+*Overage: ~1.7k changed lines for the notifier adapter, bounds storage, and
+composition; the two additions have no legal home in an earlier slice.*
 
 > **MT gate C — cockpit parity + mobile regression (user-run, after step
 > 20).** Desktop: manage harnesses end-to-end (install + login a real one) ·
 > browse projects/sessions · full chat round-trip incl. a permission answer ·
 > diffs · new session (worktree) · bridge-off → Start-the-bridge recovers ·
 > internet-down shows truthful offline while supervision still works · window
-> ergonomics usable. Mobile (real device, release-target platform): login →
+> ergonomics usable, size/position survive relaunch · window hidden to tray +
+> phone-less permission request → OS notification → click focuses the window
+> on that session; request answered elsewhere → notification clears; toggle
+> off → silence · no push token registered by the desktop (phone still
+> notified once). Mobile (real device, release-target platform): login →
 > lists → chat/composer/pickers → voice message → diffs → new session →
 > settings + notifications — unchanged after the extraction, release
 > pipeline dry-run green.
@@ -573,10 +607,14 @@ scope to the affected feature docs (expected: account-and-onboarding,
 plugin-setup-and-lifecycle, plugin-runtime-installation, projects-and-sessions,
 session-creation-and-options, session-turns, questions-and-permissions,
 attachments-and-images, diffs-and-source-control, session-archiving-and-
-deletion, popup-alerts, navigation-transitions, voice-input (mobile-only
-boundary restated), bridge-connectivity, bridge-installation-and-updates
-(desktop app as an install path: still distribution-scope — note only));
-remove stale references.
+deletion, popup-alerts, navigation-transitions, pull-request-monitoring,
+session-history-and-recovery, tools-and-file-changes, permission-auto-approval,
+notifications (desktop = local SSE-derived attention alerts, never push — D6),
+voice-input (mobile-only boundary restated), bridge-connectivity,
+bridge-installation-and-updates (desktop app as an install path: still
+distribution-scope — note only)); remove stale references, including
+`account-and-onboarding.md`'s "desktop shell is not shipped" and
+`projects-and-sessions.md`'s "phone-only" coverage note.
 
 **Step 22 — 🌿 Coverage run, retirement, distribution handoff.** Run the
 recorded coverage (below), record results in the tracker, move the plan to
@@ -614,11 +652,16 @@ intended stops from crashes); log ring buffer + rotating file (crash
 diagnosis; pipe-drain necessity); single-instance lock + persisted
 autostart/last-on prefs (daily-driver behavior); GUI-persisted `bridgeId`
 copy (offline unregister, C8 — `BridgeIdStorage` + tracker write, step 11);
-`module_auth` logout generation (R1 — closes a real race). Deliberately
+`module_auth` logout generation (R1 — closes a real race); persisted window
+bounds + the OS-notification adapter and its attention cubit (step 20 — the
+tray-resident cockpit's only out-of-window signal, D6). Deliberately
 **not** added: per-plugin control DTOs, a loopback data transport, a
 GUI-crash watchdog (C6 trade), a second reconnect driver, any token-push path
 (pull-on-demand is the contract; `tokenUpdate` is deleted in step 5),
-provisioning UI on the control channel, and any multi-bridge machinery.
+provisioning UI on the control channel, any multi-bridge machinery, a desktop
+push registration or notification-preference matrix (D6), and a relay
+pairing/QR path (the room key is delivered in-band over the authenticated
+relay key exchange; the desktop inherits it through `ConnectionService`).
 
 ## Cleanup assessment
 
@@ -643,9 +686,13 @@ provisioning UI on the control channel, and any multi-bridge machinery.
 - **Extraction regression risk (steps 14–19)** is the plan's main risk:
   mitigated by slice-per-PR with mobile analyze/tests green per step, device
   regression at MT gate C, and the `session_split` adaptive precedent.
-- **In-flight UI series overlap** (`claude-inline-subtasks`, drafts touching
-  composer/attachments): sequence extraction slices after checking each
-  series' state at implementation time; never move a screen mid-flight under
-  an active series without rebasing agreement.
+- **In-flight UI series overlap** (`claude-inline-subtasks` — step 2/8 open,
+  touches `subtask_part_widget` and the force dialog; `instant-session-launch`
+  — step 1/7, relocates the queued-submission model and edits
+  `new_session_screen`, `session_detail_body`, `session_detail_loaded_view`,
+  `prompt_send_queue`; drafts touching composer/attachments): sequence
+  extraction slices after checking each series' tracker at implementation
+  time; never move a screen mid-flight under an active series without rebasing
+  agreement.
 - **Windows/Linux verification depth** is limited pre-distribution (recorded
   reduction above).

--- a/.plan/active/desktop-app/PLAN.md
+++ b/.plan/active/desktop-app/PLAN.md
@@ -146,8 +146,8 @@ client/desktop ──────────┼→ module_app_ui → module_cor
 
 ## Steps
 
-Sizes are soft-capped at 1,500 changed lines; steps 1, 2, 14, 17, 18 record
-expected overages below. Any step that ships or
+Sizes are soft-capped at 1,500 changed lines; steps 1, 2, 4, 5, 7, 14, 17,
+18, 20 record expected overages below. Any step that ships or
 materially changes user-facing behavior updates the directly affected
 `docs/regression/` feature document in the same PR; step 21 is final
 reconciliation only, never the first write.
@@ -521,7 +521,9 @@ behavior unchanged.
 Decouple and move both lists (incl. `session_split`, the session
 archive/delete/force dialogs, the PR-status row, and the project-list first-run
 onboarding view + "why a bridge" sheet — they travel with the lists, not
-later). Bridge-offline / never-registered states **and the first-run
+later; their `assets/images/projects_onboarding/` images move into
+`module_app_ui`'s declared assets with package-qualified paths, since neither
+`module_app_ui` nor the desktop bundle declares them today). Bridge-offline / never-registered states **and the first-run
 onboarding view** act through an injected strategy: mobile keeps CLI install
 copy + `reconnectBridge()`; desktop offers **Start the bridge** (drives
 `BridgeProcessService`) — never CLI-install or "connect your computer" copy
@@ -565,23 +567,37 @@ composition over the slice-built router (the skeleton landed in step 14):
 window navigation (sidebar/split composition from the adaptive screens),
 keyboard basics (Enter-to-send vs newline, Esc dismissal, text selection), and
 the supervision surfaces (login-required, crash give-up, takeover) integrated
-around the cockpit. **Window bounds restore:** persist size/position in
-desktop-owned Layer-1 storage (step-8 storage pattern) and restore on show,
-clamped to the current display — the fixed 720×620 default is not a daily
-driver. **Attention notifications (D6):** a Layer-0 `DesktopNotifier` adapter
-in `module_desktop_core` (dumb: show a titled notification, emit a click) with
-a shell implementation; a Layer-4 cubit derives "permission asked" and
-"question asked" from the SSE tracker the cockpit already runs, shows an OS
-notification **only while the window is hidden or unfocused**, and on click
-focuses the window and routes to the session. Content is category-level copy
-plus the session title — never prompt, transcript, or tool payload (same
-privacy line as the bridge's push content builder). Auto-dismiss when the
-request resolves, mirroring the in-app `pending_request_auto_dismiss`. No
-new preferences: a single on/off in desktop settings, persisted
-desktop-namespaced (C11). Without this a tray-resident cockpit cannot tell the
-user a session is blocked — the phone gets push, the desktop got nothing.
-*Overage: ~1.7k changed lines for the notifier adapter, bounds storage, and
-composition; the two additions have no legal home in an earlier slice.*
+around the cockpit. **Window bounds restore:** `WindowHost` (Layer 0) gains a
+typed `WindowBounds` model with `getBounds`/`setBounds` and `moved`/`resized`
+events; a Layer-3 `WindowBoundsService` reads the last bounds from
+desktop-owned Layer-1 storage (step-8 storage pattern), clamps them to a
+current display, applies them before first show, and debounce-writes on every
+move/resize — the adapter stays dumb, the shell holds no persistence logic.
+The fixed 720×620 default is not a daily driver. **Attention notifications
+(D6):** reuse the `module_core` `LocalNotificationClient`/`NotificationCanceller`
+seam (mobile's OS-notification contract, already keyed by session for
+cancellation) with a desktop shell implementation — no new notifier
+capability. `WindowHost` also gains a typed focus/visibility state stream
+(`focused` / `unfocused` / `hidden`), since a Cmd-Tab away is not observable
+today. A Layer-3 `DesktopAttentionService` owns the pipeline: it subscribes to
+`ConnectionService.events` directly (the existing `SseEventTracker` ignores
+permission/question events by design and is not extended), classifies
+"permission asked" / "question asked" / resolved, resolves the display title
+through the session repository (the SSE variants carry no title), gates on the
+window state stream and a single desktop-namespaced on/off preference (C11),
+shows through the client **only while the window is hidden or unfocused**,
+cancels for that session on resolve (mirroring the in-app
+`pending_request_auto_dismiss`), and on open-request focuses the window and
+routes to the session. `DesktopLogoutOrchestrator` calls cancel-all as part
+of its sequence so a stale alert never survives an account change (the
+relay subscription ends with logout, so the resolve event never arrives).
+Any cubit here only exposes the preference toggle. Content is category-level
+copy plus the session title — never prompt, transcript, or tool payload (same
+privacy line as the bridge's push content builder). Without this a
+tray-resident cockpit cannot tell the user a session is blocked — the phone
+gets push, the desktop got nothing. *Overage: ~1.7k changed lines for the
+notification client, window seams, bounds service, attention service, and
+composition; the additions have no legal home in an earlier slice.*
 
 > **MT gate C — cockpit parity + mobile regression (user-run, after step
 > 20).** Desktop: manage harnesses end-to-end (install + login a real one) ·
@@ -653,8 +669,8 @@ diagnosis; pipe-drain necessity); single-instance lock + persisted
 autostart/last-on prefs (daily-driver behavior); GUI-persisted `bridgeId`
 copy (offline unregister, C8 — `BridgeIdStorage` + tracker write, step 11);
 `module_auth` logout generation (R1 — closes a real race); persisted window
-bounds + the OS-notification adapter and its attention cubit (step 20 — the
-tray-resident cockpit's only out-of-window signal, D6). Deliberately
+bounds + the desktop `LocalNotificationClient` and `DesktopAttentionService`
+(step 20 — the tray-resident cockpit's only out-of-window signal, D6). Deliberately
 **not** added: per-plugin control DTOs, a loopback data transport, a
 GUI-crash watchdog (C6 trade), a second reconnect driver, any token-push path
 (pull-on-demand is the contract; `tokenUpdate` is deleted in step 5),
@@ -688,8 +704,8 @@ relay key exchange; the desktop inherits it through `ConnectionService`).
   regression at MT gate C, and the `session_split` adaptive precedent.
 - **In-flight UI series overlap** (`claude-inline-subtasks` — step 2/8 open,
   touches `subtask_part_widget` and the force dialog; `instant-session-launch`
-  — step 1/7, relocates the queued-submission model and edits
-  `new_session_screen`, `session_detail_body`, `session_detail_loaded_view`,
+  — step 1/7 in flight; steps 4–5/7 relocate the queued-submission model and
+  edit `new_session_screen`, `session_detail_body`, `session_detail_loaded_view`,
   `prompt_send_queue`; drafts touching composer/attachments): sequence
   extraction slices after checking each series' tracker at implementation
   time; never move a screen mid-flight under an active series without rebasing

--- a/.plan/active/desktop-app/TRACKER.md
+++ b/.plan/active/desktop-app/TRACKER.md
@@ -28,7 +28,7 @@ user-run checkpoints, not PRs; only the user marks them passed.
 | 17 | 🚧 Session detail: transcript slice | pending |
 | 18 | 🚧 Composer slice + voice/media seams (R2) | pending |
 | 19 | ⚙️ Diffs + new-session slice | pending |
-| 20 | ⚙️ Desktop cockpit composition | pending |
+| 20 | 🚧 Desktop cockpit composition + attention notifications | pending |
 | — | MT gate C: cockpit parity + mobile regression (user-run) | pending |
 | 21 | 🌿 Regression documentation reconciliation | pending |
 | 22 | 🌿 Coverage run, retirement, `desktop-distribution` handoff | pending |


### PR DESCRIPTION
## Complexity

🌿 trivial — plan/tracker text only; no code.

## What

Post-step-15 review of `.plan/active/desktop-app/`:

- **D6 (new):** the desktop is never a push device. Out-of-window attention (permission asked, question asked) is derived locally from the SSE stream the cockpit already receives and shown as an OS notification.
- **Step 20** gains attention notifications (Layer-0 `DesktopNotifier` adapter + Layer-4 cubit, shown only while hidden/unfocused, click focuses + routes, auto-clear on resolve, single on/off pref) and window size/position restore. Complexity ⚙️ → 🚧.
- **Step 16** explicitly names archive/delete/force dialogs, PR-status row, and the first-run onboarding view as part of the list slice, with the onboarding copy behind the same injected strategy.
- **Steps 17/19 + risks:** `instant-session-launch` (7 steps, rewrites `new_session_screen`, `session_detail_body`, queued submission) is a second extraction collision the plan did not list.
- **Step 21:** regression-doc list completed (`notifications`, `pull-request-monitoring`, `session-history-and-recovery`, `tools-and-file-changes`, `permission-auto-approval`) plus two stale "desktop not shipped / phone-only" notes to remove.
- **Gate C** adds the hidden-window notification and bounds-restore checks; complexity budget records the two new mutable parts and rules out desktop push registration and a relay pairing/QR path.

## Why

A tray-resident cockpit that cannot tell the user a session is blocked on a permission fails the ambient-cockpit goal; mobile relies on push, desktop registers none and should not (double notification). The rest closes gaps found by checking the plan against current code and the other active plans.

Verified non-gaps (no change): relay E2E room key is delivered in-band over the authenticated key exchange, so desktop needs no pairing path; the client has no bridge self-update control to gate for supervised helpers; splash/root wiring already covered.

## Risk and test focus

None — documentation only. No user-visible, database, or wire impact. The step 20 scope addition is a proposal; drop the D6 paragraph and step 20 additions if you disagree.

## Expected result

Steps 16–21 execute with the named collisions, slice contents, and step 20 deliverables; no re-planning at gate C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the desktop-app plan after step 15 so the tray-resident cockpit can surface attention notifications and restore window bounds, and records two extraction collisions found against current code.

- Adds D6: the desktop never registers for push; attention notifications derive locally from the SSE stream and render as OS notifications.
- Step 20 now restores window bounds via `WindowHost`/`WindowBoundsService` and shows attention notifications by reusing the `module_core` `LocalNotificationClient` seam through a `DesktopAttentionService` (hidden/unfocused only, click focuses and routes, auto-clear on resolve and logout, single on/off pref); complexity goes from ⚙️ to 🚧.
- Step 16 explicitly includes archive/delete/force dialogs, the PR-status row, and the first-run onboarding view in the list slice.
- Names `instant-session-launch` as a second extraction collision alongside `claude-inline-subtasks` in steps 17/19 and the risk section.
- Completes the step 21 regression-doc list and flags two stale "desktop not shipped / phone-only" notes to remove.
- Gate C adds hidden-window notification and bounds-restore checks; the complexity budget rules out desktop push registration and a relay pairing/QR path.
- Confirms non-gaps: the relay room key is delivered in-band over the authenticated key exchange, so no desktop pairing path is needed.
- Documentation only — no user-visible, database, or wire impact. The step 20 additions are a proposal; drop the D6 paragraph and step 20 additions if you disagree.

<sup>Written for commit 9ad04410e78e62748e60c2b5d45de166c3a06c70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

