### PR TITLE
⚙️ [antigravity-harness] feat(antigravity): pin the official ACP runtime contract [step 2/12]

### DIFF
--- a/.plan/active/antigravity-harness/PLAN.md
+++ b/.plan/active/antigravity-harness/PLAN.md
@@ -3,9 +3,9 @@
 ## Status
 
 - **Plan slug:** `antigravity-harness`
-- **Status:** active; Step 1 architecture review findings applied, validation in progress
+- **Status:** active; Step 1 merged, Step 2 in progress
 - **Plan date:** 2026-09-03
-- **Implementation base:** `origin/main` at `a87f30ab98b07dd7262afba462a36d4fbcc2dd9a`
+- **Implementation base:** `origin/main` at `3d65382e8cd4e33bbaedaf6c6a679a24ad211320`
 - **Delivery:** twelve ordered PRs with fixed titles below
 - **Delivery order:** user-supplied official runtime pair first; pinned managed installation follows after local
   support is live
@@ -108,7 +108,7 @@ that privacy-safe result as a contract fixture. The released binary wins over T3
 - Use only the official Google pair from the ACP registry. Explicit `--antigravity-bin <path>` points at
   `agy_acp_server.par`/`.exe`; the matching `localharness_external` sibling is mandatory. Without an explicit path,
   resolve that official pair on PATH first, then an already-installed managed pair.
-- Local/manual runtime support activates in Step 8. Managed installation is intentionally later, in Step 9, matching
+- Local/manual runtime support activates in Step 9. Managed installation is intentionally later, in Step 10, matching
   the user's requested delivery order.
 - Pin registry package `1.0.0` and runtime `agy_acp_server_20260818_01_RC01`. Because no compatibility range is
   published, both local and managed pairs must pass the exact ACP identity/version/capability probe. A future release
@@ -200,16 +200,18 @@ module_app_ui (render/collect only)
 PluginLifecycleService (one active operation per plugin)
   -> AntigravityAuthenticationOperation (stateful consumer)
        -> AntigravityProfileService -> AntigravityProfileRepository -> AntigravityProfileStorage
-       -> AntigravityAuthenticationService -> AntigravityAuthorizationParser
-            -> AntigravityAuthenticationRepository
-                 -> AntigravityAcpApi -> official ACP process
-                 -> AntigravityLoopbackClient -> exact bridge-host callback
+       -> AntigravityRuntimeService -> AntigravityRuntimeRepository -> storage/ACP API
+       -> AntigravityAuthenticationService -> AntigravityAuthenticationRepository
+            -> AntigravityAuthorizationMapper
+            -> AntigravityAcpApi -> official ACP process
+            -> AntigravityLoopbackClient -> exact bridge-host callback
 
 bridge app -> AntigravityPluginDescriptor (composition root)
   -> AntigravitySetupService
        -> AntigravityRuntimeService -> AntigravityRuntimeRepository -> Layer-1 storage/ACP APIs
        -> AntigravityProfileService -> AntigravityProfileRepository -> AntigravityProfileStorage
-  -> AntigravityPlugin -> sesori_plugin_acp -> agy_acp_server + localharness_external
+  -> AntigravityPlugin -> options/interaction composers -> layered connection-scoped peers
+       -> sesori_plugin_acp -> agy_acp_server + localharness_external
   -> isolated GEMINI_HOME
 ```
 
@@ -220,9 +222,9 @@ bridge app -> AntigravityPluginDescriptor (composition root)
 - `AntigravityPluginDescriptor` is the plugin-package composition root. Its lifecycle entries construct peer
   collaborators together from `PluginHost` dependencies and pass each dependency through a required named constructor.
   No service constructs a repository, and no repository constructs an API, client, or storage collaborator.
-- `AntigravityPlugin` receives all process-lifetime peers plus a descriptor-owned options-service composer. After a
-  live ACP client exists, hooks may invoke that composer with the shared connection-scoped config repository and create
-  the approval registry. The plugin never invokes a collaborator constructor itself.
+- `AntigravityPlugin` receives process-lifetime peers plus descriptor-owned options and interaction composers. After a
+  live ACP client exists, hooks invoke those composers with shared connection-scoped dependencies and receive the
+  options service plus approval registry; the plugin never invokes a collaborator constructor itself.
 - `AntigravityAuthenticationOperation` receives already-composed profile, runtime, and authentication services. It owns
   one-shot state machine and closes its composed process/HTTP leases, but it does not instantiate peers.
 - Dependencies have no production defaults. Tests fake concrete classes with `implements`; no one-implementation
@@ -237,7 +239,8 @@ bridge app -> AntigravityPluginDescriptor (composition root)
 - `sesori_shared` owns backend-neutral wire DTOs for `deviceCode`, `browser`, `unknown`, and redirect submission. The
   browser DTO carries an authorization URL and expected loopback callback URL, not Google-specific state semantics.
 - Bridge runtime/lifecycle owns single-flight authentication, generation fencing, cancellation, and routing a
-  continuation only to the current active operation. It does not inspect Google URL semantics or issue HTTP itself.
+  continuation only to the current active operation. It supplies the same plugin-scoped `HostJsonStore` to auth and live
+  host composition; it does not inspect Google URL semantics or issue HTTP itself.
 - `sesori_plugin_antigravity` owns Google/runtime identity, profile policy, interactions, protocol/metadata mapping,
   and recovery. Layer-3 services own runtime selection/probe, combined setup readiness, callback/state/code, model/mode,
   interaction/permission policy, and metadata-recovery workflows.
@@ -264,7 +267,6 @@ pair, `PluginHost`, timeout, cwd, or prepared profile are domain inputs, not hid
 | `AntigravityRelease` | `foundation/antigravity_release.dart` | L0 |
 | `AntigravityRuntimeManifest` | `runtime/antigravity_runtime_manifest.dart` | L0 manifest |
 | `AntigravityLaunchSpecBuilder` | `builders/antigravity_launch_spec_builder.dart` | L0 |
-| `AntigravityAuthorizationParser` | `parsers/antigravity_authorization_parser.dart` | L0 |
 | `AntigravityProfileStorage` | `storage/antigravity_profile_storage.dart` | L1 |
 | `AntigravityRuntimeStorage` | `storage/antigravity_runtime_storage.dart` | L1 |
 | `AntigravitySessionMetadataStorage` | `storage/antigravity_session_metadata_storage.dart` | L1 |
@@ -273,7 +275,9 @@ pair, `PluginHost`, timeout, cwd, or prepared profile are domain inputs, not hid
 | `AntigravityProfileRepository` | `repositories/antigravity_profile_repository.dart` | L2 |
 | `AntigravityRuntimeRepository` | `repositories/antigravity_runtime_repository.dart` | L2 |
 | `AntigravityAuthenticationRepository` | `repositories/antigravity_authentication_repository.dart` | L2 |
+| `AntigravityInteractionRepository` | `repositories/antigravity_interaction_repository.dart` | L2 |
 | `AntigravitySessionMetadataRepository` | `repositories/antigravity_session_metadata_repository.dart` | L2 |
+| `AntigravityAuthorizationMapper` | `repositories/mappers/antigravity_authorization_mapper.dart` | L2 mapper |
 | `AntigravityProtocolMapper` | `repositories/mappers/antigravity_protocol_mapper.dart` | L2 mapper |
 | `AntigravityProfileService` | `services/antigravity_profile_service.dart` | L3 |
 | `AntigravityRuntimeService` | `services/antigravity_runtime_service.dart` | L3 |
@@ -294,35 +298,37 @@ pair, `PluginHost`, timeout, cwd, or prepared profile are domain inputs, not hid
 | `AntigravityIdentity` / `AntigravityRelease` | none | descriptor | immutable values |
 | `AntigravityRuntimeManifest` | release facts | descriptor | immutable target map |
 | `AntigravityLaunchSpecBuilder` | none | descriptor | none |
-| `AntigravityAuthorizationParser` | none | descriptor | none |
-| `AntigravityProfileStorage` | command executor, platform target | descriptor | filesystem/permission boundary |
-| `AntigravityRuntimeStorage` | PATH resolver | descriptor | filesystem boundary only |
+| `AntigravityProfileStorage` | host JSON store, command executor, platform target | descriptor | files/permissions |
+| `AntigravityRuntimeStorage` | none | descriptor | filesystem/PATH boundary |
 | `AntigravitySessionMetadataStorage` | none | descriptor | filesystem boundary only |
 | `AntigravityLoopbackClient` | HTTP client | descriptor | one HTTP client lease |
 | `AntigravityAcpApi` | process factory | descriptor | one scratch ACP lease |
 | `AntigravityProfileRepository` | profile storage | descriptor | none |
 | `AntigravityRuntimeRepository` | runtime storage, ACP API, launch builder | descriptor | none |
-| `AntigravityAuthenticationRepository` | ACP API, loopback client | descriptor | none |
+| `AntigravityAuthenticationRepository` | ACP API, loopback client, authorization mapper | descriptor | none |
+| `AntigravityInteractionRepository` | live ACP client | interaction composer | none |
 | `AntigravitySessionMetadataRepository` | metadata storage | descriptor | none |
+| `AntigravityAuthorizationMapper` | auth-line limits | descriptor | none |
 | `AntigravityProtocolMapper` | ACP content limits | descriptor | none |
 | `AntigravityProfileService` | profile repository | descriptor | none |
 | `AntigravityRuntimeService` | runtime repository | descriptor | none |
 | `AntigravitySetupService` | runtime service, profile service | descriptor | none |
-| `AntigravityAuthenticationService` | auth repository, auth parser | descriptor | none |
-| `AntigravitySessionOptionsService` | mapper, tracker, ACP config repo | descriptor callback | none |
-| `AntigravityInteractionService` | protocol mapper | descriptor | none |
+| `AntigravityAuthenticationService` | auth repository | descriptor | none |
+| `AntigravitySessionOptionsService` | mapper, tracker, ACP config repo | options composer | none |
+| `AntigravityInteractionService` | protocol mapper, interaction repository | interaction composer | none |
 | `AntigravitySessionMetadataService` | metadata repository | descriptor | none |
 | `AntigravityRuntimeVersionValidator` | runtime service | descriptor | none |
 | `AntigravityCatalogTracker` | none | descriptor | last-good immutable catalog |
 | `AntigravityAuthenticationOperation` | profile/runtime/auth services | descriptor | one auth attempt |
-| `AntigravityApprovalRegistry` | ACP client, pending stores, interaction service | plugin hook | pending lifecycle |
+| `AntigravityApprovalRegistry` | pending stores, interaction service | interaction composer | pending lifecycle |
 | `AntigravityPlugin` | launch/ACP/mapping/recovery peers, options composer | descriptor | live ACP processes |
 | `AntigravityPluginDescriptor` | none | bridge registry | lifecycle composition root |
 
-`AntigravityProfileStorage` creates the profile and, before any agent launch, uses its injected `CommandExecutor` to
-apply owner-only `700` mode on POSIX; Windows relies on the user-profile ACL and runs no chmod command. Permission
-failure blocks setup. `AntigravityProfileRepository` maps typed storage DTOs and `AntigravityProfileService` owns auth
-readiness plus environment policy. `AntigravitySessionMetadataStorage` alone lists and decodes bounded `.meta` DTOs;
+`AntigravityProfileStorage` persists typed settings through its injected plugin-scoped `HostJsonStore`, shared with the
+live `PluginHost`, so writes retain the host's atomic locked state contract. It creates the profile and uses an injected
+`CommandExecutor` to apply owner-only `700` mode on POSIX before launch; Windows relies on the user-profile ACL.
+Permission failure blocks setup. `AntigravityProfileRepository` maps storage DTOs; `AntigravityProfileService` owns
+auth readiness and environment policy. `AntigravitySessionMetadataStorage` alone lists/decodes bounded `.meta` DTOs;
 its repository maps UUID/cwd records into plugin-domain values. `AntigravitySessionMetadataService` owns bounded scan,
 validation, deduplication, and privacy-safe skips, then returns one registration batch. `AntigravityPlugin` hands only
 that batch to the shared protected bulk-registration seam. None reads SQLite.
@@ -332,25 +338,28 @@ that batch to the shared protected bulk-registration seam. None reads SQLite.
 `AntigravityRuntimeService` owns static pair inspection, explicit/PATH/managed precedence, and exact identity/version/
 capability probing when a prepared launch environment is supplied. `AntigravitySetupService` combines static runtime
 and profile service outcomes without launching the backend; the runtime layer never reads profile state.
-`AntigravityAuthenticationRepository` maps ACP auth and callback HTTP outcomes only.
-`AntigravityAuthenticationService` parses and validates Google authorization/callback semantics, sequences repository
-calls, and permits one no-redirect GET only after exact endpoint/state/code validation. The
-operation coordinates profile/runtime/authentication services and owns state transitions. `AntigravityProtocolMapper` is
-the Layer-2 mapper for raw updates, grouped config options, and interaction/permission requests. Trackers and hooks
-consume only its typed normalized results. `AntigravityInteractionService` owns classification, safe option filtering,
-label-to-ID policy, and answer validation; the approval registry owns only pending-request lifecycle and ACP replies.
+`AntigravityAuthorizationMapper` consumes bounded raw auth stdout at Layer 2. The authentication repository owns it and
+returns only a typed parsed authorization or mapped failure alongside ACP/callback outcomes. The authentication service
+applies Google endpoint/state/code policy and sequencing to those domain results; no raw line reaches Layer 3. The
+operation coordinates profile/runtime/authentication services and owns state transitions.
+
+`AntigravityProtocolMapper` maps raw updates, grouped config options, and interaction/permission requests at Layer 2.
+`AntigravityInteractionRepository` is connection-scoped over the live ACP client and sends already-typed reply outcomes.
+`AntigravityInteractionService` owns classification, safe filtering, label-to-ID policy, answer validation, and reply
+dispatch through that repository. The approval registry owns only pending lifecycle and delegates every answer.
 
 Shared ACP changes preserve the same layering: `AcpAgentApi` exposes separate initialize-only/authenticate and
 `session/set_mode` Layer-1 calls; `AcpSessionConfigRepository` maps model/mode writes for consumers. The shared stdout
-hook owns a bounded partial-line buffer per process and delegates complete authorization lines to the plugin parser.
+hook owns a bounded partial-line buffer and lets a repository callback consume complete non-JSON lines before logging;
+the Antigravity repository invokes its authorization mapper there, so raw authorization URLs never reach a service.
 A protected backend-neutral residency-preference hook defaults to existing load-first behavior; Antigravity alone
 selects resume-first. A launch-spec/host-process `includeParentEnvironment` flag is a required named parameter. Every
 existing caller is updated in lockstep to choose `true`; Antigravity chooses `false` and supplies the profile service's
 filtered `PluginHost.environment`. No Antigravity service or plugin calls `AcpStdioClient.request` directly.
 
-Step 4 changes existing client collaborators without adding a parallel model layer:
+Step 5 changes existing client collaborators without adding a parallel model layer:
 
-| Existing client collaborator | Layer/owner | Step 4 responsibility |
+| Existing client collaborator | Layer/owner | Step 5 responsibility |
 | --- | --- | --- |
 | `PluginApi` | L1 HTTP, injected by client DI | encode/decode backend-neutral shared DTOs only |
 | `PluginRepository` | L2, injected by client DI | map `deviceCode`, `browser`, and `unknown` to internal variants |
@@ -472,7 +481,8 @@ catalog import/cold resume
 The model tracker replaces its catalog only after a complete valid capture; a malformed refresh retains the prior
 catalog. A fresh process does not create a Google-owned scratch session merely to populate pre-create UI: its first new
 session uses the account default, then the returned catalog becomes available for later turns and sessions. This gap is
-documented at activation. No model IDs, account values, prompts, or tool bodies are logged.
+documented at activation. Local failure diagnostics retain the bounded model ID and operation context needed to debug
+catalog/selection drift, but never dump a catalog, account value, prompt, or tool body. Analytics carry no model ID.
 
 ## Compatibility And Security
 
@@ -511,7 +521,7 @@ New persistent mutable state:
 - Google-owned isolated profile under the plugin state root: typed `settings.json` written by Sesori, then token,
   conversation databases, metadata, and brain files written by the official agent. This is required for explicit
   authentication and recovery without touching a user's unrelated Google profile.
-- Managed runtime package directory and existing shared runtime activation metadata after Step 9. No automatic install
+- Managed runtime package directory and existing shared runtime activation metadata after Step 10. No automatic install
   or update.
 - Existing bridge session/project/tombstone tables only. No schema, migration, duplicated session sidecar, or persisted
   auth continuation.
@@ -565,47 +575,50 @@ outside the closed analytics privacy contract, and a setup-button tap would not 
 1. `🌱 [antigravity-harness] docs: plan Antigravity ACP support [step 1/12]`
    - Add and architecture-review this plan/tracker; no production behavior.
 2. `⚙️ [antigravity-harness] feat(antigravity): pin the official ACP runtime contract [step 2/12]`
-   - Add the package/workspace skeleton, official pair/release identity, initialize-only probe seam, layered local-pair
-     resolution, privacy-safe released-agent fixture, and focused contract tests. Do not create/register the plugin.
-3. `🚧 [antigravity-harness] feat(auth): accept browser authentication continuations [step 3/12]`
+   - Add the package/workspace skeleton, official pair/release identity and launch facts, generated initialize DTOs,
+     initialize-only ACP probe seam, privacy-safe released-agent fixture, and focused boundary tests. Do not register
+     it.
+3. `⚙️ [antigravity-harness] feat(antigravity): resolve local runtime pairs [step 3/12]`
+   - Add pair inspection, layered resolution, explicit/PATH/managed precedence, exact contract policy, and focused
+     storage/repository/service tests. Keep the package unregistered.
+4. `🚧 [antigravity-harness] feat(auth): accept browser authentication continuations [step 4/12]`
    - Extend the plugin authentication operation and bridge runtime/lifecycle ownership with a one-shot browser redirect
      continuation while preserving Codex device-code behavior. Keep it internal and unreachable from HTTP for now.
-4. `🚧 [antigravity-harness] feat(client): add remote browser authentication handoff [step 4/12]`
+5. `🚧 [antigravity-harness] feat(client): add remote browser authentication handoff [step 5/12]`
    - Add the browser challenge/redirect wire DTO and route; repository-owned DTO mapping; pure-Dart service validation;
      cubit flow; presentation-only shared settings UI; unknown fallback; cancellation; mobile/desktop tests; and the
      browser-flow regression contract. No plugin emits it yet.
-5. `🚧 [antigravity-harness] feat(antigravity): add isolated profile authentication [step 5/12]`
+6. `🚧 [antigravity-harness] feat(antigravity): add isolated profile authentication [step 6/12]`
    - Add layered profile Storage/Repository/Service ownership, auth stdout filtering, ACP/HTTP lower boundaries,
      Google/loopback validation, personal OAuth operation, callback forwarding, cancellation, and deterministic tests.
-6. `🚧 [antigravity-harness] feat(antigravity): map ACP options and interactions [step 6/12]`
+7. `🚧 [antigravity-harness] feat(antigravity): map ACP options and interactions [step 7/12]`
    - Add partial pre-catalog options, later exact model selection, fixed default mode, question conversion,
      persistent-approval filtering, bounded tool normalization, and live/replay hooks with direct collaborator tests.
-7. `🚧 [antigravity-harness] feat(antigravity): compose persistent ACP sessions [step 7/12]`
+8. `🚧 [antigravity-harness] feat(antigravity): compose persistent ACP sessions [step 8/12]`
    - Create the unregistered `AntigravityPlugin` and descriptor, compose typed metadata Storage/Repository/Service
      recovery, load/resume/history, turn lanes, options wiring, commands, crash/reconnect,
      tombstone-compatible deletion, and conformance tests.
-8. `⚙️ [antigravity-harness] feat(bridge): activate local Antigravity runtimes [step 8/12]`
+9. `⚙️ [antigravity-harness] feat(bridge): activate local Antigravity runtimes [step 9/12]`
    - Register the local-only descriptor through app composition with its plugin-owned opaque ID; update exact-set
      fixtures, inventories, backend-neutral routing, and every regression contract affected by activation.
-9. `🚧 [antigravity-harness] feat(antigravity): install the managed ACP runtime [step 9/12]`
-   - Independently pin all five official archives, add package-directory managed install/selection/validation, explicit
-     unsupported macOS x64 behavior, install tests/lifecycle integration, and runtime-installation regression coverage.
-10. `🌱 [antigravity-harness] docs: complete Antigravity product guidance [step 10/12]`
-    - Complete README/architecture/operator guidance after activation while retaining descriptor-provided naming and
-      generic harness artwork.
-11. `🌱 [antigravity-harness] docs: reconcile Antigravity regression coverage [step 11/12]`
-    - Penultimate step: audit and reconcile already-updated regression contracts, cross-links, matrices, and limits.
+10. `🚧 [antigravity-harness] feat(antigravity): install the managed ACP runtime [step 10/12]`
+    - Independently pin all five official archives, add package-directory managed install/selection/validation, explicit
+      unsupported macOS x64 behavior, install tests/lifecycle integration, and runtime-installation regression coverage.
+11. `🌱 [antigravity-harness] docs: complete guidance and regression coverage [step 11/12]`
+    - Complete product/operator guidance, then audit and reconcile already-updated regression contracts, cross-links,
+      matrices, and limits.
 12. `🚧 [antigravity-harness] test: verify Antigravity and retire the plan [step 12/12]`
     - Run architecture implementation review and the recorded L1-L5 matrix, fix only in-scope defects, record evidence,
       and move the passing plan to `.plan/completed/antigravity-harness/`.
 
-Each PR targets at most 1,500 changed lines including tests and generated output. Step 4 may approach the cap because
-the new wire variant must compile through shared DTO generation and exhaustive client presentation consumers. If the
-measured change exceeds it, split transport/service from UI before opening that PR and update the fixed plan total
-first. No other step has an expected overage.
+Each PR targets at most 1,500 changed lines including tests and generated output. The original Step 2 exceeded the cap,
+so its ACP boundary/release pin remains Step 2 and local runtime resolution moves to Step 3; the two small final docs
+steps were combined to preserve the twelve-PR total. Step 5 may approach the cap because its wire variant must compile
+through shared DTO generation and exhaustive client presentation consumers. If it exceeds the measured budget, split
+transport/service from UI and update the fixed plan total before opening that PR.
 
 Every PR that makes behavior reachable updates its relevant `docs/regression/` feature contract in the same change.
-Internal/unregistered Steps 3 and 5-7 do not claim unavailable product support; if they materially change an existing
+Internal/unregistered Steps 2-4 and 6-8 do not claim unavailable product support; if they materially change an existing
 documented invariant, they update that document immediately. Step 11 is final reconciliation, not first documentation.
 
 ## Step Details
@@ -620,32 +633,45 @@ documented invariant, they update that document immediately. Step 11 is final re
 ### Step 2/12: Pin the official runtime contract
 
 - Create `bridge/sesori_plugin_antigravity/` with package metadata, exports, analysis/build-runner configuration,
-  identity/release facts, `AntigravityLaunchSpecBuilder`, Layer-1 runtime Storage/ACP API, Layer-2 runtime repository,
-  Layer-3 runtime service, and tests. Add it to bridge workspace, Makefile, and CI inventories; create no plugin or
-  production descriptor yet.
+  identity/release facts, `AntigravityRuntimePair`, `AntigravityLaunchSpecBuilder`, generated initialize DTOs, and a
+  Layer-1 `AntigravityAcpApi`. Add it to the bridge workspace, Makefile, and CI inventory; create no plugin, descriptor,
+  runtime repository/service, or app dependency yet.
 - Refactor `AcpAgentApi` so initialize-only and authenticate are separately callable while its existing combined method
-  and every current harness retain behavior. `AntigravityAcpApi` owns scratch process/client access; the repository maps
-  storage/probe results, while `AntigravityRuntimeService` owns exact validation, candidate precedence, and sequencing.
+  and every current harness retain behavior. `AntigravityAcpApi` owns the scratch process/client lease and maps raw
+  initialize data into generated typed DTOs before returning from Layer 1.
 - Download the official macOS arm64 archive from the pinned registry URL in an isolated temporary directory; compute
   hash/size, inspect exactly the pair, launch with the registry arguments/environment, and capture only privacy-safe
-  initialize identity/capability structure. Do not commit the archive, credentials, URLs, account/model IDs, or logs.
-- Freeze exact agent version, required load/resume/auth capability facts, process exit, and whether session list/close
-  are actually advertised. Update later step wording if the release contradicts reviewed evidence.
-- Cover explicit path authority, PATH pair resolution, missing/mismatched sibling, platform names/args, malformed
-  initialize, wrong identity/version, timeout, cancellation, and cleanup.
+  initialize identity/capability structure. Do not commit the archive, credentials, authentication/callback URLs,
+  account/model IDs, or logs.
+- Freeze exact agent version, filenames, target support, Linux argument, required load/resume/auth capability facts,
+  process exit, and whether session list/close are advertised. Cover launch facts, generated parsing, malformed
+  initialize, timeout, cancellation, exit, and cleanup.
 
-### Step 3/12: Browser continuation ownership
+### Step 3/12: Resolve official local runtime pairs
+
+- Add Layer-1 `AntigravityRuntimeStorage`, Layer-2 `AntigravityRuntimeRepository`, Layer-3
+  `AntigravityRuntimeService`, resolution outcomes, and focused tests without
+  creating or registering the plugin or adding the package to the bridge app.
+- Require exact filenames, regular files, resolved sibling placement, and distinct server/harness files. Build the
+  official harness environment and Linux-only `--uid=` argument from the selected pair.
+- Keep the repository to storage/probe-result mapping. The service owns explicit -> PATH -> managed precedence,
+  explicit-path authority, exact identity/version/capability validation, timeout budgeting, and cancellation checks.
+- Cover explicit/PATH/managed precedence, missing/mismatched/non-file siblings, platform names/arguments, wrong
+  identity/version/capabilities, storage/probe failures, timeout budgeting, cancellation, and launch cleanup.
+
+### Step 4/12: Browser continuation ownership
 
 - Replace the stream-only descriptor result with a backend-neutral authentication operation that exposes events and can
-  reject or accept a browser redirect according to its sealed operation kind. Update Codex and all in-repository fakes
-  in lockstep; no compatibility shim for the internal Dart API.
+  reject or accept a browser redirect according to its sealed operation kind. Add required `HostJsonStore` access to
+  the authentication descriptor contract. App composition creates one store per plugin state root and shares that
+  instance with authentication and the live `PluginHost`; update Codex and all fakes without a compatibility shim.
 - Route continuation only to the current plugin's single active, generation-fenced authentication. Define typed
   no-active/wrong-kind/already-submitted conflicts and preserve cancel/shutdown settlement.
 - Keep browser semantics out of bridge core: it owns operation identity/order, not provider URL validation or HTTP.
 - Cover same-request joining, submit-before/after challenge, stale generation, duplicate submit, cancel race, shutdown,
-  Codex rejection, and terminal cleanup without synthetic unreachable guards.
+  Codex rejection, shared scoped-store identity/atomic writes, and terminal cleanup without unreachable guards.
 
-### Step 4/12: Remote browser handoff
+### Step 5/12: Remote browser handoff
 
 - Add backend-neutral shared transport variants for `deviceCode`, `browser`, and `unknown`. The browser DTO carries an
   HTTPS authorization URL and expected loopback callback URL; it contains no Google provider, state, or code policy.
@@ -664,7 +690,7 @@ documented invariant, they update that document immediately. Step 11 is final re
   challenge's expected scheme/host/port/path, and reject userinfo/fragment or the wrong challenge kind before calling
   `PluginRepository` with a typed URI. This is generic client validation, not the plugin security boundary.
 - Keep provider-specific authorization origin, exact callback endpoint, state, and code validation in the Antigravity
-  plugin in Step 5. The bridge must independently reject a malicious or outdated client even when client checks passed.
+  plugin in Step 6. The bridge must independently reject a malicious or outdated client even when client checks passed.
 - Keep `HarnessesSettingsView` presentation-only: render typed state, open the URL through the cubit action, explain
   local versus remote completion, collect raw text, dispatch the typed intent, and show typed errors/cancel/retry. It
   performs no URI parsing, validation, or normalization. Mobile and desktop shells share this view and business flow.
@@ -674,28 +700,29 @@ documented invariant, they update that document immediately. Step 11 is final re
 - Update `docs/regression/plugin-setup-and-lifecycle.md` in this PR for the reachable backend-neutral browser flow,
   unknown/older-peer behavior, failure signals, both client shells, and the current-client requirement.
 
-### Step 5/12: Isolated personal authentication
+### Step 6/12: Isolated personal authentication
 
-- Add typed `{auth: {type: oauth-personal}}` settings. `AntigravityProfileStorage` creates the profile, uses an injected
-  `CommandExecutor` backed by `PluginHost.processes` to apply POSIX `700` before launch, writes/reads the typed settings
-  DTO, and reports opaque token-file presence below the plugin state root. Windows performs no chmod and relies on its
-  user-profile ACL. Permission failure blocks setup. The repository maps storage results; `AntigravityProfileService`
-  produces the sanitized environment. All dependencies are required and tests cover mode, ordering, and failure.
+- Add typed `{auth: {type: oauth-personal}}` settings. `AntigravityProfileStorage` uses the injected scoped
+  `HostJsonStore` for atomic settings reads/writes and a `CommandExecutor` backed by the provided host process service
+  to create/harden the profile to POSIX `700` before launch. Windows relies on its user-profile ACL. It reports only
+  opaque token-file presence; permission/persistence failure blocks setup. The repository maps storage results, and
+  `AntigravityProfileService` produces the sanitized environment. Test atomic interruption, mode, ordering, and failure.
 - Add a narrow backend-neutral `includeParentEnvironment` launch/host-process flag as a required named parameter.
   Update every in-repository caller in lockstep to choose `true`; Antigravity chooses `false` and supplies a filtered
   copy of injected `PluginHost.environment`, removing ambient Google/Gemini credentials/profile overrides before adding
   `GEMINI_HOME`, `AGY_ACP_FORCE_FILE_STORAGE=1`, and the harness path for live/auth/local-probe/replay processes.
-- Extend the shared ACP stdout seam with a bounded per-process partial-line buffer. The pure Antigravity parser
-  recognizes the exact auth prefix, while `AntigravityAcpApi` owns scratch process I/O. Preserve every non-auth byte,
-  reject malformed Google URLs with sanitized errors, and turn a live-login line into an auth-required exception.
+- Extend shared ACP stdout with a bounded per-process partial-line buffer and a raw-line callback before logging.
+  `AntigravityAcpApi` owns scratch process I/O; `AntigravityAuthenticationRepository` supplies a callback that invokes
+  Layer-2 `AntigravityAuthorizationMapper`, consumes only the exact auth prefix, and returns a typed parsed result.
+  Preserve every other byte, reject malformed URLs with sanitized errors, and map a live-login line to auth-required.
 - Put all outbound callback transport in `AntigravityLoopbackClient`, which accepts one already-validated URI, uses a
   required injected HTTP client, disables redirects, and exposes no generic fetch surface. It makes no Google decision.
-- `AntigravityAuthenticationRepository` consumes `AntigravityAcpApi` and the loopback client. It maps typed ACP/HTTP
-  results and performs only the already-authorized no-redirect GET; it does not decide Google origin, state, or code
-  policy.
-- `AntigravityAuthenticationService` consumes that repository and `AntigravityAuthorizationParser`. It validates
-  authorization origin/path/query and the issued callback; continuation requires the same endpoint/state, one bounded
-  code, and no userinfo/fragment before the service permits the repository GET.
+- `AntigravityAuthenticationRepository` consumes the ACP API, loopback client, and authorization mapper. It maps raw
+  auth lines plus ACP/HTTP outcomes into typed plugin-domain results and performs only an already-authorized no-redirect
+  GET; it does not decide Google origin, state, or code policy.
+- `AntigravityAuthenticationService` consumes only that repository. It validates authorization origin/path/query and
+  the issued callback; continuation requires the same endpoint/state, one bounded code, and no userinfo/fragment before
+  the service permits the repository GET.
 - `AntigravityAuthenticationOperation` receives already-composed profile, runtime, and authentication services. It
   prepares the profile through its service, requests runtime selection/exact probing with that environment, then starts
   auth through its service. It owns one challenge/completer, transitions, cancellation, and terminal cleanup; it never
@@ -705,7 +732,7 @@ documented invariant, they update that document immediately. Step 11 is final re
 - Treat repository-reported token-file presence only as setup evidence; live authenticate is authoritative. Do not parse
   token content or auto-start login.
 
-### Step 6/12: Options, questions, permissions, and updates
+### Step 7/12: Options, questions, permissions, and updates
 
 - Extend Layer-2 `AntigravityProtocolMapper` to map raw grouped `configOptions` into a typed catalog with exact
   IDs/names/current value. `AntigravitySessionOptionsService` validates the mapped catalog before replacing the
@@ -715,24 +742,25 @@ documented invariant, they update that document immediately. Step 11 is final re
 - Extend Layer-1 `AcpAgentApi` and Layer-2 `AcpSessionConfigRepository` with standard `session/set_mode`. Add
   `AntigravitySessionOptionsService(required protocolMapper, required catalogTracker, required configRepository)`;
   it captures only mapped catalogs, validates the model, performs exact selection, then sends `default` as one
-  operation. Test it directly with fakes in this step; defer plugin/descriptor wiring to Step 7. Any write failure
+  operation. Test it directly with fakes in this step; defer plugin/descriptor wiring to Step 8. Any write failure
   prevents later dispatch.
 - Add a narrow shared ACP session-update normalizer hook used identically by live events and `AcpReplayCollector`; every
   existing plugin gets identity behavior. The Layer-2 mapper converts Antigravity command/output/image keys into bounded
   normalized fields, strips duplicate inline image bytes after retaining supported metadata, and preserves nonzero exit
   separately from protocol/tool failure.
-- Map raw permission requests into typed options before policy. `AntigravityInteractionService` classifies only valid
-  `interaction_` requests as single-choice questions, owns unique label-to-ID mapping and malformed-answer rejection,
-  filters `allow_always`, and preserves allow-once/reject/cancel without inventing an absent option.
-- Keep `AntigravityApprovalRegistry` focused on pending-request lifecycle and sending the already-normalized service
-  decision through the live ACP client; it does not parse raw provider maps or decide permission policy.
+- Map raw permission requests into typed options before policy. A connection-scoped
+  `AntigravityInteractionRepository` wraps the live ACP reply boundary. `AntigravityInteractionService` classifies valid
+  `interaction_` questions, owns unique label-to-ID mapping, malformed-answer rejection, safe option filtering, and
+  typed reply dispatch through that repository without inventing absent choices.
+- Keep `AntigravityApprovalRegistry` focused on pending lifecycle and delegation to the interaction service; it neither
+  parses provider maps, decides permission policy, nor sends directly through the ACP client.
 - Cover raw-to-typed catalog/permission mapping, fresh/restarted partial discovery, first-session account default,
   post-new/load/resume visibility, grouped/empty/stale models, failed selection/mode, duplicate labels/IDs, reject-kind
   choices, prompt-injection warning filtering, malformed requests, bounded payloads, and live/replay equality.
 
-### Step 7/12: Persistent ACP plugin composition
+### Step 8/12: Persistent ACP plugin composition
 
-- Create the unregistered `AntigravityPlugin` and `AntigravityPluginDescriptor`; registration waits for Step 8.
+- Create the unregistered `AntigravityPlugin` and `AntigravityPluginDescriptor`; registration waits for Step 9.
 - Add the smallest shared protected directory-registration seam. `AntigravitySessionMetadataStorage` alone lists
   bounded `.meta` files in the isolated conversations directory and decodes each through a typed generated DTO. It
   never reads SQLite or brain content.
@@ -740,26 +768,26 @@ documented invariant, they update that document immediately. Step 11 is final re
   `AntigravitySessionMetadataService` owns bounded scan, validation, deduplication, and privacy-safe malformed-entry
   skips, then returns one typed registration batch. The plugin consumes only that service and hands its batch to the
   shared protected bulk-registration seam; ordinary reads remain DB-only and scans run only for import/cold recovery.
-- In the descriptor composition root, build process-lifetime trackers, protocol mapper, interaction service, metadata
-  repository/service, process factory, and other peers. Define the required composer that combines a live
-  `AcpSessionConfigRepository`, mapper, and catalog tracker into the Step 6 options service. The connection hook invokes
-  it and creates the approval registry from the live client plus the existing interaction service; peers construct no
-  peers.
+- In the descriptor composition root, build process-lifetime trackers, mappers, metadata repository/service, process
+  factory, and other peers. The options composer combines a live `AcpSessionConfigRepository`, mapper, and tracker.
+  A separate interaction composer wraps the live ACP client in `AntigravityInteractionRepository`, passes it plus the
+  mapper to `AntigravityInteractionService`, and builds the approval registry from that service. The plugin invokes
+  composers but constructs no peers.
 - Add a backend-neutral protected ACP residency-preference hook whose default preserves today's load-first behavior.
   Antigravity selects resume-first for live residency, with availability fallback owned by shared ACP; history replay
   continues to use load. Cover unchanged existing plugins plus Antigravity load/resume fallback.
 - Cover new/load/resume, bridge restart directory recovery, long replay, two sessions, active cancel/delete, question
   cleanup, process crash/reconnect, stale auth, tombstone-compatible re-import, and idempotent dispose with ACP fakes.
 
-### Step 8/12: Local descriptor and activation
+### Step 9/12: Local descriptor and activation
 
-- Register the Step 7 `AntigravityPluginDescriptor` with `--antigravity-bin`. Setup inspection combines only static
+- Register the Step 8 `AntigravityPluginDescriptor` with `--antigravity-bin`. Setup inspection combines only static
   pair availability from `AntigravityRuntimeService` with profile auth readiness and creates no files/processes.
   Authentication and `ensureRuntime` prepare the profile environment, then request exact probe validation before use;
   keep abort checks and current-client guidance in their owning lifecycle services.
 - Launch every process through `PluginHost.processes`; never call `io.Process.start` directly.
 - Advertise browser authentication only while personal auth is required. Its action hint requires a current client and
-  tells unsupported older clients to update; do not claim a CLI or bridge-host login. Keep install absent until Step 9.
+  tells unsupported older clients to update; do not claim a CLI or bridge-host login. Keep install absent until Step 10.
 - Add the package dependency and descriptor to the bridge app registry through `AntigravityIdentity.pluginId`; do not
   add a shared `Harness` case. Update exact built-in, CLI-option, app composition, and architecture inventories.
   Preserve OpenCode as preferred default and on-demand start.
@@ -772,7 +800,7 @@ documented invariant, they update that document immediately. Step 11 is final re
 - Verify a missing runtime remains inert, an explicit pair is authoritative, local auth blocks only Antigravity, and a
   current client can route/list the generic built-in with the required disclosure.
 
-### Step 9/12: Managed runtime installation
+### Step 10/12: Managed runtime installation
 
 - Independently download all five registry archives; recompute SHA-256, archive size, member names/sizes, and compare
   against the registry/T3 evidence. Record only immutable public artifact facts; do not trust copied third-party hashes.
@@ -802,7 +830,7 @@ documented invariant, they update that document immediately. Step 11 is final re
   superseded cleanup, prior-runtime retention, unsupported host, slow extraction, timeout, and disk-failure messaging
   without building a second installer.
 
-### Step 10/12: Complete product guidance
+### Step 11/12: Complete guidance and reconcile regression documents
 
 - Complete README and architecture/operator docs with the final official pair/release, manual and managed setup,
   five-target support, macOS x64 gap, personal OAuth/remote callback, isolated profile, supervised mode, fresh-process
@@ -812,11 +840,9 @@ documented invariant, they update that document immediately. Step 11 is final re
   `Antigravity`; ID-only surfaces retain the generic `antigravity` name/plug fallback. Do not add an Antigravity branch
   or asset to `PregoBrandLogo`, add a presentation-only contract, or add provider-specific analytics.
 - Reconcile any remaining non-regression inventory/support prose without postponing behavior-critical disclosure from
-  Steps 8 or 9.
+  Steps 9 or 10.
 
-### Step 11/12: Reconcile regression documents
-
-Audit and reconcile at least the documents already updated with their feature PRs:
+Audit and reconcile at least the regression documents already updated with their feature PRs:
 
 - `plugin-setup-and-lifecycle.md`
 - `plugin-runtime-installation.md`

--- a/.plan/active/antigravity-harness/TRACKER.md
+++ b/.plan/active/antigravity-harness/TRACKER.md
@@ -158,8 +158,8 @@ applicable catalog entry from L1 through L5 across its required plugin/platform 
 - 2026-09-04 — Step 2 architecture review rejected handwritten additions to the shared ACP initialize parser. The
   correction keeps legacy parsing unchanged, maps raw initialize data to generated typed DTOs inside Layer 1, and
   exposes only typed values to Layer 2. The second review approved the corrected architecture.
-- 2026-09-04 — The combined runtime-contract WIP measured 2,209 changed lines, so local pair resolution moved to Step 3
-  and the final guidance/regression steps were combined to retain twelve PRs. No behavior or retirement coverage was
-  dropped.
+- 2026-09-04 — The combined runtime-contract WIP measured 2,209 changed lines, so local pair resolution moved to
+  Step 3 and the final guidance/regression steps were combined to retain twelve PRs. No behavior or retirement
+  coverage was dropped.
 - 2026-09-04 — Split Step 2 verification passed: generated output is fresh, Antigravity analysis and 10 tests pass,
   shared ACP analysis and 305 tests pass, and Git/Markdown validation reports no source-width or whitespace failures.

--- a/.plan/active/antigravity-harness/TRACKER.md
+++ b/.plan/active/antigravity-harness/TRACKER.md
@@ -161,5 +161,5 @@ applicable catalog entry from L1 through L5 across its required plugin/platform 
 - 2026-09-04 — The combined runtime-contract WIP measured 2,209 changed lines, so local pair resolution moved to
   Step 3 and the final guidance/regression steps were combined to retain twelve PRs. No behavior or retirement
   coverage was dropped.
-- 2026-09-04 — Split Step 2 verification passed: generated output is fresh, Antigravity analysis and 10 tests pass,
+- 2026-09-04 — Split Step 2 verification passed: generated output is fresh, Antigravity analysis and 11 tests pass,
   shared ACP analysis and 305 tests pass, and Git/Markdown validation reports no source-width or whitespace failures.

--- a/.plan/active/antigravity-harness/TRACKER.md
+++ b/.plan/active/antigravity-harness/TRACKER.md
@@ -3,26 +3,25 @@
 ## Current State
 
 - **Plan:** `.plan/active/antigravity-harness/PLAN.md`
-- **Status:** Step 1/12 open for review; Step 2/12 in progress locally
-- **Base:** `origin/main` at `a87f30ab98b07dd7262afba462a36d4fbcc2dd9a`
-- **Current PR branch:** `antigravity-acp-plan`
-- **Local successor:** `antigravity-harness-step-2-runtime-contract`
-- **Open PR:** [#1285](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1285) (Step 1)
-- **Next action:** monitor Step 1 while implementing and verifying Step 2 locally
+- **Status:** Step 1/12 merged; Step 2/12 in progress locally
+- **Base:** `origin/main` at `3d65382e8cd4e33bbaedaf6c6a679a24ad211320`
+- **Current branch:** `antigravity-harness-step-2-runtime-contract`
+- **Merged PR:** [#1285](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1285) (Step 1)
+- **Next action:** commit, push, and open the verified Step 2 PR; retain local-pair WIP for Step 3
 
 ## Fixed PR Series
 
-- [ ] Step 1/12 — `🌱 [antigravity-harness] docs: plan Antigravity ACP support [step 1/12]`
+- [x] Step 1/12 — `🌱 [antigravity-harness] docs: plan Antigravity ACP support [step 1/12]`
 - [ ] Step 2/12 — `⚙️ [antigravity-harness] feat(antigravity): pin the official ACP runtime contract [step 2/12]`
-- [ ] Step 3/12 — `🚧 [antigravity-harness] feat(auth): accept browser authentication continuations [step 3/12]`
-- [ ] Step 4/12 — `🚧 [antigravity-harness] feat(client): add remote browser authentication handoff [step 4/12]`
-- [ ] Step 5/12 — `🚧 [antigravity-harness] feat(antigravity): add isolated profile authentication [step 5/12]`
-- [ ] Step 6/12 — `🚧 [antigravity-harness] feat(antigravity): map ACP options and interactions [step 6/12]`
-- [ ] Step 7/12 — `🚧 [antigravity-harness] feat(antigravity): compose persistent ACP sessions [step 7/12]`
-- [ ] Step 8/12 — `⚙️ [antigravity-harness] feat(bridge): activate local Antigravity runtimes [step 8/12]`
-- [ ] Step 9/12 — `🚧 [antigravity-harness] feat(antigravity): install the managed ACP runtime [step 9/12]`
-- [ ] Step 10/12 — `🌱 [antigravity-harness] docs: complete Antigravity product guidance [step 10/12]`
-- [ ] Step 11/12 — `🌱 [antigravity-harness] docs: reconcile Antigravity regression coverage [step 11/12]`
+- [ ] Step 3/12 — `⚙️ [antigravity-harness] feat(antigravity): resolve local runtime pairs [step 3/12]`
+- [ ] Step 4/12 — `🚧 [antigravity-harness] feat(auth): accept browser authentication continuations [step 4/12]`
+- [ ] Step 5/12 — `🚧 [antigravity-harness] feat(client): add remote browser authentication handoff [step 5/12]`
+- [ ] Step 6/12 — `🚧 [antigravity-harness] feat(antigravity): add isolated profile authentication [step 6/12]`
+- [ ] Step 7/12 — `🚧 [antigravity-harness] feat(antigravity): map ACP options and interactions [step 7/12]`
+- [ ] Step 8/12 — `🚧 [antigravity-harness] feat(antigravity): compose persistent ACP sessions [step 8/12]`
+- [ ] Step 9/12 — `⚙️ [antigravity-harness] feat(bridge): activate local Antigravity runtimes [step 9/12]`
+- [ ] Step 10/12 — `🚧 [antigravity-harness] feat(antigravity): install the managed ACP runtime [step 10/12]`
+- [ ] Step 11/12 — `🌱 [antigravity-harness] docs: complete guidance and regression coverage [step 11/12]`
 - [ ] Step 12/12 — `🚧 [antigravity-harness] test: verify Antigravity and retire the plan [step 12/12]`
 
 ## Step 1 Checklist
@@ -39,6 +38,19 @@
 - [x] Commit, push, open the Step 1 PR, and start the PR monitor.
 - [x] Create the Step 2 successor branch and begin the package/runtime-contract work locally.
 
+## Step 2 Checklist
+
+- [x] Sync the successor branch to merged Step 1 and preserve the reviewed plan corrections.
+- [x] Independently download, hash, inspect, and initialize-probe the official macOS arm64 runtime pair.
+- [x] Separate shared ACP initialize-only and authenticate operations without changing combined callers.
+- [x] Add the inactive package, pair/launch facts, generated initialize DTO, release facts, and Layer-1 ACP probe API.
+- [x] Add the package to bridge workspace, Makefile, and CI discovery inventories without app registration.
+- [x] Cover official target/launch facts, generated parsing, malformed/timeout/abort/exit handling, and cleanup.
+- [x] Split local pair resolution into Step 3 after the combined diff measured above the 1,500-line cap.
+- [x] Complete architecture implementation review and apply the generated-DTO boundary finding.
+- [x] Run final focused analysis/tests and Git/Markdown validation.
+- [ ] Commit, push, open the Step 2 PR, and start the PR monitor.
+
 ## Architecture Reviews
 
 - **Plan review:** completed 2026-09-03. The reviewer rejected the first draft with six concrete findings across
@@ -51,8 +63,13 @@
   preflight and documents fresh-process first-session default-model behavior. The fourth wave adds metadata/setup
   service ownership, Layer-2 protocol mapping, per-feature regression updates, and current-client-only new auth. The
   fifth wave adds typed catalog/interaction mapping and policy ownership, staging-contained managed validation, and a
-  backend-neutral residency-preference hook.
-- **Implementation review:** required in Step 12 over the Step 2-10 production range; maximum two passes
+  backend-neutral residency-preference hook. A follow-up aligned the authentication-operation dependency list. Four
+  post-merge findings add layered interaction replies, Layer-2 auth-line mapping, useful local model diagnostics, and
+  atomic host-store injection for profile settings; these corrections travel with Step 2.
+- **Step 2 implementation review:** first pass rejected handwritten parsing of newly exposed ACP initialize fields. The
+  shared parser additions were reverted, and Layer 1 now maps into generated Antigravity Freezed/JSON DTOs before the
+  repository. The second and final pass approved the corrected architecture with no remaining violations.
+- **Series implementation review:** required in Step 12 over the Step 2-10 production range; maximum two passes
 
 ## Locked Decisions
 
@@ -60,15 +77,16 @@
 - Plugin ID/name: `antigravity` / `Antigravity`, owned by `sesori_plugin_antigravity`; no shared `Harness` case.
 - Exact initial pin: registry `1.0.0`, agent `agy_acp_server_20260818_01_RC01`.
 - Personal OAuth only in initial support; other advertised auth methods remain documented gaps.
-- Private profile under plugin state; no default-profile credential copy; POSIX setup applies owner-only mode through
-  an injected host-backed command boundary before agent launch.
+- Private profile under plugin state; no default-profile credential copy. Settings use the same plugin-scoped atomic
+  host store across authentication and live hosting, and POSIX setup applies owner-only mode before launch.
 - Remote auth uses pure-Dart generic loopback-input validation, then independent exact plugin validation before relay.
 - New browser authentication requires a current mobile/desktop client; older clients retain already-authenticated use
   and receive an update-client hint, with no claimed CLI/bridge-host login.
 - Agent mode is always `default`; `allow_always`, `auto_edit`, `yolo`, and dangerous skip are unavailable.
 - Before a process observes a model catalog from new/load/resume, options are partial and the first session uses the
   account default; no persistent scratch Google session is created for discovery. Raw catalogs and permissions cross
-  the plugin boundary through a Layer-2 mapper before their Layer-3 policy services or trackers consume them.
+  a Layer-2 mapper before policy, and outbound interaction replies cross a connection-scoped repository/service path.
+  Bounded model IDs remain in local failure diagnostics only; analytics carry none.
 - Shared ACP retains load-first residency by default; Antigravity selects resume-first through a backend-neutral hook.
 - Managed exact probing uses an owner-only disposable home inside staging before atomic placement; it cannot touch the
   persistent profile, authenticate, or create a session.
@@ -134,3 +152,13 @@ applicable catalog entry from L1 through L5 across its required plugin/platform 
 - 2026-09-04 — PR #1285 fifth review produced four actionable findings. The protocol mapper now normalizes
   catalogs and permission requests for owning services. Managed exact validation uses a disposable staging home before
   placement, and a backend-neutral ACP hook preserves load-first behavior while Antigravity selects resume-first.
+- 2026-09-04 — PR #1285 merged as `3d65382e8c`; a final post-merge review found four valid plan gaps. Step 2 carries
+  layered reply dispatch, Layer-2 auth parsing, bounded local model-ID diagnostics, and atomic profile settings.
+- 2026-09-04 — Step 2 architecture review rejected handwritten additions to the shared ACP initialize parser. The
+  correction keeps legacy parsing unchanged, maps raw initialize data to generated typed DTOs inside Layer 1, and
+  exposes only typed values to Layer 2. The second review approved the corrected architecture.
+- 2026-09-04 — The combined runtime-contract WIP measured 2,209 changed lines, so local pair resolution moved to Step 3
+  and the final guidance/regression steps were combined to retain twelve PRs. No behavior or retirement coverage was
+  dropped.
+- 2026-09-04 — Split Step 2 verification passed: generated output is fresh, Antigravity analysis and 10 tests pass,
+  shared ACP analysis and 305 tests pass, and Git/Markdown validation reports no source-width or whitespace failures.

--- a/.plan/active/antigravity-harness/TRACKER.md
+++ b/.plan/active/antigravity-harness/TRACKER.md
@@ -3,11 +3,12 @@
 ## Current State
 
 - **Plan:** `.plan/active/antigravity-harness/PLAN.md`
-- **Status:** Step 1/12 merged; Step 2/12 in progress locally
+- **Status:** Step 1/12 merged; Step 2/12 open for review
 - **Base:** `origin/main` at `3d65382e8cd4e33bbaedaf6c6a679a24ad211320`
 - **Current branch:** `antigravity-harness-step-2-runtime-contract`
 - **Merged PR:** [#1285](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1285) (Step 1)
-- **Next action:** commit, push, and open the verified Step 2 PR; retain local-pair WIP for Step 3
+- **Open PR:** [#1286](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1286) (Step 2)
+- **Next action:** monitor Step 2 through readiness; retain local-pair WIP for Step 3
 
 ## Fixed PR Series
 
@@ -49,7 +50,7 @@
 - [x] Split local pair resolution into Step 3 after the combined diff measured above the 1,500-line cap.
 - [x] Complete architecture implementation review and apply the generated-DTO boundary finding.
 - [x] Run final focused analysis/tests and Git/Markdown validation.
-- [ ] Commit, push, open the Step 2 PR, and start the PR monitor.
+- [x] Commit, push, open the Step 2 PR, and start the PR monitor.
 
 ## Architecture Reviews
 

--- a/bridge/Makefile
+++ b/bridge/Makefile
@@ -2,7 +2,7 @@ TOOL_VERSIONS := $(shell git rev-parse --show-toplevel)/.tool-versions
 FLUTTER_VERSION := $(shell grep '^flutter' $(TOOL_VERSIONS) | awk '{print $$2}')
 DART := $(HOME)/.asdf/installs/flutter/$(FLUTTER_VERSION)/bin/cache/dart-sdk/bin/dart
 
-MODULES := sesori_plugin_interface sesori_bridge_foundation sesori_plugin_runtime sesori_plugin_opencode sesori_plugin_codex sesori_plugin_acp sesori_plugin_cursor sesori_plugin_omp sesori_plugin_claude sesori_plugin_pi sesori_plugin_hermes sesori_plugin_grok sesori_plugin_deepseek sesori_plugin_copilot app
+MODULES := sesori_plugin_interface sesori_bridge_foundation sesori_plugin_runtime sesori_plugin_opencode sesori_plugin_codex sesori_plugin_acp sesori_plugin_cursor sesori_plugin_omp sesori_plugin_claude sesori_plugin_pi sesori_plugin_hermes sesori_plugin_grok sesori_plugin_deepseek sesori_plugin_antigravity sesori_plugin_copilot app
 
 .PHONY: codegen opencode-codegen pub-get test analyze
 

--- a/bridge/pubspec.yaml
+++ b/bridge/pubspec.yaml
@@ -20,3 +20,4 @@ workspace:
   - sesori_plugin_hermes
   - sesori_plugin_grok
   - sesori_plugin_deepseek
+  - sesori_plugin_antigravity

--- a/bridge/sesori_plugin_acp/lib/src/api/acp_agent_api.dart
+++ b/bridge/sesori_plugin_acp/lib/src/api/acp_agent_api.dart
@@ -28,15 +28,13 @@ class AcpAgentApi({required final AcpStdioClient client}) {
   /// with a remaining budget (the scratch catalog/cleanup leases) cannot
   /// overrun it by a second full timeout on the auth round trip.
   ///
-  /// [authMethodId] names the method to authenticate with. When it is `null`,
-  /// the first advertised non-terminal method allowed by [authMethodAllowlist]
-  /// is selected. A `null` allowlist preserves the unrestricted stock behavior.
+  /// Existing callers use this combined operation. Runtime probes that must
+  /// inspect an unauthenticated agent use [initializeOnly] instead.
   ///
-  /// Throws [StateError] when the agent negotiates a protocol version other
-  /// than v1 (it could not understand our v1-shaped `session/*` calls),
-  /// [PluginAuthenticationRequiredException] when no usable auth method exists
-  /// or the agent rejects authentication, and [TimeoutException] when the
-  /// deadline passes.
+  /// Throws [StateError] for an unsupported protocol version,
+  /// [PluginAuthenticationRequiredException] when no usable method exists or
+  /// authentication fails, and [TimeoutException] when the shared deadline
+  /// passes.
   Future<AcpInitializeResult> initialize({
     required bool formElicitation,
     required Map<String, dynamic>? capabilityMeta,
@@ -45,6 +43,38 @@ class AcpAgentApi({required final AcpStdioClient client}) {
     required Duration timeout,
   }) async {
     final deadline = Stopwatch()..start();
+    final init = await initializeOnly(
+      formElicitation: formElicitation,
+      capabilityMeta: capabilityMeta,
+      timeout: timeout,
+    );
+    _validateProtocolVersion(init);
+    if (!init.requiresAuth) return init;
+
+    final remaining = timeout - deadline.elapsed;
+    if (remaining <= Duration.zero) {
+      throw TimeoutException("${client.logTag} initialize handshake exceeded its deadline before authenticate");
+    }
+    await authenticate(
+      initializeResult: init,
+      authMethodId: authMethodId,
+      authMethodAllowlist: authMethodAllowlist,
+      timeout: remaining,
+    );
+    return init;
+  }
+
+  /// Sends and parses only the standard ACP `initialize` request.
+  ///
+  /// This deliberately returns the negotiated version and advertised auth
+  /// methods without validating policy or invoking authentication. It is for
+  /// runtime probes that must inspect an unauthenticated agent. The combined
+  /// [initialize] operation still rejects unsupported protocol versions.
+  Future<AcpInitializeResult> initializeOnly({
+    required bool formElicitation,
+    required Map<String, dynamic>? capabilityMeta,
+    required Duration timeout,
+  }) async {
     final raw = await client.request(
       method: AcpMethods.initialize,
       params: buildInitializeParams(
@@ -53,17 +83,25 @@ class AcpAgentApi({required final AcpStdioClient client}) {
       ),
       timeout: timeout,
     );
-    final init = AcpInitializeResult.fromJson(_asJson(raw));
-    // A missing version parses as v1, so agents that omit the field (some
-    // cursor-agent builds) still connect.
-    if (init.protocolVersion != acpProtocolVersion) {
-      throw StateError(
-        "ACP agent negotiated protocol version ${init.protocolVersion}, "
-        "but this client only speaks v$acpProtocolVersion",
-      );
-    }
-    if (!init.requiresAuth) return init;
-    final methodId = authMethodId ?? _firstNonTerminalAuthMethod(init: init, allowlist: authMethodAllowlist);
+    return AcpInitializeResult.fromJson(_asJson(raw));
+  }
+
+  /// Authenticates using a method advertised by [initializeResult].
+  ///
+  /// [authMethodId] names the method explicitly. When it is `null`, the first
+  /// advertised non-terminal method allowed by [authMethodAllowlist] is used.
+  /// A `null` allowlist preserves the unrestricted stock behavior. Throws
+  /// [PluginAuthenticationRequiredException] when no usable method exists or
+  /// authentication fails, and [TimeoutException] for an elapsed deadline.
+  Future<void> authenticate({
+    required AcpInitializeResult initializeResult,
+    required String? authMethodId,
+    required Set<String>? authMethodAllowlist,
+    required Duration timeout,
+  }) async {
+    if (!initializeResult.requiresAuth) return;
+    final methodId =
+        authMethodId ?? _firstNonTerminalAuthMethod(init: initializeResult, allowlist: authMethodAllowlist);
     if (methodId == null) {
       throw PluginAuthenticationRequiredException(
         AcpMethods.authenticate,
@@ -71,15 +109,14 @@ class AcpAgentApi({required final AcpStdioClient client}) {
         message: "${client.logTag} requires an authentication method the bridge cannot complete",
       );
     }
-    final remaining = timeout - deadline.elapsed;
-    if (remaining <= Duration.zero) {
-      throw TimeoutException("${client.logTag} initialize handshake exceeded its deadline before authenticate");
+    if (timeout <= Duration.zero) {
+      throw TimeoutException("${client.logTag} authentication deadline has elapsed");
     }
     try {
       await client.request(
         method: AcpMethods.authenticate,
         params: {"methodId": methodId},
-        timeout: remaining,
+        timeout: timeout,
       );
     } on AcpRpcException catch (error) {
       if (error.method != "<response>") rethrow;
@@ -90,7 +127,6 @@ class AcpAgentApi({required final AcpStdioClient client}) {
         cause: error,
       );
     }
-    return init;
   }
 
   /// `session/new` in [cwd]. Throws [StateError] when the agent answers
@@ -195,6 +231,17 @@ class AcpAgentApi({required final AcpStdioClient client}) {
 
   static Map<String, dynamic> _asJson(Object? raw) =>
       raw is Map ? raw.cast<String, dynamic>() : const <String, dynamic>{};
+
+  static void _validateProtocolVersion(AcpInitializeResult init) {
+    // A missing version parses as v1, so agents that omit the field (some
+    // cursor-agent builds) still connect.
+    if (init.protocolVersion != acpProtocolVersion) {
+      throw StateError(
+        "ACP agent negotiated protocol version ${init.protocolVersion}, "
+        "but this client only speaks v$acpProtocolVersion",
+      );
+    }
+  }
 
   static String? _firstNonTerminalAuthMethod({
     required AcpInitializeResult init,

--- a/bridge/sesori_plugin_acp/test/acp_agent_api_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_agent_api_test.dart
@@ -42,6 +42,79 @@ void main() {
       "authMethods": authMethods,
     };
 
+    test("initializeOnly returns auth methods without authenticating", () async {
+      final initializing = api.initializeOnly(
+        formElicitation: false,
+        capabilityMeta: null,
+        timeout: const Duration(seconds: 5),
+      );
+      final initialize = await waitForFrame("initialize");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": initialize["id"],
+        "result": initializeResult(
+          authMethods: [
+            {"id": "oauth-personal", "name": "Log in with Google"},
+          ],
+        ),
+      });
+
+      final result = await initializing;
+
+      expect(result.authMethods.single.id, "oauth-personal");
+      expect(fake.written.where((frame) => frame["method"] == "authenticate"), isEmpty);
+    });
+
+    test("initializeOnly returns an unsupported negotiated version for probe policy", () async {
+      final initializing = api.initializeOnly(
+        formElicitation: false,
+        capabilityMeta: null,
+        timeout: const Duration(seconds: 5),
+      );
+      final initialize = await waitForFrame("initialize");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": initialize["id"],
+        "result": {
+          ...initializeResult(authMethods: const []),
+          "protocolVersion": 2,
+        },
+      });
+
+      expect((await initializing).protocolVersion, 2);
+    });
+
+    test("authenticate can continue an initializeOnly result", () async {
+      final initializing = api.initializeOnly(
+        formElicitation: false,
+        capabilityMeta: null,
+        timeout: const Duration(seconds: 5),
+      );
+      final initialize = await waitForFrame("initialize");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": initialize["id"],
+        "result": initializeResult(
+          authMethods: [
+            {"id": "oauth-personal", "name": "Log in with Google"},
+          ],
+        ),
+      });
+      final initialized = await initializing;
+
+      final authenticating = api.authenticate(
+        initializeResult: initialized,
+        authMethodId: "oauth-personal",
+        authMethodAllowlist: null,
+        timeout: const Duration(seconds: 5),
+      );
+      final authenticate = await waitForFrame("authenticate");
+      expect(authenticate["params"], {"methodId": "oauth-personal"});
+      fake.emit({"jsonrpc": "2.0", "id": authenticate["id"], "result": <String, dynamic>{}});
+
+      await authenticating;
+    });
+
     test("picks the first non-terminal auth method when none is configured", () async {
       final initializing = api.initialize(
         formElicitation: false,

--- a/bridge/sesori_plugin_antigravity/analysis_options.yaml
+++ b/bridge/sesori_plugin_antigravity/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../analysis_options.yaml

--- a/bridge/sesori_plugin_antigravity/build.yaml
+++ b/bridge/sesori_plugin_antigravity/build.yaml
@@ -1,0 +1,13 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          any_map: true
+          explicit_to_json: true
+          include_if_null: false
+      freezed:
+        options:
+          format: false
+          map: false
+          when: false

--- a/bridge/sesori_plugin_antigravity/lib/antigravity_plugin.dart
+++ b/bridge/sesori_plugin_antigravity/lib/antigravity_plugin.dart
@@ -1,0 +1,9 @@
+/// Google Antigravity ACP runtime contract and plugin foundations.
+library;
+
+export "src/api/antigravity_acp_api.dart";
+export "src/api/models/antigravity_initialize_dto.dart";
+export "src/builders/antigravity_launch_spec_builder.dart";
+export "src/foundation/antigravity_identity.dart";
+export "src/foundation/antigravity_release.dart";
+export "src/models/antigravity_runtime_pair.dart";

--- a/bridge/sesori_plugin_antigravity/lib/src/api/antigravity_acp_api.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/api/antigravity_acp_api.dart
@@ -36,7 +36,9 @@ class AntigravityAcpApi({required final AcpProcessFactory _processFactory}) {
         deadline: deadline,
         abortSignal: abortSignal,
       );
-      return AntigravityInitializeDto.fromJson(initialized.raw);
+      final result = AntigravityInitializeDto.fromJson(initialized.raw);
+      _throwIfAborted(abortSignal: abortSignal);
+      return result;
     } finally {
       await client.dispose();
     }

--- a/bridge/sesori_plugin_antigravity/lib/src/api/antigravity_acp_api.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/api/antigravity_acp_api.dart
@@ -1,0 +1,73 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "models/antigravity_initialize_dto.dart";
+
+/// Layer-1 ACP process boundary used by unauthenticated runtime probes.
+class AntigravityAcpApi({required final AcpProcessFactory _processFactory}) {
+  Future<AntigravityInitializeDto> initializeOnly({
+    required AcpLaunchSpec launchSpec,
+    required Duration timeout,
+    required StartAbortSignal abortSignal,
+  }) async {
+    final deadline = Stopwatch()..start();
+    _throwIfAborted(abortSignal: abortSignal);
+    final client = AcpStdioClient(
+      launchSpec: launchSpec,
+      processFactory: _processFactory,
+      logTag: "antigravity-probe",
+    );
+    try {
+      await _awaitPhase(
+        operation: client.connect(),
+        timeout: timeout,
+        deadline: deadline,
+        abortSignal: abortSignal,
+      );
+      final initialized = await _awaitPhase(
+        operation: AcpAgentApi(client: client).initializeOnly(
+          formElicitation: false,
+          capabilityMeta: null,
+          timeout: _remaining(timeout: timeout, deadline: deadline),
+        ),
+        timeout: timeout,
+        deadline: deadline,
+        abortSignal: abortSignal,
+      );
+      return AntigravityInitializeDto.fromJson(initialized.raw);
+    } finally {
+      await client.dispose();
+    }
+  }
+
+  Future<T> _awaitPhase<T>({
+    required Future<T> operation,
+    required Duration timeout,
+    required Stopwatch deadline,
+    required StartAbortSignal abortSignal,
+  }) {
+    _throwIfAborted(abortSignal: abortSignal);
+    final remaining = _remaining(timeout: timeout, deadline: deadline);
+    return Future.any<T>([
+      operation,
+      abortSignal.whenAborted.then<T>((_) => throw const PluginStartAbortedException()),
+    ]).timeout(
+      remaining,
+      onTimeout: () => throw TimeoutException("Antigravity ACP initialize probe exceeded its deadline"),
+    );
+  }
+
+  Duration _remaining({required Duration timeout, required Stopwatch deadline}) {
+    final remaining = timeout - deadline.elapsed;
+    if (remaining <= Duration.zero) {
+      throw TimeoutException("Antigravity ACP initialize probe exceeded its deadline");
+    }
+    return remaining;
+  }
+
+  void _throwIfAborted({required StartAbortSignal abortSignal}) {
+    if (abortSignal.isAborted) throw const PluginStartAbortedException();
+  }
+}

--- a/bridge/sesori_plugin_antigravity/lib/src/api/models/antigravity_initialize_dto.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/api/models/antigravity_initialize_dto.dart
@@ -1,0 +1,89 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "antigravity_initialize_dto.freezed.dart";
+part "antigravity_initialize_dto.g.dart";
+
+const _dtoOptions = Freezed(
+  fromJson: true,
+  toJson: false,
+  copyWith: false,
+  equal: false,
+  toStringOverride: false,
+);
+
+/// Released `initialize` fields used by the Antigravity runtime contract probe.
+@_dtoOptions
+sealed class AntigravityInitializeDto with _$AntigravityInitializeDto {
+  const factory({
+    required int? protocolVersion,
+    required AntigravityAgentInfoDto? agentInfo,
+    required AntigravityAgentCapabilitiesDto? agentCapabilities,
+    required List<AntigravityAuthMethodDto>? authMethods,
+  }) = _AntigravityInitializeDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$AntigravityInitializeDtoFromJson(json);
+}
+
+@_dtoOptions
+sealed class AntigravityAgentInfoDto with _$AntigravityAgentInfoDto {
+  const factory({
+    required String? name,
+    required String? title,
+    required String? version,
+  }) = _AntigravityAgentInfoDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$AntigravityAgentInfoDtoFromJson(json);
+}
+
+@_dtoOptions
+sealed class AntigravityAgentCapabilitiesDto with _$AntigravityAgentCapabilitiesDto {
+  const factory({
+    required bool? loadSession,
+    required AntigravitySessionCapabilitiesDto? sessionCapabilities,
+    required AntigravityAuthCapabilitiesDto? auth,
+  }) = _AntigravityAgentCapabilitiesDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$AntigravityAgentCapabilitiesDtoFromJson(json);
+}
+
+@_dtoOptions
+sealed class AntigravitySessionCapabilitiesDto with _$AntigravitySessionCapabilitiesDto {
+  const factory({
+    @AntigravityCapabilityPresenceConverter() required bool list,
+    @AntigravityCapabilityPresenceConverter() required bool resume,
+    @AntigravityCapabilityPresenceConverter() required bool close,
+  }) = _AntigravitySessionCapabilitiesDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$AntigravitySessionCapabilitiesDtoFromJson(json);
+}
+
+@_dtoOptions
+sealed class AntigravityAuthCapabilitiesDto with _$AntigravityAuthCapabilitiesDto {
+  const factory({
+    @AntigravityCapabilityPresenceConverter() required bool logout,
+  }) = _AntigravityAuthCapabilitiesDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$AntigravityAuthCapabilitiesDtoFromJson(json);
+}
+
+@_dtoOptions
+sealed class AntigravityAuthMethodDto with _$AntigravityAuthMethodDto {
+  const factory({required String? id}) = _AntigravityAuthMethodDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$AntigravityAuthMethodDtoFromJson(json);
+}
+
+/// ACP capability markers are advertised as objects; explicit `false` and
+/// omission both mean unsupported.
+// ignore: no_slop_linter/prefer_specific_type, ACP capability markers are object-or-false wire values
+class const AntigravityCapabilityPresenceConverter() implements JsonConverter<bool, Object?> {
+  @override
+  bool fromJson(Object? json) => switch (json) {
+    null || false => false,
+    true || Map<Object?, Object?>() => true,
+    _ => throw const FormatException("invalid ACP capability marker"),
+  };
+
+  @override
+  Object? toJson(bool object) => object ? const <String, dynamic>{} : null;
+}

--- a/bridge/sesori_plugin_antigravity/lib/src/api/models/antigravity_initialize_dto.freezed.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/api/models/antigravity_initialize_dto.freezed.dart
@@ -1,0 +1,266 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint, type=warning, deprecated_member_use, deprecated_member_use_from_same_package
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'antigravity_initialize_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$AntigravityInitializeDto {
+
+ int? get protocolVersion; AntigravityAgentInfoDto? get agentInfo; AntigravityAgentCapabilitiesDto? get agentCapabilities; List<AntigravityAuthMethodDto>? get authMethods;
+
+
+
+
+
+
+
+}
+
+
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _AntigravityInitializeDto implements AntigravityInitializeDto {
+  const _AntigravityInitializeDto({required this.protocolVersion, required this.agentInfo, required this.agentCapabilities, required  List<AntigravityAuthMethodDto>? authMethods}): _authMethods = authMethods;
+  factory _AntigravityInitializeDto.fromJson(Map<String, dynamic> json) => _$AntigravityInitializeDtoFromJson(json);
+
+@override final  int? protocolVersion;
+@override final  AntigravityAgentInfoDto? agentInfo;
+@override final  AntigravityAgentCapabilitiesDto? agentCapabilities;
+ final  List<AntigravityAuthMethodDto>? _authMethods;
+@override List<AntigravityAuthMethodDto>? get authMethods {
+  final value = _authMethods;
+  if (value == null) return null;
+  if (_authMethods is EqualUnmodifiableListView) return _authMethods;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+
+
+
+
+
+
+
+
+}
+
+
+
+
+
+/// @nodoc
+mixin _$AntigravityAgentInfoDto {
+
+ String? get name; String? get title; String? get version;
+
+
+
+
+
+
+
+}
+
+
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _AntigravityAgentInfoDto implements AntigravityAgentInfoDto {
+  const _AntigravityAgentInfoDto({required this.name, required this.title, required this.version});
+  factory _AntigravityAgentInfoDto.fromJson(Map<String, dynamic> json) => _$AntigravityAgentInfoDtoFromJson(json);
+
+@override final  String? name;
+@override final  String? title;
+@override final  String? version;
+
+
+
+
+
+
+
+
+}
+
+
+
+
+
+/// @nodoc
+mixin _$AntigravityAgentCapabilitiesDto {
+
+ bool? get loadSession; AntigravitySessionCapabilitiesDto? get sessionCapabilities; AntigravityAuthCapabilitiesDto? get auth;
+
+
+
+
+
+
+
+}
+
+
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _AntigravityAgentCapabilitiesDto implements AntigravityAgentCapabilitiesDto {
+  const _AntigravityAgentCapabilitiesDto({required this.loadSession, required this.sessionCapabilities, required this.auth});
+  factory _AntigravityAgentCapabilitiesDto.fromJson(Map<String, dynamic> json) => _$AntigravityAgentCapabilitiesDtoFromJson(json);
+
+@override final  bool? loadSession;
+@override final  AntigravitySessionCapabilitiesDto? sessionCapabilities;
+@override final  AntigravityAuthCapabilitiesDto? auth;
+
+
+
+
+
+
+
+
+}
+
+
+
+
+
+/// @nodoc
+mixin _$AntigravitySessionCapabilitiesDto {
+
+@AntigravityCapabilityPresenceConverter() bool get list;@AntigravityCapabilityPresenceConverter() bool get resume;@AntigravityCapabilityPresenceConverter() bool get close;
+
+
+
+
+
+
+
+}
+
+
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _AntigravitySessionCapabilitiesDto implements AntigravitySessionCapabilitiesDto {
+  const _AntigravitySessionCapabilitiesDto({@AntigravityCapabilityPresenceConverter() required this.list, @AntigravityCapabilityPresenceConverter() required this.resume, @AntigravityCapabilityPresenceConverter() required this.close});
+  factory _AntigravitySessionCapabilitiesDto.fromJson(Map<String, dynamic> json) => _$AntigravitySessionCapabilitiesDtoFromJson(json);
+
+@override@AntigravityCapabilityPresenceConverter() final  bool list;
+@override@AntigravityCapabilityPresenceConverter() final  bool resume;
+@override@AntigravityCapabilityPresenceConverter() final  bool close;
+
+
+
+
+
+
+
+
+}
+
+
+
+
+
+/// @nodoc
+mixin _$AntigravityAuthCapabilitiesDto {
+
+@AntigravityCapabilityPresenceConverter() bool get logout;
+
+
+
+
+
+
+
+}
+
+
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _AntigravityAuthCapabilitiesDto implements AntigravityAuthCapabilitiesDto {
+  const _AntigravityAuthCapabilitiesDto({@AntigravityCapabilityPresenceConverter() required this.logout});
+  factory _AntigravityAuthCapabilitiesDto.fromJson(Map<String, dynamic> json) => _$AntigravityAuthCapabilitiesDtoFromJson(json);
+
+@override@AntigravityCapabilityPresenceConverter() final  bool logout;
+
+
+
+
+
+
+
+
+}
+
+
+
+
+
+/// @nodoc
+mixin _$AntigravityAuthMethodDto {
+
+ String? get id;
+
+
+
+
+
+
+
+}
+
+
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _AntigravityAuthMethodDto implements AntigravityAuthMethodDto {
+  const _AntigravityAuthMethodDto({required this.id});
+  factory _AntigravityAuthMethodDto.fromJson(Map<String, dynamic> json) => _$AntigravityAuthMethodDtoFromJson(json);
+
+@override final  String? id;
+
+
+
+
+
+
+
+
+}
+
+
+
+
+// dart format on

--- a/bridge/sesori_plugin_antigravity/lib/src/api/models/antigravity_initialize_dto.g.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/api/models/antigravity_initialize_dto.g.dart
@@ -1,0 +1,73 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'antigravity_initialize_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_AntigravityInitializeDto _$AntigravityInitializeDtoFromJson(Map json) =>
+    _AntigravityInitializeDto(
+      protocolVersion: (json['protocolVersion'] as num?)?.toInt(),
+      agentInfo: json['agentInfo'] == null
+          ? null
+          : AntigravityAgentInfoDto.fromJson(
+              Map<String, dynamic>.from(json['agentInfo'] as Map),
+            ),
+      agentCapabilities: json['agentCapabilities'] == null
+          ? null
+          : AntigravityAgentCapabilitiesDto.fromJson(
+              Map<String, dynamic>.from(json['agentCapabilities'] as Map),
+            ),
+      authMethods: (json['authMethods'] as List<dynamic>?)
+          ?.map(
+            (e) => AntigravityAuthMethodDto.fromJson(
+              Map<String, dynamic>.from(e as Map),
+            ),
+          )
+          .toList(),
+    );
+
+_AntigravityAgentInfoDto _$AntigravityAgentInfoDtoFromJson(Map json) =>
+    _AntigravityAgentInfoDto(
+      name: json['name'] as String?,
+      title: json['title'] as String?,
+      version: json['version'] as String?,
+    );
+
+_AntigravityAgentCapabilitiesDto _$AntigravityAgentCapabilitiesDtoFromJson(
+  Map json,
+) => _AntigravityAgentCapabilitiesDto(
+  loadSession: json['loadSession'] as bool?,
+  sessionCapabilities: json['sessionCapabilities'] == null
+      ? null
+      : AntigravitySessionCapabilitiesDto.fromJson(
+          Map<String, dynamic>.from(json['sessionCapabilities'] as Map),
+        ),
+  auth: json['auth'] == null
+      ? null
+      : AntigravityAuthCapabilitiesDto.fromJson(
+          Map<String, dynamic>.from(json['auth'] as Map),
+        ),
+);
+
+_AntigravitySessionCapabilitiesDto _$AntigravitySessionCapabilitiesDtoFromJson(
+  Map json,
+) => _AntigravitySessionCapabilitiesDto(
+  list: const AntigravityCapabilityPresenceConverter().fromJson(json['list']),
+  resume: const AntigravityCapabilityPresenceConverter().fromJson(
+    json['resume'],
+  ),
+  close: const AntigravityCapabilityPresenceConverter().fromJson(json['close']),
+);
+
+_AntigravityAuthCapabilitiesDto _$AntigravityAuthCapabilitiesDtoFromJson(
+  Map json,
+) => _AntigravityAuthCapabilitiesDto(
+  logout: const AntigravityCapabilityPresenceConverter().fromJson(
+    json['logout'],
+  ),
+);
+
+_AntigravityAuthMethodDto _$AntigravityAuthMethodDtoFromJson(Map json) =>
+    _AntigravityAuthMethodDto(id: json['id'] as String?);

--- a/bridge/sesori_plugin_antigravity/lib/src/builders/antigravity_launch_spec_builder.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/builders/antigravity_launch_spec_builder.dart
@@ -1,0 +1,23 @@
+import "package:acp_plugin/acp_plugin.dart";
+
+import "../foundation/antigravity_release.dart";
+import "../models/antigravity_runtime_pair.dart";
+
+/// Builds an ACP launch specification from one already-validated runtime pair.
+class const AntigravityLaunchSpecBuilder() {
+  AcpLaunchSpec build({
+    required AntigravityRuntimePair pair,
+    required String? cwd,
+    required Map<String, String> environment,
+  }) {
+    return AcpLaunchSpec(
+      command: pair.serverPath,
+      args: AntigravityRelease.launchArguments(target: pair.target),
+      cwd: cwd,
+      environment: Map<String, String>.unmodifiable({
+        ...environment,
+        AntigravityRelease.harnessPathEnvironmentKey: pair.harnessPath,
+      }),
+    );
+  }
+}

--- a/bridge/sesori_plugin_antigravity/lib/src/foundation/antigravity_identity.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/foundation/antigravity_identity.dart
@@ -1,0 +1,6 @@
+/// Stable Sesori and upstream identities for Google Antigravity.
+abstract final class AntigravityIdentity() {
+  static const String pluginId = "antigravity";
+  static const String displayName = "Antigravity";
+  static const String upstreamAgentName = "antigravity-acp";
+}

--- a/bridge/sesori_plugin_antigravity/lib/src/foundation/antigravity_release.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/foundation/antigravity_release.dart
@@ -1,0 +1,65 @@
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+
+/// Public facts pinned from Google's official ACP registry release.
+abstract final class AntigravityRelease() {
+  static const String registryCommit = "536e378b70a7a6d5f078a9160180e3569a23253c";
+  static const String registryPackageVersion = "1.0.0";
+  static const int protocolVersion = 1;
+  static const String agentVersion = "agy_acp_server_20260818_01_RC01";
+
+  static const String personalOauthMethodId = "oauth-personal";
+  static const Set<String> advertisedAuthenticationMethodIds = {
+    personalOauthMethodId,
+    "oauth-business",
+    "gemini-api-key",
+    "agent-platform",
+  };
+
+  static const String posixServerFileName = "agy_acp_server.par";
+  static const String posixHarnessFileName = "localharness_external";
+  static const String windowsServerFileName = "agy_acp_server.exe";
+  static const String windowsHarnessFileName = "localharness_external.exe";
+  static const String harnessPathEnvironmentKey = "ANTIGRAVITY_HARNESS_PATH";
+  static const String linuxUidArgument = "--uid=";
+
+  /// Immutable facts independently verified from the Step 2 macOS arm64 artifact.
+  static const String macosArm64ArchiveUrl =
+      "https://dl.google.com/agy-extensions/releases/macos/"
+      "agy-acp-server-agy_acp_server_20260818_01_RC01-darwin-arm64.zip";
+  static const String macosArm64ArchiveSha256 = "f122ca7e7030a27f9649da4cf1a7d80e12c48c5f6118ff35affc34d56cbf83dd";
+  static const int macosArm64ArchiveBytes = 314500221;
+  static const int macosArm64ServerBytes = 792105680;
+  static const String macosArm64ServerSha256 = "6d700b48eaaab70b1083b4d18d63e81b6d8cdc1da1c4670db29f5986f9d484ef";
+  static const int macosArm64HarnessBytes = 101551680;
+  static const String macosArm64HarnessSha256 = "34d78dd5fd0e24a628ed6487bc6a042ff9419f7122f5f761b001d218f2c9d026";
+
+  static bool supportsTarget({required PlatformTarget target}) => switch ((target.os, target.arch)) {
+    (PlatformOs.macos, PlatformArch.arm64) ||
+    (PlatformOs.linux, PlatformArch.x64) ||
+    (PlatformOs.linux, PlatformArch.arm64) ||
+    (PlatformOs.windows, PlatformArch.x64) ||
+    (PlatformOs.windows, PlatformArch.arm64) => true,
+    (PlatformOs.macos, PlatformArch.x64) => false,
+  };
+
+  static String serverFileName({required PlatformTarget target}) {
+    _requireSupported(target: target);
+    return target.os == PlatformOs.windows ? windowsServerFileName : posixServerFileName;
+  }
+
+  static String harnessFileName({required PlatformTarget target}) {
+    _requireSupported(target: target);
+    return target.os == PlatformOs.windows ? windowsHarnessFileName : posixHarnessFileName;
+  }
+
+  static List<String> launchArguments({required PlatformTarget target}) {
+    _requireSupported(target: target);
+    return target.os == PlatformOs.linux ? const [linuxUidArgument] : const [];
+  }
+
+  static void _requireSupported({required PlatformTarget target}) {
+    if (!supportsTarget(target: target)) {
+      throw UnsupportedError("Google does not publish Antigravity ACP for ${target.key}");
+    }
+  }
+}

--- a/bridge/sesori_plugin_antigravity/lib/src/models/antigravity_runtime_pair.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/models/antigravity_runtime_pair.dart
@@ -1,0 +1,43 @@
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+
+/// One official ACP server and its mandatory sibling harness.
+final class const AntigravityRuntimePair({
+  required final String serverPath,
+  required final String harnessPath,
+  required final PlatformTarget target,
+});
+
+enum AntigravityRuntimeComponent() {
+  server,
+  harness,
+}
+
+enum AntigravityRuntimePairInvalidReason() {
+  wrongServerName,
+  notAFile,
+  notSiblings,
+  notDistinct,
+}
+
+/// Layer-1 result of reading an official runtime pair from local storage.
+sealed class const AntigravityRuntimePairReadResult();
+
+final class const AntigravityRuntimePairFound({required final AntigravityRuntimePair pair})
+    extends AntigravityRuntimePairReadResult;
+
+final class const AntigravityRuntimePairMissing({required final AntigravityRuntimeComponent component})
+    extends AntigravityRuntimePairReadResult;
+
+final class const AntigravityRuntimePairInvalid({
+  required final AntigravityRuntimeComponent component,
+  required final AntigravityRuntimePairInvalidReason reason,
+}) extends AntigravityRuntimePairReadResult;
+
+final class const AntigravityRuntimeTargetUnsupported({required final PlatformTarget target})
+    extends AntigravityRuntimePairReadResult;
+
+final class const AntigravityRuntimeStorageFailure({
+  // ignore: no_slop_linter/prefer_specific_type, caught storage failures remain opaque
+  required final Object cause,
+  required final StackTrace stackTrace,
+}) extends AntigravityRuntimePairReadResult;

--- a/bridge/sesori_plugin_antigravity/lib/src/models/antigravity_runtime_pair.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/models/antigravity_runtime_pair.dart
@@ -6,38 +6,3 @@ final class const AntigravityRuntimePair({
   required final String harnessPath,
   required final PlatformTarget target,
 });
-
-enum AntigravityRuntimeComponent() {
-  server,
-  harness,
-}
-
-enum AntigravityRuntimePairInvalidReason() {
-  wrongServerName,
-  notAFile,
-  notSiblings,
-  notDistinct,
-}
-
-/// Layer-1 result of reading an official runtime pair from local storage.
-sealed class const AntigravityRuntimePairReadResult();
-
-final class const AntigravityRuntimePairFound({required final AntigravityRuntimePair pair})
-    extends AntigravityRuntimePairReadResult;
-
-final class const AntigravityRuntimePairMissing({required final AntigravityRuntimeComponent component})
-    extends AntigravityRuntimePairReadResult;
-
-final class const AntigravityRuntimePairInvalid({
-  required final AntigravityRuntimeComponent component,
-  required final AntigravityRuntimePairInvalidReason reason,
-}) extends AntigravityRuntimePairReadResult;
-
-final class const AntigravityRuntimeTargetUnsupported({required final PlatformTarget target})
-    extends AntigravityRuntimePairReadResult;
-
-final class const AntigravityRuntimeStorageFailure({
-  // ignore: no_slop_linter/prefer_specific_type, caught storage failures remain opaque
-  required final Object cause,
-  required final StackTrace stackTrace,
-}) extends AntigravityRuntimePairReadResult;

--- a/bridge/sesori_plugin_antigravity/pubspec.yaml
+++ b/bridge/sesori_plugin_antigravity/pubspec.yaml
@@ -1,0 +1,27 @@
+name: antigravity_plugin
+version: 0.1.0
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.13.2
+
+dependencies:
+  acp_plugin:
+    path: ../sesori_plugin_acp
+  freezed_annotation: ^3.1.0
+  json_annotation: ^4.12.0
+  path: ^1.9.1
+  sesori_bridge_foundation:
+    path: ../sesori_bridge_foundation
+  sesori_plugin_interface:
+    path: ../sesori_plugin_interface
+
+dev_dependencies:
+  build_runner: any
+  freezed: ^4.0.0
+  json_serializable: ^6.14.1
+  lints: ^6.1.0
+  sesori_shared:
+    path: ../../shared/sesori_shared
+  test: ^1.31.2

--- a/bridge/sesori_plugin_antigravity/test/antigravity_acp_api_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_acp_api_test.dart
@@ -1,0 +1,109 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:antigravity_plugin/antigravity_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  late FakeAcpProcess process;
+  late List<AcpLaunchSpec> launchSpecs;
+  late AntigravityAcpApi api;
+
+  setUp(() {
+    process = FakeAcpProcess();
+    launchSpecs = [];
+    api = AntigravityAcpApi(
+      processFactory: (spec) async {
+        launchSpecs.add(spec);
+        return process;
+      },
+    );
+  });
+  tearDown(() => process.close());
+
+  Future<Map<String, dynamic>> waitForInitialize() async {
+    for (var attempt = 0; attempt < 400; attempt++) {
+      final frames = process.written.where((frame) => frame["method"] == "initialize");
+      if (frames.isNotEmpty) return frames.last;
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+    throw StateError("agent never received initialize");
+  }
+
+  Future<AntigravityInitializeDto> probe({required Duration timeout, required StartAbortSignal abortSignal}) =>
+      api.initializeOnly(
+        launchSpec: const AcpLaunchSpec(command: "/runtime/agy_acp_server.par", args: []),
+        timeout: timeout,
+        abortSignal: abortSignal,
+      );
+
+  Map<String, dynamic> initializeResult() => {
+    "protocolVersion": 1,
+    "agentInfo": {
+      "name": "antigravity-acp",
+      "title": "Google Antigravity",
+      "version": AntigravityRelease.agentVersion,
+    },
+    "agentCapabilities": {
+      "loadSession": true,
+      "sessionCapabilities": {"list": <String, dynamic>{}, "resume": <String, dynamic>{}},
+      "auth": {"logout": <String, dynamic>{}},
+    },
+    "authMethods": [
+      {"id": "oauth-personal", "name": "Log in with Google"},
+    ],
+  };
+
+  test("runs initialize-only and cleans up without authenticating", () async {
+    final probing = probe(timeout: const Duration(seconds: 2), abortSignal: StartAbortSignal.never);
+    final initialize = await waitForInitialize();
+    process.emit({"jsonrpc": "2.0", "id": initialize["id"], "result": initializeResult()});
+
+    final result = await probing;
+    expect(launchSpecs.single.command, "/runtime/agy_acp_server.par");
+    expect((result.agentInfo?.name, result.authMethods?.single.id), ("antigravity-acp", "oauth-personal"));
+    expect(process.written.where((frame) => frame["method"] == "authenticate"), isEmpty);
+    expect(await process.exitCode, -15);
+  });
+
+  test("surfaces malformed initialize data and cleans up", () async {
+    final probing = probe(timeout: const Duration(seconds: 2), abortSignal: StartAbortSignal.never);
+    final initialize = await waitForInitialize();
+    process.emit({
+      "jsonrpc": "2.0",
+      "id": initialize["id"],
+      "result": {...initializeResult(), "protocolVersion": "invalid"},
+    });
+    await expectLater(probing, throwsA(isA<TypeError>()));
+    expect(await process.exitCode, -15);
+  });
+
+  test("bounds an unresponsive initialize request", () async {
+    final probing = probe(timeout: const Duration(milliseconds: 250), abortSignal: StartAbortSignal.never);
+    await waitForInitialize();
+    await expectLater(probing, throwsA(isA<TimeoutException>()));
+    expect(await process.exitCode, -15);
+  });
+
+  test("aborts an in-flight initialize and cleans up", () async {
+    final controller = StartAbortController();
+    final probing = probe(timeout: const Duration(seconds: 2), abortSignal: controller.signal);
+    await waitForInitialize();
+    controller.abort();
+    await expectLater(probing, throwsA(isA<PluginStartAbortedException>()));
+    expect(await process.exitCode, -15);
+  });
+
+  test("preserves process-exit context and cleans up", () async {
+    final probing = probe(timeout: const Duration(seconds: 2), abortSignal: StartAbortSignal.never);
+    await waitForInitialize();
+    process.exit(23);
+    await expectLater(
+      probing,
+      throwsA(isA<AcpRpcException>().having((error) => error.message, "message", contains("23"))),
+    );
+    expect(await process.exitCode, 23);
+  });
+}

--- a/bridge/sesori_plugin_antigravity/test/antigravity_acp_api_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_acp_api_test.dart
@@ -6,6 +6,16 @@ import "package:antigravity_plugin/antigravity_plugin.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
+class _AbortAfterInitializeSignal() implements StartAbortSignal {
+  int _polls = 0;
+
+  @override
+  bool get isAborted => ++_polls >= 4;
+
+  @override
+  Future<void> get whenAborted => Completer<void>().future;
+}
+
 void main() {
   late FakeAcpProcess process;
   late List<AcpLaunchSpec> launchSpecs;
@@ -92,6 +102,17 @@ void main() {
     final probing = probe(timeout: const Duration(seconds: 2), abortSignal: controller.signal);
     await waitForInitialize();
     controller.abort();
+    await expectLater(probing, throwsA(isA<PluginStartAbortedException>()));
+    expect(await process.exitCode, -15);
+  });
+
+  test("rechecks cancellation after initialize completes", () async {
+    final probing = probe(
+      timeout: const Duration(seconds: 2),
+      abortSignal: _AbortAfterInitializeSignal(),
+    );
+    final initialize = await waitForInitialize();
+    process.emit({"jsonrpc": "2.0", "id": initialize["id"], "result": initializeResult()});
     await expectLater(probing, throwsA(isA<PluginStartAbortedException>()));
     expect(await process.exitCode, -15);
   });

--- a/bridge/sesori_plugin_antigravity/test/antigravity_initialize_fixture_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_initialize_fixture_test.dart
@@ -1,0 +1,38 @@
+import "dart:io";
+
+import "package:antigravity_plugin/antigravity_plugin.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("official 1.0.0 initialize fixture preserves the released contract", () {
+    final dto = AntigravityInitializeDto.fromJson(
+      jsonDecodeMap(File("test/fixtures/official_initialize_1_0_0.json").readAsStringSync()),
+    );
+
+    expect(dto.protocolVersion, AntigravityRelease.protocolVersion);
+    expect(dto.agentInfo?.name, AntigravityIdentity.upstreamAgentName);
+    expect(dto.agentInfo?.title, "Google Antigravity");
+    expect(dto.agentInfo?.version, AntigravityRelease.agentVersion);
+    expect(dto.agentCapabilities?.loadSession, isTrue);
+    expect(dto.agentCapabilities?.sessionCapabilities?.list, isTrue);
+    expect(dto.agentCapabilities?.sessionCapabilities?.resume, isTrue);
+    expect(dto.agentCapabilities?.sessionCapabilities?.close, isFalse);
+    expect(dto.agentCapabilities?.auth?.logout, isTrue);
+    expect(
+      dto.authMethods?.map((method) => method.id).toSet(),
+      AntigravityRelease.advertisedAuthenticationMethodIds,
+    );
+  });
+
+  test("rejects a malformed capability marker at the generated boundary", () {
+    expect(
+      () => AntigravityInitializeDto.fromJson({
+        "agentCapabilities": {
+          "sessionCapabilities": {"list": "invalid"},
+        },
+      }),
+      throwsFormatException,
+    );
+  });
+}

--- a/bridge/sesori_plugin_antigravity/test/antigravity_release_and_launch_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_release_and_launch_test.dart
@@ -1,0 +1,106 @@
+import "package:antigravity_plugin/antigravity_plugin.dart";
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:test/test.dart";
+
+void main() {
+  const macArm = PlatformTarget(os: PlatformOs.macos, arch: PlatformArch.arm64);
+  const macX64 = PlatformTarget(os: PlatformOs.macos, arch: PlatformArch.x64);
+  const linuxX64 = PlatformTarget(os: PlatformOs.linux, arch: PlatformArch.x64);
+  const linuxArm = PlatformTarget(os: PlatformOs.linux, arch: PlatformArch.arm64);
+  const winX64 = PlatformTarget(os: PlatformOs.windows, arch: PlatformArch.x64);
+  const winArm = PlatformTarget(os: PlatformOs.windows, arch: PlatformArch.arm64);
+
+  test("pins the independently verified official release", () {
+    expect(
+      (
+        AntigravityIdentity.pluginId,
+        AntigravityIdentity.upstreamAgentName,
+        AntigravityRelease.registryCommit,
+        AntigravityRelease.registryPackageVersion,
+        AntigravityRelease.agentVersion,
+      ),
+      (
+        "antigravity",
+        "antigravity-acp",
+        "536e378b70a7a6d5f078a9160180e3569a23253c",
+        "1.0.0",
+        "agy_acp_server_20260818_01_RC01",
+      ),
+    );
+    expect(
+      (
+        AntigravityRelease.macosArm64ArchiveBytes,
+        AntigravityRelease.macosArm64ServerBytes,
+        AntigravityRelease.macosArm64HarnessBytes,
+      ),
+      (314500221, 792105680, 101551680),
+    );
+    expect(
+      AntigravityRelease.macosArm64ArchiveUrl,
+      "https://dl.google.com/agy-extensions/releases/macos/"
+      "agy-acp-server-agy_acp_server_20260818_01_RC01-darwin-arm64.zip",
+    );
+    expect(
+      AntigravityRelease.macosArm64ArchiveSha256,
+      "f122ca7e7030a27f9649da4cf1a7d80e12c48c5f6118ff35affc34d56cbf83dd",
+    );
+    expect(
+      AntigravityRelease.macosArm64ServerSha256,
+      "6d700b48eaaab70b1083b4d18d63e81b6d8cdc1da1c4670db29f5986f9d484ef",
+    );
+    expect(
+      AntigravityRelease.macosArm64HarnessSha256,
+      "34d78dd5fd0e24a628ed6487bc6a042ff9419f7122f5f761b001d218f2c9d026",
+    );
+    expect(
+      AntigravityRelease.advertisedAuthenticationMethodIds,
+      {"oauth-personal", "oauth-business", "gemini-api-key", "agent-platform"},
+    );
+  });
+
+  test("maps the five published targets and rejects macOS x64", () {
+    for (final target in [macArm, linuxX64, linuxArm, winX64, winArm]) {
+      expect(AntigravityRelease.supportsTarget(target: target), isTrue);
+    }
+    expect(AntigravityRelease.supportsTarget(target: macX64), isFalse);
+    expect(() => AntigravityRelease.serverFileName(target: macX64), throwsUnsupportedError);
+    expect(AntigravityRelease.serverFileName(target: winArm), "agy_acp_server.exe");
+    expect(AntigravityRelease.harnessFileName(target: winArm), "localharness_external.exe");
+    expect(AntigravityRelease.serverFileName(target: linuxArm), "agy_acp_server.par");
+    expect(AntigravityRelease.harnessFileName(target: linuxArm), "localharness_external");
+  });
+
+  test("builds exact Linux and Windows launch specs", () {
+    const linuxPair = AntigravityRuntimePair(
+      serverPath: "/runtime/agy_acp_server.par",
+      harnessPath: "/runtime/localharness_external",
+      target: linuxArm,
+    );
+    final linux = const AntigravityLaunchSpecBuilder().build(
+      pair: linuxPair,
+      cwd: "/workspace",
+      environment: const {"GEMINI_HOME": "/profile"},
+    );
+    expect((linux.command, linux.cwd), (linuxPair.serverPath, "/workspace"));
+    expect(linux.args, ["--uid="]);
+    expect(linux.environment, {
+      "GEMINI_HOME": "/profile",
+      "ANTIGRAVITY_HARNESS_PATH": linuxPair.harnessPath,
+    });
+    expect(() => linux.environment["ambient"] = "value", throwsUnsupportedError);
+
+    const windowsPair = AntigravityRuntimePair(
+      serverPath: r"C:\runtime\agy_acp_server.exe",
+      harnessPath: r"C:\runtime\localharness_external.exe",
+      target: winArm,
+    );
+    final windows = const AntigravityLaunchSpecBuilder().build(
+      pair: windowsPair,
+      cwd: null,
+      environment: const {},
+    );
+    expect(windows.command, windowsPair.serverPath);
+    expect(windows.args, isEmpty);
+    expect(windows.environment[AntigravityRelease.harnessPathEnvironmentKey], windowsPair.harnessPath);
+  });
+}

--- a/bridge/sesori_plugin_antigravity/test/fixtures/official_initialize_1_0_0.json
+++ b/bridge/sesori_plugin_antigravity/test/fixtures/official_initialize_1_0_0.json
@@ -1,0 +1,33 @@
+{
+  "protocolVersion": 1,
+  "agentInfo": {
+    "name": "antigravity-acp",
+    "title": "Google Antigravity",
+    "version": "agy_acp_server_20260818_01_RC01"
+  },
+  "agentCapabilities": {
+    "loadSession": true,
+    "mcpCapabilities": {
+      "http": true,
+      "sse": true
+    },
+    "promptCapabilities": {
+      "audio": true,
+      "embeddedContext": true,
+      "image": true
+    },
+    "sessionCapabilities": {
+      "list": {},
+      "resume": {}
+    },
+    "auth": {
+      "logout": {}
+    }
+  },
+  "authMethods": [
+    {"id": "oauth-personal"},
+    {"id": "oauth-business"},
+    {"id": "gemini-api-key"},
+    {"id": "agent-platform"}
+  ]
+}


### PR DESCRIPTION
## Complexity

⚙️ Moderate. This adds an inactive bridge package and a narrow shared ACP handshake seam, with generated wire DTOs and process-lifecycle cleanup. The PR is 1,456 changed lines including tests and generated output.

## What

- Add the unregistered `sesori_plugin_antigravity` package to bridge workspace and CI discovery.
- Pin Google Antigravity registry package `1.0.0` / runtime `agy_acp_server_20260818_01_RC01`, official pair names, supported targets, Linux argument, and independently verified macOS arm64 artifact facts.
- Split `AcpAgentApi.initialize` into separately callable initialize-only and authenticate operations while preserving all existing combined callers.
- Add a Layer-1 scratch ACP probe that parses released initialize data into generated typed Freezed/JSON DTOs before returning it.
- Add the pair launch-spec builder, privacy-safe official initialize fixture, and focused boundary tests.
- Split local pair Storage/Repository/Service resolution into Step 3 to remain under the 1,500-line PR cap; combine the final small docs steps so the plan remains twelve PRs.

## Why

Antigravity must verify the official proprietary ACP runtime without authenticating, creating a session, or trusting raw provider data above Layer 1. This establishes that boundary before local runtime selection and later profile/authentication work.

## Risk and test focus

Primary risk is changing initialization behavior for existing ACP plugins or leaking an unauthenticated probe process. Tests preserve combined initialization/authentication behavior, exercise separate continuation, parse the released typed contract, and cover malformed data, timeout, cancellation, process exit, and cleanup.

There is no user-visible behavior, database impact, app registration, managed download, or authentication flow in this PR.

## Expected result

The bridge workspace contains an inactive Antigravity contract package that can perform a bounded initialize-only probe over an already-prepared launch spec. Existing ACP harnesses continue using the unchanged combined handshake behavior.

## Verification

- `cd bridge/sesori_plugin_antigravity && dart analyze --fatal-infos`
- `cd bridge/sesori_plugin_antigravity && dart test` — 11 passed
- `cd bridge/sesori_plugin_acp && dart analyze --fatal-infos`
- `cd bridge/sesori_plugin_acp && dart test` — 305 passed
- `cd bridge/sesori_plugin_antigravity && dart run build_runner build`
- `git diff --check`
- Architecture implementation review: approved after replacing handwritten initialize-field parsing with generated Layer-1 DTO mapping.
