### PR TITLE
🌿 Reject Claude synthetic model selections

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -41,6 +41,7 @@ final class ClaudePlugin({
   }
 
   static const String pluginId = "claude";
+  static const String _syntheticModelId = "<synthetic>";
 
   final String _launchDirectory = normalizeProjectDirectory(directory: launchDirectory);
   final Map<String, PluginSession> _createdSessions = {};
@@ -517,7 +518,9 @@ final class ClaudePlugin({
     required bool staleOptions,
   }) {
     if (model == null) return;
-    if (model.providerID != ClaudeBackendCatalogRepository.providerId || model.modelID.trim().isEmpty) {
+    if (model.providerID != ClaudeBackendCatalogRepository.providerId ||
+        model.modelID.trim().isEmpty ||
+        model.modelID == _syntheticModelId) {
       throw _unsupportedSelection(
         operation: operation,
         message: "unsupported Claude model",

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -181,6 +181,27 @@ void main() {
       expect(await harness.plugin.getQueuedPrompts(sessionId: testSessionId), isEmpty);
     });
 
+    test("rejects Claude's synthetic model before enqueueing", () async {
+      await harness.createSession();
+
+      await expectLater(
+        harness.plugin.sendPrompt(
+          promptId: "prompt-1",
+          sessionId: testSessionId,
+          parts: const [PluginPromptPart.text(text: "hello")],
+          variant: null,
+          agent: "Agent",
+          model: (providerID: "anthropic", modelID: "<synthetic>"),
+        ),
+        throwsA(
+          isA<PluginStaleOptionsException>()
+              .having((error) => error.statusCode, "status", 409)
+              .having((error) => error.message, "message", "unsupported Claude model"),
+        ),
+      );
+      expect(await harness.plugin.getQueuedPrompts(sessionId: testSessionId), isEmpty);
+    });
+
     test("rejects unsupported selections on session creation", () async {
       await expectLater(
         harness.plugin.createSession(


### PR DESCRIPTION
## Complexity

🌿 Straightforward — one Claude-plugin validation rule plus focused regression coverage.

## What

- Reject Claude Code's internal `<synthetic>` model marker inside `ClaudePlugin` before an existing-session prompt is enqueued.
- Surface the rejection through the existing `PluginStaleOptionsException` contract.
- Keep shared bridge and client code fully harness-agnostic.
- Verify that the rejected prompt never enters Claude's queue.

## Why

Historical Claude API-error attribution can leave a persisted prompt selection pointing at `<synthetic>`, which is not a model Claude Code can launch. This is a Claude-specific sentinel, so its interpretation belongs in the Claude plugin rather than shared client model-selection logic.

The existing backend-neutral stale-options flow can then refresh the catalog, choose a supported selection, and retry once with the same prompt ID.

## Risk and test focus

The user-visible effect occurs only when sending with the synthetic historical selection: the existing options-updated recovery replaces it with a supported Claude model and retries the same visible prompt once.

There is no database schema or migration impact, and historical rows are not rewritten. Valid Claude model IDs—including values not present in a retained catalog—continue through the existing validation path unchanged.

The focused risk is rejecting before enqueue so Claude never receives `--model <synthetic>` and no duplicate prompt is created.

## Expected result

Claude-specific synthetic attribution cannot be launched as a model. Affected historical sessions recover through the existing generic stale-options behavior while all shared client code remains backend-neutral.

## Verification

- `dart test test/claude_plugin_impl_test.dart`
- `dart analyze --fatal-infos` (from `bridge/sesori_plugin_claude`)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects Claude Code's internal `<synthetic>` model marker in `ClaudePlugin` before enqueueing, so affected historical sessions recover via the existing stale-options flow instead of launching an invalid model.

- Throws the existing `PluginStaleOptionsException` for synthetic selections.
- Keeps shared bridge and client code backend-neutral.
- Adds regression coverage verifying the prompt never enters Claude's queue.

<sup>Written for commit ea2b1d747e423943a1ac1a40aa17732f8f996338. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

