### PR TITLE
⚙️ perf(bridge): verify the gh identity once per PR refresh instead of four times

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,27 @@ eagerly "just in case."
   wrapper's presentation privacy-safe when the original may contain sensitive
   payload data.
 
+## Code Quality And Change Risk
+
+- Leave touched code cleaner and simpler than you found it when the
+  improvement is small and local: a clearer name, a short extraction of
+  duplicated logic, a removed dead branch, less mutable state. Do it inside
+  the change you are already making.
+- Every change is a regression risk. Weigh a quality improvement against the
+  chance of introducing a bug and the review cost, not only against the
+  theoretical gain. Prefer no change over a marginal cleanup of working code.
+- Never let "improve quality" widen a task into a tangent refactor. If a
+  worthwhile improvement is more than a few localized edits, finish the
+  requested work first and propose the refactor separately with its
+  approximate size, as the refactor rule under Verification And Review
+  requires.
+- Low risk means small diffs, reusable code, and classes with few mutable
+  fields and one clear owner of each piece of state. Prefer composing small
+  immutable values and sealed types over adding coordination fields to an
+  existing class.
+- Write for the maintainer years from now: obvious control flow, no clever
+  tricks, and no machinery whose purpose is not visible from its call sites.
+
 ## Analytics
 
 - When adding a user-facing feature or action, consider whether analytics would

--- a/bridge/app/lib/src/repositories/pr_source_repository.dart
+++ b/bridge/app/lib/src/repositories/pr_source_repository.dart
@@ -194,10 +194,8 @@ class PrSourceRepository({required final GhCliApi _ghCli, required final GitCliA
       }
     }
 
-    final finalGithubLogin = await getAuthenticatedIdentity();
-    if (finalGithubLogin?.login != expectedGithubLogin.login) {
-      return const PullRequestSelectionIdentityChanged();
-    }
+    // Every query response above carried viewer.login and was fenced against
+    // [expectedGithubLogin], so the fetched data is already identity-proven.
     return PullRequestSelectionCompleted(selections: selections);
   }
 

--- a/bridge/app/lib/src/services/pr_sync_service.dart
+++ b/bridge/app/lib/src/services/pr_sync_service.dart
@@ -32,7 +32,7 @@ class PrSyncService({
   final Map<String, int> _pendingProjectGenerations = <String, int>{};
   Map<String, int> _activeProjectGenerations = const <String, int>{};
   final List<_PrRefreshWaiter> _refreshWaiters = <_PrRefreshWaiter>[];
-  ({bool capable, DateTime checkedAt})? _githubCliCapabilityCache;
+  DateTime? _githubCliCapableAt;
   Future<bool>? _githubCliCapabilityCheck;
   bool _identityVerificationFailureReported = false;
   Future<void>? _activeDrain;
@@ -40,7 +40,11 @@ class PrSyncService({
   bool _isDraining = false;
   bool _disposed = false;
 
-  static const _githubCliCacheTtl = Duration(seconds: 30);
+  /// How long a positive gh capability or identity result is reused. Only
+  /// successes are cached, so a fresh `gh auth login` is picked up on the next
+  /// refresh, while a logout or account switch takes up to this long to fail
+  /// closed on the user's own devices.
+  static const _githubCliCacheTtl = Duration(hours: 1);
   ({VerifiedGithubLogin login, DateTime checkedAt})? _verifiedIdentityCache;
   Future<VerifiedGithubLogin?>? _identityVerification;
 
@@ -191,9 +195,9 @@ class PrSyncService({
     final inFlight = _githubCliCapabilityCheck;
     if (inFlight != null) return await inFlight;
 
-    final cached = _githubCliCapabilityCache;
-    if (cached != null && _clock.now().difference(cached.checkedAt) < _githubCliCacheTtl) {
-      return cached.capable;
+    final capableAt = _githubCliCapableAt;
+    if (capableAt != null && _clock.now().difference(capableAt) < _githubCliCacheTtl) {
+      return true;
     }
 
     final check = _checkGithubCliCapability();
@@ -210,7 +214,7 @@ class PrSyncService({
   Future<bool> _checkGithubCliCapability() async {
     final available = await _prSource.isGithubCliAvailable();
     final capable = available && await _prSource.isGithubCliAuthenticated();
-    _githubCliCapabilityCache = (capable: capable, checkedAt: _clock.now());
+    if (capable) _githubCliCapableAt = _clock.now();
     return capable;
   }
 

--- a/bridge/app/lib/src/services/pr_sync_service.dart
+++ b/bridge/app/lib/src/services/pr_sync_service.dart
@@ -40,11 +40,37 @@ class PrSyncService({
   bool _isDraining = false;
   bool _disposed = false;
 
-  static const _githubCliCapabilityCacheTtl = Duration(seconds: 30);
+  static const _githubCliCacheTtl = Duration(seconds: 30);
+  ({VerifiedGithubLogin login, DateTime checkedAt})? _verifiedIdentityCache;
+  Future<VerifiedGithubLogin?>? _identityVerification;
 
   Stream<PullRequestRenderedChange> get renderedChanges => _renderedChangesController.stream;
 
+  /// Verifies the active gh login, sharing one in-flight `gh api user` call and
+  /// reusing a successful result for [_githubCliCacheTtl]. Each call is a
+  /// network round trip, and an explicit refresh otherwise pays for several in
+  /// series. Failures are never cached so a fixed login is picked up at once.
   Future<VerifiedGithubLogin?> verifyGithubIdentity() async {
+    final inFlight = _identityVerification;
+    if (inFlight != null) return await inFlight;
+
+    final cached = _verifiedIdentityCache;
+    if (cached != null && _clock.now().difference(cached.checkedAt) < _githubCliCacheTtl) {
+      return cached.login;
+    }
+
+    final verification = _verifyGithubIdentity();
+    _identityVerification = verification;
+    try {
+      return await verification;
+    } finally {
+      if (identical(_identityVerification, verification)) {
+        _identityVerification = null;
+      }
+    }
+  }
+
+  Future<VerifiedGithubLogin?> _verifyGithubIdentity() async {
     try {
       final identity = await _prSource.getAuthenticatedIdentity();
       if (identity == null) {
@@ -52,6 +78,7 @@ class PrSyncService({
         return null;
       }
       _identityVerificationFailureReported = false;
+      _verifiedIdentityCache = (login: identity, checkedAt: _clock.now());
       return identity;
     } on Object catch (error, stackTrace) {
       _reportIdentityVerificationFailure();
@@ -165,7 +192,7 @@ class PrSyncService({
     if (inFlight != null) return await inFlight;
 
     final cached = _githubCliCapabilityCache;
-    if (cached != null && _clock.now().difference(cached.checkedAt) < _githubCliCapabilityCacheTtl) {
+    if (cached != null && _clock.now().difference(cached.checkedAt) < _githubCliCacheTtl) {
       return cached.capable;
     }
 

--- a/bridge/app/test/bridge/repositories/pr_source_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/pr_source_repository_test.dart
@@ -567,7 +567,9 @@ void main() {
 
       expect((outcome as PullRequestSelectionCompleted).selections, hasLength(21));
       expect(ghCli.initialCalls.map((call) => call.length), [20, 1]);
-      expect(ghCli.identityCalls, 1);
+      // The viewer login inside each query response is the fence; no separate
+      // identity round trip is spent on selection.
+      expect(ghCli.identityCalls, 0);
 
       final changedCli = _FakeGhCliApi(
         initialResponses: [_emptyInitialResponse(targetCount: 1, viewerLogin: "hubot")],
@@ -578,17 +580,6 @@ void main() {
       );
       expect(changedOutcome, isA<PullRequestSelectionIdentityChanged>());
       expect(changedCli.identityCalls, 0);
-
-      final finalChangedCli = _FakeGhCliApi(
-        initialResponses: [_emptyInitialResponse(targetCount: 1)],
-        finalIdentityLogin: "hubot",
-      );
-      final finalChangedOutcome = await _selectionRepository(ghCli: finalChangedCli).selectPullRequests(
-        targets: const [_selectionTarget],
-        expectedGithubLogin: _verifiedGithubLogin,
-      );
-      expect(finalChangedOutcome, isA<PullRequestSelectionIdentityChanged>());
-      expect(finalChangedCli.identityCalls, 1);
     });
   });
 }
@@ -702,7 +693,6 @@ ProcessResult _result({required String stdout}) {
 final class _FakeGhCliApi({
   required List<GhPullRequestBatchResponse> initialResponses,
   List<GhPullRequestBatchResponse> cursorResponses = const [],
-  var String finalIdentityLogin = "octocat",
 }) implements GhCliApi {
   final Queue<GhPullRequestBatchResponse> _initialResponses = Queue<GhPullRequestBatchResponse>.from(initialResponses);
   final Queue<GhPullRequestBatchResponse> _cursorResponses = Queue<GhPullRequestBatchResponse>.from(cursorResponses);
@@ -713,7 +703,7 @@ final class _FakeGhCliApi({
   @override
   Future<GhAuthenticatedIdentity> getAuthenticatedIdentity() async {
     identityCalls++;
-    return GhAuthenticatedIdentity(rawLogin: finalIdentityLogin);
+    return const GhAuthenticatedIdentity(rawLogin: "octocat");
   }
 
   @override

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -517,7 +517,7 @@ void main() {
       expect(source.resolveCalls, hasLength(2));
     });
 
-    test("shares and expires the gh capability cache", () async {
+    test("shares and expires a positive gh capability but never caches a negative one", () async {
       var now = DateTime.utc(2026, 8, 2);
       final source = _FakePrSource(
         targetsByDirectory: {
@@ -537,24 +537,24 @@ void main() {
       );
       addTearDown(service.dispose);
 
-      await service.triggerRefresh(
-        projectIds: {"one"},
-        refreshPolicy: PrRefreshPolicy.explicit,
-      );
-      await service.triggerRefresh(
-        projectIds: {"two"},
-        refreshPolicy: PrRefreshPolicy.explicit,
-      );
-      expect(source.isAvailableCallCount, 1);
+      Future<PrRefreshOutcome> refresh(String projectId) =>
+          service.triggerRefresh(projectIds: {projectId}, refreshPolicy: PrRefreshPolicy.explicit);
 
-      now = now.add(const Duration(seconds: 30));
-      source.isAvailableResult = true;
-      await service.triggerRefresh(
-        projectIds: {"one"},
-        refreshPolicy: PrRefreshPolicy.explicit,
-      );
+      await refresh("one");
+      await refresh("two");
       expect(source.isAvailableCallCount, 2);
-      expect(source.selectionCalls, hasLength(1));
+      expect(source.selectionCalls, isEmpty);
+
+      source.isAvailableResult = true;
+      await refresh("one");
+      now = now.add(const Duration(minutes: 59));
+      await refresh("two");
+      expect(source.isAvailableCallCount, 3);
+      expect(source.selectionCalls, hasLength(2));
+
+      now = now.add(const Duration(minutes: 1));
+      await refresh("one");
+      expect(source.isAvailableCallCount, 4);
     });
 
     test("shares and expires a verified identity but never caches a failure", () async {
@@ -577,11 +577,11 @@ void main() {
       expect(concurrent, everyElement(_verifiedGithubLogin));
       expect(source.identityCallCount, 3);
 
-      now = now.add(const Duration(seconds: 29));
+      now = now.add(const Duration(minutes: 59));
       expect(await service.verifyGithubIdentity(), _verifiedGithubLogin);
       expect(source.identityCallCount, 3);
 
-      now = now.add(const Duration(seconds: 1));
+      now = now.add(const Duration(minutes: 1));
       source.authenticatedIdentity = null;
       expect(await service.verifyGithubIdentity(), isNull);
       expect(source.identityCallCount, 4);

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -557,6 +557,36 @@ void main() {
       expect(source.selectionCalls, hasLength(1));
     });
 
+    test("shares and expires a verified identity but never caches a failure", () async {
+      var now = DateTime.utc(2026, 8, 2);
+      final source = _FakePrSource()..authenticatedIdentity = null;
+      final service = _service(
+        source: source,
+        pullRequests: _FakePullRequestRepository(),
+        sessionsByProject: const {},
+        clock: Clock(() => now),
+      );
+      addTearDown(service.dispose);
+
+      expect(await service.verifyGithubIdentity(), isNull);
+      expect(await service.verifyGithubIdentity(), isNull);
+      expect(source.identityCallCount, 2);
+
+      source.authenticatedIdentity = _verifiedGithubLogin;
+      final concurrent = await Future.wait([service.verifyGithubIdentity(), service.verifyGithubIdentity()]);
+      expect(concurrent, everyElement(_verifiedGithubLogin));
+      expect(source.identityCallCount, 3);
+
+      now = now.add(const Duration(seconds: 29));
+      expect(await service.verifyGithubIdentity(), _verifiedGithubLogin);
+      expect(source.identityCallCount, 3);
+
+      now = now.add(const Duration(seconds: 1));
+      source.authenticatedIdentity = null;
+      expect(await service.verifyGithubIdentity(), isNull);
+      expect(source.identityCallCount, 4);
+    });
+
     test("isolates replacement exceptions and continues later projects", () async {
       final source = _FakePrSource(
         targetsByDirectory: {

--- a/docs/regression/pull-request-monitoring.md
+++ b/docs/regression/pull-request-monitoring.md
@@ -24,11 +24,13 @@ change. Bridge-owned, plugin-agnostic, backed by the user's local gh CLI.
   reconciles selection. A refresh resolved against the old durable branch cannot
   overwrite that result, and local or fetched remote-ref collisions receive a
   different generated suffix.
-- Every PR-bearing read is gated on a gh identity check at most 30s old, shared
-  with concurrent reads and never cached on failure; unknown, failed, or switched
-  login returns session and branch without PR metadata instead of another
-  account's cache. Fetched PR data is fenced by the viewer login in the same
-  response. No token is stored and no GitHub login reaches clients. Routine
+- Every PR-bearing read is gated on a gh identity check at most one hour old,
+  shared with concurrent reads; gh availability and authentication are cached on
+  the same terms. Only successes are cached, so a fresh gh login is picked up on
+  the next refresh, while an unknown, failed, or switched login returns session
+  and branch without PR metadata instead of another account's cache. Fetched PR
+  data is fenced by the viewer login in the same response. No token is stored
+  and no GitHub login reaches clients. Routine
   logs carry no branch, repo slug, PR title, URL, or path; recovered failures retain
   the original error, stack, and diagnostically useful local context.
 - Presence is connection-scoped and unioned across devices; one timer serves the

--- a/docs/regression/pull-request-monitoring.md
+++ b/docs/regression/pull-request-monitoring.md
@@ -24,9 +24,11 @@ change. Bridge-owned, plugin-agnostic, backed by the user's local gh CLI.
   reconciles selection. A refresh resolved against the old durable branch cannot
   overwrite that result, and local or fetched remote-ref collisions receive a
   different generated suffix.
-- Every PR-bearing read is gated on a fresh gh identity check; unknown, failed, or
-  switched login returns session and branch without PR metadata instead of another
-  account's cache. No token is stored and no GitHub login reaches clients. Routine
+- Every PR-bearing read is gated on a gh identity check at most 30s old, shared
+  with concurrent reads and never cached on failure; unknown, failed, or switched
+  login returns session and branch without PR metadata instead of another
+  account's cache. Fetched PR data is fenced by the viewer login in the same
+  response. No token is stored and no GitHub login reaches clients. Routine
   logs carry no branch, repo slug, PR title, URL, or path; recovered failures retain
   the original error, stack, and diagnostically useful local context.
 - Presence is connection-scoped and unioned across devices; one timer serves the


### PR DESCRIPTION
## Complexity
⚙️ moderate. Small diff in two bridge files, but it relaxes a documented identity-gating invariant from "fresh per read" to "at most one hour old", so review is about the security trade rather than the code.

## What
- `PrSyncService.verifyGithubIdentity` now shares one in-flight `gh api user` call and reuses a successful login for one hour. The gh availability and authentication check shares the same window. Only successes are cached, so a fresh `gh auth login` is picked up on the next refresh.
- `PrSourceRepository.selectPullRequests` no longer makes a separate identity call after the GraphQL selection. Every query response already carries `viewer.login` and is fenced against the expected login.
- Regression doc updated; one new service test covers sharing, expiry, and non-caching of failures.

## Why
Pull-to-refresh deliberately waits for PR data, and the user pulls precisely because PR data is stale, so returning early is not an option. Measured on this machine, the wait was dominated by four serial `gh api user` round trips rather than the PR query itself:

| Step | Cost |
|---|---|
| `gh api user` (each, four in series) | ~0.4 s |
| GraphQL PR query, 1 to 20 targets | 0.5 to 0.8 s |

After this change an explicit refresh pays for at most one identity call per hour, so the wait drops from roughly 2.2 s (often hitting the 5 s cap) to the PR query alone, about 0.6 s. Background session-list reads also stop paying 0.4 s each.

## Risk and test focus
- **Identity switch or logout fails closed within an hour instead of immediately.** After `gh auth switch` or `gh auth logout`, cached PR badges for the previous account can stay visible on the user's own devices for up to an hour. Accepted by the user: account switches are rare and the damage is a stale badge on their own device. New fetches are still fenced by `viewer.login` in the response, so no new data is ever stored under the wrong login. The capability cache previously had a 30 s window in both directions; it now caches only positive results.
- No wire contract, database, or client change.
- Verified: `dart analyze` clean for `bridge/app`; PR sync, PR source, sessions handler, FK regression, and viewed-project listener tests pass (94 tests).

## Expected result
Pull-to-refresh on the session list completes in about a second with genuinely refreshed PR data, and the success toast still fires only after that data is in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also in this PR
AGENTS.md gains a "Code Quality And Change Risk" section: leave touched code a little cleaner when the edit is small and local, weigh every cleanup against regression risk, and never let quality work grow into a tangent refactor. Requested by the user; unrelated to the bridge change.
