### PR TITLE
🌿 Show new catalog projects and silence startup no-ops

### DIFF
--- a/bridge/app/lib/src/repositories/catalog_import_repository.dart
+++ b/bridge/app/lib/src/repositories/catalog_import_repository.dart
@@ -525,7 +525,7 @@ class CatalogImportRepository({
     return ProjectDto(
       projectId: existing?.projectId ?? observation.preferredId,
       path: observation.path,
-      hidden: existing?.hidden ?? true,
+      hidden: existing?.hidden ?? false,
       baseBranch: existing?.baseBranch,
       prCacheGithubLogin: existing?.prCacheGithubLogin,
       displayName: existing?.displayName ?? observation.displayName,

--- a/bridge/app/lib/src/services/catalog_import_service.dart
+++ b/bridge/app/lib/src/services/catalog_import_service.dart
@@ -104,21 +104,7 @@ class CatalogImportService({
           _publish(CatalogImportProgress.cancelled(pluginId: pluginId));
           return;
         }
-        if (!control.explicitImportRequested && completion != null) {
-          _publish(
-            CatalogImportProgress.completed(
-              pluginId: pluginId,
-              projectsImported: 0,
-              sessionsImported: 0,
-              // No import ran, so nothing is new. Zero rather than null: null
-              // means the bridge does not report deltas at all, and this one
-              // does.
-              newItems: const CatalogImportNewItems(projects: 0, sessions: 0),
-              completedAt: completion.completedAt,
-            ),
-          );
-          return;
-        }
+        if (!control.explicitImportRequested && completion != null) return;
       }
 
       await for (final progress in _repository.importCatalog(pluginId: pluginId, control: control)) {

--- a/bridge/app/test/repositories/catalog_import_repository_test.dart
+++ b/bridge/app/test/repositories/catalog_import_repository_test.dart
@@ -171,15 +171,21 @@ void main() {
       );
     });
 
-    test("native import hides new projects while preserving existing visibility", () async {
+    test("native import shows new projects while preserving existing visibility", () async {
       final visiblePath = "${directory.path}/visible";
+      final hiddenPath = "${directory.path}/hidden";
       final importedPath = "${directory.path}/imported";
       await database.projectsDao.upsertProjectRows(
-        rows: [_projectRow(id: "visible-project", path: visiblePath)],
+        rows: [
+          _projectRow(id: "visible-project", path: visiblePath),
+          _projectRow(id: "hidden-project", path: hiddenPath),
+        ],
       );
+      await database.projectsDao.hideProject(projectId: "hidden-project");
       final plugin = _NativeImportPlugin(
         projects: [
           PluginProject(id: "visible-project", directory: visiblePath),
+          PluginProject(id: "hidden-project", directory: hiddenPath),
           PluginProject(id: "imported-project", directory: importedPath),
         ],
         rootsByProject: {
@@ -199,10 +205,11 @@ void main() {
           .drain<void>();
 
       expect((await database.projectsDao.getProject(projectId: "visible-project"))?.hidden, isFalse);
-      expect((await database.projectsDao.getProject(projectId: "imported-project"))?.hidden, isTrue);
+      expect((await database.projectsDao.getProject(projectId: "hidden-project"))?.hidden, isTrue);
+      expect((await database.projectsDao.getProject(projectId: "imported-project"))?.hidden, isFalse);
       expect(
         (await database.projectsDao.getCatalogProjects()).map((project) => project.projectId),
-        ["visible-project"],
+        unorderedEquals(["visible-project", "imported-project"]),
       );
       expect(
         (await database.sessionDao.getSessionByBinding(
@@ -211,6 +218,27 @@ void main() {
         ))?.projectId,
         "imported-project",
       );
+    });
+
+    test("automatic native hydration shows newly discovered projects", () async {
+      final importedPath = "${directory.path}/automatic-import";
+      final plugin = _NativeImportPlugin(
+        projects: [PluginProject(id: "automatic-project", directory: importedPath)],
+        rootsByProject: const {},
+        childrenByParent: const {},
+      );
+
+      await _repository(database: database, plugin: plugin)
+          .importCatalog(
+            pluginId: plugin.id,
+            control: CatalogImportControl(
+              explicitImportRequested: false,
+              hydrationMarkerRequested: true,
+            ),
+          )
+          .drain<void>();
+
+      expect((await database.projectsDao.getProject(projectId: "automatic-project"))?.hidden, isFalse);
     });
 
     test("native import gives an exact project id precedence during a move", () async {
@@ -703,6 +731,8 @@ void main() {
 
       expect(second.sessionsImported, 2);
       expect(second.newItems, const CatalogImportNewItems(projects: 1, sessions: 1));
+      final addedProject = (await database.projectsDao.getProjectsByPath(path: addedDirectory)).single;
+      expect(addedProject.hidden, isFalse);
     });
 
     test("root-only import filters tombstones", () async {

--- a/bridge/app/test/services/catalog_import_service_test.dart
+++ b/bridge/app/test/services/catalog_import_service_test.dart
@@ -45,7 +45,7 @@ void main() {
       expect(repository.importCalls, 0);
     });
 
-    test("an existing marker completes an automatic request without enumeration", () async {
+    test("an existing marker skips an automatic request without publishing progress", () async {
       final repository = _FakeCatalogImportRepository(
         completion: const CatalogHydrationDto(
           pluginId: "selected",
@@ -63,16 +63,17 @@ void main() {
         policy: CatalogEmptyHydrationPolicy.complete,
       );
       addTearDown(service.dispose);
-      final completed = service.progress.firstWhere((status) => status is CatalogImportCompleted);
+      final progress = <CatalogImportProgress>[];
+      final subscription = service.progress.listen(progress.add);
+      addTearDown(subscription.cancel);
 
       service.start(pluginId: "selected", trigger: CatalogImportTrigger.automatic);
+      await pumpEventQueue();
 
-      expect(
-        await completed,
-        isA<CatalogImportCompleted>().having((status) => status.completedAt, "completedAt", 1234),
-      );
+      expect(repository.hydrationReads, 1);
       expect(repository.importCalls, 0);
-      expect(service.latestStatuses.single, isA<CatalogImportCompleted>());
+      expect(progress, isEmpty);
+      expect(service.latestStatuses, isEmpty);
     });
 
     test("overlapping automatic and explicit starts join and combine control", () async {

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -29,8 +29,10 @@ state.
   up arrow moves to the parent, while Home and Root shortcuts jump to the host
   user's home directory and filesystem root. Those controls remain available
   while a navigated directory loads or reports an access failure. Hiding delists
-  without destroying sessions or history. Import is explicit, per plugin,
-  atomic, non-destructive, cancellable, and attributes progress.
+  without destroying sessions or history. A catalog import lists newly inserted
+  projects immediately and preserves the stored visibility of every existing
+  project; it does not infer why an existing row is hidden. Import is explicit,
+  per plugin, atomic, non-destructive, cancellable, and attributes progress.
 - A completed import reports both the totals it published and, separately, how
   much of that was new. The two are not interchangeable: a re-import of an
   unchanged catalog still publishes every row, so the totals stay at the full
@@ -39,7 +41,9 @@ state.
   nothing changed; a consumer that cannot tell them apart would announce
   "nothing new" after an import that added everything. A headless completion
   line therefore states the delta, or `Nothing new.`, or the totals alone when
-  the producer omits the delta.
+  the producer omits the delta. An automatic hydration request whose completion
+  marker is already current runs no import and emits no progress or completion
+  line.
 - A user can start an import from the app. The three list surfaces — the
   project list, the full-screen session list, and the wide split-view pane —
   offer it as a second, deeper stage of their pull, which invites itself with a
@@ -78,9 +82,11 @@ state.
   back would announce a stale success on every connect.
 - Every observed `CatalogImportCompleted` that publishes at least one project
   or session invalidates mounted project and session lists only after the
-  bridge's atomic catalog transaction completed. An automatic hydration marker
-  publishes zero rows and never interrupts an ordinary list read. A pre-commit
-  list response cannot overwrite a later snapshot; another completion while it
+  bridge's atomic catalog transaction completed. An automatic hydration request
+  already satisfied by its marker publishes no progress and never interrupts an
+  ordinary list read. Current clients still ignore the synthetic zero-count
+  completion published by older bridges. A pre-commit list response cannot
+  overwrite a later snapshot; another completion while it
   is loading produces one trailing read. If the snapshot fails, the committed
   change remains pending for the next ordinary, reconnect, or staleness refresh
   rather than being discarded. A failed forced snapshot replaces a full-screen
@@ -220,7 +226,7 @@ state.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Headless bridge, representative plugin: project list and one project's session list return committed data with plugin attribution. |
-| L2 Routine | Headless bridge, representative plugin: open, rename, hide; create a session and see it listed before metadata, then observe generated title and eligible branch refinement through the existing session update without unseen change; unseen otherwise advances and clears; the existing activity marker appears in REST and live list-state projections; statuses report idle/busy. A first import reports every published row as new, a re-import of an unchanged catalog reports the same totals with a zero delta, and a completion whose delta is absent reports its totals without claiming nothing changed. Focused client coverage holds pre-commit list reads through a completion, ignores a zero-count hydration completion, proves the post-commit snapshot wins and a second completion gets a trailing snapshot, retains a failed snapshot for the next refresh, proves an interrupted full-screen load and pull surface the winning failure while retaining session PR-data waiting, and covers a completion after immediate cancellation. Focused shared-presentation and shell tests cover project/session empty and row states, split-pane behavior, mobile CLI recovery, both desktop disconnected variants using supervised Start without CLI copy, and desktop list-to-detail plus child-session routing with unsupported detail controls omitted. Focused client coverage also proves the deeper pull starts one scan however far it travels, that a pull which fired it runs no ordinary refresh and raises no confirmation while an ordinary pull still does, that the row keeps one height from starting through running to its result, and that a scan started from harness settings is announced there while one started elsewhere is not. |
+| L2 Routine | Headless bridge, representative plugin: open, rename, hide; create a session and see it listed before metadata, then observe generated title and eligible branch refinement through the existing session update without unseen change; unseen otherwise advances and clears; the existing activity marker appears in REST and live list-state projections; statuses report idle/busy. A first import reports every published row as new and lists its newly inserted projects, while preserving an existing project's stored visibility; a re-import of an unchanged catalog reports the same totals with a zero delta, and a completion whose delta is absent reports its totals without claiming nothing changed. An automatic hydration request with a current marker does not enumerate or publish progress. Focused client coverage holds pre-commit list reads through a completion, ignores a zero-count hydration completion, proves the post-commit snapshot wins and a second completion gets a trailing snapshot, retains a failed snapshot for the next refresh, proves an interrupted full-screen load and pull surface the winning failure while retaining session PR-data waiting, and covers a completion after immediate cancellation. Focused shared-presentation and shell tests cover project/session empty and row states, split-pane behavior, mobile CLI recovery, both desktop disconnected variants using supervised Start without CLI copy, and desktop list-to-detail plus child-session routing with unsupported detail controls omitted. Focused client coverage also proves the deeper pull starts one scan however far it travels, that a pull which fired it runs no ordinary refresh and raises no confirmation while an ordinary pull still does, that the row keeps one height from starting through running to its result, and that a scan started from harness settings is announced there while one started elsewhere is not. |
 | L3 Release | Client end to end (phone): every supporting production plugin still covers native/derived ownership, import, and child resolution; Pi imports configured/default/known roots with explicit names and resolvable lineage; Copilot exhausts a multi-page standard ACP catalog and exposes one newly imported session without a second manual refresh; Grok explicitly imports a persisted session with `grok` attribution, then an unchanged re-import leaves the committed catalog intact; one representative plugin proves two running roots and two projects with running roots reorder after committed user-side activity, inactive session/project order is unchanged, a live patch reorders without another status event or project summary, and omitted ordering facts use updated-time fallbacks. Focused ACP protocol and client ordering tests prove the exact awaiting-only state is not promoted because normal production root prompts remain running while awaiting input. Lists and unseen badges render; project and session row swipes stay inert from the iOS back edge and both Android gesture-navigation edges while remaining active at unreserved edges and under Android button navigation. A catalog scan started by the deeper pull renders its row through starting, running, and its result on one mobile platform and in the wide split-view pane, which drives its pull through a different scroll owner; two *routable* harnesses at once, so the fan-out has two members and a partial failure is reachable at all — enabled is not enough, since a blocked or failed harness is enabled and still left out; one native-ownership and one bridge-derived harness, which count new projects differently; and one run that genuinely imports a new session, visible in the list without a second manual refresh. |
 | L4 Extended | Relay integration, every supporting production plugin: bridge and plugin restart preserve identity and overrides; a moved backend-native project keeps them while a moved bridge-derived project is discovered as new without mutating the old catalog; a cancelled or first-page failed import leaves the prior catalog intact; reads during import stay consistent; an unavailable plugin is reported while others keep listing. Copilot later-page failure commits gathered pages as a non-destructive fail-soft partial observation. Scanning against older and interrupted peers: a bridge that omits its new-item delta falls back to totals rather than reporting nothing new; a supported bridge with no import route at all reports that it cannot scan, and so does one that has the import route but not the management route the app needs to learn its harnesses — two different bridge versions reaching the same state by different paths; a bridge holding terminal import statuses is reconnected to without announcing a stale success; a disconnect mid-scan reconnects and settles without claiming a summary; and a bridge whose harnesses are all blocked reports that there is nothing to scan. |
 | L5 Full | Client end to end, every supporting production plugin: multiple clients observe consistent listings and unseen transitions; large catalogs and paged listings behave; unattributed payloads resolve to the historical identity. |
@@ -244,16 +250,18 @@ navigation, and a non-mobile platform; begin drags inside and just outside each
 For catalog scanning, vary the number of enabled harnesses, whether any is
 blocked or failed, and which surface starts the run — each of the three lists
 and the harness settings card. Vary a first import against a re-import of an
-unchanged catalog, and a bridge that reports its delta against one that omits
-it. Interrupt runs: cancel mid-scan, disconnect mid-scan and reconnect, and
+unchanged catalog, newly discovered versus already-hidden projects, and a bridge
+that reports its delta against one that omits it. Interrupt runs: cancel
+mid-scan, disconnect mid-scan and reconnect, and
 leave the surface that started one. Restore harness eligibility afterwards.
 
 ## Failure Signals
 
 - A catalog read starts a backend, hangs on import, returns a partial list, or an
   older response overwrites a post-commit snapshot.
-- A zero-count hydration completion interrupts an ordinary list read, a
-  committed catalog change is lost after a failed list snapshot, a forced
+- An already-satisfied automatic hydration emits a misleading zero-count
+  completion, a legacy zero-count completion interrupts an ordinary list read,
+  a committed catalog change is lost after a failed list snapshot, a forced
   catalog failure leaves a full-screen list loading or reports a superseded pull
   as successful or without its requested PR data, or a commit that finishes
   after cancellation leaves the mounted list stale.


### PR DESCRIPTION
Related to #1264.

## Complexity

🌿 Straightforward — localized catalog merge and startup-progress policy changes.

## What

- List projects immediately when a catalog import inserts them.
- Preserve the stored hidden/visible state for every project already in the database.
- Let marker-satisfied automatic hydration exit silently instead of publishing a synthetic `0 project(s), 0 session(s)` completion.
- Update focused repository/service coverage and the projects-and-sessions regression contract.

## Why

Catalog scans should surface newly discovered projects without undoing an existing hidden choice. The automatic hydration short-circuit also reported a successful import even though it had not enumerated a backend, producing misleading `Nothing new.` startup lines for every already-hydrated plugin.

This deliberately does not infer why an existing project is hidden or migrate rows hidden by v1.8.2.

## Risk and test focus

User-visible impact: newly inserted catalog projects appear in project lists, and repeated marker-satisfied startup checks no longer print import summaries.

Database impact: no schema change or migration. Only the default visibility of rows newly inserted by catalog import changes; existing rows remain authoritative.

Wire impact: a no-op automatic hydration no longer emits progress. Current clients already treat missing plugin status as idle and retain compatibility handling for synthetic zero-count completions from older bridges.

Focused coverage verifies native and derived ownership, automatic hydration, preservation of existing hidden state, and silent marker short-circuiting.

## Expected result

A scan that discovers a project adds it to the visible project list. Re-scanning does not unhide any existing row. Starting a bridge whose hydration markers are current produces no synthetic zero-count catalog completion lines.

## Verification

- `cd bridge/app && dart test test/repositories/catalog_import_repository_test.dart test/services/catalog_import_service_test.dart`
- `cd bridge/app && dart analyze --fatal-infos`
- Architecture implementation review: approved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes catalog imports list newly discovered projects immediately while preserving existing hidden state, and silences the misleading zero-count completion when automatic hydration finds its marker already satisfied. Related to #1264.

**What changed**
- Newly imported projects default to visible; existing rows keep their stored hidden flag.
- Automatic hydration with a current marker returns silently, emitting no progress or completion.
- No schema change; only the default visibility for new rows changes.
- Updated the regression contract and focused tests.

<sup>Written for commit 5620642fd3ea8c6901ff8e5992a982c0e52dadf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

