### PR TITLE
🌿 Restore running status for resumed Claude agents

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -616,6 +616,10 @@ final class ClaudeEventDispatcher({
       );
       if (!terminal) busy.add(childId);
       events.add(_childStatus(childId: childId, busy: !terminal));
+    } else if (childId != null && !terminal && busy.add(childId)) {
+      // Claude can resume an already-announced agent after it stopped. Restore
+      // the child to busy before publishing the reopened subtask part.
+      events.add(_childStatus(childId: childId, busy: true));
     }
     if (part != null) events.add(BridgeSseMessagePartUpdated(part: part));
     if (childId != null && terminal && busy.remove(childId)) events.add(_childStatus(childId: childId, busy: false));

--- a/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
@@ -12,9 +12,10 @@ final class const ClaudeHistoryMapper({
   required final ClaudeContentMapper _content,
 }) {
   /// [residentTaskToolUseIds] names the sub-agent tasks the session's current
-  /// resident process is still running. Any other replayed task that never
-  /// reached a terminal record is dead — sub-agents die with their process —
-  /// and renders as cancelled.
+  /// resident process is still running. It reopens a task whose transcript has
+  /// an earlier terminal notification when Claude resumed the same agent. Any
+  /// other replayed task that never reached a terminal record is dead —
+  /// sub-agents die with their process — and renders as cancelled.
   ///
   /// [agentId] selects child mode: a sub-agent transcript's records are
   /// sidechain records stamped with the **parent's** session id, so they are
@@ -161,6 +162,9 @@ final class const ClaudeHistoryMapper({
       }
     }
 
+    for (final toolUseId in residentTaskToolUseIds) {
+      tasks.markTaskRunning(toolUseId: toolUseId);
+    }
     for (final toolUseId in tasks.runningTaskToolUseIds(sessionId: sessionId).difference(residentTaskToolUseIds)) {
       tasks.cancelTask(toolUseId: toolUseId);
     }

--- a/bridge/sesori_plugin_claude/lib/src/repositories/trackers/claude_tool_tracker.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/trackers/claude_tool_tracker.dart
@@ -245,8 +245,7 @@ final class ClaudeToolTracker() {
       switch (result) {
         case ClaudeToolUseResultAsyncLaunched(:final agentId):
           tool.taskId ??= agentId;
-          if (!_isTerminal(tool.status)) tool.status = PluginToolStatus.running;
-          return tool.snapshot(sessionDiffRequired: false);
+          return _markTaskRunning(tool);
         case ClaudeToolUseResultCompleted(:final agentId):
           tool.taskId ??= agentId;
         case ClaudeToolUseResultAbsent() || ClaudeToolUseResultUnknown():
@@ -271,11 +270,30 @@ final class ClaudeToolTracker() {
   }
 
   /// Binds a `task_started` frame to its launching call.
+  ///
+  /// Claude can resume the same background agent after it previously stopped,
+  /// reusing both ids. A repeated start therefore reopens the task rather than
+  /// leaving its prior terminal presentation in place.
   ClaudeTrackedTool? taskStarted({required String toolUseId, required String taskId}) {
     final task = _tasks[toolUseId];
     if (task == null) return null;
     task.taskId ??= taskId;
-    if (!_isTerminal(task.status)) task.status = PluginToolStatus.running;
+    return _markTaskRunning(task);
+  }
+
+  /// Reconciles a replayed task with the resident process's current lifecycle.
+  ClaudeTrackedTool? markTaskRunning({required String toolUseId}) {
+    final task = _tasks[toolUseId];
+    return task == null ? null : _markTaskRunning(task);
+  }
+
+  ClaudeTrackedTool _markTaskRunning(_TrackedTool task) {
+    task
+      ..notified = false
+      ..status = PluginToolStatus.running
+      ..output = null
+      ..error = null
+      ..attachments = const [];
     return task.snapshot(sessionDiffRequired: false);
   }
 

--- a/bridge/sesori_plugin_claude/test/claude_subagent_child_sessions_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_subagent_child_sessions_test.dart
@@ -113,7 +113,7 @@ void main() {
       dispatcher.beginTurn(sessionId: _root, directory: "/workspace");
     });
 
-    test("announces the child once, busy while running, idle at its terminal update", () {
+    test("announces the child once and follows repeated running and terminal transitions", () {
       dispatcher.map(message: ClaudeStreamMessage.parse(_agentAssistantFrame()));
       final launched = dispatcher.map(message: ClaudeStreamMessage.parse(_launchResultFrame()));
 
@@ -145,6 +145,21 @@ void main() {
       expect(shared.SessionStatus.fromJson(idle.status), isA<shared.SessionStatusIdle>());
       expect(dispatcher.childSessionStatuses(), {_child: const PluginSessionStatus.idle()});
       expect(dispatcher.busyChildSessionIds(sessionId: _root), isEmpty);
+
+      final resumed = dispatcher.map(message: ClaudeStreamMessage.parse(_taskStartedFrame()));
+      expect(resumed.map((event) => event.runtimeType), [BridgeSseSessionStatus, BridgeSseMessagePartUpdated]);
+      expect(
+        shared.SessionStatus.fromJson((resumed.first as BridgeSseSessionStatus).status),
+        isA<shared.SessionStatusBusy>(),
+      );
+      final resumedPart = (resumed.last as BridgeSseMessagePartUpdated).part as PluginMessagePartSubtask;
+      expect(resumedPart.taskState?.status, PluginToolStatus.running);
+      expect(resumedPart.taskState?.output, isNull);
+      expect(dispatcher.childSessionStatuses(), {_child: const PluginSessionStatus.busy()});
+
+      final finishedAgain = dispatcher.map(message: ClaudeStreamMessage.parse(_taskNotificationFrame()));
+      expect(finishedAgain.map((event) => event.runtimeType), [BridgeSseMessagePartUpdated, BridgeSseSessionStatus]);
+      expect(dispatcher.childSessionStatuses(), {_child: const PluginSessionStatus.idle()});
     });
 
     test("routes forwarded sub-agent frames into the child session once its id is known", () {

--- a/bridge/sesori_plugin_claude/test/claude_subtask_lifecycle_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_subtask_lifecycle_test.dart
@@ -136,6 +136,35 @@ void main() {
       expect(tracker.runningTaskToolUseIds(sessionId: _session), isEmpty);
     });
 
+    test("a repeated task start reopens a terminal task", () {
+      _upsertAgent(tracker);
+      tracker.taskNotified(
+        toolUseId: _toolUseId,
+        taskId: _agentId,
+        status: ClaudeTaskStatus.failed,
+        summary: "first attempt failed",
+        result: null,
+      );
+
+      final resumed = tracker.taskStarted(toolUseId: _toolUseId, taskId: _agentId);
+
+      expect(resumed?.state.status, PluginToolStatus.running);
+      expect(resumed?.state.output, isNull);
+      expect(resumed?.state.error, isNull);
+      expect(tracker.runningTaskToolUseIds(sessionId: _session), {_toolUseId});
+
+      final completed = tracker.complete(
+        sessionId: _session,
+        toolId: _toolUseId,
+        output: "second attempt finished",
+        isError: false,
+        attachments: const [],
+        result: const ClaudeToolUseResultCompleted(agentId: _agentId),
+      );
+      expect(completed?.state.status, PluginToolStatus.completed);
+      expect(completed?.state.output, "second attempt finished");
+    });
+
     test("a tool result is a fallback that a later notification replaces", () {
       _upsertAgent(tracker);
       final fallback = tracker.complete(
@@ -312,6 +341,23 @@ void main() {
 
       expect((dead.single.parts.single as PluginMessagePartSubtask).taskState?.status, PluginToolStatus.cancelled);
       expect((live.single.parts.single as PluginMessagePartSubtask).taskState?.status, PluginToolStatus.running);
+    });
+
+    test("a resident restart overrides an earlier terminal transcript state", () {
+      final messages = mapper.map(
+        sessionId: _session,
+        agentId: null,
+        records: [
+          _agentRecord(),
+          _launchResultRecord(),
+          _notificationRecord(text: _notificationText),
+        ],
+        residentTaskToolUseIds: const {_toolUseId},
+      );
+
+      final part = messages.single.parts.single as PluginMessagePartSubtask;
+      expect(part.taskState?.status, PluginToolStatus.running);
+      expect(part.taskState?.output, isNull);
     });
 
     test("a foreground result finalizes without a notification and injected records never render", () {

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -36,10 +36,14 @@ signal that a tool changed files.
   a `childSessionID` naming the sub-agent's child session once known. The task
   notification is the authoritative terminal source; the launching call's own
   tool result is a fallback that a later notification replaces, and a
-  background launch never finalizes the part. A part appears only once its
-  input names the description and prompt, never with placeholder text. On
-  replay the same parts render from the transcript, and a still-running task
-  the session's resident process no longer owns renders as `cancelled`.
+  background launch never finalizes the part. When Claude resumes the same
+  agent after it stopped, the repeated start reopens the existing part as
+  `running`, clears its prior outcome, and restores the already-announced child
+  to busy. A part appears only once its input names the description and prompt,
+  never with placeholder text. On replay the same parts render from the
+  transcript, current resident state overrides an earlier terminal notification,
+  and a still-running task the session's resident process no longer owns renders
+  as `cancelled`.
   Process exit — natural or an explicit stop — cancels every running task.
   OpenCode subtask parts keep a null lifecycle and the child-status fallback.
 - DeepSeek projects tool calls and updates through standard ACP with exact call
@@ -66,7 +70,7 @@ signal that a tool changed files.
 | L1 Smoke | Not included because proving tool behavior requires a live turn. |
 | L2 Routine | Live plugin, representative: a file-editing tool produces a tool part with name, terminal status, and bounded output. |
 | L3 Release | Client end to end (phone), every supporting production plugin: title, status, output bound, and errors normalize consistently; a mutating tool emits the file-change signal once and a read-only tool emits none; tool cards, errors, and subtask/agent parts render. Claude covers a foreground and a background sub-agent tile going running → completed with the result text, tapping the tile opening the child transcript, and a cancelled tile after the process is killed; OpenCode proves a null-lifecycle subtask part still renders and opens as before. Copilot covers one read-only tool, one file mutation with permission linkage and diff invalidation, and one failing tool. Grok covers a complete tool lifecycle with bounded output, a file diff and invalidation, live permission linkage, and cold-replay identity/status parity. |
-| L4 Extended | Live plugin, every supporting production plugin: tool parts survive history reload with identity, status, and output intact; a failing tool surfaces an error rather than a stuck running state; child-session tool activity is attributed correctly; repeated completion updates do not duplicate the file-change signal. Claude: a reloaded session with a finished background sub-agent shows one completed subtask tile with the same identity and `childSessionID`, a still-running one stays running while its process lives, and a failed sub-agent renders `error` with the notification summary. |
+| L4 Extended | Live plugin, every supporting production plugin: tool parts survive history reload with identity, status, and output intact; a failing tool surfaces an error rather than a stuck running state; child-session tool activity is attributed correctly; repeated completion updates do not duplicate the file-change signal. Claude: a reloaded session with a finished background sub-agent shows one completed subtask tile with the same identity and `childSessionID`, a still-running one stays running while its process lives, a resumed terminal agent returns to running in both its tile and child status, and a failed sub-agent renders `error` with the notification summary. |
 | L5 Full | Client end to end, every supporting production plugin: rune-boundary truncation is exact for multi-byte output; attachments render where emitted and unsafe or malformed sources degrade to metadata; unknown status from a newer peer degrades gracefully. |
 
 ## Exploration Guidance


### PR DESCRIPTION
## Complexity

🌿 Straightforward — this is a localized correction to Claude task lifecycle reconciliation and child status projection.

## What

- Reopen an existing Claude subtask when the CLI emits another `task_started` for the same agent.
- Clear the prior terminal output/error and restore the already-announced child session to busy.
- Let current resident-task state override an older terminal transcript state during history replay.
- Add tracker, dispatcher, replay, and regression coverage for terminal → running → terminal transitions.

## Why

Claude can resume a background agent after it previously stopped while reusing its task and tool-use identities. Stop accounting already treated the repeated start as running, but the presentation tracker refused to leave a terminal state and the child remained idle. This made a genuinely running agent look finished even though stopping the parent correctly detected it.

## Risk and test focus

The user-visible impact is limited to corrected status for resumed Claude sub-agents. There is no database schema or wire-contract change. The main regression risk is disturbing ordinary one-shot task terminal precedence, so coverage retains notification authority while proving a later start reopens the task and a later completion closes it again.

## Expected result

A resumed Claude sub-agent immediately returns to `running` in both its inline tile and child-session status, remains running after a history refresh, and transitions normally on its next terminal notification or stop.

## Verification

- `dart test` in `bridge/sesori_plugin_claude` — 297 tests passed.
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_claude` — no issues.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the running status for resumed Claude sub-agents so a running agent no longer appears finished after being stopped and restarted.

- A repeated `task_started` for the same agent now reopens the task, clears its prior output/error, and marks the child session busy.
- History replay lets current resident task state override an earlier terminal transcript state.
- Adds tracker, dispatcher, replay, and regression coverage for terminal → running → terminal transitions.

<sup>Written for commit a840368db60489c5aabd9ebac5ba7666be4291c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

