### PR TITLE
🌿 Step the Flutter spinner fallback at eight frames per second

### DIFF
--- a/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
+++ b/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
@@ -77,8 +77,10 @@ class const PregoActivityIndicator({
 /// the whole frame pipeline busy at 60-120 Hz. Here each step repaints exactly
 /// once and nothing schedules a frame in between, which is the difference
 /// between an idle and a continuously rendering app on Android. The timer
-/// pauses while the app is not in the foreground, where a ticker would have
-/// been frozen anyway, and `animating: false` shows one static frame.
+/// stops while the app is not visible (paused, hidden, or detached), where a
+/// ticker would have been frozen anyway; an inactive-but-visible app (an
+/// unfocused desktop window, a system dialog) keeps spinning because the
+/// spinner is still on screen. `animating: false` shows one static frame.
 class const PregoSteppedActivityIndicator({
   super.key,
   required final Color color,
@@ -122,10 +124,11 @@ class _PregoSteppedActivityIndicatorState() extends State<PregoSteppedActivityIn
 
   void _syncTimer() {
     final lifecycle = WidgetsBinding.instance.lifecycleState;
-    // Unknown (not yet reported) counts as foreground; inactive is still visible.
-    final foreground =
+    // Unknown (not yet reported) counts as visible; inactive is unfocused but
+    // still on screen, so only paused/hidden/detached stop the timer.
+    final visible =
         lifecycle == null || lifecycle == AppLifecycleState.resumed || lifecycle == AppLifecycleState.inactive;
-    final shouldRun = widget.animating && foreground;
+    final shouldRun = widget.animating && visible;
     if (shouldRun == (_timer != null)) return;
     if (shouldRun) {
       _timer = Timer.periodic(PregoSteppedActivityIndicator.stepDuration, (_) {

--- a/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
+++ b/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
@@ -1,3 +1,6 @@
+import "dart:async";
+import "dart:math" as math;
+
 import "package:flutter/foundation.dart";
 import "package:flutter/rendering.dart";
 import "package:flutter/services.dart";
@@ -10,8 +13,6 @@ class const PregoActivityIndicator({
 }) extends StatelessWidget {
   static const _nativeViewType = "sesori/native-activity-indicator";
   static const _defaultDimension = 36.0;
-  static const _staticArcSweep = 0.75;
-  static const _fallbackStrokeWidth = 2.0;
 
   @override
   Widget build(BuildContext context) {
@@ -24,7 +25,9 @@ class const PregoActivityIndicator({
         child: RepaintBoundary(
           child: SizedBox.square(
             dimension: _defaultDimension,
-            child: animationsEnabled ? _animatedIndicator() : _indicator(value: _staticArcSweep),
+            child: animationsEnabled
+                ? _animatedIndicator()
+                : PregoSteppedActivityIndicator(color: color, animating: false),
           ),
         ),
       ),
@@ -33,13 +36,13 @@ class const PregoActivityIndicator({
 
   Widget _animatedIndicator() {
     if (kIsWeb) {
-      return _indicator(value: null);
+      return PregoSteppedActivityIndicator(color: color, animating: true);
     }
 
     // Android deliberately has no native branch: a hybrid-composition platform
     // view idles Flutter beautifully on a static screen, but wrecks scroll
     // performance wherever a spinner shares the screen with a scrolling list
-    // (measured on-device, 2026-08-31), so the animated Flutter arc stays.
+    // (measured on-device, 2026-08-31), so the stepped Flutter spinner stays.
     final nativeView = switch (defaultTargetPlatform) {
       TargetPlatform.iOS => UiKitView(
         viewType: _nativeViewType,
@@ -57,23 +60,129 @@ class const PregoActivityIndicator({
     };
 
     if (nativeView == null) {
-      return _indicator(value: null);
+      return PregoSteppedActivityIndicator(color: color, animating: true);
     }
     // Native views consume creationParams only at creation, so a colour change
     // (a theme switch while a spinner is visible) must recreate the view.
     return KeyedSubtree(key: ValueKey(color.toARGB32()), child: nativeView);
   }
+}
 
-  Widget _indicator({required double? value}) {
-    // The approved wrapper owns the Flutter fallback for platforms without a
-    // native renderer and for static reduced-motion states.
-    // ignore: no_slop_linter/avoid_flutter_spinners
-    return CircularProgressIndicator(
-      value: value,
-      strokeWidth: _fallbackStrokeWidth,
-      strokeCap: StrokeCap.round,
-      color: color,
-      backgroundColor: Colors.transparent,
+/// The Flutter spinner for platforms without a native renderer: the iOS
+/// eight-tick activity indicator, stepped by a plain timer instead of a ticker.
+///
+/// The indicator's picture only changes when its active tick advances — eight
+/// times per second — yet the stock Cupertino widget repaints on every vsync of
+/// a continuous animation controller for those same eight pictures, keeping
+/// the whole frame pipeline busy at 60-120 Hz. Here each step repaints exactly
+/// once and nothing schedules a frame in between, which is the difference
+/// between an idle and a continuously rendering app on Android. The timer
+/// pauses while the app is not in the foreground, where a ticker would have
+/// been frozen anyway, and `animating: false` shows one static frame.
+class const PregoSteppedActivityIndicator({
+  super.key,
+  required final Color color,
+  required final bool animating,
+}) extends StatefulWidget {
+  /// Ticks per revolution; one revolution per second matches the stock indicator.
+  static const tickCount = 8;
+  static const stepDuration = Duration(milliseconds: 1000 ~/ tickCount);
+
+  @override
+  State<PregoSteppedActivityIndicator> createState() => _PregoSteppedActivityIndicatorState();
+}
+
+class _PregoSteppedActivityIndicatorState() extends State<PregoSteppedActivityIndicator> with WidgetsBindingObserver {
+  final _tick = ValueNotifier<int>(0);
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _syncTimer();
+  }
+
+  @override
+  void didUpdateWidget(PregoSteppedActivityIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.animating != widget.animating) _syncTimer();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) => _syncTimer();
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _timer?.cancel();
+    _tick.dispose();
+    super.dispose();
+  }
+
+  void _syncTimer() {
+    final lifecycle = WidgetsBinding.instance.lifecycleState;
+    // Unknown (not yet reported) counts as foreground; inactive is still visible.
+    final foreground =
+        lifecycle == null || lifecycle == AppLifecycleState.resumed || lifecycle == AppLifecycleState.inactive;
+    final shouldRun = widget.animating && foreground;
+    if (shouldRun == (_timer != null)) return;
+    if (shouldRun) {
+      _timer = Timer.periodic(PregoSteppedActivityIndicator.stepDuration, (_) {
+        _tick.value = (_tick.value + 1) % PregoSteppedActivityIndicator.tickCount;
+      });
+    } else {
+      _timer?.cancel();
+      _timer = null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: _SteppedTickPainter(tick: _tick, color: widget.color),
     );
   }
+}
+
+/// Paints the eight ticks. Geometry and alpha ramp mirror Flutter's Cupertino
+/// indicator at its default 10 px radius, which is also the size of the native
+/// medium spinner used on iOS, so the fallback and the native branch look alike.
+class _SteppedTickPainter({
+  required ValueListenable<int> tick,
+  required final Color color,
+}) extends CustomPainter {
+  this : super(repaint: tick);
+
+  final ValueListenable<int> tick = tick;
+
+  static const _radius = 10.0;
+  static const _alphas = [47, 47, 47, 47, 72, 97, 122, 147];
+  static const _tickShape = RRect.fromLTRBXY(
+    -_radius / 10,
+    -_radius / 3,
+    _radius / 10,
+    -_radius,
+    _radius / 10,
+    _radius / 10,
+  );
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const tickCount = PregoSteppedActivityIndicator.tickCount;
+    final paint = Paint();
+    canvas
+      ..save()
+      ..translate(size.width / 2, size.height / 2);
+    for (var i = 0; i < tickCount; i++) {
+      paint.color = color.withAlpha(_alphas[(i - tick.value) % tickCount]);
+      canvas
+        ..drawRRect(_tickShape, paint)
+        ..rotate(2 * math.pi / tickCount);
+    }
+    canvas.restore();
+  }
+
+  @override
+  bool shouldRepaint(_SteppedTickPainter oldDelegate) => oldDelegate.tick != tick || oldDelegate.color != color;
 }

--- a/client/module_prego/test/components/prego_activity_indicator_test.dart
+++ b/client/module_prego/test/components/prego_activity_indicator_test.dart
@@ -18,173 +18,225 @@ void main() {
     );
   }
 
-  void usePlatform(TargetPlatform platform) {
+  // The override must be cleared inside the test body: the binding verifies
+  // foundation debug variables before tearDown callbacks run.
+  Future<void> onPlatform(TargetPlatform platform, Future<void> Function() body) async {
     debugDefaultTargetPlatformOverride = platform;
+    try {
+      await body();
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
   }
 
-  testWidgets("Android keeps the animated Flutter arc, deliberately", (tester) async {
+  // MaterialApp leaves follow-up frames scheduled after its first pump; flush
+  // them (without elapsing fake time, so no timer step fires) before judging
+  // what the spinner itself schedules.
+  Future<void> settle(WidgetTester tester) async {
+    for (var i = 0; i < 5 && tester.binding.hasScheduledFrame; i++) {
+      await tester.pump();
+    }
+  }
+
+  testWidgets("Android uses the stepped Flutter spinner, deliberately", (tester) async {
     // A hybrid-composition platform view idles Flutter on a static screen but
     // wrecks scroll performance (measured on-device), so Android never gets a
-    // native spinner branch.
-    usePlatform(TargetPlatform.android);
-    final handle = tester.ensureSemantics();
-    await tester.pumpWidget(
-      wrap(const PregoActivityIndicator(color: color)),
-    );
+    // native spinner branch; it gets the timer-stepped Cupertino derivative.
+    await onPlatform(TargetPlatform.android, () async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(
+        wrap(const PregoActivityIndicator(color: color)),
+      );
 
-    expect(
-      find.descendant(
-        of: find.byType(PregoActivityIndicator),
-        matching: find.byType(RepaintBoundary),
-      ),
-      findsOneWidget,
-    );
-    expect(find.byType(PlatformViewLink), findsNothing);
-    expect(find.byType(AndroidView), findsNothing);
-    expect(
-      tester.widget<CircularProgressIndicator>(find.byType(CircularProgressIndicator)).value,
-      isNull,
-    );
-    expect(tester.hasRunningAnimations, isTrue);
+      expect(
+        find.descendant(
+          of: find.byType(PregoActivityIndicator),
+          matching: find.byType(RepaintBoundary),
+        ),
+        findsOneWidget,
+      );
+      expect(find.byType(PlatformViewLink), findsNothing);
+      expect(find.byType(AndroidView), findsNothing);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(
+        tester.widget<PregoSteppedActivityIndicator>(find.byType(PregoSteppedActivityIndicator)).animating,
+        isTrue,
+      );
 
-    final data = tester.getSemantics(find.byType(PregoActivityIndicator)).getSemanticsData();
-    expect(data.role, SemanticsRole.loadingSpinner);
+      final data = tester.getSemantics(find.byType(PregoActivityIndicator)).getSemanticsData();
+      expect(data.role, SemanticsRole.loadingSpinner);
 
-    handle.dispose();
-    debugDefaultTargetPlatformOverride = null;
+      handle.dispose();
+    });
+  });
+
+  testWidgets("the stepped spinner repaints once per step and schedules nothing in between", (tester) async {
+    await onPlatform(TargetPlatform.android, () async {
+      await tester.pumpWidget(
+        wrap(const PregoActivityIndicator(color: color)),
+      );
+
+      // No ticker: a Flutter animation would register a transient frame callback
+      // and keep a frame scheduled at every vsync.
+      await settle(tester);
+      expect(tester.hasRunningAnimations, isFalse);
+      expect(tester.binding.hasScheduledFrame, isFalse);
+
+      await tester.binding.delayed(const Duration(milliseconds: 110));
+      expect(tester.binding.hasScheduledFrame, isFalse, reason: "no frame before the first step");
+
+      await tester.binding.delayed(const Duration(milliseconds: 20));
+      expect(tester.binding.hasScheduledFrame, isTrue, reason: "the step marks the painter dirty");
+
+      await tester.pump();
+      expect(tester.binding.hasScheduledFrame, isFalse);
+      await tester.binding.delayed(const Duration(milliseconds: 110));
+      expect(tester.binding.hasScheduledFrame, isFalse, reason: "one repaint per step, none between");
+    });
+  });
+
+  testWidgets("the stepped spinner pauses in the background and resumes in the foreground", (tester) async {
+    await onPlatform(TargetPlatform.android, () async {
+      await tester.pumpWidget(
+        wrap(const PregoActivityIndicator(color: color)),
+      );
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await settle(tester);
+      await tester.binding.delayed(const Duration(seconds: 1));
+      expect(tester.binding.hasScheduledFrame, isFalse, reason: "a background app must not keep stepping");
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await settle(tester);
+      await tester.binding.delayed(const Duration(milliseconds: 200));
+      expect(tester.binding.hasScheduledFrame, isTrue, reason: "stepping resumes with the app");
+    });
   });
 
   testWidgets("uses the native iOS spinner without scheduling Flutter animation", (tester) async {
-    usePlatform(TargetPlatform.iOS);
-    await tester.pumpWidget(
-      wrap(const PregoActivityIndicator(color: color)),
-    );
+    await onPlatform(TargetPlatform.iOS, () async {
+      await tester.pumpWidget(
+        wrap(const PregoActivityIndicator(color: color)),
+      );
 
-    final platformView = tester.widget<UiKitView>(find.byType(UiKitView));
-    expect(platformView.viewType, "sesori/native-activity-indicator");
-    expect(platformView.creationParams, color.toARGB32());
-    expect(platformView.hitTestBehavior, PlatformViewHitTestBehavior.transparent);
-    expect(find.byType(CircularProgressIndicator), findsNothing);
-    expect(tester.hasRunningAnimations, isFalse);
-
-    debugDefaultTargetPlatformOverride = null;
+      final platformView = tester.widget<UiKitView>(find.byType(UiKitView));
+      expect(platformView.viewType, "sesori/native-activity-indicator");
+      expect(platformView.creationParams, color.toARGB32());
+      expect(platformView.hitTestBehavior, PlatformViewHitTestBehavior.transparent);
+      expect(find.byType(PregoSteppedActivityIndicator), findsNothing);
+      expect(tester.hasRunningAnimations, isFalse);
+    });
   });
 
   testWidgets("uses the native macOS spinner without scheduling Flutter animation", (tester) async {
-    usePlatform(TargetPlatform.macOS);
-    await tester.pumpWidget(
-      wrap(const PregoActivityIndicator(color: color)),
-    );
+    await onPlatform(TargetPlatform.macOS, () async {
+      await tester.pumpWidget(
+        wrap(const PregoActivityIndicator(color: color)),
+      );
 
-    final platformView = tester.widget<AppKitView>(find.byType(AppKitView));
-    expect(platformView.viewType, "sesori/native-activity-indicator");
-    expect(platformView.creationParams, color.toARGB32());
-    expect(platformView.hitTestBehavior, PlatformViewHitTestBehavior.transparent);
-    expect(find.byType(CircularProgressIndicator), findsNothing);
-    expect(tester.hasRunningAnimations, isFalse);
-
-    debugDefaultTargetPlatformOverride = null;
+      final platformView = tester.widget<AppKitView>(find.byType(AppKitView));
+      expect(platformView.viewType, "sesori/native-activity-indicator");
+      expect(platformView.creationParams, color.toARGB32());
+      expect(platformView.hitTestBehavior, PlatformViewHitTestBehavior.transparent);
+      expect(find.byType(PregoSteppedActivityIndicator), findsNothing);
+      expect(tester.hasRunningAnimations, isFalse);
+    });
   });
 
   testWidgets("recreates the native view when the colour changes", (tester) async {
-    usePlatform(TargetPlatform.iOS);
-    const other = Color(0xFF654321);
-    await tester.pumpWidget(
-      wrap(const PregoActivityIndicator(color: color)),
-    );
-    expect(find.byKey(ValueKey(color.toARGB32())), findsOneWidget);
+    await onPlatform(TargetPlatform.iOS, () async {
+      const other = Color(0xFF654321);
+      await tester.pumpWidget(
+        wrap(const PregoActivityIndicator(color: color)),
+      );
+      expect(find.byKey(ValueKey(color.toARGB32())), findsOneWidget);
 
-    await tester.pumpWidget(
-      wrap(const PregoActivityIndicator(color: other)),
-    );
-    expect(find.byKey(ValueKey(color.toARGB32())), findsNothing);
-    expect(find.byKey(ValueKey(other.toARGB32())), findsOneWidget);
-    expect(
-      tester.widget<UiKitView>(find.byType(UiKitView)).creationParams,
-      other.toARGB32(),
-    );
-
-    debugDefaultTargetPlatformOverride = null;
+      await tester.pumpWidget(
+        wrap(const PregoActivityIndicator(color: other)),
+      );
+      expect(find.byKey(ValueKey(color.toARGB32())), findsNothing);
+      expect(find.byKey(ValueKey(other.toARGB32())), findsOneWidget);
+      expect(
+        tester.widget<UiKitView>(find.byType(UiKitView)).creationParams,
+        other.toARGB32(),
+      );
+    });
   });
 
   testWidgets("gives a loosely constrained Flutter spinner a 36 pixel square", (tester) async {
-    usePlatform(TargetPlatform.linux);
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: ThemeData(
-          progressIndicatorTheme: const ProgressIndicatorThemeData(
-            constraints: BoxConstraints.tightFor(width: 72, height: 72),
+    await onPlatform(TargetPlatform.linux, () async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Center(
+            child: PregoActivityIndicator(color: color),
           ),
         ),
-        home: const Center(
-          child: PregoActivityIndicator(color: color),
+      );
+
+      expect(tester.getSize(find.byType(PregoSteppedActivityIndicator)), const Size.square(36));
+    });
+  });
+
+  testWidgets("reduced motion shows a static stepped frame", (tester) async {
+    await onPlatform(TargetPlatform.android, () async {
+      await tester.pumpWidget(
+        wrap(
+          const PregoActivityIndicator(color: color),
+          reduceMotion: true,
         ),
-      ),
-    );
+      );
 
-    expect(tester.getSize(find.byType(CircularProgressIndicator)), const Size.square(36));
-
-    debugDefaultTargetPlatformOverride = null;
+      expect(
+        tester.widget<PregoSteppedActivityIndicator>(find.byType(PregoSteppedActivityIndicator)).animating,
+        isFalse,
+      );
+      expect(find.byType(AndroidView), findsNothing);
+      expect(find.byType(PlatformViewLink), findsNothing);
+      await settle(tester);
+      await tester.binding.delayed(const Duration(seconds: 1));
+      expect(tester.hasRunningAnimations, isFalse);
+      expect(tester.binding.hasScheduledFrame, isFalse);
+    });
   });
 
-  testWidgets("reduced motion uses a static Flutter arc", (tester) async {
-    usePlatform(TargetPlatform.android);
-    await tester.pumpWidget(
-      wrap(
-        const PregoActivityIndicator(color: color),
-        reduceMotion: true,
-      ),
-    );
-
-    expect(
-      tester.widget<CircularProgressIndicator>(find.byType(CircularProgressIndicator)).value,
-      isNotNull,
-    );
-    expect(find.byType(AndroidView), findsNothing);
-    expect(find.byType(PlatformViewLink), findsNothing);
-    await tester.pump(const Duration(seconds: 1));
-    expect(tester.hasRunningAnimations, isFalse);
-
-    debugDefaultTargetPlatformOverride = null;
-  });
-
-  testWidgets("disabled TickerMode uses a static Flutter arc", (tester) async {
-    usePlatform(TargetPlatform.macOS);
-    await tester.pumpWidget(
-      wrap(
-        const TickerMode(
-          enabled: false,
-          child: PregoActivityIndicator(color: color),
+  testWidgets("disabled TickerMode shows a static stepped frame", (tester) async {
+    await onPlatform(TargetPlatform.macOS, () async {
+      await tester.pumpWidget(
+        wrap(
+          const TickerMode(
+            enabled: false,
+            child: PregoActivityIndicator(color: color),
+          ),
         ),
-      ),
-    );
+      );
 
-    expect(
-      tester.widget<CircularProgressIndicator>(find.byType(CircularProgressIndicator)).value,
-      isNotNull,
-    );
-    expect(find.byType(AppKitView), findsNothing);
-    await tester.pump(const Duration(seconds: 1));
-    expect(tester.hasRunningAnimations, isFalse);
-
-    debugDefaultTargetPlatformOverride = null;
+      expect(
+        tester.widget<PregoSteppedActivityIndicator>(find.byType(PregoSteppedActivityIndicator)).animating,
+        isFalse,
+      );
+      expect(find.byType(AppKitView), findsNothing);
+      await settle(tester);
+      await tester.binding.delayed(const Duration(seconds: 1));
+      expect(tester.hasRunningAnimations, isFalse);
+      expect(tester.binding.hasScheduledFrame, isFalse);
+    });
   });
 
-  testWidgets("unsupported targets keep the animated Flutter fallback", (tester) async {
-    usePlatform(TargetPlatform.linux);
-    await tester.pumpWidget(
-      wrap(const PregoActivityIndicator(color: color)),
-    );
+  testWidgets("unsupported targets use the stepped Flutter spinner", (tester) async {
+    await onPlatform(TargetPlatform.linux, () async {
+      await tester.pumpWidget(
+        wrap(const PregoActivityIndicator(color: color)),
+      );
 
-    expect(
-      tester.widget<CircularProgressIndicator>(find.byType(CircularProgressIndicator)).value,
-      isNull,
-    );
-    expect(find.byType(AndroidView), findsNothing);
-    expect(find.byType(UiKitView), findsNothing);
-    expect(find.byType(AppKitView), findsNothing);
-    expect(tester.hasRunningAnimations, isTrue);
-
-    debugDefaultTargetPlatformOverride = null;
+      expect(
+        tester.widget<PregoSteppedActivityIndicator>(find.byType(PregoSteppedActivityIndicator)).animating,
+        isTrue,
+      );
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.byType(AndroidView), findsNothing);
+      expect(find.byType(UiKitView), findsNothing);
+      expect(find.byType(AppKitView), findsNothing);
+      expect(tester.hasRunningAnimations, isFalse);
+    });
   });
 }

--- a/docs/regression/native-activity-indicators.md
+++ b/docs/regression/native-activity-indicators.md
@@ -12,7 +12,8 @@ spinner is `PregoSteppedActivityIndicator`: a derivative of the iOS eight-tick
 indicator at the native medium size, stepped by a plain timer instead of a
 ticker. Its picture only changes when the active tick advances, so it repaints
 exactly eight times per second, registers no ticker, schedules no frame between
-steps, and pauses its timer while the app is not in the foreground. The sparkle
+steps, and stops its timer while the app is not visible (paused, hidden, or
+detached; an unfocused but visible window keeps spinning). The sparkle
 keeps its animated Flutter fallback there. Reduced motion and disabled tickers
 replace the native views with static Flutter frames (the spinner rests on one
 stepped frame; the sparkle rests on its solid keyframe, matching its
@@ -25,7 +26,7 @@ creation.
 Material failure signals: a native-platform spinner or sparkle driving
 continuous Flutter frame production again; the stepped spinner registering a
 ticker, scheduling frames between its eight steps per second, or keeping its
-timer alive while the app is in the background; a native indicator branch
+timer alive while the app is paused, hidden, or detached; a native indicator branch
 reappearing on Android and degrading scroll; crashes,
 frozen or corrupted scene rendering, or leaked native views when an indicator
 scrolls out of view, is inserted and removed repeatedly, or composes with

--- a/docs/regression/native-activity-indicators.md
+++ b/docs/regression/native-activity-indicators.md
@@ -7,17 +7,25 @@ Core Animation outside Flutter's frame pipeline, so an otherwise-static screen
 schedules no Flutter frames. Android is deliberately all-Flutter for both
 indicators: hybrid-composition platform views idle Flutter on a static screen
 but wreck Android scroll performance on-device, and the sparkle lives in
-scrolling list rows. Web and the remaining desktop platforms use the animated
-Flutter fallbacks. Reduced motion and disabled tickers
-replace the native views with static Flutter frames (the sparkle rests on its
-solid keyframe, matching its `animate: false` still), the spinner owns
-loading-spinner semantics on every platform, and the sparkle stays decorative.
+scrolling list rows. On Android, web, and the remaining desktop platforms the
+spinner is `PregoSteppedActivityIndicator`: a derivative of the iOS eight-tick
+indicator at the native medium size, stepped by a plain timer instead of a
+ticker. Its picture only changes when the active tick advances, so it repaints
+exactly eight times per second, registers no ticker, schedules no frame between
+steps, and pauses its timer while the app is not in the foreground. The sparkle
+keeps its animated Flutter fallback there. Reduced motion and disabled tickers
+replace the native views with static Flutter frames (the spinner rests on one
+stepped frame; the sparkle rests on its solid keyframe, matching its
+`animate: false` still), the spinner owns loading-spinner semantics on every
+platform, and the sparkle stays decorative.
 The sparkle's native renderer duplicates the Dart painter's geometry,
 keyframes, and 1.4s period, including the per-row phase stagger passed at
 creation.
 
 Material failure signals: a native-platform spinner or sparkle driving
-continuous Flutter frame production again; a native indicator branch
+continuous Flutter frame production again; the stepped spinner registering a
+ticker, scheduling frames between its eight steps per second, or keeping its
+timer alive while the app is in the background; a native indicator branch
 reappearing on Android and degrading scroll; crashes,
 frozen or corrupted scene rendering, or leaked native views when an indicator
 scrolls out of view, is inserted and removed repeatedly, or composes with
@@ -30,7 +38,7 @@ still animating.
 
 | Level | Additional coverage |
 |---|---|
-| L1 Smoke | Automated: the owning widget test suite proves per-platform widget selection, creation parameters, semantics role, and the reduced-motion and disabled-ticker fallbacks. |
+| L1 Smoke | Automated: the owning widget test suite proves per-platform widget selection, creation parameters, semantics role, the reduced-motion and disabled-ticker fallbacks, and that the stepped spinner schedules one repaint per step, none between, no ticker, and nothing while the app is backgrounded. |
 | L2 Routine | Client end to end (release-target client platform): a screen with a spinning indicator renders correctly while the app shows no continuous Flutter UI/raster work attributable to the spinner; list scrolling stays smooth with indicators on screen. |
 | L3 Release | Client end to end: repeat on the alternate mobile platform and macOS desktop (include a session list with working-session sparkles on iOS and macOS); scroll an indicator through a list, insert and remove it repeatedly, and overlap it with glass/blur without crashes or scene corruption. |
 | L4 Extended | Client end to end: toggle system reduce motion mid-spin; background and foreground the app while an indicator is animating. |


### PR DESCRIPTION
## Complexity

🌿 straightforward — one widget file in `module_prego` plus its tests and regression doc; no cross-layer or contract changes.

## What

`PregoActivityIndicator` keeps its native Core Animation platform views on iOS and macOS, unchanged. Every other platform (Android, web, Linux, Windows) now renders `PregoSteppedActivityIndicator`: a derivative of the iOS eight-tick Cupertino indicator at the native medium size (radius 10, matching `UIActivityIndicatorView.medium`), driven by a plain `Timer.periodic` at 125 ms instead of a ticker. The picture only changes when the active tick advances, so it repaints exactly eight times per second and schedules no Flutter frame in between; the stock Cupertino widget repaints on every vsync for the same eight pictures. The timer pauses while the app is not in the foreground (`WidgetsBindingObserver`), and reduced motion / disabled `TickerMode` render one static stepped frame. The Material `CircularProgressIndicator` fallback (and its lint suppression) is deleted.

## Why

On Android the spinner cost is the frame pipeline, not the widget: a continuously animating Flutter indicator keeps the whole scene re-rastering at 60-120 Hz (measured 2026-08-31: ~10% of a core for one spinner versus 0% idle). Platform views were rejected there because hybrid composition wrecks scroll on-device. Stepping the indicator to the eight visual states it actually has cuts frame production by roughly 8-15x with no visible change to the animation, which lowers battery drain wherever a spinner sits on screen.

## Risk and test focus

Low. Impacted: every non-Apple spinner (session detail busy state, queued bubbles, pickers, attachment viewer, subtask/background rows). Not impacted: iOS/macOS native branches, the sparkle loader, semantics. Test focus: `prego_activity_indicator_test.dart` proves one repaint per step and none between (frame scheduling asserted directly), no ticker, background pause/resume, static reduced-motion and disabled-ticker frames, unchanged native selection and 36 px sizing. On-device: confirm the Android spinner looks like the iOS one and that CPU/frame production drops on a static loading screen.

## Expected result

User-visible: on Android/web/desktop the spinner becomes the iOS-style eight-tick indicator at the same size as the native one; iOS/macOS look identical to before. No database change. Internally the fallback registers no ticker and produces at most eight frames per second while visible, none while backgrounded.

## Verification

- `flutter test` in `client/module_prego`: 261 passed (10 in the owning suite).
- `flutter test test/features/session_detail` in `client/app`: 268 passed.
- `flutter analyze --fatal-infos` in `client/module_prego`: no issues (includes the `no_slop_linter` plugin).
- `docs/regression/native-activity-indicators.md` updated with the stepped fallback contract and failure signals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the animated `CircularProgressIndicator` fallback on Android, web, and desktop with `PregoSteppedActivityIndicator`, an iOS-style eight-tick spinner driven by a 125 ms timer. The old fallback repainted on every vsync, keeping the whole scene re-rasterizing at 60–120 Hz; the new one repaints exactly eight times per second, cutting frame production roughly 8–15×. iOS/macOS keep their native Core Animation platform views unchanged.

**Notes**
- Only a paused, hidden, or detached app stops the timer; an unfocused but visible window keeps spinning.
- Reduced motion and disabled `TickerMode` render a static stepped frame.
- No migration or rollout steps; affected platforms show the same eight-tick animation at the same 36 px size.

<sup>Written for commit 39ce9df4c70b8f6070b980502c41174c5f17c6cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

