### PR TITLE
⚙️ [claude-inline-subtasks] claude: stream sub-agent frames into child sessions [step 5/8]

### DIFF
--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -5,7 +5,7 @@
 - **Plan slug:** `claude-inline-subtasks`
 - **Implementation base:** `main` at `86ccc283fb`
 - **Series state:** Steps 1/8 to 4/8 merged; Step 5/8 (live sub-agent
-  streaming) in PR (branch `claude-subagent-streaming`)
+  streaming) PR [#1253](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1253) open (branch `claude-subagent-streaming`)
 - **Next action:** merge Step 5/8, then Step 6/8 (scoped stop)
 - **Pinned facts source:** `PLAN.md` "Claude Code CLI 2.1.237 facts" plus the
   Step 3 capture below (CLI 2.1.257); the completed
@@ -120,7 +120,7 @@
 | [x] | 2/8 | `⚙️ [claude-inline-subtasks] contract: subtask lifecycle state, cancelled status, child link [step 2/8]` | 500-800 | [PR #1044](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1044) merged |
 | [x] | 3/8 | `🚧 [claude-inline-subtasks] claude: live and replayed subtask lifecycle for Agent calls [step 3/8]` | 900-1,300 | [PR #1247](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1247) merged |
 | [x] | 4/8 | `🚧 [claude-inline-subtasks] claude: sub-agent transcripts as child sessions [step 4/8]` | 900-1,400 | [PR #1249](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1249) merged |
-| [ ] | 5/8 | `⚙️ [claude-inline-subtasks] claude: stream sub-agent frames into child sessions [step 5/8]` | 300-500 | In PR |
+| [ ] | 5/8 | `⚙️ [claude-inline-subtasks] claude: stream sub-agent frames into child sessions [step 5/8]` | 300-500 | [PR #1253](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1253) open |
 | [ ] | 6/8 | `🚧 [claude-inline-subtasks] stop: confirm main-agent-only or full stop while sub-agents run [step 6/8]` | 600-1,000 | Pending |
 | [ ] | 7/8 | `🌱 [claude-inline-subtasks] docs: reconcile regression docs [step 7/8]` | 80-200 | Pending |
 | [ ] | 8/8 | `🌱 [claude-inline-subtasks] docs: run coverage and retire the plan [step 8/8]` | 40-120 | Pending |

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -4,9 +4,9 @@
 
 - **Plan slug:** `claude-inline-subtasks`
 - **Implementation base:** `main` at `86ccc283fb`
-- **Series state:** Steps 1/8 to 3/8 merged; Step 4/8 (sub-agent child
-  sessions) PR [#1249](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1249) open (branch `claude-subagent-child-sessions`)
-- **Next action:** merge Step 4/8, then Step 5/8 (live sub-agent streaming)
+- **Series state:** Steps 1/8 to 4/8 merged; Step 5/8 (live sub-agent
+  streaming) in PR (branch `claude-subagent-streaming`)
+- **Next action:** merge Step 5/8, then Step 6/8 (scoped stop)
 - **Pinned facts source:** `PLAN.md` "Claude Code CLI 2.1.237 facts" plus the
   Step 3 capture below (CLI 2.1.257); the completed
   `claude-code-plugin/PROTOCOL.md` is historical and is not edited
@@ -99,6 +99,18 @@
   (foreground agents appear at completion); `childSessionStatuses()` reports
   every announced child across roots and `busyChildSessionIds` feeds
   `PluginActiveSession.childSessionIds`.
+- [x] Step 5 implementation refinements (recorded 2026-09-01, code is truth):
+  the tracker's task map is indexed by tool-use id across sessions and each
+  task remembers its owning rendered session (`ClaudeTrackedTool.sessionId`),
+  so `taskStarted`/`taskNotified`/`isKnownTask`/`task`/`cancelTask` resolve
+  by tool-use id alone while `runningTaskToolUseIds`/`cancelAll`/
+  `forgetSession` stay per owner; `childSessionIdForToolUse` maps a
+  `parent_tool_use_id` to its child session; the dispatcher keeps a
+  child→root map, announces nested children under the root (flattened, one
+  level), keys announced/busy sets by root, and `cancelTasks`/`forgetSession`
+  on a root cover its children's tasks and rendered state; a forwarded frame
+  arriving before the launching task knows its sub-agent id is dropped (no
+  session exists to render it into).
 
 ## Delivery Steps
 
@@ -107,8 +119,8 @@
 | [x] | 1/8 | `🌱 [claude-inline-subtasks] docs: plan inline Claude sub-agent subtasks [step 1/8]` | 450-650 | [PR #1027](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1027) merged |
 | [x] | 2/8 | `⚙️ [claude-inline-subtasks] contract: subtask lifecycle state, cancelled status, child link [step 2/8]` | 500-800 | [PR #1044](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1044) merged |
 | [x] | 3/8 | `🚧 [claude-inline-subtasks] claude: live and replayed subtask lifecycle for Agent calls [step 3/8]` | 900-1,300 | [PR #1247](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1247) merged |
-| [ ] | 4/8 | `🚧 [claude-inline-subtasks] claude: sub-agent transcripts as child sessions [step 4/8]` | 900-1,400 | [PR #1249](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1249) open |
-| [ ] | 5/8 | `⚙️ [claude-inline-subtasks] claude: stream sub-agent frames into child sessions [step 5/8]` | 300-500 | Pending |
+| [x] | 4/8 | `🚧 [claude-inline-subtasks] claude: sub-agent transcripts as child sessions [step 4/8]` | 900-1,400 | [PR #1249](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1249) merged |
+| [ ] | 5/8 | `⚙️ [claude-inline-subtasks] claude: stream sub-agent frames into child sessions [step 5/8]` | 300-500 | In PR |
 | [ ] | 6/8 | `🚧 [claude-inline-subtasks] stop: confirm main-agent-only or full stop while sub-agents run [step 6/8]` | 600-1,000 | Pending |
 | [ ] | 7/8 | `🌱 [claude-inline-subtasks] docs: reconcile regression docs [step 7/8]` | 80-200 | Pending |
 | [ ] | 8/8 | `🌱 [claude-inline-subtasks] docs: run coverage and retire the plan [step 8/8]` | 40-120 | Pending |
@@ -204,6 +216,14 @@
   and cancel/forget) and the bridge tool-finalization suite 12/12 (1 new:
   open subtask swept to cancelled, terminal and OpenCode-shaped parts
   untouched). Changed lines: see the PR diff stat.
+- **Step 4:** merged as `911b6935f1` after one architecture finding and three
+  bot rounds (see Plan Review).
+- **Step 5:** implemented on `main` at `911b6935f1` (branch
+  `claude-subagent-streaming`). `dart analyze
+  --fatal-infos` clean; `dart test` 285/285 in the plugin (2 new: forwarded
+  frames route into the child session only once its id is known; a nested
+  Agent call inside a child binds through the root's `task_started`, renders
+  its part in the child, and its grandchild is flattened under the root).
 - **Final disposition:** pending
 
 ## Plan Review

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -332,6 +332,9 @@
   `childSessionId`; now a sealed type with `ClaudeTrackedToolCall` and
   `ClaudeTrackedTask` (the latter owns `childSessionId`). Layering, boundary
   parsing, and the recorded refinements passed; not re-reviewed.
+- **Step 5 `architecture-implementation-review` (sub-agent, 2026-09-02), scope
+  branch vs `origin/main`: approved, no findings; its out-of-scope note about
+  two unused `sessionId` parameters on the dispatcher task mappers was applied.**
 - **Step 4 `architecture-implementation-review` (sub-agent, 2026-09-01), scope
   branch vs `origin/main`: rejected with one finding, applied in `0a6bd0b67a`:**
   the tracker still encoded `agent-<id>` as a literal while

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -37,6 +37,12 @@ final class ClaudeEventDispatcher({
   final Map<String, Set<String>> _announcedChildren = {};
   final Map<String, Set<String>> _busyChildren = {};
 
+  /// Child session → root session. Nested sub-agents are flattened under the
+  /// root, so this is one level deep by construction.
+  final Map<String, String> _roots = {};
+
+  String _rootOf(String sessionId) => _roots[sessionId] ?? sessionId;
+
   void beginTurn({required String sessionId, required String directory}) {
     _directories[sessionId] = directory;
     _resetTurn(sessionId: sessionId);
@@ -53,26 +59,35 @@ final class ClaudeEventDispatcher({
   }
 
   void forgetSession({required String sessionId}) {
+    for (final childId in _announcedChildren.remove(sessionId) ?? const <String>{}) {
+      _forgetRendered(sessionId: childId);
+      _roots.remove(childId);
+    }
+    _forgetRendered(sessionId: sessionId);
+    _directories.remove(sessionId);
+    _busyChildren.remove(sessionId);
+    // A deleted child must also leave its root's membership sets, or it keeps
+    // reporting a status and blocks a later re-announcement.
+    if (_roots.remove(sessionId) case final root?) {
+      _announcedChildren[root]?.remove(sessionId);
+      _busyChildren[root]?.remove(sessionId);
+    }
+  }
+
+  void _forgetRendered({required String sessionId}) {
     _messageIds.remove(sessionId);
     _announcedMessageIds.remove(sessionId);
     _models.remove(sessionId);
     _clearStreamedMessages(sessionId: sessionId);
     _tools.forgetSession(sessionId: sessionId);
-    _directories.remove(sessionId);
-    _announcedChildren.remove(sessionId);
-    _busyChildren.remove(sessionId);
-    // A deleted child must also leave its root's membership sets, or it keeps
-    // reporting a status and blocks a later re-announcement.
-    for (final children in [..._announcedChildren.values, ..._busyChildren.values]) {
-      children.remove(sessionId);
-    }
   }
 
-  /// Cancels every running sub-agent task of [sessionId] — its process is gone
-  /// — and returns the subtask part updates and child idle statuses that make
-  /// that visible.
+  /// Cancels every running sub-agent task of root [sessionId] and its children
+  /// — their process is gone — and returns the subtask part updates and child
+  /// idle statuses that make that visible.
   List<BridgeSseEvent> cancelTasks({required String sessionId}) => [
-    for (final task in _tools.cancelAll(sessionId: sessionId)) ..._partEvents(sessionId: sessionId, tool: task),
+    for (final owner in {sessionId, ...?_announcedChildren[sessionId]})
+      for (final task in _tools.cancelAll(sessionId: owner)) ..._partEvents(tool: task),
   ];
 
   /// Statuses of the child sessions this dispatcher announced, for every root.
@@ -117,11 +132,22 @@ final class ClaudeEventDispatcher({
 
   List<BridgeSseEvent> map({required ClaudeStreamMessage message, DateTime? now}) {
     if (message.sessionId case final sessionId? when sessionId.isNotEmpty) {
+      // A forwarded sub-agent frame renders in that sub-agent's child session,
+      // resolved from the launching task; before the task knows its sub-agent
+      // id there is no session to render into, so the frame is dropped.
       if (message
-          case ClaudeAssistantMessage(parentToolUseId: final String _) ||
-              ClaudeUserMessage(parentToolUseId: final String _) ||
-              ClaudeStreamEventMessage(parentToolUseId: final String _)) {
-        return const [];
+          case ClaudeAssistantMessage(:final String parentToolUseId) ||
+              ClaudeUserMessage(:final String parentToolUseId) ||
+              ClaudeStreamEventMessage(:final String parentToolUseId)) {
+        final childId = _tools.childSessionIdForToolUse(toolUseId: parentToolUseId);
+        if (childId == null) return const [];
+        _roots[childId] = _rootOf(sessionId);
+        return switch (message) {
+          ClaudeStreamEventMessage() => _mapStream(sessionId: childId, message: message),
+          ClaudeAssistantMessage() => _mapAssistant(sessionId: childId, message: message),
+          ClaudeUserMessage() => _mapUser(sessionId: childId, message: message, promptId: null),
+          _ => const [],
+        };
       }
       return switch (message) {
         ClaudeStreamEventMessage() => _mapStream(sessionId: sessionId, message: message),
@@ -220,7 +246,7 @@ final class ClaudeEventDispatcher({
               name: name,
               input: input,
             )
-            .toPart(sessionId: sessionId),
+            .toPart(),
       ClaudeMappedToolResultContentBlock() ||
       ClaudeMappedTaskNotificationContentBlock() ||
       ClaudeMappedImageContentBlock() ||
@@ -262,7 +288,6 @@ final class ClaudeEventDispatcher({
         final partialJson = message.delta["partial_json"];
         if (partialJson is! String) return const [];
         return _partEvents(
-          sessionId: sessionId,
           tool: _tools.appendInput(
             sessionId: sessionId,
             messageId: messageId,
@@ -286,7 +311,7 @@ final class ClaudeEventDispatcher({
     final tool = _tools.stopInput(sessionId: sessionId, messageId: messageId, blockIndex: index);
     final completed = _completedStreamedParts[messageId]?.remove(index);
     return [
-      ..._partEvents(sessionId: sessionId, tool: tool),
+      ..._partEvents(tool: tool),
       if (tool == null && completed != null) BridgeSseMessagePartUpdated(part: completed),
     ];
   }
@@ -339,7 +364,7 @@ final class ClaudeEventDispatcher({
                 name: name,
                 input: input,
               )
-              .toPart(sessionId: sessionId),
+              .toPart(),
         _ => parts[offset],
       };
       if (part == null) continue;
@@ -375,7 +400,7 @@ final class ClaudeEventDispatcher({
           result: typedResult,
         );
         if (tool == null) continue;
-        events.addAll(_partEvents(sessionId: sessionId, tool: tool));
+        events.addAll(_partEvents(tool: tool));
         if (tool.sessionDiffRequired) events.add(BridgeSseSessionDiff(sessionID: sessionId));
         if (tool.todoRefreshRequired) events.add(BridgeSseTodoUpdated(sessionID: sessionId));
       }
@@ -420,8 +445,7 @@ final class ClaudeEventDispatcher({
     final taskId = message.taskId;
     if (toolUseId == null || taskId == null) return const [];
     return _partEvents(
-      sessionId: sessionId,
-      tool: _tools.taskStarted(sessionId: sessionId, toolUseId: toolUseId, taskId: taskId),
+      tool: _tools.taskStarted(toolUseId: toolUseId, taskId: taskId),
     );
   }
 
@@ -433,9 +457,7 @@ final class ClaudeEventDispatcher({
     final taskId = message.taskId;
     if (toolUseId == null || taskId == null) return const [];
     return _partEvents(
-      sessionId: sessionId,
       tool: _tools.taskNotified(
-        sessionId: sessionId,
         toolUseId: toolUseId,
         taskId: taskId,
         status: message.status,
@@ -453,14 +475,13 @@ final class ClaudeEventDispatcher({
     required ClaudeTaskNotification notification,
   }) {
     final tool = _tools.taskNotified(
-      sessionId: sessionId,
       toolUseId: notification.toolUseId,
       taskId: notification.taskId,
       status: notification.status,
       summary: notification.summary,
       result: notification.result,
     );
-    return tool == null ? null : _partEvents(sessionId: sessionId, tool: tool);
+    return tool == null ? null : _partEvents(tool: tool);
   }
 
   List<BridgeSseEvent> _mapRetry({
@@ -539,25 +560,29 @@ final class ClaudeEventDispatcher({
   /// implies: `session.created` + busy the first time its sub-agent id is
   /// known, and idle once it is terminal. Order matters — the bridge binds the
   /// child on `created` before it translates the part's `childSessionID`.
-  List<BridgeSseEvent> _partEvents({required String sessionId, required ClaudeTrackedTool? tool}) {
-    final part = tool?.toPart(sessionId: sessionId);
-    final directory = _directories[sessionId];
-    if (tool is! ClaudeTrackedTask || tool.childSessionId == null || directory == null) {
+  List<BridgeSseEvent> _partEvents({required ClaudeTrackedTool? tool}) {
+    final part = tool?.toPart();
+    // Children of children are flattened under the root: one directory, one
+    // parent, one place to look for them.
+    final root = tool == null ? null : _rootOf(tool.sessionId);
+    final directory = root == null ? null : _directories[root];
+    if (tool is! ClaudeTrackedTask || tool.childSessionId == null || root == null || directory == null) {
       return part == null ? const [] : [BridgeSseMessagePartUpdated(part: part)];
     }
     final childId = tool.childSessionId;
     final terminal = tool.state.status.isTerminal;
-    final announced = _announcedChildren.putIfAbsent(sessionId, () => {});
-    final busy = _busyChildren.putIfAbsent(sessionId, () => {});
+    final announced = _announcedChildren.putIfAbsent(root, () => {});
+    final busy = _busyChildren.putIfAbsent(root, () => {});
     final events = <BridgeSseEvent>[];
     if (childId != null && announced.add(childId)) {
+      _roots[childId] = root;
       events.add(
         BridgeSseSessionCreated(
           info: PluginSession(
             id: childId,
             projectID: directory,
             directory: directory,
-            parentID: sessionId,
+            parentID: root,
             title: switch (tool.input) {
               {"description": final String description} => description,
               _ => null,

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -155,8 +155,8 @@ final class ClaudeEventDispatcher({
         ClaudeUserMessage() => _mapUser(sessionId: sessionId, message: message, promptId: null),
         ClaudeApiRetryMessage() => _mapRetry(sessionId: sessionId, message: message, now: now ?? DateTime.now()),
         ClaudeResultMessage() => _mapResult(sessionId: sessionId, message: message),
-        ClaudeTaskStartedMessage() => _mapTaskStarted(sessionId: sessionId, message: message),
-        ClaudeTaskNotificationMessage() => _mapTaskNotification(sessionId: sessionId, message: message),
+        ClaudeTaskStartedMessage() => _mapTaskStarted(message: message),
+        ClaudeTaskNotificationMessage() => _mapTaskNotification(message: message),
         ClaudeInitMessage() ||
         ClaudeStatusMessage() ||
         // ponytail: parsed but not surfaced — no client UI consumes thinking
@@ -438,7 +438,6 @@ final class ClaudeEventDispatcher({
   }
 
   List<BridgeSseEvent> _mapTaskStarted({
-    required String sessionId,
     required ClaudeTaskStartedMessage message,
   }) {
     final toolUseId = message.toolUseId;
@@ -450,7 +449,6 @@ final class ClaudeEventDispatcher({
   }
 
   List<BridgeSseEvent> _mapTaskNotification({
-    required String sessionId,
     required ClaudeTaskNotificationMessage message,
   }) {
     final toolUseId = message.toolUseId;

--- a/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
@@ -81,7 +81,7 @@ final class const ClaudeHistoryMapper({
             final typedResult = results.length == 1 ? record.toolUseResult : const ClaudeToolUseResultAbsent();
             final toolResults = <ClaudeMappedToolResultContentBlock>[];
             for (final result in results) {
-              if (!tasks.isKnownTask(sessionId: sessionId, toolUseId: result.toolUseId)) {
+              if (!tasks.isKnownTask(toolUseId: result.toolUseId)) {
                 toolResults.add(result);
                 continue;
               }
@@ -101,9 +101,8 @@ final class const ClaudeHistoryMapper({
             continue;
           }
           if (blocks.whereType<ClaudeMappedTaskNotificationContentBlock>().firstOrNull case final block?
-              when tasks.isKnownTask(sessionId: sessionId, toolUseId: block.notification.toolUseId)) {
+              when tasks.isKnownTask(toolUseId: block.notification.toolUseId)) {
             tasks.taskNotified(
-              sessionId: sessionId,
               toolUseId: block.notification.toolUseId,
               taskId: block.notification.taskId,
               status: block.notification.status,
@@ -145,7 +144,7 @@ final class const ClaudeHistoryMapper({
     }
 
     for (final toolUseId in tasks.runningTaskToolUseIds(sessionId: sessionId).difference(residentTaskToolUseIds)) {
-      tasks.cancelTask(sessionId: sessionId, toolUseId: toolUseId);
+      tasks.cancelTask(toolUseId: toolUseId);
     }
 
     final messages = <PluginMessageWithParts>[];
@@ -181,10 +180,10 @@ final class const ClaudeHistoryMapper({
       final existingIndex = toolIndexById[part.id];
       if (existingIndex == null) {
         toolIndexById[part.id] = parts.length;
-        final task = tasks.task(sessionId: sessionId, toolUseId: part.id);
+        final task = tasks.task(toolUseId: part.id);
         if (task == null) {
           parts.add(part);
-        } else if (task.toPart(sessionId: sessionId) case final subtask?) {
+        } else if (task.toPart() case final subtask?) {
           parts.add(subtask);
         }
         continue;

--- a/bridge/sesori_plugin_claude/lib/src/repositories/trackers/claude_tool_tracker.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/trackers/claude_tool_tracker.dart
@@ -9,6 +9,10 @@ import "../mappers/claude_task_status_mapping.dart";
 /// An immutable presentation snapshot of one Claude tool call.
 sealed class const ClaudeTrackedTool({
   required final String id,
+
+  /// The rendered session that owns this call's part: the root, or a child
+  /// session when the call was made by a sub-agent.
+  required final String sessionId,
   required final String messageId,
   required final String name,
   required final Object? input,
@@ -25,7 +29,7 @@ sealed class const ClaudeTrackedTool({
   /// A task renders only once its input carries the description and prompt
   /// the subtask part requires; while the input is still streaming there is
   /// nothing honest to show, so the caller emits no part.
-  PluginMessagePart? toPart({required String sessionId}) => switch (this) {
+  PluginMessagePart? toPart() => switch (this) {
     ClaudeTrackedToolCall() => PluginMessagePart.tool(
       id: id,
       sessionID: sessionId,
@@ -56,6 +60,7 @@ sealed class const ClaudeTrackedTool({
 /// An ordinary tool call, rendered as a tool part.
 final class const ClaudeTrackedToolCall({
   required super.id,
+  required super.sessionId,
   required super.messageId,
   required super.name,
   required super.input,
@@ -70,6 +75,7 @@ final class const ClaudeTrackedTask({
   /// tool result named it.
   required final String? childSessionId,
   required super.id,
+  required super.sessionId,
   required super.messageId,
   required super.name,
   required super.input,
@@ -86,7 +92,12 @@ final class const ClaudeTrackedTask({
 /// launched it; only [cancelAll] and [forgetSession] clear it.
 final class ClaudeToolTracker() {
   final Map<String, _SessionTools> _sessions = {};
-  final Map<String, Map<String, _TrackedTool>> _tasks = {};
+
+  /// Tasks by tool-use id, across sessions: a nested sub-agent's lifecycle
+  /// frames arrive from the root process without the rendered session that
+  /// carried its `tool_use`, so tasks resolve by the process-unique tool id
+  /// and remember the session that owns their part.
+  final Map<String, _TrackedTool> _tasks = {};
 
   ClaudeTrackedTool start({
     required String sessionId,
@@ -153,10 +164,17 @@ final class ClaudeToolTracker() {
   }) {
     final tool = session.tools.putIfAbsent(
       toolId,
-      () => _TrackedTool(id: toolId, messageId: messageId, name: name, input: input, status: status),
+      () => _TrackedTool(
+        id: toolId,
+        sessionId: sessionId,
+        messageId: messageId,
+        name: name,
+        input: input,
+        status: status,
+      ),
     );
     tool.name = name;
-    if (tool.isTask) _tasks.putIfAbsent(sessionId, () => {}).putIfAbsent(toolId, () => tool);
+    if (tool.isTask) _tasks.putIfAbsent(toolId, () => tool);
     return tool;
   }
 
@@ -221,7 +239,7 @@ final class ClaudeToolTracker() {
     required List<PluginMessageAttachment> attachments,
     required ClaudeToolUseResult result,
   }) {
-    final tool = _sessions[sessionId]?.tools[toolId] ?? _tasks[sessionId]?[toolId];
+    final tool = _sessions[sessionId]?.tools[toolId] ?? _tasks[toolId];
     if (tool == null) return null;
     if (tool.isTask) {
       switch (result) {
@@ -253,8 +271,8 @@ final class ClaudeToolTracker() {
   }
 
   /// Binds a `task_started` frame to its launching call.
-  ClaudeTrackedTool? taskStarted({required String sessionId, required String toolUseId, required String taskId}) {
-    final task = _tasks[sessionId]?[toolUseId];
+  ClaudeTrackedTool? taskStarted({required String toolUseId, required String taskId}) {
+    final task = _tasks[toolUseId];
     if (task == null) return null;
     task.taskId ??= taskId;
     if (!_isTerminal(task.status)) task.status = PluginToolStatus.running;
@@ -262,17 +280,16 @@ final class ClaudeToolTracker() {
   }
 
   /// Applies the authoritative terminal notification for a task, replacing
-  /// any tool-result fallback. Returns null when [toolUseId] is not a task in
-  /// this session, so callers keep an unmatched envelope visible.
+  /// any tool-result fallback. Returns null when [toolUseId] is not a known
+  /// task, so callers keep an unmatched envelope visible.
   ClaudeTrackedTool? taskNotified({
-    required String sessionId,
     required String toolUseId,
     required String taskId,
     required ClaudeTaskStatus status,
     required String? summary,
     required String? result,
   }) {
-    final task = _tasks[sessionId]?[toolUseId];
+    final task = _tasks[toolUseId];
     if (task == null) return null;
     final mapped = status.toPluginToolStatus();
     task
@@ -284,34 +301,39 @@ final class ClaudeToolTracker() {
     return task.snapshot(sessionDiffRequired: false);
   }
 
-  bool isKnownTask({required String sessionId, required String toolUseId}) =>
-      _tasks[sessionId]?.containsKey(toolUseId) ?? false;
+  bool isKnownTask({required String toolUseId}) => _tasks.containsKey(toolUseId);
 
-  ClaudeTrackedTool? task({required String sessionId, required String toolUseId}) =>
-      _tasks[sessionId]?[toolUseId]?.snapshot(sessionDiffRequired: false);
+  ClaudeTrackedTool? task({required String toolUseId}) => _tasks[toolUseId]?.snapshot(sessionDiffRequired: false);
 
-  /// The tool-use ids of tasks still running inside the session's process.
+  /// The child session a sub-agent frame's `parent_tool_use_id` belongs to,
+  /// once the launching task knows its sub-agent id.
+  String? childSessionIdForToolUse({required String toolUseId}) => switch (_tasks[toolUseId]) {
+    _TrackedTool(taskId: final id?) => ClaudeSubagentSessionId.fromAgentId(id),
+    _ => null,
+  };
+
+  /// The tool-use ids of tasks owned by [sessionId] that are still running.
   Set<String> runningTaskToolUseIds({required String sessionId}) => {
-    for (final task in _tasks[sessionId]?.values ?? const <_TrackedTool>[])
-      if (!_isTerminal(task.status)) task.id,
+    for (final task in _tasks.values)
+      if (task.sessionId == sessionId && !_isTerminal(task.status)) task.id,
   };
 
   /// Marks one running task cancelled; null when it is unknown or already done.
-  ClaudeTrackedTool? cancelTask({required String sessionId, required String toolUseId}) {
-    final task = _tasks[sessionId]?[toolUseId];
+  ClaudeTrackedTool? cancelTask({required String toolUseId}) {
+    final task = _tasks[toolUseId];
     if (task == null || _isTerminal(task.status)) return null;
     task.status = PluginToolStatus.cancelled;
     return task.snapshot(sessionDiffRequired: false);
   }
 
-  /// Marks every running task cancelled — the process that hosted them is
-  /// gone — and forgets the session's tasks. Returns the updated snapshots.
+  /// Marks every running task owned by [sessionId] cancelled — the process
+  /// that hosted them is gone — and forgets those tasks. Returns the updated
+  /// snapshots.
   List<ClaudeTrackedTool> cancelAll({required String sessionId}) {
     final cancelled = [
-      for (final toolUseId in runningTaskToolUseIds(sessionId: sessionId))
-        ?cancelTask(sessionId: sessionId, toolUseId: toolUseId),
+      for (final toolUseId in runningTaskToolUseIds(sessionId: sessionId)) ?cancelTask(toolUseId: toolUseId),
     ];
-    _tasks.remove(sessionId);
+    _tasks.removeWhere((_, task) => task.sessionId == sessionId);
     return cancelled;
   }
 
@@ -320,7 +342,7 @@ final class ClaudeToolTracker() {
 
   void forgetSession({required String sessionId}) {
     _sessions.remove(sessionId);
-    _tasks.remove(sessionId);
+    _tasks.removeWhere((_, task) => task.sessionId == sessionId);
   }
 }
 
@@ -340,6 +362,7 @@ final class _StreamedToolBlock() {
 
 final class _TrackedTool({
   required final String id,
+  required final String sessionId,
   required final String messageId,
   required var String _name,
   required var Object? input,
@@ -377,6 +400,7 @@ final class _TrackedTool({
               null => null,
             },
             id: id,
+            sessionId: sessionId,
             messageId: messageId,
             name: name,
             input: input,
@@ -386,6 +410,7 @@ final class _TrackedTool({
           )
         : ClaudeTrackedToolCall(
             id: id,
+            sessionId: sessionId,
             messageId: messageId,
             name: name,
             input: input,

--- a/bridge/sesori_plugin_claude/test/claude_subagent_child_sessions_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_subagent_child_sessions_test.dart
@@ -147,6 +147,74 @@ void main() {
       expect(dispatcher.busyChildSessionIds(sessionId: _root), isEmpty);
     });
 
+    test("routes forwarded sub-agent frames into the child session once its id is known", () {
+      dispatcher.map(message: ClaudeStreamMessage.parse(_agentAssistantFrame()));
+      final early = dispatcher.map(message: ClaudeStreamMessage.parse(_childTextFrame(text: "too early")));
+      dispatcher.map(message: ClaudeStreamMessage.parse(_launchResultFrame()));
+      dispatcher.completeTurn(sessionId: _root);
+
+      final routed = dispatcher.map(message: ClaudeStreamMessage.parse(_childTextFrame(text: "hi")));
+
+      expect(early, isEmpty, reason: "no child session exists before the sub-agent id is known");
+      expect(routed.map((event) => event.runtimeType), [BridgeSseMessageUpdated, BridgeSseMessagePartUpdated]);
+      expect(shared.Message.fromJson((routed[0] as BridgeSseMessageUpdated).info).sessionID, _child);
+      final part = (routed[1] as BridgeSseMessagePartUpdated).part;
+      expect(part.sessionID, _child);
+      expect(part.text, "hi");
+      expect(dispatcher.childSessionStatuses(), {_child: const PluginSessionStatus.busy()});
+    });
+
+    test("a nested Agent call inside a child binds through the root's task frames and flattens under the root", () {
+      dispatcher.map(message: ClaudeStreamMessage.parse(_agentAssistantFrame()));
+      dispatcher.map(message: ClaudeStreamMessage.parse(_launchResultFrame()));
+      dispatcher.map(
+        message: ClaudeStreamMessage.parse({
+          "type": "assistant",
+          "session_id": _root,
+          "parent_tool_use_id": _toolUseId,
+          "message": {
+            "id": "child-msg-2",
+            "model": "claude-opus-5",
+            "content": [
+              {
+                "type": "tool_use",
+                "id": "toolu-nested",
+                "name": "Agent",
+                "input": {"description": "Nested", "prompt": "go deeper"},
+              },
+            ],
+          },
+        }),
+      );
+
+      final started = dispatcher.map(
+        message: ClaudeStreamMessage.parse({
+          "type": "system",
+          "subtype": "task_started",
+          "session_id": _root,
+          "task_id": "nested-agent",
+          "tool_use_id": "toolu-nested",
+          "task_type": "local_agent",
+        }),
+      );
+
+      expect(started.map((event) => event.runtimeType), [
+        BridgeSseSessionCreated,
+        BridgeSseSessionStatus,
+        BridgeSseMessagePartUpdated,
+      ]);
+      final created = (started[0] as BridgeSseSessionCreated).info;
+      expect(created["id"], "agent-nested-agent");
+      expect(created["parentID"], _root, reason: "nested children are flattened under the root");
+      expect(created["directory"], "/workspace");
+      final part = (started[2] as BridgeSseMessagePartUpdated).part as PluginMessagePartSubtask;
+      expect(part.sessionID, _child, reason: "the part renders in the session that made the call");
+      expect(part.childSessionID, "agent-nested-agent");
+      expect(dispatcher.busyChildSessionIds(sessionId: _root), unorderedEquals([_child, "agent-nested-agent"]));
+
+      expect(dispatcher.cancelTasks(sessionId: _root).whereType<BridgeSseSessionStatus>(), hasLength(2));
+    });
+
     test("cancelTasks idles the announced child and forgetSession drops it", () {
       dispatcher.map(message: ClaudeStreamMessage.parse(_agentAssistantFrame()));
       dispatcher.map(message: ClaudeStreamMessage.parse(_launchResultFrame()));
@@ -259,6 +327,19 @@ Map<String, Object?> _launchResultFrame() => {
     ],
   },
   "tool_use_result": {"isAsync": true, "status": "async_launched", "agentId": _agentId},
+};
+
+Map<String, Object?> _childTextFrame({required String text}) => {
+  "type": "assistant",
+  "session_id": _root,
+  "parent_tool_use_id": _toolUseId,
+  "message": {
+    "id": "child-msg-1",
+    "model": "claude-haiku-4-5",
+    "content": [
+      {"type": "text", "text": text},
+    ],
+  },
 };
 
 Map<String, Object?> _taskStartedFrame() => {

--- a/bridge/sesori_plugin_claude/test/claude_subtask_lifecycle_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_subtask_lifecycle_test.dart
@@ -84,11 +84,11 @@ void main() {
         input: const <String, Object?>{},
       );
       expect(started, isA<ClaudeTrackedTask>());
-      expect(started.toPart(sessionId: _session), isNull);
+      expect(started.toPart(), isNull);
 
       final complete = _upsertAgent(tracker);
       expect(
-        complete.toPart(sessionId: _session),
+        complete.toPart(),
         isA<PluginMessagePartSubtask>()
             .having((p) => p.description, "description", "Say hi")
             .having((p) => p.agent, "agent", "general-purpose")
@@ -114,7 +114,6 @@ void main() {
       expect(tracker.runningTaskToolUseIds(sessionId: _session), {_toolUseId});
 
       final notified = tracker.taskNotified(
-        sessionId: _session,
         toolUseId: _toolUseId,
         taskId: _agentId,
         status: ClaudeTaskStatus.completed,
@@ -152,7 +151,6 @@ void main() {
       expect(fallback, isA<ClaudeTrackedTask>().having((t) => t.childSessionId, "child", "agent-$_agentId"));
 
       final stopped = tracker.taskNotified(
-        sessionId: _session,
         toolUseId: _toolUseId,
         taskId: _agentId,
         status: ClaudeTaskStatus.stopped,
@@ -162,7 +160,6 @@ void main() {
       expect(stopped?.state.status, PluginToolStatus.cancelled);
 
       final failed = tracker.taskNotified(
-        sessionId: _session,
         toolUseId: _toolUseId,
         taskId: _agentId,
         status: ClaudeTaskStatus.failed,
@@ -185,19 +182,18 @@ void main() {
         input: _agentInput,
       );
       tracker.taskNotified(
-        sessionId: _session,
         toolUseId: "toolu-done",
         taskId: "other",
         status: ClaudeTaskStatus.completed,
         summary: null,
         result: null,
       );
-      expect(tracker.taskStarted(sessionId: _session, toolUseId: "toolu-unknown", taskId: "x"), isNull);
+      expect(tracker.taskStarted(toolUseId: "toolu-unknown", taskId: "x"), isNull);
 
       final cancelled = tracker.cancelAll(sessionId: _session);
       expect(cancelled.map((t) => t.id), [_toolUseId]);
       expect(cancelled.single.state.status, PluginToolStatus.cancelled);
-      expect(tracker.task(sessionId: _session, toolUseId: _toolUseId), isNull);
+      expect(tracker.task(toolUseId: _toolUseId), isNull);
       expect(tracker.cancelAll(sessionId: _session), isEmpty);
     });
   });


### PR DESCRIPTION
## Complexity

⚙️ moderate — dispatcher routing and tracker indexing inside the Claude plugin; no contract, persistence, or bridge/app change.

## What

Step 5/8 of `.plan/active/claude-inline-subtasks`. Forwarded sub-agent frames (`assistant`/`user`/`stream_event` carrying `parent_tool_use_id`) now render in the launching task's child session instead of being dropped:

- `ClaudeToolTracker` indexes tasks by tool-use id across sessions and records the owning rendered session on each snapshot (`ClaudeTrackedTool.sessionId`); `childSessionIdForToolUse` maps a `parent_tool_use_id` to its child session; per-owner queries (`runningTaskToolUseIds`, `cancelAll`, `forgetSession`) stay scoped.
- `ClaudeEventDispatcher.map` routes forwarded frames through the existing `_mapStream`/`_mapAssistant`/`_mapUser` with the child id; per-session maps isolate child state from the root. A frame arriving before the launching task knows its sub-agent id is dropped (no session exists yet).
- Nested `Agent` calls inside a child: their `task_started`/notification frames come from the root process without a parent id, so they resolve by tool-use id, render their subtask part in the child, and their own child is flattened under the root (one directory, one parent). `cancelTasks`/`forgetSession` on a root cover its children.
- The one part builder (`toPart`) now takes its session from the snapshot.

## Why

Tapping a running sub-agent tile opened an empty child transcript; the sub-agent's prompt, tool calls, and final text only appeared after a reload.

## Risk and test focus

Low–medium. Impacted: live Claude child-session transcripts, root transcript isolation (a forwarded frame must never land in the root), nested sub-agent lifecycle. Most valuable checks: open a running sub-agent tile and watch parts appear live; confirm the root transcript shows no sub-agent text; a reload of the child converges without duplicates (same transcript ids).

No wire-contract, database, or bridge/app change.

## Expected result

- User-visible: a running sub-agent's transcript streams live in its child session; nested sub-agents appear as further children of the root with their tiles inside the child that launched them.
- Database/persisted: none.
- Internal: tracker task index keyed by tool-use id with owning session; dispatcher child→root map.

## Verification

- `dart analyze --fatal-infos` clean, `dart format` clean, `git diff --check` clean.
- `dart test` 286/286 in `bridge/sesori_plugin_claude` (2 new: routing gated on the known sub-agent id; nested task binding and flattening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sub-agent frames forwarded from the root process now stream live into the launching task's child session instead of being dropped. A running sub-agent tile used to open an empty transcript that only populated after a reload.

**Changes**
- `ClaudeToolTracker` indexes tasks by tool-use id across sessions, and each task records the session that owns its rendered part.
- The dispatcher routes forwarded `assistant`, `user`, and `stream_event` frames to the child session mapped from the `parent_tool_use_id`; frames arriving before that mapping exists are dropped.
- Nested Agent calls inside a child bind through the root's task frames, render their part in the child, and their own child session is flattened under the root.
- `cancelTasks` and `forgetSession` on a root now cover its announced children.

<sup>Written for commit 31ae8c25130e9a861743fb1392367836ff8bf7b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

