### PR TITLE
🌱 Clarify that archived sessions remain viewable

### DIFF
--- a/client/app/test/features/session_list/session_tile_swipe_test.dart
+++ b/client/app/test/features/session_list/session_tile_swipe_test.dart
@@ -140,8 +140,14 @@ void main() {
     await tester.tap(find.text("Archive"));
     await tester.pumpAndSettle();
 
-    // Archiving is permanent, so the pill confirms before it commits.
-    expect(find.textContaining("Archiving is permanent"), findsOneWidget);
+    // The confirmation makes clear that archived history remains viewable.
+    expect(
+      find.text(
+        "Archiving makes this session permanently read-only. "
+        "You can still view its history, but you can’t send new prompts or unarchive it.",
+      ),
+      findsOneWidget,
+    );
     verifyNever(
       () => cubit.archiveSession(
         sessionId: any(named: "sessionId"),

--- a/client/module_app_ui/lib/src/l10n/app_en.arb
+++ b/client/module_app_ui/lib/src/l10n/app_en.arb
@@ -890,7 +890,7 @@
   "sessionListDeleteWorktreeCheckbox": "Delete worktree",
   "sessionDetailArchivedNotice": "This session is archived and read-only.",
   "sessionListArchiveConfirmTitle": "Archive session?",
-  "sessionListArchiveConfirmMessage": "Archiving is permanent. This session becomes read-only — you can still read it, but you cannot reopen it, send prompts, or unarchive it.",
+  "sessionListArchiveConfirmMessage": "Archiving makes this session permanently read-only. You can still view its history, but you can’t send new prompts or unarchive it.",
   "sessionListArchiveConfirmAction": "Archive",
   "sessionListForceDeleteTitle": "Force delete?",
   "sessionListForceArchiveTitle": "Force archive?",

--- a/client/module_app_ui/lib/src/l10n/app_localizations.dart
+++ b/client/module_app_ui/lib/src/l10n/app_localizations.dart
@@ -2914,7 +2914,7 @@ abstract class AppLocalizations {
   /// No description provided for @sessionListArchiveConfirmMessage.
   ///
   /// In en, this message translates to:
-  /// **'Archiving is permanent. This session becomes read-only — you can still read it, but you cannot reopen it, send prompts, or unarchive it.'**
+  /// **'Archiving makes this session permanently read-only. You can still view its history, but you can’t send new prompts or unarchive it.'**
   String get sessionListArchiveConfirmMessage;
 
   /// No description provided for @sessionListArchiveConfirmAction.

--- a/client/module_app_ui/lib/src/l10n/app_localizations_en.dart
+++ b/client/module_app_ui/lib/src/l10n/app_localizations_en.dart
@@ -1567,7 +1567,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get sessionListArchiveConfirmMessage =>
-      'Archiving is permanent. This session becomes read-only — you can still read it, but you cannot reopen it, send prompts, or unarchive it.';
+      'Archiving makes this session permanently read-only. You can still view its history, but you can’t send new prompts or unarchive it.';
 
   @override
   String get sessionListArchiveConfirmAction => 'Archive';


### PR DESCRIPTION
## Complexity

🌱 Trivial.

## What

Reworded the archive confirmation message.

Old: 
_Archiving is permanent. This session becomes read-only
— you can still read it, but you cannot reopen it, send prompts, or unarchive it._

New - More concise & human oriented:
_Archiving makes this session permanently read-only. You can still view its history, but you can’t send new prompts or unarchive it._

To make it clearer what happens when a session is archived.

## Risk and test focus

Copy-only change. No functional or database impact.

## Expected result

Users can tell that archived sessions remain viewable but cannot accept new prompts or be unarchived.

## Verification

Focused widget tests and Flutter analysis pass.
