### PR TITLE
⚙️ [desktop-app] Restore desktop window bounds [step 1/3]

### DIFF
--- a/.plan/active/desktop-app/PLAN.md
+++ b/.plan/active/desktop-app/PLAN.md
@@ -595,9 +595,36 @@ Any cubit here only exposes the preference toggle. Content is category-level
 copy plus the session title — never prompt, transcript, or tool payload (same
 privacy line as the bridge's push content builder). Without this a
 tray-resident cockpit cannot tell the user a session is blocked — the phone
-gets push, the desktop got nothing. *Overage: ~1.7k changed lines for the
-notification client, window seams, bounds service, attention service, and
-composition; the additions have no legal home in an earlier slice.*
+gets push, the desktop got nothing.
+
+**Step 20 delivery reset (2026-09-02).** PR #1265 was closed unmerged after its
+5,611-line, six-package scope caused repeated whole-feature review churn. The
+approved behavior is retained but delivered as this fixed replacement series,
+with one PR open at a time:
+
+1. `⚙️ [desktop-app] Restore desktop window bounds [step 1/3]` — typed bounds
+   and window events, desktop-instance persistence, display-aware clamping,
+   restore before first show, debounced writes, and terminal-Quit flushing.
+2. `🚧 [desktop-app] Compose the desktop cockpit [step 2/3]` — persistent
+   cockpit navigation, project/session route ownership, supervision recovery,
+   Enter/Shift+Enter with IME protection, safe Escape behavior, and selectable
+   transcript/diff source without navigation or gutter metadata.
+3. `🚧 [desktop-app] Add desktop attention notifications [step 3/3]` — shared
+   notification contract changes, native desktop client, persisted preference,
+   account-bound SSE attention, open routing, and logout/auth-loss cleanup.
+
+The split changes delivery order, not the approved architecture or MT Gate C.
+Slice 1 is independently valid and remains below the 1,500-line soft cap.
+Slices 2 and 3 may exceed that cap because each keeps its production flow with
+its directly proving tests; another split would either expose an unused cockpit
+or notification contract or separate account-ending cleanup from the service
+that owns native writes. Mutable-state budget: slice 1 adds one bounds service
+with a debounce timer, event subscription, and serialized pending write; slice
+2 adds no persisted state; slice 3 adds one persisted preference plus the
+bounded pending-request/generation/write-lane state needed for account-safe
+notification replacement and cleanup. It deliberately adds no desktop push
+registration, migration/backfill, compatibility shim, global coordination
+registry, or background retry worker.
 
 > **MT gate C — cockpit parity + mobile regression (user-run, after step
 > 20).** Desktop: manage harnesses end-to-end (install + login a real one) ·

--- a/.plan/active/desktop-app/TRACKER.md
+++ b/.plan/active/desktop-app/TRACKER.md
@@ -28,7 +28,7 @@ user-run checkpoints, not PRs; only the user marks them passed.
 | 17 | 🚧 Session detail: transcript slice | done |
 | 18 | 🚧 Composer slice + voice/media seams (R2) | done |
 | 19 | ⚙️ Diffs + new-session slice | done |
-| 20 | 🚧 Desktop cockpit composition + attention notifications | pending |
+| 20 | 🚧 Desktop cockpit composition + attention notifications | in-progress |
 | — | MT gate C: cockpit parity + mobile regression (user-run) | pending |
 | 21 | 🌿 Regression documentation reconciliation | pending |
 | 22 | 🌿 Coverage run, retirement, `desktop-distribution` handoff | pending |

--- a/.plan/active/desktop-app/TRACKER.md
+++ b/.plan/active/desktop-app/TRACKER.md
@@ -41,7 +41,7 @@ fixed, sequential replacement series; only one PR is opened at a time.
 
 | Slice | Fixed PR title | Status |
 |---|---|---|
-| 1/3 | ⚙️ `[desktop-app] Restore desktop window bounds [step 1/3]` | in-progress |
+| 1/3 | ⚙️ `[desktop-app] Restore desktop window bounds [step 1/3]` | done |
 | 2/3 | 🚧 `[desktop-app] Compose the desktop cockpit [step 2/3]` | pending |
 | 3/3 | 🚧 `[desktop-app] Add desktop attention notifications [step 3/3]` | pending |
 

--- a/.plan/active/desktop-app/TRACKER.md
+++ b/.plan/active/desktop-app/TRACKER.md
@@ -33,6 +33,21 @@ user-run checkpoints, not PRs; only the user marks them passed.
 | 21 | 🌿 Regression documentation reconciliation | pending |
 | 22 | 🌿 Coverage run, retirement, `desktop-distribution` handoff | pending |
 
+## Step 20 replacement series
+
+PR #1265 was closed unmerged on 2026-09-02 because its 5,611-line scope was too
+broad for efficient review. Its implementation remains the source for this
+fixed, sequential replacement series; only one PR is opened at a time.
+
+| Slice | Fixed PR title | Status |
+|---|---|---|
+| 1/3 | ⚙️ `[desktop-app] Restore desktop window bounds [step 1/3]` | in-progress |
+| 2/3 | 🚧 `[desktop-app] Compose the desktop cockpit [step 2/3]` | pending |
+| 3/3 | 🚧 `[desktop-app] Add desktop attention notifications [step 3/3]` | pending |
+
+MT Gate C remains after all three slices. The top-level Step 20 row stays
+`in-progress` until the replacement series is complete.
+
 ## MT Gate A — accepted 2026-08-30
 
 The user accepted the macOS manual gate after browser login/session restore,

--- a/.plan/active/desktop-app/steps/step-20-1.md
+++ b/.plan/active/desktop-app/steps/step-20-1.md
@@ -1,0 +1,51 @@
+# Step 20 slice 1/3 — Desktop window bounds
+
+- **Status:** `done`
+- **Complexity:** `⚙️`
+- **User value:** Desktop window size and position survive relaunch and remain usable after display changes.
+- **Dependencies:** Step 19
+- **Pinned implementation range:** `74d84c4ddcd4818ea2b435088f014cdfd5229c9a..e763e0513c221464d3ae5050bc27d5dcd03cc21b`
+
+## Scope
+
+- Add platform-neutral window bounds, size, move, and resize contracts.
+- Persist bounds through the existing desktop-instance storage/repository layers.
+- Restore validated, display-clamped bounds before the first explicit show.
+- Debounce move/resize persistence and flush the final observation before terminal window disposal.
+- Exclude cockpit navigation and attention-notification state from this independently usable slice.
+
+## Implementation Summary
+
+- Added immutable `WindowBounds` and `WindowSize` models plus `moved`/`resized` events to the Layer-0 `WindowHost` capability.
+- Extended `DesktopInstanceStorage` and `DesktopInstanceRepository` with typed window-bounds persistence under desktop-owned application data.
+- Added `WindowBoundsService` as the Layer-3 owner of persisted-value validation, display selection, usable-work-area clamping, restoration, debounce, retry after failed writes, and final flushing.
+- Kept `FlutterWindowHost` as a native adapter for `window_manager` and `screen_retriever`; it applies service-owned bounds before show but owns no persistence policy.
+- Routed startup through `DesktopStartupOrchestrator.initializeWindow()` and made terminal Quit await `WindowBoundsService.dispose()` before `WindowHost.dispose()`.
+- Kept the existing centered 720×620 fallback and a 560×480 minimum where the current display can accommodate it.
+- Updated the desktop supervision regression contract and recorded the three-PR Step 20 replacement after closing oversized PR #1265 unmerged.
+
+## Architecture Review
+
+- The first bounded review confirmed restore-before-show, flush-before-host-dispose, persistence layering, and adapter boundaries, but rejected unused focus/visibility state that belonged to the later attention slice.
+- Removed `WindowHostState`, `currentState`, `states`, and all adapter/test state machinery while retaining the bounds APIs and consumed move/resize events.
+- The second bounded review over the pinned range was **APPROVED** with no findings. It confirmed the prior A5 finding was resolved and all lifecycle and layering invariants remained intact.
+
+## Verification
+
+- `client/module_desktop_core`: `asdf exec dart analyze --fatal-infos` passes; the full suite passes 215 tests.
+- `client/desktop`: `asdf exec dart analyze --fatal-infos` passes; the full suite passes 97 tests.
+- Dart LSP reports zero diagnostics across all 12 changed production Dart files.
+- `git diff --check` passes.
+- A clean `asdf exec flutter build macos` succeeds (65.7 MB reported by Flutter), and `codesign --verify --deep --strict` accepts the resulting app bundle.
+- The pinned implementation range changes 23 files with 914 additions and 63 deletions (977 total changed lines), below the 1,500-line soft cap. This measurement excludes this evidence-only commit.
+- Real display rearrangement and relaunch ergonomics remain part of user-run MT Gate C after all three Step 20 slices.
+
+## Acceptance
+
+- [x] Valid saved bounds are clamped to a current display and applied before first show.
+- [x] Missing, invalid, or undiscoverable bounds use the centered default.
+- [x] Move and resize observations debounce persistence, and a failed write does not poison a later write.
+- [x] Terminal Quit flushes final bounds before native window disposal.
+- [x] The adapter remains policy-free and persistence follows Layer 1 → Layer 2 → Layer 3 ownership.
+- [x] Attention-only focus/visibility state is deferred to the slice that consumes it.
+- [x] Relevant analyzers, full suites, LSP diagnostics, clean macOS release build, codesign verification, and architecture review pass.

--- a/.plan/active/desktop-app/steps/step-20-1.md
+++ b/.plan/active/desktop-app/steps/step-20-1.md
@@ -4,7 +4,7 @@
 - **Complexity:** `⚙️`
 - **User value:** Desktop window size and position survive relaunch and remain usable after display changes.
 - **Dependencies:** Step 19
-- **Pinned implementation range:** `74d84c4ddcd4818ea2b435088f014cdfd5229c9a..e763e0513c221464d3ae5050bc27d5dcd03cc21b`
+- **Pinned implementation range:** `74d84c4ddcd4818ea2b435088f014cdfd5229c9a..34cf314c807259174c99c7649f33256522fbddd9`
 
 ## Scope
 
@@ -21,7 +21,8 @@
 - Added `WindowBoundsService` as the Layer-3 owner of persisted-value validation, display selection, usable-work-area clamping, restoration, debounce, retry after failed writes, and final flushing.
 - Kept `FlutterWindowHost` as a native adapter for `window_manager` and `screen_retriever`; it applies service-owned bounds before show but owns no persistence policy.
 - Routed startup through `DesktopStartupOrchestrator.initializeWindow()` and made terminal Quit await `WindowBoundsService.dispose()` before `WindowHost.dispose()`.
-- Kept the existing centered 720×620 fallback and a 560×480 minimum where the current display can accommodate it.
+- Kept the existing centered 720×620 fallback and a 560×480 minimum where the selected display can accommodate it; compact work areas receive a display-adjusted native minimum.
+- Suppressed MainMenu.xib's first native window ordering on every macOS launch so Dart restores bounds before the first visible show.
 - Updated the desktop supervision regression contract and recorded the three-PR Step 20 replacement after closing oversized PR #1265 unmerged.
 
 ## Architecture Review
@@ -32,7 +33,7 @@
 
 ## Verification
 
-- `client/module_desktop_core`: `asdf exec dart analyze --fatal-infos` passes; the full suite passes 215 tests.
+- `client/module_desktop_core`: `asdf exec dart analyze --fatal-infos` passes; the full suite passes 216 tests.
 - `client/desktop`: `asdf exec dart analyze --fatal-infos` passes; the full suite passes 97 tests.
 - Dart LSP reports zero diagnostics across all 12 changed production Dart files.
 - `git diff --check` passes.
@@ -41,22 +42,24 @@
 
 ### Line-budget reproduction
 
-The reviewed implementation head is `e763e0513c221464d3ae5050bc27d5dcd03cc21b`. The measurement is intentionally
-not self-inclusive: it excludes the later evidence-only commit that created this file.
+The implementation head is `34cf314c807259174c99c7649f33256522fbddd9`. The measurement is intentionally
+not self-inclusive: it excludes only the later evidence-only commit that updates this section.
 
 ```bash
-base=$(git merge-base 74d84c4ddcd4818ea2b435088f014cdfd5229c9a e763e0513c221464d3ae5050bc27d5dcd03cc21b)
-git diff --numstat "$base" e763e0513c221464d3ae5050bc27d5dcd03cc21b \
+base=$(git merge-base 74d84c4ddcd4818ea2b435088f014cdfd5229c9a 34cf314c807259174c99c7649f33256522fbddd9)
+git diff --numstat "$base" 34cf314c807259174c99c7649f33256522fbddd9 \
   | awk '{ additions += $1; deletions += $2 } END { print additions, deletions, additions + deletions }'
-# 914 63 977
+# 1016 72 1088
 ```
 
-The 914 additions plus 63 deletions reconcile to 977 total changed lines across 23 files, below the 1,500-line soft cap.
+The 1,016 additions plus 72 deletions reconcile to 1,088 total changed lines across 25 files, below the 1,500-line soft cap.
 
 ## Acceptance
 
 - [x] Valid saved bounds are clamped to a current display and applied before first show.
 - [x] Missing, invalid, or undiscoverable bounds use the centered default.
+- [x] Compact display work areas reduce the native minimum instead of forcing restored bounds off-screen.
+- [x] macOS suppresses the XIB frame until the adapter performs the post-restoration show.
 - [x] Move and resize observations debounce persistence, and a failed write does not poison a later write.
 - [x] Terminal Quit flushes final bounds before native window disposal.
 - [x] The adapter remains policy-free and persistence follows Layer 1 → Layer 2 → Layer 3 ownership.

--- a/.plan/active/desktop-app/steps/step-20-1.md
+++ b/.plan/active/desktop-app/steps/step-20-1.md
@@ -37,8 +37,21 @@
 - Dart LSP reports zero diagnostics across all 12 changed production Dart files.
 - `git diff --check` passes.
 - A clean `asdf exec flutter build macos` succeeds (65.7 MB reported by Flutter), and `codesign --verify --deep --strict` accepts the resulting app bundle.
-- The pinned implementation range changes 23 files with 914 additions and 63 deletions (977 total changed lines), below the 1,500-line soft cap. This measurement excludes this evidence-only commit.
 - Real display rearrangement and relaunch ergonomics remain part of user-run MT Gate C after all three Step 20 slices.
+
+### Line-budget reproduction
+
+The reviewed implementation head is `e763e0513c221464d3ae5050bc27d5dcd03cc21b`. The measurement is intentionally
+not self-inclusive: it excludes the later evidence-only commit that created this file.
+
+```bash
+base=$(git merge-base 74d84c4ddcd4818ea2b435088f014cdfd5229c9a e763e0513c221464d3ae5050bc27d5dcd03cc21b)
+git diff --numstat "$base" e763e0513c221464d3ae5050bc27d5dcd03cc21b \
+  | awk '{ additions += $1; deletions += $2 } END { print additions, deletions, additions + deletions }'
+# 914 63 977
+```
+
+The 914 additions plus 63 deletions reconcile to 977 total changed lines across 23 files, below the 1,500-line soft cap.
 
 ## Acceptance
 

--- a/client/desktop/lib/app.dart
+++ b/client/desktop/lib/app.dart
@@ -75,6 +75,7 @@ class const _DesktopAppShell({required final bool hiddenLaunch}) extends Statele
               statusTracker: getIt(),
               systemTray: getIt(),
               windowHost: getIt(),
+              windowBoundsService: getIt(),
               applicationTerminator: getIt(),
               logRepository: getIt(),
               instanceService: getIt(),

--- a/client/desktop/lib/core/platform/flutter_window_host.dart
+++ b/client/desktop/lib/core/platform/flutter_window_host.dart
@@ -22,20 +22,12 @@ class FlutterWindowHost.forTesting({
   static const Size _defaultSize = Size(720, 620);
 
   final StreamController<WindowHostEvent> _events = StreamController<WindowHostEvent>.broadcast(sync: true);
-  final StreamController<WindowHostState> _states = StreamController<WindowHostState>.broadcast(sync: true);
-  WindowHostState _currentState = WindowHostState.hidden;
   bool _listenerRegistered = false;
   bool _initialized = false;
   bool _disposed = false;
 
   @override
   Stream<WindowHostEvent> get events => _events.stream;
-
-  @override
-  WindowHostState get currentState => _currentState;
-
-  @override
-  Stream<WindowHostState> get states => _states.stream;
 
   @override
   Future<void> initialize({
@@ -71,15 +63,12 @@ class FlutterWindowHost.forTesting({
       await _manager.setSkipTaskbar(hidden);
       if (hidden) {
         // Native runners hide the window before the first frame where
-        // possible; keep the state explicit here as a cross-platform
-        // fallback for hosts that initially order the window.
+        // possible; keep this as a cross-platform fallback for hosts that
+        // initially order the window.
         await _manager.hide();
-        _emitState(state: WindowHostState.hidden);
       } else {
         await _manager.show();
-        _emitState(state: WindowHostState.unfocused);
         await _manager.focus();
-        _emitState(state: WindowHostState.focused);
       }
       _initialized = true;
     } on Object {
@@ -112,28 +101,6 @@ class FlutterWindowHost.forTesting({
   @override
   void onWindowResize() {
     _emitEvent(event: WindowHostEvent.resized);
-  }
-
-  @override
-  void onWindowFocus() {
-    _emitState(state: WindowHostState.focused);
-  }
-
-  @override
-  void onWindowBlur() {
-    if (_currentState != WindowHostState.hidden) {
-      _emitState(state: WindowHostState.unfocused);
-    }
-  }
-
-  @override
-  void onWindowMinimize() {
-    _emitState(state: WindowHostState.hidden);
-  }
-
-  @override
-  void onWindowRestore() {
-    _emitState(state: WindowHostState.unfocused);
   }
 
   @override
@@ -174,16 +141,13 @@ class FlutterWindowHost.forTesting({
     // puts the app back in the Dock before the window is shown.
     await _manager.setSkipTaskbar(false);
     await _manager.show();
-    _emitState(state: WindowHostState.unfocused);
     await _manager.focus();
-    _emitState(state: WindowHostState.focused);
   }
 
   @override
   Future<void> hide() async {
     _ensureInitialized();
     await _manager.hide();
-    _emitState(state: WindowHostState.hidden);
     // On macOS this switches to the accessory activation policy: the tray
     // remains available while the hidden window disappears from the Dock.
     await _manager.setSkipTaskbar(true);
@@ -192,16 +156,6 @@ class FlutterWindowHost.forTesting({
   void _emitEvent({required WindowHostEvent event}) {
     if (!_events.isClosed) {
       _events.add(event);
-    }
-  }
-
-  void _emitState({required WindowHostState state}) {
-    if (_currentState == state) {
-      return;
-    }
-    _currentState = state;
-    if (!_states.isClosed) {
-      _states.add(state);
     }
   }
 
@@ -223,7 +177,7 @@ class FlutterWindowHost.forTesting({
     } on Object catch (error, stackTrace) {
       logw("Failed to restore native close behavior while disposing the window host", error, stackTrace);
     } finally {
-      await Future.wait<void>([_events.close(), _states.close()]);
+      await _events.close();
     }
   }
 

--- a/client/desktop/lib/core/platform/flutter_window_host.dart
+++ b/client/desktop/lib/core/platform/flutter_window_host.dart
@@ -20,7 +20,6 @@ class FlutterWindowHost.forTesting({
   this;
 
   static const Size _defaultSize = Size(720, 620);
-  static const Size _minimumSize = Size(WindowBoundsService.minimumWidth, WindowBoundsService.minimumHeight);
 
   final StreamController<WindowHostEvent> _events = StreamController<WindowHostEvent>.broadcast(sync: true);
   final StreamController<WindowHostState> _states = StreamController<WindowHostState>.broadcast(sync: true);
@@ -39,7 +38,11 @@ class FlutterWindowHost.forTesting({
   Stream<WindowHostState> get states => _states.stream;
 
   @override
-  Future<void> initialize({required bool hidden, required WindowBounds? initialBounds}) async {
+  Future<void> initialize({
+    required bool hidden,
+    required WindowBounds? initialBounds,
+    required WindowSize minimumSize,
+  }) async {
     _ensureNotDisposed();
     if (_initialized) {
       throw StateError("WindowHost is already initialized");
@@ -56,7 +59,7 @@ class FlutterWindowHost.forTesting({
             final bounds? => Size(bounds.width, bounds.height),
             null => _defaultSize,
           },
-          minimumSize: _minimumSize,
+          minimumSize: Size(minimumSize.width, minimumSize.height),
           center: initialBounds == null,
           backgroundColor: const Color(0x00000000),
           title: "Sesori",

--- a/client/desktop/lib/core/platform/flutter_window_host.dart
+++ b/client/desktop/lib/core/platform/flutter_window_host.dart
@@ -3,27 +3,28 @@ import "dart:ui";
 
 import "package:flutter/foundation.dart" show visibleForTesting;
 import "package:injectable/injectable.dart";
+import "package:screen_retriever/screen_retriever.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_desktop_core/sesori_desktop_core.dart";
 import "package:window_manager/window_manager.dart";
 
 /// Dumb `window_manager` adapter for the Sesori desktop window.
 @LazySingleton(as: WindowHost)
-class FlutterWindowHost.forTesting({required final WindowManager _manager}) with WindowListener implements WindowHost {
-  new() : this.forTesting(manager: windowManager);
+class FlutterWindowHost.forTesting({
+  required final WindowManager _manager,
+  required final ScreenRetriever _screenRetriever,
+}) with WindowListener implements WindowHost {
+  new() : this.forTesting(manager: windowManager, screenRetriever: screenRetriever);
 
   @visibleForTesting
   this;
 
-  static const WindowOptions _options = WindowOptions(
-    size: Size(720, 620),
-    minimumSize: Size(560, 480),
-    center: true,
-    backgroundColor: Color(0x00000000),
-    title: "Sesori",
-  );
+  static const Size _defaultSize = Size(720, 620);
+  static const Size _minimumSize = Size(WindowBoundsService.minimumWidth, WindowBoundsService.minimumHeight);
 
   final StreamController<WindowHostEvent> _events = StreamController<WindowHostEvent>.broadcast(sync: true);
+  final StreamController<WindowHostState> _states = StreamController<WindowHostState>.broadcast(sync: true);
+  WindowHostState _currentState = WindowHostState.hidden;
   bool _listenerRegistered = false;
   bool _initialized = false;
   bool _disposed = false;
@@ -32,7 +33,13 @@ class FlutterWindowHost.forTesting({required final WindowManager _manager}) with
   Stream<WindowHostEvent> get events => _events.stream;
 
   @override
-  Future<void> initialize({required bool hidden}) async {
+  WindowHostState get currentState => _currentState;
+
+  @override
+  Stream<WindowHostState> get states => _states.stream;
+
+  @override
+  Future<void> initialize({required bool hidden, required WindowBounds? initialBounds}) async {
     _ensureNotDisposed();
     if (_initialized) {
       throw StateError("WindowHost is already initialized");
@@ -43,16 +50,33 @@ class FlutterWindowHost.forTesting({required final WindowManager _manager}) with
     _listenerRegistered = true;
     try {
       await _manager.setPreventClose(true);
-      await _manager.waitUntilReadyToShow(_options);
+      await _manager.waitUntilReadyToShow(
+        WindowOptions(
+          size: switch (initialBounds) {
+            final bounds? => Size(bounds.width, bounds.height),
+            null => _defaultSize,
+          },
+          minimumSize: _minimumSize,
+          center: initialBounds == null,
+          backgroundColor: const Color(0x00000000),
+          title: "Sesori",
+        ),
+      );
+      if (initialBounds != null) {
+        await setBounds(bounds: initialBounds);
+      }
       await _manager.setSkipTaskbar(hidden);
       if (hidden) {
         // Native runners hide the window before the first frame where
         // possible; keep the state explicit here as a cross-platform
         // fallback for hosts that initially order the window.
         await _manager.hide();
+        _emitState(state: WindowHostState.hidden);
       } else {
         await _manager.show();
+        _emitState(state: WindowHostState.unfocused);
         await _manager.focus();
+        _emitState(state: WindowHostState.focused);
       }
       _initialized = true;
     } on Object {
@@ -74,9 +98,70 @@ class FlutterWindowHost.forTesting({required final WindowManager _manager}) with
 
   @override
   void onWindowClose() {
-    if (!_events.isClosed) {
-      _events.add(WindowHostEvent.closeRequested);
+    _emitEvent(event: WindowHostEvent.closeRequested);
+  }
+
+  @override
+  void onWindowMove() {
+    _emitEvent(event: WindowHostEvent.moved);
+  }
+
+  @override
+  void onWindowResize() {
+    _emitEvent(event: WindowHostEvent.resized);
+  }
+
+  @override
+  void onWindowFocus() {
+    _emitState(state: WindowHostState.focused);
+  }
+
+  @override
+  void onWindowBlur() {
+    if (_currentState != WindowHostState.hidden) {
+      _emitState(state: WindowHostState.unfocused);
     }
+  }
+
+  @override
+  void onWindowMinimize() {
+    _emitState(state: WindowHostState.hidden);
+  }
+
+  @override
+  void onWindowRestore() {
+    _emitState(state: WindowHostState.unfocused);
+  }
+
+  @override
+  Future<WindowBounds> getBounds() async {
+    _ensureInitialized();
+    final bounds = await _manager.getBounds();
+    return WindowBounds(
+      left: bounds.left,
+      top: bounds.top,
+      width: bounds.width,
+      height: bounds.height,
+    );
+  }
+
+  @override
+  Future<void> setBounds({required WindowBounds bounds}) async {
+    _ensureNotDisposed();
+    await _manager.setBounds(Rect.fromLTWH(bounds.left, bounds.top, bounds.width, bounds.height));
+  }
+
+  @override
+  Future<List<WindowBounds>> getDisplayBounds() async {
+    _ensureNotDisposed();
+    final displays = await _screenRetriever.getAllDisplays();
+    return List<WindowBounds>.unmodifiable(
+      displays.map((display) {
+        final position = display.visiblePosition ?? Offset.zero;
+        final size = display.visibleSize ?? display.size;
+        return WindowBounds(left: position.dx, top: position.dy, width: size.width, height: size.height);
+      }),
+    );
   }
 
   @override
@@ -86,16 +171,35 @@ class FlutterWindowHost.forTesting({required final WindowManager _manager}) with
     // puts the app back in the Dock before the window is shown.
     await _manager.setSkipTaskbar(false);
     await _manager.show();
+    _emitState(state: WindowHostState.unfocused);
     await _manager.focus();
+    _emitState(state: WindowHostState.focused);
   }
 
   @override
   Future<void> hide() async {
     _ensureInitialized();
     await _manager.hide();
+    _emitState(state: WindowHostState.hidden);
     // On macOS this switches to the accessory activation policy: the tray
     // remains available while the hidden window disappears from the Dock.
     await _manager.setSkipTaskbar(true);
+  }
+
+  void _emitEvent({required WindowHostEvent event}) {
+    if (!_events.isClosed) {
+      _events.add(event);
+    }
+  }
+
+  void _emitState({required WindowHostState state}) {
+    if (_currentState == state) {
+      return;
+    }
+    _currentState = state;
+    if (!_states.isClosed) {
+      _states.add(state);
+    }
   }
 
   @override
@@ -116,7 +220,7 @@ class FlutterWindowHost.forTesting({required final WindowManager _manager}) with
     } on Object catch (error, stackTrace) {
       logw("Failed to restore native close behavior while disposing the window host", error, stackTrace);
     } finally {
-      await _events.close();
+      await Future.wait<void>([_events.close(), _states.close()]);
     }
   }
 

--- a/client/desktop/lib/main.dart
+++ b/client/desktop/lib/main.dart
@@ -21,7 +21,7 @@ Future<void> main(List<String> arguments) async {
   final ChatInputMode initialChatInputMode = await getIt<ChatInputModeStore>().read();
 
   try {
-    await getIt<WindowHost>().initialize(hidden: hiddenLaunch);
+    await startupOrchestrator.initializeWindow(hidden: hiddenLaunch);
   } on Object catch (error, stackTrace) {
     try {
       await getIt.reset();

--- a/client/desktop/macos/Runner/MainFlutterWindow.swift
+++ b/client/desktop/macos/Runner/MainFlutterWindow.swift
@@ -3,8 +3,6 @@ import FlutterMacOS
 import window_manager
 
 class MainFlutterWindow: NSWindow {
-  private static let hiddenLaunchArgument = "--hidden"
-
   override func awakeFromNib() {
     let flutterProject = FlutterDartProject()
     // Pass the native process arguments through explicitly so LaunchAgent
@@ -21,14 +19,12 @@ class MainFlutterWindow: NSWindow {
     super.awakeFromNib()
   }
 
-  // MainMenu.xib orders the Flutter window before Dart can apply its hidden
-  // startup policy. Use window_manager's native first-order hook so a
-  // LaunchAgent startup never flashes the window; normal launches retain the
-  // existing visible behavior and are shown by FlutterWindowHost.
+  // MainMenu.xib orders the Flutter window before Dart can restore persisted
+  // bounds. Hide that first native ordering for every launch; window_manager's
+  // configured guard applies this only once, so FlutterWindowHost can perform
+  // the first visible show after restoration (or remain hidden for --hidden).
   override public func order(_ place: NSWindow.OrderingMode, relativeTo otherWin: Int) {
     super.order(place, relativeTo: otherWin)
-    if CommandLine.arguments.dropFirst().contains(Self.hiddenLaunchArgument) {
-      hiddenWindowAtLaunch()
-    }
+    hiddenWindowAtLaunch()
   }
 }

--- a/client/desktop/pubspec.yaml
+++ b/client/desktop/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   path_provider: ^2.1.6
   pasteboard: ^0.5.0
   rxdart: ^0.28.0
+  screen_retriever: ^0.2.2
   # DI-call only (configureAuthDependencies) — sesori_auth types MUST NOT be
   # imported outside lib/core/di/ (see client/AGENTS.md).
   sesori_auth:

--- a/client/desktop/test/app_smoke_test.dart
+++ b/client/desktop/test/app_smoke_test.dart
@@ -87,7 +87,11 @@ class _FakeWindowHost() implements WindowHost {
   Stream<WindowHostState> get states => const Stream<WindowHostState>.empty();
 
   @override
-  Future<void> initialize({required bool hidden, required WindowBounds? initialBounds}) async {}
+  Future<void> initialize({
+    required bool hidden,
+    required WindowBounds? initialBounds,
+    required WindowSize minimumSize,
+  }) async {}
 
   @override
   Future<WindowBounds> getBounds() async => const WindowBounds(left: 0, top: 0, width: 720, height: 620);

--- a/client/desktop/test/app_smoke_test.dart
+++ b/client/desktop/test/app_smoke_test.dart
@@ -81,12 +81,6 @@ class _FakeWindowHost() implements WindowHost {
   Stream<WindowHostEvent> get events => const Stream<WindowHostEvent>.empty();
 
   @override
-  WindowHostState get currentState => WindowHostState.focused;
-
-  @override
-  Stream<WindowHostState> get states => const Stream<WindowHostState>.empty();
-
-  @override
   Future<void> initialize({
     required bool hidden,
     required WindowBounds? initialBounds,

--- a/client/desktop/test/app_smoke_test.dart
+++ b/client/desktop/test/app_smoke_test.dart
@@ -81,7 +81,22 @@ class _FakeWindowHost() implements WindowHost {
   Stream<WindowHostEvent> get events => const Stream<WindowHostEvent>.empty();
 
   @override
-  Future<void> initialize({required bool hidden}) async {}
+  WindowHostState get currentState => WindowHostState.focused;
+
+  @override
+  Stream<WindowHostState> get states => const Stream<WindowHostState>.empty();
+
+  @override
+  Future<void> initialize({required bool hidden, required WindowBounds? initialBounds}) async {}
+
+  @override
+  Future<WindowBounds> getBounds() async => const WindowBounds(left: 0, top: 0, width: 720, height: 620);
+
+  @override
+  Future<void> setBounds({required WindowBounds bounds}) async {}
+
+  @override
+  Future<List<WindowBounds>> getDisplayBounds() async => const <WindowBounds>[];
 
   @override
   Future<void> show() async {}

--- a/client/desktop/test/core/platform/flutter_window_host_test.dart
+++ b/client/desktop/test/core/platform/flutter_window_host_test.dart
@@ -7,6 +7,8 @@ import "package:sesori_desktop/core/platform/flutter_window_host.dart";
 import "package:sesori_desktop_core/sesori_desktop_core.dart";
 import "package:window_manager/window_manager.dart";
 
+const _minimumSize = WindowSize(width: 560, height: 480);
+
 void main() {
   setUpAll(() {
     registerFallbackValue(const WindowOptions());
@@ -49,7 +51,7 @@ void main() {
     final host = createHost();
     addTearDown(host.dispose);
 
-    await host.initialize(hidden: false, initialBounds: null);
+    await host.initialize(hidden: false, initialBounds: null, minimumSize: _minimumSize);
     final options = verify(() => manager.waitUntilReadyToShow(captureAny())).captured.single as WindowOptions;
     final event = host.events.first;
     host.onWindowClose();
@@ -75,7 +77,7 @@ void main() {
     addTearDown(host.dispose);
     const bounds = WindowBounds(left: 80, top: 90, width: 1000, height: 760);
 
-    await host.initialize(hidden: false, initialBounds: bounds);
+    await host.initialize(hidden: false, initialBounds: bounds, minimumSize: _minimumSize);
 
     final options = verify(() => manager.waitUntilReadyToShow(captureAny())).captured.single as WindowOptions;
     expect(options.size, const Size(1000, 760));
@@ -92,7 +94,7 @@ void main() {
     final host = createHost();
     addTearDown(host.dispose);
 
-    await host.initialize(hidden: true, initialBounds: null);
+    await host.initialize(hidden: true, initialBounds: null, minimumSize: _minimumSize);
 
     verifyInOrder(<void Function()>[
       () => manager.setSkipTaskbar(true),
@@ -106,7 +108,7 @@ void main() {
   test("translates bounds and attached display work areas", () async {
     final host = createHost();
     addTearDown(host.dispose);
-    await host.initialize(hidden: false, initialBounds: null);
+    await host.initialize(hidden: false, initialBounds: null, minimumSize: _minimumSize);
     clearInteractions(manager);
     when(manager.getBounds).thenAnswer((_) async => const Rect.fromLTWH(-20, 30, 860, 640));
     when(() => manager.setBounds(any())).thenAnswer((_) async {});
@@ -129,7 +131,7 @@ void main() {
   test("emits move and resize events plus focus and visibility states", () async {
     final host = createHost();
     addTearDown(host.dispose);
-    await host.initialize(hidden: false, initialBounds: null);
+    await host.initialize(hidden: false, initialBounds: null, minimumSize: _minimumSize);
     final events = <WindowHostEvent>[];
     final states = <WindowHostState>[];
     final eventSubscription = host.events.listen(events.add);
@@ -159,7 +161,7 @@ void main() {
   test("show focuses the restored window and hide updates visibility", () async {
     final host = createHost();
     addTearDown(host.dispose);
-    await host.initialize(hidden: false, initialBounds: null);
+    await host.initialize(hidden: false, initialBounds: null, minimumSize: _minimumSize);
     clearInteractions(manager);
 
     await host.hide();
@@ -180,7 +182,7 @@ void main() {
     final host = createHost();
     when(() => manager.waitUntilReadyToShow(any())).thenThrow(StateError("native window unavailable"));
 
-    await expectLater(host.initialize(hidden: false, initialBounds: null), throwsStateError);
+    await expectLater(host.initialize(hidden: false, initialBounds: null, minimumSize: _minimumSize), throwsStateError);
 
     verify(() => manager.removeListener(host)).called(1);
     verify(() => manager.setPreventClose(false)).called(1);
@@ -189,7 +191,7 @@ void main() {
 
   test("dispose removes its listener and restores native close behavior", () async {
     final host = createHost();
-    await host.initialize(hidden: false, initialBounds: null);
+    await host.initialize(hidden: false, initialBounds: null, minimumSize: _minimumSize);
 
     await host.dispose();
 

--- a/client/desktop/test/core/platform/flutter_window_host_test.dart
+++ b/client/desktop/test/core/platform/flutter_window_host_test.dart
@@ -1,7 +1,8 @@
-import "dart:ui" show Size;
+import "dart:ui" show Offset, Rect, Size;
 
 import "package:flutter_test/flutter_test.dart";
 import "package:mocktail/mocktail.dart";
+import "package:screen_retriever/screen_retriever.dart";
 import "package:sesori_desktop/core/platform/flutter_window_host.dart";
 import "package:sesori_desktop_core/sesori_desktop_core.dart";
 import "package:window_manager/window_manager.dart";
@@ -9,29 +10,48 @@ import "package:window_manager/window_manager.dart";
 void main() {
   setUpAll(() {
     registerFallbackValue(const WindowOptions());
+    registerFallbackValue(Rect.zero);
   });
 
   late _MockWindowManager manager;
+  late _MockScreenRetriever screenRetriever;
+
+  FlutterWindowHost createHost() => FlutterWindowHost.forTesting(
+    manager: manager,
+    screenRetriever: screenRetriever,
+  );
 
   setUp(() {
     manager = _MockWindowManager();
+    screenRetriever = _MockScreenRetriever();
     when(manager.ensureInitialized).thenAnswer((_) async {});
     when(() => manager.setPreventClose(any())).thenAnswer((_) async {});
     when(() => manager.waitUntilReadyToShow(any())).thenAnswer((_) async {});
+    when(() => manager.setBounds(any())).thenAnswer((_) async {});
+    when(manager.getBounds).thenAnswer((_) async => const Rect.fromLTWH(40, 60, 900, 700));
     when(manager.show).thenAnswer((_) async {});
     when(manager.focus).thenAnswer((_) async {});
     when(() => manager.setSkipTaskbar(any())).thenAnswer((_) async {});
     when(manager.hide).thenAnswer((_) async {});
+    when(screenRetriever.getAllDisplays).thenAnswer(
+      (_) async => const <Display>[
+        Display(
+          id: "main",
+          size: Size(1512, 982),
+          visiblePosition: Offset(0, 24),
+          visibleSize: Size(1512, 958),
+        ),
+      ],
+    );
   });
 
-  test("initializes the native window and emits typed close requests", () async {
-    final FlutterWindowHost host = FlutterWindowHost.forTesting(manager: manager);
+  test("initializes the default native window and emits typed close requests", () async {
+    final host = createHost();
     addTearDown(host.dispose);
 
-    await host.initialize(hidden: false);
-    final WindowOptions options =
-        verify(() => manager.waitUntilReadyToShow(captureAny())).captured.single as WindowOptions;
-    final Future<WindowHostEvent> event = host.events.first;
+    await host.initialize(hidden: false, initialBounds: null);
+    final options = verify(() => manager.waitUntilReadyToShow(captureAny())).captured.single as WindowOptions;
+    final event = host.events.first;
     host.onWindowClose();
 
     verifyInOrder(<void Function()>[
@@ -44,15 +64,35 @@ void main() {
     ]);
     expect(options.size, const Size(720, 620));
     expect(options.minimumSize, const Size(560, 480));
+    expect(options.center, isTrue);
     expect(options.title, "Sesori");
+    expect(host.currentState, WindowHostState.focused);
     expect(await event, WindowHostEvent.closeRequested);
   });
 
+  test("applies restored bounds before the first visible show", () async {
+    final host = createHost();
+    addTearDown(host.dispose);
+    const bounds = WindowBounds(left: 80, top: 90, width: 1000, height: 760);
+
+    await host.initialize(hidden: false, initialBounds: bounds);
+
+    final options = verify(() => manager.waitUntilReadyToShow(captureAny())).captured.single as WindowOptions;
+    expect(options.size, const Size(1000, 760));
+    expect(options.center, isFalse);
+    verifyInOrder(<void Function()>[
+      () => manager.setBounds(const Rect.fromLTWH(80, 90, 1000, 760)),
+      () => manager.setSkipTaskbar(false),
+      () => manager.show(),
+      () => manager.focus(),
+    ]);
+  });
+
   test("hidden initialization never shows or focuses the window", () async {
-    final FlutterWindowHost host = FlutterWindowHost.forTesting(manager: manager);
+    final host = createHost();
     addTearDown(host.dispose);
 
-    await host.initialize(hidden: true);
+    await host.initialize(hidden: true, initialBounds: null);
 
     verifyInOrder(<void Function()>[
       () => manager.setSkipTaskbar(true),
@@ -60,34 +100,87 @@ void main() {
     ]);
     verifyNever(manager.show);
     verifyNever(manager.focus);
+    expect(host.currentState, WindowHostState.hidden);
   });
 
-  test("show focuses the restored window and hide delegates to the plugin", () async {
-    final FlutterWindowHost host = FlutterWindowHost.forTesting(manager: manager);
+  test("translates bounds and attached display work areas", () async {
+    final host = createHost();
     addTearDown(host.dispose);
-    await host.initialize(hidden: false);
+    await host.initialize(hidden: false, initialBounds: null);
     clearInteractions(manager);
-    when(manager.show).thenAnswer((_) async {});
-    when(manager.focus).thenAnswer((_) async {});
-    when(manager.hide).thenAnswer((_) async {});
+    when(manager.getBounds).thenAnswer((_) async => const Rect.fromLTWH(-20, 30, 860, 640));
+    when(() => manager.setBounds(any())).thenAnswer((_) async {});
 
-    await host.show();
+    expect(
+      await host.getBounds(),
+      const WindowBounds(left: -20, top: 30, width: 860, height: 640),
+    );
+    await host.setBounds(bounds: const WindowBounds(left: 10, top: 20, width: 900, height: 700));
+    expect(
+      await host.getDisplayBounds(),
+      const <WindowBounds>[
+        WindowBounds(left: 0, top: 24, width: 1512, height: 958),
+      ],
+    );
+
+    verify(() => manager.setBounds(const Rect.fromLTWH(10, 20, 900, 700))).called(1);
+  });
+
+  test("emits move and resize events plus focus and visibility states", () async {
+    final host = createHost();
+    addTearDown(host.dispose);
+    await host.initialize(hidden: false, initialBounds: null);
+    final events = <WindowHostEvent>[];
+    final states = <WindowHostState>[];
+    final eventSubscription = host.events.listen(events.add);
+    final stateSubscription = host.states.listen(states.add);
+    addTearDown(eventSubscription.cancel);
+    addTearDown(stateSubscription.cancel);
+
+    host.onWindowMove();
+    host.onWindowResize();
+    host.onWindowBlur();
+    host.onWindowMinimize();
+    host.onWindowRestore();
+    host.onWindowFocus();
+
+    expect(events, <WindowHostEvent>[WindowHostEvent.moved, WindowHostEvent.resized]);
+    expect(
+      states,
+      <WindowHostState>[
+        WindowHostState.unfocused,
+        WindowHostState.hidden,
+        WindowHostState.unfocused,
+        WindowHostState.focused,
+      ],
+    );
+  });
+
+  test("show focuses the restored window and hide updates visibility", () async {
+    final host = createHost();
+    addTearDown(host.dispose);
+    await host.initialize(hidden: false, initialBounds: null);
+    clearInteractions(manager);
+
     await host.hide();
+    expect(host.currentState, WindowHostState.hidden);
+    await host.show();
+    expect(host.currentState, WindowHostState.focused);
 
     verifyInOrder(<void Function()>[
+      () => manager.hide(),
+      () => manager.setSkipTaskbar(true),
       () => manager.setSkipTaskbar(false),
       () => manager.show(),
       () => manager.focus(),
-      () => manager.hide(),
-      () => manager.setSkipTaskbar(true),
     ]);
   });
 
   test("failed initialization restores native close handling and removes its listener", () async {
-    final FlutterWindowHost host = FlutterWindowHost.forTesting(manager: manager);
+    final host = createHost();
     when(() => manager.waitUntilReadyToShow(any())).thenThrow(StateError("native window unavailable"));
 
-    await expectLater(host.initialize(hidden: false), throwsStateError);
+    await expectLater(host.initialize(hidden: false, initialBounds: null), throwsStateError);
 
     verify(() => manager.removeListener(host)).called(1);
     verify(() => manager.setPreventClose(false)).called(1);
@@ -95,8 +188,8 @@ void main() {
   });
 
   test("dispose removes its listener and restores native close behavior", () async {
-    final FlutterWindowHost host = FlutterWindowHost.forTesting(manager: manager);
-    await host.initialize(hidden: false);
+    final host = createHost();
+    await host.initialize(hidden: false, initialBounds: null);
 
     await host.dispose();
 
@@ -106,3 +199,5 @@ void main() {
 }
 
 class _MockWindowManager() extends Mock implements WindowManager;
+
+class _MockScreenRetriever() extends Mock implements ScreenRetriever;

--- a/client/desktop/test/core/platform/flutter_window_host_test.dart
+++ b/client/desktop/test/core/platform/flutter_window_host_test.dart
@@ -68,7 +68,6 @@ void main() {
     expect(options.minimumSize, const Size(560, 480));
     expect(options.center, isTrue);
     expect(options.title, "Sesori");
-    expect(host.currentState, WindowHostState.focused);
     expect(await event, WindowHostEvent.closeRequested);
   });
 
@@ -102,7 +101,6 @@ void main() {
     ]);
     verifyNever(manager.show);
     verifyNever(manager.focus);
-    expect(host.currentState, WindowHostState.hidden);
   });
 
   test("translates bounds and attached display work areas", () async {
@@ -128,46 +126,28 @@ void main() {
     verify(() => manager.setBounds(const Rect.fromLTWH(10, 20, 900, 700))).called(1);
   });
 
-  test("emits move and resize events plus focus and visibility states", () async {
+  test("emits move and resize events", () async {
     final host = createHost();
     addTearDown(host.dispose);
     await host.initialize(hidden: false, initialBounds: null, minimumSize: _minimumSize);
     final events = <WindowHostEvent>[];
-    final states = <WindowHostState>[];
     final eventSubscription = host.events.listen(events.add);
-    final stateSubscription = host.states.listen(states.add);
     addTearDown(eventSubscription.cancel);
-    addTearDown(stateSubscription.cancel);
 
     host.onWindowMove();
     host.onWindowResize();
-    host.onWindowBlur();
-    host.onWindowMinimize();
-    host.onWindowRestore();
-    host.onWindowFocus();
 
     expect(events, <WindowHostEvent>[WindowHostEvent.moved, WindowHostEvent.resized]);
-    expect(
-      states,
-      <WindowHostState>[
-        WindowHostState.unfocused,
-        WindowHostState.hidden,
-        WindowHostState.unfocused,
-        WindowHostState.focused,
-      ],
-    );
   });
 
-  test("show focuses the restored window and hide updates visibility", () async {
+  test("show focuses the restored window and hide updates taskbar visibility", () async {
     final host = createHost();
     addTearDown(host.dispose);
     await host.initialize(hidden: false, initialBounds: null, minimumSize: _minimumSize);
     clearInteractions(manager);
 
     await host.hide();
-    expect(host.currentState, WindowHostState.hidden);
     await host.show();
-    expect(host.currentState, WindowHostState.focused);
 
     verifyInOrder(<void Function()>[
       () => manager.hide(),

--- a/client/module_desktop_core/lib/sesori_desktop_core.dart
+++ b/client/module_desktop_core/lib/sesori_desktop_core.dart
@@ -40,6 +40,7 @@ export "src/services/bridge_process_state.dart";
 export "src/services/control_command_service.dart";
 export "src/services/desktop_instance_service.dart";
 export "src/services/desktop_relay_connection_service.dart";
+export "src/services/window_bounds_service.dart";
 export "src/trackers/bridge_control_status.dart";
 export "src/trackers/bridge_process_log_tracker.dart";
 export "src/trackers/bridge_prompt_tracker.dart";

--- a/client/module_desktop_core/lib/src/api/desktop_instance_storage.dart
+++ b/client/module_desktop_core/lib/src/api/desktop_instance_storage.dart
@@ -1,3 +1,4 @@
+import "dart:convert";
 import "dart:io";
 
 import "package:injectable/injectable.dart";
@@ -6,8 +7,9 @@ import "package:sesori_dart_core/sesori_dart_core.dart";
 
 import "../foundation/bridge_process_desired_state.dart";
 import "../foundation/platform/desktop_application_support_directory.dart";
+import "../foundation/platform/window_host.dart";
 
-/// Layer-1 persistence boundary for desktop-owned last desired bridge state.
+/// Layer-1 persistence boundary for desktop-owned instance state.
 @lazySingleton
 class DesktopInstanceStorage._create({
   required final DesktopApplicationSupportDirectory _applicationSupportDirectory,
@@ -17,6 +19,7 @@ class DesktopInstanceStorage._create({
 
   static const String _directoryName = "desktop-instance";
   static const String _desiredStateFileName = "bridge-desired-state";
+  static const String _windowBoundsFileName = "window-bounds";
 
   Future<BridgeProcessDesiredState> readBridgeDesiredState() async {
     final File file = await _desiredStateFile();
@@ -35,13 +38,46 @@ class DesktopInstanceStorage._create({
   }
 
   Future<void> writeBridgeDesiredState({required BridgeProcessDesiredState state}) async {
-    final File file = await _desiredStateFile();
+    final File file = await _fileNamed(fileName: _desiredStateFileName);
     await file.parent.create(recursive: true);
     await file.writeAsString(state.name, flush: true);
   }
 
-  Future<File> _desiredStateFile() async {
+  Future<WindowBounds?> readWindowBounds() async {
+    final File file = await _fileNamed(fileName: _windowBoundsFileName);
+    // ignore: avoid_slow_async_io, one startup read must not block the UI isolate
+    if (!await file.exists()) {
+      return null;
+    }
+    final List<String> components = const LineSplitter().convert(await file.readAsString());
+    if (components.length != 4) {
+      logw("Ignoring invalid persisted desktop window bounds");
+      return null;
+    }
+    final left = double.tryParse(components[0]);
+    final top = double.tryParse(components[1]);
+    final width = double.tryParse(components[2]);
+    final height = double.tryParse(components[3]);
+    if (left == null || top == null || width == null || height == null) {
+      logw("Ignoring invalid persisted desktop window bounds");
+      return null;
+    }
+    return WindowBounds(left: left, top: top, width: width, height: height);
+  }
+
+  Future<void> writeWindowBounds({required WindowBounds bounds}) async {
+    final File file = await _fileNamed(fileName: _windowBoundsFileName);
+    await file.parent.create(recursive: true);
+    await file.writeAsString(
+      <double>[bounds.left, bounds.top, bounds.width, bounds.height].join("\n"),
+      flush: true,
+    );
+  }
+
+  Future<File> _desiredStateFile() => _fileNamed(fileName: _desiredStateFileName);
+
+  Future<File> _fileNamed({required String fileName}) async {
     final Directory root = await _applicationSupportDirectory.resolve();
-    return File(path.join(root.path, _directoryName, _desiredStateFileName));
+    return File(path.join(root.path, _directoryName, fileName));
   }
 }

--- a/client/module_desktop_core/lib/src/cubits/bridge_control/bridge_control_cubit.dart
+++ b/client/module_desktop_core/lib/src/cubits/bridge_control/bridge_control_cubit.dart
@@ -168,6 +168,8 @@ class BridgeControlCubit._create({
 
   void _onWindowEvent({required WindowHostEvent event}) {
     switch (event) {
+      case WindowHostEvent.moved || WindowHostEvent.resized:
+        return;
       case WindowHostEvent.closeRequested:
         if (_trayAvailability.isAvailable) {
           unawaited(hideWindow());

--- a/client/module_desktop_core/lib/src/cubits/bridge_control/bridge_control_cubit.dart
+++ b/client/module_desktop_core/lib/src/cubits/bridge_control/bridge_control_cubit.dart
@@ -14,6 +14,7 @@ import "../../repositories/bridge_process_log_repository.dart";
 import "../../services/bridge_process_service.dart";
 import "../../services/bridge_process_state.dart";
 import "../../services/desktop_instance_service.dart";
+import "../../services/window_bounds_service.dart";
 import "../../trackers/bridge_control_status.dart";
 import "../../trackers/bridge_status_tracker.dart";
 import "../../trackers/desktop_logout_tracker.dart";
@@ -31,6 +32,7 @@ class BridgeControlCubit._create({
   required final BridgeStatusTracker _statusTracker,
   required final SystemTray _systemTray,
   required final WindowHost _windowHost,
+  required final WindowBoundsService _windowBoundsService,
   required final DesktopApplicationTerminator _applicationTerminator,
   required final BridgeProcessLogRepository _logRepository,
   required final DesktopInstanceService _instanceService,
@@ -45,6 +47,7 @@ class BridgeControlCubit._create({
     required BridgeStatusTracker statusTracker,
     required SystemTray systemTray,
     required WindowHost windowHost,
+    required WindowBoundsService windowBoundsService,
     required DesktopApplicationTerminator applicationTerminator,
     required BridgeProcessLogRepository logRepository,
     required DesktopInstanceService instanceService,
@@ -58,6 +61,7 @@ class BridgeControlCubit._create({
          statusTracker: statusTracker,
          systemTray: systemTray,
          windowHost: windowHost,
+         windowBoundsService: windowBoundsService,
          applicationTerminator: applicationTerminator,
          logRepository: logRepository,
          instanceService: instanceService,
@@ -364,6 +368,11 @@ class BridgeControlCubit._create({
       await _systemTray.dispose();
     } on Object catch (error, stackTrace) {
       logw("Failed to dispose the system tray during desktop quit", error, stackTrace);
+    }
+    try {
+      await _windowBoundsService.dispose();
+    } on Object catch (error, stackTrace) {
+      logw("Failed to flush desktop window bounds during quit", error, stackTrace);
     }
     try {
       await _windowHost.dispose();

--- a/client/module_desktop_core/lib/src/di/injection.config.dart
+++ b/client/module_desktop_core/lib/src/di/injection.config.dart
@@ -33,6 +33,8 @@ import 'package:sesori_desktop_core/src/foundation/platform/desktop_application_
     as _i695;
 import 'package:sesori_desktop_core/src/foundation/platform/desktop_application_terminator.dart'
     as _i746;
+import 'package:sesori_desktop_core/src/foundation/platform/window_host.dart'
+    as _i732;
 import 'package:sesori_desktop_core/src/orchestration/desktop_bridge_takeover_orchestrator.dart'
     as _i850;
 import 'package:sesori_desktop_core/src/orchestration/desktop_logout_orchestrator.dart'
@@ -55,6 +57,8 @@ import 'package:sesori_desktop_core/src/services/desktop_instance_service.dart'
     as _i494;
 import 'package:sesori_desktop_core/src/services/desktop_relay_connection_service.dart'
     as _i314;
+import 'package:sesori_desktop_core/src/services/window_bounds_service.dart'
+    as _i68;
 import 'package:sesori_desktop_core/src/trackers/bridge_process_log_tracker.dart'
     as _i866;
 import 'package:sesori_desktop_core/src/trackers/bridge_prompt_tracker.dart'
@@ -170,6 +174,13 @@ extension GetItInjectableX on _i174.GetIt {
         repository: gh<_i210.DesktopInstanceRepository>(),
       ),
     );
+    gh.lazySingleton<_i68.WindowBoundsService>(
+      () => _i68.WindowBoundsService(
+        windowHost: gh<_i732.WindowHost>(),
+        repository: gh<_i210.DesktopInstanceRepository>(),
+      ),
+      dispose: (i) => i.dispose(),
+    );
     gh.lazySingleton<_i175.ControlCommandService>(
       () => _i175.ControlCommandService(
         repository: gh<_i171.ControlCommandRepository>(),
@@ -199,6 +210,14 @@ extension GetItInjectableX on _i174.GetIt {
         authSession: gh<_i948.AuthSession>(),
       ),
     );
+    gh.lazySingleton<_i455.DesktopStartupOrchestrator>(
+      () => _i455.DesktopStartupOrchestrator(
+        instanceService: gh<_i494.DesktopInstanceService>(),
+        processService: gh<_i765.BridgeProcessService>(),
+        applicationTerminator: gh<_i746.DesktopApplicationTerminator>(),
+        windowBoundsService: gh<_i68.WindowBoundsService>(),
+      ),
+    );
     gh.lazySingleton<_i850.DesktopBridgeTakeoverOrchestrator>(
       () => _i850.DesktopBridgeTakeoverOrchestrator(
         processService: gh<_i765.BridgeProcessService>(),
@@ -207,13 +226,6 @@ extension GetItInjectableX on _i174.GetIt {
         promptTracker: gh<_i686.BridgePromptTracker>(),
         statusTracker: gh<_i227.BridgeStatusTracker>(),
         logoutTracker: gh<_i786.DesktopLogoutTracker>(),
-      ),
-    );
-    gh.lazySingleton<_i455.DesktopStartupOrchestrator>(
-      () => _i455.DesktopStartupOrchestrator(
-        instanceService: gh<_i494.DesktopInstanceService>(),
-        processService: gh<_i765.BridgeProcessService>(),
-        applicationTerminator: gh<_i746.DesktopApplicationTerminator>(),
       ),
     );
     return this;

--- a/client/module_desktop_core/lib/src/di/injection.dart
+++ b/client/module_desktop_core/lib/src/di/injection.dart
@@ -7,6 +7,7 @@ import "../foundation/platform/bridge_executable_path_resolver.dart";
 import "../foundation/platform/bridge_process_environment.dart";
 import "../foundation/platform/desktop_application_support_directory.dart";
 import "../foundation/platform/desktop_application_terminator.dart";
+import "../foundation/platform/window_host.dart";
 import "injection.config.dart";
 
 // Phase 4 of the desktop 4-phase DI init (see client/AGENTS.md):
@@ -28,6 +29,7 @@ import "injection.config.dart";
     BridgeRepository,
     DesktopApplicationSupportDirectory,
     DesktopApplicationTerminator,
+    WindowHost,
   ],
 )
 void configureDesktopCoreDependencies(GetIt getIt) => getIt.init();

--- a/client/module_desktop_core/lib/src/foundation/platform/window_host.dart
+++ b/client/module_desktop_core/lib/src/foundation/platform/window_host.dart
@@ -7,13 +7,6 @@ enum WindowHostEvent() {
   resized,
 }
 
-/// Focus and visibility state reported by the native window.
-enum WindowHostState() {
-  focused,
-  unfocused,
-  hidden,
-}
-
 /// Platform-neutral native window size in logical pixels.
 @immutable
 class const WindowSize({
@@ -57,10 +50,6 @@ class const WindowBounds({
 /// and whether a close hides the window or performs a safe application quit.
 abstract interface class WindowHost() {
   Stream<WindowHostEvent> get events;
-
-  WindowHostState get currentState;
-
-  Stream<WindowHostState> get states;
 
   /// Prepares the native window before the Flutter application is rendered.
   ///

--- a/client/module_desktop_core/lib/src/foundation/platform/window_host.dart
+++ b/client/module_desktop_core/lib/src/foundation/platform/window_host.dart
@@ -12,7 +12,13 @@ enum WindowHostEvent() {
 class const WindowSize({
   required final double width,
   required final double height,
-});
+}) {
+  @override
+  bool operator ==(Object other) => other is WindowSize && other.width == width && other.height == height;
+
+  @override
+  int get hashCode => Object.hash(width, height);
+}
 
 /// Platform-neutral native window or display rectangle in logical pixels.
 @immutable

--- a/client/module_desktop_core/lib/src/foundation/platform/window_host.dart
+++ b/client/module_desktop_core/lib/src/foundation/platform/window_host.dart
@@ -1,22 +1,76 @@
+import "package:meta/meta.dart";
+
 /// Events emitted by the dumb native-window adapter.
 enum WindowHostEvent() {
   closeRequested,
+  moved,
+  resized,
+}
+
+/// Focus and visibility state reported by the native window.
+enum WindowHostState() {
+  focused,
+  unfocused,
+  hidden,
+}
+
+/// Platform-neutral native window or display rectangle in logical pixels.
+@immutable
+class const WindowBounds({
+  required final double left,
+  required final double top,
+  required final double width,
+  required final double height,
+}) {
+  double get right => left + width;
+
+  double get bottom => top + height;
+
+  double get centerX => left + width / 2;
+
+  double get centerY => top + height / 2;
+
+  @override
+  bool operator ==(Object other) {
+    return other is WindowBounds &&
+        other.left == left &&
+        other.top == top &&
+        other.width == width &&
+        other.height == height;
+  }
+
+  @override
+  int get hashCode => Object.hash(left, top, width, height);
 }
 
 /// Layer-0 capability for the desktop application's native window.
 ///
 /// The adapter owns only native window operations and translates callbacks to
-/// typed events. Layer-4 business logic decides whether a close hides the
-/// window or performs a safe application quit.
+/// typed events. Layer-3/4 business logic owns persistence, attention policy,
+/// and whether a close hides the window or performs a safe application quit.
 abstract interface class WindowHost() {
   Stream<WindowHostEvent> get events;
 
+  WindowHostState get currentState;
+
+  Stream<WindowHostState> get states;
+
   /// Prepares the native window before the Flutter application is rendered.
   ///
-  /// A hidden launch keeps the native surface out of sight until the tray
-  /// availability decision is known; the owning cubit shows it when no usable
-  /// tray exists.
-  Future<void> initialize({required bool hidden});
+  /// [initialBounds] has already been validated by the owning service and is
+  /// applied before the first explicit show. A hidden launch keeps the native
+  /// surface out of sight until the tray availability decision is known.
+  Future<void> initialize({
+    required bool hidden,
+    required WindowBounds? initialBounds,
+  });
+
+  Future<WindowBounds> getBounds();
+
+  Future<void> setBounds({required WindowBounds bounds});
+
+  /// Returns usable work-area rectangles for the currently attached displays.
+  Future<List<WindowBounds>> getDisplayBounds();
 
   Future<void> show();
 

--- a/client/module_desktop_core/lib/src/foundation/platform/window_host.dart
+++ b/client/module_desktop_core/lib/src/foundation/platform/window_host.dart
@@ -14,6 +14,13 @@ enum WindowHostState() {
   hidden,
 }
 
+/// Platform-neutral native window size in logical pixels.
+@immutable
+class const WindowSize({
+  required final double width,
+  required final double height,
+});
+
 /// Platform-neutral native window or display rectangle in logical pixels.
 @immutable
 class const WindowBounds({
@@ -57,12 +64,14 @@ abstract interface class WindowHost() {
 
   /// Prepares the native window before the Flutter application is rendered.
   ///
-  /// [initialBounds] has already been validated by the owning service and is
-  /// applied before the first explicit show. A hidden launch keeps the native
-  /// surface out of sight until the tray availability decision is known.
+  /// [initialBounds] and [minimumSize] have already been validated by the
+  /// owning service. Bounds are applied before the first explicit show. A
+  /// hidden launch keeps the native surface out of sight until the tray
+  /// availability decision is known.
   Future<void> initialize({
     required bool hidden,
     required WindowBounds? initialBounds,
+    required WindowSize minimumSize,
   });
 
   Future<WindowBounds> getBounds();

--- a/client/module_desktop_core/lib/src/orchestration/desktop_startup_orchestrator.dart
+++ b/client/module_desktop_core/lib/src/orchestration/desktop_startup_orchestrator.dart
@@ -5,6 +5,7 @@ import "../foundation/bridge_process_desired_state.dart";
 import "../foundation/platform/desktop_application_terminator.dart";
 import "../services/bridge_process_service.dart";
 import "../services/desktop_instance_service.dart";
+import "../services/window_bounds_service.dart";
 
 /// Layer-4 owner of launch ownership and last-On bridge restoration.
 @lazySingleton
@@ -12,15 +13,18 @@ class DesktopStartupOrchestrator._create({
   required final DesktopInstanceService _instanceService,
   required final BridgeProcessService _processService,
   required final DesktopApplicationTerminator _applicationTerminator,
+  required final WindowBoundsService _windowBoundsService,
 }) {
   new({
     required DesktopInstanceService instanceService,
     required BridgeProcessService processService,
     required DesktopApplicationTerminator applicationTerminator,
+    required WindowBoundsService windowBoundsService,
   }) : this._create(
          instanceService: instanceService,
          processService: processService,
          applicationTerminator: applicationTerminator,
+         windowBoundsService: windowBoundsService,
        );
 
   /// Claims the primary process role and terminates every secondary launch.
@@ -35,6 +39,9 @@ class DesktopStartupOrchestrator._create({
     _applicationTerminator.terminate(exitCode: 0);
     return false;
   }
+
+  /// Restores and begins tracking the native window before UI construction.
+  Future<void> initializeWindow({required bool hidden}) => _windowBoundsService.initializeWindow(hidden: hidden);
 
   Future<void> restoreBridgeDesiredState() async {
     final BridgeProcessDesiredState? desiredState;

--- a/client/module_desktop_core/lib/src/repositories/desktop_instance_repository.dart
+++ b/client/module_desktop_core/lib/src/repositories/desktop_instance_repository.dart
@@ -3,6 +3,7 @@ import "package:injectable/injectable.dart";
 import "../api/desktop_instance_api.dart";
 import "../api/desktop_instance_storage.dart";
 import "../foundation/bridge_process_desired_state.dart";
+import "../foundation/platform/window_host.dart";
 
 /// Layer-2 aggregate over instance coordination and persisted desktop state.
 @lazySingleton
@@ -23,4 +24,8 @@ class DesktopInstanceRepository._create({
 
   Future<void> writeBridgeDesiredState({required BridgeProcessDesiredState state}) =>
       _storage.writeBridgeDesiredState(state: state);
+
+  Future<WindowBounds?> readWindowBounds() => _storage.readWindowBounds();
+
+  Future<void> writeWindowBounds({required WindowBounds bounds}) => _storage.writeWindowBounds(bounds: bounds);
 }

--- a/client/module_desktop_core/lib/src/services/window_bounds_service.dart
+++ b/client/module_desktop_core/lib/src/services/window_bounds_service.dart
@@ -35,12 +35,11 @@ class WindowBoundsService._create({
          persistenceDebounce: persistenceDebounce,
        );
 
-  static const double minimumWidth = 560;
-  static const double minimumHeight = 480;
+  static const WindowSize minimumSize = WindowSize(width: 560, height: 480);
 
   StreamSubscription<WindowHostEvent>? _eventSubscription;
   Timer? _persistenceTimer;
-  Future<void> _pendingWrite = Future<void>.value();
+  Future<void>? _pendingWrite;
   bool _initialized = false;
   bool _disposed = false;
 
@@ -61,7 +60,11 @@ class WindowBoundsService._create({
       logw("Failed to restore desktop window bounds; using the default window", error, stackTrace);
     }
 
-    await _windowHost.initialize(hidden: hidden, initialBounds: initialBounds);
+    await _windowHost.initialize(
+      hidden: hidden,
+      initialBounds: initialBounds,
+      minimumSize: minimumSize,
+    );
     _eventSubscription = _windowHost.events.listen(
       (event) => _onWindowEvent(event: event),
       onError: (Object error, StackTrace stackTrace) {
@@ -118,7 +121,8 @@ class WindowBoundsService._create({
   }
 
   void _queuePersistence() {
-    _pendingWrite = _pendingWrite.then((_) => _persistCurrentBounds());
+    final pendingWrite = _pendingWrite;
+    _pendingWrite = pendingWrite == null ? _persistCurrentBounds() : pendingWrite.then((_) => _persistCurrentBounds());
   }
 
   Future<void> _persistCurrentBounds() async {
@@ -171,8 +175,8 @@ class WindowBoundsService._create({
   }
 
   static WindowBounds _clampToDisplay({required WindowBounds bounds, required WindowBounds display}) {
-    final minimumUsableWidth = math.min(minimumWidth, display.width);
-    final minimumUsableHeight = math.min(minimumHeight, display.height);
+    final minimumUsableWidth = math.min(minimumSize.width, display.width);
+    final minimumUsableHeight = math.min(minimumSize.height, display.height);
     final width = bounds.width.clamp(minimumUsableWidth, display.width).toDouble();
     final height = bounds.height.clamp(minimumUsableHeight, display.height).toDouble();
     final left = bounds.left.clamp(display.left, display.right - width).toDouble();
@@ -196,7 +200,14 @@ class WindowBoundsService._create({
     }
     _disposed = true;
     _flushScheduledPersistence();
-    await _eventSubscription?.cancel();
-    await _pendingWrite;
+    try {
+      await _eventSubscription?.cancel();
+    } on Object catch (error, stackTrace) {
+      logw("Failed to stop desktop window-bounds observation", error, stackTrace);
+    }
+    final pendingWrite = _pendingWrite;
+    if (pendingWrite != null) {
+      await pendingWrite;
+    }
   }
 }

--- a/client/module_desktop_core/lib/src/services/window_bounds_service.dart
+++ b/client/module_desktop_core/lib/src/services/window_bounds_service.dart
@@ -53,17 +53,17 @@ class WindowBoundsService._create({
       throw StateError("WindowBoundsService is already initialized");
     }
 
-    WindowBounds? initialBounds;
+    ({WindowBounds bounds, WindowSize minimumSize})? restoredWindow;
     try {
-      initialBounds = await _loadClampedBounds();
+      restoredWindow = await _loadClampedBounds();
     } on Object catch (error, stackTrace) {
       logw("Failed to restore desktop window bounds; using the default window", error, stackTrace);
     }
 
     await _windowHost.initialize(
       hidden: hidden,
-      initialBounds: initialBounds,
-      minimumSize: minimumSize,
+      initialBounds: restoredWindow?.bounds,
+      minimumSize: restoredWindow?.minimumSize ?? minimumSize,
     );
     _eventSubscription = _windowHost.events.listen(
       (event) => _onWindowEvent(event: event),
@@ -74,7 +74,7 @@ class WindowBoundsService._create({
     _initialized = true;
   }
 
-  Future<WindowBounds?> _loadClampedBounds() async {
+  Future<({WindowBounds bounds, WindowSize minimumSize})?> _loadClampedBounds() async {
     final savedBounds = await _repository.readWindowBounds();
     if (savedBounds == null) {
       return null;
@@ -91,7 +91,13 @@ class WindowBoundsService._create({
     }
 
     final display = _selectDisplay(savedBounds: savedBounds, displays: displays);
-    return _clampToDisplay(bounds: savedBounds, display: display);
+    return (
+      bounds: _clampToDisplay(bounds: savedBounds, display: display),
+      minimumSize: WindowSize(
+        width: math.min(minimumSize.width, display.width),
+        height: math.min(minimumSize.height, display.height),
+      ),
+    );
   }
 
   void _onWindowEvent({required WindowHostEvent event}) {

--- a/client/module_desktop_core/lib/src/services/window_bounds_service.dart
+++ b/client/module_desktop_core/lib/src/services/window_bounds_service.dart
@@ -1,0 +1,202 @@
+import "dart:async";
+import "dart:math" as math;
+
+import "package:injectable/injectable.dart";
+import "package:meta/meta.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+
+import "../foundation/platform/window_host.dart";
+import "../repositories/desktop_instance_repository.dart";
+
+/// Layer-3 owner of native window-bounds restoration and persistence.
+@lazySingleton
+class WindowBoundsService._create({
+  required final WindowHost _windowHost,
+  required final DesktopInstanceRepository _repository,
+  required final Duration _persistenceDebounce,
+}) {
+  new({
+    required WindowHost windowHost,
+    required DesktopInstanceRepository repository,
+  }) : this._create(
+         windowHost: windowHost,
+         repository: repository,
+         persistenceDebounce: const Duration(milliseconds: 300),
+       );
+
+  @visibleForTesting
+  new test({
+    required WindowHost windowHost,
+    required DesktopInstanceRepository repository,
+    required Duration persistenceDebounce,
+  }) : this._create(
+         windowHost: windowHost,
+         repository: repository,
+         persistenceDebounce: persistenceDebounce,
+       );
+
+  static const double minimumWidth = 560;
+  static const double minimumHeight = 480;
+
+  StreamSubscription<WindowHostEvent>? _eventSubscription;
+  Timer? _persistenceTimer;
+  Future<void> _pendingWrite = Future<void>.value();
+  bool _initialized = false;
+  bool _disposed = false;
+
+  /// Restores valid saved bounds before the native adapter first shows the
+  /// window, then begins tracking user moves and resizes.
+  Future<void> initializeWindow({required bool hidden}) async {
+    if (_disposed) {
+      throw StateError("WindowBoundsService is disposed");
+    }
+    if (_initialized) {
+      throw StateError("WindowBoundsService is already initialized");
+    }
+
+    WindowBounds? initialBounds;
+    try {
+      initialBounds = await _loadClampedBounds();
+    } on Object catch (error, stackTrace) {
+      logw("Failed to restore desktop window bounds; using the default window", error, stackTrace);
+    }
+
+    await _windowHost.initialize(hidden: hidden, initialBounds: initialBounds);
+    _eventSubscription = _windowHost.events.listen(
+      (event) => _onWindowEvent(event: event),
+      onError: (Object error, StackTrace stackTrace) {
+        loge("Desktop window event stream failed", error, stackTrace);
+      },
+    );
+    _initialized = true;
+  }
+
+  Future<WindowBounds?> _loadClampedBounds() async {
+    final savedBounds = await _repository.readWindowBounds();
+    if (savedBounds == null) {
+      return null;
+    }
+    if (!_isUsable(bounds: savedBounds)) {
+      logw("Ignoring unusable persisted desktop window bounds");
+      return null;
+    }
+
+    final displays = (await _windowHost.getDisplayBounds()).where((bounds) => _isUsable(bounds: bounds)).toList();
+    if (displays.isEmpty) {
+      logw("No usable display work area was available for desktop window restoration");
+      return null;
+    }
+
+    final display = _selectDisplay(savedBounds: savedBounds, displays: displays);
+    return _clampToDisplay(bounds: savedBounds, display: display);
+  }
+
+  void _onWindowEvent({required WindowHostEvent event}) {
+    switch (event) {
+      case WindowHostEvent.moved || WindowHostEvent.resized:
+        _schedulePersistence();
+      case WindowHostEvent.closeRequested:
+        _flushScheduledPersistence();
+    }
+  }
+
+  void _schedulePersistence() {
+    _persistenceTimer?.cancel();
+    _persistenceTimer = Timer(_persistenceDebounce, () {
+      _persistenceTimer = null;
+      _queuePersistence();
+    });
+  }
+
+  void _flushScheduledPersistence() {
+    if (_persistenceTimer == null) {
+      return;
+    }
+    _persistenceTimer?.cancel();
+    _persistenceTimer = null;
+    _queuePersistence();
+  }
+
+  void _queuePersistence() {
+    _pendingWrite = _pendingWrite.then((_) => _persistCurrentBounds());
+  }
+
+  Future<void> _persistCurrentBounds() async {
+    try {
+      final bounds = await _windowHost.getBounds();
+      if (!_isUsable(bounds: bounds)) {
+        logw("Ignoring unusable desktop window bounds update");
+        return;
+      }
+      await _repository.writeWindowBounds(bounds: bounds);
+    } on Object catch (error, stackTrace) {
+      logw("Failed to persist desktop window bounds", error, stackTrace);
+    }
+  }
+
+  static WindowBounds _selectDisplay({
+    required WindowBounds savedBounds,
+    required List<WindowBounds> displays,
+  }) {
+    WindowBounds selected = displays.first;
+    double greatestIntersection = -1;
+    for (final display in displays) {
+      final intersection = _intersectionArea(first: savedBounds, second: display);
+      if (intersection > greatestIntersection) {
+        selected = display;
+        greatestIntersection = intersection;
+      }
+    }
+    if (greatestIntersection > 0) {
+      return selected;
+    }
+
+    double shortestDistance = double.infinity;
+    for (final display in displays) {
+      final horizontalDistance = savedBounds.centerX - display.centerX;
+      final verticalDistance = savedBounds.centerY - display.centerY;
+      final distance = horizontalDistance * horizontalDistance + verticalDistance * verticalDistance;
+      if (distance < shortestDistance) {
+        selected = display;
+        shortestDistance = distance;
+      }
+    }
+    return selected;
+  }
+
+  static double _intersectionArea({required WindowBounds first, required WindowBounds second}) {
+    final width = math.max(0.0, math.min(first.right, second.right) - math.max(first.left, second.left));
+    final height = math.max(0.0, math.min(first.bottom, second.bottom) - math.max(first.top, second.top));
+    return (width * height).toDouble();
+  }
+
+  static WindowBounds _clampToDisplay({required WindowBounds bounds, required WindowBounds display}) {
+    final minimumUsableWidth = math.min(minimumWidth, display.width);
+    final minimumUsableHeight = math.min(minimumHeight, display.height);
+    final width = bounds.width.clamp(minimumUsableWidth, display.width).toDouble();
+    final height = bounds.height.clamp(minimumUsableHeight, display.height).toDouble();
+    final left = bounds.left.clamp(display.left, display.right - width).toDouble();
+    final top = bounds.top.clamp(display.top, display.bottom - height).toDouble();
+    return WindowBounds(left: left, top: top, width: width, height: height);
+  }
+
+  static bool _isUsable({required WindowBounds bounds}) {
+    return bounds.left.isFinite &&
+        bounds.top.isFinite &&
+        bounds.width.isFinite &&
+        bounds.height.isFinite &&
+        bounds.width > 0 &&
+        bounds.height > 0;
+  }
+
+  @disposeMethod
+  Future<void> dispose() async {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    _flushScheduledPersistence();
+    await _eventSubscription?.cancel();
+    await _pendingWrite;
+  }
+}

--- a/client/module_desktop_core/test/api/desktop_instance_storage_test.dart
+++ b/client/module_desktop_core/test/api/desktop_instance_storage_test.dart
@@ -42,6 +42,30 @@ void main() {
 
     expect(await storage.readBridgeDesiredState(), BridgeProcessDesiredState.off);
   });
+
+  test("missing window bounds have no restored value", () async {
+    expect(await storage.readWindowBounds(), isNull);
+  });
+
+  test("persists typed window bounds under desktop-owned application data", () async {
+    const bounds = WindowBounds(left: -120, top: 42, width: 1080, height: 760);
+
+    await storage.writeWindowBounds(bounds: bounds);
+
+    expect(await storage.readWindowBounds(), bounds);
+    expect(
+      File(path.join(root.path, "desktop-instance", "window-bounds")).readAsStringSync(),
+      "-120.0\n42.0\n1080.0\n760.0",
+    );
+  });
+
+  test("malformed window bounds are ignored", () async {
+    final File file = File(path.join(root.path, "desktop-instance", "window-bounds"));
+    file.createSync(recursive: true);
+    file.writeAsStringSync("12\ninvalid\n720");
+
+    expect(await storage.readWindowBounds(), isNull);
+  });
 }
 
 class _FixedApplicationSupportDirectory({required final Directory directory})

--- a/client/module_desktop_core/test/cubits/bridge_control/bridge_control_cubit_test.dart
+++ b/client/module_desktop_core/test/cubits/bridge_control/bridge_control_cubit_test.dart
@@ -14,6 +14,7 @@ void main() {
     late BridgeStatusTracker statusTracker;
     late _FakeSystemTray systemTray;
     late _FakeWindowHost windowHost;
+    late _FakeWindowBoundsService windowBoundsService;
     late _FakeDesktopApplicationTerminator applicationTerminator;
     late _FakeBridgeProcessLogRepository logRepository;
     late _FakeDesktopInstanceService instanceService;
@@ -28,6 +29,7 @@ void main() {
       statusTracker = BridgeStatusTracker(bridgeIdStorage: MemoryBridgeIdStorage());
       systemTray = _FakeSystemTray();
       windowHost = _FakeWindowHost();
+      windowBoundsService = _FakeWindowBoundsService();
       applicationTerminator = _FakeDesktopApplicationTerminator();
       logRepository = _FakeBridgeProcessLogRepository();
       instanceService = _FakeDesktopInstanceService();
@@ -40,6 +42,7 @@ void main() {
         statusTracker: statusTracker,
         systemTray: systemTray,
         windowHost: windowHost,
+        windowBoundsService: windowBoundsService,
         applicationTerminator: applicationTerminator,
         logRepository: logRepository,
         instanceService: instanceService,
@@ -171,6 +174,7 @@ void main() {
         statusTracker: statusTracker,
         systemTray: systemTray,
         windowHost: windowHost,
+        windowBoundsService: windowBoundsService,
         applicationTerminator: applicationTerminator,
         logRepository: logRepository,
         instanceService: instanceService,
@@ -412,6 +416,7 @@ void main() {
       expect(processService.stopCalls, 1);
       expect(applicationTerminator.exitCodes, <int>[0]);
       expect(systemTray.disposeCalls, 1);
+      expect(windowBoundsService.disposeCalls, 1);
       expect(cubit.state.activity, BridgeControlActivity.quitting);
     });
 
@@ -435,10 +440,50 @@ void main() {
       await pumpEventQueue(times: 2);
 
       expect(systemTray.disposeCalls, 1);
+      expect(windowBoundsService.disposeCalls, 1);
       expect(windowHost.disposeCalls, 1);
       expect(instanceService.writes, isEmpty);
       expect(applicationTerminator.exitCodes, <int>[0]);
       expect(cubit.state.activity, BridgeControlActivity.quitting);
+    });
+
+    test("tray Quit flushes a pending resize before disposing the native window", () async {
+      await cubit.close();
+      final boundsRepository = _RecordingDesktopInstanceRepository();
+      final boundsService = WindowBoundsService.test(
+        windowHost: windowHost,
+        repository: boundsRepository,
+        persistenceDebounce: const Duration(hours: 1),
+      );
+      await boundsService.initializeWindow(hidden: false);
+      const latestBounds = WindowBounds(left: 30, top: 40, width: 900, height: 700);
+      windowHost.bounds = latestBounds;
+      final quittingCubit = BridgeControlCubit(
+        processService: processService,
+        statusTracker: statusTracker,
+        systemTray: systemTray,
+        windowHost: windowHost,
+        windowBoundsService: boundsService,
+        applicationTerminator: applicationTerminator,
+        logRepository: logRepository,
+        instanceService: instanceService,
+        takeoverOrchestrator: takeoverOrchestrator,
+        logoutTracker: logoutTracker,
+        urlLauncher: urlLauncher,
+        launchAtLogin: launchAtLogin,
+        hiddenLaunch: false,
+      );
+      addTearDown(quittingCubit.close);
+      addTearDown(boundsService.dispose);
+      await quittingCubit.initialize();
+
+      windowHost.emit(event: WindowHostEvent.resized);
+      systemTray.emit(command: SystemTrayCommand.quit);
+      await pumpEventQueue(times: 3);
+
+      expect(boundsRepository.windowBoundsWrites, <WindowBounds>[latestBounds]);
+      expect(windowHost.disposeCalls, 1);
+      expect(applicationTerminator.exitCodes, <int>[0]);
     });
 
     test("Quit leaves the app alive when expected bridge stop fails", () async {
@@ -566,6 +611,7 @@ class _FakeSystemTray() implements SystemTray {
 
 class _FakeWindowHost() implements WindowHost {
   final StreamController<WindowHostEvent> _events = StreamController<WindowHostEvent>.broadcast(sync: true);
+  WindowBounds bounds = const WindowBounds(left: 0, top: 0, width: 720, height: 620);
   int showCalls = 0;
   int hideCalls = 0;
   int disposeCalls = 0;
@@ -580,10 +626,14 @@ class _FakeWindowHost() implements WindowHost {
   Stream<WindowHostState> get states => const Stream<WindowHostState>.empty();
 
   @override
-  Future<void> initialize({required bool hidden, required WindowBounds? initialBounds}) async {}
+  Future<void> initialize({
+    required bool hidden,
+    required WindowBounds? initialBounds,
+    required WindowSize minimumSize,
+  }) async {}
 
   @override
-  Future<WindowBounds> getBounds() async => const WindowBounds(left: 0, top: 0, width: 720, height: 620);
+  Future<WindowBounds> getBounds() async => bounds;
 
   @override
   Future<void> setBounds({required WindowBounds bounds}) async {}
@@ -611,6 +661,33 @@ class _FakeWindowHost() implements WindowHost {
   }
 
   Future<void> disposeFake() => _events.close();
+}
+
+class _FakeWindowBoundsService() implements WindowBoundsService {
+  int disposeCalls = 0;
+
+  @override
+  Future<void> initializeWindow({required bool hidden}) async {}
+
+  @override
+  Future<void> dispose() async {
+    disposeCalls++;
+  }
+}
+
+class _RecordingDesktopInstanceRepository() implements DesktopInstanceRepository {
+  final List<WindowBounds> windowBoundsWrites = <WindowBounds>[];
+
+  @override
+  Future<WindowBounds?> readWindowBounds() async => null;
+
+  @override
+  Future<void> writeWindowBounds({required WindowBounds bounds}) async {
+    windowBoundsWrites.add(bounds);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _FakeBridgeProcessLogRepository() implements BridgeProcessLogRepository {

--- a/client/module_desktop_core/test/cubits/bridge_control/bridge_control_cubit_test.dart
+++ b/client/module_desktop_core/test/cubits/bridge_control/bridge_control_cubit_test.dart
@@ -620,12 +620,6 @@ class _FakeWindowHost() implements WindowHost {
   Stream<WindowHostEvent> get events => _events.stream;
 
   @override
-  WindowHostState get currentState => WindowHostState.focused;
-
-  @override
-  Stream<WindowHostState> get states => const Stream<WindowHostState>.empty();
-
-  @override
   Future<void> initialize({
     required bool hidden,
     required WindowBounds? initialBounds,

--- a/client/module_desktop_core/test/cubits/bridge_control/bridge_control_cubit_test.dart
+++ b/client/module_desktop_core/test/cubits/bridge_control/bridge_control_cubit_test.dart
@@ -574,7 +574,22 @@ class _FakeWindowHost() implements WindowHost {
   Stream<WindowHostEvent> get events => _events.stream;
 
   @override
-  Future<void> initialize({required bool hidden}) async {}
+  WindowHostState get currentState => WindowHostState.focused;
+
+  @override
+  Stream<WindowHostState> get states => const Stream<WindowHostState>.empty();
+
+  @override
+  Future<void> initialize({required bool hidden, required WindowBounds? initialBounds}) async {}
+
+  @override
+  Future<WindowBounds> getBounds() async => const WindowBounds(left: 0, top: 0, width: 720, height: 620);
+
+  @override
+  Future<void> setBounds({required WindowBounds bounds}) async {}
+
+  @override
+  Future<List<WindowBounds>> getDisplayBounds() async => const <WindowBounds>[];
 
   @override
   Future<void> show() async {

--- a/client/module_desktop_core/test/orchestration/desktop_startup_orchestrator_test.dart
+++ b/client/module_desktop_core/test/orchestration/desktop_startup_orchestrator_test.dart
@@ -8,16 +8,19 @@ void main() {
   late _MockDesktopInstanceService instanceService;
   late _MockBridgeProcessService processService;
   late _MockDesktopApplicationTerminator applicationTerminator;
+  late _MockWindowBoundsService windowBoundsService;
   late DesktopStartupOrchestrator orchestrator;
 
   setUp(() {
     instanceService = _MockDesktopInstanceService();
     processService = _MockBridgeProcessService();
     applicationTerminator = _MockDesktopApplicationTerminator();
+    windowBoundsService = _MockWindowBoundsService();
     orchestrator = DesktopStartupOrchestrator(
       instanceService: instanceService,
       processService: processService,
       applicationTerminator: applicationTerminator,
+      windowBoundsService: windowBoundsService,
     );
   });
 
@@ -34,6 +37,14 @@ void main() {
     );
     expect(await orchestrator.preparePrimaryLaunch(), isFalse);
     verify(() => applicationTerminator.terminate(exitCode: 0)).called(1);
+  });
+
+  test("initializes the persisted native window through the bounds service", () async {
+    when(() => windowBoundsService.initializeWindow(hidden: true)).thenAnswer((_) async {});
+
+    await orchestrator.initializeWindow(hidden: true);
+
+    verify(() => windowBoundsService.initializeWindow(hidden: true)).called(1);
   });
 
   test("restores a persisted desired On through the process service", () async {
@@ -81,3 +92,5 @@ class _MockDesktopInstanceService() extends Mock implements DesktopInstanceServi
 class _MockBridgeProcessService() extends Mock implements BridgeProcessService;
 
 class _MockDesktopApplicationTerminator() extends Mock implements DesktopApplicationTerminator;
+
+class _MockWindowBoundsService() extends Mock implements WindowBoundsService;

--- a/client/module_desktop_core/test/repositories/desktop_instance_repository_test.dart
+++ b/client/module_desktop_core/test/repositories/desktop_instance_repository_test.dart
@@ -35,6 +35,17 @@ void main() {
 
     verify(() => storage.writeBridgeDesiredState(state: BridgeProcessDesiredState.off)).called(1);
   });
+
+  test("delegates window-bounds persistence to Layer-1 storage", () async {
+    const bounds = WindowBounds(left: 10, top: 20, width: 900, height: 700);
+    when(() => storage.readWindowBounds()).thenAnswer((_) async => bounds);
+    when(() => storage.writeWindowBounds(bounds: bounds)).thenAnswer((_) async {});
+
+    expect(await repository.readWindowBounds(), bounds);
+    await repository.writeWindowBounds(bounds: bounds);
+
+    verify(() => storage.writeWindowBounds(bounds: bounds)).called(1);
+  });
 }
 
 class _MockDesktopInstanceApi() extends Mock implements DesktopInstanceApi;

--- a/client/module_desktop_core/test/services/window_bounds_service_test.dart
+++ b/client/module_desktop_core/test/services/window_bounds_service_test.dart
@@ -74,6 +74,23 @@ void main() {
     ]);
   });
 
+  test("reduces the native minimum to a smaller selected work area", () async {
+    const saved = WindowBounds(left: 10, top: 20, width: 800, height: 600);
+    const compactDisplay = WindowBounds(left: 0, top: 0, width: 480, height: 360);
+    when(() => repository.readWindowBounds()).thenAnswer((_) async => saved);
+    when(() => windowHost.getDisplayBounds()).thenAnswer((_) async => const <WindowBounds>[compactDisplay]);
+
+    await service.initializeWindow(hidden: false);
+
+    verify(
+      () => windowHost.initialize(
+        hidden: false,
+        initialBounds: compactDisplay,
+        minimumSize: const WindowSize(width: 480, height: 360),
+      ),
+    ).called(1);
+  });
+
   test("chooses the nearest display for fully off-screen saved bounds", () async {
     const saved = WindowBounds(left: -5000, top: 100, width: 800, height: 600);
     const leftDisplay = WindowBounds(left: -1920, top: 0, width: 1920, height: 1080);

--- a/client/module_desktop_core/test/services/window_bounds_service_test.dart
+++ b/client/module_desktop_core/test/services/window_bounds_service_test.dart
@@ -7,6 +7,7 @@ import "package:test/test.dart";
 void main() {
   setUpAll(() {
     registerFallbackValue(const WindowBounds(left: 0, top: 0, width: 1, height: 1));
+    registerFallbackValue(const WindowSize(width: 1, height: 1));
   });
 
   late _MockWindowHost windowHost;
@@ -29,6 +30,7 @@ void main() {
       () => windowHost.initialize(
         hidden: any(named: "hidden"),
         initialBounds: any(named: "initialBounds"),
+        minimumSize: any(named: "minimumSize"),
       ),
     ).thenAnswer((_) async {});
   });
@@ -43,7 +45,13 @@ void main() {
 
     verify(() => repository.readWindowBounds()).called(1);
     verifyNever(() => windowHost.getDisplayBounds());
-    verify(() => windowHost.initialize(hidden: false, initialBounds: null)).called(1);
+    verify(
+      () => windowHost.initialize(
+        hidden: false,
+        initialBounds: null,
+        minimumSize: WindowBoundsService.minimumSize,
+      ),
+    ).called(1);
   });
 
   test("clamps restored bounds to the display they overlap before initializing", () async {
@@ -61,6 +69,7 @@ void main() {
       () => windowHost.initialize(
         hidden: true,
         initialBounds: const WindowBounds(left: 1440, top: 0, width: 900, height: 1080),
+        minimumSize: WindowBoundsService.minimumSize,
       ),
     ]);
   });
@@ -78,6 +87,7 @@ void main() {
       () => windowHost.initialize(
         hidden: false,
         initialBounds: const WindowBounds(left: -1920, top: 100, width: 800, height: 600),
+        minimumSize: WindowBoundsService.minimumSize,
       ),
     ).called(1);
   });
@@ -90,7 +100,13 @@ void main() {
     await service.initializeWindow(hidden: false);
 
     verifyNever(() => windowHost.getDisplayBounds());
-    verify(() => windowHost.initialize(hidden: false, initialBounds: null)).called(1);
+    verify(
+      () => windowHost.initialize(
+        hidden: false,
+        initialBounds: null,
+        minimumSize: WindowBoundsService.minimumSize,
+      ),
+    ).called(1);
   });
 
   test("debounces move and resize events into the latest bounds write", () async {
@@ -117,6 +133,18 @@ void main() {
     events.add(WindowHostEvent.resized);
     events.add(WindowHostEvent.closeRequested);
     await Future<void>.delayed(Duration.zero);
+
+    verify(() => repository.writeWindowBounds(bounds: latest)).called(1);
+  });
+
+  test("dispose flushes and awaits a pending bounds update", () async {
+    const latest = WindowBounds(left: 60, top: 70, width: 840, height: 640);
+    when(() => windowHost.getBounds()).thenAnswer((_) async => latest);
+    when(() => repository.writeWindowBounds(bounds: latest)).thenAnswer((_) async {});
+    await service.initializeWindow(hidden: false);
+
+    events.add(WindowHostEvent.resized);
+    await service.dispose();
 
     verify(() => repository.writeWindowBounds(bounds: latest)).called(1);
   });

--- a/client/module_desktop_core/test/services/window_bounds_service_test.dart
+++ b/client/module_desktop_core/test/services/window_bounds_service_test.dart
@@ -1,0 +1,145 @@
+import "dart:async";
+
+import "package:mocktail/mocktail.dart";
+import "package:sesori_desktop_core/sesori_desktop_core.dart";
+import "package:test/test.dart";
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(const WindowBounds(left: 0, top: 0, width: 1, height: 1));
+  });
+
+  late _MockWindowHost windowHost;
+  late _MockDesktopInstanceRepository repository;
+  late StreamController<WindowHostEvent> events;
+  late WindowBoundsService service;
+
+  setUp(() {
+    windowHost = _MockWindowHost();
+    repository = _MockDesktopInstanceRepository();
+    events = StreamController<WindowHostEvent>.broadcast(sync: true);
+    service = WindowBoundsService.test(
+      windowHost: windowHost,
+      repository: repository,
+      persistenceDebounce: const Duration(milliseconds: 5),
+    );
+    when(() => windowHost.events).thenAnswer((_) => events.stream);
+    when(() => repository.readWindowBounds()).thenAnswer((_) async => null);
+    when(
+      () => windowHost.initialize(
+        hidden: any(named: "hidden"),
+        initialBounds: any(named: "initialBounds"),
+      ),
+    ).thenAnswer((_) async {});
+  });
+
+  tearDown(() async {
+    await service.dispose();
+    await events.close();
+  });
+
+  test("uses the centered default when no bounds were persisted", () async {
+    await service.initializeWindow(hidden: false);
+
+    verify(() => repository.readWindowBounds()).called(1);
+    verifyNever(() => windowHost.getDisplayBounds());
+    verify(() => windowHost.initialize(hidden: false, initialBounds: null)).called(1);
+  });
+
+  test("clamps restored bounds to the display they overlap before initializing", () async {
+    const saved = WindowBounds(left: 1300, top: -100, width: 900, height: 1200);
+    const primary = WindowBounds(left: 0, top: 24, width: 1440, height: 876);
+    const secondary = WindowBounds(left: 1440, top: 0, width: 1920, height: 1080);
+    when(() => repository.readWindowBounds()).thenAnswer((_) async => saved);
+    when(() => windowHost.getDisplayBounds()).thenAnswer((_) async => const <WindowBounds>[primary, secondary]);
+
+    await service.initializeWindow(hidden: true);
+
+    verifyInOrder(<void Function()>[
+      () => repository.readWindowBounds(),
+      () => windowHost.getDisplayBounds(),
+      () => windowHost.initialize(
+        hidden: true,
+        initialBounds: const WindowBounds(left: 1440, top: 0, width: 900, height: 1080),
+      ),
+    ]);
+  });
+
+  test("chooses the nearest display for fully off-screen saved bounds", () async {
+    const saved = WindowBounds(left: -5000, top: 100, width: 800, height: 600);
+    const leftDisplay = WindowBounds(left: -1920, top: 0, width: 1920, height: 1080);
+    const primary = WindowBounds(left: 0, top: 0, width: 1440, height: 900);
+    when(() => repository.readWindowBounds()).thenAnswer((_) async => saved);
+    when(() => windowHost.getDisplayBounds()).thenAnswer((_) async => const <WindowBounds>[primary, leftDisplay]);
+
+    await service.initializeWindow(hidden: false);
+
+    verify(
+      () => windowHost.initialize(
+        hidden: false,
+        initialBounds: const WindowBounds(left: -1920, top: 100, width: 800, height: 600),
+      ),
+    ).called(1);
+  });
+
+  test("ignores unusable saved bounds", () async {
+    when(
+      () => repository.readWindowBounds(),
+    ).thenAnswer((_) async => const WindowBounds(left: double.nan, top: 0, width: 720, height: 620));
+
+    await service.initializeWindow(hidden: false);
+
+    verifyNever(() => windowHost.getDisplayBounds());
+    verify(() => windowHost.initialize(hidden: false, initialBounds: null)).called(1);
+  });
+
+  test("debounces move and resize events into the latest bounds write", () async {
+    const latest = WindowBounds(left: 120, top: 80, width: 1000, height: 760);
+    when(() => windowHost.getBounds()).thenAnswer((_) async => latest);
+    when(() => repository.writeWindowBounds(bounds: latest)).thenAnswer((_) async {});
+    await service.initializeWindow(hidden: false);
+
+    events.add(WindowHostEvent.moved);
+    events.add(WindowHostEvent.resized);
+    events.add(WindowHostEvent.moved);
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    verify(() => windowHost.getBounds()).called(1);
+    verify(() => repository.writeWindowBounds(bounds: latest)).called(1);
+  });
+
+  test("a close request flushes a pending bounds update", () async {
+    const latest = WindowBounds(left: 30, top: 40, width: 800, height: 600);
+    when(() => windowHost.getBounds()).thenAnswer((_) async => latest);
+    when(() => repository.writeWindowBounds(bounds: latest)).thenAnswer((_) async {});
+    await service.initializeWindow(hidden: false);
+
+    events.add(WindowHostEvent.resized);
+    events.add(WindowHostEvent.closeRequested);
+    await Future<void>.delayed(Duration.zero);
+
+    verify(() => repository.writeWindowBounds(bounds: latest)).called(1);
+  });
+
+  test("a failed persistence attempt does not poison later updates", () async {
+    const first = WindowBounds(left: 10, top: 20, width: 800, height: 600);
+    const second = WindowBounds(left: 30, top: 40, width: 900, height: 700);
+    var readCount = 0;
+    when(() => windowHost.getBounds()).thenAnswer((_) async => readCount++ == 0 ? first : second);
+    when(() => repository.writeWindowBounds(bounds: first)).thenThrow(StateError("disk unavailable"));
+    when(() => repository.writeWindowBounds(bounds: second)).thenAnswer((_) async {});
+    await service.initializeWindow(hidden: false);
+
+    events.add(WindowHostEvent.moved);
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    events.add(WindowHostEvent.resized);
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    verify(() => repository.writeWindowBounds(bounds: first)).called(1);
+    verify(() => repository.writeWindowBounds(bounds: second)).called(1);
+  });
+}
+
+class _MockWindowHost() extends Mock implements WindowHost;
+
+class _MockDesktopInstanceRepository() extends Mock implements DesktopInstanceRepository;

--- a/docs/regression/desktop-bridge-supervision.md
+++ b/docs/regression/desktop-bridge-supervision.md
@@ -44,8 +44,11 @@ and keep native close/quit behavior safe.
 - Window position and size persist under desktop-owned application data. Startup
   validates the saved bounds, selects the current display with greatest overlap
   (or nearest center), clamps them to its usable work area, and applies them
-  before the first explicit show. Missing or invalid bounds and display lookup
-  failures use the centered 720×620 default. Move/resize events debounce writes;
+  before the first explicit show; on macOS the native runner suppresses the
+  XIB's first ordering for normal and hidden launches so restoration cannot
+  flash the default frame. Missing or invalid bounds and display lookup failures
+  use the centered 720×620 default. The 560×480 minimum shrinks only when the
+  selected display work area is smaller. Move/resize events debounce writes;
   terminal Quit flushes the final observation before disposing the window host.
 - Primary and secondary (right/trackpad) clicks on the tray icon open the same
   typed context menu. The macOS Dock icon is a desktop-owned copy of the
@@ -145,8 +148,9 @@ the status and bounded recent output.
   or the macOS tray icon has an opaque background/wrong light-dark treatment,
   the Dock still shows a hidden window, or secondary tray clicks do nothing.
 - Restored bounds are applied after a visible flash, land wholly off-screen,
-  ignore current display work areas, fail to persist after move/resize, or one
-  failed write prevents later bounds from saving.
+  ignore current display work areas, retain a native minimum larger than the
+  selected work area, fail to persist after move/resize, or one failed write
+  prevents later bounds from saving.
 - Quit or sign-out clears auth or exits while a supervised helper remains alive,
   a profile logout bypasses the desktop logout orchestrator, or an On command
   can race between logout's helper stop and token clearing.

--- a/docs/regression/desktop-bridge-supervision.md
+++ b/docs/regression/desktop-bridge-supervision.md
@@ -41,6 +41,12 @@ and keep native close/quit behavior safe.
   hidden, and Open restores/focuses it and returns it to the Dock. Without a
   usable tray host, close defers safe Quit until active lifecycle work settles
   instead of dropping the request or leaving an invisible process.
+- Window position and size persist under desktop-owned application data. Startup
+  validates the saved bounds, selects the current display with greatest overlap
+  (or nearest center), clamps them to its usable work area, and applies them
+  before the first explicit show. Missing or invalid bounds and display lookup
+  failures use the centered 720×620 default. Move/resize events debounce writes;
+  terminal Quit flushes the final observation before disposing the window host.
 - Primary and secondary (right/trackpad) clicks on the tray icon open the same
   typed context menu. The macOS Dock icon is a desktop-owned copy of the
   Sesori Icon Composer asset used by the main client, not the Flutter starter
@@ -103,7 +109,7 @@ and keep native close/quit behavior safe.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Automated desktop startup proves eager tray initialization, Prego theme assembly, signed-out login rendering, signed-in supervision rendering, shared desktop Settings with mobile-only notifications omitted, and the typed session-detail route. No plugin. |
-| L2 Routine | Automated cubit/adapter coverage for Open/focus, close-to-hide, no-tray close-to-Quit, ordered Quit, quit-preserved desired state, failed-stop/persistence refusal to exit, On/Off recovery, explicit idempotent Start, diagnostics launch, durable-Off-before-local-logout, helper unregister command, no-competing-shutdown expected stop, account-bound persisted bridge-id restart, owner-mismatch protection, 404-idempotent deletion, offline deletion failure, explicit Take Over, both project recovery variants omitting CLI copy, desktop transcript rendering and pending-question presentation without dead composer/diff controls, app-wide preference persistence, desktop settings/harness composition, profile logout delegation, analytics-before-auth logout ordering, and failed-logout analytics recovery; cross-process lock/activation, killed-owner recovery, persisted desired state, and auth-gated startup restoration. No plugin. |
+| L2 Routine | Automated cubit/adapter coverage for Open/focus, close-to-hide, no-tray close-to-Quit, ordered Quit, quit-preserved desired state, failed-stop/persistence refusal to exit, On/Off recovery, explicit idempotent Start, diagnostics launch, bounds restore/clamp/debounce/terminal flush before first show, durable-Off-before-local-logout, helper unregister command, no-competing-shutdown expected stop, account-bound persisted bridge-id restart, owner-mismatch protection, 404-idempotent deletion, offline deletion failure, explicit Take Over, both project recovery variants omitting CLI copy, desktop transcript rendering and pending-question presentation without dead composer/diff controls, app-wide preference persistence, desktop settings/harness composition, profile logout delegation, analytics-before-auth logout ordering, and failed-logout analytics recovery; cross-process lock/activation, killed-owner recovery, persisted desired state, and auth-gated startup restoration. No plugin. |
 | L3 Release | Client end to end on macOS with a dev-built helper and representative live plugin: browser login/relaunch restore, healthy handshake, phone session round-trip, helper crash/backoff, exit-86 restart, login-required behavior, Off/close/Quit orphan checks, and standalone CLI coexistence. |
 | L4 Extended | Client end to end on Windows and Linux, including a Linux StatusNotifier host and a no-host windowed fallback; vary helper startup/stop failures, relay takeover, crash give-up output, and default log-file application availability. |
 | L5 Full | Packaged desktop artifacts on every release target, including native tray/window appearance, signing/install behavior, and long-running supervision through repeated sleep, reconnect, restart, hide/show, and relaunch cycles. |
@@ -138,6 +144,9 @@ the status and bounded recent output.
   lifecycle work, Open shows without focusing, native close bypasses teardown,
   or the macOS tray icon has an opaque background/wrong light-dark treatment,
   the Dock still shows a hidden window, or secondary tray clicks do nothing.
+- Restored bounds are applied after a visible flash, land wholly off-screen,
+  ignore current display work areas, fail to persist after move/resize, or one
+  failed write prevents later bounds from saving.
 - Quit or sign-out clears auth or exits while a supervised helper remains alive,
   a profile logout bypasses the desktop logout orchestrator, or an On command
   can race between logout's helper stop and token clearing.
@@ -197,6 +206,7 @@ the status and bounded recent output.
 - `client/desktop/lib/core/platform/io_bridge_process_environment.dart`
 - `client/module_desktop_core/lib/src/orchestration/desktop_bridge_takeover_orchestrator.dart`
 - `client/module_desktop_core/lib/src/orchestration/desktop_logout_orchestrator.dart`
+- `client/module_desktop_core/lib/src/services/window_bounds_service.dart`
 - `client/module_desktop_core/lib/src/api/bridge_id_storage.dart`
 - `client/module_core/lib/src/api/bridge_api.dart`
 - `client/module_core/lib/src/repositories/bridge_repository.dart`


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this is a focused persistence and native-window lifecycle change spanning a pure-Dart service and the Flutter desktop adapter.

## What

- Add typed window size/bounds and move/resize events to the desktop window capability.
- Persist bounds through desktop-instance storage and repository ownership.
- Restore validated, display-clamped bounds before the first explicit show, including suppressing macOS's native XIB ordering.
- Adjust the native minimum when the selected work area is smaller than 560×480.
- Debounce move/resize writes and flush the final observation before terminal Quit disposes the native host.
- Record the fixed three-PR replacement for oversized, closed-unmerged PR #1265.

This is replacement slice 1/3. It intentionally excludes cockpit navigation/input and all attention-only focus/visibility state.

## Why

The fixed 720×620 window is not suitable as a daily-driver cockpit, while the prior combined Step 20 PR was too broad for efficient review. This slice makes bounds restoration independently useful and reviewable without exposing infrastructure that has no current production consumer.

## Risk and test focus

Moderate risk, concentrated in startup ordering, multi-display clamping, write failure recovery, and terminal Quit ordering. Review should focus on:

- bounds being applied before any visible show;
- off-screen/oversized saved values being clamped to a current usable work area;
- debounced writes retaining the latest observation and recovering after failure;
- final flush completing before `WindowHost.dispose()`;
- hidden launch and existing close-to-tray behavior remaining unchanged.

No database or wire-contract impact. User-visible impact is limited to persisted desktop window placement and size. Persistence is a new local application-support value.

## Expected result

After a successful run, moving or resizing the desktop window and relaunching restores a usable position and size on an attached display. Invalid or unavailable saved state falls back to a centered 720×620 window. Terminal Quit does not lose the last pending bounds observation.

## Verification

- `client/module_desktop_core`: fatal-info analysis passes; full suite passes 216 tests.
- `client/desktop`: fatal-info analysis passes; full suite passes 97 tests.
- Dart LSP: zero diagnostics across 12 changed production files.
- Clean macOS release build succeeds at 65.7 MB.
- `codesign --verify --deep --strict` passes.
- Architecture review: approved after removing unused future attention-state infrastructure.
- `git diff --check` passes.
- Pinned implementation range: `74d84c4ddcd4818ea2b435088f014cdfd5229c9a..34cf314c807259174c99c7649f33256522fbddd9` — 1,016 additions, 72 deletions, 1,088 total changed lines. The exact non-self-inclusive reproduction command is recorded in `step-20-1.md`.
- Real display rearrangement and relaunch ergonomics remain in user-run MT Gate C after all three slices.
