### PR TITLE
🌿 Stop duplicate Claude Code API errors

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_stream_message.dart
@@ -374,6 +374,7 @@ final class const ClaudeHookOutputMessage({
 }
 
 enum ClaudeAssistantError() {
+  none,
   authenticationFailed,
   oauthOrgNotAllowed,
   billingError,
@@ -386,6 +387,7 @@ enum ClaudeAssistantError() {
   unknown;
 
   static ClaudeAssistantError parse(Object? raw) => switch (raw) {
+    null => none,
     "authentication_failed" => authenticationFailed,
     "oauth_org_not_allowed" => oauthOrgNotAllowed,
     "billing_error" => billingError,
@@ -447,6 +449,7 @@ final class const ClaudeAssistantMessage({
   /// Non-null marks subagent traffic.
   required final String? parentToolUseId,
   required final ClaudeAssistantError error,
+  required final int? apiErrorStatus,
   required final DateTime? timestamp,
   required super.sessionId,
   required super.uuid,
@@ -464,6 +467,7 @@ final class const ClaudeAssistantMessage({
       model: _stringOrNull(message["model"]),
       parentToolUseId: _stringOrNull(json["parent_tool_use_id"]),
       error: ClaudeAssistantError.parse(json["error"]),
+      apiErrorStatus: _intOrNull(json["api_error_status"] ?? json["apiErrorStatus"]),
       timestamp: _dateTimeOrNull(json["timestamp"]),
       sessionId: sessionId,
       uuid: uuid,

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_transcript_record_dto.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_transcript_record_dto.dart
@@ -31,6 +31,8 @@ sealed class ClaudeTranscriptRecordDto with _$ClaudeTranscriptRecordDto {
     @JsonKey(fromJson: _stringOrNull) required String? uuid,
     @JsonKey(fromJson: _boolOrNull) required bool? isMeta,
     @JsonKey(fromJson: _boolOrNull) required bool? isVisibleInTranscriptOnly,
+    @JsonKey(fromJson: _boolOrNull) required bool? isApiErrorMessage,
+    @JsonKey(fromJson: _intOrNull) required int? apiErrorStatus,
     @JsonKey(fromJson: _stringOrNull) required String? effort,
     @JsonKey(fromJson: _messageOrNull) required ClaudeTranscriptMessageDto? message,
 
@@ -60,6 +62,8 @@ sealed class ClaudeTranscriptMessageDto with _$ClaudeTranscriptMessageDto {
 String? _stringOrNull(Object? value) => value is String ? value : null;
 
 bool? _boolOrNull(Object? value) => value is bool ? value : null;
+
+int? _intOrNull(Object? value) => value is num ? value.toInt() : null;
 
 String? _originKindOrNull(Object? value) => value is Map ? _stringOrNull(value["kind"]) : null;
 

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_transcript_record_dto.freezed.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_transcript_record_dto.freezed.dart
@@ -17,7 +17,7 @@ T _$identity<T>(T value) => value;
 mixin _$ClaudeTranscriptRecordDto {
 
 @JsonKey(fromJson: _stringOrNull) String? get type;@JsonKey(fromJson: _stringOrNull) String? get sessionId;@JsonKey(fromJson: _stringOrNull) String? get cwd;@JsonKey(fromJson: _timestampOrNull) DateTime? get timestamp;@JsonKey(fromJson: _boolOrNull) bool? get isSidechain;/// The sub-agent that wrote the record; null on a root session's records.
-@JsonKey(fromJson: _stringOrNull) String? get agentId;@JsonKey(fromJson: _stringOrNull) String? get gitBranch;@JsonKey(fromJson: _stringOrNull) String? get version;@JsonKey(fromJson: _stringOrNull) String? get aiTitle;@JsonKey(fromJson: _stringOrNull) String? get uuid;@JsonKey(fromJson: _boolOrNull) bool? get isMeta;@JsonKey(fromJson: _boolOrNull) bool? get isVisibleInTranscriptOnly;@JsonKey(fromJson: _stringOrNull) String? get effort;@JsonKey(fromJson: _messageOrNull) ClaudeTranscriptMessageDto? get message;/// The typed result persisted beside a `user` record's tool result.
+@JsonKey(fromJson: _stringOrNull) String? get agentId;@JsonKey(fromJson: _stringOrNull) String? get gitBranch;@JsonKey(fromJson: _stringOrNull) String? get version;@JsonKey(fromJson: _stringOrNull) String? get aiTitle;@JsonKey(fromJson: _stringOrNull) String? get uuid;@JsonKey(fromJson: _boolOrNull) bool? get isMeta;@JsonKey(fromJson: _boolOrNull) bool? get isVisibleInTranscriptOnly;@JsonKey(fromJson: _boolOrNull) bool? get isApiErrorMessage;@JsonKey(fromJson: _intOrNull) int? get apiErrorStatus;@JsonKey(fromJson: _stringOrNull) String? get effort;@JsonKey(fromJson: _messageOrNull) ClaudeTranscriptMessageDto? get message;/// The typed result persisted beside a `user` record's tool result.
 @JsonKey(fromJson: ClaudeToolUseResult.parse) ClaudeToolUseResult get toolUseResult;/// `origin.kind`: how the CLI injected a `user` record that the user did
 /// not author, e.g. `task-notification`.
 @JsonKey(name: "origin", fromJson: _originKindOrNull) String? get originKind;
@@ -31,12 +31,12 @@ $ClaudeTranscriptRecordDtoCopyWith<ClaudeTranscriptRecordDto> get copyWith => _$
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ClaudeTranscriptRecordDto&&(identical(other.type, type) || other.type == type)&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.isSidechain, isSidechain) || other.isSidechain == isSidechain)&&(identical(other.agentId, agentId) || other.agentId == agentId)&&(identical(other.gitBranch, gitBranch) || other.gitBranch == gitBranch)&&(identical(other.version, version) || other.version == version)&&(identical(other.aiTitle, aiTitle) || other.aiTitle == aiTitle)&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.isMeta, isMeta) || other.isMeta == isMeta)&&(identical(other.isVisibleInTranscriptOnly, isVisibleInTranscriptOnly) || other.isVisibleInTranscriptOnly == isVisibleInTranscriptOnly)&&(identical(other.effort, effort) || other.effort == effort)&&(identical(other.message, message) || other.message == message)&&(identical(other.toolUseResult, toolUseResult) || other.toolUseResult == toolUseResult)&&(identical(other.originKind, originKind) || other.originKind == originKind));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ClaudeTranscriptRecordDto&&(identical(other.type, type) || other.type == type)&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.isSidechain, isSidechain) || other.isSidechain == isSidechain)&&(identical(other.agentId, agentId) || other.agentId == agentId)&&(identical(other.gitBranch, gitBranch) || other.gitBranch == gitBranch)&&(identical(other.version, version) || other.version == version)&&(identical(other.aiTitle, aiTitle) || other.aiTitle == aiTitle)&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.isMeta, isMeta) || other.isMeta == isMeta)&&(identical(other.isVisibleInTranscriptOnly, isVisibleInTranscriptOnly) || other.isVisibleInTranscriptOnly == isVisibleInTranscriptOnly)&&(identical(other.isApiErrorMessage, isApiErrorMessage) || other.isApiErrorMessage == isApiErrorMessage)&&(identical(other.apiErrorStatus, apiErrorStatus) || other.apiErrorStatus == apiErrorStatus)&&(identical(other.effort, effort) || other.effort == effort)&&(identical(other.message, message) || other.message == message)&&(identical(other.toolUseResult, toolUseResult) || other.toolUseResult == toolUseResult)&&(identical(other.originKind, originKind) || other.originKind == originKind));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,type,sessionId,cwd,timestamp,isSidechain,agentId,gitBranch,version,aiTitle,uuid,isMeta,isVisibleInTranscriptOnly,effort,message,toolUseResult,originKind);
+int get hashCode => Object.hash(runtimeType,type,sessionId,cwd,timestamp,isSidechain,agentId,gitBranch,version,aiTitle,uuid,isMeta,isVisibleInTranscriptOnly,isApiErrorMessage,apiErrorStatus,effort,message,toolUseResult,originKind);
 
 
 
@@ -47,7 +47,7 @@ abstract mixin class $ClaudeTranscriptRecordDtoCopyWith<$Res>  {
   factory $ClaudeTranscriptRecordDtoCopyWith(ClaudeTranscriptRecordDto value, $Res Function(ClaudeTranscriptRecordDto) _then) = _$ClaudeTranscriptRecordDtoCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(fromJson: _stringOrNull) String? type,@JsonKey(fromJson: _stringOrNull) String? sessionId,@JsonKey(fromJson: _stringOrNull) String? cwd,@JsonKey(fromJson: _timestampOrNull) DateTime? timestamp,@JsonKey(fromJson: _boolOrNull) bool? isSidechain,@JsonKey(fromJson: _stringOrNull) String? agentId,@JsonKey(fromJson: _stringOrNull) String? gitBranch,@JsonKey(fromJson: _stringOrNull) String? version,@JsonKey(fromJson: _stringOrNull) String? aiTitle,@JsonKey(fromJson: _stringOrNull) String? uuid,@JsonKey(fromJson: _boolOrNull) bool? isMeta,@JsonKey(fromJson: _boolOrNull) bool? isVisibleInTranscriptOnly,@JsonKey(fromJson: _stringOrNull) String? effort,@JsonKey(fromJson: _messageOrNull) ClaudeTranscriptMessageDto? message,@JsonKey(fromJson: ClaudeToolUseResult.parse) ClaudeToolUseResult toolUseResult,@JsonKey(name: "origin", fromJson: _originKindOrNull) String? originKind
+@JsonKey(fromJson: _stringOrNull) String? type,@JsonKey(fromJson: _stringOrNull) String? sessionId,@JsonKey(fromJson: _stringOrNull) String? cwd,@JsonKey(fromJson: _timestampOrNull) DateTime? timestamp,@JsonKey(fromJson: _boolOrNull) bool? isSidechain,@JsonKey(fromJson: _stringOrNull) String? agentId,@JsonKey(fromJson: _stringOrNull) String? gitBranch,@JsonKey(fromJson: _stringOrNull) String? version,@JsonKey(fromJson: _stringOrNull) String? aiTitle,@JsonKey(fromJson: _stringOrNull) String? uuid,@JsonKey(fromJson: _boolOrNull) bool? isMeta,@JsonKey(fromJson: _boolOrNull) bool? isVisibleInTranscriptOnly,@JsonKey(fromJson: _boolOrNull) bool? isApiErrorMessage,@JsonKey(fromJson: _intOrNull) int? apiErrorStatus,@JsonKey(fromJson: _stringOrNull) String? effort,@JsonKey(fromJson: _messageOrNull) ClaudeTranscriptMessageDto? message,@JsonKey(fromJson: ClaudeToolUseResult.parse) ClaudeToolUseResult toolUseResult,@JsonKey(name: "origin", fromJson: _originKindOrNull) String? originKind
 });
 
 
@@ -64,7 +64,7 @@ class _$ClaudeTranscriptRecordDtoCopyWithImpl<$Res>
 
 /// Create a copy of ClaudeTranscriptRecordDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? type = freezed,Object? sessionId = freezed,Object? cwd = freezed,Object? timestamp = freezed,Object? isSidechain = freezed,Object? agentId = freezed,Object? gitBranch = freezed,Object? version = freezed,Object? aiTitle = freezed,Object? uuid = freezed,Object? isMeta = freezed,Object? isVisibleInTranscriptOnly = freezed,Object? effort = freezed,Object? message = freezed,Object? toolUseResult = null,Object? originKind = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? type = freezed,Object? sessionId = freezed,Object? cwd = freezed,Object? timestamp = freezed,Object? isSidechain = freezed,Object? agentId = freezed,Object? gitBranch = freezed,Object? version = freezed,Object? aiTitle = freezed,Object? uuid = freezed,Object? isMeta = freezed,Object? isVisibleInTranscriptOnly = freezed,Object? isApiErrorMessage = freezed,Object? apiErrorStatus = freezed,Object? effort = freezed,Object? message = freezed,Object? toolUseResult = null,Object? originKind = freezed,}) {
   return _then(ClaudeTranscriptRecordDto(
 type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
 as String?,sessionId: freezed == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
@@ -78,7 +78,9 @@ as String?,aiTitle: freezed == aiTitle ? _self.aiTitle : aiTitle // ignore: cast
 as String?,uuid: freezed == uuid ? _self.uuid : uuid // ignore: cast_nullable_to_non_nullable
 as String?,isMeta: freezed == isMeta ? _self.isMeta : isMeta // ignore: cast_nullable_to_non_nullable
 as bool?,isVisibleInTranscriptOnly: freezed == isVisibleInTranscriptOnly ? _self.isVisibleInTranscriptOnly : isVisibleInTranscriptOnly // ignore: cast_nullable_to_non_nullable
-as bool?,effort: freezed == effort ? _self.effort : effort // ignore: cast_nullable_to_non_nullable
+as bool?,isApiErrorMessage: freezed == isApiErrorMessage ? _self.isApiErrorMessage : isApiErrorMessage // ignore: cast_nullable_to_non_nullable
+as bool?,apiErrorStatus: freezed == apiErrorStatus ? _self.apiErrorStatus : apiErrorStatus // ignore: cast_nullable_to_non_nullable
+as int?,effort: freezed == effort ? _self.effort : effort // ignore: cast_nullable_to_non_nullable
 as String?,message: freezed == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
 as ClaudeTranscriptMessageDto?,toolUseResult: null == toolUseResult ? _self.toolUseResult : toolUseResult // ignore: cast_nullable_to_non_nullable
 as ClaudeToolUseResult,originKind: freezed == originKind ? _self.originKind : originKind // ignore: cast_nullable_to_non_nullable
@@ -106,7 +108,7 @@ $ClaudeTranscriptMessageDtoCopyWith<$Res>? get message {
 @JsonSerializable(createToJson: false)
 
 class _ClaudeTranscriptRecordDto implements ClaudeTranscriptRecordDto {
-  const _ClaudeTranscriptRecordDto({@JsonKey(fromJson: _stringOrNull) required this.type, @JsonKey(fromJson: _stringOrNull) required this.sessionId, @JsonKey(fromJson: _stringOrNull) required this.cwd, @JsonKey(fromJson: _timestampOrNull) required this.timestamp, @JsonKey(fromJson: _boolOrNull) required this.isSidechain, @JsonKey(fromJson: _stringOrNull) required this.agentId, @JsonKey(fromJson: _stringOrNull) required this.gitBranch, @JsonKey(fromJson: _stringOrNull) required this.version, @JsonKey(fromJson: _stringOrNull) required this.aiTitle, @JsonKey(fromJson: _stringOrNull) required this.uuid, @JsonKey(fromJson: _boolOrNull) required this.isMeta, @JsonKey(fromJson: _boolOrNull) required this.isVisibleInTranscriptOnly, @JsonKey(fromJson: _stringOrNull) required this.effort, @JsonKey(fromJson: _messageOrNull) required this.message, @JsonKey(fromJson: ClaudeToolUseResult.parse) required this.toolUseResult, @JsonKey(name: "origin", fromJson: _originKindOrNull) required this.originKind});
+  const _ClaudeTranscriptRecordDto({@JsonKey(fromJson: _stringOrNull) required this.type, @JsonKey(fromJson: _stringOrNull) required this.sessionId, @JsonKey(fromJson: _stringOrNull) required this.cwd, @JsonKey(fromJson: _timestampOrNull) required this.timestamp, @JsonKey(fromJson: _boolOrNull) required this.isSidechain, @JsonKey(fromJson: _stringOrNull) required this.agentId, @JsonKey(fromJson: _stringOrNull) required this.gitBranch, @JsonKey(fromJson: _stringOrNull) required this.version, @JsonKey(fromJson: _stringOrNull) required this.aiTitle, @JsonKey(fromJson: _stringOrNull) required this.uuid, @JsonKey(fromJson: _boolOrNull) required this.isMeta, @JsonKey(fromJson: _boolOrNull) required this.isVisibleInTranscriptOnly, @JsonKey(fromJson: _boolOrNull) required this.isApiErrorMessage, @JsonKey(fromJson: _intOrNull) required this.apiErrorStatus, @JsonKey(fromJson: _stringOrNull) required this.effort, @JsonKey(fromJson: _messageOrNull) required this.message, @JsonKey(fromJson: ClaudeToolUseResult.parse) required this.toolUseResult, @JsonKey(name: "origin", fromJson: _originKindOrNull) required this.originKind});
   factory _ClaudeTranscriptRecordDto.fromJson(Map<String, dynamic> json) => _$ClaudeTranscriptRecordDtoFromJson(json);
 
 @override@JsonKey(fromJson: _stringOrNull) final  String? type;
@@ -122,6 +124,8 @@ class _ClaudeTranscriptRecordDto implements ClaudeTranscriptRecordDto {
 @override@JsonKey(fromJson: _stringOrNull) final  String? uuid;
 @override@JsonKey(fromJson: _boolOrNull) final  bool? isMeta;
 @override@JsonKey(fromJson: _boolOrNull) final  bool? isVisibleInTranscriptOnly;
+@override@JsonKey(fromJson: _boolOrNull) final  bool? isApiErrorMessage;
+@override@JsonKey(fromJson: _intOrNull) final  int? apiErrorStatus;
 @override@JsonKey(fromJson: _stringOrNull) final  String? effort;
 @override@JsonKey(fromJson: _messageOrNull) final  ClaudeTranscriptMessageDto? message;
 /// The typed result persisted beside a `user` record's tool result.
@@ -140,12 +144,12 @@ _$ClaudeTranscriptRecordDtoCopyWith<_ClaudeTranscriptRecordDto> get copyWith => 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ClaudeTranscriptRecordDto&&(identical(other.type, type) || other.type == type)&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.isSidechain, isSidechain) || other.isSidechain == isSidechain)&&(identical(other.agentId, agentId) || other.agentId == agentId)&&(identical(other.gitBranch, gitBranch) || other.gitBranch == gitBranch)&&(identical(other.version, version) || other.version == version)&&(identical(other.aiTitle, aiTitle) || other.aiTitle == aiTitle)&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.isMeta, isMeta) || other.isMeta == isMeta)&&(identical(other.isVisibleInTranscriptOnly, isVisibleInTranscriptOnly) || other.isVisibleInTranscriptOnly == isVisibleInTranscriptOnly)&&(identical(other.effort, effort) || other.effort == effort)&&(identical(other.message, message) || other.message == message)&&(identical(other.toolUseResult, toolUseResult) || other.toolUseResult == toolUseResult)&&(identical(other.originKind, originKind) || other.originKind == originKind));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ClaudeTranscriptRecordDto&&(identical(other.type, type) || other.type == type)&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.isSidechain, isSidechain) || other.isSidechain == isSidechain)&&(identical(other.agentId, agentId) || other.agentId == agentId)&&(identical(other.gitBranch, gitBranch) || other.gitBranch == gitBranch)&&(identical(other.version, version) || other.version == version)&&(identical(other.aiTitle, aiTitle) || other.aiTitle == aiTitle)&&(identical(other.uuid, uuid) || other.uuid == uuid)&&(identical(other.isMeta, isMeta) || other.isMeta == isMeta)&&(identical(other.isVisibleInTranscriptOnly, isVisibleInTranscriptOnly) || other.isVisibleInTranscriptOnly == isVisibleInTranscriptOnly)&&(identical(other.isApiErrorMessage, isApiErrorMessage) || other.isApiErrorMessage == isApiErrorMessage)&&(identical(other.apiErrorStatus, apiErrorStatus) || other.apiErrorStatus == apiErrorStatus)&&(identical(other.effort, effort) || other.effort == effort)&&(identical(other.message, message) || other.message == message)&&(identical(other.toolUseResult, toolUseResult) || other.toolUseResult == toolUseResult)&&(identical(other.originKind, originKind) || other.originKind == originKind));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,type,sessionId,cwd,timestamp,isSidechain,agentId,gitBranch,version,aiTitle,uuid,isMeta,isVisibleInTranscriptOnly,effort,message,toolUseResult,originKind);
+int get hashCode => Object.hash(runtimeType,type,sessionId,cwd,timestamp,isSidechain,agentId,gitBranch,version,aiTitle,uuid,isMeta,isVisibleInTranscriptOnly,isApiErrorMessage,apiErrorStatus,effort,message,toolUseResult,originKind);
 
 
 
@@ -156,7 +160,7 @@ abstract mixin class _$ClaudeTranscriptRecordDtoCopyWith<$Res> implements $Claud
   factory _$ClaudeTranscriptRecordDtoCopyWith(_ClaudeTranscriptRecordDto value, $Res Function(_ClaudeTranscriptRecordDto) _then) = __$ClaudeTranscriptRecordDtoCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(fromJson: _stringOrNull) String? type,@JsonKey(fromJson: _stringOrNull) String? sessionId,@JsonKey(fromJson: _stringOrNull) String? cwd,@JsonKey(fromJson: _timestampOrNull) DateTime? timestamp,@JsonKey(fromJson: _boolOrNull) bool? isSidechain,@JsonKey(fromJson: _stringOrNull) String? agentId,@JsonKey(fromJson: _stringOrNull) String? gitBranch,@JsonKey(fromJson: _stringOrNull) String? version,@JsonKey(fromJson: _stringOrNull) String? aiTitle,@JsonKey(fromJson: _stringOrNull) String? uuid,@JsonKey(fromJson: _boolOrNull) bool? isMeta,@JsonKey(fromJson: _boolOrNull) bool? isVisibleInTranscriptOnly,@JsonKey(fromJson: _stringOrNull) String? effort,@JsonKey(fromJson: _messageOrNull) ClaudeTranscriptMessageDto? message,@JsonKey(fromJson: ClaudeToolUseResult.parse) ClaudeToolUseResult toolUseResult,@JsonKey(name: "origin", fromJson: _originKindOrNull) String? originKind
+@JsonKey(fromJson: _stringOrNull) String? type,@JsonKey(fromJson: _stringOrNull) String? sessionId,@JsonKey(fromJson: _stringOrNull) String? cwd,@JsonKey(fromJson: _timestampOrNull) DateTime? timestamp,@JsonKey(fromJson: _boolOrNull) bool? isSidechain,@JsonKey(fromJson: _stringOrNull) String? agentId,@JsonKey(fromJson: _stringOrNull) String? gitBranch,@JsonKey(fromJson: _stringOrNull) String? version,@JsonKey(fromJson: _stringOrNull) String? aiTitle,@JsonKey(fromJson: _stringOrNull) String? uuid,@JsonKey(fromJson: _boolOrNull) bool? isMeta,@JsonKey(fromJson: _boolOrNull) bool? isVisibleInTranscriptOnly,@JsonKey(fromJson: _boolOrNull) bool? isApiErrorMessage,@JsonKey(fromJson: _intOrNull) int? apiErrorStatus,@JsonKey(fromJson: _stringOrNull) String? effort,@JsonKey(fromJson: _messageOrNull) ClaudeTranscriptMessageDto? message,@JsonKey(fromJson: ClaudeToolUseResult.parse) ClaudeToolUseResult toolUseResult,@JsonKey(name: "origin", fromJson: _originKindOrNull) String? originKind
 });
 
 
@@ -173,7 +177,7 @@ class __$ClaudeTranscriptRecordDtoCopyWithImpl<$Res>
 
 /// Create a copy of ClaudeTranscriptRecordDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? type = freezed,Object? sessionId = freezed,Object? cwd = freezed,Object? timestamp = freezed,Object? isSidechain = freezed,Object? agentId = freezed,Object? gitBranch = freezed,Object? version = freezed,Object? aiTitle = freezed,Object? uuid = freezed,Object? isMeta = freezed,Object? isVisibleInTranscriptOnly = freezed,Object? effort = freezed,Object? message = freezed,Object? toolUseResult = null,Object? originKind = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? type = freezed,Object? sessionId = freezed,Object? cwd = freezed,Object? timestamp = freezed,Object? isSidechain = freezed,Object? agentId = freezed,Object? gitBranch = freezed,Object? version = freezed,Object? aiTitle = freezed,Object? uuid = freezed,Object? isMeta = freezed,Object? isVisibleInTranscriptOnly = freezed,Object? isApiErrorMessage = freezed,Object? apiErrorStatus = freezed,Object? effort = freezed,Object? message = freezed,Object? toolUseResult = null,Object? originKind = freezed,}) {
   return _then(_ClaudeTranscriptRecordDto(
 type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
 as String?,sessionId: freezed == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
@@ -187,7 +191,9 @@ as String?,aiTitle: freezed == aiTitle ? _self.aiTitle : aiTitle // ignore: cast
 as String?,uuid: freezed == uuid ? _self.uuid : uuid // ignore: cast_nullable_to_non_nullable
 as String?,isMeta: freezed == isMeta ? _self.isMeta : isMeta // ignore: cast_nullable_to_non_nullable
 as bool?,isVisibleInTranscriptOnly: freezed == isVisibleInTranscriptOnly ? _self.isVisibleInTranscriptOnly : isVisibleInTranscriptOnly // ignore: cast_nullable_to_non_nullable
-as bool?,effort: freezed == effort ? _self.effort : effort // ignore: cast_nullable_to_non_nullable
+as bool?,isApiErrorMessage: freezed == isApiErrorMessage ? _self.isApiErrorMessage : isApiErrorMessage // ignore: cast_nullable_to_non_nullable
+as bool?,apiErrorStatus: freezed == apiErrorStatus ? _self.apiErrorStatus : apiErrorStatus // ignore: cast_nullable_to_non_nullable
+as int?,effort: freezed == effort ? _self.effort : effort // ignore: cast_nullable_to_non_nullable
 as String?,message: freezed == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
 as ClaudeTranscriptMessageDto?,toolUseResult: null == toolUseResult ? _self.toolUseResult : toolUseResult // ignore: cast_nullable_to_non_nullable
 as ClaudeToolUseResult,originKind: freezed == originKind ? _self.originKind : originKind // ignore: cast_nullable_to_non_nullable

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_transcript_record_dto.g.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_transcript_record_dto.g.dart
@@ -6,27 +6,31 @@ part of 'claude_transcript_record_dto.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_ClaudeTranscriptRecordDto _$ClaudeTranscriptRecordDtoFromJson(Map json) => _ClaudeTranscriptRecordDto(
-  type: _stringOrNull(json['type']),
-  sessionId: _stringOrNull(json['sessionId']),
-  cwd: _stringOrNull(json['cwd']),
-  timestamp: _timestampOrNull(json['timestamp']),
-  isSidechain: _boolOrNull(json['isSidechain']),
-  agentId: _stringOrNull(json['agentId']),
-  gitBranch: _stringOrNull(json['gitBranch']),
-  version: _stringOrNull(json['version']),
-  aiTitle: _stringOrNull(json['aiTitle']),
-  uuid: _stringOrNull(json['uuid']),
-  isMeta: _boolOrNull(json['isMeta']),
-  isVisibleInTranscriptOnly: _boolOrNull(json['isVisibleInTranscriptOnly']),
-  effort: _stringOrNull(json['effort']),
-  message: _messageOrNull(json['message']),
-  toolUseResult: ClaudeToolUseResult.parse(json['toolUseResult']),
-  originKind: _originKindOrNull(json['origin']),
-);
+_ClaudeTranscriptRecordDto _$ClaudeTranscriptRecordDtoFromJson(Map json) =>
+    _ClaudeTranscriptRecordDto(
+      type: _stringOrNull(json['type']),
+      sessionId: _stringOrNull(json['sessionId']),
+      cwd: _stringOrNull(json['cwd']),
+      timestamp: _timestampOrNull(json['timestamp']),
+      isSidechain: _boolOrNull(json['isSidechain']),
+      agentId: _stringOrNull(json['agentId']),
+      gitBranch: _stringOrNull(json['gitBranch']),
+      version: _stringOrNull(json['version']),
+      aiTitle: _stringOrNull(json['aiTitle']),
+      uuid: _stringOrNull(json['uuid']),
+      isMeta: _boolOrNull(json['isMeta']),
+      isVisibleInTranscriptOnly: _boolOrNull(json['isVisibleInTranscriptOnly']),
+      isApiErrorMessage: _boolOrNull(json['isApiErrorMessage']),
+      apiErrorStatus: _intOrNull(json['apiErrorStatus']),
+      effort: _stringOrNull(json['effort']),
+      message: _messageOrNull(json['message']),
+      toolUseResult: ClaudeToolUseResult.parse(json['toolUseResult']),
+      originKind: _originKindOrNull(json['origin']),
+    );
 
-_ClaudeTranscriptMessageDto _$ClaudeTranscriptMessageDtoFromJson(Map json) => _ClaudeTranscriptMessageDto(
-  id: _stringOrNull(json['id']),
-  model: _stringOrNull(json['model']),
-  content: json['content'],
-);
+_ClaudeTranscriptMessageDto _$ClaudeTranscriptMessageDtoFromJson(Map json) =>
+    _ClaudeTranscriptMessageDto(
+      id: _stringOrNull(json['id']),
+      model: _stringOrNull(json['model']),
+      content: json['content'],
+    );

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -18,6 +18,7 @@ final class ClaudeEventDispatcher({
   final Map<String, Set<int>> _streamedBlocks = {};
   final Map<String, Map<int, PluginMessagePart>> _completedStreamedParts = {};
   final Map<String, Set<String>> _streamedMessageIds = {};
+  final Set<String> _mappedApiErrorSessions = {};
 
   /// Content blocks already carried by `assistant` frames, per message id.
   ///
@@ -54,6 +55,7 @@ final class ClaudeEventDispatcher({
   void _resetTurn({required String sessionId}) {
     _messageIds.remove(sessionId);
     _announcedMessageIds.remove(sessionId);
+    _mappedApiErrorSessions.remove(sessionId);
     _clearStreamedMessages(sessionId: sessionId);
     _tools.beginTurn(sessionId: sessionId);
   }
@@ -77,6 +79,7 @@ final class ClaudeEventDispatcher({
   void _forgetRendered({required String sessionId}) {
     _messageIds.remove(sessionId);
     _announcedMessageIds.remove(sessionId);
+    _mappedApiErrorSessions.remove(sessionId);
     _models.remove(sessionId);
     _clearStreamedMessages(sessionId: sessionId);
     _tools.forgetSession(sessionId: sessionId);
@@ -326,6 +329,24 @@ final class ClaudeEventDispatcher({
     _streamedMessageIds.putIfAbsent(sessionId, () => <String>{}).add(messageId);
     if (_realModel(model: message.model) case final model?) _models[sessionId] = model;
     final mapped = _content.map(content: message.message["content"]);
+    if (message.error != ClaudeAssistantError.none) {
+      _mappedApiErrorSessions.add(sessionId);
+      return [
+        BridgeSseMessageUpdated(
+          info: PluginMessage.error(
+            id: messageId,
+            sessionID: sessionId,
+            agent: "claude",
+            modelID: _models[sessionId],
+            providerID: "anthropic",
+            variant: null,
+            errorName: _apiErrorName(status: message.apiErrorStatus),
+            errorMessage: _apiErrorMessage(blocks: mapped) ?? "Claude Code could not complete the API request.",
+            time: _messageTime(message.timestamp),
+          ).toJson(),
+        ),
+      ];
+    }
     // Counted before any filtering so a skipped block still occupies its
     // ordinal, exactly as it does in the stream and the transcript.
     final firstBlockIndex = _assistantBlockCounts[messageId] ?? 0;
@@ -509,6 +530,8 @@ final class ClaudeEventDispatcher({
     if (!message.isError && message.subtype == ClaudeResultSubtype.success && message.permissionDenials.isEmpty) {
       return const [];
     }
+    final mappedApiError = _mappedApiErrorSessions.remove(sessionId);
+    if (mappedApiError && message.isError) return const [];
     final messageId = _nonEmptyString(message.uuid);
     if (messageId == null) return const [];
     final error = _resultError(message);
@@ -639,6 +662,16 @@ PluginMessageTime? _messageTime(DateTime? timestamp) =>
 
 String _retryMessage(ClaudeApiRetryMessage message) => message.rawError ?? "Claude Code is retrying the request.";
 
+String? _apiErrorMessage({required List<ClaudeMappedContentBlock> blocks}) {
+  final text = [
+    for (final block in blocks)
+      if (block case ClaudeMappedTextContentBlock(:final text)) text,
+  ].join("\n");
+  return text.isEmpty ? null : text;
+}
+
+String _apiErrorName({required int? status}) => status == 401 || status == 403 ? "authentication_failed" : "api_error";
+
 ({String name, String message}) _resultError(ClaudeResultMessage result) {
   if (!result.isError && result.subtype == ClaudeResultSubtype.success && result.permissionDenials.isNotEmpty) {
     return (name: "permission_denied", message: "Claude Code denied a tool without requesting permission.");
@@ -650,7 +683,7 @@ String _retryMessage(ClaudeApiRetryMessage message) => message.rawError ?? "Clau
 
 ({String name, String message}) _resultErrorFallback(ClaudeResultMessage result) {
   if (result.apiErrorStatus == 401 || result.apiErrorStatus == 403) {
-    return (name: "authentication_failed", message: "Claude Code authentication failed.");
+    return (name: _apiErrorName(status: result.apiErrorStatus), message: "Claude Code authentication failed.");
   }
   return switch (result.terminalReason) {
     ClaudeTerminalReason.budgetExhausted => (
@@ -666,7 +699,7 @@ String _retryMessage(ClaudeApiRetryMessage message) => message.rawError ?? "Clau
       message: "Claude Code could not produce valid structured output.",
     ),
     ClaudeTerminalReason.apiError => (
-      name: "api_error",
+      name: _apiErrorName(status: result.apiErrorStatus),
       message: result.apiErrorStatus == null
           ? "Claude Code could not complete the API request."
           : "Claude Code could not complete the API request (HTTP ${result.apiErrorStatus}).",

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -4,6 +4,7 @@ import "package:sesori_shared/sesori_shared.dart" as shared;
 import "api/models/claude_stream_message.dart";
 import "models/claude_task_notification.dart";
 import "models/claude_tool_use_result.dart";
+import "repositories/mappers/claude_api_error_mapper.dart";
 import "repositories/mappers/claude_content_mapper.dart";
 import "repositories/trackers/claude_tool_tracker.dart";
 
@@ -331,6 +332,7 @@ final class ClaudeEventDispatcher({
     final mapped = _content.map(content: message.message["content"]);
     if (message.error != ClaudeAssistantError.none) {
       _mappedApiErrorSessions.add(sessionId);
+      final error = mapClaudeApiError(blocks: mapped, status: message.apiErrorStatus);
       return [
         BridgeSseMessageUpdated(
           info: PluginMessage.error(
@@ -340,8 +342,8 @@ final class ClaudeEventDispatcher({
             modelID: _models[sessionId],
             providerID: "anthropic",
             variant: null,
-            errorName: _apiErrorName(status: message.apiErrorStatus),
-            errorMessage: _apiErrorMessage(blocks: mapped) ?? "Claude Code could not complete the API request.",
+            errorName: error.name,
+            errorMessage: error.message,
             time: _messageTime(message.timestamp),
           ).toJson(),
         ),
@@ -662,16 +664,6 @@ PluginMessageTime? _messageTime(DateTime? timestamp) =>
 
 String _retryMessage(ClaudeApiRetryMessage message) => message.rawError ?? "Claude Code is retrying the request.";
 
-String? _apiErrorMessage({required List<ClaudeMappedContentBlock> blocks}) {
-  final text = [
-    for (final block in blocks)
-      if (block case ClaudeMappedTextContentBlock(:final text)) text,
-  ].join("\n");
-  return text.isEmpty ? null : text;
-}
-
-String _apiErrorName({required int? status}) => status == 401 || status == 403 ? "authentication_failed" : "api_error";
-
 ({String name, String message}) _resultError(ClaudeResultMessage result) {
   if (!result.isError && result.subtype == ClaudeResultSubtype.success && result.permissionDenials.isNotEmpty) {
     return (name: "permission_denied", message: "Claude Code denied a tool without requesting permission.");
@@ -683,7 +675,7 @@ String _apiErrorName({required int? status}) => status == 401 || status == 403 ?
 
 ({String name, String message}) _resultErrorFallback(ClaudeResultMessage result) {
   if (result.apiErrorStatus == 401 || result.apiErrorStatus == 403) {
-    return (name: _apiErrorName(status: result.apiErrorStatus), message: "Claude Code authentication failed.");
+    return (name: claudeApiErrorName(status: result.apiErrorStatus), message: "Claude Code authentication failed.");
   }
   return switch (result.terminalReason) {
     ClaudeTerminalReason.budgetExhausted => (
@@ -699,7 +691,7 @@ String _apiErrorName({required int? status}) => status == 401 || status == 403 ?
       message: "Claude Code could not produce valid structured output.",
     ),
     ClaudeTerminalReason.apiError => (
-      name: _apiErrorName(status: result.apiErrorStatus),
+      name: claudeApiErrorName(status: result.apiErrorStatus),
       message: result.apiErrorStatus == null
           ? "Claude Code could not complete the API request."
           : "Claude Code could not complete the API request (HTTP ${result.apiErrorStatus}).",

--- a/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
@@ -1,6 +1,7 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "models/claude_tool_use_result.dart";
+import "repositories/mappers/claude_api_error_mapper.dart";
 import "repositories/mappers/claude_content_mapper.dart";
 import "repositories/models/claude_transcript_record.dart";
 import "repositories/trackers/claude_tool_tracker.dart";
@@ -31,6 +32,7 @@ final class const ClaudeHistoryMapper({
     final entries = <_ClaudeHistoryEntry>[];
     final assistantsByMessageId = <String, _AssistantHistoryMessage>{};
     final assistantsByToolId = <String, _AssistantHistoryMessage>{};
+    final apiErrorsByMessageId = <String, _ApiErrorHistoryMessage>{};
     String? lastRealModel;
     // Task lifecycle replays through the same tracker the live path uses, so
     // terminal precedence has exactly one implementation.
@@ -71,26 +73,18 @@ final class const ClaudeHistoryMapper({
           }
         case ClaudeTranscriptApiErrorRecord():
           if (skip(record)) continue;
-          final errorMessage = _apiErrorMessage(blocks: _content.map(content: record.content));
-          if (errorMessage == null) continue;
-          entries.add(
-            _ErrorHistoryMessage(
-              message: PluginMessageWithParts(
-                info: PluginMessage.error(
-                  id: record.id,
-                  sessionID: sessionId,
-                  agent: "claude",
-                  modelID: lastRealModel,
-                  providerID: "anthropic",
-                  variant: null,
-                  errorName: _apiErrorName(status: record.apiErrorStatus),
-                  errorMessage: errorMessage,
-                  time: _messageTime(record.timestamp),
-                ),
-                parts: const [],
-              ),
-            ),
-          );
+          final apiError = apiErrorsByMessageId.putIfAbsent(record.id, () {
+            final created = _ApiErrorHistoryMessage(
+              id: record.id,
+              timestamp: record.timestamp,
+              model: lastRealModel,
+              apiErrorStatus: record.apiErrorStatus,
+            );
+            entries.add(created);
+            return created;
+          });
+          apiError.content.add(record.content);
+          apiError.apiErrorStatus ??= record.apiErrorStatus;
         case ClaudeTranscriptUserRecord():
           if (skip(record) || record.isMeta || record.isVisibleInTranscriptOnly) {
             continue;
@@ -174,14 +168,40 @@ final class const ClaudeHistoryMapper({
     final messages = <PluginMessageWithParts>[];
     for (final entry in entries) {
       switch (entry) {
-        case _UserHistoryMessage(:final message) || _ErrorHistoryMessage(:final message):
+        case _UserHistoryMessage(:final message):
           messages.add(message);
+        case _ApiErrorHistoryMessage():
+          messages.add(_buildApiError(entry: entry, sessionId: sessionId));
         case _AssistantHistoryMessage():
           final message = _buildAssistant(entry: entry, sessionId: sessionId, tasks: tasks);
           if (message != null) messages.add(message);
       }
     }
     return messages;
+  }
+
+  PluginMessageWithParts _buildApiError({
+    required _ApiErrorHistoryMessage entry,
+    required String sessionId,
+  }) {
+    final error = mapClaudeApiError(
+      blocks: _content.map(content: entry.content),
+      status: entry.apiErrorStatus,
+    );
+    return PluginMessageWithParts(
+      info: PluginMessage.error(
+        id: entry.id,
+        sessionID: sessionId,
+        agent: "claude",
+        modelID: entry.model,
+        providerID: "anthropic",
+        variant: null,
+        errorName: error.name,
+        errorMessage: error.message,
+        time: _messageTime(entry.timestamp),
+      ),
+      parts: const [],
+    );
   }
 
   PluginMessageWithParts? _buildAssistant({
@@ -239,7 +259,14 @@ sealed class const _ClaudeHistoryEntry();
 
 final class const _UserHistoryMessage({required final PluginMessageWithParts message}) extends _ClaudeHistoryEntry;
 
-final class const _ErrorHistoryMessage({required final PluginMessageWithParts message}) extends _ClaudeHistoryEntry;
+final class _ApiErrorHistoryMessage({
+  required final String id,
+  required final DateTime? timestamp,
+  required final String? model,
+  required var int? apiErrorStatus,
+}) extends _ClaudeHistoryEntry {
+  final List<Object?> content = [];
+}
 
 final class _AssistantHistoryMessage({
   required final String id,
@@ -252,13 +279,3 @@ final class _AssistantHistoryMessage({
 
 PluginMessageTime? _messageTime(DateTime? timestamp) =>
     timestamp == null ? null : PluginMessageTime(created: timestamp.millisecondsSinceEpoch, completed: null);
-
-String? _apiErrorMessage({required List<ClaudeMappedContentBlock> blocks}) {
-  final text = [
-    for (final block in blocks)
-      if (block case ClaudeMappedTextContentBlock(:final text)) text,
-  ].join("\n");
-  return text.isEmpty ? null : text;
-}
-
-String _apiErrorName({required int? status}) => status == 401 || status == 403 ? "authentication_failed" : "api_error";

--- a/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
@@ -31,6 +31,7 @@ final class const ClaudeHistoryMapper({
     final entries = <_ClaudeHistoryEntry>[];
     final assistantsByMessageId = <String, _AssistantHistoryMessage>{};
     final assistantsByToolId = <String, _AssistantHistoryMessage>{};
+    String? lastRealModel;
     // Task lifecycle replays through the same tracker the live path uses, so
     // terminal precedence has exactly one implementation.
     final tasks = ClaudeToolTracker();
@@ -41,6 +42,7 @@ final class const ClaudeHistoryMapper({
           if (skip(record)) continue;
           final blocks = _content.map(content: record.content);
           if (_content.containsInternalCommandOutput(blocks: blocks)) continue;
+          if (record.model case final model? when model != "<synthetic>") lastRealModel = model;
           final assistant = assistantsByMessageId.putIfAbsent(record.id, () {
             final created = _AssistantHistoryMessage(
               id: record.id,
@@ -67,6 +69,28 @@ final class const ClaudeHistoryMapper({
               );
             }
           }
+        case ClaudeTranscriptApiErrorRecord():
+          if (skip(record)) continue;
+          final errorMessage = _apiErrorMessage(blocks: _content.map(content: record.content));
+          if (errorMessage == null) continue;
+          entries.add(
+            _ErrorHistoryMessage(
+              message: PluginMessageWithParts(
+                info: PluginMessage.error(
+                  id: record.id,
+                  sessionID: sessionId,
+                  agent: "claude",
+                  modelID: lastRealModel,
+                  providerID: "anthropic",
+                  variant: null,
+                  errorName: _apiErrorName(status: record.apiErrorStatus),
+                  errorMessage: errorMessage,
+                  time: _messageTime(record.timestamp),
+                ),
+                parts: const [],
+              ),
+            ),
+          );
         case ClaudeTranscriptUserRecord():
           if (skip(record) || record.isMeta || record.isVisibleInTranscriptOnly) {
             continue;
@@ -150,7 +174,7 @@ final class const ClaudeHistoryMapper({
     final messages = <PluginMessageWithParts>[];
     for (final entry in entries) {
       switch (entry) {
-        case _UserHistoryMessage(:final message):
+        case _UserHistoryMessage(:final message) || _ErrorHistoryMessage(:final message):
           messages.add(message);
         case _AssistantHistoryMessage():
           final message = _buildAssistant(entry: entry, sessionId: sessionId, tasks: tasks);
@@ -215,6 +239,8 @@ sealed class const _ClaudeHistoryEntry();
 
 final class const _UserHistoryMessage({required final PluginMessageWithParts message}) extends _ClaudeHistoryEntry;
 
+final class const _ErrorHistoryMessage({required final PluginMessageWithParts message}) extends _ClaudeHistoryEntry;
+
 final class _AssistantHistoryMessage({
   required final String id,
   required final DateTime? timestamp,
@@ -226,3 +252,13 @@ final class _AssistantHistoryMessage({
 
 PluginMessageTime? _messageTime(DateTime? timestamp) =>
     timestamp == null ? null : PluginMessageTime(created: timestamp.millisecondsSinceEpoch, completed: null);
+
+String? _apiErrorMessage({required List<ClaudeMappedContentBlock> blocks}) {
+  final text = [
+    for (final block in blocks)
+      if (block case ClaudeMappedTextContentBlock(:final text)) text,
+  ].join("\n");
+  return text.isEmpty ? null : text;
+}
+
+String _apiErrorName({required int? status}) => status == 401 || status == 403 ? "authentication_failed" : "api_error";

--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_transcript_catalog_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_transcript_catalog_repository.dart
@@ -333,6 +333,21 @@ ClaudeTranscriptRecord _mapTranscriptRecord(ClaudeTranscriptLineDto line) {
   if (type == ClaudeTranscriptAssistantRecord.wireType) {
     final id = _nonEmpty(dto.message?.id);
     if (id != null) {
+      if (dto.isApiErrorMessage ?? false) {
+        return ClaudeTranscriptApiErrorRecord(
+          id: id,
+          content: dto.message?.content,
+          apiErrorStatus: dto.apiErrorStatus,
+          cwd: dto.cwd,
+          timestamp: dto.timestamp,
+          isSidechain: dto.isSidechain,
+          agentId: dto.agentId,
+          gitBranch: dto.gitBranch,
+          version: dto.version,
+          sessionId: dto.sessionId,
+          raw: line.raw,
+        );
+      }
       return ClaudeTranscriptAssistantRecord(
         id: id,
         model: _nonEmpty(dto.message?.model),

--- a/bridge/sesori_plugin_claude/lib/src/repositories/mappers/claude_api_error_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/mappers/claude_api_error_mapper.dart
@@ -1,0 +1,23 @@
+import "claude_content_mapper.dart";
+
+/// The backend-neutral fields used to render one Claude API failure.
+typedef ClaudeMappedApiError = ({String name, String message});
+
+/// Maps the API-failure shape shared by Claude's live and transcript paths.
+ClaudeMappedApiError mapClaudeApiError({
+  required List<ClaudeMappedContentBlock> blocks,
+  required int? status,
+}) {
+  final text = [
+    for (final block in blocks)
+      if (block case ClaudeMappedTextContentBlock(:final text)) text,
+  ].join("\n");
+  return (
+    name: claudeApiErrorName(status: status),
+    message: text.isEmpty ? "Claude Code could not complete the API request." : text,
+  );
+}
+
+/// The stable error category used by API failures with [status].
+String claudeApiErrorName({required int? status}) =>
+    status == 401 || status == 403 ? "authentication_failed" : "api_error";

--- a/bridge/sesori_plugin_claude/lib/src/repositories/models/claude_transcript_record.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/models/claude_transcript_record.dart
@@ -109,6 +109,26 @@ final class const ClaudeTranscriptAssistantRecord({
   static const String wireType = "assistant";
 }
 
+/// A CLI-generated API failure persisted using the `assistant` wire type.
+///
+/// Claude marks these records with `isApiErrorMessage` and uses a synthetic
+/// model. They are errors rather than assistant replies; keeping a separate
+/// variant prevents cold replay from rendering the explanatory text beside the
+/// equivalent terminal error captured from the live stream.
+final class const ClaudeTranscriptApiErrorRecord({
+  required final String id,
+  required final Object? content,
+  required final int? apiErrorStatus,
+  required super.cwd,
+  required super.timestamp,
+  required super.isSidechain,
+  required super.agentId,
+  required super.gitBranch,
+  required super.version,
+  required super.sessionId,
+  required super.raw,
+}) extends ClaudeTranscriptAttributedRecord;
+
 /// A user or assistant record with no usable persisted message identity.
 ///
 /// It can still attribute the transcript to a project, but cannot be replayed

--- a/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
@@ -569,6 +569,51 @@ void main() {
       expect(contextOnly, isEmpty);
     });
 
+    test("renders a synthetic API failure once with the transcript message identity", () {
+      _startMessage(mapper, messageId: "msg-real", model: "claude-opus-5");
+      final assistantEvents = _map(
+        mapper,
+        {
+          "type": "assistant",
+          "session_id": "session-1",
+          "uuid": "assistant-error-frame",
+          "error": "rate_limit",
+          "api_error_status": 429,
+          "timestamp": "2026-08-10T10:00:00.000Z",
+          "message": {
+            "id": "synthetic-error-message",
+            "model": "<synthetic>",
+            "content": [
+              {"type": "text", "text": "You've hit your session limit"},
+            ],
+          },
+        },
+      );
+      final resultEvents = _map(
+        mapper,
+        {
+          "type": "result",
+          "subtype": "success",
+          "session_id": "session-1",
+          "uuid": "separate-result-identity",
+          "is_error": true,
+          "terminal_reason": "api_error",
+          "api_error_status": 429,
+          "result": "You've hit your session limit",
+        },
+      );
+
+      final info = shared.Message.fromJson((assistantEvents.single as BridgeSseMessageUpdated).info);
+      expect(info, isA<shared.MessageError>());
+      final error = info as shared.MessageError;
+      expect(error.id, "synthetic-error-message");
+      expect(error.errorName, "api_error");
+      expect(error.errorMessage, "You've hit your session limit");
+      expect(error.modelID, "claude-opus-5");
+      expect(error.time?.created, DateTime.utc(2026, 8, 10, 10).millisecondsSinceEpoch);
+      expect(resultEvents, isEmpty, reason: "the terminal result describes the same API failure");
+    });
+
     test("maps retry and terminal errors without replacing backend text", () {
       final before = DateTime.now().millisecondsSinceEpoch;
       final retry =

--- a/bridge/sesori_plugin_claude/test/claude_history_mapper_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_history_mapper_test.dart
@@ -282,6 +282,52 @@ IMPORTANT: Do NOT create new worktrees.
       );
     });
 
+    test("replays CLI API failures as one error instead of a synthetic assistant", () async {
+      _writeTranscript(
+        temp: temp,
+        records: [
+          _messageRecord(
+            type: "assistant",
+            uuid: "real-assistant-record",
+            messageId: "real-assistant-message",
+            model: "claude-test-model",
+            content: const [
+              {"type": "text", "text": "answer"},
+            ],
+          ),
+          _messageRecord(
+            type: "assistant",
+            uuid: "api-error-record",
+            messageId: "synthetic-error-message",
+            model: "<synthetic>",
+            isApiErrorMessage: true,
+            apiErrorStatus: 429,
+            error: "rate_limit",
+            content: const [
+              {"type": "text", "text": "You've hit your session limit"},
+            ],
+          ),
+        ],
+      );
+
+      final messages = mapper.map(
+        sessionId: _sessionId,
+        agentId: null,
+        records: await transcripts.readTranscriptRecordsInIsolate(sessionId: _sessionId),
+        residentTaskToolUseIds: const {},
+      );
+
+      expect(messages, hasLength(2));
+      final error = messages.last;
+      expect(error.info, isA<PluginMessageError>());
+      expect(error.info.id, "synthetic-error-message");
+      expect((error.info as PluginMessageError).errorName, "api_error");
+      expect((error.info as PluginMessageError).errorMessage, "You've hit your session limit");
+      expect((error.info as PluginMessageError).modelID, "claude-test-model");
+      expect((error.info as PluginMessageError).providerID, "anthropic");
+      expect(error.parts, isEmpty);
+    });
+
     test("reads the typed tool-use result and task-notification origin from the transcript", () async {
       _writeTranscript(
         temp: temp,
@@ -355,6 +401,9 @@ Map<String, Object?> _messageRecord({
   bool? isSidechain,
   bool? isMeta,
   bool? isVisibleInTranscriptOnly,
+  bool? isApiErrorMessage,
+  int? apiErrorStatus,
+  String? error,
 }) => {
   "type": type,
   "sessionId": _sessionId,
@@ -363,6 +412,9 @@ Map<String, Object?> _messageRecord({
   "isSidechain": ?isSidechain,
   "isMeta": ?isMeta,
   "isVisibleInTranscriptOnly": ?isVisibleInTranscriptOnly,
+  "isApiErrorMessage": ?isApiErrorMessage,
+  "apiErrorStatus": ?apiErrorStatus,
+  "error": ?error,
   "effort": ?effort,
   "message": {"id": ?messageId, "model": ?model, "content": content},
 };

--- a/bridge/sesori_plugin_claude/test/claude_history_mapper_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_history_mapper_test.dart
@@ -307,6 +307,14 @@ IMPORTANT: Do NOT create new worktrees.
               {"type": "text", "text": "You've hit your session limit"},
             ],
           ),
+          _messageRecord(
+            type: "assistant",
+            uuid: "api-error-record-continuation",
+            messageId: "synthetic-error-message",
+            model: "<synthetic>",
+            isApiErrorMessage: true,
+            content: const [],
+          ),
         ],
       );
 
@@ -326,6 +334,32 @@ IMPORTANT: Do NOT create new worktrees.
       expect((error.info as PluginMessageError).modelID, "claude-test-model");
       expect((error.info as PluginMessageError).providerID, "anthropic");
       expect(error.parts, isEmpty);
+    });
+
+    test("uses the live fallback for a persisted API failure without text", () async {
+      _writeTranscript(
+        temp: temp,
+        records: [
+          _messageRecord(
+            type: "assistant",
+            uuid: "empty-api-error-record",
+            messageId: "empty-synthetic-error-message",
+            model: "<synthetic>",
+            isApiErrorMessage: true,
+            content: const [],
+          ),
+        ],
+      );
+
+      final messages = mapper.map(
+        sessionId: _sessionId,
+        agentId: null,
+        records: await transcripts.readTranscriptRecordsInIsolate(sessionId: _sessionId),
+        residentTaskToolUseIds: const {},
+      );
+
+      final error = messages.single.info as PluginMessageError;
+      expect(error.errorMessage, "Claude Code could not complete the API request.");
     });
 
     test("reads the typed tool-use result and task-notification origin from the transcript", () async {

--- a/bridge/sesori_plugin_claude/test/claude_stream_message_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_stream_message_test.dart
@@ -40,6 +40,26 @@ void main() {
       expect(message.model, "test-model-large");
       expect(message.messageId, "msg_1");
       expect(message.parentToolUseId, isNull);
+      expect(message.error, ClaudeAssistantError.none);
+    });
+
+    test("reads assistant API error metadata", () {
+      final message = ClaudeStreamMessage.parse({
+        "type": "assistant",
+        "session_id": "session-1",
+        "error": "rate_limit",
+        "api_error_status": 429,
+        "message": {
+          "id": "synthetic-error",
+          "model": "<synthetic>",
+          "content": [
+            {"type": "text", "text": "rate limited"},
+          ],
+        },
+      }) as ClaudeAssistantMessage;
+
+      expect(message.error, ClaudeAssistantError.rateLimit);
+      expect(message.apiErrorStatus, 429);
     });
 
     test("marks subagent traffic by parent tool use id", () {

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -95,10 +95,14 @@ reconnect or restart.
   part is swept the same way but to `cancelled` with no error text; because a
   root stays busy while any of its sub-agents runs, a live background
   sub-agent is never swept, only one whose bridge died.
-- Claude sub-agent transcripts (`<root>/subagents/agent-<agentId>.jsonl`)
-  replay as child sessions with stable message and part identities, so an open
-  child screen converges after a reload without duplicates; nested sub-agents
-  replay under the root.
+- Claude's CLI-authored API-failure assistant frame and its terminal result
+  render as one error with the persisted assistant message identity. Transcript
+  records marked `isApiErrorMessage` replay as that same error rather than as a
+  synthetic assistant reply, so live capture, cold open, and stale re-read do
+  not show the backend text twice. Claude sub-agent transcripts
+  (`<root>/subagents/agent-<agentId>.jsonl`) replay as child sessions with stable
+  message and part identities, so an open child screen converges after a reload
+  without duplicates; nested sub-agents replay under the root.
 - Pi history follows the active `leafId` branch while retaining visible
   pre-compaction messages, applies thinking-level changes to later assistant and
   error messages on that branch, and omits compaction and branch-summary
@@ -119,7 +123,7 @@ reconnect or restart.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Headless bridge, one representative plugin: a previously synced session's transcript is served with every backend stopped. |
-| L2 Routine | Live plugin, representative: first backfill, replayed prompt-default persistence and response precedence, live capture that becomes immediately queryable, semantic identity reconciliation with ordered-context and multiplicity preservation (including normalized attachments), stale re-read ordering for retained live-only rows, and paging older messages on a transcript longer than one page. Automated OpenCode, Codex, Claude, and Pi coverage preserves available historical effort or thinking-level variants from assistant/error messages; Pi covers active-branch attribution and file fallback. Automated Pi coverage also includes v1-v3 fallback migration, compaction visibility, hidden-context decoding, bounded tool/image mapping, content-index streaming, early tool-call metadata with the pre-0.84.3 fallback, duplicate terminal suppression, cumulative tool updates, and live/replay final parity. |
+| L2 Routine | Live plugin, representative: first backfill, replayed prompt-default persistence and response precedence, live capture that becomes immediately queryable, semantic identity reconciliation with ordered-context and multiplicity preservation (including normalized attachments), stale re-read ordering for retained live-only rows, and paging older messages on a transcript longer than one page. Automated OpenCode, Codex, Claude, and Pi coverage preserves available historical effort or thinking-level variants from assistant/error messages; Claude also covers one stable live/replay identity for a CLI-authored API failure and suppression of its duplicate terminal result, while Pi covers active-branch attribution and file fallback. Automated Pi coverage also includes v1-v3 fallback migration, compaction visibility, hidden-context decoding, bounded tool/image mapping, content-index streaming, early tool-call metadata with the pre-0.84.3 fallback, duplicate terminal suppression, cumulative tool updates, and live/replay final parity. |
 | L3 Release | Client end to end on the release-target client platform, every supporting production plugin: open a long session, page back, continue a live turn, reopen cold, and confirm live and replayed content converge including tool parts and image parts where declared. Grok additionally retains its exact loaded model/effort attribution across first load, cold reopen, plugin restart, and bridge restart. |
 | L4 Extended | Relay integration plus owning client automated coverage, every supporting production plugin: session advanced through the backend's own CLI, plugin restart and event-stream-gap invalidation, bridge restart, client reconnect inside and outside the replay window without refresh losing concurrently finalized content, two clients on one session, a slow request beside unrelated traffic. Copilot and Grok additionally replace their ACP process, reload the same session, and converge standard replay with the bridge transcript without duplicate live delivery. |
 | L5 Full | Automated and headless bridge for unreadable or partial store artifacts, interrupted backfill, and startup reconciliation; packaged or external for pagination's released-client shape; live plugin for very large transcripts. Every supporting production plugin. |
@@ -168,9 +172,11 @@ rules where supported.
   the session idle before `agent_settled`.
 - Buffered events are lost after a reconnect inside the replay window, or a slow
   request stalls other requests, plugins, or reconnects.
-- After a bridge restart an idle Claude root still shows a running subtask tile,
-  or a busy root's live background sub-agent tile is swept to cancelled; a
-  child transcript duplicates its parts after reload.
+- A Claude API failure appears once as ordinary assistant text and again as an
+  error, or changes identity between live delivery and transcript replay. After
+  a bridge restart an idle Claude root still shows a running subtask tile, or a
+  busy root's live background sub-agent tile is swept to cancelled; a child
+  transcript duplicates its parts after reload.
 - A Copilot restart prompts before `session/load`, duplicates replay as new live
   output, or reads private history files instead of the ACP replay boundary.
 - Grok replay mutates live defaults during initialize, stamps messages from an


### PR DESCRIPTION
## Complexity

🌿 Straightforward — the fix stays within Claude Code's stream/transcript mapping boundary and reuses existing message-error presentation.

## What

- Map Claude API-error assistant frames directly to one error message using the persisted assistant message ID.
- Suppress the paired terminal result so it cannot create a second error identity.
- Decode `isApiErrorMessage` and `apiErrorStatus` from Claude transcripts and replay those records as the same error shape instead of a synthetic assistant reply.
- Add live, parsing, cold-history, and regression-document coverage.

## Why

Claude Code emits one API failure through two representations: a synthetic assistant record containing the user-facing text and a terminal error result. Sesori rendered both, producing identical normal-text and red-error rows, and cold replay could restore the synthetic row again.

## Risk and test focus

The change is Claude-plugin-specific. Tests focus on preserving backend text, prior real-model attribution, stable live/replay identity, and terminal duplicate suppression. There is no database schema, migration, client wire-contract, or analytics impact.

## Expected result

Rate-limit, authentication, and other Claude API failures appear once as an error, both while monitored live and after a cold history remap.

## Verification

- `cd bridge/sesori_plugin_claude && dart test` — 295 tests passed
- `cd bridge/sesori_plugin_claude && dart analyze --fatal-infos` — no issues
- Architecture implementation review — approved
