### PR TITLE
🌿 Stop tinting activity indicators everywhere

### DIFF
--- a/client/app/lib/core/widgets/command_picker_sheet.dart
+++ b/client/app/lib/core/widgets/command_picker_sheet.dart
@@ -123,7 +123,7 @@ class _CommandPickerSheetState() extends State<CommandPickerSheet> {
           const SizedBox(height: 8),
           Expanded(
             child: switch (_filtered) {
-              null => Center(child: PregoActivityIndicator(color: prego.colors.fgBrandPrimary)),
+              null => const Center(child: PregoActivityIndicator(color: null)),
               final filtered when filtered.isEmpty => Center(
                 child: Padding(
                   padding: const EdgeInsets.all(24),

--- a/client/app/lib/core/widgets/legal_document_sheet.dart
+++ b/client/app/lib/core/widgets/legal_document_sheet.dart
@@ -44,10 +44,10 @@ class const _LegalDocumentBody() extends StatelessWidget {
     final state = context.watch<LegalDocumentCubit>().state;
 
     return switch (state) {
-      LegalDocumentLoading() => SizedBox(
+      LegalDocumentLoading() => const SizedBox(
         height: _placeholderHeight,
         child: Center(
-          child: PregoActivityIndicator(color: prego.colors.fgBrandPrimary),
+          child: PregoActivityIndicator(color: null),
         ),
       ),
       LegalDocumentFailed(:final reason) => _FailureView(reason: reason),

--- a/client/app/lib/core/widgets/model_picker_sheet.dart
+++ b/client/app/lib/core/widgets/model_picker_sheet.dart
@@ -179,7 +179,7 @@ class _ModelPickerSheetState() extends State<ModelPickerSheet> {
           const SizedBox(height: 4),
           Expanded(
             child: switch (_rows) {
-              null => Center(child: PregoActivityIndicator(color: prego.colors.fgBrandPrimary)),
+              null => const Center(child: PregoActivityIndicator(color: null)),
               final rows => _buildModelList(context: context, rows: rows),
             },
           ),

--- a/client/app/lib/features/session_detail/widgets/background_task_row.dart
+++ b/client/app/lib/features/session_detail/widgets/background_task_row.dart
@@ -52,13 +52,11 @@ class const BackgroundTaskRow({
   Widget _statusIcon({required SessionStatus? status, required PregoDesignSystem prego}) => switch (status) {
     // The leading slot is a tight 32px wide but leaves its height free. Center
     // re-loosens those constraints around a fixed 16px square.
-    SessionStatusBusy() || SessionStatusRetry() => Center(
+    SessionStatusBusy() || SessionStatusRetry() => const Center(
       heightFactor: 1,
       child: SizedBox.square(
         dimension: 16,
-        child: PregoActivityIndicator(
-          color: prego.colors.bgBrandSolid,
-        ),
+        child: PregoActivityIndicator(color: null),
       ),
     ),
     SessionStatusIdle() || null => Icon(

--- a/client/app/lib/features/session_detail/widgets/background_tasks_header.dart
+++ b/client/app/lib/features/session_detail/widgets/background_tasks_header.dart
@@ -24,13 +24,11 @@ class const BackgroundTasksHeader({
       leading: hasRunning
           // The leading slot is a tight 32px wide but leaves its height free.
           // Center re-loosens those constraints around a fixed 16px square.
-          ? Center(
+          ? const Center(
               heightFactor: 1,
               child: SizedBox.square(
                 dimension: 16,
-                child: PregoActivityIndicator(
-                  color: prego.colors.bgBrandSolid,
-                ),
+                child: PregoActivityIndicator(color: null),
               ),
             )
           : Icon(

--- a/client/app/lib/features/session_detail/widgets/file_part_widget.dart
+++ b/client/app/lib/features/session_detail/widgets/file_part_widget.dart
@@ -217,7 +217,7 @@ class const _FilePartContent({required final MessageAttachment attachment}) exte
                   color: prego.colors.bgSurface2,
                   child: Center(
                     child: loading
-                        ? PregoActivityIndicator(color: prego.colors.textSecondary)
+                        ? const PregoActivityIndicator(color: null)
                         : Icon(icon, size: prego.spacing.x6l, color: prego.colors.textSecondary),
                   ),
                 ),

--- a/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
+++ b/client/app/lib/features/session_detail/widgets/image_attachment_viewer.dart
@@ -161,12 +161,12 @@ class _StoredImageAttachmentViewerState() extends State<_StoredImageAttachmentVi
 enum ImageAttachmentOriginalPresentation() {
   idle,
   loading,
-  failed;
+  failed,
 }
 
 enum ImageAttachmentHeroPresentation() {
   cropped,
-  contained;
+  contained,
 }
 
 class const _StoredImageAttachmentViewerContent({
@@ -698,7 +698,7 @@ class _ImageAttachmentViewerState() extends State<ImageAttachmentViewer> with Ti
                   padding: EdgeInsets.all(prego.spacing.md),
                   child: SizedBox.square(
                     dimension: prego.spacing.x2l,
-                    child: PregoActivityIndicator(color: prego.colors.fgBrandPrimary),
+                    child: const PregoActivityIndicator(color: null),
                   ),
                 )
               else ...[
@@ -819,7 +819,7 @@ class _ImageAttachmentViewerState() extends State<ImageAttachmentViewer> with Ti
                     PositionedDirectional(
                       bottom: prego.spacing.lg,
                       end: prego.spacing.lg,
-                      child: PregoActivityIndicator(color: prego.colors.fgBrandPrimary),
+                      child: const PregoActivityIndicator(color: null),
                     ),
                   if (widget.originalPresentation == ImageAttachmentOriginalPresentation.failed)
                     Align(

--- a/client/app/lib/features/session_detail/widgets/queued_message_bubble.dart
+++ b/client/app/lib/features/session_detail/widgets/queued_message_bubble.dart
@@ -41,10 +41,10 @@ class const QueuedMessageBubble({
     final status = switch (presentation) {
       SendingMessageBubblePresentation() => _status(
         prego: prego,
-        icon: ExcludeSemantics(
+        icon: const ExcludeSemantics(
           child: SizedBox.square(
             dimension: 14,
-            child: PregoActivityIndicator(color: prego.colors.textTertiary),
+            child: PregoActivityIndicator(color: null),
           ),
         ),
         label: loc.sessionDetailSendingMessage,

--- a/client/app/lib/features/session_detail/widgets/session_detail_body.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_body.dart
@@ -122,16 +122,14 @@ class _SessionDetailBodyState() extends State<SessionDetailBody> {
       if (isBusy)
         // A status indicator, not a button — sized to the glass button's 40×40
         // footprint so the bar height stays stable as work starts and stops.
-        SizedBox(
+        const SizedBox(
           width: 40,
           height: 40,
           child: Center(
             child: SizedBox(
               width: 20,
               height: 20,
-              child: PregoActivityIndicator(
-                color: context.prego.colors.bgBrandSolid,
-              ),
+              child: PregoActivityIndicator(color: null),
             ),
           ),
         ),

--- a/client/app/lib/features/session_detail/widgets/subtask_part_widget.dart
+++ b/client/app/lib/features/session_detail/widgets/subtask_part_widget.dart
@@ -31,9 +31,7 @@ class const SubtaskPartWidget({
     // A backend that reports the subtask's own lifecycle is authoritative for
     // it. Otherwise the child session's status is the only signal available.
     final status = part.taskState?.status;
-    final childStatus = childSession == null
-        ? null
-        : childStatuses[childSession.id] ?? const SessionStatus.idle();
+    final childStatus = childSession == null ? null : childStatuses[childSession.id] ?? const SessionStatus.idle();
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
@@ -112,12 +110,10 @@ class const SubtaskPartWidget({
   }
 
   Widget _subtaskStatusIcon({required ToolStatus status, required PregoDesignSystem prego}) => switch (status) {
-    ToolStatus.pending || ToolStatus.running => SizedBox(
+    ToolStatus.pending || ToolStatus.running => const SizedBox(
       width: 16,
       height: 16,
-      child: PregoActivityIndicator(
-        color: prego.colors.bgBrandSolid,
-      ),
+      child: PregoActivityIndicator(color: null),
     ),
     ToolStatus.completed => Icon(
       Icons.check_circle,
@@ -143,12 +139,10 @@ class const SubtaskPartWidget({
   };
 
   Widget _sessionStatusIcon({required SessionStatus? status, required PregoDesignSystem prego}) => switch (status) {
-    SessionStatusBusy() || SessionStatusRetry() => SizedBox(
+    SessionStatusBusy() || SessionStatusRetry() => const SizedBox(
       width: 16,
       height: 16,
-      child: PregoActivityIndicator(
-        color: prego.colors.bgBrandSolid,
-      ),
+      child: PregoActivityIndicator(color: null),
     ),
     SessionStatusIdle() => Icon(
       Icons.check_circle,

--- a/client/app/lib/features/session_detail/widgets/tool_part_widget.dart
+++ b/client/app/lib/features/session_detail/widgets/tool_part_widget.dart
@@ -91,12 +91,10 @@ class const ToolPartWidget({super.key, required final MessagePartTool part}) ext
   }
 
   Widget _statusIcon({required ToolStatus status, required PregoDesignSystem prego}) => switch (status) {
-    ToolStatus.pending || ToolStatus.running => SizedBox(
+    ToolStatus.pending || ToolStatus.running => const SizedBox(
       width: 16,
       height: 16,
-      child: PregoActivityIndicator(
-        color: prego.colors.bgBrandSolid,
-      ),
+      child: PregoActivityIndicator(color: null),
     ),
     ToolStatus.completed => Icon(
       Icons.check_circle,

--- a/client/app/lib/features/session_diffs/session_diffs_body.dart
+++ b/client/app/lib/features/session_diffs/session_diffs_body.dart
@@ -62,9 +62,9 @@ class _SessionDiffsBodyState() extends State<SessionDiffsBody> {
   List<Widget> _buildContentSlivers({required BuildContext context, required DiffState state}) {
     return switch (state) {
       DiffStateLoading() => [
-        SliverFillRemaining(
+        const SliverFillRemaining(
           hasScrollBody: false,
-          child: Center(child: PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary)),
+          child: Center(child: PregoActivityIndicator(color: null)),
         ),
       ],
       DiffStateFailed(:final error) => [
@@ -97,9 +97,9 @@ class _SessionDiffsBodyState() extends State<SessionDiffsBody> {
     final viewModels = _viewModels;
     if (_isComputing || viewModels == null) {
       return [
-        SliverFillRemaining(
+        const SliverFillRemaining(
           hasScrollBody: false,
-          child: Center(child: PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary)),
+          child: Center(child: PregoActivityIndicator(color: null)),
         ),
       ];
     }

--- a/client/desktop/lib/features/auth_gate/auth_gate.dart
+++ b/client/desktop/lib/features/auth_gate/auth_gate.dart
@@ -39,8 +39,8 @@ class const AuthGateView({required final Widget child, super.key}) extends State
         unawaited(context.read<AuthGateCubit>().onSignedInDestinationReady());
       },
       child: switch (state) {
-        AuthGateChecking() => Scaffold(
-          body: Center(child: PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary)),
+        AuthGateChecking() => const Scaffold(
+          body: Center(child: PregoActivityIndicator(color: null)),
         ),
         AuthGateSignedOut() => const LoginScreen(),
         AuthGateSignedIn() => child,

--- a/client/desktop/lib/features/login/login_screen.dart
+++ b/client/desktop/lib/features/login/login_screen.dart
@@ -123,9 +123,9 @@ class const _StatusRow({required final String message}) extends StatelessWidget 
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        SizedBox.square(
+        const SizedBox.square(
           dimension: 16,
-          child: PregoActivityIndicator(color: Theme.of(context).colorScheme.primary),
+          child: PregoActivityIndicator(color: null),
         ),
         const SizedBox(width: 12),
         Flexible(child: Text(message)),

--- a/client/module_app_ui/lib/src/features/settings/harnesses_settings_view.dart
+++ b/client/module_app_ui/lib/src/features/settings/harnesses_settings_view.dart
@@ -171,9 +171,9 @@ class const _LoadingView() extends StatelessWidget {
   Widget build(BuildContext context) {
     return Semantics(
       label: context.loc.harnessesLoading,
-      child: Padding(
-        padding: const EdgeInsetsDirectional.only(top: PregoSpacing.x4l),
-        child: Center(child: PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary)),
+      child: const Padding(
+        padding: EdgeInsetsDirectional.only(top: PregoSpacing.x4l),
+        child: Center(child: PregoActivityIndicator(color: null)),
       ),
     );
   }
@@ -280,7 +280,7 @@ class const _ReadyView({required final PluginManagementReady state}) extends Sta
                   title: Text(loc.harnessManagementDefaultTimeout),
                   subtitle: Text(loc.harnessManagementDefaultTimeoutDescription),
                   trailing: defaultTimeoutActionInProgress
-                      ? PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary)
+                      ? const PregoActivityIndicator(color: null)
                       : Text(_timeoutLabel(context: context, minutes: response.defaultIdleTimeoutMins)),
                   onTap: _controlsBlocked(state.action)
                       ? null
@@ -462,7 +462,7 @@ class const _HarnessControlCard({
               ],
             ),
             subtitle: actionHint == null ? null : Text(actionHint),
-            trailing: actionForThisHarness ? PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary) : null,
+            trailing: actionForThisHarness ? const PregoActivityIndicator(color: null) : null,
           ),
           _FactRow(
             title: loc.harnessesSetupStatus,
@@ -483,9 +483,7 @@ class const _HarnessControlCard({
                     : loc.harnessAuthenticationLogIn,
               ),
               subtitle: Text(loc.harnessAuthenticationDescription),
-              trailing: authenticationStarting
-                  ? PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary)
-                  : null,
+              trailing: authenticationStarting ? const PregoActivityIndicator(color: null) : null,
               // Only one authentication flow can exist. Its own row can reopen
               // a retained challenge after uncertain cancellation; every other
               // row stays disabled until that flow settles.
@@ -537,7 +535,7 @@ class const _HarnessControlCard({
                   PluginInstallProgress() => loc.harnessManagementInstallInProgress,
                 },
               ),
-              trailing: installing ? PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary) : null,
+              trailing: installing ? const PregoActivityIndicator(color: null) : null,
               // Also blocked between the tap and the first progress event: the
               // command returns as soon as the bridge accepts it, long before
               // any phase arrives.
@@ -589,7 +587,7 @@ class const _HarnessControlCard({
               icon: TablerRegular.refresh_dot,
               title: Text(loc.harnessManagementScan),
               subtitle: Text(scanRejectionText ?? loc.harnessManagementScanDescription),
-              trailing: scanning ? PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary) : null,
+              trailing: scanning ? const PregoActivityIndicator(color: null) : null,
               onTap: blocked || scanning
                   ? null
                   : () => context.read<PluginManagementCubit>().startCatalogScanFor(pluginId: pluginId),
@@ -970,9 +968,9 @@ class const _AuthenticationSheet() extends StatelessWidget {
     final state = context.watch<PluginManagementCubit>().state;
     final challenge = _authenticationChallenge(state: state);
     if (challenge == null) {
-      return Padding(
-        padding: const EdgeInsetsDirectional.only(bottom: PregoSpacing.xl),
-        child: Center(child: PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary)),
+      return const Padding(
+        padding: EdgeInsetsDirectional.only(bottom: PregoSpacing.xl),
+        child: Center(child: PregoActivityIndicator(color: null)),
       );
     }
 

--- a/client/module_app_ui/lib/src/features/settings/notification_settings_view.dart
+++ b/client/module_app_ui/lib/src/features/settings/notification_settings_view.dart
@@ -45,9 +45,9 @@ class const NotificationSettingsView({
               vertical: _contentTopPadding,
             ),
             child: switch (state) {
-              NotificationPreferencesLoading() => Padding(
-                padding: const EdgeInsetsDirectional.only(top: PregoSpacing.x4l),
-                child: Center(child: PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary)),
+              NotificationPreferencesLoading() => const Padding(
+                padding: EdgeInsetsDirectional.only(top: PregoSpacing.x4l),
+                child: Center(child: PregoActivityIndicator(color: null)),
               ),
               NotificationPreferencesAccountUnavailable() => const _NotificationPreferencesUnavailable(),
               NotificationPreferencesLoadFailed() => const _NotificationPreferencesFailure(),
@@ -162,8 +162,8 @@ class const _NotificationToggleRow({
             child: SizedBox(
               key: ValueKey("notification_preference_loading_${category.name}"),
               width: context.prego.spacing.spacing16,
-              child: Center(
-                child: PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary),
+              child: const Center(
+                child: PregoActivityIndicator(color: null),
               ),
             ),
           )

--- a/client/module_app_ui/lib/src/features/settings/profile_view.dart
+++ b/client/module_app_ui/lib/src/features/settings/profile_view.dart
@@ -103,10 +103,10 @@ class _ProfileViewState() extends State<ProfileView> {
                       icon: TablerRegular.logout,
                       title: Text(loc.settingsLogout),
                       trailing: _isLoggingOut
-                          ? SizedBox(
+                          ? const SizedBox(
                               width: 20,
                               height: 20,
-                              child: PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary),
+                              child: PregoActivityIndicator(color: null),
                             )
                           : null,
                       onTap: _isLoggingOut ? null : () => unawaited(_logout()),

--- a/client/module_app_ui/lib/src/features/settings/widgets/bridge_settings_section.dart
+++ b/client/module_app_ui/lib/src/features/settings/widgets/bridge_settings_section.dart
@@ -70,8 +70,8 @@ class const _YoloSettingsRow() extends StatelessWidget {
         title: Text(context.loc.settingsYoloTitle),
         subtitle: Text(_yoloDescription(context: context, state: state)),
         trailing: switch (state) {
-          BridgeSettingsLoading() || BridgeSettingsReadyFull(yoloMutation: YoloMutationInProgress()) =>
-            PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary),
+          BridgeSettingsLoading() ||
+          BridgeSettingsReadyFull(yoloMutation: YoloMutationInProgress()) => const PregoActivityIndicator(color: null),
           BridgeSettingsReadyFull(yoloMutation: YoloMutationUnsupported()) => Text(
             context.loc.settingsPullRequestRefreshUnavailable,
             style: context.prego.textTheme.textSm.regular.copyWith(color: context.prego.colors.textSecondary),
@@ -151,7 +151,7 @@ Widget _trailing({required BuildContext context, required BridgeSettingsState st
     BridgeSettingsLoading() ||
     BridgeSettingsReady(
       pullRequestRefreshMutation: PullRequestRefreshMutationInProgress(),
-    ) => PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary),
+    ) => const PregoActivityIndicator(color: null),
     BridgeSettingsReady(pullRequestRefreshMutation: PullRequestRefreshMutationUnsupported()) => Text(
       context.loc.settingsPullRequestRefreshUnavailable,
       style: context.prego.textTheme.textSm.regular.copyWith(color: context.prego.colors.textSecondary),

--- a/client/module_app_ui/lib/src/widgets/catalog_scan_row.dart
+++ b/client/module_app_ui/lib/src/widgets/catalog_scan_row.dart
@@ -303,7 +303,7 @@ class const _ScanCard({required final _RowContent content}) extends StatelessWid
               dimension: _markSize,
               child: switch (content.icon) {
                 final icon? => Icon(icon, size: _markSize, color: foreground),
-                null => PregoActivityIndicator(color: foreground),
+                null => const PregoActivityIndicator(color: null),
               },
             ),
             const SizedBox(width: PregoSpacing.lg),

--- a/client/module_app_ui/lib/src/widgets/rename_sheet.dart
+++ b/client/module_app_ui/lib/src/widgets/rename_sheet.dart
@@ -54,10 +54,10 @@ class _RenameSheetState() extends State<RenameSheet> {
     final action = FilledButton(
       onPressed: _loading || _controller.text.trim().isEmpty ? null : _save,
       child: _loading
-          ? SizedBox(
+          ? const SizedBox(
               width: 16,
               height: 16,
-              child: PregoActivityIndicator(color: context.prego.colors.textWhite),
+              child: PregoActivityIndicator(color: null),
             )
           : Text(widget.saveLabel),
     );

--- a/client/module_app_ui/lib/src/widgets/rename_sheet.dart
+++ b/client/module_app_ui/lib/src/widgets/rename_sheet.dart
@@ -60,10 +60,12 @@ class _RenameSheetState() extends State<RenameSheet> {
           ? SizedBox(
               width: 16,
               height: 16,
-              // The primary button paints the inverse of the page surface, so
-              // the spinner takes the untinted grey of the opposite brightness.
-              child: PregoActivityIndicator(
-                color: PregoActivityIndicator.naturalColor(brightness: _inverse(Theme.of(context).brightness)),
+              // The primary button's fill (bgPrimarySolid) paints the inverse
+              // of the page surface, so the untinted spinner follows the
+              // opposite brightness.
+              child: PregoActivityIndicator.onSurface(
+                brightness: _inverse(Theme.of(context).brightness),
+                color: null,
               ),
             )
           : Text(widget.saveLabel),

--- a/client/module_app_ui/lib/src/widgets/rename_sheet.dart
+++ b/client/module_app_ui/lib/src/widgets/rename_sheet.dart
@@ -49,15 +49,22 @@ class _RenameSheetState() extends State<RenameSheet> {
     }
   }
 
+  static Brightness _inverse(Brightness brightness) =>
+      brightness == Brightness.dark ? Brightness.light : Brightness.dark;
+
   @override
   Widget build(BuildContext context) {
     final action = FilledButton(
       onPressed: _loading || _controller.text.trim().isEmpty ? null : _save,
       child: _loading
-          ? const SizedBox(
+          ? SizedBox(
               width: 16,
               height: 16,
-              child: PregoActivityIndicator(color: null),
+              // The primary button paints the inverse of the page surface, so
+              // the spinner takes the untinted grey of the opposite brightness.
+              child: PregoActivityIndicator(
+                color: PregoActivityIndicator.naturalColor(brightness: _inverse(Theme.of(context).brightness)),
+              ),
             )
           : Text(widget.saveLabel),
     );

--- a/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
+++ b/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
@@ -55,7 +55,7 @@ private struct ActivityIndicatorCreationParams {
     } else {
       self.color = nil
     }
-    self.dark = dictionary["dark"] as? Bool ?? false
+    self.dark = (dictionary["dark"] as? NSNumber)?.boolValue ?? false
   }
 }
 

--- a/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
+++ b/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
@@ -200,31 +200,33 @@ private enum AiLoaderSparkle {
       viewIdentifier viewId: Int64,
       arguments args: Any?
     ) -> FlutterPlatformView {
-      guard let color = args as? NSNumber else {
-        preconditionFailure("Invalid native activity indicator creation arguments")
-      }
-      let components = ColorComponents(fromARGB: color.int64Value)
-      return NativeActivityIndicatorPlatformView(
-        frame: frame,
-        color: UIColor(
+      // A nil colour keeps the system spinner colour; a tint is still honoured
+      // when a caller asks for one.
+      var tint: UIColor?
+      if let color = args as? NSNumber {
+        let components = ColorComponents(fromARGB: color.int64Value)
+        tint = UIColor(
           red: components.red,
           green: components.green,
           blue: components.blue,
           alpha: components.alpha
         )
-      )
+      } else if args != nil {
+        preconditionFailure("Invalid native activity indicator creation arguments")
+      }
+      return NativeActivityIndicatorPlatformView(frame: frame, color: tint)
     }
   }
 
   private final class NativeActivityIndicatorPlatformView: UIView, FlutterPlatformView {
     private let indicator = UIActivityIndicatorView(style: .medium)
 
-    init(frame: CGRect, color: UIColor) {
+    init(frame: CGRect, color: UIColor?) {
       super.init(frame: frame)
 
       isAccessibilityElement = false
       accessibilityElementsHidden = true
-      indicator.color = color
+      if let color { indicator.color = color }
       indicator.hidesWhenStopped = false
       indicator.translatesAutoresizingMaskIntoConstraints = false
       addSubview(indicator)
@@ -405,25 +407,28 @@ private enum AiLoaderSparkle {
     }
 
     func create(withViewIdentifier viewId: Int64, arguments args: Any?) -> NSView {
-      guard let color = args as? NSNumber else {
-        preconditionFailure("Invalid native activity indicator creation arguments")
-      }
-      let components = ColorComponents(fromARGB: color.int64Value)
-      return NativeActivityIndicatorView(
-        color: NSColor(
+      // A nil colour keeps the system spinner colour; a tint is still honoured
+      // when a caller asks for one.
+      var tint: NSColor?
+      if let color = args as? NSNumber {
+        let components = ColorComponents(fromARGB: color.int64Value)
+        tint = NSColor(
           red: components.red,
           green: components.green,
           blue: components.blue,
           alpha: components.alpha
         )
-      )
+      } else if args != nil {
+        preconditionFailure("Invalid native activity indicator creation arguments")
+      }
+      return NativeActivityIndicatorView(color: tint)
     }
   }
 
   private final class NativeActivityIndicatorView: NSView {
     private let indicator = NSProgressIndicator()
 
-    init(color: NSColor) {
+    init(color: NSColor?) {
       super.init(frame: .zero)
 
       // The Flutter wrapper owns the loading-spinner semantics; hide both the
@@ -434,17 +439,16 @@ private enum AiLoaderSparkle {
       indicator.isIndeterminate = true
       indicator.isDisplayedWhenStopped = true
       indicator.translatesAutoresizingMaskIntoConstraints = false
-      // Content filters only apply to a layer-backed view.
-      indicator.wantsLayer = true
-      // The spinner draws its ticks in the label colour at varying alpha:
-      // black under the light appearance, white under dark. A monochrome
-      // filter maps luminance onto the requested colour, so black ticks would
-      // stay black; pin the dark appearance so the ticks are white, which the
-      // filter maps exactly onto the colour while keeping each tick's alpha.
-      indicator.appearance = NSAppearance(named: .darkAqua)
-      // NSProgressIndicator has no tint API; a monochrome content filter
-      // recolours the spinner to the requested colour.
-      if let filter = CIFilter(name: "CIColorMonochrome"), let ciColor = CIColor(color: color) {
+      if let color, let filter = CIFilter(name: "CIColorMonochrome"), let ciColor = CIColor(color: color) {
+        // Content filters only apply to a layer-backed view.
+        indicator.wantsLayer = true
+        // The spinner draws its ticks in the label colour at varying alpha:
+        // black under the light appearance, white under dark. A monochrome
+        // filter maps luminance onto the requested colour, so black ticks
+        // would stay black; pin the dark appearance so the ticks are white,
+        // which the filter maps exactly onto the colour while keeping each
+        // tick's alpha. NSProgressIndicator has no tint API of its own.
+        indicator.appearance = NSAppearance(named: .darkAqua)
         filter.setValue(ciColor, forKey: "inputColor")
         filter.setValue(1.0, forKey: "inputIntensity")
         indicator.contentFilters = [filter]

--- a/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
+++ b/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
@@ -49,11 +49,14 @@ private struct ActivityIndicatorCreationParams {
 
   init?(from args: Any?) {
     guard let dictionary = args as? [String: Any] else { return nil }
-    if let color = dictionary["color"] {
-      guard let number = color as? NSNumber else { return nil }
-      self.color = number.int64Value
-    } else {
+    // The codec decodes Dart's null as NSNull; both spellings mean untinted.
+    switch dictionary["color"] {
+    case nil, is NSNull:
       self.color = nil
+    case let number as NSNumber:
+      self.color = number.int64Value
+    default:
+      return nil
     }
     self.dark = (dictionary["dark"] as? NSNumber)?.boolValue ?? false
   }

--- a/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
+++ b/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
@@ -41,6 +41,24 @@ private struct ColorComponents {
   }
 }
 
+/// What the Dart spinner sends when it creates a native indicator: an optional
+/// ARGB tint and whether the app's resolved theme is dark.
+private struct ActivityIndicatorCreationParams {
+  let color: Int64?
+  let dark: Bool
+
+  init?(from args: Any?) {
+    guard let dictionary = args as? [String: Any] else { return nil }
+    if let color = dictionary["color"] {
+      guard let number = color as? NSNumber else { return nil }
+      self.color = number.int64Value
+    } else {
+      self.color = nil
+    }
+    self.dark = dictionary["dark"] as? Bool ?? false
+  }
+}
+
 /// The three keyframe colours and phase offset the Dart sparkle sends when
 /// it creates a native twinkle view.
 private struct AiLoaderCreationParams {
@@ -200,33 +218,30 @@ private enum AiLoaderSparkle {
       viewIdentifier viewId: Int64,
       arguments args: Any?
     ) -> FlutterPlatformView {
-      // A nil colour keeps the system spinner colour; a tint is still honoured
-      // when a caller asks for one.
-      var tint: UIColor?
-      if let color = args as? NSNumber {
-        let components = ColorComponents(fromARGB: color.int64Value)
-        tint = UIColor(
-          red: components.red,
-          green: components.green,
-          blue: components.blue,
-          alpha: components.alpha
-        )
-      } else if args != nil {
+      guard let params = ActivityIndicatorCreationParams(from: args) else {
         preconditionFailure("Invalid native activity indicator creation arguments")
       }
-      return NativeActivityIndicatorPlatformView(frame: frame, color: tint)
+      return NativeActivityIndicatorPlatformView(frame: frame, params: params)
     }
   }
 
   private final class NativeActivityIndicatorPlatformView: UIView, FlutterPlatformView {
     private let indicator = UIActivityIndicatorView(style: .medium)
 
-    init(frame: CGRect, color: UIColor?) {
+    init(frame: CGRect, params: ActivityIndicatorCreationParams) {
       super.init(frame: frame)
 
       isAccessibilityElement = false
       accessibilityElementsHidden = true
-      if let color { indicator.color = color }
+      // Follow the app's resolved appearance rather than the host's: a forced
+      // in-app dark mode must not leave dark ticks on dark Flutter surfaces.
+      indicator.overrideUserInterfaceStyle = params.dark ? .dark : .light
+      // A nil colour keeps the system spinner colour; a tint is still honoured
+      // when a caller asks for one.
+      if let color = params.color {
+        let c = ColorComponents(fromARGB: color)
+        indicator.color = UIColor(red: c.red, green: c.green, blue: c.blue, alpha: c.alpha)
+      }
       indicator.hidesWhenStopped = false
       indicator.translatesAutoresizingMaskIntoConstraints = false
       addSubview(indicator)
@@ -407,29 +422,28 @@ private enum AiLoaderSparkle {
     }
 
     func create(withViewIdentifier viewId: Int64, arguments args: Any?) -> NSView {
-      // A nil colour keeps the system spinner colour; a tint is still honoured
-      // when a caller asks for one.
-      var tint: NSColor?
-      if let color = args as? NSNumber {
-        let components = ColorComponents(fromARGB: color.int64Value)
-        tint = NSColor(
-          red: components.red,
-          green: components.green,
-          blue: components.blue,
-          alpha: components.alpha
-        )
-      } else if args != nil {
+      guard let params = ActivityIndicatorCreationParams(from: args) else {
         preconditionFailure("Invalid native activity indicator creation arguments")
       }
-      return NativeActivityIndicatorView(color: tint)
+      return NativeActivityIndicatorView(params: params)
     }
   }
 
   private final class NativeActivityIndicatorView: NSView {
     private let indicator = NSProgressIndicator()
 
-    init(color: NSColor?) {
+    init(params: ActivityIndicatorCreationParams) {
       super.init(frame: .zero)
+      // Follow the app's resolved appearance rather than the host's: a forced
+      // in-app dark mode must not leave dark ticks on dark Flutter surfaces.
+      indicator.appearance = NSAppearance(named: params.dark ? .darkAqua : .aqua)
+      // A nil colour keeps the system spinner colour; a tint is still honoured
+      // when a caller asks for one.
+      var color: NSColor?
+      if let argb = params.color {
+        let c = ColorComponents(fromARGB: argb)
+        color = NSColor(red: c.red, green: c.green, blue: c.blue, alpha: c.alpha)
+      }
 
       // The Flutter wrapper owns the loading-spinner semantics; hide both the
       // container and the native indicator from VoiceOver.

--- a/client/module_prego/lib/components/alerts/prego_inline_alerts_notifications.dart
+++ b/client/module_prego/lib/components/alerts/prego_inline_alerts_notifications.dart
@@ -157,14 +157,14 @@ class const PregoInlineAlertsNotifications({
               PregoSpacing.lg, // 12
               PregoSpacing.lg, // 12
             ),
-            child: _buildBody(prego),
+            child: _buildBody(prego, brightness: Theme.of(context).brightness),
           ),
         ],
       ),
     );
   }
 
-  Widget _buildBody(PregoDesignSystem prego) {
+  Widget _buildBody(PregoDesignSystem prego, {required Brightness brightness}) {
     final colors = prego.colors;
     final hasBelow = supportingText != null || additionalContent != null;
 
@@ -173,7 +173,7 @@ class const PregoInlineAlertsNotifications({
     final titleRow = Row(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        _buildLeading(colors),
+        _buildLeading(colors, brightness: brightness),
         const SizedBox(width: _leadingGap),
         Expanded(
           child: Text(
@@ -236,11 +236,14 @@ class const PregoInlineAlertsNotifications({
     );
   }
 
-  Widget _buildLeading(PregoColors colors) {
+  Widget _buildLeading(PregoColors colors, {required Brightness brightness}) {
     if (_isLoading) {
-      return const SizedBox.square(
+      // The card surface is the inverse of the page, so the spinner takes the
+      // untinted grey of the opposite brightness to stay visible.
+      final inverse = brightness == Brightness.dark ? Brightness.light : Brightness.dark;
+      return SizedBox.square(
         dimension: _spinnerSize,
-        child: PregoActivityIndicator(color: null),
+        child: PregoActivityIndicator(color: PregoActivityIndicator.naturalColor(brightness: inverse)),
       );
     }
     return Icon(icon ?? _defaultIcon, size: _iconSize, color: _iconColor(colors));

--- a/client/module_prego/lib/components/alerts/prego_inline_alerts_notifications.dart
+++ b/client/module_prego/lib/components/alerts/prego_inline_alerts_notifications.dart
@@ -238,12 +238,12 @@ class const PregoInlineAlertsNotifications({
 
   Widget _buildLeading(PregoColors colors, {required Brightness brightness}) {
     if (_isLoading) {
-      // The card surface is the inverse of the page, so the spinner takes the
-      // untinted grey of the opposite brightness to stay visible.
+      // The card surface is the inverse of the page, so the untinted spinner
+      // follows the opposite brightness to stay visible.
       final inverse = brightness == Brightness.dark ? Brightness.light : Brightness.dark;
       return SizedBox.square(
         dimension: _spinnerSize,
-        child: PregoActivityIndicator(color: PregoActivityIndicator.naturalColor(brightness: inverse)),
+        child: PregoActivityIndicator.onSurface(brightness: inverse, color: null),
       );
     }
     return Icon(icon ?? _defaultIcon, size: _iconSize, color: _iconColor(colors));

--- a/client/module_prego/lib/components/alerts/prego_inline_alerts_notifications.dart
+++ b/client/module_prego/lib/components/alerts/prego_inline_alerts_notifications.dart
@@ -39,13 +39,15 @@ enum PregoInlineAlertsNotificationsType() {
 /// for the corresponding [PregoInlineAlertsNotifications] field to omit a
 /// button.
 class const PregoInlineAlertsNotificationsAction({
-    /// Button label.
+  /// Button label.
   required final String label,
-    /// Called when the button is tapped.
+
+  /// Called when the button is tapped.
   required final VoidCallback onPressed,
-    /// Optional icon placed before the [label].
+
+  /// Optional icon placed before the [label].
   final IconData? icon,
-  });
+});
 
 /// An inline alert / notification card — a faithful port of the Figma
 /// `pregoInlineAletsNotifications` component (sic).
@@ -77,32 +79,40 @@ class const PregoInlineAlertsNotificationsAction({
 /// )
 /// ```
 class const PregoInlineAlertsNotifications({
-    super.key,
-    /// Bold headline text shown on the first row. Long titles ellipsize on a
+  super.key,
+
+  /// Bold headline text shown on the first row. Long titles ellipsize on a
   /// single line so the actions stay aligned to the trailing edge.
   required final String title,
-    /// Selects the leading icon, accent gradient, and primary-action fill.
+
+  /// Selects the leading icon, accent gradient, and primary-action fill.
   final PregoInlineAlertsNotificationsType type = PregoInlineAlertsNotificationsType.info,
-    /// Optional supporting text shown below the title. When `null`, no supporting
+
+  /// Optional supporting text shown below the title. When `null`, no supporting
   /// text row is rendered.
   final String? supportingText,
-    /// Overrides the leading icon. When `null`, the [type]'s default icon is
+
+  /// Overrides the leading icon. When `null`, the [type]'s default icon is
   /// used. Ignored for [PregoInlineAlertsNotificationsType.loading], which
   /// always shows a spinner.
   final IconData? icon,
-    /// Optional primary (solid, accent-coloured) action button. When `null`, no
+
+  /// Optional primary (solid, accent-coloured) action button. When `null`, no
   /// primary button is rendered.
   final PregoInlineAlertsNotificationsAction? primaryAction,
-    /// Optional secondary (tertiary, label-only) action button, placed before
+
+  /// Optional secondary (tertiary, label-only) action button, placed before
   /// the [primaryAction]. When `null`, no secondary button is rendered.
   final PregoInlineAlertsNotificationsAction? secondaryAction,
-    /// Called when the close button is tapped. When `null`, the close button is
+
+  /// Called when the close button is tapped. When `null`, the close button is
   /// not rendered.
   final VoidCallback? onClose,
-    /// Optional custom widget rendered in the content column, below the
+
+  /// Optional custom widget rendered in the content column, below the
   /// [supportingText]. Use for richer content (links, inline controls, etc.).
   final Widget? additionalContent,
-  }) extends StatelessWidget {
+}) extends StatelessWidget {
   // Gap between the leading icon and the content column. Figma uses 10px —
   // between spacing-md (8) and spacing-lg (12) — so it has no named token.
   static const double _leadingGap = 10.0;
@@ -228,9 +238,9 @@ class const PregoInlineAlertsNotifications({
 
   Widget _buildLeading(PregoColors colors) {
     if (_isLoading) {
-      return SizedBox.square(
+      return const SizedBox.square(
         dimension: _spinnerSize,
-        child: PregoActivityIndicator(color: colors.buttonPrimaryIcon),
+        child: PregoActivityIndicator(color: null),
       );
     }
     return Icon(icon ?? _defaultIcon, size: _iconSize, color: _iconColor(colors));
@@ -379,9 +389,7 @@ class const _InvertedSurfaceTheme({required final Widget child}) extends Statele
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final inverted = theme.brightness == Brightness.light
-        ? PregoDesignSystem.dark
-        : PregoDesignSystem.light;
+    final inverted = theme.brightness == Brightness.light ? PregoDesignSystem.dark : PregoDesignSystem.light;
     // Append after the existing extensions so the inverted PregoDesignSystem
     // wins by type; all other theme extensions are preserved.
     return Theme(
@@ -400,7 +408,8 @@ class const _InvertedSurfaceTheme({required final Widget child}) extends Statele
 /// sat far above the card — matching the Figma radial.
 class const _WideEllipseGradientTransform(
   /// How many times wider than tall each iso-colour ring is drawn.
-  final double scaleX) extends GradientTransform {
+  final double scaleX,
+) extends GradientTransform {
   @override
   Matrix4 transform(Rect bounds, {TextDirection? textDirection}) {
     // Scale x by [scaleX] about the gradient centre (the card's mid-x). The

--- a/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
+++ b/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
@@ -41,11 +41,24 @@ class const PregoActivityIndicator({
     );
   }
 
-  /// The untinted spinner colour for a surface of [brightness]: the stock
-  /// Cupertino indicator's grey. A null [color] resolves to it for the theme
-  /// brightness; a surface that paints the inverse of the theme (a primary
-  /// button, an inverted alert card) passes the opposite brightness explicitly
-  /// so the spinner stays visible without becoming a brand tint.
+  /// The spinner for a surface whose brightness differs from the theme's (a
+  /// primary button, an inverted alert card). Both the native views and the
+  /// Flutter fallback resolve their natural colour from the theme brightness,
+  /// so the override is expressed as a theme rather than a tint: the native
+  /// spinner stays untinted and simply follows [brightness].
+  static Widget onSurface({required Brightness brightness, required Color? color}) => Builder(
+    builder: (context) {
+      final theme = Theme.of(context);
+      return Theme(
+        data: theme.copyWith(colorScheme: theme.colorScheme.copyWith(brightness: brightness)),
+        child: PregoActivityIndicator(color: color),
+      );
+    },
+  );
+
+  /// The untinted Flutter-fallback colour for a surface of [brightness]: the
+  /// stock Cupertino indicator's grey. A null [color] resolves to it for the
+  /// theme brightness; see [onSurface] for surfaces that invert the theme.
   static Color naturalColor({required Brightness brightness}) => switch (brightness) {
     Brightness.light => const Color(0xFF3C3C44),
     Brightness.dark => const Color(0xFFEBEBF5),

--- a/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
+++ b/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
@@ -7,9 +7,14 @@ import "package:flutter/services.dart";
 import "package:material_ui/material_ui.dart";
 
 /// A Prego activity indicator that animates outside Flutter where supported.
+///
+/// A null [color] keeps each platform's natural spinner colour (the system
+/// indicator on iOS/macOS, the Cupertino grey on the Flutter fallback); a
+/// colour tints it. Product surfaces currently pass null everywhere on
+/// purpose — the brand tint read poorly — while the capability stays available.
 class const PregoActivityIndicator({
   super.key,
-  required final Color color,
+  required final Color? color,
 }) extends StatelessWidget {
   static const _nativeViewType = "sesori/native-activity-indicator";
   static const _defaultDimension = 36.0;
@@ -18,6 +23,7 @@ class const PregoActivityIndicator({
   Widget build(BuildContext context) {
     final reducedMotion = MediaQuery.maybeDisableAnimationsOf(context) ?? false;
     final animationsEnabled = !reducedMotion && TickerMode.valuesOf(context).enabled;
+    final fallbackColor = color ?? _defaultFallbackColor(brightness: Theme.of(context).brightness);
 
     return Semantics(
       role: SemanticsRole.loadingSpinner,
@@ -26,17 +32,23 @@ class const PregoActivityIndicator({
           child: SizedBox.square(
             dimension: _defaultDimension,
             child: animationsEnabled
-                ? _animatedIndicator()
-                : PregoSteppedActivityIndicator(color: color, animating: false),
+                ? _animatedIndicator(fallbackColor: fallbackColor)
+                : PregoSteppedActivityIndicator(color: fallbackColor, animating: false),
           ),
         ),
       ),
     );
   }
 
-  Widget _animatedIndicator() {
+  /// The stock Cupertino indicator's untinted colour per brightness.
+  static Color _defaultFallbackColor({required Brightness brightness}) => switch (brightness) {
+    Brightness.light => const Color(0xFF3C3C44),
+    Brightness.dark => const Color(0xFFEBEBF5),
+  };
+
+  Widget _animatedIndicator({required Color fallbackColor}) {
     if (kIsWeb) {
-      return PregoSteppedActivityIndicator(color: color, animating: true);
+      return PregoSteppedActivityIndicator(color: fallbackColor, animating: true);
     }
 
     // Android deliberately has no native branch: a hybrid-composition platform
@@ -46,13 +58,13 @@ class const PregoActivityIndicator({
     final nativeView = switch (defaultTargetPlatform) {
       TargetPlatform.iOS => UiKitView(
         viewType: _nativeViewType,
-        creationParams: color.toARGB32(),
+        creationParams: color?.toARGB32(),
         creationParamsCodec: const StandardMessageCodec(),
         hitTestBehavior: PlatformViewHitTestBehavior.transparent,
       ),
       TargetPlatform.macOS => AppKitView(
         viewType: _nativeViewType,
-        creationParams: color.toARGB32(),
+        creationParams: color?.toARGB32(),
         creationParamsCodec: const StandardMessageCodec(),
         hitTestBehavior: PlatformViewHitTestBehavior.transparent,
       ),
@@ -60,11 +72,11 @@ class const PregoActivityIndicator({
     };
 
     if (nativeView == null) {
-      return PregoSteppedActivityIndicator(color: color, animating: true);
+      return PregoSteppedActivityIndicator(color: fallbackColor, animating: true);
     }
     // Native views consume creationParams only at creation, so a colour change
     // (a theme switch while a spinner is visible) must recreate the view.
-    return KeyedSubtree(key: ValueKey(color.toARGB32()), child: nativeView);
+    return KeyedSubtree(key: ValueKey<int?>(color?.toARGB32()), child: nativeView);
   }
 }
 

--- a/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
+++ b/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
@@ -51,12 +51,13 @@ class const PregoActivityIndicator({
     Brightness.dark => const Color(0xFFEBEBF5),
   };
 
-  /// The native renderers consume this once at creation: an optional tint and
-  /// the app's resolved brightness, so a forced in-app appearance keeps the
-  /// system spinner legible even when the host OS appearance differs.
-  Map<String, Object?> _nativeCreationParams({required Brightness brightness}) => {
+  /// The native renderers consume this once at creation: an optional ARGB
+  /// tint and the app's resolved brightness (`dark` is 1 or 0), so a forced
+  /// in-app appearance keeps the system spinner legible even when the host OS
+  /// appearance differs.
+  Map<String, int?> _nativeCreationParams({required Brightness brightness}) => {
     "color": color?.toARGB32(),
-    "dark": brightness == Brightness.dark,
+    "dark": brightness == Brightness.dark ? 1 : 0,
   };
 
   Widget _animatedIndicator({required Color fallbackColor, required Brightness brightness}) {

--- a/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
+++ b/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
@@ -23,7 +23,8 @@ class const PregoActivityIndicator({
   Widget build(BuildContext context) {
     final reducedMotion = MediaQuery.maybeDisableAnimationsOf(context) ?? false;
     final animationsEnabled = !reducedMotion && TickerMode.valuesOf(context).enabled;
-    final fallbackColor = color ?? _defaultFallbackColor(brightness: Theme.of(context).brightness);
+    final brightness = Theme.of(context).brightness;
+    final fallbackColor = color ?? naturalColor(brightness: brightness);
 
     return Semantics(
       role: SemanticsRole.loadingSpinner,
@@ -32,7 +33,7 @@ class const PregoActivityIndicator({
           child: SizedBox.square(
             dimension: _defaultDimension,
             child: animationsEnabled
-                ? _animatedIndicator(fallbackColor: fallbackColor)
+                ? _animatedIndicator(fallbackColor: fallbackColor, brightness: brightness)
                 : PregoSteppedActivityIndicator(color: fallbackColor, animating: false),
           ),
         ),
@@ -40,13 +41,25 @@ class const PregoActivityIndicator({
     );
   }
 
-  /// The stock Cupertino indicator's untinted colour per brightness.
-  static Color _defaultFallbackColor({required Brightness brightness}) => switch (brightness) {
+  /// The untinted spinner colour for a surface of [brightness]: the stock
+  /// Cupertino indicator's grey. A null [color] resolves to it for the theme
+  /// brightness; a surface that paints the inverse of the theme (a primary
+  /// button, an inverted alert card) passes the opposite brightness explicitly
+  /// so the spinner stays visible without becoming a brand tint.
+  static Color naturalColor({required Brightness brightness}) => switch (brightness) {
     Brightness.light => const Color(0xFF3C3C44),
     Brightness.dark => const Color(0xFFEBEBF5),
   };
 
-  Widget _animatedIndicator({required Color fallbackColor}) {
+  /// The native renderers consume this once at creation: an optional tint and
+  /// the app's resolved brightness, so a forced in-app appearance keeps the
+  /// system spinner legible even when the host OS appearance differs.
+  Map<String, Object?> _nativeCreationParams({required Brightness brightness}) => {
+    "color": color?.toARGB32(),
+    "dark": brightness == Brightness.dark,
+  };
+
+  Widget _animatedIndicator({required Color fallbackColor, required Brightness brightness}) {
     if (kIsWeb) {
       return PregoSteppedActivityIndicator(color: fallbackColor, animating: true);
     }
@@ -58,13 +71,13 @@ class const PregoActivityIndicator({
     final nativeView = switch (defaultTargetPlatform) {
       TargetPlatform.iOS => UiKitView(
         viewType: _nativeViewType,
-        creationParams: color?.toARGB32(),
+        creationParams: _nativeCreationParams(brightness: brightness),
         creationParamsCodec: const StandardMessageCodec(),
         hitTestBehavior: PlatformViewHitTestBehavior.transparent,
       ),
       TargetPlatform.macOS => AppKitView(
         viewType: _nativeViewType,
-        creationParams: color?.toARGB32(),
+        creationParams: _nativeCreationParams(brightness: brightness),
         creationParamsCodec: const StandardMessageCodec(),
         hitTestBehavior: PlatformViewHitTestBehavior.transparent,
       ),
@@ -74,9 +87,13 @@ class const PregoActivityIndicator({
     if (nativeView == null) {
       return PregoSteppedActivityIndicator(color: fallbackColor, animating: true);
     }
-    // Native views consume creationParams only at creation, so a colour change
-    // (a theme switch while a spinner is visible) must recreate the view.
-    return KeyedSubtree(key: ValueKey<int?>(color?.toARGB32()), child: nativeView);
+    // Native views consume creationParams only at creation, so a colour or
+    // brightness change (a theme switch while a spinner is visible) must
+    // recreate the view.
+    return KeyedSubtree(
+      key: ValueKey<(int?, Brightness)>((color?.toARGB32(), brightness)),
+      child: nativeView,
+    );
   }
 }
 

--- a/client/module_prego/lib/components/loaders/prego_launch_status.dart
+++ b/client/module_prego/lib/components/loaders/prego_launch_status.dart
@@ -73,7 +73,7 @@ class _PregoLaunchStatusState()
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                PregoActivityIndicator(color: prego.colors.bgBrandSolid),
+                const PregoActivityIndicator(color: null),
                 SizedBox(height: prego.spacing.xl),
                 AnimatedSwitcher(
                   duration: reducedMotion ? Duration.zero : _transitionDuration,

--- a/client/module_prego/test/components/prego_activity_indicator_test.dart
+++ b/client/module_prego/test/components/prego_activity_indicator_test.dart
@@ -121,7 +121,7 @@ void main() {
 
       final platformView = tester.widget<UiKitView>(find.byType(UiKitView));
       expect(platformView.viewType, "sesori/native-activity-indicator");
-      expect(platformView.creationParams, {"color": color.toARGB32(), "dark": false});
+      expect(platformView.creationParams, {"color": color.toARGB32(), "dark": 0});
       expect(platformView.hitTestBehavior, PlatformViewHitTestBehavior.transparent);
       expect(find.byType(PregoSteppedActivityIndicator), findsNothing);
       expect(tester.hasRunningAnimations, isFalse);
@@ -136,7 +136,7 @@ void main() {
 
       final platformView = tester.widget<AppKitView>(find.byType(AppKitView));
       expect(platformView.viewType, "sesori/native-activity-indicator");
-      expect(platformView.creationParams, {"color": color.toARGB32(), "dark": false});
+      expect(platformView.creationParams, {"color": color.toARGB32(), "dark": 0});
       expect(platformView.hitTestBehavior, PlatformViewHitTestBehavior.transparent);
       expect(find.byType(PregoSteppedActivityIndicator), findsNothing);
       expect(tester.hasRunningAnimations, isFalse);
@@ -158,7 +158,7 @@ void main() {
       expect(find.byKey(const ValueKey<(int?, Brightness)>((0xFF654321, Brightness.light))), findsOneWidget);
       expect(
         tester.widget<UiKitView>(find.byType(UiKitView)).creationParams,
-        {"color": other.toARGB32(), "dark": false},
+        {"color": other.toARGB32(), "dark": 0},
       );
     });
   });
@@ -246,7 +246,7 @@ void main() {
       );
 
       final platformView = tester.widget<UiKitView>(find.byType(UiKitView));
-      expect(platformView.creationParams, {"color": null, "dark": false});
+      expect(platformView.creationParams, {"color": null, "dark": 0});
     });
   });
 
@@ -260,7 +260,7 @@ void main() {
       );
 
       final platformView = tester.widget<UiKitView>(find.byType(UiKitView));
-      expect(platformView.creationParams, {"color": null, "dark": true});
+      expect(platformView.creationParams, {"color": null, "dark": 1});
       expect(find.byKey(const ValueKey<(int?, Brightness)>((null, Brightness.dark))), findsOneWidget);
     });
   });

--- a/client/module_prego/test/components/prego_activity_indicator_test.dart
+++ b/client/module_prego/test/components/prego_activity_indicator_test.dart
@@ -149,13 +149,13 @@ void main() {
       await tester.pumpWidget(
         wrap(const PregoActivityIndicator(color: color)),
       );
-      expect(find.byKey(ValueKey(color.toARGB32())), findsOneWidget);
+      expect(find.byKey(const ValueKey<int?>(0xFF123456)), findsOneWidget);
 
       await tester.pumpWidget(
         wrap(const PregoActivityIndicator(color: other)),
       );
-      expect(find.byKey(ValueKey(color.toARGB32())), findsNothing);
-      expect(find.byKey(ValueKey(other.toARGB32())), findsOneWidget);
+      expect(find.byKey(const ValueKey<int?>(0xFF123456)), findsNothing);
+      expect(find.byKey(const ValueKey<int?>(0xFF654321)), findsOneWidget);
       expect(
         tester.widget<UiKitView>(find.byType(UiKitView)).creationParams,
         other.toARGB32(),
@@ -237,6 +237,48 @@ void main() {
       expect(find.byType(UiKitView), findsNothing);
       expect(find.byType(AppKitView), findsNothing);
       expect(tester.hasRunningAnimations, isFalse);
+    });
+  });
+  testWidgets("a null colour leaves the native spinner untinted", (tester) async {
+    await onPlatform(TargetPlatform.iOS, () async {
+      await tester.pumpWidget(
+        wrap(const PregoActivityIndicator(color: null)),
+      );
+
+      final platformView = tester.widget<UiKitView>(find.byType(UiKitView));
+      expect(platformView.creationParams, isNull);
+    });
+  });
+
+  testWidgets("a null colour gives the Flutter spinner the Cupertino grey for the brightness", (tester) async {
+    await onPlatform(TargetPlatform.android, () async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(colorScheme: const ColorScheme.light()),
+          home: const PregoActivityIndicator(color: null),
+        ),
+      );
+      expect(
+        tester.widget<PregoSteppedActivityIndicator>(find.byType(PregoSteppedActivityIndicator)).color,
+        const Color(0xFF3C3C44),
+      );
+
+      // MaterialApp applies the dark theme from the platform brightness.
+      tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
+      addTearDown(tester.platformDispatcher.clearPlatformBrightnessTestValue);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(colorScheme: const ColorScheme.light()),
+          darkTheme: ThemeData(colorScheme: const ColorScheme.dark()),
+          home: const PregoActivityIndicator(color: null),
+        ),
+      );
+      // MaterialApp animates a theme change; read the colour once it settled.
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(
+        tester.widget<PregoSteppedActivityIndicator>(find.byType(PregoSteppedActivityIndicator)).color,
+        const Color(0xFFEBEBF5),
+      );
     });
   });
 }

--- a/client/module_prego/test/components/prego_activity_indicator_test.dart
+++ b/client/module_prego/test/components/prego_activity_indicator_test.dart
@@ -121,7 +121,7 @@ void main() {
 
       final platformView = tester.widget<UiKitView>(find.byType(UiKitView));
       expect(platformView.viewType, "sesori/native-activity-indicator");
-      expect(platformView.creationParams, color.toARGB32());
+      expect(platformView.creationParams, {"color": color.toARGB32(), "dark": false});
       expect(platformView.hitTestBehavior, PlatformViewHitTestBehavior.transparent);
       expect(find.byType(PregoSteppedActivityIndicator), findsNothing);
       expect(tester.hasRunningAnimations, isFalse);
@@ -136,7 +136,7 @@ void main() {
 
       final platformView = tester.widget<AppKitView>(find.byType(AppKitView));
       expect(platformView.viewType, "sesori/native-activity-indicator");
-      expect(platformView.creationParams, color.toARGB32());
+      expect(platformView.creationParams, {"color": color.toARGB32(), "dark": false});
       expect(platformView.hitTestBehavior, PlatformViewHitTestBehavior.transparent);
       expect(find.byType(PregoSteppedActivityIndicator), findsNothing);
       expect(tester.hasRunningAnimations, isFalse);
@@ -149,16 +149,16 @@ void main() {
       await tester.pumpWidget(
         wrap(const PregoActivityIndicator(color: color)),
       );
-      expect(find.byKey(const ValueKey<int?>(0xFF123456)), findsOneWidget);
+      expect(find.byKey(const ValueKey<(int?, Brightness)>((0xFF123456, Brightness.light))), findsOneWidget);
 
       await tester.pumpWidget(
         wrap(const PregoActivityIndicator(color: other)),
       );
-      expect(find.byKey(const ValueKey<int?>(0xFF123456)), findsNothing);
-      expect(find.byKey(const ValueKey<int?>(0xFF654321)), findsOneWidget);
+      expect(find.byKey(const ValueKey<(int?, Brightness)>((0xFF123456, Brightness.light))), findsNothing);
+      expect(find.byKey(const ValueKey<(int?, Brightness)>((0xFF654321, Brightness.light))), findsOneWidget);
       expect(
         tester.widget<UiKitView>(find.byType(UiKitView)).creationParams,
-        other.toARGB32(),
+        {"color": other.toARGB32(), "dark": false},
       );
     });
   });
@@ -246,7 +246,22 @@ void main() {
       );
 
       final platformView = tester.widget<UiKitView>(find.byType(UiKitView));
-      expect(platformView.creationParams, isNull);
+      expect(platformView.creationParams, {"color": null, "dark": false});
+    });
+  });
+
+  testWidgets("the native spinner is told the app's resolved brightness", (tester) async {
+    await onPlatform(TargetPlatform.iOS, () async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(colorScheme: const ColorScheme.dark()),
+          home: const PregoActivityIndicator(color: null),
+        ),
+      );
+
+      final platformView = tester.widget<UiKitView>(find.byType(UiKitView));
+      expect(platformView.creationParams, {"color": null, "dark": true});
+      expect(find.byKey(const ValueKey<(int?, Brightness)>((null, Brightness.dark))), findsOneWidget);
     });
   });
 

--- a/client/module_prego/test/components/prego_inline_alerts_notifications_test.dart
+++ b/client/module_prego/test/components/prego_inline_alerts_notifications_test.dart
@@ -1,0 +1,43 @@
+import "package:flutter/foundation.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:material_ui/material_ui.dart";
+import "package:theme_prego/module_prego.dart";
+
+void main() {
+  Widget app({required Brightness brightness}) {
+    final design = brightness == Brightness.dark ? PregoDesignSystem.dark : PregoDesignSystem.light;
+    final scheme = brightness == Brightness.dark ? const ColorScheme.dark() : const ColorScheme.light();
+    return MaterialApp(
+      theme: ThemeData(colorScheme: scheme, extensions: [design]),
+      home: const Scaffold(
+        body: PregoInlineAlertsNotifications(
+          title: "Loading",
+          type: PregoInlineAlertsNotificationsType.loading,
+        ),
+      ),
+    );
+  }
+
+  Color spinnerColor(WidgetTester tester) =>
+      tester.widget<PregoActivityIndicator>(find.byType(PregoActivityIndicator)).color ?? const Color(0x00000000);
+
+  testWidgets("a loading alert on the inverted light-theme card uses the dark-surface grey", (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    try {
+      await tester.pumpWidget(app(brightness: Brightness.light));
+      expect(spinnerColor(tester), PregoActivityIndicator.naturalColor(brightness: Brightness.dark));
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
+  testWidgets("a loading alert on the inverted dark-theme card uses the light-surface grey", (tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    try {
+      await tester.pumpWidget(app(brightness: Brightness.dark));
+      expect(spinnerColor(tester), PregoActivityIndicator.naturalColor(brightness: Brightness.light));
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+}

--- a/client/module_prego/test/components/prego_inline_alerts_notifications_test.dart
+++ b/client/module_prego/test/components/prego_inline_alerts_notifications_test.dart
@@ -18,8 +18,12 @@ void main() {
     );
   }
 
-  Color spinnerColor(WidgetTester tester) =>
-      tester.widget<PregoActivityIndicator>(find.byType(PregoActivityIndicator)).color ?? const Color(0x00000000);
+  // The indicator stays untinted (null colour); the inverted surface reaches
+  // the Flutter fallback as its resolved brightness.
+  Color spinnerColor(WidgetTester tester) {
+    expect(tester.widget<PregoActivityIndicator>(find.byType(PregoActivityIndicator)).color, isNull);
+    return tester.widget<PregoSteppedActivityIndicator>(find.byType(PregoSteppedActivityIndicator)).color;
+  }
 
   testWidgets("a loading alert on the inverted light-theme card uses the dark-surface grey", (tester) async {
     debugDefaultTargetPlatformOverride = TargetPlatform.android;

--- a/docs/regression/native-activity-indicators.md
+++ b/docs/regression/native-activity-indicators.md
@@ -31,8 +31,10 @@ reappearing on Android and degrading scroll; crashes,
 frozen or corrupted scene rendering, or leaked native views when an indicator
 scrolls out of view, is inserted and removed repeatedly, or composes with
 glass and blur; an indicator ignoring a requested colour or a theme switch — product surfaces
-currently request no tint anywhere, so every spinner shows its platform's
-natural colour while the tint capability stays available;
+request no brand tint, so every spinner shows its platform's natural colour
+for the app's resolved brightness (native views receive that brightness and
+surfaces that invert the page ask for the opposite natural grey) while the
+tint capability stays available;
 sparkles in a list twinkling in lockstep despite distinct phases; the native
 sparkle keyframes visibly diverging from the Flutter fallback; reduce motion
 still animating.

--- a/docs/regression/native-activity-indicators.md
+++ b/docs/regression/native-activity-indicators.md
@@ -30,7 +30,9 @@ timer alive while the app is paused, hidden, or detached; a native indicator bra
 reappearing on Android and degrading scroll; crashes,
 frozen or corrupted scene rendering, or leaked native views when an indicator
 scrolls out of view, is inserted and removed repeatedly, or composes with
-glass and blur; an indicator ignoring its requested colours or theme switches;
+glass and blur; an indicator ignoring a requested colour or a theme switch — product surfaces
+currently request no tint anywhere, so every spinner shows its platform's
+natural colour while the tint capability stays available;
 sparkles in a list twinkling in lockstep despite distinct phases; the native
 sparkle keyframes visibly diverging from the Flutter fallback; reduce motion
 still animating.


### PR DESCRIPTION
## Complexity

🌿 straightforward — one nullable parameter on the shared spinner, the native factories accepting a nil colour, and a mechanical sweep of every call site (mostly `const` fixes that followed).

## What

`PregoActivityIndicator.color` becomes `Color?`. A null colour means "no tint": the iOS `UIActivityIndicatorView` and macOS `NSProgressIndicator` keep their system colour (the native factories accept a nil creation argument and only apply their tint paths when a colour arrives), and the stepped Flutter fallback paints the stock Cupertino grey for the current theme brightness (`0xFF3C3C44` light / `0xFFEBEBF5` dark). Every product call site across `app`, `module_app_ui`, `desktop`, and `module_prego` now passes `color: null`. The tint capability itself is unchanged and still exercised by the widget tests.

## Why

The brand tint on the spinner read poorly on macOS once it actually applied (#1246) and the owner prefers each platform's natural spinner look everywhere — without removing the ability to tint later.

## Risk and test focus

Low. Impacted: the colour of every busy spinner on every platform. Not impacted: spinner sizing, stepping/frame behaviour, reduce-motion handling, semantics, the sparkle loader. Test focus: `prego_activity_indicator_test.dart` gains null-colour cases (native creation argument is nil; fallback picks the brightness-matched grey) while the existing tint tests still pass; a visual check on iOS, macOS, and Android that spinners look like the platform default.

## Expected result

User-visible: spinners show the system grey on iOS/macOS and the Cupertino grey on Android/web/desktop, in both light and dark mode. No database change; the platform-view creation argument is now nullable but otherwise unchanged.

## Verification

- `flutter test` in `client/module_prego`: 263 passed.
- `flutter analyze --fatal-infos` clean in `module_prego`, `module_app_ui`, `app`, and `desktop`.
- `flutter build macos --debug` and `flutter build ios --simulator --debug` succeed with the Swift changes.
- Affected consumer tests pass (`add_project_dialog_test`, `session_lifecycle_ui_test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops tinting activity indicators everywhere so each platform's spinner shows its natural color instead of the brand tint.

- `PregoActivityIndicator.color` is now `Color?`; null means no tint, and the native renderers accept a nil colour.
- Native iOS and macOS spinners receive the app's resolved brightness at creation, so a forced in-app theme keeps the system indicator legible.
- Surfaces that invert the page—the primary rename button and loading alert cards—use the opposite brightness's grey via `PregoActivityIndicator.onSurface`.
- The Flutter fallback paints the Cupertino grey for the current theme brightness.
- Every product call site passes `color: null`; the tint capability remains.
- Widget tests cover the null-color path, brightness propagation, and the inverted-surface cases.

<sup>Written for commit 717b1f31f13ba0886c0b217b2a611a2c2765b04f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

