### PR TITLE
🚧 [antigravity-harness] feat(auth): accept browser authentication continuations [step 4/12]

### DIFF
--- a/.plan/active/antigravity-harness/PLAN.md
+++ b/.plan/active/antigravity-harness/PLAN.md
@@ -662,9 +662,9 @@ documented invariant, they update that document immediately. Step 11 is final re
 ### Step 4/12: Browser continuation ownership
 
 - Replace the stream-only descriptor result with sealed backend-neutral authentication operation variants that couple
-  each challenge event stream to device-code rejection or browser redirect acceptance. Add required `HostJsonStore` access to
-  the authentication descriptor contract. App composition creates one store per plugin state root and shares that
-  instance with authentication and the live `PluginHost`; update Codex and all fakes without a compatibility shim.
+  each challenge event stream to device-code rejection or browser redirect acceptance. Add required `HostJsonStore`
+  access to the authentication descriptor contract. App composition creates one store per plugin state root and shares
+  that instance with authentication and the live `PluginHost`; update Codex and all fakes without a compatibility shim.
 - Route continuation only to the current plugin's single active, generation-fenced authentication. Define typed
   no-active/wrong-kind/already-submitted conflicts and preserve cancel/shutdown settlement.
 - Keep browser semantics out of bridge core: it owns operation identity/order, not provider URL validation or HTTP.

--- a/.plan/active/antigravity-harness/PLAN.md
+++ b/.plan/active/antigravity-harness/PLAN.md
@@ -661,8 +661,8 @@ documented invariant, they update that document immediately. Step 11 is final re
 
 ### Step 4/12: Browser continuation ownership
 
-- Replace the stream-only descriptor result with a backend-neutral authentication operation that exposes events and can
-  reject or accept a browser redirect according to its sealed operation kind. Add required `HostJsonStore` access to
+- Replace the stream-only descriptor result with sealed backend-neutral authentication operation variants that couple
+  each challenge event stream to device-code rejection or browser redirect acceptance. Add required `HostJsonStore` access to
   the authentication descriptor contract. App composition creates one store per plugin state root and shares that
   instance with authentication and the live `PluginHost`; update Codex and all fakes without a compatibility shim.
 - Route continuation only to the current plugin's single active, generation-fenced authentication. Define typed

--- a/.plan/active/antigravity-harness/TRACKER.md
+++ b/.plan/active/antigravity-harness/TRACKER.md
@@ -202,5 +202,5 @@ applicable catalog entry from L1 through L5 across its required plugin/platform 
   scoped-store composition, and Codex lockstep update with no violations. Interface (161), Codex (415), and focused app
   authentication/runtime tests (129) pass; all three packages analyze cleanly.
 - 2026-09-04 — Step 4's self-inclusive cap check used
-  `git diff --numstat d85d9fcb1d36 3f5e5018e3f6` with an additions/deletions sum: 774 + 139 = 913 changed lines,
-  leaving 587 lines below the 1,500-line cap.
+  `git diff --numstat d85d9fcb1d36 dfcf2058644a` with an additions/deletions sum: 778 + 142 = 920 changed lines,
+  leaving 580 lines below the 1,500-line cap.

--- a/.plan/active/antigravity-harness/TRACKER.md
+++ b/.plan/active/antigravity-harness/TRACKER.md
@@ -3,13 +3,13 @@
 ## Current State
 
 - **Plan:** `.plan/active/antigravity-harness/PLAN.md`
-- **Status:** Steps 1-2/12 merged; Step 3/12 open for review
-- **Base:** `origin/main` at `4c587bcefed5601a83b24d202b2edff75611cbe2`
-- **Current branch:** `antigravity-harness-step-3-runtime-resolution`
+- **Status:** Steps 1-2/12 merged; Step 3/12 open for review; Step 4/12 in progress locally
+- **Base:** Step 3 PR head `d4f1004b97`
+- **Current branch:** `antigravity-harness-step-4-browser-auth-continuation`
 - **Merged PRs:** [#1285](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1285) (Step 1),
   [#1286](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1286) (Step 2)
 - **Open PR:** [#1287](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1287) (Step 3)
-- **Next action:** monitor Step 3 through readiness and begin Step 4 locally
+- **Next action:** monitor Step 3 through readiness and finish the local Step 4 implementation
 
 ## Fixed PR Series
 
@@ -65,6 +65,19 @@
 - [x] Run final focused analysis/tests and Git/Markdown validation, including self-inclusive merge-base numstat
   reconciliation against the 1,500-line cap.
 - [x] Commit, push, open the Step 3 PR, and start the PR monitor.
+
+## Step 4 Checklist
+
+- [x] Inspect descriptor, runtime, lifecycle, Codex authentication, scoped-store composition, and focused tests.
+- [x] Replace the stream-only descriptor return with a typed operation and sealed device-code/browser kinds.
+- [x] Pass a required per-state-root `HostJsonStore` instance to authentication and every live plugin generation.
+- [x] Add active-generation redirect routing with typed no-active, wrong-kind, and already-submitted conflicts.
+- [x] Preserve Codex device-code behavior while rejecting browser redirect submission.
+- [x] Finish focused same-request, challenge-order, generation, duplicate, cancel, shutdown, store, and cleanup
+  coverage.
+- [x] Complete architecture implementation review and apply valid findings.
+- [x] Run final focused analysis/tests and Git/Markdown validation.
+- [x] After Step 3 merges, sync, commit, push, open the Step 4 PR, and start its monitor.
 
 ## Architecture Reviews
 
@@ -183,3 +196,10 @@ applicable catalog entry from L1 through L5 across its required plugin/platform 
 - 2026-09-04 — Step 3's self-inclusive cap check used
   `git diff --numstat 4c587bcefed5 1c7f3d955ac1` with an additions/deletions sum: 1246 + 7 = 1253
   changed lines, leaving 247 lines below the 1,500-line cap.
+- 2026-09-04 — PR #1287 merged as `d85d9fcb1d`; Step 4 was synced to that merge before publication.
+- 2026-09-04 — Step 4 architecture implementation review approved the backend-neutral operation, generation fencing,
+  scoped-store composition, and Codex lockstep update with no violations. Interface (161), Codex (415), and focused app
+  authentication/runtime tests (129) pass; all three packages analyze cleanly.
+- 2026-09-04 — Step 4's self-inclusive cap check used
+  `git diff --numstat d85d9fcb1d36 CCCCCCCCCCCC` with an additions/deletions sum: XXXX + YYY = ZZZZ changed lines,
+  leaving MMM lines below the 1,500-line cap.

--- a/.plan/active/antigravity-harness/TRACKER.md
+++ b/.plan/active/antigravity-harness/TRACKER.md
@@ -202,5 +202,5 @@ applicable catalog entry from L1 through L5 across its required plugin/platform 
   scoped-store composition, and Codex lockstep update with no violations. Interface (161), Codex (415), and focused app
   authentication/runtime tests (129) pass; all three packages analyze cleanly.
 - 2026-09-04 — Step 4's self-inclusive cap check used
-  `git diff --numstat d85d9fcb1d36 dfcf2058644a` with an additions/deletions sum: 778 + 142 = 920 changed lines,
-  leaving 580 lines below the 1,500-line cap.
+  `git diff --numstat d85d9fcb1d36 a6068b67c8` with an additions/deletions sum: 818 + 156 = 974 changed lines,
+  leaving 526 lines below the 1,500-line cap.

--- a/.plan/active/antigravity-harness/TRACKER.md
+++ b/.plan/active/antigravity-harness/TRACKER.md
@@ -3,19 +3,20 @@
 ## Current State
 
 - **Plan:** `.plan/active/antigravity-harness/PLAN.md`
-- **Status:** Steps 1-2/12 merged; Step 3/12 open for review; Step 4/12 in progress locally
-- **Base:** Step 3 PR head `d4f1004b97`
+- **Status:** Steps 1-3/12 merged; Step 4/12 open for review; Step 5/12 in progress locally
+- **Base:** Step 3 merge `d85d9fcb1d`
 - **Current branch:** `antigravity-harness-step-4-browser-auth-continuation`
 - **Merged PRs:** [#1285](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1285) (Step 1),
-  [#1286](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1286) (Step 2)
-- **Open PR:** [#1287](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1287) (Step 3)
-- **Next action:** monitor Step 3 through readiness and finish the local Step 4 implementation
+  [#1286](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1286) (Step 2),
+  [#1287](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1287) (Step 3)
+- **Open PR:** [#1288](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1288) (Step 4)
+- **Next action:** monitor Step 4 through readiness and finish the local Step 5 implementation
 
 ## Fixed PR Series
 
 - [x] Step 1/12 — `🌱 [antigravity-harness] docs: plan Antigravity ACP support [step 1/12]`
 - [x] Step 2/12 — `⚙️ [antigravity-harness] feat(antigravity): pin the official ACP runtime contract [step 2/12]`
-- [ ] Step 3/12 — `⚙️ [antigravity-harness] feat(antigravity): resolve local runtime pairs [step 3/12]`
+- [x] Step 3/12 — `⚙️ [antigravity-harness] feat(antigravity): resolve local runtime pairs [step 3/12]`
 - [ ] Step 4/12 — `🚧 [antigravity-harness] feat(auth): accept browser authentication continuations [step 4/12]`
 - [ ] Step 5/12 — `🚧 [antigravity-harness] feat(client): add remote browser authentication handoff [step 5/12]`
 - [ ] Step 6/12 — `🚧 [antigravity-harness] feat(antigravity): add isolated profile authentication [step 6/12]`

--- a/.plan/active/antigravity-harness/TRACKER.md
+++ b/.plan/active/antigravity-harness/TRACKER.md
@@ -202,5 +202,5 @@ applicable catalog entry from L1 through L5 across its required plugin/platform 
   scoped-store composition, and Codex lockstep update with no violations. Interface (161), Codex (415), and focused app
   authentication/runtime tests (129) pass; all three packages analyze cleanly.
 - 2026-09-04 — Step 4's self-inclusive cap check used
-  `git diff --numstat d85d9fcb1d36 a6068b67c8` with an additions/deletions sum: 818 + 156 = 974 changed lines,
-  leaving 526 lines below the 1,500-line cap.
+  `git diff --numstat d85d9fcb1d36 6da24f133c` with an additions/deletions sum: 838 + 158 = 996 changed lines,
+  leaving 504 lines below the 1,500-line cap.

--- a/.plan/active/antigravity-harness/TRACKER.md
+++ b/.plan/active/antigravity-harness/TRACKER.md
@@ -201,5 +201,5 @@ applicable catalog entry from L1 through L5 across its required plugin/platform 
   scoped-store composition, and Codex lockstep update with no violations. Interface (161), Codex (415), and focused app
   authentication/runtime tests (129) pass; all three packages analyze cleanly.
 - 2026-09-04 — Step 4's self-inclusive cap check used
-  `git diff --numstat d85d9fcb1d36 CCCCCCCCCCCC` with an additions/deletions sum: XXXX + YYY = ZZZZ changed lines,
-  leaving MMM lines below the 1,500-line cap.
+  `git diff --numstat d85d9fcb1d36 3f5e5018e3f6` with an additions/deletions sum: 774 + 139 = 913 changed lines,
+  leaving 587 lines below the 1,500-line cap.

--- a/bridge/app/lib/src/repositories/plugin_lifecycle_repository.dart
+++ b/bridge/app/lib/src/repositories/plugin_lifecycle_repository.dart
@@ -39,6 +39,16 @@ class PluginLifecycleRepository({required final PluginRuntime _runtime}) {
   PluginRuntimeAuthenticationOperation authenticate({required String pluginId}) =>
       _runtime.authenticate(pluginId: pluginId);
 
+  Future<PluginRuntimeAuthenticationContinuationResult> submitAuthenticationRedirect({
+    required String pluginId,
+    required int generation,
+    required Uri redirectUri,
+  }) => _runtime.submitAuthenticationRedirect(
+    pluginId: pluginId,
+    generation: generation,
+    redirectUri: redirectUri,
+  );
+
   Future<PluginRuntimeCommandResult> prepareDisable({
     required String pluginId,
     required PluginStopIntent intent,

--- a/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
@@ -18,6 +18,7 @@ import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart"
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
     show
         Console,
+        HostJsonStore,
         Log,
         PluginConfig,
         PluginStartAbortedException,
@@ -77,6 +78,7 @@ import "../server/api/terminal_prompt_api.dart";
 import "../server/foundation/bridge_replace_prompt.dart";
 import "../server/foundation/bridge_restart_command_builder.dart";
 import "../server/foundation/bridge_restart_env.dart";
+import "../server/host/bridge_host_json_store.dart";
 import "../server/host/bridge_host_process_service.dart";
 import "../server/host/plugin_state_directory.dart";
 import "../server/repositories/bridge_instance_repository.dart";
@@ -127,7 +129,10 @@ import "plugin_registry.dart";
 import "plugin_runtime.dart";
 import "runtime_provision_formatter.dart";
 
-enum _PhoneConnectionWaitOutcome() { connected, sessionStopped }
+enum _PhoneConnectionWaitOutcome() {
+  connected,
+  sessionStopped,
+}
 
 class const BridgeRuntimeRunner._() {
   /// Soft deadline granted to the plugin's ordered `shutdown()` step. The
@@ -249,6 +254,9 @@ class const BridgeRuntimeRunner._() {
     // live here under a frozen cross-version contract (see pluginStateDirectoryPath).
     final runtimeDirectory = path.join(managedRuntimePaths.cacheDirectory, "runtime");
     final runtimeFileApi = RuntimeFileApi(runtimeDirectory: runtimeDirectory);
+    final pluginStoresByStateDirectory = <String, HostJsonStore>{
+      runtimeDirectory: BridgeHostJsonStore(fileApi: runtimeFileApi),
+    };
     final systemProcessApi = SystemProcessApi(
       processRunner: processRunner,
       clock: serverClock,
@@ -568,6 +576,28 @@ class const BridgeRuntimeRunner._() {
         isWindows: io.Platform.isWindows,
         platform: io.Platform.operatingSystem,
       );
+      final pluginRuntimeRegistrations = <PluginRuntimeRegistration>[];
+      for (final descriptor in knownPlugins) {
+        final stateDirectory = pluginStateDirectoryPath(
+          paths: managedRuntimePaths,
+          pluginId: descriptor.id,
+          stateStorage: descriptor.stateStorage,
+        );
+        final store = pluginStoresByStateDirectory.putIfAbsent(
+          stateDirectory,
+          () => BridgeHostJsonStore(
+            fileApi: RuntimeFileApi(runtimeDirectory: stateDirectory),
+          ),
+        );
+        pluginRuntimeRegistrations.add(
+          PluginRuntimeRegistration(
+            descriptor: descriptor,
+            config: pluginConfigs[descriptor.id]!,
+            stateDirectory: stateDirectory,
+            store: store,
+          ),
+        );
+      }
       final generationFactory = PluginGenerationFactory(
         managedRuntimePaths: managedRuntimePaths,
         currentBridgeIdentity: currentBridgeIdentity,
@@ -575,7 +605,6 @@ class const BridgeRuntimeRunner._() {
         startupMutexRepository: startupMutexRepository,
         bridgeInstanceService: bridgeInstanceService,
         processRepository: processRepository,
-        runtimeFileApi: runtimeFileApi,
         clock: serverClock,
         environment: environment,
         currentUser: currentUser,
@@ -584,18 +613,7 @@ class const BridgeRuntimeRunner._() {
         settingsChanges: bridgeSettingsRepository.settingsChanges,
       );
       final activePluginRuntime = PluginRuntime(
-        registrations: [
-          for (final descriptor in knownPlugins)
-            PluginRuntimeRegistration(
-              descriptor: descriptor,
-              config: pluginConfigs[descriptor.id]!,
-              stateDirectory: pluginStateDirectoryPath(
-                paths: managedRuntimePaths,
-                pluginId: descriptor.id,
-                stateStorage: descriptor.stateStorage,
-              ),
-            ),
-        ],
+        registrations: pluginRuntimeRegistrations,
         generationFactory: generationFactory,
         setupProcesses: hostProcessService,
         environment: environment,
@@ -604,26 +622,25 @@ class const BridgeRuntimeRunner._() {
       );
       pluginRuntime = activePluginRuntime;
       final lifecycleRepository = PluginLifecycleRepository(runtime: activePluginRuntime);
-      final activePluginLifecycleService =
-          PluginLifecycleService(
-            lifecycleRepository: lifecycleRepository,
-            preferredDefaultPluginId: preferredDefaultPluginId,
-            bridgeSettingsRepository: bridgeSettingsRepository,
-            idleTimerScheduler: const PluginIdleTimerScheduler(),
-            bridgeIdProvider: bridgeRegistrationService,
-            plugins: [
-              for (final descriptor in knownPlugins)
-                (
-                  id: descriptor.id,
-                  displayName: descriptor.displayName,
-                  activationPolicy: descriptor.activationPolicy(config: pluginConfigs[descriptor.id]!),
-                  residencyPolicy: descriptor.residencyPolicy(config: pluginConfigs[descriptor.id]!),
-                  sessionOptionsScope: descriptor.sessionOptionsScope,
-                  managementCapabilities: descriptor.managementCapabilities(config: pluginConfigs[descriptor.id]!),
-                  supportsPromptAttachments: descriptor.supportsPromptAttachments,
-                ),
-            ],
-          );
+      final activePluginLifecycleService = PluginLifecycleService(
+        lifecycleRepository: lifecycleRepository,
+        preferredDefaultPluginId: preferredDefaultPluginId,
+        bridgeSettingsRepository: bridgeSettingsRepository,
+        idleTimerScheduler: const PluginIdleTimerScheduler(),
+        bridgeIdProvider: bridgeRegistrationService,
+        plugins: [
+          for (final descriptor in knownPlugins)
+            (
+              id: descriptor.id,
+              displayName: descriptor.displayName,
+              activationPolicy: descriptor.activationPolicy(config: pluginConfigs[descriptor.id]!),
+              residencyPolicy: descriptor.residencyPolicy(config: pluginConfigs[descriptor.id]!),
+              sessionOptionsScope: descriptor.sessionOptionsScope,
+              managementCapabilities: descriptor.managementCapabilities(config: pluginConfigs[descriptor.id]!),
+              supportsPromptAttachments: descriptor.supportsPromptAttachments,
+            ),
+        ],
+      );
       pluginLifecycleService = activePluginLifecycleService;
       final uncontrollableDisabledPluginIds = activePluginLifecycleService.uncontrollableDisabledPluginIds(
         disabledPluginIds: bridgeSettings.plugins.disabledPluginIds,

--- a/bridge/app/lib/src/runtime/plugin_generation_factory.dart
+++ b/bridge/app/lib/src/runtime/plugin_generation_factory.dart
@@ -4,9 +4,7 @@ import "dart:io" as io;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "../server/api/loopback_port_api.dart";
-import "../server/api/runtime_file_api.dart";
 import "../server/host/bridge_host_info_impl.dart";
-import "../server/host/bridge_host_json_store.dart";
 import "../server/host/bridge_host_port_service.dart";
 import "../server/host/bridge_host_process_service.dart";
 import "../server/host/bridge_plugin_host_impl.dart";
@@ -21,6 +19,7 @@ class const PluginRuntimeRegistration({
   required final BridgePluginDescriptor descriptor,
   required final PluginConfig config,
   required final String stateDirectory,
+  required final HostJsonStore store,
 });
 
 /// A failure isolated to one descriptor's runtime resolution or start attempt.
@@ -50,7 +49,6 @@ class PluginGenerationFactory({
   required final StartupMutexRepository _startupMutexRepository,
   required final BridgeInstanceService _bridgeInstanceService,
   required final ProcessRepository _processRepository,
-  required RuntimeFileApi runtimeFileApi,
   required final ServerClock _clock,
   required Map<String, String> environment,
   required final ProcessUser? _currentUser,
@@ -62,9 +60,6 @@ class PluginGenerationFactory({
   required final Stream<Object?> _settingsChanges,
 }) {
   final Map<String, String> _environment = Map<String, String>.unmodifiable(environment);
-  final Map<String, RuntimeFileApi> _fileApisByStateDirectory = <String, RuntimeFileApi>{
-    runtimeFileApi.runtimeDirectory: runtimeFileApi,
-  };
   final List<_GenerationStartRequest> _pending = <_GenerationStartRequest>[];
   bool _drainScheduled = false;
   bool _draining = false;
@@ -73,15 +68,14 @@ class PluginGenerationFactory({
     final minutes = _resolveIdleTimeoutMins(pluginId: pluginId);
     return minutes > 0 ? Duration(minutes: minutes) : null;
   }
+
   Stream<Duration?> _idleTimeoutChangesForPlugin({required String pluginId}) {
     var previous = _idleTimeoutForPlugin(pluginId: pluginId);
-    return _settingsChanges
-        .map<Duration?>((_) => _idleTimeoutForPlugin(pluginId: pluginId))
-        .where((current) {
-          if (current == previous) return false;
-          previous = current;
-          return true;
-        });
+    return _settingsChanges.map<Duration?>((_) => _idleTimeoutForPlugin(pluginId: pluginId)).where((current) {
+      if (current == previous) return false;
+      previous = current;
+      return true;
+    });
   }
 
   Future<void> enforceBridgeOwnership() => _attemptBatch(attempt: 1, batch: const []);
@@ -259,10 +253,6 @@ class PluginGenerationFactory({
       throw StateError('Plugin "${descriptor.id}" registration has an unexpected state directory.');
     }
     await io.Directory(stateDirectory).create(recursive: true);
-    final fileApi = _fileApisByStateDirectory.putIfAbsent(
-      stateDirectory,
-      () => RuntimeFileApi(runtimeDirectory: stateDirectory),
-    );
     return BridgePluginHostImpl(
       config: request.registration.config,
       stateDirectory: stateDirectory,
@@ -284,7 +274,7 @@ class PluginGenerationFactory({
         platform: io.Platform.operatingSystem,
       ),
       ports: const BridgeHostPortService(loopbackPortApi: LoopbackPortApi()),
-      store: BridgeHostJsonStore(fileApi: fileApi),
+      store: request.registration.store,
       resolveIdleTimeout: () => _idleTimeoutForPlugin(pluginId: descriptor.id),
       pluginIdleTimeoutChanges: _idleTimeoutChangesForPlugin(pluginId: descriptor.id),
     );

--- a/bridge/app/lib/src/runtime/plugin_runtime.dart
+++ b/bridge/app/lib/src/runtime/plugin_runtime.dart
@@ -5,34 +5,61 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "plugin_generation_factory.dart";
 
-enum PluginRuntimeAccessGate() { enabled, draining, disabled }
+enum PluginRuntimeAccessGate() {
+  enabled,
+  draining,
+  disabled,
+}
 
 class const PluginRuntimeAccess({
-    required final String pluginId,
-    required final PluginRuntimeAccessGate gate,
-    required final bool startAllowed,
-  });
+  required final String pluginId,
+  required final PluginRuntimeAccessGate gate,
+  required final bool startAllowed,
+});
 
-enum PluginRuntimeState() { disabled, blocked, dormant, starting, active, degraded, stopping, failed }
+enum PluginRuntimeState() {
+  disabled,
+  blocked,
+  dormant,
+  starting,
+  active,
+  degraded,
+  stopping,
+  failed,
+}
 
-enum PluginRuntimeTransition() { none, starting, stopping, restarting }
+enum PluginRuntimeTransition() {
+  none,
+  starting,
+  stopping,
+  restarting,
+}
 
-enum PluginStopIntent() { safe, force }
+enum PluginStopIntent() {
+  safe,
+  force,
+}
 
-enum PluginRuntimeConflictReason() { inFlight, busy, workStateUnknown, transitioning, notEligible }
+enum PluginRuntimeConflictReason() {
+  inFlight,
+  busy,
+  workStateUnknown,
+  transitioning,
+  notEligible,
+}
 
 class const PluginRuntimeSnapshot({
-    required final String pluginId,
-    required final PluginProjectOwnership projectOwnership,
-    required final PluginSetupStatus setup,
-    required final PluginRuntimeAccessGate accessGate,
-    required final bool startAllowed,
-    required final int? generation,
-    required final PluginRuntimeState state,
-    required final PluginWorkState workState,
-    required final int leaseCount,
-    required final PluginRuntimeTransition transition,
-  });
+  required final String pluginId,
+  required final PluginProjectOwnership projectOwnership,
+  required final PluginSetupStatus setup,
+  required final PluginRuntimeAccessGate accessGate,
+  required final bool startAllowed,
+  required final int? generation,
+  required final PluginRuntimeState state,
+  required final PluginWorkState workState,
+  required final int leaseCount,
+  required final PluginRuntimeTransition transition,
+});
 
 typedef SourcedPluginRuntimeEvent = ({
   String pluginId,
@@ -43,7 +70,26 @@ typedef SourcedPluginRuntimeEvent = ({
 });
 typedef SourcedPluginProvisionProgress = ({String pluginId, RuntimeProvisionProgress event});
 
-class const PluginRuntimeAuthenticationOperation({required final Stream<PluginAuthenticationEvent> events, required final void Function() abort});
+class const PluginRuntimeAuthenticationOperation({
+  required final Stream<PluginAuthenticationEvent> events,
+  required final void Function() abort,
+  required final int generation,
+});
+
+enum PluginRuntimeAuthenticationContinuationConflictReason() {
+  staleGeneration,
+  wrongKind,
+  alreadySubmitted,
+}
+
+sealed class const PluginRuntimeAuthenticationContinuationResult();
+
+final class const PluginRuntimeAuthenticationContinuationApplied()
+    extends PluginRuntimeAuthenticationContinuationResult;
+
+final class const PluginRuntimeAuthenticationContinuationConflict({
+  required final PluginRuntimeAuthenticationContinuationConflictReason reason,
+}) extends PluginRuntimeAuthenticationContinuationResult;
 
 sealed class const PluginRuntimeCommandResult({required final PluginRuntimeSnapshot snapshot});
 
@@ -51,18 +97,22 @@ final class const PluginRuntimeCommandApplied({required super.snapshot}) extends
 
 final class const PluginRuntimeCommandCurrent({required super.snapshot}) extends PluginRuntimeCommandResult;
 
-final class const PluginRuntimeCommandConflict({required super.snapshot, required final List<PluginRuntimeConflictReason> reasons}) extends PluginRuntimeCommandResult;
+final class const PluginRuntimeCommandConflict({
+  required super.snapshot,
+  required final List<PluginRuntimeConflictReason> reasons,
+}) extends PluginRuntimeCommandResult;
 
-final class const PluginRuntimeCommandFailed({required super.snapshot, required final String message}) extends PluginRuntimeCommandResult;
+final class const PluginRuntimeCommandFailed({required super.snapshot, required final String message})
+    extends PluginRuntimeCommandResult;
 
 class PluginRuntime({
-    required List<PluginRuntimeRegistration> registrations,
-    required final PluginGenerationFactory _generationFactory,
-    required final HostProcessService _setupProcesses,
-    required Map<String, String> environment,
-    required final ServerClock _clock,
-    required final Duration _shutdownBudget,
-  }) {
+  required List<PluginRuntimeRegistration> registrations,
+  required final PluginGenerationFactory _generationFactory,
+  required final HostProcessService _setupProcesses,
+  required Map<String, String> environment,
+  required final ServerClock _clock,
+  required final Duration _shutdownBudget,
+}) {
   this {
     if (_slots.length != registrations.length) {
       throw ArgumentError.value(registrations, "registrations", "must not contain duplicate plugin ids");
@@ -72,9 +122,9 @@ class PluginRuntime({
 
   final Map<String, String> _environment = Map<String, String>.unmodifiable(environment);
   final Map<String, _PluginRuntimeSlot> _slots = <String, _PluginRuntimeSlot>{
-         for (final registration in registrations)
-           registration.descriptor.id: _PluginRuntimeSlot(registration: registration),
-       };
+    for (final registration in registrations)
+      registration.descriptor.id: _PluginRuntimeSlot(registration: registration),
+  };
   late final BehaviorSubject<List<PluginRuntimeSnapshot>> _snapshotsSubject;
   final ReplaySubject<SourcedPluginRuntimeEvent> _backendEventsSubject = ReplaySubject<SourcedPluginRuntimeEvent>(
     maxSize: 1024,
@@ -203,27 +253,88 @@ class PluginRuntime({
   PluginRuntimeAuthenticationOperation authenticate({required String pluginId}) {
     final slot = _requireSlot(pluginId);
     if (_shuttingDown) throw const PluginStartAbortedException();
+    if (slot.authentication != null) {
+      throw StateError('Plugin "$pluginId" already has an active authentication operation.');
+    }
     final descriptor = slot.registration.descriptor;
     if (descriptor is! InteractivePluginAuthenticationDescriptor) {
       throw StateError('Plugin "$pluginId" does not support interactive authentication.');
     }
     final authenticationDescriptor = descriptor as InteractivePluginAuthenticationDescriptor;
     final abortController = StartAbortController();
+    final descriptorOperation = authenticationDescriptor.authenticate(
+      config: slot.registration.config,
+      processes: _setupProcesses,
+      environment: _environment,
+      stateDirectory: slot.registration.stateDirectory,
+      store: slot.registration.store,
+      aborted: abortController.signal,
+    );
+    final authentication = _PluginRuntimeAuthentication(
+      generation: ++slot.authenticationGeneration,
+      abortController: abortController,
+      kind: descriptorOperation.kind,
+    );
+    slot.authentication = authentication;
     _authenticationAbortControllers.add(abortController);
     final events = (() async* {
       try {
-        yield* authenticationDescriptor.authenticate(
-          config: slot.registration.config,
-          processes: _setupProcesses,
-          environment: _environment,
-          stateDirectory: slot.registration.stateDirectory,
-          aborted: abortController.signal,
-        );
+        yield* descriptorOperation.events;
       } finally {
+        authentication.acceptingContinuations = false;
         _authenticationAbortControllers.remove(abortController);
+        if (identical(slot.authentication, authentication)) {
+          slot.authentication = null;
+        }
       }
     })();
-    return PluginRuntimeAuthenticationOperation(events: events, abort: abortController.abort);
+    return PluginRuntimeAuthenticationOperation(
+      events: events,
+      abort: () => _abortAuthentication(slot: slot, authentication: authentication),
+      generation: authentication.generation,
+    );
+  }
+
+  Future<PluginRuntimeAuthenticationContinuationResult> submitAuthenticationRedirect({
+    required String pluginId,
+    required int generation,
+    required Uri redirectUri,
+  }) async {
+    final slot = _requireSlot(pluginId);
+    final authentication = slot.authentication;
+    if (_shuttingDown ||
+        authentication == null ||
+        authentication.generation != generation ||
+        !authentication.acceptingContinuations) {
+      return const PluginRuntimeAuthenticationContinuationConflict(
+        reason: PluginRuntimeAuthenticationContinuationConflictReason.staleGeneration,
+      );
+    }
+    switch (authentication.kind) {
+      case PluginAuthenticationDeviceCodeOperationKind():
+        return const PluginRuntimeAuthenticationContinuationConflict(
+          reason: PluginRuntimeAuthenticationContinuationConflictReason.wrongKind,
+        );
+      case PluginAuthenticationBrowserOperationKind(:final submitRedirect):
+        if (authentication.redirectSubmitted) {
+          return const PluginRuntimeAuthenticationContinuationConflict(
+            reason: PluginRuntimeAuthenticationContinuationConflictReason.alreadySubmitted,
+          );
+        }
+        authentication.redirectSubmitted = true;
+        await submitRedirect(redirectUri: redirectUri);
+        return const PluginRuntimeAuthenticationContinuationApplied();
+    }
+  }
+
+  void _abortAuthentication({
+    required _PluginRuntimeSlot slot,
+    required _PluginRuntimeAuthentication authentication,
+  }) {
+    if (identical(slot.authentication, authentication)) {
+      authentication.acceptingContinuations = false;
+    }
+    authentication.abortController.abort();
   }
 
   void applyAccess({required List<PluginRuntimeAccess> entries}) {
@@ -1711,6 +1822,8 @@ class _PluginRuntimeSlot({required final PluginRuntimeRegistration registration}
   Future<BridgePlugin?>? startFuture;
   Future<void>? cleanupFuture;
   StartAbortController? startAbortController;
+  int authenticationGeneration = 0;
+  _PluginRuntimeAuthentication? authentication;
   // ignore: cancel_subscriptions - generation ownership cancels these in PluginRuntime.
   StreamSubscription<PluginStatus>? statusSubscription;
   // ignore: cancel_subscriptions - generation ownership cancels these in PluginRuntime.
@@ -1721,4 +1834,17 @@ class _PluginRuntimeSlot({required final PluginRuntimeRegistration registration}
   final Set<Future<void> Function()> operationStreamCancellations = <Future<void> Function()>{};
 }
 
-class const _PluginLease({required final _PluginRuntimeSlot slot, required final int generation, required final BridgePluginApi api});
+class _PluginRuntimeAuthentication({
+  required final int generation,
+  required final StartAbortController abortController,
+  required final PluginAuthenticationOperationKind kind,
+}) {
+  bool acceptingContinuations = true;
+  bool redirectSubmitted = false;
+}
+
+class const _PluginLease({
+  required final _PluginRuntimeSlot slot,
+  required final int generation,
+  required final BridgePluginApi api,
+});

--- a/bridge/app/lib/src/runtime/plugin_runtime.dart
+++ b/bridge/app/lib/src/runtime/plugin_runtime.dart
@@ -273,7 +273,7 @@ class PluginRuntime({
     final authentication = _PluginRuntimeAuthentication(
       generation: ++slot.authenticationGeneration,
       abortController: abortController,
-      kind: descriptorOperation.kind,
+      operation: descriptorOperation,
     );
     slot.authentication = authentication;
     _authenticationAbortControllers.add(abortController);
@@ -310,12 +310,12 @@ class PluginRuntime({
         reason: PluginRuntimeAuthenticationContinuationConflictReason.staleGeneration,
       );
     }
-    switch (authentication.kind) {
-      case PluginAuthenticationDeviceCodeOperationKind():
+    switch (authentication.operation) {
+      case PluginAuthenticationDeviceCodeOperation():
         return const PluginRuntimeAuthenticationContinuationConflict(
           reason: PluginRuntimeAuthenticationContinuationConflictReason.wrongKind,
         );
-      case PluginAuthenticationBrowserOperationKind(:final submitRedirect):
+      case PluginAuthenticationBrowserOperation(:final submitRedirect):
         if (authentication.redirectSubmitted) {
           return const PluginRuntimeAuthenticationContinuationConflict(
             reason: PluginRuntimeAuthenticationContinuationConflictReason.alreadySubmitted,
@@ -323,6 +323,11 @@ class PluginRuntime({
         }
         authentication.redirectSubmitted = true;
         await submitRedirect(redirectUri: redirectUri);
+        if (_shuttingDown || !identical(slot.authentication, authentication) || !authentication.acceptingContinuations) {
+          return const PluginRuntimeAuthenticationContinuationConflict(
+            reason: PluginRuntimeAuthenticationContinuationConflictReason.staleGeneration,
+          );
+        }
         return const PluginRuntimeAuthenticationContinuationApplied();
     }
   }
@@ -1837,7 +1842,7 @@ class _PluginRuntimeSlot({required final PluginRuntimeRegistration registration}
 class _PluginRuntimeAuthentication({
   required final int generation,
   required final StartAbortController abortController,
-  required final PluginAuthenticationOperationKind kind,
+  required final PluginAuthenticationOperation operation,
 }) {
   bool acceptingContinuations = true;
   bool redirectSubmitted = false;

--- a/bridge/app/lib/src/runtime/plugin_runtime.dart
+++ b/bridge/app/lib/src/runtime/plugin_runtime.dart
@@ -323,7 +323,7 @@ class PluginRuntime({
         }
         authentication.redirectSubmitted = true;
         await submitRedirect(redirectUri: redirectUri);
-        if (_shuttingDown || !identical(slot.authentication, authentication) || !authentication.acceptingContinuations) {
+        if (_shuttingDown || authentication.aborted) {
           return const PluginRuntimeAuthenticationContinuationConflict(
             reason: PluginRuntimeAuthenticationContinuationConflictReason.staleGeneration,
           );
@@ -336,6 +336,7 @@ class PluginRuntime({
     required _PluginRuntimeSlot slot,
     required _PluginRuntimeAuthentication authentication,
   }) {
+    authentication.aborted = true;
     if (identical(slot.authentication, authentication)) {
       authentication.acceptingContinuations = false;
     }
@@ -1846,6 +1847,7 @@ class _PluginRuntimeAuthentication({
 }) {
   bool acceptingContinuations = true;
   bool redirectSubmitted = false;
+  bool aborted = false;
 }
 
 class const _PluginLease({

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -376,6 +376,45 @@ class PluginLifecycleService({
     return authentication.challenge.future;
   }
 
+  Future<void> submitAuthenticationRedirect({
+    required String pluginId,
+    required Uri redirectUri,
+  }) async {
+    if (_setupById == null) {
+      throw StateError("Plugin lifecycle has not been initialized.");
+    }
+    if (!_knownPluginIds.contains(pluginId)) {
+      throw PluginManagementPluginNotFoundException(pluginId);
+    }
+    _requireBridgeId();
+    final authentication = _activePluginAuthentications[pluginId];
+    if (authentication == null) {
+      throw const PluginAuthenticationContinuationConflictException(
+        reason: PluginAuthenticationContinuationConflictReason.noActive,
+      );
+    }
+    final result = await _lifecycleRepository.submitAuthenticationRedirect(
+      pluginId: pluginId,
+      generation: authentication.operation.generation,
+      redirectUri: redirectUri,
+    );
+    switch (result) {
+      case PluginRuntimeAuthenticationContinuationApplied():
+        return;
+      case PluginRuntimeAuthenticationContinuationConflict(:final reason):
+        throw PluginAuthenticationContinuationConflictException(
+          reason: switch (reason) {
+            PluginRuntimeAuthenticationContinuationConflictReason.staleGeneration =>
+              PluginAuthenticationContinuationConflictReason.noActive,
+            PluginRuntimeAuthenticationContinuationConflictReason.wrongKind =>
+              PluginAuthenticationContinuationConflictReason.wrongKind,
+            PluginRuntimeAuthenticationContinuationConflictReason.alreadySubmitted =>
+              PluginAuthenticationContinuationConflictReason.alreadySubmitted,
+          },
+        );
+    }
+  }
+
   Future<SuccessEmptyResponse> cancelAuthentication({required String pluginId}) async {
     if (_setupById == null) {
       throw StateError("Plugin lifecycle has not been initialized.");
@@ -425,6 +464,9 @@ class PluginLifecycleService({
             }
             return terminal;
           }(),
+          PluginAuthenticationBrowserChallenge() => throw StateError(
+            "Browser authentication challenge transport is not available.",
+          ),
           PluginAuthenticationCompleted() => const PluginAuthenticationProgress.completed(),
           PluginAuthenticationFailed(:final message) => () {
             Log.w('Plugin "$pluginId" authentication failed: $message');
@@ -1429,6 +1471,16 @@ class const PluginManagementPluginNotFoundException(final String pluginId) imple
 class const PluginManagementConflictException(final PluginLifecycleConflict conflict) implements Exception;
 
 class const PluginAuthenticationConflictException(final PluginAuthenticationConflict conflict) implements Exception;
+
+enum PluginAuthenticationContinuationConflictReason() {
+  noActive,
+  wrongKind,
+  alreadySubmitted,
+}
+
+class const PluginAuthenticationContinuationConflictException({
+  required final PluginAuthenticationContinuationConflictReason reason,
+}) implements Exception;
 
 class const PluginAuthenticationChallengeUnavailableException() implements Exception;
 

--- a/bridge/app/test/bridge/runtime/plugin_generation_factory_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_generation_factory_test.dart
@@ -5,6 +5,7 @@ import "package:sesori_bridge/src/runtime/bridge_runtime_server_exception.dart";
 import "package:sesori_bridge/src/runtime/plugin_generation_factory.dart";
 import "package:sesori_bridge/src/server/api/runtime_file_api.dart";
 import "package:sesori_bridge/src/server/foundation/process_match.dart";
+import "package:sesori_bridge/src/server/host/bridge_host_json_store.dart";
 import "package:sesori_bridge/src/server/host/plugin_state_directory.dart";
 import "package:sesori_bridge/src/server/models/bridge_startup_lock.dart";
 import "package:sesori_bridge/src/server/repositories/startup_mutex_repository.dart";
@@ -28,6 +29,7 @@ void main() {
     late Directory runtimeDirectory;
     late List<BridgePlugin> startedPlugins;
     late StreamController<Object?> settingsChanges;
+    late HostJsonStore registrationStore;
     late int idleTimeoutMins;
 
     setUp(() async {
@@ -61,6 +63,14 @@ void main() {
         binaryPath: "$directory/bin/sesori-bridge",
         cacheDirectory: directory,
       );
+      final pluginStateDirectory = pluginStateDirectoryPath(
+        paths: managedRuntimePaths,
+        pluginId: descriptor.id,
+        stateStorage: descriptor.stateStorage,
+      );
+      registrationStore = BridgeHostJsonStore(
+        fileApi: RuntimeFileApi(runtimeDirectory: pluginStateDirectory),
+      );
       final factory = PluginGenerationFactory(
         managedRuntimePaths: managedRuntimePaths,
         currentBridgeIdentity: currentBridgeIdentity,
@@ -68,7 +78,6 @@ void main() {
         startupMutexRepository: startupMutexRepository,
         bridgeInstanceService: bridgeInstanceService,
         processRepository: _FakeProcessRepository(),
-        runtimeFileApi: RuntimeFileApi(runtimeDirectory: directory),
         clock: const ServerClock(),
         environment: const <String, String>{"HOME": "/home/alex"},
         currentUser: ProcessUser.fromRawUser("alex"),
@@ -80,11 +89,8 @@ void main() {
         registration: PluginRuntimeRegistration(
           descriptor: descriptor,
           config: const PluginConfig(values: <String, Object?>{"port": "4096"}),
-          stateDirectory: pluginStateDirectoryPath(
-            paths: managedRuntimePaths,
-            pluginId: descriptor.id,
-            stateStorage: descriptor.stateStorage,
-          ),
+          stateDirectory: pluginStateDirectory,
+          store: registrationStore,
         ),
         startAborted: StartAbortSignal.never,
       )) {
@@ -127,6 +133,9 @@ void main() {
       final host = descriptor.startedHosts.single;
       expect(host.config.value("port"), equals("4096"));
       expect(host.stateDirectory, equals("${runtimeDirectory.path}/plugins/fake"));
+      expect(identical(host.store, registrationStore), isTrue);
+      await host.store.write(name: "shared.json", contents: '{"ready":true}');
+      expect(await registrationStore.read(name: "shared.json"), '{"ready":true}');
       expect(host.environment, containsPair("HOME", "/home/alex"));
       expect(host.bridge.identity.pid, equals(100));
       expect(host.bridge.ownerSessionId, equals("owner-session"));
@@ -164,7 +173,6 @@ void main() {
         startupMutexRepository: startupMutexRepository,
         bridgeInstanceService: bridgeInstanceService,
         processRepository: _FakeProcessRepository(),
-        runtimeFileApi: RuntimeFileApi(runtimeDirectory: runtimeDirectory.path),
         clock: const ServerClock(),
         environment: const <String, String>{},
         currentUser: null,

--- a/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
@@ -78,17 +78,19 @@ void main() {
   test("authenticate forwards safe events and aborts on shutdown", () async {
     final authenticationGate = Completer<void>();
     final authenticationStores = <HostJsonStore>[];
+    Stream<PluginAuthenticationDeviceCodeEvent> authenticationEvents({required StartAbortSignal aborted}) async* {
+      yield PluginAuthenticationDeviceCodeChallenge(
+        verificationUri: Uri.parse("https://auth.example/device"),
+        userCode: "ABCD-EFGH",
+      );
+      await authenticationGate.future;
+      if (aborted.isAborted) throw const PluginStartAbortedException();
+      yield const PluginAuthenticationCompleted();
+    }
+
     final descriptor = _AuthenticationDescriptor(
-      authenticate: ({required aborted}) async* {
-        yield PluginAuthenticationDeviceCodeChallenge(
-          verificationUri: Uri.parse("https://auth.example/device"),
-          userCode: "ABCD-EFGH",
-        );
-        await authenticationGate.future;
-        if (aborted.isAborted) throw const PluginStartAbortedException();
-        yield const PluginAuthenticationCompleted();
-      },
-      kind: const PluginAuthenticationDeviceCodeOperationKind(),
+      authenticate: ({required aborted}) =>
+          PluginAuthenticationOperation.deviceCode(events: authenticationEvents(aborted: aborted)),
       recordStore: ({required store}) => authenticationStores.add(store),
     );
     final runtime = _runtime(
@@ -136,13 +138,20 @@ void main() {
   });
 
   test("browser redirects are one-shot and fenced to the active generation", () async {
-    final streams = [StreamController<PluginAuthenticationEvent>(), StreamController<PluginAuthenticationEvent>()];
+    final streams = [
+      StreamController<PluginAuthenticationBrowserEvent>(),
+      StreamController<PluginAuthenticationBrowserEvent>(),
+    ];
     var streamIndex = 0;
     final submitted = <Uri>[];
+    Completer<void>? redirectGate;
     final descriptor = _AuthenticationDescriptor(
-      authenticate: ({required aborted}) => streams[streamIndex++].stream,
-      kind: PluginAuthenticationBrowserOperationKind(
-        submitRedirect: ({required redirectUri}) async => submitted.add(redirectUri),
+      authenticate: ({required aborted}) => PluginAuthenticationOperation.browser(
+        events: streams[streamIndex++].stream,
+        submitRedirect: ({required redirectUri}) async {
+          submitted.add(redirectUri);
+          await redirectGate?.future;
+        },
       ),
       recordStore: ({required store}) {},
     );
@@ -203,17 +212,24 @@ void main() {
         PluginRuntimeAuthenticationContinuationConflictReason.staleGeneration,
       ),
     );
-    expect(
-      await runtime.submitAuthenticationRedirect(
-        pluginId: "one",
-        generation: second.generation,
-        redirectUri: secondRedirect,
-      ),
-      isA<PluginRuntimeAuthenticationContinuationApplied>(),
+    redirectGate = Completer<void>();
+    final cancelledSubmission = runtime.submitAuthenticationRedirect(
+      pluginId: "one",
+      generation: second.generation,
+      redirectUri: secondRedirect,
     );
     expect(submitted, [firstRedirect, secondRedirect]);
 
     second.abort();
+    redirectGate.complete();
+    expect(
+      await cancelledSubmission,
+      isA<PluginRuntimeAuthenticationContinuationConflict>().having(
+        (result) => result.reason,
+        "reason",
+        PluginRuntimeAuthenticationContinuationConflictReason.staleGeneration,
+      ),
+    );
     final afterCancel = await runtime.submitAuthenticationRedirect(
       pluginId: "one",
       generation: second.generation,
@@ -1935,8 +1951,7 @@ class const _FakeDescriptor({
 }
 
 class const _AuthenticationDescriptor({
-  required final Stream<PluginAuthenticationEvent> Function({required StartAbortSignal aborted}) _authenticate,
-  required final PluginAuthenticationOperationKind _kind,
+  required final PluginAuthenticationOperation Function({required StartAbortSignal aborted}) _authenticate,
   required final void Function({required HostJsonStore store}) _recordStore,
 }) extends _FakeDescriptor implements InteractivePluginAuthenticationDescriptor {
   @override
@@ -1949,10 +1964,7 @@ class const _AuthenticationDescriptor({
     required StartAbortSignal aborted,
   }) {
     _recordStore(store: store);
-    return PluginAuthenticationOperation(
-      events: _authenticate(aborted: aborted),
-      kind: _kind,
-    );
+    return _authenticate(aborted: aborted);
   }
 }
 

--- a/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
@@ -141,8 +141,10 @@ void main() {
     final streams = [
       StreamController<PluginAuthenticationBrowserEvent>(),
       StreamController<PluginAuthenticationBrowserEvent>(),
+      StreamController<PluginAuthenticationBrowserEvent>(),
     ];
     var streamIndex = 0;
+    var settleOnSubmit = false;
     final submitted = <Uri>[];
     Completer<void>? redirectGate;
     final descriptor = _AuthenticationDescriptor(
@@ -150,6 +152,7 @@ void main() {
         events: streams[streamIndex++].stream,
         submitRedirect: ({required redirectUri}) async {
           submitted.add(redirectUri);
+          if (settleOnSubmit) await streams[streamIndex - 1].close();
           await redirectGate?.future;
         },
       ),
@@ -243,8 +246,21 @@ void main() {
         PluginRuntimeAuthenticationContinuationConflictReason.staleGeneration,
       ),
     );
-    await streams.last.close();
+    await streams[1].close();
     await secondDone;
+
+    settleOnSubmit = true;
+    final third = runtime.authenticate(pluginId: "one");
+    final thirdDone = third.events.drain<void>();
+    expect(
+      await runtime.submitAuthenticationRedirect(
+        pluginId: "one",
+        generation: third.generation,
+        redirectUri: Uri.parse("http://127.0.0.1/callback?code=third"),
+      ),
+      isA<PluginRuntimeAuthenticationContinuationApplied>(),
+    );
+    await thirdDone;
   });
 
   test("authenticate rejects descriptors without the optional capability", () {

--- a/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
@@ -7,6 +7,8 @@ import "package:sesori_bridge/src/runtime/plugin_runtime.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
+const _testHostJsonStore = _UnusedHostJsonStore();
+
 void main() {
   test("snapshot emissions cannot be mutated by subscribers", () async {
     final runtime = _runtime(factory: _FakeGenerationFactory(startGate: Future<void>.value()));
@@ -75,8 +77,9 @@ void main() {
 
   test("authenticate forwards safe events and aborts on shutdown", () async {
     final authenticationGate = Completer<void>();
+    final authenticationStores = <HostJsonStore>[];
     final descriptor = _AuthenticationDescriptor(
-      authenticate: (aborted) async* {
+      authenticate: ({required aborted}) async* {
         yield PluginAuthenticationDeviceCodeChallenge(
           verificationUri: Uri.parse("https://auth.example/device"),
           userCode: "ABCD-EFGH",
@@ -85,6 +88,8 @@ void main() {
         if (aborted.isAborted) throw const PluginStartAbortedException();
         yield const PluginAuthenticationCompleted();
       },
+      kind: const PluginAuthenticationDeviceCodeOperationKind(),
+      recordStore: ({required store}) => authenticationStores.add(store),
     );
     final runtime = _runtime(
       factory: _FakeGenerationFactory(startGate: Future<void>.value()),
@@ -97,9 +102,133 @@ void main() {
     await Future<void>.delayed(Duration.zero);
 
     expect(events.single, isA<PluginAuthenticationDeviceCodeChallenge>());
+    expect(identical(authenticationStores.single, _testHostJsonStore), isTrue);
+    final wrongKind = await runtime.submitAuthenticationRedirect(
+      pluginId: "one",
+      generation: operation.generation,
+      redirectUri: Uri.parse("http://127.0.0.1/callback?code=code"),
+    );
+    expect(
+      wrongKind,
+      isA<PluginRuntimeAuthenticationContinuationConflict>().having(
+        (result) => result.reason,
+        "reason",
+        PluginRuntimeAuthenticationContinuationConflictReason.wrongKind,
+      ),
+    );
+
     runtime.beginShutdown();
+    final shutdownSubmission = await runtime.submitAuthenticationRedirect(
+      pluginId: "one",
+      generation: operation.generation,
+      redirectUri: Uri.parse("http://127.0.0.1/callback?code=code"),
+    );
+    expect(
+      shutdownSubmission,
+      isA<PluginRuntimeAuthenticationContinuationConflict>().having(
+        (result) => result.reason,
+        "reason",
+        PluginRuntimeAuthenticationContinuationConflictReason.staleGeneration,
+      ),
+    );
     authenticationGate.complete();
     await expectLater(done, throwsA(isA<PluginStartAbortedException>()));
+  });
+
+  test("browser redirects are one-shot and fenced to the active generation", () async {
+    final streams = [StreamController<PluginAuthenticationEvent>(), StreamController<PluginAuthenticationEvent>()];
+    var streamIndex = 0;
+    final submitted = <Uri>[];
+    final descriptor = _AuthenticationDescriptor(
+      authenticate: ({required aborted}) => streams[streamIndex++].stream,
+      kind: PluginAuthenticationBrowserOperationKind(
+        submitRedirect: ({required redirectUri}) async => submitted.add(redirectUri),
+      ),
+      recordStore: ({required store}) {},
+    );
+    final runtime = _runtime(
+      factory: _FakeGenerationFactory(startGate: Future<void>.value()),
+      descriptor: descriptor,
+    );
+    addTearDown(runtime.dispose);
+
+    final first = runtime.authenticate(pluginId: "one");
+    expect(() => runtime.authenticate(pluginId: "one"), throwsStateError);
+    final firstDone = first.events.drain<void>();
+    streams.first.add(
+      PluginAuthenticationBrowserChallenge(
+        authorizationUri: Uri.parse("https://accounts.example/authorize"),
+        expectedCallbackUri: Uri.parse("http://127.0.0.1/callback"),
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+    final firstRedirect = Uri.parse("http://127.0.0.1/callback?code=first");
+    expect(
+      await runtime.submitAuthenticationRedirect(
+        pluginId: "one",
+        generation: first.generation,
+        redirectUri: firstRedirect,
+      ),
+      isA<PluginRuntimeAuthenticationContinuationApplied>(),
+    );
+    final duplicate = await runtime.submitAuthenticationRedirect(
+      pluginId: "one",
+      generation: first.generation,
+      redirectUri: firstRedirect,
+    );
+    expect(
+      duplicate,
+      isA<PluginRuntimeAuthenticationContinuationConflict>().having(
+        (result) => result.reason,
+        "reason",
+        PluginRuntimeAuthenticationContinuationConflictReason.alreadySubmitted,
+      ),
+    );
+    await streams.first.close();
+    await firstDone;
+
+    final second = runtime.authenticate(pluginId: "one");
+    final secondDone = second.events.drain<void>();
+    final secondRedirect = Uri.parse("http://127.0.0.1/callback?code=second");
+    final stale = await runtime.submitAuthenticationRedirect(
+      pluginId: "one",
+      generation: first.generation,
+      redirectUri: firstRedirect,
+    );
+    expect(
+      stale,
+      isA<PluginRuntimeAuthenticationContinuationConflict>().having(
+        (result) => result.reason,
+        "reason",
+        PluginRuntimeAuthenticationContinuationConflictReason.staleGeneration,
+      ),
+    );
+    expect(
+      await runtime.submitAuthenticationRedirect(
+        pluginId: "one",
+        generation: second.generation,
+        redirectUri: secondRedirect,
+      ),
+      isA<PluginRuntimeAuthenticationContinuationApplied>(),
+    );
+    expect(submitted, [firstRedirect, secondRedirect]);
+
+    second.abort();
+    final afterCancel = await runtime.submitAuthenticationRedirect(
+      pluginId: "one",
+      generation: second.generation,
+      redirectUri: secondRedirect,
+    );
+    expect(
+      afterCancel,
+      isA<PluginRuntimeAuthenticationContinuationConflict>().having(
+        (result) => result.reason,
+        "reason",
+        PluginRuntimeAuthenticationContinuationConflictReason.staleGeneration,
+      ),
+    );
+    await streams.last.close();
+    await secondDone;
   });
 
   test("authenticate rejects descriptors without the optional capability", () {
@@ -1693,6 +1822,7 @@ PluginRuntime _runtime({
         descriptor: descriptor,
         config: const PluginConfig(values: {}),
         stateDirectory: ".",
+        store: _testHostJsonStore,
       ),
     ],
     generationFactory: factory,
@@ -1722,11 +1852,11 @@ Future<void> _waitUntil(bool Function() predicate) async {
 }
 
 class _FakeGenerationFactory({
-    required final Future<void> startGate,
-    final _FakePlugin Function(int generation)? pluginFactory,
-    final Object? startError,
-    final bool honorAbort = true,
-  }) implements PluginGenerationFactory {
+  required final Future<void> startGate,
+  final _FakePlugin Function(int generation)? pluginFactory,
+  final Object? startError,
+  final bool honorAbort = true,
+}) implements PluginGenerationFactory {
   final List<_FakePlugin> plugins = <_FakePlugin>[];
   int startCount = 0;
 
@@ -1750,7 +1880,10 @@ class _FakeGenerationFactory({
   }
 }
 
-class const _FakeDescriptor({final Future<PluginSetupStatus> Function()? inspect, final Stream<RuntimeProvisionProgress> Function(StartAbortSignal startAborted)? install}) extends BridgePluginDescriptor {
+class const _FakeDescriptor({
+  final Future<PluginSetupStatus> Function()? inspect,
+  final Stream<RuntimeProvisionProgress> Function(StartAbortSignal startAborted)? install,
+}) extends BridgePluginDescriptor {
   @override
   String get id => "one";
 
@@ -1802,21 +1935,52 @@ class const _FakeDescriptor({final Future<PluginSetupStatus> Function()? inspect
 }
 
 class const _AuthenticationDescriptor({
-    required final Stream<PluginAuthenticationEvent> Function(StartAbortSignal aborted) _authenticate,
-  }) extends _FakeDescriptor implements InteractivePluginAuthenticationDescriptor {
+  required final Stream<PluginAuthenticationEvent> Function({required StartAbortSignal aborted}) _authenticate,
+  required final PluginAuthenticationOperationKind _kind,
+  required final void Function({required HostJsonStore store}) _recordStore,
+}) extends _FakeDescriptor implements InteractivePluginAuthenticationDescriptor {
   @override
-  Stream<PluginAuthenticationEvent> authenticate({
+  PluginAuthenticationOperation authenticate({
     required PluginConfig config,
     required HostProcessService processes,
     required Map<String, String> environment,
     required String stateDirectory,
+    required HostJsonStore store,
     required StartAbortSignal aborted,
-  }) => _authenticate(aborted);
+  }) {
+    _recordStore(store: store);
+    return PluginAuthenticationOperation(
+      events: _authenticate(aborted: aborted),
+      kind: _kind,
+    );
+  }
+}
+
+class const _UnusedHostJsonStore() implements HostJsonStore {
+  @override
+  Future<void> delete({required String name}) => throw UnsupportedError("unused");
+
+  @override
+  Future<void> quarantine({required String name, required String quarantinedName}) => throw UnsupportedError("unused");
+
+  @override
+  Future<String?> read({required String name}) => throw UnsupportedError("unused");
+
+  @override
+  Future<String?> update({
+    required String name,
+    required FutureOr<String?> Function(String? current) transform,
+  }) => throw UnsupportedError("unused");
+
+  @override
+  Future<void> write({required String name, required String contents}) => throw UnsupportedError("unused");
 }
 
 class _FakePlugin({
-  @override
-  required final _FakeApi api, final Future<void>? shutdownGate, final Object? shutdownError}) implements BridgePlugin {
+  @override required final _FakeApi api,
+  final Future<void>? shutdownGate,
+  final Object? shutdownError,
+}) implements BridgePlugin {
   final BehaviorSubject<PluginStatus> statuses = BehaviorSubject.seeded(const PluginReady());
   final BehaviorSubject<PluginWorkState> workStates = BehaviorSubject.seeded(PluginWorkState.idle);
   Future<void>? _shutdownFuture;
@@ -1864,11 +2028,10 @@ class _FakePlugin({
 }
 
 class _FakeApi({
-    @override
-  final String id = "one",
-    final bool closeEventsOnDispose = false,
-    final List<PluginProjectActivitySummary> activeSessionsSummary = const [],
-  }) extends NativeProjectsPluginApi {
+  @override final String id = "one",
+  final bool closeEventsOnDispose = false,
+  final List<PluginProjectActivitySummary> activeSessionsSummary = const [],
+}) extends NativeProjectsPluginApi {
   final StreamController<BridgeSseEvent> eventsController = StreamController.broadcast();
   int disposeCount = 0;
   int getActiveSessionsSummaryCount = 0;

--- a/bridge/app/test/helpers/plugin_runtime_test_support.dart
+++ b/bridge/app/test/helpers/plugin_runtime_test_support.dart
@@ -25,6 +25,7 @@ PluginRuntime createRegisteredTestPluginRuntime({required Iterable<String> plugi
           descriptor: _TestDescriptor(id: pluginId),
           config: const PluginConfig(values: {}),
           stateDirectory: ".",
+          store: const _UnusedHostJsonStore(),
         ),
     ],
     generationFactory: const _UnusedGenerationFactory(),
@@ -334,6 +335,26 @@ class const _TestDescriptor({@override required final String id}) extends Bridge
 
   @override
   Future<BridgePlugin> start(PluginHost host) => throw UnsupportedError("unused");
+}
+
+class const _UnusedHostJsonStore() implements HostJsonStore {
+  @override
+  Future<void> delete({required String name}) => throw UnsupportedError("unused");
+
+  @override
+  Future<void> quarantine({required String name, required String quarantinedName}) => throw UnsupportedError("unused");
+
+  @override
+  Future<String?> read({required String name}) => throw UnsupportedError("unused");
+
+  @override
+  Future<String?> update({
+    required String name,
+    required FutureOr<String?> Function(String? current) transform,
+  }) => throw UnsupportedError("unused");
+
+  @override
+  Future<void> write({required String name, required String contents}) => throw UnsupportedError("unused");
 }
 
 class const _UnusedHostProcessService() implements HostProcessService {

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -59,6 +59,94 @@ void main() {
     expect(service.managementSnapshot.plugins.single.setup.state, PluginSetupState.ready);
   });
 
+  test("authentication continuation maps active-generation outcomes and terminal cleanup", () async {
+    final repository =
+        _CommandLifecycleRepository(
+            inspectionResult: const PluginSetupAuthenticationRequired(actionHint: "Sign in."),
+            inspectionGate: null,
+            startFailureMessage: null,
+          )
+          ..authenticationContinuationResult = const PluginRuntimeAuthenticationContinuationConflict(
+            reason: PluginRuntimeAuthenticationContinuationConflictReason.wrongKind,
+          );
+    final service = _commandService(
+      repository: repository,
+      settingsRepository: null,
+      managementCapabilities: const {PluginControlCapability.authentication},
+    );
+    addTearDown(service.dispose);
+    service.initialize(
+      disabledPluginIds: const {},
+      setupById: const {"one": PluginSetupAuthenticationRequired(actionHint: "Sign in.")},
+    );
+    final challenge = service.authenticate(pluginId: "one");
+    final redirectUri = Uri.parse("http://127.0.0.1/callback?code=code");
+
+    await expectLater(
+      service.submitAuthenticationRedirect(pluginId: "one", redirectUri: redirectUri),
+      throwsA(
+        isA<PluginAuthenticationContinuationConflictException>().having(
+          (error) => error.reason,
+          "reason",
+          PluginAuthenticationContinuationConflictReason.wrongKind,
+        ),
+      ),
+    );
+    repository.authenticationEvents.add(
+      PluginAuthenticationDeviceCodeChallenge(
+        verificationUri: Uri.parse("https://auth.example/device"),
+        userCode: "ABCD-EFGH",
+      ),
+    );
+    await challenge;
+
+    repository.authenticationContinuationResult = const PluginRuntimeAuthenticationContinuationConflict(
+      reason: PluginRuntimeAuthenticationContinuationConflictReason.alreadySubmitted,
+    );
+    await expectLater(
+      service.submitAuthenticationRedirect(pluginId: "one", redirectUri: redirectUri),
+      throwsA(
+        isA<PluginAuthenticationContinuationConflictException>().having(
+          (error) => error.reason,
+          "reason",
+          PluginAuthenticationContinuationConflictReason.alreadySubmitted,
+        ),
+      ),
+    );
+    repository.authenticationContinuationResult = const PluginRuntimeAuthenticationContinuationConflict(
+      reason: PluginRuntimeAuthenticationContinuationConflictReason.staleGeneration,
+    );
+    await expectLater(
+      service.submitAuthenticationRedirect(pluginId: "one", redirectUri: redirectUri),
+      throwsA(
+        isA<PluginAuthenticationContinuationConflictException>().having(
+          (error) => error.reason,
+          "reason",
+          PluginAuthenticationContinuationConflictReason.noActive,
+        ),
+      ),
+    );
+    repository.authenticationContinuationResult = const PluginRuntimeAuthenticationContinuationApplied();
+    await service.submitAuthenticationRedirect(pluginId: "one", redirectUri: redirectUri);
+    expect(repository.authenticationRedirects.map((request) => request.generation), everyElement(1));
+
+    repository.authenticationEvents.add(const PluginAuthenticationFailed(message: "done"));
+    await repository.authenticationEvents.close();
+    while (service.managementSnapshot.plugins.single.authenticationState != PluginAuthenticationState.idle) {
+      await Future<void>.delayed(Duration.zero);
+    }
+    await expectLater(
+      service.submitAuthenticationRedirect(pluginId: "one", redirectUri: redirectUri),
+      throwsA(
+        isA<PluginAuthenticationContinuationConflictException>().having(
+          (error) => error.reason,
+          "reason",
+          PluginAuthenticationContinuationConflictReason.noActive,
+        ),
+      ),
+    );
+  });
+
   test("authentication cancellation aborts upstream and emits cancelled", () async {
     final repository = _CommandLifecycleRepository(
       inspectionResult: const PluginSetupAuthenticationRequired(actionHint: "Sign in."),
@@ -91,6 +179,19 @@ void main() {
     expect(repository.authenticationAborted, isTrue);
     expect(progress.single.progress, const PluginAuthenticationProgress.cancelled());
     expect(service.managementSnapshot.plugins.single.authenticationState, PluginAuthenticationState.idle);
+    await expectLater(
+      service.submitAuthenticationRedirect(
+        pluginId: "one",
+        redirectUri: Uri.parse("http://127.0.0.1/callback?code=late"),
+      ),
+      throwsA(
+        isA<PluginAuthenticationContinuationConflictException>().having(
+          (error) => error.reason,
+          "reason",
+          PluginAuthenticationContinuationConflictReason.noActive,
+        ),
+      ),
+    );
   });
 
   test("authentication cancellation remains cancelled when setup inspection fails", () async {
@@ -2513,6 +2614,9 @@ class _CommandLifecycleRepository({
       StreamController<PluginAuthenticationEvent>();
   int authenticationCalls = 0;
   bool authenticationAborted = false;
+  PluginRuntimeAuthenticationContinuationResult authenticationContinuationResult =
+      const PluginRuntimeAuthenticationContinuationApplied();
+  final List<({String pluginId, int generation, Uri redirectUri})> authenticationRedirects = [];
   Object? inspectionError;
 
   @override
@@ -2526,7 +2630,18 @@ class _CommandLifecycleRepository({
           ..addError(const PluginStartAbortedException())
           ..close();
       },
+      generation: authenticationCalls,
     );
+  }
+
+  @override
+  Future<PluginRuntimeAuthenticationContinuationResult> submitAuthenticationRedirect({
+    required String pluginId,
+    required int generation,
+    required Uri redirectUri,
+  }) async {
+    authenticationRedirects.add((pluginId: pluginId, generation: generation, redirectUri: redirectUri));
+    return authenticationContinuationResult;
   }
 
   @override

--- a/bridge/app/tool/benchmarks/multi_plugin_startup_benchmark.dart
+++ b/bridge/app/tool/benchmarks/multi_plugin_startup_benchmark.dart
@@ -6,6 +6,7 @@ import "package:path/path.dart" as p;
 import "package:sesori_bridge/src/runtime/plugin_generation_factory.dart";
 import "package:sesori_bridge/src/runtime/plugin_runtime.dart";
 import "package:sesori_bridge/src/server/api/runtime_file_api.dart";
+import "package:sesori_bridge/src/server/host/bridge_host_json_store.dart";
 import "package:sesori_bridge/src/server/host/plugin_state_directory.dart";
 import "package:sesori_bridge/src/server/repositories/process_repository.dart";
 import "package:sesori_bridge/src/server/repositories/startup_mutex_repository.dart";
@@ -101,7 +102,6 @@ Future<_StartupSample> _runFixture({required int selectedCount}) async {
     startupMutexRepository: startupMutexRepository,
     bridgeInstanceService: bridgeInstanceService,
     processRepository: _FakeProcessRepository(),
-    runtimeFileApi: RuntimeFileApi(runtimeDirectory: runtimeDirectory.path),
     clock: const ServerClock(),
     environment: const <String, String>{},
     currentUser: null,
@@ -119,6 +119,15 @@ Future<_StartupSample> _runFixture({required int selectedCount}) async {
                 paths: managedRuntimePaths,
                 pluginId: descriptor.id,
                 stateStorage: descriptor.stateStorage,
+              ),
+              store: BridgeHostJsonStore(
+                fileApi: RuntimeFileApi(
+                  runtimeDirectory: pluginStateDirectoryPath(
+                    paths: managedRuntimePaths,
+                    pluginId: descriptor.id,
+                    stateStorage: descriptor.stateStorage,
+                  ),
+                ),
               ),
             ),
         ],

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
@@ -445,7 +445,7 @@ class const CodexPluginDescriptor({
     required String stateDirectory,
     required HostJsonStore store,
     required StartAbortSignal aborted,
-  }) => PluginAuthenticationOperation(
+  }) => PluginAuthenticationOperation.deviceCode(
     events: _authenticate(
       config: config,
       processes: processes,
@@ -453,10 +453,9 @@ class const CodexPluginDescriptor({
       stateDirectory: stateDirectory,
       aborted: aborted,
     ),
-    kind: const PluginAuthenticationDeviceCodeOperationKind(),
   );
 
-  Stream<PluginAuthenticationEvent> _authenticate({
+  Stream<PluginAuthenticationDeviceCodeEvent> _authenticate({
     required PluginConfig config,
     required HostProcessService processes,
     required Map<String, String> environment,

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
@@ -438,7 +438,25 @@ class const CodexPluginDescriptor({
   }
 
   @override
-  Stream<PluginAuthenticationEvent> authenticate({
+  PluginAuthenticationOperation authenticate({
+    required PluginConfig config,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+    required String stateDirectory,
+    required HostJsonStore store,
+    required StartAbortSignal aborted,
+  }) => PluginAuthenticationOperation(
+    events: _authenticate(
+      config: config,
+      processes: processes,
+      environment: environment,
+      stateDirectory: stateDirectory,
+      aborted: aborted,
+    ),
+    kind: const PluginAuthenticationDeviceCodeOperationKind(),
+  );
+
+  Stream<PluginAuthenticationEvent> _authenticate({
     required PluginConfig config,
     required HostProcessService processes,
     required Map<String, String> environment,

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_authentication_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_authentication_service.dart
@@ -13,7 +13,7 @@ class CodexAuthenticationService({
 }) {
   late final Future<Never> _abort = _abortOperation();
 
-  Stream<PluginAuthenticationEvent> authenticate() async* {
+  Stream<PluginAuthenticationDeviceCodeEvent> authenticate() async* {
     try {
       await _abortable(
         _client.connect(

--- a/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
@@ -290,18 +290,19 @@ void main() {
         ],
       );
 
+      final operation = descriptor.authenticate(
+        config: const PluginConfig(
+          values: {"port": null, "bin": "/custom/codex"},
+        ),
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDirectory,
+        store: const _UnusedHostJsonStore(),
+        aborted: _AbortOnThirdCheck(),
+      );
+      expect(operation.kind, isA<PluginAuthenticationDeviceCodeOperationKind>());
       await expectLater(
-        descriptor
-            .authenticate(
-              config: const PluginConfig(
-                values: {"port": null, "bin": "/custom/codex"},
-              ),
-              processes: processes,
-              environment: const <String, String>{},
-              stateDirectory: stateDirectory,
-              aborted: _AbortOnThirdCheck(),
-            )
-            .toList(),
+        operation.events.toList(),
         throwsA(isA<PluginStartAbortedException>()),
       );
     });
@@ -428,6 +429,26 @@ void main() {
       expect(result.runtimeVersion, "0.148.0");
     });
   });
+}
+
+class const _UnusedHostJsonStore() implements HostJsonStore {
+  @override
+  Future<void> delete({required String name}) => throw UnsupportedError("unused");
+
+  @override
+  Future<void> quarantine({required String name, required String quarantinedName}) => throw UnsupportedError("unused");
+
+  @override
+  Future<String?> read({required String name}) => throw UnsupportedError("unused");
+
+  @override
+  Future<String?> update({
+    required String name,
+    required FutureOr<String?> Function(String? current) transform,
+  }) => throw UnsupportedError("unused");
+
+  @override
+  Future<void> write({required String name, required String contents}) => throw UnsupportedError("unused");
 }
 
 class _ProbeProcessService({

--- a/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
@@ -300,7 +300,7 @@ void main() {
         store: const _UnusedHostJsonStore(),
         aborted: _AbortOnThirdCheck(),
       );
-      expect(operation.kind, isA<PluginAuthenticationDeviceCodeOperationKind>());
+      expect(operation, isA<PluginAuthenticationDeviceCodeOperation>());
       await expectLater(
         operation.events.toList(),
         throwsA(isA<PluginStartAbortedException>()),

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_authentication.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_authentication.dart
@@ -20,34 +20,49 @@ abstract interface class InteractivePluginAuthenticationDescriptor() {
   });
 }
 
-/// One plugin-owned login attempt and its backend-neutral continuation kind.
-final class const PluginAuthenticationOperation({
-  required final Stream<PluginAuthenticationEvent> events,
-  required final PluginAuthenticationOperationKind kind,
-});
+/// One plugin-owned login attempt with challenge events coupled to its continuation behavior.
+sealed class const PluginAuthenticationOperation() {
+  const factory deviceCode({
+    required Stream<PluginAuthenticationDeviceCodeEvent> events,
+  }) = PluginAuthenticationDeviceCodeOperation;
 
-sealed class const PluginAuthenticationOperationKind();
+  const factory browser({
+    required Stream<PluginAuthenticationBrowserEvent> events,
+    required Future<void> Function({required Uri redirectUri}) submitRedirect,
+  }) = PluginAuthenticationBrowserOperation;
+
+  Stream<PluginAuthenticationEvent> get events;
+}
 
 /// Device-code login has no browser redirect for the bridge to submit.
-final class const PluginAuthenticationDeviceCodeOperationKind() extends PluginAuthenticationOperationKind;
+final class const PluginAuthenticationDeviceCodeOperation({
+  @override required final Stream<PluginAuthenticationDeviceCodeEvent> events,
+}) extends PluginAuthenticationOperation;
 
 /// Browser login accepts one redirect URI through the active operation.
-final class const PluginAuthenticationBrowserOperationKind({
+final class const PluginAuthenticationBrowserOperation({
+  @override required final Stream<PluginAuthenticationBrowserEvent> events,
   required final Future<void> Function({required Uri redirectUri}) submitRedirect,
-}) extends PluginAuthenticationOperationKind;
+}) extends PluginAuthenticationOperation;
 
 sealed class const PluginAuthenticationEvent();
+
+sealed class const PluginAuthenticationDeviceCodeEvent() implements PluginAuthenticationEvent;
+
+sealed class const PluginAuthenticationBrowserEvent() implements PluginAuthenticationEvent;
 
 final class const PluginAuthenticationDeviceCodeChallenge({
   required final Uri verificationUri,
   required final String userCode,
-}) extends PluginAuthenticationEvent;
+}) extends PluginAuthenticationEvent implements PluginAuthenticationDeviceCodeEvent;
 
 final class const PluginAuthenticationBrowserChallenge({
   required final Uri authorizationUri,
   required final Uri expectedCallbackUri,
-}) extends PluginAuthenticationEvent;
+}) extends PluginAuthenticationEvent implements PluginAuthenticationBrowserEvent;
 
-final class const PluginAuthenticationCompleted() extends PluginAuthenticationEvent;
+final class const PluginAuthenticationCompleted() extends PluginAuthenticationEvent
+    implements PluginAuthenticationDeviceCodeEvent, PluginAuthenticationBrowserEvent;
 
-final class const PluginAuthenticationFailed({required final String message}) extends PluginAuthenticationEvent;
+final class const PluginAuthenticationFailed({required final String message}) extends PluginAuthenticationEvent
+    implements PluginAuthenticationDeviceCodeEvent, PluginAuthenticationBrowserEvent;

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_authentication.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_authentication.dart
@@ -1,3 +1,4 @@
+import "../host/host_json_store.dart";
 import "../host/host_process_service.dart";
 import "plugin_config.dart";
 import "start_abort_signal.dart";
@@ -9,20 +10,42 @@ abstract interface class InteractivePluginAuthenticationDescriptor() {
   /// The first actionable event is a challenge. The plugin must release every
   /// process and subscription it owns before the stream completes or errors.
   /// Aborting settles with `PluginStartAbortedException` after cleanup.
-  Stream<PluginAuthenticationEvent> authenticate({
+  PluginAuthenticationOperation authenticate({
     required PluginConfig config,
     required HostProcessService processes,
     required Map<String, String> environment,
     required String stateDirectory,
+    required HostJsonStore store,
     required StartAbortSignal aborted,
   });
 }
+
+/// One plugin-owned login attempt and its backend-neutral continuation kind.
+final class const PluginAuthenticationOperation({
+  required final Stream<PluginAuthenticationEvent> events,
+  required final PluginAuthenticationOperationKind kind,
+});
+
+sealed class const PluginAuthenticationOperationKind();
+
+/// Device-code login has no browser redirect for the bridge to submit.
+final class const PluginAuthenticationDeviceCodeOperationKind() extends PluginAuthenticationOperationKind;
+
+/// Browser login accepts one redirect URI through the active operation.
+final class const PluginAuthenticationBrowserOperationKind({
+  required final Future<void> Function({required Uri redirectUri}) submitRedirect,
+}) extends PluginAuthenticationOperationKind;
 
 sealed class const PluginAuthenticationEvent();
 
 final class const PluginAuthenticationDeviceCodeChallenge({
   required final Uri verificationUri,
   required final String userCode,
+}) extends PluginAuthenticationEvent;
+
+final class const PluginAuthenticationBrowserChallenge({
+  required final Uri authorizationUri,
+  required final Uri expectedCallbackUri,
 }) extends PluginAuthenticationEvent;
 
 final class const PluginAuthenticationCompleted() extends PluginAuthenticationEvent;

--- a/bridge/sesori_plugin_interface/test/lifecycle/plugin_authentication_test.dart
+++ b/bridge/sesori_plugin_interface/test/lifecycle/plugin_authentication_test.dart
@@ -51,27 +51,22 @@ void main() {
     );
   });
 
-  test("authentication operations expose a sealed continuation kind", () async {
+  test("authentication operation variants couple challenge type and continuation", () async {
     Uri? submitted;
-    final browser = PluginAuthenticationOperation(
-      events: const Stream<PluginAuthenticationEvent>.empty(),
-      kind: PluginAuthenticationBrowserOperationKind(
-        submitRedirect: ({required redirectUri}) async => submitted = redirectUri,
-      ),
+    final browser = PluginAuthenticationOperation.browser(
+      events: const Stream<PluginAuthenticationBrowserEvent>.empty(),
+      submitRedirect: ({required redirectUri}) async => submitted = redirectUri,
     );
     final redirectUri = Uri.http("127.0.0.1", "/callback", {"code": "code"});
 
-    await (browser.kind as PluginAuthenticationBrowserOperationKind).submitRedirect(
-      redirectUri: redirectUri,
-    );
+    await (browser as PluginAuthenticationBrowserOperation).submitRedirect(redirectUri: redirectUri);
 
     expect(submitted, redirectUri);
     expect(
-      const PluginAuthenticationOperation(
-        events: Stream<PluginAuthenticationEvent>.empty(),
-        kind: PluginAuthenticationDeviceCodeOperationKind(),
-      ).kind,
-      isA<PluginAuthenticationDeviceCodeOperationKind>(),
+      const PluginAuthenticationOperation.deviceCode(
+        events: Stream<PluginAuthenticationDeviceCodeEvent>.empty(),
+      ),
+      isA<PluginAuthenticationDeviceCodeOperation>(),
     );
   });
 }

--- a/bridge/sesori_plugin_interface/test/lifecycle/plugin_authentication_test.dart
+++ b/bridge/sesori_plugin_interface/test/lifecycle/plugin_authentication_test.dart
@@ -8,6 +8,10 @@ void main() {
         verificationUri: Uri.https("auth.example", "/device"),
         userCode: "CODE",
       ),
+      PluginAuthenticationBrowserChallenge(
+        authorizationUri: Uri.https("accounts.example", "/authorize"),
+        expectedCallbackUri: Uri.http("127.0.0.1", "/callback"),
+      ),
       const PluginAuthenticationCompleted(),
       const PluginAuthenticationFailed(message: "Sanitized failure"),
     ];
@@ -22,14 +26,52 @@ void main() {
           )
           .having((event) => event.userCode, "userCode", "CODE"),
     );
-    expect(events[1], isA<PluginAuthenticationCompleted>());
     expect(
-      events[2],
+      events[1],
+      isA<PluginAuthenticationBrowserChallenge>()
+          .having(
+            (event) => event.authorizationUri,
+            "authorizationUri",
+            Uri.https("accounts.example", "/authorize"),
+          )
+          .having(
+            (event) => event.expectedCallbackUri,
+            "expectedCallbackUri",
+            Uri.http("127.0.0.1", "/callback"),
+          ),
+    );
+    expect(events[2], isA<PluginAuthenticationCompleted>());
+    expect(
+      events[3],
       isA<PluginAuthenticationFailed>().having(
         (event) => event.message,
         "message",
         "Sanitized failure",
       ),
+    );
+  });
+
+  test("authentication operations expose a sealed continuation kind", () async {
+    Uri? submitted;
+    final browser = PluginAuthenticationOperation(
+      events: const Stream<PluginAuthenticationEvent>.empty(),
+      kind: PluginAuthenticationBrowserOperationKind(
+        submitRedirect: ({required redirectUri}) async => submitted = redirectUri,
+      ),
+    );
+    final redirectUri = Uri.http("127.0.0.1", "/callback", {"code": "code"});
+
+    await (browser.kind as PluginAuthenticationBrowserOperationKind).submitRedirect(
+      redirectUri: redirectUri,
+    );
+
+    expect(submitted, redirectUri);
+    expect(
+      const PluginAuthenticationOperation(
+        events: Stream<PluginAuthenticationEvent>.empty(),
+        kind: PluginAuthenticationDeviceCodeOperationKind(),
+      ).kind,
+      isA<PluginAuthenticationDeviceCodeOperationKind>(),
     );
   });
 }


### PR DESCRIPTION
## Complexity

🚧 Complex — this changes cross-layer authentication lifecycle ownership, generation-fenced continuation routing, and plugin-scoped store composition while preserving existing Codex behavior.

## What

- Replace the stream-only interactive authentication contract with a typed operation exposing events and a sealed device-code or browser continuation kind.
- Track one active authentication generation per plugin and route a browser redirect only to that current operation.
- Return typed no-active, wrong-kind, and already-submitted conflicts through the lifecycle repository and service.
- Fence continuation dispatch across duplicate submission, cancellation, terminal settlement, and shutdown.
- Create one `HostJsonStore` per plugin state root in app composition and pass that exact instance to authentication and every live `PluginHost` generation.
- Update Codex, test descriptors, helpers, and benchmarks in lockstep without compatibility shims.

The PR is 996 changed lines including tests and tracker updates.

## Why

Antigravity personal OAuth needs a browser challenge whose redirect can return later from a mobile or desktop client. The bridge must own operation identity, ordering, and lifecycle before transport and provider-specific validation are added, while keeping backend semantics inside their plugin.

## Risk and test focus

Risk is high but currently internal: no HTTP route or client handoff consumes this seam yet. Review should focus on authentication generation fencing, one-shot dispatch, cancel/shutdown settlement, terminal cleanup, unchanged Codex device-code behavior, and identity of the scoped store shared between authentication and live hosting.

## Expected result

There is no user-visible or database impact. Existing Codex authentication remains device-code based and rejects browser redirects. Bridge internals can safely host a future browser authentication operation without accepting stale, duplicate, or wrong-kind continuations. Provider URL, state, code, and HTTP policy remain outside bridge core for the Antigravity-owned implementation step.

## Verification

- `cd bridge/sesori_plugin_interface && dart analyze --fatal-infos` — no issues
- `cd bridge/sesori_plugin_interface && dart test` — 161 passed
- `cd bridge/sesori_plugin_codex && dart analyze --fatal-infos` — no issues
- `cd bridge/sesori_plugin_codex && dart test` — 415 passed
- `cd bridge/app && dart analyze --fatal-infos` — no issues
- Focused bridge authentication/runtime tests — 129 passed
- `git diff --check` and added-source 120-column validation — passed
- Architecture implementation review — approved with no violations
