### PR TITLE
🌱 Leave the macOS native spinner in its system colour

### DIFF
--- a/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
+++ b/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
@@ -5,7 +5,6 @@ import Foundation
   import UIKit
 #elseif os(macOS)
   import AppKit
-  import CoreImage
   import FlutterMacOS
 #endif
 
@@ -405,25 +404,21 @@ private enum AiLoaderSparkle {
     }
 
     func create(withViewIdentifier viewId: Int64, arguments args: Any?) -> NSView {
-      guard let color = args as? NSNumber else {
+      // The shared creation contract carries the requested colour for iOS;
+      // the macOS spinner deliberately keeps its system appearance colour
+      // (a monochrome-filtered tint looked worse and read poorly), so the
+      // argument is validated but not applied here.
+      guard args is NSNumber else {
         preconditionFailure("Invalid native activity indicator creation arguments")
       }
-      let components = ColorComponents(fromARGB: color.int64Value)
-      return NativeActivityIndicatorView(
-        color: NSColor(
-          red: components.red,
-          green: components.green,
-          blue: components.blue,
-          alpha: components.alpha
-        )
-      )
+      return NativeActivityIndicatorView()
     }
   }
 
   private final class NativeActivityIndicatorView: NSView {
     private let indicator = NSProgressIndicator()
 
-    init(color: NSColor) {
+    init() {
       super.init(frame: .zero)
 
       // The Flutter wrapper owns the loading-spinner semantics; hide both the
@@ -434,21 +429,6 @@ private enum AiLoaderSparkle {
       indicator.isIndeterminate = true
       indicator.isDisplayedWhenStopped = true
       indicator.translatesAutoresizingMaskIntoConstraints = false
-      // Content filters only apply to a layer-backed view.
-      indicator.wantsLayer = true
-      // The spinner draws its ticks in the label colour at varying alpha:
-      // black under the light appearance, white under dark. A monochrome
-      // filter maps luminance onto the requested colour, so black ticks would
-      // stay black; pin the dark appearance so the ticks are white, which the
-      // filter maps exactly onto the colour while keeping each tick's alpha.
-      indicator.appearance = NSAppearance(named: .darkAqua)
-      // NSProgressIndicator has no tint API; a monochrome content filter
-      // recolours the spinner to the requested colour.
-      if let filter = CIFilter(name: "CIColorMonochrome"), let ciColor = CIColor(color: color) {
-        filter.setValue(ciColor, forKey: "inputColor")
-        filter.setValue(1.0, forKey: "inputIntensity")
-        indicator.contentFilters = [filter]
-      }
       addSubview(indicator)
       NSLayoutConstraint.activate([
         indicator.centerXAnchor.constraint(equalTo: centerXAnchor),

--- a/docs/regression/native-activity-indicators.md
+++ b/docs/regression/native-activity-indicators.md
@@ -30,7 +30,9 @@ timer alive while the app is paused, hidden, or detached; a native indicator bra
 reappearing on Android and degrading scroll; crashes,
 frozen or corrupted scene rendering, or leaked native views when an indicator
 scrolls out of view, is inserted and removed repeatedly, or composes with
-glass and blur; an indicator ignoring its requested colours or theme switches;
+glass and blur; an iOS native or Flutter indicator ignoring its requested
+colours or theme switches (the macOS native spinner deliberately keeps its
+system appearance colour);
 sparkles in a list twinkling in lockstep despite distinct phases; the native
 sparkle keyframes visibly diverging from the Flutter fallback; reduce motion
 still animating.


### PR DESCRIPTION
## Complexity

🌱 trivial — removes the tint block from the macOS native activity indicator view and adjusts one regression-doc sentence.

## What

The macOS `NSProgressIndicator` inside `NativeActivityIndicatorView` no longer receives a `CIColorMonochrome` content filter, the pinned dark appearance, or layer backing; it draws in its normal system appearance colour. The platform-view factory still validates the shared colour creation argument (iOS keeps using it via `UIActivityIndicatorView.color`) but ignores it on macOS. The now-unused `CoreImage` import is dropped, and the regression doc records that the macOS native spinner intentionally keeps its system colour.

## Why

After #1246 made the tint actually apply in the light appearance, the brand-blue spinner turned out to be barely visible and looked worse than the system-grey indicator that macOS users expect. The owner prefers the untinted native look.

## Risk and test focus

Low. Impacted: every native spinner on macOS (session detail busy state, pickers, loading views). Not impacted: iOS tinting, the Android/web/desktop stepped Flutter spinner, sizing, reduce-motion handling, semantics. Test focus: on macOS in both system appearances the spinner renders in the system colour and still animates; no build warnings from the removed import.

## Expected result

User-visible: macOS spinners return to the standard system-grey appearance. No database change; no wire change (the creation argument is unchanged, only unused on macOS).

## Verification

- `flutter build macos --debug` in `client/app` succeeds with the change.
- Visual confirmation on a Mac is the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the tint applied to the macOS native activity indicator so it renders in the system default grey instead of the brand blue. The blue spinner was barely visible and looked worse than the native look, so the shared colour argument is validated but not used on macOS; iOS tinting is unaffected.

<sup>Written for commit 61d2ed745b94f6de3f9f579f26dcb174274c01ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

