### PR TITLE
🚧 [claude-inline-subtasks] deepseek: inline subtask tiles and live child sessions

### DIFF
--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -505,21 +505,26 @@ confirmation, no child session or partial stop) and gets that subset.
   mapper feeds start/end facts through the shared `AcpChildSessionTracker`;
   child standard updates retain the child session id. Typed tool-call lookup
   carries cross-session ambiguity through standard nested permission routing,
-  which cancels rather than falling back to an unrelated active turn. Protocol
-  v1 retains its generic delegation card because it supplies no lifecycle replacement.
-  The protocol has no authoritative settlement lifecycle, so DeepSeek creates
+  which cancels rather than falling back to an unrelated active turn. Exact
+  title-bearing updates reordered ahead of their call are deferred too, and
+  lifecycle frames stay behind an accepted prompt while its frame is writing.
+  Protocol v1 retains its generic delegation card because it supplies no
+  lifecycle replacement. The protocol has no authoritative settlement
+  lifecycle, so DeepSeek creates
   no Grok-style autonomous root hold.
 - `DeepSeekHistoryRepository` indexes boundary-validated typed replay metadata
   by the enclosing update's `toolCallId`. A narrow replay-local
   `AcpReplayCollector` replacement callback turns the generic delegation tool
-  into one subtask part without reading or mutating live tracker state.
+  into one subtask part without reading or mutating live tracker state. Splitting
+  its child-owned envelope preserves the order of surrounding ordinary parts.
 - `DeepSeekSessionService` merges persisted child rows with direct live tracker
   children, preferring persisted title/time metadata by id. Live descendants
   inherit the tracker's root project before persistence catches up. Live and
   replay tiles stay in the direct parent's transcript, while shared ACP child
   activity rolls up to the owning root. Deleting a parent clears its full tracked
-  descendant subtree; existing disconnect, process-exit, and disposal cleanup
-  owns cancellation.
+  descendant subtree and leaves process-scoped tombstones against late frames;
+  existing disconnect, process-exit, and disposal cleanup owns cancellation and
+  releases those tombstones after the old event source drains.
 - Consumer support temporarily accepts protocol versions 1 and 2. Adapter
   v0.1.3 is not published yet, so managed target 0.1.2 and PATH floor 0.1.0 stay
   unchanged. After this consumer merges, the adapter release-prep PR records

--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -512,11 +512,11 @@ confirmation, no child session or partial stop) and gets that subset.
   `AcpReplayCollector` replacement callback turns the generic delegation tool
   into one subtask part without reading or mutating live tracker state.
 - `DeepSeekSessionService` merges persisted child rows with direct live tracker
-  children, preferring persisted title/time metadata by id, and resolves
-  persisted ancestry before nested history reconstructs root-owned identities.
-  Shared ACP child accounting retains direct parents for navigation while
-  rolling activity up to roots; existing delete, disconnect, process-exit, and
-  disposal cleanup owns cancellation.
+  children, preferring persisted title/time metadata by id. Live and replay
+  tiles stay in the direct parent's transcript, while shared ACP child activity
+  rolls up to the owning root. Deleting a parent clears its full tracked
+  descendant subtree; existing disconnect, process-exit, and disposal cleanup
+  owns cancellation.
 - Consumer support temporarily accepts protocol versions 1 and 2. Adapter
   v0.1.3 is not published yet, so managed target 0.1.2 and PATH floor 0.1.0 stay
   unchanged. After this consumer merges, the adapter release-prep PR records

--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -37,9 +37,8 @@ confirmation, no child session or partial stop) and gets that subset.
 ## Shared Rules
 
 - Backend payloads, DTOs, and lifecycle mapping stay inside the owning plugin
-  package. The generic ACP plugin gains exactly five backend-neutral seams,
-  introduced by the Grok chain (their first consumer) and reused by DeepSeek
-  and Cursor:
+  package. The generic ACP plugin gains only the backend-neutral seams below,
+  each landing with its first production consumer rather than ahead of it:
   1. `AcpChildSessionTracker`
      (`bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_child_session_tracker.dart`),
      a Layer-2 tracker with one instance per plugin, constructed at the harness
@@ -118,25 +117,19 @@ confirmation, no child session or partial stop) and gets that subset.
      reported as complete. `interruptActiveWork` uses `stop`.
   4. One abstract backend seam `cancelChild({sessionId, childSessionId})` on
      the per-harness ACP API; Grok and DeepSeek supply only the request shape.
-  5. A backend-neutral replay hook: `getSessionMessages` builds history from
+  5. A narrow backend-neutral replay replacement hook on
      `AcpReplayCollector`, which consumes `session/update` frames into
-     `PluginMessageWithParts` and never runs the live mapper. The collector
-     therefore accepts a harness-supplied replay projection that turns the
-     non-`session/update` notifications replayed by `session/load` into the
-     same `subtask` parts and child records the collector materialises. The
-     projection owns replay-local `AcpChildSessionTracker` and
-     `AcpDeferredToolCallTracker` instances created per `getSessionMessages`
-     call; it never touches either live tracker, the child change-stream
-     subscription, or the event buffer, so reading history cannot leave the
-     plugin busy, retain deferred calls, or emit live status transitions. Before the collector
-     runs, a harness may have its Layer-3 session service prepare an immutable,
-     backend-neutral `AcpReplayContext` through the harness API and repository;
-     the pure projection receives that context and performs no data access.
-     Grok uses this part of seam 5 to supply child prompts keyed by child id.
-     `mapExtension` stays a live-only seam.
-  Harness subclasses therefore override payload parsing, tool-call
-  classification, `mapExtension`, the replay projection, and `cancelChild`, and
-  nothing else.
+     `PluginMessageWithParts` without running the live mapper. A harness
+     repository may replace one fully materialized generic tool part with a
+     backend-neutral message part using the standard tool-call id. The callback
+     receives immutable replay data, performs no I/O, and never reads or mutates
+     live trackers, subscriptions, or the event buffer. DeepSeek is the first
+     consumer: its repository indexes typed metadata from those same replayed
+     standard updates, then asks its pure mapper to replace the delegation card
+     with one subtask tile. Future harness replay needs add no broader projection
+     until a concrete contract requires one. `mapExtension` stays live-only.
+  Harness subclasses add only the parsing, mapping, and transport overrides
+  required by the capability currently being delivered.
 - Child session ids are the harness's own session or thread ids. Parentage is
   data on the session record, never an id prefix.
 - One child equals one tile. Progress events do not update the tile; only
@@ -479,122 +472,63 @@ confirmation, no child session or partial stop) and gets that subset.
 5. Is `spawn_subagent` also surfaced as a standard `tool_call`; does a
    background finish trigger a wake-up turn?
 
-## DeepSeek (`sesori-deepseek-acp` 0.1.2 over dsh 0.1.1-rc.2)
+## DeepSeek (`sesori-deepseek-acp` 0.1.3 source over dsh 0.1.1-rc.2; release pending)
 
 ### Verified facts
 
-- dsh emits `subagent/start {runId, provider, id}` and `subagent/end
-  {..., stopReason: completed | aborted | error | max-tokens | refusal,
-  lastAssistantMessage?}` with the parent as scoped carrier; neither carries a
-  label, mode, or the parent tool call id. A log-only `subagent/descriptor`
-  records `mode: one-shot | continuable` and `label`.
-- Child headers inherit the parent `cwd` and set `parentSession`,
-  `origin: "subagent"`, `delegationDepth`.
-- The `subagent` tool is background (continuable) by default;
-  `run_in_background: false` runs a foreground one-shot. `subagent_fork` is
-  one-shot. A foreground child is cancelled by the parent tool's signal;
-  continuable children survive a parent cancel and are disposed only with the
-  parent agent. `ctx.subagents.interrupt(childId, {kind: "user",
-  parentSessionId})` interrupts continuable children; one-shot background
-  fork jobs cannot be interrupted individually.
-- The adapter (`src/sessions.ts`) forwards `tool/call` as a generic
-  `tool_call`, never forwards `subagent/*`, drops `session/event` for sessions
-  it does not own (so child events are discarded today), and already exposes
-  `parentSessionId`, `origin`, `delegationDepth` in `listSessions`.
-  `loadSession` and history work for any persisted id with a matching `cwd`,
-  so child history is reachable now. `_meta["sesori.ai/deepseek"]` is the
-  established extension envelope; the schema is Ajv-validated and
-  `EXTENSION_PROTOCOL_VERSION = 1`.
+- dsh emits `subagent/start` and `subagent/end` under the owning root context;
+  child headers retain direct `parentSession`, `origin: "subagent"`,
+  `delegationDepth`, and the inherited `cwd`.
+- Adapter PRs #13, #14, and #15 are merged. Protocol v2 (source commit
+  `d7a48471bf5339793beb0c9e1c1889e63f76ec92`) emits
+  `deepseek/subagent` `started {sessionId, childSessionId, toolCallId, prompt,
+  label, mode}` and `ended {sessionId, childSessionId, stopReason, summary?}`.
+  The normalized presentation prompt is required and bounded to 32,768 Unicode
+  scalar values. There is no settlement variant, settlement outcome,
+  post-child action, or uncorrelated-start wire shape.
+- History replay annotates the enclosing standard ACP delegation update at
+  `_meta["sesori.ai/deepseek"].subagent` with prompt, label, mode, optional
+  child id, and optional terminal outcome. Its `toolCallId` remains the
+  enclosing update's standard field rather than being duplicated in metadata.
+  Protocol v1 remains byte-for-byte frozen.
+- The same adapter source includes `deepseek/subagent/interrupt`, but the
+  monorepo consumes that method only in the separate scoped-stop PR.
 
-### Current plugin
+### Current plugin design
 
-- `deepseek_plugin_impl.dart` already parses `parentSessionId` from `_meta`
-  and lists persisted children through `listAllSessions`. Live child status,
-  tiles, and links are missing. `deepseek_event_mapper.dart` overrides
-  `mapExtension` for `deepseek/session/status`.
-
-### Design
-
-- **Adapter extension (protocol v2, additive; v1 stays frozen).** New
-  notification `deepseek/subagent` is sealed by `kind`: `started {sessionId,
-  childSessionId, toolCallId, prompt, label, mode: foreground | background}`;
-  `ended {sessionId, childSessionId, stopReason, summary?, postChildAction:
-  none | parentSettlementTurn}` (summary is bounded text of the last assistant
-  message); and `settlementEnded {sessionId, childSessionId, outcome}` with a
-  closed `completed | cancelled | errored` outcome enum. `toolCallId` and
-  `prompt` are required: the probe showed the `AsyncLocalStorage` scope
-  around the root `tools/execute` waterfall gives every `subagent/start` its
-  executing call id and typed call arguments, including parallel calls and
-  forks, so the adapter takes the prompt and label from that exact call and
-  there is no uncorrelated or prompt-less variant. Mode derives from the call's
-  `run_in_background` argument with the tool defaults; labels are never used
-  for correlation. A continuable child's `ended` declares
-  `parentSettlementTurn`; the adapter binds the later parent `user/message`
-  whose `source.kind` is `subagent-settled` and whose `senderSessionId` is that
-  child to the active parent turn, then emits `settlementEnded` on every
-  terminal path for that turn, normalizing completion, cancellation/interrupt,
-  and failure into its closed outcome enum. The adapter also applies the owning
-  root's provider/model
-  selection to its descendants through a root-level `agent/request`
-  listener, because children inherit `AgentOptions.provider/model`, which
-  the adapter never sets, and otherwise fail at once (probe defect). Child
-  transcripts: the adapter projects events for every descendant of an owned
-  root (ancestry resolved by walking each header's `parentSession`, since a
-  grandchild names the child, not the root) as ordinary `session/update`s
-  under the child id, while the tile keeps the direct parent. New method
-  `deepseek/subagent/interrupt {sessionId, childSessionId}` calls
-  `ctx.subagents.interrupt`. History replay: the parent log never names a
-  foreground child and parallel calls open overlapping windows, so the
-  adapter persists `toolCallId -> childSessionId` in its own session store at
-  `subagent/start`, and `history` folds that start/end info into the `_meta`
-  envelope of the parent's `subagent` tool call so a reload rebuilds the tile
-  from one page without timing-window attribution.
-- **Plugin.** DTOs and payload parsing live in `sesori_plugin_deepseek`;
-  lifecycle goes through `AcpChildSessionTracker` (seam 1). `started` opens
-  the tile keyed by its `toolCallId` and required `prompt`, and the matching
-  `subagent*` `tool_call` card is suppressed (seam 2). `started` also binds
-  `childSessionID`, label, and `isBackground` from `mode`; `ended` maps
-  `aborted` to cancelled and `error`, `max-tokens`, `refusal` to error. For
-  `parentSettlementTurn`, `DeepSeekEventMapper` atomically replaces the
-  finishing child with a backend-neutral root hold keyed by an opaque child id;
-  it releases that hold for every `settlementEnded` outcome, including a
-  cancelled or interrupted settlement turn. Only the adapter and DeepSeek
-  mapper know the dsh settlement message or turn convention; the ACP tracker
-  stores opaque holds. Abort/cancel releases through that terminal event, while
-  session delete, disconnect, and process exit clear any outstanding root holds
-  with the tracker. Tracker state is independent of the per-turn `_liveTools`
-  clear. Replay does not pass
-  through seam 5's notification hook, because
-  `DeepSeekHistoryRepository` feeds `session/update` envelopes straight into
-  `AcpReplayCollector.consume`: that repository parses the folded `_meta`
-  envelope of each `subagent*` tool call itself and hands the resulting
-  `subtask` parts to the collector, so the generic collector never learns
-  DeepSeek payloads.
-- **Busy accounting and scoped stop.** Through seams 1 and 3. A continuable
-  child's terminal event swaps its busy child entry for the settlement hold,
-  so root status and `PluginWorkState` stay busy across the prompt-less parent
-  follow-up and release only on its correlated completion.
-  `DeepSeekAcpApi.cancelChild` sends `deepseek/subagent/interrupt`.
-  Uninterruptible one-shot fork jobs are recorded with `canCancel: false` and
-  as foreground, so they never make `mainAgentOnlySupported` true, a `stop`
-  that leaves one running reports `workKept: true`, and the matrix notes they
-  cannot be stopped alone.
-- **Adapter version.** `EXTENSION_PROTOCOL_VERSION` becomes 2. The runtime
-  manifest raises `targetVersion` and `minPathVersion` to 0.1.3, so an
-  explicitly configured or PATH adapter below 0.1.3 is reported by setup as
-  needing an update instead of failing at initialization; setup tests cover
-  the floor. With the floor raised no flow launches a v1 adapter, so the
-  plugin has no v1 fallback path.
+- Typed DeepSeek DTOs validate protocol-v2 lifecycle and replay metadata at the
+  boundary. For protocol v2, `DeepSeekEventMapper` suppresses the matching
+  standard `subagent` or `subagent_fork` tool card and feeds the start/end facts
+  through the shared `AcpChildSessionTracker`; child standard updates retain the
+  child session id. Protocol v1 retains its generic delegation card because it
+  supplies no lifecycle replacement.
+  The protocol has no authoritative settlement lifecycle, so DeepSeek creates
+  no Grok-style autonomous root hold.
+- `DeepSeekHistoryRepository` indexes typed replay metadata by the enclosing
+  update's `toolCallId`. A narrow replay-local `AcpReplayCollector` replacement
+  callback turns the generic delegation tool into one subtask part without
+  reading or mutating live tracker state.
+- `DeepSeekSessionService` merges persisted child rows with live tracker
+  children, preferring persisted title/time metadata by id. Shared ACP child
+  accounting keeps roots and plugin work busy while a child runs and existing
+  delete, disconnect, process-exit, and disposal cleanup owns cancellation.
+- Consumer support temporarily accepts protocol versions 1 and 2. Adapter
+  v0.1.3 is not published yet, so managed target 0.1.2 and PATH floor 0.1.0 stay
+  unchanged. After this consumer merges, the adapter release-prep PR records
+  its consumer commit and publishes v0.1.3; the later scoped-stop PR pins target
+  and floor to 0.1.3, narrows initialization to v2, and consumes interrupt.
 
 ### PRs
 
 | Repo | Emoji | Description | Scope |
 |---|---|---|---|
-| adapter | ⚙️ | `sessions: sub-agent lifecycle notifications and child transcripts` | `subagent/*` and descendant `session/event` listeners, root-level `agent/request` provider/model propagation to descendants, child records, required prompt/call correlation, terminal settlement-turn correlation including cancel/error, `deepseek/subagent`, `_meta` history fold, schema and fixtures, protocol version 2 |
-| adapter | ⚙️ | `sessions: per-child interrupt; release v0.1.3` | `deepseek/subagent/interrupt`, schema, version bump, release checksums |
-| monorepo | 🚧 | `deepseek: inline subtask tiles and live child sessions` | DTOs, required prompt mapping, mapper feeding seams 1 and 2, settlement hold/release for every terminal outcome plus delete/disconnect/exit cleanup, `_meta` fold parsed in `DeepSeekHistoryRepository`, runtime manifest target and PATH floor 0.1.3 with setup tests; lands after the Grok lifecycle PRs |
-| monorepo | ⚙️ | `deepseek: scoped stop for sub-agents` | `DeepSeekAcpApi.cancelChild` (seam 4), mixed foreground/background and unsupported-`keep` policy tests through seam 3 |
-| monorepo | 🌱 | `docs: record DeepSeek sub-agent coverage` | matrix footnote ⁹ resolved, regression docs |
+| adapter | ⚙️ | `sessions: sub-agent lifecycle notifications and child transcripts` | Merged PR #13 (`0a85fb2`): lifecycle, descendant transcripts, bindings, and protocol v2 |
+| adapter | ⚙️ | `sessions: per-child interrupt; release v0.1.3` | Merged PR #14 (`1f839c3`): interrupt contract and package version; release intentionally pending |
+| adapter | 🌿 | `protocol: carry sub-agent prompts for tile replay` | Merged PR #15 (`d7a4847`): required normalized prompt in live and replay metadata |
+| monorepo | 🚧 | `deepseek: inline subtask tiles and live child sessions` | In progress: v2 DTOs/fixtures, live lifecycle, replay replacement, merged child catalog; runtime policy unchanged |
+| adapter | 🌱 | `release: publish v0.1.3 for the merged consumer` | Next after the monorepo consumer merges: record its commit, tag, publish, and verify assets |
+| monorepo | ⚙️ | `deepseek: scoped stop for sub-agents` | Pending: consume interrupt, pin target/PATH floor 0.1.3, narrow initialization to v2, and test mixed modes |
+| monorepo | 🌱 | `docs: record DeepSeek sub-agent coverage` | Pending final E2E matrix and plan retirement |
 
 ### Probe results (dsh 0.1.1-rc.2, 2026-09-03, details in `followups/deepseek-probe.md`)
 

--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -503,8 +503,10 @@ confirmation, no child session or partial stop) and gets that subset.
   suppresses the matching standard `subagent` or `subagent_fork` tool card,
   `DeepSeekDelegationTracker` owns its cross-turn lifecycle correlation, and the
   mapper feeds start/end facts through the shared `AcpChildSessionTracker`;
-  child standard updates retain the child session id. Protocol v1 retains its
-  generic delegation card because it supplies no lifecycle replacement.
+  child standard updates retain the child session id. Typed tool-call lookup
+  carries cross-session ambiguity through standard nested permission routing,
+  which cancels rather than falling back to an unrelated active turn. Protocol
+  v1 retains its generic delegation card because it supplies no lifecycle replacement.
   The protocol has no authoritative settlement lifecycle, so DeepSeek creates
   no Grok-style autonomous root hold.
 - `DeepSeekHistoryRepository` indexes boundary-validated typed replay metadata
@@ -512,9 +514,10 @@ confirmation, no child session or partial stop) and gets that subset.
   `AcpReplayCollector` replacement callback turns the generic delegation tool
   into one subtask part without reading or mutating live tracker state.
 - `DeepSeekSessionService` merges persisted child rows with direct live tracker
-  children, preferring persisted title/time metadata by id. Live and replay
-  tiles stay in the direct parent's transcript, while shared ACP child activity
-  rolls up to the owning root. Deleting a parent clears its full tracked
+  children, preferring persisted title/time metadata by id. Live descendants
+  inherit the tracker's root project before persistence catches up. Live and
+  replay tiles stay in the direct parent's transcript, while shared ACP child
+  activity rolls up to the owning root. Deleting a parent clears its full tracked
   descendant subtree; existing disconnect, process-exit, and disposal cleanup
   owns cancellation.
 - Consumer support temporarily accepts protocol versions 1 and 2. Adapter

--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -516,7 +516,9 @@ confirmation, no child session or partial stop) and gets that subset.
   by the enclosing update's `toolCallId`. A narrow replay-local
   `AcpReplayCollector` replacement callback turns the generic delegation tool
   into one subtask part without reading or mutating live tracker state. Splitting
-  its child-owned envelope preserves the order of surrounding ordinary parts.
+  its child-owned envelope preserves the order of surrounding ordinary parts;
+  every additional parent run gets deterministic storage-safe message and part
+  identities.
 - `DeepSeekSessionService` merges persisted child rows with direct live tracker
   children, preferring persisted title/time metadata by id. Live descendants
   inherit the tracker's root project before persistence catches up. Live and

--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -498,22 +498,25 @@ confirmation, no child session or partial stop) and gets that subset.
 
 ### Current plugin design
 
-- Typed DeepSeek DTOs validate protocol-v2 lifecycle and replay metadata at the
-  boundary. For protocol v2, `DeepSeekEventMapper` suppresses the matching
-  standard `subagent` or `subagent_fork` tool card and feeds the start/end facts
-  through the shared `AcpChildSessionTracker`; child standard updates retain the
-  child session id. Protocol v1 retains its generic delegation card because it
-  supplies no lifecycle replacement.
+- Typed DeepSeek DTOs parse and validate protocol-v2 lifecycle and replay
+  metadata once at the boundary. For protocol v2, `DeepSeekEventMapper`
+  suppresses the matching standard `subagent` or `subagent_fork` tool card,
+  `DeepSeekDelegationTracker` owns its cross-turn lifecycle correlation, and the
+  mapper feeds start/end facts through the shared `AcpChildSessionTracker`;
+  child standard updates retain the child session id. Protocol v1 retains its
+  generic delegation card because it supplies no lifecycle replacement.
   The protocol has no authoritative settlement lifecycle, so DeepSeek creates
   no Grok-style autonomous root hold.
-- `DeepSeekHistoryRepository` indexes typed replay metadata by the enclosing
-  update's `toolCallId`. A narrow replay-local `AcpReplayCollector` replacement
-  callback turns the generic delegation tool into one subtask part without
-  reading or mutating live tracker state.
-- `DeepSeekSessionService` merges persisted child rows with live tracker
-  children, preferring persisted title/time metadata by id. Shared ACP child
-  accounting keeps roots and plugin work busy while a child runs and existing
-  delete, disconnect, process-exit, and disposal cleanup owns cancellation.
+- `DeepSeekHistoryRepository` indexes boundary-validated typed replay metadata
+  by the enclosing update's `toolCallId`. A narrow replay-local
+  `AcpReplayCollector` replacement callback turns the generic delegation tool
+  into one subtask part without reading or mutating live tracker state.
+- `DeepSeekSessionService` merges persisted child rows with direct live tracker
+  children, preferring persisted title/time metadata by id, and resolves
+  persisted ancestry before nested history reconstructs root-owned identities.
+  Shared ACP child accounting retains direct parents for navigation while
+  rolling activity up to roots; existing delete, disconnect, process-exit, and
+  disposal cleanup owns cancellation.
 - Consumer support temporarily accepts protocol versions 1 and 2. Adapter
   v0.1.3 is not published yet, so managed target 0.1.2 and PATH floor 0.1.0 stay
   unchanged. After this consumer merges, the adapter release-prep PR records

--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -123,11 +123,13 @@ confirmation, no child session or partial stop) and gets that subset.
      repository may replace one fully materialized generic tool part with a
      backend-neutral message part using the standard tool-call id. The callback
      receives immutable replay data, performs no I/O, and never reads or mutates
-     live trackers, subscriptions, or the event buffer. DeepSeek is the first
-     consumer: its repository indexes typed metadata from those same replayed
-     standard updates, then asks its pure mapper to replace the delegation card
-     with one subtask tile. Future harness replay needs add no broader projection
-     until a concrete contract requires one. `mapExtension` stays live-only.
+     live trackers, subscriptions, or the event buffer. DeepSeek consumes this
+     narrow replacement form: its repository indexes typed metadata from those
+     same replayed standard updates, then asks its pure mapper to replace the
+     delegation card with one subtask tile. Grok's earlier seam-5 work instead
+     uses collector-provided replay context to route historical extension frames;
+     it does not use the generic-tool replacement callback. `mapExtension` stays
+     live-only for the DeepSeek path.
   Harness subclasses add only the parsing, mapping, and transport overrides
   required by the capability currently being delivered.
 - Child session ids are the harness's own session or thread ids. Parentage is

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -569,9 +569,17 @@ unbounded deferred notification list with one bounded merged snapshot, and
 moved optional replay-shape validation into the DTO factories shared by direct
 and history parsing.
 
+A final Codex pass found that standard ACP permissions nest their tool-call ID,
+that a live child did not populate the plugin's separate directory cache, and
+that naively unioning deferred `content` with `rawOutput` lost chronological
+precedence. Server-request attribution now carries a typed ambiguous result all
+the way to cancellation, live descendant catalogs read the mapper's tracked
+root project, and the bounded snapshot makes the newest content representation
+authoritative.
+
 DeepSeek tile verification on 2026-09-04: protocol v2 vendoring and codegen
-completed; `dart analyze --fatal-infos` and 82 tests passed in
-`sesori_plugin_deepseek`; `dart analyze --fatal-infos` and 308 tests passed in
+completed; `dart analyze --fatal-infos` and 83 tests passed in
+`sesori_plugin_deepseek`; `dart analyze --fatal-infos` and 310 tests passed in
 `sesori_plugin_acp`; `dart analyze --fatal-infos` and 83 tests passed in
 `sesori_plugin_grok`; `git diff --check` passed; protocol-v1 fixture bytes and
 the DeepSeek runtime manifest remained unchanged.

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -580,8 +580,9 @@ authoritative.
 The next review found three additional ordering gaps—mixed replay parts,
 update-before-call delivery, and lifecycle frames racing the accepted user
 message—plus stale lifecycle resurrection after subtree deletion. Replay now
-splits into order-preserving identity runs, identifiable reordered delegation
-updates enter the same bounded accumulator, lifecycle events share prompt-write
+splits into order-preserving runs with distinct deterministic message and part
+identities, identifiable reordered delegation updates enter the same bounded
+accumulator, lifecycle events share prompt-write
 ordering, and process-scoped tracker tombstones reject late session and child
 frames until connection reset.
 

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -569,7 +569,7 @@ unbounded deferred notification list with one bounded merged snapshot, and
 moved optional replay-shape validation into the DTO factories shared by direct
 and history parsing.
 
-A final Codex pass found that standard ACP permissions nest their tool-call ID,
+A subsequent Codex pass found that standard ACP permissions nest their tool-call ID,
 that a live child did not populate the plugin's separate directory cache, and
 that naively unioning deferred `content` with `rawOutput` lost chronological
 precedence. Server-request attribution now carries a typed ambiguous result all
@@ -577,9 +577,17 @@ the way to cancellation, live descendant catalogs read the mapper's tracked
 root project, and the bounded snapshot makes the newest content representation
 authoritative.
 
+The next review found three additional ordering gaps—mixed replay parts,
+update-before-call delivery, and lifecycle frames racing the accepted user
+message—plus stale lifecycle resurrection after subtree deletion. Replay now
+splits into order-preserving identity runs, identifiable reordered delegation
+updates enter the same bounded accumulator, lifecycle events share prompt-write
+ordering, and process-scoped tracker tombstones reject late session and child
+frames until connection reset.
+
 DeepSeek tile verification on 2026-09-04: protocol v2 vendoring and codegen
-completed; `dart analyze --fatal-infos` and 83 tests passed in
-`sesori_plugin_deepseek`; `dart analyze --fatal-infos` and 310 tests passed in
+completed; `dart analyze --fatal-infos` and 87 tests passed in
+`sesori_plugin_deepseek`; `dart analyze --fatal-infos` and 311 tests passed in
 `sesori_plugin_acp`; `dart analyze --fatal-infos` and 83 tests passed in
 `sesori_plugin_grok`; `git diff --check` passed; protocol-v1 fixture bytes and
 the DeepSeek runtime manifest remained unchanged.

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -174,7 +174,7 @@ implementation PR. E2E testing is performed after each PR merges.
 | [x] | DeepSeek (adapter) | `⚙️ sessions: sub-agent lifecycle notifications and child transcripts` | [sesori-deepseek-acp #13](https://github.com/sesori-ai/sesori-deepseek-acp/pull/13) merged at `0a85fb2` |
 | [x] | DeepSeek (adapter) | `⚙️ sessions: per-child interrupt; release v0.1.3` | [sesori-deepseek-acp #14](https://github.com/sesori-ai/sesori-deepseek-acp/pull/14) merged at `1f839c3`; package version staged, release pending |
 | [x] | DeepSeek (adapter) | `🌿 protocol: carry sub-agent prompts for tile replay` | [sesori-deepseek-acp #15](https://github.com/sesori-ai/sesori-deepseek-acp/pull/15) merged at `d7a4847` |
-| [ ] | DeepSeek | `🚧 [claude-inline-subtasks] deepseek: inline subtask tiles and live child sessions` | In progress on `claude-inline-subtasks-deepseek-tiles` |
+| [ ] | DeepSeek | `🚧 [claude-inline-subtasks] deepseek: inline subtask tiles and live child sessions` | [PR #1293](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1293) open |
 | [ ] | DeepSeek (adapter) | `🌱 release: publish v0.1.3 for the merged consumer` | Next after the tile/live-child consumer merges |
 | [ ] | DeepSeek | `⚙️ [claude-inline-subtasks] deepseek: scoped stop for sub-agents` | Pending adapter v0.1.3 release |
 | [ ] | DeepSeek | `🌱 [claude-inline-subtasks] docs: record DeepSeek sub-agent coverage` | Pending final E2E matrix and plan retirement |

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -171,11 +171,13 @@ implementation PR. E2E testing is performed after each PR merges.
 | [ ] | Grok | `🌿 [claude-inline-subtasks] grok: child session history` | Not started |
 | [ ] | Grok | `⚙️ [claude-inline-subtasks] grok: scoped stop for sub-agents` | Not started |
 | [ ] | Grok | `🌱 [claude-inline-subtasks] docs: record Grok Build sub-agent coverage` | Not started |
-| [ ] | DeepSeek (adapter) | `⚙️ sessions: sub-agent lifecycle notifications and child transcripts` | [sesori-deepseek-acp #13](https://github.com/sesori-ai/sesori-deepseek-acp/pull/13) |
-| [ ] | DeepSeek (adapter) | `⚙️ sessions: per-child interrupt; release v0.1.3` | [sesori-deepseek-acp #14](https://github.com/sesori-ai/sesori-deepseek-acp/pull/14) |
-| [ ] | DeepSeek | `🚧 [claude-inline-subtasks] deepseek: inline subtask tiles and live child sessions` | Not started |
-| [ ] | DeepSeek | `⚙️ [claude-inline-subtasks] deepseek: scoped stop for sub-agents` | Not started |
-| [ ] | DeepSeek | `🌱 [claude-inline-subtasks] docs: record DeepSeek sub-agent coverage` | Not started |
+| [x] | DeepSeek (adapter) | `⚙️ sessions: sub-agent lifecycle notifications and child transcripts` | [sesori-deepseek-acp #13](https://github.com/sesori-ai/sesori-deepseek-acp/pull/13) merged at `0a85fb2` |
+| [x] | DeepSeek (adapter) | `⚙️ sessions: per-child interrupt; release v0.1.3` | [sesori-deepseek-acp #14](https://github.com/sesori-ai/sesori-deepseek-acp/pull/14) merged at `1f839c3`; package version staged, release pending |
+| [x] | DeepSeek (adapter) | `🌿 protocol: carry sub-agent prompts for tile replay` | [sesori-deepseek-acp #15](https://github.com/sesori-ai/sesori-deepseek-acp/pull/15) merged at `d7a4847` |
+| [ ] | DeepSeek | `🚧 [claude-inline-subtasks] deepseek: inline subtask tiles and live child sessions` | In progress on `claude-inline-subtasks-deepseek-tiles` |
+| [ ] | DeepSeek (adapter) | `🌱 release: publish v0.1.3 for the merged consumer` | Next after the tile/live-child consumer merges |
+| [ ] | DeepSeek | `⚙️ [claude-inline-subtasks] deepseek: scoped stop for sub-agents` | Pending adapter v0.1.3 release |
+| [ ] | DeepSeek | `🌱 [claude-inline-subtasks] docs: record DeepSeek sub-agent coverage` | Pending final E2E matrix and plan retirement |
 | [ ] | Cursor | `⚙️ [claude-inline-subtasks] cursor: subtask tiles and stop confirmation for task subagents` | Not started |
 | [ ] | Cursor | `🌱 [claude-inline-subtasks] docs: record Cursor sub-agent coverage` | Not started |
 
@@ -534,3 +536,26 @@ A third follow-up `architecture-plan-review` on 2026-09-03 approved the Codex
 service-owned lifecycle flow and replay replacement, the proportional Grok
 denied-attempt replay limitation, and terminal DeepSeek settlement cleanup
 with no findings.
+
+A fourth follow-up `architecture-plan-review` on 2026-09-04 reconciled the
+DeepSeek design to the merged adapter contract and approved the sequence:
+prompt-contract correction, monorepo tiles/live children, release preparation,
+then scoped stop. The corrected design carries a bounded truthful prompt, has
+no settlement lifecycle or autonomous hold, and uses the enclosing standard
+update's tool-call id for replay correlation.
+
+The DeepSeek tile implementation's `architecture-implementation-review`
+rejected one deferred scoped-stop addition: interrupt request/response DTOs and
+parsers had no production consumer in this change. They were removed and stay
+owned by the later scoped-stop PR; the complete protocol-v2 source fixture
+remains pinned as integrity evidence. The approved replay callback, boundary,
+mapper, tracker, service, and composition ownership passed and were not
+re-reviewed. A correctness review found Unicode-scalar validation and child
+project/parent attribution gaps; both were fixed with regressions, and its
+focused re-review passed with no findings.
+
+DeepSeek tile verification on 2026-09-04: protocol v2 vendoring and codegen
+completed; `dart analyze --fatal-infos` and 61 tests passed in
+`sesori_plugin_deepseek`; `dart analyze --fatal-infos` and 306 tests passed in
+`sesori_plugin_acp`; `git diff --check` passed; protocol-v1 fixture bytes and
+the DeepSeek runtime manifest remained unchanged.

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -552,21 +552,26 @@ remains pinned as integrity evidence. An initial correctness review found
 Unicode-scalar validation and child project/parent attribution gaps; both were
 fixed with regressions, and its focused re-review passed with no findings.
 
-Fresh PR feedback then identified prompt echoes, nested direct-parent and replay
-root identity mismatches, cross-turn delegation correlation, dropped partial
-startup updates, and repeated history metadata decoding. The fixes retain
-parent and root separately, resolve persisted ancestry after restart, parse and
-validate typed metadata once at the API boundary, and replay every deferred ACP
-update. A follow-up architecture implementation review required the new
-multi-turn correlation state to move from the event mapper into an injected
+Fresh PR feedback then identified prompt echoes, nested parent/root accounting,
+cross-turn delegation correlation, dropped partial startup updates, and
+repeated history metadata decoding. The fixes retain direct parent and owning
+root separately and decode typed metadata once at the API boundary. A follow-up
+architecture implementation review required the new multi-turn correlation
+state to move from the event mapper into an injected
 `DeepSeekDelegationTracker`; the revised boundary was approved with no findings.
-A focused correctness follow-up found one final nested replay envelope still
-owned by the child; the envelope now adopts the root-owned part's session id and
-the persisted-ancestry regression asserts both identities.
+
+A later review caught that rolling nested tile identities up to the root
+orphaned those tiles from both root and child message reads. Live and replay
+tiles now remain in the direct parent's transcript while activity alone rolls
+up to the root. The same review made parent deletion recursive, changed
+ambiguous cross-session tool-call correlation to fail closed, replaced the
+unbounded deferred notification list with one bounded merged snapshot, and
+moved optional replay-shape validation into the DTO factories shared by direct
+and history parsing.
 
 DeepSeek tile verification on 2026-09-04: protocol v2 vendoring and codegen
-completed; `dart analyze --fatal-infos` and 80 tests passed in
-`sesori_plugin_deepseek`; `dart analyze --fatal-infos` and 306 tests passed in
+completed; `dart analyze --fatal-infos` and 82 tests passed in
+`sesori_plugin_deepseek`; `dart analyze --fatal-infos` and 308 tests passed in
 `sesori_plugin_acp`; `dart analyze --fatal-infos` and 83 tests passed in
 `sesori_plugin_grok`; `git diff --check` passed; protocol-v1 fixture bytes and
 the DeepSeek runtime manifest remained unchanged.

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -548,14 +548,25 @@ The DeepSeek tile implementation's `architecture-implementation-review`
 rejected one deferred scoped-stop addition: interrupt request/response DTOs and
 parsers had no production consumer in this change. They were removed and stay
 owned by the later scoped-stop PR; the complete protocol-v2 source fixture
-remains pinned as integrity evidence. The approved replay callback, boundary,
-mapper, tracker, service, and composition ownership passed and were not
-re-reviewed. A correctness review found Unicode-scalar validation and child
-project/parent attribution gaps; both were fixed with regressions, and its
-focused re-review passed with no findings.
+remains pinned as integrity evidence. An initial correctness review found
+Unicode-scalar validation and child project/parent attribution gaps; both were
+fixed with regressions, and its focused re-review passed with no findings.
+
+Fresh PR feedback then identified prompt echoes, nested direct-parent and replay
+root identity mismatches, cross-turn delegation correlation, dropped partial
+startup updates, and repeated history metadata decoding. The fixes retain
+parent and root separately, resolve persisted ancestry after restart, parse and
+validate typed metadata once at the API boundary, and replay every deferred ACP
+update. A follow-up architecture implementation review required the new
+multi-turn correlation state to move from the event mapper into an injected
+`DeepSeekDelegationTracker`; the revised boundary was approved with no findings.
+A focused correctness follow-up found one final nested replay envelope still
+owned by the child; the envelope now adopts the root-owned part's session id and
+the persisted-ancestry regression asserts both identities.
 
 DeepSeek tile verification on 2026-09-04: protocol v2 vendoring and codegen
-completed; `dart analyze --fatal-infos` and 61 tests passed in
+completed; `dart analyze --fatal-infos` and 80 tests passed in
 `sesori_plugin_deepseek`; `dart analyze --fatal-infos` and 306 tests passed in
-`sesori_plugin_acp`; `git diff --check` passed; protocol-v1 fixture bytes and
+`sesori_plugin_acp`; `dart analyze --fatal-infos` and 83 tests passed in
+`sesori_plugin_grok`; `git diff --check` passed; protocol-v1 fixture bytes and
 the DeepSeek runtime manifest remained unchanged.

--- a/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
@@ -149,6 +149,23 @@ class AcpApprovalRegistry({
   /// Routes one server request received by the owning plugin.
   void handleServerRequest({required AcpServerRequest request}) => handleRequest(request);
 
+  /// Rejects a request whose tool-call id matches more than one live session.
+  /// No active-turn fallback is safe because it could present and approve the
+  /// request under the wrong source context.
+  void rejectAmbiguousServerRequest({required AcpServerRequest request}) {
+    Log.w("[acp] server request has ambiguous tool-call session attribution; cancelling");
+    switch (request.method) {
+      case AcpMethods.sessionRequestPermission:
+        _respond(request.id, const {
+          "outcome": {"outcome": "cancelled"},
+        });
+      case AcpMethods.elicitationCreate:
+        _respond(request.id, const {"action": "cancel"});
+      default:
+        _respondError(request.id, -32602, "ambiguous tool-call session attribution");
+    }
+  }
+
   /// Responds to a server request with a result payload.
   void respond(Object acpId, Object? result) => _respond(acpId, result);
 

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -448,8 +448,9 @@ class AcpEventMapper({
           time: messageTime,
         );
       case "user_message_chunk":
-        // A child session's first user message is the prompt its parent gave
-        // it, which no client sent: it is the one source of the tile's prompt.
+        // When lifecycle omitted the launch prompt, a child session's first
+        // user message supplies it. Trackers whose start already carried the
+        // prompt ignore this echo and every later direct child prompt.
         if (childSessions.isChild(sessionId: sessionId)) {
           return _childPromptChunk(childSessionId: sessionId, update: update);
         }
@@ -1213,7 +1214,7 @@ class AcpEventMapper({
       pluginId: pluginId,
       projectID: project,
       directory: project,
-      parentID: childSessions.isChild(sessionId: id) ? childSessions.rootOf(sessionId: id) : null,
+      parentID: childSessions.parentOf(sessionId: id),
       title: snapshot?.title,
       time: created == null && updated == null
           ? null

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -10,6 +10,14 @@ import "repositories/trackers/acp_child_session_tracker.dart";
 import "repositories/trackers/acp_content_tracker.dart";
 import "repositories/trackers/acp_tool_content_tracker.dart";
 
+sealed class const AcpToolCallSessionLookup();
+
+final class const AcpToolCallSessionNotFound() extends AcpToolCallSessionLookup;
+
+final class const AcpToolCallSessionAmbiguous() extends AcpToolCallSessionLookup;
+
+final class const AcpToolCallSessionFound({required final String sessionId}) extends AcpToolCallSessionLookup;
+
 /// A backend "halt notice": the agent ended a turn without doing the requested
 /// work and instead streamed a terminal notice telling the user to change
 /// something (account, plan, model, or settings). Cursor's account/plan gate
@@ -190,17 +198,28 @@ class AcpEventMapper({
   final Map<String, Map<String, _LiveTool>> _liveTools = {};
 
   /// Resolves the live session that owns [toolCallId], when a harness extension
-  /// omits `sessionId` but carries the originating tool call id.
-  String? sessionIdForToolCallId({required String? toolCallId}) {
-    if (toolCallId == null || toolCallId.isEmpty) return null;
-    for (final entry in _liveTools.entries) {
-      if (entry.value.containsKey(toolCallId)) return entry.key;
-    }
-    for (final entry in _spawnToolCalls.entries) {
-      if (entry.value.contains(toolCallId)) return entry.key;
-    }
-    return null;
+  /// omits `sessionId` but carries the originating tool call id. Duplicate ids
+  /// across concurrent sessions are ambiguous rather than insertion-ordered.
+  AcpToolCallSessionLookup lookupSessionForToolCallId({required String? toolCallId}) {
+    if (toolCallId == null || toolCallId.isEmpty) return const AcpToolCallSessionNotFound();
+    final sessionIds = <String>{
+      for (final entry in _liveTools.entries)
+        if (entry.value.containsKey(toolCallId)) entry.key,
+      for (final entry in _spawnToolCalls.entries)
+        if (entry.value.contains(toolCallId)) entry.key,
+    };
+    return switch (sessionIds.toList(growable: false)) {
+      [final sessionId] => AcpToolCallSessionFound(sessionId: sessionId),
+      [] => const AcpToolCallSessionNotFound(),
+      _ => const AcpToolCallSessionAmbiguous(),
+    };
   }
+
+  String? sessionIdForToolCallId({required String? toolCallId}) =>
+      switch (lookupSessionForToolCallId(toolCallId: toolCallId)) {
+        AcpToolCallSessionFound(:final sessionId) => sessionId,
+        AcpToolCallSessionNotFound() || AcpToolCallSessionAmbiguous() => null,
+      };
 
   /// sessionId -> current turn number, advanced by [beginTurn].
   final Map<String, int> _turnSeq = {};

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -590,7 +590,7 @@ class AcpEventMapper({
       spawn: spawn,
       directory: directory,
     );
-    if (result.events.isNotEmpty) setSessionProject(spawn.childSessionId, directory);
+    setSessionProject(spawn.childSessionId, directory);
     return _childTileEvents(result);
   }
 

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -614,7 +614,7 @@ class AcpEventMapper({
 
   /// A tile's first render needs the assistant envelope it hangs from.
   List<BridgeSseEvent> _childTileEvents(AcpChildTileResult result) => [
-    if (result.opensMessage) _toolEnvelope(sessionId: result.rootSessionId, messageId: result.messageId, time: null),
+    if (result.opensMessage) _toolEnvelope(sessionId: result.renderSessionId, messageId: result.messageId, time: null),
     ...result.events,
   ];
 

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -299,8 +299,7 @@ class AcpEventMapper({
 
   int _turn(String sessionId) => _turnSeq[sessionId] ?? 1;
 
-  String _fallbackTurnMessageId(String sessionId) =>
-      _turnMessageIds[sessionId] ?? "$sessionId-t${_turn(sessionId)}";
+  String _fallbackTurnMessageId(String sessionId) => _turnMessageIds[sessionId] ?? "$sessionId-t${_turn(sessionId)}";
 
   static String initialUserMessageId(String sessionId) => "$sessionId-initial-user";
 
@@ -585,13 +584,14 @@ class AcpEventMapper({
   List<BridgeSseEvent> mapChildSpawned({required String sessionId, required AcpChildSpawn spawn}) {
     // Same boundary rule as [map]: an id-less session event is undeliverable.
     if (sessionId.isEmpty || spawn.childSessionId.isEmpty) return const [];
-    return _childTileEvents(
-      childSessions.spawn(
-        sessionId: sessionId,
-        spawn: spawn,
-        directory: projectForSession(sessionId: childSessions.rootOf(sessionId: sessionId)),
-      ),
+    final directory = projectForSession(sessionId: childSessions.rootOf(sessionId: sessionId));
+    final result = childSessions.spawn(
+      sessionId: sessionId,
+      spawn: spawn,
+      directory: directory,
     );
+    if (result.events.isNotEmpty) setSessionProject(spawn.childSessionId, directory);
+    return _childTileEvents(result);
   }
 
   /// Records the model a harness reports for a spawned child, so the child's
@@ -699,9 +699,7 @@ class AcpEventMapper({
   }) {
     final identity = _chunkIdentity(
       sessionId: sessionId,
-      update: messageId == null
-          ? const <String, dynamic>{}
-          : <String, dynamic>{"messageId": messageId},
+      update: messageId == null ? const <String, dynamic>{} : <String, dynamic>{"messageId": messageId},
       role: _ChunkRole.assistant,
     );
     final tracker = (_contentTrackers[sessionId] ??= {}).putIfAbsent(
@@ -1215,7 +1213,7 @@ class AcpEventMapper({
       pluginId: pluginId,
       projectID: project,
       directory: project,
-      parentID: null,
+      parentID: childSessions.isChild(sessionId: id) ? childSessions.rootOf(sessionId: id) : null,
       title: snapshot?.title,
       time: created == null && updated == null
           ? null
@@ -1329,7 +1327,10 @@ class AcpEventMapper({
   }
 }
 
-enum _ChunkRole() { user, assistant }
+enum _ChunkRole() {
+  user,
+  assistant,
+}
 
 /// Last-known metadata for one session, merged into the `session.updated`
 /// payload a `session_info_update` emits.
@@ -1340,10 +1341,10 @@ class _SessionSnapshot() {
 }
 
 class _TextPartAccumulator({
-    required final String partId,
-    required final String messageId,
-    required final PluginMessagePartType type,
-  }) {
+  required final String partId,
+  required final String messageId,
+  required final PluginMessagePartType type,
+}) {
   final StringBuffer text = StringBuffer();
   bool isStreaming = false;
 }
@@ -1351,13 +1352,13 @@ class _TextPartAccumulator({
 /// The last-rendered state of one live tool call, so a partial
 /// `tool_call_update` merges onto it instead of replacing it.
 class _LiveTool({
-    required final String tool,
-    required final String? title,
-    required final PluginToolStatus status,
-    required final AcpToolContentTracker contentTracker,
-    required final bool isFileMutation,
-    required var bool diffEmitted,
-    required final bool hasExplicitKind,
-    required final bool hasExplicitStatus,
-    required final PluginMessageTime? time,
-  });
+  required final String tool,
+  required final String? title,
+  required final PluginToolStatus status,
+  required final AcpToolContentTracker contentTracker,
+  required final bool isFileMutation,
+  required var bool diffEmitted,
+  required final bool hasExplicitKind,
+  required final bool hasExplicitStatus,
+  required final PluginMessageTime? time,
+});

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -587,6 +587,12 @@ class AcpEventMapper({
     );
   }
 
+  /// Whether [notification] must remain behind an accepted prompt whose frame
+  /// is still being written. Standard updates always do; a harness lifecycle
+  /// extension that can synchronously follow prompt receipt overrides this.
+  bool shouldBufferDuringPromptWrite({required AcpNotification notification}) =>
+      notification.method == AcpMethods.sessionUpdate;
+
   /// Hook for non-`session/update` notifications (harness extensions such as
   /// Cursor's `cursor/update_todos`). Base implementation drops them.
   List<BridgeSseEvent> mapExtension(AcpNotification notification) => const [];
@@ -610,6 +616,7 @@ class AcpEventMapper({
       spawn: spawn,
       directory: directory,
     );
+    if (result == null) return const [];
     setSessionProject(spawn.childSessionId, directory);
     return _childTileEvents(result);
   }

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -373,13 +373,16 @@ abstract class AcpPlugin({
   /// (see `CursorApprovalRegistry`), so both wire shapes share one mapping path.
   void handleAgentNotification(AcpNotification notification) {
     final sid = notification.params["sessionId"];
+    if (sid is String && childSessionTracker.isDeleted(sessionId: sid)) return;
     if (sid is String && _suppressedSessions.contains(sid) && isResumeReplayNotification(notification)) {
       // Replay from an in-flight resume-load — drop so old history does not
       // re-stream into the live conversation or reconstruct stale live state.
       _suppressedReplayCounts[sid] = (_suppressedReplayCounts[sid] ?? 0) + 1;
       return;
     }
-    if (notification.method == AcpMethods.sessionUpdate && sid is String && _isPromptFrameWriting(sessionId: sid)) {
+    if (sid is String &&
+        eventMapper.shouldBufferDuringPromptWrite(notification: notification) &&
+        _isPromptFrameWriting(sessionId: sid)) {
       _promptWriteNotifications.putIfAbsent(sid, () => []).add(notification);
       return;
     }

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1832,6 +1832,7 @@ abstract class AcpPlugin({
       // Reclassify a halt notice (e.g. Cursor's account/plan gate) the same way
       // the live stream does, so reloaded history renders it identically.
       haltClassifier: eventMapper.classifyHaltNotice,
+      toolPartReplacement: null,
     );
     List<PluginMessageWithParts> buildReplay() => collector.buildWithAssistantSelection(
       modelId: eventMapper.modelForSession(sessionId: sessionId),

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -390,18 +390,21 @@ abstract class AcpPlugin({
     final registry = _approvalRegistry;
     if (registry == null) return;
     final attribution = _serverRequestAttribution(request: request);
-    final sessionId = attribution.sessionId;
-    // Pin heuristic sessionless attribution at receipt: another concurrent turn
-    // can dispatch before this request leaves the prompt-write buffer. Preserve
-    // exact tool correlation so a harness mapper can resolve its owning turn.
-    final routedRequest = sessionId == null || attribution.fromTool
-        ? request
-        : _serverRequestWithSession(request: request, sessionId: sessionId);
-    if (sessionId != null && _isPromptFrameWriting(sessionId: sessionId)) {
-      _promptWriteServerRequests.putIfAbsent(sessionId, () => []).add(routedRequest);
-      return;
+    switch (attribution) {
+      case AcpToolCallSessionAmbiguous():
+        registry.rejectAmbiguousServerRequest(request: request);
+      case AcpToolCallSessionNotFound():
+        registry.handleServerRequest(request: request);
+      case AcpToolCallSessionFound(:final sessionId):
+        // Pin sessionless attribution at receipt: another concurrent turn can
+        // dispatch before this request leaves the prompt-write buffer.
+        final routedRequest = _serverRequestWithSession(request: request, sessionId: sessionId);
+        if (_isPromptFrameWriting(sessionId: sessionId)) {
+          _promptWriteServerRequests.putIfAbsent(sessionId, () => []).add(routedRequest);
+          return;
+        }
+        registry.handleServerRequest(request: routedRequest);
     }
-    registry.handleServerRequest(request: routedRequest);
   }
 
   AcpServerRequest _serverRequestWithSession({required AcpServerRequest request, required String sessionId}) {
@@ -414,28 +417,57 @@ abstract class AcpPlugin({
     );
   }
 
-  ({String? sessionId, bool fromTool}) _serverRequestAttribution({required AcpServerRequest request}) {
+  AcpToolCallSessionLookup _serverRequestAttribution({required AcpServerRequest request}) {
     final rawSessionId = request.params["sessionId"];
-    if (rawSessionId != null && rawSessionId is! String) return (sessionId: null, fromTool: false);
+    if (rawSessionId != null && rawSessionId is! String) return const AcpToolCallSessionNotFound();
     final explicit = rawSessionId is String ? rawSessionId.trim() : null;
-    if (explicit != null && explicit.isNotEmpty) return (sessionId: explicit, fromTool: false);
-    final toolSessionId = _serverRequestToolSessionId(request: request);
-    if (toolSessionId != null) return (sessionId: toolSessionId, fromTool: true);
-    return (sessionId: activeTurnSessionId, fromTool: false);
+    if (explicit != null && explicit.isNotEmpty) return AcpToolCallSessionFound(sessionId: explicit);
+    final toolLookup = _serverRequestToolSessionLookup(request: request);
+    if (toolLookup is! AcpToolCallSessionNotFound) return toolLookup;
+    final activeSessionId = activeTurnSessionId;
+    return activeSessionId == null
+        ? const AcpToolCallSessionNotFound()
+        : AcpToolCallSessionFound(sessionId: activeSessionId);
   }
 
-  String? _serverRequestToolSessionId({required AcpServerRequest request}) {
-    final rawToolCallId = request.params["toolCallId"];
-    if (rawToolCallId is! String || rawToolCallId.isEmpty) return null;
-    final mapped = eventMapper.sessionIdForToolCallId(toolCallId: rawToolCallId);
-    if (mapped != null) return mapped;
-    for (final entry in _promptWriteNotifications.entries) {
-      for (final notification in entry.value) {
-        final update = notification.params["update"];
-        if (update is Map && update["toolCallId"] == rawToolCallId) return entry.key;
+  AcpToolCallSessionLookup _serverRequestToolSessionLookup({required AcpServerRequest request}) {
+    final toolCallIds = <String>{};
+    final topLevelToolCallId = request.params["toolCallId"];
+    if (topLevelToolCallId is String && topLevelToolCallId.isNotEmpty) {
+      toolCallIds.add(topLevelToolCallId);
+    }
+    final toolCall = request.params["toolCall"];
+    if (toolCall is Map) {
+      final nestedToolCallId = toolCall["toolCallId"];
+      if (nestedToolCallId is String && nestedToolCallId.isNotEmpty) {
+        toolCallIds.add(nestedToolCallId);
       }
     }
-    return null;
+    if (toolCallIds.length > 1) return const AcpToolCallSessionAmbiguous();
+    if (toolCallIds.isEmpty) return const AcpToolCallSessionNotFound();
+    final toolCallId = toolCallIds.single;
+    final sessionIds = <String>{};
+    switch (eventMapper.lookupSessionForToolCallId(toolCallId: toolCallId)) {
+      case AcpToolCallSessionFound(:final sessionId):
+        sessionIds.add(sessionId);
+      case AcpToolCallSessionAmbiguous():
+        return const AcpToolCallSessionAmbiguous();
+      case AcpToolCallSessionNotFound():
+        break;
+    }
+    for (final entry in _promptWriteNotifications.entries) {
+      if (entry.value.any((notification) {
+        final update = notification.params["update"];
+        return update is Map && update["toolCallId"] == toolCallId;
+      })) {
+        sessionIds.add(entry.key);
+      }
+    }
+    return switch (sessionIds.toList(growable: false)) {
+      [final sessionId] => AcpToolCallSessionFound(sessionId: sessionId),
+      [] => const AcpToolCallSessionNotFound(),
+      _ => const AcpToolCallSessionAmbiguous(),
+    };
   }
 
   bool _isPromptFrameWriting({required String sessionId}) =>

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -7,6 +7,10 @@ import "repositories/trackers/acp_tool_content_tracker.dart";
 
 typedef AcpReplayUserMessageIdOverride = String? Function({required String acpMessageId});
 typedef AcpReplayMessageTimeResolver = PluginMessageTime? Function({required Map<String, dynamic> params});
+typedef AcpReplayToolPartReplacement = PluginMessagePart? Function({
+  required String toolCallId,
+  required PluginMessagePartTool toolPart,
+});
 typedef _AcpReplayAssistantSelection = ({String? modelId, String? providerId, String? variant});
 
 /// Accumulates the `session/update` notifications replayed by `session/load`
@@ -31,6 +35,11 @@ class AcpReplayCollector({
   /// notice as an error message exactly as it appeared live. Null on backends
   /// with no halt notices.
   required final AcpHaltNotice? Function({required String text})? haltClassifier,
+
+  /// Replaces one materialized standard tool part with a harness-specific part.
+  /// Null retains the generic ACP projection. The callback is replay-local and
+  /// receives only immutable materialized data; it must not touch live state.
+  required final AcpReplayToolPartReplacement? toolPartReplacement,
 }) {
   static const AcpContentMapper _contentMapper = AcpContentMapper();
 
@@ -404,7 +413,7 @@ class AcpReplayCollector({
     required _ToolDraft tool,
   }) {
     final content = tool.contentTracker.snapshot;
-    return PluginMessagePart.tool(
+    final toolPart = PluginMessagePart.tool(
       id: "${draft.id}-tool-$toolId",
       sessionID: sessionId,
       messageID: draft.id,
@@ -416,7 +425,8 @@ class AcpReplayCollector({
         error: tool.status == PluginToolStatus.error ? content.output : null,
         attachments: content.attachments,
       ),
-    );
+    ) as PluginMessagePartTool;
+    return toolPartReplacement?.call(toolCallId: toolId, toolPart: toolPart) ?? toolPart;
   }
 
   void _retainTime({required _Draft draft, required PluginMessageTime? time}) {

--- a/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_child_session_tracker.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_child_session_tracker.dart
@@ -20,10 +20,10 @@ final class const AcpRunningChild({
   required final bool isBackground,
 });
 
-/// The events one lifecycle fact produced, plus the envelope the mapper must
-/// emit first when this is the tile's first render.
+/// The events one lifecycle fact produced, plus the direct-parent session
+/// where the mapper must render the tile envelope.
 final class const AcpChildTileResult({
-  required final String rootSessionId,
+  required final String renderSessionId,
   required final String messageId,
   required final bool opensMessage,
   required final List<BridgeSseEvent> events,
@@ -40,10 +40,10 @@ final class const AcpChildSessionTrackerChange({required final String rootSessio
 /// [forgetSession] and [clear].
 ///
 /// Every tile is keyed by the child session id the harness reports, never by
-/// a tool call, so one child is exactly one tile. Tile placement and activity
-/// roll up to the owning root, while each child session retains the direct
-/// parent the harness reported for nested navigation. State survives turn
-/// boundaries because a background child outlives the turn that launched it.
+/// a tool call, so one child is exactly one tile. A tile belongs to the direct
+/// parent whose transcript launched it, while activity rolls up to the owning
+/// root. State survives turn boundaries because a background child outlives
+/// the turn that launched it.
 final class AcpChildSessionTracker() {
   /// Children per root, in spawn order.
   final Map<String, List<_Child>> _byRoot = {};
@@ -91,13 +91,13 @@ final class AcpChildSessionTracker() {
     final existing = _byChild[spawn.childSessionId];
     if (existing != null) {
       return AcpChildTileResult(
-        rootSessionId: existing.rootSessionId,
+        renderSessionId: existing.parentSessionId,
         messageId: existing.messageId,
         opensMessage: false,
         events: const [],
       );
     }
-    final messageId = "$root-subagent-${spawn.childSessionId}";
+    final messageId = "$sessionId-subagent-${spawn.childSessionId}";
     final child = _Child(
       rootSessionId: root,
       parentSessionId: sessionId,
@@ -115,7 +115,7 @@ final class AcpChildSessionTracker() {
     _notify(rootSessionId: root);
     final part = child.partOrNull();
     return AcpChildTileResult(
-      rootSessionId: root,
+      renderSessionId: sessionId,
       messageId: messageId,
       opensMessage: part != null,
       events: [
@@ -144,7 +144,7 @@ final class AcpChildSessionTracker() {
     child.prompt.write(delta);
     final part = child.partOrNull();
     return AcpChildTileResult(
-      rootSessionId: child.rootSessionId,
+      renderSessionId: child.parentSessionId,
       messageId: child.messageId,
       opensMessage: firstRender && part != null,
       events: [if (part != null) BridgeSseMessagePartUpdated(part: part)],
@@ -301,9 +301,9 @@ final class AcpChildSessionTracker() {
       entry.key: entry.value.status.isTerminal ? const PluginSessionStatus.idle() : const PluginSessionStatus.busy(),
   };
 
-  /// Every child of [sessionId], running or finished.
+  /// Every descendant of [sessionId], running or finished.
   List<String> childSessionIds({required String sessionId}) => [
-    for (final child in _byRoot[sessionId] ?? const <_Child>[]) child.childSessionId,
+    for (final child in _descendantsOf(sessionId: sessionId)) child.childSessionId,
   ];
 
   /// The children of [sessionId] still running.
@@ -318,8 +318,8 @@ final class AcpChildSessionTracker() {
         AcpRunningChild(childSessionId: child.childSessionId, isBackground: child.isBackground),
   ];
 
-  /// Drops every record of a deleted root, or the single record of a deleted
-  /// child. Emits nothing: the session is gone.
+  /// Drops every record of a deleted root or child subtree. Emits nothing:
+  /// the sessions are gone.
   void forgetSession({required String sessionId}) {
     final removedRootHolds = _rootHolds.remove(sessionId);
     final children = _byRoot.remove(sessionId);
@@ -333,7 +333,7 @@ final class AcpChildSessionTracker() {
       if (hadActiveWork) _notify(rootSessionId: sessionId);
       return;
     }
-    final child = _byChild.remove(sessionId);
+    final child = _byChild[sessionId];
     if (child == null) {
       if (removedRootHolds?.isNotEmpty ?? false) {
         _signalRootHoldChange(rootSessionId: sessionId);
@@ -341,18 +341,39 @@ final class AcpChildSessionTracker() {
       }
       return;
     }
+    final removedChildren = [child, ..._descendantsOf(sessionId: sessionId)];
+    final removedChildIds = {for (final removedChild in removedChildren) removedChild.childSessionId};
     final siblings = _byRoot[child.rootSessionId];
-    siblings?.remove(child);
+    siblings?.removeWhere((candidate) => removedChildIds.contains(candidate.childSessionId));
     if (siblings?.isEmpty ?? false) _byRoot.remove(child.rootSessionId);
+    removedChildIds.forEach(_byChild.remove);
     final siblingHolds = _rootHolds[child.rootSessionId];
     final holdCount = siblingHolds?.length ?? 0;
-    siblingHolds?.removeWhere((_, heldChildSessionId) => heldChildSessionId == sessionId);
+    siblingHolds?.removeWhere((_, heldChildSessionId) => removedChildIds.contains(heldChildSessionId));
     final removedChildHold = siblingHolds != null && siblingHolds.length != holdCount;
     if (siblingHolds?.isEmpty ?? false) _rootHolds.remove(child.rootSessionId);
     if (removedChildHold) _signalRootHoldChange(rootSessionId: child.rootSessionId);
-    if (!child.status.isTerminal || removedChildHold) {
+    if (removedChildren.any((removedChild) => !removedChild.status.isTerminal) || removedChildHold) {
       _notify(rootSessionId: child.rootSessionId);
     }
+  }
+
+  List<_Child> _descendantsOf({required String sessionId}) {
+    final candidates = _byRoot[rootOf(sessionId: sessionId)] ?? const <_Child>[];
+    final descendants = <_Child>[];
+    final seen = <String>{};
+    var parentIds = <String>{sessionId};
+    while (parentIds.isNotEmpty) {
+      final nextParentIds = <String>{};
+      for (final child in candidates) {
+        if (parentIds.contains(child.parentSessionId) && seen.add(child.childSessionId)) {
+          descendants.add(child);
+          nextParentIds.add(child.childSessionId);
+        }
+      }
+      parentIds = nextParentIds;
+    }
+    return descendants;
   }
 
   /// Drops every record: the agent process that hosted the children is gone.
@@ -414,7 +435,7 @@ final class _Child({
     if (description == null || agent == null) return null;
     return PluginMessagePart.subtask(
       id: partId,
-      sessionID: rootSessionId,
+      sessionID: parentSessionId,
       messageID: messageId,
       prompt: prompt.toString(),
       description: description,

--- a/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_child_session_tracker.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_child_session_tracker.dart
@@ -40,10 +40,10 @@ final class const AcpChildSessionTrackerChange({required final String rootSessio
 /// [forgetSession] and [clear].
 ///
 /// Every tile is keyed by the child session id the harness reports, never by
-/// a tool call, so one child is exactly one tile. Children are flattened under
-/// the root that owns them, so a nested spawn reported under a child id files
-/// under the same root. State survives turn boundaries because a background
-/// child outlives the turn that launched it.
+/// a tool call, so one child is exactly one tile. Tile placement and activity
+/// roll up to the owning root, while each child session retains the direct
+/// parent the harness reported for nested navigation. State survives turn
+/// boundaries because a background child outlives the turn that launched it.
 final class AcpChildSessionTracker() {
   /// Children per root, in spawn order.
   final Map<String, List<_Child>> _byRoot = {};
@@ -75,6 +75,9 @@ final class AcpChildSessionTracker() {
   /// The root that owns [sessionId]: itself unless it is a known child.
   String rootOf({required String sessionId}) => _byChild[sessionId]?.rootSessionId ?? sessionId;
 
+  /// The direct parent reported for a known child.
+  String? parentOf({required String sessionId}) => _byChild[sessionId]?.parentSessionId;
+
   /// Records that [spawn] started under [sessionId] (the parent as the harness
   /// reports it) and emits the child session, its busy status, and, when the
   /// prompt is already known, the tile. [directory] is the root's project
@@ -88,7 +91,7 @@ final class AcpChildSessionTracker() {
     final existing = _byChild[spawn.childSessionId];
     if (existing != null) {
       return AcpChildTileResult(
-        rootSessionId: root,
+        rootSessionId: existing.rootSessionId,
         messageId: existing.messageId,
         opensMessage: false,
         events: const [],
@@ -97,11 +100,13 @@ final class AcpChildSessionTracker() {
     final messageId = "$root-subagent-${spawn.childSessionId}";
     final child = _Child(
       rootSessionId: root,
+      parentSessionId: sessionId,
       childSessionId: spawn.childSessionId,
       messageId: messageId,
       partId: "$messageId-subtask",
       description: spawn.description,
       agent: spawn.agent,
+      acceptsPromptChunks: spawn.prompt == null,
       isBackground: spawn.isBackground,
     );
     if (spawn.prompt case final prompt?) child.prompt.write(prompt);
@@ -119,7 +124,7 @@ final class AcpChildSessionTracker() {
             id: spawn.childSessionId,
             projectID: directory,
             directory: directory,
-            parentID: root,
+            parentID: sessionId,
             title: spawn.description,
             time: null,
           ).toJson(),
@@ -134,7 +139,7 @@ final class AcpChildSessionTracker() {
   /// message streams under the child id; renders the tile once a prompt exists.
   AcpChildTileResult? appendPrompt({required String childSessionId, required String delta}) {
     final child = _byChild[childSessionId];
-    if (child == null || delta.isEmpty) return null;
+    if (child == null || !child.acceptsPromptChunks || delta.isEmpty) return null;
     final firstRender = child.prompt.isEmpty;
     child.prompt.write(delta);
     final part = child.partOrNull();
@@ -275,18 +280,19 @@ final class AcpChildSessionTracker() {
   /// Whether any root has child or autonomous settlement work.
   bool get hasActiveWork => hasBusyChildren || _rootHolds.values.any((holds) => holds.isNotEmpty);
 
-  /// The children of [sessionId] as sessions, for a harness whose listing
-  /// carries no parent marker. [directory] is the root's project directory.
+  /// The direct children of [sessionId] as sessions, for a harness whose
+  /// listing carries no parent marker. [directory] is the root's project.
   List<PluginSession> childSessions({required String sessionId, required String directory}) => [
-    for (final child in _byRoot[sessionId] ?? const <_Child>[])
-      PluginSession(
-        id: child.childSessionId,
-        projectID: directory,
-        directory: directory,
-        parentID: sessionId,
-        title: child.description,
-        time: null,
-      ),
+    for (final child in _byRoot[rootOf(sessionId: sessionId)] ?? const <_Child>[])
+      if (child.parentSessionId == sessionId)
+        PluginSession(
+          id: child.childSessionId,
+          projectID: directory,
+          directory: directory,
+          parentID: sessionId,
+          title: child.description,
+          time: null,
+        ),
   ];
 
   /// Statuses of every child this tracker announced, across roots.
@@ -386,11 +392,13 @@ final class AcpChildSessionTracker() {
 
 final class _Child({
   required final String rootSessionId,
+  required final String parentSessionId,
   required final String childSessionId,
   required final String messageId,
   required final String partId,
   required final String? description,
   required final String? agent,
+  required final bool acceptsPromptChunks,
   required final bool isBackground,
 }) {
   final StringBuffer prompt = StringBuffer();

--- a/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_child_session_tracker.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_child_session_tracker.dart
@@ -49,6 +49,11 @@ final class AcpChildSessionTracker() {
   final Map<String, List<_Child>> _byRoot = {};
   final Map<String, _Child> _byChild = {};
 
+  /// Deleted roots and child subtrees for the current agent process. Late
+  /// lifecycle frames cannot recreate them; a process reset drains that old
+  /// event source and [clear] releases the tombstones.
+  final Set<String> _deletedSessionIds = {};
+
   /// Opaque backend-neutral work holds that keep a root active after a child
   /// terminal event and until its autonomous settlement turn completes. Each
   /// hold retains its originating child so deleting that child clears the
@@ -69,6 +74,9 @@ final class AcpChildSessionTracker() {
     }
   }
 
+  /// Whether [sessionId] was deleted from the current agent process.
+  bool isDeleted({required String sessionId}) => _deletedSessionIds.contains(sessionId);
+
   /// Whether [sessionId] is a child this tracker announced.
   bool isChild({required String sessionId}) => _byChild.containsKey(sessionId);
 
@@ -80,13 +88,17 @@ final class AcpChildSessionTracker() {
 
   /// Records that [spawn] started under [sessionId] (the parent as the harness
   /// reports it) and emits the child session, its busy status, and, when the
-  /// prompt is already known, the tile. [directory] is the root's project
-  /// directory; children never carry their own.
-  AcpChildTileResult spawn({
+  /// prompt is already known, the tile. Returns null for a late lifecycle
+  /// frame targeting a deleted parent or child. [directory] is the root's
+  /// project directory; children never carry their own.
+  AcpChildTileResult? spawn({
     required String sessionId,
     required AcpChildSpawn spawn,
     required String directory,
   }) {
+    if (_deletedSessionIds.contains(sessionId) || _deletedSessionIds.contains(spawn.childSessionId)) {
+      return null;
+    }
     final root = rootOf(sessionId: sessionId);
     final existing = _byChild[spawn.childSessionId];
     if (existing != null) {
@@ -321,9 +333,11 @@ final class AcpChildSessionTracker() {
   /// Drops every record of a deleted root or child subtree. Emits nothing:
   /// the sessions are gone.
   void forgetSession({required String sessionId}) {
+    _deletedSessionIds.add(sessionId);
     final removedRootHolds = _rootHolds.remove(sessionId);
     final children = _byRoot.remove(sessionId);
     if (children != null) {
+      _deletedSessionIds.addAll(children.map((child) => child.childSessionId));
       final hadActiveWork =
           children.any((child) => !child.status.isTerminal) || (removedRootHolds?.isNotEmpty ?? false);
       if (removedRootHolds?.isNotEmpty ?? false) _signalRootHoldChange(rootSessionId: sessionId);
@@ -343,6 +357,7 @@ final class AcpChildSessionTracker() {
     }
     final removedChildren = [child, ..._descendantsOf(sessionId: sessionId)];
     final removedChildIds = {for (final removedChild in removedChildren) removedChild.childSessionId};
+    _deletedSessionIds.addAll(removedChildIds);
     final siblings = _byRoot[child.rootSessionId];
     siblings?.removeWhere((candidate) => removedChildIds.contains(candidate.childSessionId));
     if (siblings?.isEmpty ?? false) _byRoot.remove(child.rootSessionId);
@@ -378,7 +393,7 @@ final class AcpChildSessionTracker() {
 
   /// Drops every record: the agent process that hosted the children is gone.
   void clear() {
-    if (_byChild.isEmpty && _byRoot.isEmpty && _rootHolds.isEmpty) return;
+    if (_byChild.isEmpty && _byRoot.isEmpty && _rootHolds.isEmpty && _deletedSessionIds.isEmpty) return;
     final affectedRoots = <String>{
       for (final entry in _byRoot.entries)
         if (entry.value.any((child) => !child.status.isTerminal)) entry.key,
@@ -388,6 +403,7 @@ final class AcpChildSessionTracker() {
     _byRoot.clear();
     _byChild.clear();
     _rootHolds.clear();
+    _deletedSessionIds.clear();
     for (final rootSessionId in affectedRoots) {
       _signalRootHoldChange(rootSessionId: rootSessionId);
       _notify(rootSessionId: rootSessionId);

--- a/bridge/sesori_plugin_acp/test/acp_plugin_child_busy_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_child_busy_test.dart
@@ -93,7 +93,7 @@ void main() {
         ),
         directory: cwd,
       );
-      result.events.forEach(plugin.emitEvent);
+      result?.events.forEach(plugin.emitEvent);
     }
 
     /// The harness mapper's push: a child finished. Tracker-driven events reach
@@ -376,6 +376,25 @@ void main() {
       expect(await plugin.getSessionStatuses(), {sessionId: const PluginSessionStatus.idle()});
       expect(plugin.childSessionTracker.childStatuses, isEmpty);
       expect(plugin.currentWorkState, PluginWorkState.idle);
+
+      emitted.clear();
+      plugin.handleAgentNotification(
+        const AcpNotification(
+          method: AcpMethods.sessionUpdate,
+          params: {
+            "sessionId": "c1",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": {"type": "text", "text": "late"},
+            },
+          },
+        ),
+      );
+      spawnChild(root: "c1", childId: "late-grandchild");
+      spawnChild(root: sessionId, childId: "c1");
+      await pump();
+      expect(plugin.childSessionTracker.childStatuses, isEmpty);
+      expect(emitted, isEmpty);
     });
 
     test("deleting the root drops its children from the statuses", () async {

--- a/bridge/sesori_plugin_acp/test/acp_plugin_child_busy_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_child_busy_test.dart
@@ -364,6 +364,20 @@ void main() {
       expect(plugin.childSessionTracker.childStatuses, isEmpty);
     });
 
+    test("deleting a child drops its descendant subtree from plugin state", () async {
+      final sessionId = await connectAndCreateSession();
+      spawnChild(root: sessionId, childId: "c1");
+      spawnChild(root: "c1", childId: "c2");
+      expect((await plugin.getSessionStatuses()).keys, containsAll([sessionId, "c1", "c2"]));
+
+      await plugin.deleteSession("c1");
+      await pump();
+
+      expect(await plugin.getSessionStatuses(), {sessionId: const PluginSessionStatus.idle()});
+      expect(plugin.childSessionTracker.childStatuses, isEmpty);
+      expect(plugin.currentWorkState, PluginWorkState.idle);
+    });
+
     test("deleting the root drops its children from the statuses", () async {
       final sessionId = await connectAndCreateSession();
       spawnChild(root: sessionId, childId: "c1");

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -89,6 +89,7 @@ void main() {
           messageIdOverride: null,
           messageTimeResolver: null,
           haltClassifier: null,
+          toolPartReplacement: null,
         );
         final liveEvents = <BridgeSseEvent>[];
 
@@ -134,6 +135,7 @@ void main() {
                   messageIdOverride: null,
                   messageTimeResolver: null,
                   haltClassifier: null,
+                  toolPartReplacement: null,
                 )
                 ..consume(
                   upd({
@@ -177,6 +179,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -236,6 +239,7 @@ void main() {
             messageIdOverride: null,
             messageTimeResolver: null,
             haltClassifier: null,
+            toolPartReplacement: null,
           )..consume(
             upd({
               "sessionUpdate": "tool_call",
@@ -272,6 +276,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -310,6 +315,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -354,6 +360,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -387,6 +394,7 @@ void main() {
             messageIdOverride: null,
             messageTimeResolver: null,
             haltClassifier: null,
+            toolPartReplacement: null,
           )..consume(
             upd({
               "sessionUpdate": "tool_call",
@@ -411,6 +419,7 @@ void main() {
             messageIdOverride: null,
             messageTimeResolver: null,
             haltClassifier: null,
+            toolPartReplacement: null,
           )..consume(
             upd({
               "sessionUpdate": "agent_message_chunk",
@@ -443,6 +452,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -482,6 +492,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -507,6 +518,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -532,6 +544,7 @@ void main() {
         messageIdOverride: null,
         messageTimeResolver: null,
         haltClassifier: null,
+        toolPartReplacement: null,
       );
 
       expect(
@@ -549,6 +562,7 @@ void main() {
         messageIdOverride: null,
         messageTimeResolver: null,
         haltClassifier: null,
+        toolPartReplacement: null,
       );
       final output = _captureWarnings(() {
         for (var index = 0; index < 2; index++) {
@@ -576,6 +590,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -687,6 +702,7 @@ void main() {
                 messageIdOverride: null,
                 messageTimeResolver: null,
                 haltClassifier: null,
+                toolPartReplacement: null,
               )
               ..consume(
                 upd({
@@ -740,6 +756,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -780,6 +797,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -810,6 +828,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -840,6 +859,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -885,6 +905,7 @@ void main() {
             messageTimeResolver: null,
             haltClassifier: ({required text}) =>
                 text.trim() == "Check your settings to continue" ? const AcpHaltNotice(errorName: "cursor_gate") : null,
+            toolPartReplacement: null,
           )..consume(
             upd({
               "sessionUpdate": "agent_message_chunk",
@@ -913,6 +934,7 @@ void main() {
             messageIdOverride: null,
             messageTimeResolver: null,
             haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate"),
+            toolPartReplacement: null,
           )..consume(
             upd({
               "sessionUpdate": "agent_message_chunk",
@@ -933,6 +955,7 @@ void main() {
             messageIdOverride: null,
             messageTimeResolver: null,
             haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate"),
+            toolPartReplacement: null,
           )..consume(
             upd({
               "sessionUpdate": "agent_message_chunk",
@@ -966,6 +989,7 @@ void main() {
             messageIdOverride: null,
             messageTimeResolver: null,
             haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate"),
+            toolPartReplacement: null,
           )..consume(
             upd({
               "sessionUpdate": "agent_message_chunk",
@@ -990,6 +1014,7 @@ void main() {
             messageIdOverride: null,
             messageTimeResolver: null,
             haltClassifier: null,
+            toolPartReplacement: null,
           )..consume(
             upd({
               "sessionUpdate": "agent_message_chunk",
@@ -999,6 +1024,48 @@ void main() {
       final message = collector.build().single;
       expect(message.info, isA<PluginMessageAssistant>());
       expect(message.parts, isNotEmpty);
+    });
+
+    test("a replay-local callback can replace one generic tool part", () {
+      final collector =
+          AcpReplayCollector(
+            sessionId: "s1",
+            agentId: "ACP",
+            initialUserMessageId: null,
+            messageIdOverride: null,
+            messageTimeResolver: null,
+            haltClassifier: null,
+            toolPartReplacement: ({required toolCallId, required toolPart}) {
+              expect(toolCallId, "call-1");
+              return PluginMessagePart.subtask(
+                id: toolPart.id,
+                sessionID: toolPart.sessionID,
+                messageID: toolPart.messageID,
+                prompt: "Synthetic prompt",
+                description: "Synthetic child",
+                agent: "synthetic",
+                taskState: const PluginToolState(
+                  status: PluginToolStatus.running,
+                  title: null,
+                  output: null,
+                  error: null,
+                  attachments: [],
+                ),
+                childSessionID: "child-1",
+              );
+            },
+          )..consume(
+            upd({
+              "sessionUpdate": "tool_call",
+              "toolCallId": "call-1",
+              "title": "delegate",
+              "status": "in_progress",
+            }),
+          );
+
+      final part = collector.build().single.parts.single as PluginMessagePartSubtask;
+      expect(part.id, "s1-h0-assistant-tool-call-1");
+      expect(part.childSessionID, "child-1");
     });
   });
 }

--- a/bridge/sesori_plugin_acp/test/acp_tool_content_integration_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_tool_content_integration_test.dart
@@ -617,6 +617,7 @@ AcpReplayCollector _collector() => AcpReplayCollector(
   messageIdOverride: null,
   messageTimeResolver: null,
   haltClassifier: null,
+  toolPartReplacement: null,
 );
 
 PluginToolState _replayState({required AcpReplayCollector collector}) => collector.build().single.parts.single.state;

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -490,6 +490,98 @@ void main() {
       respondTo(secondPrompt, {"stopReason": "end_turn"});
     });
 
+    test("a nested permission uses its exact tool-call session instead of the active turn", () async {
+      await connect();
+      final firstSessionId = await createSession(cwd, "s1");
+      final secondSessionId = await createSession(cwd, "s2");
+      await sendPrompt(secondSessionId, "keep active");
+      final activePrompt = await waitForFrame("session/prompt");
+      plugin.handleAgentNotification(
+        AcpNotification(
+          method: AcpMethods.sessionUpdate,
+          params: {
+            "sessionId": firstSessionId,
+            "update": {
+              "sessionUpdate": "tool_call",
+              "toolCallId": "shared-shape",
+              "title": "Run command",
+              "kind": "execute",
+            },
+          },
+        ),
+      );
+      emitted.clear();
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 9001,
+        "method": AcpMethods.sessionRequestPermission,
+        "params": {
+          "toolCall": {"toolCallId": "shared-shape", "title": "Run command", "kind": "execute"},
+          "options": [
+            {"optionId": "reject", "name": "Reject", "kind": "reject_once"},
+          ],
+        },
+      });
+      for (var index = 0; index < 20 && emitted.whereType<BridgeSsePermissionAsked>().isEmpty; index++) {
+        await pump();
+      }
+
+      final permission = emitted.whereType<BridgeSsePermissionAsked>().single;
+      expect(permission.sessionID, firstSessionId);
+      await plugin.replyToPermission(
+        requestId: permission.requestID,
+        sessionId: firstSessionId,
+        reply: PluginPermissionReply.reject,
+      );
+      respondTo(activePrompt, {"stopReason": "end_turn"});
+    });
+
+    test("an ambiguous nested permission cannot fall back to the active turn", () async {
+      await connect();
+      final firstSessionId = await createSession(cwd, "s1");
+      final secondSessionId = await createSession(cwd, "s2");
+      await sendPrompt(secondSessionId, "keep active");
+      final activePrompt = await waitForFrame("session/prompt");
+      for (final sessionId in [firstSessionId, secondSessionId]) {
+        plugin.handleAgentNotification(
+          AcpNotification(
+            method: AcpMethods.sessionUpdate,
+            params: {
+              "sessionId": sessionId,
+              "update": {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "ambiguous",
+                "title": "Run command",
+                "kind": "execute",
+              },
+            },
+          ),
+        );
+      }
+      emitted.clear();
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 9002,
+        "method": AcpMethods.sessionRequestPermission,
+        "params": {
+          "toolCall": {"toolCallId": "ambiguous", "title": "Run command", "kind": "execute"},
+          "options": [
+            {"optionId": "reject", "name": "Reject", "kind": "reject_once"},
+          ],
+        },
+      });
+      for (var index = 0; index < 20 && !fake.written.any((frame) => frame["id"] == 9002); index++) {
+        await pump();
+      }
+
+      expect(emitted.whereType<BridgeSsePermissionAsked>(), isEmpty);
+      final response = fake.written.singleWhere((frame) => frame["id"] == 9002);
+      expect((response["result"] as Map)["outcome"], {"outcome": "cancelled"});
+      respondTo(activePrompt, {"stopReason": "end_turn"});
+    });
+
     test("a queued prompt message uses its dispatch time", () async {
       final configurationTracker = AcpSessionConfigurationTracker();
       final commandTracker = AcpCommandTracker();

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -66,6 +66,37 @@ class _TimestampingEventMapper({
       PluginMessageTime(created: createdAtMs, completed: null);
 }
 
+class _PromptOrderedChildMapper({
+  required super.launchDirectory,
+  required super.pluginId,
+  required super.configurationTracker,
+  required super.childSessions,
+}) extends AcpEventMapper {
+  static const childMethod = "test/subagent";
+
+  @override
+  bool shouldBufferDuringPromptWrite({required AcpNotification notification}) =>
+      notification.method == childMethod || super.shouldBufferDuringPromptWrite(notification: notification);
+
+  @override
+  List<BridgeSseEvent> mapExtension(AcpNotification notification) {
+    if (notification.method != childMethod) return super.mapExtension(notification);
+    final sessionId = notification.params["sessionId"];
+    final childSessionId = notification.params["childSessionId"];
+    if (sessionId is! String || childSessionId is! String) return const [];
+    return mapChildSpawned(
+      sessionId: sessionId,
+      spawn: AcpChildSpawn(
+        childSessionId: childSessionId,
+        description: "Child",
+        agent: pluginId,
+        prompt: "Inspect",
+        isBackground: true,
+      ),
+    );
+  }
+}
+
 class _FlushControlledAcpProcess() extends FakeAcpProcess {
   final _FlushControlledIOSink _controlledStdin = _FlushControlledIOSink();
 
@@ -444,6 +475,66 @@ void main() {
       final response = fake.written.singleWhere((frame) => frame["id"] == 92);
       expect((response["result"] as Map)["outcome"], {"outcome": "cancelled"});
 
+      respondTo(prompt, {"stopReason": "end_turn"});
+    });
+
+    test("a prompt-ordered lifecycle extension stays behind its accepted user message", () async {
+      final configurationTracker = AcpSessionConfigurationTracker();
+      final commandTracker = AcpCommandTracker();
+      final childSessionTracker = AcpChildSessionTracker();
+      final mapper = _PromptOrderedChildMapper(
+        launchDirectory: cwd,
+        pluginId: "acp",
+        configurationTracker: configurationTracker,
+        childSessions: childSessionTracker,
+      );
+      final orderedPlugin = TestAcpPlugin(
+        id: "acp",
+        agentDisplayName: "ACP",
+        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+        launchDirectory: cwd,
+        childSessionTracker: childSessionTracker,
+        eventMapper: mapper,
+        commandTracker: commandTracker,
+        sessionOptionsService: AcpSessionOptionsService(
+          configurationTracker: configurationTracker,
+          commandTracker: commandTracker,
+          pluginId: "acp",
+          agentDisplayName: "ACP",
+        ),
+        processFactory: (_) async => fake,
+      );
+      await plugin.dispose();
+      plugin = orderedPlugin;
+      plugin.events.listen(emitted.add, onError: streamErrors.add);
+
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+      emitted.clear();
+      final flush = fake.holdNextFlush();
+      await sendPrompt(sessionId, "start a child");
+      final prompt = await waitForFrame("session/prompt");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": _PromptOrderedChildMapper.childMethod,
+        "params": {"sessionId": sessionId, "childSessionId": "child"},
+      });
+      await pump();
+      expect(emitted.whereType<BridgeSseSessionCreated>(), isEmpty);
+
+      flush.complete();
+      for (var index = 0; index < 20 && emitted.whereType<BridgeSseSessionCreated>().isEmpty; index++) {
+        await pump();
+      }
+
+      final userIndex = emitted.indexWhere(
+        (event) => event is BridgeSseMessageUpdated && event.info["role"] == "user",
+      );
+      final childIndex = emitted.indexWhere(
+        (event) => event is BridgeSseSessionCreated && event.info["id"] == "child",
+      );
+      expect(userIndex, greaterThanOrEqualTo(0));
+      expect(childIndex, greaterThan(userIndex));
       respondTo(prompt, {"stopReason": "end_turn"});
     });
 

--- a/bridge/sesori_plugin_acp/test/repositories/trackers/acp_child_session_tracker_test.dart
+++ b/bridge/sesori_plugin_acp/test/repositories/trackers/acp_child_session_tracker_test.dart
@@ -76,6 +76,7 @@ void main() {
       expect(result.opensMessage, isTrue);
       expect(result.events, hasLength(3));
       expect(_subtaskPart(result.events[2]).prompt, "p");
+      expect(tracker.appendPrompt(childSessionId: "child", delta: "p"), isNull);
       expect(tracker.runningChildren(sessionId: "root").single.isBackground, isTrue);
     });
 
@@ -251,7 +252,7 @@ void main() {
       expect(failed.taskState?.output, isNull);
     });
 
-    test("a nested spawn under a child is flattened to the root", () {
+    test("a nested spawn retains its direct parent while activity rolls up to the root", () {
       tracker.spawn(
         sessionId: "root",
         spawn: _spawn(childId: "child"),
@@ -263,8 +264,13 @@ void main() {
         directory: "/r",
       );
       expect(nested.rootSessionId, "root");
-      expect(shared.Session.fromJson((nested.events[0] as BridgeSseSessionCreated).info).parentID, "root");
+      expect(shared.Session.fromJson((nested.events[0] as BridgeSseSessionCreated).info).parentID, "child");
+      expect(tracker.childSessions(sessionId: "root", directory: "/r").map((session) => session.id), ["child"]);
+      expect(tracker.childSessions(sessionId: "child", directory: "/r").map((session) => session.id), [
+        "grandchild",
+      ]);
       expect(tracker.busyChildIds(sessionId: "root"), {"child", "grandchild"});
+      expect(tracker.parentOf(sessionId: "grandchild"), "child");
       expect(tracker.rootOf(sessionId: "grandchild"), "root");
       expect(tracker.rootOf(sessionId: "root"), "root");
     });

--- a/bridge/sesori_plugin_acp/test/repositories/trackers/acp_child_session_tracker_test.dart
+++ b/bridge/sesori_plugin_acp/test/repositories/trackers/acp_child_session_tracker_test.dart
@@ -34,7 +34,7 @@ void main() {
         sessionId: "root",
         spawn: _spawn(childId: "child"),
         directory: "/repo",
-      );
+      )!;
       expect(result.renderSessionId, "root");
       expect(result.messageId, "root-subagent-child");
       expect(result.opensMessage, isFalse, reason: "no prompt yet: session events only");
@@ -72,7 +72,7 @@ void main() {
         sessionId: "root",
         spawn: _spawn(childId: "child", prompt: "p", isBackground: true),
         directory: "/r",
-      );
+      )!;
       expect(result.opensMessage, isTrue);
       expect(result.events, hasLength(3));
       expect(_subtaskPart(result.events[2]).prompt, "p");
@@ -262,7 +262,7 @@ void main() {
         sessionId: "child",
         spawn: _spawn(childId: "grandchild", prompt: "nested"),
         directory: "/r",
-      );
+      )!;
       expect(nested.renderSessionId, "child");
       expect(shared.Session.fromJson((nested.events[0] as BridgeSseSessionCreated).info).parentID, "child");
       final tile = _subtaskPart(nested.events.last);
@@ -310,6 +310,33 @@ void main() {
       expect(tracker.busyChildIds(sessionId: "root"), {"sibling"});
       expect(tracker.isChild(sessionId: "grandchild"), isFalse);
       expect(tracker.isChild(sessionId: "great-grandchild"), isFalse);
+      expect(
+        tracker.spawn(
+          sessionId: "child",
+          spawn: _spawn(childId: "late-grandchild"),
+          directory: "/r",
+        ),
+        isNull,
+      );
+      expect(
+        tracker.spawn(
+          sessionId: "root",
+          spawn: _spawn(childId: "child"),
+          directory: "/r",
+        ),
+        isNull,
+      );
+
+      tracker.clear();
+      expect(
+        tracker.spawn(
+          sessionId: "root",
+          spawn: _spawn(childId: "child"),
+          directory: "/r",
+        ),
+        isNotNull,
+        reason: "a new process has drained the deleted process's late frames",
+      );
     });
 
     test("a repeated spawn for a known child is a no-op", () {
@@ -322,7 +349,7 @@ void main() {
         sessionId: "root",
         spawn: _spawn(childId: "child"),
         directory: "/r",
-      );
+      )!;
       expect(again.events, isEmpty);
       expect(again.opensMessage, isFalse);
       expect(tracker.childStatuses.keys, ["child"]);

--- a/bridge/sesori_plugin_acp/test/repositories/trackers/acp_child_session_tracker_test.dart
+++ b/bridge/sesori_plugin_acp/test/repositories/trackers/acp_child_session_tracker_test.dart
@@ -35,7 +35,7 @@ void main() {
         spawn: _spawn(childId: "child"),
         directory: "/repo",
       );
-      expect(result.rootSessionId, "root");
+      expect(result.renderSessionId, "root");
       expect(result.messageId, "root-subagent-child");
       expect(result.opensMessage, isFalse, reason: "no prompt yet: session events only");
       expect(result.events, hasLength(2));
@@ -260,11 +260,15 @@ void main() {
       );
       final nested = tracker.spawn(
         sessionId: "child",
-        spawn: _spawn(childId: "grandchild"),
+        spawn: _spawn(childId: "grandchild", prompt: "nested"),
         directory: "/r",
       );
-      expect(nested.rootSessionId, "root");
+      expect(nested.renderSessionId, "child");
       expect(shared.Session.fromJson((nested.events[0] as BridgeSseSessionCreated).info).parentID, "child");
+      final tile = _subtaskPart(nested.events.last);
+      expect(tile.id, "child-subagent-grandchild-subtask");
+      expect(tile.messageID, "child-subagent-grandchild");
+      expect(tile.sessionID, "child");
       expect(tracker.childSessions(sessionId: "root", directory: "/r").map((session) => session.id), ["child"]);
       expect(tracker.childSessions(sessionId: "child", directory: "/r").map((session) => session.id), [
         "grandchild",
@@ -273,6 +277,39 @@ void main() {
       expect(tracker.parentOf(sessionId: "grandchild"), "child");
       expect(tracker.rootOf(sessionId: "grandchild"), "root");
       expect(tracker.rootOf(sessionId: "root"), "root");
+    });
+
+    test("forgetting a child removes its full descendant subtree", () {
+      tracker
+        ..spawn(
+          sessionId: "root",
+          spawn: _spawn(childId: "child"),
+          directory: "/r",
+        )
+        ..spawn(
+          sessionId: "child",
+          spawn: _spawn(childId: "grandchild"),
+          directory: "/r",
+        )
+        ..spawn(
+          sessionId: "grandchild",
+          spawn: _spawn(childId: "great-grandchild"),
+          directory: "/r",
+        )
+        ..spawn(
+          sessionId: "root",
+          spawn: _spawn(childId: "sibling"),
+          directory: "/r",
+        );
+
+      expect(tracker.childSessionIds(sessionId: "child"), ["grandchild", "great-grandchild"]);
+      tracker.forgetSession(sessionId: "child");
+
+      expect(tracker.childStatuses.keys, ["sibling"]);
+      expect(tracker.childSessions(sessionId: "root", directory: "/r").map((session) => session.id), ["sibling"]);
+      expect(tracker.busyChildIds(sessionId: "root"), {"sibling"});
+      expect(tracker.isChild(sessionId: "grandchild"), isFalse);
+      expect(tracker.isChild(sessionId: "great-grandchild"), isFalse);
     });
 
     test("a repeated spawn for a known child is a no-op", () {

--- a/bridge/sesori_plugin_deepseek/lib/deepseek_testing.dart
+++ b/bridge/sesori_plugin_deepseek/lib/deepseek_testing.dart
@@ -4,5 +4,6 @@ export "src/repositories/deepseek_catalog_repository.dart";
 export "src/repositories/deepseek_history_repository.dart";
 export "src/repositories/deepseek_session_repository.dart";
 export "src/repositories/mappers/deepseek_catalog_mapper.dart";
+export "src/repositories/mappers/deepseek_subagent_mapper.dart";
 export "src/services/deepseek_session_options_service.dart";
 export "src/services/deepseek_session_service.dart";

--- a/bridge/sesori_plugin_deepseek/lib/deepseek_testing.dart
+++ b/bridge/sesori_plugin_deepseek/lib/deepseek_testing.dart
@@ -5,5 +5,6 @@ export "src/repositories/deepseek_history_repository.dart";
 export "src/repositories/deepseek_session_repository.dart";
 export "src/repositories/mappers/deepseek_catalog_mapper.dart";
 export "src/repositories/mappers/deepseek_subagent_mapper.dart";
+export "src/repositories/trackers/deepseek_delegation_tracker.dart";
 export "src/services/deepseek_session_options_service.dart";
 export "src/services/deepseek_session_service.dart";

--- a/bridge/sesori_plugin_deepseek/lib/src/api/deepseek_acp_api.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/deepseek_acp_api.dart
@@ -181,23 +181,9 @@ class const DeepSeekAcpApi({required final String pluginId}) {
 
   // ignore: no_slop_linter/prefer_specific_type, ACP JSON object values are heterogeneous
   DeepSeekSubagentReplayDto parseSubagentReplay(Map<String, dynamic> json) {
-    _validateSubagentReplayJson(json);
     final replay = DeepSeekSubagentReplayDto.fromJson(json);
     _validateSubagentReplay(replay);
     return replay;
-  }
-
-  // ignore: no_slop_linter/prefer_specific_type, ACP JSON object values are heterogeneous
-  void _validateSubagentReplayJson(Map<String, dynamic> json) {
-    if (json.containsKey("childSessionId") && json["childSessionId"] is! String) {
-      throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
-    }
-    if (json.containsKey("ended")) {
-      final endedJson = _json(json["ended"], method: "DeepSeek sub-agent replay end metadata");
-      if (endedJson.containsKey("summary") && endedJson["summary"] is! String) {
-        throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
-      }
-    }
   }
 
   void _validateSubagentReplay(DeepSeekSubagentReplayDto replay) {

--- a/bridge/sesori_plugin_deepseek/lib/src/api/deepseek_acp_api.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/deepseek_acp_api.dart
@@ -8,13 +8,17 @@ class const DeepSeekAcpApi({required final String pluginId}) {
   static const String renameMethod = "deepseek/session/rename";
   static const String askUserQuestionMethod = "deepseek/ask_user_question";
   static const String sessionStatusMethod = "deepseek/session/status";
+  static const String subagentMethod = "deepseek/subagent";
   static const String initializeMetadataKey = "sesori.ai/deepseek";
-  static const int extensionProtocolVersion = 1;
+  static const int extensionProtocolVersion = 2;
+  // COMPATIBILITY 2026-09-04 (v1.8.3): Public adapter 0.1.2 speaks v1 while the managed target and PATH floor
+  // still select it. Remove v1 when both DeepSeek runtime target and PATH floor are 0.1.3.
+  static const Set<int> supportedExtensionProtocolVersions = {1, extensionProtocolVersion};
 
   // ignore: no_slop_linter/prefer_specific_type, ACP JSON object values are heterogeneous
   DeepSeekInitializeMetadataDto parseInitializeMetadata(Map<String, dynamic> json) {
     final metadata = DeepSeekInitializeMetadataDto.fromJson(json);
-    if (metadata.extensionProtocolVersion != extensionProtocolVersion ||
+    if (!supportedExtensionProtocolVersions.contains(metadata.extensionProtocolVersion) ||
         metadata.persistenceOwner != "sesori" ||
         !_nonblank(metadata.adapterVersion, maxLength: 64) ||
         !_nonblank(metadata.harnessVersion, maxLength: 64)) {
@@ -148,6 +152,42 @@ class const DeepSeekAcpApi({required final String pluginId}) {
     return status;
   }
 
+  // ignore: no_slop_linter/prefer_specific_type, ACP JSON object values are heterogeneous
+  DeepSeekSubagentNotificationDto parseSubagentNotification(Map<String, dynamic> json) {
+    final notification = DeepSeekSubagentNotificationDto.fromJson(json);
+    if (!_validSubagentText(notification.sessionId, maxScalars: 256) ||
+        !_validSubagentText(notification.childSessionId, maxScalars: 256)) {
+      throw const FormatException("Invalid DeepSeek sub-agent notification");
+    }
+    switch (notification) {
+      case DeepSeekSubagentStartedDto(:final toolCallId, :final prompt, :final label, :final mode):
+        if (!_validSubagentText(toolCallId, maxScalars: 256) ||
+            !_validSubagentText(label, maxScalars: 256) ||
+            !_validSubagentPrompt(prompt) ||
+            mode == DeepSeekSubagentMode.unknown) {
+          throw const FormatException("Invalid DeepSeek sub-agent notification");
+        }
+      case DeepSeekSubagentEndedDto(:final stopReason, :final summary):
+        if (stopReason == DeepSeekSubagentStopReason.unknown || !_validSubagentSummary(summary)) {
+          throw const FormatException("Invalid DeepSeek sub-agent notification");
+        }
+    }
+    return notification;
+  }
+
+  // ignore: no_slop_linter/prefer_specific_type, ACP JSON object values are heterogeneous
+  DeepSeekSubagentReplayDto parseSubagentReplay(Map<String, dynamic> json) {
+    final replay = DeepSeekSubagentReplayDto.fromJson(json);
+    if (!_validSubagentText(replay.label, maxScalars: 256) ||
+        !_validSubagentPrompt(replay.prompt) ||
+        replay.mode == DeepSeekSubagentMode.unknown ||
+        !_validOptionalSubagentText(replay.childSessionId, maxScalars: 256) ||
+        !_validSubagentReplayEnd(replay.ended)) {
+      throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
+    }
+    return replay;
+  }
+
   // ignore: no_slop_linter/prefer_specific_type, ACP response and JSON object values are heterogeneous
   static Map<String, dynamic> _json(Object? raw, {required String method}) {
     if (raw is! Map) throw FormatException("$method returned a non-object result");
@@ -155,7 +195,7 @@ class const DeepSeekAcpApi({required final String pluginId}) {
     return raw.cast<String, dynamic>();
   }
 
-  static void _validateHistoryResponse(DeepSeekHistoryResponseDto response, {required String? sessionId}) {
+  void _validateHistoryResponse(DeepSeekHistoryResponseDto response, {required String? sessionId}) {
     if (response.updates.length > 10000 ||
         response.updates.any(
           (update) =>
@@ -166,6 +206,45 @@ class const DeepSeekAcpApi({required final String pluginId}) {
     if (response case DeepSeekPaginatedHistoryResponseDto(nextBeforeSeq: final cursor) when cursor < 1) {
       throw const FormatException("Invalid DeepSeek history response");
     }
+    for (final update in response.updates) {
+      final deepSeek = update.metadata?.deepSeek;
+      final createdAt = deepSeek?.messageCreatedAt;
+      if (createdAt != null && (createdAt < 0 || createdAt > 9007199254740991)) {
+        throw const FormatException("Invalid DeepSeek history response");
+      }
+      final replay = deepSeek?.subagent;
+      if (replay != null) parseSubagentReplay(replay.toJson());
+    }
+  }
+
+  static bool _validSubagentReplayEnd(DeepSeekSubagentReplayEndedDto? ended) =>
+      ended == null || ended.stopReason != DeepSeekSubagentStopReason.unknown && _validSubagentSummary(ended.summary);
+
+  static bool _validSubagentSummary(String? value) => _validOptionalSubagentText(value, maxScalars: 512);
+
+  static bool _validSubagentPrompt(String value) =>
+      value == value.trim() && _validSubagentText(value, maxScalars: 32768);
+
+  static bool _validOptionalSubagentText(String? value, {required int maxScalars}) =>
+      value == null || _validSubagentText(value, maxScalars: maxScalars);
+
+  static bool _validSubagentText(String value, {required int maxScalars}) {
+    if (value.isEmpty || !value.contains(RegExp(r"\S"))) return false;
+    var scalars = 0;
+    final units = value.codeUnits;
+    for (var index = 0; index < units.length; index++) {
+      final unit = units[index];
+      if (unit >= 0xD800 && unit <= 0xDBFF) {
+        if (index + 1 >= units.length) return false;
+        final next = units[++index];
+        if (next < 0xDC00 || next > 0xDFFF) return false;
+      } else if (unit >= 0xDC00 && unit <= 0xDFFF) {
+        return false;
+      }
+      scalars++;
+      if (scalars > maxScalars) return false;
+    }
+    return true;
   }
 
   static bool _optionalNonblank(String? value, {required int maxLength}) =>

--- a/bridge/sesori_plugin_deepseek/lib/src/api/deepseek_acp_api.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/deepseek_acp_api.dart
@@ -9,10 +9,11 @@ class const DeepSeekAcpApi({required final String pluginId}) {
   static const String askUserQuestionMethod = "deepseek/ask_user_question";
   static const String sessionStatusMethod = "deepseek/session/status";
   static const String subagentMethod = "deepseek/subagent";
-  static const String initializeMetadataKey = "sesori.ai/deepseek";
+  static const String initializeMetadataKey = deepSeekExtensionMetadataKey;
   static const int extensionProtocolVersion = 2;
-  // COMPATIBILITY 2026-09-04 (v1.8.3): Public adapter 0.1.2 speaks v1 while the managed target and PATH floor
-  // still select it. Remove v1 when both DeepSeek runtime target and PATH floor are 0.1.3.
+  // COMPATIBILITY 2026-09-04 (v1.8.3): This consumer must merge before adapter 0.1.3 records its consumer
+  // commit and publishes, so managed installs still select protocol-v1 adapter 0.1.2 in this PR. Remove v1 when
+  // both the DeepSeek runtime target and PATH floor are 0.1.3.
   static const Set<int> supportedExtensionProtocolVersions = {1, extensionProtocolVersion};
 
   // ignore: no_slop_linter/prefer_specific_type, ACP JSON object values are heterogeneous
@@ -79,24 +80,6 @@ class const DeepSeekAcpApi({required final String pluginId}) {
     final response = DeepSeekHistoryResponseDto.fromJson(json);
     _validateHistoryResponse(response, sessionId: sessionId);
     return response;
-  }
-
-  /// Parses only DeepSeek's known member of the open ACP `_meta` container.
-  /// The envelope retains the original map so additive shared or future
-  /// metadata reaches replay unchanged.
-  DeepSeekEnvelopeDeepSeekMetadataDto? parseHistoryMetadata({
-    required DeepSeekSessionUpdateEnvelopeDto envelope,
-  }) {
-    final metadata = envelope.metadata;
-    if (metadata == null || !metadata.containsKey(initializeMetadataKey)) return null;
-    final json = _json(metadata[initializeMetadataKey], method: "DeepSeek history metadata");
-    if (json.containsKey("messageCreatedAt") && json["messageCreatedAt"] is! int) {
-      throw const FormatException("Invalid DeepSeek history metadata");
-    }
-    if (json.containsKey("subagent")) {
-      parseSubagentReplay(_json(json["subagent"], method: "DeepSeek sub-agent replay metadata"));
-    }
-    return DeepSeekEnvelopeDeepSeekMetadataDto.fromJson(json);
   }
 
   Future<DeepSeekRenameResponseDto> rename({
@@ -198,6 +181,14 @@ class const DeepSeekAcpApi({required final String pluginId}) {
 
   // ignore: no_slop_linter/prefer_specific_type, ACP JSON object values are heterogeneous
   DeepSeekSubagentReplayDto parseSubagentReplay(Map<String, dynamic> json) {
+    _validateSubagentReplayJson(json);
+    final replay = DeepSeekSubagentReplayDto.fromJson(json);
+    _validateSubagentReplay(replay);
+    return replay;
+  }
+
+  // ignore: no_slop_linter/prefer_specific_type, ACP JSON object values are heterogeneous
+  void _validateSubagentReplayJson(Map<String, dynamic> json) {
     if (json.containsKey("childSessionId") && json["childSessionId"] is! String) {
       throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
     }
@@ -207,7 +198,9 @@ class const DeepSeekAcpApi({required final String pluginId}) {
         throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
       }
     }
-    final replay = DeepSeekSubagentReplayDto.fromJson(json);
+  }
+
+  void _validateSubagentReplay(DeepSeekSubagentReplayDto replay) {
     if (!_validSubagentText(replay.label, maxScalars: 256) ||
         !_validSubagentPrompt(replay.prompt) ||
         replay.mode == DeepSeekSubagentMode.unknown ||
@@ -215,7 +208,6 @@ class const DeepSeekAcpApi({required final String pluginId}) {
         !_validSubagentReplayEnd(replay.ended)) {
       throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
     }
-    return replay;
   }
 
   // ignore: no_slop_linter/prefer_specific_type, ACP response and JSON object values are heterogeneous
@@ -237,11 +229,13 @@ class const DeepSeekAcpApi({required final String pluginId}) {
       throw const FormatException("Invalid DeepSeek history response");
     }
     for (final update in response.updates) {
-      final deepSeek = parseHistoryMetadata(envelope: update);
+      final deepSeek = update.metadata?.deepSeek;
       final createdAt = deepSeek?.messageCreatedAt;
       if (createdAt != null && (createdAt < 0 || createdAt > 9007199254740991)) {
         throw const FormatException("Invalid DeepSeek history response");
       }
+      final subagent = deepSeek?.subagent;
+      if (subagent != null) _validateSubagentReplay(subagent);
     }
   }
 

--- a/bridge/sesori_plugin_deepseek/lib/src/api/deepseek_acp_api.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/deepseek_acp_api.dart
@@ -81,6 +81,24 @@ class const DeepSeekAcpApi({required final String pluginId}) {
     return response;
   }
 
+  /// Parses only DeepSeek's known member of the open ACP `_meta` container.
+  /// The envelope retains the original map so additive shared or future
+  /// metadata reaches replay unchanged.
+  DeepSeekEnvelopeDeepSeekMetadataDto? parseHistoryMetadata({
+    required DeepSeekSessionUpdateEnvelopeDto envelope,
+  }) {
+    final metadata = envelope.metadata;
+    if (metadata == null || !metadata.containsKey(initializeMetadataKey)) return null;
+    final json = _json(metadata[initializeMetadataKey], method: "DeepSeek history metadata");
+    if (json.containsKey("messageCreatedAt") && json["messageCreatedAt"] is! int) {
+      throw const FormatException("Invalid DeepSeek history metadata");
+    }
+    if (json.containsKey("subagent")) {
+      parseSubagentReplay(_json(json["subagent"], method: "DeepSeek sub-agent replay metadata"));
+    }
+    return DeepSeekEnvelopeDeepSeekMetadataDto.fromJson(json);
+  }
+
   Future<DeepSeekRenameResponseDto> rename({
     required AcpStdioClient client,
     required String sessionId,
@@ -154,6 +172,9 @@ class const DeepSeekAcpApi({required final String pluginId}) {
 
   // ignore: no_slop_linter/prefer_specific_type, ACP JSON object values are heterogeneous
   DeepSeekSubagentNotificationDto parseSubagentNotification(Map<String, dynamic> json) {
+    if (json["kind"] == "ended" && json.containsKey("summary") && json["summary"] is! String) {
+      throw const FormatException("Invalid DeepSeek sub-agent notification");
+    }
     final notification = DeepSeekSubagentNotificationDto.fromJson(json);
     if (!_validSubagentText(notification.sessionId, maxScalars: 256) ||
         !_validSubagentText(notification.childSessionId, maxScalars: 256)) {
@@ -177,6 +198,15 @@ class const DeepSeekAcpApi({required final String pluginId}) {
 
   // ignore: no_slop_linter/prefer_specific_type, ACP JSON object values are heterogeneous
   DeepSeekSubagentReplayDto parseSubagentReplay(Map<String, dynamic> json) {
+    if (json.containsKey("childSessionId") && json["childSessionId"] is! String) {
+      throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
+    }
+    if (json.containsKey("ended")) {
+      final endedJson = _json(json["ended"], method: "DeepSeek sub-agent replay end metadata");
+      if (endedJson.containsKey("summary") && endedJson["summary"] is! String) {
+        throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
+      }
+    }
     final replay = DeepSeekSubagentReplayDto.fromJson(json);
     if (!_validSubagentText(replay.label, maxScalars: 256) ||
         !_validSubagentPrompt(replay.prompt) ||
@@ -207,13 +237,11 @@ class const DeepSeekAcpApi({required final String pluginId}) {
       throw const FormatException("Invalid DeepSeek history response");
     }
     for (final update in response.updates) {
-      final deepSeek = update.metadata?.deepSeek;
+      final deepSeek = parseHistoryMetadata(envelope: update);
       final createdAt = deepSeek?.messageCreatedAt;
       if (createdAt != null && (createdAt < 0 || createdAt > 9007199254740991)) {
         throw const FormatException("Invalid DeepSeek history response");
       }
-      final replay = deepSeek?.subagent;
-      if (replay != null) parseSubagentReplay(replay.toJson());
     }
   }
 

--- a/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.dart
@@ -181,23 +181,8 @@ class const DeepSeekEnvelopeMetadataDto({
     }
     final value = json[deepSeekExtensionMetadataKey];
     // ignore: no_slop_linter/prefer_specific_type, protocol metadata values are heterogeneous
-    if (value is! Map<String, dynamic> || value.containsKey("messageCreatedAt") && value["messageCreatedAt"] is! int) {
+    if (value is! Map<String, dynamic>) {
       throw const FormatException("Invalid DeepSeek history metadata");
-    }
-    final subagent = value["subagent"];
-    if (value.containsKey("subagent")) {
-      // ignore: no_slop_linter/prefer_specific_type, protocol metadata values are heterogeneous
-      if (subagent is! Map<String, dynamic> ||
-          subagent.containsKey("childSessionId") && subagent["childSessionId"] is! String) {
-        throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
-      }
-      final ended = subagent["ended"];
-      if (subagent.containsKey("ended")) {
-        // ignore: no_slop_linter/prefer_specific_type, protocol metadata values are heterogeneous
-        if (ended is! Map<String, dynamic> || ended.containsKey("summary") && ended["summary"] is! String) {
-          throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
-        }
-      }
     }
     return DeepSeekEnvelopeMetadataDto(
       raw: Map.unmodifiable(json),
@@ -213,7 +198,17 @@ class const DeepSeekEnvelopeDeepSeekMetadataDto({
   @JsonKey(fromJson: _nullableInteger, includeIfNull: false) required final int? messageCreatedAt,
   @JsonKey(includeIfNull: false) required final DeepSeekSubagentReplayDto? subagent,
 }) {
-  factory fromJson(Map<String, dynamic> json) => _$DeepSeekEnvelopeDeepSeekMetadataDtoFromJson(json);
+  factory fromJson(Map<String, dynamic> json) {
+    if (json.containsKey("messageCreatedAt") && json["messageCreatedAt"] is! int) {
+      throw const FormatException("Invalid DeepSeek history metadata");
+    }
+    final subagent = json["subagent"];
+    // ignore: no_slop_linter/prefer_specific_type, protocol metadata values are heterogeneous
+    if (json.containsKey("subagent") && subagent is! Map<String, dynamic>) {
+      throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
+    }
+    return _$DeepSeekEnvelopeDeepSeekMetadataDtoFromJson(json);
+  }
   Map<String, dynamic> toJson() => _$DeepSeekEnvelopeDeepSeekMetadataDtoToJson(this);
 }
 
@@ -266,7 +261,17 @@ class const DeepSeekSubagentReplayDto({
   @JsonKey(includeIfNull: false) required final String? childSessionId,
   @JsonKey(includeIfNull: false) required final DeepSeekSubagentReplayEndedDto? ended,
 }) {
-  factory fromJson(Map<String, dynamic> json) => _$DeepSeekSubagentReplayDtoFromJson(json);
+  factory fromJson(Map<String, dynamic> json) {
+    if (json.containsKey("childSessionId") && json["childSessionId"] is! String) {
+      throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
+    }
+    final ended = json["ended"];
+    // ignore: no_slop_linter/prefer_specific_type, protocol metadata values are heterogeneous
+    if (json.containsKey("ended") && ended is! Map<String, dynamic>) {
+      throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
+    }
+    return _$DeepSeekSubagentReplayDtoFromJson(json);
+  }
   Map<String, dynamic> toJson() => _$DeepSeekSubagentReplayDtoToJson(this);
 }
 
@@ -275,7 +280,12 @@ class const DeepSeekSubagentReplayEndedDto({
   @JsonKey(unknownEnumValue: DeepSeekSubagentStopReason.unknown) required final DeepSeekSubagentStopReason stopReason,
   @JsonKey(includeIfNull: false) required final String? summary,
 }) {
-  factory fromJson(Map<String, dynamic> json) => _$DeepSeekSubagentReplayEndedDtoFromJson(json);
+  factory fromJson(Map<String, dynamic> json) {
+    if (json.containsKey("summary") && json["summary"] is! String) {
+      throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
+    }
+    return _$DeepSeekSubagentReplayEndedDtoFromJson(json);
+  }
   Map<String, dynamic> toJson() => _$DeepSeekSubagentReplayEndedDtoToJson(this);
 }
 

--- a/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.dart
@@ -2,6 +2,8 @@ import "package:json_annotation/json_annotation.dart";
 
 part "deepseek_protocol_dto.g.dart";
 
+const String deepSeekExtensionMetadataKey = "sesori.ai/deepseek";
+
 // ignore: no_slop_linter/prefer_specific_type, json_serializable converter input is heterogeneous
 int _integer(Object? value) {
   if (value is! int) throw const FormatException("Expected integer");
@@ -155,19 +157,55 @@ class const DeepSeekTerminalHistoryResponseDto({
   Map<String, dynamic> toJson() => _$DeepSeekTerminalHistoryResponseDtoToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class const DeepSeekSessionUpdateEnvelopeDto({
-  // `_meta` is an open ACP extension container. Keep its untouched entries for
-  // the shared replay collector; the API separately parses the known DeepSeek
-  // member into [DeepSeekEnvelopeDeepSeekMetadataDto].
-  // ignore: no_slop_linter/prefer_specific_type, protocol metadata values are heterogeneous
-  @JsonKey(name: "_meta") required final Map<String, dynamic>? metadata,
+  @JsonKey(name: "_meta") required final DeepSeekEnvelopeMetadataDto? metadata,
   required final String sessionId,
   // ignore: no_slop_linter/prefer_specific_type, standard ACP update values are heterogeneous
   required final Map<String, dynamic> update,
 }) {
   factory fromJson(Map<String, dynamic> json) => _$DeepSeekSessionUpdateEnvelopeDtoFromJson(json);
   Map<String, dynamic> toJson() => _$DeepSeekSessionUpdateEnvelopeDtoToJson(this);
+}
+
+/// Typed view of DeepSeek's member inside the open ACP `_meta` container while
+/// retaining every original entry for shared and forward-compatible replay.
+class const DeepSeekEnvelopeMetadataDto({
+  // ignore: no_slop_linter/prefer_specific_type, protocol metadata values are heterogeneous
+  required final Map<String, dynamic> raw,
+  required final DeepSeekEnvelopeDeepSeekMetadataDto? deepSeek,
+}) {
+  factory fromJson(Map<String, dynamic> json) {
+    if (!json.containsKey(deepSeekExtensionMetadataKey)) {
+      return DeepSeekEnvelopeMetadataDto(raw: Map.unmodifiable(json), deepSeek: null);
+    }
+    final value = json[deepSeekExtensionMetadataKey];
+    // ignore: no_slop_linter/prefer_specific_type, protocol metadata values are heterogeneous
+    if (value is! Map<String, dynamic> || value.containsKey("messageCreatedAt") && value["messageCreatedAt"] is! int) {
+      throw const FormatException("Invalid DeepSeek history metadata");
+    }
+    final subagent = value["subagent"];
+    if (value.containsKey("subagent")) {
+      // ignore: no_slop_linter/prefer_specific_type, protocol metadata values are heterogeneous
+      if (subagent is! Map<String, dynamic> ||
+          subagent.containsKey("childSessionId") && subagent["childSessionId"] is! String) {
+        throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
+      }
+      final ended = subagent["ended"];
+      if (subagent.containsKey("ended")) {
+        // ignore: no_slop_linter/prefer_specific_type, protocol metadata values are heterogeneous
+        if (ended is! Map<String, dynamic> || ended.containsKey("summary") && ended["summary"] is! String) {
+          throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
+        }
+      }
+    }
+    return DeepSeekEnvelopeMetadataDto(
+      raw: Map.unmodifiable(json),
+      deepSeek: DeepSeekEnvelopeDeepSeekMetadataDto.fromJson(value),
+    );
+  }
+
+  Map<String, dynamic> toJson() => raw;
 }
 
 @JsonSerializable(explicitToJson: true)

--- a/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.dart
@@ -155,9 +155,13 @@ class const DeepSeekTerminalHistoryResponseDto({
   Map<String, dynamic> toJson() => _$DeepSeekTerminalHistoryResponseDtoToJson(this);
 }
 
-@JsonSerializable(explicitToJson: true)
+@JsonSerializable()
 class const DeepSeekSessionUpdateEnvelopeDto({
-  @JsonKey(name: "_meta") required final DeepSeekEnvelopeMetadataDto? metadata,
+  // `_meta` is an open ACP extension container. Keep its untouched entries for
+  // the shared replay collector; the API separately parses the known DeepSeek
+  // member into [DeepSeekEnvelopeDeepSeekMetadataDto].
+  // ignore: no_slop_linter/prefer_specific_type, protocol metadata values are heterogeneous
+  @JsonKey(name: "_meta") required final Map<String, dynamic>? metadata,
   required final String sessionId,
   // ignore: no_slop_linter/prefer_specific_type, standard ACP update values are heterogeneous
   required final Map<String, dynamic> update,
@@ -167,17 +171,9 @@ class const DeepSeekSessionUpdateEnvelopeDto({
 }
 
 @JsonSerializable(explicitToJson: true)
-class const DeepSeekEnvelopeMetadataDto({
-  @JsonKey(name: "sesori.ai/deepseek") required final DeepSeekEnvelopeDeepSeekMetadataDto? deepSeek,
-}) {
-  factory fromJson(Map<String, dynamic> json) => _$DeepSeekEnvelopeMetadataDtoFromJson(json);
-  Map<String, dynamic> toJson() => _$DeepSeekEnvelopeMetadataDtoToJson(this);
-}
-
-@JsonSerializable(explicitToJson: true)
 class const DeepSeekEnvelopeDeepSeekMetadataDto({
-  @JsonKey(fromJson: _nullableInteger) required final int? messageCreatedAt,
-  required final DeepSeekSubagentReplayDto? subagent,
+  @JsonKey(fromJson: _nullableInteger, includeIfNull: false) required final int? messageCreatedAt,
+  @JsonKey(includeIfNull: false) required final DeepSeekSubagentReplayDto? subagent,
 }) {
   factory fromJson(Map<String, dynamic> json) => _$DeepSeekEnvelopeDeepSeekMetadataDtoFromJson(json);
   Map<String, dynamic> toJson() => _$DeepSeekEnvelopeDeepSeekMetadataDtoToJson(this);
@@ -215,7 +211,7 @@ class const DeepSeekSubagentEndedDto({
   @override required final String sessionId,
   @override required final String childSessionId,
   @JsonKey(unknownEnumValue: DeepSeekSubagentStopReason.unknown) required final DeepSeekSubagentStopReason stopReason,
-  required final String? summary,
+  @JsonKey(includeIfNull: false) required final String? summary,
 }) extends DeepSeekSubagentNotificationDto {
   factory fromJson(Map<String, dynamic> json) => _$DeepSeekSubagentEndedDtoFromJson(json);
   @JsonKey(includeFromJson: false, includeToJson: true)
@@ -229,8 +225,8 @@ class const DeepSeekSubagentReplayDto({
   required final String prompt,
   required final String label,
   @JsonKey(unknownEnumValue: DeepSeekSubagentMode.unknown) required final DeepSeekSubagentMode mode,
-  required final String? childSessionId,
-  required final DeepSeekSubagentReplayEndedDto? ended,
+  @JsonKey(includeIfNull: false) required final String? childSessionId,
+  @JsonKey(includeIfNull: false) required final DeepSeekSubagentReplayEndedDto? ended,
 }) {
   factory fromJson(Map<String, dynamic> json) => _$DeepSeekSubagentReplayDtoFromJson(json);
   Map<String, dynamic> toJson() => _$DeepSeekSubagentReplayDtoToJson(this);
@@ -239,7 +235,7 @@ class const DeepSeekSubagentReplayDto({
 @JsonSerializable()
 class const DeepSeekSubagentReplayEndedDto({
   @JsonKey(unknownEnumValue: DeepSeekSubagentStopReason.unknown) required final DeepSeekSubagentStopReason stopReason,
-  required final String? summary,
+  @JsonKey(includeIfNull: false) required final String? summary,
 }) {
   factory fromJson(Map<String, dynamic> json) => _$DeepSeekSubagentReplayEndedDtoFromJson(json);
   Map<String, dynamic> toJson() => _$DeepSeekSubagentReplayEndedDtoToJson(this);

--- a/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.dart
@@ -11,6 +11,22 @@ int _integer(Object? value) {
 // ignore: no_slop_linter/prefer_specific_type, json_serializable converter input is heterogeneous
 int? _nullableInteger(Object? value) => value == null ? null : _integer(value);
 
+enum DeepSeekSubagentMode() {
+  foreground,
+  background,
+  unknown,
+}
+
+enum DeepSeekSubagentStopReason() {
+  completed,
+  aborted,
+  error,
+  @JsonValue("max-tokens")
+  maxTokens,
+  refusal,
+  unknown,
+}
+
 @JsonSerializable()
 class const DeepSeekInitializeMetadataDto({
   @JsonKey(fromJson: _integer) required final int extensionProtocolVersion,
@@ -139,16 +155,94 @@ class const DeepSeekTerminalHistoryResponseDto({
   Map<String, dynamic> toJson() => _$DeepSeekTerminalHistoryResponseDtoToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class const DeepSeekSessionUpdateEnvelopeDto({
-  // ignore: no_slop_linter/prefer_specific_type, protocol metadata values are heterogeneous
-  @JsonKey(name: "_meta") required final Map<String, dynamic>? metadata,
+  @JsonKey(name: "_meta") required final DeepSeekEnvelopeMetadataDto? metadata,
   required final String sessionId,
   // ignore: no_slop_linter/prefer_specific_type, standard ACP update values are heterogeneous
   required final Map<String, dynamic> update,
 }) {
   factory fromJson(Map<String, dynamic> json) => _$DeepSeekSessionUpdateEnvelopeDtoFromJson(json);
   Map<String, dynamic> toJson() => _$DeepSeekSessionUpdateEnvelopeDtoToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class const DeepSeekEnvelopeMetadataDto({
+  @JsonKey(name: "sesori.ai/deepseek") required final DeepSeekEnvelopeDeepSeekMetadataDto? deepSeek,
+}) {
+  factory fromJson(Map<String, dynamic> json) => _$DeepSeekEnvelopeMetadataDtoFromJson(json);
+  Map<String, dynamic> toJson() => _$DeepSeekEnvelopeMetadataDtoToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class const DeepSeekEnvelopeDeepSeekMetadataDto({
+  @JsonKey(fromJson: _nullableInteger) required final int? messageCreatedAt,
+  required final DeepSeekSubagentReplayDto? subagent,
+}) {
+  factory fromJson(Map<String, dynamic> json) => _$DeepSeekEnvelopeDeepSeekMetadataDtoFromJson(json);
+  Map<String, dynamic> toJson() => _$DeepSeekEnvelopeDeepSeekMetadataDtoToJson(this);
+}
+
+sealed class const DeepSeekSubagentNotificationDto() {
+  factory fromJson(Map<String, dynamic> json) => switch (json["kind"]) {
+    "started" => DeepSeekSubagentStartedDto.fromJson(json),
+    "ended" => DeepSeekSubagentEndedDto.fromJson(json),
+    _ => throw const FormatException("Invalid DeepSeek sub-agent notification"),
+  };
+  String get sessionId;
+  String get childSessionId;
+  Map<String, dynamic> toJson();
+}
+
+@JsonSerializable()
+class const DeepSeekSubagentStartedDto({
+  @override required final String sessionId,
+  @override required final String childSessionId,
+  required final String toolCallId,
+  required final String prompt,
+  required final String label,
+  @JsonKey(unknownEnumValue: DeepSeekSubagentMode.unknown) required final DeepSeekSubagentMode mode,
+}) extends DeepSeekSubagentNotificationDto {
+  factory fromJson(Map<String, dynamic> json) => _$DeepSeekSubagentStartedDtoFromJson(json);
+  @JsonKey(includeFromJson: false, includeToJson: true)
+  String get kind => "started";
+  @override
+  Map<String, dynamic> toJson() => _$DeepSeekSubagentStartedDtoToJson(this);
+}
+
+@JsonSerializable()
+class const DeepSeekSubagentEndedDto({
+  @override required final String sessionId,
+  @override required final String childSessionId,
+  @JsonKey(unknownEnumValue: DeepSeekSubagentStopReason.unknown) required final DeepSeekSubagentStopReason stopReason,
+  required final String? summary,
+}) extends DeepSeekSubagentNotificationDto {
+  factory fromJson(Map<String, dynamic> json) => _$DeepSeekSubagentEndedDtoFromJson(json);
+  @JsonKey(includeFromJson: false, includeToJson: true)
+  String get kind => "ended";
+  @override
+  Map<String, dynamic> toJson() => _$DeepSeekSubagentEndedDtoToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class const DeepSeekSubagentReplayDto({
+  required final String prompt,
+  required final String label,
+  @JsonKey(unknownEnumValue: DeepSeekSubagentMode.unknown) required final DeepSeekSubagentMode mode,
+  required final String? childSessionId,
+  required final DeepSeekSubagentReplayEndedDto? ended,
+}) {
+  factory fromJson(Map<String, dynamic> json) => _$DeepSeekSubagentReplayDtoFromJson(json);
+  Map<String, dynamic> toJson() => _$DeepSeekSubagentReplayDtoToJson(this);
+}
+
+@JsonSerializable()
+class const DeepSeekSubagentReplayEndedDto({
+  @JsonKey(unknownEnumValue: DeepSeekSubagentStopReason.unknown) required final DeepSeekSubagentStopReason stopReason,
+  required final String? summary,
+}) {
+  factory fromJson(Map<String, dynamic> json) => _$DeepSeekSubagentReplayEndedDtoFromJson(json);
+  Map<String, dynamic> toJson() => _$DeepSeekSubagentReplayEndedDtoToJson(this);
 }
 
 @JsonSerializable()

--- a/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.g.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.g.dart
@@ -220,7 +220,11 @@ Map<String, dynamic> _$DeepSeekTerminalHistoryResponseDtoToJson(
 DeepSeekSessionUpdateEnvelopeDto _$DeepSeekSessionUpdateEnvelopeDtoFromJson(
   Map json,
 ) => DeepSeekSessionUpdateEnvelopeDto(
-  metadata: (json['_meta'] as Map?)?.map((k, e) => MapEntry(k as String, e)),
+  metadata: json['_meta'] == null
+      ? null
+      : DeepSeekEnvelopeMetadataDto.fromJson(
+          Map<String, dynamic>.from(json['_meta'] as Map),
+        ),
   sessionId: json['sessionId'] as String,
   update: Map<String, dynamic>.from(json['update'] as Map),
 );
@@ -228,7 +232,7 @@ DeepSeekSessionUpdateEnvelopeDto _$DeepSeekSessionUpdateEnvelopeDtoFromJson(
 Map<String, dynamic> _$DeepSeekSessionUpdateEnvelopeDtoToJson(
   DeepSeekSessionUpdateEnvelopeDto instance,
 ) => <String, dynamic>{
-  '_meta': ?instance.metadata,
+  '_meta': ?instance.metadata?.toJson(),
   'sessionId': instance.sessionId,
   'update': instance.update,
 };

--- a/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.g.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.g.dart
@@ -220,7 +220,11 @@ Map<String, dynamic> _$DeepSeekTerminalHistoryResponseDtoToJson(
 DeepSeekSessionUpdateEnvelopeDto _$DeepSeekSessionUpdateEnvelopeDtoFromJson(
   Map json,
 ) => DeepSeekSessionUpdateEnvelopeDto(
-  metadata: (json['_meta'] as Map?)?.map((k, e) => MapEntry(k as String, e)),
+  metadata: json['_meta'] == null
+      ? null
+      : DeepSeekEnvelopeMetadataDto.fromJson(
+          Map<String, dynamic>.from(json['_meta'] as Map),
+        ),
   sessionId: json['sessionId'] as String,
   update: Map<String, dynamic>.from(json['update'] as Map),
 );
@@ -228,9 +232,148 @@ DeepSeekSessionUpdateEnvelopeDto _$DeepSeekSessionUpdateEnvelopeDtoFromJson(
 Map<String, dynamic> _$DeepSeekSessionUpdateEnvelopeDtoToJson(
   DeepSeekSessionUpdateEnvelopeDto instance,
 ) => <String, dynamic>{
-  '_meta': ?instance.metadata,
+  '_meta': ?instance.metadata?.toJson(),
   'sessionId': instance.sessionId,
   'update': instance.update,
+};
+
+DeepSeekEnvelopeMetadataDto _$DeepSeekEnvelopeMetadataDtoFromJson(Map json) =>
+    DeepSeekEnvelopeMetadataDto(
+      deepSeek: json['sesori.ai/deepseek'] == null
+          ? null
+          : DeepSeekEnvelopeDeepSeekMetadataDto.fromJson(
+              Map<String, dynamic>.from(json['sesori.ai/deepseek'] as Map),
+            ),
+    );
+
+Map<String, dynamic> _$DeepSeekEnvelopeMetadataDtoToJson(
+  DeepSeekEnvelopeMetadataDto instance,
+) => <String, dynamic>{'sesori.ai/deepseek': ?instance.deepSeek?.toJson()};
+
+DeepSeekEnvelopeDeepSeekMetadataDto
+_$DeepSeekEnvelopeDeepSeekMetadataDtoFromJson(Map json) =>
+    DeepSeekEnvelopeDeepSeekMetadataDto(
+      messageCreatedAt: _nullableInteger(json['messageCreatedAt']),
+      subagent: json['subagent'] == null
+          ? null
+          : DeepSeekSubagentReplayDto.fromJson(
+              Map<String, dynamic>.from(json['subagent'] as Map),
+            ),
+    );
+
+Map<String, dynamic> _$DeepSeekEnvelopeDeepSeekMetadataDtoToJson(
+  DeepSeekEnvelopeDeepSeekMetadataDto instance,
+) => <String, dynamic>{
+  'messageCreatedAt': ?instance.messageCreatedAt,
+  'subagent': ?instance.subagent?.toJson(),
+};
+
+DeepSeekSubagentStartedDto _$DeepSeekSubagentStartedDtoFromJson(Map json) =>
+    DeepSeekSubagentStartedDto(
+      sessionId: json['sessionId'] as String,
+      childSessionId: json['childSessionId'] as String,
+      toolCallId: json['toolCallId'] as String,
+      prompt: json['prompt'] as String,
+      label: json['label'] as String,
+      mode: $enumDecode(
+        _$DeepSeekSubagentModeEnumMap,
+        json['mode'],
+        unknownValue: DeepSeekSubagentMode.unknown,
+      ),
+    );
+
+Map<String, dynamic> _$DeepSeekSubagentStartedDtoToJson(
+  DeepSeekSubagentStartedDto instance,
+) => <String, dynamic>{
+  'sessionId': instance.sessionId,
+  'childSessionId': instance.childSessionId,
+  'toolCallId': instance.toolCallId,
+  'prompt': instance.prompt,
+  'label': instance.label,
+  'mode': _$DeepSeekSubagentModeEnumMap[instance.mode]!,
+  'kind': instance.kind,
+};
+
+const _$DeepSeekSubagentModeEnumMap = {
+  DeepSeekSubagentMode.foreground: 'foreground',
+  DeepSeekSubagentMode.background: 'background',
+  DeepSeekSubagentMode.unknown: 'unknown',
+};
+
+DeepSeekSubagentEndedDto _$DeepSeekSubagentEndedDtoFromJson(Map json) =>
+    DeepSeekSubagentEndedDto(
+      sessionId: json['sessionId'] as String,
+      childSessionId: json['childSessionId'] as String,
+      stopReason: $enumDecode(
+        _$DeepSeekSubagentStopReasonEnumMap,
+        json['stopReason'],
+        unknownValue: DeepSeekSubagentStopReason.unknown,
+      ),
+      summary: json['summary'] as String?,
+    );
+
+Map<String, dynamic> _$DeepSeekSubagentEndedDtoToJson(
+  DeepSeekSubagentEndedDto instance,
+) => <String, dynamic>{
+  'sessionId': instance.sessionId,
+  'childSessionId': instance.childSessionId,
+  'stopReason': _$DeepSeekSubagentStopReasonEnumMap[instance.stopReason]!,
+  'summary': ?instance.summary,
+  'kind': instance.kind,
+};
+
+const _$DeepSeekSubagentStopReasonEnumMap = {
+  DeepSeekSubagentStopReason.completed: 'completed',
+  DeepSeekSubagentStopReason.aborted: 'aborted',
+  DeepSeekSubagentStopReason.error: 'error',
+  DeepSeekSubagentStopReason.maxTokens: 'max-tokens',
+  DeepSeekSubagentStopReason.refusal: 'refusal',
+  DeepSeekSubagentStopReason.unknown: 'unknown',
+};
+
+DeepSeekSubagentReplayDto _$DeepSeekSubagentReplayDtoFromJson(Map json) =>
+    DeepSeekSubagentReplayDto(
+      prompt: json['prompt'] as String,
+      label: json['label'] as String,
+      mode: $enumDecode(
+        _$DeepSeekSubagentModeEnumMap,
+        json['mode'],
+        unknownValue: DeepSeekSubagentMode.unknown,
+      ),
+      childSessionId: json['childSessionId'] as String?,
+      ended: json['ended'] == null
+          ? null
+          : DeepSeekSubagentReplayEndedDto.fromJson(
+              Map<String, dynamic>.from(json['ended'] as Map),
+            ),
+    );
+
+Map<String, dynamic> _$DeepSeekSubagentReplayDtoToJson(
+  DeepSeekSubagentReplayDto instance,
+) => <String, dynamic>{
+  'prompt': instance.prompt,
+  'label': instance.label,
+  'mode': _$DeepSeekSubagentModeEnumMap[instance.mode]!,
+  'childSessionId': ?instance.childSessionId,
+  'ended': ?instance.ended?.toJson(),
+};
+
+DeepSeekSubagentReplayEndedDto _$DeepSeekSubagentReplayEndedDtoFromJson(
+  Map json,
+) => DeepSeekSubagentReplayEndedDto(
+  stopReason: $enumDecode(
+    _$DeepSeekSubagentStopReasonEnumMap,
+    json['stopReason'],
+    unknownValue: DeepSeekSubagentStopReason.unknown,
+  ),
+  summary: json['summary'] as String?,
+);
+
+Map<String, dynamic> _$DeepSeekSubagentReplayEndedDtoToJson(
+  DeepSeekSubagentReplayEndedDto instance,
+) => <String, dynamic>{
+  'stopReason': _$DeepSeekSubagentStopReasonEnumMap[instance.stopReason]!,
+  'summary': ?instance.summary,
 };
 
 DeepSeekRenameRequestDto _$DeepSeekRenameRequestDtoFromJson(Map json) =>

--- a/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.g.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.g.dart
@@ -220,11 +220,7 @@ Map<String, dynamic> _$DeepSeekTerminalHistoryResponseDtoToJson(
 DeepSeekSessionUpdateEnvelopeDto _$DeepSeekSessionUpdateEnvelopeDtoFromJson(
   Map json,
 ) => DeepSeekSessionUpdateEnvelopeDto(
-  metadata: json['_meta'] == null
-      ? null
-      : DeepSeekEnvelopeMetadataDto.fromJson(
-          Map<String, dynamic>.from(json['_meta'] as Map),
-        ),
+  metadata: (json['_meta'] as Map?)?.map((k, e) => MapEntry(k as String, e)),
   sessionId: json['sessionId'] as String,
   update: Map<String, dynamic>.from(json['update'] as Map),
 );
@@ -232,23 +228,10 @@ DeepSeekSessionUpdateEnvelopeDto _$DeepSeekSessionUpdateEnvelopeDtoFromJson(
 Map<String, dynamic> _$DeepSeekSessionUpdateEnvelopeDtoToJson(
   DeepSeekSessionUpdateEnvelopeDto instance,
 ) => <String, dynamic>{
-  '_meta': ?instance.metadata?.toJson(),
+  '_meta': ?instance.metadata,
   'sessionId': instance.sessionId,
   'update': instance.update,
 };
-
-DeepSeekEnvelopeMetadataDto _$DeepSeekEnvelopeMetadataDtoFromJson(Map json) =>
-    DeepSeekEnvelopeMetadataDto(
-      deepSeek: json['sesori.ai/deepseek'] == null
-          ? null
-          : DeepSeekEnvelopeDeepSeekMetadataDto.fromJson(
-              Map<String, dynamic>.from(json['sesori.ai/deepseek'] as Map),
-            ),
-    );
-
-Map<String, dynamic> _$DeepSeekEnvelopeMetadataDtoToJson(
-  DeepSeekEnvelopeMetadataDto instance,
-) => <String, dynamic>{'sesori.ai/deepseek': ?instance.deepSeek?.toJson()};
 
 DeepSeekEnvelopeDeepSeekMetadataDto
 _$DeepSeekEnvelopeDeepSeekMetadataDtoFromJson(Map json) =>

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_event_mapper.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_event_mapper.dart
@@ -49,14 +49,26 @@ class DeepSeekEventMapper({
 
   @override
   String? sessionIdForToolCallId({required String? toolCallId}) {
-    if (toolCallId != null && toolCallId.isNotEmpty) {
-      for (final entry in _deferredDelegations.entries) {
-        if (entry.value.containsKey(toolCallId)) return entry.key;
-      }
-      final startedSessionId = delegationTracker.sessionIdForToolCallId(toolCallId: toolCallId);
-      if (startedSessionId != null) return startedSessionId;
+    if (toolCallId == null || toolCallId.isEmpty) {
+      return super.sessionIdForToolCallId(toolCallId: toolCallId);
     }
-    return super.sessionIdForToolCallId(toolCallId: toolCallId);
+    final sessionIds = <String>{
+      for (final entry in _deferredDelegations.entries)
+        if (entry.value.containsKey(toolCallId)) entry.key,
+    };
+    switch (delegationTracker.lookupToolCallId(toolCallId: toolCallId)) {
+      case DeepSeekDelegationFound(:final sessionId):
+        sessionIds.add(sessionId);
+      case DeepSeekDelegationAmbiguous():
+        return null;
+      case DeepSeekDelegationNotFound():
+        break;
+    }
+    return switch (sessionIds.toList(growable: false)) {
+      [final sessionId] => sessionId,
+      [] => super.sessionIdForToolCallId(toolCallId: toolCallId),
+      _ => null,
+    };
   }
 
   /// Protocol v2 delays only the two exact delegation calls until either their
@@ -111,14 +123,10 @@ class DeepSeekEventMapper({
         }
         final deferred = _deferredDelegations[sessionId]?[toolCallId];
         if (deferred == null) return super.map(notification);
+        deferred.merge(notification: notification, update: update);
         if (status != null && _isTerminalToolStatus(status)) {
-          return _flushDeferredDelegation(
-            sessionId: sessionId,
-            toolCallId: toolCallId,
-            terminalUpdate: notification,
-          );
+          return _flushDeferredDelegation(sessionId: sessionId, toolCallId: toolCallId);
         }
-        deferred.updates.add(notification);
         return const [];
     }
     return super.map(notification);
@@ -184,11 +192,7 @@ class DeepSeekEventMapper({
       final sessionId = params["sessionId"];
       final toolCallId = params["toolCallId"];
       if (sessionId is String && toolCallId is String) {
-        return _flushDeferredDelegation(
-          sessionId: sessionId,
-          toolCallId: toolCallId,
-          terminalUpdate: null,
-        );
+        return _flushDeferredDelegation(sessionId: sessionId, toolCallId: toolCallId);
       }
       return const [];
     }
@@ -207,17 +211,12 @@ class DeepSeekEventMapper({
     return const [];
   }
 
-  List<BridgeSseEvent> _flushDeferredDelegation({
-    required String sessionId,
-    required String toolCallId,
-    required AcpNotification? terminalUpdate,
-  }) {
+  List<BridgeSseEvent> _flushDeferredDelegation({required String sessionId, required String toolCallId}) {
     final deferred = _removeDeferredDelegation(sessionId: sessionId, toolCallId: toolCallId);
     if (deferred == null) return const [];
     return [
       ...super.map(deferred.call),
-      for (final update in deferred.updates) ...super.map(update),
-      if (terminalUpdate != null) ...super.map(terminalUpdate),
+      if (deferred.mergedUpdate case final update?) ...super.map(update),
     ];
   }
 
@@ -253,5 +252,40 @@ class DeepSeekEventMapper({
 }
 
 final class _DeferredDeepSeekDelegation({required final AcpNotification call}) {
-  final List<AcpNotification> updates = [];
+  static const _retainedUpdateKeys = {
+    "sessionUpdate",
+    "toolCallId",
+    "kind",
+    "title",
+    "status",
+    "content",
+    "rawOutput",
+  };
+
+  // ignore: no_slop_linter/prefer_specific_type, standard ACP update values are heterogeneous
+  final Map<String, dynamic> _mergedUpdate = {};
+  // ignore: no_slop_linter/prefer_specific_type, standard ACP params are heterogeneous
+  Map<String, dynamic>? _latestParams;
+
+  void merge({
+    required AcpNotification notification,
+    // ignore: no_slop_linter/prefer_specific_type, standard ACP update values are heterogeneous
+    required Map<String, dynamic> update,
+  }) {
+    for (final entry in update.entries) {
+      if (_retainedUpdateKeys.contains(entry.key)) _mergedUpdate[entry.key] = entry.value;
+    }
+    _latestParams = notification.params;
+  }
+
+  AcpNotification? get mergedUpdate {
+    final params = _latestParams;
+    if (params == null) return null;
+    // ignore: no_slop_linter/prefer_specific_type, standard ACP update values are heterogeneous
+    final mergedUpdate = Map<String, dynamic>.unmodifiable(_mergedUpdate);
+    return AcpNotification(
+      method: AcpMethods.sessionUpdate,
+      params: {...params, "update": mergedUpdate},
+    );
+  }
 }

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_event_mapper.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_event_mapper.dart
@@ -48,9 +48,9 @@ class DeepSeekEventMapper({
   }
 
   @override
-  String? sessionIdForToolCallId({required String? toolCallId}) {
+  AcpToolCallSessionLookup lookupSessionForToolCallId({required String? toolCallId}) {
     if (toolCallId == null || toolCallId.isEmpty) {
-      return super.sessionIdForToolCallId(toolCallId: toolCallId);
+      return super.lookupSessionForToolCallId(toolCallId: toolCallId);
     }
     final sessionIds = <String>{
       for (final entry in _deferredDelegations.entries)
@@ -60,14 +60,22 @@ class DeepSeekEventMapper({
       case DeepSeekDelegationFound(:final sessionId):
         sessionIds.add(sessionId);
       case DeepSeekDelegationAmbiguous():
-        return null;
+        return const AcpToolCallSessionAmbiguous();
       case DeepSeekDelegationNotFound():
         break;
     }
+    switch (super.lookupSessionForToolCallId(toolCallId: toolCallId)) {
+      case AcpToolCallSessionFound(:final sessionId):
+        sessionIds.add(sessionId);
+      case AcpToolCallSessionAmbiguous():
+        return const AcpToolCallSessionAmbiguous();
+      case AcpToolCallSessionNotFound():
+        break;
+    }
     return switch (sessionIds.toList(growable: false)) {
-      [final sessionId] => sessionId,
-      [] => super.sessionIdForToolCallId(toolCallId: toolCallId),
-      _ => null,
+      [final sessionId] => AcpToolCallSessionFound(sessionId: sessionId),
+      [] => const AcpToolCallSessionNotFound(),
+      _ => const AcpToolCallSessionAmbiguous(),
     };
   }
 
@@ -272,6 +280,11 @@ final class _DeferredDeepSeekDelegation({required final AcpNotification call}) {
     // ignore: no_slop_linter/prefer_specific_type, standard ACP update values are heterogeneous
     required Map<String, dynamic> update,
   }) {
+    if (update.containsKey("content")) {
+      _mergedUpdate.remove("rawOutput");
+    } else if (update.containsKey("rawOutput")) {
+      _mergedUpdate.remove("content");
+    }
     for (final entry in update.entries) {
       if (_retainedUpdateKeys.contains(entry.key)) _mergedUpdate[entry.key] = entry.value;
     }

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_event_mapper.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_event_mapper.dart
@@ -24,19 +24,95 @@ class DeepSeekEventMapper({
       PluginMessageTime(created: createdAtMs, completed: null);
 
   var _extensionProtocolVersion = 1;
+  final Map<String, Map<String, _DeferredDeepSeekDelegation>> _deferredDelegations = {};
+  final Map<String, Set<String>> _startedDelegationToolCalls = {};
 
   void setExtensionProtocolVersion({required int extensionProtocolVersion}) {
     _extensionProtocolVersion = extensionProtocolVersion;
+    _deferredDelegations.clear();
+    _startedDelegationToolCalls.clear();
   }
 
   @override
-  bool isSubagentSpawnToolCall({required Map<String, dynamic> update}) =>
-      _extensionProtocolVersion == DeepSeekAcpApi.extensionProtocolVersion &&
-      (update["title"] == "subagent" || update["title"] == "subagent_fork");
+  void beginTurn({required String sessionId, required String? messageId}) {
+    _deferredDelegations.remove(sessionId);
+    _startedDelegationToolCalls.remove(sessionId);
+    super.beginTurn(sessionId: sessionId, messageId: messageId);
+  }
+
+  @override
+  void forgetSession(String sessionId) {
+    _deferredDelegations.remove(sessionId);
+    _startedDelegationToolCalls.remove(sessionId);
+    super.forgetSession(sessionId);
+  }
+
+  @override
+  String? sessionIdForToolCallId({required String? toolCallId}) {
+    if (toolCallId != null && toolCallId.isNotEmpty) {
+      for (final entry in _deferredDelegations.entries) {
+        if (entry.value.containsKey(toolCallId)) return entry.key;
+      }
+      for (final entry in _startedDelegationToolCalls.entries) {
+        if (entry.value.contains(toolCallId)) return entry.key;
+      }
+    }
+    return super.sessionIdForToolCallId(toolCallId: toolCallId);
+  }
+
+  /// Protocol v2 delays only the two exact delegation calls until either their
+  /// correlated lifecycle start arrives (the child tile replaces the call) or
+  /// a standard terminal update proves startup failed (the generic error card
+  /// remains visible). This avoids both duplicate cards and invisible failures.
+  @override
+  List<BridgeSseEvent> map(AcpNotification notification) {
+    if (_extensionProtocolVersion != DeepSeekAcpApi.extensionProtocolVersion ||
+        notification.method != AcpMethods.sessionUpdate) {
+      return super.map(notification);
+    }
+    final sessionId = notification.params["sessionId"];
+    final update = notification.params["update"];
+    if (sessionId is! String || sessionId.isEmpty || update is! Map<String, dynamic>) {
+      return super.map(notification);
+    }
+    final toolCallId = update["toolCallId"];
+    if (toolCallId is! String || toolCallId.isEmpty) return super.map(notification);
+    final sessionStartedCalls = _startedDelegationToolCalls[sessionId];
+    final title = switch (update["title"]) {
+      final String value => value,
+      _ => null,
+    };
+    final status = switch (update["status"]) {
+      final String value => value,
+      _ => null,
+    };
+    switch (update["sessionUpdate"]) {
+      case "tool_call" when title != null && _isDelegationTitle(title):
+        if (sessionStartedCalls?.contains(toolCallId) ?? false) return const [];
+        if (status != null && _isTerminalToolStatus(status)) return super.map(notification);
+        (_deferredDelegations[sessionId] ??= {})[toolCallId] = _DeferredDeepSeekDelegation(call: notification);
+        return const [];
+      case "tool_call_update":
+        if (sessionStartedCalls?.contains(toolCallId) ?? false) return const [];
+        final deferred = _deferredDelegations[sessionId]?[toolCallId];
+        if (deferred == null) return super.map(notification);
+        if (status != null && _isTerminalToolStatus(status)) {
+          return _flushDeferredDelegation(
+            sessionId: sessionId,
+            toolCallId: toolCallId,
+            terminalUpdate: notification,
+          );
+        }
+        deferred.latestUpdate = notification;
+        return const [];
+    }
+    return super.map(notification);
+  }
 
   @override
   List<BridgeSseEvent> mapExtension(AcpNotification notification) {
-    if (notification.method == DeepSeekAcpApi.subagentMethod) {
+    if (_extensionProtocolVersion == DeepSeekAcpApi.extensionProtocolVersion &&
+        notification.method == DeepSeekAcpApi.subagentMethod) {
       return _mapSubagent(notification);
     }
     if (notification.method != DeepSeekAcpApi.sessionStatusMethod) {
@@ -59,17 +135,82 @@ class DeepSeekEventMapper({
     try {
       final subagent = api.parseSubagentNotification(notification.params);
       return switch (subagent) {
-        DeepSeekSubagentStartedDto() => mapChildSpawned(
-          sessionId: subagent.sessionId,
-          spawn: subagentMapper.mapStarted(notification: subagent),
-        ),
+        DeepSeekSubagentStartedDto() => _mapSubagentStarted(subagent),
         DeepSeekSubagentEndedDto() => _mapSubagentEnded(subagent),
       };
     } on Object catch (error, stackTrace) {
+      final recoveryEvents = _recoverMalformedSubagent(notification: notification);
       Log.w("[deepseek] ignored malformed sub-agent notification", error, stackTrace);
-      return const [];
+      return recoveryEvents;
     }
   }
+
+  List<BridgeSseEvent> _mapSubagentStarted(DeepSeekSubagentStartedDto notification) {
+    _removeDeferredDelegation(sessionId: notification.sessionId, toolCallId: notification.toolCallId);
+    (_startedDelegationToolCalls[notification.sessionId] ??= {}).add(notification.toolCallId);
+    final events = mapChildSpawned(
+      sessionId: notification.sessionId,
+      spawn: subagentMapper.mapStarted(notification: notification),
+    );
+    setChildModel(
+      childSessionId: notification.childSessionId,
+      modelId: modelForSession(sessionId: notification.sessionId),
+    );
+    return events;
+  }
+
+  List<BridgeSseEvent> _recoverMalformedSubagent({required AcpNotification notification}) {
+    final params = notification.params;
+    if (params["kind"] == "started") {
+      final sessionId = params["sessionId"];
+      final toolCallId = params["toolCallId"];
+      if (sessionId is String && toolCallId is String) {
+        return _flushDeferredDelegation(
+          sessionId: sessionId,
+          toolCallId: toolCallId,
+          terminalUpdate: null,
+        );
+      }
+      return const [];
+    }
+    if (params["kind"] == "ended") {
+      final childSessionId = params["childSessionId"];
+      if (childSessionId is String && childSessions.isChild(sessionId: childSessionId)) {
+        return mapChildFinished(
+          childSessionId: childSessionId,
+          status: PluginToolStatus.error,
+          output: null,
+          error: "DeepSeek sub-agent returned an invalid completion",
+        );
+      }
+    }
+    return const [];
+  }
+
+  List<BridgeSseEvent> _flushDeferredDelegation({
+    required String sessionId,
+    required String toolCallId,
+    required AcpNotification? terminalUpdate,
+  }) {
+    final deferred = _removeDeferredDelegation(sessionId: sessionId, toolCallId: toolCallId);
+    if (deferred == null) return const [];
+    return [
+      ...super.map(deferred.call),
+      if (deferred.latestUpdate case final update?) ...super.map(update),
+      if (terminalUpdate != null) ...super.map(terminalUpdate),
+    ];
+  }
+
+  _DeferredDeepSeekDelegation? _removeDeferredDelegation({required String sessionId, required String toolCallId}) {
+    final byToolCall = _deferredDelegations[sessionId];
+    final deferred = byToolCall?.remove(toolCallId);
+    if (byToolCall?.isEmpty ?? false) _deferredDelegations.remove(sessionId);
+    return deferred;
+  }
+
+  static bool _isDelegationTitle(String title) => title == "subagent" || title == "subagent_fork";
+
+  static bool _isTerminalToolStatus(String status) => status == "completed" || status == "failed";
 
   List<BridgeSseEvent> _mapSubagentEnded(DeepSeekSubagentEndedDto notification) {
     final state = subagentMapper.mapState(
@@ -88,4 +229,8 @@ class DeepSeekEventMapper({
     Log.w("[deepseek] session warning for ${status.sessionId}: ${status.message}");
     return [BridgeSseSessionError(sessionID: status.sessionId)];
   }
+}
+
+final class _DeferredDeepSeekDelegation({required final AcpNotification call}) {
+  AcpNotification? latestUpdate;
 }

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_event_mapper.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_event_mapper.dart
@@ -4,6 +4,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "api/deepseek_acp_api.dart";
 import "api/models/deepseek_protocol_dto.dart";
 import "deepseek_message_time_parser.dart";
+import "repositories/mappers/deepseek_subagent_mapper.dart";
 
 class DeepSeekEventMapper({
   required super.launchDirectory,
@@ -12,6 +13,7 @@ class DeepSeekEventMapper({
   required super.childSessions,
   required final DeepSeekAcpApi api,
   required final DeepSeekMessageTimeParser messageTimeParser,
+  required final DeepSeekSubagentMapper subagentMapper,
 }) extends AcpEventMapper {
   @override
   PluginMessageTime? messageTimeForNotification({required AcpNotification notification}) =>
@@ -21,8 +23,22 @@ class DeepSeekEventMapper({
   PluginMessageTime localUserMessageTime({required int createdAtMs}) =>
       PluginMessageTime(created: createdAtMs, completed: null);
 
+  var _extensionProtocolVersion = 1;
+
+  void setExtensionProtocolVersion({required int extensionProtocolVersion}) {
+    _extensionProtocolVersion = extensionProtocolVersion;
+  }
+
+  @override
+  bool isSubagentSpawnToolCall({required Map<String, dynamic> update}) =>
+      _extensionProtocolVersion == DeepSeekAcpApi.extensionProtocolVersion &&
+      (update["title"] == "subagent" || update["title"] == "subagent_fork");
+
   @override
   List<BridgeSseEvent> mapExtension(AcpNotification notification) {
+    if (notification.method == DeepSeekAcpApi.subagentMethod) {
+      return _mapSubagent(notification);
+    }
     if (notification.method != DeepSeekAcpApi.sessionStatusMethod) {
       return super.mapExtension(notification);
     }
@@ -37,6 +53,35 @@ class DeepSeekEventMapper({
       Log.w("[deepseek] ignored malformed session status notification", error, stackTrace);
       return const [];
     }
+  }
+
+  List<BridgeSseEvent> _mapSubagent(AcpNotification notification) {
+    try {
+      final subagent = api.parseSubagentNotification(notification.params);
+      return switch (subagent) {
+        DeepSeekSubagentStartedDto() => mapChildSpawned(
+          sessionId: subagent.sessionId,
+          spawn: subagentMapper.mapStarted(notification: subagent),
+        ),
+        DeepSeekSubagentEndedDto() => _mapSubagentEnded(subagent),
+      };
+    } on Object catch (error, stackTrace) {
+      Log.w("[deepseek] ignored malformed sub-agent notification", error, stackTrace);
+      return const [];
+    }
+  }
+
+  List<BridgeSseEvent> _mapSubagentEnded(DeepSeekSubagentEndedDto notification) {
+    final state = subagentMapper.mapState(
+      stopReason: notification.stopReason,
+      summary: notification.summary,
+    );
+    return mapChildFinished(
+      childSessionId: notification.childSessionId,
+      status: state.status,
+      output: state.output,
+      error: state.error,
+    );
   }
 
   List<BridgeSseEvent> _mapWarning(DeepSeekWarningStatusDto status) {

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_event_mapper.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_event_mapper.dart
@@ -5,6 +5,7 @@ import "api/deepseek_acp_api.dart";
 import "api/models/deepseek_protocol_dto.dart";
 import "deepseek_message_time_parser.dart";
 import "repositories/mappers/deepseek_subagent_mapper.dart";
+import "repositories/trackers/deepseek_delegation_tracker.dart";
 
 class DeepSeekEventMapper({
   required super.launchDirectory,
@@ -14,6 +15,7 @@ class DeepSeekEventMapper({
   required final DeepSeekAcpApi api,
   required final DeepSeekMessageTimeParser messageTimeParser,
   required final DeepSeekSubagentMapper subagentMapper,
+  required final DeepSeekDelegationTracker delegationTracker,
 }) extends AcpEventMapper {
   @override
   PluginMessageTime? messageTimeForNotification({required AcpNotification notification}) =>
@@ -25,25 +27,23 @@ class DeepSeekEventMapper({
 
   var _extensionProtocolVersion = 1;
   final Map<String, Map<String, _DeferredDeepSeekDelegation>> _deferredDelegations = {};
-  final Map<String, Set<String>> _startedDelegationToolCalls = {};
 
   void setExtensionProtocolVersion({required int extensionProtocolVersion}) {
     _extensionProtocolVersion = extensionProtocolVersion;
     _deferredDelegations.clear();
-    _startedDelegationToolCalls.clear();
+    delegationTracker.clear();
   }
 
   @override
   void beginTurn({required String sessionId, required String? messageId}) {
     _deferredDelegations.remove(sessionId);
-    _startedDelegationToolCalls.remove(sessionId);
     super.beginTurn(sessionId: sessionId, messageId: messageId);
   }
 
   @override
   void forgetSession(String sessionId) {
     _deferredDelegations.remove(sessionId);
-    _startedDelegationToolCalls.remove(sessionId);
+    delegationTracker.forgetSession(sessionId: sessionId);
     super.forgetSession(sessionId);
   }
 
@@ -53,9 +53,8 @@ class DeepSeekEventMapper({
       for (final entry in _deferredDelegations.entries) {
         if (entry.value.containsKey(toolCallId)) return entry.key;
       }
-      for (final entry in _startedDelegationToolCalls.entries) {
-        if (entry.value.contains(toolCallId)) return entry.key;
-      }
+      final startedSessionId = delegationTracker.sessionIdForToolCallId(toolCallId: toolCallId);
+      if (startedSessionId != null) return startedSessionId;
     }
     return super.sessionIdForToolCallId(toolCallId: toolCallId);
   }
@@ -77,7 +76,10 @@ class DeepSeekEventMapper({
     }
     final toolCallId = update["toolCallId"];
     if (toolCallId is! String || toolCallId.isEmpty) return super.map(notification);
-    final sessionStartedCalls = _startedDelegationToolCalls[sessionId];
+    final delegationStarted = delegationTracker.isStarted(
+      parentSessionId: sessionId,
+      toolCallId: toolCallId,
+    );
     final title = switch (update["title"]) {
       final String value => value,
       _ => null,
@@ -88,12 +90,25 @@ class DeepSeekEventMapper({
     };
     switch (update["sessionUpdate"]) {
       case "tool_call" when title != null && _isDelegationTitle(title):
-        if (sessionStartedCalls?.contains(toolCallId) ?? false) return const [];
+        if (delegationStarted) {
+          if (status != null && _isTerminalToolStatus(status)) {
+            delegationTracker.markToolTerminal(parentSessionId: sessionId, toolCallId: toolCallId);
+          }
+          return const [];
+        }
         if (status != null && _isTerminalToolStatus(status)) return super.map(notification);
-        (_deferredDelegations[sessionId] ??= {})[toolCallId] = _DeferredDeepSeekDelegation(call: notification);
+        (_deferredDelegations[sessionId] ??= {}).putIfAbsent(
+          toolCallId,
+          () => _DeferredDeepSeekDelegation(call: notification),
+        );
         return const [];
       case "tool_call_update":
-        if (sessionStartedCalls?.contains(toolCallId) ?? false) return const [];
+        if (delegationStarted) {
+          if (status != null && _isTerminalToolStatus(status)) {
+            delegationTracker.markToolTerminal(parentSessionId: sessionId, toolCallId: toolCallId);
+          }
+          return const [];
+        }
         final deferred = _deferredDelegations[sessionId]?[toolCallId];
         if (deferred == null) return super.map(notification);
         if (status != null && _isTerminalToolStatus(status)) {
@@ -103,7 +118,7 @@ class DeepSeekEventMapper({
             terminalUpdate: notification,
           );
         }
-        deferred.latestUpdate = notification;
+        deferred.updates.add(notification);
         return const [];
     }
     return super.map(notification);
@@ -147,7 +162,11 @@ class DeepSeekEventMapper({
 
   List<BridgeSseEvent> _mapSubagentStarted(DeepSeekSubagentStartedDto notification) {
     _removeDeferredDelegation(sessionId: notification.sessionId, toolCallId: notification.toolCallId);
-    (_startedDelegationToolCalls[notification.sessionId] ??= {}).add(notification.toolCallId);
+    delegationTracker.start(
+      parentSessionId: notification.sessionId,
+      toolCallId: notification.toolCallId,
+      childSessionId: notification.childSessionId,
+    );
     final events = mapChildSpawned(
       sessionId: notification.sessionId,
       spawn: subagentMapper.mapStarted(notification: notification),
@@ -176,6 +195,7 @@ class DeepSeekEventMapper({
     if (params["kind"] == "ended") {
       final childSessionId = params["childSessionId"];
       if (childSessionId is String && childSessions.isChild(sessionId: childSessionId)) {
+        delegationTracker.markChildEnded(childSessionId: childSessionId);
         return mapChildFinished(
           childSessionId: childSessionId,
           status: PluginToolStatus.error,
@@ -196,7 +216,7 @@ class DeepSeekEventMapper({
     if (deferred == null) return const [];
     return [
       ...super.map(deferred.call),
-      if (deferred.latestUpdate case final update?) ...super.map(update),
+      for (final update in deferred.updates) ...super.map(update),
       if (terminalUpdate != null) ...super.map(terminalUpdate),
     ];
   }
@@ -213,6 +233,7 @@ class DeepSeekEventMapper({
   static bool _isTerminalToolStatus(String status) => status == "completed" || status == "failed";
 
   List<BridgeSseEvent> _mapSubagentEnded(DeepSeekSubagentEndedDto notification) {
+    delegationTracker.markChildEnded(childSessionId: notification.childSessionId);
     final state = subagentMapper.mapState(
       stopReason: notification.stopReason,
       summary: notification.summary,
@@ -232,5 +253,5 @@ class DeepSeekEventMapper({
 }
 
 final class _DeferredDeepSeekDelegation({required final AcpNotification call}) {
-  AcpNotification? latestUpdate;
+  final List<AcpNotification> updates = [];
 }

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_event_mapper.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_event_mapper.dart
@@ -79,10 +79,11 @@ class DeepSeekEventMapper({
     };
   }
 
-  /// Protocol v2 delays only the two exact delegation calls until either their
-  /// correlated lifecycle start arrives (the child tile replaces the call) or
-  /// a standard terminal update proves startup failed (the generic error card
-  /// remains visible). This avoids both duplicate cards and invisible failures.
+  /// Protocol v2 delays exact delegation calls and identifiable reordered
+  /// updates until either their correlated lifecycle start arrives (the child
+  /// tile replaces them) or a standard terminal frame proves startup failed
+  /// (one generic error card remains visible). This avoids both duplicate cards
+  /// and invisible failures.
   @override
   List<BridgeSseEvent> map(AcpNotification notification) {
     if (_extensionProtocolVersion != DeepSeekAcpApi.extensionProtocolVersion ||
@@ -116,11 +117,15 @@ class DeepSeekEventMapper({
           }
           return const [];
         }
-        if (status != null && _isTerminalToolStatus(status)) return super.map(notification);
-        (_deferredDelegations[sessionId] ??= {}).putIfAbsent(
-          toolCallId,
-          () => _DeferredDeepSeekDelegation(call: notification),
-        );
+        (_deferredDelegations[sessionId] ??= {})
+            .putIfAbsent(
+              toolCallId,
+              _DeferredDeepSeekDelegation.new,
+            )
+            .merge(notification: notification, update: update);
+        if (status != null && _isTerminalToolStatus(status)) {
+          return _flushDeferredDelegation(sessionId: sessionId, toolCallId: toolCallId);
+        }
         return const [];
       case "tool_call_update":
         if (delegationStarted) {
@@ -129,9 +134,17 @@ class DeepSeekEventMapper({
           }
           return const [];
         }
-        final deferred = _deferredDelegations[sessionId]?[toolCallId];
-        if (deferred == null) return super.map(notification);
-        deferred.merge(notification: notification, update: update);
+        final byToolCall = _deferredDelegations[sessionId];
+        final deferred = byToolCall?[toolCallId];
+        if (deferred == null && (title == null || !_isDelegationTitle(title))) {
+          return super.map(notification);
+        }
+        (_deferredDelegations[sessionId] ??= {})
+            .putIfAbsent(
+              toolCallId,
+              _DeferredDeepSeekDelegation.new,
+            )
+            .merge(notification: notification, update: update);
         if (status != null && _isTerminalToolStatus(status)) {
           return _flushDeferredDelegation(sessionId: sessionId, toolCallId: toolCallId);
         }
@@ -139,6 +152,11 @@ class DeepSeekEventMapper({
     }
     return super.map(notification);
   }
+
+  @override
+  bool shouldBufferDuringPromptWrite({required AcpNotification notification}) =>
+      notification.method == DeepSeekAcpApi.subagentMethod ||
+      super.shouldBufferDuringPromptWrite(notification: notification);
 
   @override
   List<BridgeSseEvent> mapExtension(AcpNotification notification) {
@@ -165,6 +183,10 @@ class DeepSeekEventMapper({
   List<BridgeSseEvent> _mapSubagent(AcpNotification notification) {
     try {
       final subagent = api.parseSubagentNotification(notification.params);
+      if (childSessions.isDeleted(sessionId: subagent.sessionId) ||
+          childSessions.isDeleted(sessionId: subagent.childSessionId)) {
+        return const [];
+      }
       return switch (subagent) {
         DeepSeekSubagentStartedDto() => _mapSubagentStarted(subagent),
         DeepSeekSubagentEndedDto() => _mapSubagentEnded(subagent),
@@ -178,14 +200,15 @@ class DeepSeekEventMapper({
 
   List<BridgeSseEvent> _mapSubagentStarted(DeepSeekSubagentStartedDto notification) {
     _removeDeferredDelegation(sessionId: notification.sessionId, toolCallId: notification.toolCallId);
+    final events = mapChildSpawned(
+      sessionId: notification.sessionId,
+      spawn: subagentMapper.mapStarted(notification: notification),
+    );
+    if (!childSessions.isChild(sessionId: notification.childSessionId)) return events;
     delegationTracker.start(
       parentSessionId: notification.sessionId,
       toolCallId: notification.toolCallId,
       childSessionId: notification.childSessionId,
-    );
-    final events = mapChildSpawned(
-      sessionId: notification.sessionId,
-      spawn: subagentMapper.mapStarted(notification: notification),
     );
     setChildModel(
       childSessionId: notification.childSessionId,
@@ -196,8 +219,13 @@ class DeepSeekEventMapper({
 
   List<BridgeSseEvent> _recoverMalformedSubagent({required AcpNotification notification}) {
     final params = notification.params;
+    final sessionId = params["sessionId"];
+    final childSessionId = params["childSessionId"];
+    if (sessionId is String && childSessions.isDeleted(sessionId: sessionId) ||
+        childSessionId is String && childSessions.isDeleted(sessionId: childSessionId)) {
+      return const [];
+    }
     if (params["kind"] == "started") {
-      final sessionId = params["sessionId"];
       final toolCallId = params["toolCallId"];
       if (sessionId is String && toolCallId is String) {
         return _flushDeferredDelegation(sessionId: sessionId, toolCallId: toolCallId);
@@ -205,7 +233,6 @@ class DeepSeekEventMapper({
       return const [];
     }
     if (params["kind"] == "ended") {
-      final childSessionId = params["childSessionId"];
       if (childSessionId is String && childSessions.isChild(sessionId: childSessionId)) {
         delegationTracker.markChildEnded(childSessionId: childSessionId);
         return mapChildFinished(
@@ -221,11 +248,8 @@ class DeepSeekEventMapper({
 
   List<BridgeSseEvent> _flushDeferredDelegation({required String sessionId, required String toolCallId}) {
     final deferred = _removeDeferredDelegation(sessionId: sessionId, toolCallId: toolCallId);
-    if (deferred == null) return const [];
-    return [
-      ...super.map(deferred.call),
-      if (deferred.mergedUpdate case final update?) ...super.map(update),
-    ];
+    final snapshot = deferred?.snapshot;
+    return snapshot == null ? const [] : super.map(snapshot);
   }
 
   _DeferredDeepSeekDelegation? _removeDeferredDelegation({required String sessionId, required String toolCallId}) {
@@ -259,7 +283,7 @@ class DeepSeekEventMapper({
   }
 }
 
-final class _DeferredDeepSeekDelegation({required final AcpNotification call}) {
+final class _DeferredDeepSeekDelegation() {
   static const _retainedUpdateKeys = {
     "sessionUpdate",
     "toolCallId",
@@ -291,7 +315,7 @@ final class _DeferredDeepSeekDelegation({required final AcpNotification call}) {
     _latestParams = notification.params;
   }
 
-  AcpNotification? get mergedUpdate {
+  AcpNotification? get snapshot {
     final params = _latestParams;
     if (params == null) return null;
     // ignore: no_slop_linter/prefer_specific_type, standard ACP update values are heterogeneous

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
@@ -152,18 +152,11 @@ class DeepSeekPlugin({
   }
 
   @override
-  Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId) async {
-    final client = await requireConnectedClient();
-    final persistedSessions = await listAllSessions(knownDirectories: const {});
-    return await historyRepository.getMessages(
-      client: client,
-      sessionId: sessionId,
-      rootSessionId: deepSeekSessionService.rootSessionIdFor(
+  Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId) async =>
+      await historyRepository.getMessages(
+        client: await requireConnectedClient(),
         sessionId: sessionId,
-        persistedSessions: persistedSessions,
-      ),
-    );
-  }
+      );
 
   @override
   Future<PluginSession> renameSession({required String sessionId, required String title}) async =>

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
@@ -11,7 +11,7 @@ import "services/deepseek_session_service.dart";
 class DeepSeekPlugin({
   required super.launchSpec,
   required super.launchDirectory,
-  required DeepSeekEventMapper mapper,
+  required final DeepSeekEventMapper mapper,
   required super.childSessionTracker,
   required final DeepSeekAcpApi api,
   required final DeepSeekHistoryRepository historyRepository,
@@ -38,10 +38,21 @@ class DeepSeekPlugin({
 
   @override
   void validateInitializeResult(AcpInitializeResult result) {
+    _extensionProtocolVersion(result: result);
+  }
+
+  @override
+  void captureLiveInitializeResult(AcpInitializeResult result) {
+    mapper.setExtensionProtocolVersion(extensionProtocolVersion: _extensionProtocolVersion(result: result));
+  }
+
+  int _extensionProtocolVersion({required AcpInitializeResult result}) {
     final metadata = result.raw["_meta"];
     final deepSeekMetadata = metadata is Map ? metadata[DeepSeekAcpApi.initializeMetadataKey] : null;
+    // ignore: no_slop_linter/prefer_specific_type, ACP metadata values are heterogeneous
     if (deepSeekMetadata is! Map) throw const FormatException("DeepSeek initialize metadata is missing");
-    api.parseInitializeMetadata(deepSeekMetadata.cast<String, dynamic>());
+    // ignore: no_slop_linter/prefer_specific_type, ACP metadata values are heterogeneous
+    return api.parseInitializeMetadata(deepSeekMetadata.cast<String, dynamic>()).extensionProtocolVersion;
   }
 
   @override
@@ -131,10 +142,11 @@ class DeepSeekPlugin({
   };
 
   @override
-  Future<List<PluginSession>> getChildSessions(String sessionId) async => [
-    for (final session in await listAllSessions(knownDirectories: const {}))
-      if (session.parentID == sessionId) session,
-  ];
+  Future<List<PluginSession>> getChildSessions(String sessionId) async => deepSeekSessionService.getChildSessions(
+    sessionId: sessionId,
+    directory: directoryForSession(sessionId: sessionId),
+    persistedSessions: await listAllSessions(knownDirectories: const {}),
+  );
 
   @override
   Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId) async {

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
@@ -154,7 +154,15 @@ class DeepSeekPlugin({
   @override
   Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId) async {
     final client = await requireConnectedClient();
-    return await historyRepository.getMessages(client: client, sessionId: sessionId);
+    final persistedSessions = await listAllSessions(knownDirectories: const {});
+    return await historyRepository.getMessages(
+      client: client,
+      sessionId: sessionId,
+      rootSessionId: deepSeekSessionService.rootSessionIdFor(
+        sessionId: sessionId,
+        persistedSessions: persistedSessions,
+      ),
+    );
   }
 
   @override

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
@@ -146,7 +146,9 @@ class DeepSeekPlugin({
     final persistedSessions = await listAllSessions(knownDirectories: const {});
     return deepSeekSessionService.getChildSessions(
       sessionId: sessionId,
-      directory: directoryForSession(sessionId: sessionId),
+      directory: mapper.projectForSession(
+        sessionId: childSessionTracker.rootOf(sessionId: sessionId),
+      ),
       persistedSessions: persistedSessions,
     );
   }

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
@@ -142,11 +142,14 @@ class DeepSeekPlugin({
   };
 
   @override
-  Future<List<PluginSession>> getChildSessions(String sessionId) async => deepSeekSessionService.getChildSessions(
-    sessionId: sessionId,
-    directory: directoryForSession(sessionId: sessionId),
-    persistedSessions: await listAllSessions(knownDirectories: const {}),
-  );
+  Future<List<PluginSession>> getChildSessions(String sessionId) async {
+    final persistedSessions = await listAllSessions(knownDirectories: const {});
+    return deepSeekSessionService.getChildSessions(
+      sessionId: sessionId,
+      directory: directoryForSession(sessionId: sessionId),
+      persistedSessions: persistedSessions,
+    );
+  }
 
   @override
   Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId) async {

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_history_repository.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_history_repository.dart
@@ -51,17 +51,19 @@ class DeepSeekHistoryRepository({
             for (final updates in pages.reversed) {
               for (final envelope in updates) {
                 final toolCallId = envelope.update["toolCallId"];
-                final subagent = envelope.metadata?.deepSeek?.subagent;
+                final subagent = api.parseHistoryMetadata(envelope: envelope)?.subagent;
                 if (toolCallId is String && toolCallId.isNotEmpty && subagent != null) {
                   subagentsByToolCallId[toolCallId] = subagent;
                 }
                 collector.consume(envelope.toJson());
               }
             }
-            return collector.buildWithAssistantSelection(
-              modelId: eventMapper.modelForSession(sessionId: sessionId),
-              providerId: eventMapper.providerForSession(sessionId: sessionId),
-              variant: null,
+            return subagentMapper.alignReplayChildIdentities(
+              messages: collector.buildWithAssistantSelection(
+                modelId: eventMapper.modelForSession(sessionId: sessionId),
+                providerId: eventMapper.providerForSession(sessionId: sessionId),
+                variant: null,
+              ),
             );
           case DeepSeekPaginatedHistoryResponseDto(:final nextBeforeSeq):
             if (cursor != null && nextBeforeSeq >= cursor) {

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_history_repository.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_history_repository.dart
@@ -20,7 +20,6 @@ class DeepSeekHistoryRepository({
   Future<List<PluginMessageWithParts>> getMessages({
     required AcpStdioClient client,
     required String sessionId,
-    required String rootSessionId,
   }) async {
     final subagentsByToolCallId = <String, DeepSeekSubagentReplayDto>{};
     final collector = AcpReplayCollector(
@@ -37,7 +36,6 @@ class DeepSeekHistoryRepository({
             : subagentMapper.mapReplay(
                 toolPart: toolPart,
                 replay: replay,
-                rootSessionId: rootSessionId,
               );
       },
     );

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_history_repository.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_history_repository.dart
@@ -5,12 +5,14 @@ import "../api/deepseek_acp_api.dart";
 import "../api/models/deepseek_protocol_dto.dart";
 import "../deepseek_event_mapper.dart";
 import "../deepseek_message_time_parser.dart";
+import "mappers/deepseek_subagent_mapper.dart";
 
 class DeepSeekHistoryRepository({
   required final DeepSeekAcpApi api,
   required final DeepSeekEventMapper eventMapper,
   required final String pluginId,
   required final DeepSeekMessageTimeParser messageTimeParser,
+  required final DeepSeekSubagentMapper subagentMapper,
 }) {
   static const int _maxPages = 100;
   static const int _pageSize = 100;
@@ -19,6 +21,7 @@ class DeepSeekHistoryRepository({
     required AcpStdioClient client,
     required String sessionId,
   }) async {
+    final subagentsByToolCallId = <String, DeepSeekSubagentReplayDto>{};
     final collector = AcpReplayCollector(
       sessionId: sessionId,
       agentId: pluginId,
@@ -26,6 +29,10 @@ class DeepSeekHistoryRepository({
       messageIdOverride: ({required acpMessageId}) => acpMessageId,
       messageTimeResolver: ({required params}) => messageTimeParser.parse(params),
       haltClassifier: eventMapper.classifyHaltNotice,
+      toolPartReplacement: ({required toolCallId, required toolPart}) {
+        final replay = subagentsByToolCallId[toolCallId];
+        return replay == null ? null : subagentMapper.mapReplay(toolPart: toolPart, replay: replay);
+      },
     );
     int? cursor;
     final pages = <List<DeepSeekSessionUpdateEnvelopeDto>>[];
@@ -43,6 +50,11 @@ class DeepSeekHistoryRepository({
           case DeepSeekTerminalHistoryResponseDto():
             for (final updates in pages.reversed) {
               for (final envelope in updates) {
+                final toolCallId = envelope.update["toolCallId"];
+                final subagent = envelope.metadata?.deepSeek?.subagent;
+                if (toolCallId is String && toolCallId.isNotEmpty && subagent != null) {
+                  subagentsByToolCallId[toolCallId] = subagent;
+                }
                 collector.consume(envelope.toJson());
               }
             }

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_history_repository.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_history_repository.dart
@@ -20,6 +20,7 @@ class DeepSeekHistoryRepository({
   Future<List<PluginMessageWithParts>> getMessages({
     required AcpStdioClient client,
     required String sessionId,
+    required String rootSessionId,
   }) async {
     final subagentsByToolCallId = <String, DeepSeekSubagentReplayDto>{};
     final collector = AcpReplayCollector(
@@ -31,7 +32,13 @@ class DeepSeekHistoryRepository({
       haltClassifier: eventMapper.classifyHaltNotice,
       toolPartReplacement: ({required toolCallId, required toolPart}) {
         final replay = subagentsByToolCallId[toolCallId];
-        return replay == null ? null : subagentMapper.mapReplay(toolPart: toolPart, replay: replay);
+        return replay == null
+            ? null
+            : subagentMapper.mapReplay(
+                toolPart: toolPart,
+                replay: replay,
+                rootSessionId: rootSessionId,
+              );
       },
     );
     int? cursor;
@@ -51,7 +58,7 @@ class DeepSeekHistoryRepository({
             for (final updates in pages.reversed) {
               for (final envelope in updates) {
                 final toolCallId = envelope.update["toolCallId"];
-                final subagent = api.parseHistoryMetadata(envelope: envelope)?.subagent;
+                final subagent = envelope.metadata?.deepSeek?.subagent;
                 if (toolCallId is String && toolCallId.isNotEmpty && subagent != null) {
                   subagentsByToolCallId[toolCallId] = subagent;
                 }

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/mappers/deepseek_subagent_mapper.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/mappers/deepseek_subagent_mapper.dart
@@ -59,12 +59,13 @@ class const DeepSeekSubagentMapper({required final String agentId}) {
   PluginMessagePart mapReplay({
     required PluginMessagePartTool toolPart,
     required DeepSeekSubagentReplayDto replay,
+    required String rootSessionId,
   }) {
     final childSessionId = replay.childSessionId;
-    final messageId = childSessionId == null ? toolPart.messageID : "${toolPart.sessionID}-subagent-$childSessionId";
+    final messageId = childSessionId == null ? toolPart.messageID : "$rootSessionId-subagent-$childSessionId";
     return PluginMessagePart.subtask(
       id: childSessionId == null ? toolPart.id : "$messageId-subtask",
-      sessionID: toolPart.sessionID,
+      sessionID: childSessionId == null ? toolPart.sessionID : rootSessionId,
       messageID: messageId,
       prompt: replay.prompt,
       description: replay.label,
@@ -97,7 +98,7 @@ class const DeepSeekSubagentMapper({required final String agentId}) {
       for (final part in childParts) {
         aligned.add(
           PluginMessageWithParts(
-            info: message.info.copyWith(id: part.messageID),
+            info: message.info.copyWith(id: part.messageID, sessionID: part.sessionID),
             parts: [part],
           ),
         );

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/mappers/deepseek_subagent_mapper.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/mappers/deepseek_subagent_mapper.dart
@@ -1,0 +1,85 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../../api/models/deepseek_protocol_dto.dart";
+
+/// Pure projection of DeepSeek's sub-agent protocol into shared child and tile
+/// vocabulary. Live and replay paths share the same terminal-state policy.
+class const DeepSeekSubagentMapper({required final String agentId}) {
+  AcpChildSpawn mapStarted({required DeepSeekSubagentStartedDto notification}) => AcpChildSpawn(
+    childSessionId: notification.childSessionId,
+    description: notification.label,
+    agent: agentId,
+    prompt: notification.prompt,
+    isBackground: notification.mode == DeepSeekSubagentMode.background,
+  );
+
+  PluginToolState mapState({
+    required DeepSeekSubagentStopReason? stopReason,
+    required String? summary,
+  }) {
+    if (stopReason == null) {
+      return const PluginToolState(
+        status: PluginToolStatus.running,
+        title: null,
+        output: null,
+        error: null,
+        attachments: [],
+      );
+    }
+    return switch (stopReason) {
+      DeepSeekSubagentStopReason.completed => PluginToolState(
+        status: PluginToolStatus.completed,
+        title: null,
+        output: summary,
+        error: null,
+        attachments: const [],
+      ),
+      DeepSeekSubagentStopReason.aborted => const PluginToolState(
+        status: PluginToolStatus.cancelled,
+        title: null,
+        output: null,
+        error: null,
+        attachments: [],
+      ),
+      DeepSeekSubagentStopReason.error ||
+      DeepSeekSubagentStopReason.maxTokens ||
+      DeepSeekSubagentStopReason.refusal => PluginToolState(
+        status: PluginToolStatus.error,
+        title: null,
+        output: null,
+        error: summary ?? _errorFor(stopReason: stopReason),
+        attachments: const [],
+      ),
+      DeepSeekSubagentStopReason.unknown => throw const FormatException("Unknown DeepSeek sub-agent stop reason"),
+    };
+  }
+
+  PluginMessagePart mapReplay({
+    required PluginMessagePartTool toolPart,
+    required DeepSeekSubagentReplayDto replay,
+  }) => PluginMessagePart.subtask(
+    // Retain the generic ACP tool identity so replay replacement is an upsert,
+    // never a second card for the same delegation call.
+    id: toolPart.id,
+    sessionID: toolPart.sessionID,
+    messageID: toolPart.messageID,
+    prompt: replay.prompt,
+    description: replay.label,
+    agent: agentId,
+    taskState: mapState(
+      stopReason: replay.ended?.stopReason,
+      summary: replay.ended?.summary,
+    ),
+    childSessionID: replay.childSessionId,
+  );
+
+  String _errorFor({required DeepSeekSubagentStopReason stopReason}) => switch (stopReason) {
+    DeepSeekSubagentStopReason.error => "DeepSeek sub-agent failed",
+    DeepSeekSubagentStopReason.maxTokens => "DeepSeek sub-agent reached its token limit",
+    DeepSeekSubagentStopReason.refusal => "DeepSeek sub-agent declined the task",
+    DeepSeekSubagentStopReason.completed ||
+    DeepSeekSubagentStopReason.aborted ||
+    DeepSeekSubagentStopReason.unknown => throw StateError("DeepSeek sub-agent stop reason is not an error"),
+  };
+}

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/mappers/deepseek_subagent_mapper.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/mappers/deepseek_subagent_mapper.dart
@@ -84,27 +84,51 @@ class const DeepSeekSubagentMapper({required final String agentId}) {
   List<PluginMessageWithParts> alignReplayChildIdentities({required List<PluginMessageWithParts> messages}) {
     final aligned = <PluginMessageWithParts>[];
     for (final message in messages) {
-      final originalParts = <PluginMessagePart>[];
-      final childParts = <PluginMessagePart>[];
+      var runParts = <PluginMessagePart>[];
+      var runMessageId = message.info.id;
+      var runSessionId = message.info.sessionID;
       for (final part in message.parts) {
-        (part is PluginMessagePartSubtask && part.messageID != message.info.id ? childParts : originalParts).add(
-          part,
-        );
+        final isChildEnvelope = part is PluginMessagePartSubtask && part.messageID != message.info.id;
+        final partMessageId = isChildEnvelope ? part.messageID : message.info.id;
+        final partSessionId = isChildEnvelope ? part.sessionID : message.info.sessionID;
+        if (runParts.isNotEmpty && (partMessageId != runMessageId || partSessionId != runSessionId)) {
+          aligned.add(
+            _alignedReplayRun(
+              message: message,
+              messageId: runMessageId,
+              sessionId: runSessionId,
+              parts: runParts,
+            ),
+          );
+          runParts = [];
+        }
+        runMessageId = partMessageId;
+        runSessionId = partSessionId;
+        runParts.add(part);
       }
-      if (originalParts.isNotEmpty) {
-        aligned.add(PluginMessageWithParts(info: message.info, parts: originalParts));
-      }
-      for (final part in childParts) {
+      if (runParts.isNotEmpty) {
         aligned.add(
-          PluginMessageWithParts(
-            info: message.info.copyWith(id: part.messageID, sessionID: part.sessionID),
-            parts: [part],
+          _alignedReplayRun(
+            message: message,
+            messageId: runMessageId,
+            sessionId: runSessionId,
+            parts: runParts,
           ),
         );
       }
     }
     return aligned;
   }
+
+  PluginMessageWithParts _alignedReplayRun({
+    required PluginMessageWithParts message,
+    required String messageId,
+    required String sessionId,
+    required List<PluginMessagePart> parts,
+  }) => PluginMessageWithParts(
+    info: message.info.copyWith(id: messageId, sessionID: sessionId),
+    parts: parts,
+  );
 
   String? _bounded(String? value) =>
       value == null || value.isEmpty ? null : String.fromCharCodes(value.runes.take(maxToolOutputLength));

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/mappers/deepseek_subagent_mapper.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/mappers/deepseek_subagent_mapper.dart
@@ -78,26 +78,30 @@ class const DeepSeekSubagentMapper({required final String agentId}) {
   }
 
   /// Separates a child-linked replay replacement from the generic ACP message
-  /// envelope that originally owned its tool call. The resulting message and
-  /// part identities are exactly those used by the live child tracker, so a
-  /// later terminal lifecycle event updates the imported running tile.
+  /// envelope that originally owned its tool call. Child identities exactly
+  /// match the live tracker; the first parent run keeps its source identity and
+  /// later runs receive deterministic message and part identities for storage.
   List<PluginMessageWithParts> alignReplayChildIdentities({required List<PluginMessageWithParts> messages}) {
     final aligned = <PluginMessageWithParts>[];
     for (final message in messages) {
       var runParts = <PluginMessagePart>[];
       var runMessageId = message.info.id;
       var runSessionId = message.info.sessionID;
+      var parentRunOrdinal = 0;
       for (final part in message.parts) {
         final isChildEnvelope = part is PluginMessagePartSubtask && part.messageID != message.info.id;
         final partMessageId = isChildEnvelope ? part.messageID : message.info.id;
         final partSessionId = isChildEnvelope ? part.sessionID : message.info.sessionID;
         if (runParts.isNotEmpty && (partMessageId != runMessageId || partSessionId != runSessionId)) {
+          final isParentRun = runMessageId == message.info.id && runSessionId == message.info.sessionID;
+          if (isParentRun) parentRunOrdinal++;
           aligned.add(
             _alignedReplayRun(
               message: message,
               messageId: runMessageId,
               sessionId: runSessionId,
               parts: runParts,
+              parentRunOrdinal: isParentRun ? parentRunOrdinal : null,
             ),
           );
           runParts = [];
@@ -107,12 +111,15 @@ class const DeepSeekSubagentMapper({required final String agentId}) {
         runParts.add(part);
       }
       if (runParts.isNotEmpty) {
+        final isParentRun = runMessageId == message.info.id && runSessionId == message.info.sessionID;
+        if (isParentRun) parentRunOrdinal++;
         aligned.add(
           _alignedReplayRun(
             message: message,
             messageId: runMessageId,
             sessionId: runSessionId,
             parts: runParts,
+            parentRunOrdinal: isParentRun ? parentRunOrdinal : null,
           ),
         );
       }
@@ -125,10 +132,27 @@ class const DeepSeekSubagentMapper({required final String agentId}) {
     required String messageId,
     required String sessionId,
     required List<PluginMessagePart> parts,
-  }) => PluginMessageWithParts(
-    info: message.info.copyWith(id: messageId, sessionID: sessionId),
-    parts: parts,
-  );
+    required int? parentRunOrdinal,
+  }) {
+    final identitySuffix = switch (parentRunOrdinal) {
+      null || 1 => null,
+      final ordinal => "-deepseek-replay-run-$ordinal",
+    };
+    final alignedMessageId = identitySuffix == null ? messageId : "$messageId$identitySuffix";
+    return PluginMessageWithParts(
+      info: message.info.copyWith(id: alignedMessageId, sessionID: sessionId),
+      parts: [
+        for (final part in parts)
+          identitySuffix == null
+              ? part
+              : part.copyWith(
+                  id: "${part.id}$identitySuffix",
+                  sessionID: sessionId,
+                  messageID: alignedMessageId,
+                ),
+      ],
+    );
+  }
 
   String? _bounded(String? value) =>
       value == null || value.isEmpty ? null : String.fromCharCodes(value.runes.take(maxToolOutputLength));

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/mappers/deepseek_subagent_mapper.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/mappers/deepseek_subagent_mapper.dart
@@ -59,13 +59,12 @@ class const DeepSeekSubagentMapper({required final String agentId}) {
   PluginMessagePart mapReplay({
     required PluginMessagePartTool toolPart,
     required DeepSeekSubagentReplayDto replay,
-    required String rootSessionId,
   }) {
     final childSessionId = replay.childSessionId;
-    final messageId = childSessionId == null ? toolPart.messageID : "$rootSessionId-subagent-$childSessionId";
+    final messageId = childSessionId == null ? toolPart.messageID : "${toolPart.sessionID}-subagent-$childSessionId";
     return PluginMessagePart.subtask(
       id: childSessionId == null ? toolPart.id : "$messageId-subtask",
-      sessionID: childSessionId == null ? toolPart.sessionID : rootSessionId,
+      sessionID: toolPart.sessionID,
       messageID: messageId,
       prompt: replay.prompt,
       description: replay.label,

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/mappers/deepseek_subagent_mapper.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/mappers/deepseek_subagent_mapper.dart
@@ -18,6 +18,7 @@ class const DeepSeekSubagentMapper({required final String agentId}) {
     required DeepSeekSubagentStopReason? stopReason,
     required String? summary,
   }) {
+    final boundedSummary = _bounded(summary);
     if (stopReason == null) {
       return const PluginToolState(
         status: PluginToolStatus.running,
@@ -31,7 +32,7 @@ class const DeepSeekSubagentMapper({required final String agentId}) {
       DeepSeekSubagentStopReason.completed => PluginToolState(
         status: PluginToolStatus.completed,
         title: null,
-        output: summary,
+        output: boundedSummary,
         error: null,
         attachments: const [],
       ),
@@ -48,7 +49,7 @@ class const DeepSeekSubagentMapper({required final String agentId}) {
         status: PluginToolStatus.error,
         title: null,
         output: null,
-        error: summary ?? _errorFor(stopReason: stopReason),
+        error: boundedSummary ?? _errorFor(stopReason: stopReason),
         attachments: const [],
       ),
       DeepSeekSubagentStopReason.unknown => throw const FormatException("Unknown DeepSeek sub-agent stop reason"),
@@ -58,21 +59,55 @@ class const DeepSeekSubagentMapper({required final String agentId}) {
   PluginMessagePart mapReplay({
     required PluginMessagePartTool toolPart,
     required DeepSeekSubagentReplayDto replay,
-  }) => PluginMessagePart.subtask(
-    // Retain the generic ACP tool identity so replay replacement is an upsert,
-    // never a second card for the same delegation call.
-    id: toolPart.id,
-    sessionID: toolPart.sessionID,
-    messageID: toolPart.messageID,
-    prompt: replay.prompt,
-    description: replay.label,
-    agent: agentId,
-    taskState: mapState(
-      stopReason: replay.ended?.stopReason,
-      summary: replay.ended?.summary,
-    ),
-    childSessionID: replay.childSessionId,
-  );
+  }) {
+    final childSessionId = replay.childSessionId;
+    final messageId = childSessionId == null ? toolPart.messageID : "${toolPart.sessionID}-subagent-$childSessionId";
+    return PluginMessagePart.subtask(
+      id: childSessionId == null ? toolPart.id : "$messageId-subtask",
+      sessionID: toolPart.sessionID,
+      messageID: messageId,
+      prompt: replay.prompt,
+      description: replay.label,
+      agent: agentId,
+      taskState: mapState(
+        stopReason: replay.ended?.stopReason,
+        summary: replay.ended?.summary,
+      ),
+      childSessionID: childSessionId,
+    );
+  }
+
+  /// Separates a child-linked replay replacement from the generic ACP message
+  /// envelope that originally owned its tool call. The resulting message and
+  /// part identities are exactly those used by the live child tracker, so a
+  /// later terminal lifecycle event updates the imported running tile.
+  List<PluginMessageWithParts> alignReplayChildIdentities({required List<PluginMessageWithParts> messages}) {
+    final aligned = <PluginMessageWithParts>[];
+    for (final message in messages) {
+      final originalParts = <PluginMessagePart>[];
+      final childParts = <PluginMessagePart>[];
+      for (final part in message.parts) {
+        (part is PluginMessagePartSubtask && part.messageID != message.info.id ? childParts : originalParts).add(
+          part,
+        );
+      }
+      if (originalParts.isNotEmpty) {
+        aligned.add(PluginMessageWithParts(info: message.info, parts: originalParts));
+      }
+      for (final part in childParts) {
+        aligned.add(
+          PluginMessageWithParts(
+            info: message.info.copyWith(id: part.messageID),
+            parts: [part],
+          ),
+        );
+      }
+    }
+    return aligned;
+  }
+
+  String? _bounded(String? value) =>
+      value == null || value.isEmpty ? null : String.fromCharCodes(value.runes.take(maxToolOutputLength));
 
   String _errorFor({required DeepSeekSubagentStopReason stopReason}) => switch (stopReason) {
     DeepSeekSubagentStopReason.error => "DeepSeek sub-agent failed",

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/trackers/deepseek_delegation_tracker.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/trackers/deepseek_delegation_tracker.dart
@@ -1,0 +1,90 @@
+/// Owns the correlation between DeepSeek's standard ACP delegation tool calls
+/// and its extension lifecycle notifications. A correlation survives parent
+/// turn boundaries and is released only after both the child lifecycle and the
+/// standard tool call are terminal, or when its session is forgotten.
+final class DeepSeekDelegationTracker() {
+  final Map<String, Map<String, _Delegation>> _byParent = {};
+  final Map<String, _Delegation> _byChild = {};
+
+  bool isStarted({required String parentSessionId, required String toolCallId}) =>
+      _byParent[parentSessionId]?.containsKey(toolCallId) ?? false;
+
+  String? sessionIdForToolCallId({required String toolCallId}) {
+    for (final entry in _byParent.entries) {
+      if (entry.value.containsKey(toolCallId)) return entry.key;
+    }
+    return null;
+  }
+
+  void start({
+    required String parentSessionId,
+    required String toolCallId,
+    required String childSessionId,
+  }) {
+    final existing = _byParent[parentSessionId]?[toolCallId];
+    if (existing != null && existing.childSessionId == childSessionId) return;
+    if (existing != null) _remove(existing);
+    final priorChildDelegation = _byChild[childSessionId];
+    if (priorChildDelegation != null) _remove(priorChildDelegation);
+    final delegation = _Delegation(
+      parentSessionId: parentSessionId,
+      toolCallId: toolCallId,
+      childSessionId: childSessionId,
+    );
+    (_byParent[parentSessionId] ??= {})[toolCallId] = delegation;
+    _byChild[childSessionId] = delegation;
+  }
+
+  void markToolTerminal({required String parentSessionId, required String toolCallId}) {
+    final delegation = _byParent[parentSessionId]?[toolCallId];
+    if (delegation == null) return;
+    delegation.toolTerminalSeen = true;
+    _removeIfSettled(delegation);
+  }
+
+  void markChildEnded({required String childSessionId}) {
+    final delegation = _byChild[childSessionId];
+    if (delegation == null) return;
+    delegation.childEnded = true;
+    _removeIfSettled(delegation);
+  }
+
+  void forgetSession({required String sessionId}) {
+    final childDelegation = _byChild[sessionId];
+    if (childDelegation != null) _remove(childDelegation);
+    final parentDelegations = _byParent.remove(sessionId);
+    if (parentDelegations == null) return;
+    for (final delegation in parentDelegations.values) {
+      _byChild.remove(delegation.childSessionId);
+    }
+  }
+
+  void clear() {
+    _byParent.clear();
+    _byChild.clear();
+  }
+
+  void _removeIfSettled(_Delegation delegation) {
+    if (delegation.childEnded && delegation.toolTerminalSeen) _remove(delegation);
+  }
+
+  void _remove(_Delegation delegation) {
+    final byToolCall = _byParent[delegation.parentSessionId];
+    if (identical(byToolCall?[delegation.toolCallId], delegation)) {
+      byToolCall?.remove(delegation.toolCallId);
+      if (byToolCall?.isEmpty ?? false) _byParent.remove(delegation.parentSessionId);
+    }
+    if (identical(_byChild[delegation.childSessionId], delegation)) {
+      _byChild.remove(delegation.childSessionId);
+    }
+  }
+}
+
+final class _Delegation({
+  required final String parentSessionId,
+  required final String toolCallId,
+  required final String childSessionId,
+}) {
+  bool childEnded = false;
+  bool toolTerminalSeen = false;
+}

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/trackers/deepseek_delegation_tracker.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/trackers/deepseek_delegation_tracker.dart
@@ -1,3 +1,11 @@
+sealed class const DeepSeekDelegationLookup();
+
+final class const DeepSeekDelegationNotFound() extends DeepSeekDelegationLookup;
+
+final class const DeepSeekDelegationAmbiguous() extends DeepSeekDelegationLookup;
+
+final class const DeepSeekDelegationFound({required final String sessionId}) extends DeepSeekDelegationLookup;
+
 /// Owns the correlation between DeepSeek's standard ACP delegation tool calls
 /// and its extension lifecycle notifications. A correlation survives parent
 /// turn boundaries and is released only after both the child lifecycle and the
@@ -9,11 +17,14 @@ final class DeepSeekDelegationTracker() {
   bool isStarted({required String parentSessionId, required String toolCallId}) =>
       _byParent[parentSessionId]?.containsKey(toolCallId) ?? false;
 
-  String? sessionIdForToolCallId({required String toolCallId}) {
+  DeepSeekDelegationLookup lookupToolCallId({required String toolCallId}) {
+    String? sessionId;
     for (final entry in _byParent.entries) {
-      if (entry.value.containsKey(toolCallId)) return entry.key;
+      if (!entry.value.containsKey(toolCallId)) continue;
+      if (sessionId != null) return const DeepSeekDelegationAmbiguous();
+      sessionId = entry.key;
     }
-    return null;
+    return sessionId == null ? const DeepSeekDelegationNotFound() : DeepSeekDelegationFound(sessionId: sessionId);
   }
 
   void start({

--- a/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_plugin_descriptor.dart
@@ -17,6 +17,7 @@ import "../repositories/deepseek_history_repository.dart";
 import "../repositories/deepseek_session_repository.dart";
 import "../repositories/mappers/deepseek_catalog_mapper.dart";
 import "../repositories/mappers/deepseek_subagent_mapper.dart";
+import "../repositories/trackers/deepseek_delegation_tracker.dart";
 import "../services/deepseek_session_options_service.dart";
 import "../services/deepseek_session_service.dart";
 import "deepseek_runtime_manifest.dart";
@@ -241,6 +242,7 @@ class const DeepSeekPluginDescriptor() extends BridgePluginDescriptor {
     const api = DeepSeekAcpApi(pluginId: DeepSeekIdentity.id);
     const messageTimeParser = DeepSeekMessageTimeParser();
     const subagentMapper = DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id);
+    final delegationTracker = DeepSeekDelegationTracker();
     final mapper = DeepSeekEventMapper(
       launchDirectory: cwd,
       pluginId: DeepSeekIdentity.id,
@@ -249,6 +251,7 @@ class const DeepSeekPluginDescriptor() extends BridgePluginDescriptor {
       api: api,
       messageTimeParser: messageTimeParser,
       subagentMapper: subagentMapper,
+      delegationTracker: delegationTracker,
     );
     const catalogMapper = DeepSeekCatalogMapper();
     const catalogRepository = DeepSeekCatalogRepository(api: api, mapper: catalogMapper);

--- a/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_plugin_descriptor.dart
@@ -16,6 +16,7 @@ import "../repositories/deepseek_catalog_repository.dart";
 import "../repositories/deepseek_history_repository.dart";
 import "../repositories/deepseek_session_repository.dart";
 import "../repositories/mappers/deepseek_catalog_mapper.dart";
+import "../repositories/mappers/deepseek_subagent_mapper.dart";
 import "../services/deepseek_session_options_service.dart";
 import "../services/deepseek_session_service.dart";
 import "deepseek_runtime_manifest.dart";
@@ -239,6 +240,7 @@ class const DeepSeekPluginDescriptor() extends BridgePluginDescriptor {
     final childSessionTracker = AcpChildSessionTracker();
     const api = DeepSeekAcpApi(pluginId: DeepSeekIdentity.id);
     const messageTimeParser = DeepSeekMessageTimeParser();
+    const subagentMapper = DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id);
     final mapper = DeepSeekEventMapper(
       launchDirectory: cwd,
       pluginId: DeepSeekIdentity.id,
@@ -246,6 +248,7 @@ class const DeepSeekPluginDescriptor() extends BridgePluginDescriptor {
       childSessions: childSessionTracker,
       api: api,
       messageTimeParser: messageTimeParser,
+      subagentMapper: subagentMapper,
     );
     const catalogMapper = DeepSeekCatalogMapper();
     const catalogRepository = DeepSeekCatalogRepository(api: api, mapper: catalogMapper);
@@ -271,9 +274,11 @@ class const DeepSeekPluginDescriptor() extends BridgePluginDescriptor {
         eventMapper: mapper,
         pluginId: DeepSeekIdentity.id,
         messageTimeParser: messageTimeParser,
+        subagentMapper: subagentMapper,
       ),
-      deepSeekSessionService: const DeepSeekSessionService(
-        repository: DeepSeekSessionRepository(api: api),
+      deepSeekSessionService: DeepSeekSessionService(
+        repository: const DeepSeekSessionRepository(api: api),
+        childSessions: childSessionTracker,
       ),
       deepSeekSessionOptionsService: deepSeekOptions,
       commandTracker: commandTracker,

--- a/bridge/sesori_plugin_deepseek/lib/src/services/deepseek_session_service.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/services/deepseek_session_service.dart
@@ -3,7 +3,25 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "../repositories/deepseek_session_repository.dart";
 
-class const DeepSeekSessionService({required final DeepSeekSessionRepository repository}) {
+class const DeepSeekSessionService({
+  required final DeepSeekSessionRepository repository,
+  required final AcpChildSessionTracker childSessions,
+}) {
+  List<PluginSession> getChildSessions({
+    required String sessionId,
+    required String directory,
+    required List<PluginSession> persistedSessions,
+  }) {
+    final childrenById = <String, PluginSession>{
+      for (final session in persistedSessions)
+        if (session.parentID == sessionId) session.id: session,
+    };
+    for (final session in childSessions.childSessions(sessionId: sessionId, directory: directory)) {
+      childrenById.putIfAbsent(session.id, () => session);
+    }
+    return childrenById.values.toList(growable: false);
+  }
+
   Future<PluginSession> rename({
     required AcpStdioClient client,
     required String sessionId,

--- a/bridge/sesori_plugin_deepseek/lib/src/services/deepseek_session_service.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/services/deepseek_session_service.dart
@@ -22,6 +22,27 @@ class const DeepSeekSessionService({
     return childrenById.values.toList(growable: false);
   }
 
+  String rootSessionIdFor({
+    required String sessionId,
+    required List<PluginSession> persistedSessions,
+  }) {
+    final liveRootSessionId = childSessions.rootOf(sessionId: sessionId);
+    if (liveRootSessionId != sessionId) return liveRootSessionId;
+    final parentBySessionId = <String, String>{};
+    for (final session in persistedSessions) {
+      final parentId = session.parentID;
+      if (parentId != null) parentBySessionId[session.id] = parentId;
+    }
+    final visited = <String>{sessionId};
+    var currentSessionId = sessionId;
+    while (true) {
+      final parentId = parentBySessionId[currentSessionId];
+      if (parentId == null) return currentSessionId;
+      if (!visited.add(parentId)) return sessionId;
+      currentSessionId = parentId;
+    }
+  }
+
   Future<PluginSession> rename({
     required AcpStdioClient client,
     required String sessionId,

--- a/bridge/sesori_plugin_deepseek/lib/src/services/deepseek_session_service.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/services/deepseek_session_service.dart
@@ -22,27 +22,6 @@ class const DeepSeekSessionService({
     return childrenById.values.toList(growable: false);
   }
 
-  String rootSessionIdFor({
-    required String sessionId,
-    required List<PluginSession> persistedSessions,
-  }) {
-    final liveRootSessionId = childSessions.rootOf(sessionId: sessionId);
-    if (liveRootSessionId != sessionId) return liveRootSessionId;
-    final parentBySessionId = <String, String>{};
-    for (final session in persistedSessions) {
-      final parentId = session.parentID;
-      if (parentId != null) parentBySessionId[session.id] = parentId;
-    }
-    final visited = <String>{sessionId};
-    var currentSessionId = sessionId;
-    while (true) {
-      final parentId = parentBySessionId[currentSessionId];
-      if (parentId == null) return currentSessionId;
-      if (!visited.add(parentId)) return sessionId;
-      currentSessionId = parentId;
-    }
-  }
-
   Future<PluginSession> rename({
     required AcpStdioClient client,
     required String sessionId,

--- a/bridge/sesori_plugin_deepseek/test/deepseek_approval_registry_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_approval_registry_test.dart
@@ -54,6 +54,7 @@ void main() {
       api: api,
       messageTimeParser: const DeepSeekMessageTimeParser(),
       subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
+      delegationTracker: DeepSeekDelegationTracker(),
     );
     final plugin = DeepSeekPlugin(
       launchSpec: const AcpLaunchSpec(command: "deepseek", args: []),

--- a/bridge/sesori_plugin_deepseek/test/deepseek_approval_registry_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_approval_registry_test.dart
@@ -53,6 +53,7 @@ void main() {
       childSessions: childSessionTracker,
       api: api,
       messageTimeParser: const DeepSeekMessageTimeParser(),
+      subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
     );
     final plugin = DeepSeekPlugin(
       launchSpec: const AcpLaunchSpec(command: "deepseek", args: []),
@@ -66,9 +67,11 @@ void main() {
         eventMapper: mapper,
         pluginId: DeepSeekIdentity.id,
         messageTimeParser: const DeepSeekMessageTimeParser(),
+        subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
       ),
-      deepSeekSessionService: const DeepSeekSessionService(
-        repository: DeepSeekSessionRepository(api: api),
+      deepSeekSessionService: DeepSeekSessionService(
+        repository: const DeepSeekSessionRepository(api: api),
+        childSessions: childSessionTracker,
       ),
       deepSeekSessionOptionsService: DeepSeekSessionOptionsService(
         repository: const DeepSeekCatalogRepository(api: api, mapper: DeepSeekCatalogMapper()),

--- a/bridge/sesori_plugin_deepseek/test/deepseek_history_repository_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_history_repository_test.dart
@@ -18,7 +18,7 @@ void main() {
         ],
       ),
     ]);
-    final repository = _repository(api);
+    final repository = _repository(api: api, childSessions: AcpChildSessionTracker());
     final messages = await repository.getMessages(client: _unusedClient(), sessionId: "s1");
 
     expect(api.cursors, [null, 10]);
@@ -36,10 +36,11 @@ void main() {
 
   test("history rejects a non-progressing cursor with preserved cause", () async {
     final repository = _repository(
-      _HistoryApi([
+      api: _HistoryApi([
         const DeepSeekPaginatedHistoryResponseDto(updates: [], nextBeforeSeq: 10),
         const DeepSeekPaginatedHistoryResponseDto(updates: [], nextBeforeSeq: 10),
       ]),
+      childSessions: AcpChildSessionTracker(),
     );
 
     await expectLater(
@@ -51,21 +52,83 @@ void main() {
       ),
     );
   });
+
+  test("history replaces a running delegation tool with one child-linked subtask", () async {
+    final tracker = AcpChildSessionTracker();
+    final repository = _repository(
+      api: _HistoryApi([
+        DeepSeekTerminalHistoryResponseDto(
+          updates: [_subagentUpdate(sessionUpdate: "tool_call", ended: null)],
+        ),
+      ]),
+      childSessions: tracker,
+    );
+
+    final messages = await repository.getMessages(client: _unusedClient(), sessionId: "s1");
+    final tile = messages.single.parts.single as PluginMessagePartSubtask;
+    expect(tile.id, "s1-h0-assistant-tool-call-1");
+    expect(tile.sessionID, "s1");
+    expect(tile.messageID, "s1-h0-assistant");
+    expect(tile.prompt, "Inspect the synthetic module");
+    expect(tile.description, "Research child");
+    expect(tile.childSessionID, "child-1");
+    expect(tile.taskState?.status, PluginToolStatus.running);
+    expect(tracker.childStatuses, isEmpty, reason: "history replay is isolated from live lifecycle state");
+    await tracker.dispose();
+  });
+
+  test("latest replay metadata settles the same delegation tile", () async {
+    final tracker = AcpChildSessionTracker();
+    final repository = _repository(
+      api: _HistoryApi([
+        DeepSeekTerminalHistoryResponseDto(
+          updates: [
+            _subagentUpdate(sessionUpdate: "tool_call", ended: null),
+            _subagentUpdate(
+              sessionUpdate: "tool_call_update",
+              ended: const DeepSeekSubagentReplayEndedDto(
+                stopReason: DeepSeekSubagentStopReason.completed,
+                summary: "Done",
+              ),
+            ),
+          ],
+        ),
+      ]),
+      childSessions: tracker,
+    );
+
+    final messages = await repository.getMessages(client: _unusedClient(), sessionId: "s1");
+    expect(messages.single.parts, hasLength(1));
+    final tile = messages.single.parts.single as PluginMessagePartSubtask;
+    expect(tile.id, "s1-h0-assistant-tool-call-1");
+    expect(tile.taskState?.status, PluginToolStatus.completed);
+    expect(tile.taskState?.output, "Done");
+    expect(tracker.childStatuses, isEmpty);
+    await tracker.dispose();
+  });
 }
 
-DeepSeekHistoryRepository _repository(DeepSeekAcpApi api) => DeepSeekHistoryRepository(
-  api: api,
-  messageTimeParser: const DeepSeekMessageTimeParser(),
-  eventMapper: DeepSeekEventMapper(
-    messageTimeParser: const DeepSeekMessageTimeParser(),
-    launchDirectory: "/project",
-    pluginId: DeepSeekIdentity.id,
-    configurationTracker: AcpSessionConfigurationTracker(),
-    childSessions: AcpChildSessionTracker(),
+DeepSeekHistoryRepository _repository({
+  required DeepSeekAcpApi api,
+  required AcpChildSessionTracker childSessions,
+}) {
+  const subagentMapper = DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id);
+  return DeepSeekHistoryRepository(
     api: api,
-  ),
-  pluginId: DeepSeekIdentity.id,
-);
+    messageTimeParser: const DeepSeekMessageTimeParser(),
+    subagentMapper: subagentMapper,
+    eventMapper: DeepSeekEventMapper(
+      messageTimeParser: const DeepSeekMessageTimeParser(),
+      subagentMapper: subagentMapper,
+      launchDirectory: "/project",
+      pluginId: DeepSeekIdentity.id,
+      configurationTracker: AcpSessionConfigurationTracker(),
+      childSessions: childSessions,
+      api: api,
+    ),
+    pluginId: DeepSeekIdentity.id,
+  );
+}
 
 AcpStdioClient _unusedClient() => AcpStdioClient(
   launchSpec: const AcpLaunchSpec(command: "unused", args: [], cwd: "/", environment: {}),
@@ -82,6 +145,31 @@ DeepSeekSessionUpdateEnvelopeDto _update(String sessionId, String kind, String m
         "content": {"type": "text", "text": text},
       },
     );
+
+DeepSeekSessionUpdateEnvelopeDto _subagentUpdate({
+  required String sessionUpdate,
+  required DeepSeekSubagentReplayEndedDto? ended,
+}) => DeepSeekSessionUpdateEnvelopeDto(
+  metadata: DeepSeekEnvelopeMetadataDto(
+    deepSeek: DeepSeekEnvelopeDeepSeekMetadataDto(
+      messageCreatedAt: 1,
+      subagent: DeepSeekSubagentReplayDto(
+        prompt: "Inspect the synthetic module",
+        label: "Research child",
+        mode: DeepSeekSubagentMode.background,
+        childSessionId: "child-1",
+        ended: ended,
+      ),
+    ),
+  ),
+  sessionId: "s1",
+  update: {
+    "sessionUpdate": sessionUpdate,
+    "toolCallId": "call-1",
+    "title": "subagent",
+    "status": ended == null ? "in_progress" : "completed",
+  },
+);
 
 class _HistoryApi(final List<DeepSeekHistoryResponseDto> responses) extends DeepSeekAcpApi {
   this : super(pluginId: DeepSeekIdentity.id);

--- a/bridge/sesori_plugin_deepseek/test/deepseek_history_repository_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_history_repository_test.dart
@@ -19,7 +19,11 @@ void main() {
       ),
     ]);
     final repository = _repository(api: api, childSessions: AcpChildSessionTracker());
-    final messages = await repository.getMessages(client: _unusedClient(), sessionId: "s1");
+    final messages = await repository.getMessages(
+      client: _unusedClient(),
+      sessionId: "s1",
+      rootSessionId: "s1",
+    );
 
     expect(api.cursors, [null, 10]);
     expect(messages.map((message) => message.info.id), [
@@ -44,7 +48,7 @@ void main() {
     );
 
     await expectLater(
-      repository.getMessages(client: _unusedClient(), sessionId: "s1"),
+      repository.getMessages(client: _unusedClient(), sessionId: "s1", rootSessionId: "s1"),
       throwsA(
         isA<PluginOperationException>()
             .having((error) => error.operation, "operation", DeepSeekAcpApi.historyMethod)
@@ -58,13 +62,24 @@ void main() {
     final repository = _repository(
       api: _HistoryApi([
         DeepSeekTerminalHistoryResponseDto(
-          updates: [_subagentUpdate(sessionUpdate: "tool_call", ended: null)],
+          updates: [
+            _subagentUpdate(
+              sessionId: "s1",
+              childSessionId: "child-1",
+              sessionUpdate: "tool_call",
+              ended: null,
+            ),
+          ],
         ),
       ]),
       childSessions: tracker,
     );
 
-    final messages = await repository.getMessages(client: _unusedClient(), sessionId: "s1");
+    final messages = await repository.getMessages(
+      client: _unusedClient(),
+      sessionId: "s1",
+      rootSessionId: "s1",
+    );
     final tile = messages.single.parts.single as PluginMessagePartSubtask;
     expect(tile.id, "s1-subagent-child-1-subtask");
     expect(tile.sessionID, "s1");
@@ -95,13 +110,24 @@ void main() {
     final repository = _repository(
       api: _HistoryApi([
         DeepSeekTerminalHistoryResponseDto(
-          updates: [_subagentUpdate(sessionUpdate: "tool_call", ended: null)],
+          updates: [
+            _subagentUpdate(
+              sessionId: "s1",
+              childSessionId: "child-1",
+              sessionUpdate: "tool_call",
+              ended: null,
+            ),
+          ],
         ),
       ]),
       childSessions: tracker,
     );
 
-    final messages = await repository.getMessages(client: _unusedClient(), sessionId: "s1");
+    final messages = await repository.getMessages(
+      client: _unusedClient(),
+      sessionId: "s1",
+      rootSessionId: "s1",
+    );
     final replayTile = messages.single.parts.single;
     final liveEnd = tracker.finish(
       childSessionId: "child-1",
@@ -118,14 +144,76 @@ void main() {
     await tracker.dispose();
   });
 
+  test("nested replay uses persisted ancestry when live tracking is empty", () async {
+    final tracker = AcpChildSessionTracker();
+    final api = _HistoryApi([
+      DeepSeekTerminalHistoryResponseDto(
+        updates: [
+          _subagentUpdate(
+            sessionId: "child",
+            childSessionId: "grandchild",
+            sessionUpdate: "tool_call",
+            ended: null,
+          ),
+        ],
+      ),
+    ]);
+    final rootSessionId =
+        DeepSeekSessionService(
+          repository: DeepSeekSessionRepository(api: api),
+          childSessions: tracker,
+        ).rootSessionIdFor(
+          sessionId: "child",
+          persistedSessions: const [
+            PluginSession(
+              id: "root",
+              projectID: "/project",
+              directory: "/project",
+              parentID: null,
+              title: "Root",
+              time: null,
+            ),
+            PluginSession(
+              id: "child",
+              projectID: "/project",
+              directory: "/project",
+              parentID: "root",
+              title: "Child",
+              time: null,
+            ),
+          ],
+        );
+    final repository = _repository(api: api, childSessions: tracker);
+
+    expect(rootSessionId, "root");
+    final messages = await repository.getMessages(
+      client: _unusedClient(),
+      sessionId: "child",
+      rootSessionId: rootSessionId,
+    );
+    final tile = messages.single.parts.single as PluginMessagePartSubtask;
+    expect(messages.single.info.id, "root-subagent-grandchild");
+    expect(messages.single.info.sessionID, "root");
+    expect(tile.id, "root-subagent-grandchild-subtask");
+    expect(tile.sessionID, "root");
+    await tracker.dispose();
+  });
+
   test("latest replay metadata settles the same delegation tile", () async {
     final tracker = AcpChildSessionTracker();
     final repository = _repository(
       api: _HistoryApi([
         DeepSeekTerminalHistoryResponseDto(
           updates: [
-            _subagentUpdate(sessionUpdate: "tool_call", ended: null),
             _subagentUpdate(
+              sessionId: "s1",
+              childSessionId: "child-1",
+              sessionUpdate: "tool_call",
+              ended: null,
+            ),
+            _subagentUpdate(
+              sessionId: "s1",
+              childSessionId: "child-1",
               sessionUpdate: "tool_call_update",
               ended: const DeepSeekSubagentReplayEndedDto(
                 stopReason: DeepSeekSubagentStopReason.completed,
@@ -138,7 +226,11 @@ void main() {
       childSessions: tracker,
     );
 
-    final messages = await repository.getMessages(client: _unusedClient(), sessionId: "s1");
+    final messages = await repository.getMessages(
+      client: _unusedClient(),
+      sessionId: "s1",
+      rootSessionId: "s1",
+    );
     expect(messages.single.parts, hasLength(1));
     final tile = messages.single.parts.single as PluginMessagePartSubtask;
     expect(tile.id, "s1-subagent-child-1-subtask");
@@ -166,6 +258,7 @@ DeepSeekHistoryRepository _repository({
       configurationTracker: AcpSessionConfigurationTracker(),
       childSessions: childSessions,
       api: api,
+      delegationTracker: DeepSeekDelegationTracker(),
     ),
     pluginId: DeepSeekIdentity.id,
   );
@@ -188,22 +281,24 @@ DeepSeekSessionUpdateEnvelopeDto _update(String sessionId, String kind, String m
     );
 
 DeepSeekSessionUpdateEnvelopeDto _subagentUpdate({
+  required String sessionId,
+  required String childSessionId,
   required String sessionUpdate,
   required DeepSeekSubagentReplayEndedDto? ended,
 }) => DeepSeekSessionUpdateEnvelopeDto(
-  metadata: {
+  metadata: DeepSeekEnvelopeMetadataDto.fromJson({
     DeepSeekAcpApi.initializeMetadataKey: DeepSeekEnvelopeDeepSeekMetadataDto(
       messageCreatedAt: 1,
       subagent: DeepSeekSubagentReplayDto(
         prompt: "Inspect the synthetic module",
         label: "Research child",
         mode: DeepSeekSubagentMode.background,
-        childSessionId: "child-1",
+        childSessionId: childSessionId,
         ended: ended,
       ),
     ).toJson(),
-  },
-  sessionId: "s1",
+  }),
+  sessionId: sessionId,
   update: {
     "sessionUpdate": sessionUpdate,
     "toolCallId": "call-1",

--- a/bridge/sesori_plugin_deepseek/test/deepseek_history_repository_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_history_repository_test.dart
@@ -66,14 +66,55 @@ void main() {
 
     final messages = await repository.getMessages(client: _unusedClient(), sessionId: "s1");
     final tile = messages.single.parts.single as PluginMessagePartSubtask;
-    expect(tile.id, "s1-h0-assistant-tool-call-1");
+    expect(tile.id, "s1-subagent-child-1-subtask");
     expect(tile.sessionID, "s1");
-    expect(tile.messageID, "s1-h0-assistant");
+    expect(tile.messageID, "s1-subagent-child-1");
+    expect(messages.single.info.id, tile.messageID);
     expect(tile.prompt, "Inspect the synthetic module");
     expect(tile.description, "Research child");
     expect(tile.childSessionID, "child-1");
     expect(tile.taskState?.status, PluginToolStatus.running);
     expect(tracker.childStatuses, isEmpty, reason: "history replay is isolated from live lifecycle state");
+    await tracker.dispose();
+  });
+
+  test("a running replay and later live end address the same child tile", () async {
+    final tracker = AcpChildSessionTracker();
+    final liveStart = tracker.spawn(
+      sessionId: "s1",
+      spawn: const AcpChildSpawn(
+        childSessionId: "child-1",
+        description: "Research child",
+        agent: DeepSeekIdentity.id,
+        prompt: "Inspect the synthetic module",
+        isBackground: true,
+      ),
+      directory: "/project",
+    );
+    final liveTile = liveStart.events.whereType<BridgeSseMessagePartUpdated>().single.part;
+    final repository = _repository(
+      api: _HistoryApi([
+        DeepSeekTerminalHistoryResponseDto(
+          updates: [_subagentUpdate(sessionUpdate: "tool_call", ended: null)],
+        ),
+      ]),
+      childSessions: tracker,
+    );
+
+    final messages = await repository.getMessages(client: _unusedClient(), sessionId: "s1");
+    final replayTile = messages.single.parts.single;
+    final liveEnd = tracker.finish(
+      childSessionId: "child-1",
+      status: PluginToolStatus.completed,
+      output: "Done",
+      error: null,
+    );
+    final endedTile = liveEnd.whereType<BridgeSseMessagePartUpdated>().single.part;
+
+    expect(replayTile.id, liveTile.id);
+    expect(replayTile.messageID, liveTile.messageID);
+    expect(endedTile.id, replayTile.id);
+    expect(endedTile.messageID, replayTile.messageID);
     await tracker.dispose();
   });
 
@@ -100,7 +141,7 @@ void main() {
     final messages = await repository.getMessages(client: _unusedClient(), sessionId: "s1");
     expect(messages.single.parts, hasLength(1));
     final tile = messages.single.parts.single as PluginMessagePartSubtask;
-    expect(tile.id, "s1-h0-assistant-tool-call-1");
+    expect(tile.id, "s1-subagent-child-1-subtask");
     expect(tile.taskState?.status, PluginToolStatus.completed);
     expect(tile.taskState?.output, "Done");
     expect(tracker.childStatuses, isEmpty);
@@ -150,8 +191,8 @@ DeepSeekSessionUpdateEnvelopeDto _subagentUpdate({
   required String sessionUpdate,
   required DeepSeekSubagentReplayEndedDto? ended,
 }) => DeepSeekSessionUpdateEnvelopeDto(
-  metadata: DeepSeekEnvelopeMetadataDto(
-    deepSeek: DeepSeekEnvelopeDeepSeekMetadataDto(
+  metadata: {
+    DeepSeekAcpApi.initializeMetadataKey: DeepSeekEnvelopeDeepSeekMetadataDto(
       messageCreatedAt: 1,
       subagent: DeepSeekSubagentReplayDto(
         prompt: "Inspect the synthetic module",
@@ -160,8 +201,8 @@ DeepSeekSessionUpdateEnvelopeDto _subagentUpdate({
         childSessionId: "child-1",
         ended: ended,
       ),
-    ),
-  ),
+    ).toJson(),
+  },
   sessionId: "s1",
   update: {
     "sessionUpdate": sessionUpdate,

--- a/bridge/sesori_plugin_deepseek/test/deepseek_history_repository_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_history_repository_test.dart
@@ -91,6 +91,43 @@ void main() {
     await tracker.dispose();
   });
 
+  test("history preserves ordinary part order around a child-linked tile", () async {
+    final tracker = AcpChildSessionTracker();
+    final repository = _repository(
+      api: _HistoryApi([
+        DeepSeekTerminalHistoryResponseDto(
+          updates: [
+            _update("s1", "agent_message_chunk", "assistant", "before"),
+            _subagentUpdate(
+              sessionId: "s1",
+              childSessionId: "child-1",
+              sessionUpdate: "tool_call",
+              ended: null,
+            ),
+            _update("s1", "agent_message_chunk", "assistant", "after"),
+          ],
+        ),
+      ]),
+      childSessions: tracker,
+    );
+
+    final messages = await repository.getMessages(
+      client: _unusedClient(),
+      sessionId: "s1",
+    );
+
+    expect(messages, hasLength(3));
+    expect(messages.map((message) => message.info.id), [
+      "s1-massistant-assistant",
+      "s1-subagent-child-1",
+      "s1-massistant-assistant",
+    ]);
+    expect((messages[0].parts.single as PluginMessagePartText).text, "before");
+    expect(messages[1].parts.single, isA<PluginMessagePartSubtask>());
+    expect((messages[2].parts.single as PluginMessagePartText).text, "after");
+    await tracker.dispose();
+  });
+
   test("a running replay and later live end address the same child tile", () async {
     final tracker = AcpChildSessionTracker();
     final liveStart = tracker.spawn(
@@ -103,7 +140,7 @@ void main() {
         isBackground: true,
       ),
       directory: "/project",
-    );
+    )!;
     final liveTile = liveStart.events.whereType<BridgeSseMessagePartUpdated>().single.part;
     final repository = _repository(
       api: _HistoryApi([

--- a/bridge/sesori_plugin_deepseek/test/deepseek_history_repository_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_history_repository_test.dart
@@ -120,8 +120,16 @@ void main() {
     expect(messages.map((message) => message.info.id), [
       "s1-massistant-assistant",
       "s1-subagent-child-1",
-      "s1-massistant-assistant",
+      "s1-massistant-assistant-deepseek-replay-run-2",
     ]);
+    expect(messages.map((message) => message.info.id).toSet(), hasLength(3));
+    expect(messages.expand((message) => message.parts).map((part) => part.id).toSet(), hasLength(3));
+    for (final message in messages) {
+      for (final part in message.parts) {
+        expect(part.messageID, message.info.id);
+        expect(part.sessionID, message.info.sessionID);
+      }
+    }
     expect((messages[0].parts.single as PluginMessagePartText).text, "before");
     expect(messages[1].parts.single, isA<PluginMessagePartSubtask>());
     expect((messages[2].parts.single as PluginMessagePartText).text, "after");

--- a/bridge/sesori_plugin_deepseek/test/deepseek_history_repository_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_history_repository_test.dart
@@ -22,7 +22,6 @@ void main() {
     final messages = await repository.getMessages(
       client: _unusedClient(),
       sessionId: "s1",
-      rootSessionId: "s1",
     );
 
     expect(api.cursors, [null, 10]);
@@ -48,7 +47,7 @@ void main() {
     );
 
     await expectLater(
-      repository.getMessages(client: _unusedClient(), sessionId: "s1", rootSessionId: "s1"),
+      repository.getMessages(client: _unusedClient(), sessionId: "s1"),
       throwsA(
         isA<PluginOperationException>()
             .having((error) => error.operation, "operation", DeepSeekAcpApi.historyMethod)
@@ -78,7 +77,6 @@ void main() {
     final messages = await repository.getMessages(
       client: _unusedClient(),
       sessionId: "s1",
-      rootSessionId: "s1",
     );
     final tile = messages.single.parts.single as PluginMessagePartSubtask;
     expect(tile.id, "s1-subagent-child-1-subtask");
@@ -126,7 +124,6 @@ void main() {
     final messages = await repository.getMessages(
       client: _unusedClient(),
       sessionId: "s1",
-      rootSessionId: "s1",
     );
     final replayTile = messages.single.parts.single;
     final liveEnd = tracker.finish(
@@ -144,58 +141,33 @@ void main() {
     await tracker.dispose();
   });
 
-  test("nested replay uses persisted ancestry when live tracking is empty", () async {
+  test("nested replay stays in its direct parent's history when live tracking is empty", () async {
     final tracker = AcpChildSessionTracker();
-    final api = _HistoryApi([
-      DeepSeekTerminalHistoryResponseDto(
-        updates: [
-          _subagentUpdate(
-            sessionId: "child",
-            childSessionId: "grandchild",
-            sessionUpdate: "tool_call",
-            ended: null,
-          ),
-        ],
-      ),
-    ]);
-    final rootSessionId =
-        DeepSeekSessionService(
-          repository: DeepSeekSessionRepository(api: api),
-          childSessions: tracker,
-        ).rootSessionIdFor(
-          sessionId: "child",
-          persistedSessions: const [
-            PluginSession(
-              id: "root",
-              projectID: "/project",
-              directory: "/project",
-              parentID: null,
-              title: "Root",
-              time: null,
-            ),
-            PluginSession(
-              id: "child",
-              projectID: "/project",
-              directory: "/project",
-              parentID: "root",
-              title: "Child",
-              time: null,
+    final repository = _repository(
+      api: _HistoryApi([
+        DeepSeekTerminalHistoryResponseDto(
+          updates: [
+            _subagentUpdate(
+              sessionId: "child",
+              childSessionId: "grandchild",
+              sessionUpdate: "tool_call",
+              ended: null,
             ),
           ],
-        );
-    final repository = _repository(api: api, childSessions: tracker);
+        ),
+      ]),
+      childSessions: tracker,
+    );
 
-    expect(rootSessionId, "root");
     final messages = await repository.getMessages(
       client: _unusedClient(),
       sessionId: "child",
-      rootSessionId: rootSessionId,
     );
     final tile = messages.single.parts.single as PluginMessagePartSubtask;
-    expect(messages.single.info.id, "root-subagent-grandchild");
-    expect(messages.single.info.sessionID, "root");
-    expect(tile.id, "root-subagent-grandchild-subtask");
-    expect(tile.sessionID, "root");
+    expect(messages.single.info.id, "child-subagent-grandchild");
+    expect(messages.single.info.sessionID, "child");
+    expect(tile.id, "child-subagent-grandchild-subtask");
+    expect(tile.sessionID, "child");
     await tracker.dispose();
   });
 
@@ -229,7 +201,6 @@ void main() {
     final messages = await repository.getMessages(
       client: _unusedClient(),
       sessionId: "s1",
-      rootSessionId: "s1",
     );
     expect(messages.single.parts, hasLength(1));
     final tile = messages.single.parts.single as PluginMessagePartSubtask;

--- a/bridge/sesori_plugin_deepseek/test/deepseek_message_times_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_message_times_test.dart
@@ -3,6 +3,7 @@ import "package:deepseek_plugin/src/api/deepseek_acp_api.dart";
 import "package:deepseek_plugin/src/deepseek_event_mapper.dart";
 import "package:deepseek_plugin/src/deepseek_message_time_parser.dart";
 import "package:deepseek_plugin/src/repositories/mappers/deepseek_subagent_mapper.dart";
+import "package:deepseek_plugin/src/repositories/trackers/deepseek_delegation_tracker.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
@@ -16,6 +17,7 @@ void main() {
     api: const DeepSeekAcpApi(pluginId: "deepseek"),
     messageTimeParser: parser,
     subagentMapper: const DeepSeekSubagentMapper(agentId: "deepseek"),
+    delegationTracker: DeepSeekDelegationTracker(),
   );
 
   AcpNotification notification(Map<String, dynamic> update, [int? createdAt]) => AcpNotification(

--- a/bridge/sesori_plugin_deepseek/test/deepseek_message_times_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_message_times_test.dart
@@ -2,6 +2,7 @@ import "package:acp_plugin/acp_plugin.dart";
 import "package:deepseek_plugin/src/api/deepseek_acp_api.dart";
 import "package:deepseek_plugin/src/deepseek_event_mapper.dart";
 import "package:deepseek_plugin/src/deepseek_message_time_parser.dart";
+import "package:deepseek_plugin/src/repositories/mappers/deepseek_subagent_mapper.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
@@ -14,6 +15,7 @@ void main() {
     childSessions: AcpChildSessionTracker(),
     api: const DeepSeekAcpApi(pluginId: "deepseek"),
     messageTimeParser: parser,
+    subagentMapper: const DeepSeekSubagentMapper(agentId: "deepseek"),
   );
 
   AcpNotification notification(Map<String, dynamic> update, [int? createdAt]) => AcpNotification(
@@ -33,40 +35,52 @@ void main() {
 
   test("live assistant and tool envelopes use DeepSeek metadata time", () {
     expect(
-      liveCreated(mapper.map(notification({
-        "sessionUpdate": "agent_message_chunk",
-        "messageId": "a1",
-        "content": {"type": "text", "text": "hello"},
-      }, 10))),
+      liveCreated(
+        mapper.map(
+          notification({
+            "sessionUpdate": "agent_message_chunk",
+            "messageId": "a1",
+            "content": {"type": "text", "text": "hello"},
+          }, 10),
+        ),
+      ),
       10,
     );
     expect(
-      liveCreated(mapper.map(notification({
-        "sessionUpdate": "tool_call",
-        "toolCallId": "t1",
-        "kind": "read",
-      }, 20))),
+      liveCreated(
+        mapper.map(
+          notification({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "t1",
+            "kind": "read",
+          }, 20),
+        ),
+      ),
       20,
     );
   });
 
   test("local initial and queued users use accepted creation times", () {
     expect(
-      liveCreated(mapper.mapInitialPrompt(
-        sessionId: "s1",
-        parts: const [PluginPromptPart.text(text: "initial")],
-        createdAtMs: 30,
-      )),
+      liveCreated(
+        mapper.mapInitialPrompt(
+          sessionId: "s1",
+          parts: const [PluginPromptPart.text(text: "initial")],
+          createdAtMs: 30,
+        ),
+      ),
       30,
     );
     expect(
-      liveCreated(mapper.mapSentPrompt(
-        sessionId: "s1",
-        messageId: "queued-user",
-        promptId: "queued",
-        parts: const [PluginPromptPart.text(text: "queued")],
-        createdAtMs: 40,
-      )),
+      liveCreated(
+        mapper.mapSentPrompt(
+          sessionId: "s1",
+          messageId: "queued-user",
+          promptId: "queued",
+          parts: const [PluginPromptPart.text(text: "queued")],
+          createdAtMs: 40,
+        ),
+      ),
       40,
     );
   });
@@ -79,32 +93,43 @@ void main() {
       messageIdOverride: ({required acpMessageId}) => acpMessageId,
       messageTimeResolver: ({required params}) => parser.parse(params),
       haltClassifier: null,
+      toolPartReplacement: null,
     );
-    collector.consume(notification({
-      "sessionUpdate": "user_message_chunk",
-      "messageId": "u1",
-      "content": {"type": "text", "text": "user"},
-    }, 30).params);
-    collector.consume(notification({
-      "sessionUpdate": "agent_message_chunk",
-      "messageId": "a1",
-      "content": {"type": "text", "text": "first"},
-    }, 20).params);
-    collector.consume(notification({
-      "sessionUpdate": "agent_message_chunk",
-      "messageId": "a1",
-      "content": {"type": "text", "text": "later"},
-    }, 50).params);
-    collector.consume(notification({
-      "sessionUpdate": "tool_call",
-      "toolCallId": "t1",
-      "kind": "read",
-    }, 10).params);
-    collector.consume(notification({
-      "sessionUpdate": "tool_call_update",
-      "toolCallId": "t1",
-      "status": "completed",
-    }, 60).params);
+    collector.consume(
+      notification({
+        "sessionUpdate": "user_message_chunk",
+        "messageId": "u1",
+        "content": {"type": "text", "text": "user"},
+      }, 30).params,
+    );
+    collector.consume(
+      notification({
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "a1",
+        "content": {"type": "text", "text": "first"},
+      }, 20).params,
+    );
+    collector.consume(
+      notification({
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "a1",
+        "content": {"type": "text", "text": "later"},
+      }, 50).params,
+    );
+    collector.consume(
+      notification({
+        "sessionUpdate": "tool_call",
+        "toolCallId": "t1",
+        "kind": "read",
+      }, 10).params,
+    );
+    collector.consume(
+      notification({
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "t1",
+        "status": "completed",
+      }, 60).params,
+    );
 
     final messages = collector.build();
     expect(messages.map((message) => message.info.time?.created), [30, 10]);
@@ -118,19 +143,25 @@ void main() {
       messageIdOverride: null,
       messageTimeResolver: ({required params}) => parser.parse(params),
       haltClassifier: classifier,
+      toolPartReplacement: null,
     );
     final halted = collector(({required text}) => const AcpHaltNotice(errorName: "halt"));
-    halted.consume(notification({
-      "sessionUpdate": "agent_message_chunk",
-      "content": {"type": "text", "text": "halt"},
-    }, 70).params);
+    halted.consume(
+      notification({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "halt"},
+      }, 70).params,
+    );
     expect(halted.build().single.info.time?.created, 70);
     expect(halted.build().single.info.toJson()["errorName"], "halt");
 
-    final old = collector(null)..consume(notification({
-      "sessionUpdate": "agent_message_chunk",
-      "content": {"type": "text", "text": "old"},
-    }).params);
+    final old = collector(null)
+      ..consume(
+        notification({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "old"},
+        }).params,
+      );
     expect(old.build().single.info.time, isNull);
   });
 }

--- a/bridge/sesori_plugin_deepseek/test/deepseek_plugin_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_plugin_test.dart
@@ -122,6 +122,7 @@ DeepSeekPlugin _buildPlugin(FakeAcpProcess fake) {
     childSessions: childSessionTracker,
     api: api,
     messageTimeParser: const DeepSeekMessageTimeParser(),
+    subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
   );
   return DeepSeekPlugin(
     launchSpec: const AcpLaunchSpec(command: "deepseek", args: [], cwd: "/repo", environment: {}),
@@ -134,9 +135,11 @@ DeepSeekPlugin _buildPlugin(FakeAcpProcess fake) {
       eventMapper: mapper,
       pluginId: DeepSeekIdentity.id,
       messageTimeParser: const DeepSeekMessageTimeParser(),
+      subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
     ),
-    deepSeekSessionService: const DeepSeekSessionService(
-      repository: DeepSeekSessionRepository(api: api),
+    deepSeekSessionService: DeepSeekSessionService(
+      repository: const DeepSeekSessionRepository(api: api),
+      childSessions: childSessionTracker,
     ),
     deepSeekSessionOptionsService: DeepSeekSessionOptionsService(
       repository: const DeepSeekCatalogRepository(api: api, mapper: DeepSeekCatalogMapper()),

--- a/bridge/sesori_plugin_deepseek/test/deepseek_plugin_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_plugin_test.dart
@@ -123,6 +123,7 @@ DeepSeekPlugin _buildPlugin(FakeAcpProcess fake) {
     api: api,
     messageTimeParser: const DeepSeekMessageTimeParser(),
     subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
+    delegationTracker: DeepSeekDelegationTracker(),
   );
   return DeepSeekPlugin(
     launchSpec: const AcpLaunchSpec(command: "deepseek", args: [], cwd: "/repo", environment: {}),

--- a/bridge/sesori_plugin_deepseek/test/deepseek_protocol_conformance_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_protocol_conformance_test.dart
@@ -137,9 +137,26 @@ void main() {
 
     final encodedUpdate = (response.toJson()["updates"] as List).single as Map<String, dynamic>;
     expect(encodedUpdate["_meta"], metadata);
+    expect(response.updates.single.metadata?.deepSeek?.subagent?.childSessionId, "child");
+  });
+
+  test("history validates typed DeepSeek metadata before repositories consume it", () {
     expect(
-      api.parseHistoryMetadata(envelope: response.updates.single)?.subagent?.childSessionId,
-      "child",
+      () => api.parseHistoryResponse({
+        "updates": [
+          {
+            "sessionId": "root",
+            "update": {"sessionUpdate": "tool_call", "toolCallId": "call"},
+            "_meta": {
+              DeepSeekAcpApi.initializeMetadataKey: {
+                "subagent": {"label": "Child", "prompt": "Inspect", "mode": "detached"},
+              },
+            },
+          },
+        ],
+        "hasMore": false,
+      }, sessionId: "root"),
+      throwsFormatException,
     );
   });
 

--- a/bridge/sesori_plugin_deepseek/test/deepseek_protocol_conformance_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_protocol_conformance_test.dart
@@ -4,48 +4,50 @@ import "dart:io";
 import "package:deepseek_plugin/src/api/deepseek_acp_api.dart";
 import "package:deepseek_plugin/src/api/models/deepseek_protocol_dto.dart";
 import "package:deepseek_plugin/src/deepseek_identity.dart";
-import "package:deepseek_plugin/src/deepseek_message_time_parser.dart";
 import "package:test/test.dart";
 
 void main() {
   const api = DeepSeekAcpApi(pluginId: DeepSeekIdentity.id);
-  final fixtureDirectory = Directory("test/fixtures/protocol/v1");
-  test("all valid runtime fixtures decode and encode through generated DTOs", () async {
-    final corpus = jsonDecode(await File("${fixtureDirectory.path}/valid.json").readAsString()) as List;
-    final definitions = <String>{};
-    for (final fixture in corpus.cast<Map<String, dynamic>>()) {
-      final definition = fixture["definition"] as String;
-      final value = (fixture["value"] as Map).cast<String, dynamic>();
-      definitions.add(definition);
-      expect(_decodeValid(api, definition, value), isA<Map<String, dynamic>>(), reason: definition);
-    }
-    expect(definitions, {
-      "initializeMetadata",
-      "promptMetadata",
-      "catalogRequest",
-      "catalogResponse",
-      "historyRequest",
-      "historyResponse",
-      "renameRequest",
-      "renameResponse",
-      "askUserQuestionRequest",
-      "askUserQuestionResponse",
-      "sessionStatusNotification",
+
+  for (final protocolVersion in const [1, 2]) {
+    final fixtureDirectory = Directory("test/fixtures/protocol/v$protocolVersion");
+    test("protocol v$protocolVersion consumed valid fixtures decode and encode through typed DTOs", () async {
+      final corpus = jsonDecode(await File("${fixtureDirectory.path}/valid.json").readAsString()) as List;
+      final expectedDefinitions = _definitionsFor(protocolVersion: protocolVersion);
+      final definitions = <String>{};
+      for (final fixture in corpus.cast<Map<String, dynamic>>()) {
+        final definition = fixture["definition"] as String;
+        // The complete source corpus also pins contracts whose consumer lands in a later PR.
+        if (!expectedDefinitions.contains(definition)) continue;
+        final value = (fixture["value"] as Map).cast<String, dynamic>();
+        definitions.add(definition);
+        expect(
+          _decode(api: api, protocolVersion: protocolVersion, definition: definition, value: value),
+          isA<Map<String, dynamic>>(),
+          reason: definition,
+        );
+      }
+      expect(definitions, expectedDefinitions);
     });
-  });
-  test("all invalid runtime fixtures are rejected", () async {
-    final corpus = jsonDecode(await File("${fixtureDirectory.path}/invalid.json").readAsString()) as List;
-    for (final fixture in corpus.cast<Map<String, dynamic>>()) {
-      final value = (fixture["value"] as Map).cast<String, dynamic>();
-      expect(
-        () => _rejectInvalid(api, fixture["definition"] as String, value),
-        throwsA(anything),
-        reason: fixture["definition"] as String,
-      );
-    }
-  });
+
+    test("protocol v$protocolVersion consumed invalid fixtures are rejected", () async {
+      final corpus = jsonDecode(await File("${fixtureDirectory.path}/invalid.json").readAsString()) as List;
+      final expectedDefinitions = _definitionsFor(protocolVersion: protocolVersion);
+      for (final fixture in corpus.cast<Map<String, dynamic>>()) {
+        final definition = fixture["definition"] as String;
+        if (!expectedDefinitions.contains(definition)) continue;
+        final value = (fixture["value"] as Map).cast<String, dynamic>();
+        expect(
+          () => _decode(api: api, protocolVersion: protocolVersion, definition: definition, value: value),
+          throwsA(anything),
+          reason: definition,
+        );
+      }
+    });
+  }
+
   test("catalog rejects bounded collection and entry violations", () async {
-    final corpus = jsonDecode(await File("${fixtureDirectory.path}/valid.json").readAsString()) as List;
+    final corpus = jsonDecode(await File("test/fixtures/protocol/v2/valid.json").readAsString()) as List;
     Map<String, dynamic> fixture(String definition) =>
         (corpus.cast<Map<String, dynamic>>().firstWhere(
                   (fixture) => fixture["definition"] == definition,
@@ -94,54 +96,134 @@ void main() {
     (questions["questions"] as List).add((questions["questions"] as List).first);
     expect(() => api.parseQuestionRequest(questions), throwsFormatException);
   });
+
+  test("temporarily accepts protocol v1 and v2 initialize metadata only", () {
+    Map<String, dynamic> metadata(int version) => {
+      "extensionProtocolVersion": version,
+      "adapterVersion": "0.1.3",
+      "harnessVersion": "0.1.1-rc.2",
+      "persistenceOwner": "sesori",
+    };
+
+    expect(api.parseInitializeMetadata(metadata(1)).extensionProtocolVersion, 1);
+    expect(api.parseInitializeMetadata(metadata(2)).extensionProtocolVersion, 2);
+    expect(() => api.parseInitializeMetadata(metadata(3)), throwsFormatException);
+  });
+
+  test("sub-agent presentation fields validate Unicode scalar structure and bounds", () {
+    Map<String, dynamic> started({required String prompt, String label = "Child"}) => {
+      "kind": "started",
+      "sessionId": "root",
+      "childSessionId": "child",
+      "toolCallId": "call",
+      "label": label,
+      "prompt": prompt,
+      "mode": "foreground",
+    };
+    Map<String, dynamic> ended(String summary) => {
+      "kind": "ended",
+      "sessionId": "root",
+      "childSessionId": "child",
+      "stopReason": "completed",
+      "summary": summary,
+    };
+
+    expect(
+      api.parseSubagentNotification(started(prompt: List.filled(32768, "😀").join())),
+      isA<DeepSeekSubagentStartedDto>(),
+    );
+    expect(
+      api.parseSubagentNotification(started(prompt: "valid", label: List.filled(256, "😀").join())),
+      isA<DeepSeekSubagentStartedDto>(),
+    );
+    expect(
+      api.parseSubagentNotification(ended(List.filled(512, "😀").join())),
+      isA<DeepSeekSubagentEndedDto>(),
+    );
+    expect(
+      () => api.parseSubagentNotification(started(prompt: List.filled(32769, "😀").join())),
+      throwsFormatException,
+    );
+    expect(
+      () => api.parseSubagentNotification(started(prompt: "valid", label: List.filled(257, "😀").join())),
+      throwsFormatException,
+    );
+    expect(() => api.parseSubagentNotification(ended(List.filled(513, "😀").join())), throwsFormatException);
+    expect(() => api.parseSubagentNotification(started(prompt: "valid\uD800")), throwsFormatException);
+    expect(() => api.parseSubagentNotification(started(prompt: " padded ")), throwsFormatException);
+  });
 }
 
-Map<String, dynamic> _decodeValid(DeepSeekAcpApi api, String definition, Map<String, dynamic> value) =>
-    switch (definition) {
-      "initializeMetadata" => api.parseInitializeMetadata(value).toJson(),
-      "promptMetadata" => api.parsePromptMetadata(value).toJson(),
-      "catalogRequest" => DeepSeekCatalogRequestDto.fromJson(value).toJson(),
-      "catalogResponse" => api.parseCatalogResponse(value).toJson(),
-      "historyRequest" => DeepSeekHistoryRequestDto.fromJson(value).toJson(),
-      "historyResponse" => DeepSeekHistoryResponseDto.fromJson(value).toJson(),
-      "renameRequest" => DeepSeekRenameRequestDto.fromJson(value).toJson(),
-      "renameResponse" => DeepSeekRenameResponseDto.fromJson(value).toJson(),
-      "askUserQuestionRequest" => api.parseQuestionRequest(value).toJson(),
-      "askUserQuestionResponse" => api.parseQuestionResponse(value).toJson(),
-      "sessionStatusNotification" => api.parseSessionStatus(value).toJson(),
-      _ => throw StateError("Unknown fixture definition $definition"),
-    };
-void _rejectInvalid(DeepSeekAcpApi api, String definition, Map<String, dynamic> value) {
-  switch (definition) {
-    case "initializeMetadata" ||
-        "promptMetadata" ||
-        "catalogResponse" ||
-        "askUserQuestionRequest" ||
-        "askUserQuestionResponse" ||
-        "sessionStatusNotification":
-      _decodeValid(api, definition, value);
-    case "historyResponse":
-      final response = DeepSeekHistoryResponseDto.fromJson(value);
-      for (final update in response.updates) {
-        if (update.metadata != null && const DeepSeekMessageTimeParser().parse(update.toJson()) == null) {
-          throw const FormatException("messageCreatedAt");
-        }
-      }
-    case "catalogRequest":
-      final request = DeepSeekCatalogRequestDto.fromJson(value);
-      if (!request.cwd.startsWith("/") && !RegExp(r"^[A-Za-z]:[\\/]").hasMatch(request.cwd)) {
-        throw const FormatException("cwd");
-      }
-    case "historyRequest":
-      final request = DeepSeekHistoryRequestDto.fromJson(value);
-      if (request.maxMessages < 1 || request.maxMessages > 100) throw const FormatException("maxMessages");
-    case "renameRequest":
-      final request = DeepSeekRenameRequestDto.fromJson(value);
-      if (!request.title.contains(RegExp(r"\S"))) throw const FormatException("title");
-    case "renameResponse":
-      final response = DeepSeekRenameResponseDto.fromJson(value);
-      if (!response.title.contains(RegExp(r"\S"))) throw const FormatException("title");
-    default:
-      throw StateError("Unknown fixture definition $definition");
+Set<String> _definitionsFor({required int protocolVersion}) => {
+  "initializeMetadata",
+  "promptMetadata",
+  "catalogRequest",
+  "catalogResponse",
+  "historyRequest",
+  "historyResponse",
+  "renameRequest",
+  "renameResponse",
+  "askUserQuestionRequest",
+  "askUserQuestionResponse",
+  "sessionStatusNotification",
+  if (protocolVersion == 2) "subagentNotification",
+};
+
+Map<String, dynamic> _decode({
+  required DeepSeekAcpApi api,
+  required int protocolVersion,
+  required String definition,
+  required Map<String, dynamic> value,
+}) => switch (definition) {
+  "initializeMetadata" => _initialize(api: api, protocolVersion: protocolVersion, value: value),
+  "promptMetadata" => api.parsePromptMetadata(value).toJson(),
+  "catalogRequest" => _catalogRequest(value),
+  "catalogResponse" => api.parseCatalogResponse(value).toJson(),
+  "historyRequest" => _historyRequest(value),
+  "historyResponse" => api.parseHistoryResponse(value, sessionId: null).toJson(),
+  "renameRequest" => _renameRequest(value),
+  "renameResponse" => _renameResponse(value),
+  "askUserQuestionRequest" => api.parseQuestionRequest(value).toJson(),
+  "askUserQuestionResponse" => api.parseQuestionResponse(value).toJson(),
+  "sessionStatusNotification" => api.parseSessionStatus(value).toJson(),
+  "subagentNotification" => api.parseSubagentNotification(value).toJson(),
+  _ => throw StateError("Unknown fixture definition $definition"),
+};
+
+Map<String, dynamic> _initialize({
+  required DeepSeekAcpApi api,
+  required int protocolVersion,
+  required Map<String, dynamic> value,
+}) {
+  final metadata = api.parseInitializeMetadata(value);
+  if (metadata.extensionProtocolVersion != protocolVersion) {
+    throw FormatException("Initialize metadata does not conform to protocol v$protocolVersion");
   }
+  return metadata.toJson();
+}
+
+Map<String, dynamic> _catalogRequest(Map<String, dynamic> value) {
+  final request = DeepSeekCatalogRequestDto.fromJson(value);
+  if (!request.cwd.startsWith("/") && !RegExp(r"^[A-Za-z]:[\\/]").hasMatch(request.cwd)) {
+    throw const FormatException("cwd");
+  }
+  return request.toJson();
+}
+
+Map<String, dynamic> _historyRequest(Map<String, dynamic> value) {
+  final request = DeepSeekHistoryRequestDto.fromJson(value);
+  if (request.maxMessages < 1 || request.maxMessages > 100) throw const FormatException("maxMessages");
+  return request.toJson();
+}
+
+Map<String, dynamic> _renameRequest(Map<String, dynamic> value) {
+  final request = DeepSeekRenameRequestDto.fromJson(value);
+  if (!request.title.contains(RegExp(r"\S"))) throw const FormatException("title");
+  return request.toJson();
+}
+
+Map<String, dynamic> _renameResponse(Map<String, dynamic> value) {
+  final response = DeepSeekRenameResponseDto.fromJson(value);
+  if (!response.title.contains(RegExp(r"\S"))) throw const FormatException("title");
+  return response.toJson();
 }

--- a/bridge/sesori_plugin_deepseek/test/deepseek_protocol_conformance_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_protocol_conformance_test.dart
@@ -189,6 +189,31 @@ void main() {
       }),
       throwsFormatException,
     );
+    for (final subagent in [
+      {"label": "Child", "prompt": "Inspect", "mode": "background", "childSessionId": null},
+      {
+        "label": "Child",
+        "prompt": "Inspect",
+        "mode": "background",
+        "ended": {"stopReason": "completed", "summary": null},
+      },
+    ]) {
+      expect(
+        () => api.parseHistoryResponse({
+          "updates": [
+            {
+              "sessionId": "root",
+              "update": {"sessionUpdate": "tool_call", "toolCallId": "call"},
+              "_meta": {
+                DeepSeekAcpApi.initializeMetadataKey: {"subagent": subagent},
+              },
+            },
+          ],
+          "hasMore": false,
+        }, sessionId: "root"),
+        throwsFormatException,
+      );
+    }
   });
 
   test("sub-agent presentation fields validate Unicode scalar structure and bounds", () {

--- a/bridge/sesori_plugin_deepseek/test/deepseek_protocol_conformance_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_protocol_conformance_test.dart
@@ -110,6 +110,70 @@ void main() {
     expect(() => api.parseInitializeMetadata(metadata(3)), throwsFormatException);
   });
 
+  test("history preserves additive metadata while parsing typed DeepSeek fields", () {
+    final metadata = {
+      "shared/future": {"retained": true},
+      DeepSeekAcpApi.initializeMetadataKey: {
+        "messageCreatedAt": 1,
+        "futureField": "retained",
+        "subagent": {
+          "label": "Child",
+          "prompt": "Inspect",
+          "mode": "background",
+          "childSessionId": "child",
+        },
+      },
+    };
+    final response = api.parseHistoryResponse({
+      "updates": [
+        {
+          "sessionId": "root",
+          "update": {"sessionUpdate": "tool_call", "toolCallId": "call"},
+          "_meta": metadata,
+        },
+      ],
+      "hasMore": false,
+    }, sessionId: "root");
+
+    final encodedUpdate = (response.toJson()["updates"] as List).single as Map<String, dynamic>;
+    expect(encodedUpdate["_meta"], metadata);
+    expect(
+      api.parseHistoryMetadata(envelope: response.updates.single)?.subagent?.childSessionId,
+      "child",
+    );
+  });
+
+  test("sub-agent optional fields reject explicit null", () {
+    expect(
+      () => api.parseSubagentNotification({
+        "kind": "ended",
+        "sessionId": "root",
+        "childSessionId": "child",
+        "stopReason": "completed",
+        "summary": null,
+      }),
+      throwsFormatException,
+    );
+    expect(
+      () => api.parseSubagentReplay({
+        "label": "Child",
+        "prompt": "Inspect",
+        "mode": "background",
+        "childSessionId": null,
+      }),
+      throwsFormatException,
+    );
+    expect(
+      () => api.parseSubagentReplay({
+        "label": "Child",
+        "prompt": "Inspect",
+        "mode": "background",
+        "ended": {"stopReason": "completed", "summary": null},
+      }),
+      throwsFormatException,
+    );
+  });
+
   test("sub-agent presentation fields validate Unicode scalar structure and bounds", () {
     Map<String, dynamic> started({required String prompt, String label = "Child"}) => {
       "kind": "started",
@@ -149,6 +213,16 @@ void main() {
       throwsFormatException,
     );
     expect(() => api.parseSubagentNotification(ended(List.filled(513, "😀").join())), throwsFormatException);
+    expect(() => api.parseSubagentNotification(ended("valid\uD800")), throwsFormatException);
+    expect(
+      () => api.parseSubagentReplay({
+        "label": "Child",
+        "prompt": "Inspect",
+        "mode": "background",
+        "ended": {"stopReason": "completed", "summary": "valid\uD800"},
+      }),
+      throwsFormatException,
+    );
     expect(() => api.parseSubagentNotification(started(prompt: "valid\uD800")), throwsFormatException);
     expect(() => api.parseSubagentNotification(started(prompt: " padded ")), throwsFormatException);
   });

--- a/bridge/sesori_plugin_deepseek/test/deepseek_protocol_integrity_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_protocol_integrity_test.dart
@@ -5,23 +5,29 @@ import "package:crypto/crypto.dart";
 import "package:test/test.dart";
 
 void main() {
-  test("vendored protocol files match the source manifest", () async {
-    final directory = Directory("test/fixtures/protocol/v1");
-    final manifest = jsonDecode(
-      await File("${directory.path}/source_manifest.json").readAsString(),
-    ) as Map<String, dynamic>;
+  const commits = {
+    1: "9731711f079dc0d7acf7e5eff29c81a3622bc4a0",
+    2: "d7a48471bf5339793beb0c9e1c1889e63f76ec92",
+  };
+  for (final entry in commits.entries) {
+    test("vendored protocol v${entry.key} files match the source manifest", () async {
+      final directory = Directory("test/fixtures/protocol/v${entry.key}");
+      final manifest = jsonDecode(
+        await File("${directory.path}/source_manifest.json").readAsString(),
+      ) as Map<String, dynamic>;
 
-    expect(manifest["repository"], "sesori-ai/sesori-deepseek-acp");
-    expect(manifest["commit"], "9731711f079dc0d7acf7e5eff29c81a3622bc4a0");
-    final expected = (manifest["files"] as Map).cast<String, String>();
-    expect(expected.keys.toSet(), {
-      "deepseek-acp.schema.json",
-      "valid.json",
-      "invalid.json",
+      expect(manifest["repository"], "sesori-ai/sesori-deepseek-acp");
+      expect(manifest["commit"], entry.value);
+      final expected = (manifest["files"] as Map).cast<String, String>();
+      expect(expected.keys.toSet(), {
+        "deepseek-acp.schema.json",
+        "valid.json",
+        "invalid.json",
+      });
+      for (final file in expected.entries) {
+        final bytes = await File("${directory.path}/${file.key}").readAsBytes();
+        expect(sha256.convert(bytes).toString(), file.value, reason: file.key);
+      }
     });
-    for (final entry in expected.entries) {
-      final bytes = await File("${directory.path}/${entry.key}").readAsBytes();
-      expect(sha256.convert(bytes).toString(), entry.value, reason: entry.key);
-    }
-  });
+  }
 }

--- a/bridge/sesori_plugin_deepseek/test/deepseek_scaffold_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_scaffold_test.dart
@@ -33,6 +33,7 @@ void main() {
       childSessions: AcpChildSessionTracker(),
       messageTimeParser: const DeepSeekMessageTimeParser(),
       subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
+      delegationTracker: DeepSeekDelegationTracker(),
       api: const DeepSeekAcpApi(pluginId: DeepSeekIdentity.id),
     );
     List<BridgeSseEvent> map(Map<String, dynamic> params) => mapper.map(
@@ -58,6 +59,7 @@ void main() {
       childSessions: AcpChildSessionTracker(),
       messageTimeParser: const DeepSeekMessageTimeParser(),
       subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
+      delegationTracker: DeepSeekDelegationTracker(),
       api: const DeepSeekAcpApi(pluginId: DeepSeekIdentity.id),
     )..beginTurn(sessionId: "session-1", messageId: null);
     final events = mapper.map(

--- a/bridge/sesori_plugin_deepseek/test/deepseek_scaffold_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_scaffold_test.dart
@@ -32,6 +32,7 @@ void main() {
       configurationTracker: AcpSessionConfigurationTracker(),
       childSessions: AcpChildSessionTracker(),
       messageTimeParser: const DeepSeekMessageTimeParser(),
+      subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
       api: const DeepSeekAcpApi(pluginId: DeepSeekIdentity.id),
     );
     List<BridgeSseEvent> map(Map<String, dynamic> params) => mapper.map(
@@ -56,6 +57,7 @@ void main() {
       configurationTracker: AcpSessionConfigurationTracker(),
       childSessions: AcpChildSessionTracker(),
       messageTimeParser: const DeepSeekMessageTimeParser(),
+      subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
       api: const DeepSeekAcpApi(pluginId: DeepSeekIdentity.id),
     )..beginTurn(sessionId: "session-1", messageId: null);
     final events = mapper.map(

--- a/bridge/sesori_plugin_deepseek/test/deepseek_session_metadata_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_session_metadata_test.dart
@@ -22,6 +22,7 @@ void main() {
       api: api,
       messageTimeParser: const DeepSeekMessageTimeParser(),
       subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
+      delegationTracker: DeepSeekDelegationTracker(),
     );
     final plugin = DeepSeekPlugin(
       launchSpec: const AcpLaunchSpec(command: "deepseek", args: [], cwd: "/repo", environment: {}),

--- a/bridge/sesori_plugin_deepseek/test/deepseek_session_metadata_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_session_metadata_test.dart
@@ -65,9 +65,18 @@ void main() {
       throw StateError("DeepSeek never wrote $count '$method' frame(s)");
     }
 
+    final parentRow = {
+      "sessionId": "parent",
+      "cwd": "/other",
+      "title": "Parent",
+      "updatedAt": 2000,
+      "_meta": {
+        "sesori.ai/deepseek": {"createdAt": 1000},
+      },
+    };
     final sessionRow = {
       "sessionId": "child",
-      "cwd": "/repo",
+      "cwd": "/other",
       "title": "Child",
       "updatedAt": 2000,
       "_meta": {
@@ -102,7 +111,7 @@ void main() {
             "jsonrpc": "2.0",
             "id": request["id"],
             "result": {
-              "sessions": [sessionRow, malformedParentRow, blankParentRow],
+              "sessions": [parentRow, sessionRow, malformedParentRow, blankParentRow],
             },
           });
         }
@@ -135,15 +144,27 @@ void main() {
       });
       expect(await connecting, isTrue);
 
+      childSessionTracker.spawn(
+        sessionId: "parent",
+        spawn: const AcpChildSpawn(
+          childSessionId: "live-child",
+          description: "Live child",
+          agent: DeepSeekIdentity.id,
+          prompt: "Inspect",
+          isBackground: true,
+        ),
+        directory: "/repo",
+      );
+      final children = await plugin.getChildSessions("parent");
+      expect(children.map((session) => session.id), ["child", "live-child"]);
+      expect(children.singleWhere((session) => session.id == "live-child").projectID, "/other");
+
       final sessions = await plugin.listAllSessions(knownDirectories: const {});
       final child = sessions.singleWhere((session) => session.id == "child");
       expect(child.parentID, "parent");
       expect(child.time, const PluginSessionTime(created: 1000, updated: 2000, archived: null));
       expect(sessions.singleWhere((session) => session.id == "malformed-parent").parentID, isNull);
       expect(sessions.singleWhere((session) => session.id == "blank-parent").parentID, isNull);
-
-      final children = await plugin.getChildSessions("parent");
-      expect(children.map((session) => session.id), ["child"]);
 
       final events = mapper.map(
         const AcpNotification(
@@ -154,10 +175,9 @@ void main() {
           },
         ),
       );
-      expect(
-        events.whereType<BridgeSseSessionUpdated>().single.info["time"],
-        const {"created": 1000, "updated": 3000},
-      );
+      final updatedChild = events.whereType<BridgeSseSessionUpdated>().single.info;
+      expect(updatedChild["projectID"], "/other");
+      expect(updatedChild["time"], const {"created": 1000, "updated": 3000});
     } finally {
       responding = false;
       await responder;

--- a/bridge/sesori_plugin_deepseek/test/deepseek_session_metadata_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_session_metadata_test.dart
@@ -21,6 +21,7 @@ void main() {
       childSessions: childSessionTracker,
       api: api,
       messageTimeParser: const DeepSeekMessageTimeParser(),
+      subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
     );
     final plugin = DeepSeekPlugin(
       launchSpec: const AcpLaunchSpec(command: "deepseek", args: [], cwd: "/repo", environment: {}),
@@ -33,9 +34,11 @@ void main() {
         eventMapper: mapper,
         pluginId: DeepSeekIdentity.id,
         messageTimeParser: const DeepSeekMessageTimeParser(),
+        subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
       ),
-      deepSeekSessionService: const DeepSeekSessionService(
-        repository: DeepSeekSessionRepository(api: api),
+      deepSeekSessionService: DeepSeekSessionService(
+        repository: const DeepSeekSessionRepository(api: api),
+        childSessions: childSessionTracker,
       ),
       deepSeekSessionOptionsService: DeepSeekSessionOptionsService(
         repository: const DeepSeekCatalogRepository(api: api, mapper: DeepSeekCatalogMapper()),

--- a/bridge/sesori_plugin_deepseek/test/deepseek_session_metadata_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_session_metadata_test.dart
@@ -160,6 +160,22 @@ void main() {
       expect(children.map((session) => session.id), ["child", "live-child"]);
       expect(children.singleWhere((session) => session.id == "live-child").projectID, "/other");
 
+      childSessionTracker.spawn(
+        sessionId: "live-child",
+        spawn: const AcpChildSpawn(
+          childSessionId: "live-grandchild",
+          description: "Live grandchild",
+          agent: DeepSeekIdentity.id,
+          prompt: "Inspect more",
+          isBackground: true,
+        ),
+        directory: "/other",
+      );
+      final grandchildren = await plugin.getChildSessions("live-child");
+      expect(grandchildren.single.id, "live-grandchild");
+      expect(grandchildren.single.projectID, "/other");
+      expect(grandchildren.single.directory, "/other");
+
       final sessions = await plugin.listAllSessions(knownDirectories: const {});
       final child = sessions.singleWhere((session) => session.id == "child");
       expect(child.parentID, "parent");

--- a/bridge/sesori_plugin_deepseek/test/deepseek_session_service_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_session_service_test.dart
@@ -1,0 +1,77 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:deepseek_plugin/deepseek_plugin.dart";
+import "package:deepseek_plugin/deepseek_testing.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("child reads merge persisted and live sessions with persisted rows winning", () async {
+    final tracker = AcpChildSessionTracker();
+    tracker
+      ..spawn(
+        sessionId: "root",
+        spawn: const AcpChildSpawn(
+          childSessionId: "persisted-child",
+          description: "Live duplicate",
+          agent: "deepseek",
+          prompt: "Synthetic prompt",
+          isBackground: false,
+        ),
+        directory: "/project",
+      )
+      ..spawn(
+        sessionId: "root",
+        spawn: const AcpChildSpawn(
+          childSessionId: "live-child",
+          description: "Live only",
+          agent: "deepseek",
+          prompt: "Synthetic prompt",
+          isBackground: true,
+        ),
+        directory: "/project",
+      );
+    final service = DeepSeekSessionService(
+      repository: const DeepSeekSessionRepository(
+        api: DeepSeekAcpApi(pluginId: DeepSeekIdentity.id),
+      ),
+      childSessions: tracker,
+    );
+    const persisted = PluginSession(
+      id: "persisted-child",
+      projectID: "/project",
+      directory: "/project",
+      parentID: "root",
+      title: "Persisted title",
+      time: PluginSessionTime(created: 1, updated: 2, archived: null),
+    );
+
+    final children = service.getChildSessions(
+      sessionId: "root",
+      directory: "/project",
+      persistedSessions: const [
+        persisted,
+        PluginSession(
+          id: "other-child",
+          projectID: "/project",
+          directory: "/project",
+          parentID: "root",
+          title: "Persisted only",
+          time: null,
+        ),
+        PluginSession(
+          id: "another-root-child",
+          projectID: "/project",
+          directory: "/project",
+          parentID: "another-root",
+          title: null,
+          time: null,
+        ),
+      ],
+    );
+
+    expect(children.map((session) => session.id), ["persisted-child", "other-child", "live-child"]);
+    expect(children.first, persisted);
+    expect(children.last.title, "Live only");
+    await tracker.dispose();
+  });
+}

--- a/bridge/sesori_plugin_deepseek/test/deepseek_subagent_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_subagent_test.dart
@@ -1,0 +1,201 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:deepseek_plugin/deepseek_plugin.dart";
+import "package:deepseek_plugin/deepseek_testing.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("DeepSeek sub-agent lifecycle", () {
+    late AcpChildSessionTracker tracker;
+    late DeepSeekEventMapper mapper;
+
+    setUp(() {
+      tracker = AcpChildSessionTracker();
+      mapper = DeepSeekEventMapper(
+        launchDirectory: "/launch",
+        pluginId: DeepSeekIdentity.id,
+        configurationTracker: AcpSessionConfigurationTracker(),
+        childSessions: tracker,
+        api: const DeepSeekAcpApi(pluginId: DeepSeekIdentity.id),
+        messageTimeParser: const DeepSeekMessageTimeParser(),
+        subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
+      )..setSessionProject("root", "/project");
+      mapper.setExtensionProtocolVersion(extensionProtocolVersion: DeepSeekAcpApi.extensionProtocolVersion);
+      mapper.beginTurn(sessionId: "root", messageId: null);
+    });
+
+    tearDown(() => tracker.dispose());
+
+    test("protocol v1 retains generic delegation cards without lifecycle replacements", () {
+      mapper.setExtensionProtocolVersion(extensionProtocolVersion: 1);
+
+      final events = mapper.map(_toolCall(toolCallId: "legacy-call", title: "subagent"));
+
+      expect(events.whereType<BridgeSseMessagePartUpdated>().single.part, isA<PluginMessagePartTool>());
+    });
+
+    test("suppresses exact delegation tool calls and their later updates", () {
+      for (final title in const ["subagent", "subagent_fork"]) {
+        final toolCallId = "call-$title";
+        expect(mapper.map(_toolCall(toolCallId: toolCallId, title: title)), isEmpty);
+        expect(mapper.sessionIdForToolCallId(toolCallId: toolCallId), "root");
+        expect(mapper.map(_toolUpdate(toolCallId: toolCallId)), isEmpty);
+      }
+
+      final ordinary = mapper.map(_toolCall(toolCallId: "ordinary", title: "subagent_read"));
+      expect(ordinary.whereType<BridgeSseMessagePartUpdated>().single.part, isA<PluginMessagePartTool>());
+    });
+
+    test("started announces child, opens a running tile, and retains background mode", () {
+      final events = mapper.map(_started(mode: "background"));
+
+      expect(events, hasLength(4));
+      final envelope = (events[0] as BridgeSseMessageUpdated).info;
+      expect(envelope["id"], "root-subagent-child");
+      expect(envelope["sessionID"], "root");
+      final child = (events[1] as BridgeSseSessionCreated).info;
+      expect(child["id"], "child");
+      expect(child["parentID"], "root");
+      expect(child["projectID"], "/project");
+      expect(child["title"], "Research child");
+      expect((events[2] as BridgeSseSessionStatus).status["type"], "busy");
+      final tile = (events[3] as BridgeSseMessagePartUpdated).part as PluginMessagePartSubtask;
+      expect(tile.id, "root-subagent-child-subtask");
+      expect(tile.messageID, envelope["id"]);
+      expect(tile.prompt, "Inspect the synthetic module");
+      expect(tile.description, "Research child");
+      expect(tile.agent, DeepSeekIdentity.id);
+      expect(tile.childSessionID, "child");
+      expect(tile.taskState?.status, PluginToolStatus.running);
+      expect(tracker.runningChildren(sessionId: "root").single.isBackground, isTrue);
+    });
+
+    test("child standard updates stay attributed to the child transcript", () {
+      mapper.map(_started(mode: "foreground"));
+      final events = mapper.map(
+        const AcpNotification(
+          method: AcpMethods.sessionUpdate,
+          params: {
+            "sessionId": "child",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "messageId": "reply",
+              "content": {"type": "text", "text": "Child reply"},
+            },
+          },
+        ),
+      );
+
+      final message = events.whereType<BridgeSseMessageUpdated>().single.info;
+      expect(message["sessionID"], "child");
+      final text = events.whereType<BridgeSseMessagePartUpdated>().single.part as PluginMessagePartText;
+      expect(text.sessionID, "child");
+      expect(events.whereType<BridgeSseMessagePartDelta>().single.delta, "Child reply");
+    });
+
+    test("child session metadata updates retain root project and parent attribution", () {
+      mapper.map(_started(mode: "foreground"));
+
+      final events = mapper.map(
+        const AcpNotification(
+          method: AcpMethods.sessionUpdate,
+          params: {
+            "sessionId": "child",
+            "update": {
+              "sessionUpdate": "session_info_update",
+              "title": "Updated child",
+            },
+          },
+        ),
+      );
+
+      final child = events.whereType<BridgeSseSessionUpdated>().single.info;
+      expect(child["projectID"], "/project");
+      expect(child["directory"], "/project");
+      expect(child["parentID"], "root");
+    });
+
+    test("astral terminal summaries remain valid and release root work", () {
+      final summary = List.filled(300, "😀").join();
+      mapper.map(_started(mode: "foreground"));
+
+      final events = mapper.map(_ended(reason: "completed", summary: summary));
+
+      final tile = (events.first as BridgeSseMessagePartUpdated).part as PluginMessagePartSubtask;
+      expect(tile.taskState?.output, summary);
+      expect(tracker.hasActiveWorkForRoot(sessionId: "root"), isFalse);
+    });
+
+    for (final testCase in const [
+      (reason: "completed", status: PluginToolStatus.completed, summary: "Done", error: null),
+      (reason: "aborted", status: PluginToolStatus.cancelled, summary: null, error: null),
+      (reason: "error", status: PluginToolStatus.error, summary: "Failed safely", error: "Failed safely"),
+      (
+        reason: "max-tokens",
+        status: PluginToolStatus.error,
+        summary: null,
+        error: "DeepSeek sub-agent reached its token limit",
+      ),
+      (reason: "refusal", status: PluginToolStatus.error, summary: null, error: "DeepSeek sub-agent declined the task"),
+    ]) {
+      test("ended ${testCase.reason} maps the tile terminal state", () {
+        mapper.map(_started(mode: "foreground"));
+        final events = mapper.map(_ended(reason: testCase.reason, summary: testCase.summary));
+
+        expect(events, hasLength(2));
+        final tile = (events[0] as BridgeSseMessagePartUpdated).part as PluginMessagePartSubtask;
+        expect(tile.taskState?.status, testCase.status);
+        expect(tile.taskState?.output, testCase.status == PluginToolStatus.completed ? testCase.summary : null);
+        expect(tile.taskState?.error, testCase.error);
+        expect((events[1] as BridgeSseSessionStatus).status["type"], "idle");
+        expect(tracker.hasActiveWorkForRoot(sessionId: "root"), isFalse);
+        expect(tracker.hasRootHold(sessionId: "root"), isFalse);
+      });
+    }
+  });
+}
+
+AcpNotification _toolCall({required String toolCallId, required String title}) => AcpNotification(
+  method: AcpMethods.sessionUpdate,
+  params: {
+    "sessionId": "root",
+    "update": {
+      "sessionUpdate": "tool_call",
+      "toolCallId": toolCallId,
+      "title": title,
+      "status": "in_progress",
+    },
+  },
+);
+
+AcpNotification _toolUpdate({required String toolCallId}) => AcpNotification(
+  method: AcpMethods.sessionUpdate,
+  params: {
+    "sessionId": "root",
+    "update": {"sessionUpdate": "tool_call_update", "toolCallId": toolCallId, "status": "completed"},
+  },
+);
+
+AcpNotification _started({required String mode}) => AcpNotification(
+  method: DeepSeekAcpApi.subagentMethod,
+  params: {
+    "kind": "started",
+    "sessionId": "root",
+    "childSessionId": "child",
+    "toolCallId": "call",
+    "prompt": "Inspect the synthetic module",
+    "label": "Research child",
+    "mode": mode,
+  },
+);
+
+AcpNotification _ended({required String reason, required String? summary}) => AcpNotification(
+  method: DeepSeekAcpApi.subagentMethod,
+  params: {
+    "kind": "ended",
+    "sessionId": "root",
+    "childSessionId": "child",
+    "stopReason": reason,
+    "summary": ?summary,
+  },
+);

--- a/bridge/sesori_plugin_deepseek/test/deepseek_subagent_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_subagent_test.dart
@@ -7,14 +7,16 @@ import "package:test/test.dart";
 void main() {
   group("DeepSeek sub-agent lifecycle", () {
     late AcpChildSessionTracker tracker;
+    late AcpSessionConfigurationTracker configurationTracker;
     late DeepSeekEventMapper mapper;
 
     setUp(() {
       tracker = AcpChildSessionTracker();
+      configurationTracker = AcpSessionConfigurationTracker();
       mapper = DeepSeekEventMapper(
         launchDirectory: "/launch",
         pluginId: DeepSeekIdentity.id,
-        configurationTracker: AcpSessionConfigurationTracker(),
+        configurationTracker: configurationTracker,
         childSessions: tracker,
         api: const DeepSeekAcpApi(pluginId: DeepSeekIdentity.id),
         messageTimeParser: const DeepSeekMessageTimeParser(),
@@ -26,24 +28,68 @@ void main() {
 
     tearDown(() => tracker.dispose());
 
-    test("protocol v1 retains generic delegation cards without lifecycle replacements", () {
+    test("protocol v1 retains generic delegation cards and ignores v2 lifecycle", () {
       mapper.setExtensionProtocolVersion(extensionProtocolVersion: 1);
 
       final events = mapper.map(_toolCall(toolCallId: "legacy-call", title: "subagent"));
 
       expect(events.whereType<BridgeSseMessagePartUpdated>().single.part, isA<PluginMessagePartTool>());
+      expect(mapper.map(_started(mode: "foreground")), isEmpty);
+      expect(tracker.isChild(sessionId: "child"), isFalse);
     });
 
-    test("suppresses exact delegation tool calls and their later updates", () {
+    test("defers exact delegation calls until a correlated start and suppresses later updates", () {
       for (final title in const ["subagent", "subagent_fork"]) {
         final toolCallId = "call-$title";
+        final childSessionId = "child-$title";
         expect(mapper.map(_toolCall(toolCallId: toolCallId, title: title)), isEmpty);
         expect(mapper.sessionIdForToolCallId(toolCallId: toolCallId), "root");
-        expect(mapper.map(_toolUpdate(toolCallId: toolCallId)), isEmpty);
+
+        final started = mapper.map(
+          _startedWithIdentity(
+            mode: "foreground",
+            childSessionId: childSessionId,
+            toolCallId: toolCallId,
+          ),
+        );
+        expect(started.whereType<BridgeSseMessagePartUpdated>().single.part, isA<PluginMessagePartSubtask>());
+        expect(mapper.map(_toolUpdate(toolCallId: toolCallId, status: "completed")), isEmpty);
       }
 
       final ordinary = mapper.map(_toolCall(toolCallId: "ordinary", title: "subagent_read"));
       expect(ordinary.whereType<BridgeSseMessagePartUpdated>().single.part, isA<PluginMessagePartTool>());
+    });
+
+    test("retains a generic error card when delegation fails before child start", () {
+      expect(mapper.map(_toolCall(toolCallId: "failed-call", title: "subagent")), isEmpty);
+
+      final events = mapper.map(_toolUpdate(toolCallId: "failed-call", status: "failed"));
+
+      final tool = events.whereType<BridgeSseMessagePartUpdated>().last.part as PluginMessagePartTool;
+      expect(tool.state.status, PluginToolStatus.error);
+      expect(tracker.childStatuses, isEmpty);
+    });
+
+    test("a malformed start releases its deferred generic delegation card", () {
+      expect(mapper.map(_toolCall(toolCallId: "call", title: "subagent")), isEmpty);
+
+      final events = mapper.map(
+        const AcpNotification(
+          method: DeepSeekAcpApi.subagentMethod,
+          params: {
+            "kind": "started",
+            "sessionId": "root",
+            "childSessionId": "child",
+            "toolCallId": "call",
+            "prompt": "Inspect the synthetic module",
+            "label": "",
+            "mode": "foreground",
+          },
+        ),
+      );
+
+      expect(events.whereType<BridgeSseMessagePartUpdated>().single.part, isA<PluginMessagePartTool>());
+      expect(tracker.childStatuses, isEmpty);
     });
 
     test("started announces child, opens a running tile, and retains background mode", () {
@@ -68,6 +114,36 @@ void main() {
       expect(tile.childSessionID, "child");
       expect(tile.taskState?.status, PluginToolStatus.running);
       expect(tracker.runningChildren(sessionId: "root").single.isBackground, isTrue);
+    });
+
+    test("child standard updates inherit the root model and provider selection", () {
+      configurationTracker.setSessionOverride(
+        sessionId: "root",
+        modelId: "deepseek-chat",
+        providerId: "deepseek",
+      );
+      mapper.map(_started(mode: "foreground"));
+      final events = mapper.map(
+        const AcpNotification(
+          method: AcpMethods.sessionUpdate,
+          params: {
+            "sessionId": "child",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "messageId": "reply",
+              "content": {"type": "text", "text": "Child reply"},
+            },
+          },
+        ),
+      );
+
+      final message = events.whereType<BridgeSseMessageUpdated>().single.info;
+      expect(message["sessionID"], "child");
+      expect(message["modelID"], "deepseek-chat");
+      expect(message["providerID"], "deepseek");
+      final text = events.whereType<BridgeSseMessagePartUpdated>().single.part as PluginMessagePartText;
+      expect(text.sessionID, "child");
+      expect(events.whereType<BridgeSseMessagePartDelta>().single.delta, "Child reply");
     });
 
     test("child standard updates stay attributed to the child transcript", () {
@@ -115,6 +191,49 @@ void main() {
       expect(child["parentID"], "root");
     });
 
+    test("a duplicate start refreshes the child's corrected root project", () {
+      mapper.map(_started(mode: "foreground"));
+      mapper.setSessionProject("root", "/corrected");
+
+      expect(mapper.map(_started(mode: "foreground")), isEmpty);
+      final events = mapper.map(
+        const AcpNotification(
+          method: AcpMethods.sessionUpdate,
+          params: {
+            "sessionId": "child",
+            "update": {"sessionUpdate": "session_info_update", "title": "Updated child"},
+          },
+        ),
+      );
+
+      final child = events.whereType<BridgeSseSessionUpdated>().single.info;
+      expect(child["projectID"], "/corrected");
+      expect(child["directory"], "/corrected");
+    });
+
+    test("a malformed terminal notification errors the child and releases root work", () {
+      mapper.map(_started(mode: "foreground"));
+
+      final events = mapper.map(
+        const AcpNotification(
+          method: DeepSeekAcpApi.subagentMethod,
+          params: {
+            "kind": "ended",
+            "sessionId": "root",
+            "childSessionId": "child",
+            "stopReason": "completed",
+            "summary": null,
+          },
+        ),
+      );
+
+      final tile = (events.first as BridgeSseMessagePartUpdated).part as PluginMessagePartSubtask;
+      expect(tile.taskState?.status, PluginToolStatus.error);
+      expect(tile.taskState?.error, "DeepSeek sub-agent returned an invalid completion");
+      expect((events.last as BridgeSseSessionStatus).status["type"], "idle");
+      expect(tracker.hasActiveWorkForRoot(sessionId: "root"), isFalse);
+    });
+
     test("astral terminal summaries remain valid and release root work", () {
       final summary = List.filled(300, "😀").join();
       mapper.map(_started(mode: "foreground"));
@@ -124,6 +243,23 @@ void main() {
       final tile = (events.first as BridgeSseMessagePartUpdated).part as PluginMessagePartSubtask;
       expect(tile.taskState?.output, summary);
       expect(tracker.hasActiveWorkForRoot(sessionId: "root"), isFalse);
+    });
+
+    test("replay terminal summaries use the same 500-scalar bound as live tiles", () {
+      const subagentMapper = DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id);
+      final summary = List.filled(512, "😀").join();
+
+      final completed = subagentMapper.mapState(
+        stopReason: DeepSeekSubagentStopReason.completed,
+        summary: summary,
+      );
+      final failed = subagentMapper.mapState(
+        stopReason: DeepSeekSubagentStopReason.error,
+        summary: summary,
+      );
+
+      expect(completed.output?.runes.length, maxToolOutputLength);
+      expect(failed.error?.runes.length, maxToolOutputLength);
     });
 
     for (final testCase in const [
@@ -168,21 +304,28 @@ AcpNotification _toolCall({required String toolCallId, required String title}) =
   },
 );
 
-AcpNotification _toolUpdate({required String toolCallId}) => AcpNotification(
+AcpNotification _toolUpdate({required String toolCallId, required String status}) => AcpNotification(
   method: AcpMethods.sessionUpdate,
   params: {
     "sessionId": "root",
-    "update": {"sessionUpdate": "tool_call_update", "toolCallId": toolCallId, "status": "completed"},
+    "update": {"sessionUpdate": "tool_call_update", "toolCallId": toolCallId, "status": status},
   },
 );
 
-AcpNotification _started({required String mode}) => AcpNotification(
+AcpNotification _started({required String mode}) =>
+    _startedWithIdentity(mode: mode, childSessionId: "child", toolCallId: "call");
+
+AcpNotification _startedWithIdentity({
+  required String mode,
+  required String childSessionId,
+  required String toolCallId,
+}) => AcpNotification(
   method: DeepSeekAcpApi.subagentMethod,
   params: {
     "kind": "started",
     "sessionId": "root",
-    "childSessionId": "child",
-    "toolCallId": "call",
+    "childSessionId": childSessionId,
+    "toolCallId": toolCallId,
     "prompt": "Inspect the synthetic module",
     "label": "Research child",
     "mode": mode,

--- a/bridge/sesori_plugin_deepseek/test/deepseek_subagent_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_subagent_test.dart
@@ -97,6 +97,7 @@ void main() {
         ),
       );
 
+      expect(mapper.lookupSessionForToolCallId(toolCallId: "call"), isA<AcpToolCallSessionAmbiguous>());
       expect(mapper.sessionIdForToolCallId(toolCallId: "call"), isNull);
     });
 
@@ -198,7 +199,20 @@ void main() {
         );
       }
 
-      final events = mapper.map(_toolUpdate(toolCallId: "failed-call", status: "failed"));
+      final events = mapper.map(
+        const AcpNotification(
+          method: AcpMethods.sessionUpdate,
+          params: {
+            "sessionId": "root",
+            "update": {
+              "sessionUpdate": "tool_call_update",
+              "toolCallId": "failed-call",
+              "status": "failed",
+              "rawOutput": "terminal failure",
+            },
+          },
+        ),
+      );
       final tools = events
           .whereType<BridgeSseMessagePartUpdated>()
           .map((event) => event.part)
@@ -209,9 +223,48 @@ void main() {
         PluginToolStatus.running,
         PluginToolStatus.error,
       ]);
-      expect(tools.last.state.output, "startup detail");
+      expect(tools.last.state.output, "terminal failure");
       expect(tools.last.state.title, "Delegation startup");
-      expect(tools.last.state.error, "startup detail");
+      expect(tools.last.state.error, "terminal failure");
+    });
+
+    test("later structured content replaces stale deferred raw output", () {
+      expect(mapper.map(_toolCall(toolCallId: "failed-call", title: "subagent")), isEmpty);
+      expect(
+        mapper.map(
+          const AcpNotification(
+            method: AcpMethods.sessionUpdate,
+            params: {
+              "sessionId": "root",
+              "update": {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "failed-call",
+                "rawOutput": "stale progress",
+              },
+            },
+          ),
+        ),
+        isEmpty,
+      );
+
+      final events = mapper.map(
+        const AcpNotification(
+          method: AcpMethods.sessionUpdate,
+          params: {
+            "sessionId": "root",
+            "update": {
+              "sessionUpdate": "tool_call_update",
+              "toolCallId": "failed-call",
+              "status": "failed",
+              "content": <Object?>[],
+            },
+          },
+        ),
+      );
+      final terminal = events.whereType<BridgeSseMessagePartUpdated>().last.part as PluginMessagePartTool;
+      expect(terminal.state.status, PluginToolStatus.error);
+      expect(terminal.state.output, isNull);
+      expect(terminal.state.error, isNull);
     });
 
     test("a malformed start releases its deferred generic delegation card", () {

--- a/bridge/sesori_plugin_deepseek/test/deepseek_subagent_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_subagent_test.dart
@@ -39,6 +39,16 @@ void main() {
       expect(tracker.isChild(sessionId: "child"), isFalse);
     });
 
+    test("sub-agent lifecycle frames opt into accepted-prompt write ordering", () {
+      expect(mapper.shouldBufferDuringPromptWrite(notification: _started(mode: "foreground")), isTrue);
+      expect(
+        mapper.shouldBufferDuringPromptWrite(
+          notification: _ended(reason: "completed", summary: "Done"),
+        ),
+        isTrue,
+      );
+    });
+
     test("defers exact delegation calls until a correlated start and suppresses later updates", () {
       for (final title in const ["subagent", "subagent_fork"]) {
         final toolCallId = "call-$title";
@@ -101,6 +111,39 @@ void main() {
       expect(mapper.sessionIdForToolCallId(toolCallId: "call"), isNull);
     });
 
+    test("a late lifecycle start cannot recreate a deleted child subtree", () {
+      mapper.map(_started(mode: "background"));
+      mapper.forgetSession("child");
+      tracker.forgetSession(sessionId: "child");
+
+      final events = mapper.map(
+        _startedWithIdentity(
+          parentSessionId: "child",
+          mode: "background",
+          childSessionId: "late-grandchild",
+          toolCallId: "late-call",
+        ),
+      );
+
+      final repeatedChild = mapper.map(
+        _startedWithIdentity(
+          parentSessionId: "root",
+          mode: "background",
+          childSessionId: "child",
+          toolCallId: "repeated-child-call",
+        ),
+      );
+
+      expect(events, isEmpty);
+      expect(repeatedChild, isEmpty);
+      expect(tracker.isChild(sessionId: "late-grandchild"), isFalse);
+      expect(mapper.lookupSessionForToolCallId(toolCallId: "late-call"), isA<AcpToolCallSessionNotFound>());
+      expect(
+        mapper.lookupSessionForToolCallId(toolCallId: "repeated-child-call"),
+        isA<AcpToolCallSessionNotFound>(),
+      );
+    });
+
     test("session and protocol resets clear started delegation correlation", () {
       mapper.map(_toolCall(toolCallId: "call", title: "subagent"));
       mapper.map(_started(mode: "background"));
@@ -128,6 +171,36 @@ void main() {
       expect(mapper.sessionIdForToolCallId(toolCallId: "call"), "root");
       expect(mapper.map(_toolUpdate(toolCallId: "call", status: "completed")), isEmpty);
       expect(mapper.sessionIdForToolCallId(toolCallId: "call"), isNull);
+    });
+
+    test("defers an identifiable delegation update that arrives before its call", () {
+      expect(
+        mapper.map(
+          const AcpNotification(
+            method: AcpMethods.sessionUpdate,
+            params: {
+              "sessionId": "root",
+              "update": {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "call",
+                "title": "subagent",
+                "status": "in_progress",
+                "rawOutput": "starting",
+              },
+            },
+          ),
+        ),
+        isEmpty,
+      );
+      expect(mapper.map(_toolCall(toolCallId: "call", title: "subagent")), isEmpty);
+
+      final events = mapper.map(_started(mode: "foreground"));
+
+      expect(
+        events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part),
+        everyElement(isA<PluginMessagePartSubtask>()),
+      );
+      expect(events.whereType<BridgeSseMessagePartUpdated>(), hasLength(1));
     });
 
     test("retains a generic error card when delegation fails before child start", () {
@@ -218,11 +291,8 @@ void main() {
           .map((event) => event.part)
           .whereType<PluginMessagePartTool>()
           .toList(growable: false);
-      expect(tools, hasLength(2));
-      expect(tools.map((tool) => tool.state.status), [
-        PluginToolStatus.running,
-        PluginToolStatus.error,
-      ]);
+      expect(tools, hasLength(1));
+      expect(tools.single.state.status, PluginToolStatus.error);
       expect(tools.last.state.output, "terminal failure");
       expect(tools.last.state.title, "Delegation startup");
       expect(tools.last.state.error, "terminal failure");

--- a/bridge/sesori_plugin_deepseek/test/deepseek_subagent_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_subagent_test.dart
@@ -21,6 +21,7 @@ void main() {
         api: const DeepSeekAcpApi(pluginId: DeepSeekIdentity.id),
         messageTimeParser: const DeepSeekMessageTimeParser(),
         subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
+        delegationTracker: DeepSeekDelegationTracker(),
       )..setSessionProject("root", "/project");
       mapper.setExtensionProtocolVersion(extensionProtocolVersion: DeepSeekAcpApi.extensionProtocolVersion);
       mapper.beginTurn(sessionId: "root", messageId: null);
@@ -47,6 +48,7 @@ void main() {
 
         final started = mapper.map(
           _startedWithIdentity(
+            parentSessionId: "root",
             mode: "foreground",
             childSessionId: childSessionId,
             toolCallId: toolCallId,
@@ -60,6 +62,59 @@ void main() {
       expect(ordinary.whereType<BridgeSseMessagePartUpdated>().single.part, isA<PluginMessagePartTool>());
     });
 
+    test("retains started delegation correlation across parent turns until both sides finish", () {
+      expect(mapper.map(_toolCall(toolCallId: "call", title: "subagent")), isEmpty);
+      mapper.map(_started(mode: "background"));
+      expect(mapper.map(_toolUpdate(toolCallId: "call", status: "completed")), isEmpty);
+
+      mapper.beginTurn(sessionId: "root", messageId: null);
+      expect(
+        mapper.map(
+          const AcpNotification(
+            method: AcpMethods.sessionUpdate,
+            params: {
+              "sessionId": "root",
+              "update": {"sessionUpdate": "tool_call_update", "toolCallId": "call"},
+            },
+          ),
+        ),
+        isEmpty,
+      );
+      expect(mapper.sessionIdForToolCallId(toolCallId: "call"), "root");
+
+      mapper.map(_ended(reason: "completed", summary: "Done"));
+      expect(mapper.sessionIdForToolCallId(toolCallId: "call"), isNull);
+    });
+
+    test("session and protocol resets clear started delegation correlation", () {
+      mapper.map(_toolCall(toolCallId: "call", title: "subagent"));
+      mapper.map(_started(mode: "background"));
+      mapper.forgetSession("root");
+      expect(mapper.sessionIdForToolCallId(toolCallId: "call"), isNull);
+
+      mapper.map(_toolCall(toolCallId: "call-2", title: "subagent"));
+      mapper.map(
+        _startedWithIdentity(
+          parentSessionId: "root",
+          mode: "background",
+          childSessionId: "child-2",
+          toolCallId: "call-2",
+        ),
+      );
+      mapper.setExtensionProtocolVersion(extensionProtocolVersion: 1);
+      expect(mapper.sessionIdForToolCallId(toolCallId: "call-2"), isNull);
+    });
+
+    test("keeps an ended child correlated until the standard terminal update is suppressed", () {
+      mapper.map(_toolCall(toolCallId: "call", title: "subagent"));
+      mapper.map(_started(mode: "foreground"));
+
+      mapper.map(_ended(reason: "completed", summary: "Done"));
+      expect(mapper.sessionIdForToolCallId(toolCallId: "call"), "root");
+      expect(mapper.map(_toolUpdate(toolCallId: "call", status: "completed")), isEmpty);
+      expect(mapper.sessionIdForToolCallId(toolCallId: "call"), isNull);
+    });
+
     test("retains a generic error card when delegation fails before child start", () {
       expect(mapper.map(_toolCall(toolCallId: "failed-call", title: "subagent")), isEmpty);
 
@@ -68,6 +123,61 @@ void main() {
       final tool = events.whereType<BridgeSseMessagePartUpdated>().last.part as PluginMessagePartTool;
       expect(tool.state.status, PluginToolStatus.error);
       expect(tracker.childStatuses, isEmpty);
+    });
+
+    test("replays every deferred partial update when child startup fails", () {
+      expect(mapper.map(_toolCall(toolCallId: "failed-call", title: "subagent")), isEmpty);
+      expect(
+        mapper.map(
+          const AcpNotification(
+            method: AcpMethods.sessionUpdate,
+            params: {
+              "sessionId": "root",
+              "update": {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "failed-call",
+                "status": "in_progress",
+                "content": [
+                  {
+                    "type": "content",
+                    "content": {"type": "text", "text": "startup detail"},
+                  },
+                ],
+              },
+            },
+          ),
+        ),
+        isEmpty,
+      );
+      expect(
+        mapper.map(
+          const AcpNotification(
+            method: AcpMethods.sessionUpdate,
+            params: {
+              "sessionId": "root",
+              "update": {"sessionUpdate": "tool_call_update", "toolCallId": "failed-call"},
+            },
+          ),
+        ),
+        isEmpty,
+      );
+
+      final events = mapper.map(_toolUpdate(toolCallId: "failed-call", status: "failed"));
+      final tools = events
+          .whereType<BridgeSseMessagePartUpdated>()
+          .map((event) => event.part)
+          .whereType<PluginMessagePartTool>()
+          .toList(growable: false);
+      expect(tools, hasLength(4));
+      expect(tools.map((tool) => tool.state.status), [
+        PluginToolStatus.running,
+        PluginToolStatus.running,
+        PluginToolStatus.running,
+        PluginToolStatus.error,
+      ]);
+      expect(tools[1].state.output, "startup detail");
+      expect(tools[2].state.output, "startup detail");
+      expect(tools.last.state.error, "startup detail");
     });
 
     test("a malformed start releases its deferred generic delegation card", () {
@@ -114,6 +224,66 @@ void main() {
       expect(tile.childSessionID, "child");
       expect(tile.taskState?.status, PluginToolStatus.running);
       expect(tracker.runningChildren(sessionId: "root").single.isBackground, isTrue);
+    });
+
+    test("a lifecycle prompt ignores child user-message echoes", () {
+      mapper.map(_started(mode: "foreground"));
+
+      expect(
+        mapper.map(
+          const AcpNotification(
+            method: AcpMethods.sessionUpdate,
+            params: {
+              "sessionId": "child",
+              "update": {
+                "sessionUpdate": "user_message_chunk",
+                "messageId": "launch-prompt",
+                "content": {"type": "text", "text": "Inspect the synthetic module"},
+              },
+            },
+          ),
+        ),
+        isEmpty,
+      );
+      final ended = mapper.map(_ended(reason: "completed", summary: "Done"));
+      final tile = ended.whereType<BridgeSseMessagePartUpdated>().single.part as PluginMessagePartSubtask;
+      expect(tile.prompt, "Inspect the synthetic module");
+    });
+
+    test("a nested child retains its direct parent while its tile and activity roll up to root", () {
+      mapper.map(_started(mode: "foreground"));
+
+      final nested = mapper.map(
+        _startedWithIdentity(
+          parentSessionId: "child",
+          mode: "background",
+          childSessionId: "grandchild",
+          toolCallId: "nested-call",
+        ),
+      );
+
+      final session = nested.whereType<BridgeSseSessionCreated>().single.info;
+      expect(session["parentID"], "child");
+      expect(tracker.childSessions(sessionId: "root", directory: "/project").map((child) => child.id), [
+        "child",
+      ]);
+      expect(tracker.childSessions(sessionId: "child", directory: "/project").map((child) => child.id), [
+        "grandchild",
+      ]);
+      final tile = nested.whereType<BridgeSseMessagePartUpdated>().single.part as PluginMessagePartSubtask;
+      expect(tile.sessionID, "root");
+      expect(tile.id, "root-subagent-grandchild-subtask");
+
+      final updated = mapper.map(
+        const AcpNotification(
+          method: AcpMethods.sessionUpdate,
+          params: {
+            "sessionId": "grandchild",
+            "update": {"sessionUpdate": "session_info_update", "title": "Nested"},
+          },
+        ),
+      );
+      expect(updated.whereType<BridgeSseSessionUpdated>().single.info["parentID"], "child");
     });
 
     test("child standard updates inherit the root model and provider selection", () {
@@ -312,10 +482,15 @@ AcpNotification _toolUpdate({required String toolCallId, required String status}
   },
 );
 
-AcpNotification _started({required String mode}) =>
-    _startedWithIdentity(mode: mode, childSessionId: "child", toolCallId: "call");
+AcpNotification _started({required String mode}) => _startedWithIdentity(
+  parentSessionId: "root",
+  mode: mode,
+  childSessionId: "child",
+  toolCallId: "call",
+);
 
 AcpNotification _startedWithIdentity({
+  required String parentSessionId,
   required String mode,
   required String childSessionId,
   required String toolCallId,
@@ -323,7 +498,7 @@ AcpNotification _startedWithIdentity({
   method: DeepSeekAcpApi.subagentMethod,
   params: {
     "kind": "started",
-    "sessionId": "root",
+    "sessionId": parentSessionId,
     "childSessionId": childSessionId,
     "toolCallId": toolCallId,
     "prompt": "Inspect the synthetic module",

--- a/bridge/sesori_plugin_deepseek/test/deepseek_subagent_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_subagent_test.dart
@@ -86,6 +86,20 @@ void main() {
       expect(mapper.sessionIdForToolCallId(toolCallId: "call"), isNull);
     });
 
+    test("an ambiguous cross-session tool call id does not fall back to the active turn", () {
+      mapper.map(_started(mode: "background"));
+      mapper.map(
+        _startedWithIdentity(
+          parentSessionId: "other-root",
+          mode: "background",
+          childSessionId: "other-child",
+          toolCallId: "call",
+        ),
+      );
+
+      expect(mapper.sessionIdForToolCallId(toolCallId: "call"), isNull);
+    });
+
     test("session and protocol resets clear started delegation correlation", () {
       mapper.map(_toolCall(toolCallId: "call", title: "subagent"));
       mapper.map(_started(mode: "background"));
@@ -125,7 +139,7 @@ void main() {
       expect(tracker.childStatuses, isEmpty);
     });
 
-    test("replays every deferred partial update when child startup fails", () {
+    test("merges a bounded deferred snapshot when child startup fails", () {
       expect(mapper.map(_toolCall(toolCallId: "failed-call", title: "subagent")), isEmpty);
       expect(
         mapper.map(
@@ -155,12 +169,34 @@ void main() {
             method: AcpMethods.sessionUpdate,
             params: {
               "sessionId": "root",
-              "update": {"sessionUpdate": "tool_call_update", "toolCallId": "failed-call"},
+              "update": {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "failed-call",
+                "title": "Delegation startup",
+              },
             },
           ),
         ),
         isEmpty,
       );
+      for (var index = 0; index < 256; index += 1) {
+        expect(
+          mapper.map(
+            AcpNotification(
+              method: AcpMethods.sessionUpdate,
+              params: {
+                "sessionId": "root",
+                "update": {
+                  "sessionUpdate": "tool_call_update",
+                  "toolCallId": "failed-call",
+                  "futureField-$index": index,
+                },
+              },
+            ),
+          ),
+          isEmpty,
+        );
+      }
 
       final events = mapper.map(_toolUpdate(toolCallId: "failed-call", status: "failed"));
       final tools = events
@@ -168,15 +204,13 @@ void main() {
           .map((event) => event.part)
           .whereType<PluginMessagePartTool>()
           .toList(growable: false);
-      expect(tools, hasLength(4));
+      expect(tools, hasLength(2));
       expect(tools.map((tool) => tool.state.status), [
-        PluginToolStatus.running,
-        PluginToolStatus.running,
         PluginToolStatus.running,
         PluginToolStatus.error,
       ]);
-      expect(tools[1].state.output, "startup detail");
-      expect(tools[2].state.output, "startup detail");
+      expect(tools.last.state.output, "startup detail");
+      expect(tools.last.state.title, "Delegation startup");
       expect(tools.last.state.error, "startup detail");
     });
 
@@ -250,7 +284,7 @@ void main() {
       expect(tile.prompt, "Inspect the synthetic module");
     });
 
-    test("a nested child retains its direct parent while its tile and activity roll up to root", () {
+    test("a nested child renders in its direct parent while activity rolls up to root", () {
       mapper.map(_started(mode: "foreground"));
 
       final nested = mapper.map(
@@ -270,9 +304,13 @@ void main() {
       expect(tracker.childSessions(sessionId: "child", directory: "/project").map((child) => child.id), [
         "grandchild",
       ]);
+      final envelope = nested.whereType<BridgeSseMessageUpdated>().single.info;
+      expect(envelope["id"], "child-subagent-grandchild");
+      expect(envelope["sessionID"], "child");
       final tile = nested.whereType<BridgeSseMessagePartUpdated>().single.part as PluginMessagePartSubtask;
-      expect(tile.sessionID, "root");
-      expect(tile.id, "root-subagent-grandchild-subtask");
+      expect(tile.sessionID, "child");
+      expect(tile.id, "child-subagent-grandchild-subtask");
+      expect(tracker.busyChildIds(sessionId: "root"), {"child", "grandchild"});
 
       final updated = mapper.map(
         const AcpNotification(

--- a/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v2/deepseek-acp.schema.json
+++ b/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v2/deepseek-acp.schema.json
@@ -1,0 +1,835 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sesori.ai/protocol/v2/deepseek-acp.schema.json",
+  "title": "Sesori DeepSeek ACP extension protocol v2",
+  "$defs": {
+    "nonblank": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "pattern": "\\S"
+    },
+    "sessionId": {
+      "$ref": "#/$defs/nonblank"
+    },
+    "selectionId": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 512,
+      "pattern": "^v1(?:[A-Za-z0-9_-]{2,3}|(?:[A-Za-z0-9_-]{4})+(?:[A-Za-z0-9_-]{2,3})?)$"
+    },
+    "absolutePath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096,
+      "anyOf": [
+        {
+          "pattern": "^/"
+        },
+        {
+          "pattern": "^[A-Za-z]:[\\\\/]"
+        },
+        {
+          "pattern": "^\\\\\\\\"
+        }
+      ]
+    },
+    "initializeMetadata": {
+      "type": "object",
+      "required": [
+        "extensionProtocolVersion",
+        "adapterVersion",
+        "harnessVersion",
+        "persistenceOwner"
+      ],
+      "properties": {
+        "extensionProtocolVersion": {
+          "const": 2
+        },
+        "adapterVersion": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "\\S"
+        },
+        "harnessVersion": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "\\S"
+        },
+        "persistenceOwner": {
+          "const": "sesori"
+        }
+      },
+      "additionalProperties": true
+    },
+    "promptMetadata": {
+      "type": "object",
+      "properties": {
+        "messageId": {
+          "$ref": "#/$defs/nonblank"
+        }
+      },
+      "additionalProperties": true
+    },
+    "catalogRequest": {
+      "type": "object",
+      "required": [
+        "cwd"
+      ],
+      "properties": {
+        "cwd": {
+          "$ref": "#/$defs/absolutePath"
+        }
+      },
+      "additionalProperties": false
+    },
+    "catalogResponse": {
+      "type": "object",
+      "required": [
+        "agent",
+        "providers",
+        "defaultSelectionId",
+        "commands",
+        "failures"
+      ],
+      "properties": {
+        "agent": {
+          "type": "object",
+          "required": [
+            "id",
+            "name",
+            "primary"
+          ],
+          "properties": {
+            "id": {
+              "const": "deepseek"
+            },
+            "name": {
+              "$ref": "#/$defs/nonblank"
+            },
+            "primary": {
+              "const": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "providers": {
+          "type": "array",
+          "maxItems": 64,
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "name",
+              "models"
+            ],
+            "properties": {
+              "id": {
+                "$ref": "#/$defs/nonblank"
+              },
+              "name": {
+                "$ref": "#/$defs/nonblank"
+              },
+              "models": {
+                "type": "array",
+                "maxItems": 256,
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "upstreamModelId",
+                    "name",
+                    "reasoningEfforts",
+                    "defaultReasoningEffort",
+                    "supportsImages"
+                  ],
+                  "properties": {
+                    "id": {
+                      "$ref": "#/$defs/selectionId"
+                    },
+                    "upstreamModelId": {
+                      "$ref": "#/$defs/nonblank"
+                    },
+                    "name": {
+                      "$ref": "#/$defs/nonblank"
+                    },
+                    "reasoningEfforts": {
+                      "type": "array",
+                      "maxItems": 16,
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/$defs/nonblank"
+                      }
+                    },
+                    "defaultReasoningEffort": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/$defs/nonblank"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "supportsImages": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "defaultSelectionId": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/selectionId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "commands": {
+          "type": "array",
+          "maxItems": 128,
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "description"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "pattern": "^[A-Za-z0-9_-]+$"
+              },
+              "description": {
+                "$ref": "#/$defs/nonblank"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "failures": {
+          "type": "array",
+          "maxItems": 64,
+          "items": {
+            "type": "object",
+            "required": [
+              "providerId",
+              "category",
+              "message"
+            ],
+            "properties": {
+              "providerId": {
+                "$ref": "#/$defs/nonblank"
+              },
+              "category": {
+                "$ref": "#/$defs/nonblank"
+              },
+              "message": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 512,
+                "pattern": "\\S"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "historyRequest": {
+      "type": "object",
+      "required": [
+        "sessionId"
+      ],
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "beforeSeq": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "maxMessages": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "default": 50
+        }
+      },
+      "additionalProperties": false
+    },
+    "sessionUpdateEnvelope": {
+      "type": "object",
+      "required": [
+        "sessionId",
+        "update"
+      ],
+      "properties": {
+        "_meta": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "sesori.ai/deepseek": {
+                  "type": "object",
+                  "properties": {
+                    "messageCreatedAt": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "subagent": {
+                      "$ref": "#/$defs/subagentReplay"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              },
+              "additionalProperties": true
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "update": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    "historyResponse": {
+      "type": "object",
+      "required": [
+        "updates",
+        "hasMore"
+      ],
+      "properties": {
+        "updates": {
+          "type": "array",
+          "maxItems": 10000,
+          "items": {
+            "$ref": "#/$defs/sessionUpdateEnvelope"
+          }
+        },
+        "nextBeforeSeq": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "hasMore": {
+          "type": "boolean"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "nextBeforeSeq"
+          ],
+          "properties": {
+            "nextBeforeSeq": true,
+            "hasMore": {
+              "const": true
+            }
+          }
+        },
+        {
+          "properties": {
+            "nextBeforeSeq": false,
+            "hasMore": {
+              "const": false
+            }
+          }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "renameRequest": {
+      "type": "object",
+      "required": [
+        "sessionId",
+        "title"
+      ],
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "pattern": "\\S"
+        }
+      },
+      "additionalProperties": false
+    },
+    "renameResponse": {
+      "type": "object",
+      "required": [
+        "title"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "pattern": "\\S"
+        }
+      },
+      "additionalProperties": false
+    },
+    "question": {
+      "type": "object",
+      "required": [
+        "id",
+        "text"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/nonblank"
+        },
+        "text": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048,
+          "pattern": "\\S"
+        },
+        "header": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "\\S"
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4096,
+          "pattern": "\\S"
+        },
+        "options": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "pattern": "\\S"
+          }
+        },
+        "multiSelect": {
+          "type": "boolean"
+        },
+        "intent": {
+          "const": "plan_review"
+        },
+        "approveLabel": {
+          "$ref": "#/$defs/nonblank"
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "intent": {
+              "const": "plan_review"
+            },
+            "approveLabel": {
+              "$ref": "#/$defs/nonblank"
+            },
+            "options": true
+          },
+          "required": [
+            "intent",
+            "approveLabel",
+            "options"
+          ]
+        },
+        {
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "intent"
+                ]
+              },
+              {
+                "required": [
+                  "approveLabel"
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "askUserQuestionRequest": {
+      "type": "object",
+      "required": [
+        "sessionId",
+        "questions"
+      ],
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "questions": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/question"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "askUserQuestionResponse": {
+      "type": "object",
+      "required": [
+        "answers"
+      ],
+      "properties": {
+        "answers": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "type": "object",
+            "required": [
+              "questionId",
+              "selectedLabels"
+            ],
+            "properties": {
+              "questionId": {
+                "$ref": "#/$defs/nonblank"
+              },
+              "selectedLabels": {
+                "type": "array",
+                "maxItems": 32,
+                "uniqueItems": true,
+                "items": {
+                  "$ref": "#/$defs/nonblank"
+                }
+              },
+              "customAnswer": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 2048,
+                "pattern": "\\S"
+              }
+            },
+            "anyOf": [
+              {
+                "properties": {
+                  "selectedLabels": {
+                    "type": "array",
+                    "minItems": 1
+                  }
+                }
+              },
+              {
+                "required": [
+                  "customAnswer"
+                ],
+                "properties": {
+                  "customAnswer": true
+                }
+              }
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "sessionStatusRetry": {
+      "type": "object",
+      "required": [
+        "sessionId",
+        "kind",
+        "attempt"
+      ],
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "kind": {
+          "const": "retry"
+        },
+        "attempt": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      "additionalProperties": false
+    },
+    "sessionStatusCompactionStarted": {
+      "type": "object",
+      "required": [
+        "sessionId",
+        "kind"
+      ],
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "kind": {
+          "const": "compaction_started"
+        }
+      },
+      "additionalProperties": false
+    },
+    "sessionStatusCompactionCompleted": {
+      "type": "object",
+      "required": [
+        "sessionId",
+        "kind"
+      ],
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "kind": {
+          "const": "compaction_completed"
+        }
+      },
+      "additionalProperties": false
+    },
+    "sessionStatusWarning": {
+      "type": "object",
+      "required": [
+        "sessionId",
+        "kind",
+        "message"
+      ],
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "kind": {
+          "const": "warning"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512,
+          "pattern": "\\S"
+        }
+      },
+      "additionalProperties": false
+    },
+    "sessionStatusNotification": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/sessionStatusRetry"
+        },
+        {
+          "$ref": "#/$defs/sessionStatusCompactionStarted"
+        },
+        {
+          "$ref": "#/$defs/sessionStatusCompactionCompleted"
+        },
+        {
+          "$ref": "#/$defs/sessionStatusWarning"
+        }
+      ]
+    },
+    "subagentMode": {
+      "enum": [
+        "foreground",
+        "background"
+      ]
+    },
+    "subagentStopReason": {
+      "enum": [
+        "completed",
+        "aborted",
+        "error",
+        "max-tokens",
+        "refusal"
+      ]
+    },
+    "subagentPrompt": {
+      "description": "Trimmed tile presentation prompt, bounded to 32768 Unicode scalar values.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 32768,
+      "pattern": "\\S",
+      "allOf": [
+        {
+          "pattern": "^[^\\uD800-\\uDFFF]*$"
+        }
+      ]
+    },
+    "subagentSummary": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "\\S"
+    },
+    "subagentStarted": {
+      "type": "object",
+      "required": [
+        "kind",
+        "sessionId",
+        "childSessionId",
+        "toolCallId",
+        "label",
+        "prompt",
+        "mode"
+      ],
+      "properties": {
+        "kind": {
+          "const": "started"
+        },
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "childSessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "toolCallId": {
+          "$ref": "#/$defs/nonblank"
+        },
+        "label": {
+          "$ref": "#/$defs/nonblank"
+        },
+        "prompt": {
+          "$ref": "#/$defs/subagentPrompt"
+        },
+        "mode": {
+          "$ref": "#/$defs/subagentMode"
+        }
+      },
+      "additionalProperties": false
+    },
+    "subagentEnded": {
+      "type": "object",
+      "required": [
+        "kind",
+        "sessionId",
+        "childSessionId",
+        "stopReason"
+      ],
+      "properties": {
+        "kind": {
+          "const": "ended"
+        },
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "childSessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "stopReason": {
+          "$ref": "#/$defs/subagentStopReason"
+        },
+        "summary": {
+          "$ref": "#/$defs/subagentSummary"
+        }
+      },
+      "additionalProperties": false
+    },
+    "subagentNotification": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/subagentStarted"
+        },
+        {
+          "$ref": "#/$defs/subagentEnded"
+        }
+      ]
+    },
+    "subagentReplay": {
+      "type": "object",
+      "required": [
+        "label",
+        "prompt",
+        "mode"
+      ],
+      "properties": {
+        "label": {
+          "$ref": "#/$defs/nonblank"
+        },
+        "prompt": {
+          "$ref": "#/$defs/subagentPrompt"
+        },
+        "mode": {
+          "$ref": "#/$defs/subagentMode"
+        },
+        "childSessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "ended": {
+          "type": "object",
+          "required": [
+            "stopReason"
+          ],
+          "properties": {
+            "stopReason": {
+              "$ref": "#/$defs/subagentStopReason"
+            },
+            "summary": {
+              "$ref": "#/$defs/subagentSummary"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "subagentInterruptRequest": {
+      "type": "object",
+      "required": [
+        "sessionId",
+        "childSessionId"
+      ],
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "childSessionId": {
+          "$ref": "#/$defs/sessionId"
+        }
+      },
+      "additionalProperties": false
+    },
+    "subagentInterruptResponse": {
+      "type": "object",
+      "required": [
+        "result"
+      ],
+      "properties": {
+        "result": {
+          "enum": [
+            "interrupted",
+            "not_cancellable",
+            "unknown_child"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v2/invalid.json
+++ b/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v2/invalid.json
@@ -1,0 +1,375 @@
+[
+  {
+    "definition": "initializeMetadata",
+    "value": {
+      "extensionProtocolVersion": 1,
+      "adapterVersion": "0.1.0",
+      "harnessVersion": "0.1.1",
+      "persistenceOwner": "sesori"
+    }
+  },
+  {
+    "definition": "promptMetadata",
+    "value": {
+      "messageId": ""
+    }
+  },
+  {
+    "definition": "catalogRequest",
+    "value": {
+      "cwd": "relative/project"
+    }
+  },
+  {
+    "definition": "catalogResponse",
+    "value": {
+      "agent": {
+        "id": "other",
+        "name": "DeepSeek",
+        "primary": true
+      },
+      "providers": [],
+      "defaultSelectionId": null,
+      "commands": [],
+      "failures": []
+    }
+  },
+  {
+    "definition": "catalogResponse",
+    "value": {
+      "agent": {
+        "id": "deepseek",
+        "name": "DeepSeek",
+        "primary": true
+      },
+      "providers": [],
+      "defaultSelectionId": "v1",
+      "commands": [],
+      "failures": []
+    }
+  },
+  {
+    "definition": "catalogResponse",
+    "value": {
+      "agent": {
+        "id": "deepseek",
+        "name": "DeepSeek",
+        "primary": true
+      },
+      "providers": [],
+      "defaultSelectionId": "v1payload+",
+      "commands": [],
+      "failures": []
+    }
+  },
+  {
+    "definition": "catalogResponse",
+    "value": {
+      "agent": {
+        "id": "deepseek",
+        "name": "DeepSeek",
+        "primary": true
+      },
+      "providers": [],
+      "defaultSelectionId": "v1A",
+      "commands": [],
+      "failures": []
+    }
+  },
+  {
+    "definition": "historyRequest",
+    "value": {
+      "sessionId": "session-1",
+      "maxMessages": 101
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [],
+      "hasMore": "yes"
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [],
+      "hasMore": true
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [],
+      "nextBeforeSeq": 1,
+      "hasMore": false
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [
+        {
+          "sessionId": "session-1",
+          "update": {
+            "sessionUpdate": "agent_message_chunk"
+          },
+          "_meta": {
+            "sesori.ai/deepseek": {
+              "messageCreatedAt": -1
+            }
+          }
+        }
+      ],
+      "hasMore": false
+    }
+  },
+  {
+    "definition": "renameRequest",
+    "value": {
+      "sessionId": "session-1",
+      "title": "   "
+    }
+  },
+  {
+    "definition": "renameResponse",
+    "value": {
+      "title": ""
+    }
+  },
+  {
+    "definition": "askUserQuestionRequest",
+    "value": {
+      "sessionId": "session-1",
+      "questions": []
+    }
+  },
+  {
+    "definition": "askUserQuestionRequest",
+    "value": {
+      "sessionId": "session-1",
+      "questions": [
+        {
+          "id": "plan-1",
+          "text": "Review the plan",
+          "intent": "plan_review"
+        }
+      ]
+    }
+  },
+  {
+    "definition": "askUserQuestionRequest",
+    "value": {
+      "sessionId": "session-1",
+      "questions": [
+        {
+          "id": "q1",
+          "text": "Choose an option",
+          "intent": "question",
+          "approveLabel": "Approve"
+        }
+      ]
+    }
+  },
+  {
+    "definition": "askUserQuestionRequest",
+    "value": {
+      "sessionId": "session-1",
+      "questions": [
+        {
+          "id": "plan-1",
+          "text": "Review the plan",
+          "intent": "plan_review",
+          "approveLabel": "Approve"
+        }
+      ]
+    }
+  },
+  {
+    "definition": "askUserQuestionResponse",
+    "value": {
+      "answers": [
+        {
+          "questionId": "q1",
+          "selectedLabels": [
+            "Alpha",
+            "Alpha"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "definition": "askUserQuestionResponse",
+    "value": {
+      "answers": [
+        {
+          "questionId": "q1",
+          "selectedLabels": []
+        }
+      ]
+    }
+  },
+  {
+    "definition": "sessionStatusNotification",
+    "value": {
+      "sessionId": "session-1",
+      "kind": "future_status"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "started",
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "label": "Probe child",
+      "prompt": "Synthetic child prompt",
+      "mode": "foreground"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "started",
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "toolCallId": "call-1",
+      "label": "Probe child",
+      "prompt": "Synthetic child prompt",
+      "mode": "detached"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "ended",
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "stopReason": "vanished"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "ended",
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "stopReason": "completed",
+      "summary": "   "
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [
+        {
+          "sessionId": "session-1",
+          "update": {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "call-1"
+          },
+          "_meta": {
+            "sesori.ai/deepseek": {
+              "subagent": {
+                "prompt": "Synthetic child prompt",
+                "mode": "background"
+              }
+            }
+          }
+        }
+      ],
+      "hasMore": false
+    }
+  },
+  {
+    "definition": "subagentInterruptRequest",
+    "value": {
+      "sessionId": "session-1"
+    }
+  },
+  {
+    "definition": "subagentInterruptRequest",
+    "value": {
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "force": true
+    }
+  },
+  {
+    "definition": "subagentInterruptResponse",
+    "value": {
+      "result": "killed"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "started",
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "toolCallId": "call-1",
+      "label": "Probe child",
+      "mode": "foreground"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "started",
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "toolCallId": "call-1",
+      "label": "Probe child",
+      "prompt": "   ",
+      "mode": "foreground"
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [
+        {
+          "sessionId": "session-1",
+          "update": {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "call-1"
+          },
+          "_meta": {
+            "sesori.ai/deepseek": {
+              "subagent": {
+                "label": "Probe child",
+                "mode": "background"
+              }
+            }
+          }
+        }
+      ],
+      "hasMore": false
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [
+        {
+          "sessionId": "session-1",
+          "update": {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "call-1"
+          },
+          "_meta": {
+            "sesori.ai/deepseek": {
+              "subagent": {
+                "label": "Probe child",
+                "prompt": "   ",
+                "mode": "background"
+              }
+            }
+          }
+        }
+      ],
+      "hasMore": false
+    }
+  }
+]

--- a/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v2/source_manifest.json
+++ b/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v2/source_manifest.json
@@ -1,0 +1,9 @@
+{
+  "repository": "sesori-ai/sesori-deepseek-acp",
+  "commit": "d7a48471bf5339793beb0c9e1c1889e63f76ec92",
+  "files": {
+    "deepseek-acp.schema.json": "0214eee120039d7d573ee6bf4c585f3501570dfc568ce872066b39715992b4dc",
+    "valid.json": "a88483d685dc38766e2be4e0dda9e8a2be374635664074e8f59ea76dc7401f5a",
+    "invalid.json": "bf8a6b368bd2a3aa87c5591fcac83b16d9ed052ff295c0bc04362d01c7de39f2"
+  }
+}

--- a/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v2/valid.json
+++ b/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v2/valid.json
@@ -1,0 +1,337 @@
+[
+  {
+    "definition": "initializeMetadata",
+    "value": {
+      "extensionProtocolVersion": 2,
+      "adapterVersion": "0.1.0",
+      "harnessVersion": "0.1.1-rc.2",
+      "persistenceOwner": "sesori"
+    }
+  },
+  {
+    "definition": "initializeMetadata",
+    "value": {
+      "extensionProtocolVersion": 2,
+      "adapterVersion": "0.1.0",
+      "harnessVersion": "0.1.1-rc.2",
+      "persistenceOwner": "sesori",
+      "futureCapability": true
+    }
+  },
+  {
+    "definition": "promptMetadata",
+    "value": {
+      "messageId": "message-1"
+    }
+  },
+  {
+    "definition": "promptMetadata",
+    "value": {}
+  },
+  {
+    "definition": "catalogRequest",
+    "value": {
+      "cwd": "/synthetic/project"
+    }
+  },
+  {
+    "definition": "catalogRequest",
+    "value": {
+      "cwd": "C:\\synthetic\\project"
+    }
+  },
+  {
+    "definition": "catalogResponse",
+    "value": {
+      "agent": {
+        "id": "deepseek",
+        "name": "DeepSeek",
+        "primary": true
+      },
+      "providers": [
+        {
+          "id": "provider/alpha-\u03b1",
+          "name": "Synthetic Provider",
+          "models": [
+            {
+              "id": "v1c3ludGhldGlj",
+              "upstreamModelId": "model/alpha-\u03b1",
+              "name": "Synthetic Model",
+              "reasoningEfforts": [
+                "low",
+                "high"
+              ],
+              "defaultReasoningEffort": "low",
+              "supportsImages": true
+            }
+          ]
+        }
+      ],
+      "defaultSelectionId": "v1c3ludGhldGlj",
+      "commands": [
+        {
+          "name": "inspect",
+          "description": "Synthetic command"
+        }
+      ],
+      "failures": [
+        {
+          "providerId": "offline",
+          "category": "unavailable",
+          "message": "Synthetic provider unavailable"
+        }
+      ]
+    }
+  },
+  {
+    "definition": "historyRequest",
+    "value": {
+      "sessionId": "session-1",
+      "maxMessages": 50
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [
+        {
+          "sessionId": "session-1",
+          "update": {
+            "sessionUpdate": "agent_message_chunk"
+          },
+          "_meta": {
+            "sesori.ai/deepseek": {
+              "messageCreatedAt": 1787831943365
+            }
+          }
+        }
+      ],
+      "nextBeforeSeq": 12,
+      "hasMore": true
+    }
+  },
+  {
+    "definition": "renameRequest",
+    "value": {
+      "sessionId": "session-1",
+      "title": "Synthetic title"
+    }
+  },
+  {
+    "definition": "renameResponse",
+    "value": {
+      "title": "Synthetic title"
+    }
+  },
+  {
+    "definition": "askUserQuestionRequest",
+    "value": {
+      "sessionId": "session-1",
+      "questions": [
+        {
+          "id": "q1",
+          "text": "Choose synthetic option",
+          "options": [
+            "Alpha",
+            "Beta"
+          ],
+          "multiSelect": false
+        }
+      ]
+    }
+  },
+  {
+    "definition": "askUserQuestionResponse",
+    "value": {
+      "answers": [
+        {
+          "questionId": "q1",
+          "selectedLabels": [
+            "Alpha"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "definition": "askUserQuestionResponse",
+    "value": {
+      "answers": [
+        {
+          "questionId": "q1",
+          "selectedLabels": [],
+          "customAnswer": "Synthetic custom answer"
+        }
+      ]
+    }
+  },
+  {
+    "definition": "askUserQuestionResponse",
+    "value": {
+      "answers": [
+        {
+          "questionId": "q1",
+          "selectedLabels": [
+            "Alpha"
+          ],
+          "customAnswer": "Synthetic additional answer"
+        }
+      ]
+    }
+  },
+  {
+    "definition": "askUserQuestionRequest",
+    "value": {
+      "sessionId": "session-1",
+      "questions": [
+        {
+          "id": "plan-1",
+          "text": "Review the plan",
+          "options": [
+            "Approve",
+            "Reject"
+          ],
+          "intent": "plan_review",
+          "approveLabel": "Approve"
+        }
+      ]
+    }
+  },
+  {
+    "definition": "sessionStatusNotification",
+    "value": {
+      "sessionId": "session-1",
+      "kind": "retry",
+      "attempt": 1,
+      "limit": 3
+    }
+  },
+  {
+    "definition": "sessionStatusNotification",
+    "value": {
+      "sessionId": "session-1",
+      "kind": "retry",
+      "attempt": 2
+    }
+  },
+  {
+    "definition": "sessionStatusNotification",
+    "value": {
+      "sessionId": "session-1",
+      "kind": "compaction_started"
+    }
+  },
+  {
+    "definition": "sessionStatusNotification",
+    "value": {
+      "sessionId": "session-1",
+      "kind": "compaction_completed"
+    }
+  },
+  {
+    "definition": "sessionStatusNotification",
+    "value": {
+      "sessionId": "session-1",
+      "kind": "warning",
+      "message": "Synthetic warning"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "started",
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "toolCallId": "call-1",
+      "label": "Probe child",
+      "prompt": "Synthetic prompt for child-1",
+      "mode": "foreground"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "started",
+      "sessionId": "session-1",
+      "childSessionId": "child-2",
+      "toolCallId": "call-2",
+      "label": "Probe child",
+      "prompt": "Synthetic prompt for child-2",
+      "mode": "background"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "ended",
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "stopReason": "completed",
+      "summary": "Done."
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "ended",
+      "sessionId": "session-1",
+      "childSessionId": "child-2",
+      "stopReason": "aborted"
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [
+        {
+          "sessionId": "session-1",
+          "update": {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "call-1"
+          },
+          "_meta": {
+            "sesori.ai/deepseek": {
+              "messageCreatedAt": 1,
+              "subagent": {
+                "label": "Probe child",
+                "prompt": "Synthetic child prompt",
+                "mode": "background",
+                "childSessionId": "child-1",
+                "ended": {
+                  "stopReason": "completed",
+                  "summary": "Done."
+                }
+              }
+            }
+          }
+        }
+      ],
+      "hasMore": false
+    }
+  },
+  {
+    "definition": "subagentInterruptRequest",
+    "value": {
+      "sessionId": "session-1",
+      "childSessionId": "child-1"
+    }
+  },
+  {
+    "definition": "subagentInterruptResponse",
+    "value": {
+      "result": "interrupted"
+    }
+  },
+  {
+    "definition": "subagentInterruptResponse",
+    "value": {
+      "result": "not_cancellable"
+    }
+  },
+  {
+    "definition": "subagentInterruptResponse",
+    "value": {
+      "result": "unknown_child"
+    }
+  }
+]

--- a/bridge/sesori_plugin_deepseek/test/repositories/trackers/deepseek_delegation_tracker_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/repositories/trackers/deepseek_delegation_tracker_test.dart
@@ -1,6 +1,9 @@
 import "package:deepseek_plugin/deepseek_testing.dart";
 import "package:test/test.dart";
 
+Matcher _found({required String sessionId}) =>
+    isA<DeepSeekDelegationFound>().having((lookup) => lookup.sessionId, "sessionId", sessionId);
+
 void main() {
   test("correlation remains until child and standard tool lifecycles are terminal", () {
     for (final childEndsFirst in [true, false]) {
@@ -13,7 +16,7 @@ void main() {
         tracker.markToolTerminal(parentSessionId: "root", toolCallId: "call");
       }
       expect(tracker.isStarted(parentSessionId: "root", toolCallId: "call"), isTrue);
-      expect(tracker.sessionIdForToolCallId(toolCallId: "call"), "root");
+      expect(tracker.lookupToolCallId(toolCallId: "call"), _found(sessionId: "root"));
 
       if (childEndsFirst) {
         tracker.markToolTerminal(parentSessionId: "root", toolCallId: "call");
@@ -21,7 +24,7 @@ void main() {
         tracker.markChildEnded(childSessionId: "child");
       }
       expect(tracker.isStarted(parentSessionId: "root", toolCallId: "call"), isFalse);
-      expect(tracker.sessionIdForToolCallId(toolCallId: "call"), isNull);
+      expect(tracker.lookupToolCallId(toolCallId: "call"), isA<DeepSeekDelegationNotFound>());
     }
   });
 
@@ -31,14 +34,22 @@ void main() {
       ..start(parentSessionId: "child-1", toolCallId: "call-2", childSessionId: "child-2");
 
     tracker.forgetSession(sessionId: "child-2");
-    expect(tracker.sessionIdForToolCallId(toolCallId: "call-2"), isNull);
-    expect(tracker.sessionIdForToolCallId(toolCallId: "call-1"), "root");
+    expect(tracker.lookupToolCallId(toolCallId: "call-2"), isA<DeepSeekDelegationNotFound>());
+    expect(tracker.lookupToolCallId(toolCallId: "call-1"), _found(sessionId: "root"));
 
     tracker.forgetSession(sessionId: "root");
-    expect(tracker.sessionIdForToolCallId(toolCallId: "call-1"), isNull);
+    expect(tracker.lookupToolCallId(toolCallId: "call-1"), isA<DeepSeekDelegationNotFound>());
 
     tracker.start(parentSessionId: "root", toolCallId: "call-3", childSessionId: "child-3");
     tracker.clear();
-    expect(tracker.sessionIdForToolCallId(toolCallId: "call-3"), isNull);
+    expect(tracker.lookupToolCallId(toolCallId: "call-3"), isA<DeepSeekDelegationNotFound>());
+  });
+
+  test("a tool call id active in two sessions is ambiguous", () {
+    final tracker = DeepSeekDelegationTracker()
+      ..start(parentSessionId: "root-1", toolCallId: "shared", childSessionId: "child-1")
+      ..start(parentSessionId: "root-2", toolCallId: "shared", childSessionId: "child-2");
+
+    expect(tracker.lookupToolCallId(toolCallId: "shared"), isA<DeepSeekDelegationAmbiguous>());
   });
 }

--- a/bridge/sesori_plugin_deepseek/test/repositories/trackers/deepseek_delegation_tracker_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/repositories/trackers/deepseek_delegation_tracker_test.dart
@@ -1,0 +1,44 @@
+import "package:deepseek_plugin/deepseek_testing.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("correlation remains until child and standard tool lifecycles are terminal", () {
+    for (final childEndsFirst in [true, false]) {
+      final tracker = DeepSeekDelegationTracker()
+        ..start(parentSessionId: "root", toolCallId: "call", childSessionId: "child");
+
+      if (childEndsFirst) {
+        tracker.markChildEnded(childSessionId: "child");
+      } else {
+        tracker.markToolTerminal(parentSessionId: "root", toolCallId: "call");
+      }
+      expect(tracker.isStarted(parentSessionId: "root", toolCallId: "call"), isTrue);
+      expect(tracker.sessionIdForToolCallId(toolCallId: "call"), "root");
+
+      if (childEndsFirst) {
+        tracker.markToolTerminal(parentSessionId: "root", toolCallId: "call");
+      } else {
+        tracker.markChildEnded(childSessionId: "child");
+      }
+      expect(tracker.isStarted(parentSessionId: "root", toolCallId: "call"), isFalse);
+      expect(tracker.sessionIdForToolCallId(toolCallId: "call"), isNull);
+    }
+  });
+
+  test("forget and clear remove both correlation indexes", () {
+    final tracker = DeepSeekDelegationTracker()
+      ..start(parentSessionId: "root", toolCallId: "call-1", childSessionId: "child-1")
+      ..start(parentSessionId: "child-1", toolCallId: "call-2", childSessionId: "child-2");
+
+    tracker.forgetSession(sessionId: "child-2");
+    expect(tracker.sessionIdForToolCallId(toolCallId: "call-2"), isNull);
+    expect(tracker.sessionIdForToolCallId(toolCallId: "call-1"), "root");
+
+    tracker.forgetSession(sessionId: "root");
+    expect(tracker.sessionIdForToolCallId(toolCallId: "call-1"), isNull);
+
+    tracker.start(parentSessionId: "root", toolCallId: "call-3", childSessionId: "child-3");
+    tracker.clear();
+    expect(tracker.sessionIdForToolCallId(toolCallId: "call-3"), isNull);
+  });
+}

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -20,8 +20,8 @@ Columns are the plugins registered in `bridge/app/lib/src/runtime/plugin_registr
 
 | Capability | Claude | OpenCode | Codex | Copilot | Cursor | Hermes | Pi | OMP | DeepSeek | Grok |
 |---|---|---|---|---|---|---|---|---|---|---|
-| Sub-agents rendered as inline subtask tiles | ✅ | ✅ | ⬜³ | 🚫⁴ | ⬜⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | ⬜¹⁰ |
-| Sub-agent transcripts exposed as child sessions | ✅ | ✅ | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | ⬜¹⁰ |
+| Sub-agents rendered as inline subtask tiles | ✅ | ✅ | ⬜³ | 🚫⁴ | ⬜⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ⬜¹⁰ |
+| Sub-agent transcripts exposed as child sessions | ✅ | ✅ | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ⬜¹⁰ |
 | Scoped stop: confirmation while sub-agents run, `stop` cancels them all | ✅ | ✅ | ⬜³ | 🚫⁴ | ⬜⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | ⬜¹⁰ |
 | Stop the sub-agents only while the main agent is idle (`stop`) | ✅ | ✅ | ⬜³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | ⬜¹⁰ |
 | Stop the main agent only while it runs, keeping its sub-agents | 🚫¹ | 🚫² | ⬜³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | 🚫¹⁰ |
@@ -69,13 +69,14 @@ generic `tool_call` with no ids or lifecycle notifications; those exist only in
 `--mode rpc`, which Sesori does not drive. `session/cancel` aborts the whole
 turn.
 
-⁹ DeepSeek (Sesori's own `sesori-deepseek-acp` 0.1.2 over dsh 0.1.1-rc.2,
-probed 2026-09-03): the harness emits `subagent/start`/`subagent/end` with
-child session ids and `ctx.subagents.interrupt` stops a continuable child; the
-adapter forwards none of it yet but is ours to extend, and the executing tool
-call is known for every start. Foreground children die with the parent while
-background ones survive, and the adapter can tell them apart, so
-main-agent-only is supportable when every running child is background.
+⁹ DeepSeek (`sesori-deepseek-acp` 0.1.3 source over dsh 0.1.1-rc.2,
+probed 2026-09-03) now has protocol-v2 lifecycle, descendant transcript, replay,
+and per-child interrupt contracts. Sesori maps its live and replayed child work
+to tiles and child sessions, including foreground/background mode; a protocol-v1
+adapter retains its generic delegation cards. Adapter v0.1.3 remains unpublished:
+managed target 0.1.2 and PATH floor 0.1.0 remain in force until release preparation
+records the merged consumer commit. Scoped stop
+is intentionally pending the subsequent runtime-pin/interrupt consumer PR.
 
 ¹⁰ Grok Build (1.0.5, probed 2026-09-03) sends `subagent_spawned`/`subagent_progress`/
 `subagent_finished` with parent and child session ids as

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -20,8 +20,8 @@ Columns are the plugins registered in `bridge/app/lib/src/runtime/plugin_registr
 
 | Capability | Claude | OpenCode | Codex | Copilot | Cursor | Hermes | Pi | OMP | DeepSeek | Grok |
 |---|---|---|---|---|---|---|---|---|---|---|
-| Sub-agents rendered as inline subtask tiles | ✅ | ✅ | ⬜³ | 🚫⁴ | ⬜⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ⬜¹⁰ |
-| Sub-agent transcripts exposed as child sessions | ✅ | ✅ | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ⬜¹⁰ |
+| Sub-agents rendered as inline subtask tiles | ✅ | ✅ | ⬜³ | 🚫⁴ | ⬜⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | ⬜¹⁰ |
+| Sub-agent transcripts exposed as child sessions | ✅ | ✅ | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | ⬜¹⁰ |
 | Scoped stop: confirmation while sub-agents run, `stop` cancels them all | ✅ | ✅ | ⬜³ | 🚫⁴ | ⬜⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | ⬜¹⁰ |
 | Stop the sub-agents only while the main agent is idle (`stop`) | ✅ | ✅ | ⬜³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | ⬜¹⁰ |
 | Stop the main agent only while it runs, keeping its sub-agents | 🚫¹ | 🚫² | ⬜³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | 🚫¹⁰ |
@@ -71,12 +71,13 @@ turn.
 
 ⁹ DeepSeek (`sesori-deepseek-acp` 0.1.3 source over dsh 0.1.1-rc.2,
 probed 2026-09-03) now has protocol-v2 lifecycle, descendant transcript, replay,
-and per-child interrupt contracts. Sesori maps its live and replayed child work
-to tiles and child sessions, including foreground/background mode; a protocol-v1
-adapter retains its generic delegation cards. Adapter v0.1.3 remains unpublished:
-managed target 0.1.2 and PATH floor 0.1.0 remain in force until release preparation
-records the merged consumer commit. Scoped stop
-is intentionally pending the subsequent runtime-pin/interrupt consumer PR.
+and per-child interrupt contracts. Sesori's protocol-v2 consumer maps live and
+replayed child work to tiles and child sessions, including foreground/background
+mode; a protocol-v1 adapter retains its generic delegation cards. Adapter v0.1.3
+remains unpublished, so the capability cells stay open: managed target 0.1.2 and
+PATH floor 0.1.0 remain in force until release preparation records the merged
+consumer commit. Scoped stop is intentionally pending the subsequent
+runtime-pin/interrupt consumer PR.
 
 ¹⁰ Grok Build (1.0.5, probed 2026-09-03) sends `subagent_spawned`/`subagent_progress`/
 `subagent_finished` with parent and child session ids as

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -23,21 +23,24 @@ idle suspension, the management snapshot, and lifecycle commands.
   Hermes entries give local setup guidance rather than offering bridge-managed login.
 - DeepSeek is an ACP harness with six-platform managed package archives. Its
   descriptor honors an explicit `--deepseek-bin` path before a compatible PATH
-  release (`>=0.1.0`) and the exact managed `0.1.1` release. An old or malformed
+  release (`>=0.1.0`) and the exact managed `0.1.2` release. An old or malformed
   PATH candidate falls through to managed selection. It performs bounded parseable-version and
   side-effect-free `check --state-dir` probes, advertises install only on a
   supported platform without an explicit path, and gives local DeepSeek
   provider/setup guidance. Managed installation verifies the immutable archive
   digest and preserves the packaged launcher with its bundled Node runtime. Startup
-  validates ACP v1 plus required DeepSeek extension metadata, owns one stdio
-  child through the host process seam, degrades on an unexpected exit, lazily
-  reconnects on demand, and shuts down idempotently without treating its own
-  termination as a crash.
+  validates ACP v1 plus required DeepSeek extension metadata and temporarily
+  accepts extension protocol v1 or v2 while adapter v0.1.3 remains unpublished.
+  The managed target and PATH floor stay at 0.1.2/0.1.0 until that release records
+  the merged consumer commit. The plugin owns one stdio child through the host
+  process seam, degrades on an unexpected exit, lazily reconnects on demand, and
+  shuts down idempotently without treating its own termination as a crash.
 - Standard ACP owns DeepSeek lifecycle, prompts, config options, and permissions;
-  `deepseek/*` is limited to catalog, detached history, rename, questions, and
-  bounded statuses on that same connection. Normal `DSH_HOME` remains the source
-  of settings, credentials, providers, and skills but its session root is never
-  scanned. Session, attachment, query, and spill mutations stay below plugin
+  `deepseek/*` is limited to catalog, detached history, rename, questions,
+  bounded statuses, and sub-agent lifecycle on that same connection. Normal
+  `DSH_HOME` remains the source of settings, credentials, providers, and skills,
+  but its session root is never scanned. Session, attachment, query, and spill
+  mutations stay below plugin
   state, and session-local model/reasoning writes never modify user settings.
 - GitHub Copilot is a standard ACP v1 harness launched as
   `copilot --no-auto-update --acp`. Setup keeps an explicit `--copilot-bin`

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -200,9 +200,11 @@ state.
   `DSH_HOME/sessions`. Ordinary project/session list reads remain bridge-database
   reads after import; adapter JSONL is not a second normal catalog source. Child
   reads merge those persisted rows with not-yet-persisted live protocol-v2
-  children by id, preferring persisted title and time metadata. Nested children
-  retain their direct parent for catalog navigation and transcript ownership,
-  while activity alone rolls up to the root. Deleting a tracked parent clears
+  children by id, preferring persisted title and time metadata. A live-only
+  descendant listing inherits the tracked root's project even before its parent
+  appears in persisted session results. Nested children retain their direct
+  parent for catalog navigation and transcript ownership, while activity alone
+  rolls up to the root. Deleting a tracked parent clears
   its full live descendant subtree from status and mapper state.
 - GitHub Copilot explicit import follows standard ACP `session/list` pagination,
   up to the bounded page limit, attributes committed rows to `copilot`, and then

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -200,10 +200,10 @@ state.
   `DSH_HOME/sessions`. Ordinary project/session list reads remain bridge-database
   reads after import; adapter JSONL is not a second normal catalog source. Child
   reads merge those persisted rows with not-yet-persisted live protocol-v2
-  children by id, preferring persisted title and time metadata. Nested live
-  children retain their direct parent while activity rolls up to the root;
-  after restart, persisted ancestry resolves that same root before child history
-  identities are reconstructed.
+  children by id, preferring persisted title and time metadata. Nested children
+  retain their direct parent for catalog navigation and transcript ownership,
+  while activity alone rolls up to the root. Deleting a tracked parent clears
+  its full live descendant subtree from status and mapper state.
 - GitHub Copilot explicit import follows standard ACP `session/list` pagination,
   up to the bounded page limit, attributes committed rows to `copilot`, and then
   returns to bridge-database reads for ordinary listing. Sesori never scans

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -196,9 +196,11 @@ state.
   messages to derive titles.
 - DeepSeek explicit import enumerates only adapter-owned session headers below
   the isolated plugin state. It derives projects from normalized session `cwd`,
-  preserves parent/child metadata, and never scans or imports normal
+  preserves direct parent/child metadata, and never scans or imports normal
   `DSH_HOME/sessions`. Ordinary project/session list reads remain bridge-database
-  reads after import; adapter JSONL is not a second normal catalog source.
+  reads after import; adapter JSONL is not a second normal catalog source. Child
+  reads merge those persisted rows with not-yet-persisted live protocol-v2
+  children by id, preferring persisted title and time metadata.
 - GitHub Copilot explicit import follows standard ACP `session/list` pagination,
   up to the bounded page limit, attributes committed rows to `copilot`, and then
   returns to bridge-database reads for ordinary listing. Sesori never scans

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -204,8 +204,9 @@ state.
   descendant listing inherits the tracked root's project even before its parent
   appears in persisted session results. Nested children retain their direct
   parent for catalog navigation and transcript ownership, while activity alone
-  rolls up to the root. Deleting a tracked parent clears
-  its full live descendant subtree from status and mapper state.
+  rolls up to the root. Deleting a tracked parent clears its full live
+  descendant subtree from status and mapper state; process-scoped tombstones
+  reject queued lifecycle and transcript frames until that process is drained.
 - GitHub Copilot explicit import follows standard ACP `session/list` pagination,
   up to the bounded page limit, attributes committed rows to `copilot`, and then
   returns to bridge-database reads for ordinary listing. Sesori never scans

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -200,7 +200,10 @@ state.
   `DSH_HOME/sessions`. Ordinary project/session list reads remain bridge-database
   reads after import; adapter JSONL is not a second normal catalog source. Child
   reads merge those persisted rows with not-yet-persisted live protocol-v2
-  children by id, preferring persisted title and time metadata.
+  children by id, preferring persisted title and time metadata. Nested live
+  children retain their direct parent while activity rolls up to the root;
+  after restart, persisted ancestry resolves that same root before child history
+  identities are reconstructed.
 - GitHub Copilot explicit import follows standard ACP `session/list` pagination,
   up to the bounded page limit, attributes committed rows to `copilot`, and then
   returns to bridge-database reads for ordinary listing. Sesori never scans

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -42,8 +42,10 @@ reaches the backend so the turn continues.
   pinned CLI does not forward `ask_user` over ACP, so Copilot declares no
   question capability and Sesori never invents a custom question channel.
 - DeepSeek standard ACP permissions use the request's explicit session ID when
-  present and retain the ACP active-turn fallback when an agent omits it. They
-  preserve the exact tool call ID and expose only the scopes the adapter offers;
+  present, otherwise resolve the standard nested tool-call ID against live
+  delegation state before using ACP's active-turn fallback. A tool-call ID
+  shared by concurrent sessions is cancelled as ambiguous rather than shown in
+  the wrong transcript. Permissions expose only the scopes the adapter offers;
   v1 does not offer allow-always.
   DeepSeek extension questions preserve ordered question IDs, single/multiple/
   custom answer variants, plan-review fixed choices, and supplemental free-form
@@ -55,9 +57,11 @@ reaches the backend so the turn continues.
   phone-mediated unless an existing explicit bridge auto-approval rule applies.
   Abort, process exit, and disposal cancel pending Grok requests rather than
   broadening or silently approving them.
-- A sessionless backend request is attributed to the most recently dispatched
-  active turn, falling back to the last dispatched turn at its settlement
-  boundary. A backend requiring exact form correlation must serialize prompts
+- A sessionless backend request with a live tool-call correlation is pinned to
+  that exact session at receipt. Multiple matching sessions fail closed; only a
+  request with no tool correlation falls back to the most recently dispatched
+  active turn or the last dispatched turn at its settlement boundary. A backend
+  requiring exact form correlation must serialize prompts
   process-wide so another session cannot become the attribution target. OMP
   supplies explicit session IDs on permissions and forms, so its independent
   session turns remain attributable while running concurrently.

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -23,13 +23,14 @@ reconnect or restart.
   reads isolated persistence without resuming an agent or starting a scratch
   process. It pages at complete message boundaries, returns at most 100 messages
   per page, rejects non-progressing or over-100-page traversal, and reuses the
-  shared ACP replay collector. Direct user message IDs remain exact; assistant
-  IDs use the deterministic ACP projection. Protocol-v2 sub-agent metadata is
-  parsed by the DeepSeek repository and correlated through the enclosing
-  standard update's tool-call id; a replay-local collector callback replaces
-  that generic delegation tool with one subtask tile carrying prompt, child link,
-  and running or terminal state. Replay never mutates the live child tracker or
-  publishes lifecycle events.
+  shared ACP replay collector. Direct user message IDs remain exact; ordinary
+  assistant IDs use the deterministic ACP projection. Protocol-v2 sub-agent
+  metadata is parsed by the DeepSeek repository and correlated through the
+  enclosing standard update's tool-call id; a replay-local collector callback
+  replaces that generic delegation tool with one subtask tile carrying prompt,
+  child link, and running or terminal state. A child-linked tile uses the same
+  child-derived message and part identities as live lifecycle events. Replay
+  never mutates the live child tracker or publishes lifecycle events.
 - GitHub Copilot history uses standard ACP `session/load` on a dedicated
   short-lived connection. Replayed updates backfill the bridge transcript, while
   reopening a prior session after plugin, process, or bridge restart loads it
@@ -136,7 +137,7 @@ reconnect or restart.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Headless bridge, one representative plugin: a previously synced session's transcript is served with every backend stopped. |
-| L2 Routine | Live plugin, representative: first backfill, replayed prompt-default persistence and response precedence, live capture that becomes immediately queryable, semantic identity reconciliation with ordered-context and multiplicity preservation (including normalized attachments), stale re-read ordering for retained live-only rows, and paging older messages on a transcript longer than one page. Automated OpenCode, Codex, Claude, and Pi coverage preserves available historical effort or thinking-level variants from assistant/error messages; Codex also trims only verified sub-agent copied prefixes while preserving root and ordinary-fork history; Claude also covers one stable live/replay identity for a CLI-authored API failure and suppression of its duplicate terminal result, while Pi covers active-branch attribution and file fallback. Automated Pi coverage also includes v1-v3 fallback migration, compaction visibility, hidden-context decoding, bounded tool/image mapping, content-index streaming, early tool-call metadata with the pre-0.84.3 fallback, duplicate terminal suppression, cumulative tool updates, and live/replay final parity. |
+| L2 Routine | Live plugin, representative: first backfill, replayed prompt-default persistence and response precedence, live capture that becomes immediately queryable, semantic identity reconciliation with ordered-context and multiplicity preservation (including normalized attachments), stale re-read ordering for retained live-only rows, and paging older messages on a transcript longer than one page. Automated OpenCode, Codex, Claude, and Pi coverage preserves available historical effort or thinking-level variants from assistant/error messages; Codex also trims only verified sub-agent copied prefixes while preserving root and ordinary-fork history; Claude also covers one stable live/replay identity for a CLI-authored API failure and suppression of its duplicate terminal result, while Pi covers active-branch attribution and file fallback. Automated Pi coverage also includes v1-v3 fallback migration, compaction visibility, hidden-context decoding, bounded tool/image mapping, content-index streaming, early tool-call metadata with the pre-0.84.3 fallback, duplicate terminal suppression, cumulative tool updates, and live/replay final parity. DeepSeek covers child-derived live/replay tile identity, running-root retention and terminal release, and replay isolation from lifecycle events and live tracker state. |
 | L3 Release | Client end to end on the release-target client platform, every supporting production plugin: open a long session, page back, continue a live turn, reopen cold, and confirm live and replayed content converge including tool parts and image parts where declared. Grok additionally retains its exact loaded model/effort attribution across first load, cold reopen, plugin restart, and bridge restart. |
 | L4 Extended | Relay integration plus owning client automated coverage, every supporting production plugin: session advanced through the backend's own CLI, plugin restart and event-stream-gap invalidation, bridge restart, client reconnect inside and outside the replay window without refresh losing concurrently finalized content, two clients on one session, a slow request beside unrelated traffic. Copilot and Grok additionally replace their ACP process, reload the same session, and converge standard replay with the bridge transcript without duplicate live delivery. |
 | L5 Full | Automated and headless bridge for unreadable or partial store artifacts, interrupted backfill, and startup reconciliation; packaged or external for pagination's released-client shape; live plugin for very large transcripts. Every supporting production plugin. |
@@ -193,6 +194,9 @@ rules where supported.
   a bridge restart an idle Claude root still shows a running subtask tile, or a
   busy root's live background sub-agent tile is swept to cancelled; a child
   transcript duplicates its parts after reload.
+- A DeepSeek history refresh changes a child tile's live identity, duplicates
+  that tile, leaves the root busy after its terminal lifecycle event, or emits
+  replay as live child/session activity.
 - A Copilot restart prompts before `session/load`, duplicates replay as new live
   output, or reads private history files instead of the ACP replay boundary.
 - Grok replay mutates live defaults during initialize, stamps messages from an
@@ -219,5 +223,6 @@ Bridge chat-history service, repository, reconcile service, history listeners,
 SSE replay window, and routed request dispatch; database and audit compatibility
 tests under `bridge/app/test/bridge/services/`; Pi session process repository,
 storage API, and history mapper; shared ACP event mapper, turn serialization,
-and session loader plus Copilot and Grok plugins and package tests; shared
+and session loader plus Copilot and Grok plugins and package tests; DeepSeek
+history repository, sub-agent mapper, and protocol/history tests; shared
 pagination cursor; client detail load service and cubit.

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -25,12 +25,14 @@ reconnect or restart.
   per page, rejects non-progressing or over-100-page traversal, and reuses the
   shared ACP replay collector. Direct user message IDs remain exact; ordinary
   assistant IDs use the deterministic ACP projection. Protocol-v2 sub-agent
-  metadata is parsed by the DeepSeek repository and correlated through the
-  enclosing standard update's tool-call id; a replay-local collector callback
-  replaces that generic delegation tool with one subtask tile carrying prompt,
-  child link, and running or terminal state. A child-linked tile uses the same
-  child-derived message and part identities as live lifecycle events. Replay
-  never mutates the live child tracker or publishes lifecycle events.
+  metadata is parsed and validated once at the DeepSeek API boundary, then the
+  repository correlates that typed result through the enclosing standard
+  update's tool-call id. A replay-local collector callback replaces that generic
+  delegation tool with one subtask tile carrying prompt, child link, and running
+  or terminal state. A child-linked tile uses the same root-owned, child-derived
+  message and part identities as live lifecycle events, including when persisted
+  ancestry must resolve the root after restart. Replay never mutates the live
+  child tracker or publishes lifecycle events.
 - GitHub Copilot history uses standard ACP `session/load` on a dedicated
   short-lived connection. Replayed updates backfill the bridge transcript, while
   reopening a prior session after plugin, process, or bridge restart loads it

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -29,10 +29,10 @@ reconnect or restart.
   repository correlates that typed result through the enclosing standard
   update's tool-call id. A replay-local collector callback replaces that generic
   delegation tool with one subtask tile carrying prompt, child link, and running
-  or terminal state. A child-linked tile uses the same root-owned, child-derived
-  message and part identities as live lifecycle events, including when persisted
-  ancestry must resolve the root after restart. Replay never mutates the live
-  child tracker or publishes lifecycle events.
+  or terminal state. A child-linked tile uses the same direct-parent-owned,
+  child-derived message and part identities as live lifecycle events, so nested
+  tiles remain visible in the transcript that launched them. Replay never mutates
+  the live child tracker or publishes lifecycle events.
 - GitHub Copilot history uses standard ACP `session/load` on a dedicated
   short-lived connection. Replayed updates backfill the bridge transcript, while
   reopening a prior session after plugin, process, or bridge restart loads it

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -33,8 +33,9 @@ reconnect or restart.
   child-derived message and part identities as live lifecycle events, so nested
   tiles remain visible in the transcript that launched them. When ordinary parts
   surround a child tile in one ACP assistant message, identity splitting retains
-  their original order. Replay never mutates the live child tracker or publishes
-  lifecycle events.
+  their original order and gives every additional parent run deterministic,
+  storage-safe message and part IDs. Replay never mutates the live child tracker
+  or publishes lifecycle events.
 - GitHub Copilot history uses standard ACP `session/load` on a dedicated
   short-lived connection. Replayed updates backfill the bridge transcript, while
   reopening a prior session after plugin, process, or bridge restart loads it

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -31,8 +31,10 @@ reconnect or restart.
   delegation tool with one subtask tile carrying prompt, child link, and running
   or terminal state. A child-linked tile uses the same direct-parent-owned,
   child-derived message and part identities as live lifecycle events, so nested
-  tiles remain visible in the transcript that launched them. Replay never mutates
-  the live child tracker or publishes lifecycle events.
+  tiles remain visible in the transcript that launched them. When ordinary parts
+  surround a child tile in one ACP assistant message, identity splitting retains
+  their original order. Replay never mutates the live child tracker or publishes
+  lifecycle events.
 - GitHub Copilot history uses standard ACP `session/load` on a dedicated
   short-lived connection. Replayed updates backfill the bridge transcript, while
   reopening a prior session after plugin, process, or bridge restart loads it

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -24,7 +24,12 @@ reconnect or restart.
   process. It pages at complete message boundaries, returns at most 100 messages
   per page, rejects non-progressing or over-100-page traversal, and reuses the
   shared ACP replay collector. Direct user message IDs remain exact; assistant
-  IDs use the deterministic ACP projection.
+  IDs use the deterministic ACP projection. Protocol-v2 sub-agent metadata is
+  parsed by the DeepSeek repository and correlated through the enclosing
+  standard update's tool-call id; a replay-local collector callback replaces
+  that generic delegation tool with one subtask tile carrying prompt, child link,
+  and running or terminal state. Replay never mutates the live child tracker or
+  publishes lifecycle events.
 - GitHub Copilot history uses standard ACP `session/load` on a dedicated
   short-lived connection. Replayed updates backfill the bridge transcript, while
   reopening a prior session after plugin, process, or bridge restart loads it

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -227,7 +227,9 @@ defaults and queued client sends coherent.
   and form requests carry explicit session IDs.
 - DeepSeek maps text, reasoning, ordinary tools, plans, title/config updates,
   compaction completion, and bounded warning errors through standard ACP plus
-  its narrow status and sub-agent extensions. Retry and compaction-start
+  its narrow status and sub-agent extensions. Sub-agent lifecycle frames that
+  arrive while the launching prompt is still being written remain buffered
+  until the accepted user message is published. Retry and compaction-start
   notifications are validated but intentionally emit no shared event because
   DeepSeek does not supply the timing required by the shared retry state and the
   active turn is already busy. A protocol-v2 sub-agent start keeps the root and

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -225,11 +225,17 @@ defaults and queued client sends coherent.
   user-visible text plus those images; injected context, local paths, and URLs
   remain absent. OMP runs different sessions concurrently because its permission
   and form requests carry explicit session IDs.
-- DeepSeek maps text, reasoning, tools, plans, title/config updates, compaction
-  completion, and bounded warning errors through standard ACP plus its narrow
-  status extension. Retry and compaction-start notifications are validated but
-  intentionally emit no shared event because DeepSeek does not supply the timing
-  required by the shared retry state and the active turn is already busy.
+- DeepSeek maps text, reasoning, ordinary tools, plans, title/config updates,
+  compaction completion, and bounded warning errors through standard ACP plus
+  its narrow status and sub-agent extensions. Retry and compaction-start
+  notifications are validated but intentionally emit no shared event because
+  DeepSeek does not supply the timing required by the shared retry state and the
+  active turn is already busy. A protocol-v2 sub-agent start keeps the root and
+  plugin busy after a background parent turn settles; its terminal event updates
+  the tile and releases that child work. DeepSeek creates no autonomous
+  settlement hold because its protocol-v2 lifecycle contract has no authoritative
+  settlement event. Existing process-exit, disconnect, deletion, and disposal
+  cleanup cancels or clears remaining child activity.
 - Normalized user-message events feed the durable user-side activity marker used
   to order running roots. Known event times are applied monotonically. Backend
   input represented as a user message, including automatic compaction or other

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -67,7 +67,8 @@ signal that a tool changed files.
   outcomes map to error. Nested children retain their direct parent for
   navigation, live tiles, and history identities, while activity alone rolls up
   to the owning root. Replay preserves ordinary part order on both sides of a
-  child tile when one ACP assistant message contains all three.
+  child tile when one ACP assistant message contains all three, using distinct
+  deterministic message and part IDs for every additional parent run.
 - Cursor's fire-and-forget tool extensions preserve their top-level tool-call
   correlation before falling back to the active turn, including while another
   session is in flight.

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -51,8 +51,9 @@ signal that a tool changed files.
   and diff content. Presenter failure degrades to a generic bounded tool card
   instead of dropping the call or result. Its exact `subagent` and
   `subagent_fork` calls render no duplicate generic card: protocol-v2 defers
-  the exact delegation call until its correlated lifecycle start opens one
-  child-linked subtask tile with the normalized prompt and label. A standard
+  the exact delegation call and any title-bearing update that arrives before
+  it until the correlated lifecycle start opens one child-linked subtask tile
+  with the normalized prompt and label. A standard
   terminal update received before a valid start instead retains the generic
   failure card after folding partial fields in arrival order into one bounded
   snapshot. Later structured content and raw output replace each other, so the
@@ -65,7 +66,8 @@ signal that a tool changed files.
   bounded summary, abort maps to cancelled, and failure, token-limit, and refusal
   outcomes map to error. Nested children retain their direct parent for
   navigation, live tiles, and history identities, while activity alone rolls up
-  to the owning root.
+  to the owning root. Replay preserves ordinary part order on both sides of a
+  child tile when one ACP assistant message contains all three.
 - Cursor's fire-and-forget tool extensions preserve their top-level tool-call
   correlation before falling back to the active turn, including while another
   session is in flight.

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -50,13 +50,15 @@ signal that a tool changed files.
   exact call identity, bounded presenter output, terminal result/error state,
   and diff content. Presenter failure degrades to a generic bounded tool card
   instead of dropping the call or result. Its exact `subagent` and
-  `subagent_fork` calls render no duplicate generic card: protocol-v2 lifecycle
-  opens one child-linked subtask tile with the normalized prompt and label.
-  During the release compatibility window, a protocol-v1 adapter retains its
-  generic delegation card because it supplies no lifecycle replacement.
-  Completion retains the bounded summary, abort maps to cancelled, and failure,
-  token-limit, and refusal outcomes map to error. History replaces the same
-  delegation tool identity with one equivalent subtask part.
+  `subagent_fork` calls render no duplicate generic card: protocol-v2 defers
+  the exact delegation call until its correlated lifecycle start opens one
+  child-linked subtask tile with the normalized prompt and label. A standard
+  terminal update received before a valid start instead retains the generic
+  failure card. During the release compatibility window, a protocol-v1 adapter
+  retains its generic delegation card because it supplies no lifecycle
+  replacement. Completion retains the bounded summary, abort maps to cancelled,
+  and failure, token-limit, and refusal outcomes map to error. A child-linked
+  history tile uses the live child-derived identity and bounded terminal payload.
 - Cursor's fire-and-forget tool extensions preserve their top-level tool-call
   correlation before falling back to the active turn, including while another
   session is in flight.
@@ -110,6 +112,10 @@ one permission-gated mutation and one repeated terminal update.
 - A Grok tool loses live permission correlation, changes call identity or status
   after replay, exposes unbounded output, loses diff content, or emits the wrong
   number of file-change invalidations.
+- A DeepSeek delegation disappears when child startup fails, renders both a
+  generic card and a child tile after a valid start, opens the wrong child
+  transcript, changes tile identity or payload bounds after replay, leaves a
+  malformed terminal child running, or mutates live child activity during replay.
 - The file-change signal is missing after a real mutation, emitted for a
   read-only tool, emitted repeatedly for one call, or wrongly attributed.
 - A Claude sub-agent renders as a generic `Agent` tool card, its tile stays
@@ -154,5 +160,9 @@ one permission-gated mutation and one repeated terminal update.
 - Claude sub-agents: `bridge/sesori_plugin_claude/lib/src/repositories/trackers/claude_tool_tracker.dart`,
   `claude_event_dispatcher.dart`, `claude_history_mapper.dart`, and
   `test/claude_subtask_lifecycle_test.dart`
+- DeepSeek sub-agents: `bridge/sesori_plugin_deepseek/lib/src/deepseek_event_mapper.dart`,
+  `repositories/deepseek_history_repository.dart`,
+  `repositories/mappers/deepseek_subagent_mapper.dart`, and
+  `test/deepseek_{subagent,history_repository,protocol_conformance}_test.dart`
 - Plans (discovery only): `.plan/completed/output-image-support`,
   `.plan/completed/attachment-references`, `.plan/active/claude-inline-subtasks`

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -46,10 +46,17 @@ signal that a tool changed files.
   as `cancelled`.
   Process exit — natural or an explicit stop — cancels every running task.
   OpenCode subtask parts keep a null lifecycle and the child-status fallback.
-- DeepSeek projects tool calls and updates through standard ACP with exact call
-  identity, bounded presenter output, terminal result/error state, and diff
-  content. Presenter failure degrades to a generic bounded tool card instead of
-  dropping the call or result.
+- DeepSeek projects ordinary tool calls and updates through standard ACP with
+  exact call identity, bounded presenter output, terminal result/error state,
+  and diff content. Presenter failure degrades to a generic bounded tool card
+  instead of dropping the call or result. Its exact `subagent` and
+  `subagent_fork` calls render no duplicate generic card: protocol-v2 lifecycle
+  opens one child-linked subtask tile with the normalized prompt and label.
+  During the release compatibility window, a protocol-v1 adapter retains its
+  generic delegation card because it supplies no lifecycle replacement.
+  Completion retains the bounded summary, abort maps to cancelled, and failure,
+  token-limit, and refusal outcomes map to error. History replaces the same
+  delegation tool identity with one equivalent subtask part.
 - Cursor's fire-and-forget tool extensions preserve their top-level tool-call
   correlation before falling back to the active turn, including while another
   session is in flight.
@@ -69,8 +76,8 @@ signal that a tool changed files.
 |---|---|
 | L1 Smoke | Not included because proving tool behavior requires a live turn. |
 | L2 Routine | Live plugin, representative: a file-editing tool produces a tool part with name, terminal status, and bounded output. |
-| L3 Release | Client end to end (phone), every supporting production plugin: title, status, output bound, and errors normalize consistently; a mutating tool emits the file-change signal once and a read-only tool emits none; tool cards, errors, and subtask/agent parts render. Claude covers a foreground and a background sub-agent tile going running → completed with the result text, tapping the tile opening the child transcript, and a cancelled tile after the process is killed; OpenCode proves a null-lifecycle subtask part still renders and opens as before. Copilot covers one read-only tool, one file mutation with permission linkage and diff invalidation, and one failing tool. Grok covers a complete tool lifecycle with bounded output, a file diff and invalidation, live permission linkage, and cold-replay identity/status parity. |
-| L4 Extended | Live plugin, every supporting production plugin: tool parts survive history reload with identity, status, and output intact; a failing tool surfaces an error rather than a stuck running state; child-session tool activity is attributed correctly; repeated completion updates do not duplicate the file-change signal. Claude: a reloaded session with a finished background sub-agent shows one completed subtask tile with the same identity and `childSessionID`, a still-running one stays running while its process lives, a resumed terminal agent returns to running in both its tile and child status, and a failed sub-agent renders `error` with the notification summary. |
+| L3 Release | Client end to end (phone), every supporting production plugin: title, status, output bound, and errors normalize consistently; a mutating tool emits the file-change signal once and a read-only tool emits none; tool cards, errors, and subtask/agent parts render. Claude covers a foreground and a background sub-agent tile going running → completed with the result text, tapping the tile opening the child transcript, and a cancelled tile after the process is killed; OpenCode proves a null-lifecycle subtask part still renders and opens as before. Copilot covers one read-only tool, one file mutation with permission linkage and diff invalidation, and one failing tool. Grok covers a complete tool lifecycle with bounded output, a file diff and invalidation, live permission linkage, and cold-replay identity/status parity. After adapter v0.1.3 publishes, DeepSeek covers foreground/background running → terminal tiles, child navigation, and no duplicate generic delegation card. |
+| L4 Extended | Live plugin, every supporting production plugin: tool parts survive history reload with identity, status, and output intact; a failing tool surfaces an error rather than a stuck running state; child-session tool activity is attributed correctly; repeated completion updates do not duplicate the file-change signal. Claude: a reloaded session with a finished background sub-agent shows one completed subtask tile with the same identity and `childSessionID`, a still-running one stays running while its process lives, a resumed terminal agent returns to running in both its tile and child status, and a failed sub-agent renders `error` with the notification summary. DeepSeek: protocol-v2 replay preserves delegation identity, prompt, child link, and terminal state without changing live child activity. |
 | L5 Full | Client end to end, every supporting production plugin: rune-boundary truncation is exact for multi-byte output; attachments render where emitted and unsafe or malformed sources degrade to metadata; unknown status from a newer peer degrades gracefully. |
 
 ## Exploration Guidance

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -55,8 +55,9 @@ signal that a tool changed files.
   child-linked subtask tile with the normalized prompt and label. A standard
   terminal update received before a valid start instead retains the generic
   failure card after folding partial fields in arrival order into one bounded
-  snapshot. Started-delegation
-  correlation survives parent turn boundaries until both lifecycle and standard
+  snapshot. Later structured content and raw output replace each other, so the
+  newest representation remains authoritative. Started-delegation correlation
+  survives parent turn boundaries until both lifecycle and standard
   tool completion arrive. The lifecycle prompt is authoritative, so the child's
   echoed user chunk cannot duplicate or extend it. During the release
   compatibility window, a protocol-v1 adapter retains its generic delegation

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -54,7 +54,8 @@ signal that a tool changed files.
   the exact delegation call until its correlated lifecycle start opens one
   child-linked subtask tile with the normalized prompt and label. A standard
   terminal update received before a valid start instead retains the generic
-  failure card with every partial update applied in order. Started-delegation
+  failure card after folding partial fields in arrival order into one bounded
+  snapshot. Started-delegation
   correlation survives parent turn boundaries until both lifecycle and standard
   tool completion arrive. The lifecycle prompt is authoritative, so the child's
   echoed user chunk cannot duplicate or extend it. During the release
@@ -62,8 +63,8 @@ signal that a tool changed files.
   card because it supplies no lifecycle replacement. Completion retains the
   bounded summary, abort maps to cancelled, and failure, token-limit, and refusal
   outcomes map to error. Nested children retain their direct parent for
-  navigation while activity, live tiles, and history identities roll up to the
-  owning root.
+  navigation, live tiles, and history identities, while activity alone rolls up
+  to the owning root.
 - Cursor's fire-and-forget tool extensions preserve their top-level tool-call
   correlation before falling back to the active turn, including while another
   session is in flight.

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -54,11 +54,16 @@ signal that a tool changed files.
   the exact delegation call until its correlated lifecycle start opens one
   child-linked subtask tile with the normalized prompt and label. A standard
   terminal update received before a valid start instead retains the generic
-  failure card. During the release compatibility window, a protocol-v1 adapter
-  retains its generic delegation card because it supplies no lifecycle
-  replacement. Completion retains the bounded summary, abort maps to cancelled,
-  and failure, token-limit, and refusal outcomes map to error. A child-linked
-  history tile uses the live child-derived identity and bounded terminal payload.
+  failure card with every partial update applied in order. Started-delegation
+  correlation survives parent turn boundaries until both lifecycle and standard
+  tool completion arrive. The lifecycle prompt is authoritative, so the child's
+  echoed user chunk cannot duplicate or extend it. During the release
+  compatibility window, a protocol-v1 adapter retains its generic delegation
+  card because it supplies no lifecycle replacement. Completion retains the
+  bounded summary, abort maps to cancelled, and failure, token-limit, and refusal
+  outcomes map to error. Nested children retain their direct parent for
+  navigation while activity, live tiles, and history identities roll up to the
+  owning root.
 - Cursor's fire-and-forget tool extensions preserve their top-level tool-call
   correlation before falling back to the active turn, including while another
   session is in flight.
@@ -162,7 +167,8 @@ one permission-gated mutation and one repeated terminal update.
   `test/claude_subtask_lifecycle_test.dart`
 - DeepSeek sub-agents: `bridge/sesori_plugin_deepseek/lib/src/deepseek_event_mapper.dart`,
   `repositories/deepseek_history_repository.dart`,
-  `repositories/mappers/deepseek_subagent_mapper.dart`, and
+  `repositories/mappers/deepseek_subagent_mapper.dart`,
+  `repositories/trackers/deepseek_delegation_tracker.dart`, and
   `test/deepseek_{subagent,history_repository,protocol_conformance}_test.dart`
 - Plans (discovery only): `.plan/completed/output-image-support`,
   `.plan/completed/attachment-references`, `.plan/active/claude-inline-subtasks`


### PR DESCRIPTION
## Complexity

🚧 Complex — this connects an unpublished backend protocol revision to shared ACP lifecycle/replay seams, child-session catalog behavior, and user-visible subtask projection while preserving the released protocol-v1 runtime.

## What

- Vendor and verify DeepSeek extension protocol v2 from adapter commit `d7a48471bf5339793beb0c9e1c1889e63f76ec92` while keeping `protocol/v1/**` frozen.
- Parse typed sub-agent lifecycle and replay metadata, validate bounded Unicode presentation fields, and temporarily accept initialize versions 1 and 2.
- Map protocol-v2 starts/ends into shared ACP child lifecycle, busy accounting, prompt-write ordering, inline subtask tiles, child transcript attribution, and terminal outcomes; retain direct parents while rolling activity up to roots.
- Keep cross-turn standard/lifecycle correlation in an injected `DeepSeekDelegationTracker`, carry ambiguous nested permission tool-call IDs to fail-closed cancellation, suppress prompt echoes, and fold calls plus identifiable reordered updates into one bounded, chronology-preserving snapshot.
- Replace replayed generic delegation cards with the same direct-parent-owned child projection through a narrow replay-local collector callback while preserving surrounding part order and assigning deterministic storage-safe identities to split parent runs.
- Merge persisted and live DeepSeek child sessions with persisted metadata winning, inherit the tracked root project for live-only descendants, and clear a deleted parent's full tracked descendant subtree behind process-scoped late-frame tombstones.
- Update capability, regression, and active-plan documentation to match the staged release sequence.

## Why

The adapter now has correlated sub-agent lifecycle, descendant transcript, and replay contracts, but the bridge previously dropped those notifications and rendered no DeepSeek child sessions or inline tiles. This change consumes that contract without fabricating prompts or leaking backend vocabulary into shared/client layers.

## Risk and test focus

- Highest risk: live/replayed ordering and persisted identity, root busy release, late lifecycle cleanup, and exact attribution of child updates and permissions to the correct project/session family.
- Protocol-v1 adapters retain their existing generic delegation cards; protocol v2 defers exact delegation cards and replaces them only after a valid correlated child start, retaining a generic failure card when startup fails first.
- Replay consumes metadata decoded once and semantically validated at the API boundary; it never mutates the live tracker or event stream.
- Malformed Unicode, explicit nulls, and over-bound presentation fields fail closed without logging prompt/transcript content; a malformed terminal frame for an announced child finalizes it with a privacy-safe error instead of leaving it busy.
- Adapter v0.1.3 is still unpublished. Managed target `0.1.2` and PATH floor `0.1.0` are intentionally unchanged; scoped child stop remains a separate PR.
- User-visible impact: once adapter v0.1.3 is released, DeepSeek sub-agents appear as inline tiles and navigable child sessions.
- Database impact: none.

## Expected result

With a protocol-v2 DeepSeek adapter, one delegation produces one truthful running-to-terminal subtask tile, child output streams under the child session, and running children keep the root/plugin active. Protocol-v1 behavior remains compatible until the release and scoped-stop follow-ups land.

## Verification

- `cd bridge/sesori_plugin_deepseek && dart run build_runner build --delete-conflicting-outputs` — passed
- `cd bridge/sesori_plugin_deepseek && dart analyze --fatal-infos` — clean
- `cd bridge/sesori_plugin_deepseek && dart test` — 87 passed
- `cd bridge/sesori_plugin_acp && dart analyze --fatal-infos` — clean
- `cd bridge/sesori_plugin_acp && dart test` — 311 passed
- `cd bridge/sesori_plugin_grok && dart analyze --fatal-infos` — clean
- `cd bridge/sesori_plugin_grok && dart test` — 83 passed
- `git diff --check`
- Verified `bridge/sesori_plugin_deepseek/test/fixtures/protocol/v1/**` and `deepseek_runtime_manifest.dart` unchanged
- Audited all 12 reported lint suppressions; each is narrowly attached to an inherently heterogeneous ACP/protocol JSON map and includes its boundary rationale
- Post-feedback architecture implementation review: APPROVED with no findings after the required tracker extraction
- Focused correctness findings resolved with regressions for prompt echoes, direct-parent tile ownership, replay part order and unique stored run identities, accepted-prompt lifecycle order, reordered tool frames, root activity and project accounting, lifecycle reset/tombstones, chronology-preserving bounded deferred updates, nested permission ambiguity, recursive descendant cleanup, and single-pass metadata validation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consumes DeepSeek extension protocol v2 sub-agent lifecycle notifications so DeepSeek delegations render as inline subtask tiles and navigable child sessions, instead of being dropped and shown as generic delegation cards. Protocol v1 adapters keep the old generic cards, and user-visible change lands only once adapter v0.1.3 is released.

**New Features**
- Protocol-v2 starts and stops map to shared child lifecycle, busy accounting, inline subtask tiles, child transcript attribution, and terminal outcomes.
- Replayed history replaces generic delegation cards with the same child-linked subtask projection via a replay-local collector callback.
- Child session reads merge persisted rows with live protocol-v2 children, with persisted metadata winning.

**Migration**
- Protocol v1 fixtures and runtime stay frozen; the adapter temporarily accepts initialize protocol versions 1 and 2.
- Managed DeepSeek target stays at 0.1.2 and PATH floor at 0.1.0.
- Malformed Unicode and over-bound prompt, label, and summary fields fail closed without logging content.
- No database impact; scoped child stop ships in a separate PR.

<sup>Written for commit 948de715804c7120623f7ff379112f4d65c6adde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

