### PR TITLE
⚙️ Re-arm Claude Code and Pi idle timers on timeout changes

### DIFF
--- a/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
@@ -581,6 +581,7 @@ class const BridgeRuntimeRunner._() {
         currentUser: currentUser,
         resolveIdleTimeoutMins: ({required pluginId}) =>
             bridgeSettingsRepository.currentSettings.plugins.idleTimeoutMinsFor(pluginId: pluginId),
+        settingsChanges: bridgeSettingsRepository.settingsChanges,
       );
       final activePluginRuntime = PluginRuntime(
         registrations: [

--- a/bridge/app/lib/src/runtime/plugin_generation_factory.dart
+++ b/bridge/app/lib/src/runtime/plugin_generation_factory.dart
@@ -73,6 +73,16 @@ class PluginGenerationFactory({
     final minutes = _resolveIdleTimeoutMins(pluginId: pluginId);
     return minutes > 0 ? Duration(minutes: minutes) : null;
   }
+  Stream<Duration?> _idleTimeoutChangesForPlugin({required String pluginId}) {
+    var previous = _idleTimeoutForPlugin(pluginId: pluginId);
+    return _settingsChanges
+        .map<Duration?>((_) => _idleTimeoutForPlugin(pluginId: pluginId))
+        .where((current) {
+          if (current == previous) return false;
+          previous = current;
+          return true;
+        });
+  }
 
   Future<void> enforceBridgeOwnership() => _attemptBatch(attempt: 1, batch: const []);
 
@@ -276,9 +286,7 @@ class PluginGenerationFactory({
       ports: const BridgeHostPortService(loopbackPortApi: LoopbackPortApi()),
       store: BridgeHostJsonStore(fileApi: fileApi),
       resolveIdleTimeout: () => _idleTimeoutForPlugin(pluginId: descriptor.id),
-      pluginIdleTimeoutChanges: _settingsChanges
-          .map<Duration?>((_) => _idleTimeoutForPlugin(pluginId: descriptor.id))
-          .distinct(),
+      pluginIdleTimeoutChanges: _idleTimeoutChangesForPlugin(pluginId: descriptor.id),
     );
   }
 }

--- a/bridge/app/lib/src/runtime/plugin_generation_factory.dart
+++ b/bridge/app/lib/src/runtime/plugin_generation_factory.dart
@@ -59,6 +59,7 @@ class PluginGenerationFactory({
   /// Read live at each [PluginHost.pluginIdleTimeout] access so runtime
   /// settings changes reach plugins without a restart.
   required final int Function({required String pluginId}) _resolveIdleTimeoutMins,
+  required final Stream<Object?> _settingsChanges,
 }) {
   final Map<String, String> _environment = Map<String, String>.unmodifiable(environment);
   final Map<String, RuntimeFileApi> _fileApisByStateDirectory = <String, RuntimeFileApi>{
@@ -67,6 +68,11 @@ class PluginGenerationFactory({
   final List<_GenerationStartRequest> _pending = <_GenerationStartRequest>[];
   bool _drainScheduled = false;
   bool _draining = false;
+
+  Duration? _idleTimeoutForPlugin({required String pluginId}) {
+    final minutes = _resolveIdleTimeoutMins(pluginId: pluginId);
+    return minutes > 0 ? Duration(minutes: minutes) : null;
+  }
 
   Future<void> enforceBridgeOwnership() => _attemptBatch(attempt: 1, batch: const []);
 
@@ -269,10 +275,10 @@ class PluginGenerationFactory({
       ),
       ports: const BridgeHostPortService(loopbackPortApi: LoopbackPortApi()),
       store: BridgeHostJsonStore(fileApi: fileApi),
-      resolveIdleTimeout: () {
-        final minutes = _resolveIdleTimeoutMins(pluginId: descriptor.id);
-        return minutes > 0 ? Duration(minutes: minutes) : null;
-      },
+      resolveIdleTimeout: () => _idleTimeoutForPlugin(pluginId: descriptor.id),
+      pluginIdleTimeoutChanges: _settingsChanges
+          .map<Duration?>((_) => _idleTimeoutForPlugin(pluginId: descriptor.id))
+          .distinct(),
     );
   }
 }

--- a/bridge/app/lib/src/server/host/bridge_plugin_host_impl.dart
+++ b/bridge/app/lib/src/server/host/bridge_plugin_host_impl.dart
@@ -34,11 +34,15 @@ class BridgePluginHostImpl({
   @override required final HostPortService ports,
   @override required final HostJsonStore store,
   required final Duration? Function() _resolveIdleTimeout,
+  required final Stream<Duration?> _pluginIdleTimeoutChanges,
 }) implements PluginHost {
   /// Live view over the bridge's runtime-mutable per-plugin idle timeout, so
   /// a settings change reaches the plugin without a restart.
   @override
   Duration? get pluginIdleTimeout => _resolveIdleTimeout();
+
+  @override
+  Stream<Duration?> get pluginIdleTimeoutChanges => _pluginIdleTimeoutChanges;
 
   /// Set by the bridge runner from `ensureRuntime`'s [ProvisionReady] result,
   /// after the host is built and before `start()` runs; `null` when the plugin

--- a/bridge/app/test/bridge/runtime/plugin_generation_factory_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_generation_factory_test.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:io";
 
 import "package:sesori_bridge/src/runtime/bridge_runtime_server_exception.dart";
@@ -26,6 +27,8 @@ void main() {
     late ProcessIdentity currentBridgeIdentity;
     late Directory runtimeDirectory;
     late List<BridgePlugin> startedPlugins;
+    late StreamController<Object?> settingsChanges;
+    late int idleTimeoutMins;
 
     setUp(() async {
       startupMutexRepository = _FakeStartupMutexRepository();
@@ -34,12 +37,15 @@ void main() {
       currentBridgeIdentity = _identity(pid: 100, startMarker: "bridge-start");
       runtimeDirectory = await Directory.systemTemp.createTemp("bridge-runtime-server-test");
       startedPlugins = [];
+      settingsChanges = StreamController<Object?>.broadcast(sync: true);
+      idleTimeoutMins = 10;
     });
 
     tearDown(() async {
       for (final plugin in startedPlugins) {
         await plugin.shutdown(budget: const Duration(seconds: 1));
       }
+      await settingsChanges.close();
       if (runtimeDirectory.existsSync()) {
         await runtimeDirectory.delete(recursive: true);
       }
@@ -66,7 +72,8 @@ void main() {
         clock: const ServerClock(),
         environment: const <String, String>{"HOME": "/home/alex"},
         currentUser: ProcessUser.fromRawUser("alex"),
-        resolveIdleTimeoutMins: ({required pluginId}) => 10,
+        resolveIdleTimeoutMins: ({required pluginId}) => idleTimeoutMins,
+        settingsChanges: settingsChanges.stream,
       );
       BridgePlugin? startedPlugin;
       await for (final event in factory.start(
@@ -129,6 +136,18 @@ void main() {
         reason: "stale cleanup must be authorized to reclaim records of the bridge this one replaced",
       );
     });
+    test("forwards live idle timeout changes through the plugin host", () async {
+      await startPlugin();
+      final host = descriptor.startedHosts.single;
+      final changes = <Duration?>[];
+      final subscription = host.pluginIdleTimeoutChanges.listen(changes.add);
+
+      idleTimeoutMins = 25;
+      settingsChanges.add(Object());
+
+      expect(changes, [const Duration(minutes: 25)]);
+      await subscription.cancel();
+    });
 
     test("zero-plugin startup still performs single-live-bridge enforcement", () async {
       final factory = PluginGenerationFactory(
@@ -147,6 +166,7 @@ void main() {
         environment: const <String, String>{},
         currentUser: null,
         resolveIdleTimeoutMins: ({required pluginId}) => 10,
+        settingsChanges: settingsChanges.stream,
       );
       await factory.enforceBridgeOwnership();
 

--- a/bridge/app/test/bridge/runtime/plugin_generation_factory_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_generation_factory_test.dart
@@ -136,11 +136,14 @@ void main() {
         reason: "stale cleanup must be authorized to reclaim records of the bridge this one replaced",
       );
     });
-    test("forwards live idle timeout changes through the plugin host", () async {
+    test("forwards only changed idle timeout values through the plugin host", () async {
       await startPlugin();
       final host = descriptor.startedHosts.single;
       final changes = <Duration?>[];
       final subscription = host.pluginIdleTimeoutChanges.listen(changes.add);
+
+      settingsChanges.add(Object());
+      expect(changes, isEmpty);
 
       idleTimeoutMins = 25;
       settingsChanges.add(Object());

--- a/bridge/app/tool/benchmarks/multi_plugin_startup_benchmark.dart
+++ b/bridge/app/tool/benchmarks/multi_plugin_startup_benchmark.dart
@@ -106,6 +106,7 @@ Future<_StartupSample> _runFixture({required int selectedCount}) async {
     environment: const <String, String>{},
     currentUser: null,
     resolveIdleTimeoutMins: ({required pluginId}) => 10,
+    settingsChanges: const Stream<Object?>.empty(),
   );
   final runtime =
       PluginRuntime(

--- a/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
@@ -212,6 +212,7 @@ final class const ClaudePluginDescriptor({
       approvals: approvals,
       clock: host.clock,
       resolveIdleTimeout: () => host.pluginIdleTimeout,
+      idleTimeoutChanges: host.pluginIdleTimeoutChanges,
     );
     const content = ClaudeContentMapper();
     final plugin = ClaudePlugin(

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -1,6 +1,7 @@
 import "dart:async";
 import "dart:collection";
 
+import "package:rxdart/rxdart.dart";
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show PendingOperations;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" as shared;
@@ -100,8 +101,8 @@ final class ClaudeSessionService({
   required final Stream<Duration?> _idleTimeoutChanges,
 }) {
   this {
-    _processEvents = _processes.events.listen(_handleProcessEvent);
-    _idleTimeoutSubscription = _idleTimeoutChanges.listen(_handleIdleTimeoutChange);
+    _processes.events.listen(_handleProcessEvent).addTo(_subscriptions);
+    _idleTimeoutChanges.listen(_handleIdleTimeoutChange).addTo(_subscriptions);
   }
 
   /// See [_SessionTurnState.recentlyDispatched]. 64 comfortably exceeds any
@@ -116,8 +117,7 @@ final class ClaudeSessionService({
   final PluginWorkStateController _workState = PluginWorkStateController(initial: PluginWorkState.idle);
   final PendingOperations _inFlightTeardowns = PendingOperations();
   final Map<String, Future<void>> _teardownsBySession = {};
-  late final StreamSubscription<ClaudeSessionProcessEvent> _processEvents;
-  late final StreamSubscription<Duration?> _idleTimeoutSubscription;
+  final CompositeSubscription _subscriptions = CompositeSubscription();
   Future<void>? _disposeFuture;
   bool _disposed = false;
 
@@ -607,8 +607,7 @@ final class ClaudeSessionService({
       state.idleGeneration++;
       _completeSelfStartedTurn(state: state);
     }
-    await _processEvents.cancel();
-    await _idleTimeoutSubscription.cancel();
+    await _subscriptions.cancel();
     _approvals.dispose();
     await _processes.dispose();
     await _inFlightTeardowns.drain();

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -95,12 +95,13 @@ final class ClaudeSessionService({
   required final ServerClock _clock,
 
   /// Resolves the current per-session idle timeout, or null when idle reaping
-  /// is disabled. Read at every timer arm so a runtime settings change takes
-  /// effect at the next idle transition.
+  /// is disabled. Read whenever an idle timer is armed.
   required final Duration? Function() _resolveIdleTimeout,
+  required final Stream<Duration?> _idleTimeoutChanges,
 }) {
   this {
     _processEvents = _processes.events.listen(_handleProcessEvent);
+    _idleTimeoutSubscription = _idleTimeoutChanges.listen(_handleIdleTimeoutChange);
   }
 
   /// See [_SessionTurnState.recentlyDispatched]. 64 comfortably exceeds any
@@ -116,6 +117,7 @@ final class ClaudeSessionService({
   final PendingOperations _inFlightTeardowns = PendingOperations();
   final Map<String, Future<void>> _teardownsBySession = {};
   late final StreamSubscription<ClaudeSessionProcessEvent> _processEvents;
+  late final StreamSubscription<Duration?> _idleTimeoutSubscription;
   Future<void>? _disposeFuture;
   bool _disposed = false;
 
@@ -606,6 +608,7 @@ final class ClaudeSessionService({
       _completeSelfStartedTurn(state: state);
     }
     await _processEvents.cancel();
+    await _idleTimeoutSubscription.cancel();
     _approvals.dispose();
     await _processes.dispose();
     await _inFlightTeardowns.drain();
@@ -633,6 +636,20 @@ final class ClaudeSessionService({
     _emit(const BridgeSseProjectUpdated());
     _syncWorkState();
     _scheduleIdleReap(sessionId: sessionId, state: state);
+  }
+
+  void _handleIdleTimeoutChange(Duration? _) {
+    if (_disposed) return;
+    for (final entry in _turns.entries) {
+      final state = entry.value;
+      if (state.hasWork ||
+          state.aborting != null ||
+          !_processes.isResident(sessionId: entry.key) ||
+          _teardownsBySession.containsKey(entry.key)) {
+        continue;
+      }
+      _scheduleIdleReap(sessionId: entry.key, state: state);
+    }
   }
 
   void _scheduleIdleReap({required String sessionId, required _SessionTurnState state}) {

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -884,6 +884,7 @@ final class _PluginHarness({final bool failInitialize = false, bool failTranscri
       approvals: approvals,
       clock: const _NeverIdleClock(),
       resolveIdleTimeout: () => const Duration(minutes: 5),
+      idleTimeoutChanges: const Stream<Duration?>.empty(),
     );
     const content = ClaudeContentMapper();
     final transcripts = ClaudeTranscriptCatalogRepository(

--- a/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
@@ -392,26 +392,31 @@ void main() {
       expect(harness.repository.isResident(sessionId: testSessionId), isFalse);
     });
 
-    test("reads the idle timeout live at each reap arm", () async {
-      harness.idleTimeout = null;
+    test("rearms the idle timeout immediately when settings change", () async {
       unawaited(harness.enqueue("first"));
       final process = await harness.firstProcess;
       await waitForFrame(process, "user");
       process.emit(_result());
       await harness.waitForIdle();
 
-      // Reaping disabled: no delay armed, process stays resident.
-      harness.clock.elapse();
+      expect(harness.clock.delays, [const Duration(minutes: 5)]);
+
+      harness.idleTimeout = null;
+      harness.idleTimeoutChanges.add(null);
+      await pump();
+      harness.clock.elapseAt(index: 0);
       await pump();
       expect(harness.repository.isResident(sessionId: testSessionId), isTrue);
 
-      // Settings change takes effect at the next idle transition.
       harness.idleTimeout = const Duration(minutes: 1);
-      unawaited(harness.enqueue("second"));
-      await _waitForUserFrames(process, 2);
-      process.emit(_result());
-      await harness.waitForIdle();
-      harness.clock.elapse();
+      harness.idleTimeoutChanges.add(harness.idleTimeout);
+      await pump();
+      expect(harness.clock.delays, [
+        const Duration(minutes: 5),
+        const Duration(minutes: 1),
+      ]);
+
+      harness.clock.elapseAt(index: 1);
       await pump();
       expect(harness.repository.isResident(sessionId: testSessionId), isFalse);
     });
@@ -820,6 +825,7 @@ void main() {
 final class _ServiceHarness({final bool stdinCloseCompletes = true, final bool failInterrupt = false}) {
   /// Mutable so tests can exercise runtime settings changes.
   Duration? idleTimeout = const Duration(minutes: 5);
+  final StreamController<Duration?> idleTimeoutChanges = StreamController<Duration?>.broadcast(sync: true);
 
   this {
     repository = ClaudeSessionProcessRepository(
@@ -837,6 +843,7 @@ final class _ServiceHarness({final bool stdinCloseCompletes = true, final bool f
       approvals: approvals,
       clock: clock,
       resolveIdleTimeout: () => idleTimeout,
+      idleTimeoutChanges: idleTimeoutChanges.stream,
     );
     subscription = service.events.listen(events.add);
   }
@@ -910,6 +917,7 @@ final class _ServiceHarness({final bool stdinCloseCompletes = true, final bool f
   Future<void> dispose() async {
     await service.dispose();
     await subscription.cancel();
+    await idleTimeoutChanges.close();
     for (final process in processes) {
       await process.close();
     }
@@ -919,9 +927,11 @@ final class _ServiceHarness({final bool stdinCloseCompletes = true, final bool f
 final class _ControlledClock() extends ServerClock {
   final List<Completer<void>> _delays = [];
 
+  final List<Duration> delays = [];
   @override
   Future<void> delay({required Duration duration}) {
     final completer = Completer<void>();
+    delays.add(duration);
     _delays.add(completer);
     return completer.future;
   }
@@ -931,6 +941,10 @@ final class _ControlledClock() extends ServerClock {
       if (!delay.isCompleted) delay.complete();
     }
     _delays.clear();
+  }
+  void elapseAt({required int index}) {
+    final delay = _delays[index];
+    if (!delay.isCompleted) delay.complete();
   }
 }
 

--- a/bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_claude/test/runtime/claude_plugin_descriptor_test.dart
@@ -279,6 +279,8 @@ final class _PluginHost({
 
   @override
   ServerClock get clock => const ServerClock();
+  @override
+  Stream<Duration?> get pluginIdleTimeoutChanges => const Stream<Duration?>.empty();
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/bridge/sesori_plugin_interface/lib/src/host/plugin_host.dart
+++ b/bridge/sesori_plugin_interface/lib/src/host/plugin_host.dart
@@ -65,11 +65,14 @@ abstract class PluginHost() {
   /// The user-configured idle timeout for this plugin, or null when idle
   /// cleanup is disabled.
   ///
-  /// A live getter over the bridge's runtime-mutable settings: read it when
-  /// arming an idle timer rather than caching it, so a settings change takes
-  /// effect at the next idle transition without a plugin restart. Plugins
-  /// whose descriptor declares `PluginResidencyPolicy.resident` own idle
-  /// cleanup themselves (the bridge's whole-plugin suspension timer never
-  /// arms) and use this value for their internal reclamation instead.
+  /// A live getter over the bridge's runtime-mutable settings. Read it when
+  /// arming an idle timer rather than caching it, so settings changes reach
+  /// plugins without a restart.
   Duration? get pluginIdleTimeout;
+
+  /// Emits the newly effective timeout whenever it changes at runtime.
+  ///
+  /// The stream does not emit an initial value; read [pluginIdleTimeout] for
+  /// the current value when starting. A null event disables idle cleanup.
+  Stream<Duration?> get pluginIdleTimeoutChanges;
 }

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_test.dart
@@ -993,6 +993,8 @@ class _FakeHost({@override required final PluginConfig config}) implements Plugi
 
   @override
   Duration? get pluginIdleTimeout => null;
+  @override
+  Stream<Duration?> get pluginIdleTimeoutChanges => const Stream<Duration?>.empty();
 
   @override
   String? provisionedRuntimePath;

--- a/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
+++ b/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
@@ -49,6 +49,7 @@ final class PiPlugin._({
     required Duration catalogTimeout,
     required Duration healthTimeout,
     required Duration? Function() resolveIdleTimeout,
+    required Stream<Duration?> idleTimeoutChanges,
     required Duration editorTimeout,
   }) {
     final storage = PiSessionStorageApi(environment: storageEnvironment);
@@ -90,6 +91,7 @@ final class PiPlugin._({
       extensionUiService: extensionUiService,
       clock: clock,
       resolveIdleTimeout: resolveIdleTimeout,
+      idleTimeoutChanges: idleTimeoutChanges,
     );
     final catalogService = PiCatalogService(
       repository: PiBackendCatalogRepository(

--- a/bridge/sesori_plugin_pi/lib/src/runtime/pi_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_pi/lib/src/runtime/pi_plugin_descriptor.dart
@@ -25,6 +25,7 @@ typedef PiPluginFactory = PiPlugin Function({
   required Duration catalogTimeout,
   required Duration healthTimeout,
   required Duration? Function() resolveIdleTimeout,
+  required Stream<Duration?> idleTimeoutChanges,
   required Duration editorTimeout,
 });
 
@@ -41,6 +42,7 @@ PiPlugin _buildPiPlugin({
   required Duration catalogTimeout,
   required Duration healthTimeout,
   required Duration? Function() resolveIdleTimeout,
+  required Stream<Duration?> idleTimeoutChanges,
   required Duration editorTimeout,
 }) => PiPlugin(
   binaryPath: binaryPath,
@@ -55,6 +57,7 @@ PiPlugin _buildPiPlugin({
   catalogTimeout: catalogTimeout,
   healthTimeout: healthTimeout,
   resolveIdleTimeout: resolveIdleTimeout,
+  idleTimeoutChanges: idleTimeoutChanges,
   editorTimeout: editorTimeout,
 );
 
@@ -274,6 +277,7 @@ final class const PiPluginDescriptor({
         catalogTimeout: const Duration(seconds: 30),
         healthTimeout: const Duration(seconds: 10),
         resolveIdleTimeout: () => host.pluginIdleTimeout,
+        idleTimeoutChanges: host.pluginIdleTimeoutChanges,
         editorTimeout: const Duration(minutes: 30),
       );
     } on Object {

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -1,6 +1,7 @@
 import "dart:async";
 import "dart:collection";
 
+import "package:rxdart/rxdart.dart";
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show PendingOperations;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" as shared;
@@ -157,9 +158,9 @@ final class PiSessionService({
   required final Stream<Duration?> idleTimeoutChanges,
 }) {
   this {
-    _frameSubscription = _processes.frames.listen(_handleFrame);
-    _exitSubscription = _processes.exits.listen(_handleExit);
-    _idleTimeoutSubscription = idleTimeoutChanges.listen(_handleIdleTimeoutChange);
+    _processes.frames.listen(_handleFrame).addTo(_subscriptions);
+    _processes.exits.listen(_handleExit).addTo(_subscriptions);
+    idleTimeoutChanges.listen(_handleIdleTimeoutChange).addTo(_subscriptions);
   }
 
   final PiSessionProcessRepository _processes = processRepository;
@@ -173,9 +174,7 @@ final class PiSessionService({
   final PendingOperations _activeIdleReaps = PendingOperations();
   final StreamController<BridgeSseEvent> _events = StreamController.broadcast();
   final PluginWorkStateController _workState = PluginWorkStateController(initial: PluginWorkState.idle);
-  late final StreamSubscription<PiSessionProcessFrame> _frameSubscription;
-  late final StreamSubscription<PiSessionProcessExit> _exitSubscription;
-  late final StreamSubscription<Duration?> _idleTimeoutSubscription;
+  final CompositeSubscription _subscriptions = CompositeSubscription();
   Future<void>? _disposeFuture;
   bool _disposed = false;
 
@@ -1273,9 +1272,7 @@ final class PiSessionService({
         }
       }
     }
-    await _frameSubscription.cancel();
-    await _exitSubscription.cancel();
-    await _idleTimeoutSubscription.cancel();
+    await _subscriptions.cancel();
     await _extensionUi.dispose();
     await _processes.dispose(shutdownBudget: shutdownBudget);
     await _activeIdleReaps.drain();

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -154,10 +154,12 @@ final class PiSessionService({
   required final PiExtensionUiService extensionUiService,
   required final ServerClock clock,
   required final Duration? Function() resolveIdleTimeout,
+  required final Stream<Duration?> idleTimeoutChanges,
 }) {
   this {
     _frameSubscription = _processes.frames.listen(_handleFrame);
     _exitSubscription = _processes.exits.listen(_handleExit);
+    _idleTimeoutSubscription = idleTimeoutChanges.listen(_handleIdleTimeoutChange);
   }
 
   final PiSessionProcessRepository _processes = processRepository;
@@ -173,6 +175,7 @@ final class PiSessionService({
   final PluginWorkStateController _workState = PluginWorkStateController(initial: PluginWorkState.idle);
   late final StreamSubscription<PiSessionProcessFrame> _frameSubscription;
   late final StreamSubscription<PiSessionProcessExit> _exitSubscription;
+  late final StreamSubscription<Duration?> _idleTimeoutSubscription;
   Future<void>? _disposeFuture;
   bool _disposed = false;
 
@@ -1159,6 +1162,15 @@ final class PiSessionService({
     return descendants;
   }
 
+  void _handleIdleTimeoutChange(Duration? _) {
+    if (_disposed) return;
+    for (final entry in _sessions.entries) {
+      final state = entry.value;
+      if (state.hasWork || state.residentGeneration == null || state.idleReap != null) continue;
+      _scheduleIdleReap(sessionId: entry.key, state: state);
+    }
+  }
+
   void _scheduleIdleReap({required String sessionId, required _PiSessionTurnState state}) {
     final generation = ++state.idleGeneration;
     final idleTimeout = _resolveIdleTimeout();
@@ -1263,6 +1275,7 @@ final class PiSessionService({
     }
     await _frameSubscription.cancel();
     await _exitSubscription.cancel();
+    await _idleTimeoutSubscription.cancel();
     await _extensionUi.dispose();
     await _processes.dispose(shutdownBudget: shutdownBudget);
     await _activeIdleReaps.drain();

--- a/bridge/sesori_plugin_pi/pubspec.yaml
+++ b/bridge/sesori_plugin_pi/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   freezed_annotation: ^3.1.0
   json_annotation: ^4.12.0
   path: ^1.9.1
+  rxdart: ^0.28.0
 
 dev_dependencies:
   build_runner: any

--- a/bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart
@@ -138,6 +138,7 @@ void main() {
               required catalogTimeout,
               required healthTimeout,
               required resolveIdleTimeout,
+              required idleTimeoutChanges,
               required editorTimeout,
             }) {
               capturedBinaryPath = binaryPath;
@@ -157,6 +158,7 @@ void main() {
                 catalogTimeout: catalogTimeout,
                 healthTimeout: healthTimeout,
                 resolveIdleTimeout: resolveIdleTimeout,
+                idleTimeoutChanges: idleTimeoutChanges,
                 editorTimeout: editorTimeout,
               );
             },
@@ -199,6 +201,7 @@ void main() {
               required healthTimeout,
               required resolveIdleTimeout,
               required editorTimeout,
+              required idleTimeoutChanges,
             }) {
               built = _plugin(
                 binaryPath: binaryPath,
@@ -213,6 +216,7 @@ void main() {
                 catalogTimeout: catalogTimeout,
                 healthTimeout: healthTimeout,
                 resolveIdleTimeout: resolveIdleTimeout,
+                idleTimeoutChanges: idleTimeoutChanges,
                 editorTimeout: editorTimeout,
               );
               abort.abort();
@@ -273,6 +277,7 @@ PiPlugin _plugin({
   required Duration catalogTimeout,
   required Duration healthTimeout,
   required Duration? Function() resolveIdleTimeout,
+  required Stream<Duration?> idleTimeoutChanges,
   required Duration editorTimeout,
 }) => PiPlugin(
   binaryPath: binaryPath,
@@ -287,6 +292,7 @@ PiPlugin _plugin({
   catalogTimeout: catalogTimeout,
   healthTimeout: healthTimeout,
   resolveIdleTimeout: resolveIdleTimeout,
+  idleTimeoutChanges: idleTimeoutChanges,
   editorTimeout: editorTimeout,
 );
 
@@ -299,6 +305,8 @@ class _Host({
 }) implements PluginHost {
   @override
   final StartAbortSignal startAborted = startAborted ?? StartAbortSignal.never;
+  @override
+  Stream<Duration?> get pluginIdleTimeoutChanges => const Stream<Duration?>.empty();
 
   @override
   Map<String, String> get environment => const {"HOME": "/home/test", "PI_CODING_AGENT_DIR": "/profile"};

--- a/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
@@ -559,6 +559,7 @@ final class _Harness({bool stdinCloseCompletes = true, String catalogCommand = "
       catalogTimeout: const Duration(seconds: 2),
       healthTimeout: const Duration(seconds: 1),
       resolveIdleTimeout: () => const Duration(minutes: 5),
+      idleTimeoutChanges: const Stream<Duration?>.empty(),
       editorTimeout: const Duration(minutes: 1),
     );
   }

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -1952,13 +1952,12 @@ void main() {
     expect(second.killed, isTrue);
   });
 
-  test("reads the configured idle timeout live at each reap arm", () async {
+  test("rearms the idle timeout immediately when settings change", () async {
     final process = FakePiProcess();
     final fixture = _Fixture(processes: [process]);
     addTearDown(fixture.dispose);
     final clock = _ManualClock();
     final service = fixture.service(clock: clock);
-    fixture.idleTimeout = null;
 
     await service.sendPrompt(
       sessionId: "session",
@@ -1975,28 +1974,24 @@ void main() {
     process.emit(frame: {"type": "agent_settled"});
     await _waitForIdle(service: service, sessionId: "session");
 
-    expect(clock.delays, isEmpty);
-    clock.elapse();
+    expect(clock.delays, [const Duration(minutes: 5)]);
+
+    fixture.idleTimeout = null;
+    fixture.idleTimeoutChanges.add(null);
+    await pump();
+    clock.elapseAt(index: 0);
     await pump();
     expect(fixture.repository.residentSessionIds, contains("session"));
 
     fixture.idleTimeout = const Duration(minutes: 1);
-    await service.sendPrompt(
-      sessionId: "session",
-      promptId: "prompt-reap",
-      directory: "/project",
-      parts: [const PluginPromptPart.text(text: "second")],
-      userVisibleText: "second",
-      variant: null,
-      model: null,
-    );
-    final secondPrompt = await _waitForNthCommand(process: process, type: "prompt", count: 2);
-    process.emitResponse(id: secondPrompt["id"]! as String, command: "prompt");
-    process.emit(frame: {"type": "agent_settled"});
-    await _waitForIdle(service: service, sessionId: "session");
+    fixture.idleTimeoutChanges.add(fixture.idleTimeout);
+    await pump();
+    expect(clock.delays, [
+      const Duration(minutes: 5),
+      const Duration(minutes: 1),
+    ]);
 
-    expect(clock.delays, [const Duration(minutes: 1)]);
-    clock.elapse();
+    clock.elapseAt(index: 1);
     await pump();
     expect(process.killed, isTrue);
   });
@@ -2344,6 +2339,7 @@ final class _Fixture({
 }) {
   final List<FakePiProcess> _processes = List.of(processes);
   Duration? idleTimeout = const Duration(minutes: 5);
+  final StreamController<Duration?> idleTimeoutChanges = StreamController<Duration?>.broadcast(sync: true);
   Duration historyRpcTimeout = const Duration(seconds: 2);
   Duration abortRpcTimeout = const Duration(seconds: 1);
   Duration promptRpcTimeout = const Duration(seconds: 2);
@@ -2390,6 +2386,7 @@ final class _Fixture({
       extensionUiService: extension,
       clock: clock,
       resolveIdleTimeout: () => idleTimeout,
+      idleTimeoutChanges: idleTimeoutChanges.stream,
     );
     extensions.add(extension);
     _services.add(service);
@@ -2400,6 +2397,7 @@ final class _Fixture({
     for (final service in _services) {
       await service.dispose();
     }
+    await idleTimeoutChanges.close();
     await repository.dispose();
     for (final process in _processes) {
       await process.close();
@@ -2449,14 +2447,23 @@ final class _HistoryStorage({required super.storageApi}) extends PiSessionHistor
 final class _ManualClock() implements ServerClock {
   Completer<void>? _delay;
   final List<Duration> delays = [];
+  final List<Completer<void>> _allDelays = [];
 
   @override
   Future<void> delay({required Duration duration}) {
     delays.add(duration);
-    return (_delay = Completer<void>()).future;
+    final completer = Completer<void>();
+    _allDelays.add(completer);
+    _delay = completer;
+    return completer.future;
   }
 
   void elapse() => _delay?.complete();
+
+  void elapseAt({required int index}) {
+    final delay = _allDelays[index];
+    if (!delay.isCompleted) delay.complete();
+  }
 
   @override
   DateTime now() => DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -89,9 +89,10 @@ idle suspension, the management snapshot, and lifecycle commands.
   the configured timeout instead of zero and consumes it internally through the host.
   Each plugin reaps its idle per-session CLI/RPC child process after that window and
   transparently resumes it on the next prompt, so the settings knob stays effective
-  without a competing whole-plugin suspension timer. A runtime timeout change applies
-  at each session's next idle transition without a plugin restart; no timeout keeps the
-  child resident.
+  without a competing whole-plugin suspension timer. A runtime timeout change
+  immediately re-arms each currently idle session from the change, while busy
+  sessions pick it up at their next idle transition; no timeout invalidates the
+  existing idle timer and keeps the child resident.
 - A Claude session whose CLI scheduled a `ScheduleWakeup` loop wakeup is not reaped
   before the wakeup fires (the in-process timer would die and `--resume` cannot rearm
   it); a wakeup that never fires stops deferring one idle window past its fire time.


### PR DESCRIPTION
## Complexity
Moderate: adds one live timeout-change signal through the existing plugin host seam and reuses each plugin's existing generation-based idle timer invalidation.

## What
- Expose effective per-plugin idle-timeout changes through `PluginHost`.
- Map successful bridge settings mutations to per-plugin timeout events.
- Re-arm currently idle Claude Code and Pi session timers immediately; busy sessions use the new value at their next idle transition.
- Invalidate pending timers when idle cleanup is disabled.
- Add wiring, lifecycle, and regression coverage plus update the lifecycle regression contract.

## Why
Claude Code and Pi previously read the live timeout only when a session became idle. A session that was already idle kept its old timer until another turn. Runtime timeout edits now take effect for those sessions without restarting the plugin.

## Risk and test focus
- Timer-generation invalidation must prevent stale delayed callbacks from tearing down a session after a timeout change.
- Busy sessions, in-flight teardown, and disabled-timeout paths must remain safe.
- No database schema or transport payload changes.

## Expected result
Changing the Claude Code or Pi timeout immediately resets the countdown for every currently idle resident session. Setting no timeout cancels pending idle reaps. Running sessions pick up the value when they next become idle.

## Verification
- `make analyze`
- `make test`
- Targeted Claude, Pi, and bridge timeout/wiring tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-arms Claude Code and Pi idle timers immediately when timeout settings change, so already-idle sessions use the new timeout without waiting for their next turn.

- Exposes per-plugin timeout changes through `PluginHost.pluginIdleTimeoutChanges`, fed by bridge settings mutations.
- Claude and Pi session services re-arm idle timers for currently idle resident sessions; busy sessions pick up the new value at their next idle transition.
- Setting no timeout invalidates pending idle reaps, keeping sessions resident.

<sup>Written for commit 586e2c4ed2e3f9b137ca9c5bf2d7eeb184ffab1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

