### PR TITLE
🚧 [claude-inline-subtasks] stop: confirm main-agent-only or full stop while sub-agents run [step 6/8]

### DIFF
--- a/.plan/active/claude-inline-subtasks/PLAN.md
+++ b/.plan/active/claude-inline-subtasks/PLAN.md
@@ -879,9 +879,10 @@ Scope:
   non-sub-agent-only tasks), and that `keep` leaves the running set, reap
   deferral, and child statuses intact and renders the later wake-up turn.
 - `client`: `SessionApi.abortSession({sessionId, subAgents})` sends
-  `AbortSessionRequest` and parses the 409 → `SessionAbortRejectedException`;
-  `SessionRepository.abortSession` and `capabilities/session/SessionService.
-  abortSession` updated in lockstep; `SessionDetailCubit.abort({subAgents})`
+  `AbortSessionRequest` and parses the 409 → `SessionAbortApiRejectedException`;
+  `SessionRepository.abortSession` updated in lockstep (there is no
+  `capabilities/session/SessionService` abort seam — implementation
+  refinement 2026-09-02, see `TRACKER.md`); `SessionDetailCubit.abort({subAgents})`
   sealed outcome, side-effect-free `confirm` (queue clearing and the child
   fan-out only after a root `aborted` under `stop`, queue clearing also on
   `keep`); stop action sends `confirm`, shows the scope dialog on rejection,

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -368,6 +368,13 @@
   `childSessionId`; now a sealed type with `ClaudeTrackedToolCall` and
   `ClaudeTrackedTask` (the latter owns `childSessionId`). Layering, boundary
   parsing, and the recorded refinements passed; not re-reviewed.
+- **Step 6 `architecture-implementation-review` (sub-agent, 2026-09-02), scope
+  branch vs `origin/main`: rejected with one finding, applied:** the cubit
+  imported and caught the API-layer `SessionAbortApiRejectedException`; the
+  client `SessionRepository` now translates it into a repository-owned
+  `SessionAbortRejectedException` (with `innerError`, mirroring the cleanup
+  path) and the cubit depends only on that. Shared, bridge, plugin, and Claude
+  layering passed; not re-reviewed.
 - **Step 5 `architecture-implementation-review` (sub-agent, 2026-09-02), scope
   branch vs `origin/main`: approved, no findings; its out-of-scope note about
   two unused `sessionId` parameters on the dispatcher task mappers was applied.**

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -4,7 +4,7 @@
 
 - **Plan slug:** `claude-inline-subtasks`
 - **Implementation base:** `main` at `86ccc283fb`
-- **Series state:** Steps 1/8 to 5/8 merged; Step 6/8 (scoped stop) in PR
+- **Series state:** Steps 1/8 to 5/8 merged; Step 6/8 (scoped stop) PR [#1254](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1254) open
   (branch `claude-scoped-stop`)
 - **Next action:** merge Step 6/8, then Step 7/8 (regression docs)
 - **Pinned facts source:** `PLAN.md` "Claude Code CLI 2.1.237 facts" plus the
@@ -140,7 +140,7 @@
 | [x] | 3/8 | `🚧 [claude-inline-subtasks] claude: live and replayed subtask lifecycle for Agent calls [step 3/8]` | 900-1,300 | [PR #1247](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1247) merged |
 | [x] | 4/8 | `🚧 [claude-inline-subtasks] claude: sub-agent transcripts as child sessions [step 4/8]` | 900-1,400 | [PR #1249](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1249) merged |
 | [x] | 5/8 | `⚙️ [claude-inline-subtasks] claude: stream sub-agent frames into child sessions [step 5/8]` | 300-500 | [PR #1253](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1253) merged |
-| [ ] | 6/8 | `🚧 [claude-inline-subtasks] stop: confirm main-agent-only or full stop while sub-agents run [step 6/8]` | 600-1,000 | In PR |
+| [ ] | 6/8 | `🚧 [claude-inline-subtasks] stop: confirm main-agent-only or full stop while sub-agents run [step 6/8]` | 600-1,000 | [PR #1254](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1254) open |
 | [ ] | 7/8 | `🌱 [claude-inline-subtasks] docs: reconcile regression docs [step 7/8]` | 80-200 | Pending |
 | [ ] | 8/8 | `🌱 [claude-inline-subtasks] docs: run coverage and retire the plan [step 8/8]` | 40-120 | Pending |
 

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -4,9 +4,9 @@
 
 - **Plan slug:** `claude-inline-subtasks`
 - **Implementation base:** `main` at `86ccc283fb`
-- **Series state:** Steps 1/8 to 4/8 merged; Step 5/8 (live sub-agent
-  streaming) PR [#1253](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1253) open (branch `claude-subagent-streaming`)
-- **Next action:** merge Step 5/8, then Step 6/8 (scoped stop)
+- **Series state:** Steps 1/8 to 5/8 merged; Step 6/8 (scoped stop) in PR
+  (branch `claude-scoped-stop`)
+- **Next action:** merge Step 6/8, then Step 7/8 (regression docs)
 - **Pinned facts source:** `PLAN.md` "Claude Code CLI 2.1.237 facts" plus the
   Step 3 capture below (CLI 2.1.257); the completed
   `claude-code-plugin/PROTOCOL.md` is historical and is not edited
@@ -111,6 +111,25 @@
   on a root cover its children's tasks and rendered state; a forwarded frame
   arriving before the launching task knows its sub-agent id is dropped (no
   session exists to render it into).
+- [x] Step 6 implementation refinements (recorded 2026-09-02, code is truth):
+  the plugin contract is `abortSession({sessionId, subAgents:
+  PluginAbortSubAgentPolicy}) → PluginAbortResult` (`PluginAbortAccepted` |
+  `PluginAbortRejectedSubAgentsRunning`), non-Claude plugins wrap their
+  existing abort and answer accepted; the bridge repository returns a sealed
+  `SessionAbortResult` (`SessionAborted` | `SessionAbortRejected`) mapped in
+  `plugin_to_shared_mapping.dart`; `SessionAbortService` emits
+  `abortedSessions` only for an accepted non-`keep` stop and
+  `abortFailedSessions` (clear pending) for `keep` and rejections; the Claude
+  `keep` path interrupts and returns without touching `wakeupAt` or the
+  running set, and `ClaudeSessionProcessRepository` closes the interrupt
+  window at the first `task_notification` that arrives while no turn is
+  active (a `sendTurn` also closes it, as before); the client has no
+  `capabilities/session/SessionService` abort seam (none exists), so
+  `SessionApi` → `SessionRepository` → `SessionDetailCubit.abort({subAgents})`
+  returning a sealed `SessionAbortOutcome` is the whole chain, the 409 body is
+  the shared `SessionAbortRejection` (no module_core mirror), and the scope
+  dialog lives in `client/app/.../session_abort_scope_dialog.dart` next to
+  the view that owns the stop button, reusing the existing cancel label.
 
 ## Delivery Steps
 
@@ -120,8 +139,8 @@
 | [x] | 2/8 | `⚙️ [claude-inline-subtasks] contract: subtask lifecycle state, cancelled status, child link [step 2/8]` | 500-800 | [PR #1044](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1044) merged |
 | [x] | 3/8 | `🚧 [claude-inline-subtasks] claude: live and replayed subtask lifecycle for Agent calls [step 3/8]` | 900-1,300 | [PR #1247](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1247) merged |
 | [x] | 4/8 | `🚧 [claude-inline-subtasks] claude: sub-agent transcripts as child sessions [step 4/8]` | 900-1,400 | [PR #1249](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1249) merged |
-| [ ] | 5/8 | `⚙️ [claude-inline-subtasks] claude: stream sub-agent frames into child sessions [step 5/8]` | 300-500 | [PR #1253](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1253) open |
-| [ ] | 6/8 | `🚧 [claude-inline-subtasks] stop: confirm main-agent-only or full stop while sub-agents run [step 6/8]` | 600-1,000 | Pending |
+| [x] | 5/8 | `⚙️ [claude-inline-subtasks] claude: stream sub-agent frames into child sessions [step 5/8]` | 300-500 | [PR #1253](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1253) merged |
+| [ ] | 6/8 | `🚧 [claude-inline-subtasks] stop: confirm main-agent-only or full stop while sub-agents run [step 6/8]` | 600-1,000 | In PR |
 | [ ] | 7/8 | `🌱 [claude-inline-subtasks] docs: reconcile regression docs [step 7/8]` | 80-200 | Pending |
 | [ ] | 8/8 | `🌱 [claude-inline-subtasks] docs: run coverage and retire the plan [step 8/8]` | 40-120 | Pending |
 
@@ -224,6 +243,23 @@
   frames route into the child session only once its id is known; a nested
   Agent call inside a child binds through the root's `task_started`, renders
   its part in the child, and its grandchild is flattened under the root).
+- **Step 5:** merged as `8ff7fba910`; both bot rounds declined (tool-use ids
+  are globally unique Anthropic block ids).
+- **Step 6:** implemented on `main` at `8ff7fba910` (branch `claude-scoped-stop`;
+  rebased across the desktop transcripts move of the loaded view into
+  `module_app_ui`, so the stop dialog is wired from
+  `client/app/.../session_detail_composer_controls.dart`). Codegen re-run for `sesori_shared`
+  (`AbortSessionRequest`, `SessionAbortRejection`) and `flutter gen-l10n`.
+  `dart analyze --fatal-infos` clean in shared, interface, bridge/app, every
+  plugin, `client/module_core`; `flutter analyze` clean in `client/app`.
+  Tests: Claude 289/289 (3 new: confirm refused with count and
+  `mainAgentRunning`, keep leaves the process and tasks resident and settles
+  once after the wake-up turn, stop tears down), acp 275, codex 380, opencode
+  425, pi 291, bridge/app routing+services+repository 516, module_core
+  session-detail+repositories 350, client body test 94 — all pass. Changed
+  lines 1,257 across 49 files including generated code and the mechanical
+  `subAgents` argument at every plugin, fake, and test call site; the
+  non-generated production change is well inside the 600-1,000 target.
 - **Final disposition:** pending
 
 ## Plan Review

--- a/bridge/app/lib/src/repositories/mappers/plugin_to_shared_mapping.dart
+++ b/bridge/app/lib/src/repositories/mappers/plugin_to_shared_mapping.dart
@@ -16,6 +16,19 @@ extension PluginToolStatusMapping on PluginToolStatus {
   };
 }
 
+extension SessionAbortSubAgentPolicyMapping on SessionAbortSubAgentPolicy {
+  PluginAbortSubAgentPolicy toPlugin() => switch (this) {
+    SessionAbortSubAgentPolicy.confirm => PluginAbortSubAgentPolicy.confirm,
+    SessionAbortSubAgentPolicy.keep => PluginAbortSubAgentPolicy.keep,
+    SessionAbortSubAgentPolicy.stop => PluginAbortSubAgentPolicy.stop,
+  };
+}
+
+extension PluginAbortRejectionMapping on PluginAbortRejectedSubAgentsRunning {
+  SessionAbortRejection toShared() =>
+      SessionAbortRejection(runningSubAgentCount: runningSubAgentCount, mainAgentRunning: mainAgentRunning);
+}
+
 /// Maps a plugin-normalized attachment into the shared wire contract.
 extension PluginMessageAttachmentMapping on PluginMessageAttachment {
   MessageAttachment toShared() => switch (this) {

--- a/bridge/app/lib/src/repositories/models/session_abort_result.dart
+++ b/bridge/app/lib/src/repositories/models/session_abort_result.dart
@@ -1,0 +1,9 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+/// Outcome of a scoped stop, in wire terms.
+sealed class const SessionAbortResult();
+
+final class const SessionAborted() extends SessionAbortResult;
+
+/// A `confirm` stop the plugin refused because sub-agents are running.
+final class const SessionAbortRejected({required final SessionAbortRejection rejection}) extends SessionAbortResult;

--- a/bridge/app/lib/src/repositories/models/session_abort_result.dart
+++ b/bridge/app/lib/src/repositories/models/session_abort_result.dart
@@ -3,7 +3,8 @@ import "package:sesori_shared/sesori_shared.dart";
 /// Outcome of a scoped stop, in wire terms.
 sealed class const SessionAbortResult();
 
-final class const SessionAborted() extends SessionAbortResult;
+/// The stop was performed; [workKept] says resident work was left running.
+final class const SessionAborted({required final bool workKept}) extends SessionAbortResult;
 
 /// A `confirm` stop the plugin refused because sub-agents are running.
 final class const SessionAbortRejected({required final SessionAbortRejection rejection}) extends SessionAbortResult;

--- a/bridge/app/lib/src/repositories/session_repository.dart
+++ b/bridge/app/lib/src/repositories/session_repository.dart
@@ -975,7 +975,7 @@ class SessionRepository({
       sessionId: binding.backendSessionId,
       subAgents: subAgents.toPlugin(),
     )) {
-      PluginAbortAccepted() => const SessionAborted(),
+      PluginAbortAccepted(:final workKept) => SessionAborted(workKept: workKept),
       final PluginAbortRejectedSubAgentsRunning rejected => SessionAbortRejected(rejection: rejected.toShared()),
     },
   );

--- a/bridge/app/lib/src/repositories/session_repository.dart
+++ b/bridge/app/lib/src/repositories/session_repository.dart
@@ -2,13 +2,14 @@ import "dart:async";
 import "dart:math";
 
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
-
     show
         BridgeDerivedProjectsPluginApi,
         BridgePluginApi,
         Log,
         NativeProjectsPluginApi,
         PersistedSessionCleanupApi,
+        PluginAbortAccepted,
+        PluginAbortRejectedSubAgentsRunning,
         PluginActiveSession,
         PluginOperationException,
         PluginProjectActivitySummary,
@@ -28,6 +29,7 @@ import "package:sesori_shared/sesori_shared.dart"
         PullRequestInfo,
         QueuedSessionPrompt,
         Session,
+        SessionAbortSubAgentPolicy,
         SessionPromptDefaults,
         SessionStatus,
         SessionStatusResponse,
@@ -50,6 +52,7 @@ import "mappers/pull_request_mapper.dart";
 import "mappers/session_catalog_mapper.dart";
 import "mappers/stored_session_mapper.dart";
 import "models/project_not_found_exception.dart";
+import "models/session_abort_result.dart";
 import "models/session_operation.dart";
 import "models/stored_session.dart";
 import "models/verified_github_login.dart";
@@ -57,7 +60,10 @@ import "project_catalog_identity_calculator.dart";
 import "random_hex_id.dart";
 import "session_unseen_calculator.dart";
 
-enum SessionBindingCommitKind() { sessionCreation, catalogSync }
+enum SessionBindingCommitKind() {
+  sessionCreation,
+  catalogSync,
+}
 
 typedef SessionBindingsCommitted = ({
   String pluginId,
@@ -78,14 +84,14 @@ typedef SessionMessagesSnapshot = ({
 });
 
 class SessionRepository({
-    required final PluginRuntime _runtime,
-    required final SessionDao _sessionDao,
-    required final ProjectsDao _projectsDao,
-    required final PullRequestDao _pullRequestDao,
-    required final SessionUnseenCalculator _unseenCalculator,
-    required final ProjectCatalogIdentityCalculator _projectCatalogIdentityCalculator,
-    required final Duration _aggregateSourceDeadline,
-  }) {
+  required final PluginRuntime _runtime,
+  required final SessionDao _sessionDao,
+  required final ProjectsDao _projectsDao,
+  required final PullRequestDao _pullRequestDao,
+  required final SessionUnseenCalculator _unseenCalculator,
+  required final ProjectCatalogIdentityCalculator _projectCatalogIdentityCalculator,
+  required final Duration _aggregateSourceDeadline,
+}) {
   static const SessionCatalogMapper _sessionCatalogMapper = SessionCatalogMapper();
 
   final Map<String, Set<String>> _tombstonedBackendSessionIds = <String, Set<String>>{};
@@ -96,9 +102,7 @@ class SessionRepository({
   final Set<String> _tombstonesLoaded = <String>{};
   int _lastProjectionTimestamp = 0;
 
-
   Stream<SessionBindingsCommitted> get bindingCommits => _bindingCommitsController.stream;
-
 
   Future<SessionFamilyScope> resolveSessionFamily({
     required String sessionId,
@@ -810,9 +814,7 @@ class SessionRepository({
           preferredProjectId: project.id,
           observedPath: project.directory,
         );
-        final hydratedProject =
-            existing ??
-            _hiddenProjectPlaceholder(projectId: project.id, path: project.directory);
+        final hydratedProject = existing ?? _hiddenProjectPlaceholder(projectId: project.id, path: project.directory);
         if (hydratedProjectIds.contains(hydratedProject.projectId)) continue;
         final sessions = await plugin.getSessions(projectId: project.directory, start: null, limit: null);
         hydratedProjectIds.add(hydratedProject.projectId);
@@ -888,8 +890,7 @@ class SessionRepository({
         observedPath: projectDirectory,
       );
       final hydratedProject =
-          existingProject ??
-          _hiddenProjectPlaceholder(projectId: preferredProjectId, path: projectDirectory);
+          existingProject ?? _hiddenProjectPlaceholder(projectId: preferredProjectId, path: projectDirectory);
       await _projectsDao.insertProjectIfMissing(
         projectId: hydratedProject.projectId,
         path: projectDirectory,
@@ -950,7 +951,6 @@ class SessionRepository({
     };
   }
 
-
   /// The plugin and project that own [sessionId], which together scope its
   /// session options cache. `null` when the session has no stored row.
   Future<({String pluginId, String projectId})?> findSessionOptionsScope({required String sessionId}) async {
@@ -965,10 +965,19 @@ class SessionRepository({
     body: (plugin, binding) => plugin.archiveSession(sessionId: binding.backendSessionId),
   );
 
-  Future<void> abortSession({required String sessionId}) => _useSessionPlugin(
+  Future<SessionAbortResult> abortSession({
+    required String sessionId,
+    required SessionAbortSubAgentPolicy subAgents,
+  }) => _useSessionPlugin(
     sessionId: sessionId,
     operation: SessionOperation.abortSession,
-    body: (plugin, binding) => plugin.abortSession(sessionId: binding.backendSessionId),
+    body: (plugin, binding) async => switch (await plugin.abortSession(
+      sessionId: binding.backendSessionId,
+      subAgents: subAgents.toPlugin(),
+    )) {
+      PluginAbortAccepted() => const SessionAborted(),
+      final PluginAbortRejectedSubAgentsRunning rejected => SessionAbortRejected(rejection: rejected.toShared()),
+    },
   );
 
   Future<SessionStatusResponse> getSessionStatuses() async {
@@ -1628,19 +1637,18 @@ class SessionRepository({
       reservedSessionIds?.remove(candidate);
     }
   }
-
 }
 
 class const _PluginActivityObservation({
-    required final String pluginId,
-    required final List<PluginProjectActivitySummary> summaries,
-    required final Set<String> backendSessionIds,
-    required final List<_ActiveRootHydration> hydrations,
-  });
+  required final String pluginId,
+  required final List<PluginProjectActivitySummary> summaries,
+  required final Set<String> backendSessionIds,
+  required final List<_ActiveRootHydration> hydrations,
+});
 
 class const _ActiveRootHydration({
-    required final String summaryId,
-    required final String preferredProjectId,
-    required final String projectDirectory,
-    required final List<PluginSession> sessions,
-  });
+  required final String summaryId,
+  required final String preferredProjectId,
+  required final String projectDirectory,
+  required final List<PluginSession> sessions,
+});

--- a/bridge/app/lib/src/routing/abort_session_handler.dart
+++ b/bridge/app/lib/src/routing/abort_session_handler.dart
@@ -1,25 +1,30 @@
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../repositories/models/session_abort_result.dart";
 import "../services/session_abort_service.dart";
 import "request_handler.dart";
 
-/// Handles `POST /session/:id/abort` — aborts in-progress session execution.
+/// Handles `POST /session/abort` — stops in-progress session execution.
 class AbortSessionHandler({
   required final SessionAbortService _sessionAbortService,
-}) extends BodyRequestHandler<SessionIdRequest, SuccessEmptyResponse> {
+}) extends BodyRequestHandler<AbortSessionRequest, SuccessEmptyResponse> {
   this
     : super(
         HttpMethod.post,
         "/session/abort",
-        fromJson: SessionIdRequest.fromJson,
+        fromJson: AbortSessionRequest.fromJson,
       );
 
   @override
   Future<SuccessEmptyResponse> handle(
     RelayRequest request, {
-    required SessionIdRequest body,
+    required AbortSessionRequest body,
   }) async {
-    await _sessionAbortService.abortSession(sessionId: body.sessionId);
+    final result = await _sessionAbortService.abortSession(sessionId: body.sessionId, subAgents: body.subAgents);
+    if (result case SessionAbortRejected(:final rejection)) {
+      // The app parses the 409 body as SessionAbortRejection JSON.
+      throw buildJsonErrorResponse(request: request, status: 409, body: rejection.toJson());
+    }
     return const SuccessEmptyResponse();
   }
 }

--- a/bridge/app/lib/src/services/session_abort_service.dart
+++ b/bridge/app/lib/src/services/session_abort_service.dart
@@ -33,7 +33,9 @@ class SessionAbortService({
       operation: SessionOperation.abortSession,
       body: () async {
         final result = await _sessionRepository.abortSession(sessionId: sessionId, subAgents: subAgents);
-        if (result is SessionAborted && subAgents != SessionAbortSubAgentPolicy.keep) {
+        // Decided by what the plugin actually did, not by the requested policy:
+        // a `keep` with nothing to keep is a full stop.
+        if (result case SessionAborted(workKept: false)) {
           _abortedSessionsController.add(sessionId);
         } else {
           _abortFailedSessionsController.add(sessionId);

--- a/bridge/app/lib/src/services/session_abort_service.dart
+++ b/bridge/app/lib/src/services/session_abort_service.dart
@@ -1,5 +1,8 @@
 import "dart:async";
 
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../repositories/models/session_abort_result.dart";
 import "../repositories/models/session_operation.dart";
 import "../repositories/session_repository.dart";
 import "session_operation_dispatcher.dart";
@@ -16,18 +19,31 @@ class SessionAbortService({
   Stream<String> get abortedSessions => _abortedSessionsController.stream;
   Stream<String> get abortFailedSessions => _abortFailedSessionsController.stream;
 
-  Future<void> abortSession({required String sessionId}) {
-    final operation = _dispatcher.dispatch<void>(
+  /// Stops [sessionId] with the given sub-agent scope.
+  ///
+  /// Push suppression follows the outcome: only a full stop marks the session
+  /// aborted; a rejection or a main-agent-only stop clears the pending mark,
+  /// because work that keeps running still earns its completion push.
+  Future<SessionAbortResult> abortSession({
+    required String sessionId,
+    required SessionAbortSubAgentPolicy subAgents,
+  }) {
+    final operation = _dispatcher.dispatch<SessionAbortResult>(
       sessionId: sessionId,
       operation: SessionOperation.abortSession,
       body: () async {
-        await _sessionRepository.abortSession(sessionId: sessionId);
-        _abortedSessionsController.add(sessionId);
+        final result = await _sessionRepository.abortSession(sessionId: sessionId, subAgents: subAgents);
+        if (result is SessionAborted && subAgents != SessionAbortSubAgentPolicy.keep) {
+          _abortedSessionsController.add(sessionId);
+        } else {
+          _abortFailedSessionsController.add(sessionId);
+        }
+        return result;
       },
     );
     _abortStartedSessionsController.add(sessionId);
-    return operation.then<void>(
-      (_) {},
+    return operation.then<SessionAbortResult>(
+      (result) => result,
       onError: (Object error, StackTrace stackTrace) {
         _abortFailedSessionsController.add(sessionId);
         Error.throwWithStackTrace(error, stackTrace);

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -1178,7 +1178,7 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi, _SubscriptionAware
   Future<PluginAbortResult> abortSession({
     required String sessionId,
     required PluginAbortSubAgentPolicy subAgents,
-  }) async => const PluginAbortAccepted();
+  }) async => const PluginAbortAccepted(workKept: false);
 
   @override
   Future<List<PluginAgent>> getAgents({required String projectId}) async => [];
@@ -1315,7 +1315,7 @@ class _BlockingRoutesPlugin() extends _FakeBridgePlugin {
   }) async {
     _abortStarted.complete();
     await _abortRelease.future;
-    return const PluginAbortAccepted();
+    return const PluginAbortAccepted(workKept: false);
   }
 }
 
@@ -1434,7 +1434,7 @@ class _TrackingBridgePlugin() implements NativeProjectsPluginApi, _SubscriptionA
   Future<PluginAbortResult> abortSession({
     required String sessionId,
     required PluginAbortSubAgentPolicy subAgents,
-  }) async => const PluginAbortAccepted();
+  }) async => const PluginAbortAccepted(workKept: false);
 
   @override
   Future<List<PluginAgent>> getAgents({required String projectId}) async => [];

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -1175,7 +1175,10 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi, _SubscriptionAware
   }) async {}
 
   @override
-  Future<void> abortSession({required String sessionId}) async {}
+  Future<PluginAbortResult> abortSession({
+    required String sessionId,
+    required PluginAbortSubAgentPolicy subAgents,
+  }) async => const PluginAbortAccepted();
 
   @override
   Future<List<PluginAgent>> getAgents({required String projectId}) async => [];
@@ -1306,9 +1309,13 @@ class _BlockingRoutesPlugin() extends _FakeBridgePlugin {
   }
 
   @override
-  Future<void> abortSession({required String sessionId}) async {
+  Future<PluginAbortResult> abortSession({
+    required String sessionId,
+    required PluginAbortSubAgentPolicy subAgents,
+  }) async {
     _abortStarted.complete();
     await _abortRelease.future;
+    return const PluginAbortAccepted();
   }
 }
 
@@ -1424,7 +1431,10 @@ class _TrackingBridgePlugin() implements NativeProjectsPluginApi, _SubscriptionA
   }) async {}
 
   @override
-  Future<void> abortSession({required String sessionId}) async {}
+  Future<PluginAbortResult> abortSession({
+    required String sessionId,
+    required PluginAbortSubAgentPolicy subAgents,
+  }) async => const PluginAbortAccepted();
 
   @override
   Future<List<PluginAgent>> getAgents({required String projectId}) async => [];

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -493,7 +493,10 @@ class _ThrowingSummaryPlugin() implements NativeProjectsPluginApi {
   }) async {}
 
   @override
-  Future<void> abortSession({required String sessionId}) async {}
+  Future<PluginAbortResult> abortSession({
+    required String sessionId,
+    required PluginAbortSubAgentPolicy subAgents,
+  }) async => const PluginAbortAccepted();
 
   @override
   Future<List<PluginAgent>> getAgents({required String projectId}) async => [];

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -496,7 +496,7 @@ class _ThrowingSummaryPlugin() implements NativeProjectsPluginApi {
   Future<PluginAbortResult> abortSession({
     required String sessionId,
     required PluginAbortSubAgentPolicy subAgents,
-  }) async => const PluginAbortAccepted();
+  }) async => const PluginAbortAccepted(workKept: false);
 
   @override
   Future<List<PluginAgent>> getAgents({required String projectId}) async => [];

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -1714,7 +1714,7 @@ void main() {
         throwsA(isA<PluginOperationException>().having((error) => error.isNotFound, "isNotFound", isTrue)),
       );
       await expectLater(
-        repository.abortSession(sessionId: "unknown"),
+        repository.abortSession(sessionId: "unknown", subAgents: SessionAbortSubAgentPolicy.stop),
         throwsA(isA<PluginOperationException>().having((error) => error.isNotFound, "isNotFound", isTrue)),
       );
       expect(plugin.lastGetMessagesSessionId, isNull);
@@ -2525,7 +2525,7 @@ void main() {
         ),
         () async => await repository.getSessionMessages(sessionId: "gone"),
         () => repository.notifySessionArchived(sessionId: "gone"),
-        () => repository.abortSession(sessionId: "gone"),
+        () => repository.abortSession(sessionId: "gone", subAgents: SessionAbortSubAgentPolicy.stop),
         () async => await repository.getChildSessions(sessionId: "gone"),
       ];
       for (final operation in guardedOperations) {
@@ -2934,8 +2934,12 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi {
   List<PluginProjectActivitySummary> getActiveSessionsSummary() => activitySummaries;
 
   @override
-  Future<void> abortSession({required String sessionId}) async {
+  Future<PluginAbortResult> abortSession({
+    required String sessionId,
+    required PluginAbortSubAgentPolicy subAgents,
+  }) async {
     lastAbortSessionId = sessionId;
+    return const PluginAbortAccepted();
   }
 
   @override

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -2939,7 +2939,7 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi {
     required PluginAbortSubAgentPolicy subAgents,
   }) async {
     lastAbortSessionId = sessionId;
-    return const PluginAbortAccepted();
+    return const PluginAbortAccepted(workKept: false);
   }
 
   @override

--- a/bridge/app/test/bridge/routing/abort_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/abort_session_handler_test.dart
@@ -36,7 +36,7 @@ void main() {
     test("extracts sessionId from request body", () async {
       await handler.handle(
         makeRequest("POST", "/session/abort"),
-        body: const SessionIdRequest(sessionId: "s1"),
+        body: const AbortSessionRequest(sessionId: "s1"),
       );
 
       expect(plugin.lastAbortSessionId, equals("s1"));
@@ -45,7 +45,7 @@ void main() {
     test("returns 200", () async {
       final response = await handler.handle(
         makeRequest("POST", "/session/abort"),
-        body: const SessionIdRequest(sessionId: "s1"),
+        body: const AbortSessionRequest(sessionId: "s1"),
       );
 
       expect(response, equals(const SuccessEmptyResponse()));

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -14,6 +14,7 @@ import "package:sesori_bridge/src/repositories/mappers/pull_request_mapper.dart"
 import "package:sesori_bridge/src/repositories/mappers/stored_session_mapper.dart";
 import "package:sesori_bridge/src/repositories/models/pull_request_selection.dart";
 import "package:sesori_bridge/src/repositories/models/pull_request_target.dart";
+import "package:sesori_bridge/src/repositories/models/session_abort_result.dart";
 import "package:sesori_bridge/src/repositories/models/session_operation.dart";
 import "package:sesori_bridge/src/repositories/models/stored_session.dart";
 import "package:sesori_bridge/src/repositories/models/verified_github_login.dart";
@@ -578,7 +579,10 @@ class _NoopSessionRepository() implements SessionRepository {
   Future<({String pluginId, String projectId})?> findSessionOptionsScope({required String sessionId}) async => null;
 
   @override
-  Future<void> abortSession({required String sessionId}) async {}
+  Future<SessionAbortResult> abortSession({
+    required String sessionId,
+    required SessionAbortSubAgentPolicy subAgents,
+  }) async => const SessionAborted();
 
   @override
   Future<void> notifySessionArchived({required String sessionId}) async {}
@@ -1085,8 +1089,12 @@ class FakeSessionRepository({
   Future<({String pluginId, String projectId})?> findSessionOptionsScope({required String sessionId}) async => null;
 
   @override
-  Future<void> abortSession({required String sessionId}) async {
-    await _plugin.abortSession(sessionId: sessionId);
+  Future<SessionAbortResult> abortSession({
+    required String sessionId,
+    required SessionAbortSubAgentPolicy subAgents,
+  }) async {
+    await _plugin.abortSession(sessionId: sessionId, subAgents: subAgents.toPlugin());
+    return const SessionAborted();
   }
 
   @override

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -582,7 +582,7 @@ class _NoopSessionRepository() implements SessionRepository {
   Future<SessionAbortResult> abortSession({
     required String sessionId,
     required SessionAbortSubAgentPolicy subAgents,
-  }) async => const SessionAborted();
+  }) async => const SessionAborted(workKept: false);
 
   @override
   Future<void> notifySessionArchived({required String sessionId}) async {}
@@ -1094,7 +1094,7 @@ class FakeSessionRepository({
     required SessionAbortSubAgentPolicy subAgents,
   }) async {
     await _plugin.abortSession(sessionId: sessionId, subAgents: subAgents.toPlugin());
-    return const SessionAborted();
+    return const SessionAborted(workKept: false);
   }
 
   @override

--- a/bridge/app/test/bridge/services/session_abort_service_test.dart
+++ b/bridge/app/test/bridge/services/session_abort_service_test.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:sesori_bridge/src/repositories/models/session_abort_result.dart";
 import "package:sesori_bridge/src/repositories/models/session_operation.dart";
 import "package:sesori_bridge/src/repositories/models/stored_session.dart";
 import "package:sesori_bridge/src/repositories/session_repository.dart";
@@ -42,7 +43,7 @@ void main() {
       addTearDown(startedSubscription.cancel);
       addTearDown(subscription.cancel);
 
-      final abortFuture = service.abortSession(sessionId: "session-1");
+      final abortFuture = service.abortSession(sessionId: "session-1", subAgents: SessionAbortSubAgentPolicy.stop);
       await abortStarted.future;
 
       expect(startedSessionIds, equals(["session-1"]));
@@ -70,7 +71,7 @@ void main() {
       addTearDown(failedSubscription.cancel);
 
       await expectLater(
-        service.abortSession(sessionId: "session-1"),
+        service.abortSession(sessionId: "session-1", subAgents: SessionAbortSubAgentPolicy.stop),
         throwsA(isA<StateError>()),
       );
 
@@ -88,7 +89,10 @@ void main() {
       addTearDown(startedSubscription.cancel);
       addTearDown(failedSubscription.cancel);
 
-      await expectLater(service.abortSession(sessionId: "missing"), throwsStateError);
+      await expectLater(
+        service.abortSession(sessionId: "missing", subAgents: SessionAbortSubAgentPolicy.stop),
+        throwsStateError,
+      );
 
       expect(startedSessionIds, ["missing"]);
       expect(failedSessionIds, ["missing"]);
@@ -102,8 +106,12 @@ class _FakeSessionRepository() implements SessionRepository {
   Object? resolutionError;
 
   @override
-  Future<void> abortSession({required String sessionId}) async {
+  Future<SessionAbortResult> abortSession({
+    required String sessionId,
+    required SessionAbortSubAgentPolicy subAgents,
+  }) async {
     await onAbort?.call(sessionId: sessionId);
+    return const SessionAborted();
   }
 
   @override

--- a/bridge/app/test/bridge/services/session_abort_service_test.dart
+++ b/bridge/app/test/bridge/services/session_abort_service_test.dart
@@ -111,7 +111,7 @@ class _FakeSessionRepository() implements SessionRepository {
     required SessionAbortSubAgentPolicy subAgents,
   }) async {
     await onAbort?.call(sessionId: sessionId);
-    return const SessionAborted();
+    return const SessionAborted(workKept: false);
   }
 
   @override

--- a/bridge/app/test/bridge/services/session_prompt_service_test.dart
+++ b/bridge/app/test/bridge/services/session_prompt_service_test.dart
@@ -239,7 +239,7 @@ void main() {
       while (plugin.lastSendCommandSessionId == null) {
         await Future<void>.delayed(Duration.zero);
       }
-      final abort = abortService.abortSession(sessionId: "s1");
+      final abort = abortService.abortSession(sessionId: "s1", subAgents: SessionAbortSubAgentPolicy.stop);
       final prompt = service.sendPrompt(
         promptId: "prompt-1",
         sessionId: "s1",

--- a/bridge/app/test/helpers/fakes/fake_bridge_plugin.dart
+++ b/bridge/app/test/helpers/fakes/fake_bridge_plugin.dart
@@ -287,7 +287,7 @@ class FakeBridgePlugin() implements NativeProjectsPluginApi {
     required PluginAbortSubAgentPolicy subAgents,
   }) async {
     lastAbortSessionId = sessionId;
-    return const PluginAbortAccepted();
+    return const PluginAbortAccepted(workKept: false);
   }
 
   @override

--- a/bridge/app/test/helpers/fakes/fake_bridge_plugin.dart
+++ b/bridge/app/test/helpers/fakes/fake_bridge_plugin.dart
@@ -282,8 +282,12 @@ class FakeBridgePlugin() implements NativeProjectsPluginApi {
   }
 
   @override
-  Future<void> abortSession({required String sessionId}) async {
+  Future<PluginAbortResult> abortSession({
+    required String sessionId,
+    required PluginAbortSubAgentPolicy subAgents,
+  }) async {
     lastAbortSessionId = sessionId;
+    return const PluginAbortAccepted();
   }
 
   @override

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -840,9 +840,7 @@ abstract class AcpPlugin({
       directory: directory,
       parentID: sessionParentId(info),
       title: info.title,
-      time: ts == null
-          ? null
-          : PluginSessionTime(created: sessionCreatedAtMs(info) ?? ts, updated: ts, archived: null),
+      time: ts == null ? null : PluginSessionTime(created: sessionCreatedAtMs(info) ?? ts, updated: ts, archived: null),
     );
   }
 
@@ -908,8 +906,7 @@ abstract class AcpPlugin({
     );
     emitEvent(eventMapper.mapCreatedSession(session: created));
     final visibleParts = [
-      if (userVisibleText != null && userVisibleText.trim().isNotEmpty)
-        PluginPromptPart.text(text: userVisibleText),
+      if (userVisibleText != null && userVisibleText.trim().isNotEmpty) PluginPromptPart.text(text: userVisibleText),
       ...parts.whereType<PluginPromptPartFileData>(),
     ];
     final initialPromptEvents = eventMapper.mapInitialPrompt(
@@ -1547,7 +1544,15 @@ abstract class AcpPlugin({
   }
 
   @override
-  Future<void> abortSession({required String sessionId}) async {
+  Future<PluginAbortResult> abortSession({
+    required String sessionId,
+    required PluginAbortSubAgentPolicy subAgents,
+  }) async {
+    await _abortSession(sessionId: sessionId);
+    return const PluginAbortAccepted();
+  }
+
+  Future<void> _abortSession({required String sessionId}) async {
     // Aborting means "stop this conversation now": drop the queued-but-
     // undispatched turns first so they don't dispatch after the cancel. The
     // in-flight turn (if any) ends via the agent's cancellation, which
@@ -1590,7 +1595,7 @@ abstract class AcpPlugin({
       if (activeSessionIds.isEmpty) return const <String>{};
 
       await Future.wait([
-        for (final sessionId in activeSessionIds) abortSession(sessionId: sessionId),
+        for (final sessionId in activeSessionIds) _abortSession(sessionId: sessionId),
       ]);
       if (currentWorkState != PluginWorkState.idle) {
         await workState.firstWhere((state) => state == PluginWorkState.idle);
@@ -1621,7 +1626,7 @@ abstract class AcpPlugin({
   Future<void> deleteSession(String sessionId) async {
     final state = _turnStates[sessionId];
     if ((state?.pending ?? 0) > 0) {
-      await abortSession(sessionId: sessionId);
+      await _abortSession(sessionId: sessionId);
     }
     _approvalRegistry?.cancelForSession(sessionId: sessionId);
     final canClose = _initResult?.agentCapabilities.closeSession ?? false;
@@ -2063,7 +2068,11 @@ class _QueuedAcpPrompt({
   _QueuedAcpPromptPhase phase = _QueuedAcpPromptPhase.queued;
 }
 
-enum _QueuedAcpPromptPhase() { queued, writing, cancelled }
+enum _QueuedAcpPromptPhase() {
+  queued,
+  writing,
+  cancelled,
+}
 
 class const _TurnSelection({
   required final ({String providerID, String modelID})? model,

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1549,7 +1549,7 @@ abstract class AcpPlugin({
     required PluginAbortSubAgentPolicy subAgents,
   }) async {
     await _abortSession(sessionId: sessionId);
-    return const PluginAbortAccepted();
+    return const PluginAbortAccepted(workKept: false);
   }
 
   Future<void> _abortSession({required String sessionId}) async {

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -425,7 +425,7 @@ void main() {
       await pump();
       expect(emitted.whereType<BridgeSsePermissionAsked>(), isEmpty);
 
-      await plugin.abortSession(sessionId: sessionId);
+      await plugin.abortSession(sessionId: sessionId, subAgents: PluginAbortSubAgentPolicy.stop);
       flush.complete();
       for (var i = 0; i < 20 && !fake.written.any((frame) => frame["id"] == 92); i++) {
         await pump();
@@ -927,7 +927,7 @@ void main() {
       final firstPrompt = await waitForFrame("session/prompt");
       await sendPrompt(sessionId, "queued");
 
-      await plugin.abortSession(sessionId: sessionId);
+      await plugin.abortSession(sessionId: sessionId, subAgents: PluginAbortSubAgentPolicy.stop);
       expect(
         frames("session/cancel"),
         hasLength(2),
@@ -1068,7 +1068,7 @@ void main() {
       for (var i = 0; i < 5; i++) {
         await pump();
       }
-      await gated.abortSession(sessionId: "s1");
+      await gated.abortSession(sessionId: "s1", subAgents: PluginAbortSubAgentPolicy.stop);
       gate.complete();
       for (var i = 0; i < 10; i++) {
         await pump();

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -589,6 +589,11 @@ final class ClaudePlugin({
       return;
     }
     if (event case ClaudeSessionProcessMessage(:final message, :final interrupted, :final promptId)) {
+      // Between an acknowledged interrupt and the interrupted turn's result the
+      // CLI can still stream that turn's output; a full stop tears the process
+      // down, a main-agent-only stop keeps it, so assistant output is dropped
+      // here. User echoes still render: they are the prompt's transcript identity.
+      if (interrupted && (message is ClaudeAssistantMessage || message is ClaudeStreamEventMessage)) return;
       if (message is ClaudeResultMessage) {
         final denialsWereHandled = _approvals.consumeHandledPermissionDenials(
           sessionId: event.sessionId,

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -295,9 +295,8 @@ final class ClaudePlugin({
       _sessions.cancelQueuedPrompt(sessionId: sessionId, promptId: promptId);
 
   @override
-  Future<void> abortSession({required String sessionId}) async {
-    await _sessions.abort(sessionId: sessionId);
-  }
+  Future<PluginAbortResult> abortSession({required String sessionId, required PluginAbortSubAgentPolicy subAgents}) =>
+      _sessions.abort(sessionId: sessionId, subAgents: subAgents);
 
   @override
   // Claude declares plugin-scoped options, so projectId does not select a catalog.

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -592,8 +592,16 @@ final class ClaudePlugin({
       // Between an acknowledged interrupt and the interrupted turn's result the
       // CLI can still stream that turn's output; a full stop tears the process
       // down, a main-agent-only stop keeps it, so assistant output is dropped
-      // here. User echoes still render: they are the prompt's transcript identity.
-      if (interrupted && (message is ClaudeAssistantMessage || message is ClaudeStreamEventMessage)) return;
+      // here. User echoes still render (they are the prompt's transcript identity)
+      // and so do forwarded sub-agent frames, which belong to the kept work.
+      if (interrupted) {
+        switch (message) {
+          case ClaudeAssistantMessage(parentToolUseId: null) || ClaudeStreamEventMessage(parentToolUseId: null):
+            return;
+          case ClaudeStreamMessage():
+            break;
+        }
+      }
       if (message is ClaudeResultMessage) {
         final denialsWereHandled = _approvals.consumeHandledPermissionDenials(
           sessionId: event.sessionId,

--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
@@ -68,6 +68,10 @@ final class _ResidentProcess({
   late final StreamSubscription<ClaudeStreamMessage> messages;
   final Queue<_PendingTurn> pendingTurns = Queue<_PendingTurn>();
   bool interrupted = false;
+
+  /// The interrupted turn's result has arrived; the next turn to start is new
+  /// work and closes the post-interrupt window.
+  bool interruptSettled = false;
   bool turnActive = false;
 
   Future<void> cancelMessages() => messages.cancel();
@@ -204,6 +208,7 @@ final class ClaudeSessionProcessRepository({
     }
 
     process.interrupted = false;
+    process.interruptSettled = false;
     // A resident process can absorb several stdin messages into one agent turn.
     // User echoes mark which queued messages joined that turn, and its result
     // settles exactly that started prefix.
@@ -412,13 +417,16 @@ final class ClaudeSessionProcessRepository({
           return promptId;
         }
       case ClaudeStreamEventMessage() || ClaudeAssistantMessage() || ClaudeControlRequestMessage():
+        // A turn starting after the interrupted turn settled is new work — the
+        // wake-up turn a kept sub-agent triggers — so the post-interrupt window
+        // closes here and its frames render again.
+        if (!process.turnActive && process.interruptSettled) {
+          process.interrupted = false;
+          process.interruptSettled = false;
+        }
         process.turnActive = true;
-      case ClaudeTaskNotificationMessage() when process.interrupted && !process.turnActive:
-        // A stop that kept the process resident for its tasks: the interrupted
-        // turn has settled, and this notification opens the wake-up turn that
-        // must render again, so the post-interrupt window closes here.
-        process.interrupted = false;
       case final ClaudeResultMessage message:
+        if (process.interrupted) process.interruptSettled = true;
         final outcome = process.interrupted
             ? const ClaudeTurnInterrupted()
             : message.isError

--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
@@ -393,6 +393,13 @@ final class ClaudeSessionProcessRepository({
   }
 
   String? _trackTurnMessage({required _ResidentProcess process, required ClaudeStreamMessage message}) {
+    // A turn starting after the interrupted turn settled is new work — the
+    // wake-up turn a kept sub-agent triggers, or the notification that opens
+    // it — so the post-interrupt window closes and its frames render again.
+    if (!process.turnActive && process.interruptSettled && _startsNewTurn(message)) {
+      process.interrupted = false;
+      process.interruptSettled = false;
+    }
     switch (message) {
       case ClaudeUserMessage(parentToolUseId: null):
         // Claude normally marks stdin echoes with `isReplay`, but attachment
@@ -417,13 +424,6 @@ final class ClaudeSessionProcessRepository({
           return promptId;
         }
       case ClaudeStreamEventMessage() || ClaudeAssistantMessage() || ClaudeControlRequestMessage():
-        // A turn starting after the interrupted turn settled is new work — the
-        // wake-up turn a kept sub-agent triggers — so the post-interrupt window
-        // closes here and its frames render again.
-        if (!process.turnActive && process.interruptSettled) {
-          process.interrupted = false;
-          process.interruptSettled = false;
-        }
         process.turnActive = true;
       case final ClaudeResultMessage message:
         if (process.interrupted) process.interruptSettled = true;
@@ -546,3 +546,11 @@ List<Map<String, Object?>> _promptContent(List<PluginPromptPart> parts) => [
       ],
     },
 ];
+
+/// Frames that prove a new turn (or the task completion that opens one).
+bool _startsNewTurn(ClaudeStreamMessage message) => switch (message) {
+  ClaudeStreamEventMessage() || ClaudeAssistantMessage() || ClaudeControlRequestMessage() => true,
+  ClaudeTaskNotificationMessage() => true,
+  ClaudeUserMessage(:final taskNotifications) => taskNotifications.isNotEmpty,
+  ClaudeStreamMessage() => false,
+};

--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_session_process_repository.dart
@@ -413,6 +413,11 @@ final class ClaudeSessionProcessRepository({
         }
       case ClaudeStreamEventMessage() || ClaudeAssistantMessage() || ClaudeControlRequestMessage():
         process.turnActive = true;
+      case ClaudeTaskNotificationMessage() when process.interrupted && !process.turnActive:
+        // A stop that kept the process resident for its tasks: the interrupted
+        // turn has settled, and this notification opens the wake-up turn that
+        // must render again, so the post-interrupt window closes here.
+        process.interrupted = false;
       case final ClaudeResultMessage message:
         final outcome = process.interrupted
             ? const ClaudeTurnInterrupted()

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -484,11 +484,11 @@ final class ClaudeSessionService({
   /// tears the process down, cancelling every task with it.
   Future<PluginAbortResult> abort({required String sessionId, required PluginAbortSubAgentPolicy subAgents}) async {
     final state = _turns[sessionId];
-    if (state == null) return const PluginAbortAccepted();
+    if (state == null) return const PluginAbortAccepted(workKept: false);
     final activeAbort = state.aborting;
     if (activeAbort != null) {
       await activeAbort.future;
-      return const PluginAbortAccepted();
+      return const PluginAbortAccepted(workKept: false);
     }
     final runningSubAgents = state.runningTaskIds.values.where((type) => type == ClaudeTaskType.subAgent).length;
     if (subAgents == PluginAbortSubAgentPolicy.confirm && runningSubAgents > 0) {
@@ -499,7 +499,7 @@ final class ClaudeSessionService({
     }
     if (!state.hasWork) {
       _approvals.cancelForSession(sessionId: sessionId);
-      return const PluginAbortAccepted();
+      return const PluginAbortAccepted(workKept: false);
     }
     final keepTasks = subAgents == PluginAbortSubAgentPolicy.keep && state.runningTaskIds.isNotEmpty;
     final aborting = Completer<void>();
@@ -516,8 +516,14 @@ final class ClaudeSessionService({
         // The process stays resident for its tasks; the interrupted turn's own
         // result settles the pending/self-started turn through the normal path
         // and the running set keeps the session busy until the tasks report.
-        await _processes.interrupt(sessionId: sessionId);
-        return const PluginAbortAccepted();
+        try {
+          await _processes.interrupt(sessionId: sessionId);
+          return const PluginAbortAccepted(workKept: true);
+        } on Object catch (error, stack) {
+          // A process that will not take the interrupt cannot be trusted to keep
+          // anything; fall through to the full teardown below.
+          Log.w("[claude] interrupt failed for $sessionId; stopping everything", error, stack);
+        }
       }
       // Teardown kills the CLI's in-process wakeup timer, and `--resume` does
       // not rearm it, so a pending wakeup cannot survive an abort.
@@ -538,7 +544,7 @@ final class ClaudeSessionService({
         _completeSelfStartedTurn(state: state);
         _settleIdle(sessionId: sessionId, state: state);
       }
-      return const PluginAbortAccepted();
+      return const PluginAbortAccepted(workKept: false);
     } finally {
       if (identical(state.aborting, aborting)) state.aborting = null;
       if (!aborting.isCompleted) aborting.complete();

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -475,31 +475,53 @@ final class ClaudeSessionService({
     _emitQueueUpdate(sessionId: sessionId, state: state);
   }
 
-  Future<void> abort({required String sessionId}) async {
+  /// Stops the session's work with the given sub-agent scope.
+  ///
+  /// `confirm` is refused while typed sub-agents run, with no side effect, so
+  /// the caller can ask the user. `keep` interrupts the main agent but leaves
+  /// the process resident so its tasks continue and their notifications wake
+  /// it as usual; `stop` (and `keep` with nothing resident) interrupts and
+  /// tears the process down, cancelling every task with it.
+  Future<PluginAbortResult> abort({required String sessionId, required PluginAbortSubAgentPolicy subAgents}) async {
     final state = _turns[sessionId];
-    if (state == null) return;
+    if (state == null) return const PluginAbortAccepted();
     final activeAbort = state.aborting;
     if (activeAbort != null) {
       await activeAbort.future;
-      return;
+      return const PluginAbortAccepted();
+    }
+    final runningSubAgents = state.runningTaskIds.values.where((type) => type == ClaudeTaskType.subAgent).length;
+    if (subAgents == PluginAbortSubAgentPolicy.confirm && runningSubAgents > 0) {
+      return PluginAbortRejectedSubAgentsRunning(
+        runningSubAgentCount: runningSubAgents,
+        mainAgentRunning: state.pending > 0 || state.selfStartedTurn != null,
+      );
     }
     if (!state.hasWork) {
       _approvals.cancelForSession(sessionId: sessionId);
-      return;
+      return const PluginAbortAccepted();
     }
+    final keepTasks = subAgents == PluginAbortSubAgentPolicy.keep && state.runningTaskIds.isNotEmpty;
     final aborting = Completer<void>();
     state.aborting = aborting;
     try {
       state.generation++;
       state.idleGeneration++;
-      // Teardown kills the CLI's in-process wakeup timer, and `--resume` does
-      // not rearm it, so a pending wakeup cannot survive an abort.
-      state.wakeupAt = null;
       if (state.queue.isNotEmpty) {
         state.queue.clear();
         _emitQueueUpdate(sessionId: sessionId, state: state);
       }
       _approvals.cancelForSession(sessionId: sessionId);
+      if (keepTasks) {
+        // The process stays resident for its tasks; the interrupted turn's own
+        // result settles the pending/self-started turn through the normal path
+        // and the running set keeps the session busy until the tasks report.
+        await _processes.interrupt(sessionId: sessionId);
+        return const PluginAbortAccepted();
+      }
+      // Teardown kills the CLI's in-process wakeup timer, and `--resume` does
+      // not rearm it, so a pending wakeup cannot survive an abort.
+      state.wakeupAt = null;
       try {
         await _processes.interrupt(sessionId: sessionId);
       } on Object catch (error, stack) {
@@ -516,6 +538,7 @@ final class ClaudeSessionService({
         _completeSelfStartedTurn(state: state);
         _settleIdle(sessionId: sessionId, state: state);
       }
+      return const PluginAbortAccepted();
     } finally {
       if (identical(state.aborting, aborting)) state.aborting = null;
       if (!aborting.isCompleted) aborting.complete();
@@ -530,7 +553,8 @@ final class ClaudeSessionService({
       };
       if (activeSessionIds.isEmpty) return const <String>{};
       await Future.wait([
-        for (final sessionId in activeSessionIds) abort(sessionId: sessionId),
+        for (final sessionId in activeSessionIds)
+          abort(sessionId: sessionId, subAgents: PluginAbortSubAgentPolicy.stop),
       ]);
       if (currentWorkState != PluginWorkState.idle) {
         await workState.firstWhere((state) => state == PluginWorkState.idle);

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -511,13 +511,15 @@ final class ClaudeSessionService({
         state.queue.clear();
         _emitQueueUpdate(sessionId: sessionId, state: state);
       }
-      _approvals.cancelForSession(sessionId: sessionId);
       if (keepTasks) {
-        // The process stays resident for its tasks; the interrupted turn's own
-        // result settles the pending/self-started turn through the normal path
-        // and the running set keeps the session busy until the tasks report.
+        // The process stays resident for its tasks, so pending approvals are left
+        // alone: a kept sub-agent may be waiting on one, and the interrupted
+        // main turn resolves its own. The interrupted turn's result settles the
+        // pending/self-started turn through the normal path; waiting for it here
+        // keeps the abort fence up so a follow-up send cannot join that turn.
         try {
           await _processes.interrupt(sessionId: sessionId);
+          await Future.wait([...state.settlements, ?state.selfStartedTurn?.future]);
           return const PluginAbortAccepted(workKept: true);
         } on Object catch (error, stack) {
           // A process that will not take the interrupt cannot be trusted to keep
@@ -525,6 +527,7 @@ final class ClaudeSessionService({
           Log.w("[claude] interrupt failed for $sessionId; stopping everything", error, stack);
         }
       }
+      _approvals.cancelForSession(sessionId: sessionId);
       // Teardown kills the CLI's in-process wakeup timer, and `--resume` does
       // not rearm it, so a pending wakeup cannot survive an abort.
       state.wakeupAt = null;

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -487,8 +487,10 @@ final class ClaudeSessionService({
     if (state == null) return const PluginAbortAccepted(workKept: false);
     final activeAbort = state.aborting;
     if (activeAbort != null) {
+      // The in-flight abort may have kept work this caller wants stopped; run
+      // the requested scope once its fence releases.
       await activeAbort.future;
-      return const PluginAbortAccepted(workKept: false);
+      return await abort(sessionId: sessionId, subAgents: subAgents);
     }
     final runningSubAgents = state.runningTaskIds.values.where((type) => type == ClaudeTaskType.subAgent).length;
     if (subAgents == PluginAbortSubAgentPolicy.confirm && runningSubAgents > 0) {
@@ -520,7 +522,9 @@ final class ClaudeSessionService({
         try {
           await _processes.interrupt(sessionId: sessionId);
           await Future.wait([...state.settlements, ?state.selfStartedTurn?.future]);
-          return const PluginAbortAccepted(workKept: true);
+          // Reported from what survived the wait: a task that finished meanwhile,
+          // or a process that died with its tasks, leaves nothing kept.
+          return PluginAbortAccepted(workKept: state.runningTaskIds.isNotEmpty);
         } on Object catch (error, stack) {
           // A process that will not take the interrupt cannot be trusted to keep
           // anything; fall through to the full teardown below.

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -490,7 +490,7 @@ void main() {
       final subscription = harness.plugin.events.listen(events.add);
       final written = first.written.lastWhere((frame) => frame["type"] == "user");
       first.emit(_replayOf(written, uuid: "late-echo"));
-      final abort = harness.plugin.abortSession(sessionId: testSessionId);
+      final abort = harness.plugin.abortSession(sessionId: testSessionId, subAgents: PluginAbortSubAgentPolicy.stop);
       final interrupt = await _waitForControl(first, "interrupt");
       first.emitControlResponse(requestId: interrupt["request_id"]! as String, payload: const {});
       await abort;
@@ -775,7 +775,7 @@ void main() {
       final process = harness.processes.single;
       await waitForFrame(process, "user");
 
-      await harness.plugin.abortSession(sessionId: testSessionId);
+      await harness.plugin.abortSession(sessionId: testSessionId, subAgents: PluginAbortSubAgentPolicy.stop);
       process.emit({
         "type": "result",
         "subtype": "error_during_execution",
@@ -833,7 +833,7 @@ void main() {
       await pump();
       // An explicit stop tears the process down without a natural exit; the
       // sub-agent must still surface as cancelled.
-      final abort = harness.plugin.abortSession(sessionId: testSessionId);
+      final abort = harness.plugin.abortSession(sessionId: testSessionId, subAgents: PluginAbortSubAgentPolicy.stop);
       final interrupt = await _waitForControl(process, "interrupt");
       process.emitControlResponse(requestId: interrupt["request_id"]! as String, payload: const {});
       await abort;

--- a/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
@@ -734,8 +734,9 @@ void main() {
       final abort = harness.service.abort(sessionId: testSessionId, subAgents: PluginAbortSubAgentPolicy.keep);
       final interrupt = await _waitForControlSubtype(process, "interrupt");
       process.emitControlResponse(requestId: interrupt["request_id"]! as String, payload: const {});
-      expect(await abort, isA<PluginAbortAccepted>());
+      // The abort resolves only once the interrupted turn's result settles.
       process.emit(_result());
+      expect(await abort, isA<PluginAbortAccepted>().having((r) => r.workKept, "kept", isTrue));
       await pump();
 
       expect(harness.repository.isResident(sessionId: testSessionId), isTrue);

--- a/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
@@ -70,7 +70,7 @@ void main() {
       final process = await harness.firstProcess;
       await _waitForUserFrames(process, 2);
 
-      final abort = harness.service.abort(sessionId: testSessionId);
+      final abort = harness.service.abort(sessionId: testSessionId, subAgents: PluginAbortSubAgentPolicy.stop);
       final interrupt = await _waitForControlSubtype(process, "interrupt");
       process.emitControlResponse(requestId: interrupt["request_id"]! as String, payload: const {});
       await abort;
@@ -85,7 +85,7 @@ void main() {
       unawaited(harness.enqueue("first"));
       final first = await harness.firstProcess;
       await waitForFrame(first, "user");
-      final abort = harness.service.abort(sessionId: testSessionId);
+      final abort = harness.service.abort(sessionId: testSessionId, subAgents: PluginAbortSubAgentPolicy.stop);
       final interrupt = await _waitForControlSubtype(first, "interrupt");
 
       unawaited(harness.enqueue("second"));
@@ -107,7 +107,7 @@ void main() {
       final first = await harness.firstProcess;
       await waitForFrame(first, "user");
 
-      final abort = harness.service.abort(sessionId: testSessionId);
+      final abort = harness.service.abort(sessionId: testSessionId, subAgents: PluginAbortSubAgentPolicy.stop);
       final interrupt = await _waitForControlSubtype(first, "interrupt");
       first.emitControlResponse(requestId: interrupt["request_id"]! as String, payload: const {});
       await abort;
@@ -128,7 +128,7 @@ void main() {
       final process = await harness.firstProcess;
       await waitForFrame(process, "user");
 
-      await harness.service.abort(sessionId: testSessionId);
+      await harness.service.abort(sessionId: testSessionId, subAgents: PluginAbortSubAgentPolicy.stop);
       await harness.waitForIdle();
 
       expect(harness.repository.isResident(sessionId: testSessionId), isFalse);
@@ -222,7 +222,7 @@ void main() {
       process.emit(_result());
       await harness.waitForIdle();
 
-      await harness.service.abort(sessionId: testSessionId);
+      await harness.service.abort(sessionId: testSessionId, subAgents: PluginAbortSubAgentPolicy.stop);
       harness.clock.elapse();
       await pump();
 
@@ -363,7 +363,7 @@ void main() {
       process.emit(_assistantTextFrame(text: "waking up"));
       await harness.waitForBusy();
 
-      final abort = harness.service.abort(sessionId: testSessionId);
+      final abort = harness.service.abort(sessionId: testSessionId, subAgents: PluginAbortSubAgentPolicy.stop);
       final interrupt = await _waitForControlSubtype(process, "interrupt");
       process.emitControlResponse(requestId: interrupt["request_id"]! as String, payload: const {});
       await abort;
@@ -559,7 +559,7 @@ void main() {
       unawaited(harness.enqueue("second"));
       await pump();
 
-      final abort = harness.service.abort(sessionId: testSessionId);
+      final abort = harness.service.abort(sessionId: testSessionId, subAgents: PluginAbortSubAgentPolicy.stop);
       final interrupt = await _waitForControlSubtype(process, "interrupt");
       process.emitControlResponse(requestId: interrupt["request_id"]! as String, payload: const {});
       await abort;
@@ -679,10 +679,91 @@ void main() {
       process.emit(_result());
       await pump();
 
-      final abort = harness.service.abort(sessionId: testSessionId);
+      final abort = harness.service.abort(sessionId: testSessionId, subAgents: PluginAbortSubAgentPolicy.stop);
       final interrupt = await _waitForControlSubtype(process, "interrupt");
       process.emitControlResponse(requestId: interrupt["request_id"]! as String, payload: const {});
       await abort;
+      await harness.waitForIdle();
+
+      expect(harness.repository.isResident(sessionId: testSessionId), isFalse);
+      expect(await _status(harness), isA<PluginSessionStatusIdle>());
+    });
+
+    test("a confirm stop is refused with the sub-agent count while sub-agents run, with no side effect", () async {
+      unawaited(harness.enqueue("first"));
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      process.emit(_taskStartedFrame());
+      await pump();
+
+      final midTurn = await harness.service.abort(
+        sessionId: testSessionId,
+        subAgents: PluginAbortSubAgentPolicy.confirm,
+      );
+      process.emit(_result());
+      await pump();
+      final afterTurn = await harness.service.abort(
+        sessionId: testSessionId,
+        subAgents: PluginAbortSubAgentPolicy.confirm,
+      );
+
+      expect(
+        midTurn,
+        isA<PluginAbortRejectedSubAgentsRunning>()
+            .having((r) => r.runningSubAgentCount, "count", 1)
+            .having((r) => r.mainAgentRunning, "main", isTrue),
+      );
+      expect(afterTurn, isA<PluginAbortRejectedSubAgentsRunning>().having((r) => r.mainAgentRunning, "main", isFalse));
+      expect(
+        process.written.any(
+          (frame) => frame["type"] == "control_request" && (frame["request"]! as Map)["subtype"] == "interrupt",
+        ),
+        isFalse,
+      );
+      expect(harness.repository.isResident(sessionId: testSessionId), isTrue);
+      expect(harness.service.currentWorkState, PluginWorkState.busy);
+    });
+
+    test("a keep stop interrupts the main agent but leaves the process and its tasks resident", () async {
+      unawaited(harness.enqueue("first"));
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      process.emit(_taskStartedFrame());
+      await pump();
+
+      final abort = harness.service.abort(sessionId: testSessionId, subAgents: PluginAbortSubAgentPolicy.keep);
+      final interrupt = await _waitForControlSubtype(process, "interrupt");
+      process.emitControlResponse(requestId: interrupt["request_id"]! as String, payload: const {});
+      expect(await abort, isA<PluginAbortAccepted>());
+      process.emit(_result());
+      await pump();
+
+      expect(harness.repository.isResident(sessionId: testSessionId), isTrue);
+      expect(harness.service.currentWorkState, PluginWorkState.busy, reason: "the sub-agent still runs");
+      expect(harness.events.whereType<BridgeSseSessionIdle>(), isEmpty);
+
+      // The kept sub-agent finishes and its wake-up turn renders and settles.
+      process.emit(_taskNotificationFrame());
+      process.emit(_assistantTextFrame(text: "Agent completed with result: hi"));
+      process.emit(_result());
+      await harness.waitForIdle();
+
+      expect(harness.events.whereType<BridgeSseSessionIdle>(), hasLength(1));
+      expect(harness.repository.isResident(sessionId: testSessionId), isTrue);
+    });
+
+    test("a stop tears the process down and cancels its tasks; keep with no tasks does the same", () async {
+      unawaited(harness.enqueue("first"));
+      final process = await harness.firstProcess;
+      await waitForFrame(process, "user");
+      process.emit(_taskStartedFrame());
+      process.emit(_result());
+      await pump();
+
+      final abort = harness.service.abort(sessionId: testSessionId, subAgents: PluginAbortSubAgentPolicy.stop);
+      final interrupt = await _waitForControlSubtype(process, "interrupt");
+      process.emitControlResponse(requestId: interrupt["request_id"]! as String, payload: const {});
+      expect(await abort, isA<PluginAbortAccepted>());
       await harness.waitForIdle();
 
       expect(harness.repository.isResident(sessionId: testSessionId), isFalse);

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -799,7 +799,15 @@ class CodexPlugin._({
   }
 
   @override
-  Future<void> abortSession({required String sessionId}) async {
+  Future<PluginAbortResult> abortSession({
+    required String sessionId,
+    required PluginAbortSubAgentPolicy subAgents,
+  }) async {
+    await _abortSession(sessionId: sessionId);
+    return const PluginAbortAccepted();
+  }
+
+  Future<void> _abortSession({required String sessionId}) async {
     _approvalRegistry?.cancelForSession(sessionId: sessionId);
     final turnId = _activeTurnByThread[sessionId];
     if (turnId == null) {
@@ -920,7 +928,7 @@ class CodexPlugin._({
       if (activeSessionIds.isEmpty) return const <String>{};
 
       await Future.wait([
-        for (final sessionId in activeSessionIds) abortSession(sessionId: sessionId),
+        for (final sessionId in activeSessionIds) _abortSession(sessionId: sessionId),
       ]);
       await _notificationWork;
       if (currentWorkState != PluginWorkState.idle) {
@@ -1169,7 +1177,7 @@ class CodexPlugin._({
     _advanceTurnEvidenceRevision(sessionId);
     if (_activeTurnByThread.containsKey(sessionId)) {
       try {
-        await abortSession(sessionId: sessionId);
+        await _abortSession(sessionId: sessionId);
       } on Object catch (error, stackTrace) {
         Log.w("[codex] failed to abort session $sessionId before deletion; continuing", error, stackTrace);
       }

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -804,7 +804,7 @@ class CodexPlugin._({
     required PluginAbortSubAgentPolicy subAgents,
   }) async {
     await _abortSession(sessionId: sessionId);
-    return const PluginAbortAccepted();
+    return const PluginAbortAccepted(workKept: false);
   }
 
   Future<void> _abortSession({required String sessionId}) async {

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -332,8 +332,7 @@ void main() {
       );
       final idle = plugin.events.firstWhere(
         (event) =>
-            event is BridgeSseSessionStatus &&
-            shared.SessionStatus.fromJson(event.status) is shared.SessionStatusIdle,
+            event is BridgeSseSessionStatus && shared.SessionStatus.fromJson(event.status) is shared.SessionStatusIdle,
       );
       fake.pushNotification("thread/status/changed", {
         "threadId": "t-compact",
@@ -1171,7 +1170,7 @@ void main() {
       // Give the event subscription a microtask to process.
       await Future<void>.delayed(Duration.zero);
 
-      await plugin.abortSession(sessionId: "t-1");
+      await plugin.abortSession(sessionId: "t-1", subAgents: PluginAbortSubAgentPolicy.stop);
 
       expect(fake.sentMethods, contains("turn/interrupt"));
       final params = fake.sentParamsFor("turn/interrupt");
@@ -1351,7 +1350,7 @@ void main() {
 
       expect((await plugin.getSessionStatuses())["t-steered"], isA<PluginSessionStatusIdle>());
       expect(plugin.getActiveSessionsSummary(), isEmpty);
-      await plugin.abortSession(sessionId: "t-steered");
+      await plugin.abortSession(sessionId: "t-steered", subAgents: PluginAbortSubAgentPolicy.stop);
       expect(fake.sentMethods.where((method) => method == "turn/interrupt"), isEmpty);
     });
 
@@ -1543,7 +1542,7 @@ void main() {
         mode: FileMode.append,
       );
 
-      await plugin.abortSession(sessionId: sessionId);
+      await plugin.abortSession(sessionId: sessionId, subAgents: PluginAbortSubAgentPolicy.stop);
 
       expect((await terminalTool.timeout(const Duration(seconds: 1))).part.state.status, PluginToolStatus.error);
       expect((await idleEvent).sessionID, sessionId);
@@ -1619,7 +1618,7 @@ void main() {
         mode: FileMode.append,
       );
 
-      await plugin.abortSession(sessionId: sessionId);
+      await plugin.abortSession(sessionId: sessionId, subAgents: PluginAbortSubAgentPolicy.stop);
       await idle;
 
       final errorIndex = emittedEvents.indexWhere(
@@ -1680,7 +1679,7 @@ void main() {
       final emittedEvents = <BridgeSseEvent>[];
       final eventSubscription = plugin.events.listen(emittedEvents.add);
 
-      final abort = plugin.abortSession(sessionId: "t-abort-race");
+      final abort = plugin.abortSession(sessionId: "t-abort-race", subAgents: PluginAbortSubAgentPolicy.stop);
       await interruptRequested.future;
       await Future<void>.delayed(const Duration(milliseconds: 20));
       fake.pushNotification("turn/started", {
@@ -1820,7 +1819,8 @@ void main() {
             .whereType<BridgeSseMessagePartUpdated>()
             .lastWhere((event) => event.part.messageID == "call-error")
             .part
-            .state.status,
+            .state
+            .status,
         PluginToolStatus.error,
       );
     });
@@ -2677,8 +2677,7 @@ class _FakeAppServer() {
     return frame.params ?? const {};
   }
 
-  bool sentRequestHasParams(String method) =>
-      _sent.firstWhere((frame) => frame.method == method).params != null;
+  bool sentRequestHasParams(String method) => _sent.firstWhere((frame) => frame.method == method).params != null;
 
   Map<String, dynamic> serverResponseFor(Object id) =>
       _serverResponses[id] ?? (throw StateError("no response for $id"));

--- a/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
+++ b/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
@@ -30,6 +30,7 @@ export "src/lifecycle/start_abort_signal.dart";
 export "src/lifecycle/steady_plugin_lifecycle.dart";
 export "src/log.dart";
 export "src/messages/attachment_normalization.dart";
+export "src/models/plugin_abort.dart";
 export "src/models/plugin_active_session.dart";
 export "src/models/plugin_agent.dart";
 export "src/models/plugin_command.dart";

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -1,4 +1,5 @@
 import "bridge_sse_event.dart";
+import "models/plugin_abort.dart";
 import "models/plugin_agent.dart";
 import "models/plugin_command.dart";
 import "models/plugin_message.dart";
@@ -183,7 +184,10 @@ sealed class BridgePluginApi() {
   /// dispatched, which callers treat as benign (the prompt became a turn).
   Future<bool> cancelQueuedPrompt({required String sessionId, required String promptId}) async => false;
 
-  Future<void> abortSession({required String sessionId});
+  /// Stops the session's in-progress work. [subAgents] scopes the stop for
+  /// plugins whose sessions run sub-agents; every other plugin ignores it and
+  /// answers [PluginAbortAccepted].
+  Future<PluginAbortResult> abortSession({required String sessionId, required PluginAbortSubAgentPolicy subAgents});
 
   /// Returns the agents available for the given project.
   ///

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_abort.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_abort.dart
@@ -1,0 +1,22 @@
+/// What a stop should do about sub-agents the session is still running.
+/// Plugins without sub-agents ignore it and stop as they always have.
+enum PluginAbortSubAgentPolicy() {
+  /// Refuse while sub-agents run, so the caller can confirm the scope.
+  confirm,
+
+  /// Interrupt the main agent only; running sub-agents keep going.
+  keep,
+
+  /// Interrupt the main agent and every running sub-agent.
+  stop,
+}
+
+sealed class const PluginAbortResult();
+
+final class const PluginAbortAccepted() extends PluginAbortResult;
+
+/// A `confirm` stop refused because sub-agents are running.
+final class const PluginAbortRejectedSubAgentsRunning({
+  required final int runningSubAgentCount,
+  required final bool mainAgentRunning,
+}) extends PluginAbortResult;

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_abort.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_abort.dart
@@ -13,7 +13,10 @@ enum PluginAbortSubAgentPolicy() {
 
 sealed class const PluginAbortResult();
 
-final class const PluginAbortAccepted() extends PluginAbortResult;
+/// The stop was performed. [workKept] is true only when resident work (running
+/// sub-agents) was deliberately left alive, so the caller knows the session
+/// will still finish something later.
+final class const PluginAbortAccepted({required final bool workKept}) extends PluginAbortResult;
 
 /// A `confirm` stop refused because sub-agents are running.
 final class const PluginAbortRejectedSubAgentsRunning({

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -618,7 +618,7 @@ class OpenCodePlugin._({
     required PluginAbortSubAgentPolicy subAgents,
   }) async {
     await _abortSession(sessionId: sessionId);
-    return const PluginAbortAccepted();
+    return const PluginAbortAccepted(workKept: false);
   }
 
   Future<void> _abortSession({required String sessionId}) {

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -12,7 +12,11 @@ import "prompt_message_tracker.dart";
 import "sse/sse_connection.dart";
 import "sse_event_mapper.dart";
 
-enum _StaleSessionOption() { agent, model, variant }
+enum _StaleSessionOption() {
+  agent,
+  model,
+  variant,
+}
 
 String formatDroppedSseFrameLog({
   required String category,
@@ -609,7 +613,15 @@ class OpenCodePlugin._({
   }
 
   @override
-  Future<void> abortSession({required String sessionId}) {
+  Future<PluginAbortResult> abortSession({
+    required String sessionId,
+    required PluginAbortSubAgentPolicy subAgents,
+  }) async {
+    await _abortSession(sessionId: sessionId);
+    return const PluginAbortAccepted();
+  }
+
+  Future<void> _abortSession({required String sessionId}) {
     final directory = _service.tracker.getSessionDirectory(sessionId: sessionId);
     return _call(
       () => _service.repository.api.abortSession(
@@ -626,7 +638,7 @@ class OpenCodePlugin._({
       if (activeSessionIds.isEmpty) return const <String>{};
 
       await Future.wait([
-        for (final sessionId in activeSessionIds) abortSession(sessionId: sessionId),
+        for (final sessionId in activeSessionIds) _abortSession(sessionId: sessionId),
       ]);
       if (currentWorkState != PluginWorkState.idle) {
         await workState.firstWhere((state) => state == PluginWorkState.idle);

--- a/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
+++ b/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
@@ -395,7 +395,13 @@ final class PiPlugin._({
   }
 
   @override
-  Future<void> abortSession({required String sessionId}) => _sessionService.abort(sessionId: sessionId);
+  Future<PluginAbortResult> abortSession({
+    required String sessionId,
+    required PluginAbortSubAgentPolicy subAgents,
+  }) async {
+    await _sessionService.abort(sessionId: sessionId);
+    return const PluginAbortAccepted();
+  }
 
   Future<Set<String>> interruptActiveWork({required Duration budget}) =>
       _sessionService.interruptActiveWork(budget: budget);

--- a/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
+++ b/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
@@ -400,7 +400,7 @@ final class PiPlugin._({
     required PluginAbortSubAgentPolicy subAgents,
   }) async {
     await _sessionService.abort(sessionId: sessionId);
-    return const PluginAbortAccepted();
+    return const PluginAbortAccepted(workKept: false);
   }
 
   Future<Set<String>> interruptActiveWork({required Duration budget}) =>

--- a/client/app/lib/features/session_detail/widgets/session_abort_scope_dialog.dart
+++ b/client/app/lib/features/session_detail/widgets/session_abort_scope_dialog.dart
@@ -1,0 +1,46 @@
+import "package:go_router/go_router.dart";
+import "package:material_ui/material_ui.dart";
+import "package:sesori_app_ui/sesori_app_ui.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/module_prego.dart";
+
+/// Stops the session, asking for scope when the bridge refuses a plain stop
+/// because sub-agents are still running.
+///
+/// The first request is a side-effect-free `confirm` probe. On rejection the
+/// dialog offers "main agent only" (only while the main agent runs) and "stop
+/// everything"; dismissing it leaves everything running.
+Future<void> stopSessionWithScope({required BuildContext context, required SessionDetailCubit cubit}) async {
+  final outcome = await cubit.abort(subAgents: SessionAbortSubAgentPolicy.confirm);
+  if (outcome case SessionAbortRejected(:final rejection) when context.mounted) {
+    final loc = context.loc;
+    final count = rejection.runningSubAgentCount;
+    final policy = await showDialog<SessionAbortSubAgentPolicy>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(loc.sessionDetailStopScopeTitle),
+        content: Text(loc.sessionDetailStopScopeMessage(count)),
+        actions: [
+          TextButton(
+            onPressed: () => dialogContext.pop(),
+            child: Text(loc.sessionListDeleteConfirmCancel),
+          ),
+          if (rejection.mainAgentRunning)
+            TextButton(
+              onPressed: () => dialogContext.pop(SessionAbortSubAgentPolicy.keep),
+              child: Text(loc.sessionDetailStopMainAgentOnly),
+            ),
+          TextButton(
+            onPressed: () => dialogContext.pop(SessionAbortSubAgentPolicy.stop),
+            child: Text(
+              loc.sessionDetailStopAll(count),
+              style: TextStyle(color: context.prego.colors.fgErrorPrimary),
+            ),
+          ),
+        ],
+      ),
+    );
+    if (policy != null) await cubit.abort(subAgents: policy);
+  }
+}

--- a/client/app/lib/features/session_detail/widgets/session_abort_scope_dialog.dart
+++ b/client/app/lib/features/session_detail/widgets/session_abort_scope_dialog.dart
@@ -8,9 +8,10 @@ import "package:theme_prego/module_prego.dart";
 /// Stops the session, asking for scope when the bridge refuses a plain stop
 /// because sub-agents are still running.
 ///
-/// The first request is a side-effect-free `confirm` probe. On rejection the
-/// dialog offers "main agent only" (only while the main agent runs) and "stop
-/// everything"; dismissing it leaves everything running.
+/// The first request is a `confirm` probe: with no sub-agents running the
+/// bridge performs it as a plain stop, and only a rejection is side-effect
+/// free. On rejection the dialog offers "main agent only" (only while the main
+/// agent runs) and "stop everything"; dismissing it leaves everything running.
 Future<void> stopSessionWithScope({required BuildContext context, required SessionDetailCubit cubit}) async {
   final outcome = await cubit.abort(subAgents: SessionAbortSubAgentPolicy.confirm);
   if (outcome case SessionAbortRejected(:final rejection) when context.mounted) {
@@ -41,6 +42,6 @@ Future<void> stopSessionWithScope({required BuildContext context, required Sessi
         ],
       ),
     );
-    if (policy != null) await cubit.abort(subAgents: policy);
+    if (policy != null && context.mounted) await cubit.abort(subAgents: policy);
   }
 }

--- a/client/app/lib/features/session_detail/widgets/session_abort_scope_dialog.dart
+++ b/client/app/lib/features/session_detail/widgets/session_abort_scope_dialog.dart
@@ -13,6 +13,19 @@ import "package:theme_prego/module_prego.dart";
 /// free. On rejection the dialog offers "main agent only" (only while the main
 /// agent runs) and "stop everything"; dismissing it leaves everything running.
 Future<void> stopSessionWithScope({required BuildContext context, required SessionDetailCubit cubit}) async {
+  // One probe-and-dialog sequence per session at a time: a second tap while the
+  // first is in flight would stack a stale dialog over the fresh one.
+  if (!_stopping.add(cubit)) return;
+  try {
+    await _stopSessionWithScope(context: context, cubit: cubit);
+  } finally {
+    _stopping.remove(cubit);
+  }
+}
+
+final Set<SessionDetailCubit> _stopping = {};
+
+Future<void> _stopSessionWithScope({required BuildContext context, required SessionDetailCubit cubit}) async {
   final outcome = await cubit.abort(subAgents: SessionAbortSubAgentPolicy.confirm);
   if (outcome case SessionAbortRejected(:final rejection) when context.mounted) {
     final loc = context.loc;

--- a/client/app/lib/features/session_detail/widgets/session_abort_scope_dialog.dart
+++ b/client/app/lib/features/session_detail/widgets/session_abort_scope_dialog.dart
@@ -21,7 +21,11 @@ Future<void> stopSessionWithScope({required BuildContext context, required Sessi
       context: context,
       builder: (dialogContext) => AlertDialog(
         title: Text(loc.sessionDetailStopScopeTitle),
-        content: Text(loc.sessionDetailStopScopeMessage(count)),
+        content: Text(
+          rejection.mainAgentRunning
+              ? loc.sessionDetailStopScopeMessage(count)
+              : loc.sessionDetailStopScopeMessageMainIdle(count),
+        ),
         actions: [
           TextButton(
             onPressed: () => dialogContext.pop(),
@@ -35,7 +39,7 @@ Future<void> stopSessionWithScope({required BuildContext context, required Sessi
           TextButton(
             onPressed: () => dialogContext.pop(SessionAbortSubAgentPolicy.stop),
             child: Text(
-              loc.sessionDetailStopAll(count),
+              rejection.mainAgentRunning ? loc.sessionDetailStopAll(count) : loc.sessionDetailStopSubAgentsOnly(count),
               style: TextStyle(color: context.prego.colors.fgErrorPrimary),
             ),
           ),

--- a/client/app/lib/features/session_detail/widgets/session_detail_composer_controls.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_composer_controls.dart
@@ -9,6 +9,7 @@ import "../../../core/widgets/agent_model_buttons.dart";
 import "../../../core/widgets/composer_surface_style.dart";
 import "background_tasks_bar.dart";
 import "prompt_input.dart";
+import "session_abort_scope_dialog.dart";
 
 /// Mobile-owned composer controls injected below the shared transcript view.
 class const SessionDetailComposerControls({
@@ -96,7 +97,7 @@ class _SessionDetailComposerControlsState() extends State<SessionDetailComposerC
               onVoiceTranscriptionCompleted: context.read<SessionDetailCubit>().reportVoiceTranscriptionCompleted,
               onDraftChanged: (draft) => context.read<SessionDetailCubit>().saveComposerDraft(draft: draft),
               onDraftCleared: context.read<SessionDetailCubit>().clearComposerDraft,
-              onAbort: () => context.read<SessionDetailCubit>().abort(),
+              onAbort: () => stopSessionWithScope(context: context, cubit: context.read<SessionDetailCubit>()),
               surfaceStyleController: _composerSurfaceStyle,
               header: null,
               composerHeader: ValueListenableBuilder<PregoComposerSurfaceStyle>(

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -226,6 +226,7 @@ void main() {
   setUpAll(() {
     registerFallbackValue(ComposerDraft.typed(text: ""));
     registerFallbackValue(ComposerInputMode.typed);
+    registerFallbackValue(SessionAbortSubAgentPolicy.stop);
   });
 
   Finder semanticsWithLabel(String label) =>
@@ -1405,7 +1406,8 @@ void main() {
     );
     when(() => cubit.state).thenReturn(state);
     whenListen(cubit, const Stream<SessionDetailState>.empty(), initialState: state);
-    when(() => cubit.abort()).thenAnswer((_) async {});
+    when(() => cubit.abort(subAgents: any(named: "subAgents")))
+        .thenAnswer((_) async => const SessionAbortOutcome.aborted());
 
     await tester.pumpWidget(_buildApp(cubit: cubit));
     // Bounded pumps throughout: the busy status keeps an activity indicator
@@ -1417,7 +1419,7 @@ void main() {
     // reachable next to the keyboard button even in the resting voice pill.
     expect(find.byIcon(TablerRegular.arrow_up), findsNothing);
     await tester.tap(find.byIcon(TablerSolid.player_stop));
-    verify(() => cubit.abort()).called(1);
+    verify(() => cubit.abort(subAgents: SessionAbortSubAgentPolicy.confirm)).called(1);
 
     // Typed text flips the same button back to send: sending queues while the
     // agent works, so it must stay reachable.

--- a/client/module_app_ui/lib/src/l10n/app_en.arb
+++ b/client/module_app_ui/lib/src/l10n/app_en.arb
@@ -535,6 +535,24 @@
   "sessionDetailNoCommands": "No slash commands are available for this project.",
   "sessionDetailSend": "Send",
   "sessionDetailAbort": "Stop",
+  "sessionDetailStopScopeTitle": "Sub-agents are running",
+  "sessionDetailStopScopeMessage": "{count, plural, =1{This session has 1 sub-agent still working. Stop only the main agent, or stop everything?} other{This session has {count} sub-agents still working. Stop only the main agent, or stop everything?}}",
+  "@sessionDetailStopScopeMessage": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "sessionDetailStopMainAgentOnly": "Stop main agent only",
+  "sessionDetailStopAll": "{count, plural, =1{Stop main agent and 1 sub-agent} other{Stop main agent and {count} sub-agents}}",
+  "@sessionDetailStopAll": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "sessionDetailThinking": "Thinking...",
   "sessionDetailThought": "Thought",
   "sessionDetailToolUnknown": "Tool",

--- a/client/module_app_ui/lib/src/l10n/app_en.arb
+++ b/client/module_app_ui/lib/src/l10n/app_en.arb
@@ -544,6 +544,22 @@
       }
     }
   },
+  "sessionDetailStopScopeMessageMainIdle": "{count, plural, =1{The main agent is done, but 1 sub-agent is still working. Stop it?} other{The main agent is done, but {count} sub-agents are still working. Stop them?}}",
+  "@sessionDetailStopScopeMessageMainIdle": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "sessionDetailStopSubAgentsOnly": "{count, plural, =1{Stop 1 sub-agent} other{Stop {count} sub-agents}}",
+  "@sessionDetailStopSubAgentsOnly": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "sessionDetailStopMainAgentOnly": "Stop main agent only",
   "sessionDetailStopAll": "{count, plural, =1{Stop main agent and 1 sub-agent} other{Stop main agent and {count} sub-agents}}",
   "@sessionDetailStopAll": {

--- a/client/module_app_ui/lib/src/l10n/app_localizations.dart
+++ b/client/module_app_ui/lib/src/l10n/app_localizations.dart
@@ -1711,6 +1711,30 @@ abstract class AppLocalizations {
   /// **'Stop'**
   String get sessionDetailAbort;
 
+  /// No description provided for @sessionDetailStopScopeTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Sub-agents are running'**
+  String get sessionDetailStopScopeTitle;
+
+  /// No description provided for @sessionDetailStopScopeMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{This session has 1 sub-agent still working. Stop only the main agent, or stop everything?} other{This session has {count} sub-agents still working. Stop only the main agent, or stop everything?}}'**
+  String sessionDetailStopScopeMessage(int count);
+
+  /// No description provided for @sessionDetailStopMainAgentOnly.
+  ///
+  /// In en, this message translates to:
+  /// **'Stop main agent only'**
+  String get sessionDetailStopMainAgentOnly;
+
+  /// No description provided for @sessionDetailStopAll.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{Stop main agent and 1 sub-agent} other{Stop main agent and {count} sub-agents}}'**
+  String sessionDetailStopAll(int count);
+
   /// No description provided for @sessionDetailThinking.
   ///
   /// In en, this message translates to:

--- a/client/module_app_ui/lib/src/l10n/app_localizations.dart
+++ b/client/module_app_ui/lib/src/l10n/app_localizations.dart
@@ -1723,6 +1723,18 @@ abstract class AppLocalizations {
   /// **'{count, plural, =1{This session has 1 sub-agent still working. Stop only the main agent, or stop everything?} other{This session has {count} sub-agents still working. Stop only the main agent, or stop everything?}}'**
   String sessionDetailStopScopeMessage(int count);
 
+  /// No description provided for @sessionDetailStopScopeMessageMainIdle.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{The main agent is done, but 1 sub-agent is still working. Stop it?} other{The main agent is done, but {count} sub-agents are still working. Stop them?}}'**
+  String sessionDetailStopScopeMessageMainIdle(int count);
+
+  /// No description provided for @sessionDetailStopSubAgentsOnly.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{Stop 1 sub-agent} other{Stop {count} sub-agents}}'**
+  String sessionDetailStopSubAgentsOnly(int count);
+
   /// No description provided for @sessionDetailStopMainAgentOnly.
   ///
   /// In en, this message translates to:

--- a/client/module_app_ui/lib/src/l10n/app_localizations_en.dart
+++ b/client/module_app_ui/lib/src/l10n/app_localizations_en.dart
@@ -882,6 +882,34 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionDetailAbort => 'Stop';
 
   @override
+  String get sessionDetailStopScopeTitle => 'Sub-agents are running';
+
+  @override
+  String sessionDetailStopScopeMessage(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'This session has $count sub-agents still working. Stop only the main agent, or stop everything?',
+      one: 'This session has 1 sub-agent still working. Stop only the main agent, or stop everything?',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get sessionDetailStopMainAgentOnly => 'Stop main agent only';
+
+  @override
+  String sessionDetailStopAll(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Stop main agent and $count sub-agents',
+      one: 'Stop main agent and 1 sub-agent',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get sessionDetailThinking => 'Thinking...';
 
   @override

--- a/client/module_app_ui/lib/src/l10n/app_localizations_en.dart
+++ b/client/module_app_ui/lib/src/l10n/app_localizations_en.dart
@@ -896,6 +896,28 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String sessionDetailStopScopeMessageMainIdle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'The main agent is done, but $count sub-agents are still working. Stop them?',
+      one: 'The main agent is done, but 1 sub-agent is still working. Stop it?',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String sessionDetailStopSubAgentsOnly(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Stop $count sub-agents',
+      one: 'Stop 1 sub-agent',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get sessionDetailStopMainAgentOnly => 'Stop main agent only';
 
   @override

--- a/client/module_core/lib/sesori_dart_core.dart
+++ b/client/module_core/lib/sesori_dart_core.dart
@@ -149,6 +149,7 @@ export "src/repositories/models/bridge_settings_result.dart";
 export "src/repositories/models/installed_app_build.dart";
 export "src/repositories/models/plugin_management_result.dart";
 export "src/repositories/models/repo_provider.dart";
+export "src/repositories/models/session_abort_rejected_exception.dart";
 export "src/repositories/models/session_cleanup_rejection.dart";
 export "src/repositories/notification_preferences_repository.dart";
 export "src/repositories/notification_repository.dart";

--- a/client/module_core/lib/sesori_dart_core.dart
+++ b/client/module_core/lib/sesori_dart_core.dart
@@ -85,6 +85,7 @@ export "src/cubits/project_list/add_project_outcome.dart";
 export "src/cubits/project_list/project_list_cubit.dart";
 export "src/cubits/project_list/project_list_state.dart";
 export "src/cubits/session_detail/queued_session_submission.dart";
+export "src/cubits/session_detail/session_abort_outcome.dart";
 export "src/cubits/session_detail/session_detail_cubit.dart";
 export "src/cubits/session_detail/session_detail_notice.dart";
 export "src/cubits/session_detail/session_detail_resolvers.dart";

--- a/client/module_core/lib/src/api/session_api.dart
+++ b/client/module_core/lib/src/api/session_api.dart
@@ -12,6 +12,9 @@ import "client/relay_http_client.dart";
 
 class const SessionCleanupApiRejectedException({required final SessionCleanupRejection rejection}) implements Exception;
 
+/// A `confirm` stop the bridge refused because sub-agents are running.
+class const SessionAbortApiRejectedException({required final SessionAbortRejection rejection}) implements Exception;
+
 @lazySingleton
 class SessionApi({required final RelayHttpApiClient _client}) {
   static const Duration _attachmentRequestTimeout = Duration(minutes: 2);
@@ -332,12 +335,28 @@ class SessionApi({required final RelayHttpApiClient _client}) {
     );
   }
 
-  Future<ApiResponse<SuccessEmptyResponse>> abortSession({required String sessionId}) {
-    return _client.post(
+  /// Stops a session with the given sub-agent scope. A 409 carrying a
+  /// [SessionAbortRejection] surfaces as [SessionAbortApiRejectedException].
+  Future<ApiResponse<SuccessEmptyResponse>> abortSession({
+    required String sessionId,
+    required SessionAbortSubAgentPolicy subAgents,
+  }) async {
+    final response = await _client.post(
       "/session/abort",
       fromJson: SuccessEmptyResponse.fromJson,
-      body: SessionIdRequest(sessionId: sessionId),
+      body: AbortSessionRequest(sessionId: sessionId, subAgents: subAgents),
     );
+    if (response case ErrorResponse(error: NonSuccessCodeError(errorCode: 409, rawErrorString: final String rawBody))) {
+      final SessionAbortRejection rejection;
+      try {
+        rejection = SessionAbortRejection.fromJson(jsonDecodeMap(rawBody));
+      } on Object catch (e) {
+        logw("Failed to parse 409 abort rejection body: ${e.toString()}");
+        return response;
+      }
+      throw SessionAbortApiRejectedException(rejection: rejection);
+    }
+    return response;
   }
 
   /// Marks a session read ([read] == true) or unread ([read] == false).

--- a/client/module_core/lib/src/api/session_api.dart
+++ b/client/module_core/lib/src/api/session_api.dart
@@ -350,8 +350,8 @@ class SessionApi({required final RelayHttpApiClient _client}) {
       final SessionAbortRejection rejection;
       try {
         rejection = SessionAbortRejection.fromJson(jsonDecodeMap(rawBody));
-      } on Object catch (e) {
-        logw("Failed to parse 409 abort rejection body: ${e.toString()}");
+      } on Object catch (e, st) {
+        logw("Failed to parse 409 abort rejection body", e, st);
         return response;
       }
       throw SessionAbortApiRejectedException(rejection: rejection);

--- a/client/module_core/lib/src/cubits/session_detail/session_abort_outcome.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_abort_outcome.dart
@@ -1,0 +1,14 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+/// What a stop request came back with.
+sealed class const SessionAbortOutcome() {
+  const factory aborted() = SessionAbortAccepted;
+  const factory rejected({required SessionAbortRejection rejection}) = SessionAbortRejected;
+}
+
+/// The bridge accepted the stop (or the attempt failed and was logged; the
+/// caller has nothing further to decide either way).
+final class const SessionAbortAccepted() extends SessionAbortOutcome;
+
+/// A `confirm` stop refused because sub-agents run; the user must choose.
+final class const SessionAbortRejected({required final SessionAbortRejection rejection}) extends SessionAbortOutcome;

--- a/client/module_core/lib/src/cubits/session_detail/session_abort_outcome.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_abort_outcome.dart
@@ -4,11 +4,14 @@ import "package:sesori_shared/sesori_shared.dart";
 sealed class const SessionAbortOutcome() {
   const factory aborted() = SessionAbortAccepted;
   const factory rejected({required SessionAbortRejection rejection}) = SessionAbortRejected;
+  const factory failed() = SessionAbortFailed;
 }
 
-/// The bridge accepted the stop (or the attempt failed and was logged; the
-/// caller has nothing further to decide either way).
+/// The bridge accepted the stop.
 final class const SessionAbortAccepted() extends SessionAbortOutcome;
 
 /// A `confirm` stop refused because sub-agents run; the user must choose.
 final class const SessionAbortRejected({required final SessionAbortRejection rejection}) extends SessionAbortOutcome;
+
+/// The stop request failed (transport or bridge error); already logged.
+final class const SessionAbortFailed() extends SessionAbortOutcome;

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -7,7 +7,6 @@ import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
-import "../../api/session_api.dart" show SessionAbortApiRejectedException;
 import "../../capabilities/server_connection/connection_service.dart";
 import "../../capabilities/server_connection/models/connection_status.dart";
 import "../../capabilities/server_connection/models/sse_event.dart";
@@ -21,6 +20,7 @@ import "../../platform/lifecycle_source.dart";
 import "../../platform/notification_canceller.dart";
 import "../../repositories/composer_draft_repository.dart";
 import "../../repositories/models/analytics_delivery_result.dart";
+import "../../repositories/models/session_abort_rejected_exception.dart";
 import "../../repositories/models/session_options_repository_result.dart";
 import "../../repositories/permission_repository.dart";
 import "../../repositories/session_repository.dart";
@@ -2234,7 +2234,7 @@ class SessionDetailCubit(
       }
       _reportProductEvent(event: const ProductAnalyticsEvent.sessionAbortSucceeded());
       return const SessionAbortOutcome.aborted();
-    } on SessionAbortApiRejectedException catch (e) {
+    } on SessionAbortRejectedException catch (e) {
       return SessionAbortOutcome.rejected(rejection: e.rejection);
     } on Object catch (e, st) {
       loge("Failed to abort session(s)", e, st);

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -7,6 +7,7 @@ import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../../api/session_api.dart" show SessionAbortApiRejectedException;
 import "../../capabilities/server_connection/connection_service.dart";
 import "../../capabilities/server_connection/models/connection_status.dart";
 import "../../capabilities/server_connection/models/sse_event.dart";
@@ -31,6 +32,7 @@ import "../../utils/model_filter/default_model_selector.dart";
 import "deferred_part_event_buffer.dart";
 import "prompt_send_queue.dart";
 import "queued_session_submission.dart";
+import "session_abort_outcome.dart";
 import "session_detail_notice.dart";
 import "session_detail_resolvers.dart";
 import "session_detail_state.dart";
@@ -2202,37 +2204,41 @@ class SessionDetailCubit(
     emit(current.copyWith(stagedCommand: null));
   }
 
-  Future<void> abort() async {
+  /// Stops the session with the given sub-agent scope.
+  ///
+  /// `confirm` is a side-effect-free probe: nothing local changes until the
+  /// bridge accepts. On acceptance the local prompt queue is cleared (stop
+  /// means "run nothing further"; the bridge clears its own queue), and under
+  /// `stop` every busy child session is aborted too — plugins whose children
+  /// are real sessions keep today's stop-everything behavior.
+  Future<SessionAbortOutcome> abort({required SessionAbortSubAgentPolicy subAgents}) async {
     try {
       final current = state;
-      // Stop means "run nothing further": staged local sends must not fire on
-      // the next drain. The bridge clears its own queue as part of the abort.
+      final root = await _sessionRepository.abortSession(sessionId: _sessionId, subAgents: subAgents);
+      if (root case ErrorResponse(:final error)) throw error;
+
       if (_promptQueue.isNotEmpty || _promptQueue.isSending || _promptQueue.awaitingBridge.isNotEmpty) {
         _promptQueue.clear();
         _staleOptionsRecoveryAttemptedPromptIds.clear();
         _emitQueueUpdate(current is SessionDetailLoaded ? current : null);
       }
-      final futures = <Future<ApiResponse<void>>>[_sessionRepository.abortSession(sessionId: _sessionId)];
-
-      // Also abort any active child sessions (busy or retrying).
-      if (current is SessionDetailLoaded) {
-        for (final entry in current.childStatuses.entries) {
-          final status = entry.value;
-          if (status is SessionStatusBusy || status is SessionStatusRetry) {
-            futures.add(_sessionRepository.abortSession(sessionId: entry.key));
-          }
-        }
-      }
-
-      final results = await Future.wait(futures);
-      for (final result in results) {
-        if (result case ErrorResponse(:final error)) {
-          throw error;
+      if (subAgents != SessionAbortSubAgentPolicy.keep && current is SessionDetailLoaded) {
+        final results = await Future.wait([
+          for (final MapEntry(key: childId, value: status) in current.childStatuses.entries)
+            if (status is SessionStatusBusy || status is SessionStatusRetry)
+              _sessionRepository.abortSession(sessionId: childId, subAgents: SessionAbortSubAgentPolicy.stop),
+        ]);
+        for (final result in results) {
+          if (result case ErrorResponse(:final error)) throw error;
         }
       }
       _reportProductEvent(event: const ProductAnalyticsEvent.sessionAbortSucceeded());
+      return const SessionAbortOutcome.aborted();
+    } on SessionAbortApiRejectedException catch (e) {
+      return SessionAbortOutcome.rejected(rejection: e.rejection);
     } on Object catch (e, st) {
       loge("Failed to abort session(s)", e, st);
+      return const SessionAbortOutcome.aborted();
     }
   }
 

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -2213,10 +2213,12 @@ class SessionDetailCubit(
   /// are real sessions keep today's stop-everything behavior.
   Future<SessionAbortOutcome> abort({required SessionAbortSubAgentPolicy subAgents}) async {
     try {
-      final current = state;
       final root = await _sessionRepository.abortSession(sessionId: _sessionId, subAgents: subAgents);
       if (root case ErrorResponse(:final error)) throw error;
 
+      // Read state after the await: an abort-driven status or transcript event
+      // may have landed meanwhile and must not be overwritten by a stale copy.
+      final current = state;
       if (_promptQueue.isNotEmpty || _promptQueue.isSending || _promptQueue.awaitingBridge.isNotEmpty) {
         _promptQueue.clear();
         _staleOptionsRecoveryAttemptedPromptIds.clear();

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -2237,6 +2237,9 @@ class SessionDetailCubit(
     } on SessionAbortRejectedException catch (e) {
       return SessionAbortOutcome.rejected(rejection: e.rejection);
     } on Object catch (e, st) {
+      // The bridge may have accepted a probe whose response was lost; only the
+      // typed rejection proves nothing happened, so the queue is cleared here too.
+      _clearLocalPromptQueue();
       loge("Failed to abort session(s)", e, st);
       return const SessionAbortOutcome.failed();
     }

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -2206,24 +2206,22 @@ class SessionDetailCubit(
 
   /// Stops the session with the given sub-agent scope.
   ///
-  /// `confirm` is a side-effect-free probe: nothing local changes until the
-  /// bridge accepts. On acceptance the local prompt queue is cleared (stop
-  /// means "run nothing further"; the bridge clears its own queue), and under
-  /// `stop` every busy child session is aborted too — plugins whose children
-  /// are real sessions keep today's stop-everything behavior.
+  /// Stop means "run nothing further": for `keep` and `stop` the local prompt
+  /// queue is cleared before the request so a staged send cannot drain while
+  /// it is in flight (the bridge clears its own queue). A `confirm` probe may
+  /// be refused, so it clears the queue only once the bridge accepted it.
+  /// Under `stop` every busy child session is aborted too — plugins whose
+  /// children are real sessions keep today's stop-everything behavior.
   Future<SessionAbortOutcome> abort({required SessionAbortSubAgentPolicy subAgents}) async {
     try {
+      if (subAgents != SessionAbortSubAgentPolicy.confirm) _clearLocalPromptQueue();
       final root = await _sessionRepository.abortSession(sessionId: _sessionId, subAgents: subAgents);
       if (root case ErrorResponse(:final error)) throw error;
+      _clearLocalPromptQueue();
 
       // Read state after the await: an abort-driven status or transcript event
       // may have landed meanwhile and must not be overwritten by a stale copy.
       final current = state;
-      if (_promptQueue.isNotEmpty || _promptQueue.isSending || _promptQueue.awaitingBridge.isNotEmpty) {
-        _promptQueue.clear();
-        _staleOptionsRecoveryAttemptedPromptIds.clear();
-        _emitQueueUpdate(current is SessionDetailLoaded ? current : null);
-      }
       if (subAgents != SessionAbortSubAgentPolicy.keep && current is SessionDetailLoaded) {
         final results = await Future.wait([
           for (final MapEntry(key: childId, value: status) in current.childStatuses.entries)
@@ -2240,8 +2238,16 @@ class SessionDetailCubit(
       return SessionAbortOutcome.rejected(rejection: e.rejection);
     } on Object catch (e, st) {
       loge("Failed to abort session(s)", e, st);
-      return const SessionAbortOutcome.aborted();
+      return const SessionAbortOutcome.failed();
     }
+  }
+
+  void _clearLocalPromptQueue() {
+    if (_promptQueue.isEmpty && !_promptQueue.isSending && _promptQueue.awaitingBridge.isEmpty) return;
+    _promptQueue.clear();
+    _staleOptionsRecoveryAttemptedPromptIds.clear();
+    final current = state;
+    _emitQueueUpdate(current is SessionDetailLoaded ? current : null);
   }
 
   _SnapshotDerivation _deriveSnapshot(SessionDetailSnapshot snapshot) {

--- a/client/module_core/lib/src/repositories/models/session_abort_rejected_exception.dart
+++ b/client/module_core/lib/src/repositories/models/session_abort_rejected_exception.dart
@@ -1,0 +1,7 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+/// A `confirm` stop the bridge refused because sub-agents are running.
+class const SessionAbortRejectedException({
+  required final SessionAbortRejection rejection,
+  required final Object innerError,
+}) implements Exception;

--- a/client/module_core/lib/src/repositories/session_repository.dart
+++ b/client/module_core/lib/src/repositories/session_repository.dart
@@ -5,6 +5,7 @@ import "package:sesori_shared/sesori_shared.dart" hide SessionCleanupRejection;
 import "../api/session_api.dart";
 import "../foundation/models/composer/composer_attachment.dart";
 import "../foundation/models/session_options/session_options_request_mode.dart";
+import "models/session_abort_rejected_exception.dart";
 import "models/session_cleanup_rejection.dart";
 import "models/session_options_repository_result.dart";
 
@@ -60,9 +61,19 @@ class SessionRepository({
     }
   }
 
-  /// Propagates [SessionAbortApiRejectedException] for a refused `confirm`.
-  Future<ApiResponse<void>> abortSession({required String sessionId, required SessionAbortSubAgentPolicy subAgents}) {
-    return _api.abortSession(sessionId: sessionId, subAgents: subAgents);
+  /// Throws [SessionAbortRejectedException] for a refused `confirm`.
+  Future<ApiResponse<void>> abortSession({
+    required String sessionId,
+    required SessionAbortSubAgentPolicy subAgents,
+  }) async {
+    try {
+      return await _api.abortSession(sessionId: sessionId, subAgents: subAgents);
+    } on SessionAbortApiRejectedException catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        SessionAbortRejectedException(rejection: error.rejection, innerError: error),
+        stackTrace,
+      );
+    }
   }
 
   Future<ApiResponse<void>> markSessionSeen({required String sessionId, required bool read}) {

--- a/client/module_core/lib/src/repositories/session_repository.dart
+++ b/client/module_core/lib/src/repositories/session_repository.dart
@@ -60,8 +60,9 @@ class SessionRepository({
     }
   }
 
-  Future<ApiResponse<void>> abortSession({required String sessionId}) {
-    return _api.abortSession(sessionId: sessionId);
+  /// Propagates [SessionAbortApiRejectedException] for a refused `confirm`.
+  Future<ApiResponse<void>> abortSession({required String sessionId, required SessionAbortSubAgentPolicy subAgents}) {
+    return _api.abortSession(sessionId: sessionId, subAgents: subAgents);
   }
 
   Future<ApiResponse<void>> markSessionSeen({required String sessionId, required bool read}) {

--- a/client/module_core/lib/src/testing/test_helpers.dart
+++ b/client/module_core/lib/src/testing/test_helpers.dart
@@ -363,9 +363,15 @@ void delegateSessionRepository({
   required MockSessionRepository repository,
   required MockSessionRepository source,
 }) {
-  when(() => repository.abortSession(sessionId: any(named: "sessionId"))).thenAnswer(
+  when(
+    () => repository.abortSession(
+      sessionId: any(named: "sessionId"),
+      subAgents: any(named: "subAgents"),
+    ),
+  ).thenAnswer(
     (invocation) => source.abortSession(
       sessionId: _namedArgument<String>(invocation: invocation, name: #sessionId),
+      subAgents: _namedArgument<SessionAbortSubAgentPolicy>(invocation: invocation, name: #subAgents),
     ),
   );
   when(
@@ -548,6 +554,7 @@ void registerCoreFallbackValues() {
   registerFallbackValue(const ServerConnectionConfig(relayHost: "fake.example.com", authToken: null));
   registerFallbackValue(FakeUri());
   registerFallbackValue(StackTrace.empty);
+  registerFallbackValue(SessionAbortSubAgentPolicy.stop);
   registerFallbackValue(const ProductAnalyticsEvent.analyticsSchemaReady());
   registerFallbackValue(AccountStatus.existing);
   registerFallbackValue(SessionOptionsRequestMode.dynamic);

--- a/client/module_core/test/cubits/session_detail/session_detail_bridge_queue_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_bridge_queue_test.dart
@@ -971,7 +971,12 @@ void main() {
           command: any(named: "command"),
         ),
       ).thenAnswer((_) async => ApiResponse.success(null));
-      when(() => mockSessionRepository.abortSession(sessionId: _sessionId)).thenAnswer(
+      when(
+        () => mockSessionRepository.abortSession(
+          sessionId: _sessionId,
+          subAgents: any(named: "subAgents"),
+        ),
+      ).thenAnswer(
         (_) async => ApiResponse.success(null),
       );
       final cubit = await createLoadedCubit();
@@ -979,7 +984,7 @@ void main() {
       await Future<void>.delayed(Duration.zero);
       expect((cubit.state as SessionDetailLoaded).awaitingBridgeSubmissions, hasLength(1));
 
-      await cubit.abort();
+      await cubit.abort(subAgents: SessionAbortSubAgentPolicy.stop);
 
       expect((cubit.state as SessionDetailLoaded).awaitingBridgeSubmissions, isEmpty);
     });
@@ -1248,7 +1253,12 @@ void main() {
     });
 
     test("abort drops locally staged sends", () async {
-      when(() => mockSessionRepository.abortSession(sessionId: _sessionId)).thenAnswer(
+      when(
+        () => mockSessionRepository.abortSession(
+          sessionId: _sessionId,
+          subAgents: any(named: "subAgents"),
+        ),
+      ).thenAnswer(
         (_) async => ApiResponse.success(null),
       );
       final sendCompleter = Completer<ApiResponse<void>>();
@@ -1274,7 +1284,7 @@ void main() {
       await Future<void>.delayed(Duration.zero);
       expect((cubit.state as SessionDetailLoaded).queuedMessages, isNotEmpty);
 
-      await cubit.abort();
+      await cubit.abort(subAgents: SessionAbortSubAgentPolicy.stop);
 
       final state = cubit.state as SessionDetailLoaded;
       expect(state.queuedMessages, isEmpty);

--- a/client/module_core/test/cubits/session_detail/session_detail_bridge_queue_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_bridge_queue_test.dart
@@ -7,11 +7,13 @@ import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/models/connection_status.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/models/sse_event.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/server_connection_config.dart";
+import "package:sesori_dart_core/src/cubits/session_detail/session_abort_outcome.dart";
 import "package:sesori_dart_core/src/cubits/session_detail/session_detail_cubit.dart";
 import "package:sesori_dart_core/src/cubits/session_detail/session_detail_notice.dart";
 import "package:sesori_dart_core/src/cubits/session_detail/session_detail_state.dart";
 import "package:sesori_dart_core/src/foundation/models/composer/composer_draft.dart";
 import "package:sesori_dart_core/src/foundation/models/session_options/session_options_request_mode.dart";
+import "package:sesori_dart_core/src/repositories/models/session_abort_rejected_exception.dart";
 import "package:sesori_dart_core/src/repositories/models/session_options_repository_result.dart";
 import "package:sesori_dart_core/src/services/session_detail_load_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -987,6 +989,33 @@ void main() {
       await cubit.abort(subAgents: SessionAbortSubAgentPolicy.stop);
 
       expect((cubit.state as SessionDetailLoaded).awaitingBridgeSubmissions, isEmpty);
+    });
+
+    test("a refused confirm stop returns the rejection and leaves queued work untouched", () async {
+      when(
+        () => mockSessionRepository.sendMessage(
+          sessionId: _sessionId,
+          promptId: any(named: "promptId"),
+          text: any(named: "text"),
+          attachments: any(named: "attachments"),
+          agent: any(named: "agent"),
+          model: any(named: "model"),
+          variant: any(named: "variant"),
+          command: any(named: "command"),
+        ),
+      ).thenAnswer((_) async => ApiResponse.success(null));
+      const rejection = SessionAbortRejection(runningSubAgentCount: 2, mainAgentRunning: true);
+      when(
+        () => mockSessionRepository.abortSession(sessionId: _sessionId, subAgents: SessionAbortSubAgentPolicy.confirm),
+      ).thenThrow(SessionAbortRejectedException(rejection: rejection, innerError: StateError("409")));
+      final cubit = await createLoadedCubit();
+      await cubit.sendMessage(text: "parked", command: null, inputMode: ComposerInputMode.typed, attachments: const []);
+      await Future<void>.delayed(Duration.zero);
+
+      final outcome = await cubit.abort(subAgents: SessionAbortSubAgentPolicy.confirm);
+
+      expect(outcome, isA<SessionAbortRejected>().having((o) => o.rejection, "rejection", rejection));
+      expect((cubit.state as SessionDetailLoaded).awaitingBridgeSubmissions, hasLength(1));
     });
 
     test("cancel removes the entry on success and on not-found, keeps it on transport failure", () async {

--- a/client/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
@@ -423,7 +423,10 @@ void main() {
         ),
       ).thenAnswer((_) async => ApiResponse<void>.success(null));
       when(
-        () => mockSessionService.abortSession(sessionId: any(named: "sessionId")),
+        () => mockSessionService.abortSession(
+          sessionId: any(named: "sessionId"),
+          subAgents: any(named: "subAgents"),
+        ),
       ).thenAnswer((_) async => ApiResponse<void>.success(null));
       final analyticsService = stubbedProductAnalyticsService();
       final cubit = _buildCubit(
@@ -449,7 +452,7 @@ void main() {
         isTrue,
       );
       expect(await cubit.rejectQuestion("question-2"), isTrue);
-      await cubit.abort();
+      await cubit.abort(subAgents: SessionAbortSubAgentPolicy.stop);
 
       final events = verify(
         () => analyticsService.logEvent(

--- a/client/module_core/test/cubits/session_detail/session_detail_cubit_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_cubit_test.dart
@@ -821,13 +821,18 @@ void main() {
       ),
       act: (cubit) async {
         await _awaitLoaded(cubit);
-        await cubit.abort();
+        await cubit.abort(subAgents: SessionAbortSubAgentPolicy.stop);
       },
       expect: () => [
         isA<SessionDetailLoaded>(),
       ],
       verify: (_) {
-        verify(() => mockSessionService.abortSession(sessionId: sessionId)).called(1);
+        verify(
+          () => mockSessionService.abortSession(
+            sessionId: sessionId,
+            subAgents: any(named: "subAgents"),
+          ),
+        ).called(1);
       },
     );
 
@@ -2833,7 +2838,10 @@ void _stubAllDefaults(
     ),
   ).thenAnswer((_) async => ApiResponse<void>.success(null));
   when(
-    () => service.abortSession(sessionId: any(named: "sessionId")),
+    () => service.abortSession(
+      sessionId: any(named: "sessionId"),
+      subAgents: any(named: "subAgents"),
+    ),
   ).thenAnswer((_) async => ApiResponse.success(null));
   when(
     () => service.replyToQuestion(

--- a/client/module_core/test/repositories/session_repository_test.dart
+++ b/client/module_core/test/repositories/session_repository_test.dart
@@ -10,7 +10,11 @@ import "package:test/test.dart";
 
 import "../helpers/test_helpers.dart";
 
-enum _LegacyOptionsFailureSource() { agents, providers, commands }
+enum _LegacyOptionsFailureSource() {
+  agents,
+  providers,
+  commands,
+}
 
 void main() {
   setUpAll(registerAllFallbackValues);
@@ -40,14 +44,13 @@ void main() {
     final repository = SessionRepository(api: api);
 
     when(() => api.getMessages(sessionId: "session-1", limit: null, before: null)).thenAnswer(
-      (_) async =>
-          ApiResponse.success(
-            const MessageWithPartsResponse(
-              messages: <MessageWithParts>[],
-              nextCursor: null,
-              replayedPromptDefaults: null,
-            ),
-          ),
+      (_) async => ApiResponse.success(
+        const MessageWithPartsResponse(
+          messages: <MessageWithParts>[],
+          nextCursor: null,
+          replayedPromptDefaults: null,
+        ),
+      ),
     );
     when(() => api.getPendingQuestions(sessionId: "session-1")).thenAnswer(
       (_) async => ApiResponse.success(const PendingQuestionResponse(data: <PendingQuestion>[])),
@@ -79,7 +82,8 @@ void main() {
       (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
     );
     when(
-      () => api.sendMessage(promptId: any(named: "promptId"), 
+      () => api.sendMessage(
+        promptId: any(named: "promptId"),
         attachments: const [],
         sessionId: "session-1",
         text: "hello",
@@ -90,7 +94,7 @@ void main() {
       ),
     ).thenAnswer((_) async => ApiResponse.success(null));
     when(
-      () => api.abortSession(sessionId: "session-1"),
+      () => api.abortSession(sessionId: "session-1", subAgents: SessionAbortSubAgentPolicy.stop),
     ).thenAnswer((_) async => ApiResponse.success(const SuccessEmptyResponse()));
     when(
       () => api.replyToQuestion(
@@ -112,7 +116,8 @@ void main() {
     await repository.listAgents(projectId: "project-1", pluginId: "plugin-1");
     await repository.listProviders(projectId: "project-1", pluginId: "plugin-1");
     await repository.listCommands(projectId: "project-1", pluginId: "plugin-1");
-    await repository.sendMessage(promptId: "prompt-1", 
+    await repository.sendMessage(
+      promptId: "prompt-1",
       attachments: const [],
       sessionId: "session-1",
       text: "hello",
@@ -121,7 +126,7 @@ void main() {
       variant: const SessionVariant(id: "xhigh"),
       command: "review",
     );
-    await repository.abortSession(sessionId: "session-1");
+    await repository.abortSession(sessionId: "session-1", subAgents: SessionAbortSubAgentPolicy.stop);
     await repository.replyToQuestion(
       requestId: "question-1",
       sessionId: "session-1",
@@ -139,7 +144,8 @@ void main() {
     verify(() => api.listProviders(projectId: "project-1", pluginId: "plugin-1")).called(1);
     verify(() => api.listCommands(projectId: "project-1", pluginId: "plugin-1")).called(1);
     verify(
-      () => api.sendMessage(promptId: "prompt-1", 
+      () => api.sendMessage(
+        promptId: "prompt-1",
         attachments: const [],
         sessionId: "session-1",
         text: "hello",
@@ -149,7 +155,7 @@ void main() {
         command: "review",
       ),
     ).called(1);
-    verify(() => api.abortSession(sessionId: "session-1")).called(1);
+    verify(() => api.abortSession(sessionId: "session-1", subAgents: SessionAbortSubAgentPolicy.stop)).called(1);
     verify(
       () => api.replyToQuestion(
         requestId: "question-1",

--- a/shared/sesori_shared/lib/sesori_shared.dart
+++ b/shared/sesori_shared/lib/sesori_shared.dart
@@ -29,6 +29,7 @@ export "src/models/auth/product_analytics_preference_update_request.dart";
 export "src/models/auth/project_glossary_words_request.dart";
 export "src/models/auth/register_bridge_request.dart";
 export "src/models/auth/session_status_response.dart";
+export "src/models/sesori/abort_session_request.dart";
 export "src/models/sesori/active_session.dart";
 export "src/models/sesori/agent_info.dart";
 export "src/models/sesori/agent_mode.dart";

--- a/shared/sesori_shared/lib/src/models/sesori/abort_session_request.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/abort_session_request.dart
@@ -1,0 +1,51 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "abort_session_request.freezed.dart";
+part "abort_session_request.g.dart";
+
+/// What a stop should do about sub-agents the session is still running.
+@JsonEnum()
+enum SessionAbortSubAgentPolicy() {
+  /// Refuse with [SessionAbortRejection] while sub-agents run, so the client
+  /// can ask the user; proceeds as [stop] when none run.
+  @JsonValue("confirm")
+  confirm,
+
+  /// Interrupt the main agent only; running sub-agents keep going.
+  @JsonValue("keep")
+  keep,
+
+  /// Interrupt the main agent and every running sub-agent.
+  @JsonValue("stop")
+  stop,
+}
+
+/// Request body for `POST /session/abort`.
+///
+/// A superset of `SessionIdRequest` so an older app's body still decodes.
+@Freezed(fromJson: true, toJson: true)
+sealed class AbortSessionRequest with _$AbortSessionRequest {
+  const factory({
+    required String sessionId,
+    // COMPATIBILITY 2026-09-02 (v1.8.3): Apps predating scoped stop omit
+    // subAgents and mean today's stop-everything. Make it required once those
+    // apps are unsupported.
+    @Default(SessionAbortSubAgentPolicy.stop) SessionAbortSubAgentPolicy subAgents,
+  }) = _AbortSessionRequest;
+
+  factory fromJson(Map<String, dynamic> json) => _$AbortSessionRequestFromJson(json);
+}
+
+/// 409 body for a `confirm` stop the bridge refused because sub-agents run.
+@Freezed(fromJson: true, toJson: true)
+sealed class SessionAbortRejection with _$SessionAbortRejection {
+  const factory({
+    required int runningSubAgentCount,
+
+    /// Whether the main agent itself is mid-turn, which decides whether a
+    /// "main agent only" stop is worth offering.
+    required bool mainAgentRunning,
+  }) = _SessionAbortRejection;
+
+  factory fromJson(Map<String, dynamic> json) => _$SessionAbortRejectionFromJson(json);
+}

--- a/shared/sesori_shared/lib/src/models/sesori/abort_session_request.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/abort_session_request.freezed.dart
@@ -1,0 +1,293 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint, type=warning, deprecated_member_use, deprecated_member_use_from_same_package
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'abort_session_request.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$AbortSessionRequest {
+
+ String get sessionId; SessionAbortSubAgentPolicy get subAgents;
+/// Create a copy of AbortSessionRequest
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AbortSessionRequestCopyWith<AbortSessionRequest> get copyWith => _$AbortSessionRequestCopyWithImpl<AbortSessionRequest>(this as AbortSessionRequest, _$identity);
+
+  /// Serializes this AbortSessionRequest to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AbortSessionRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.subAgents, subAgents) || other.subAgents == subAgents));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,sessionId,subAgents);
+
+@override
+String toString() {
+  return 'AbortSessionRequest(sessionId: $sessionId, subAgents: $subAgents)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AbortSessionRequestCopyWith<$Res>  {
+  factory $AbortSessionRequestCopyWith(AbortSessionRequest value, $Res Function(AbortSessionRequest) _then) = _$AbortSessionRequestCopyWithImpl;
+@useResult
+$Res call({
+ String sessionId, SessionAbortSubAgentPolicy subAgents
+});
+
+
+
+
+}
+/// @nodoc
+class _$AbortSessionRequestCopyWithImpl<$Res>
+    implements $AbortSessionRequestCopyWith<$Res> {
+  _$AbortSessionRequestCopyWithImpl(this._self, this._then);
+
+  final AbortSessionRequest _self;
+  final $Res Function(AbortSessionRequest) _then;
+
+/// Create a copy of AbortSessionRequest
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? sessionId = null,Object? subAgents = null,}) {
+  return _then(AbortSessionRequest(
+sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String,subAgents: null == subAgents ? _self.subAgents : subAgents // ignore: cast_nullable_to_non_nullable
+as SessionAbortSubAgentPolicy,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _AbortSessionRequest implements AbortSessionRequest {
+  const _AbortSessionRequest({required this.sessionId, this.subAgents = SessionAbortSubAgentPolicy.stop});
+  factory _AbortSessionRequest.fromJson(Map<String, dynamic> json) => _$AbortSessionRequestFromJson(json);
+
+@override final  String sessionId;
+@override@JsonKey() final  SessionAbortSubAgentPolicy subAgents;
+
+/// Create a copy of AbortSessionRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AbortSessionRequestCopyWith<_AbortSessionRequest> get copyWith => __$AbortSessionRequestCopyWithImpl<_AbortSessionRequest>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$AbortSessionRequestToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AbortSessionRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.subAgents, subAgents) || other.subAgents == subAgents));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,sessionId,subAgents);
+
+@override
+String toString() {
+  return 'AbortSessionRequest(sessionId: $sessionId, subAgents: $subAgents)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$AbortSessionRequestCopyWith<$Res> implements $AbortSessionRequestCopyWith<$Res> {
+  factory _$AbortSessionRequestCopyWith(_AbortSessionRequest value, $Res Function(_AbortSessionRequest) _then) = __$AbortSessionRequestCopyWithImpl;
+@override @useResult
+$Res call({
+ String sessionId, SessionAbortSubAgentPolicy subAgents
+});
+
+
+
+
+}
+/// @nodoc
+class __$AbortSessionRequestCopyWithImpl<$Res>
+    implements _$AbortSessionRequestCopyWith<$Res> {
+  __$AbortSessionRequestCopyWithImpl(this._self, this._then);
+
+  final _AbortSessionRequest _self;
+  final $Res Function(_AbortSessionRequest) _then;
+
+/// Create a copy of AbortSessionRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? sessionId = null,Object? subAgents = null,}) {
+  return _then(_AbortSessionRequest(
+sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String,subAgents: null == subAgents ? _self.subAgents : subAgents // ignore: cast_nullable_to_non_nullable
+as SessionAbortSubAgentPolicy,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$SessionAbortRejection {
+
+ int get runningSubAgentCount;/// Whether the main agent itself is mid-turn, which decides whether a
+/// "main agent only" stop is worth offering.
+ bool get mainAgentRunning;
+/// Create a copy of SessionAbortRejection
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SessionAbortRejectionCopyWith<SessionAbortRejection> get copyWith => _$SessionAbortRejectionCopyWithImpl<SessionAbortRejection>(this as SessionAbortRejection, _$identity);
+
+  /// Serializes this SessionAbortRejection to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionAbortRejection&&(identical(other.runningSubAgentCount, runningSubAgentCount) || other.runningSubAgentCount == runningSubAgentCount)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,runningSubAgentCount,mainAgentRunning);
+
+@override
+String toString() {
+  return 'SessionAbortRejection(runningSubAgentCount: $runningSubAgentCount, mainAgentRunning: $mainAgentRunning)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SessionAbortRejectionCopyWith<$Res>  {
+  factory $SessionAbortRejectionCopyWith(SessionAbortRejection value, $Res Function(SessionAbortRejection) _then) = _$SessionAbortRejectionCopyWithImpl;
+@useResult
+$Res call({
+ int runningSubAgentCount, bool mainAgentRunning
+});
+
+
+
+
+}
+/// @nodoc
+class _$SessionAbortRejectionCopyWithImpl<$Res>
+    implements $SessionAbortRejectionCopyWith<$Res> {
+  _$SessionAbortRejectionCopyWithImpl(this._self, this._then);
+
+  final SessionAbortRejection _self;
+  final $Res Function(SessionAbortRejection) _then;
+
+/// Create a copy of SessionAbortRejection
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? runningSubAgentCount = null,Object? mainAgentRunning = null,}) {
+  return _then(SessionAbortRejection(
+runningSubAgentCount: null == runningSubAgentCount ? _self.runningSubAgentCount : runningSubAgentCount // ignore: cast_nullable_to_non_nullable
+as int,mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _SessionAbortRejection implements SessionAbortRejection {
+  const _SessionAbortRejection({required this.runningSubAgentCount, required this.mainAgentRunning});
+  factory _SessionAbortRejection.fromJson(Map<String, dynamic> json) => _$SessionAbortRejectionFromJson(json);
+
+@override final  int runningSubAgentCount;
+/// Whether the main agent itself is mid-turn, which decides whether a
+/// "main agent only" stop is worth offering.
+@override final  bool mainAgentRunning;
+
+/// Create a copy of SessionAbortRejection
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SessionAbortRejectionCopyWith<_SessionAbortRejection> get copyWith => __$SessionAbortRejectionCopyWithImpl<_SessionAbortRejection>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SessionAbortRejectionToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionAbortRejection&&(identical(other.runningSubAgentCount, runningSubAgentCount) || other.runningSubAgentCount == runningSubAgentCount)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,runningSubAgentCount,mainAgentRunning);
+
+@override
+String toString() {
+  return 'SessionAbortRejection(runningSubAgentCount: $runningSubAgentCount, mainAgentRunning: $mainAgentRunning)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SessionAbortRejectionCopyWith<$Res> implements $SessionAbortRejectionCopyWith<$Res> {
+  factory _$SessionAbortRejectionCopyWith(_SessionAbortRejection value, $Res Function(_SessionAbortRejection) _then) = __$SessionAbortRejectionCopyWithImpl;
+@override @useResult
+$Res call({
+ int runningSubAgentCount, bool mainAgentRunning
+});
+
+
+
+
+}
+/// @nodoc
+class __$SessionAbortRejectionCopyWithImpl<$Res>
+    implements _$SessionAbortRejectionCopyWith<$Res> {
+  __$SessionAbortRejectionCopyWithImpl(this._self, this._then);
+
+  final _SessionAbortRejection _self;
+  final $Res Function(_SessionAbortRejection) _then;
+
+/// Create a copy of SessionAbortRejection
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? runningSubAgentCount = null,Object? mainAgentRunning = null,}) {
+  return _then(_SessionAbortRejection(
+runningSubAgentCount: null == runningSubAgentCount ? _self.runningSubAgentCount : runningSubAgentCount // ignore: cast_nullable_to_non_nullable
+as int,mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/shared/sesori_shared/lib/src/models/sesori/abort_session_request.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/abort_session_request.g.dart
@@ -1,0 +1,44 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'abort_session_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_AbortSessionRequest _$AbortSessionRequestFromJson(Map json) =>
+    _AbortSessionRequest(
+      sessionId: json['sessionId'] as String,
+      subAgents:
+          $enumDecodeNullable(
+            _$SessionAbortSubAgentPolicyEnumMap,
+            json['subAgents'],
+          ) ??
+          SessionAbortSubAgentPolicy.stop,
+    );
+
+Map<String, dynamic> _$AbortSessionRequestToJson(
+  _AbortSessionRequest instance,
+) => <String, dynamic>{
+  'sessionId': instance.sessionId,
+  'subAgents': _$SessionAbortSubAgentPolicyEnumMap[instance.subAgents]!,
+};
+
+const _$SessionAbortSubAgentPolicyEnumMap = {
+  SessionAbortSubAgentPolicy.confirm: 'confirm',
+  SessionAbortSubAgentPolicy.keep: 'keep',
+  SessionAbortSubAgentPolicy.stop: 'stop',
+};
+
+_SessionAbortRejection _$SessionAbortRejectionFromJson(Map json) =>
+    _SessionAbortRejection(
+      runningSubAgentCount: (json['runningSubAgentCount'] as num).toInt(),
+      mainAgentRunning: json['mainAgentRunning'] as bool,
+    );
+
+Map<String, dynamic> _$SessionAbortRejectionToJson(
+  _SessionAbortRejection instance,
+) => <String, dynamic>{
+  'runningSubAgentCount': instance.runningSubAgentCount,
+  'mainAgentRunning': instance.mainAgentRunning,
+};


### PR DESCRIPTION
## Complexity

🚧 complex — a wire-contract addition, a plugin-interface contract change across every plugin, bridge abort flow with a 409 path and push-suppression semantics, Claude interrupt-without-teardown lifecycle, and a client probe-then-dialog flow.

## What

Step 6/8 of `.plan/active/claude-inline-subtasks`. Stopping a Claude session while sub-agents run no longer silently kills them:

- **Wire (shared):** `POST /session/abort` takes `AbortSessionRequest { sessionId, subAgents: confirm | keep | stop }` with `@Default(stop)` and a dated `COMPATIBILITY` comment, so an older app's `{sessionId}` body keeps today's stop-everything behavior. A refused `confirm` answers 409 with `SessionAbortRejection { runningSubAgentCount, mainAgentRunning }`.
- **Plugin interface:** `abortSession({sessionId, subAgents: PluginAbortSubAgentPolicy}) → PluginAbortResult` (`PluginAbortAccepted` | `PluginAbortRejectedSubAgentsRunning`). ACP, Codex, OpenCode, and Pi wrap their existing abort and always accept.
- **Bridge:** `SessionRepository.abortSession` maps policy/result through `plugin_to_shared_mapping.dart` into a sealed `SessionAbortResult`; `SessionAbortService` emits `abortedSessions` only for an accepted non-`keep` stop and `abortFailedSessions` (clears the pending-abort push mark) for `keep` and rejections, so kept work still earns its completion push; `AbortSessionHandler` maps a rejection to the 409.
- **Claude:** `ClaudeSessionService.abort` refuses `confirm` while typed sub-agents run (count + whether a turn is running) with no side effect; `keep` interrupts the main agent and leaves the process resident so tasks continue and their notifications wake it; `stop` (or `keep` with nothing resident) keeps interrupt + teardown. `ClaudeSessionProcessRepository` closes the post-interrupt window at the first `task_notification` that arrives with no turn active, so the wake-up turn renders. `interruptActiveWork` uses `stop`.
- **Client:** `SessionApi.abortSession` sends the new body and parses the 409 into `SessionAbortApiRejectedException`; `SessionRepository` forwards; `SessionDetailCubit.abort({subAgents})` returns a sealed `SessionAbortOutcome`, clears the local queue only after acceptance, and fans out to busy children only under `stop`. The Stop button probes with `confirm`; on rejection a dialog offers "Stop main agent only" (when the main agent runs) and "Stop main agent and N sub-agents"; dismissing leaves everything running. New l10n strings.

## Why

User direction: a plain stop killing background sub-agents is often not what the user wants; the choice must be explicit.

## Risk and test focus

Medium–high. Impacted: the abort route for every plugin (contract change, older-app default), completion-push suppression after a stop, Claude session lifecycle after a main-agent-only stop, the stop button on phone. Most valuable checks: stop a Claude session with a running sub-agent — dialog appears, "main agent only" leaves the tile running and the wake-up turn arrives later, "stop all" cancels it; stop a session without sub-agents — no dialog, behaves as before; OpenCode/Codex/ACP/Pi stop unchanged; an older app build stops everything without a dialog.

No database change. Wire: two additive models on one route; older peers degrade as described.

## Expected result

- User-visible: stopping while sub-agents run asks for scope; otherwise stop is unchanged. A kept sub-agent still produces the session's completion notification.
- Database/persisted: none.
- Internal: plugin abort contract, bridge sealed abort result, Claude keep path and interrupt window, client outcome model and dialog.

## Verification

- Codegen: `sesori_shared` build_runner, `flutter gen-l10n` (module_app_ui).
- `dart analyze --fatal-infos` clean in shared, plugin interface, bridge/app, all five plugins, `client/module_core`; `flutter analyze` clean in `client/app`; `git diff --check` clean.
- Tests: Claude plugin 289/289 (3 new: confirm refused with count and `mainAgentRunning`, keep leaves process and tasks resident and settles once after the wake-up turn, stop tears down); acp 275, codex 380, opencode 425, pi 291; bridge/app routing + services + repository suites; `client/module_core` session-detail + repository suites 352; `client/app` session_detail widget tests 117 — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stopping a session while sub-agents run now asks whether to stop only the main agent or all work instead of silently killing the sub-agents. A main-agent-only stop leaves sub-agents resident so they can finish and notify the session; stopping all retains the existing teardown behavior.

- `POST /session/abort` accepts `confirm`, `keep`, or `stop`; older apps still default to stopping everything.
- Claude preserves approvals during `keep`, falls back to teardown if interruption fails, and reruns overlapping aborts with the latest scope.
- Interrupted main-agent frames are dropped while sub-agent frames continue through the interrupt window until their task notification closes it.
- All plugins support the new abort result, and completion-push suppression follows whether work was actually kept.
- The client handles 409 rejections, serializes the probe dialog, clears queued work for chosen stops, reports failures separately, and provides idle-main copy.
- The cubit applies state after the abort completes so in-flight status and transcript events are not overwritten.

<sup>Written for commit d2a91e04c6159303263f48e463e41527c6b91f32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

