### PR TITLE
🌱 [claude-inline-subtasks] docs: reconcile regression docs [step 7/8]

### DIFF
--- a/.plan/active/claude-inline-subtasks/PLAN.md
+++ b/.plan/active/claude-inline-subtasks/PLAN.md
@@ -684,8 +684,9 @@ idle only after its last running task and the wake-up turn settle; a plain
 stop while sub-agents run is refused and confirmed as main-agent-only or full
 stop), `notifications.md` (completion fires once, after the last sub-agent
 settles), `plugin-setup-and-lifecycle.md` (idle reap and safe stop defer
-while a Claude task runs), `popup-alerts.md` (the stop-scope confirmation
-dialog).
+while a Claude task runs). `popup-alerts.md` was listed for the stop-scope
+dialog but covers the transient alert surface, not modal dialogs; the dialog
+is documented under `session-turns.md` instead (Step 7 decision, 2026-09-02).
 
 Highest level needed: **L4**. Matrix: Claude plugin for all new behavior;
 OpenCode representative proof that a `state: null` subtask part still renders

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -4,9 +4,9 @@
 
 - **Plan slug:** `claude-inline-subtasks`
 - **Implementation base:** `main` at `86ccc283fb`
-- **Series state:** Steps 1/8 to 5/8 merged; Step 6/8 (scoped stop) PR [#1254](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1254) open
-  (branch `claude-scoped-stop`)
-- **Next action:** merge Step 6/8, then Step 7/8 (regression docs)
+- **Series state:** Steps 1/8 to 6/8 merged; Step 7/8 (regression docs) in PR
+  (branch `claude-inline-subtasks-regression-docs`)
+- **Next action:** merge Step 7/8, then Step 8/8 (run the L4 matrix, retire)
 - **Pinned facts source:** `PLAN.md` "Claude Code CLI 2.1.237 facts" plus the
   Step 3 capture below (CLI 2.1.257); the completed
   `claude-code-plugin/PROTOCOL.md` is historical and is not edited
@@ -140,8 +140,8 @@
 | [x] | 3/8 | `🚧 [claude-inline-subtasks] claude: live and replayed subtask lifecycle for Agent calls [step 3/8]` | 900-1,300 | [PR #1247](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1247) merged |
 | [x] | 4/8 | `🚧 [claude-inline-subtasks] claude: sub-agent transcripts as child sessions [step 4/8]` | 900-1,400 | [PR #1249](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1249) merged |
 | [x] | 5/8 | `⚙️ [claude-inline-subtasks] claude: stream sub-agent frames into child sessions [step 5/8]` | 300-500 | [PR #1253](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1253) merged |
-| [ ] | 6/8 | `🚧 [claude-inline-subtasks] stop: confirm main-agent-only or full stop while sub-agents run [step 6/8]` | 600-1,000 | [PR #1254](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1254) open |
-| [ ] | 7/8 | `🌱 [claude-inline-subtasks] docs: reconcile regression docs [step 7/8]` | 80-200 | Pending |
+| [x] | 6/8 | `🚧 [claude-inline-subtasks] stop: confirm main-agent-only or full stop while sub-agents run [step 6/8]` | 600-1,000 | [PR #1254](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1254) merged |
+| [ ] | 7/8 | `🌱 [claude-inline-subtasks] docs: reconcile regression docs [step 7/8]` | 80-200 | In PR |
 | [ ] | 8/8 | `🌱 [claude-inline-subtasks] docs: run coverage and retire the plan [step 8/8]` | 40-120 | Pending |
 
 ## Step 1 Checklist
@@ -260,6 +260,21 @@
   lines 1,257 across 49 files including generated code and the mechanical
   `subAgents` argument at every plugin, fake, and test call site; the
   non-generated production change is well inside the 600-1,000 target.
+- **Step 6:** merged after one architecture finding and four bot rounds (see
+  Plan Review); the newer-app/older-bridge `confirm` degradation is recorded as
+  accepted compatibility behavior.
+- **Step 7:** regression docs reconciled on `main` after Step 6 (branch
+  `claude-inline-subtasks-regression-docs`):
+  tools-and-file-changes (Claude subtask lifecycle, L3/L4 coverage, failure
+  signals, two known limitations), session-history-and-recovery (subtask
+  sweep to cancelled, child replay identity), projects-and-sessions (sub-agent
+  transcripts as children, read-only children, delete paths),
+  session-turns (busy across background tasks, hidden notification records,
+  scoped stop, L3 coverage, missing-notification limitation), notifications
+  (single completion, keep does not suppress), plugin-setup-and-lifecycle
+  (reap/safe-stop deferral). `popup-alerts.md` deliberately untouched: it
+  documents the transient alert surface, not modal dialogs. `git diff
+  --check` clean.
 - **Final disposition:** pending
 
 ## Plan Review

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -4,7 +4,7 @@
 
 - **Plan slug:** `claude-inline-subtasks`
 - **Implementation base:** `main` at `86ccc283fb`
-- **Series state:** Steps 1/8 to 6/8 merged; Step 7/8 (regression docs) in PR
+- **Series state:** Steps 1/8 to 6/8 merged; Step 7/8 (regression docs) PR [#1256](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1256) open
   (branch `claude-inline-subtasks-regression-docs`)
 - **Next action:** merge Step 7/8, then Step 8/8 (run the L4 matrix, retire)
 - **Pinned facts source:** `PLAN.md` "Claude Code CLI 2.1.237 facts" plus the
@@ -141,7 +141,7 @@
 | [x] | 4/8 | `🚧 [claude-inline-subtasks] claude: sub-agent transcripts as child sessions [step 4/8]` | 900-1,400 | [PR #1249](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1249) merged |
 | [x] | 5/8 | `⚙️ [claude-inline-subtasks] claude: stream sub-agent frames into child sessions [step 5/8]` | 300-500 | [PR #1253](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1253) merged |
 | [x] | 6/8 | `🚧 [claude-inline-subtasks] stop: confirm main-agent-only or full stop while sub-agents run [step 6/8]` | 600-1,000 | [PR #1254](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1254) merged |
-| [ ] | 7/8 | `🌱 [claude-inline-subtasks] docs: reconcile regression docs [step 7/8]` | 80-200 | In PR |
+| [ ] | 7/8 | `🌱 [claude-inline-subtasks] docs: reconcile regression docs [step 7/8]` | 80-200 | [PR #1256](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1256) open |
 | [ ] | 8/8 | `🌱 [claude-inline-subtasks] docs: run coverage and retire the plan [step 8/8]` | 40-120 | Pending |
 
 ## Step 1 Checklist

--- a/docs/regression/notifications.md
+++ b/docs/regression/notifications.md
@@ -11,7 +11,11 @@ Apple and Google is external.
 
 - Immediate notifications exist only for question-asked, permission-asked, and installation-update events. Completion
   fires after a debounced busy-to-idle transition, is blocked while a question or permission is pending, and is
-  suppressed for a user abort until the group is busy again.
+  suppressed for a user abort until the group is busy again. A Claude session
+  with background sub-agents stays busy until the last one and its wake-up turn
+  settle, so completion fires once for the whole span; a main-agent-only stop
+  (`keep`) does not suppress the completion the kept sub-agents later earn,
+  while a full stop does.
 - A child prompt is attributed to its display (root) session. Rate limiting is per category plus session, so a
   throttled completion never suppresses a more urgent question, and every notification for a session collapses to one
   identity derived identically by bridge, server, and client.
@@ -52,7 +56,10 @@ provider because current payload content leaves the encrypted channel.
 
 ## Failure Signals
 
-- A completion arrives while a question or permission is pending, or after abort.
+- A completion arrives while a question or permission is pending, or after a
+  full abort; a Claude session with a running background sub-agent fires a
+  completion before the sub-agent's wake-up turn settles, or fires twice; a
+  main-agent-only stop suppresses the completion of the kept sub-agents.
 - Notifications for one session do not collapse, or a tap opens the wrong session or a child instead of its root.
 - A question is suppressed by an unrelated completion cooldown.
 - Delivery continues after logout, or a new account receives the prior account's notifications.

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -97,6 +97,11 @@ idle suspension, the management snapshot, and lifecycle commands.
   it); a wakeup that never fires stops deferring one idle window past its fire time.
   The wakeup-fired turn the CLI starts on its own is surfaced busy, then idle on its
   result, and abort interrupts it like any enqueued turn.
+- A Claude session with a running background task (sub-agent, shell, or workflow the
+  CLI reported) is busy for lifecycle purposes: the idle reap does not arm, the plugin
+  work state stays busy so a safe stop or suspension refuses, and only a forced stop, a
+  full-scope session stop, delete, or process exit ends it. A main-agent-only stop
+  keeps the process resident for its tasks.
 - A busy harness conflicts explicitly, forcing needs confirmation and is sent once, the
   snapshot changes only on real content change with a new token, and a terminal failure
   removes only that harness's routing and new-session choice.
@@ -189,6 +194,8 @@ owned-process exit; and restart.
   different from the executable selected by setup inspection and runtime resolution.
 - A control offered for an undeclared capability, a supported control missing, a busy
   harness accepting a safe command, or idle suspension on a resident or busy harness.
+- The Claude idle reap or a safe stop kills a resident process while a background
+  sub-agent it reported is still running.
 - A catalog scan offered on a harness the bridge will not import from, a scan already
   covering a harness still accepting another start from its card, a targeted rejection
   landing on the wrong harness or on none, or a request error reaching the card as text.

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -150,6 +150,16 @@ state.
   and detail adopt the durable session facts without marking unseen or moving the
   worktree directory. The initial system prompt remains truthful about the
   directory and branch that existed when the backend session was created.
+- Claude import lists a sub-agent transcript under `<root>/subagents/` as a
+  child session of that root (id `agent-<agentId>`, title from its meta
+  description, the root's directory), roots only in per-project pages and
+  children through the child-session route and full enumeration. A child whose
+  root is absent from the scan and the older flat `agent-<slug>-<hex>.jsonl`
+  layout are not sessions. A live Claude sub-agent appears as a child with
+  busy/idle status and in the root's active children while it runs. Children
+  are read-only: prompts and commands to an `agent-` id are refused. Deleting
+  a root also removes its `subagents/` directory; deleting a child removes its
+  transcript and meta file.
 - Pi import discovers persisted JSONL sessions from its inherited environment,
   configured storage, default per-project storage, and bridge-known directories.
   Enumeration is metadata-only and bounded: it reads session headers and
@@ -243,7 +253,10 @@ leave the surface that started one. Restore harness eligibility afterwards.
   git in the old location; a moved bridge-derived project mutates the old catalog
   identity instead of being discovered as new.
 - Sessions lose attribution, land under the wrong project, or a child lists as a
-  root.
+  root. A Claude sub-agent transcript lists as a root, is missing under its
+  root, or survives its root's deletion on disk; a legacy flat sub-agent file
+  or an orphan child is imported; a running sub-agent is absent from the
+  root's active children.
 - Pi import exposes prompt/transcript text, treats it as a title, follows an
   unbounded symlink/parent tree, or loses sessions stored under a configured or
   bridge-known directory.

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -91,7 +91,14 @@ reconnect or restart.
   kept fresh across an abrupt bridge death — including when the status is
   unobservable, since a stopped backend hosts no live tool. Finalization never
   advances the session's freshness marks, and a genuinely running tool swept by
-  the turn-start race is corrected by its next live capture.
+  the turn-start race is corrected by its next live capture. An open subtask
+  part is swept the same way but to `cancelled` with no error text; because a
+  root stays busy while any of its sub-agents runs, a live background
+  sub-agent is never swept, only one whose bridge died.
+- Claude sub-agent transcripts (`<root>/subagents/agent-<agentId>.jsonl`)
+  replay as child sessions with stable message and part identities, so an open
+  child screen converges after a reload without duplicates; nested sub-agents
+  replay under the root.
 - Pi history follows the active `leafId` branch while retaining visible
   pre-compaction messages, applies thinking-level changes to later assistant and
   error messages on that branch, and omits compaction and branch-summary
@@ -161,6 +168,9 @@ rules where supported.
   the session idle before `agent_settled`.
 - Buffered events are lost after a reconnect inside the replay window, or a slow
   request stalls other requests, plugins, or reconnects.
+- After a bridge restart an idle Claude root still shows a running subtask tile,
+  or a busy root's live background sub-agent tile is swept to cancelled; a
+  child transcript duplicates its parts after reload.
 - A Copilot restart prompts before `session/load`, duplicates replay as new live
   output, or reads private history files instead of the ACP replay boundary.
 - Grok replay mutates live defaults during initialize, stamps messages from an

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -67,6 +67,25 @@ defaults and queued client sends coherent.
   while a prompt that starts later settles on that later result. Slash commands
   and model, effort, or permission-mode changes wait for a turn boundary
   instead of changing the active turn.
+- A Claude session stays busy while any background task the CLI reported
+  (`task_started`) is still running, even after the launching turn's result,
+  and returns to idle only after the last task notification and the wake-up
+  turn it triggers settle, so one continuous busy span covers launch →
+  background work → wake-up and the completion push fires once. The CLI's
+  `<task-notification>` delivery records are internal: they finalize the
+  matching subtask and are never rendered as user messages, while user text
+  that merely discusses the envelope stays visible. Forwarded sub-agent frames
+  render in the sub-agent's child session, never as a root turn.
+- Stop is scoped. The client first asks with `confirm`; while Claude sub-agents
+  run the bridge refuses with the running count and whether the main agent is
+  mid-turn, and the app offers "Stop main agent only" (only while the main
+  agent runs) and "Stop main agent and N sub-agents"; dismissing leaves
+  everything running. `keep` interrupts the main agent but leaves the process
+  and its sub-agents resident, so their later wake-up turn still renders and
+  the completion push is not suppressed; `stop` interrupts and tears down,
+  cancelling every sub-agent. With no sub-agents running, stop behaves as
+  before with no dialog. An older app stops everything; an older bridge
+  ignores the scope.
 - Pi keeps at most one lazy resident RPC process per active session and allows
   different sessions to run concurrently. A cold resident starts with the
   turn's requested model and thinking level on Pi's command line so
@@ -287,7 +306,7 @@ defaults and queued client sends coherent.
 |---|---|
 | L1 Smoke | Automated shared presentation and desktop shell coverage: representative transcript content renders through the shared session-detail view, the desktop session route is present, and desktop omits composer and diff controls. Live plugin, representative: a prompt streams assistant output and returns the session to idle. |
 | L2 Routine | Live plugin, representative: slash command returns on acceptance; prompt defaults update; first and stale transcript replay reconciles prompt defaults before the opening snapshot is applied; abort stops a turn and reports its outcome; finalized messages are immediately readable from history; a recognized stale option returns the typed rejection only after cache invalidation. Automated Pi coverage keeps visible custom messages system-attributed across live and replay without changing agent defaults or completion text. |
-| L3 Release | Client end to end (phone for composer and turn control; desktop for transcript presentation), every supporting production plugin: text, reasoning, tool, and status events stream with consistent normalization and the shared output bound; agent, model, and variant apply per phone send; streaming and queued feedback render on both surfaces, while composer, sending, and abort controls render on phone; a stale selection refreshes, warns, and retries once without losing the queued prompt. DeepSeek, Copilot, and Grok cover busy stop-and-send. Copilot additionally covers an exact advertised slash command and reasoning only when its selected model emits it. Grok covers exact model/effort application, accepted-send timing, abort, visible failure, and idle completion without claiming image input. A Pi custom message renders as labelled automation rather than agent output. |
+| L3 Release | Client end to end (phone for composer and turn control; desktop for transcript presentation), every supporting production plugin: text, reasoning, tool, and status events stream with consistent normalization and the shared output bound; agent, model, and variant apply per phone send; streaming and queued feedback render on both surfaces, while composer, sending, and abort controls render on phone; a stale selection refreshes, warns, and retries once without losing the queued prompt. Claude: a stop while a background sub-agent runs shows the scope dialog, "main agent only" leaves the tile running and its wake-up turn later arrives, "stop all" cancels it, and a stop with no sub-agents shows no dialog; the session stays busy until the last sub-agent's wake-up turn settles. DeepSeek, Copilot, and Grok cover busy stop-and-send. Copilot additionally covers an exact advertised slash command and reasoning only when its selected model emits it. Grok covers exact model/effort application, accepted-send timing, abort, visible failure, and idle completion without claiming image input. A Pi custom message renders as labelled automation rather than agent output. |
 | L4 Extended | Relay integration, every supporting production plugin: a slow or unresponsive plugin leaves other sessions, plugins, and the relay responsive; archived sends and queued-prompt cancels are refused without racing archiving; disconnect and reconnect mid-turn resumes without lost or duplicated parts; bridge-owned prompts survive leaving and reopening in order and appear on a second client; a prompt waiting at a dispatch boundary can be cancelled; a permission reply lands while a command or selection-changing prompt waits behind the running turn; a second client observes the same turn and steering prompt. Two Copilot sessions and two Grok sessions run concurrently while each preserves its own ordering and selection. |
 | L5 Full | Client end to end, every supporting production plugin: retry status surfaces with attempt and timing; concurrent sends across sessions and plugins interleave without ordering damage; background and resume mid-turn recovers live state; an aborted turn triggers no completion notification. |
 
@@ -366,6 +385,14 @@ provider failure, early and late abort, busy stop-and-send, and two sessions.
   resume after Stop, or leaves later sends stuck in their sending state.
 - Recovery or interruption artifacts from an aborted turn appear in the next
   user turn.
+- A Claude session reports idle while a background sub-agent still runs, or
+  shows a transient idle between the task notification and its wake-up turn; a
+  `<task-notification>` envelope renders as a user bubble, or a prompt that
+  quotes the envelope disappears; sub-agent text appears in the root transcript.
+- A plain stop kills running Claude sub-agents without asking, the scope dialog
+  appears when none run, "main agent only" tears the process down or leaves the
+  session stuck busy after the kept sub-agents finish, or dismissing the dialog
+  stops anything.
 - A Grok turn dispatches before exact model/effort selection settles, accepts a
   stale tuple, overlaps same-session prompts, serializes unrelated sessions, or
   loses text, reasoning, tool, status, or terminal failure output.
@@ -414,6 +441,9 @@ provider failure, early and late abort, busy stop-and-send, and two sessions.
   ACP plan updates currently produce only an internal todo invalidation that the
   session client ignores and cold replay does not collect, so plan presentation
   is not supported Copilot release coverage.
+- A Claude task that never reports a notification keeps the session busy and
+  its process resident until a stop, delete, or exit; `background_tasks_changed`
+  is not used to reconcile because it precedes the frames it would race.
 - Untested Hermes gap (remove this entry once verified): reasoning streaming
   was never observed from Hermes. An explicit chain-of-thought prompt produced
   no `agent_thought_chunk` against the tested model, so thought-part
@@ -425,7 +455,11 @@ provider failure, early and late abort, busy stop-and-send, and two sessions.
   chat history), `bridge/app/lib/src/sse/`, and their tests
 - Contract: `bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart`;
   `shared/sesori_shared/lib/src/models/sesori/send_prompt_error_response.dart`;
-  `shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart`
+  `shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart`;
+  `shared/sesori_shared/lib/src/models/sesori/abort_session_request.dart`
+- Claude: `bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart`
+  (running tasks, scoped abort) and `test/claude_session_service_test.dart`;
+  `client/app/lib/features/session_detail/widgets/session_abort_scope_dialog.dart`
 - Hermes: `bridge/sesori_plugin_hermes/` and the shared ACP plugin implementation
 - DeepSeek: `bridge/sesori_plugin_deepseek/` and the shared ACP plugin implementation
 - Copilot: `bridge/sesori_plugin_copilot/` and the shared ACP plugin implementation

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -30,6 +30,18 @@ signal that a tool changed files.
   reload with the same identity, status, and output; unknown status renders as
   the fallback. A backend abort without a turn identifier still finalizes tools
   in the active turn.
+- Claude `Agent`/`Task` calls render as subtask parts keyed by the tool-use
+  id, with the sub-agent description, prompt, and agent type, a lifecycle of
+  their own (`pending`/`running` → `completed`, `error`, or `cancelled`), and
+  a `childSessionID` naming the sub-agent's child session once known. The task
+  notification is the authoritative terminal source; the launching call's own
+  tool result is a fallback that a later notification replaces, and a
+  background launch never finalizes the part. A part appears only once its
+  input names the description and prompt, never with placeholder text. On
+  replay the same parts render from the transcript, and a still-running task
+  the session's resident process no longer owns renders as `cancelled`.
+  Process exit — natural or an explicit stop — cancels every running task.
+  OpenCode subtask parts keep a null lifecycle and the child-status fallback.
 - DeepSeek projects tool calls and updates through standard ACP with exact call
   identity, bounded presenter output, terminal result/error state, and diff
   content. Presenter failure degrades to a generic bounded tool card instead of
@@ -53,8 +65,8 @@ signal that a tool changed files.
 |---|---|
 | L1 Smoke | Not included because proving tool behavior requires a live turn. |
 | L2 Routine | Live plugin, representative: a file-editing tool produces a tool part with name, terminal status, and bounded output. |
-| L3 Release | Client end to end (phone), every supporting production plugin: title, status, output bound, and errors normalize consistently; a mutating tool emits the file-change signal once and a read-only tool emits none; tool cards, errors, and subtask/agent parts render. Copilot covers one read-only tool, one file mutation with permission linkage and diff invalidation, and one failing tool. Grok covers a complete tool lifecycle with bounded output, a file diff and invalidation, live permission linkage, and cold-replay identity/status parity. |
-| L4 Extended | Live plugin, every supporting production plugin: tool parts survive history reload with identity, status, and output intact; a failing tool surfaces an error rather than a stuck running state; child-session tool activity is attributed correctly; repeated completion updates do not duplicate the file-change signal. |
+| L3 Release | Client end to end (phone), every supporting production plugin: title, status, output bound, and errors normalize consistently; a mutating tool emits the file-change signal once and a read-only tool emits none; tool cards, errors, and subtask/agent parts render. Claude covers a foreground and a background sub-agent tile going running → completed with the result text, tapping the tile opening the child transcript, and a cancelled tile after the process is killed; OpenCode proves a null-lifecycle subtask part still renders and opens as before. Copilot covers one read-only tool, one file mutation with permission linkage and diff invalidation, and one failing tool. Grok covers a complete tool lifecycle with bounded output, a file diff and invalidation, live permission linkage, and cold-replay identity/status parity. |
+| L4 Extended | Live plugin, every supporting production plugin: tool parts survive history reload with identity, status, and output intact; a failing tool surfaces an error rather than a stuck running state; child-session tool activity is attributed correctly; repeated completion updates do not duplicate the file-change signal. Claude: a reloaded session with a finished background sub-agent shows one completed subtask tile with the same identity and `childSessionID`, a still-running one stays running while its process lives, and a failed sub-agent renders `error` with the notification summary. |
 | L5 Full | Client end to end, every supporting production plugin: rune-boundary truncation is exact for multi-byte output; attachments render where emitted and unsafe or malformed sources degrade to metadata; unknown status from a newer peer degrades gracefully. |
 
 ## Exploration Guidance
@@ -89,8 +101,21 @@ one permission-gated mutation and one repeated terminal update.
   number of file-change invalidations.
 - The file-change signal is missing after a real mutation, emitted for a
   read-only tool, emitted repeatedly for one call, or wrongly attributed.
+- A Claude sub-agent renders as a generic `Agent` tool card, its tile stays
+  running after the sub-agent finished or its process died, a background
+  launch's "Async agent launched" tool result finalizes the tile, a late tool
+  result overwrites a notification-set status, tapping the tile opens the wrong
+  or no child transcript, or the tile shows placeholder text before its input
+  is complete.
 
 ## Known Limitations
+
+- An interrupted Claude foreground sub-agent renders `cancelled` live (the
+  notification reports `stopped`) but `error` on replay, because the transcript
+  persists only its error tool result; tool-result text is never matched.
+- The Claude CLI 2.1.221 floor was not probed for `task_started` and
+  `task_notification` frames; the typed tool-result and notification-text
+  substitutes are unit-tested only.
 
 - Available tools, attachments, and sub-agents are backend-specific; a plugin
   that cannot produce a case is not a failure but is also not coverage.
@@ -115,5 +140,8 @@ one permission-gated mutation and one repeated terminal update.
   `bridge/sesori_plugin_*/`; `client/app/lib/features/session_detail/widgets/`
 - Tests: `shared/sesori_shared/test/models/message_attachment_test.dart`,
   `bridge/app/test/bridge/sse/bridge_event_mapper_test.dart`
+- Claude sub-agents: `bridge/sesori_plugin_claude/lib/src/repositories/trackers/claude_tool_tracker.dart`,
+  `claude_event_dispatcher.dart`, `claude_history_mapper.dart`, and
+  `test/claude_subtask_lifecycle_test.dart`
 - Plans (discovery only): `.plan/completed/output-image-support`,
-  `.plan/completed/attachment-references`
+  `.plan/completed/attachment-references`, `.plan/active/claude-inline-subtasks`


### PR DESCRIPTION
## Complexity

🌱 trivial — documentation only.

## What

Step 7/8 of `.plan/active/claude-inline-subtasks`: reconciles the six regression documents the series affects with the behavior shipped in Steps 2–6.

- `tools-and-file-changes.md`: Claude subtask lifecycle (authoritative notification, fallback tool result, cancelled on process exit, replay downgrade), L3/L4 coverage, failure signals, two known limitations (interrupted foreground replay divergence; unprobed 2.1.221 floor).
- `session-history-and-recovery.md`: open subtask parts swept to `cancelled`, child transcripts reload with stable identity.
- `projects-and-sessions.md`: sub-agent transcripts as read-only child sessions, orphan and legacy layouts excluded, root/child delete paths.
- `session-turns.md`: busy across background tasks with no transient idle, hidden `<task-notification>` records, scoped stop (confirm → dialog → keep/stop), L3 coverage, missing-notification limitation, sources.
- `notifications.md`: one completion per span; `keep` does not suppress the kept sub-agents' completion.
- `plugin-setup-and-lifecycle.md`: idle reap and safe stop defer while a Claude task runs.

`popup-alerts.md` was listed in the plan but documents the transient alert surface, not modal dialogs; the stop-scope dialog is documented under `session-turns.md` and the plan records that decision.

## Why

Regression documents are the durable source of truth; the plan reconciles them in its penultimate step before the L4 matrix is run and the plan retired.

## Risk and test focus

None (documentation). Reviewers may check the statements against the merged Steps 3–6 behavior.

## Expected result

- User-visible: none.
- Database/persisted: none.
- Internal: documentation only.

## Verification

`git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles the six regression documents with the Claude sub-agent behavior shipped in Steps 2–6, keeping them the source of truth before the L4 matrix runs. Documentation only; no behavior, user-visible, or persistence changes.

The docs now record: the Claude subtask lifecycle (authoritative notification, fallback tool result, cancelled on process exit, replay downgrade), sub-agent transcripts as read-only child sessions, the busy-until-last-task rule with a single completion push, scoped stop with `keep`/`stop`, and idle reap and safe-stop deferral — each with its failure signals and known limitations. `popup-alerts.md` was deliberately left out: it documents the transient alert surface, not the modal stop-scope dialog, which is covered under `session-turns.md` instead.

<sup>Written for commit b9b87cf703d2e2ecd2b5008cf56d0ef0c6a270e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

