### PR TITLE
⚙️ Codex child sessions preserve live state

### DIFF
--- a/bridge/sesori_plugin_codex/lib/src/approval_registry.dart
+++ b/bridge/sesori_plugin_codex/lib/src/approval_registry.dart
@@ -44,7 +44,10 @@ const String _userInputMethod = "item/tool/requestUserInput";
 
 const String _elicitationApprovalKindKey = "codex_approval_kind";
 
-enum _ElicitationApprovalKind() { mcpToolCall, toolSuggestion }
+enum _ElicitationApprovalKind() {
+  mcpToolCall,
+  toolSuggestion,
+}
 
 class _PendingApproval({
   required final Object codexId,
@@ -105,6 +108,7 @@ class ApprovalRegistry({
   required super.emit,
   required final ApprovalResponder _respond,
   required final ApprovalErrorResponder _respondError,
+  required final String Function(String sessionId) _resolveDisplaySessionId,
   super.idGenerator,
 }) extends PendingPermissionRegistry<CodexServerRequest, _PendingApproval> {
   this
@@ -137,13 +141,14 @@ class ApprovalRegistry({
       respondError: _respondError,
     );
     final resolvedSessionId = sessionId ?? "";
+    final displaySessionId = _resolveDisplaySessionId(resolvedSessionId);
 
     if (isPermission) {
       final allowAlways = _allowsAlways(entry);
       registerPendingPermission(
         payload: entry,
         sessionId: resolvedSessionId,
-        displaySessionId: resolvedSessionId,
+        displaySessionId: displaySessionId,
         tool: _toolHintFor(method),
         description: _permissionDescriptionFor(entry),
         allowAlways: allowAlways,
@@ -152,7 +157,7 @@ class ApprovalRegistry({
       registerPendingQuestion(
         payload: entry,
         sessionId: resolvedSessionId,
-        displaySessionId: resolvedSessionId,
+        displaySessionId: displaySessionId,
         questions: [_questionInfoFor(entry)],
       );
     }

--- a/bridge/sesori_plugin_codex/lib/src/approval_registry.dart
+++ b/bridge/sesori_plugin_codex/lib/src/approval_registry.dart
@@ -61,6 +61,9 @@ class _PendingApproval({
 /// registry stays decoupled from [CodexAppServerClient].
 typedef ApprovalResponder = void Function(Object id, Object? result);
 typedef ApprovalErrorResponder = void Function(Object id, int code, String message);
+typedef PendingInputScopeResolver = ({String displaySessionId, List<String> sourceSessionIds}) Function({
+  required String sessionId,
+});
 
 void _resolveCodexPermission({required _PendingApproval payload, required PluginPermissionReply reply}) {
   payload.respond(payload.codexId, ApprovalRegistry._permissionResponse(payload, reply));
@@ -108,7 +111,7 @@ class ApprovalRegistry({
   required super.emit,
   required final ApprovalResponder _respond,
   required final ApprovalErrorResponder _respondError,
-  required final String Function(String sessionId) _resolveDisplaySessionId,
+  required final PendingInputScopeResolver _resolvePendingInputScope,
   super.idGenerator,
 }) extends PendingPermissionRegistry<CodexServerRequest, _PendingApproval> {
   this
@@ -141,7 +144,7 @@ class ApprovalRegistry({
       respondError: _respondError,
     );
     final resolvedSessionId = sessionId ?? "";
-    final displaySessionId = _resolveDisplaySessionId(resolvedSessionId);
+    final displaySessionId = _resolvePendingInputScope(sessionId: resolvedSessionId).displaySessionId;
 
     if (isPermission) {
       final allowAlways = _allowsAlways(entry);
@@ -161,6 +164,24 @@ class ApprovalRegistry({
         questions: [_questionInfoFor(entry)],
       );
     }
+  }
+
+  List<PluginPendingQuestion> pendingQuestionsForSessionTree({required String sessionId}) {
+    final scope = _resolvePendingInputScope(sessionId: sessionId);
+    return [
+      for (final sourceSessionId in scope.sourceSessionIds)
+        for (final question in pendingForSession(sessionId: sourceSessionId))
+          question.copyWith(displaySessionId: scope.displaySessionId),
+    ];
+  }
+
+  List<PluginPendingPermission> pendingPermissionsForSessionTree({required String sessionId}) {
+    final scope = _resolvePendingInputScope(sessionId: sessionId);
+    return [
+      for (final sourceSessionId in scope.sourceSessionIds)
+        for (final permission in pendingPermissionsForSession(sessionId: sourceSessionId))
+          permission.copyWith(displaySessionId: scope.displaySessionId),
+    ];
   }
 
   bool _allowsAlways(_PendingApproval entry) {

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -102,6 +102,18 @@ class CodexEventMapper({
   /// the current bridge run never started or resumed).
   final Map<String, String> _threadDirectory = {};
 
+  /// Direct parent for a live child thread. Minimal updates must preserve this
+  /// relationship or the bridge rejects them against the stored child row.
+  final Map<String, String> _threadParent = {};
+
+  void setThreadParent({required String threadId, required String? parentId}) {
+    if (parentId == null || parentId.isEmpty) {
+      _threadParent.remove(threadId);
+    } else {
+      _threadParent[threadId] = parentId;
+    }
+  }
+
   /// Records the normalized project [directory] the plugin resolved for
   /// [threadId]. Passing a null/empty [directory] clears the override (falls
   /// back to [projectCwd]).
@@ -133,6 +145,7 @@ class CodexEventMapper({
     _threadModel.remove(threadId);
     _threadProvider.remove(threadId);
     _threadDirectory.remove(threadId);
+    _threadParent.remove(threadId);
     _forgetItemTimes(threadId);
   }
 
@@ -149,6 +162,7 @@ class CodexEventMapper({
     setThreadTime(record);
     setThreadProvider(record.id, record.modelProvider);
     setThreadDirectory(record.id, record.directory);
+    setThreadParent(threadId: record.id, parentId: record.parentId);
     return [
       BridgeSseSessionCreated(info: _threadToSession(record).toJson()),
     ];
@@ -915,7 +929,7 @@ class CodexEventMapper({
       pluginId: pluginId,
       projectID: projectId,
       directory: projectId,
-      parentID: null,
+      parentID: _threadParent[id],
       title: title,
       time: time,
       pullRequest: null,

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -315,7 +315,13 @@ class CodexPlugin._({
       return;
     }
     final threadId = notification.params["threadId"] as String?;
-    if (threadId != null && _deletedThreadIds.contains(threadId)) return;
+    if (threadId != null && _deletedThreadIds.contains(threadId)) {
+      await _interruptDeletedThreadIfStarted(
+        notification: notification,
+        threadId: threadId,
+      );
+      return;
+    }
     if (_isSupersededTurnLifecycleNotification(notification)) return;
     if (_subAgentItemParser.parse(notification: notification) case CodexSubAgentActivity(
       lifecycle: CodexCorrelatableItemLifecycle.started,
@@ -590,6 +596,35 @@ class CodexPlugin._({
     if (value is! String) return null;
     final trimmed = value.trim();
     return trimmed.isEmpty ? null : trimmed;
+  }
+
+  Future<void> _interruptDeletedThreadIfStarted({
+    required CodexServerNotification notification,
+    required String threadId,
+  }) async {
+    if (notification.method != "turn/started" || !_interruptOnTurnStartThreadIds.contains(threadId)) return;
+    final turnId = _notificationTurnId(notification.params);
+    if (turnId == null) {
+      Log.w("[codex] deleted session $threadId started without an interruptible turn id");
+      return;
+    }
+    final client = _client;
+    if (client == null) return;
+    _interruptOnTurnStartThreadIds.remove(threadId);
+    try {
+      await client.request(
+        method: "turn/interrupt",
+        params: {"threadId": threadId, "turnId": turnId},
+      );
+    } on CodexRpcException catch (error, stackTrace) {
+      final backendAlreadyIdle =
+          error.code == -32602 || error.code == -32600 && error.message == "no active turn to interrupt";
+      if (!backendAlreadyIdle) {
+        Log.w("[codex] failed to interrupt deleted session $threadId after its turn started", error, stackTrace);
+      }
+    } on Object catch (error, stackTrace) {
+      Log.w("[codex] failed to interrupt deleted session $threadId after its turn started", error, stackTrace);
+    }
   }
 
   bool _maintainBookkeeping(CodexServerNotification notification) {
@@ -888,7 +923,7 @@ class CodexPlugin._({
     _approvalRegistry?.cancelForSession(sessionId: sessionId);
     final turnId = _activeTurnByThread[sessionId];
     if (turnId == null) {
-      if (_sessionService.isTrackedChild(sessionId: sessionId) && _isActiveStatus(_sessionStatuses[sessionId])) {
+      if (_sessionService.isActiveTrackedChild(sessionId: sessionId)) {
         _interruptOnTurnStartThreadIds.add(sessionId);
       }
       _syncWorkState();
@@ -1124,6 +1159,10 @@ class CodexPlugin._({
       _activeTurnByThread[threadId] = turnId;
       _provisionalAcceptedTurnThreadIds.add(threadId);
     }
+    _sessionService.observeSessionStatus(
+      sessionId: threadId,
+      status: const PluginSessionStatus.busy(),
+    );
   }
 
   bool _recordAuthoritativeTurnEvidence(String threadId) {
@@ -1279,10 +1318,15 @@ class CodexPlugin._({
   @override
   Future<void> deleteSession(String sessionId) async {
     final sessionIds = await _sessionService.getSessionSubtreeIds(sessionId: sessionId);
+    _sessionService.markSessionsDeleted(sessionIds: sessionIds);
     for (final deletedId in sessionIds) {
       _deletedThreadIds.add(deletedId);
       _provisionalAcceptedTurnThreadIds.remove(deletedId);
-      _interruptOnTurnStartThreadIds.remove(deletedId);
+      if (!_activeTurnByThread.containsKey(deletedId) && _sessionService.isActiveTrackedChild(sessionId: deletedId)) {
+        _interruptOnTurnStartThreadIds.add(deletedId);
+      } else {
+        _interruptOnTurnStartThreadIds.remove(deletedId);
+      }
       _pendingTurnRequestRevisionByThread.remove(deletedId);
       _advanceTurnEvidenceRevision(deletedId);
     }
@@ -1339,9 +1383,14 @@ class CodexPlugin._({
   Future<List<PluginSession>> getChildSessions(String sessionId) =>
       _sessionService.getChildSessions(sessionId: sessionId);
 
+  Map<String, PluginSessionStatus> _sessionStatusSnapshot() => {
+    ..._sessionStatuses,
+    for (final sessionId in _provisionalAcceptedTurnThreadIds) sessionId: const PluginSessionStatus.busy(),
+  };
+
   @override
   Future<Map<String, PluginSessionStatus>> getSessionStatuses() async =>
-      _sessionService.effectiveSessionStatuses(ownStatuses: _sessionStatuses);
+      _sessionService.effectiveSessionStatuses(ownStatuses: _sessionStatusSnapshot());
 
   @override
   Future<List<PluginMessageWithParts>> getSessionMessages(
@@ -1431,13 +1480,16 @@ class CodexPlugin._({
       _sessionService.getProviders(projectId: projectId);
 
   @override
-  List<PluginProjectActivitySummary> getActiveSessionsSummary() => _sessionService.getActiveSessionsSummary(
-    ownStatuses: _sessionStatuses,
-    pendingInputSessionIds: _approvalRegistry?.pendingSessionIds ?? const <String>{},
-    projectIdBySession: {
-      for (final sessionId in _sessionStatuses.keys) sessionId: _directoryForSession(sessionId),
-    },
-  );
+  List<PluginProjectActivitySummary> getActiveSessionsSummary() {
+    final statuses = _sessionStatusSnapshot();
+    return _sessionService.getActiveSessionsSummary(
+      ownStatuses: statuses,
+      pendingInputSessionIds: _approvalRegistry?.pendingSessionIds ?? const <String>{},
+      projectIdBySession: {
+        for (final sessionId in statuses.keys) sessionId: _directoryForSession(sessionId),
+      },
+    );
+  }
 
   @override
   Future<void> dispose() async {

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -246,16 +246,15 @@ class CodexPlugin._({
   /// forwards the signal to the runtime descriptor's status reporter.
   void _handleClientDisconnected() {
     final registry = _approvalRegistry;
-    final activeSessionIds = [
-      for (final entry in _sessionStatuses.entries)
+    final effectiveStatuses = _sessionService.effectiveSessionStatuses(
+      ownStatuses: _sessionStatusSnapshot(),
+    );
+    final activeSessionIds = {
+      for (final entry in effectiveStatuses.entries)
         if (_isActiveStatus(entry.value)) entry.key,
       ..._sessionService.deferredRootIds,
-    ];
-    final hadVisibleActivity =
-        activeSessionIds.isNotEmpty ||
-        _sessionStatuses.keys.any(
-          (sessionId) => registry?.hasPendingInput(sessionId: sessionId) ?? false,
-        );
+    };
+    final hadVisibleActivity = activeSessionIds.isNotEmpty || (registry?.hasAnyPendingInput ?? false);
     _connectFuture = null;
     _client = null;
     _sessionService.detachAppServerRepositories();

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -109,6 +109,10 @@ class CodexPlugin._({
   /// exposing codex turn identifiers outside the plugin.
   final Set<String> _provisionalAcceptedTurnThreadIds = {};
 
+  /// Stop requests received after an active status but before Codex exposes the
+  /// turn id. The matching `turn/started` is interrupted as soon as it arrives.
+  final Set<String> _interruptOnTurnStartThreadIds = {};
+
   /// In-flight turn requests authorize the next authoritative `turn/started`
   /// to replace a stale active id left behind by a missing terminal event.
   final Map<String, int> _pendingTurnRequestRevisionByThread = {};
@@ -197,6 +201,7 @@ class CodexPlugin._({
       final client = _createClient();
       _client = client;
       try {
+        await _sessionService.hydratePersistedChildAncestry();
         await client.connect();
         final appServerApi = CodexAppServerApi(client: client);
         _sessionService.attachAppServerRepositories(
@@ -270,6 +275,7 @@ class CodexPlugin._({
       _eventBuffer.add(const BridgeSseProjectUpdated());
     }
     _provisionalAcceptedTurnThreadIds.clear();
+    _interruptOnTurnStartThreadIds.clear();
     _pendingTurnRequestRevisionByThread.clear();
     _turnEvidenceRevisionByThread.keys.toList().forEach(_advanceTurnEvidenceRevision);
     _workState.set(PluginWorkState.unknown);
@@ -405,6 +411,9 @@ class CodexPlugin._({
           events: mappedEvents,
         )
         .forEach(_eventBuffer.add);
+    if (notification.method == "turn/started" && threadId != null) {
+      _interruptPendingStartIfReady(threadId: threadId);
+    }
   }
 
   /// Dispatches the typed activity fact to Layer 3 and buffers the ordered
@@ -509,7 +518,7 @@ class CodexPlugin._({
         code: code,
         message: message,
       ),
-      resolveDisplaySessionId: (sessionId) => _sessionService.pendingInputScope(sessionId: sessionId).displaySessionId,
+      resolvePendingInputScope: _sessionService.pendingInputScope,
     );
     _approvalRegistry = registry;
     registry.attach(stream: client.serverRequests);
@@ -597,11 +606,13 @@ class CodexPlugin._({
       case "turn/completed":
         if (threadId == null) return false;
         if (!_recordAuthoritativeTurnEvidence(threadId)) return false;
+        _interruptOnTurnStartThreadIds.remove(threadId);
         _activeTurnByThread.remove(threadId);
         return _setSessionStatus(threadId, const PluginSessionStatus.idle());
       case "error":
         if (threadId == null) return false;
         if (!_recordAuthoritativeTurnEvidence(threadId)) return false;
+        _interruptOnTurnStartThreadIds.remove(threadId);
         _activeTurnByThread.remove(threadId);
         // PluginSessionStatus has no explicit "error" — surfacing as idle
         // and letting the mapped BridgeSseSessionError carry the signal.
@@ -612,7 +623,10 @@ class CodexPlugin._({
         if ((idle || !_hasCurrentPendingTurnRequest(threadId)) && !_recordAuthoritativeTurnEvidence(threadId)) {
           return false;
         }
-        if (idle) _activeTurnByThread.remove(threadId);
+        if (idle) {
+          _interruptOnTurnStartThreadIds.remove(threadId);
+          _activeTurnByThread.remove(threadId);
+        }
         return _setSessionStatus(
           threadId,
           idle ? const PluginSessionStatus.idle() : const PluginSessionStatus.busy(),
@@ -623,6 +637,7 @@ class CodexPlugin._({
           _recordAuthoritativeTurnEvidence(threadId);
         }
         _approvalRegistry?.cancelForSession(sessionId: threadId);
+        _interruptOnTurnStartThreadIds.remove(threadId);
         _activeTurnByThread.remove(threadId);
         final wasActive = _isActiveStatus(_sessionStatuses.remove(threadId));
         _sessionService.observeSessionStatus(
@@ -873,9 +888,13 @@ class CodexPlugin._({
     _approvalRegistry?.cancelForSession(sessionId: sessionId);
     final turnId = _activeTurnByThread[sessionId];
     if (turnId == null) {
+      if (_sessionService.isTrackedChild(sessionId: sessionId) && _isActiveStatus(_sessionStatuses[sessionId])) {
+        _interruptOnTurnStartThreadIds.add(sessionId);
+      }
       _syncWorkState();
       return;
     }
+    _interruptOnTurnStartThreadIds.remove(sessionId);
     final client = _client;
     if (client == null) {
       _syncWorkState();
@@ -903,6 +922,19 @@ class CodexPlugin._({
       }
       _syncWorkState();
     }
+  }
+
+  void _interruptPendingStartIfReady({required String threadId}) {
+    if (!_interruptOnTurnStartThreadIds.remove(threadId)) return;
+    unawaited(
+      _abortSession(sessionId: threadId).catchError((Object error, StackTrace stackTrace) {
+        Log.e(
+          "[codex] failed to interrupt pending-start session $threadId",
+          error,
+          stackTrace,
+        );
+      }),
+    );
   }
 
   Future<void> _queueAlreadyIdleTurnReconciliation({
@@ -1105,6 +1137,7 @@ class CodexPlugin._({
   void _recordAuthoritativeThreadCreation(String threadId) {
     _deletedThreadIds.remove(threadId);
     _provisionalAcceptedTurnThreadIds.remove(threadId);
+    _interruptOnTurnStartThreadIds.remove(threadId);
     _pendingTurnRequestRevisionByThread.remove(threadId);
     _advanceTurnEvidenceRevision(threadId);
   }
@@ -1136,9 +1169,14 @@ class CodexPlugin._({
     required CodexThreadRecord? response,
   }) {
     if (response == null) return;
+    _sessionService.observeResumedThread(
+      thread: response,
+      status: _sessionStatuses[threadId] ?? const PluginSessionStatus.idle(),
+    );
     _eventMapper.setThreadTime(response);
     _eventMapper.setThreadModel(threadId, response.model);
     _eventMapper.setThreadProvider(threadId, response.modelProvider);
+    _eventMapper.setThreadParent(threadId: threadId, parentId: response.parentId);
     // A thread resumed from a prior bridge run never re-emits `thread/started`,
     // so learn its directory here (from the resume payload, else its rollout)
     // to keep live rename events attributed to its real project.
@@ -1244,6 +1282,7 @@ class CodexPlugin._({
     for (final deletedId in sessionIds) {
       _deletedThreadIds.add(deletedId);
       _provisionalAcceptedTurnThreadIds.remove(deletedId);
+      _interruptOnTurnStartThreadIds.remove(deletedId);
       _pendingTurnRequestRevisionByThread.remove(deletedId);
       _advanceTurnEvidenceRevision(deletedId);
     }
@@ -1335,30 +1374,12 @@ class CodexPlugin._({
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({
     required String sessionId,
-  }) async {
-    final registry = _approvalRegistry;
-    if (registry == null) return const [];
-    final scope = _sessionService.pendingInputScope(sessionId: sessionId);
-    return [
-      for (final sourceSessionId in scope.sourceSessionIds)
-        for (final question in registry.pendingForSession(sessionId: sourceSessionId))
-          question.copyWith(displaySessionId: scope.displaySessionId),
-    ];
-  }
+  }) async => _approvalRegistry?.pendingQuestionsForSessionTree(sessionId: sessionId) ?? const [];
 
   @override
   Future<List<PluginPendingPermission>> getPendingPermissions({
     required String sessionId,
-  }) async {
-    final registry = _approvalRegistry;
-    if (registry == null) return const [];
-    final scope = _sessionService.pendingInputScope(sessionId: sessionId);
-    return [
-      for (final sourceSessionId in scope.sourceSessionIds)
-        for (final permission in registry.pendingPermissionsForSession(sessionId: sourceSessionId))
-          permission.copyWith(displaySessionId: scope.displaySessionId),
-    ];
-  }
+  }) async => _approvalRegistry?.pendingPermissionsForSessionTree(sessionId: sessionId) ?? const [];
 
   @override
   Future<List<PluginPendingQuestion>> getProjectQuestions({

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -401,6 +401,7 @@ class CodexPlugin._({
           sessionId: mappedThreadId,
           sessionIsIdle: mappedThreadId != null && _sessionStatuses[mappedThreadId] is PluginSessionStatusIdle,
           activityChanged: activityChanged,
+          sessionClosed: notification.method == "thread/closed",
           events: mappedEvents,
         )
         .forEach(_eventBuffer.add);
@@ -427,8 +428,10 @@ class CodexPlugin._({
     );
     if (announcement == null) return;
     final child = announcement.child;
+    _sessionStatuses[childId] = announcement.status;
     _eventMapper.setThreadTime(child);
     _eventMapper.setThreadProvider(childId, child.modelProvider);
+    _eventMapper.setThreadParent(threadId: childId, parentId: child.parentId);
     final directory = child.directory;
     if (directory != null) _recordThreadDirectory(childId, directory);
     announcement.events.forEach(_eventBuffer.add);
@@ -506,6 +509,7 @@ class CodexPlugin._({
         code: code,
         message: message,
       ),
+      resolveDisplaySessionId: (sessionId) => _sessionService.pendingInputScope(sessionId: sessionId).displaySessionId,
     );
     _approvalRegistry = registry;
     registry.attach(stream: client.serverRequests);
@@ -945,6 +949,7 @@ class CodexPlugin._({
             sessionId: sessionId,
             sessionIsIdle: true,
             activityChanged: activityChanged,
+            sessionClosed: false,
             events: _eventMapper.map(terminal),
           )
           .forEach(_eventBuffer.add);
@@ -1330,12 +1335,30 @@ class CodexPlugin._({
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({
     required String sessionId,
-  }) async => _approvalRegistry?.pendingForSession(sessionId: sessionId) ?? const [];
+  }) async {
+    final registry = _approvalRegistry;
+    if (registry == null) return const [];
+    final scope = _sessionService.pendingInputScope(sessionId: sessionId);
+    return [
+      for (final sourceSessionId in scope.sourceSessionIds)
+        for (final question in registry.pendingForSession(sessionId: sourceSessionId))
+          question.copyWith(displaySessionId: scope.displaySessionId),
+    ];
+  }
 
   @override
   Future<List<PluginPendingPermission>> getPendingPermissions({
     required String sessionId,
-  }) async => _approvalRegistry?.pendingPermissionsForSession(sessionId: sessionId) ?? const [];
+  }) async {
+    final registry = _approvalRegistry;
+    if (registry == null) return const [];
+    final scope = _sessionService.pendingInputScope(sessionId: sessionId);
+    return [
+      for (final sourceSessionId in scope.sourceSessionIds)
+        for (final permission in registry.pendingPermissionsForSession(sessionId: sourceSessionId))
+          permission.copyWith(displaySessionId: scope.displaySessionId),
+    ];
+  }
 
   @override
   Future<List<PluginPendingQuestion>> getProjectQuestions({

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_catalog_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_catalog_repository.dart
@@ -53,6 +53,7 @@ class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
           cliVersion: metadata?.cliVersion,
           modelProvider: metadata?.modelProvider,
           model: metadata?.model,
+          agentNickname: metadata?.agentNickname,
           parentId: metadata?.parentId,
         ),
       );
@@ -294,6 +295,7 @@ class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
     String? modelProvider;
     String? cliVersion;
     String? model;
+    String? agentNickname;
     String? parentId;
     for (final line in lines) {
       switch (line) {
@@ -311,6 +313,7 @@ class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
           cliVersion = payload.cliVersion;
           if (payload.threadSource == CodexRolloutThreadSource.subagent) {
             parentId = payload.parentThreadId;
+            agentNickname = payload.agentNickname;
           }
         case CodexRolloutTurnContextLineDto(:final payload):
           final candidate = payload.model;
@@ -330,6 +333,7 @@ class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
       modelProvider: modelProvider,
       model: model,
       cliVersion: cliVersion,
+      agentNickname: agentNickname,
       parentId: parentId,
     );
   }
@@ -345,7 +349,7 @@ class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
       projectID: directory,
       directory: directory,
       parentID: record.parentId,
-      title: record.threadName,
+      title: _usefulText(record.threadName) ?? _usefulText(record.agentNickname),
       time: created == null || updated == null
           ? null
           : PluginSessionTime(
@@ -369,6 +373,11 @@ class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
     if (raw == null || raw.isEmpty) return null;
     return DateTime.tryParse(raw);
   }
+
+  String? _usefulText(String? value) {
+    final normalized = value?.trim();
+    return normalized == null || normalized.isEmpty ? null : normalized;
+  }
 }
 
 class const _CodexSessionMetadata({
@@ -378,5 +387,6 @@ class const _CodexSessionMetadata({
   required final String? modelProvider,
   required final String? model,
   required final String? cliVersion,
+  required final String? agentNickname,
   required final String? parentId,
 });

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_sub_agent_tracker.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_sub_agent_tracker.dart
@@ -1,11 +1,11 @@
 import "models/codex_thread_record.dart";
 
-/// Layer-2 tracker of the sub-agent threads learned on this connection and
-/// of the root busy accounting they drive.
+/// Layer-2 tracker of persisted and live sub-agent ancestry and of the root
+/// busy accounting that live child activity drives.
 ///
 /// codex-cli 0.148.0 never emits `thread/started` for a spawned child; the
-/// parent's `subAgentActivity started` item names it, and the session service
-/// resolves the child through `thread/read` before recording it here. Each
+/// parent's `subAgentActivity started` item names it. The session service
+/// records that relationship before enriching it through `thread/read`. Each
 /// child maps to its direct parent and to the root it rolls up to, so busy
 /// children and a root's deferred idle transition span nested spawns.
 class CodexSubAgentTracker() {
@@ -25,6 +25,8 @@ class CodexSubAgentTracker() {
   /// The root session a child rolls up to, or `null` for a root.
   String? rootOf({required String sessionId}) => _rootByChild[sessionId];
 
+  CodexThreadRecord? child({required String sessionId}) => _children[sessionId];
+
   /// Records [child] under its direct parent. Returns `false` when the child
   /// was already known, so a repeated activity item is not re-announced.
   bool record({required CodexThreadRecord child}) {
@@ -35,6 +37,13 @@ class CodexSubAgentTracker() {
     _rootByChild[child.id] = root;
     (_childrenByRoot[root] ??= {}).add(child.id);
     return true;
+  }
+
+  /// Replaces display metadata for an already-recorded child without changing
+  /// its canonical ancestry or activity state.
+  void replaceChild({required CodexThreadRecord child}) {
+    if (!_children.containsKey(child.id) || _children[child.id]?.parentId != child.parentId) return;
+    _children[child.id] = child;
   }
 
   /// The children whose direct parent is [parentId].

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_sub_agent_tracker.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_sub_agent_tracker.dart
@@ -27,6 +27,12 @@ class CodexSubAgentTracker() {
 
   CodexThreadRecord? child({required String sessionId}) => _children[sessionId];
 
+  bool isChildActive({required String sessionId}) => _activeChildren.contains(sessionId);
+
+  Set<String> get activeRootIds => {
+    for (final childId in _activeChildren) ?_rootByChild[childId],
+  };
+
   /// Records [child] under its direct parent. Returns `false` when the child
   /// was already known, so a repeated activity item is not re-announced.
   bool record({required CodexThreadRecord child}) {

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_session_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_session_mapper.dart
@@ -9,15 +9,23 @@ import "../models/codex_thread_record.dart";
 class const CodexSessionMapper() {
   CodexThreadRecord mapPersistedThread({required CodexSessionRecord record}) => CodexThreadRecord(
     id: record.id,
-    name: record.threadName ?? record.agentNickname,
-    directory: record.cwd,
+    name: _usefulText(record.threadName) ?? _usefulText(record.agentNickname),
+    directory: switch (_usefulText(record.cwd)) {
+      final directory? => normalizeProjectDirectory(directory: directory),
+      null => null,
+    },
     createdAt: record.createdAt?.millisecondsSinceEpoch,
     updatedAt: record.updatedAt?.millisecondsSinceEpoch,
     model: record.model,
     modelProvider: record.modelProvider,
     parentId: record.parentId,
-    agentNickname: record.agentNickname,
+    agentNickname: _usefulText(record.agentNickname),
   );
+
+  String? _usefulText(String? value) {
+    final normalized = value?.trim();
+    return normalized == null || normalized.isEmpty ? null : normalized;
+  }
 
   PluginSession mapThread({
     required CodexThreadRecord record,

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_session_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_session_mapper.dart
@@ -1,11 +1,24 @@
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show normalizeProjectDirectory;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
+import "../models/codex_session_record.dart";
 import "../models/codex_thread_record.dart";
 
-/// Pure Layer-2 projection from normalized Codex thread records to bridge
-/// session contracts and lifecycle events.
+/// Pure Layer-2 projections among normalized Codex records and bridge session
+/// contracts and lifecycle events.
 class const CodexSessionMapper() {
+  CodexThreadRecord mapPersistedThread({required CodexSessionRecord record}) => CodexThreadRecord(
+    id: record.id,
+    name: record.threadName ?? record.agentNickname,
+    directory: record.cwd,
+    createdAt: record.createdAt?.millisecondsSinceEpoch,
+    updatedAt: record.updatedAt?.millisecondsSinceEpoch,
+    model: record.model,
+    modelProvider: record.modelProvider,
+    parentId: record.parentId,
+    agentNickname: record.agentNickname,
+  );
+
   PluginSession mapThread({
     required CodexThreadRecord record,
     required String fallbackDirectory,

--- a/bridge/sesori_plugin_codex/lib/src/repositories/models/codex_session_record.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/models/codex_session_record.dart
@@ -8,6 +8,7 @@ class const CodexSessionRecord({
   required final String? cliVersion,
   required final String? modelProvider,
   required final String? model,
+  required final String? agentNickname,
 
   /// The parent thread of a sub-agent rollout (`session_meta.parent_thread_id`
   /// with `thread_source: subagent`); `null` for a root rollout.

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
@@ -25,6 +25,7 @@ final class const CodexSessionMessageRead._({
 
 final class const CodexSubAgentThreadAnnouncement({
   required final CodexThreadRecord child,
+  required final PluginSessionStatus status,
   required final List<BridgeSseEvent> events,
 });
 
@@ -130,18 +131,38 @@ class CodexSessionService({
       agentNickname: read?.agentNickname,
     );
     if (!_subAgentTracker.record(child: child)) return null;
-    _subAgentTracker.setChildActive(childId: childThreadId, active: _isActiveStatus(status));
+    // The observed 0.148.0 sequence reports a pre-start idle status before
+    // this authoritative activity fact, then active afterwards. Treat the
+    // child as pending now so a root completion cannot slip through that gap.
+    final startedStatus = _isActiveStatus(status) ? status : const PluginSessionStatus.busy();
+    _subAgentTracker.setChildActive(childId: childThreadId, active: true);
     return CodexSubAgentThreadAnnouncement(
       child: child,
+      status: startedStatus,
       events: _sessionMapper.mapChildStarted(
         child: child,
         fallbackDirectory: _launchDirectory,
-        status: status,
+        status: startedStatus,
       ),
     );
   }
 
   Set<String> get deferredRootIds => _subAgentTracker.deferredRootIds;
+
+  /// The source sessions whose pending input belongs on [sessionId]'s screen,
+  /// plus the top-most root id each snapshot should use for display routing.
+  ({String displaySessionId, List<String> sourceSessionIds}) pendingInputScope({
+    required String sessionId,
+  }) {
+    final displaySessionId = _subAgentTracker.rootOf(sessionId: sessionId) ?? sessionId;
+    return (
+      displaySessionId: displaySessionId,
+      sourceSessionIds: [
+        sessionId,
+        for (final child in _subAgentTracker.descendantsOf(parentId: sessionId)) child.id,
+      ],
+    );
+  }
 
   void observeRootTurnStarted({required String sessionId}) =>
       _subAgentTracker.cancelDeferredRootIdle(rootId: sessionId);
@@ -155,9 +176,16 @@ class CodexSessionService({
     required String? sessionId,
     required bool sessionIsIdle,
     required bool activityChanged,
+    required bool sessionClosed,
     required Iterable<BridgeSseEvent> events,
   }) {
-    final coordinated = <BridgeSseEvent>[];
+    final coordinated = <BridgeSseEvent>[
+      if (sessionClosed && activityChanged && sessionId != null && _subAgentTracker.isChild(sessionId: sessionId))
+        BridgeSseSessionStatus(
+          sessionID: sessionId,
+          status: const PluginSessionStatus.idle().toJson(),
+        ),
+    ];
     final shouldDeferIdle =
         sessionId != null && sessionIsIdle && _subAgentTracker.busyChildIds(rootId: sessionId).isNotEmpty;
     for (final event in events) {

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
@@ -48,6 +48,7 @@ class CodexSessionService({
   CodexSkillRepository? _skillRepository;
   final Set<String> _loadedThreads = {};
   final Map<String, String> _threadModels = {};
+  final Set<String> _announcedSubAgentThreadIds = {};
 
   void attachAppServerRepositories({
     required CodexThreadRepository threadRepository,
@@ -65,6 +66,7 @@ class CodexSessionService({
     _skillRepository = null;
     _loadedThreads.clear();
     _threadModels.clear();
+    _announcedSubAgentThreadIds.clear();
     _subAgentTracker.clear();
   }
 
@@ -98,6 +100,38 @@ class CodexSessionService({
     ];
   }
 
+  /// Restores persisted parent relationships before a new app-server
+  /// connection can deliver child approval requests. Persisted children are
+  /// inactive until live status evidence says otherwise.
+  Future<void> hydratePersistedChildAncestry() async {
+    final List<CodexSessionRecord> records;
+    try {
+      records = await _catalogRepository.listSessionRecordsInIsolate();
+    } on Object catch (error, stackTrace) {
+      Log.w("[codex] failed to hydrate persisted child ancestry", error, stackTrace);
+      return;
+    }
+    final pending = {
+      for (final record in records)
+        if (record.parentId != null) record.id: record,
+    };
+    while (pending.isNotEmpty) {
+      var progressed = false;
+      for (final record in pending.values.toList(growable: false)) {
+        if (pending.containsKey(record.parentId)) continue;
+        _recordPersistedChild(record: record);
+        pending.remove(record.id);
+        progressed = true;
+      }
+      if (progressed) continue;
+      Log.w("[codex] skipped cyclic persisted child ancestry");
+      break;
+    }
+  }
+
+  void _recordPersistedChild({required CodexSessionRecord record}) =>
+      _subAgentTracker.record(child: _sessionMapper.mapPersistedThread(record: record));
+
   /// Resolves and records a child named by `subAgentActivity started`, then
   /// maps its ordered creation/status events. A repeated activity returns
   /// `null` and never announces the child twice.
@@ -108,10 +142,49 @@ class CodexSessionService({
     required String? agentPath,
     required PluginSessionStatus status,
   }) async {
-    if (_subAgentTracker.isChild(sessionId: childThreadId)) return null;
-    CodexThreadRecord? read;
+    if (!_announcedSubAgentThreadIds.add(childThreadId)) return null;
+    // Record the activity's authoritative ancestry before best-effort
+    // `thread/read`: approval requests arrive on an independent stream and
+    // must resolve to the root even while that enrichment is in flight. A
+    // child hydrated from disk is known but has not yet been announced on
+    // this connection, so preserve its metadata and continue.
+    final trackedChild = _subAgentTracker.child(sessionId: childThreadId);
+    var child =
+        trackedChild ??
+        CodexThreadRecord(
+          id: childThreadId,
+          name: agentPath,
+          directory: parentDirectory,
+          createdAt: null,
+          updatedAt: null,
+          model: null,
+          modelProvider: null,
+          parentId: parentThreadId,
+          agentNickname: null,
+        );
+    if (trackedChild == null && !_subAgentTracker.record(child: child)) {
+      _announcedSubAgentThreadIds.remove(childThreadId);
+      return null;
+    }
+    // The observed 0.148.0 sequence reports a pre-start idle status before
+    // this authoritative activity fact, then active afterwards. Treat the
+    // child as pending now so a root completion cannot slip through that gap.
+    final startedStatus = _isActiveStatus(status) ? status : const PluginSessionStatus.busy();
+    _subAgentTracker.setChildActive(childId: childThreadId, active: true);
     try {
-      read = await _connectedThreadRepository.readThread(threadId: childThreadId);
+      final read = await _connectedThreadRepository.readThread(threadId: childThreadId);
+      child = CodexThreadRecord(
+        id: childThreadId,
+        name: read.agentNickname ?? read.name ?? agentPath,
+        directory: parentDirectory,
+        createdAt: read.createdAt,
+        updatedAt: read.updatedAt,
+        model: read.model,
+        modelProvider: read.modelProvider,
+        parentId: parentThreadId,
+        agentNickname: read.agentNickname,
+      );
+      _subAgentTracker.replaceChild(child: child);
     } on Object catch (error, stackTrace) {
       Log.w(
         "[codex] failed to read sub-agent thread $childThreadId of $parentThreadId; using the activity item",
@@ -119,23 +192,6 @@ class CodexSessionService({
         stackTrace,
       );
     }
-    final child = CodexThreadRecord(
-      id: childThreadId,
-      name: read?.agentNickname ?? read?.name ?? agentPath,
-      directory: parentDirectory,
-      createdAt: read?.createdAt,
-      updatedAt: read?.updatedAt,
-      model: read?.model,
-      modelProvider: read?.modelProvider,
-      parentId: parentThreadId,
-      agentNickname: read?.agentNickname,
-    );
-    if (!_subAgentTracker.record(child: child)) return null;
-    // The observed 0.148.0 sequence reports a pre-start idle status before
-    // this authoritative activity fact, then active afterwards. Treat the
-    // child as pending now so a root completion cannot slip through that gap.
-    final startedStatus = _isActiveStatus(status) ? status : const PluginSessionStatus.busy();
-    _subAgentTracker.setChildActive(childId: childThreadId, active: true);
     return CodexSubAgentThreadAnnouncement(
       child: child,
       status: startedStatus,
@@ -148,6 +204,8 @@ class CodexSessionService({
   }
 
   Set<String> get deferredRootIds => _subAgentTracker.deferredRootIds;
+
+  bool isTrackedChild({required String sessionId}) => _subAgentTracker.isChild(sessionId: sessionId);
 
   /// The source sessions whose pending input belongs on [sessionId]'s screen,
   /// plus the top-most root id each snapshot should use for display routing.
@@ -162,6 +220,17 @@ class CodexSessionService({
         for (final child in _subAgentTracker.descendantsOf(parentId: sessionId)) child.id,
       ],
     );
+  }
+
+  /// Restores canonical child ancestry from a resumed thread response. This
+  /// path replaces the live spawn activity after a bridge reconnect.
+  void observeResumedThread({
+    required CodexThreadRecord thread,
+    required PluginSessionStatus status,
+  }) {
+    if (thread.parentId == null) return;
+    _subAgentTracker.record(child: thread);
+    _subAgentTracker.setChildActive(childId: thread.id, active: _isActiveStatus(status));
   }
 
   void observeRootTurnStarted({required String sessionId}) =>
@@ -293,6 +362,7 @@ class CodexSessionService({
     for (final sessionId in sessionIds.reversed) {
       await _deleteSession(sessionId: sessionId);
     }
+    _announcedSubAgentThreadIds.removeAll(sessionIds);
     _subAgentTracker.forget(sessionId: sessionIds.first);
     return releasedRoot == null
         ? const []

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
@@ -49,6 +49,7 @@ class CodexSessionService({
   final Set<String> _loadedThreads = {};
   final Map<String, String> _threadModels = {};
   final Set<String> _announcedSubAgentThreadIds = {};
+  final Set<String> _deletedSubAgentThreadIds = {};
 
   void attachAppServerRepositories({
     required CodexThreadRepository threadRepository,
@@ -67,6 +68,7 @@ class CodexSessionService({
     _loadedThreads.clear();
     _threadModels.clear();
     _announcedSubAgentThreadIds.clear();
+    _deletedSubAgentThreadIds.clear();
     _subAgentTracker.clear();
   }
 
@@ -142,7 +144,12 @@ class CodexSessionService({
     required String? agentPath,
     required PluginSessionStatus status,
   }) async {
-    if (!_announcedSubAgentThreadIds.add(childThreadId)) return null;
+    if (_deletedSubAgentThreadIds.contains(parentThreadId) ||
+        _deletedSubAgentThreadIds.contains(childThreadId) ||
+        !_announcedSubAgentThreadIds.add(childThreadId)) {
+      return null;
+    }
+    final threadRepository = _connectedThreadRepository;
     // Record the activity's authoritative ancestry before best-effort
     // `thread/read`: approval requests arrive on an independent stream and
     // must resolve to the root even while that enrichment is in flight. A
@@ -171,8 +178,22 @@ class CodexSessionService({
     // child as pending now so a root completion cannot slip through that gap.
     final startedStatus = _isActiveStatus(status) ? status : const PluginSessionStatus.busy();
     _subAgentTracker.setChildActive(childId: childThreadId, active: true);
+    CodexThreadRecord? read;
     try {
-      final read = await _connectedThreadRepository.readThread(threadId: childThreadId);
+      read = await threadRepository.readThread(threadId: childThreadId);
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        "[codex] failed to read sub-agent thread $childThreadId of $parentThreadId; using the activity item",
+        error,
+        stackTrace,
+      );
+    }
+    if (!identical(_threadRepository, threadRepository) ||
+        _deletedSubAgentThreadIds.contains(parentThreadId) ||
+        _deletedSubAgentThreadIds.contains(childThreadId)) {
+      return null;
+    }
+    if (read != null) {
       child = CodexThreadRecord(
         id: childThreadId,
         name: read.agentNickname ?? read.name ?? agentPath,
@@ -185,12 +206,6 @@ class CodexSessionService({
         agentNickname: read.agentNickname,
       );
       _subAgentTracker.replaceChild(child: child);
-    } on Object catch (error, stackTrace) {
-      Log.w(
-        "[codex] failed to read sub-agent thread $childThreadId of $parentThreadId; using the activity item",
-        error,
-        stackTrace,
-      );
     }
     return CodexSubAgentThreadAnnouncement(
       child: child,
@@ -205,7 +220,11 @@ class CodexSessionService({
 
   Set<String> get deferredRootIds => _subAgentTracker.deferredRootIds;
 
-  bool isTrackedChild({required String sessionId}) => _subAgentTracker.isChild(sessionId: sessionId);
+  bool isActiveTrackedChild({required String sessionId}) => _subAgentTracker.isChildActive(sessionId: sessionId);
+
+  void markSessionsDeleted({required Iterable<String> sessionIds}) {
+    _deletedSubAgentThreadIds.addAll(sessionIds);
+  }
 
   /// The source sessions whose pending input belongs on [sessionId]'s screen,
   /// plus the top-most root id each snapshot should use for display routing.
@@ -228,7 +247,12 @@ class CodexSessionService({
     required CodexThreadRecord thread,
     required PluginSessionStatus status,
   }) {
-    if (thread.parentId == null) return;
+    final parentId = thread.parentId;
+    if (parentId == null ||
+        _deletedSubAgentThreadIds.contains(parentId) ||
+        _deletedSubAgentThreadIds.contains(thread.id)) {
+      return;
+    }
     _subAgentTracker.record(child: thread);
     _subAgentTracker.setChildActive(childId: thread.id, active: _isActiveStatus(status));
   }
@@ -276,32 +300,40 @@ class CodexSessionService({
 
   Map<String, PluginSessionStatus> effectiveSessionStatuses({
     required Map<String, PluginSessionStatus> ownStatuses,
-  }) => Map.unmodifiable({
-    for (final entry in ownStatuses.entries)
-      entry.key: _isActiveStatus(entry.value) || _subAgentTracker.busyChildIds(rootId: entry.key).isEmpty
-          ? entry.value
-          : const PluginSessionStatus.busy(),
-  });
+  }) {
+    final effective = Map<String, PluginSessionStatus>.of(ownStatuses);
+    for (final rootId in _subAgentTracker.activeRootIds) {
+      if (!_isActiveStatus(effective[rootId])) {
+        effective[rootId] = const PluginSessionStatus.busy();
+      }
+    }
+    return Map.unmodifiable(effective);
+  }
 
   List<PluginProjectActivitySummary> getActiveSessionsSummary({
     required Map<String, PluginSessionStatus> ownStatuses,
     required Set<String> pendingInputSessionIds,
     required Map<String, String> projectIdBySession,
   }) {
+    final rootSessionIds = {
+      for (final sessionId in ownStatuses.keys)
+        if (!_subAgentTracker.isChild(sessionId: sessionId)) sessionId,
+      ..._subAgentTracker.activeRootIds,
+      for (final sessionId in pendingInputSessionIds) _subAgentTracker.rootOf(sessionId: sessionId) ?? sessionId,
+    };
     final byProject = <String, List<PluginActiveSession>>{};
-    for (final entry in ownStatuses.entries) {
-      if (_subAgentTracker.isChild(sessionId: entry.key)) continue;
-      final running = _isActiveStatus(entry.value);
-      final descendants = _subAgentTracker.descendantsOf(parentId: entry.key);
+    for (final sessionId in rootSessionIds) {
+      final running = _isActiveStatus(ownStatuses[sessionId]);
+      final descendants = _subAgentTracker.descendantsOf(parentId: sessionId);
       final awaitingInput =
-          pendingInputSessionIds.contains(entry.key) ||
+          pendingInputSessionIds.contains(sessionId) ||
           descendants.any((child) => pendingInputSessionIds.contains(child.id));
-      final busyChildIds = _subAgentTracker.busyChildIds(rootId: entry.key);
+      final busyChildIds = _subAgentTracker.busyChildIds(rootId: sessionId);
       if (!running && !awaitingInput && busyChildIds.isEmpty) continue;
-      final projectId = projectIdBySession[entry.key] ?? normalizeProjectDirectory(directory: _launchDirectory);
+      final projectId = projectIdBySession[sessionId] ?? directoryForSession(sessionId: sessionId);
       (byProject[projectId] ??= []).add(
         PluginActiveSession(
-          id: entry.key,
+          id: sessionId,
           mainAgentRunning: running,
           awaitingInput: awaitingInput,
           isRetrying: false,
@@ -355,6 +387,7 @@ class CodexSessionService({
   /// when the named session itself was a child of a retained root.
   Future<List<BridgeSseEvent>> deleteSessionSubtree({required List<String> sessionIds}) async {
     if (sessionIds.isEmpty) return const [];
+    markSessionsDeleted(sessionIds: sessionIds);
     for (final sessionId in sessionIds) {
       _subAgentTracker.setChildActive(childId: sessionId, active: false);
     }
@@ -362,7 +395,6 @@ class CodexSessionService({
     for (final sessionId in sessionIds.reversed) {
       await _deleteSession(sessionId: sessionId);
     }
-    _announcedSubAgentThreadIds.removeAll(sessionIds);
     _subAgentTracker.forget(sessionId: sessionIds.first);
     return releasedRoot == null
         ? const []

--- a/bridge/sesori_plugin_codex/test/approval_registry_test.dart
+++ b/bridge/sesori_plugin_codex/test/approval_registry_test.dart
@@ -23,7 +23,10 @@ void main() {
         emit: emitted.add,
         respond: (id, result) => respondCalls.add(_RespondCall(id, result)),
         respondError: (id, code, message) => errorCalls.add(_RespondError(id, code, message)),
-        resolveDisplaySessionId: (sessionId) => sessionId,
+        resolvePendingInputScope: ({required sessionId}) => (
+          displaySessionId: sessionId,
+          sourceSessionIds: [sessionId],
+        ),
       );
       registry.attach(stream: requests.stream);
     });

--- a/bridge/sesori_plugin_codex/test/approval_registry_test.dart
+++ b/bridge/sesori_plugin_codex/test/approval_registry_test.dart
@@ -23,6 +23,7 @@ void main() {
         emit: emitted.add,
         respond: (id, result) => respondCalls.add(_RespondCall(id, result)),
         respondError: (id, code, message) => errorCalls.add(_RespondError(id, code, message)),
+        resolveDisplaySessionId: (sessionId) => sessionId,
       );
       registry.attach(stream: requests.stream);
     });

--- a/bridge/sesori_plugin_codex/test/codex_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_catalog_repository_test.dart
@@ -287,6 +287,7 @@ CodexSessionRecord _record({
   cliVersion: "0.142.0",
   modelProvider: "openai",
   model: "gpt-5.4-codex",
+  agentNickname: null,
 );
 
 class _StubCodexCatalogRepository(final List<CodexSessionRecord> records) extends CodexCatalogRepository {

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -164,6 +164,42 @@ void main() {
       expect(parseAsSesori(updated), isA<shared.SesoriSessionUpdated>());
     });
 
+    test("minimal child updates preserve their recorded parent", () {
+      mapper.setThreadParent(
+        threadId: "child-parent-retained",
+        parentId: "root-parent-retained",
+      );
+
+      final turnEvents = mapper.map(
+        const CodexServerNotification(
+          method: "turn/started",
+          params: {
+            "threadId": "child-parent-retained",
+            "turn": {"id": "turn-1", "startedAt": 1779293091},
+          },
+        ),
+      );
+      final activity = shared.Session.fromJson(
+        turnEvents.whereType<BridgeSseSessionUpdated>().single.info,
+      );
+      expect(activity.parentID, "root-parent-retained");
+
+      final nameEvents = mapper.map(
+        const CodexServerNotification(
+          method: "thread/name/updated",
+          params: {
+            "threadId": "child-parent-retained",
+            "threadName": "Renamed child",
+          },
+        ),
+      );
+      final renamed = shared.Session.fromJson(
+        (nameEvents.single as BridgeSseSessionUpdated).info,
+      );
+      expect(renamed.parentID, "root-parent-retained");
+      mapper.forgetThread("child-parent-retained");
+    });
+
     test("thread/started for a non-launch cwd emits that cwd's derived project id", () {
       // The bridge derives one project per cwd, so a session started outside the
       // launch dir must carry its own cwd as the project id — otherwise the

--- a/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
@@ -406,6 +406,85 @@ void main() {
       expect(disconnectWorkStates, isNot(contains(PluginWorkState.idle)));
     });
 
+    test("disconnect idles a provisional resumed child and its hydrated root", () async {
+      final tempHome = Directory.systemTemp.createTempSync("codex-home-disconnect-");
+      addTearDown(() => tempHome.delete(recursive: true));
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
+      final socketReady = Completer<WebSocket>();
+      server.listen((request) async {
+        final socket = await WebSocketTransformer.upgrade(request);
+        socketReady.complete(socket);
+        socket.listen((frame) {
+          final decoded = jsonDecode(frame as String) as Map<String, dynamic>;
+          final result = switch (decoded["method"]) {
+            "initialize" => _initOk,
+            "thread/resume" => const {
+              "model": "gpt-5.4-mini",
+              "modelProvider": "openai",
+              "thread": {
+                "id": "child-1",
+                "parentThreadId": "root-1",
+                "threadSource": "subAgent",
+              },
+            },
+            "turn/start" => const {
+              "turn": {"id": "child-turn"},
+            },
+            _ => null,
+          };
+          if (result == null) return;
+          socket.add(
+            jsonEncode({
+              "jsonrpc": "2.0",
+              "id": decoded["id"],
+              "result": result,
+            }),
+          );
+        });
+      });
+      final plugin = createInjectedCodexPlugin(
+        serverUrl: "ws://127.0.0.1:${server.port}",
+        environment: {"CODEX_HOME": tempHome.path},
+        projectCwd: "/repo/example",
+        clientFactory: null,
+        keepaliveInterval: const Duration(seconds: 30),
+      );
+      addTearDown(plugin.dispose);
+      final idleSessionIds = <String>{};
+      final bothIdle = Completer<void>();
+      final subscription = plugin.events.listen((event) {
+        if (event case BridgeSseSessionIdle(:final sessionID)) {
+          idleSessionIds.add(sessionID);
+          if (idleSessionIds.containsAll(const {"child-1", "root-1"}) && !bothIdle.isCompleted) {
+            bothIdle.complete();
+          }
+        }
+      });
+      addTearDown(subscription.cancel);
+
+      expect(await plugin.healthCheck(), isTrue);
+      final socket = await socketReady.future;
+      await plugin.sendPrompt(
+        sessionId: "child-1",
+        promptId: "prompt-1",
+        parts: const [PluginPromptPart.text(text: "continue")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final statuses = await plugin.getSessionStatuses();
+      expect(statuses["child-1"], isA<PluginSessionStatusBusy>());
+      expect(statuses["root-1"], isA<PluginSessionStatusBusy>());
+
+      await socket.close(WebSocketStatus.goingAway);
+      await bothIdle.future.timeout(const Duration(seconds: 2));
+
+      expect(idleSessionIds, {"child-1", "root-1"});
+      expect(await plugin.getSessionStatuses(), isEmpty);
+      expect(plugin.currentWorkState, PluginWorkState.unknown);
+    });
+
     test("dispose closes event buffer without error", () async {
       final plugin = createInjectedCodexPlugin(
         serverUrl: "ws://127.0.0.1:0",

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -582,6 +582,12 @@ void main() {
       expect(fake.sentParamsFor("thread/resume")["threadId"], equals("t-existing-child"));
       expect(fake.sentParamsFor("turn/start")["threadId"], equals("t-existing-child"));
       expect(plugin.currentWorkState, PluginWorkState.busy);
+      final statuses = await plugin.getSessionStatuses();
+      expect(statuses["t-existing-child"], isA<PluginSessionStatusBusy>());
+      expect(statuses["t-existing-root"], isA<PluginSessionStatusBusy>());
+      final summary = plugin.getActiveSessionsSummary();
+      expect(summary.single.activeSessions.single.id, "t-existing-root");
+      expect(summary.single.activeSessions.single.childSessionIds, ["t-existing-child"]);
 
       final renamed = plugin.events
           .where(
@@ -675,6 +681,11 @@ void main() {
       final pending = await plugin.getPendingPermissions(sessionId: rootId);
       expect(pending.single.sessionID, childId);
       expect(pending.single.displaySessionId, rootId);
+      final summary = plugin.getActiveSessionsSummary();
+      final active = summary.single.activeSessions.single;
+      expect(active.id, rootId);
+      expect(active.mainAgentRunning, isFalse);
+      expect(active.awaitingInput, isTrue);
     });
 
     test("sendPrompt treats an omitted agent as Default so it replaces Plan mode", () async {
@@ -2836,19 +2847,9 @@ void main() {
       await subscription.cancel();
     });
 
-    test("a child stop before turn/started interrupts as soon as the turn id arrives", () async {
+    test("a child stop while thread/read is pending interrupts when the turn id arrives", () async {
       fake.respondInOrder([
         const _Response(result: _initOk),
-        const _Response(
-          result: {
-            "thread": {
-              "id": "child-pending-start",
-              "parentThreadId": "root-pending-start",
-              "agentNickname": "Raman",
-              "cwd": "/work/sample",
-            },
-          },
-        ),
       ]);
       Future<T> next<T extends BridgeSseEvent>(bool Function(T event) where) => plugin.events
           .where((event) => event is T && where(event))
@@ -2867,6 +2868,11 @@ void main() {
         "threadId": "child-pending-start",
         "status": {"type": "idle"},
       });
+      fake.holdNextResponse("thread/read");
+      final readRequested = Completer<void>();
+      fake.onRequest = (method) {
+        if (method == "thread/read" && !readRequested.isCompleted) readRequested.complete();
+      };
       final childCreated = next<BridgeSseSessionCreated>(
         (event) => event.info["id"] == "child-pending-start",
       );
@@ -2880,6 +2886,29 @@ void main() {
           "agentPath": "/root/sleeper",
         },
       });
+      await readRequested.future.timeout(const Duration(seconds: 1));
+      expect(
+        await plugin.abortSession(
+          sessionId: "child-pending-start",
+          subAgents: PluginAbortSubAgentPolicy.stop,
+        ),
+        isA<PluginAbortAccepted>(),
+      );
+      expect(fake.sentMethods, isNot(contains("turn/interrupt")));
+      fake.respondToHeld(
+        "thread/read",
+        const _Response(
+          result: {
+            "thread": {
+              "id": "child-pending-start",
+              "parentThreadId": "root-pending-start",
+              "agentNickname": "Raman",
+              "cwd": "/work/sample",
+            },
+          },
+        ),
+      );
+      fake.onRequest = null;
       await childCreated;
 
       final rootUpdated = next<BridgeSseSessionUpdated>(
@@ -2894,15 +2923,6 @@ void main() {
         "status": {"type": "idle"},
       });
       await rootUpdated;
-
-      expect(
-        await plugin.abortSession(
-          sessionId: "child-pending-start",
-          subAgents: PluginAbortSubAgentPolicy.stop,
-        ),
-        isA<PluginAbortAccepted>(),
-      );
-      expect(fake.sentMethods, isNot(contains("turn/interrupt")));
 
       final interrupted = Completer<void>();
       fake.onRequest = (method) {
@@ -2965,6 +2985,12 @@ void main() {
       final childCreated = plugin.events
           .where((event) => event is BridgeSseSessionCreated && event.info["id"] == "child-1")
           .first;
+      final childBusy = plugin.events
+          .where(
+            (event) =>
+                event is BridgeSseSessionStatus && event.sessionID == "child-1" && event.status["type"] == "busy",
+          )
+          .first;
       fake.pushNotification("item/started", {
         "threadId": "root-1",
         "item": {
@@ -2976,16 +3002,6 @@ void main() {
         },
       });
       await childCreated.timeout(const Duration(seconds: 1));
-      final childBusy = plugin.events
-          .where(
-            (event) =>
-                event is BridgeSseSessionStatus && event.sessionID == "child-1" && event.status["type"] == "busy",
-          )
-          .first;
-      fake.pushNotification("turn/started", {
-        "threadId": "child-1",
-        "turn": {"id": "child-turn"},
-      });
       await childBusy.timeout(const Duration(seconds: 1));
 
       fake.respondInOrder([
@@ -2994,6 +3010,22 @@ void main() {
       ]);
       await plugin.deleteSession("root-1");
 
+      expect(
+        fake.sentParamsForAll(method: "turn/interrupt").map((params) => params["threadId"]),
+        ["root-1"],
+      );
+      final pendingChildInterrupted = Completer<void>();
+      fake.onRequest = (method) {
+        if (method == "turn/interrupt" && !pendingChildInterrupted.isCompleted) {
+          pendingChildInterrupted.complete();
+        }
+      };
+      fake.pushNotification("turn/started", {
+        "threadId": "child-1",
+        "turn": {"id": "child-turn"},
+      });
+      await pendingChildInterrupted.future.timeout(const Duration(seconds: 1));
+      fake.onRequest = null;
       expect(
         fake.sentParamsForAll(method: "turn/interrupt").map((params) => params["threadId"]).toSet(),
         {"root-1", "child-1"},

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -545,17 +545,20 @@ void main() {
       expect(fake.sentMethods, isEmpty);
     });
 
-    test("sendPrompt resumes a thread from a prior run before the turn", () async {
-      // `t-existing` was never started in this plugin instance, so the
-      // app-server has not loaded it — the plugin must resume it on demand
-      // before turn/start, or codex would answer "thread not found".
+    test("sendPrompt hydrates persisted child ancestry when resuming", () async {
+      // The child was never observed in this plugin instance, so resume is the
+      // canonical source for both its mapper context and tracker ancestry.
       fake.respondInOrder([
         const _Response(result: _initOk),
         const _Response(
           result: {
             "model": "gpt-5.4-mini",
             "modelProvider": "openai",
-            "thread": {"id": "t-existing"},
+            "thread": {
+              "id": "t-existing-child",
+              "parentThreadId": "t-existing-root",
+              "threadSource": "subAgent",
+            },
           },
         ),
         const _Response(
@@ -567,7 +570,7 @@ void main() {
 
       await plugin.sendPrompt(
         promptId: "prompt-1",
-        sessionId: "t-existing",
+        sessionId: "t-existing-child",
         parts: const [PluginPromptPart.text(text: "go on")],
         variant: null,
         agent: null,
@@ -576,9 +579,102 @@ void main() {
 
       final methods = fake.sentMethods;
       expect(methods, equals(["initialize", "thread/resume", "turn/start"]));
-      expect(fake.sentParamsFor("thread/resume")["threadId"], equals("t-existing"));
-      expect(fake.sentParamsFor("turn/start")["threadId"], equals("t-existing"));
+      expect(fake.sentParamsFor("thread/resume")["threadId"], equals("t-existing-child"));
+      expect(fake.sentParamsFor("turn/start")["threadId"], equals("t-existing-child"));
       expect(plugin.currentWorkState, PluginWorkState.busy);
+
+      final renamed = plugin.events
+          .where(
+            (event) => event is BridgeSseSessionUpdated && event.info["id"] == "t-existing-child",
+          )
+          .cast<BridgeSseSessionUpdated>()
+          .first;
+      fake.pushNotification("thread/name/updated", {
+        "threadId": "t-existing-child",
+        "threadName": "Resumed child",
+      });
+      expect(shared.Session.fromJson((await renamed).info).parentID, "t-existing-root");
+
+      final permissionAsked = plugin.events
+          .where(
+            (event) => event is BridgeSsePermissionAsked && event.sessionID == "t-existing-child",
+          )
+          .cast<BridgeSsePermissionAsked>()
+          .first;
+      fake.pushServerRequest(
+        id: 299,
+        method: "item/commandExecution/requestApproval",
+        params: {
+          "threadId": "t-existing-child",
+          "turnId": "u-1",
+          "itemId": "resumed-child-permission",
+          "command": "ls",
+        },
+      );
+      final asked = await permissionAsked;
+      expect(asked.displaySessionId, "t-existing-root");
+      final pending = await plugin.getPendingPermissions(sessionId: "t-existing-root");
+      expect(pending.single.sessionID, "t-existing-child");
+      expect(pending.single.displaySessionId, "t-existing-root");
+    });
+
+    test("connection startup hydrates persisted child approval routing", () async {
+      const rootId = "019a0000-1111-2222-3333-000000000001";
+      const childId = "019a0000-1111-2222-3333-000000000002";
+      void writeRollout({
+        required String id,
+        required String? parentId,
+        required String? threadSource,
+      }) {
+        final rollout = File(
+          p.join(
+            codexHome.path,
+            "sessions/2026/09/03/rollout-2026-09-03T12-00-00-$id.jsonl",
+          ),
+        )..createSync(recursive: true);
+        rollout.writeAsStringSync(
+          "${jsonEncode({
+            "type": "session_meta",
+            "payload": {
+              "id": id,
+              "timestamp": "2026-09-03T12:00:00Z",
+              "cwd": "/work/sample",
+              "parent_thread_id": ?parentId,
+              "thread_source": ?threadSource,
+            },
+          })}\n",
+        );
+      }
+
+      writeRollout(id: rootId, parentId: null, threadSource: null);
+      writeRollout(id: childId, parentId: rootId, threadSource: "subagent");
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+      ]);
+      await plugin.healthCheck();
+
+      final permissionAsked = plugin.events
+          .where(
+            (event) => event is BridgeSsePermissionAsked && event.sessionID == childId,
+          )
+          .cast<BridgeSsePermissionAsked>()
+          .first;
+      fake.pushServerRequest(
+        id: 300,
+        method: "item/commandExecution/requestApproval",
+        params: {
+          "threadId": childId,
+          "turnId": "persisted-child-turn",
+          "itemId": "persisted-child-permission",
+          "command": "ls",
+        },
+      );
+
+      final asked = await permissionAsked.timeout(const Duration(seconds: 1));
+      expect(asked.displaySessionId, rootId);
+      final pending = await plugin.getPendingPermissions(sessionId: rootId);
+      expect(pending.single.sessionID, childId);
+      expect(pending.single.displaySessionId, rootId);
     });
 
     test("sendPrompt treats an omitted agent as Default so it replaces Plan mode", () async {
@@ -2533,21 +2629,6 @@ void main() {
     test("a spawned sub-agent thread becomes a child session that keeps the root busy", () async {
       fake.respondInOrder([
         const _Response(result: _initOk),
-        // thread/read for the child named by subAgentActivity.
-        const _Response(
-          result: {
-            "thread": {
-              "id": "child-1",
-              "parentThreadId": "root-1",
-              "agentNickname": "Raman",
-              "agentRole": null,
-              "threadSource": null,
-              "cwd": "/work/other",
-              "createdAt": 1700000006,
-              "updatedAt": 1700000006,
-            },
-          },
-        ),
       ]);
       final events = <BridgeSseEvent>[];
       final subscription = plugin.events.listen(events.add);
@@ -2572,6 +2653,11 @@ void main() {
         "threadId": "child-1",
         "status": {"type": "idle"},
       });
+      fake.holdNextResponse("thread/read");
+      final readRequested = Completer<void>();
+      fake.onRequest = (method) {
+        if (method == "thread/read" && !readRequested.isCompleted) readRequested.complete();
+      };
       final created = next<BridgeSseSessionCreated>((event) => event.info["id"] == "child-1");
       fake.pushNotification("item/started", {
         "threadId": "root-1",
@@ -2584,6 +2670,45 @@ void main() {
           "agentPath": "/root/sleeper",
         },
       });
+      await readRequested.future.timeout(const Duration(seconds: 1));
+
+      // Server requests use a separate stream. Parent routing is available
+      // even while thread/read is still enriching the child announcement.
+      final permissionAsked = next<BridgeSsePermissionAsked>((event) => event.sessionID == "child-1");
+      fake.pushServerRequest(
+        id: 201,
+        method: "item/commandExecution/requestApproval",
+        params: {
+          "threadId": "child-1",
+          "turnId": "u-child",
+          "itemId": "item-permission",
+          "command": "ls",
+        },
+      );
+      final permissionEvent = await permissionAsked;
+      expect(permissionEvent.displaySessionId, "root-1");
+      final pendingDuringRead = await plugin.getPendingPermissions(sessionId: "root-1");
+      expect(pendingDuringRead.single.sessionID, "child-1");
+      expect(pendingDuringRead.single.displaySessionId, "root-1");
+
+      fake.respondToHeld(
+        "thread/read",
+        const _Response(
+          result: {
+            "thread": {
+              "id": "child-1",
+              "parentThreadId": "root-1",
+              "agentNickname": "Raman",
+              "agentRole": null,
+              "threadSource": null,
+              "cwd": "/work/other",
+              "createdAt": 1700000006,
+              "updatedAt": 1700000006,
+            },
+          },
+        ),
+      );
+      fake.onRequest = null;
       final childSession = shared.Session.fromJson((await created).info);
       expect(childSession.parentID, "root-1");
       expect(childSession.title, "Raman");
@@ -2652,19 +2777,6 @@ void main() {
       expect(events.whereType<BridgeSseSessionCreated>().where((event) => event.info["id"] == "child-1"), hasLength(1));
       expect(fake.sentMethods.where((method) => method == "thread/read"), hasLength(1));
 
-      final permissionAsked = next<BridgeSsePermissionAsked>((event) => event.sessionID == "child-1");
-      fake.pushServerRequest(
-        id: 201,
-        method: "item/commandExecution/requestApproval",
-        params: {
-          "threadId": "child-1",
-          "turnId": "u-child",
-          "itemId": "item-permission",
-          "command": "ls",
-        },
-      );
-      final permissionEvent = await permissionAsked;
-      expect(permissionEvent.displaySessionId, "root-1");
       final pendingPermissions = await plugin.getPendingPermissions(sessionId: "root-1");
       expect(pendingPermissions.single.sessionID, "child-1");
       expect(pendingPermissions.single.displaySessionId, "root-1");
@@ -2722,6 +2834,104 @@ void main() {
       expect(plugin.getActiveSessionsSummary(), isEmpty);
       expect(plugin.currentWorkState, PluginWorkState.idle);
       await subscription.cancel();
+    });
+
+    test("a child stop before turn/started interrupts as soon as the turn id arrives", () async {
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "thread": {
+              "id": "child-pending-start",
+              "parentThreadId": "root-pending-start",
+              "agentNickname": "Raman",
+              "cwd": "/work/sample",
+            },
+          },
+        ),
+      ]);
+      Future<T> next<T extends BridgeSseEvent>(bool Function(T event) where) => plugin.events
+          .where((event) => event is T && where(event))
+          .cast<T>()
+          .first
+          .timeout(const Duration(seconds: 2));
+      await plugin.healthCheck();
+      fake.pushNotification("thread/started", {
+        "thread": {"id": "root-pending-start", "cwd": "/work/sample"},
+      });
+      fake.pushNotification("turn/started", {
+        "threadId": "root-pending-start",
+        "turn": {"id": "root-turn"},
+      });
+      fake.pushNotification("thread/status/changed", {
+        "threadId": "child-pending-start",
+        "status": {"type": "idle"},
+      });
+      final childCreated = next<BridgeSseSessionCreated>(
+        (event) => event.info["id"] == "child-pending-start",
+      );
+      fake.pushNotification("item/started", {
+        "threadId": "root-pending-start",
+        "item": {
+          "type": "subAgentActivity",
+          "id": "spawn-pending-start",
+          "kind": "started",
+          "agentThreadId": "child-pending-start",
+          "agentPath": "/root/sleeper",
+        },
+      });
+      await childCreated;
+
+      final rootUpdated = next<BridgeSseSessionUpdated>(
+        (event) => event.info["id"] == "root-pending-start",
+      );
+      fake.pushNotification("turn/completed", {
+        "threadId": "root-pending-start",
+        "turn": {"id": "root-turn"},
+      });
+      fake.pushNotification("thread/status/changed", {
+        "threadId": "root-pending-start",
+        "status": {"type": "idle"},
+      });
+      await rootUpdated;
+
+      expect(
+        await plugin.abortSession(
+          sessionId: "child-pending-start",
+          subAgents: PluginAbortSubAgentPolicy.stop,
+        ),
+        isA<PluginAbortAccepted>(),
+      );
+      expect(fake.sentMethods, isNot(contains("turn/interrupt")));
+
+      final interrupted = Completer<void>();
+      fake.onRequest = (method) {
+        if (method == "turn/interrupt" && !interrupted.isCompleted) interrupted.complete();
+      };
+      fake.respondInOrder([
+        const _Response(result: <String, Object?>{}),
+      ]);
+      fake.pushNotification("turn/started", {
+        "threadId": "child-pending-start",
+        "turn": {"id": "child-turn"},
+      });
+      await interrupted.future.timeout(const Duration(seconds: 1));
+      expect(fake.sentParamsFor("turn/interrupt"), {
+        "threadId": "child-pending-start",
+        "turnId": "child-turn",
+      });
+
+      final rootIdle = next<BridgeSseSessionIdle>(
+        (event) => event.sessionID == "root-pending-start",
+      );
+      fake.pushNotification("turn/completed", {
+        "threadId": "child-pending-start",
+        "turn": {"id": "child-turn"},
+      });
+      await rootIdle;
+      final statuses = await plugin.getSessionStatuses();
+      expect(statuses["root-pending-start"], isA<PluginSessionStatusIdle>());
+      expect(statuses["child-pending-start"], isA<PluginSessionStatusIdle>());
     });
 
     test("deleting a busy root cancels and clears its live descendants", () async {

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -2589,26 +2589,12 @@ void main() {
       expect(childSession.title, "Raman");
       expect(childSession.projectID, "/work/other");
       expect(fake.sentParamsFor("thread/read"), {"threadId": "child-1", "includeTurns": false});
-      // A repeated activity item (item/completed) does not re-announce.
-      fake.pushNotification("item/completed", {
-        "threadId": "root-1",
-        "turnId": "u-root",
-        "item": {
-          "type": "subAgentActivity",
-          "id": "call_spawn",
-          "kind": "started",
-          "agentThreadId": "child-1",
-          "agentPath": "/root/sleeper",
-        },
-      });
-      fake.pushNotification("turn/started", {
-        "threadId": "child-1",
-        "turn": {"id": "u-child", "startedAt": 1700000007},
-      });
-      await next<BridgeSseSessionStatus>((event) => event.sessionID == "child-1");
-      expect(events.whereType<BridgeSseSessionCreated>().where((event) => event.info["id"] == "child-1"), hasLength(1));
-      expect(fake.sentMethods.where((method) => method == "thread/read"), hasLength(1));
-
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        events.whereType<BridgeSseSessionStatus>().where((event) => event.sessionID == "child-1").last.status["type"],
+        "busy",
+        reason: "the started activity supersedes Codex's pre-start idle status",
+      );
       var statuses = await plugin.getSessionStatuses();
       expect(statuses["root-1"], isA<PluginSessionStatusBusy>());
       expect(statuses["child-1"], isA<PluginSessionStatusBusy>());
@@ -2623,7 +2609,8 @@ void main() {
       expect(children.single.parentID, "root-1");
       expect(children.single.directory, "/work/other");
 
-      // The root's own turn ends while the child still runs: no idle yet.
+      // The root can complete before Codex's later active notification for the
+      // child. The activity-start fact already holds the root busy.
       final rootUpdated = next<BridgeSseSessionUpdated>((event) => event.info["id"] == "root-1");
       fake.pushNotification("turn/completed", {
         "threadId": "root-1",
@@ -2642,6 +2629,80 @@ void main() {
       expect(summary.single.activeSessions.single.mainAgentRunning, isFalse);
       expect(summary.single.activeSessions.single.childSessionIds, ["child-1"]);
       expect(plugin.currentWorkState, PluginWorkState.busy);
+
+      // A repeated activity item does not re-announce, and later child session
+      // updates retain the parent required by the bridge projection.
+      fake.pushNotification("item/completed", {
+        "threadId": "root-1",
+        "turnId": "u-root",
+        "item": {
+          "type": "subAgentActivity",
+          "id": "call_spawn",
+          "kind": "started",
+          "agentThreadId": "child-1",
+          "agentPath": "/root/sleeper",
+        },
+      });
+      final childUpdated = next<BridgeSseSessionUpdated>((event) => event.info["id"] == "child-1");
+      fake.pushNotification("turn/started", {
+        "threadId": "child-1",
+        "turn": {"id": "u-child", "startedAt": 1700000007},
+      });
+      expect(shared.Session.fromJson((await childUpdated).info).parentID, "root-1");
+      expect(events.whereType<BridgeSseSessionCreated>().where((event) => event.info["id"] == "child-1"), hasLength(1));
+      expect(fake.sentMethods.where((method) => method == "thread/read"), hasLength(1));
+
+      final permissionAsked = next<BridgeSsePermissionAsked>((event) => event.sessionID == "child-1");
+      fake.pushServerRequest(
+        id: 201,
+        method: "item/commandExecution/requestApproval",
+        params: {
+          "threadId": "child-1",
+          "turnId": "u-child",
+          "itemId": "item-permission",
+          "command": "ls",
+        },
+      );
+      final permissionEvent = await permissionAsked;
+      expect(permissionEvent.displaySessionId, "root-1");
+      final pendingPermissions = await plugin.getPendingPermissions(sessionId: "root-1");
+      expect(pendingPermissions.single.sessionID, "child-1");
+      expect(pendingPermissions.single.displaySessionId, "root-1");
+
+      final questionAsked = next<BridgeSseQuestionAsked>((event) => event.sessionID == "child-1");
+      fake.pushServerRequest(
+        id: 202,
+        method: "item/tool/requestUserInput",
+        params: {
+          "threadId": "child-1",
+          "turnId": "u-child",
+          "itemId": "item-question",
+          "questions": [
+            {"id": "confirm", "header": "Confirm", "question": "Continue?"},
+          ],
+        },
+      );
+      final questionEvent = await questionAsked;
+      expect(questionEvent.displaySessionId, "root-1");
+      final pendingQuestions = await plugin.getPendingQuestions(sessionId: "root-1");
+      expect(pendingQuestions.single.sessionID, "child-1");
+      expect(pendingQuestions.single.displaySessionId, "root-1");
+      expect(plugin.getActiveSessionsSummary().single.activeSessions.single.awaitingInput, isTrue);
+
+      await plugin.replyToPermission(
+        requestId: permissionEvent.requestID,
+        sessionId: "child-1",
+        reply: PluginPermissionReply.once,
+      );
+      await plugin.replyToQuestion(
+        questionId: questionEvent.id,
+        sessionId: "child-1",
+        answers: const [
+          ["yes"],
+        ],
+      );
+      expect(await plugin.getPendingPermissions(sessionId: "root-1"), isEmpty);
+      expect(await plugin.getPendingQuestions(sessionId: "root-1"), isEmpty);
 
       // A no-active-turn interrupt reconciles the child to idle and releases
       // the root's deferred transition once.

--- a/bridge/sesori_plugin_codex/test/codex_sub_agent_sessions_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_sub_agent_sessions_test.dart
@@ -291,6 +291,52 @@ void main() {
       expect(children.last.title, "Hooke");
     });
 
+    test("hydrates persisted ancestry and still announces its first live activity", () async {
+      final service = _newService(
+        threadRepository: _ReadingThreadRepository(
+          read: _liveChild(id: "child-1", parentId: "root-1"),
+          error: null,
+        ),
+        catalogRepository: _StubCatalogRepository(
+          records: [
+            _record(id: "grandchild-1", cwd: "/repo/app", parentId: "child-1"),
+            _record(id: "child-1", cwd: "/repo/app", parentId: "root-1"),
+            _record(id: "root-1", cwd: "/repo/app", parentId: null),
+          ],
+        ),
+        subAgentTracker: null,
+      );
+
+      await service.hydratePersistedChildAncestry();
+
+      expect(service.pendingInputScope(sessionId: "grandchild-1").displaySessionId, "root-1");
+      expect(service.pendingInputScope(sessionId: "root-1").sourceSessionIds, [
+        "root-1",
+        "child-1",
+        "grandchild-1",
+      ]);
+
+      final announcement = await service.handleSubAgentStarted(
+        childThreadId: "child-1",
+        parentThreadId: "root-1",
+        parentDirectory: "/repo/app",
+        agentPath: "worker",
+        status: const PluginSessionStatus.idle(),
+      );
+      expect(announcement, isNotNull);
+      expect(announcement!.status, isA<PluginSessionStatusBusy>());
+      expect(
+        await service.handleSubAgentStarted(
+          childThreadId: "child-1",
+          parentThreadId: "root-1",
+          parentDirectory: "/repo/app",
+          agentPath: "worker",
+          status: const PluginSessionStatus.busy(),
+        ),
+        isNull,
+      );
+    });
+
     test("owns effective status, deferred idle, and descendant pending input", () {
       final tracker = CodexSubAgentTracker();
       tracker.record(

--- a/bridge/sesori_plugin_codex/test/codex_sub_agent_sessions_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_sub_agent_sessions_test.dart
@@ -27,18 +27,23 @@ import "support/codex_plugin_test_factory.dart";
 
 void main() {
   group("CodexCatalogRepository sub-agent rollouts", () {
-    test("reads parentage from session_meta only for subagent rollouts", () {
+    test("reads sub-agent parentage and nickname from session metadata", () async {
       final repository = CodexCatalogRepository(rolloutApi: _HeaderRolloutApi());
 
       final records = {for (final record in repository.listSessionRecords()) record.id: record};
 
       expect(records["01a06259-6e4f-77f2-8bc7-000000000001"]?.parentId, isNull);
       expect(records["01a06259-6e4f-77f2-8bc7-000000000002"]?.parentId, "01a06259-6e4f-77f2-8bc7-000000000001");
+      expect(records["01a06259-6e4f-77f2-8bc7-000000000002"]?.agentNickname, "Raman");
       expect(
         records["01a06259-6e4f-77f2-8bc7-000000000003"]?.parentId,
         isNull,
         reason: "a plain fork is not a sub-agent",
       );
+      final children = await repository.getChildSessions(
+        sessionId: "01a06259-6e4f-77f2-8bc7-000000000001",
+      );
+      expect(children.single.title, "Raman");
     });
 
     test("lists roots only, keeps children discoverable, and resolves children by parent", () async {
@@ -203,7 +208,7 @@ void main() {
         parentThreadId: "root-1",
         parentDirectory: "/repo/parent",
         agentPath: "/root/sleeper",
-        status: const PluginSessionStatus.busy(),
+        status: const PluginSessionStatus.idle(),
       );
 
       expect(threadRepository.readThreadIds, ["child-1"]);
@@ -213,11 +218,13 @@ void main() {
       expect(child.directory, "/repo/parent");
       expect(child.model, "gpt-5.6");
       expect(child.createdAt, 10);
+      expect(announcement.status, isA<PluginSessionStatusBusy>());
       final created = announcement.events.whereType<BridgeSseSessionCreated>().single;
       final session = Session.fromJson(created.info);
       expect(session.parentID, "root-1");
       expect(session.title, "Raman");
-      expect(announcement.events.last, isA<BridgeSseSessionStatus>());
+      final announcedStatus = announcement.events.last as BridgeSseSessionStatus;
+      expect(announcedStatus.status["type"], "busy");
       expect(
         await service.handleSubAgentStarted(
           childThreadId: "child-1",
@@ -254,6 +261,7 @@ void main() {
       expect(child.name, "/root/sleeper");
       expect(child.directory, "/repo/parent");
       expect(child.agentNickname, isNull);
+      expect(announcement.status, isA<PluginSessionStatusBusy>());
     });
 
     test("merges persisted children with service-owned live children", () async {
@@ -315,11 +323,18 @@ void main() {
       expect(active.mainAgentRunning, isFalse);
       expect(active.awaitingInput, isTrue);
       expect(active.childSessionIds, ["child-1"]);
+      final rootInputScope = service.pendingInputScope(sessionId: "root-1");
+      expect(rootInputScope.displaySessionId, "root-1");
+      expect(rootInputScope.sourceSessionIds, ["root-1", "child-1"]);
+      final childInputScope = service.pendingInputScope(sessionId: "child-1");
+      expect(childInputScope.displaySessionId, "root-1");
+      expect(childInputScope.sourceSessionIds, ["child-1"]);
 
       final deferred = service.coordinateSessionEvents(
         sessionId: "root-1",
         sessionIsIdle: true,
         activityChanged: true,
+        sessionClosed: false,
         events: [
           BridgeSseSessionStatus(
             sessionID: "root-1",
@@ -339,6 +354,7 @@ void main() {
         sessionId: "child-1",
         sessionIsIdle: true,
         activityChanged: true,
+        sessionClosed: false,
         events: [const BridgeSseSessionIdle(sessionID: "child-1")],
       );
       expect(released.map((event) => event.runtimeType), [
@@ -347,6 +363,51 @@ void main() {
         BridgeSseSessionIdle,
         BridgeSseProjectUpdated,
       ]);
+      expect(service.deferredRootIds, isEmpty);
+    });
+
+    test("idles an active child before releasing its root when the thread closes", () {
+      final tracker = CodexSubAgentTracker();
+      tracker.record(
+        child: _liveChild(id: "child-1", parentId: "root-1"),
+      );
+      final service = _newService(
+        threadRepository: _ReadingThreadRepository(read: null, error: null),
+        catalogRepository: null,
+        subAgentTracker: tracker,
+      );
+      service.observeSessionStatus(
+        sessionId: "child-1",
+        status: const PluginSessionStatus.busy(),
+      );
+      service.coordinateSessionEvents(
+        sessionId: "root-1",
+        sessionIsIdle: true,
+        activityChanged: true,
+        sessionClosed: false,
+        events: [const BridgeSseSessionIdle(sessionID: "root-1")],
+      );
+      service.observeSessionStatus(
+        sessionId: "child-1",
+        status: const PluginSessionStatus.idle(),
+      );
+
+      final closed = service.coordinateSessionEvents(
+        sessionId: "child-1",
+        sessionIsIdle: false,
+        activityChanged: true,
+        sessionClosed: true,
+        events: const [],
+      );
+
+      expect(closed.map((event) => event.runtimeType), [
+        BridgeSseSessionStatus,
+        BridgeSseSessionStatus,
+        BridgeSseSessionIdle,
+        BridgeSseProjectUpdated,
+      ]);
+      expect((closed.first as BridgeSseSessionStatus).sessionID, "child-1");
+      expect((closed[1] as BridgeSseSessionStatus).sessionID, "root-1");
       expect(service.deferredRootIds, isEmpty);
     });
 
@@ -474,6 +535,7 @@ CodexSessionRecord _record({required String id, required String? cwd, required S
   cliVersion: "0.148.0",
   modelProvider: "openai",
   model: null,
+  agentNickname: null,
   parentId: parentId,
 );
 

--- a/bridge/sesori_plugin_codex/test/codex_sub_agent_sessions_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_sub_agent_sessions_test.dart
@@ -26,6 +26,53 @@ import "package:test/test.dart";
 import "support/codex_plugin_test_factory.dart";
 
 void main() {
+  group("CodexSessionMapper", () {
+    test("normalizes persisted child display metadata", () {
+      CodexSessionRecord record({
+        required String id,
+        required String? cwd,
+        required String? threadName,
+        required String? agentNickname,
+      }) => CodexSessionRecord(
+        id: id,
+        rolloutPath: "/rollouts/$id.jsonl",
+        cwd: cwd,
+        threadName: threadName,
+        createdAt: null,
+        updatedAt: null,
+        cliVersion: null,
+        modelProvider: null,
+        model: null,
+        agentNickname: agentNickname,
+        parentId: "root-1",
+      );
+      const mapper = CodexSessionMapper();
+
+      final normalized = mapper.mapPersistedThread(
+        record: record(
+          id: "child-1",
+          cwd: " /repo/./app/ ",
+          threadName: "  ",
+          agentNickname: " Raman ",
+        ),
+      );
+      final blank = mapper.mapPersistedThread(
+        record: record(
+          id: "child-2",
+          cwd: "  ",
+          threadName: " ",
+          agentNickname: " ",
+        ),
+      );
+
+      expect(normalized.name, "Raman");
+      expect(normalized.agentNickname, "Raman");
+      expect(normalized.directory, "/repo/app");
+      expect(blank.name, isNull);
+      expect(blank.directory, isNull);
+    });
+  });
+
   group("CodexCatalogRepository sub-agent rollouts", () {
     test("reads sub-agent parentage and nickname from session metadata", () async {
       final repository = CodexCatalogRepository(rolloutApi: _HeaderRolloutApi());
@@ -264,6 +311,64 @@ void main() {
       expect(announcement.status, isA<PluginSessionStatusBusy>());
     });
 
+    test("suppresses in-flight and delayed announcements for a deleted child", () async {
+      final threadRepository = _GatedThreadRepository();
+      final service = _newService(
+        threadRepository: threadRepository,
+        catalogRepository: _StubCatalogRepository(records: const []),
+        subAgentTracker: null,
+      );
+      final announcement = service.handleSubAgentStarted(
+        childThreadId: "child-1",
+        parentThreadId: "root-1",
+        parentDirectory: "/repo/app",
+        agentPath: "worker",
+        status: const PluginSessionStatus.idle(),
+      );
+      await threadRepository.readStarted.future;
+
+      await service.deleteSessionSubtree(sessionIds: const ["child-1"]);
+      threadRepository.complete(
+        record: _liveChild(id: "child-1", parentId: "root-1"),
+      );
+
+      expect(await announcement, isNull);
+      expect(
+        await service.handleSubAgentStarted(
+          childThreadId: "child-1",
+          parentThreadId: "root-1",
+          parentDirectory: "/repo/app",
+          agentPath: "worker",
+          status: const PluginSessionStatus.busy(),
+        ),
+        isNull,
+      );
+    });
+
+    test("suppresses an in-flight announcement from a detached connection", () async {
+      final threadRepository = _GatedThreadRepository();
+      final service = _newService(
+        threadRepository: threadRepository,
+        catalogRepository: null,
+        subAgentTracker: null,
+      );
+      final announcement = service.handleSubAgentStarted(
+        childThreadId: "child-1",
+        parentThreadId: "root-1",
+        parentDirectory: "/repo/app",
+        agentPath: "worker",
+        status: const PluginSessionStatus.idle(),
+      );
+      await threadRepository.readStarted.future;
+
+      service.detachAppServerRepositories();
+      threadRepository.complete(
+        record: _liveChild(id: "child-1", parentId: "root-1"),
+      );
+
+      expect(await announcement, isNull);
+    });
+
     test("merges persisted children with service-owned live children", () async {
       final tracker = CodexSubAgentTracker();
       tracker.record(
@@ -352,7 +457,6 @@ void main() {
         status: const PluginSessionStatus.busy(),
       );
       const ownStatuses = <String, PluginSessionStatus>{
-        "root-1": PluginSessionStatus.idle(),
         "child-1": PluginSessionStatus.busy(),
       };
 
@@ -410,6 +514,30 @@ void main() {
         BridgeSseProjectUpdated,
       ]);
       expect(service.deferredRootIds, isEmpty);
+    });
+
+    test("includes a hydrated pending child when no live statuses exist", () {
+      final tracker = CodexSubAgentTracker();
+      tracker.record(
+        child: _liveChild(id: "child-1", parentId: "root-1"),
+      );
+      final service = _newService(
+        threadRepository: _ReadingThreadRepository(read: null, error: null),
+        catalogRepository: null,
+        subAgentTracker: tracker,
+      );
+
+      final summary = service.getActiveSessionsSummary(
+        ownStatuses: const {},
+        pendingInputSessionIds: const {"child-1"},
+        projectIdBySession: const {"root-1": "/repo/app"},
+      );
+
+      final active = summary.single.activeSessions.single;
+      expect(active.id, "root-1");
+      expect(active.mainAgentRunning, isFalse);
+      expect(active.awaitingInput, isTrue);
+      expect(active.childSessionIds, isEmpty);
     });
 
     test("idles an active child before releasing its root when the thread closes", () {
@@ -631,6 +759,24 @@ class _ReadingThreadRepository({required final CodexThreadRecord? read, required
     if (record == null) throw StateError("no read fixture");
     return record;
   }
+}
+
+class _GatedThreadRepository() extends CodexThreadRepository {
+  this
+    : super(
+        appServerApi: CodexAppServerApi(client: CodexAppServerClient(serverUrl: "ws://127.0.0.1:0")),
+      );
+
+  final Completer<void> readStarted = Completer<void>();
+  final Completer<CodexThreadRecord> _response = Completer<CodexThreadRecord>();
+
+  @override
+  Future<CodexThreadRecord> readThread({required String threadId}) {
+    if (!readStarted.isCompleted) readStarted.complete();
+    return _response.future;
+  }
+
+  void complete({required CodexThreadRecord record}) => _response.complete(record);
 }
 
 class _StubCatalogRepository({required final List<CodexSessionRecord> records}) extends CodexCatalogRepository {

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -114,7 +114,8 @@ idle suspension, the management snapshot, and lifecycle commands.
   idle keepalives never trigger remote model discovery, and stop when the plugin is disposed.
   A root remains busy for lifecycle and safe-stop purposes while any tracked
   child turn runs, even after the root's own turn completes; disconnect clears
-  that connection-scoped child state and emits the visible idle cleanup once.
+  that connection-scoped child state and emits visible idle cleanup for both a
+  provisional child and its effective root before resetting work state.
 - Codex session metadata uses the top-level `model` and `model_provider` values from
   `~/.codex/config.toml` when durable rollout metadata omits them; rollout metadata
   remains authoritative when present.

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -178,7 +178,9 @@ state.
   `thread/read`, announces it under its direct parent with the parent's project
   directory and Codex nickname (or agent path), and never depends on a missing
   child `thread/started`. Later child activity and title updates retain that
-  parent. Catalog reads expose `thread_source == subagent` rollouts as children,
+  parent. Connection startup restores persisted lifecycle ancestry before
+  pending-input routing, and resuming a child restores the same mapper context.
+  Catalog reads expose `thread_source == subagent` rollouts as children,
   keep per-project pages root-only, preserve children in full enumeration, and
   retain the metadata nickname when the session index has no usable title.
   Deleting a Codex session removes its persisted and live descendant subtree

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -177,10 +177,12 @@ state.
 - A live Codex `subAgentActivity started` resolves the named thread through
   `thread/read`, announces it under its direct parent with the parent's project
   directory and Codex nickname (or agent path), and never depends on a missing
-  child `thread/started`. Catalog reads expose `thread_source == subagent`
-  rollouts as children, keep per-project pages root-only, and preserve children
-  in full enumeration. Deleting a Codex session removes its persisted and live
-  descendant subtree before the bridge deletes the matching database family.
+  child `thread/started`. Later child activity and title updates retain that
+  parent. Catalog reads expose `thread_source == subagent` rollouts as children,
+  keep per-project pages root-only, preserve children in full enumeration, and
+  retain the metadata nickname when the session index has no usable title.
+  Deleting a Codex session removes its persisted and live descendant subtree
+  before the bridge deletes the matching database family.
 - Pi import discovers persisted JSONL sessions from its inherited environment,
   configured storage, default per-project storage, and bridge-known directories.
   Enumeration is metadata-only and bounded: it reads session headers and

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -184,7 +184,10 @@ state.
   keep per-project pages root-only, preserve children in full enumeration, and
   retain the metadata nickname when the session index has no usable title.
   Deleting a Codex session removes its persisted and live descendant subtree
-  before the bridge deletes the matching database family.
+  before the bridge deletes the matching database family. A child deleted
+  before `turn/started` is interrupted when its turn id arrives, while in-flight
+  or delayed spawn activity cannot re-announce the deleted subtree during that
+  app-server connection.
 - Pi import discovers persisted JSONL sessions from its inherited environment,
   configured storage, default per-project storage, and bridge-known directories.
   Enumeration is metadata-only and bounded: it reads session headers and

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -67,8 +67,10 @@ defaults and queued client sends coherent.
   earlier pre-start status said idle. Active-session summaries keep
   `mainAgentRunning` specific to the root, list busy child thread ids, and roll
   a child's pending permission or question up to the root's awaiting-input
-  state and pending-input snapshot. Closing an active child emits its idle
-  status before any deferred root release.
+  state and pending-input snapshot, including a request that arrives while
+  `thread/read` is still enriching the spawn. A stop accepted before the child's
+  `turn/started` queues its interrupt until the turn id arrives. Closing an
+  active child emits its idle status before any deferred root release.
 - A plain Claude prompt sent while its resident process is working is written
   immediately with `priority: next`. Claude absorbs it at the next tool
   boundary when possible, within the active agent turn; otherwise Claude keeps
@@ -425,8 +427,9 @@ provider failure, early and late abort, busy stop-and-send, and two sessions.
 - A Codex root reports idle while a child is starting or still runs, never
   releases its deferred idle after the child settles, emits completion more
   than once, omits a busy child id, reports awaiting input without returning
-  the child's actionable request from the root snapshot, or leaves a closed
-  child's visible status busy.
+  the child's actionable request from the root snapshot, accepts a pre-start
+  child stop without interrupting the arriving turn, or leaves a closed child's
+  visible status busy.
 - A plain stop kills running Claude sub-agents or OpenCode child sessions
   without asking, the scope dialog appears when none run, a confirmed stop leaves a sub-agent running or the
   session stuck busy, a killed sub-agent leaves the session busy or the stop

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -63,9 +63,12 @@ defaults and queued client sends coherent.
 - A Codex root remains effectively busy after its own turn completes while any
   tracked descendant turn is running. The root's idle status and completion
   signal are deferred and released exactly once after the last child settles;
-  active-session summaries keep `mainAgentRunning` specific to the root, list
-  busy child thread ids, and roll a child's pending permission or question up
-  to the root's awaiting-input state.
+  the `subAgentActivity started` fact counts as work immediately even when an
+  earlier pre-start status said idle. Active-session summaries keep
+  `mainAgentRunning` specific to the root, list busy child thread ids, and roll
+  a child's pending permission or question up to the root's awaiting-input
+  state and pending-input snapshot. Closing an active child emits its idle
+  status before any deferred root release.
 - A plain Claude prompt sent while its resident process is working is written
   immediately with `priority: next`. Claude absorbs it at the next tool
   boundary when possible, within the active agent turn; otherwise Claude keeps
@@ -419,9 +422,11 @@ provider failure, early and late abort, busy stop-and-send, and two sessions.
   shows a transient idle between the task notification and its wake-up turn; a
   `<task-notification>` envelope renders as a user bubble, or a prompt that
   quotes the envelope disappears; sub-agent text appears in the root transcript.
-- A Codex root reports idle while a child turn still runs, never releases its
-  deferred idle after the child settles, emits completion more than once, omits
-  a busy child id, or hides a child's pending input from the root summary.
+- A Codex root reports idle while a child is starting or still runs, never
+  releases its deferred idle after the child settles, emits completion more
+  than once, omits a busy child id, reports awaiting input without returning
+  the child's actionable request from the root snapshot, or leaves a closed
+  child's visible status busy.
 - A plain stop kills running Claude sub-agents or OpenCode child sessions
   without asking, the scope dialog appears when none run, a confirmed stop leaves a sub-agent running or the
   session stuck busy, a killed sub-agent leaves the session busy or the stop

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -64,13 +64,15 @@ defaults and queued client sends coherent.
   tracked descendant turn is running. The root's idle status and completion
   signal are deferred and released exactly once after the last child settles;
   the `subAgentActivity started` fact counts as work immediately even when an
-  earlier pre-start status said idle. Active-session summaries keep
-  `mainAgentRunning` specific to the root, list busy child thread ids, and roll
-  a child's pending permission or question up to the root's awaiting-input
-  state and pending-input snapshot, including a request that arrives while
-  `thread/read` is still enriching the spawn. A stop accepted before the child's
-  `turn/started` queues its interrupt until the turn id arrives. Closing an
-  active child emits its idle status before any deferred root release.
+  earlier pre-start status said idle. An accepted resumed turn also keeps its
+  child and root provisionally busy before `turn/started` arrives.
+  Active-session summaries keep `mainAgentRunning` specific to the root, list
+  busy child thread ids, and roll a child's pending permission or question up
+  to the root's awaiting-input state and pending-input snapshot, including a
+  restored request with no live status and a request that arrives while
+  `thread/read` is still enriching the spawn. A stop or deletion accepted before
+  the child's `turn/started` queues its interrupt until the turn id arrives.
+  Closing an active child emits its idle status before any deferred root release.
 - A plain Claude prompt sent while its resident process is working is written
   immediately with `priority: next`. Claude absorbs it at the next tool
   boundary when possible, within the active agent turn; otherwise Claude keeps
@@ -426,10 +428,11 @@ provider failure, early and late abort, busy stop-and-send, and two sessions.
   quotes the envelope disappears; sub-agent text appears in the root transcript.
 - A Codex root reports idle while a child is starting or still runs, never
   releases its deferred idle after the child settles, emits completion more
-  than once, omits a busy child id, reports awaiting input without returning
-  the child's actionable request from the root snapshot, accepts a pre-start
-  child stop without interrupting the arriving turn, or leaves a closed child's
-  visible status busy.
+  than once, omits a busy child id, omits an awaiting-input root after reconnect,
+  reports awaiting input without returning the child's actionable request from
+  the root snapshot, accepts a pre-start child stop or deletion without
+  interrupting the arriving turn, re-announces deleted child activity, or leaves
+  a closed child's visible status busy.
 - A plain stop kills running Claude sub-agents or OpenCode child sessions
   without asking, the scope dialog appears when none run, a confirmed stop leaves a sub-agent running or the
   session stuck busy, a killed sub-agent leaves the session busy or the stop


### PR DESCRIPTION
## Complexity

⚙️ Moderate: localized fixes across Codex child-session lifecycle, pending-input projection, teardown, session mapping, and persisted catalog metadata.

## What

- Treat `subAgentActivity started` as immediate child work, bind ancestry before `thread/read`, and keep roots busy until descendants settle.
- Queue child stop and deletion interrupts accepted before `turn/started`, then interrupt when Codex supplies the turn ID.
- Tombstone deleted subtrees for the connection and suppress delayed, in-flight, or detached-generation child announcements.
- Centralize descendant question/permission projection in `ApprovalRegistry`, retaining child reply ownership while routing display to the root.
- Include hydrated pending-input roots in activity summaries, project accepted resumed turns as provisionally busy, and reconcile both child and root to idle if that connection drops.
- Restore mapper/service parent context on resume; normalize persisted child titles and directories; preserve nicknames as title fallback.
- Emit idle before a closing child releases its root and extend regression documentation and coverage.

## Why

Post-merge review of #1273 found concrete lifecycle, concurrency, and restart gaps that could complete a root early, hide actionable child input, drop or recreate child updates, leave backend work running after deletion, or lose child identity. This follow-up closes those gaps at their owning layers.

## Risk and test focus

Moderate and contained to `sesori_plugin_codex`. There is no database or public wire-contract change. Focus is live versus persisted ancestry, concurrent approval and stop routing while metadata loads, reconnect summaries and disconnect cleanup, pre-turn stop/deletion delivery, detached and deleted announcement suppression, child closure ordering, and mapper normalization.

## Expected result

Codex child sessions remain attached and actionable across live activity, reconnect, disconnect, resume, stop, and deletion. Root status and pending-input projections remain accurate until descendants settle, and deleted backend work cannot silently continue when its delayed turn starts. No database impact.

## Verification

- `dart analyze --fatal-infos` in `bridge/sesori_plugin_codex`: no issues.
- `dart test` in `bridge/sesori_plugin_codex`: all 415 tests passed.
- Architecture review finding applied: persisted-record projection lives in `CodexSessionMapper` in Layer 2.
