### PR TITLE
⚙️ Install complete managed Codex packages

### DIFF
--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart
@@ -1,5 +1,6 @@
 import "dart:io" show Platform;
 
+import "package:path/path.dart" as p;
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
 import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 
@@ -33,58 +34,57 @@ class const CodexRuntimeManifest() extends RuntimeManifest {
   /// The exact codex version the managed runtime installs.
   static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: targetVersion);
 
-  /// Pinned per-platform assets for [bundledVersion]. codex ships `.tar.gz` on
-  /// darwin/linux and an `.exe.zip` on windows; the binary inside each archive is
-  /// named with the full target triple (e.g. `codex-aarch64-apple-darwin`), so
-  /// [ArchiveRuntimeAsset.archiveBinaryName] carries that member name and the installer
-  /// normalizes it to the canonical [binaryFileName] (`codex` / `codex.exe`).
+  /// Pinned per-platform assets for [bundledVersion]. Codex's canonical package
+  /// archives contain the CLI, `codex-code-mode-host`, and runtime resources.
+  /// The complete package tree must remain intact because the CLI resolves its
+  /// helper and resources relative to `bin/codex` (`bin/codex.exe` on Windows).
   static const Map<PlatformOs, Map<PlatformArch, RuntimeAsset>> _assets = {
     PlatformOs.macos: {
       PlatformArch.arm64: ArchiveRuntimeAsset(
-        assetName: "codex-aarch64-apple-darwin.tar.gz",
+        assetName: "codex-package-aarch64-apple-darwin.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "758916aa38efa7ad076a050830fcbef1a7ed6f41efae9c1cceaeef63e428fc2b",
-        archiveBinaryName: "codex-aarch64-apple-darwin",
-        layout: RuntimeArchiveLayout.singleBinary,
+        sha256: "bfae69c7bb7a3fbe68161f2ca9328839c7e6eea053a8871186eb6edbb1346870",
+        archiveBinaryName: "bin/codex",
+        layout: RuntimeArchiveLayout.packageDirectory,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
-        assetName: "codex-x86_64-apple-darwin.tar.gz",
+        assetName: "codex-package-x86_64-apple-darwin.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "54591772f242271f802f17b4dda6cecab29229ba71593e962e208549e0da1a3a",
-        archiveBinaryName: "codex-x86_64-apple-darwin",
-        layout: RuntimeArchiveLayout.singleBinary,
+        sha256: "9ac9245ea244629a9ba4db3315f0cdaebb05182b790ee34271a5060875d836e1",
+        archiveBinaryName: "bin/codex",
+        layout: RuntimeArchiveLayout.packageDirectory,
       ),
     },
     PlatformOs.linux: {
       PlatformArch.arm64: ArchiveRuntimeAsset(
-        assetName: "codex-aarch64-unknown-linux-musl.tar.gz",
+        assetName: "codex-package-aarch64-unknown-linux-musl.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "410c6ae0c763eb39c6da17665e63f9aa4a98e6ee663d81f8e8b779c97cb175ac",
-        archiveBinaryName: "codex-aarch64-unknown-linux-musl",
-        layout: RuntimeArchiveLayout.singleBinary,
+        sha256: "580db3c7411f5852b550876f185c30b61b674e01b948fd5030f2cd7a30db110a",
+        archiveBinaryName: "bin/codex",
+        layout: RuntimeArchiveLayout.packageDirectory,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
-        assetName: "codex-x86_64-unknown-linux-musl.tar.gz",
+        assetName: "codex-package-x86_64-unknown-linux-musl.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "1a36f762f6b3bef533bb86345ad9517661c2d84d53996a250cf2ca89d2cfee5a",
-        archiveBinaryName: "codex-x86_64-unknown-linux-musl",
-        layout: RuntimeArchiveLayout.singleBinary,
+        sha256: "8c790500af2ba6e74ce4948fe26c651ac1f77f6dbb005b47c8d26ff711146262",
+        archiveBinaryName: "bin/codex",
+        layout: RuntimeArchiveLayout.packageDirectory,
       ),
     },
     PlatformOs.windows: {
       PlatformArch.arm64: ArchiveRuntimeAsset(
-        assetName: "codex-aarch64-pc-windows-msvc.exe.zip",
-        format: ArchiveFormat.zip,
-        sha256: "73a2b150965d63ddc71f7d0b5a3845a5d5925757af6495110a32dea40d6e18c3",
-        archiveBinaryName: "codex-aarch64-pc-windows-msvc.exe",
-        layout: RuntimeArchiveLayout.singleBinary,
+        assetName: "codex-package-aarch64-pc-windows-msvc.tar.gz",
+        format: ArchiveFormat.tarGz,
+        sha256: "0258ac84ebf8fdc6d8e1f4b0541d55a703f3d8996debca157a013cf753134c54",
+        archiveBinaryName: "bin/codex.exe",
+        layout: RuntimeArchiveLayout.packageDirectory,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
-        assetName: "codex-x86_64-pc-windows-msvc.exe.zip",
-        format: ArchiveFormat.zip,
-        sha256: "a3f053e70bd5073d04d08ee3a2605b4015c74b0a51f3ff5a2fb67852ee37e3b0",
-        archiveBinaryName: "codex-x86_64-pc-windows-msvc.exe",
-        layout: RuntimeArchiveLayout.singleBinary,
+        assetName: "codex-package-x86_64-pc-windows-msvc.tar.gz",
+        format: ArchiveFormat.tarGz,
+        sha256: "cc09f725b8ed133b76a2882fda750b3f1672b10701e8172c9680b5ab79b861ff",
+        archiveBinaryName: "bin/codex.exe",
+        layout: RuntimeArchiveLayout.packageDirectory,
       ),
     },
   };
@@ -102,7 +102,7 @@ class const CodexRuntimeManifest() extends RuntimeManifest {
   String get pathExecutableName => "codex";
 
   @override
-  String get binaryFileName => Platform.isWindows ? "codex.exe" : "codex";
+  String get binaryFileName => p.join("bin", Platform.isWindows ? "codex.exe" : "codex");
 
   @override
   RuntimeVersion get minPathVersion => _minPathVersion;

--- a/bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart
@@ -1,3 +1,5 @@
+import "dart:io" show Platform;
+
 import "package:codex_plugin/src/runtime/codex_plugin_descriptor.dart";
 import "package:codex_plugin/src/runtime/codex_runtime_manifest.dart";
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
@@ -19,65 +21,60 @@ void main() {
       expect(manifest.minPathVersion.toString(), "0.139.0");
       expect(manifest.runtimeId, const CodexPluginDescriptor().id);
       expect(manifest.pathExecutableName, "codex");
+      expect(manifest.binaryFileName, Platform.isWindows ? r"bin\codex.exe" : "bin/codex");
     });
 
-    test("pins a sha256 asset for every platform target", () {
-      for (final os in PlatformOs.values) {
-        for (final arch in PlatformArch.values) {
+    test("pins the canonical package and digest for every platform target", () {
+      const expected = <PlatformOs, Map<PlatformArch, ({String assetName, String sha256})>>{
+        PlatformOs.macos: {
+          PlatformArch.arm64: (
+            assetName: "codex-package-aarch64-apple-darwin.tar.gz",
+            sha256: "bfae69c7bb7a3fbe68161f2ca9328839c7e6eea053a8871186eb6edbb1346870",
+          ),
+          PlatformArch.x64: (
+            assetName: "codex-package-x86_64-apple-darwin.tar.gz",
+            sha256: "9ac9245ea244629a9ba4db3315f0cdaebb05182b790ee34271a5060875d836e1",
+          ),
+        },
+        PlatformOs.linux: {
+          PlatformArch.arm64: (
+            assetName: "codex-package-aarch64-unknown-linux-musl.tar.gz",
+            sha256: "580db3c7411f5852b550876f185c30b61b674e01b948fd5030f2cd7a30db110a",
+          ),
+          PlatformArch.x64: (
+            assetName: "codex-package-x86_64-unknown-linux-musl.tar.gz",
+            sha256: "8c790500af2ba6e74ce4948fe26c651ac1f77f6dbb005b47c8d26ff711146262",
+          ),
+        },
+        PlatformOs.windows: {
+          PlatformArch.arm64: (
+            assetName: "codex-package-aarch64-pc-windows-msvc.tar.gz",
+            sha256: "0258ac84ebf8fdc6d8e1f4b0541d55a703f3d8996debca157a013cf753134c54",
+          ),
+          PlatformArch.x64: (
+            assetName: "codex-package-x86_64-pc-windows-msvc.tar.gz",
+            sha256: "cc09f725b8ed133b76a2882fda750b3f1672b10701e8172c9680b5ab79b861ff",
+          ),
+        },
+      };
+
+      for (final osEntry in expected.entries) {
+        for (final archEntry in osEntry.value.entries) {
           final asset = manifest.assetFor(
-            target: PlatformTarget(os: os, arch: arch),
+            target: PlatformTarget(os: osEntry.key, arch: archEntry.key),
           );
-          expect(asset, isNotNull, reason: "missing asset for $os/$arch");
-          expect(asset!.sha256, matches(RegExp(r"^[0-9a-f]{64}$")), reason: "$os/$arch sha256");
-          expect(asset.assetName, isNotEmpty);
+          expect(asset, isA<ArchiveRuntimeAsset>(), reason: "${osEntry.key}/${archEntry.key} asset type");
+          final archive = asset! as ArchiveRuntimeAsset;
+          expect(archive.assetName, archEntry.value.assetName);
+          expect(archive.sha256, archEntry.value.sha256);
+          expect(archive.format, ArchiveFormat.tarGz);
+          expect(archive.layout, RuntimeArchiveLayout.packageDirectory);
+          expect(
+            archive.archiveBinaryName,
+            osEntry.key == PlatformOs.windows ? "bin/codex.exe" : "bin/codex",
+          );
         }
       }
-    });
-
-    test("darwin/linux ship .tar.gz, windows ships .exe.zip", () {
-      ArchiveRuntimeAsset asset(PlatformOs os, PlatformArch arch) =>
-          manifest.assetFor(
-                target: PlatformTarget(os: os, arch: arch),
-              )!
-              as ArchiveRuntimeAsset;
-
-      expect(asset(PlatformOs.macos, PlatformArch.arm64).format, ArchiveFormat.tarGz);
-      expect(asset(PlatformOs.macos, PlatformArch.arm64).assetName, endsWith(".tar.gz"));
-      expect(asset(PlatformOs.linux, PlatformArch.x64).format, ArchiveFormat.tarGz);
-      expect(asset(PlatformOs.linux, PlatformArch.x64).assetName, endsWith(".tar.gz"));
-
-      for (final arch in PlatformArch.values) {
-        final windows = asset(PlatformOs.windows, arch);
-        expect(windows.format, ArchiveFormat.zip, reason: "windows/$arch format");
-        expect(windows.assetName, endsWith(".exe.zip"), reason: "windows/$arch asset");
-      }
-    });
-
-    test("archive member is the target-triple name (asset name minus extension)", () {
-      expect(
-        (manifest.assetFor(
-                  target: const PlatformTarget(os: PlatformOs.macos, arch: PlatformArch.arm64),
-                )!
-                as ArchiveRuntimeAsset)
-            .archiveBinaryName,
-        "codex-aarch64-apple-darwin",
-      );
-      expect(
-        (manifest.assetFor(
-                  target: const PlatformTarget(os: PlatformOs.linux, arch: PlatformArch.x64),
-                )!
-                as ArchiveRuntimeAsset)
-            .archiveBinaryName,
-        "codex-x86_64-unknown-linux-musl",
-      );
-      expect(
-        (manifest.assetFor(
-                  target: const PlatformTarget(os: PlatformOs.windows, arch: PlatformArch.x64),
-                )!
-                as ArchiveRuntimeAsset)
-            .archiveBinaryName,
-        "codex-x86_64-pc-windows-msvc.exe",
-      );
     });
 
     test("download URL embeds the rust-v bundled tag and asset name", () {
@@ -86,7 +83,10 @@ void main() {
       )!;
       expect(
         manifest.downloadUrlFor(asset: asset),
-        equals("https://github.com/openai/codex/releases/download/rust-v0.148.0/codex-aarch64-apple-darwin.tar.gz"),
+        equals(
+          "https://github.com/openai/codex/releases/download/"
+          "rust-v0.148.0/codex-package-aarch64-apple-darwin.tar.gz",
+        ),
       );
     });
 

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_install_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_install_service.dart
@@ -27,8 +27,9 @@ class const RuntimeInstallException(final String message) implements Exception {
 /// sentinel.
 ///
 /// Archive executables are located by [ArchiveRuntimeAsset.archiveBinaryName]
-/// and normalized to [binaryFileName]. Direct binaries are placed there without
-/// extraction. The sentinel (the verified SHA-256) is written last, so an
+/// (a name or package-relative path) and normalized to [binaryFileName]. Direct
+/// binaries are placed there without extraction. The sentinel (the verified
+/// SHA-256) is written last, so an
 /// interrupted install leaves no sentinel and is cleanly redone next attempt.
 /// No lock is required: single-live-bridge enforcement covers cross-process
 /// overlap, callers gate concurrent same-plugin work (setup-blocked plugins
@@ -133,7 +134,7 @@ class RuntimeInstallService({
               _placeBinary(binaryInStaging: binaryInStaging, versionDir: versionDir, binaryFileName: binaryFileName);
             case RuntimeArchiveLayout.packageDirectory:
               _placePackage(
-                packageInStaging: binaryInStaging.parent,
+                binaryInStaging: binaryInStaging,
                 versionDir: versionDir,
                 binaryFileName: binaryFileName,
                 archiveBinaryName: asset.archiveBinaryName,
@@ -177,15 +178,37 @@ class RuntimeInstallService({
 
   File? _locateBinary({required String stagingPath, required String archiveBinaryName}) {
     final Directory dir = Directory(stagingPath);
-    if (!dir.existsSync()) {
+    final String normalizedArchivePath = p.normalize(archiveBinaryName);
+    final List<String> expectedSegments = p.split(normalizedArchivePath);
+    if (!dir.existsSync() ||
+        p.isAbsolute(normalizedArchivePath) ||
+        expectedSegments.isEmpty ||
+        expectedSegments.any((segment) => segment == "..")) {
       return null;
     }
     for (final FileSystemEntity entity in dir.listSync(recursive: true, followLinks: false)) {
-      if (entity is File && p.basename(entity.path) == archiveBinaryName) {
+      if (entity is! File) {
+        continue;
+      }
+      final List<String> actualSegments = p.split(p.relative(entity.path, from: stagingPath));
+      if (_pathEndsWith(actual: actualSegments, expected: expectedSegments)) {
         return entity;
       }
     }
     return null;
+  }
+
+  bool _pathEndsWith({required List<String> actual, required List<String> expected}) {
+    if (actual.length < expected.length) {
+      return false;
+    }
+    final int offset = actual.length - expected.length;
+    for (var index = 0; index < expected.length; index++) {
+      if (actual[offset + index] != expected[index]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   void _placeBinary({
@@ -201,19 +224,30 @@ class RuntimeInstallService({
     // Same filesystem (both under managedDir), so this rename is atomic. The
     // canonical [binaryFileName] may differ from the archive member name, which
     // normalizes a target-triple-named member to a plain binary.
-    binaryInStaging.renameSync(p.join(versionDir, binaryFileName));
+    final File canonicalBinary = File(p.join(versionDir, binaryFileName));
+    canonicalBinary.parent.createSync(recursive: true);
+    binaryInStaging.renameSync(canonicalBinary.path);
   }
 
   /// Places an entire extracted package tree at [versionDir], keeping the entry
-  /// binary next to the siblings it loads at runtime. When the publisher's
-  /// entry name differs from the canonical [binaryFileName], the entry file is
-  /// renamed inside the placed tree rather than moved out of it.
+  /// binary next to the siblings it loads at runtime. A package-relative
+  /// [archiveBinaryName] identifies how far above the entry the package root
+  /// begins. When that path differs from the canonical [binaryFileName], the
+  /// entry file is renamed inside the placed tree rather than moved out of it.
   void _placePackage({
-    required Directory packageInStaging,
+    required File binaryInStaging,
     required String versionDir,
     required String binaryFileName,
     required String archiveBinaryName,
   }) {
+    final String normalizedArchiveBinaryName = p.normalize(archiveBinaryName);
+    final String normalizedBinaryFileName = p.normalize(binaryFileName);
+    final List<String> archivePathSegments = p.split(normalizedArchiveBinaryName);
+    Directory packageInStaging = binaryInStaging.parent;
+    for (var index = 1; index < archivePathSegments.length; index++) {
+      packageInStaging = packageInStaging.parent;
+    }
+
     final Directory dir = Directory(versionDir);
     if (dir.existsSync()) {
       dir.deleteSync(recursive: true);
@@ -221,8 +255,10 @@ class RuntimeInstallService({
     dir.parent.createSync(recursive: true);
     // Same filesystem (both under managedDir), so this rename is atomic.
     packageInStaging.renameSync(versionDir);
-    if (archiveBinaryName != binaryFileName) {
-      File(p.join(versionDir, archiveBinaryName)).renameSync(p.join(versionDir, binaryFileName));
+    if (normalizedArchiveBinaryName != normalizedBinaryFileName) {
+      final File canonicalBinary = File(p.join(versionDir, normalizedBinaryFileName));
+      canonicalBinary.parent.createSync(recursive: true);
+      File(p.join(versionDir, normalizedArchiveBinaryName)).renameSync(canonicalBinary.path);
     }
   }
 

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_manifest.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_manifest.dart
@@ -6,9 +6,12 @@ import "runtime_version.dart";
 /// How a publisher's extracted archive is placed into the version directory.
 ///
 /// Most runtimes ship a single self-contained executable ([singleBinary]).
-/// Cursor ships a `dist-package/` tree whose entry binary loads sibling files,
+/// Other runtimes ship a package tree whose entry binary loads sibling files,
 /// so the whole directory must be kept together ([packageDirectory]).
-enum RuntimeArchiveLayout() { singleBinary, packageDirectory }
+enum RuntimeArchiveLayout() {
+  singleBinary,
+  packageDirectory,
+}
 
 /// One platform's pinned release artifact for a managed runtime, identified by
 /// its publisher [assetName] and verified against [sha256] before placement.
@@ -27,8 +30,8 @@ final class const ArchiveRuntimeAsset({
   required super.sha256,
 
   /// The entry executable's name inside the extracted archive. For
-  /// [RuntimeArchiveLayout.packageDirectory] it names the binary within the
-  /// placed tree; its siblings travel with it.
+  /// [RuntimeArchiveLayout.packageDirectory] this may be a relative path from
+  /// the package root; the complete tree rooted above that path travels with it.
   required final String archiveBinaryName,
   required final RuntimeArchiveLayout layout,
 }) extends RuntimeAsset;
@@ -67,8 +70,8 @@ abstract class const RuntimeManifest() {
   /// `"opencode"`, `"codex"`).
   String get pathExecutableName;
 
-  /// The canonical executable file name the managed binary is placed under in
-  /// its version directory (platform-aware, e.g. `codex` / `codex.exe`).
+  /// The canonical executable file name or relative path under the managed
+  /// version directory (platform-aware, e.g. `opencode` or `bin/codex.exe`).
   String get binaryFileName;
 
   /// Minimum pre-installed (PATH) version the bridge will use as-is.

--- a/bridge/sesori_plugin_runtime/test/provisioning/runtime_install_service_test.dart
+++ b/bridge/sesori_plugin_runtime/test/provisioning/runtime_install_service_test.dart
@@ -29,8 +29,11 @@ class _FakeChecksumValidator({required final bool valid}) implements ChecksumVal
   Future<String> computeSha256({required String filePath}) async => "deadbeef";
 }
 
-class _FakeArchiveExtractor({required final bool success, required final bool packageDirectory})
-    implements ArchiveExtractor {
+class _FakeArchiveExtractor({
+  required final bool success,
+  required final bool packageDirectory,
+  final bool rootPackage = false,
+}) implements ArchiveExtractor {
   int extractCalls = 0;
 
   @override
@@ -43,7 +46,13 @@ class _FakeArchiveExtractor({required final bool success, required final bool pa
     if (!success) {
       return const ArchiveExtractionResult.failure(reason: "powershell Expand-Archive exited with code 1: boom");
     }
-    if (packageDirectory) {
+    if (rootPackage) {
+      final bin = Directory(p.join(stagingPath, "bin"))..createSync(recursive: true);
+      File(p.join(bin.path, "codex")).writeAsStringSync("BINARY");
+      File(p.join(bin.path, "codex-code-mode-host")).writeAsStringSync("SIDECAR");
+      final resources = Directory(p.join(stagingPath, "codex-resources"))..createSync();
+      File(p.join(resources.path, "resource")).writeAsStringSync("RESOURCE");
+    } else if (packageDirectory) {
       final package = Directory(p.join(stagingPath, "dist-package"))..createSync(recursive: true);
       File(p.join(package.path, "cursor-agent")).writeAsStringSync("BINARY");
       File(p.join(package.path, "node-runtime")).writeAsStringSync("SIBLING");
@@ -89,6 +98,14 @@ const _packageAsset = ArchiveRuntimeAsset(
   layout: RuntimeArchiveLayout.packageDirectory,
 );
 
+const _rootPackageAsset = ArchiveRuntimeAsset(
+  assetName: "codex-package-test.tar.gz",
+  format: ArchiveFormat.tarGz,
+  sha256: "fed321",
+  archiveBinaryName: "bin/codex",
+  layout: RuntimeArchiveLayout.packageDirectory,
+);
+
 const _directAsset = DirectBinaryRuntimeAsset(assetName: "omp-test", sha256: "789abc");
 
 void main() {
@@ -109,13 +126,20 @@ void main() {
     bool checksumValid = true,
     bool extractSuccess = true,
     bool packageDirectory = false,
+    bool rootPackage = false,
     _FakeCommandExecutor? cmd,
     _FakeArchiveExtractor? extractor,
   }) {
     return RuntimeInstallService(
       downloadClient: _FakeDownloadClient(exception: downloadError),
       checksumValidator: _FakeChecksumValidator(valid: checksumValid),
-      archiveExtractor: extractor ?? _FakeArchiveExtractor(success: extractSuccess, packageDirectory: packageDirectory),
+      archiveExtractor:
+          extractor ??
+          _FakeArchiveExtractor(
+            success: extractSuccess,
+            packageDirectory: packageDirectory,
+            rootPackage: rootPackage,
+          ),
       commandExecutor: cmd ?? _FakeCommandExecutor(),
       runtimeId: "opencode",
     );
@@ -180,6 +204,32 @@ void main() {
     expect(
       File(p.join(versionDir(), RuntimeInstallService.sentinelFileName)).readAsStringSync(),
       "def456",
+    );
+  });
+
+  test("places an archive-root package identified by a nested entry path", () async {
+    final staleFile = File(p.join(versionDir(), "stale"))
+      ..createSync(recursive: true)
+      ..writeAsStringSync("OLD");
+
+    await build(rootPackage: true)
+        .install(
+          managedDir: managedDir.path,
+          versionDir: versionDir(),
+          binaryFileName: p.join("bin", "codex"),
+          downloadUrl: "https://example.test/codex-package-test.tar.gz",
+          asset: _rootPackageAsset,
+          startAborted: StartAbortSignal.never,
+        )
+        .drain<void>();
+
+    expect(File(p.join(versionDir(), "bin", "codex")).readAsStringSync(), "BINARY");
+    expect(File(p.join(versionDir(), "bin", "codex-code-mode-host")).readAsStringSync(), "SIDECAR");
+    expect(File(p.join(versionDir(), "codex-resources", "resource")).readAsStringSync(), "RESOURCE");
+    expect(staleFile.existsSync(), isFalse);
+    expect(
+      File(p.join(versionDir(), RuntimeInstallService.sentinelFileName)).readAsStringSync(),
+      "fed321",
     );
   });
 

--- a/docs/regression/plugin-runtime-installation.md
+++ b/docs/regression/plugin-runtime-installation.md
@@ -18,6 +18,9 @@ management API, when it reports its runtime as missing or too old.
   `ldd` evidence; macOS and Windows use direct target mapping, and Windows arm64 remains unsupported.
   Pi installs its complete official package tree on all six published targets and keeps the
   `pi`/`pi.exe` entry beside its assets, native modules, and package metadata.
+  Codex installs its canonical package tree on all six targets, preserving
+  `bin/codex` (or `bin/codex.exe`), the adjacent `codex-code-mode-host`, and the
+  package's runtime resources as one checksum-verified unit.
   DeepSeek likewise installs its complete adapter package on macOS, Linux, and
   Windows for arm64 and x64. Its launcher remains beside the bundled Node runtime
   and package tree, so installation never depends on system Node or npm.
@@ -39,7 +42,7 @@ management API, when it reports its runtime as missing or too old.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Not included. Installation is a deliberate network-bound action, not a heartbeat. |
-| L2 Routine | Capability declaration is honest for every registered harness on the release-target bridge host: those with a pinned asset and no override advertise install, the rest do not. Automated manifest coverage includes Copilot's exact six platform/architecture mappings and digests. Headless bridge; every supporting production harness. |
+| L2 Routine | Capability declaration is honest for every registered harness on the release-target bridge host: those with a pinned asset and no override advertise install, the rest do not. Automated manifest coverage includes Codex's and Copilot's exact six platform/architecture mappings and digests, plus preservation of nested package entries and sibling resources. Headless bridge; every supporting production harness. |
 | L3 Release | One complete install on the release-target bridge host from missing runtime through verification and extraction to enabled, re-inspected, and selectable, with progress shown on the release-target client platform. Client end to end; every harness advertising install. |
 | L4 Extended | Checksum mismatch or interrupted download failing safely, shutdown mid-install, duplicate join, competing-command rejection, authentication-required outcome, too-old runtime, and an alternate bridge host. Live plugin for bridge outcome, client end to end for card state. |
 | L5 Full | Install on every supported platform and architecture where the harness publishes an asset, a superseded managed version swept after success, and pinned digests matching the upstream release assets. Copilot's complete matrix is its six official arm64/x64 macOS, Linux, and Windows archives. Packaged or external, since real upstream artifacts are part of the claim. |
@@ -59,7 +62,8 @@ download, verification, or placement. Use a disposable data directory.
 - The request blocking on the download, progress stalling or moving backwards, a busy
   state that never clears, or a duplicate request starting a second install.
 - A completed install leaving the harness disabled, not re-inspected, or unselectable
-  while reporting success, or raw paths and command output reaching the client.
+  while reporting success, a Codex install missing `codex-code-mode-host` or package
+  resources, or raw paths and command output reaching the client.
 
 ## Known Limitations
 


### PR DESCRIPTION
## Complexity

⚙️ Moderate — this updates all six Codex runtime artifacts and extends shared package placement to preserve an archive root around a nested executable.

## What

- Switch managed Codex 0.148.0 from standalone CLI archives to OpenAI's canonical `codex-package-*` archives and pin their published SHA-256 digests.
- Allow package manifests to identify an executable by a package-relative path, preserving the complete verified archive tree during installation.
- Add focused coverage for nested executables, sidecars, sibling resources, cross-platform path normalization, and the exact Codex asset matrix.
- Update the plugin-runtime regression contract.

## Why

The standalone Codex archive contains only the CLI. Codex 0.148.0 enables its code-mode host by default, so managed sessions could chat but every shell tool failed because `codex-code-mode-host` was absent. The canonical upstream package ships that host and its runtime resources beside the CLI.

## Risk and test focus

Moderate runtime-installation risk across macOS, Linux, and Windows. Review should focus on package-root derivation, forward-slash versus host path normalization, atomic replacement, executable selection, and the pinned six-platform digests. There is no wire-contract or database change.

## Expected result

A managed Codex install keeps `bin/codex`/`bin/codex.exe`, `codex-code-mode-host`, packaged ripgrep/zsh resources, and metadata together. Existing incomplete 0.148.0 installs are repaired because the expected executable path and archive sentinel change. Codex shell tools work after repair. There is no database impact.

## Verification

- `sesori_plugin_runtime`: fatal-info analysis; 167 tests passed.
- `sesori_plugin_codex`: fatal-info analysis; 413 tests passed.
- Bridge app: fatal-info analysis; 2,811 tests passed with 2 expected host skips; native helper bundle built.
- macOS Release and Debug desktop builds passed strict deep codesign verification.
- GitHub release API checked all six upstream asset names, sizes, and digests; the macOS arm64 archive was independently downloaded and hash-verified.
- Live macOS repair installed the complete package, passed executable/codesign/version checks, and successfully executed a shell tool through `codex-code-mode-host`.
- Dart LSP diagnostics and `git diff --check` passed.
- Architecture implementation review approved with no findings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Managed Codex 0.148.0 installs now use OpenAI's canonical `codex-package-*` archives instead of standalone CLI archives, so `codex-code-mode-host` and the runtime resources ship beside the CLI. Previously the standalone archive only contained the CLI, and because Codex 0.148.0 enables its code-mode host by default, managed sessions could chat but every shell tool failed.

**Key changes**
- Package manifests can now identify the executable by a package-relative path (for example `bin/codex`), and the installer preserves the complete verified archive tree rooted above it.
- All six platform targets now use the canonical `.tar.gz` package archives with pinned SHA-256 digests; Windows no longer uses `.exe.zip`.
- The expected executable path and archive sentinel change, so existing incomplete 0.148.0 installs are repaired on the next install attempt.
- No wire-contract or database impact.

<sup>Written for commit 0006aa60aea1afe889f5003b444329d18eafc213. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

