### PR TITLE
🌱 Log the relay close code and reason on connection loss

### DIFF
--- a/bridge/app/lib/src/orchestrator.dart
+++ b/bridge/app/lib/src/orchestrator.dart
@@ -1234,7 +1234,12 @@ class OrchestratorSession._({
         break;
       }
 
-      Log.w("Relay connection lost. Reconnecting...");
+      // 1001 with no reason is the local ping timeout (no pong within the ping
+      // interval); anything else came from the relay's close frame.
+      Log.w(
+        "Relay connection lost (closeCode=${_client.closeCode(connection: connection)} "
+        "closeReason=${_client.closeReason(connection: connection)}). Reconnecting...",
+      );
       _sseManager.orphanAll();
       activePhoneIncarnations.clear();
       // Every phone connection died with the relay link; drop their view


### PR DESCRIPTION
## Complexity
🌱 trivial — one log line in the bridge reconnect loop.

## What
The "Relay connection lost" warning in `OrchestratorSession` now includes the WebSocket close code and close reason of the dropped connection.

## Why
Unexplained relay drops have been showing up with a healthy network. The ordinary drop path inspected the close code only for the revoked and replaced cases and never logged it, so the log could not distinguish the local ping timeout (dart:io closes with 1001 when no pong arrives within the 15 s ping interval) from a close frame sent by the relay. With the code and reason in the log, the next occurrence tells us which side dropped the socket.

## Risk and test focus
No user-visible or database impact. No wire contract change. The two accessors were already used a few lines below on the same connection handle.

## Expected result
On a relay drop the bridge logs, for example:

```
[OrchestratorSession] Relay connection lost (closeCode=1001 closeReason=). Reconnecting...
```

## Verification
`dart analyze lib/src/orchestrator.dart` in `bridge/app`: no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the WebSocket close code and reason to the "Relay connection lost" log in `OrchestratorSession`. Previously the log couldn't distinguish a local ping timeout (1001) from a close frame sent by the relay; now the next relay drop will show which side closed the socket. No user-visible, database, or wire contract changes.

<sup>Written for commit 96fedc33dbcc29e35f3df9d6acc4ac5b2af51ee4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

