### PR TITLE
🌿 Fall back from unavailable transcript models

### DIFF
--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -90,6 +90,7 @@ class SessionDetailCubit(
   final SessionRepository _sessionRepository = promptDispatcher;
   final ProjectViewClaim _projectViewClaim = _projectViewingService.beginDetailClaim(projectId: _projectId);
   static const _defaultModelSelector = DefaultModelSelector();
+  static const _syntheticModelID = "<synthetic>";
   ComposerDraft _composerDraft = _composerDraftRepository.readForSession(sessionId: _sessionId);
   final PromptSendQueue _promptQueue = PromptSendQueue();
   final Set<String> _staleOptionsRecoveryAttemptedPromptIds = {};
@@ -2334,13 +2335,12 @@ class SessionDetailCubit(
         : (agents.isNotEmpty ? agents.first.name : "build");
 
     final assistantAgentModel = derived.assistantAgentModel;
-    final availableAssistantAgentModel =
-        assistantAgentModel != null && _isModelAvailable(model: assistantAgentModel, providers: providers)
-        ? assistantAgentModel
-        : null;
+    final selectableAssistantAgentModel = assistantAgentModel?.modelID == _syntheticModelID
+        ? null
+        : assistantAgentModel;
     final defaultAgentModel = hasValidPersistedModel
         ? persistedModel
-        : (availableAssistantAgentModel ?? _fallbackAgentModel(agents: agents, providers: providers));
+        : (selectableAssistantAgentModel ?? _fallbackAgentModel(agents: agents, providers: providers));
 
     final availableVariants = _deriveAvailableVariants(
       providers: providers,

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -2334,9 +2334,13 @@ class SessionDetailCubit(
         : (agents.isNotEmpty ? agents.first.name : "build");
 
     final assistantAgentModel = derived.assistantAgentModel;
+    final availableAssistantAgentModel =
+        assistantAgentModel != null && _isModelAvailable(model: assistantAgentModel, providers: providers)
+        ? assistantAgentModel
+        : null;
     final defaultAgentModel = hasValidPersistedModel
         ? persistedModel
-        : (assistantAgentModel ?? _fallbackAgentModel(agents: agents, providers: providers));
+        : (availableAssistantAgentModel ?? _fallbackAgentModel(agents: agents, providers: providers));
 
     final availableVariants = _deriveAvailableVariants(
       providers: providers,

--- a/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
@@ -435,7 +435,7 @@ void main() {
       ).called(1);
     });
 
-    test("resume falls back when persisted and transcript models are unavailable", () async {
+    test("resume ignores synthetic persisted and transcript model attribution", () async {
       stubSessionRepositoryGetSession(
         repository: mockSessionRepository,
         sessionId: sessionId,
@@ -527,6 +527,93 @@ void main() {
           text: "resume",
           agent: "coder",
           model: const PromptModel(providerID: "anthropic", modelID: "claude-3-5-sonnet"),
+          variant: null,
+          command: null,
+        ),
+      ).called(1);
+    });
+
+    test("resume forwards the transcript model when the provider cache is stale", () async {
+      when(
+        () => mockSessionService.getMessages(
+          sessionId: sessionId,
+          limit: any(named: "limit"),
+          before: any(named: "before"),
+        ),
+      ).thenAnswer(
+        (_) async => ApiResponse.success(
+          const MessageWithPartsResponse(
+            messages: [
+              MessageWithParts(
+                info: Message.error(
+                  id: "msg-custom-model",
+                  sessionID: sessionId,
+                  agent: null,
+                  modelID: "test-model",
+                  providerID: "sesori-local",
+                  errorName: "ProviderError",
+                  errorMessage: "request failed",
+                  time: null,
+                ),
+                parts: [],
+              ),
+            ],
+            nextCursor: null,
+            replayedPromptDefaults: null,
+          ),
+        ),
+      );
+      when(
+        () => mockSessionRepository.sendMessage(
+          promptId: any(named: "promptId"),
+          attachments: const [],
+          sessionId: sessionId,
+          text: "resume",
+          agent: "coder",
+          model: const PromptModel(providerID: "sesori-local", modelID: "test-model"),
+          variant: null,
+          command: null,
+        ),
+      ).thenAnswer((_) async => ApiResponse<void>.success(null));
+
+      final cubit = SessionDetailCubit(
+        mockConnectionService,
+        loadService: loadService,
+        promptDispatcher: promptDispatcher,
+        permissionRepository: mockPermissionRepository,
+        sessionViewingService: stubbedSessionViewingService(),
+        projectViewingService: stubbedProjectViewingService(),
+        lifecycleSource: FakeLifecycleSource(),
+        composerDraftRepository: inMemoryComposerDraftRepository(),
+        productAnalyticsService: stubbedProductAnalyticsService(),
+        sessionId: sessionId,
+        projectId: "project-1",
+        notificationCanceller: mockNotificationCanceller,
+        failureReporter: MockFailureReporter(),
+      );
+      addTearDown(cubit.close);
+
+      await _awaitLoaded(cubit);
+      expect(
+        (cubit.state as SessionDetailLoaded).selectedAgentModel,
+        const AgentModel(providerID: "sesori-local", modelID: "test-model", variant: null),
+      );
+
+      await cubit.sendMessage(
+        attachments: const [],
+        text: "resume",
+        command: null,
+        inputMode: ComposerInputMode.typed,
+      );
+
+      verify(
+        () => mockSessionRepository.sendMessage(
+          promptId: any(named: "promptId"),
+          attachments: const [],
+          sessionId: sessionId,
+          text: "resume",
+          agent: "coder",
+          model: const PromptModel(providerID: "sesori-local", modelID: "test-model"),
           variant: null,
           command: null,
         ),

--- a/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
@@ -435,7 +435,18 @@ void main() {
       ).called(1);
     });
 
-    test("resume forwards the transcript model when the provider cache is stale", () async {
+    test("resume falls back when persisted and transcript models are unavailable", () async {
+      stubSessionRepositoryGetSession(
+        repository: mockSessionRepository,
+        sessionId: sessionId,
+        session: testSession(
+          id: sessionId,
+          promptDefaults: const SessionPromptDefaults(
+            agent: "coder",
+            model: AgentModel(providerID: "anthropic", modelID: "<synthetic>", variant: null),
+          ),
+        ),
+      );
       when(
         () => mockSessionService.getMessages(
           sessionId: sessionId,
@@ -448,11 +459,11 @@ void main() {
             messages: [
               MessageWithParts(
                 info: Message.error(
-                  id: "msg-custom-model",
+                  id: "msg-synthetic-model",
                   sessionID: sessionId,
                   agent: null,
-                  modelID: "test-model",
-                  providerID: "sesori-local",
+                  modelID: "<synthetic>",
+                  providerID: "anthropic",
                   errorName: "ProviderError",
                   errorMessage: "request failed",
                   time: null,
@@ -472,7 +483,7 @@ void main() {
           sessionId: sessionId,
           text: "resume",
           agent: "coder",
-          model: const PromptModel(providerID: "sesori-local", modelID: "test-model"),
+          model: const PromptModel(providerID: "anthropic", modelID: "claude-3-5-sonnet"),
           variant: null,
           command: null,
         ),
@@ -498,7 +509,7 @@ void main() {
       await _awaitLoaded(cubit);
       expect(
         (cubit.state as SessionDetailLoaded).selectedAgentModel,
-        const AgentModel(providerID: "sesori-local", modelID: "test-model", variant: null),
+        const AgentModel(providerID: "anthropic", modelID: "claude-3-5-sonnet", variant: null),
       );
 
       await cubit.sendMessage(
@@ -515,7 +526,7 @@ void main() {
           sessionId: sessionId,
           text: "resume",
           agent: "coder",
-          model: const PromptModel(providerID: "sesori-local", modelID: "test-model"),
+          model: const PromptModel(providerID: "anthropic", modelID: "claude-3-5-sonnet"),
           variant: null,
           command: null,
         ),


### PR DESCRIPTION
## Complexity

🌿 Straightforward — one client-side selection guard plus focused regression coverage.

## What

- Treat the backend-generated `<synthetic>` transcript attribution as non-selectable when deriving the next prompt's model.
- Fall back through the existing agent/catalog default selection when both persisted and transcript-derived defaults contain that marker.
- Preserve real transcript models even when they are absent from a retained or stale provider catalog.
- Cover both the observed synthetic-history case and the existing stale-catalog custom-model behavior.

## Why

Claude Code uses `<synthetic>` as internal attribution for generated error records. Historical rows can therefore leave both the persisted prompt default and latest error attribution pointing at a value that is not a selectable model. The client previously rejected the persisted default but immediately reused the same synthetic value from transcript history.

## Risk and test focus

The user-visible change is limited to reopening a session whose latest transcript model is `<synthetic>`: the composer now displays and sends the available agent/catalog fallback instead of the internal marker. Real custom or newly introduced transcript models remain authoritative even when the retained provider catalog does not contain them.

There is no database schema or migration impact. Existing rows are not rewritten; a later accepted prompt continues to persist its valid selection through the existing defaults path.

The focused risk is recognizing the synthetic marker without regressing terminal-imported or stale-catalog sessions.

## Expected result

Historical synthetic attribution cannot become the next prompt's selected model. The user can continue the session normally with the available agent/catalog default, while legitimate transcript models remain selected despite incomplete catalog data.

## Verification

- `dart test test/cubits/session_detail/session_detail_stale_test.dart`
- `dart analyze` (from `client/module_core`)
