### PR TITLE
🌱 Tint the macOS native spinner under the light appearance

### DIFF
--- a/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
+++ b/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
@@ -436,6 +436,12 @@ private enum AiLoaderSparkle {
       indicator.translatesAutoresizingMaskIntoConstraints = false
       // Content filters only apply to a layer-backed view.
       indicator.wantsLayer = true
+      // The spinner draws its ticks in the label colour at varying alpha:
+      // black under the light appearance, white under dark. A monochrome
+      // filter maps luminance onto the requested colour, so black ticks would
+      // stay black; pin the dark appearance so the ticks are white, which the
+      // filter maps exactly onto the colour while keeping each tick's alpha.
+      indicator.appearance = NSAppearance(named: .darkAqua)
       // NSProgressIndicator has no tint API; a monochrome content filter
       // recolours the spinner to the requested colour.
       if let filter = CIFilter(name: "CIColorMonochrome"), let ciColor = CIColor(color: color) {


### PR DESCRIPTION
## Complexity

🌱 trivial — one line in the macOS native activity indicator view.

## What

Pins the macOS `NSProgressIndicator` inside `NativeActivityIndicatorView` to the dark appearance before applying the existing `CIColorMonochrome` content filter.

## Why

The native macOS spinner ignored its requested colour under the light appearance. `NSProgressIndicator` draws its ticks in the label colour at varying alpha — black in light mode, white in dark mode — and the monochrome filter maps *luminance* onto the requested colour, so black ticks stayed black (in dark mode it happened to work because white × colour = colour). With the ticks forced white, the filter maps them exactly onto the requested colour while each tick keeps its alpha, so the spin animation is preserved.

## Risk and test focus

Low. Impacted: every native spinner on macOS (session detail busy state, pickers, loading views). Not impacted: iOS (`UIActivityIndicatorView.color` is a real tint API), Android/web/desktop Flutter fallbacks, sizing, reduce-motion handling, semantics. Test focus: on macOS in the light system appearance, a brand-coloured spinner renders in that colour rather than black; in dark appearance it looks as before; ticks still animate.

## Expected result

User-visible: macOS spinners show their requested colour in both system appearances. No database change; no wire change.

## Verification

- `flutter build macos --debug` in `client/app` succeeds with the change.
- Visual confirmation on a Mac in light appearance is the authoritative check; the regression doc already lists "an indicator ignoring its requested colours" as a failure signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the macOS native spinner ignoring its requested color under the light appearance, so brand-colored spinners now render correctly in both system appearances.

- Pins `NSProgressIndicator` to the dark appearance before the existing `CIColorMonochrome` filter runs, so the filter maps white ticks to the requested color instead of leaving black ticks black.
- No impact on other platforms, sizing, reduce-motion handling, or semantics.

<sup>Written for commit 8bb0f573d2d5e8d73ba26ebb53bcdc206354a85b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

