### PR TITLE
⚙️ Keep active ACP prompts alive

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1380,14 +1380,15 @@ abstract class AcpPlugin({
         queuedPrompt.phase = _QueuedAcpPromptPhase.writing;
       }
       final meta = outboundPromptMeta(sessionId: sessionId, messageId: turn.messageId);
-      final dispatched = await client.dispatchRequest(
+      final dispatched = await client.dispatchSessionRequest(
         method: AcpMethods.sessionPrompt,
         params: {
           "sessionId": sessionId,
           "prompt": turn.blocks,
           "_meta": ?meta,
         },
-        timeout: const Duration(minutes: 30),
+        sessionId: sessionId,
+        inactivityTimeout: const Duration(minutes: 30),
       );
       _markTurnDispatched(sessionId: sessionId, state: state, turn: turn);
       final raw = await dispatched.response;

--- a/bridge/sesori_plugin_acp/lib/src/acp_stdio_client.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_stdio_client.dart
@@ -82,14 +82,57 @@ class AcpStdioClient({
     required String method,
     Object? params,
     Duration timeout = const Duration(seconds: 60),
+  }) => _dispatchRequest(
+    method: method,
+    params: params,
+    timeout: timeout,
+    activitySessionId: null,
+  );
+
+  /// Dispatches a long-running session request with an inactivity deadline.
+  /// Each inbound notification or server request explicitly attributed to
+  /// [sessionId] restarts [inactivityTimeout]; other sessions do not.
+  Future<({Future<dynamic> response})> dispatchSessionRequest({
+    required String method,
+    required Object? params,
+    required String sessionId,
+    required Duration inactivityTimeout,
+  }) => _dispatchRequest(
+    method: method,
+    params: params,
+    timeout: inactivityTimeout,
+    activitySessionId: sessionId,
+  );
+
+  Future<({Future<dynamic> response})> _dispatchRequest({
+    required String method,
+    required Object? params,
+    required Duration timeout,
+    required String? activitySessionId,
   }) async {
     final id = _nextId++;
     final frame = <String, Object?>{"jsonrpc": "2.0", "id": id, "method": method};
     if (params != null) frame["params"] = params;
-    final dispatched = await _transport.dispatch(id: id, frame: frame, timeout: timeout);
+    final dispatched = activitySessionId == null
+        ? await _transport.dispatch(id: id, frame: frame, timeout: timeout)
+        : await _transport.dispatchWithInactivityTimeout(
+            id: id,
+            frame: frame,
+            timeout: timeout,
+            activityMatcher: (incoming) => _isSessionActivity(
+              frame: incoming,
+              sessionId: activitySessionId,
+            ),
+          );
     final response = _mapResponse(dispatched.response);
     response.ignore();
     return (response: response);
+  }
+
+  bool _isSessionActivity({required JsonObject frame, required String sessionId}) {
+    if (frame["method"] is! String) return false;
+    final params = frame["params"];
+    return params is Map && params["sessionId"] == sessionId;
   }
 
   Future<dynamic> _mapResponse(Future<JsonObject> response) async {

--- a/bridge/sesori_plugin_acp/test/acp_stdio_client_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_stdio_client_test.dart
@@ -69,6 +69,41 @@ void main() {
       expect(seen.single.params["sessionId"], "s1");
     });
 
+    test("session request inactivity resets only for matching session activity", () async {
+      const inactivityTimeout = Duration(milliseconds: 300);
+      final first = await client.dispatchSessionRequest(
+        method: "session/prompt",
+        params: const {"sessionId": "s1"},
+        sessionId: "s1",
+        inactivityTimeout: inactivityTimeout,
+      );
+      final second = await client.dispatchSessionRequest(
+        method: "session/prompt",
+        params: const {"sessionId": "s2"},
+        sessionId: "s2",
+        inactivityTimeout: inactivityTimeout,
+      );
+      final firstId = fake.written[0]["id"];
+
+      await Future<void>.delayed(const Duration(milliseconds: 180));
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": "s1",
+          "update": {"sessionUpdate": "agent_message_chunk"},
+        },
+      });
+
+      await expectLater(second.response, throwsA(isA<TimeoutException>()));
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": firstId,
+        "result": {"stopReason": "end_turn"},
+      });
+      expect((await first.response as Map)["stopReason"], "end_turn");
+    });
+
     test("server requests route to serverRequests and can be answered", () async {
       final reqs = <AcpServerRequest>[];
       client.serverRequests.listen(reqs.add);

--- a/bridge/sesori_plugin_runtime/lib/src/transport/ndjson_process_client.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/transport/ndjson_process_client.dart
@@ -10,14 +10,29 @@ typedef JsonObject = Map<String, Object?>; // ignore: no_slop_linter/prefer_spec
 typedef NdjsonCorrelationId = Object? Function(JsonObject frame); // ignore: no_slop_linter/prefer_specific_type
 // Exit failures stay plugin-typed across transport boundary.
 typedef NdjsonExitError = Object Function(int exitCode); // ignore: no_slop_linter/prefer_specific_type
+// Long-running requests may define which uncorrelated inbound frames prove
+// progress and therefore restart their inactivity deadline.
+typedef NdjsonActivityMatcher = bool Function(JsonObject frame);
 
-enum MalformedFramePolicy() { discard, failPending }
+enum MalformedFramePolicy() {
+  discard,
+  failPending,
+}
 
-enum NonObjectFramePolicy() { discard, failPending }
+enum NonObjectFramePolicy() {
+  discard,
+  failPending,
+}
 
-enum MalformedFrameLogPolicy() { metadataOnly, sanitizedContent }
+enum MalformedFrameLogPolicy() {
+  metadataOnly,
+  sanitizedContent,
+}
 
-enum StderrPolicy() { discard, forwardSanitized }
+enum StderrPolicy() {
+  discard,
+  forwardSanitized,
+}
 
 abstract interface class NdjsonProcessHandle() {
   IOSink get stdin;
@@ -31,6 +46,14 @@ final class AttachToken._(final int generation);
 
 final class NdjsonDispatch({required final Future<JsonObject> response});
 
+final class _PendingResponse({
+  required final Completer<JsonObject> completer,
+  required final Duration timeout,
+  required final NdjsonActivityMatcher? activityMatcher,
+}) {
+  Timer? timer;
+}
+
 final class NdjsonProcessClient({
   required final NdjsonCorrelationId _responseCorrelationId,
   required final NdjsonExitError _exitError,
@@ -43,7 +66,7 @@ final class NdjsonProcessClient({
   required final Duration _reapTimeout,
 }) {
   // JSON correlation IDs are intentionally opaque protocol boundary values.
-  final Map<Object, Completer<JsonObject>> _pending = {}; // ignore: no_slop_linter/prefer_specific_type
+  final Map<Object, _PendingResponse> _pending = {}; // ignore: no_slop_linter/prefer_specific_type
   final StreamController<JsonObject> _notifications = StreamController.broadcast();
 
   NdjsonProcessHandle? _process;
@@ -137,24 +160,62 @@ final class NdjsonProcessClient({
     required Object id, // ignore: no_slop_linter/prefer_specific_type
     required JsonObject frame,
     required Duration timeout,
+  }) => _dispatch(
+    id: id,
+    frame: frame,
+    timeout: timeout,
+    activityMatcher: null,
+  );
+
+  /// Dispatches a request whose [timeout] measures inbound inactivity rather
+  /// than total wall time. Only frames accepted by [activityMatcher] restart
+  /// the deadline, so unrelated concurrent work cannot keep it alive.
+  Future<NdjsonDispatch> dispatchWithInactivityTimeout({
+    // JSON correlation IDs are intentionally opaque protocol boundary values.
+    required Object id, // ignore: no_slop_linter/prefer_specific_type
+    required JsonObject frame,
+    required Duration timeout,
+    required NdjsonActivityMatcher activityMatcher,
+  }) => _dispatch(
+    id: id,
+    frame: frame,
+    timeout: timeout,
+    activityMatcher: activityMatcher,
+  );
+
+  Future<NdjsonDispatch> _dispatch({
+    // JSON correlation IDs are intentionally opaque protocol boundary values.
+    required Object id, // ignore: no_slop_linter/prefer_specific_type
+    required JsonObject frame,
+    required Duration timeout,
+    required NdjsonActivityMatcher? activityMatcher,
   }) async {
     final process = _requireProcess();
-    final completer = Completer<JsonObject>();
-    _pending[id] = completer;
+    final pending = _PendingResponse(
+      completer: Completer<JsonObject>(),
+      timeout: timeout,
+      activityMatcher: activityMatcher,
+    );
+    _pending[id] = pending;
+    _armTimeout(id: id, pending: pending);
     try {
       sendFrame(frame: frame);
     } on Object catch (error, stackTrace) {
-      _pending.remove(id);
-      if (!completer.isCompleted) completer.completeError(error, stackTrace);
+      final failed = _removePending(id);
+      if (failed != null && !failed.completer.isCompleted) {
+        failed.completer.completeError(error, stackTrace);
+      }
       rethrow;
     }
-    final response = _awaitResponse(id: id, response: completer.future, timeout: timeout);
+    final response = pending.completer.future;
     response.ignore();
     try {
       await process.stdin.flush();
     } on Object catch (error, stackTrace) {
-      _pending.remove(id);
-      if (!completer.isCompleted) completer.completeError(error, stackTrace);
+      final failed = _removePending(id);
+      if (failed != null && !failed.completer.isCompleted) {
+        failed.completer.completeError(error, stackTrace);
+      }
       rethrow;
     }
     return NdjsonDispatch(response: response);
@@ -171,18 +232,30 @@ final class NdjsonProcessClient({
     return process;
   }
 
-  Future<JsonObject> _awaitResponse({
+  void _armTimeout({
     // JSON correlation IDs are intentionally opaque protocol boundary values.
     required Object id, // ignore: no_slop_linter/prefer_specific_type
-    required Future<JsonObject> response,
-    required Duration timeout,
-  }) async {
-    try {
-      return await response.timeout(timeout);
-    } on TimeoutException {
+    required _PendingResponse pending,
+  }) {
+    pending.timer?.cancel();
+    pending.timer = Timer(pending.timeout, () {
+      if (!identical(_pending[id], pending)) return;
       _pending.remove(id);
-      rethrow;
-    }
+      if (!pending.completer.isCompleted) {
+        pending.completer.completeError(
+          TimeoutException("No matching process activity", pending.timeout),
+          StackTrace.current,
+        );
+      }
+    });
+  }
+
+  // JSON correlation IDs are intentionally opaque protocol boundary values.
+  // ignore: no_slop_linter/prefer_specific_type
+  _PendingResponse? _removePending(Object id) {
+    final pending = _pending.remove(id);
+    pending?.timer?.cancel();
+    return pending;
   }
 
   void _handleLine({required String line}) {
@@ -220,10 +293,16 @@ final class NdjsonProcessClient({
     }
     final id = _responseCorrelationId(frame);
     if (id != null) {
-      final completer = _pending.remove(id);
-      if (completer != null) {
-        completer.complete(frame);
+      final pending = _removePending(id);
+      if (pending != null) {
+        pending.completer.complete(frame);
         return;
+      }
+    }
+    for (final entry in _pending.entries) {
+      final activityMatcher = entry.value.activityMatcher;
+      if (activityMatcher != null && activityMatcher(frame)) {
+        _armTimeout(id: entry.key, pending: entry.value);
       }
     }
     if (!_notifications.isClosed) _notifications.add(frame);
@@ -236,8 +315,9 @@ final class NdjsonProcessClient({
   }) {
     final pending = _pending.values.toList(growable: false);
     _pending.clear();
-    for (final completer in pending) {
-      if (!completer.isCompleted) completer.completeError(error, stackTrace);
+    for (final response in pending) {
+      response.timer?.cancel();
+      if (!response.completer.isCompleted) response.completer.completeError(error, stackTrace);
     }
   }
 

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -192,7 +192,10 @@ defaults and queued client sends coherent.
   synthetic user transcript message is published only after its frame flushes
   successfully to the agent's stdin. A prompt rejected after that dispatch
   renders a durable inline error, preserving the agent's diagnostic detail
-  rather than transitioning silently to idle. Follow-up and replayed user
+  rather than transitioning silently to idle. The shared 30-minute ACP prompt
+  safety bound measures same-session inactivity, not total turn duration:
+  matching inbound notifications or server requests restart it, while activity
+  from another concurrently running session does not. Follow-up and replayed user
   messages preserve ordered text and bounded data-backed image parts, including
   attachment-only prompts. Initial projection contains only normalized
   user-visible text plus those images; injected context, local paths, and URLs
@@ -321,7 +324,7 @@ defaults and queued client sends coherent.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Automated shared presentation and desktop shell coverage: representative selectable transcript content renders through the shared session-detail view, the desktop session route is present, and desktop renders the text-first composer and declared attachment/diff actions without resolving voice capture. Live plugin, representative: a prompt streams assistant output and returns the session to idle. |
-| L2 Routine | Live plugin, representative: slash command returns on acceptance; prompt defaults update; first and stale transcript replay reconciles prompt defaults before the opening snapshot is applied; abort stops a turn and reports its outcome; finalized messages are immediately readable from history; a recognized stale option returns the typed rejection only after cache invalidation. Automated Pi coverage keeps visible custom messages system-attributed across live and replay without changing agent defaults or completion text. Shared/desktop widget coverage proves Enter versus Shift+Enter policy, active-IME candidate confirmation, unchanged mobile modifier-send behavior, safe Escape popup dismissal, and selectable transcript content. |
+| L2 Routine | Live plugin, representative: slash command returns on acceptance; prompt defaults update; first and stale transcript replay reconciles prompt defaults before the opening snapshot is applied; abort stops a turn and reports its outcome; finalized messages are immediately readable from history; a recognized stale option returns the typed rejection only after cache invalidation. Automated ACP coverage proves same-session activity extends the prompt inactivity deadline while concurrent-session activity does not. Automated Pi coverage keeps visible custom messages system-attributed across live and replay without changing agent defaults or completion text. Shared/desktop widget coverage proves Enter versus Shift+Enter policy, active-IME candidate confirmation, unchanged mobile modifier-send behavior, safe Escape popup dismissal, and selectable transcript content. |
 | L3 Release | Client end to end on phone and desktop, every supporting production plugin: text, reasoning, tool, and status events stream with consistent normalization and the shared output bound; agent, model, and variant apply per send; streaming and queued feedback, text composer, sending, and abort controls render on both surfaces; voice capture remains mobile-only; and a stale selection refreshes, warns, and retries once without losing the queued prompt. Claude: a stop while a background sub-agent runs shows the scope dialog, cancelling it leaves the tile running and its wake-up turn later arrives, confirming cancels it, and a stop with no sub-agents shows no dialog; the session stays busy until the last sub-agent's wake-up turn settles. OpenCode: a stop while a delegated child session runs shows the scope dialog, cancelling it leaves the child running, confirming aborts the root and the child, and a stop with no running child shows no dialog. DeepSeek, Copilot, and Grok cover busy stop-and-send. Copilot additionally covers an exact advertised slash command and reasoning only when its selected model emits it. Grok covers exact model/effort application, accepted-send timing, abort, visible failure, and idle completion without claiming image input. A Pi custom message renders as labelled automation rather than agent output. |
 | L4 Extended | Relay integration, every supporting production plugin: a slow or unresponsive plugin leaves other sessions, plugins, and the relay responsive; archived sends and queued-prompt cancels are refused without racing archiving; disconnect and reconnect mid-turn resumes without lost or duplicated parts; bridge-owned prompts survive leaving and reopening in order and appear on a second client; a prompt waiting at a dispatch boundary can be cancelled; a permission reply lands while a command or selection-changing prompt waits behind the running turn; a second client observes the same turn and steering prompt. Two Copilot sessions and two Grok sessions run concurrently while each preserves its own ordering and selection. |
 | L5 Full | Client end to end, every supporting production plugin: retry status surfaces with attempt and timing; concurrent sends across sessions and plugins interleave without ordering damage; background and resume mid-turn recovers live state; an aborted turn triggers no completion notification. |
@@ -346,7 +349,9 @@ provider failure, early and late abort, busy stop-and-send, and two sessions.
 - A slash command holds the client request open for the whole run, or a slow
   plugin blocks unrelated sessions, other plugins, or relay traffic.
 - An accepted ACP prompt rejection returns the session to idle without a durable
-  inline error containing the backend's diagnostic detail.
+  inline error containing the backend's diagnostic detail. An active ACP turn
+  times out after 30 total minutes despite continuing same-session updates, or
+  unrelated concurrent-session traffic keeps a silent turn alive.
 - Streaming stalls, duplicates or loses parts, shows an empty user bubble,
   orders a fast assistant envelope before its accepted user message, exposes a
   permission before that user or its preceding tool card, or orders a late


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this changes shared NDJSON request timeout bookkeeping while keeping the new behavior opt-in for long-running ACP prompts.

## What

- Add an activity-aware timeout mode to the shared NDJSON process client.
- Make ACP `session/prompt` use a 30-minute inactivity deadline that resets only for inbound frames attributed to the same session.
- Keep ordinary RPC requests on their existing fixed wall-clock timeout.
- Add regression coverage and document the behavior and failure signals.

## Why

An OMP prompt remained active and continued emitting tool/reasoning updates beyond 30 minutes, but the bridge applied a fixed 30-minute response timeout and persisted a false prompt failure before OMP later completed normally.

## Risk and test focus

The activity matcher must not let traffic from another concurrently running session keep a silent request alive. Response correlation, true inactivity, and immediate process-exit failures must continue to settle pending requests correctly.

User-visible impact: active ACP turns no longer show a false timeout merely because total turn duration exceeds 30 minutes. Database/schema impact: none.

## Expected result

An ACP prompt may run longer than 30 minutes while its own session continues producing protocol activity. It still times out after 30 minutes without matching activity, and unrelated session traffic does not extend that deadline.

## Verification

- `cd bridge/sesori_plugin_acp && dart test test/acp_stdio_client_test.dart`
- `cd bridge/sesori_plugin_acp && dart test test/acp_turn_serialization_test.dart`
- `cd bridge/sesori_plugin_acp && dart analyze`
- `cd bridge/sesori_plugin_runtime && dart test test/ndjson_process_client_test.dart`
- `cd bridge/sesori_plugin_runtime && dart analyze`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ACP session prompts falsely timing out after 30 total minutes even when the turn is still producing activity. The `session/prompt` deadline now measures same-session inactivity instead of wall-clock time, and unrelated concurrent session traffic does not reset it.

- Adds an inactivity-based dispatch mode to the shared NDJSON process client; ordinary RPC requests keep their fixed timeout.
- Adds regression coverage and updates the regression docs with the new failure signals.

<sup>Written for commit c0f7faa2bd6f897d2866a296a8e9e3e97b2f0b1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

