### PR TITLE
⚙️ Give option selection one owner instead of two divergent copies

### DIFF
--- a/client/app/test/core/routing/adaptive_session_router_test_harness.dart
+++ b/client/app/test/core/routing/adaptive_session_router_test_harness.dart
@@ -253,7 +253,6 @@ class AdaptiveSessionRouterTestHarness() {
     getIt.registerSingleton<NewSessionOptionsService>(
       NewSessionOptionsService(
         sessionRepository: sessionRepository,
-        defaultModelSelector: const DefaultModelSelector(),
       ),
     );
     getIt.registerSingleton<ConnectionService>(connectionService);

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -442,7 +442,6 @@ void main() {
     GetIt.instance.registerSingleton<NewSessionOptionsService>(
       NewSessionOptionsService(
         sessionRepository: sessionRepository,
-        defaultModelSelector: const DefaultModelSelector(),
       ),
     );
     GetIt.instance.registerSingleton<ConnectionService>(connectionService);

--- a/client/module_core/lib/sesori_dart_core.dart
+++ b/client/module_core/lib/sesori_dart_core.dart
@@ -193,6 +193,7 @@ export "src/services/project_viewing_service.dart";
 export "src/services/registered_bridges_service.dart";
 export "src/services/session_detail_load_service.dart";
 export "src/services/session_list_service.dart";
+export "src/services/session_selection_calculator.dart";
 export "src/services/session_unseen_tracker.dart";
 export "src/services/session_viewing_service.dart";
 export "src/services/sse_event_tracker.dart";

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -1779,15 +1779,24 @@ class SessionDetailCubit(
         // it no longer offers is corrected rather than retained — that
         // correction is the whole point of refreshing.
         //
-        // Losing the agent moves the model with it: an agent that disappeared
-        // takes its model preference along, and pairing the replacement agent
-        // with the old one's model would leave the two describing different
-        // intents. The model already on screen still wins while the agent holds.
+        // A replacement agent's own declared model outranks the departed one's:
+        // the agent that expressed that preference is gone. It only outranks it,
+        // though — a replacement declaring no model expresses no preference, so
+        // the model on screen is kept rather than reset to a catalog default.
+        // While the agent holds, its model holds with it.
+        //
+        // "Held" means the previous agent was a real catalog entry, not the
+        // placeholder name shown when a catalog advertised no agents at all. A
+        // catalog that later advertises an agent under that same name is a new
+        // agent, and its declared model applies.
         final agentName = _selection.validatedAgentName(
           agents: agents,
           candidates: [latest.selectedAgent],
         );
-        final replacedAgentModel = agentName == latest.selectedAgent
+        final heldSameAgent =
+            agentName == latest.selectedAgent &&
+            latest.availableAgents.any((agent) => agent.name == latest.selectedAgent);
+        final replacedAgentModel = heldSameAgent
             ? null
             : agents.firstWhereOrNull((agent) => agent.name == agentName)?.model;
         final reconciled = _selection.reconcile(

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -1776,12 +1776,25 @@ class SessionDetailCubit(
         final providers = catalog.providers;
         final commands = catalog.commands;
         // A refresh answers with the catalog the backend has now, so a selection
-        // it no longer offers is corrected rather than retained.
+        // it no longer offers is corrected rather than retained — that
+        // correction is the whole point of refreshing.
+        //
+        // Losing the agent moves the model with it: an agent that disappeared
+        // takes its model preference along, and pairing the replacement agent
+        // with the old one's model would leave the two describing different
+        // intents. The model already on screen still wins while the agent holds.
+        final agentName = _selection.validatedAgentName(
+          agents: agents,
+          candidates: [latest.selectedAgent],
+        );
+        final replacedAgentModel = agentName == latest.selectedAgent
+            ? null
+            : agents.firstWhereOrNull((agent) => agent.name == agentName)?.model;
         final reconciled = _selection.reconcile(
           agents: agents,
           providers: providers,
-          agentNameCandidates: [latest.selectedAgent],
-          modelCandidates: [latest.selectedAgentModel],
+          agentNameCandidates: [agentName],
+          modelCandidates: [replacedAgentModel, latest.selectedAgentModel],
           retainedModel: null,
         );
         final selectedAgent = reconciled.agentName ?? _fallbackAgentName;

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -27,8 +27,8 @@ import "../../repositories/session_repository.dart";
 import "../../services/product_analytics_service.dart";
 import "../../services/project_viewing_service.dart";
 import "../../services/session_detail_load_service.dart";
+import "../../services/session_selection_calculator.dart";
 import "../../services/session_viewing_service.dart";
-import "../../utils/model_filter/default_model_selector.dart";
 import "deferred_part_event_buffer.dart";
 import "prompt_send_queue.dart";
 import "queued_session_submission.dart";
@@ -83,13 +83,18 @@ class SessionDetailCubit(
   /// Overridable so tests can exercise the coalescing without real waits.
   final Duration eventRefreshMinInterval = const Duration(seconds: 5),
 }) extends Cubit<SessionDetailState> {
+  static const SessionSelectionCalculator _selection = SessionSelectionCalculator();
+
+  /// Shown when a catalog offers no agent at all, so the composer still names
+  /// something. Backends that advertise agents always replace it.
+  static const String _fallbackAgentName = "build";
+
   /// Bumped whenever the transcript is replaced wholesale (a refresh or
   /// reload), so an older-page request that started before it can tell its
   /// result no longer joins onto what is shown.
   int _transcriptGeneration = 0;
   final SessionRepository _sessionRepository = promptDispatcher;
   final ProjectViewClaim _projectViewClaim = _projectViewingService.beginDetailClaim(projectId: _projectId);
-  static const _defaultModelSelector = DefaultModelSelector();
   ComposerDraft _composerDraft = _composerDraftRepository.readForSession(sessionId: _sessionId);
   final PromptSendQueue _promptQueue = PromptSendQueue();
   final Set<String> _staleOptionsRecoveryAttemptedPromptIds = {};
@@ -552,7 +557,7 @@ class SessionDetailCubit(
           final availableAgents = optionsSuperseded ? latest.availableAgents : derived.agents;
           final availableProviders = optionsSuperseded ? latest.availableProviders : derived.providers;
           final availableCommands = optionsSuperseded ? latest.availableCommands : snapshot.commands;
-          final availableVariants = _deriveAvailableVariants(
+          final availableVariants = _selection.availableVariants(
             providers: availableProviders,
             model: preservedSelectedAgentModel,
           );
@@ -594,9 +599,9 @@ class SessionDetailCubit(
               sessionTitle: snapshot.canonicalSessionTitle ?? latest.sessionTitle,
               selectedAgent: preservedSelectedAgent,
               selectedAgentModel: preservedSelectedAgentModel,
-              stagedCommand: _resolveStagedCommand(
-                availableCommands: availableCommands,
-                stagedCommand: preservedStagedCommand,
+              stagedCommand: _selection.resolveStagedCommand(
+                commands: availableCommands,
+                staged: preservedStagedCommand,
               ),
               queuedMessages: queue.queuedMessages,
               awaitingBridgeSubmissions: queue.awaitingBridgeSubmissions,
@@ -700,14 +705,6 @@ class SessionDetailCubit(
     // A plugin-scoped catalog names no project and applies to every one of them.
     if (projectId != null && projectId.normalize() != _projectId.normalize()) return;
     unawaited(_reloadOptions(mode: SessionOptionsRequestMode.cacheOnly, notify: false));
-  }
-
-  CommandInfo? _resolveStagedCommand({
-    required List<CommandInfo> availableCommands,
-    required CommandInfo? stagedCommand,
-  }) {
-    if (stagedCommand == null) return null;
-    return availableCommands.firstWhereOrNull((c) => c.name == stagedCommand.name);
   }
 
   /// Returns the latest agent-authored assistant or error [Message], or null if none.
@@ -1037,23 +1034,23 @@ class SessionDetailCubit(
     final current = state;
     if (current is! SessionDetailLoaded) return;
 
-    final agents = current.availableAgents;
-    final providers = current.availableProviders;
-    final persistedAgent = promptDefaults.agent;
-    final persistedModel = promptDefaults.model;
-
-    final bool hasValidPersistedAgent = persistedAgent != null && agents.any((a) => a.name == persistedAgent);
-    final bool hasValidPersistedModel =
-        persistedModel != null && _isModelAvailable(model: persistedModel, providers: providers);
-
-    final newAgent = hasValidPersistedAgent ? persistedAgent : current.selectedAgent;
-    final newModel = hasValidPersistedModel ? persistedModel : current.selectedAgentModel;
+    // The bridge's remembered selection wins where the catalog still offers it,
+    // otherwise what is on screen stays. Reconciling the two together keeps the
+    // variant list from describing a model that is no longer selected.
+    final reconciled = _selection.reconcile(
+      agents: current.availableAgents,
+      providers: current.availableProviders,
+      agentNameCandidates: [promptDefaults.agent, current.selectedAgent],
+      modelCandidates: [promptDefaults.model],
+      retainedModel: current.selectedAgentModel,
+    );
 
     if (isClosed) return;
     emit(
       current.copyWith(
-        selectedAgent: newAgent,
-        selectedAgentModel: newModel,
+        selectedAgent: reconciled.agentName ?? current.selectedAgent,
+        selectedAgentModel: reconciled.model,
+        availableVariants: reconciled.availableVariants,
       ),
     );
   }
@@ -1775,36 +1772,35 @@ class SessionDetailCubit(
       if (latest is! SessionDetailLoaded) return false;
 
       if (result case SessionOptionsRepositoryAvailable(:final catalog)) {
-        final agents = catalog.agents
-            .whereType<AgentInfo>()
-            .where((agent) => !agent.hidden && agent.mode != AgentMode.subagent)
-            .toList();
+        final agents = _selection.selectableAgents(agents: catalog.agents);
         final providers = catalog.providers;
         final commands = catalog.commands;
-        final selectedAgent = agents.any((agent) => agent.name == latest.selectedAgent)
-            ? latest.selectedAgent
-            : (agents.firstOrNull?.name ?? "build");
-        final agentChanged = selectedAgent != latest.selectedAgent;
-        final preferredAgentModel = agents.firstWhereOrNull((agent) => agent.name == selectedAgent)?.model;
-        final selectedModelCandidate = agentChanged && preferredAgentModel != null
-            ? preferredAgentModel
-            : latest.selectedAgentModel;
-        final selectedModel = _validatedPromptModel(
-          candidate: selectedModelCandidate,
+        // A refresh answers with the catalog the backend has now, so a selection
+        // it no longer offers is corrected rather than retained.
+        final reconciled = _selection.reconcile(
           agents: agents,
           providers: providers,
+          agentNameCandidates: [latest.selectedAgent],
+          modelCandidates: [latest.selectedAgentModel],
+          retainedModel: null,
         );
+        final selectedAgent = reconciled.agentName ?? _fallbackAgentName;
+        final selectedModel = reconciled.model;
 
         _promptQueue.replacePending(
           update: (submission) => submission.withSelection(
             agent: _validatedQueuedAgent(candidate: submission.agent, agents: agents),
             agentModel: submission.agentModel == null
                 ? null
-                : _validatedPromptModel(
-                    candidate: submission.agentModel,
-                    agents: agents,
-                    providers: providers,
-                  ),
+                : _selection
+                      .reconcile(
+                        agents: agents,
+                        providers: providers,
+                        agentNameCandidates: [submission.agent],
+                        modelCandidates: [submission.agentModel],
+                        retainedModel: null,
+                      )
+                      .model,
           ),
         );
 
@@ -1815,13 +1811,10 @@ class SessionDetailCubit(
             availableCommands: commands,
             selectedAgent: selectedAgent,
             selectedAgentModel: selectedModel,
-            availableVariants: _deriveAvailableVariants(
-              providers: providers,
-              model: selectedModel,
-            ),
-            stagedCommand: _resolveStagedCommand(
-              availableCommands: commands,
-              stagedCommand: latest.stagedCommand,
+            availableVariants: reconciled.availableVariants,
+            stagedCommand: _selection.resolveStagedCommand(
+              commands: commands,
+              staged: latest.stagedCommand,
             ),
             queuedMessages: _visibleStagedItems(bridgePrompts: latest.bridgeQueuedPrompts),
             sendingSubmission: _visibleStagedSending(bridgePrompts: latest.bridgeQueuedPrompts),
@@ -1856,60 +1849,15 @@ class SessionDetailCubit(
     }
   }
 
+  /// A queued submission's agent, revalidated against the current catalog.
+  /// Null means "whatever the session is set to" and stays null; a withdrawn
+  /// agent falls back like any other.
   String? _validatedQueuedAgent({
     required String? candidate,
     required List<AgentInfo> agents,
   }) {
-    if (candidate == null || agents.any((agent) => agent.name == candidate)) return candidate;
-    return agents.firstOrNull?.name;
-  }
-
-  AgentModel? _validatedPromptModel({
-    required AgentModel? candidate,
-    required List<AgentInfo> agents,
-    required List<ProviderInfo> providers,
-  }) {
     if (candidate == null) return null;
-    final model = _isModelAvailable(model: candidate, providers: providers)
-        ? candidate
-        : _fallbackAgentModel(agents: agents, providers: providers);
-    if (model == null) return null;
-    // Never leave a variant-offering model unset: the composer renders the
-    // first available variant when none is selected, so an unset one would
-    // display an effort the send does not carry.
-    return _withResolvedVariant(
-      model: model,
-      availableVariants: _deriveAvailableVariants(providers: providers, model: model),
-    );
-  }
-
-  bool _isModelAvailable({required AgentModel model, required List<ProviderInfo> providers}) {
-    return providers.any(
-      (provider) => provider.id == model.providerID && provider.models.containsKey(model.modelID),
-    );
-  }
-
-  AgentModel? _fallbackAgentModel({
-    required List<AgentInfo> agents,
-    required List<ProviderInfo> providers,
-  }) {
-    if (agents.firstOrNull?.model case final model?) return model;
-    // Walk every provider: the first may be misconfigured or fully
-    // deprecated and therefore have no selectable model.
-    for (final provider in providers) {
-      final picked = _defaultModelSelector.pickFromProvider(
-        models: provider.models,
-        defaultModelID: provider.defaultModelID,
-      );
-      if (picked != null) {
-        return AgentModel(
-          providerID: provider.id,
-          modelID: picked.id,
-          variant: null,
-        );
-      }
-    }
-    return null;
+    return _selection.validatedAgentName(agents: agents, candidates: [candidate]);
   }
 
   ComposerDraft get composerDraft => _composerDraft;
@@ -2204,19 +2152,22 @@ class SessionDetailCubit(
 
     final agentInfo = current.availableAgents.firstWhereOrNull((a) => a.name == agent);
     if (agentInfo == null) return;
-    // A null model means this agent has no model preference of its own.
-    final agentModel = agentInfo.model ?? current.selectedAgentModel;
-    final availableVariants = _deriveAvailableVariants(
+    // An agent with no declared model keeps the one already on screen, which is
+    // also where a declared model the catalog no longer offers falls back to.
+    final reconciled = _selection.reconcile(
+      agents: current.availableAgents,
       providers: current.availableProviders,
-      model: agentModel,
+      agentNameCandidates: [agent],
+      modelCandidates: [agentInfo.model],
+      retainedModel: current.selectedAgentModel,
     );
 
     if (isClosed) return;
     emit(
       current.copyWith(
         selectedAgent: agent,
-        selectedAgentModel: _withResolvedVariant(model: agentModel, availableVariants: availableVariants),
-        availableVariants: availableVariants,
+        selectedAgentModel: reconciled.model,
+        availableVariants: reconciled.availableVariants,
       ),
     );
   }
@@ -2227,7 +2178,7 @@ class SessionDetailCubit(
 
     final previousVariant = current.selectedAgentModel?.variant;
     final newModel = AgentModel(providerID: providerID, modelID: modelID, variant: null);
-    final availableVariants = _deriveAvailableVariants(
+    final availableVariants = _selection.availableVariants(
       providers: current.availableProviders,
       model: newModel,
     );
@@ -2330,7 +2281,7 @@ class SessionDetailCubit(
     final children = [...snapshot.childSessions];
     _sortChildrenByUpdatedDesc(children);
     final childIds = children.map((child) => child.id).toSet();
-    final agents = snapshot.agents.where((agent) => !agent.hidden && agent.mode != AgentMode.subagent).toList();
+    final agents = _selection.selectableAgents(agents: snapshot.agents);
     final assistantAgentModel = switch (latestAssistant) {
       MessageAssistant(sender: MessageSender.agent, :final modelID, :final providerID) ||
       MessageError(
@@ -2357,26 +2308,16 @@ class SessionDetailCubit(
     final agents = derived.agents;
     final providers = derived.providers;
 
-    final persistedDefaults = snapshot.promptDefaults;
-    final persistedAgent = persistedDefaults?.agent;
-    final persistedModel = persistedDefaults?.model;
-
-    final bool hasValidPersistedAgent = persistedAgent != null && agents.any((a) => a.name == persistedAgent);
-    final bool hasValidPersistedModel =
-        persistedModel != null && _isModelAvailable(model: persistedModel, providers: providers);
-
-    final String defaultAgent = hasValidPersistedAgent
-        ? persistedAgent
-        : (agents.isNotEmpty ? agents.first.name : "build");
-
     final assistantAgentModel = derived.assistantAgentModel;
-    final defaultAgentModel = hasValidPersistedModel
-        ? persistedModel
-        : (assistantAgentModel ?? _fallbackAgentModel(agents: agents, providers: providers));
-
-    final availableVariants = _deriveAvailableVariants(
+    // The transcript's own model is retained rather than validated: a session
+    // imported from a terminal must not silently resume on a different provider
+    // because a retained provider cache does not list what it ran on.
+    final reconciled = _selection.reconcile(
+      agents: agents,
       providers: providers,
-      model: defaultAgentModel,
+      agentNameCandidates: [snapshot.promptDefaults?.agent],
+      modelCandidates: [snapshot.promptDefaults?.model],
+      retainedModel: assistantAgentModel,
     );
 
     final initialSessionStatus = snapshot.statuses[_sessionId] ?? const SessionStatus.idle();
@@ -2406,37 +2347,12 @@ class SessionDetailCubit(
       availableAgents: agents,
       availableProviders: providers,
       availableCommands: snapshot.commands,
-      selectedAgent: defaultAgent,
-      selectedAgentModel: _withResolvedVariant(
-        model: defaultAgentModel,
-        availableVariants: availableVariants,
-      ),
+      selectedAgent: reconciled.agentName ?? _fallbackAgentName,
+      selectedAgentModel: reconciled.model,
       stagedCommand: null,
       isRefreshing: false,
-      availableVariants: availableVariants,
+      availableVariants: reconciled.availableVariants,
     );
-  }
-
-  /// A model that offers variants always runs at a named one. An unset variant
-  /// resolves to the first available, which plugins declare default-first.
-  AgentModel? _withResolvedVariant({
-    required AgentModel? model,
-    required List<SessionVariant> availableVariants,
-  }) {
-    if (model == null) return null;
-    if (availableVariants.any((variant) => variant.id == model.variant)) return model;
-    return model.copyWith(variant: availableVariants.firstOrNull?.id);
-  }
-
-  List<SessionVariant> _deriveAvailableVariants({
-    required List<ProviderInfo> providers,
-    required AgentModel? model,
-  }) {
-    final providerID = model?.providerID;
-    final modelID = model?.modelID;
-    final provider = providerID != null ? providers.firstWhereOrNull((p) => p.id == providerID) : null;
-    final m = provider?.models[modelID];
-    return m?.variants.where((v) => v != "none").map((v) => SessionVariant(id: v)).toList() ?? [];
   }
 
   List<SesoriQuestionAsked> _mapPendingQuestions(List<PendingQuestion> pendingQuestions) {

--- a/client/module_core/lib/src/di/injection.config.dart
+++ b/client/module_core/lib/src/di/injection.config.dart
@@ -44,7 +44,7 @@ import 'package:sesori_dart_core/src/api/storage/product_analytics_preference_st
     as _i197;
 import 'package:sesori_dart_core/src/api/view_declaration_api.dart' as _i37;
 import 'package:sesori_dart_core/src/capabilities/relay/room_key_storage.dart'
-    as _i896;
+    as _i895;
 import 'package:sesori_dart_core/src/capabilities/server_connection/connection_service.dart'
     as _i369;
 import 'package:sesori_dart_core/src/capabilities/voice/voice_api.dart'
@@ -170,8 +170,6 @@ import 'package:sesori_dart_core/src/services/session_viewing_service.dart'
 import 'package:sesori_dart_core/src/services/sse_event_tracker.dart' as _i508;
 import 'package:sesori_dart_core/src/services/voice_transcription_service.dart'
     as _i680;
-import 'package:sesori_dart_core/src/utils/model_filter/default_model_selector.dart'
-    as _i895;
 import 'package:sesori_shared/sesori_shared.dart' as _i553;
 
 extension GetItInjectableX on _i174.GetIt {
@@ -189,9 +187,6 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i84.SessionActivityCalculator>(
       () => const _i84.SessionActivityCalculator(),
-    );
-    gh.lazySingleton<_i895.DefaultModelSelector>(
-      () => const _i895.DefaultModelSelector(),
     );
     gh.lazySingleton<_i176.VoiceApi>(
       () => _i176.VoiceApi(gh<_i442.AuthenticatedHttpApiClient>()),
@@ -284,8 +279,8 @@ extension GetItInjectableX on _i174.GetIt {
         source: gh<_i345.AnalyticsReleaseCutoffSource>(),
       ),
     );
-    gh.lazySingleton<_i896.RoomKeyStorage>(
-      () => _i896.RoomKeyStorage(gh<_i442.SecureStorage>()),
+    gh.lazySingleton<_i895.RoomKeyStorage>(
+      () => _i895.RoomKeyStorage(gh<_i442.SecureStorage>()),
     );
     gh.lazySingleton<_i205.BridgeRepository>(
       () => _i205.BridgeRepository(api: gh<_i384.BridgeApi>()),
@@ -300,7 +295,7 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i369.ConnectionService>(
       () => _i369.ConnectionService(
         gh<_i553.RelayCryptoService>(),
-        gh<_i896.RoomKeyStorage>(),
+        gh<_i895.RoomKeyStorage>(),
         gh<_i442.AuthTokenProvider>(),
         gh<_i442.AuthSession>(),
         gh<_i903.LifecycleSource>(),
@@ -473,6 +468,11 @@ extension GetItInjectableX on _i174.GetIt {
         bridgeSettingsApi: gh<_i415.BridgeSettingsApi>(),
       ),
     );
+    gh.lazySingleton<_i74.NewSessionOptionsService>(
+      () => _i74.NewSessionOptionsService(
+        sessionRepository: gh<_i7.SessionRepository>(),
+      ),
+    );
     gh.lazySingleton<_i18.SessionViewingService>(
       () => _i18.SessionViewingService(
         viewRepository: gh<_i143.ViewDeclarationRepository>(),
@@ -513,12 +513,6 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i763.SessionListService(
         repository: gh<_i80.ProjectRepository>(),
         activityCalculator: gh<_i84.SessionActivityCalculator>(),
-      ),
-    );
-    gh.lazySingleton<_i74.NewSessionOptionsService>(
-      () => _i74.NewSessionOptionsService(
-        sessionRepository: gh<_i7.SessionRepository>(),
-        defaultModelSelector: gh<_i895.DefaultModelSelector>(),
       ),
     );
     gh.lazySingleton<_i888.AnalyticsRouteListener>(

--- a/client/module_core/lib/src/services/new_session_options_service.dart
+++ b/client/module_core/lib/src/services/new_session_options_service.dart
@@ -8,9 +8,9 @@ import "../foundation/models/session_options/session_options_request_mode.dart";
 import "../logging/logging.dart";
 import "../repositories/models/session_options_repository_result.dart";
 import "../repositories/session_repository.dart";
-import "../utils/model_filter/default_model_selector.dart";
 import "models/new_session_options_source.dart";
 import "models/new_session_selection_intent.dart";
+import "session_selection_calculator.dart";
 
 part "new_session_options_service.freezed.dart";
 
@@ -60,8 +60,9 @@ final class const NewSessionOptionsRefreshFailureUnavailable() extends NewSessio
 @lazySingleton
 class NewSessionOptionsService({
     required final SessionRepository _sessionRepository,
-    required final DefaultModelSelector _defaultModelSelector,
   }) {
+  static const SessionSelectionCalculator _selection = SessionSelectionCalculator();
+
   Future<NewSessionOptionsLoadResult> load({
     required String projectId,
     required String pluginId,
@@ -215,9 +216,7 @@ class NewSessionOptionsService({
     required NewSessionSelectionIntent? restoredSelection,
     required NewSessionOptionsData? previousOptions,
   }) {
-    final agents = catalog.agents
-        .where((agent) => !agent.hidden && agent.mode != AgentMode.subagent)
-        .toList(growable: false);
+    final agents = _selection.selectableAgents(agents: catalog.agents);
     final providers = catalog.providers;
     final commands = catalog.commands;
     final effectiveSelection = _mergeSelection(
@@ -225,52 +224,44 @@ class NewSessionOptionsService({
       lastUsedPromptDefaults: catalog.lastUsedPromptDefaults,
     );
 
-    final defaultAgent = agents.firstOrNull?.name;
-    final restoredAgent = effectiveSelection?.agentName;
-    final selectedAgent = restoredAgent != null && agents.any((agent) => agent.name == restoredAgent)
-        ? restoredAgent
-        : defaultAgent;
-    final selectedAgentInfo = selectedAgent == null
-        ? null
-        : agents.firstWhereOrNull((agent) => agent.name == selectedAgent);
-    final defaultAgentModel =
-        _validatedModel(
-          providers: providers,
-          model: selectedAgentInfo?.model,
-        ) ??
-        _pickDefaultModel(providers: providers);
-
     final restoredModel = effectiveSelection?.model;
-    final validatedRestoredModel = _validatedModel(
+    final reconciled = _selection.reconcile(
+      agents: agents,
       providers: providers,
-      model: restoredModel == null
-          ? null
-          : AgentModel(
-              providerID: restoredModel.providerId,
-              modelID: restoredModel.modelId,
-              variant: null,
-            ),
+      agentNameCandidates: [effectiveSelection?.agentName],
+      modelCandidates: [
+        if (restoredModel != null)
+          AgentModel(providerID: restoredModel.providerId, modelID: restoredModel.modelId, variant: null),
+      ],
+      // Only the catalog decides here: nothing has been run yet, so there is no
+      // prior selection this screen would be wrong to discard.
+      retainedModel: null,
     );
+
+    // A restored variant applies only to a restored model the catalog still
+    // offers. Falling back to a different model discards the variant with it,
+    // because an effort level named for one model means nothing on another.
+    final restoredModelSurvived =
+        restoredModel != null &&
+        reconciled.model?.providerID == restoredModel.providerId &&
+        reconciled.model?.modelID == restoredModel.modelId;
     final selectedAgentModel = _applyVariantIntent(
       providers: providers,
-      model: validatedRestoredModel ?? defaultAgentModel,
-      variantIntent: restoredModel == null || validatedRestoredModel != null
-          ? effectiveSelection?.variant
-          : null,
+      model: reconciled.model,
+      variantIntent: restoredModel == null || restoredModelSurvived ? effectiveSelection?.variant : null,
     );
-    final stagedCommandName = previousOptions?.stagedCommand?.name;
-    final stagedCommand = stagedCommandName == null
-        ? null
-        : commands.firstWhereOrNull((command) => command.name == stagedCommandName);
 
     return NewSessionOptionsData(
       agents: agents,
       providers: providers,
       commands: commands,
-      selectedAgent: selectedAgent,
+      selectedAgent: reconciled.agentName,
       selectedAgentModel: selectedAgentModel,
-      stagedCommand: stagedCommand,
-      availableVariants: availableVariants(providers: providers, model: selectedAgentModel),
+      stagedCommand: _selection.resolveStagedCommand(
+        commands: commands,
+        staged: previousOptions?.stagedCommand,
+      ),
+      availableVariants: reconciled.availableVariants,
     );
   }
 
@@ -307,7 +298,7 @@ class NewSessionOptionsService({
   }) {
     if (model == null || variantIntent == null) return model;
     final id = variantIntent.id;
-    return availableVariants(providers: providers, model: model).any((variant) => variant.id == id)
+    return _selection.availableVariants(providers: providers, model: model).any((variant) => variant.id == id)
         ? model.copyWith(variant: id)
         : model;
   }
@@ -322,15 +313,21 @@ class NewSessionOptionsService({
     final modelIntent = selectionIntent?.model;
     final selectedAgentModel = _applyVariantIntent(
       providers: options.providers,
-      model:
-          _validatedModel(
+      model: _selection
+          .reconcile(
+            agents: options.agents,
             providers: options.providers,
-            model: modelIntent == null
-                ? null
-                : AgentModel(providerID: modelIntent.providerId, modelID: modelIntent.modelId, variant: null),
-          ) ??
-          _validatedModel(providers: options.providers, model: agentInfo.model) ??
-          options.selectedAgentModel,
+            agentNameCandidates: [agent],
+            modelCandidates: [
+              if (modelIntent != null)
+                AgentModel(providerID: modelIntent.providerId, modelID: modelIntent.modelId, variant: null),
+              agentInfo.model,
+            ],
+            // The model already on screen survives a switch to an agent whose
+            // own declared model the catalog no longer offers.
+            retainedModel: options.selectedAgentModel,
+          )
+          .model,
       variantIntent: selectionIntent?.variant,
     );
     return NewSessionOptionsData(
@@ -340,7 +337,7 @@ class NewSessionOptionsService({
       selectedAgent: agent,
       selectedAgentModel: selectedAgentModel,
       stagedCommand: options.stagedCommand,
-      availableVariants: availableVariants(providers: options.providers, model: selectedAgentModel),
+      availableVariants: _selection.availableVariants(providers: options.providers, model: selectedAgentModel),
     );
   }
 
@@ -351,14 +348,14 @@ class NewSessionOptionsService({
     required NewSessionVariantIntent? variantIntent,
   }) {
     final requested = AgentModel(providerID: providerId, modelID: modelId, variant: null);
-    if (_validatedModel(providers: options.providers, model: requested) == null) return null;
+    if (!_selection.isModelAvailable(providers: options.providers, model: requested)) return null;
 
     final agentModel = options.agents
         .firstWhereOrNull(
           (agent) => agent.model?.providerID == providerId && agent.model?.modelID == modelId,
         )
         ?.model;
-    final variants = availableVariants(providers: options.providers, model: requested);
+    final variants = _selection.availableVariants(providers: options.providers, model: requested);
     final previousVariant = options.selectedAgentModel?.variant;
     final agentVariant = agentModel?.variant;
     final selectedVariant = previousVariant != null && variants.any((variant) => variant.id == previousVariant)
@@ -428,49 +425,5 @@ class NewSessionOptionsService({
       stagedCommand: null,
       availableVariants: options.availableVariants,
     );
-  }
-
-  List<SessionVariant> availableVariants({
-    required List<ProviderInfo> providers,
-    required AgentModel? model,
-  }) {
-    final providerId = model?.providerID;
-    final modelId = model?.modelID;
-    if (providerId == null || modelId == null) return const [];
-    final providerModel = providers.firstWhereOrNull((provider) => provider.id == providerId)?.models[modelId];
-    if (providerModel == null || !providerModel.isAvailable) return const [];
-    return providerModel.variants
-        .where((variant) => variant != "none")
-        .map((variant) => SessionVariant(id: variant))
-        .toList(growable: false);
-  }
-
-  AgentModel? _validatedModel({required List<ProviderInfo> providers, required AgentModel? model}) {
-    if (model == null) return null;
-    final providerModel = providers
-        .firstWhereOrNull((provider) => provider.id == model.providerID)
-        ?.models[model.modelID];
-    if (providerModel == null || !providerModel.isAvailable) return null;
-    final variants = availableVariants(providers: providers, model: model);
-    final variant = model.variant;
-    return model.copyWith(
-      variant: variants.any((available) => available.id == variant) ? variant : variants.firstOrNull?.id,
-    );
-  }
-
-  AgentModel? _pickDefaultModel({required List<ProviderInfo> providers}) {
-    for (final provider in providers) {
-      final model = _defaultModelSelector.pickFromProvider(
-        models: provider.models,
-        defaultModelID: provider.defaultModelID,
-      );
-      if (model != null) {
-        return _validatedModel(
-          providers: providers,
-          model: AgentModel(providerID: provider.id, modelID: model.id, variant: null),
-        );
-      }
-    }
-    return null;
   }
 }

--- a/client/module_core/lib/src/services/session_selection_calculator.dart
+++ b/client/module_core/lib/src/services/session_selection_calculator.dart
@@ -1,0 +1,184 @@
+import "package:collection/collection.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../utils/model_filter/default_model_selector.dart";
+
+/// A selection that survived reconciliation against a catalog: what the screen
+/// may offer, and what stays chosen.
+///
+/// [availableVariants] always belongs to [model]. Producing the two together is
+/// the point of [SessionSelectionCalculator.reconcile] — a caller that emitted
+/// a new model while keeping the previous variant list could offer a variant
+/// the model does not have.
+class const ReconciledSelection({
+  required final String? agentName,
+  required final AgentModel? model,
+  required final List<SessionVariant> availableVariants,
+});
+
+/// Resolves an agent/model/variant/command selection against the catalog a
+/// backend currently advertises.
+///
+/// This is the one owner of that policy. It previously existed twice — once for
+/// the New Session screen and once inside `SessionDetailCubit` — and the two
+/// copies drifted: only one of them honored [ProviderModel.isAvailable]. Every
+/// screen now reconciles through [reconcile] so a selection cannot be validated
+/// one way in one place and another way elsewhere.
+///
+/// Pure and stateless: it reads a catalog and returns a selection, and never
+/// emits, persists, or calls a backend. Const-constructed by its callers rather
+/// than resolved from the container, like the other calculators in this package.
+class const SessionSelectionCalculator() {
+  static const DefaultModelSelector _defaultModelSelector = DefaultModelSelector();
+
+  /// The agents a user may pick. Hidden agents and sub-agents are backend
+  /// bookkeeping, never picker entries.
+  List<AgentInfo> selectableAgents({required List<AgentInfo> agents}) {
+    return agents.where((agent) => !agent.hidden && agent.mode != AgentMode.subagent).toList(growable: false);
+  }
+
+  /// Whether [model] is one the catalog still offers.
+  ///
+  /// A model the backend marks unavailable counts as absent: it is listed so a
+  /// transcript naming it can still be read, not so it can be selected again.
+  bool isModelAvailable({required List<ProviderInfo> providers, required AgentModel model}) {
+    return _providerModel(providers: providers, model: model)?.isAvailable ?? false;
+  }
+
+  /// The effort/thinking variants [model] offers, default-first as the plugin
+  /// declared them. `"none"` is a backend spelling of "no variant", never a
+  /// picker entry.
+  List<SessionVariant> availableVariants({
+    required List<ProviderInfo> providers,
+    required AgentModel? model,
+  }) {
+    if (model == null) return const [];
+    final providerModel = _providerModel(providers: providers, model: model);
+    if (providerModel == null || !providerModel.isAvailable) return const [];
+    return providerModel.variants
+        .where((variant) => variant != "none")
+        .map((variant) => SessionVariant(id: variant))
+        .toList(growable: false);
+  }
+
+  /// The agent to run, given [candidates] in preference order: the first the
+  /// catalog still offers, otherwise the first selectable agent, otherwise null
+  /// because there is nothing to select.
+  ///
+  /// Null candidates are skipped rather than treated as a choice, so a caller
+  /// may pass a value it does not have. A caller for which "unset" is itself
+  /// meaningful — a queued prompt inheriting the session's agent — must keep
+  /// that rule on its own side rather than asking for it here.
+  String? validatedAgentName({
+    required List<AgentInfo> agents,
+    required List<String?> candidates,
+  }) {
+    final selectable = selectableAgents(agents: agents);
+    return candidates.firstWhereOrNull(
+          (candidate) => candidate != null && selectable.any((agent) => agent.name == candidate),
+        ) ??
+        selectable.firstOrNull?.name;
+  }
+
+  /// Reconciles a desired selection against the catalog.
+  ///
+  /// [agents] may be raw or already filtered; it is put through
+  /// [selectableAgents] either way.
+  ///
+  /// [agentNameCandidates] and [modelCandidates] are preference orders: the
+  /// first entry the catalog still offers wins. Nulls are skipped, so a caller
+  /// can pass a value it may not have without pre-filtering. When no candidate
+  /// survives, the agent falls back to the first selectable one and the model to
+  /// the chosen agent's declared model, then to the catalog's own default.
+  ///
+  /// [retainedModel] is adopted without catalog validation when no candidate
+  /// survives, and before those fallbacks. The caller vouches for it, so it is
+  /// the one way to keep a model the catalog does not currently advertise.
+  /// Callers use it for two things: a session's transcript model, which stays
+  /// authoritative so an imported session cannot silently resume on a different
+  /// provider, and the selection already on screen, which a catalog change
+  /// should not yank out from under the user mid-session. Pass null where only
+  /// the catalog may decide — a fresh New Session screen, or a queued prompt
+  /// being revalidated before dispatch.
+  ReconciledSelection reconcile({
+    required List<AgentInfo> agents,
+    required List<ProviderInfo> providers,
+    required List<String?> agentNameCandidates,
+    required List<AgentModel?> modelCandidates,
+    required AgentModel? retainedModel,
+  }) {
+    final selectable = selectableAgents(agents: agents);
+    final agentName = validatedAgentName(agents: selectable, candidates: agentNameCandidates);
+
+    final declaredModel = agentName == null
+        ? null
+        : selectable.firstWhereOrNull((agent) => agent.name == agentName)?.model;
+    final model =
+        modelCandidates.firstWhereOrNull(
+          (candidate) => candidate != null && isModelAvailable(providers: providers, model: candidate),
+        ) ??
+        retainedModel ??
+        _firstAvailable(providers: providers, candidates: [declaredModel]) ??
+        _catalogDefault(providers: providers);
+
+    final variants = availableVariants(providers: providers, model: model);
+    return ReconciledSelection(
+      agentName: agentName,
+      model: _withResolvedVariant(model: model, availableVariants: variants),
+      availableVariants: variants,
+    );
+  }
+
+  /// The staged command as the current catalog spells it, or null once the
+  /// backend stops offering it.
+  CommandInfo? resolveStagedCommand({
+    required List<CommandInfo> commands,
+    required CommandInfo? staged,
+  }) {
+    if (staged == null) return null;
+    return commands.firstWhereOrNull((command) => command.name == staged.name);
+  }
+
+  /// A model that offers variants always runs at a named one, so an unset or
+  /// withdrawn variant resolves to the first available. Plugins declare them
+  /// default-first, making that the plugin's own default.
+  AgentModel? _withResolvedVariant({
+    required AgentModel? model,
+    required List<SessionVariant> availableVariants,
+  }) {
+    if (model == null) return null;
+    if (availableVariants.any((variant) => variant.id == model.variant)) return model;
+    return model.copyWith(variant: availableVariants.firstOrNull?.id);
+  }
+
+  AgentModel? _firstAvailable({
+    required List<ProviderInfo> providers,
+    required List<AgentModel?> candidates,
+  }) {
+    return candidates.firstWhereOrNull(
+      (candidate) => candidate != null && isModelAvailable(providers: providers, model: candidate),
+    );
+  }
+
+  /// Walks every provider: the first may be misconfigured or fully deprecated
+  /// and therefore have no selectable model.
+  AgentModel? _catalogDefault({required List<ProviderInfo> providers}) {
+    for (final provider in providers) {
+      final picked = _defaultModelSelector.pickFromProvider(
+        models: provider.models,
+        defaultModelID: provider.defaultModelID,
+      );
+      if (picked != null) {
+        return AgentModel(providerID: provider.id, modelID: picked.id, variant: null);
+      }
+    }
+    return null;
+  }
+
+  ProviderModel? _providerModel({
+    required List<ProviderInfo> providers,
+    required AgentModel model,
+  }) {
+    return providers.firstWhereOrNull((provider) => provider.id == model.providerID)?.models[model.modelID];
+  }
+}

--- a/client/module_core/lib/src/utils/model_filter/default_model_selector.dart
+++ b/client/module_core/lib/src/utils/model_filter/default_model_selector.dart
@@ -1,4 +1,3 @@
-import "package:injectable/injectable.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 /// Pure helper that selects a single representative [ProviderModel] from a
@@ -27,7 +26,6 @@ import "package:sesori_shared/sesori_shared.dart";
 /// models are already filtered out by [ProviderModel.isAvailable] in
 /// `bridge/sesori_plugin_opencode/lib/src/provider_mapper.dart`, and a
 /// hard cutoff can hide new models whose metadata is missing or stale.
-@lazySingleton
 class const DefaultModelSelector() {
   /// Selects the default model for a single family of [ProviderModel]s.
   ///

--- a/client/module_core/test/cubits/new_session/new_session_cubit_test.dart
+++ b/client/module_core/test/cubits/new_session/new_session_cubit_test.dart
@@ -21,7 +21,6 @@ import "package:sesori_dart_core/src/services/models/new_session_selection_inten
 import "package:sesori_dart_core/src/services/new_session_options_service.dart";
 import "package:sesori_dart_core/src/services/new_session_plugin_service.dart";
 import "package:sesori_dart_core/src/services/new_session_selection_tracker.dart";
-import "package:sesori_dart_core/src/utils/model_filter/default_model_selector.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -146,7 +145,6 @@ void main() {
       ),
       newSessionOptionsService: NewSessionOptionsService(
         sessionRepository: mockSessionRepository,
-        defaultModelSelector: const DefaultModelSelector(),
       ),
       projectRepository: mockProjectRepository,
       selectionTracker: selectionTracker,
@@ -531,7 +529,6 @@ void main() {
           ),
           newSessionOptionsService: NewSessionOptionsService(
             sessionRepository: mockSessionRepository,
-            defaultModelSelector: const DefaultModelSelector(),
           ),
           projectRepository: mockProjectRepository,
           selectionTracker: selectionTracker,

--- a/client/module_core/test/cubits/new_session/new_session_plugin_selection_test.dart
+++ b/client/module_core/test/cubits/new_session/new_session_plugin_selection_test.dart
@@ -17,7 +17,6 @@ import "package:sesori_dart_core/src/services/models/new_session_selection_inten
 import "package:sesori_dart_core/src/services/new_session_options_service.dart";
 import "package:sesori_dart_core/src/services/new_session_plugin_service.dart";
 import "package:sesori_dart_core/src/services/new_session_selection_tracker.dart";
-import "package:sesori_dart_core/src/utils/model_filter/default_model_selector.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -57,7 +56,6 @@ final class _AggregateTestOptionsService({required MockSessionRepository session
   this
     : super(
         sessionRepository: sessionRepository,
-        defaultModelSelector: const DefaultModelSelector(),
       );
 
   @override
@@ -787,7 +785,6 @@ void main() {
       final cubit = buildCubit(
         optionsService: NewSessionOptionsService(
           sessionRepository: sessionRepository,
-          defaultModelSelector: const DefaultModelSelector(),
         ),
       );
       addTearDown(cubit.close);
@@ -845,7 +842,6 @@ void main() {
       final cubit = buildCubit(
         optionsService: NewSessionOptionsService(
           sessionRepository: sessionRepository,
-          defaultModelSelector: const DefaultModelSelector(),
         ),
       );
       addTearDown(cubit.close);
@@ -940,7 +936,6 @@ void main() {
       final cubit = buildCubit(
         optionsService: NewSessionOptionsService(
           sessionRepository: sessionRepository,
-          defaultModelSelector: const DefaultModelSelector(),
         ),
       );
       addTearDown(cubit.close);
@@ -988,7 +983,6 @@ void main() {
       final cubit = buildCubit(
         optionsService: NewSessionOptionsService(
           sessionRepository: sessionRepository,
-          defaultModelSelector: const DefaultModelSelector(),
         ),
       );
       addTearDown(cubit.close);
@@ -1042,7 +1036,6 @@ void main() {
       final cubit = buildCubit(
         optionsService: NewSessionOptionsService(
           sessionRepository: sessionRepository,
-          defaultModelSelector: const DefaultModelSelector(),
         ),
       );
       addTearDown(cubit.close);

--- a/client/module_core/test/cubits/session_detail/session_detail_bridge_queue_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_bridge_queue_test.dart
@@ -283,6 +283,101 @@ void main() {
       expect(state.selectedAgent, "Agent");
     });
 
+    test("a refresh that drops the selected agent adopts the replacement's own model", () async {
+      // The old agent's model is still in the catalog, so it would survive on
+      // its own. It must not, because the agent that preferred it is gone.
+      const replacement = AgentInfo(
+        name: "Agent",
+        description: "Agent",
+        model: AgentModel(providerID: "anthropic", modelID: "haiku", variant: null),
+        mode: AgentMode.primary,
+      );
+      when(
+        () => mockSessionRepository.loadSessionOptions(
+          projectId: "project-1",
+          pluginId: "claude",
+          mode: SessionOptionsRequestMode.cacheOnly,
+        ),
+      ).thenAnswer(
+        (_) async => SessionOptionsRepositoryAvailable(
+          isStale: false,
+          catalog: SessionOptionsCatalog(
+            agents: const [replacement],
+            providers: [
+              const ProviderInfo(
+                id: "anthropic",
+                name: "Anthropic",
+                defaultModelID: "opus",
+                models: {
+                  "opus": ProviderModel(
+                    id: "opus",
+                    providerID: "anthropic",
+                    name: "Opus",
+                    variants: [],
+                    family: null,
+                    releaseDate: null,
+                  ),
+                  "haiku": ProviderModel(
+                    id: "haiku",
+                    providerID: "anthropic",
+                    name: "Haiku",
+                    variants: [],
+                    family: null,
+                    releaseDate: null,
+                  ),
+                },
+              ),
+            ],
+            providersConnectedOnly: false,
+            commands: const [],
+            lastUsedPromptDefaults: null,
+          ),
+        ),
+      );
+      final cubit = await createLoadedCubit(
+        agents: const [
+          AgentInfo(
+            name: "Departing",
+            description: "Departing",
+            model: AgentModel(providerID: "anthropic", modelID: "opus", variant: null),
+            mode: AgentMode.primary,
+          ),
+        ],
+        promptDefaults: const SessionPromptDefaults(
+          agent: "Departing",
+          model: AgentModel(providerID: "anthropic", modelID: "opus", variant: null),
+        ),
+        providerData: const ProviderListResponse(
+          connectedOnly: false,
+          items: [
+            ProviderInfo(
+              id: "anthropic",
+              name: "Anthropic",
+              defaultModelID: "opus",
+              models: {
+                "opus": ProviderModel(
+                  id: "opus",
+                  providerID: "anthropic",
+                  name: "Opus",
+                  variants: [],
+                  family: null,
+                  releaseDate: null,
+                ),
+              },
+            ),
+          ],
+        ),
+      );
+      expect((cubit.state as SessionDetailLoaded).selectedAgentModel?.modelID, "opus");
+
+      globalEvents.add(
+        SseEvent(data: const SesoriSessionOptionsUpdated(pluginId: "claude", projectId: "project-1")),
+      );
+      await _awaitCondition(() => (cubit.state as SessionDetailLoaded).selectedAgent == "Agent");
+
+      expect((cubit.state as SessionDetailLoaded).selectedAgentModel?.modelID, "haiku");
+    });
+
     test("an options update for another project is ignored", () async {
       final cubit = await createLoadedCubit(
         agents: const [

--- a/client/module_core/test/cubits/session_detail/session_detail_cubit_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_cubit_test.dart
@@ -667,7 +667,7 @@ void main() {
     );
 
     blocTest<SessionDetailCubit, SessionDetailState>(
-      "selectAgent applies a known agent's model preference",
+      "selectAgent applies an agent's declared model when the catalog offers it",
       build: () {
         when(
           () => mockSessionService.listAgents(
@@ -683,8 +683,8 @@ void main() {
                   name: "reviewer",
                   description: "Reviews code",
                   model: const AgentModel(
-                    providerID: "openai",
-                    modelID: "gpt-4.1",
+                    providerID: "anthropic",
+                    modelID: "claude-3-5-sonnet",
                     variant: null,
                   ),
                 ),
@@ -723,11 +723,70 @@ void main() {
             .having(
               (state) => state.selectedAgentModel,
               "selectedAgentModel",
+              // The declared model carries no variant, so the catalog's own
+              // first variant is resolved onto it.
               const AgentModel(
-                providerID: "openai",
-                modelID: "gpt-4.1",
-                variant: null,
+                providerID: "anthropic",
+                modelID: "claude-3-5-sonnet",
+                variant: "xhigh",
               ),
+            ),
+      ],
+    );
+
+    blocTest<SessionDetailCubit, SessionDetailState>(
+      "selectAgent keeps the current model when the agent declares one the catalog omits",
+      build: () {
+        when(
+          () => mockSessionService.listAgents(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(
+            Agents(
+              agents: [
+                testAgentInfo(),
+                testAgentInfo().copyWith(
+                  name: "reviewer",
+                  description: "Reviews code",
+                  model: const AgentModel(providerID: "openai", modelID: "gpt-4.1", variant: null),
+                ),
+              ],
+            ),
+          ),
+        );
+        return SessionDetailCubit(
+          mockConnectionService,
+          loadService: loadService,
+          promptDispatcher: promptDispatcher,
+          permissionRepository: mockPermissionRepository,
+          sessionViewingService: stubbedSessionViewingService(),
+          projectViewingService: stubbedProjectViewingService(),
+          lifecycleSource: MockLifecycleSource(),
+          composerDraftRepository: inMemoryComposerDraftRepository(),
+          productAnalyticsService: mockProductAnalyticsService,
+          sessionId: sessionId,
+          projectId: "project-1",
+          notificationCanceller: mockNotificationCanceller,
+          failureReporter: mockFailureReporter,
+        );
+      },
+      act: (cubit) async {
+        await _awaitLoaded(cubit);
+        cubit.selectAgent("reviewer");
+      },
+      expect: () => [
+        isA<SessionDetailLoaded>(),
+        isA<SessionDetailLoaded>()
+            .having((state) => state.selectedAgent, "selectedAgent", "reviewer")
+            // An agent may name a model from a provider this catalog does not
+            // carry. Selecting it would put an unusable model in the composer,
+            // so the one already on screen stays.
+            .having(
+              (state) => state.selectedAgentModel,
+              "selectedAgentModel",
+              const AgentModel(providerID: "anthropic", modelID: "claude-3-5-sonnet", variant: "xhigh"),
             ),
       ],
     );

--- a/client/module_core/test/services/new_session_options_service_test.dart
+++ b/client/module_core/test/services/new_session_options_service_test.dart
@@ -5,7 +5,6 @@ import "package:sesori_dart_core/src/repositories/models/session_options_reposit
 import "package:sesori_dart_core/src/services/models/new_session_options_source.dart";
 import "package:sesori_dart_core/src/services/models/new_session_selection_intent.dart";
 import "package:sesori_dart_core/src/services/new_session_options_service.dart";
-import "package:sesori_dart_core/src/utils/model_filter/default_model_selector.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -22,7 +21,6 @@ void main() {
       repository = MockSessionRepository();
       service = NewSessionOptionsService(
         sessionRepository: repository,
-        defaultModelSelector: const DefaultModelSelector(),
       );
     });
 

--- a/client/module_core/test/services/session_selection_calculator_test.dart
+++ b/client/module_core/test/services/session_selection_calculator_test.dart
@@ -1,0 +1,261 @@
+import "package:sesori_dart_core/src/services/session_selection_calculator.dart";
+import "package:sesori_dart_core/src/testing/test_helpers.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+const _calculator = SessionSelectionCalculator();
+
+ProviderInfo _provider({
+  required String id,
+  required Map<String, ProviderModel> models,
+  String? defaultModelID,
+}) => ProviderInfo(id: id, name: id, models: models, defaultModelID: defaultModelID);
+
+ProviderModel _model({
+  required String id,
+  required String providerID,
+  List<String> variants = const [],
+  bool isAvailable = true,
+}) => ProviderModel(
+  id: id,
+  providerID: providerID,
+  name: id,
+  variants: variants,
+  family: null,
+  isAvailable: isAvailable,
+  releaseDate: null,
+);
+
+AgentInfo _agent({
+  required String name,
+  AgentModel? model,
+  AgentMode mode = AgentMode.primary,
+  bool hidden = false,
+}) => AgentInfo(name: name, description: name, model: model, mode: mode, hidden: hidden);
+
+void main() {
+  group("SessionSelectionCalculator selectable agents", () {
+    test("hidden agents and sub-agents are not picker entries", () {
+      final agents = [
+        _agent(name: "build"),
+        _agent(name: "secret", hidden: true),
+        _agent(name: "helper", mode: AgentMode.subagent),
+      ];
+
+      expect(
+        _calculator.selectableAgents(agents: agents).map((agent) => agent.name),
+        ["build"],
+      );
+    });
+  });
+
+  group("SessionSelectionCalculator availability", () {
+    final providers = [
+      _provider(
+        id: "anthropic",
+        models: {
+          "opus": _model(id: "opus", providerID: "anthropic", variants: ["high", "low"]),
+          "retired": _model(id: "retired", providerID: "anthropic", variants: ["high"], isAvailable: false),
+        },
+      ),
+    ];
+
+    test("a model the backend marks unavailable is treated as absent", () {
+      const retired = AgentModel(providerID: "anthropic", modelID: "retired", variant: null);
+
+      expect(_calculator.isModelAvailable(providers: providers, model: retired), isFalse);
+      expect(_calculator.availableVariants(providers: providers, model: retired), isEmpty);
+    });
+
+    test("an unknown model offers no variants", () {
+      const unknown = AgentModel(providerID: "openai", modelID: "gpt", variant: null);
+
+      expect(_calculator.availableVariants(providers: providers, model: unknown), isEmpty);
+    });
+
+    test("the backend's no-variant spelling is not a picker entry", () {
+      final withNone = [
+        _provider(
+          id: "anthropic",
+          models: {
+            "opus": _model(id: "opus", providerID: "anthropic", variants: ["none", "high"]),
+          },
+        ),
+      ];
+
+      expect(
+        _calculator
+            .availableVariants(
+              providers: withNone,
+              model: const AgentModel(providerID: "anthropic", modelID: "opus", variant: null),
+            )
+            .map((variant) => variant.id),
+        ["high"],
+      );
+    });
+  });
+
+  group("SessionSelectionCalculator staged command", () {
+    test("a command the backend stopped offering is dropped", () {
+      expect(
+        _calculator.resolveStagedCommand(commands: const [], staged: testCommandInfo(name: "review")),
+        isNull,
+      );
+    });
+
+    test("a staged command is re-read from the current catalog", () {
+      final current = testCommandInfo(name: "review", template: "/review new");
+
+      final resolved = _calculator.resolveStagedCommand(
+        commands: [current],
+        staged: testCommandInfo(name: "review", template: "/review old"),
+      );
+
+      expect(resolved?.template, "/review new");
+    });
+
+    test("nothing staged stays nothing", () {
+      expect(
+        _calculator.resolveStagedCommand(commands: [testCommandInfo(name: "review")], staged: null),
+        isNull,
+      );
+    });
+  });
+
+  group("SessionSelectionCalculator reconcile", () {
+    final providers = [
+      _provider(
+        id: "anthropic",
+        models: {
+          "opus": _model(id: "opus", providerID: "anthropic", variants: ["high", "low"]),
+          "retired": _model(id: "retired", providerID: "anthropic", variants: ["high"], isAvailable: false),
+        },
+        defaultModelID: "opus",
+      ),
+    ];
+    final agents = [_agent(name: "build"), _agent(name: "plan")];
+
+    test("the first candidate the catalog still offers wins, and nulls are skipped", () {
+      final resolved = _calculator.reconcile(
+        agents: agents,
+        providers: providers,
+        agentNameCandidates: [null, "plan"],
+        modelCandidates: [null, const AgentModel(providerID: "anthropic", modelID: "opus", variant: "low")],
+        retainedModel: null,
+      );
+
+      expect(resolved.agentName, "plan");
+      expect(resolved.model?.modelID, "opus");
+      expect(resolved.model?.variant, "low");
+      expect(resolved.availableVariants.map((variant) => variant.id), ["high", "low"]);
+    });
+
+    test("a withdrawn agent falls back to the first selectable one", () {
+      final resolved = _calculator.reconcile(
+        agents: agents,
+        providers: providers,
+        agentNameCandidates: ["deleted"],
+        modelCandidates: const [],
+        retainedModel: null,
+      );
+
+      expect(resolved.agentName, "build");
+    });
+
+    test("no selectable agent resolves to null rather than inventing one", () {
+      final resolved = _calculator.reconcile(
+        agents: [_agent(name: "helper", mode: AgentMode.subagent)],
+        providers: providers,
+        agentNameCandidates: ["helper"],
+        modelCandidates: const [],
+        retainedModel: null,
+      );
+
+      expect(resolved.agentName, isNull);
+    });
+
+    test("an unavailable candidate falls through to the catalog default", () {
+      final resolved = _calculator.reconcile(
+        agents: agents,
+        providers: providers,
+        agentNameCandidates: ["build"],
+        modelCandidates: [const AgentModel(providerID: "anthropic", modelID: "retired", variant: null)],
+        retainedModel: null,
+      );
+
+      expect(resolved.model?.modelID, "opus");
+    });
+
+    test("a retained model is adopted without catalog validation", () {
+      const transcriptModel = AgentModel(providerID: "openai", modelID: "gpt-4.1", variant: null);
+
+      final resolved = _calculator.reconcile(
+        agents: agents,
+        providers: providers,
+        agentNameCandidates: ["build"],
+        modelCandidates: const [],
+        retainedModel: transcriptModel,
+      );
+
+      // A session imported from a terminal keeps running on what it ran on,
+      // even when a retained provider cache does not list it.
+      expect(resolved.model?.providerID, "openai");
+      expect(resolved.model?.modelID, "gpt-4.1");
+      expect(resolved.availableVariants, isEmpty);
+    });
+
+    test("a surviving candidate outranks the retained model", () {
+      final resolved = _calculator.reconcile(
+        agents: agents,
+        providers: providers,
+        agentNameCandidates: ["build"],
+        modelCandidates: [const AgentModel(providerID: "anthropic", modelID: "opus", variant: null)],
+        retainedModel: const AgentModel(providerID: "openai", modelID: "gpt-4.1", variant: null),
+      );
+
+      expect(resolved.model?.modelID, "opus");
+    });
+
+    test("the chosen agent's declared model is validated before it is adopted", () {
+      final resolved = _calculator.reconcile(
+        agents: [
+          _agent(
+            name: "build",
+            model: const AgentModel(providerID: "anthropic", modelID: "retired", variant: null),
+          ),
+        ],
+        providers: providers,
+        agentNameCandidates: ["build"],
+        modelCandidates: const [],
+        retainedModel: null,
+      );
+
+      expect(resolved.model?.modelID, "opus");
+    });
+
+    test("a withdrawn variant resolves to the model's first, never to unset", () {
+      final resolved = _calculator.reconcile(
+        agents: agents,
+        providers: providers,
+        agentNameCandidates: ["build"],
+        modelCandidates: [const AgentModel(providerID: "anthropic", modelID: "opus", variant: "gone")],
+        retainedModel: null,
+      );
+
+      expect(resolved.model?.variant, "high");
+    });
+
+    test("variants always describe the model that was chosen", () {
+      final resolved = _calculator.reconcile(
+        agents: agents,
+        providers: providers,
+        agentNameCandidates: ["build"],
+        modelCandidates: [const AgentModel(providerID: "anthropic", modelID: "retired", variant: null)],
+        retainedModel: null,
+      );
+
+      expect(resolved.model?.modelID, "opus");
+      expect(resolved.availableVariants.map((variant) => variant.id), ["high", "low"]);
+    });
+  });
+}

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -32,9 +32,9 @@ variant, and worktree mode, and creating the session with its first input.
   the user switches agents or the bridge reports remembered defaults, even when
   the catalog no longer lists it. A refresh is the opposite case: it exists to
   adopt the catalog the backend has now, so a selection that catalog no longer
-  offers is corrected there rather than preserved. Losing the agent moves the
-  model with it — the replacement agent's own declared model is preferred over
-  the departed agent's.
+  offers is corrected there rather than preserved. A replacement agent's own
+  declared model outranks the departed agent's; a replacement that declares none
+  expresses no preference, so the model on screen is kept rather than reset.
 - After a new session and its first prompt or command are accepted, the bridge
   remembers the complete agent, model, and effort selection per plugin. The next
   New Session screen uses it as the prefill across projects for that plugin after

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -20,6 +20,16 @@ variant, and worktree mode, and creating the session with its first input.
   default-first, and a model that offers variants always has one selected: the
   agent's declared variant when valid, otherwise the first available. Selecting a
   variant is therefore a switch between named levels, never a reset to unset.
+- One rule decides what a selection reconciles to, on every surface. A model the
+  backend reports unavailable is treated as absent everywhere: it is neither
+  selectable nor a source of variants, whether the screen is New Session or a
+  live session, and an agent's declared model is validated against the catalog
+  before it is adopted. Hidden agents and sub-agents are never picker entries, a
+  withdrawn agent falls back to the first selectable one, and the variant list a
+  screen shows always belongs to the model it currently has selected. A live
+  session may still retain a model the catalog stopped advertising — its own
+  transcript's, or the one already on screen — so a catalog change never pulls a
+  running session's model out from under it.
 - After a new session and its first prompt or command are accepted, the bridge
   remembers the complete agent, model, and effort selection per plugin. The next
   New Session screen uses it as the prefill across projects for that plugin after
@@ -214,6 +224,10 @@ refresh failure with a last-good catalog, and headless-auth discovery failure.
 
 - Options are empty or stale where a discovery failure should be an explicit
   error, or a partial observation overwrites a complete cache.
+- A model the backend reports unavailable is selectable or offers variants on
+  one surface but not another, an agent's declared model is adopted without
+  being checked against the catalog, or a screen's variant list describes a
+  model it no longer has selected.
 - A successful creation does not become the next per-plugin prefill, a failed
   creation replaces it, one plugin's selection leaks into another, or a removed
   saved value prevents current catalog defaults from loading.
@@ -293,7 +307,9 @@ refresh failure with a last-good catalog, and headless-auth discovery failure.
 - Contract:
   `bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin_descriptor.dart`,
   `bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin.dart`
-- Client: `client/module_core/lib/src/services/new_session_options_service.dart`,
+- Client: `client/module_core/lib/src/services/session_selection_calculator.dart`
+  (the single owner of selection reconciliation),
+  `client/module_core/lib/src/services/new_session_options_service.dart`,
   `client/module_core/lib/src/services/session_detail_load_service.dart`,
   `client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart`,
   `client/module_app_ui/lib/src/features/new_session/`,

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -26,10 +26,15 @@ variant, and worktree mode, and creating the session with its first input.
   live session, and an agent's declared model is validated against the catalog
   before it is adopted. Hidden agents and sub-agents are never picker entries, a
   withdrawn agent falls back to the first selectable one, and the variant list a
-  screen shows always belongs to the model it currently has selected. A live
-  session may still retain a model the catalog stopped advertising — its own
-  transcript's, or the one already on screen — so a catalog change never pulls a
-  running session's model out from under it.
+  screen shows always belongs to the model it currently has selected.
+- Retention is scoped to what did not ask the catalog a new question. A live
+  session keeps its own transcript's model, and keeps the model on screen while
+  the user switches agents or the bridge reports remembered defaults, even when
+  the catalog no longer lists it. A refresh is the opposite case: it exists to
+  adopt the catalog the backend has now, so a selection that catalog no longer
+  offers is corrected there rather than preserved. Losing the agent moves the
+  model with it — the replacement agent's own declared model is preferred over
+  the departed agent's.
 - After a new session and its first prompt or command are accepted, the bridge
   remembers the complete agent, model, and effort selection per plugin. The next
   New Session screen uses it as the prefill across projects for that plugin after

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -27,14 +27,18 @@ variant, and worktree mode, and creating the session with its first input.
   before it is adopted. Hidden agents and sub-agents are never picker entries, a
   withdrawn agent falls back to the first selectable one, and the variant list a
   screen shows always belongs to the model it currently has selected.
-- Retention is scoped to what did not ask the catalog a new question. A live
-  session keeps its own transcript's model, and keeps the model on screen while
-  the user switches agents or the bridge reports remembered defaults, even when
-  the catalog no longer lists it. A refresh is the opposite case: it exists to
-  adopt the catalog the backend has now, so a selection that catalog no longer
-  offers is corrected there rather than preserved. A replacement agent's own
-  declared model outranks the departed agent's; a replacement that declares none
-  expresses no preference, so the model on screen is kept rather than reset.
+- One order decides the model, everywhere. What the caller asked for wins when
+  the catalog still offers it: the agent just picked declares one, the bridge
+  reported a remembered default, or the selection is simply being revalidated.
+  Only when nothing asked for survives does retention apply, and it is what
+  keeps a live session usable — the session's own transcript model, or the model
+  already on screen, adopted even though the catalog does not list it. Failing
+  both, the resolved agent's declared model is used, then the catalog's default.
+- Retention is therefore a fallback, never an override: switching to an agent
+  that declares an available model does change the model, and an agent declaring
+  none leaves the current one alone. A refresh takes no retention at all, since
+  adopting the catalog it just fetched is the reason it ran; there a replacement
+  agent's declared model outranks the departed agent's.
 - After a new session and its first prompt or command are accepted, the bridge
   remembers the complete agent, model, and effort selection per plugin. The next
   New Session screen uses it as the prefill across projects for that plugin after

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -248,7 +248,12 @@ defaults and queued client sends coherent.
   transcript model before falling back to agent or catalog defaults. The
   transcript model remains authoritative when a retained provider cache does
   not list it, so a terminal-imported session cannot silently resume on a
-  different provider.
+  different provider. The selection already on screen is retained the same way,
+  so a catalog change does not pull a model out from under the user mid-session.
+  Everything the catalog is asked to supply must be something it still
+  advertises as available: persisted defaults, an agent's declared model, and a
+  queued prompt's model are each validated before being adopted, so an agent
+  naming a model this catalog does not carry does not put it in the composer.
 - The bridge owns accepted-but-not-yet-visible prompts. An entry appears in the
   session snapshot and full-list `session.queued-prompts` events, survives
   leaving the screen, locking the phone, and reconnecting, and is visible to

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -248,10 +248,11 @@ defaults and queued client sends coherent.
   transcript model before falling back to agent or catalog defaults. The
   transcript model remains authoritative when a retained provider cache does
   not list it, so a terminal-imported session cannot silently resume on a
-  different provider. The selection already on screen is retained the same way
-  while the user switches agents or the bridge reports remembered defaults,
-  though an options refresh adopts the catalog it just fetched and corrects a
-  selection that catalog no longer offers.
+  different provider. The selection already on screen is retained the same way,
+  but retention is only ever a fallback: an agent the user picks, or a
+  remembered default the bridge reports, replaces the model whenever the catalog
+  still offers what it names, and an options refresh takes no retention at all
+  because adopting the catalog it just fetched is why it ran.
   Everything the catalog is asked to supply must be something it still
   advertises as available: persisted defaults, an agent's declared model, and a
   queued prompt's model are each validated before being adopted, so an agent

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -248,8 +248,10 @@ defaults and queued client sends coherent.
   transcript model before falling back to agent or catalog defaults. The
   transcript model remains authoritative when a retained provider cache does
   not list it, so a terminal-imported session cannot silently resume on a
-  different provider. The selection already on screen is retained the same way,
-  so a catalog change does not pull a model out from under the user mid-session.
+  different provider. The selection already on screen is retained the same way
+  while the user switches agents or the bridge reports remembered defaults,
+  though an options refresh adopts the catalog it just fetched and corrects a
+  selection that catalog no longer offers.
   Everything the catalog is asked to supply must be something it still
   advertises as available: persisted defaults, an agent's declared model, and a
   queued prompt's model are each validated before being adopted, so an agent


### PR DESCRIPTION
## Complexity

Moderate. One new pure class, two consumers rewired across nine call sites, and
seven private helpers deleted. No new dependencies, no DI additions, no shell
changes. Net −72 lines in existing files.

## What

- Adds `SessionSelectionCalculator`, the single owner of "resolve an
  agent/model/variant/command selection against the catalog a backend
  advertises". Pure, stateless, const-constructed by its callers like the other
  calculators in the package.
- Its `reconcile` entry point returns agent, model and variant list together, so
  a caller cannot emit a model while keeping a variant list belonging to a
  different one.
- `NewSessionOptionsService` and `SessionDetailCubit` both delegate to it.
  Deletes the cubit's seven private helpers and the service's three copies,
  along with the inline agent filters duplicated at three more sites.
- Drops `@lazySingleton` from `DefaultModelSelector`: this change removes its
  last injection site, so the container was registering something nothing
  resolved.

## Why

The policy existed twice and had already diverged. `NewSessionOptionsService`
honored `ProviderModel.isAvailable`; the cubit's `_isModelAvailable` only tested
`containsKey`. A model the backend marked unavailable was therefore hidden on
the New Session screen and still offered, with its variants, on the session
screen. `_onPromptDefaultsChanged` was a second instance of the same class of
bug: it emitted a new `selectedAgentModel` without recomputing
`availableVariants`, leaving the two describing different models.

Duplication that has already drifted once will drift again, and `client/AGENTS.md`
is explicit that cubits must not hold business logic belonging to a service.

## Risk and test focus

User-visible, all on the session screen:

1. A model the backend reports unavailable is no longer selectable there and no
   longer offers variants.
2. An agent's declared model is validated against the catalog before adoption.
   Previously `agents.first.model` was adopted unvalidated, so an agent naming a
   model from a provider the catalog does not carry put an unusable model in the
   composer.
3. Prompt-defaults changes now recompute the variant list alongside the model.

Two exemptions are deliberate and now stated in the contract rather than implied:
a session retains its own transcript model, and retains the selection already on
screen. `docs/regression/session-turns.md` documents the first as required — a
terminal-imported session must not silently resume on a different provider — and
the second keeps a catalog change from pulling a running session's model out from
under the user.

Database impact: none. Wire contract impact: none — no bridge or shared changes.

Test focus: the availability rule on both surfaces, the agent-declared-model
validation, and that both retention exemptions still hold.

## Expected result

One implementation of selection reconciliation, behaving identically on New
Session and on a live session. The `isAvailable` inconsistency is gone, and the
variant list always describes the model actually selected.

## Verification

- New `session_selection_calculator_test.dart`: 16 tests covering the
  availability rule, candidate precedence, both retention exemptions, the
  agent-declared-model validation, variant resolution, and staged commands.
- `session_detail_cubit_test.dart`: the `selectAgent` test split into the
  catalog-offers-it and catalog-omits-it cases, asserting the unified rule.
- `dart test` green: `client/module_core` (1518).
- `flutter test` green: `client/app` (667), `client/desktop` (118),
  `client/module_app_ui` (284).
- `dart analyze` clean including warnings and info across all four packages.
- Reviewed by `architecture-plan-review` (rejected once; the class suffix, the
  coarse entry point, explicit contracts for the diverging methods, the wider
  cubit edit surface, and the narrowed availability scope all come from it) and
  `architecture-implementation-review` (rejected once; the single acquisition
  model, the orphaned DI registration, the contract/document mismatch, and
  removing commands from `reconcile` all come from it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes selection reconciliation in `SessionSelectionCalculator` so New Session and live sessions apply the same catalog rules. Previously live sessions could select unavailable models and adopt unvalidated agent declarations; now unavailable models are ignored, declared models are validated, and variants always match the selected model.

- A requested model wins whenever the catalog still offers it; retention only applies when nothing requested survives.
- Prompt-default changes recompute the model and variant list together.
- Live sessions keep their transcript model and current on-screen model during ordinary updates.
- An options refresh corrects withdrawn selections; a replacement agent's declared model wins, while an agent without one keeps the current model.
- A no-agent placeholder is not treated as a retained agent, so a newly advertised agent's model applies.
- Removes `DefaultModelSelector` from dependency injection and the `NewSessionOptionsService` constructor.
- No database or wire-contract changes.

<sup>Written for commit 670575f2e76f9d00006d6d4d6838e430e20cbdd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

