### PR TITLE
🌿 Make project and session renames optimistic

### DIFF
--- a/client/module_app_ui/lib/src/features/project_list/rename_project_dialog.dart
+++ b/client/module_app_ui/lib/src/features/project_list/rename_project_dialog.dart
@@ -31,7 +31,6 @@ class const RenameProjectDialog({
       initialValue: project.name ?? "",
       hintText: loc.renameProjectHint,
       saveLabel: loc.renameSave,
-      successMessage: loc.renameProjectSuccess,
       failureMessage: loc.renameProjectFailed,
       actionHeight: 48,
       onRename: (name) => cubit.renameProject(projectId: project.id, name: name),

--- a/client/module_app_ui/lib/src/features/session_list/rename_session_dialog.dart
+++ b/client/module_app_ui/lib/src/features/session_list/rename_session_dialog.dart
@@ -20,7 +20,6 @@ Future<void> showRenameSessionDialog({
         initialValue: session.title ?? "",
         hintText: loc.renameSessionHint,
         saveLabel: loc.renameSave,
-        successMessage: loc.renameSessionSuccess,
         failureMessage: loc.renameSessionFailed,
         submitOnEnter: true,
         onRename: (title) => cubit.renameSession(sessionId: session.id, title: title),

--- a/client/module_app_ui/lib/src/l10n/app_en.arb
+++ b/client/module_app_ui/lib/src/l10n/app_en.arb
@@ -866,8 +866,6 @@
   "renameSessionHint": "Session title",
   "renameProjectHint": "Project name",
   "renameSave": "Save",
-  "renameSessionSuccess": "Session renamed",
-  "renameProjectSuccess": "Project renamed",
   "renameSessionFailed": "Failed to rename session",
   "renameProjectFailed": "Failed to rename project",
   "newSessionDedicatedWorkspace": "Dedicated workspace",

--- a/client/module_app_ui/lib/src/l10n/app_localizations.dart
+++ b/client/module_app_ui/lib/src/l10n/app_localizations.dart
@@ -2767,18 +2767,6 @@ abstract class AppLocalizations {
   /// **'Save'**
   String get renameSave;
 
-  /// No description provided for @renameSessionSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Session renamed'**
-  String get renameSessionSuccess;
-
-  /// No description provided for @renameProjectSuccess.
-  ///
-  /// In en, this message translates to:
-  /// **'Project renamed'**
-  String get renameProjectSuccess;
-
   /// No description provided for @renameSessionFailed.
   ///
   /// In en, this message translates to:

--- a/client/module_app_ui/lib/src/l10n/app_localizations_en.dart
+++ b/client/module_app_ui/lib/src/l10n/app_localizations_en.dart
@@ -1487,12 +1487,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get renameSave => 'Save';
 
   @override
-  String get renameSessionSuccess => 'Session renamed';
-
-  @override
-  String get renameProjectSuccess => 'Project renamed';
-
-  @override
   String get renameSessionFailed => 'Failed to rename session';
 
   @override

--- a/client/module_app_ui/lib/src/widgets/rename_sheet.dart
+++ b/client/module_app_ui/lib/src/widgets/rename_sheet.dart
@@ -1,12 +1,14 @@
+import "dart:async";
+
 import "package:go_router/go_router.dart";
 import "package:material_ui/material_ui.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:theme_prego/module_prego.dart";
 
 class const RenameSheet({
   required final String initialValue,
   required final String hintText,
   required final String saveLabel,
-  required final String successMessage,
   required final String failureMessage,
   required final Future<bool> Function(String value) onRename,
   final bool submitOnEnter = false,
@@ -19,7 +21,7 @@ class const RenameSheet({
 
 class _RenameSheetState() extends State<RenameSheet> {
   late final TextEditingController _controller;
-  bool _loading = false;
+  bool _submitted = false;
 
   @override
   void initState() {
@@ -33,42 +35,46 @@ class _RenameSheetState() extends State<RenameSheet> {
     super.dispose();
   }
 
-  Future<void> _save() async {
+  void _save() {
     final value = _controller.text.trim();
-    if (value.isEmpty || _loading) return;
+    if (value.isEmpty || _submitted) return;
+
     final presenter = PregoPopupAlertPresenter.of(context);
-    setState(() => _loading = true);
-    final success = await widget.onRename(value);
-    if (!mounted) return;
-    setState(() => _loading = false);
-    if (success) {
-      context.pop();
-      presenter.show(title: widget.successMessage, variant: PregoPopupAlertsNotificationsVariant.success);
-    } else {
-      presenter.show(title: widget.failureMessage, variant: PregoPopupAlertsNotificationsVariant.error);
-    }
+    setState(() => _submitted = true);
+    final rename = widget.onRename(value);
+    context.pop();
+    unawaited(
+      _showFailureIfNeeded(
+        rename: rename,
+        presenter: presenter,
+        failureMessage: widget.failureMessage,
+      ),
+    );
   }
 
-  static Brightness _inverse(Brightness brightness) =>
-      brightness == Brightness.dark ? Brightness.light : Brightness.dark;
+  Future<void> _showFailureIfNeeded({
+    required Future<bool> rename,
+    required PregoPopupAlertPresenter presenter,
+    required String failureMessage,
+  }) async {
+    final bool succeeded;
+    try {
+      succeeded = await rename;
+    } on Object catch (error, stackTrace) {
+      loge("Rename request failed unexpectedly", error, stackTrace);
+      presenter.show(title: failureMessage, variant: PregoPopupAlertsNotificationsVariant.error);
+      return;
+    }
+    if (!succeeded) {
+      presenter.show(title: failureMessage, variant: PregoPopupAlertsNotificationsVariant.error);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final action = FilledButton(
-      onPressed: _loading || _controller.text.trim().isEmpty ? null : _save,
-      child: _loading
-          ? SizedBox(
-              width: 16,
-              height: 16,
-              // The primary button's fill (bgPrimarySolid) paints the inverse
-              // of the page surface, so the untinted spinner follows the
-              // opposite brightness.
-              child: PregoActivityIndicator.onSurface(
-                brightness: _inverse(Theme.of(context).brightness),
-                color: null,
-              ),
-            )
-          : Text(widget.saveLabel),
+      onPressed: _submitted || _controller.text.trim().isEmpty ? null : _save,
+      child: Text(widget.saveLabel),
     );
     return Padding(
       padding: const EdgeInsetsDirectional.only(bottom: 16),

--- a/client/module_app_ui/lib/src/widgets/rename_sheet.dart
+++ b/client/module_app_ui/lib/src/widgets/rename_sheet.dart
@@ -2,7 +2,6 @@ import "dart:async";
 
 import "package:go_router/go_router.dart";
 import "package:material_ui/material_ui.dart";
-import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:theme_prego/module_prego.dart";
 
 class const RenameSheet({
@@ -60,8 +59,7 @@ class _RenameSheetState() extends State<RenameSheet> {
     final bool succeeded;
     try {
       succeeded = await rename;
-    } on Object catch (error, stackTrace) {
-      loge("Rename request failed unexpectedly", error, stackTrace);
+    } on Object {
       presenter.show(title: failureMessage, variant: PregoPopupAlertsNotificationsVariant.error);
       return;
     }

--- a/client/module_app_ui/test/widgets/rename_sheet_test.dart
+++ b/client/module_app_ui/test/widgets/rename_sheet_test.dart
@@ -1,0 +1,102 @@
+import "dart:async";
+
+import "package:flutter_test/flutter_test.dart";
+import "package:go_router/go_router.dart";
+import "package:material_ui/material_ui.dart";
+import "package:sesori_app_ui/sesori_app_ui.dart";
+import "package:theme_prego/module_prego.dart";
+
+Future<void> _pumpRenameSheet({
+  required WidgetTester tester,
+  required Future<bool> Function(String value) onRename,
+}) async {
+  final router = GoRouter(
+    routes: [
+      GoRoute(
+        path: "/",
+        builder: (context, _) => Scaffold(
+          body: Center(
+            child: FilledButton(
+              onPressed: () {
+                unawaited(
+                  showPregoBottomSheet<void>(
+                    context: context,
+                    title: "Rename",
+                    builder: (_) => RenameSheet(
+                      initialValue: "Original",
+                      hintText: "Name",
+                      saveLabel: "Save",
+                      failureMessage: "Rename failed",
+                      onRename: onRename,
+                    ),
+                  ),
+                );
+              },
+              child: const Text("Open rename"),
+            ),
+          ),
+        ),
+      ),
+    ],
+  );
+  addTearDown(router.dispose);
+
+  await tester.pumpWidget(
+    MaterialApp.router(
+      routerConfig: router,
+      theme: ThemeData(extensions: [PregoDesignSystem.light]),
+    ),
+  );
+  await tester.pumpAndSettle();
+  await tester.tap(find.widgetWithText(FilledButton, "Open rename"));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets("dismisses immediately and stays silent after a successful rename", (tester) async {
+    final renameCompleter = Completer<bool>();
+    String? submittedValue;
+    await _pumpRenameSheet(
+      tester: tester,
+      onRename: (value) {
+        submittedValue = value;
+        return renameCompleter.future;
+      },
+    );
+
+    await tester.enterText(find.byType(TextField), "  New name  ");
+    await tester.tap(find.widgetWithText(FilledButton, "Save"));
+    await tester.pumpAndSettle();
+
+    expect(submittedValue, "New name");
+    expect(renameCompleter.isCompleted, isFalse);
+    expect(find.byType(RenameSheet), findsNothing);
+    expect(find.byType(PregoPopupAlertsNotifications), findsNothing);
+
+    renameCompleter.complete(true);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(PregoPopupAlertsNotifications), findsNothing);
+  });
+
+  testWidgets("reports a failed rename after dismissing immediately", (tester) async {
+    final renameCompleter = Completer<bool>();
+    await _pumpRenameSheet(
+      tester: tester,
+      onRename: (_) => renameCompleter.future,
+    );
+
+    await tester.enterText(find.byType(TextField), "New name");
+    await tester.tap(find.widgetWithText(FilledButton, "Save"));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RenameSheet), findsNothing);
+    expect(find.text("Rename failed"), findsNothing);
+
+    renameCompleter.complete(false);
+    await tester.pumpAndSettle();
+
+    expect(find.text("Rename failed"), findsOneWidget);
+    expect(find.byType(PregoPopupAlertsNotifications), findsOneWidget);
+  });
+}

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -650,6 +650,9 @@ class ProjectListCubit(
     if (index < 0) return false;
 
     final previousName = currentState.projects[index].name;
+    // A read that began before this mutation can still carry the old name.
+    // Supersede it now; success starts an authoritative post-write read below.
+    _fetchGeneration++;
     final projects = [...currentState.projects];
     projects[index] = projects[index].copyWith(name: name);
     _emitOrdered(
@@ -661,8 +664,7 @@ class ProjectListCubit(
     final ApiResponse<Project> response;
     try {
       response = await _projectRepository.renameProject(projectId: projectId, name: name);
-    } on Object catch (error, stackTrace) {
-      loge("Failed to rename project", error, stackTrace);
+    } on Object {
       _restoreProjectName(
         projectId: projectId,
         optimisticName: name,
@@ -673,10 +675,16 @@ class ProjectListCubit(
 
     switch (response) {
       case SuccessResponse():
-        if (!isClosed) unawaited(refreshProjects());
+        if (!isClosed) {
+          unawaited(
+            _refreshProjects(
+              force: true,
+              catalogRefresh: false,
+            ),
+          );
+        }
         return true;
-      case ErrorResponse(:final error):
-        loge("Failed to rename project", error);
+      case ErrorResponse():
         _restoreProjectName(
           projectId: projectId,
           optimisticName: name,

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -56,6 +56,10 @@ class ProjectListCubit(
 }) extends Cubit<ProjectListState> {
   final CompositeSubscription _subscriptions = CompositeSubscription();
 
+  /// Keeps pre-rename list responses from repainting an old name while the
+  /// mutation is still pending.
+  final Map<String, String> _optimisticNameByProjectId = {};
+
   // ignore: no_slop_linter/prefer_required_named_parameters, public cubit constructor API
   this : super(const ProjectListState.loading()) {
     unawaited(_loadInitialProjects());
@@ -574,7 +578,7 @@ class ProjectListCubit(
     required Map<String, Map<String, SessionActivityInfo>> activityByProjectId,
   }) {
     final ordered = _projectListService.orderProjects(
-      projects: projects,
+      projects: _withOptimisticProjectNames(projects: projects),
       activityByProjectId: activityByProjectId,
       listStateByProjectId: _sessionUnseenTracker.currentSessionUnseen,
     );
@@ -584,6 +588,13 @@ class ProjectListCubit(
         unseenByProjectId: _unseenByProjectId(ordered),
       ),
     );
+  }
+
+  Iterable<ProjectSummary> _withOptimisticProjectNames({required Iterable<ProjectSummary> projects}) {
+    return projects.map((project) {
+      final optimisticName = _optimisticNameByProjectId[project.id];
+      return optimisticName == null ? project : project.copyWith(name: optimisticName);
+    });
   }
 
   /// Creates a new project named [name] below [parentPath].
@@ -650,9 +661,7 @@ class ProjectListCubit(
     if (index < 0) return false;
 
     final previousName = currentState.projects[index].name;
-    // A read that began before this mutation can still carry the old name.
-    // Supersede it now; success starts an authoritative post-write read below.
-    _fetchGeneration++;
+    _optimisticNameByProjectId[projectId] = name;
     final projects = [...currentState.projects];
     projects[index] = projects[index].copyWith(name: name);
     _emitOrdered(
@@ -675,6 +684,9 @@ class ProjectListCubit(
 
     switch (response) {
       case SuccessResponse():
+        if (_optimisticNameByProjectId[projectId] == name) {
+          _optimisticNameByProjectId.remove(projectId);
+        }
         if (!isClosed) {
           unawaited(
             _refreshProjects(
@@ -702,11 +714,14 @@ class ProjectListCubit(
     final currentState = state;
     if (isClosed || currentState is! ProjectListLoaded) return;
 
+    if (_optimisticNameByProjectId[projectId] == optimisticName) {
+      _optimisticNameByProjectId.remove(projectId);
+    }
     final index = currentState.projects.indexWhere((project) => project.id == projectId);
-    if (index < 0 || currentState.projects[index].name != optimisticName) return;
-
     final projects = [...currentState.projects];
-    projects[index] = projects[index].copyWith(name: previousName);
+    if (index >= 0 && projects[index].name == optimisticName) {
+      projects[index] = projects[index].copyWith(name: previousName);
+    }
     _emitOrdered(
       loaded: currentState,
       projects: projects,
@@ -822,7 +837,7 @@ class ProjectListCubit(
               )
               .projects;
           final sortedProjects = _projectListService.orderProjects(
-            projects: mergedProjects,
+            projects: _withOptimisticProjectNames(projects: mergedProjects),
             activityByProjectId: _sseEventTracker.currentSessionActivity,
             listStateByProjectId: _sessionUnseenTracker.currentSessionUnseen,
           );

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -41,6 +41,13 @@ enum _ProjectFetchOutcome() {
   superseded,
 }
 
+typedef _PendingProjectRename = ({
+  int token,
+  String name,
+  int confirmedToken,
+  String? rollbackName,
+});
+
 class ProjectListCubit(
   final ProjectRepository _projectRepository,
   final ConnectionService _connectionService,
@@ -58,7 +65,8 @@ class ProjectListCubit(
 
   /// Keeps pre-rename list responses from repainting an old name while the
   /// mutation is still pending.
-  final Map<String, String> _optimisticNameByProjectId = {};
+  final Map<String, _PendingProjectRename> _pendingRenameByProjectId = {};
+  int _nextRenameToken = 0;
 
   // ignore: no_slop_linter/prefer_required_named_parameters, public cubit constructor API
   this : super(const ProjectListState.loading()) {
@@ -592,8 +600,8 @@ class ProjectListCubit(
 
   Iterable<ProjectSummary> _withOptimisticProjectNames({required Iterable<ProjectSummary> projects}) {
     return projects.map((project) {
-      final optimisticName = _optimisticNameByProjectId[project.id];
-      return optimisticName == null ? project : project.copyWith(name: optimisticName);
+      final pendingRename = _pendingRenameByProjectId[project.id];
+      return pendingRename == null ? project : project.copyWith(name: pendingRename.name);
     });
   }
 
@@ -661,7 +669,14 @@ class ProjectListCubit(
     if (index < 0) return false;
 
     final previousName = currentState.projects[index].name;
-    _optimisticNameByProjectId[projectId] = name;
+    final token = ++_nextRenameToken;
+    final pendingRename = _pendingRenameByProjectId[projectId];
+    _pendingRenameByProjectId[projectId] = (
+      token: token,
+      name: name,
+      confirmedToken: pendingRename?.confirmedToken ?? token - 1,
+      rollbackName: pendingRename?.rollbackName ?? previousName,
+    );
     final projects = [...currentState.projects];
     projects[index] = projects[index].copyWith(name: name);
     _emitOrdered(
@@ -674,18 +689,22 @@ class ProjectListCubit(
     try {
       response = await _projectRepository.renameProject(projectId: projectId, name: name);
     } on Object {
-      _restoreProjectName(
-        projectId: projectId,
-        optimisticName: name,
-        previousName: previousName,
-      );
+      _restoreProjectName(projectId: projectId, token: token);
       return false;
     }
 
     switch (response) {
       case SuccessResponse():
-        if (_optimisticNameByProjectId[projectId] == name) {
-          _optimisticNameByProjectId.remove(projectId);
+        final pendingRename = _pendingRenameByProjectId[projectId];
+        if (pendingRename != null && pendingRename.token == token) {
+          _pendingRenameByProjectId.remove(projectId);
+        } else if (pendingRename != null && token > pendingRename.confirmedToken) {
+          _pendingRenameByProjectId[projectId] = (
+            token: pendingRename.token,
+            name: pendingRename.name,
+            confirmedToken: token,
+            rollbackName: name,
+          );
         }
         if (!isClosed) {
           unawaited(
@@ -697,30 +716,23 @@ class ProjectListCubit(
         }
         return true;
       case ErrorResponse():
-        _restoreProjectName(
-          projectId: projectId,
-          optimisticName: name,
-          previousName: previousName,
-        );
+        _restoreProjectName(projectId: projectId, token: token);
         return false;
     }
   }
 
-  void _restoreProjectName({
-    required String projectId,
-    required String optimisticName,
-    required String? previousName,
-  }) {
+  void _restoreProjectName({required String projectId, required int token}) {
+    final pendingRename = _pendingRenameByProjectId[projectId];
+    if (pendingRename == null || pendingRename.token != token) return;
+    _pendingRenameByProjectId.remove(projectId);
+
     final currentState = state;
     if (isClosed || currentState is! ProjectListLoaded) return;
 
-    if (_optimisticNameByProjectId[projectId] == optimisticName) {
-      _optimisticNameByProjectId.remove(projectId);
-    }
     final index = currentState.projects.indexWhere((project) => project.id == projectId);
     final projects = [...currentState.projects];
-    if (index >= 0 && projects[index].name == optimisticName) {
-      projects[index] = projects[index].copyWith(name: previousName);
+    if (index >= 0) {
+      projects[index] = projects[index].copyWith(name: pendingRename.rollbackName);
     }
     _emitOrdered(
       loaded: currentState,

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -41,12 +41,56 @@ enum _ProjectFetchOutcome() {
   superseded,
 }
 
-typedef _PendingProjectRename = ({
-  int token,
-  String name,
-  int confirmedToken,
-  String? rollbackName,
-});
+/// Tracks every in-flight rename so out-of-order completions preserve the
+/// newest confirmed name and the latest unresolved user intent.
+final class _ProjectRenameState({required String? confirmedName}) {
+  final Map<int, String> _pendingNames = {};
+  int _visibleToken = 0;
+  late String _visibleName;
+  int _confirmedToken = 0;
+  String? _confirmedName = confirmedName;
+
+  String get visibleName => _visibleName;
+  String? get confirmedName => _confirmedName;
+  bool get isSettled => _pendingNames.isEmpty;
+
+  void begin({required int token, required String name}) {
+    _pendingNames[token] = name;
+    _visibleToken = token;
+    _visibleName = name;
+  }
+
+  void complete({required int token, required String name, required bool succeeded}) {
+    _pendingNames.remove(token);
+    if (succeeded && token > _confirmedToken) {
+      _confirmedToken = token;
+      _confirmedName = name;
+    }
+    if (!succeeded && token == _visibleToken && _pendingNames.isNotEmpty) {
+      _selectLatestVisibleName();
+    }
+  }
+
+  void _selectLatestVisibleName() {
+    final firstPendingRename = _pendingNames.entries.first;
+    var latestPendingToken = firstPendingRename.key;
+    var latestPendingName = firstPendingRename.value;
+    for (final MapEntry(:key, :value) in _pendingNames.entries.skip(1)) {
+      if (key > latestPendingToken) {
+        latestPendingToken = key;
+        latestPendingName = value;
+      }
+    }
+    final confirmedName = _confirmedName;
+    if (_confirmedToken > latestPendingToken && confirmedName != null) {
+      _visibleToken = _confirmedToken;
+      _visibleName = confirmedName;
+      return;
+    }
+    _visibleToken = latestPendingToken;
+    _visibleName = latestPendingName;
+  }
+}
 
 class ProjectListCubit(
   final ProjectRepository _projectRepository,
@@ -65,7 +109,7 @@ class ProjectListCubit(
 
   /// Keeps pre-rename list responses from repainting an old name while the
   /// mutation is still pending.
-  final Map<String, _PendingProjectRename> _pendingRenameByProjectId = {};
+  final Map<String, _ProjectRenameState> _renameStateByProjectId = {};
   int _nextRenameToken = 0;
 
   // ignore: no_slop_linter/prefer_required_named_parameters, public cubit constructor API
@@ -600,8 +644,8 @@ class ProjectListCubit(
 
   Iterable<ProjectSummary> _withOptimisticProjectNames({required Iterable<ProjectSummary> projects}) {
     return projects.map((project) {
-      final pendingRename = _pendingRenameByProjectId[project.id];
-      return pendingRename == null ? project : project.copyWith(name: pendingRename.name);
+      final renameState = _renameStateByProjectId[project.id];
+      return renameState == null ? project : project.copyWith(name: renameState.visibleName);
     });
   }
 
@@ -668,15 +712,12 @@ class ProjectListCubit(
     final index = currentState.projects.indexWhere((project) => project.id == projectId);
     if (index < 0) return false;
 
-    final previousName = currentState.projects[index].name;
     final token = ++_nextRenameToken;
-    final pendingRename = _pendingRenameByProjectId[projectId];
-    _pendingRenameByProjectId[projectId] = (
-      token: token,
-      name: name,
-      confirmedToken: pendingRename?.confirmedToken ?? token - 1,
-      rollbackName: pendingRename?.rollbackName ?? previousName,
+    final renameState = _renameStateByProjectId.putIfAbsent(
+      projectId,
+      () => _ProjectRenameState(confirmedName: currentState.projects[index].name),
     );
+    renameState.begin(token: token, name: name);
     final projects = [...currentState.projects];
     projects[index] = projects[index].copyWith(name: name);
     _emitOrdered(
@@ -689,23 +730,23 @@ class ProjectListCubit(
     try {
       response = await _projectRepository.renameProject(projectId: projectId, name: name);
     } on Object {
-      _restoreProjectName(projectId: projectId, token: token);
+      _completeProjectRename(
+        projectId: projectId,
+        token: token,
+        name: name,
+        succeeded: false,
+      );
       return false;
     }
 
     switch (response) {
       case SuccessResponse():
-        final pendingRename = _pendingRenameByProjectId[projectId];
-        if (pendingRename != null && pendingRename.token == token) {
-          _pendingRenameByProjectId.remove(projectId);
-        } else if (pendingRename != null && token > pendingRename.confirmedToken) {
-          _pendingRenameByProjectId[projectId] = (
-            token: pendingRename.token,
-            name: pendingRename.name,
-            confirmedToken: token,
-            rollbackName: name,
-          );
-        }
+        _completeProjectRename(
+          projectId: projectId,
+          token: token,
+          name: name,
+          succeeded: true,
+        );
         if (!isClosed) {
           unawaited(
             _refreshProjects(
@@ -716,23 +757,44 @@ class ProjectListCubit(
         }
         return true;
       case ErrorResponse():
-        _restoreProjectName(projectId: projectId, token: token);
+        _completeProjectRename(
+          projectId: projectId,
+          token: token,
+          name: name,
+          succeeded: false,
+        );
         return false;
     }
   }
 
-  void _restoreProjectName({required String projectId, required int token}) {
-    final pendingRename = _pendingRenameByProjectId[projectId];
-    if (pendingRename == null || pendingRename.token != token) return;
-    _pendingRenameByProjectId.remove(projectId);
+  void _completeProjectRename({
+    required String projectId,
+    required int token,
+    required String name,
+    required bool succeeded,
+  }) {
+    final renameState = _renameStateByProjectId[projectId];
+    if (renameState == null) return;
+    renameState.complete(token: token, name: name, succeeded: succeeded);
+    if (!renameState.isSettled) {
+      final currentState = state;
+      if (!isClosed && currentState is ProjectListLoaded) {
+        _emitOrdered(
+          loaded: currentState,
+          projects: currentState.projects,
+          activityByProjectId: _sseEventTracker.currentSessionActivity,
+        );
+      }
+      return;
+    }
 
+    _renameStateByProjectId.remove(projectId);
     final currentState = state;
     if (isClosed || currentState is! ProjectListLoaded) return;
-
     final index = currentState.projects.indexWhere((project) => project.id == projectId);
     final projects = [...currentState.projects];
     if (index >= 0) {
-      projects[index] = projects[index].copyWith(name: pendingRename.rollbackName);
+      projects[index] = projects[index].copyWith(name: renameState.confirmedName);
     }
     _emitOrdered(
       loaded: currentState,

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -35,7 +35,11 @@ const refreshThrottleDuration = Duration(seconds: 30);
 @visibleForTesting
 const initialProjectLoadConnectionWaitTimeout = Duration(seconds: 15);
 
-enum _ProjectFetchOutcome() { applied, failed, superseded }
+enum _ProjectFetchOutcome() {
+  applied,
+  failed,
+  superseded,
+}
 
 class ProjectListCubit(
   final ProjectRepository _projectRepository,
@@ -636,18 +640,70 @@ class ProjectListCubit(
     return _projectRepository.parentHostPath(path: path);
   }
 
-  /// Renames the project with [projectId] to [name].
-  /// Returns `true` on success (and refreshes the project list), `false` on error.
+  /// Renames a project optimistically. Returns `false` after restoring the
+  /// prior name when the bridge rejects the rename.
   Future<bool> renameProject({required String projectId, required String name}) async {
-    final response = await _projectRepository.renameProject(projectId: projectId, name: name);
-    if (isClosed) return false;
+    final currentState = state;
+    if (currentState is! ProjectListLoaded) return false;
+
+    final index = currentState.projects.indexWhere((project) => project.id == projectId);
+    if (index < 0) return false;
+
+    final previousName = currentState.projects[index].name;
+    final projects = [...currentState.projects];
+    projects[index] = projects[index].copyWith(name: name);
+    _emitOrdered(
+      loaded: currentState,
+      projects: projects,
+      activityByProjectId: _sseEventTracker.currentSessionActivity,
+    );
+
+    final ApiResponse<Project> response;
+    try {
+      response = await _projectRepository.renameProject(projectId: projectId, name: name);
+    } on Object catch (error, stackTrace) {
+      loge("Failed to rename project", error, stackTrace);
+      _restoreProjectName(
+        projectId: projectId,
+        optimisticName: name,
+        previousName: previousName,
+      );
+      return false;
+    }
+
     switch (response) {
       case SuccessResponse():
-        await refreshProjects();
+        if (!isClosed) unawaited(refreshProjects());
         return true;
-      case ErrorResponse():
+      case ErrorResponse(:final error):
+        loge("Failed to rename project", error);
+        _restoreProjectName(
+          projectId: projectId,
+          optimisticName: name,
+          previousName: previousName,
+        );
         return false;
     }
+  }
+
+  void _restoreProjectName({
+    required String projectId,
+    required String optimisticName,
+    required String? previousName,
+  }) {
+    final currentState = state;
+    if (isClosed || currentState is! ProjectListLoaded) return;
+
+    final index = currentState.projects.indexWhere((project) => project.id == projectId);
+    if (index < 0 || currentState.projects[index].name != optimisticName) return;
+
+    final projects = [...currentState.projects];
+    projects[index] = projects[index].copyWith(name: previousName);
+    _emitOrdered(
+      loaded: currentState,
+      projects: projects,
+      activityByProjectId: _sseEventTracker.currentSessionActivity,
+    );
   }
 
   /// Discovers an existing project at [path].

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -32,6 +32,13 @@ enum _SessionFetchOutcome() {
   superseded,
 }
 
+typedef _PendingSessionRename = ({
+  int token,
+  String title,
+  int confirmedToken,
+  String? rollbackTitle,
+});
+
 class SessionListCubit({
   required final SessionRepository _sessionRepository,
   required final SessionListService _sessionListService,
@@ -424,7 +431,14 @@ class SessionListCubit({
     if (index < 0) return false;
 
     final previousTitle = _allSessions[index].title;
-    _optimisticTitleBySessionId[sessionId] = title;
+    final token = ++_nextRenameToken;
+    final pendingRename = _pendingRenameBySessionId[sessionId];
+    _pendingRenameBySessionId[sessionId] = (
+      token: token,
+      title: title,
+      confirmedToken: pendingRename?.confirmedToken ?? token - 1,
+      rollbackTitle: pendingRename?.rollbackTitle ?? previousTitle,
+    );
     _allSessions = _sessionListService.upsertSession(
       sessions: _allSessions,
       session: _allSessions[index].copyWith(title: title),
@@ -435,18 +449,15 @@ class SessionListCubit({
     try {
       response = await _sessionRepository.renameSession(sessionId: sessionId, title: title);
     } on Object {
-      _restoreSessionTitle(
-        sessionId: sessionId,
-        optimisticTitle: title,
-        previousTitle: previousTitle,
-      );
+      _restoreSessionTitle(sessionId: sessionId, token: token);
       return false;
     }
 
     switch (response) {
       case SuccessResponse():
-        if (_optimisticTitleBySessionId[sessionId] == title) {
-          _optimisticTitleBySessionId.remove(sessionId);
+        final pendingRename = _pendingRenameBySessionId[sessionId];
+        if (pendingRename != null && pendingRename.token == token) {
+          _pendingRenameBySessionId.remove(sessionId);
           if (!isClosed) {
             final index = _allSessions.indexWhere((session) => session.id == sessionId);
             if (index >= 0) {
@@ -457,6 +468,13 @@ class SessionListCubit({
               _emitFiltered();
             }
           }
+        } else if (pendingRename != null && token > pendingRename.confirmedToken) {
+          _pendingRenameBySessionId[sessionId] = (
+            token: pendingRename.token,
+            title: pendingRename.title,
+            confirmedToken: token,
+            rollbackTitle: title,
+          );
         }
         if (!isClosed) {
           unawaited(
@@ -469,30 +487,22 @@ class SessionListCubit({
         }
         return true;
       case ErrorResponse():
-        _restoreSessionTitle(
-          sessionId: sessionId,
-          optimisticTitle: title,
-          previousTitle: previousTitle,
-        );
+        _restoreSessionTitle(sessionId: sessionId, token: token);
         return false;
     }
   }
 
-  void _restoreSessionTitle({
-    required String sessionId,
-    required String optimisticTitle,
-    required String? previousTitle,
-  }) {
+  void _restoreSessionTitle({required String sessionId, required int token}) {
+    final pendingRename = _pendingRenameBySessionId[sessionId];
+    if (pendingRename == null || pendingRename.token != token) return;
+    _pendingRenameBySessionId.remove(sessionId);
     if (isClosed || state is! SessionListLoaded) return;
 
-    if (_optimisticTitleBySessionId[sessionId] == optimisticTitle) {
-      _optimisticTitleBySessionId.remove(sessionId);
-    }
     final index = _allSessions.indexWhere((session) => session.id == sessionId);
-    if (index >= 0 && _allSessions[index].title == optimisticTitle) {
+    if (index >= 0) {
       _allSessions = _sessionListService.upsertSession(
         sessions: _allSessions,
-        session: _allSessions[index].copyWith(title: previousTitle),
+        session: _allSessions[index].copyWith(title: pendingRename.rollbackTitle),
       );
     }
     _emitFiltered();
@@ -561,7 +571,8 @@ class SessionListCubit({
 
   /// Keeps pre-rename list responses from repainting an old title while the
   /// mutation is still pending.
-  final Map<String, String> _optimisticTitleBySessionId = {};
+  final Map<String, _PendingSessionRename> _pendingRenameBySessionId = {};
+  int _nextRenameToken = 0;
   bool _showArchived = false;
 
   void toggleArchived() {
@@ -572,8 +583,8 @@ class SessionListCubit({
   void _emitFiltered() {
     final visible = _sessionListService.visibleSessions(
       sessions: _allSessions.map((session) {
-        final optimisticTitle = _optimisticTitleBySessionId[session.id];
-        return optimisticTitle == null ? session : session.copyWith(title: optimisticTitle);
+        final pendingRename = _pendingRenameBySessionId[session.id];
+        return pendingRename == null ? session : session.copyWith(title: pendingRename.title);
       }),
       showArchived: _showArchived,
       activityBySessionId: _sseEventTracker.currentSessionActivity[_projectId] ?? const {},

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -26,7 +26,11 @@ import "../../services/session_unseen_tracker.dart";
 import "../../services/sse_event_tracker.dart";
 import "session_list_state.dart";
 
-enum _SessionFetchOutcome() { applied, failed, superseded }
+enum _SessionFetchOutcome() {
+  applied,
+  failed,
+  superseded,
+}
 
 class SessionListCubit({
   required final SessionRepository _sessionRepository,
@@ -411,19 +415,64 @@ class SessionListCubit({
     };
   }
 
-  /// Renames a session. Returns `true` on success so the screen can show
-  /// a confirmation message.
+  /// Renames a session optimistically. Returns `false` after restoring the
+  /// prior title when the bridge rejects the rename.
   Future<bool> renameSession({required String sessionId, required String title}) async {
-    final response = await _sessionRepository.renameSession(sessionId: sessionId, title: title);
-    if (isClosed) return false;
+    if (state is! SessionListLoaded) return false;
+
+    final index = _allSessions.indexWhere((session) => session.id == sessionId);
+    if (index < 0) return false;
+
+    final previousTitle = _allSessions[index].title;
+    _allSessions = _sessionListService.upsertSession(
+      sessions: _allSessions,
+      session: _allSessions[index].copyWith(title: title),
+    );
+    _emitFiltered();
+
+    final ApiResponse<Session> response;
+    try {
+      response = await _sessionRepository.renameSession(sessionId: sessionId, title: title);
+    } on Object catch (error, stackTrace) {
+      loge("Failed to rename session", error, stackTrace);
+      _restoreSessionTitle(
+        sessionId: sessionId,
+        optimisticTitle: title,
+        previousTitle: previousTitle,
+      );
+      return false;
+    }
 
     switch (response) {
       case SuccessResponse():
-        await refreshSessions();
+        if (!isClosed) unawaited(refreshSessions());
         return true;
-      case ErrorResponse():
+      case ErrorResponse(:final error):
+        loge("Failed to rename session", error);
+        _restoreSessionTitle(
+          sessionId: sessionId,
+          optimisticTitle: title,
+          previousTitle: previousTitle,
+        );
         return false;
     }
+  }
+
+  void _restoreSessionTitle({
+    required String sessionId,
+    required String optimisticTitle,
+    required String? previousTitle,
+  }) {
+    if (isClosed || state is! SessionListLoaded) return;
+
+    final index = _allSessions.indexWhere((session) => session.id == sessionId);
+    if (index < 0 || _allSessions[index].title != optimisticTitle) return;
+
+    _allSessions = _sessionListService.upsertSession(
+      sessions: _allSessions,
+      session: _allSessions[index].copyWith(title: previousTitle),
+    );
+    _emitFiltered();
   }
 
   /// Deletes a session permanently.

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -32,12 +32,56 @@ enum _SessionFetchOutcome() {
   superseded,
 }
 
-typedef _PendingSessionRename = ({
-  int token,
-  String title,
-  int confirmedToken,
-  String? rollbackTitle,
-});
+/// Tracks every in-flight rename so out-of-order completions preserve the
+/// newest confirmed title and the latest unresolved user intent.
+final class _SessionRenameState({required String? confirmedTitle}) {
+  final Map<int, String> _pendingTitles = {};
+  int _visibleToken = 0;
+  late String _visibleTitle;
+  int _confirmedToken = 0;
+  String? _confirmedTitle = confirmedTitle;
+
+  String get visibleTitle => _visibleTitle;
+  String? get confirmedTitle => _confirmedTitle;
+  bool get isSettled => _pendingTitles.isEmpty;
+
+  void begin({required int token, required String title}) {
+    _pendingTitles[token] = title;
+    _visibleToken = token;
+    _visibleTitle = title;
+  }
+
+  void complete({required int token, required String title, required bool succeeded}) {
+    _pendingTitles.remove(token);
+    if (succeeded && token > _confirmedToken) {
+      _confirmedToken = token;
+      _confirmedTitle = title;
+    }
+    if (!succeeded && token == _visibleToken && _pendingTitles.isNotEmpty) {
+      _selectLatestVisibleTitle();
+    }
+  }
+
+  void _selectLatestVisibleTitle() {
+    final firstPendingRename = _pendingTitles.entries.first;
+    var latestPendingToken = firstPendingRename.key;
+    var latestPendingTitle = firstPendingRename.value;
+    for (final MapEntry(:key, :value) in _pendingTitles.entries.skip(1)) {
+      if (key > latestPendingToken) {
+        latestPendingToken = key;
+        latestPendingTitle = value;
+      }
+    }
+    final confirmedTitle = _confirmedTitle;
+    if (_confirmedToken > latestPendingToken && confirmedTitle != null) {
+      _visibleToken = _confirmedToken;
+      _visibleTitle = confirmedTitle;
+      return;
+    }
+    _visibleToken = latestPendingToken;
+    _visibleTitle = latestPendingTitle;
+  }
+}
 
 class SessionListCubit({
   required final SessionRepository _sessionRepository,
@@ -430,15 +474,12 @@ class SessionListCubit({
     final index = _allSessions.indexWhere((session) => session.id == sessionId);
     if (index < 0) return false;
 
-    final previousTitle = _allSessions[index].title;
     final token = ++_nextRenameToken;
-    final pendingRename = _pendingRenameBySessionId[sessionId];
-    _pendingRenameBySessionId[sessionId] = (
-      token: token,
-      title: title,
-      confirmedToken: pendingRename?.confirmedToken ?? token - 1,
-      rollbackTitle: pendingRename?.rollbackTitle ?? previousTitle,
+    final renameState = _renameStateBySessionId.putIfAbsent(
+      sessionId,
+      () => _SessionRenameState(confirmedTitle: _allSessions[index].title),
     );
+    renameState.begin(token: token, title: title);
     _allSessions = _sessionListService.upsertSession(
       sessions: _allSessions,
       session: _allSessions[index].copyWith(title: title),
@@ -449,33 +490,23 @@ class SessionListCubit({
     try {
       response = await _sessionRepository.renameSession(sessionId: sessionId, title: title);
     } on Object {
-      _restoreSessionTitle(sessionId: sessionId, token: token);
+      _completeSessionRename(
+        sessionId: sessionId,
+        token: token,
+        title: title,
+        succeeded: false,
+      );
       return false;
     }
 
     switch (response) {
       case SuccessResponse():
-        final pendingRename = _pendingRenameBySessionId[sessionId];
-        if (pendingRename != null && pendingRename.token == token) {
-          _pendingRenameBySessionId.remove(sessionId);
-          if (!isClosed) {
-            final index = _allSessions.indexWhere((session) => session.id == sessionId);
-            if (index >= 0) {
-              _allSessions = _sessionListService.upsertSession(
-                sessions: _allSessions,
-                session: _allSessions[index].copyWith(title: title),
-              );
-              _emitFiltered();
-            }
-          }
-        } else if (pendingRename != null && token > pendingRename.confirmedToken) {
-          _pendingRenameBySessionId[sessionId] = (
-            token: pendingRename.token,
-            title: pendingRename.title,
-            confirmedToken: token,
-            rollbackTitle: title,
-          );
-        }
+        _completeSessionRename(
+          sessionId: sessionId,
+          token: token,
+          title: title,
+          succeeded: true,
+        );
         if (!isClosed) {
           unawaited(
             _refreshSessions(
@@ -487,22 +518,37 @@ class SessionListCubit({
         }
         return true;
       case ErrorResponse():
-        _restoreSessionTitle(sessionId: sessionId, token: token);
+        _completeSessionRename(
+          sessionId: sessionId,
+          token: token,
+          title: title,
+          succeeded: false,
+        );
         return false;
     }
   }
 
-  void _restoreSessionTitle({required String sessionId, required int token}) {
-    final pendingRename = _pendingRenameBySessionId[sessionId];
-    if (pendingRename == null || pendingRename.token != token) return;
-    _pendingRenameBySessionId.remove(sessionId);
-    if (isClosed || state is! SessionListLoaded) return;
+  void _completeSessionRename({
+    required String sessionId,
+    required int token,
+    required String title,
+    required bool succeeded,
+  }) {
+    final renameState = _renameStateBySessionId[sessionId];
+    if (renameState == null) return;
+    renameState.complete(token: token, title: title, succeeded: succeeded);
+    if (!renameState.isSettled) {
+      if (!isClosed && state is SessionListLoaded) _emitFiltered();
+      return;
+    }
 
+    _renameStateBySessionId.remove(sessionId);
+    if (isClosed || state is! SessionListLoaded) return;
     final index = _allSessions.indexWhere((session) => session.id == sessionId);
     if (index >= 0) {
       _allSessions = _sessionListService.upsertSession(
         sessions: _allSessions,
-        session: _allSessions[index].copyWith(title: pendingRename.rollbackTitle),
+        session: _allSessions[index].copyWith(title: renameState.confirmedTitle),
       );
     }
     _emitFiltered();
@@ -571,7 +617,7 @@ class SessionListCubit({
 
   /// Keeps pre-rename list responses from repainting an old title while the
   /// mutation is still pending.
-  final Map<String, _PendingSessionRename> _pendingRenameBySessionId = {};
+  final Map<String, _SessionRenameState> _renameStateBySessionId = {};
   int _nextRenameToken = 0;
   bool _showArchived = false;
 
@@ -583,8 +629,8 @@ class SessionListCubit({
   void _emitFiltered() {
     final visible = _sessionListService.visibleSessions(
       sessions: _allSessions.map((session) {
-        final pendingRename = _pendingRenameBySessionId[session.id];
-        return pendingRename == null ? session : session.copyWith(title: pendingRename.title);
+        final renameState = _renameStateBySessionId[session.id];
+        return renameState == null ? session : session.copyWith(title: renameState.visibleTitle);
       }),
       showArchived: _showArchived,
       activityBySessionId: _sseEventTracker.currentSessionActivity[_projectId] ?? const {},

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -424,9 +424,7 @@ class SessionListCubit({
     if (index < 0) return false;
 
     final previousTitle = _allSessions[index].title;
-    // A read that began before this mutation can still carry the old title.
-    // Supersede it now; success starts an authoritative post-write read below.
-    _fetchGeneration++;
+    _optimisticTitleBySessionId[sessionId] = title;
     _allSessions = _sessionListService.upsertSession(
       sessions: _allSessions,
       session: _allSessions[index].copyWith(title: title),
@@ -447,12 +445,25 @@ class SessionListCubit({
 
     switch (response) {
       case SuccessResponse():
+        if (_optimisticTitleBySessionId[sessionId] == title) {
+          _optimisticTitleBySessionId.remove(sessionId);
+          if (!isClosed) {
+            final index = _allSessions.indexWhere((session) => session.id == sessionId);
+            if (index >= 0) {
+              _allSessions = _sessionListService.upsertSession(
+                sessions: _allSessions,
+                session: _allSessions[index].copyWith(title: title),
+              );
+              _emitFiltered();
+            }
+          }
+        }
         if (!isClosed) {
           unawaited(
             _refreshSessions(
               force: true,
               catalogRefresh: false,
-              waitForPrData: false,
+              waitForPrData: _activeRefreshWaitsForPrData,
             ),
           );
         }
@@ -474,13 +485,16 @@ class SessionListCubit({
   }) {
     if (isClosed || state is! SessionListLoaded) return;
 
+    if (_optimisticTitleBySessionId[sessionId] == optimisticTitle) {
+      _optimisticTitleBySessionId.remove(sessionId);
+    }
     final index = _allSessions.indexWhere((session) => session.id == sessionId);
-    if (index < 0 || _allSessions[index].title != optimisticTitle) return;
-
-    _allSessions = _sessionListService.upsertSession(
-      sessions: _allSessions,
-      session: _allSessions[index].copyWith(title: previousTitle),
-    );
+    if (index >= 0 && _allSessions[index].title == optimisticTitle) {
+      _allSessions = _sessionListService.upsertSession(
+        sessions: _allSessions,
+        session: _allSessions[index].copyWith(title: previousTitle),
+      );
+    }
     _emitFiltered();
   }
 
@@ -544,6 +558,10 @@ class SessionListCubit({
   /// Tracks the full unfiltered server response so toggling archived
   /// doesn't require a network round-trip.
   List<Session> _allSessions = [];
+
+  /// Keeps pre-rename list responses from repainting an old title while the
+  /// mutation is still pending.
+  final Map<String, String> _optimisticTitleBySessionId = {};
   bool _showArchived = false;
 
   void toggleArchived() {
@@ -553,7 +571,10 @@ class SessionListCubit({
 
   void _emitFiltered() {
     final visible = _sessionListService.visibleSessions(
-      sessions: _allSessions,
+      sessions: _allSessions.map((session) {
+        final optimisticTitle = _optimisticTitleBySessionId[session.id];
+        return optimisticTitle == null ? session : session.copyWith(title: optimisticTitle);
+      }),
       showArchived: _showArchived,
       activityBySessionId: _sseEventTracker.currentSessionActivity[_projectId] ?? const {},
       listStateBySessionId:

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -424,6 +424,9 @@ class SessionListCubit({
     if (index < 0) return false;
 
     final previousTitle = _allSessions[index].title;
+    // A read that began before this mutation can still carry the old title.
+    // Supersede it now; success starts an authoritative post-write read below.
+    _fetchGeneration++;
     _allSessions = _sessionListService.upsertSession(
       sessions: _allSessions,
       session: _allSessions[index].copyWith(title: title),
@@ -433,8 +436,7 @@ class SessionListCubit({
     final ApiResponse<Session> response;
     try {
       response = await _sessionRepository.renameSession(sessionId: sessionId, title: title);
-    } on Object catch (error, stackTrace) {
-      loge("Failed to rename session", error, stackTrace);
+    } on Object {
       _restoreSessionTitle(
         sessionId: sessionId,
         optimisticTitle: title,
@@ -445,10 +447,17 @@ class SessionListCubit({
 
     switch (response) {
       case SuccessResponse():
-        if (!isClosed) unawaited(refreshSessions());
+        if (!isClosed) {
+          unawaited(
+            _refreshSessions(
+              force: true,
+              catalogRefresh: false,
+              waitForPrData: false,
+            ),
+          );
+        }
         return true;
-      case ErrorResponse(:final error):
-        loge("Failed to rename session", error);
+      case ErrorResponse():
         _restoreSessionTitle(
           sessionId: sessionId,
           optimisticTitle: title,

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -1395,6 +1395,66 @@ void main() {
       expect((cubit.state as ProjectListLoaded).projects.single.name, "New Name");
     });
 
+    test("renameProject keeps same-value overlapping requests distinct", () async {
+      final original = testProjectSummary(id: "A", path: "/home/user/A", name: "Original");
+      when(
+        () => mockProjectRepository.listProjects(),
+      ).thenAnswer((_) async => ApiResponse.success(Projects(data: [original])));
+      final firstRenameCompleter = Completer<ApiResponse<Project>>();
+      final secondRenameCompleter = Completer<ApiResponse<Project>>();
+      var renameRequestCount = 0;
+      when(
+        () => mockProjectRepository.renameProject(projectId: "A", name: "Same name"),
+      ).thenAnswer((_) {
+        renameRequestCount++;
+        return renameRequestCount == 1 ? firstRenameCompleter.future : secondRenameCompleter.future;
+      });
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await Future<void>.delayed(Duration.zero);
+
+      final firstRename = cubit.renameProject(projectId: "A", name: "Same name");
+      final secondRename = cubit.renameProject(projectId: "A", name: "Same name");
+      expect((cubit.state as ProjectListLoaded).projects.single.name, "Same name");
+
+      firstRenameCompleter.complete(ApiResponse<Project>.error(ApiError.generic()));
+      expect(await firstRename, isFalse);
+      expect((cubit.state as ProjectListLoaded).projects.single.name, "Same name");
+
+      secondRenameCompleter.complete(ApiResponse<Project>.error(ApiError.generic()));
+      expect(await secondRename, isFalse);
+      expect((cubit.state as ProjectListLoaded).projects.single.name, "Original");
+    });
+
+    test("renameProject clears a failed optimistic name while the list reloads", () async {
+      final original = testProjectSummary(id: "A", path: "/home/user/A", name: "Original");
+      when(
+        () => mockProjectRepository.listProjects(),
+      ).thenAnswer((_) async => ApiResponse.success(Projects(data: [original])));
+      final renameCompleter = Completer<ApiResponse<Project>>();
+      when(
+        () => mockProjectRepository.renameProject(projectId: "A", name: "New Name"),
+      ).thenAnswer((_) => renameCompleter.future);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await Future<void>.delayed(Duration.zero);
+
+      final reloadCompleter = Completer<ApiResponse<Projects>>();
+      when(() => mockProjectRepository.listProjects()).thenAnswer((_) => reloadCompleter.future);
+      final rename = cubit.renameProject(projectId: "A", name: "New Name");
+      final reload = cubit.loadProjects();
+      expect(cubit.state, isA<ProjectListLoading>());
+
+      renameCompleter.complete(ApiResponse<Project>.error(ApiError.generic()));
+      expect(await rename, isFalse);
+      reloadCompleter.complete(ApiResponse.success(Projects(data: [original])));
+      await reload;
+
+      expect((cubit.state as ProjectListLoaded).projects.single.name, "Original");
+    });
+
     // -------------------------------------------------------------------------
     // Test 4f: renameProject failure
     // -------------------------------------------------------------------------

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -1352,6 +1352,45 @@ void main() {
       },
     );
 
+    test("renameProject supersedes a refresh that started before the rename", () async {
+      final original = testProjectSummary(id: "A", path: "/home/user/A", name: "Original");
+      final renamed = original.copyWith(name: "New Name");
+      when(
+        () => mockProjectRepository.listProjects(),
+      ).thenAnswer((_) async => ApiResponse.success(Projects(data: [original])));
+      final renameCompleter = Completer<ApiResponse<Project>>();
+      when(
+        () => mockProjectRepository.renameProject(projectId: "A", name: "New Name"),
+      ).thenAnswer((_) => renameCompleter.future);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await Future<void>.delayed(Duration.zero);
+
+      final staleRefreshCompleter = Completer<ApiResponse<Projects>>();
+      final postRenameRefreshCompleter = Completer<ApiResponse<Projects>>();
+      var refreshRequestCount = 0;
+      when(() => mockProjectRepository.listProjects()).thenAnswer((_) {
+        refreshRequestCount++;
+        return refreshRequestCount == 1 ? staleRefreshCompleter.future : postRenameRefreshCompleter.future;
+      });
+
+      final staleRefresh = cubit.refreshProjects();
+      final rename = cubit.renameProject(projectId: "A", name: "New Name");
+      expect((cubit.state as ProjectListLoaded).projects.single.name, "New Name");
+
+      renameCompleter.complete(
+        ApiResponse.success(testProject(id: "A", path: "/home/user/A", name: "New Name")),
+      );
+      expect(await rename, isTrue);
+      expect(refreshRequestCount, 2);
+
+      staleRefreshCompleter.complete(ApiResponse.success(Projects(data: [original])));
+      postRenameRefreshCompleter.complete(ApiResponse.success(Projects(data: [renamed])));
+      expect(await staleRefresh, isTrue);
+      expect((cubit.state as ProjectListLoaded).projects.single.name, "New Name");
+    });
+
     // -------------------------------------------------------------------------
     // Test 4f: renameProject failure
     // -------------------------------------------------------------------------

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -1290,33 +1290,58 @@ void main() {
     // Test 4e: renameProject success
     // -------------------------------------------------------------------------
 
+    final originalProject = testProjectSummary(id: "A", path: "/home/user/A", name: "Original");
+    late Completer<ApiResponse<Project>> renameProjectCompleter;
     blocTest<ProjectListCubit, ProjectListState>(
-      "renameProject: calls repository, refreshes project list, and returns true on success",
+      "renameProject: updates the name before the request completes and returns true on success",
       build: () {
+        renameProjectCompleter = Completer<ApiResponse<Project>>();
         when(
           () => mockProjectRepository.listProjects(),
-        ).thenAnswer((_) async => ApiResponse.success(Projects(data: [projectA])));
+        ).thenAnswer((_) async => ApiResponse.success(Projects(data: [originalProject])));
         when(
           () => mockProjectRepository.renameProject(
             projectId: any(named: "projectId"),
             name: any(named: "name"),
           ),
-        ).thenAnswer((_) async => ApiResponse.success(testProject(id: "A", path: "/home/user/A")));
+        ).thenAnswer((_) => renameProjectCompleter.future);
         return buildCubit();
       },
       act: (cubit) async {
         await Future<void>.delayed(Duration.zero);
         when(() => mockProjectRepository.listProjects()).thenAnswer(
-          (_) async => ApiResponse.success(Projects(data: [projectA, projectB])),
+          (_) async => ApiResponse.success(
+            Projects(
+              data: [
+                originalProject.copyWith(name: "New Name"),
+                projectB,
+              ],
+            ),
+          ),
         );
-        final result = await cubit.renameProject(projectId: "A", name: "New Name");
-        expect(result, isTrue);
+
+        final rename = cubit.renameProject(projectId: "A", name: "New Name");
+        expect(
+          (cubit.state as ProjectListLoaded).projects.single.name,
+          "New Name",
+        );
+
+        renameProjectCompleter.complete(
+          ApiResponse.success(testProject(id: "A", path: "/home/user/A", name: "New Name")),
+        );
+        expect(await rename, isTrue);
+        await Future<void>.delayed(Duration.zero);
       },
       skip: 1,
       expect: () => [
         isA<ProjectListLoaded>().having(
+          (s) => s.projects.single.name,
+          "optimistic project name",
+          "New Name",
+        ),
+        isA<ProjectListLoaded>().having(
           (s) => s.projects.length,
-          "projects count after rename",
+          "projects count after refresh",
           2,
         ),
       ],
@@ -1332,26 +1357,44 @@ void main() {
     // -------------------------------------------------------------------------
 
     blocTest<ProjectListCubit, ProjectListState>(
-      "renameProject: returns false and emits no state on API error",
+      "renameProject: restores the previous name when the request fails",
       build: () {
+        renameProjectCompleter = Completer<ApiResponse<Project>>();
         when(
           () => mockProjectRepository.listProjects(),
-        ).thenAnswer((_) async => ApiResponse.success(Projects(data: [projectA])));
+        ).thenAnswer((_) async => ApiResponse.success(Projects(data: [originalProject])));
         when(
           () => mockProjectRepository.renameProject(
             projectId: any(named: "projectId"),
             name: any(named: "name"),
           ),
-        ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
+        ).thenAnswer((_) => renameProjectCompleter.future);
         return buildCubit();
       },
       act: (cubit) async {
         await Future<void>.delayed(Duration.zero);
-        final result = await cubit.renameProject(projectId: "A", name: "New Name");
-        expect(result, isFalse);
+        final rename = cubit.renameProject(projectId: "A", name: "New Name");
+        expect(
+          (cubit.state as ProjectListLoaded).projects.single.name,
+          "New Name",
+        );
+
+        renameProjectCompleter.complete(ApiResponse<Project>.error(ApiError.generic()));
+        expect(await rename, isFalse);
       },
       skip: 1,
-      expect: () => <ProjectListState>[],
+      expect: () => [
+        isA<ProjectListLoaded>().having(
+          (s) => s.projects.single.name,
+          "optimistic project name",
+          "New Name",
+        ),
+        isA<ProjectListLoaded>().having(
+          (s) => s.projects.single.name,
+          "restored project name",
+          "Original",
+        ),
+      ],
     );
 
     // -------------------------------------------------------------------------

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -1352,7 +1352,7 @@ void main() {
       },
     );
 
-    test("renameProject supersedes a refresh that started before the rename", () async {
+    test("renameProject keeps a pending refresh successful and overlays its stale name", () async {
       final original = testProjectSummary(id: "A", path: "/home/user/A", name: "Original");
       final renamed = original.copyWith(name: "New Name");
       when(
@@ -1379,15 +1379,19 @@ void main() {
       final rename = cubit.renameProject(projectId: "A", name: "New Name");
       expect((cubit.state as ProjectListLoaded).projects.single.name, "New Name");
 
+      staleRefreshCompleter.complete(ApiResponse.success(Projects(data: [original])));
+      expect(await staleRefresh, isTrue);
+      expect(refreshRequestCount, 1);
+      expect((cubit.state as ProjectListLoaded).projects.single.name, "New Name");
+
       renameCompleter.complete(
         ApiResponse.success(testProject(id: "A", path: "/home/user/A", name: "New Name")),
       );
       expect(await rename, isTrue);
       expect(refreshRequestCount, 2);
 
-      staleRefreshCompleter.complete(ApiResponse.success(Projects(data: [original])));
       postRenameRefreshCompleter.complete(ApiResponse.success(Projects(data: [renamed])));
-      expect(await staleRefresh, isTrue);
+      await Future<void>.delayed(Duration.zero);
       expect((cubit.state as ProjectListLoaded).projects.single.name, "New Name");
     });
 

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -1859,8 +1859,8 @@ void main() {
       expect((cubit.state as SessionListLoaded).sessions.single.title, "Original");
     });
 
-    test("renameSession restores the committed title after two overlapping failures", () async {
-      final original = testSession(id: "s1", title: "Original");
+    test("renameSession restores a null committed title after two overlapping failures", () async {
+      final original = testSession(id: "s1", title: null);
       when(
         () => mockProjectRepository.listSessions(
           projectId: projectId,
@@ -1890,7 +1890,48 @@ void main() {
 
       secondRenameCompleter.complete(ApiResponse<Session>.error(ApiError.generic()));
       expect(await secondRename, isFalse);
-      expect((cubit.state as SessionListLoaded).sessions.single.title, "Original");
+      expect((cubit.state as SessionListLoaded).sessions.single.title, isNull);
+    });
+
+    test("renameSession restores an older in-flight success after newer renames fail", () async {
+      final original = testSession(id: "s1", title: "Original");
+      when(
+        () => mockProjectRepository.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
+      ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [original])));
+      final firstRenameCompleter = Completer<ApiResponse<Session>>();
+      final secondRenameCompleter = Completer<ApiResponse<Session>>();
+      final thirdRenameCompleter = Completer<ApiResponse<Session>>();
+      when(
+        () => mockSessionService.renameSession(sessionId: "s1", title: "First title"),
+      ).thenAnswer((_) => firstRenameCompleter.future);
+      when(
+        () => mockSessionService.renameSession(sessionId: "s1", title: "Second title"),
+      ).thenAnswer((_) => secondRenameCompleter.future);
+      when(
+        () => mockSessionService.renameSession(sessionId: "s1", title: "Third title"),
+      ).thenAnswer((_) => thirdRenameCompleter.future);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await Future<void>.delayed(Duration.zero);
+
+      final firstRename = cubit.renameSession(sessionId: "s1", title: "First title");
+      final secondRename = cubit.renameSession(sessionId: "s1", title: "Second title");
+      secondRenameCompleter.complete(ApiResponse<Session>.error(ApiError.generic()));
+      expect(await secondRename, isFalse);
+      expect((cubit.state as SessionListLoaded).sessions.single.title, "First title");
+
+      final thirdRename = cubit.renameSession(sessionId: "s1", title: "Third title");
+      firstRenameCompleter.complete(ApiResponse.success(original.copyWith(title: "First title")));
+      expect(await firstRename, isTrue);
+      expect((cubit.state as SessionListLoaded).sessions.single.title, "Third title");
+
+      thirdRenameCompleter.complete(ApiResponse<Session>.error(ApiError.generic()));
+      expect(await thirdRename, isFalse);
+      expect((cubit.state as SessionListLoaded).sessions.single.title, "First title");
     });
 
     test("renameSession restores the latest confirmed title when a newer rename fails", () async {

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -1821,8 +1821,9 @@ void main() {
       expect((cubit.state as SessionListLoaded).sessions.single.title, "New Title");
     });
 
-    test("renameSession keeps a pending refresh successful and overlays its stale title", () async {
+    test("renameSession keeps a pending refresh successful and restores the pre-rename title", () async {
       final original = testSession(id: "s1", title: "Original");
+      final stale = testSession(id: "s1", title: "Stale snapshot");
       when(
         () => mockProjectRepository.listSessions(
           projectId: projectId,
@@ -1848,7 +1849,7 @@ void main() {
 
       final refresh = cubit.refreshSessions();
       final rename = cubit.renameSession(sessionId: "s1", title: "New Title");
-      refreshCompleter.complete(ApiResponse.success(SessionListResponse(items: [original])));
+      refreshCompleter.complete(ApiResponse.success(SessionListResponse(items: [stale])));
 
       expect(await refresh, isTrue);
       expect((cubit.state as SessionListLoaded).sessions.single.title, "New Title");
@@ -1856,6 +1857,73 @@ void main() {
       renameCompleter.complete(ApiResponse<Session>.error(ApiError.generic()));
       expect(await rename, isFalse);
       expect((cubit.state as SessionListLoaded).sessions.single.title, "Original");
+    });
+
+    test("renameSession restores the committed title after two overlapping failures", () async {
+      final original = testSession(id: "s1", title: "Original");
+      when(
+        () => mockProjectRepository.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
+      ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [original])));
+      final firstRenameCompleter = Completer<ApiResponse<Session>>();
+      final secondRenameCompleter = Completer<ApiResponse<Session>>();
+      when(
+        () => mockSessionService.renameSession(sessionId: "s1", title: "First title"),
+      ).thenAnswer((_) => firstRenameCompleter.future);
+      when(
+        () => mockSessionService.renameSession(sessionId: "s1", title: "Second title"),
+      ).thenAnswer((_) => secondRenameCompleter.future);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await Future<void>.delayed(Duration.zero);
+
+      final firstRename = cubit.renameSession(sessionId: "s1", title: "First title");
+      final secondRename = cubit.renameSession(sessionId: "s1", title: "Second title");
+      expect((cubit.state as SessionListLoaded).sessions.single.title, "Second title");
+
+      firstRenameCompleter.complete(ApiResponse<Session>.error(ApiError.generic()));
+      expect(await firstRename, isFalse);
+      expect((cubit.state as SessionListLoaded).sessions.single.title, "Second title");
+
+      secondRenameCompleter.complete(ApiResponse<Session>.error(ApiError.generic()));
+      expect(await secondRename, isFalse);
+      expect((cubit.state as SessionListLoaded).sessions.single.title, "Original");
+    });
+
+    test("renameSession restores the latest confirmed title when a newer rename fails", () async {
+      final original = testSession(id: "s1", title: "Original");
+      when(
+        () => mockProjectRepository.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
+      ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [original])));
+      final firstRenameCompleter = Completer<ApiResponse<Session>>();
+      final secondRenameCompleter = Completer<ApiResponse<Session>>();
+      when(
+        () => mockSessionService.renameSession(sessionId: "s1", title: "First title"),
+      ).thenAnswer((_) => firstRenameCompleter.future);
+      when(
+        () => mockSessionService.renameSession(sessionId: "s1", title: "Second title"),
+      ).thenAnswer((_) => secondRenameCompleter.future);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await Future<void>.delayed(Duration.zero);
+
+      final firstRename = cubit.renameSession(sessionId: "s1", title: "First title");
+      final secondRename = cubit.renameSession(sessionId: "s1", title: "Second title");
+
+      firstRenameCompleter.complete(ApiResponse.success(original.copyWith(title: "First title")));
+      expect(await firstRename, isTrue);
+      expect((cubit.state as SessionListLoaded).sessions.single.title, "Second title");
+
+      secondRenameCompleter.complete(ApiResponse<Session>.error(ApiError.generic()));
+      expect(await secondRename, isFalse);
+      expect((cubit.state as SessionListLoaded).sessions.single.title, "First title");
     });
 
     // -------------------------------------------------------------------------

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -1713,12 +1713,14 @@ void main() {
     );
 
     // -------------------------------------------------------------------------
-    // renameSession success — calls service, refreshes list, returns true
+    // renameSession success — updates optimistically and returns true
     // -------------------------------------------------------------------------
 
+    late Completer<ApiResponse<Session>> renameSessionCompleter;
     blocTest<SessionListCubit, SessionListState>(
-      "renameSession: calls service with correct args, refreshes sessions, and returns true on success",
+      "renameSession: updates the title before the request completes and returns true on success",
       build: () {
+        renameSessionCompleter = Completer<ApiResponse<Session>>();
         when(
           () => mockProjectRepository.listSessions(
             projectId: projectId,
@@ -1733,12 +1735,11 @@ void main() {
         );
         when(
           () => mockSessionService.renameSession(sessionId: "s1", title: "New Title"),
-        ).thenAnswer((_) async => ApiResponse.success(testSession(id: "s1", title: "New Title")));
+        ).thenAnswer((_) => renameSessionCompleter.future);
         return buildCubit();
       },
       act: (cubit) async {
         await Future<void>.delayed(Duration.zero);
-        // Switch mock to return renamed session on refresh.
         when(
           () => mockProjectRepository.listSessions(
             projectId: projectId,
@@ -1751,14 +1752,19 @@ void main() {
             ),
           ),
         );
-        final result = await cubit.renameSession(sessionId: "s1", title: "New Title");
-        expect(result, isTrue);
+
+        final rename = cubit.renameSession(sessionId: "s1", title: "New Title");
+        expect((cubit.state as SessionListLoaded).sessions.first.title, "New Title");
+
+        renameSessionCompleter.complete(ApiResponse.success(testSession(id: "s1", title: "New Title")));
+        expect(await rename, isTrue);
+        await Future<void>.delayed(Duration.zero);
       },
       skip: 1,
       expect: () => [
         isA<SessionListLoaded>().having(
           (s) => s.sessions.first.title,
-          "session title after rename",
+          "optimistic session title",
           "New Title",
         ),
       ],
@@ -1768,12 +1774,13 @@ void main() {
     );
 
     // -------------------------------------------------------------------------
-    // renameSession failure — service returns ErrorResponse, returns false
+    // renameSession failure — restores the previous title and returns false
     // -------------------------------------------------------------------------
 
     blocTest<SessionListCubit, SessionListState>(
-      "renameSession: returns false and leaves state unchanged when service returns error",
+      "renameSession: restores the previous title when the request fails",
       build: () {
+        renameSessionCompleter = Completer<ApiResponse<Session>>();
         when(
           () => mockProjectRepository.listSessions(
             projectId: projectId,
@@ -1788,17 +1795,30 @@ void main() {
         );
         when(
           () => mockSessionService.renameSession(sessionId: "s1", title: "New Title"),
-        ).thenAnswer((_) async => ApiResponse<Session>.error(ApiError.generic()));
+        ).thenAnswer((_) => renameSessionCompleter.future);
         return buildCubit();
       },
       act: (cubit) async {
         await Future<void>.delayed(Duration.zero);
-        final result = await cubit.renameSession(sessionId: "s1", title: "New Title");
-        expect(result, isFalse);
+        final rename = cubit.renameSession(sessionId: "s1", title: "New Title");
+        expect((cubit.state as SessionListLoaded).sessions.first.title, "New Title");
+
+        renameSessionCompleter.complete(ApiResponse<Session>.error(ApiError.generic()));
+        expect(await rename, isFalse);
       },
       skip: 1,
-      // No state changes — current loaded state is preserved.
-      expect: () => <SessionListState>[],
+      expect: () => [
+        isA<SessionListLoaded>().having(
+          (s) => s.sessions.first.title,
+          "optimistic session title",
+          "New Title",
+        ),
+        isA<SessionListLoaded>().having(
+          (s) => s.sessions.first.title,
+          "restored session title",
+          "Original",
+        ),
+      ],
     );
 
     // -------------------------------------------------------------------------

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -1773,7 +1773,7 @@ void main() {
       },
     );
 
-    test("renameSession supersedes a refresh that started before the rename", () async {
+    test("renameSession replaces an active PR-data refresh with an equivalent post-write read", () async {
       final original = testSession(id: "s1", title: "Original");
       final renamed = testSession(id: "s1", title: "New Title");
       when(
@@ -1793,29 +1793,69 @@ void main() {
 
       final staleRefreshCompleter = Completer<ApiResponse<SessionListResponse>>();
       final postRenameRefreshCompleter = Completer<ApiResponse<SessionListResponse>>();
+      final waitsForPrData = <bool>[];
       var refreshRequestCount = 0;
       when(
         () => mockProjectRepository.listSessions(
           projectId: projectId,
           waitForPrData: any(named: "waitForPrData"),
         ),
-      ).thenAnswer((_) {
+      ).thenAnswer((invocation) {
+        waitsForPrData.add(invocation.namedArguments[#waitForPrData] as bool);
         refreshRequestCount++;
         return refreshRequestCount == 1 ? staleRefreshCompleter.future : postRenameRefreshCompleter.future;
       });
 
-      final staleRefresh = cubit.refreshSessions();
+      final staleRefresh = cubit.refreshSessions(waitForPrData: true);
       final rename = cubit.renameSession(sessionId: "s1", title: "New Title");
       expect((cubit.state as SessionListLoaded).sessions.single.title, "New Title");
 
       renameCompleter.complete(ApiResponse.success(renamed));
       expect(await rename, isTrue);
       expect(refreshRequestCount, 2);
+      expect(waitsForPrData, [isTrue, isTrue]);
 
       staleRefreshCompleter.complete(ApiResponse.success(SessionListResponse(items: [original])));
       postRenameRefreshCompleter.complete(ApiResponse.success(SessionListResponse(items: [renamed])));
       expect(await staleRefresh, isTrue);
       expect((cubit.state as SessionListLoaded).sessions.single.title, "New Title");
+    });
+
+    test("renameSession keeps a pending refresh successful and overlays its stale title", () async {
+      final original = testSession(id: "s1", title: "Original");
+      when(
+        () => mockProjectRepository.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
+      ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [original])));
+      final renameCompleter = Completer<ApiResponse<Session>>();
+      when(
+        () => mockSessionService.renameSession(sessionId: "s1", title: "New Title"),
+      ).thenAnswer((_) => renameCompleter.future);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await Future<void>.delayed(Duration.zero);
+
+      final refreshCompleter = Completer<ApiResponse<SessionListResponse>>();
+      when(
+        () => mockProjectRepository.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
+      ).thenAnswer((_) => refreshCompleter.future);
+
+      final refresh = cubit.refreshSessions();
+      final rename = cubit.renameSession(sessionId: "s1", title: "New Title");
+      refreshCompleter.complete(ApiResponse.success(SessionListResponse(items: [original])));
+
+      expect(await refresh, isTrue);
+      expect((cubit.state as SessionListLoaded).sessions.single.title, "New Title");
+
+      renameCompleter.complete(ApiResponse<Session>.error(ApiError.generic()));
+      expect(await rename, isFalse);
+      expect((cubit.state as SessionListLoaded).sessions.single.title, "Original");
     });
 
     // -------------------------------------------------------------------------

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -1773,6 +1773,51 @@ void main() {
       },
     );
 
+    test("renameSession supersedes a refresh that started before the rename", () async {
+      final original = testSession(id: "s1", title: "Original");
+      final renamed = testSession(id: "s1", title: "New Title");
+      when(
+        () => mockProjectRepository.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
+      ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [original])));
+      final renameCompleter = Completer<ApiResponse<Session>>();
+      when(
+        () => mockSessionService.renameSession(sessionId: "s1", title: "New Title"),
+      ).thenAnswer((_) => renameCompleter.future);
+
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await Future<void>.delayed(Duration.zero);
+
+      final staleRefreshCompleter = Completer<ApiResponse<SessionListResponse>>();
+      final postRenameRefreshCompleter = Completer<ApiResponse<SessionListResponse>>();
+      var refreshRequestCount = 0;
+      when(
+        () => mockProjectRepository.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
+      ).thenAnswer((_) {
+        refreshRequestCount++;
+        return refreshRequestCount == 1 ? staleRefreshCompleter.future : postRenameRefreshCompleter.future;
+      });
+
+      final staleRefresh = cubit.refreshSessions();
+      final rename = cubit.renameSession(sessionId: "s1", title: "New Title");
+      expect((cubit.state as SessionListLoaded).sessions.single.title, "New Title");
+
+      renameCompleter.complete(ApiResponse.success(renamed));
+      expect(await rename, isTrue);
+      expect(refreshRequestCount, 2);
+
+      staleRefreshCompleter.complete(ApiResponse.success(SessionListResponse(items: [original])));
+      postRenameRefreshCompleter.complete(ApiResponse.success(SessionListResponse(items: [renamed])));
+      expect(await staleRefresh, isTrue);
+      expect((cubit.state as SessionListLoaded).sessions.single.title, "New Title");
+    });
+
     // -------------------------------------------------------------------------
     // renameSession failure — restores the previous title and returns false
     // -------------------------------------------------------------------------

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -225,8 +225,9 @@ state.
   payload without plugin attribution means the historical OpenCode identity,
   never "the first enabled plugin".
 - Project and session rename sheets start from the current display name, reject
-  a blank trimmed value, prevent duplicate submission while saving, and show
-  success or failure feedback without losing the failed edit.
+  a blank trimmed value, and prevent duplicate submission. Submission dismisses
+  the sheet immediately and updates the list optimistically. Successful renames
+  stay silent; a failed rename restores the prior name and shows failure feedback.
 
 ## Regression Levels
 
@@ -328,6 +329,8 @@ leave the surface that started one. Restore harness eligibility afterwards.
   a summary it never saw, or a cancelled scan leaving its row behind.
 - A bridge with no import route reported as a failure rather than as one that
   cannot scan, or a pull that finds no harness reporting nothing at all.
+- A project or session rename waits for the bridge response before dismissing,
+  confirms success, or leaves the optimistic name in place after a failure.
 - A generated title/branch update fails to reach list/detail, changes unseen,
   moves the worktree, or rewrites the backend's creation-time system context.
 

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -226,8 +226,10 @@ state.
   never "the first enabled plugin".
 - Project and session rename sheets start from the current display name, reject
   a blank trimmed value, and prevent duplicate submission. Submission dismisses
-  the sheet immediately and updates the list optimistically. Successful renames
-  stay silent; a failed rename restores the prior name and shows failure feedback.
+  the sheet immediately and updates the list optimistically. Reads that started
+  before submission cannot overwrite that value, and success starts a fresh
+  authoritative read. Successful renames stay silent; a failed rename restores
+  the prior name and shows failure feedback.
 
 ## Regression Levels
 


### PR DESCRIPTION
## Complexity

🌿 Straightforward — localized shared UI and list-cubit behavior changes with focused regression coverage.

## What

- Dismiss project and session rename sheets immediately after submission.
- Apply project names and session titles optimistically in their list cubits.
- Restore the previous value and show an error alert only when the rename fails.
- Remove successful-rename alerts and their unused localization strings.
- Document the async optimistic rename contract.

## Why

Rename requests can take long enough to block the sheet and interrupt the user's flow. The client can safely assume success while the bridge works, then recover visibly only if the request fails.

## Risk and test focus

No wire-contract or database impact. The main client risk is leaving stale optimistic state or showing incorrect feedback, so coverage holds requests pending, verifies immediate dismissal and list updates, then checks success silence and failure rollback/notification for both rename domains.

## Expected result

Submitting either rename closes the sheet immediately and updates the visible name. Success produces no notification; failure restores the prior name and displays the existing failure alert.

## Verification

- `dart test test/cubits/session_list/session_list_cubit_test.dart test/cubits/project_list/project_list_cubit_test.dart` (`client/module_core`)
- `flutter test test/widgets/rename_sheet_test.dart` (`client/module_app_ui`)
- `dart analyze --fatal-infos` (`client/module_core`)
- `flutter analyze --fatal-infos` (`client/module_app_ui`)
- `flutter analyze --fatal-infos` (`client/app`)
- `flutter analyze --fatal-infos` (`client/desktop`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Project and session rename sheets previously stayed open until the bridge responded and showed success alerts. They now dismiss immediately and update list names optimistically; successful requests stay silent, while failures restore the prior value and show the existing error alert. Overlapping renames are token-tracked so an earlier response can't clobber a newer rename, and reads already in flight when a rename starts are overlaid with the optimistic name so they can't repaint the old value. Each list refreshes in the background after a successful bridge response.

- Adds widget and cubit coverage for pending, successful, and failed renames, including stale reads and overlapping renames.
- Documents the optimistic rename contract and failure cases.

<sup>Written for commit 97eafd0559a9a85e077f7c99d0383741a29024ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

