### PR TITLE
⚙️ [antigravity-harness] feat(antigravity): resolve local runtime pairs [step 3/12]

### DIFF
--- a/.plan/active/antigravity-harness/TRACKER.md
+++ b/.plan/active/antigravity-harness/TRACKER.md
@@ -181,5 +181,5 @@ applicable catalog entry from L1 through L5 across its required plugin/platform 
 - 2026-09-04 — Step 3 architecture implementation review approved the local Storage -> Repository -> Service flow with
   no violations. Antigravity analysis passes, all 29 tests pass, and Git/line-width validation is clean.
 - 2026-09-04 — Step 3's self-inclusive cap check used
-  `git diff --numstat 4c587bcefed5601a83b24d202b2edff75611cbe2 HEAD` with an additions/deletions sum: 1215 + 7 = 1222
+  `git diff --numstat 4c587bcefed5 031c4139a2c9` with an additions/deletions sum: 1215 + 7 = 1222
   changed lines, leaving 278 lines below the 1,500-line cap.

--- a/.plan/active/antigravity-harness/TRACKER.md
+++ b/.plan/active/antigravity-harness/TRACKER.md
@@ -179,7 +179,7 @@ applicable catalog entry from L1 through L5 across its required plugin/platform 
   shared ACP analysis and 305 tests pass, and Git/Markdown validation reports no source-width or whitespace failures.
 - 2026-09-04 — PR #1286 merged as `4c587bcefe` after 16/16 CI checks, resolved review feedback, and Cubic approval.
 - 2026-09-04 — Step 3 architecture implementation review approved the local Storage -> Repository -> Service flow with
-  no violations. Antigravity analysis passes, all 29 tests pass, and Git/line-width validation is clean.
+  no violations. Antigravity analysis passes, all 30 tests pass, and Git/line-width validation is clean.
 - 2026-09-04 — Step 3's self-inclusive cap check used
   `git diff --numstat 4c587bcefed5 031c4139a2c9` with an additions/deletions sum: 1215 + 7 = 1222
   changed lines, leaving 278 lines below the 1,500-line cap.

--- a/.plan/active/antigravity-harness/TRACKER.md
+++ b/.plan/active/antigravity-harness/TRACKER.md
@@ -3,12 +3,13 @@
 ## Current State
 
 - **Plan:** `.plan/active/antigravity-harness/PLAN.md`
-- **Status:** Steps 1-2/12 merged; Step 3/12 in progress locally
+- **Status:** Steps 1-2/12 merged; Step 3/12 open for review
 - **Base:** `origin/main` at `4c587bcefed5601a83b24d202b2edff75611cbe2`
 - **Current branch:** `antigravity-harness-step-3-runtime-resolution`
 - **Merged PRs:** [#1285](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1285) (Step 1),
   [#1286](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1286) (Step 2)
-- **Next action:** finish and verify local runtime resolution, then open the Step 3 PR
+- **Open PR:** [#1287](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1287) (Step 3)
+- **Next action:** monitor Step 3 through readiness and begin Step 4 locally
 
 ## Fixed PR Series
 
@@ -62,7 +63,7 @@
 - [x] Cover pair integrity, precedence, generated mapping, contract failures, aborts, timeouts, and cleanup.
 - [x] Complete architecture implementation review and apply valid findings.
 - [x] Run final focused analysis/tests and Git/Markdown validation.
-- [ ] Commit, push, open the Step 3 PR, and start the PR monitor.
+- [x] Commit, push, open the Step 3 PR, and start the PR monitor.
 
 ## Architecture Reviews
 

--- a/.plan/active/antigravity-harness/TRACKER.md
+++ b/.plan/active/antigravity-harness/TRACKER.md
@@ -3,17 +3,17 @@
 ## Current State
 
 - **Plan:** `.plan/active/antigravity-harness/PLAN.md`
-- **Status:** Step 1/12 merged; Step 2/12 open for review
-- **Base:** `origin/main` at `3d65382e8cd4e33bbaedaf6c6a679a24ad211320`
-- **Current branch:** `antigravity-harness-step-2-runtime-contract`
-- **Merged PR:** [#1285](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1285) (Step 1)
-- **Open PR:** [#1286](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1286) (Step 2)
-- **Next action:** monitor Step 2 through readiness; retain local-pair WIP for Step 3
+- **Status:** Steps 1-2/12 merged; Step 3/12 in progress locally
+- **Base:** `origin/main` at `4c587bcefed5601a83b24d202b2edff75611cbe2`
+- **Current branch:** `antigravity-harness-step-3-runtime-resolution`
+- **Merged PRs:** [#1285](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1285) (Step 1),
+  [#1286](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1286) (Step 2)
+- **Next action:** finish and verify local runtime resolution, then open the Step 3 PR
 
 ## Fixed PR Series
 
 - [x] Step 1/12 — `🌱 [antigravity-harness] docs: plan Antigravity ACP support [step 1/12]`
-- [ ] Step 2/12 — `⚙️ [antigravity-harness] feat(antigravity): pin the official ACP runtime contract [step 2/12]`
+- [x] Step 2/12 — `⚙️ [antigravity-harness] feat(antigravity): pin the official ACP runtime contract [step 2/12]`
 - [ ] Step 3/12 — `⚙️ [antigravity-harness] feat(antigravity): resolve local runtime pairs [step 3/12]`
 - [ ] Step 4/12 — `🚧 [antigravity-harness] feat(auth): accept browser authentication continuations [step 4/12]`
 - [ ] Step 5/12 — `🚧 [antigravity-harness] feat(client): add remote browser authentication handoff [step 5/12]`
@@ -51,6 +51,18 @@
 - [x] Complete architecture implementation review and apply the generated-DTO boundary finding.
 - [x] Run final focused analysis/tests and Git/Markdown validation.
 - [x] Commit, push, open the Step 2 PR, and start the PR monitor.
+
+## Step 3 Checklist
+
+- [x] Sync the successor branch to merged Step 2 and restore the retained local-pair WIP.
+- [x] Add typed pair-read and runtime-resolution outcomes at their first storage/repository consumers.
+- [x] Add exact filesystem/PATH pair inspection without creating files or processes.
+- [x] Map storage and generated initialize DTO outcomes through `AntigravityRuntimeRepository`.
+- [x] Implement service-owned explicit -> PATH -> managed precedence and exact contract validation.
+- [x] Cover pair integrity, precedence, generated mapping, contract failures, aborts, timeouts, and cleanup.
+- [x] Complete architecture implementation review and apply valid findings.
+- [x] Run final focused analysis/tests and Git/Markdown validation.
+- [ ] Commit, push, open the Step 3 PR, and start the PR monitor.
 
 ## Architecture Reviews
 
@@ -163,3 +175,6 @@ applicable catalog entry from L1 through L5 across its required plugin/platform 
   coverage was dropped.
 - 2026-09-04 — Split Step 2 verification passed: generated output is fresh, Antigravity analysis and 11 tests pass,
   shared ACP analysis and 305 tests pass, and Git/Markdown validation reports no source-width or whitespace failures.
+- 2026-09-04 — PR #1286 merged as `4c587bcefe` after 16/16 CI checks, resolved review feedback, and Cubic approval.
+- 2026-09-04 — Step 3 architecture implementation review approved the local Storage -> Repository -> Service flow with
+  no violations. Antigravity analysis passes, all 25 tests pass, and Git/line-width validation is clean.

--- a/.plan/active/antigravity-harness/TRACKER.md
+++ b/.plan/active/antigravity-harness/TRACKER.md
@@ -62,7 +62,8 @@
 - [x] Implement service-owned explicit -> PATH -> managed precedence and exact contract validation.
 - [x] Cover pair integrity, precedence, generated mapping, contract failures, aborts, timeouts, and cleanup.
 - [x] Complete architecture implementation review and apply valid findings.
-- [x] Run final focused analysis/tests and Git/Markdown validation.
+- [x] Run final focused analysis/tests and Git/Markdown validation, including self-inclusive merge-base numstat
+  reconciliation against the 1,500-line cap.
 - [x] Commit, push, open the Step 3 PR, and start the PR monitor.
 
 ## Architecture Reviews
@@ -178,4 +179,7 @@ applicable catalog entry from L1 through L5 across its required plugin/platform 
   shared ACP analysis and 305 tests pass, and Git/Markdown validation reports no source-width or whitespace failures.
 - 2026-09-04 — PR #1286 merged as `4c587bcefe` after 16/16 CI checks, resolved review feedback, and Cubic approval.
 - 2026-09-04 — Step 3 architecture implementation review approved the local Storage -> Repository -> Service flow with
-  no violations. Antigravity analysis passes, all 27 tests pass, and Git/line-width validation is clean.
+  no violations. Antigravity analysis passes, all 29 tests pass, and Git/line-width validation is clean.
+- 2026-09-04 — Step 3's self-inclusive cap check used
+  `git diff --numstat 4c587bcefed5601a83b24d202b2edff75611cbe2 HEAD` with an additions/deletions sum: 1215 + 7 = 1222
+  changed lines, leaving 278 lines below the 1,500-line cap.

--- a/.plan/active/antigravity-harness/TRACKER.md
+++ b/.plan/active/antigravity-harness/TRACKER.md
@@ -178,4 +178,4 @@ applicable catalog entry from L1 through L5 across its required plugin/platform 
   shared ACP analysis and 305 tests pass, and Git/Markdown validation reports no source-width or whitespace failures.
 - 2026-09-04 — PR #1286 merged as `4c587bcefe` after 16/16 CI checks, resolved review feedback, and Cubic approval.
 - 2026-09-04 — Step 3 architecture implementation review approved the local Storage -> Repository -> Service flow with
-  no violations. Antigravity analysis passes, all 25 tests pass, and Git/line-width validation is clean.
+  no violations. Antigravity analysis passes, all 27 tests pass, and Git/line-width validation is clean.

--- a/.plan/active/antigravity-harness/TRACKER.md
+++ b/.plan/active/antigravity-harness/TRACKER.md
@@ -181,5 +181,5 @@ applicable catalog entry from L1 through L5 across its required plugin/platform 
 - 2026-09-04 — Step 3 architecture implementation review approved the local Storage -> Repository -> Service flow with
   no violations. Antigravity analysis passes, all 30 tests pass, and Git/line-width validation is clean.
 - 2026-09-04 — Step 3's self-inclusive cap check used
-  `git diff --numstat 4c587bcefed5 031c4139a2c9` with an additions/deletions sum: 1215 + 7 = 1222
-  changed lines, leaving 278 lines below the 1,500-line cap.
+  `git diff --numstat 4c587bcefed5 1c7f3d955ac1` with an additions/deletions sum: 1246 + 7 = 1253
+  changed lines, leaving 247 lines below the 1,500-line cap.

--- a/bridge/sesori_plugin_antigravity/lib/antigravity_plugin.dart
+++ b/bridge/sesori_plugin_antigravity/lib/antigravity_plugin.dart
@@ -7,3 +7,7 @@ export "src/builders/antigravity_launch_spec_builder.dart";
 export "src/foundation/antigravity_identity.dart";
 export "src/foundation/antigravity_release.dart";
 export "src/models/antigravity_runtime_pair.dart";
+export "src/models/antigravity_runtime_resolution.dart";
+export "src/repositories/antigravity_runtime_repository.dart";
+export "src/services/antigravity_runtime_service.dart";
+export "src/storage/antigravity_runtime_storage.dart";

--- a/bridge/sesori_plugin_antigravity/lib/src/models/antigravity_runtime_pair.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/models/antigravity_runtime_pair.dart
@@ -6,3 +6,38 @@ final class const AntigravityRuntimePair({
   required final String harnessPath,
   required final PlatformTarget target,
 });
+
+enum AntigravityRuntimeComponent() {
+  server,
+  harness,
+}
+
+enum AntigravityRuntimePairInvalidReason() {
+  wrongName,
+  notAFile,
+  notSiblings,
+  notDistinct,
+}
+
+/// Layer-1 result of reading an official runtime pair from local storage.
+sealed class const AntigravityRuntimePairReadResult();
+
+final class const AntigravityRuntimePairFound({required final AntigravityRuntimePair pair})
+    extends AntigravityRuntimePairReadResult;
+
+final class const AntigravityRuntimePairMissing({required final AntigravityRuntimeComponent component})
+    extends AntigravityRuntimePairReadResult;
+
+final class const AntigravityRuntimePairInvalid({
+  required final AntigravityRuntimeComponent component,
+  required final AntigravityRuntimePairInvalidReason reason,
+}) extends AntigravityRuntimePairReadResult;
+
+final class const AntigravityRuntimeTargetUnsupported({required final PlatformTarget target})
+    extends AntigravityRuntimePairReadResult;
+
+final class const AntigravityRuntimeStorageFailure({
+  // ignore: no_slop_linter/prefer_specific_type, caught storage failures remain opaque
+  required final Object cause,
+  required final StackTrace stackTrace,
+}) extends AntigravityRuntimePairReadResult;

--- a/bridge/sesori_plugin_antigravity/lib/src/models/antigravity_runtime_resolution.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/models/antigravity_runtime_resolution.dart
@@ -1,0 +1,141 @@
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+
+import "antigravity_runtime_pair.dart";
+
+enum AntigravityRuntimeSource() {
+  explicit,
+  path,
+  managed,
+}
+
+enum AntigravityRuntimePairIssue() {
+  wrongName,
+  notAFile,
+  notSiblings,
+  notDistinct,
+}
+
+enum AntigravityRuntimeContractViolation() {
+  protocolVersion,
+  agentName,
+  agentVersion,
+  loadSession,
+  listSessions,
+  resumeSession,
+  closeSession,
+  authLogout,
+  personalOauth,
+}
+
+/// Layer-2 domain projection of an ACP initialize response.
+final class AntigravityRuntimeProbeSnapshot({
+  required final int? protocolVersion,
+  required final String? agentName,
+  required final String? agentVersion,
+  required final bool loadsSessions,
+  required final bool listsSessions,
+  required final bool resumesSessions,
+  required final bool closesSessions,
+  required final bool logsOutAuthentication,
+  required Set<String> authenticationMethodIds,
+}) {
+  final Set<String> authenticationMethodIds = Set<String>.unmodifiable(authenticationMethodIds);
+}
+
+/// Exact validated contract retained with a selected pair.
+final class const AntigravityRuntimeContract({
+  required final String version,
+  required final bool listsSessions,
+  required final bool closesSessions,
+});
+
+sealed class const AntigravityRuntimeCandidateResult();
+
+final class const AntigravityRuntimeCandidateFound({
+  required final AntigravityRuntimeSource source,
+  required final AntigravityRuntimePair pair,
+}) extends AntigravityRuntimeCandidateResult;
+
+final class const AntigravityRuntimeCandidateMissing({
+  required final AntigravityRuntimeSource source,
+  required final AntigravityRuntimeComponent component,
+}) extends AntigravityRuntimeCandidateResult;
+
+final class const AntigravityRuntimeCandidateRejected({
+  required final AntigravityRuntimeSource source,
+  required final AntigravityRuntimeComponent component,
+  required final AntigravityRuntimePairIssue issue,
+}) extends AntigravityRuntimeCandidateResult;
+
+final class const AntigravityRuntimeCandidateStorageFailed({
+  required final AntigravityRuntimeSource source,
+  // ignore: no_slop_linter/prefer_specific_type, caught storage failures remain opaque
+  required final Object cause,
+  required final StackTrace stackTrace,
+}) extends AntigravityRuntimeCandidateResult;
+
+final class const AntigravityRuntimeCandidateUnsupported({required final PlatformTarget target})
+    extends AntigravityRuntimeCandidateResult;
+
+sealed class const AntigravityRuntimeProbeResult();
+
+final class const AntigravityRuntimeProbeCompleted({
+  required final AntigravityRuntimeSource source,
+  required final AntigravityRuntimePair pair,
+  required final AntigravityRuntimeProbeSnapshot snapshot,
+}) extends AntigravityRuntimeProbeResult;
+
+final class const AntigravityRuntimeProbeBoundaryFailed({
+  required final AntigravityRuntimeSource source,
+  required final AntigravityRuntimePair pair,
+  // ignore: no_slop_linter/prefer_specific_type, caught probe failures remain opaque
+  required final Object cause,
+  required final StackTrace stackTrace,
+}) extends AntigravityRuntimeProbeResult;
+
+sealed class const AntigravityRuntimeResolution();
+
+final class const AntigravityRuntimeSelected({
+  required final AntigravityRuntimeSource source,
+  required final AntigravityRuntimePair pair,
+  required final AntigravityRuntimeContract contract,
+}) extends AntigravityRuntimeResolution;
+
+final class const AntigravityRuntimeMissing({
+  required final AntigravityRuntimeSource source,
+  required final AntigravityRuntimeComponent component,
+}) extends AntigravityRuntimeResolution;
+
+final class const AntigravityRuntimePairRejected({
+  required final AntigravityRuntimeSource source,
+  required final AntigravityRuntimeComponent component,
+  required final AntigravityRuntimePairIssue issue,
+}) extends AntigravityRuntimeResolution;
+
+final class AntigravityRuntimeContractRejected({
+  required final AntigravityRuntimeSource source,
+  required final AntigravityRuntimePair pair,
+  required List<AntigravityRuntimeContractViolation> violations,
+}) extends AntigravityRuntimeResolution {
+  final List<AntigravityRuntimeContractViolation> violations = List<AntigravityRuntimeContractViolation>.unmodifiable(
+    violations,
+  );
+}
+
+final class const AntigravityRuntimeProbeFailed({
+  required final AntigravityRuntimeSource source,
+  required final AntigravityRuntimePair pair,
+  // ignore: no_slop_linter/prefer_specific_type, caught probe failures remain opaque
+  required final Object cause,
+  required final StackTrace stackTrace,
+}) extends AntigravityRuntimeResolution;
+
+final class const AntigravityRuntimeStorageFailed({
+  required final AntigravityRuntimeSource source,
+  // ignore: no_slop_linter/prefer_specific_type, caught storage failures remain opaque
+  required final Object cause,
+  required final StackTrace stackTrace,
+}) extends AntigravityRuntimeResolution;
+
+final class const AntigravityRuntimeUnsupported({required final PlatformTarget target})
+    extends AntigravityRuntimeResolution;

--- a/bridge/sesori_plugin_antigravity/lib/src/repositories/antigravity_runtime_repository.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/repositories/antigravity_runtime_repository.dart
@@ -1,0 +1,104 @@
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../api/antigravity_acp_api.dart";
+import "../api/models/antigravity_initialize_dto.dart";
+import "../builders/antigravity_launch_spec_builder.dart";
+import "../models/antigravity_runtime_pair.dart";
+import "../models/antigravity_runtime_resolution.dart";
+import "../storage/antigravity_runtime_storage.dart";
+
+/// Maps runtime filesystem and ACP boundaries into Antigravity domain results.
+class AntigravityRuntimeRepository({
+  required final AntigravityRuntimeStorage _runtimeStorage,
+  required final AntigravityAcpApi _acpApi,
+  required final AntigravityLaunchSpecBuilder _launchSpecBuilder,
+}) {
+  AntigravityRuntimeCandidateResult inspectPair({
+    required AntigravityRuntimeSource source,
+    required String serverPath,
+    required PlatformTarget target,
+  }) {
+    final result = _runtimeStorage.inspectPair(serverPath: serverPath, target: target);
+    return _mapPairReadResult(source: source, result: result);
+  }
+
+  AntigravityRuntimeCandidateResult inspectPath({
+    required Map<String, String> environment,
+    required PlatformTarget target,
+  }) {
+    final result = _runtimeStorage.findOnPath(environment: environment, target: target);
+    return _mapPairReadResult(source: AntigravityRuntimeSource.path, result: result);
+  }
+
+  Future<AntigravityRuntimeProbeResult> probe({
+    required AntigravityRuntimeSource source,
+    required AntigravityRuntimePair pair,
+    required Map<String, String> environment,
+    required Duration timeout,
+    required StartAbortSignal abortSignal,
+  }) async {
+    try {
+      final dto = await _acpApi.initializeOnly(
+        launchSpec: _launchSpecBuilder.build(pair: pair, cwd: null, environment: environment),
+        timeout: timeout,
+        abortSignal: abortSignal,
+      );
+      final capabilities = dto.agentCapabilities;
+      return AntigravityRuntimeProbeCompleted(
+        source: source,
+        pair: pair,
+        snapshot: AntigravityRuntimeProbeSnapshot(
+          protocolVersion: dto.protocolVersion,
+          agentName: dto.agentInfo?.name,
+          agentVersion: dto.agentInfo?.version,
+          loadsSessions: capabilities?.loadSession ?? false,
+          listsSessions: capabilities?.sessionCapabilities?.list ?? false,
+          resumesSessions: capabilities?.sessionCapabilities?.resume ?? false,
+          closesSessions: capabilities?.sessionCapabilities?.close ?? false,
+          logsOutAuthentication: capabilities?.auth?.logout ?? false,
+          authenticationMethodIds: {
+            for (final method in dto.authMethods ?? const <AntigravityAuthMethodDto>[])
+              if (method.id case final String id) id,
+          },
+        ),
+      );
+    } on PluginStartAbortedException {
+      rethrow;
+    } on Object catch (error, stackTrace) {
+      return AntigravityRuntimeProbeBoundaryFailed(
+        source: source,
+        pair: pair,
+        cause: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  AntigravityRuntimeCandidateResult _mapPairReadResult({
+    required AntigravityRuntimeSource source,
+    required AntigravityRuntimePairReadResult result,
+  }) => switch (result) {
+    AntigravityRuntimePairFound(:final pair) => AntigravityRuntimeCandidateFound(source: source, pair: pair),
+    AntigravityRuntimePairMissing(:final component) => AntigravityRuntimeCandidateMissing(
+      source: source,
+      component: component,
+    ),
+    AntigravityRuntimePairInvalid(:final component, :final reason) => AntigravityRuntimeCandidateRejected(
+      source: source,
+      component: component,
+      issue: switch (reason) {
+        AntigravityRuntimePairInvalidReason.wrongName => AntigravityRuntimePairIssue.wrongName,
+        AntigravityRuntimePairInvalidReason.notAFile => AntigravityRuntimePairIssue.notAFile,
+        AntigravityRuntimePairInvalidReason.notSiblings => AntigravityRuntimePairIssue.notSiblings,
+        AntigravityRuntimePairInvalidReason.notDistinct => AntigravityRuntimePairIssue.notDistinct,
+      },
+    ),
+    AntigravityRuntimeTargetUnsupported(:final target) => AntigravityRuntimeCandidateUnsupported(target: target),
+    AntigravityRuntimeStorageFailure(:final cause, :final stackTrace) => AntigravityRuntimeCandidateStorageFailed(
+      source: source,
+      cause: cause,
+      stackTrace: stackTrace,
+    ),
+  };
+}

--- a/bridge/sesori_plugin_antigravity/lib/src/repositories/antigravity_runtime_repository.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/repositories/antigravity_runtime_repository.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
@@ -64,6 +66,8 @@ class AntigravityRuntimeRepository({
         ),
       );
     } on PluginStartAbortedException {
+      rethrow;
+    } on TimeoutException {
       rethrow;
     } on Object catch (error, stackTrace) {
       return AntigravityRuntimeProbeBoundaryFailed(

--- a/bridge/sesori_plugin_antigravity/lib/src/services/antigravity_runtime_service.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/services/antigravity_runtime_service.dart
@@ -1,0 +1,174 @@
+import "dart:async";
+
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../foundation/antigravity_identity.dart";
+import "../foundation/antigravity_release.dart";
+import "../models/antigravity_runtime_pair.dart";
+import "../models/antigravity_runtime_resolution.dart";
+import "../repositories/antigravity_runtime_repository.dart";
+
+/// Owns Antigravity runtime precedence, exact contract policy, and sequencing.
+class AntigravityRuntimeService({required final AntigravityRuntimeRepository _runtimeRepository}) {
+  Future<AntigravityRuntimeResolution> resolve({
+    required String? explicitServerPath,
+    required String? managedServerPath,
+    required Map<String, String> pathEnvironment,
+    required Map<String, String> probeEnvironment,
+    required PlatformTarget target,
+    required Duration timeout,
+    required StartAbortSignal abortSignal,
+  }) async {
+    final deadline = Stopwatch()..start();
+    _throwIfAborted(abortSignal: abortSignal);
+
+    if (explicitServerPath != null) {
+      final candidate = _runtimeRepository.inspectPair(
+        source: AntigravityRuntimeSource.explicit,
+        serverPath: explicitServerPath,
+        target: target,
+      );
+      return await _resolveCandidate(
+        candidate: candidate,
+        probeEnvironment: probeEnvironment,
+        timeout: _remaining(timeout: timeout, deadline: deadline),
+        abortSignal: abortSignal,
+      );
+    }
+
+    final pathCandidate = _runtimeRepository.inspectPath(environment: pathEnvironment, target: target);
+    final pathResolution = await _resolveCandidate(
+      candidate: pathCandidate,
+      probeEnvironment: probeEnvironment,
+      timeout: _remaining(timeout: timeout, deadline: deadline),
+      abortSignal: abortSignal,
+    );
+    if (pathResolution is AntigravityRuntimeSelected || pathResolution is AntigravityRuntimeUnsupported) {
+      return pathResolution;
+    }
+
+    _throwIfAborted(abortSignal: abortSignal);
+    if (managedServerPath == null) return pathResolution;
+    _remaining(timeout: timeout, deadline: deadline);
+    final managedCandidate = _runtimeRepository.inspectPair(
+      source: AntigravityRuntimeSource.managed,
+      serverPath: managedServerPath,
+      target: target,
+    );
+    return await _resolveCandidate(
+      candidate: managedCandidate,
+      probeEnvironment: probeEnvironment,
+      timeout: _remaining(timeout: timeout, deadline: deadline),
+      abortSignal: abortSignal,
+    );
+  }
+
+  Future<AntigravityRuntimeResolution> validatePair({
+    required AntigravityRuntimeSource source,
+    required AntigravityRuntimePair pair,
+    required Map<String, String> probeEnvironment,
+    required Duration timeout,
+    required StartAbortSignal abortSignal,
+  }) async {
+    _throwIfAborted(abortSignal: abortSignal);
+    final result = await _runtimeRepository.probe(
+      source: source,
+      pair: pair,
+      environment: probeEnvironment,
+      timeout: timeout,
+      abortSignal: abortSignal,
+    );
+    _throwIfAborted(abortSignal: abortSignal);
+    return switch (result) {
+      AntigravityRuntimeProbeCompleted(:final source, :final pair, :final snapshot) => _validateSnapshot(
+        source: source,
+        pair: pair,
+        snapshot: snapshot,
+      ),
+      AntigravityRuntimeProbeBoundaryFailed(
+        :final source,
+        :final pair,
+        :final cause,
+        :final stackTrace,
+      ) =>
+        AntigravityRuntimeProbeFailed(
+          source: source,
+          pair: pair,
+          cause: cause,
+          stackTrace: stackTrace,
+        ),
+    };
+  }
+
+  Future<AntigravityRuntimeResolution> _resolveCandidate({
+    required AntigravityRuntimeCandidateResult candidate,
+    required Map<String, String> probeEnvironment,
+    required Duration timeout,
+    required StartAbortSignal abortSignal,
+  }) async {
+    _throwIfAborted(abortSignal: abortSignal);
+    switch (candidate) {
+      case AntigravityRuntimeCandidateFound(:final source, :final pair):
+        return await validatePair(
+          source: source,
+          pair: pair,
+          probeEnvironment: probeEnvironment,
+          timeout: timeout,
+          abortSignal: abortSignal,
+        );
+      case AntigravityRuntimeCandidateMissing(:final source, :final component):
+        return AntigravityRuntimeMissing(source: source, component: component);
+      case AntigravityRuntimeCandidateRejected(:final source, :final component, :final issue):
+        return AntigravityRuntimePairRejected(source: source, component: component, issue: issue);
+      case AntigravityRuntimeCandidateStorageFailed(:final source, :final cause, :final stackTrace):
+        return AntigravityRuntimeStorageFailed(source: source, cause: cause, stackTrace: stackTrace);
+      case AntigravityRuntimeCandidateUnsupported(:final target):
+        return AntigravityRuntimeUnsupported(target: target);
+    }
+  }
+
+  AntigravityRuntimeResolution _validateSnapshot({
+    required AntigravityRuntimeSource source,
+    required AntigravityRuntimePair pair,
+    required AntigravityRuntimeProbeSnapshot snapshot,
+  }) {
+    final violations = <AntigravityRuntimeContractViolation>[
+      if (snapshot.protocolVersion != AntigravityRelease.protocolVersion)
+        AntigravityRuntimeContractViolation.protocolVersion,
+      if (snapshot.agentName != AntigravityIdentity.upstreamAgentName) AntigravityRuntimeContractViolation.agentName,
+      if (snapshot.agentVersion != AntigravityRelease.agentVersion) AntigravityRuntimeContractViolation.agentVersion,
+      if (!snapshot.loadsSessions) AntigravityRuntimeContractViolation.loadSession,
+      if (!snapshot.listsSessions) AntigravityRuntimeContractViolation.listSessions,
+      if (!snapshot.resumesSessions) AntigravityRuntimeContractViolation.resumeSession,
+      if (snapshot.closesSessions) AntigravityRuntimeContractViolation.closeSession,
+      if (!snapshot.logsOutAuthentication) AntigravityRuntimeContractViolation.authLogout,
+      if (!snapshot.authenticationMethodIds.contains(AntigravityRelease.personalOauthMethodId))
+        AntigravityRuntimeContractViolation.personalOauth,
+    ];
+    if (violations.isNotEmpty) {
+      return AntigravityRuntimeContractRejected(source: source, pair: pair, violations: violations);
+    }
+    return AntigravityRuntimeSelected(
+      source: source,
+      pair: pair,
+      contract: AntigravityRuntimeContract(
+        version: AntigravityRelease.agentVersion,
+        listsSessions: snapshot.listsSessions,
+        closesSessions: snapshot.closesSessions,
+      ),
+    );
+  }
+
+  Duration _remaining({required Duration timeout, required Stopwatch deadline}) {
+    final remaining = timeout - deadline.elapsed;
+    if (remaining <= Duration.zero) {
+      throw TimeoutException("Antigravity runtime resolution exceeded its deadline");
+    }
+    return remaining;
+  }
+
+  void _throwIfAborted({required StartAbortSignal abortSignal}) {
+    if (abortSignal.isAborted) throw const PluginStartAbortedException();
+  }
+}

--- a/bridge/sesori_plugin_antigravity/lib/src/services/antigravity_runtime_service.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/services/antigravity_runtime_service.dart
@@ -29,12 +29,14 @@ class AntigravityRuntimeService({required final AntigravityRuntimeRepository _ru
         serverPath: explicitServerPath,
         target: target,
       );
-      return await _resolveCandidate(
+      final resolution = await _resolveCandidate(
         candidate: candidate,
         probeEnvironment: probeEnvironment,
         timeout: _remaining(timeout: timeout, deadline: deadline),
         abortSignal: abortSignal,
       );
+      _remaining(timeout: timeout, deadline: deadline);
+      return resolution;
     }
 
     final pathCandidate = _runtimeRepository.inspectPath(environment: pathEnvironment, target: target);
@@ -45,24 +47,30 @@ class AntigravityRuntimeService({required final AntigravityRuntimeRepository _ru
       abortSignal: abortSignal,
     );
     if (pathResolution is AntigravityRuntimeSelected || pathResolution is AntigravityRuntimeUnsupported) {
+      _remaining(timeout: timeout, deadline: deadline);
       return pathResolution;
     }
 
     _throwIfAborted(abortSignal: abortSignal);
-    if (managedServerPath == null) return pathResolution;
-    _logRecoveredPathFailure(resolution: pathResolution);
+    if (managedServerPath == null) {
+      _remaining(timeout: timeout, deadline: deadline);
+      return pathResolution;
+    }
+    _logPathBoundaryFailure(resolution: pathResolution);
     _remaining(timeout: timeout, deadline: deadline);
     final managedCandidate = _runtimeRepository.inspectPair(
       source: AntigravityRuntimeSource.managed,
       serverPath: managedServerPath,
       target: target,
     );
-    return await _resolveCandidate(
+    final managedResolution = await _resolveCandidate(
       candidate: managedCandidate,
       probeEnvironment: probeEnvironment,
       timeout: _remaining(timeout: timeout, deadline: deadline),
       abortSignal: abortSignal,
     );
+    _remaining(timeout: timeout, deadline: deadline);
+    return managedResolution;
   }
 
   Future<AntigravityRuntimeResolution> validatePair({
@@ -161,16 +169,12 @@ class AntigravityRuntimeService({required final AntigravityRuntimeRepository _ru
     );
   }
 
-  void _logRecoveredPathFailure({required AntigravityRuntimeResolution resolution}) {
+  void _logPathBoundaryFailure({required AntigravityRuntimeResolution resolution}) {
     switch (resolution) {
       case AntigravityRuntimeStorageFailed(:final cause, :final stackTrace):
-        Log.w("[antigravity] PATH runtime inspection failed; trying the managed runtime", cause, stackTrace);
+        Log.w("[antigravity] PATH runtime inspection failed", cause, stackTrace);
       case AntigravityRuntimeProbeFailed(:final pair, :final cause, :final stackTrace):
-        Log.w(
-          '[antigravity] PATH runtime probe failed for "${pair.serverPath}"; trying the managed runtime',
-          cause,
-          stackTrace,
-        );
+        Log.w('[antigravity] PATH runtime probe failed for "${pair.serverPath}"', cause, stackTrace);
       case AntigravityRuntimeSelected() ||
           AntigravityRuntimeMissing() ||
           AntigravityRuntimePairRejected() ||

--- a/bridge/sesori_plugin_antigravity/lib/src/services/antigravity_runtime_service.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/services/antigravity_runtime_service.dart
@@ -50,6 +50,7 @@ class AntigravityRuntimeService({required final AntigravityRuntimeRepository _ru
 
     _throwIfAborted(abortSignal: abortSignal);
     if (managedServerPath == null) return pathResolution;
+    _logRecoveredPathFailure(resolution: pathResolution);
     _remaining(timeout: timeout, deadline: deadline);
     final managedCandidate = _runtimeRepository.inspectPair(
       source: AntigravityRuntimeSource.managed,
@@ -158,6 +159,25 @@ class AntigravityRuntimeService({required final AntigravityRuntimeRepository _ru
         closesSessions: snapshot.closesSessions,
       ),
     );
+  }
+
+  void _logRecoveredPathFailure({required AntigravityRuntimeResolution resolution}) {
+    switch (resolution) {
+      case AntigravityRuntimeStorageFailed(:final cause, :final stackTrace):
+        Log.w("[antigravity] PATH runtime inspection failed; trying the managed runtime", cause, stackTrace);
+      case AntigravityRuntimeProbeFailed(:final pair, :final cause, :final stackTrace):
+        Log.w(
+          '[antigravity] PATH runtime probe failed for "${pair.serverPath}"; trying the managed runtime',
+          cause,
+          stackTrace,
+        );
+      case AntigravityRuntimeSelected() ||
+          AntigravityRuntimeMissing() ||
+          AntigravityRuntimePairRejected() ||
+          AntigravityRuntimeContractRejected() ||
+          AntigravityRuntimeUnsupported():
+        return;
+    }
   }
 
   Duration _remaining({required Duration timeout, required Stopwatch deadline}) {

--- a/bridge/sesori_plugin_antigravity/lib/src/storage/antigravity_runtime_storage.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/storage/antigravity_runtime_storage.dart
@@ -107,7 +107,6 @@ class const AntigravityRuntimeStorage() {
     final context = _pathContext(target: target);
     final separator = target.os == PlatformOs.windows ? ";" : ":";
     for (final directory in rawPath.split(separator)) {
-      if (directory.isEmpty) continue;
       final result = inspectPair(
         serverPath: context.join(directory, AntigravityRelease.serverFileName(target: target)),
         target: target,

--- a/bridge/sesori_plugin_antigravity/lib/src/storage/antigravity_runtime_storage.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/storage/antigravity_runtime_storage.dart
@@ -1,0 +1,132 @@
+import "dart:io";
+
+import "package:path/path.dart" as p;
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+
+import "../foundation/antigravity_release.dart";
+import "../models/antigravity_runtime_pair.dart";
+
+/// Layer-1 filesystem and PATH boundary for the official Antigravity pair.
+class const AntigravityRuntimeStorage() {
+  AntigravityRuntimePairReadResult inspectPair({
+    required String serverPath,
+    required PlatformTarget target,
+  }) {
+    if (!AntigravityRelease.supportsTarget(target: target)) {
+      return AntigravityRuntimeTargetUnsupported(target: target);
+    }
+
+    final context = _pathContext(target: target);
+    if (context.basename(serverPath) != AntigravityRelease.serverFileName(target: target)) {
+      return const AntigravityRuntimePairInvalid(
+        component: AntigravityRuntimeComponent.server,
+        reason: AntigravityRuntimePairInvalidReason.wrongName,
+      );
+    }
+
+    try {
+      final requestedServer = File(context.normalize(context.absolute(serverPath)));
+      final serverType = FileSystemEntity.typeSync(requestedServer.path, followLinks: true);
+      if (serverType == FileSystemEntityType.notFound) {
+        return const AntigravityRuntimePairMissing(component: AntigravityRuntimeComponent.server);
+      }
+      if (serverType != FileSystemEntityType.file) {
+        return const AntigravityRuntimePairInvalid(
+          component: AntigravityRuntimeComponent.server,
+          reason: AntigravityRuntimePairInvalidReason.notAFile,
+        );
+      }
+
+      final requestedHarness = File(
+        context.join(
+          context.dirname(requestedServer.path),
+          AntigravityRelease.harnessFileName(target: target),
+        ),
+      );
+      final harnessType = FileSystemEntity.typeSync(requestedHarness.path, followLinks: true);
+      if (harnessType == FileSystemEntityType.notFound) {
+        return const AntigravityRuntimePairMissing(component: AntigravityRuntimeComponent.harness);
+      }
+      if (harnessType != FileSystemEntityType.file) {
+        return const AntigravityRuntimePairInvalid(
+          component: AntigravityRuntimeComponent.harness,
+          reason: AntigravityRuntimePairInvalidReason.notAFile,
+        );
+      }
+
+      final resolvedServer = requestedServer.resolveSymbolicLinksSync();
+      final resolvedHarness = requestedHarness.resolveSymbolicLinksSync();
+      if (FileSystemEntity.identicalSync(resolvedServer, resolvedHarness)) {
+        return const AntigravityRuntimePairInvalid(
+          component: AntigravityRuntimeComponent.harness,
+          reason: AntigravityRuntimePairInvalidReason.notDistinct,
+        );
+      }
+      if (context.basename(resolvedServer) != AntigravityRelease.serverFileName(target: target)) {
+        return const AntigravityRuntimePairInvalid(
+          component: AntigravityRuntimeComponent.server,
+          reason: AntigravityRuntimePairInvalidReason.wrongName,
+        );
+      }
+      if (context.basename(resolvedHarness) != AntigravityRelease.harnessFileName(target: target)) {
+        return const AntigravityRuntimePairInvalid(
+          component: AntigravityRuntimeComponent.harness,
+          reason: AntigravityRuntimePairInvalidReason.wrongName,
+        );
+      }
+      if (!context.equals(context.dirname(resolvedServer), context.dirname(resolvedHarness))) {
+        return const AntigravityRuntimePairInvalid(
+          component: AntigravityRuntimeComponent.harness,
+          reason: AntigravityRuntimePairInvalidReason.notSiblings,
+        );
+      }
+      return AntigravityRuntimePairFound(
+        pair: AntigravityRuntimePair(
+          serverPath: resolvedServer,
+          harnessPath: resolvedHarness,
+          target: target,
+        ),
+      );
+    } on FileSystemException catch (error, stackTrace) {
+      return AntigravityRuntimeStorageFailure(cause: error, stackTrace: stackTrace);
+    }
+  }
+
+  AntigravityRuntimePairReadResult findOnPath({
+    required Map<String, String> environment,
+    required PlatformTarget target,
+  }) {
+    if (!AntigravityRelease.supportsTarget(target: target)) {
+      return AntigravityRuntimeTargetUnsupported(target: target);
+    }
+    final rawPath = _environmentPath(environment: environment, target: target);
+    if (rawPath == null) {
+      return const AntigravityRuntimePairMissing(component: AntigravityRuntimeComponent.server);
+    }
+
+    final context = _pathContext(target: target);
+    final separator = target.os == PlatformOs.windows ? ";" : ":";
+    for (final directory in rawPath.split(separator)) {
+      if (directory.isEmpty) continue;
+      final result = inspectPair(
+        serverPath: context.join(directory, AntigravityRelease.serverFileName(target: target)),
+        target: target,
+      );
+      if (result is! AntigravityRuntimePairMissing || result.component != AntigravityRuntimeComponent.server) {
+        return result;
+      }
+    }
+    return const AntigravityRuntimePairMissing(component: AntigravityRuntimeComponent.server);
+  }
+
+  String? _environmentPath({required Map<String, String> environment, required PlatformTarget target}) {
+    if (target.os != PlatformOs.windows) return environment["PATH"];
+    for (final entry in environment.entries) {
+      if (entry.key.toLowerCase() == "path") return entry.value;
+    }
+    return null;
+  }
+
+  p.Context _pathContext({required PlatformTarget target}) =>
+      p.Context(style: target.os == PlatformOs.windows ? p.Style.windows : p.Style.posix);
+}

--- a/bridge/sesori_plugin_antigravity/lib/src/storage/antigravity_runtime_storage.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/storage/antigravity_runtime_storage.dart
@@ -17,7 +17,7 @@ class const AntigravityRuntimeStorage() {
     }
 
     final context = _pathContext(target: target);
-    if (context.basename(serverPath) != AntigravityRelease.serverFileName(target: target)) {
+    if (!context.equals(context.basename(serverPath), AntigravityRelease.serverFileName(target: target))) {
       return const AntigravityRuntimePairInvalid(
         component: AntigravityRuntimeComponent.server,
         reason: AntigravityRuntimePairInvalidReason.wrongName,
@@ -62,13 +62,13 @@ class const AntigravityRuntimeStorage() {
           reason: AntigravityRuntimePairInvalidReason.notDistinct,
         );
       }
-      if (context.basename(resolvedServer) != AntigravityRelease.serverFileName(target: target)) {
+      if (!context.equals(context.basename(resolvedServer), AntigravityRelease.serverFileName(target: target))) {
         return const AntigravityRuntimePairInvalid(
           component: AntigravityRuntimeComponent.server,
           reason: AntigravityRuntimePairInvalidReason.wrongName,
         );
       }
-      if (context.basename(resolvedHarness) != AntigravityRelease.harnessFileName(target: target)) {
+      if (!context.equals(context.basename(resolvedHarness), AntigravityRelease.harnessFileName(target: target))) {
         return const AntigravityRuntimePairInvalid(
           component: AntigravityRuntimeComponent.harness,
           reason: AntigravityRuntimePairInvalidReason.wrongName,

--- a/bridge/sesori_plugin_antigravity/test/antigravity_runtime_service_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_runtime_service_test.dart
@@ -243,6 +243,38 @@ void main() {
     expect(storage.inspectedPaths, isEmpty);
   });
 
+  test("rejects a final explicit probe result that arrives after the shared deadline", () async {
+    final storage = _FakeStorage(
+      pairResults: const {
+        "/explicit/agy_acp_server.par": AntigravityRuntimePairFound(pair: pathPair),
+      },
+      pathResult: const AntigravityRuntimePairMissing(component: AntigravityRuntimeComponent.server),
+    );
+    final api = _FakeAcpApi(
+      outcomes: [
+        () async {
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          return initializeResult(agentVersion: AntigravityRelease.agentVersion);
+        },
+      ],
+    );
+
+    await expectLater(
+      _service(storage: storage, api: api).resolve(
+        explicitServerPath: "/explicit/agy_acp_server.par",
+        managedServerPath: null,
+        pathEnvironment: const {"PATH": "/path"},
+        probeEnvironment: const {"GEMINI_HOME": "/isolated"},
+        target: target,
+        timeout: const Duration(milliseconds: 50),
+        abortSignal: StartAbortSignal.never,
+      ),
+      throwsA(isA<TimeoutException>()),
+    );
+    expect(api.launches.map((launch) => launch.command), [pathPair.serverPath]);
+    expect(storage.pathInspections, 0);
+  });
+
   test("does not inspect managed storage after cancellation at a probe boundary", () async {
     final controller = StartAbortController();
     final storage = _FakeStorage(

--- a/bridge/sesori_plugin_antigravity/test/antigravity_runtime_service_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_runtime_service_test.dart
@@ -169,6 +169,49 @@ void main() {
     expect(api.launches.map((launch) => launch.command), [pathPair.serverPath, managedPair.serverPath]);
   });
 
+  test("falls back to managed after observable PATH boundary failures", () async {
+    final storageFailure = StateError("PATH storage failed");
+    final storage = _FakeStorage(
+      pairResults: const {"/managed/agy_acp_server.par": AntigravityRuntimePairFound(pair: managedPair)},
+      pathResult: AntigravityRuntimeStorageFailure(
+        cause: storageFailure,
+        stackTrace: StackTrace.current,
+      ),
+    );
+    final storageFallbackApi = _FakeAcpApi(
+      outcomes: [() async => initializeResult(agentVersion: AntigravityRelease.agentVersion)],
+    );
+    final storageFallback = await _resolve(
+      service: _service(storage: storage, api: storageFallbackApi),
+      explicitServerPath: null,
+      managedServerPath: managedPair.serverPath,
+      abortSignal: StartAbortSignal.never,
+    ) as AntigravityRuntimeSelected;
+    expect(storageFallback.source, AntigravityRuntimeSource.managed);
+
+    final probeFailure = StateError("PATH probe failed");
+    final probeFallbackApi = _FakeAcpApi(
+      outcomes: [
+        () async => throw probeFailure,
+        () async => initializeResult(agentVersion: AntigravityRelease.agentVersion),
+      ],
+    );
+    final probeFallback = await _resolve(
+      service: _service(
+        storage: _FakeStorage(
+          pairResults: const {"/managed/agy_acp_server.par": AntigravityRuntimePairFound(pair: managedPair)},
+          pathResult: const AntigravityRuntimePairFound(pair: pathPair),
+        ),
+        api: probeFallbackApi,
+      ),
+      explicitServerPath: null,
+      managedServerPath: managedPair.serverPath,
+      abortSignal: StartAbortSignal.never,
+    ) as AntigravityRuntimeSelected;
+    expect(probeFallback.source, AntigravityRuntimeSource.managed);
+    expect(probeFallbackApi.launches.map((launch) => launch.command), [pathPair.serverPath, managedPair.serverPath]);
+  });
+
   test("shares one timeout budget across PATH and managed probes", () async {
     final storage = _FakeStorage(
       pairResults: const {"/managed/agy_acp_server.par": AntigravityRuntimePairFound(pair: managedPair)},

--- a/bridge/sesori_plugin_antigravity/test/antigravity_runtime_service_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_runtime_service_test.dart
@@ -124,6 +124,30 @@ void main() {
     expect(storage.pathInspections, 0);
   });
 
+  test("preserves an explicit probe timeout as control flow", () async {
+    final timeoutFailure = TimeoutException("probe timed out");
+    final storage = _FakeStorage(
+      pairResults: const {
+        "/explicit/agy_acp_server.par": AntigravityRuntimePairFound(pair: pathPair),
+      },
+      pathResult: const AntigravityRuntimePairMissing(component: AntigravityRuntimeComponent.server),
+    );
+
+    await expectLater(
+      _resolve(
+        service: _service(
+          storage: storage,
+          api: _FakeAcpApi(outcomes: [() async => throw timeoutFailure]),
+        ),
+        explicitServerPath: "/explicit/agy_acp_server.par",
+        managedServerPath: managedPair.serverPath,
+        abortSignal: StartAbortSignal.never,
+      ),
+      throwsA(same(timeoutFailure)),
+    );
+    expect(storage.pathInspections, 0);
+  });
+
   test("selects PATH before managed and forwards only the prepared environment", () async {
     final storage = _FakeStorage(
       pairResults: const {},

--- a/bridge/sesori_plugin_antigravity/test/antigravity_runtime_service_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_runtime_service_test.dart
@@ -1,0 +1,294 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:antigravity_plugin/antigravity_plugin.dart";
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+const target = PlatformTarget(os: PlatformOs.linux, arch: PlatformArch.x64);
+const pathPair = AntigravityRuntimePair(
+  serverPath: "/path/agy_acp_server.par",
+  harnessPath: "/path/localharness_external",
+  target: target,
+);
+const managedPair = AntigravityRuntimePair(
+  serverPath: "/managed/agy_acp_server.par",
+  harnessPath: "/managed/localharness_external",
+  target: target,
+);
+
+AntigravityInitializeDto initializeResult({required String agentVersion}) => AntigravityInitializeDto(
+  protocolVersion: 1,
+  agentInfo: AntigravityAgentInfoDto(name: "antigravity-acp", title: "Google Antigravity", version: agentVersion),
+  agentCapabilities: const AntigravityAgentCapabilitiesDto(
+    loadSession: true,
+    sessionCapabilities: AntigravitySessionCapabilitiesDto(list: true, resume: true, close: false),
+    auth: AntigravityAuthCapabilitiesDto(logout: true),
+  ),
+  authMethods: const [AntigravityAuthMethodDto(id: "oauth-personal")],
+);
+
+class _FakeStorage({
+  required final Map<String, AntigravityRuntimePairReadResult> pairResults,
+  required final AntigravityRuntimePairReadResult pathResult,
+}) extends AntigravityRuntimeStorage {
+  int pathInspections = 0;
+  final List<String> inspectedPaths = [];
+
+  @override
+  AntigravityRuntimePairReadResult inspectPair({required String serverPath, required PlatformTarget target}) {
+    inspectedPaths.add(serverPath);
+    return pairResults[serverPath]!;
+  }
+
+  @override
+  AntigravityRuntimePairReadResult findOnPath({
+    required Map<String, String> environment,
+    required PlatformTarget target,
+  }) {
+    pathInspections++;
+    return pathResult;
+  }
+}
+
+Future<AcpProcessHandle> _unimplementedFactory(AcpLaunchSpec spec) => throw UnimplementedError();
+
+class _FakeAcpApi({required final List<Future<AntigravityInitializeDto> Function()> outcomes})
+    extends AntigravityAcpApi {
+  this : super(processFactory: _unimplementedFactory);
+
+  final List<AcpLaunchSpec> launches = [];
+
+  @override
+  Future<AntigravityInitializeDto> initializeOnly({
+    required AcpLaunchSpec launchSpec,
+    required Duration timeout,
+    required StartAbortSignal abortSignal,
+  }) {
+    launches.add(launchSpec);
+    return outcomes.removeAt(0)();
+  }
+}
+
+AntigravityRuntimeService _service({required _FakeStorage storage, required _FakeAcpApi api}) =>
+    AntigravityRuntimeService(
+      runtimeRepository: AntigravityRuntimeRepository(
+        runtimeStorage: storage,
+        acpApi: api,
+        launchSpecBuilder: const AntigravityLaunchSpecBuilder(),
+      ),
+    );
+
+Future<AntigravityRuntimeResolution> _resolve({
+  required AntigravityRuntimeService service,
+  required String? explicitServerPath,
+  required String? managedServerPath,
+  required StartAbortSignal abortSignal,
+}) => service.resolve(
+  explicitServerPath: explicitServerPath,
+  managedServerPath: managedServerPath,
+  pathEnvironment: const {"PATH": "/path"},
+  probeEnvironment: const {"GEMINI_HOME": "/isolated"},
+  target: target,
+  timeout: const Duration(seconds: 5),
+  abortSignal: abortSignal,
+);
+
+void main() {
+  test("an explicit path is authoritative and maps its storage failure", () async {
+    final failure = StateError("storage failed");
+    final stackTrace = StackTrace.current;
+    final storage = _FakeStorage(
+      pairResults: {
+        "/explicit/agy_acp_server.par": AntigravityRuntimeStorageFailure(
+          cause: failure,
+          stackTrace: stackTrace,
+        ),
+      },
+      pathResult: const AntigravityRuntimePairFound(pair: pathPair),
+    );
+    final result = await _resolve(
+      service: _service(
+        storage: storage,
+        api: _FakeAcpApi(outcomes: []),
+      ),
+      explicitServerPath: "/explicit/agy_acp_server.par",
+      managedServerPath: managedPair.serverPath,
+      abortSignal: StartAbortSignal.never,
+    ) as AntigravityRuntimeStorageFailed;
+
+    expect(result.source, AntigravityRuntimeSource.explicit);
+    expect(result.cause, same(failure));
+    expect(result.stackTrace, same(stackTrace));
+    expect(storage.pathInspections, 0);
+  });
+
+  test("selects PATH before managed and forwards only the prepared environment", () async {
+    final storage = _FakeStorage(
+      pairResults: const {},
+      pathResult: const AntigravityRuntimePairFound(pair: pathPair),
+    );
+    final api = _FakeAcpApi(
+      outcomes: [() async => initializeResult(agentVersion: AntigravityRelease.agentVersion)],
+    );
+    final result = await _resolve(
+      service: _service(storage: storage, api: api),
+      explicitServerPath: null,
+      managedServerPath: managedPair.serverPath,
+      abortSignal: StartAbortSignal.never,
+    ) as AntigravityRuntimeSelected;
+
+    expect((result.source, result.pair), (AntigravityRuntimeSource.path, pathPair));
+    expect(storage.inspectedPaths, isEmpty);
+    expect(api.launches.single.environment, {
+      "GEMINI_HOME": "/isolated",
+      AntigravityRelease.harnessPathEnvironmentKey: pathPair.harnessPath,
+    });
+  });
+
+  test("falls back to managed after a PATH contract rejection", () async {
+    final storage = _FakeStorage(
+      pairResults: const {"/managed/agy_acp_server.par": AntigravityRuntimePairFound(pair: managedPair)},
+      pathResult: const AntigravityRuntimePairFound(pair: pathPair),
+    );
+    final api = _FakeAcpApi(
+      outcomes: [
+        () async => initializeResult(agentVersion: "different-release"),
+        () async => initializeResult(agentVersion: AntigravityRelease.agentVersion),
+      ],
+    );
+    final result = await _resolve(
+      service: _service(storage: storage, api: api),
+      explicitServerPath: null,
+      managedServerPath: managedPair.serverPath,
+      abortSignal: StartAbortSignal.never,
+    ) as AntigravityRuntimeSelected;
+
+    expect((result.source, result.pair), (AntigravityRuntimeSource.managed, managedPair));
+    expect(api.launches.map((launch) => launch.command), [pathPair.serverPath, managedPair.serverPath]);
+  });
+
+  test("shares one timeout budget across PATH and managed probes", () async {
+    final storage = _FakeStorage(
+      pairResults: const {"/managed/agy_acp_server.par": AntigravityRuntimePairFound(pair: managedPair)},
+      pathResult: const AntigravityRuntimePairFound(pair: pathPair),
+    );
+    final api = _FakeAcpApi(
+      outcomes: [
+        () async {
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          return initializeResult(agentVersion: "different-release");
+        },
+        () async => initializeResult(agentVersion: AntigravityRelease.agentVersion),
+      ],
+    );
+
+    await expectLater(
+      _service(storage: storage, api: api).resolve(
+        explicitServerPath: null,
+        managedServerPath: managedPair.serverPath,
+        pathEnvironment: const {"PATH": "/path"},
+        probeEnvironment: const {"GEMINI_HOME": "/isolated"},
+        target: target,
+        timeout: const Duration(milliseconds: 50),
+        abortSignal: StartAbortSignal.never,
+      ),
+      throwsA(isA<TimeoutException>()),
+    );
+    expect(api.launches.map((launch) => launch.command), [pathPair.serverPath]);
+    expect(storage.inspectedPaths, isEmpty);
+  });
+
+  test("does not inspect managed storage after cancellation at a probe boundary", () async {
+    final controller = StartAbortController();
+    final storage = _FakeStorage(
+      pairResults: const {"/managed/agy_acp_server.par": AntigravityRuntimePairFound(pair: managedPair)},
+      pathResult: const AntigravityRuntimePairFound(pair: pathPair),
+    );
+    final api = _FakeAcpApi(
+      outcomes: [
+        () async {
+          controller.abort();
+          return initializeResult(agentVersion: "different-release");
+        },
+      ],
+    );
+
+    await expectLater(
+      _resolve(
+        service: _service(storage: storage, api: api),
+        explicitServerPath: null,
+        managedServerPath: managedPair.serverPath,
+        abortSignal: controller.signal,
+      ),
+      throwsA(isA<PluginStartAbortedException>()),
+    );
+    expect(api.launches.map((launch) => launch.command), [pathPair.serverPath]);
+    expect(storage.inspectedPaths, isEmpty);
+  });
+
+  test("reports every exact contract violation", () async {
+    const invalid = AntigravityInitializeDto(
+      protocolVersion: 2,
+      agentInfo: AntigravityAgentInfoDto(name: "other", title: null, version: "other"),
+      agentCapabilities: AntigravityAgentCapabilitiesDto(
+        loadSession: false,
+        sessionCapabilities: AntigravitySessionCapabilitiesDto(list: false, resume: false, close: true),
+        auth: AntigravityAuthCapabilitiesDto(logout: false),
+      ),
+      authMethods: [],
+    );
+    final api = _FakeAcpApi(outcomes: [() async => invalid]);
+    final result =
+        await _service(
+              storage: _FakeStorage(
+                pairResults: const {},
+                pathResult: const AntigravityRuntimePairMissing(component: AntigravityRuntimeComponent.server),
+              ),
+              api: api,
+            ).validatePair(
+              source: AntigravityRuntimeSource.explicit,
+              pair: pathPair,
+              probeEnvironment: const {},
+              timeout: const Duration(seconds: 5),
+              abortSignal: StartAbortSignal.never,
+            )
+            as AntigravityRuntimeContractRejected;
+
+    expect(result.violations, AntigravityRuntimeContractViolation.values);
+  });
+
+  test("preserves probe failures and aborts before touching boundaries", () async {
+    final failure = StateError("probe failed");
+    final storage = _FakeStorage(
+      pairResults: const {},
+      pathResult: const AntigravityRuntimePairFound(pair: pathPair),
+    );
+    final api = _FakeAcpApi(outcomes: [() async => throw failure]);
+    final failed = await _service(storage: storage, api: api).validatePair(
+      source: AntigravityRuntimeSource.explicit,
+      pair: pathPair,
+      probeEnvironment: const {},
+      timeout: const Duration(seconds: 5),
+      abortSignal: StartAbortSignal.never,
+    ) as AntigravityRuntimeProbeFailed;
+    expect(failed.cause, same(failure));
+    expect(failed.stackTrace, isNotNull);
+
+    final controller = StartAbortController()..abort();
+    await expectLater(
+      _resolve(
+        service: _service(
+          storage: storage,
+          api: _FakeAcpApi(outcomes: []),
+        ),
+        explicitServerPath: null,
+        managedServerPath: null,
+        abortSignal: controller.signal,
+      ),
+      throwsA(isA<PluginStartAbortedException>()),
+    );
+    expect(storage.pathInspections, 0);
+  });
+}

--- a/bridge/sesori_plugin_antigravity/test/antigravity_runtime_storage_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_runtime_storage_test.dart
@@ -68,6 +68,31 @@ void main() {
     );
   });
 
+  test("matches official Windows filenames case-insensitively", () {
+    const windowsTarget = PlatformTarget(os: PlatformOs.windows, arch: PlatformArch.x64);
+    final missing = storage.inspectPair(
+      serverPath: r"C:\runtime\AGY_ACP_SERVER.EXE",
+      target: windowsTarget,
+    );
+    expect(missing, isA<AntigravityRuntimePairMissing>());
+
+    if (!Platform.isWindows) return;
+    final server = p.join(
+      temporaryDirectory.path,
+      AntigravityRelease.serverFileName(target: windowsTarget).toUpperCase(),
+    );
+    final harness = p.join(
+      temporaryDirectory.path,
+      AntigravityRelease.harnessFileName(target: windowsTarget).toUpperCase(),
+    );
+    File(server).writeAsStringSync("server");
+    File(harness).writeAsStringSync("harness");
+    expect(
+      storage.inspectPair(serverPath: server, target: windowsTarget),
+      isA<AntigravityRuntimePairFound>(),
+    );
+  });
+
   test("rejects wrong resolved names and identical members", () {
     if (Platform.isWindows) return;
     final realDirectory = Directory(p.join(temporaryDirectory.path, "real"))..createSync();

--- a/bridge/sesori_plugin_antigravity/test/antigravity_runtime_storage_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_runtime_storage_test.dart
@@ -1,0 +1,165 @@
+import "dart:io";
+
+import "package:antigravity_plugin/antigravity_plugin.dart";
+import "package:path/path.dart" as p;
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:test/test.dart";
+
+void main() {
+  const target = PlatformTarget(os: PlatformOs.linux, arch: PlatformArch.x64);
+  const storage = AntigravityRuntimeStorage();
+  late Directory temporaryDirectory;
+
+  setUp(() => temporaryDirectory = Directory.systemTemp.createTempSync("antigravity-storage-"));
+  tearDown(() {
+    if (temporaryDirectory.existsSync()) temporaryDirectory.deleteSync(recursive: true);
+  });
+
+  ({String server, String harness}) writePair(Directory directory) {
+    final server = p.join(directory.path, AntigravityRelease.serverFileName(target: target));
+    final harness = p.join(directory.path, AntigravityRelease.harnessFileName(target: target));
+    File(server).writeAsStringSync("server");
+    File(harness).writeAsStringSync("harness");
+    return (server: server, harness: harness);
+  }
+
+  test("inspects a regular official sibling pair", () {
+    final paths = writePair(temporaryDirectory);
+    final result = storage.inspectPair(serverPath: paths.server, target: target) as AntigravityRuntimePairFound;
+    expect(
+      (result.pair.serverPath, result.pair.harnessPath, result.pair.target),
+      (File(paths.server).resolveSymbolicLinksSync(), File(paths.harness).resolveSymbolicLinksSync(), target),
+    );
+  });
+
+  test("distinguishes missing server and harness files", () {
+    final server = p.join(temporaryDirectory.path, AntigravityRelease.serverFileName(target: target));
+    final missingServer = storage.inspectPair(serverPath: server, target: target) as AntigravityRuntimePairMissing;
+    expect(missingServer.component, AntigravityRuntimeComponent.server);
+    File(server).writeAsStringSync("server");
+    final missingHarness = storage.inspectPair(serverPath: server, target: target) as AntigravityRuntimePairMissing;
+    expect(missingHarness.component, AntigravityRuntimeComponent.harness);
+  });
+
+  test("rejects non-regular pair members", () {
+    final server = p.join(temporaryDirectory.path, AntigravityRelease.serverFileName(target: target));
+    final harness = p.join(temporaryDirectory.path, AntigravityRelease.harnessFileName(target: target));
+    Directory(server).createSync();
+    final badServer = storage.inspectPair(serverPath: server, target: target) as AntigravityRuntimePairInvalid;
+    expect(badServer.reason, AntigravityRuntimePairInvalidReason.notAFile);
+    Directory(server).deleteSync();
+    File(server).writeAsStringSync("server");
+    Directory(harness).createSync();
+    final badHarness = storage.inspectPair(serverPath: server, target: target) as AntigravityRuntimePairInvalid;
+    expect(badHarness.reason, AntigravityRuntimePairInvalidReason.notAFile);
+  });
+
+  test("rejects a server with the wrong official filename", () {
+    final result = storage.inspectPair(
+      serverPath: p.join(temporaryDirectory.path, "renamed-server"),
+      target: target,
+    ) as AntigravityRuntimePairInvalid;
+    expect(
+      (result.component, result.reason),
+      (
+        AntigravityRuntimeComponent.server,
+        AntigravityRuntimePairInvalidReason.wrongName,
+      ),
+    );
+  });
+
+  test("rejects wrong resolved names and identical members", () {
+    if (Platform.isWindows) return;
+    final realDirectory = Directory(p.join(temporaryDirectory.path, "real"))..createSync();
+    final requestedServer = p.join(temporaryDirectory.path, AntigravityRelease.serverFileName(target: target));
+    final requestedHarness = p.join(temporaryDirectory.path, AntigravityRelease.harnessFileName(target: target));
+
+    final renamedServer = p.join(realDirectory.path, "renamed-server");
+    final officialHarness = p.join(realDirectory.path, AntigravityRelease.harnessFileName(target: target));
+    File(renamedServer).writeAsStringSync("server");
+    File(officialHarness).writeAsStringSync("harness");
+    Link(requestedServer).createSync(renamedServer);
+    Link(requestedHarness).createSync(officialHarness);
+    final wrongServer =
+        storage.inspectPair(serverPath: requestedServer, target: target) as AntigravityRuntimePairInvalid;
+    expect(
+      (wrongServer.component, wrongServer.reason),
+      (
+        AntigravityRuntimeComponent.server,
+        AntigravityRuntimePairInvalidReason.wrongName,
+      ),
+    );
+
+    Link(requestedServer).deleteSync();
+    Link(requestedHarness).deleteSync();
+    final officialServer = p.join(realDirectory.path, AntigravityRelease.serverFileName(target: target));
+    final renamedHarness = p.join(realDirectory.path, "renamed-harness");
+    File(officialServer).writeAsStringSync("server");
+    File(renamedHarness).writeAsStringSync("harness");
+    Link(requestedServer).createSync(officialServer);
+    Link(requestedHarness).createSync(renamedHarness);
+    final wrongHarness =
+        storage.inspectPair(serverPath: requestedServer, target: target) as AntigravityRuntimePairInvalid;
+    expect(
+      (wrongHarness.component, wrongHarness.reason),
+      (
+        AntigravityRuntimeComponent.harness,
+        AntigravityRuntimePairInvalidReason.wrongName,
+      ),
+    );
+
+    Link(requestedServer).deleteSync();
+    Link(requestedHarness).deleteSync();
+    final sharedFile = p.join(realDirectory.path, "shared");
+    File(sharedFile).writeAsStringSync("shared");
+    Link(requestedServer).createSync(sharedFile);
+    Link(requestedHarness).createSync(sharedFile);
+    final identical = storage.inspectPair(serverPath: requestedServer, target: target) as AntigravityRuntimePairInvalid;
+    expect(
+      (identical.component, identical.reason),
+      (
+        AntigravityRuntimeComponent.harness,
+        AntigravityRuntimePairInvalidReason.notDistinct,
+      ),
+    );
+  });
+
+  test("rejects a harness whose resolved path is not a sibling", () {
+    if (Platform.isWindows) return;
+    final elsewhere = Directory(p.join(temporaryDirectory.path, "elsewhere"))..createSync();
+    final server = p.join(temporaryDirectory.path, AntigravityRelease.serverFileName(target: target));
+    File(server).writeAsStringSync("server");
+    final externalHarness = p.join(elsewhere.path, AntigravityRelease.harnessFileName(target: target));
+    File(externalHarness).writeAsStringSync("harness");
+    Link(p.join(temporaryDirectory.path, AntigravityRelease.harnessFileName(target: target)))
+        .createSync(externalHarness);
+
+    final result = storage.inspectPair(serverPath: server, target: target) as AntigravityRuntimePairInvalid;
+    expect(result.reason, AntigravityRuntimePairInvalidReason.notSiblings);
+  });
+
+  test("PATH uses the first server hit and requires its sibling", () {
+    final missingDirectory = Directory(p.join(temporaryDirectory.path, "missing"))..createSync();
+    final pairDirectory = Directory(p.join(temporaryDirectory.path, "pair"))..createSync();
+    final paths = writePair(pairDirectory);
+    final separator = Platform.isWindows ? ";" : ":";
+    final found = storage.findOnPath(
+      environment: {
+        "PATH": [missingDirectory.path, pairDirectory.path].join(separator),
+      },
+      target: target,
+    ) as AntigravityRuntimePairFound;
+    expect(found.pair.serverPath, File(paths.server).resolveSymbolicLinksSync());
+
+    final shadowDirectory = Directory(p.join(temporaryDirectory.path, "shadow"))..createSync();
+    File(p.join(shadowDirectory.path, AntigravityRelease.serverFileName(target: target))).writeAsStringSync("server");
+    final shadowed = storage.findOnPath(
+      environment: {
+        "PATH": [shadowDirectory.path, pairDirectory.path].join(separator),
+      },
+      target: target,
+    );
+    expect(shadowed, isA<AntigravityRuntimePairMissing>());
+    expect(storage.findOnPath(environment: const {}, target: target), isA<AntigravityRuntimePairMissing>());
+  });
+}

--- a/bridge/sesori_plugin_antigravity/test/antigravity_runtime_storage_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_runtime_storage_test.dart
@@ -163,6 +163,22 @@ void main() {
     expect(result.reason, AntigravityRuntimePairInvalidReason.notSiblings);
   });
 
+  test("an empty POSIX PATH component searches the current directory", () {
+    if (Platform.isWindows) return;
+    final originalDirectory = Directory.current;
+    final paths = writePair(temporaryDirectory);
+    Directory.current = temporaryDirectory;
+    try {
+      final result = storage.findOnPath(
+        environment: const {"PATH": ":/missing"},
+        target: target,
+      ) as AntigravityRuntimePairFound;
+      expect(result.pair.serverPath, File(paths.server).resolveSymbolicLinksSync());
+    } finally {
+      Directory.current = originalDirectory;
+    }
+  });
+
   test("PATH uses the first server hit and requires its sibling", () {
     final missingDirectory = Directory(p.join(temporaryDirectory.path, "missing"))..createSync();
     final pairDirectory = Directory(p.join(temporaryDirectory.path, "pair"))..createSync();

--- a/bridge/sesori_plugin_antigravity/test/antigravity_runtime_storage_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_runtime_storage_test.dart
@@ -6,7 +6,10 @@ import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
 import "package:test/test.dart";
 
 void main() {
-  const target = PlatformTarget(os: PlatformOs.linux, arch: PlatformArch.x64);
+  final target = PlatformTarget(
+    os: Platform.isWindows ? PlatformOs.windows : PlatformOs.linux,
+    arch: PlatformArch.x64,
+  );
   const storage = AntigravityRuntimeStorage();
   late Directory temporaryDirectory;
 


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this adds a typed Storage → Repository → Service runtime-selection flow with filesystem, process-probe, timeout, and cancellation boundaries.

## What

- Add typed local-pair read, candidate, probe, contract, and resolution outcomes.
- Inspect official server/harness pairs for exact requested and resolved filenames, regular files, resolved sibling placement, and distinct file identity.
- Resolve an authoritative explicit server path, then PATH before an optional managed candidate.
- Probe each candidate through the typed initialize-only ACP API with one shared timeout budget and cooperative cancellation.
- Validate the exact pinned protocol, identity, version, load/list/resume/logout capabilities, absent close capability, and personal OAuth method.
- Export the unregistered runtime layers and cover filesystem, mapping, precedence, failure, timeout, cancellation, environment, and contract behavior.

The PR is 1,253 changed lines including tests and tracker updates.

## Why

Antigravity requires Google’s official `antigravity-acp` server and mandatory sibling harness to be selected as one trustworthy runtime pair. This establishes user-supplied explicit/PATH support and the policy seam later managed installation will reuse, without registering or activating the plugin yet.

## Risk and test focus

Risk is moderate and currently isolated to the unregistered Antigravity package. Review should focus on symlink/hard-link pair integrity, explicit-path authority, PATH shadowing and managed fallback, exact typed initialize mapping, total timeout budgeting, cancellation boundaries, and preservation of original storage/probe errors and stack traces.

## Expected result

There is no user-visible or database impact. The bridge app still does not depend on or register Antigravity. Later composition can resolve a validated official pair from an explicit path, PATH, or managed location without leaking raw filesystem or ACP wire values above their owning boundaries.

## Verification

- `cd bridge/sesori_plugin_antigravity && dart analyze --fatal-infos` — no issues
- `cd bridge/sesori_plugin_antigravity && dart test` — 30 passed
- `git diff --check` — passed
- Changed-source 120-column check — passed
- Architecture implementation review — approved with no violations
