### PR TITLE
⚙️ [claude-inline-subtasks] acp: child lifecycle and request attribution [step 1/5]

### DIFF
--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -37,9 +37,8 @@ confirmation, no child session or partial stop) and gets that subset.
 ## Shared Rules
 
 - Backend payloads, DTOs, and lifecycle mapping stay inside the owning plugin
-  package. The generic ACP plugin gains exactly five backend-neutral seams,
-  introduced by the Grok chain (their first consumer) and reused by DeepSeek
-  and Cursor:
+  package. The generic ACP plugin gains only the backend-neutral seams below,
+  each landing with its first production consumer rather than ahead of it:
   1. `AcpChildSessionTracker`
      (`bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_child_session_tracker.dart`),
      a Layer-2 tracker with one instance per plugin, constructed at the harness
@@ -118,25 +117,21 @@ confirmation, no child session or partial stop) and gets that subset.
      reported as complete. `interruptActiveWork` uses `stop`.
   4. One abstract backend seam `cancelChild({sessionId, childSessionId})` on
      the per-harness ACP API; Grok and DeepSeek supply only the request shape.
-  5. A backend-neutral replay hook: `getSessionMessages` builds history from
+  5. A narrow backend-neutral replay replacement hook on
      `AcpReplayCollector`, which consumes `session/update` frames into
-     `PluginMessageWithParts` and never runs the live mapper. The collector
-     therefore accepts a harness-supplied replay projection that turns the
-     non-`session/update` notifications replayed by `session/load` into the
-     same `subtask` parts and child records the collector materialises. The
-     projection owns replay-local `AcpChildSessionTracker` and
-     `AcpDeferredToolCallTracker` instances created per `getSessionMessages`
-     call; it never touches either live tracker, the child change-stream
-     subscription, or the event buffer, so reading history cannot leave the
-     plugin busy, retain deferred calls, or emit live status transitions. Before the collector
-     runs, a harness may have its Layer-3 session service prepare an immutable,
-     backend-neutral `AcpReplayContext` through the harness API and repository;
-     the pure projection receives that context and performs no data access.
-     Grok uses this part of seam 5 to supply child prompts keyed by child id.
-     `mapExtension` stays a live-only seam.
-  Harness subclasses therefore override payload parsing, tool-call
-  classification, `mapExtension`, the replay projection, and `cancelChild`, and
-  nothing else.
+     `PluginMessageWithParts` without running the live mapper. A harness
+     repository may replace one fully materialized generic tool part with a
+     backend-neutral message part using the standard tool-call id. The callback
+     receives immutable replay data, performs no I/O, and never reads or mutates
+     live trackers, subscriptions, or the event buffer. DeepSeek consumes this
+     narrow replacement form: its repository indexes typed metadata from those
+     same replayed standard updates, then asks its pure mapper to replace the
+     delegation card with one subtask tile. Grok's earlier seam-5 work instead
+     uses collector-provided replay context to route historical extension frames;
+     it does not use the generic-tool replacement callback. `mapExtension` stays
+     live-only for the DeepSeek path.
+  Harness subclasses add only the parsing, mapping, and transport overrides
+  required by the capability currently being delivered.
 - Child session ids are the harness's own session or thread ids. Parentage is
   data on the session record, never an id prefix.
 - One child equals one tile. Progress events do not update the tile; only
@@ -479,122 +474,128 @@ confirmation, no child session or partial stop) and gets that subset.
 5. Is `spawn_subagent` also surfaced as a standard `tool_call`; does a
    background finish trigger a wake-up turn?
 
-## DeepSeek (`sesori-deepseek-acp` 0.1.2 over dsh 0.1.1-rc.2)
+## DeepSeek (`sesori-deepseek-acp` 0.1.3 source over dsh 0.1.1-rc.2; release pending)
 
 ### Verified facts
 
-- dsh emits `subagent/start {runId, provider, id}` and `subagent/end
-  {..., stopReason: completed | aborted | error | max-tokens | refusal,
-  lastAssistantMessage?}` with the parent as scoped carrier; neither carries a
-  label, mode, or the parent tool call id. A log-only `subagent/descriptor`
-  records `mode: one-shot | continuable` and `label`.
-- Child headers inherit the parent `cwd` and set `parentSession`,
-  `origin: "subagent"`, `delegationDepth`.
-- The `subagent` tool is background (continuable) by default;
-  `run_in_background: false` runs a foreground one-shot. `subagent_fork` is
-  one-shot. A foreground child is cancelled by the parent tool's signal;
-  continuable children survive a parent cancel and are disposed only with the
-  parent agent. `ctx.subagents.interrupt(childId, {kind: "user",
-  parentSessionId})` interrupts continuable children; one-shot background
-  fork jobs cannot be interrupted individually.
-- The adapter (`src/sessions.ts`) forwards `tool/call` as a generic
-  `tool_call`, never forwards `subagent/*`, drops `session/event` for sessions
-  it does not own (so child events are discarded today), and already exposes
-  `parentSessionId`, `origin`, `delegationDepth` in `listSessions`.
-  `loadSession` and history work for any persisted id with a matching `cwd`,
-  so child history is reachable now. `_meta["sesori.ai/deepseek"]` is the
-  established extension envelope; the schema is Ajv-validated and
-  `EXTENSION_PROTOCOL_VERSION = 1`.
+- dsh emits `subagent/start` and `subagent/end` under the owning root context;
+  child headers retain direct `parentSession`, `origin: "subagent"`,
+  `delegationDepth`, and the inherited `cwd`.
+- Adapter PRs #13, #14, and #15 are merged. Protocol v2 (source commit
+  `d7a48471bf5339793beb0c9e1c1889e63f76ec92`) emits
+  `deepseek/subagent` `started {sessionId, childSessionId, toolCallId, prompt,
+  label, mode}` and `ended {sessionId, childSessionId, stopReason, summary?}`.
+  The normalized presentation prompt is required and bounded to 32,768 Unicode
+  scalar values. There is no settlement variant, settlement outcome,
+  post-child action, or uncorrelated-start wire shape.
+- History replay annotates the enclosing standard ACP delegation update at
+  `_meta["sesori.ai/deepseek"].subagent` with prompt, label, mode, optional
+  child id, and optional terminal outcome. Its `toolCallId` remains the
+  enclosing update's standard field rather than being duplicated in metadata.
+  Protocol v1 remains byte-for-byte frozen.
+- The same adapter source includes `deepseek/subagent/interrupt`, but the
+  monorepo consumes that method only in the separate scoped-stop PR.
 
-### Current plugin
+### Approved consumer design (delivery split below)
 
-- `deepseek_plugin_impl.dart` already parses `parentSessionId` from `_meta`
-  and lists persisted children through `listAllSessions`. Live child status,
-  tiles, and links are missing. `deepseek_event_mapper.dart` overrides
-  `mapExtension` for `deepseek/session/status`.
-
-### Design
-
-- **Adapter extension (protocol v2, additive; v1 stays frozen).** New
-  notification `deepseek/subagent` is sealed by `kind`: `started {sessionId,
-  childSessionId, toolCallId, prompt, label, mode: foreground | background}`;
-  `ended {sessionId, childSessionId, stopReason, summary?, postChildAction:
-  none | parentSettlementTurn}` (summary is bounded text of the last assistant
-  message); and `settlementEnded {sessionId, childSessionId, outcome}` with a
-  closed `completed | cancelled | errored` outcome enum. `toolCallId` and
-  `prompt` are required: the probe showed the `AsyncLocalStorage` scope
-  around the root `tools/execute` waterfall gives every `subagent/start` its
-  executing call id and typed call arguments, including parallel calls and
-  forks, so the adapter takes the prompt and label from that exact call and
-  there is no uncorrelated or prompt-less variant. Mode derives from the call's
-  `run_in_background` argument with the tool defaults; labels are never used
-  for correlation. A continuable child's `ended` declares
-  `parentSettlementTurn`; the adapter binds the later parent `user/message`
-  whose `source.kind` is `subagent-settled` and whose `senderSessionId` is that
-  child to the active parent turn, then emits `settlementEnded` on every
-  terminal path for that turn, normalizing completion, cancellation/interrupt,
-  and failure into its closed outcome enum. The adapter also applies the owning
-  root's provider/model
-  selection to its descendants through a root-level `agent/request`
-  listener, because children inherit `AgentOptions.provider/model`, which
-  the adapter never sets, and otherwise fail at once (probe defect). Child
-  transcripts: the adapter projects events for every descendant of an owned
-  root (ancestry resolved by walking each header's `parentSession`, since a
-  grandchild names the child, not the root) as ordinary `session/update`s
-  under the child id, while the tile keeps the direct parent. New method
-  `deepseek/subagent/interrupt {sessionId, childSessionId}` calls
-  `ctx.subagents.interrupt`. History replay: the parent log never names a
-  foreground child and parallel calls open overlapping windows, so the
-  adapter persists `toolCallId -> childSessionId` in its own session store at
-  `subagent/start`, and `history` folds that start/end info into the `_meta`
-  envelope of the parent's `subagent` tool call so a reload rebuilds the tile
-  from one page without timing-window attribution.
-- **Plugin.** DTOs and payload parsing live in `sesori_plugin_deepseek`;
-  lifecycle goes through `AcpChildSessionTracker` (seam 1). `started` opens
-  the tile keyed by its `toolCallId` and required `prompt`, and the matching
-  `subagent*` `tool_call` card is suppressed (seam 2). `started` also binds
-  `childSessionID`, label, and `isBackground` from `mode`; `ended` maps
-  `aborted` to cancelled and `error`, `max-tokens`, `refusal` to error. For
-  `parentSettlementTurn`, `DeepSeekEventMapper` atomically replaces the
-  finishing child with a backend-neutral root hold keyed by an opaque child id;
-  it releases that hold for every `settlementEnded` outcome, including a
-  cancelled or interrupted settlement turn. Only the adapter and DeepSeek
-  mapper know the dsh settlement message or turn convention; the ACP tracker
-  stores opaque holds. Abort/cancel releases through that terminal event, while
-  session delete, disconnect, and process exit clear any outstanding root holds
-  with the tracker. Tracker state is independent of the per-turn `_liveTools`
-  clear. Replay does not pass
-  through seam 5's notification hook, because
-  `DeepSeekHistoryRepository` feeds `session/update` envelopes straight into
-  `AcpReplayCollector.consume`: that repository parses the folded `_meta`
-  envelope of each `subagent*` tool call itself and hands the resulting
-  `subtask` parts to the collector, so the generic collector never learns
-  DeepSeek payloads.
-- **Busy accounting and scoped stop.** Through seams 1 and 3. A continuable
-  child's terminal event swaps its busy child entry for the settlement hold,
-  so root status and `PluginWorkState` stay busy across the prompt-less parent
-  follow-up and release only on its correlated completion.
-  `DeepSeekAcpApi.cancelChild` sends `deepseek/subagent/interrupt`.
-  Uninterruptible one-shot fork jobs are recorded with `canCancel: false` and
-  as foreground, so they never make `mainAgentOnlySupported` true, a `stop`
-  that leaves one running reports `workKept: true`, and the matrix notes they
-  cannot be stopped alone.
-- **Adapter version.** `EXTENSION_PROTOCOL_VERSION` becomes 2. The runtime
-  manifest raises `targetVersion` and `minPathVersion` to 0.1.3, so an
-  explicitly configured or PATH adapter below 0.1.3 is reported by setup as
-  needing an update instead of failing at initialization; setup tests cover
-  the floor. With the floor raised no flow launches a v1 adapter, so the
-  plugin has no v1 fallback path.
+- Typed DeepSeek DTOs parse and validate protocol-v2 lifecycle and replay
+  metadata once at the boundary. For protocol v2, `DeepSeekEventMapper`
+  suppresses the matching standard `subagent` or `subagent_fork` tool card,
+  `DeepSeekDelegationTracker` owns its cross-turn lifecycle correlation, and the
+  mapper feeds start/end facts through the shared `AcpChildSessionTracker`;
+  child standard updates retain the child session id. Typed tool-call lookup
+  carries cross-session ambiguity through standard nested permission routing,
+  which cancels rather than falling back to an unrelated active turn. Exact
+  title-bearing updates reordered ahead of their call are deferred too, and
+  lifecycle frames stay behind an accepted prompt while its frame is writing.
+  Protocol v1 retains its generic delegation card because it supplies no
+  lifecycle replacement. The protocol has no authoritative settlement
+  lifecycle, so DeepSeek creates
+  no Grok-style autonomous root hold.
+- `DeepSeekHistoryRepository` indexes boundary-validated typed replay metadata
+  by the enclosing update's `toolCallId`. A narrow replay-local
+  `AcpReplayCollector` replacement callback turns the generic delegation tool
+  into one subtask part without reading or mutating live tracker state. Splitting
+  its child-owned envelope preserves the order of surrounding ordinary parts;
+  every additional parent run gets deterministic storage-safe message and part
+  identities.
+- `DeepSeekSessionService` merges persisted child rows with direct live tracker
+  children, preferring persisted title/time metadata by id. Live descendants
+  inherit the tracker's root project before persistence catches up. Live and
+  replay tiles stay in the direct parent's transcript, while shared ACP child
+  activity rolls up to the owning root. Deleting a parent clears its full tracked
+  descendant subtree and leaves process-scoped tombstones against late frames;
+  existing disconnect, process-exit, and disposal cleanup owns cancellation and
+  releases those tombstones after the old event source drains.
+- Consumer support temporarily accepts protocol versions 1 and 2. Adapter
+  v0.1.3 is not published yet, so managed target 0.1.2 and PATH floor 0.1.0 stay
+  unchanged. After this consumer merges, the adapter release-prep PR records
+  its consumer commit and publishes v0.1.3; the later scoped-stop PR pins target
+  and floor to 0.1.3, narrows initialization to v2, and consumes interrupt.
 
 ### PRs
 
 | Repo | Emoji | Description | Scope |
 |---|---|---|---|
-| adapter | ⚙️ | `sessions: sub-agent lifecycle notifications and child transcripts` | `subagent/*` and descendant `session/event` listeners, root-level `agent/request` provider/model propagation to descendants, child records, required prompt/call correlation, terminal settlement-turn correlation including cancel/error, `deepseek/subagent`, `_meta` history fold, schema and fixtures, protocol version 2 |
-| adapter | ⚙️ | `sessions: per-child interrupt; release v0.1.3` | `deepseek/subagent/interrupt`, schema, version bump, release checksums |
-| monorepo | 🚧 | `deepseek: inline subtask tiles and live child sessions` | DTOs, required prompt mapping, mapper feeding seams 1 and 2, settlement hold/release for every terminal outcome plus delete/disconnect/exit cleanup, `_meta` fold parsed in `DeepSeekHistoryRepository`, runtime manifest target and PATH floor 0.1.3 with setup tests; lands after the Grok lifecycle PRs |
-| monorepo | ⚙️ | `deepseek: scoped stop for sub-agents` | `DeepSeekAcpApi.cancelChild` (seam 4), mixed foreground/background and unsupported-`keep` policy tests through seam 3 |
-| monorepo | 🌱 | `docs: record DeepSeek sub-agent coverage` | matrix footnote ⁹ resolved, regression docs |
+| adapter | ⚙️ | `sessions: sub-agent lifecycle notifications and child transcripts` | Merged PR #13 (`0a85fb2`): lifecycle, descendant transcripts, bindings, and protocol v2 |
+| adapter | ⚙️ | `sessions: per-child interrupt; release v0.1.3` | Merged PR #14 (`1f839c3`): interrupt contract and package version; release intentionally pending |
+| adapter | 🌿 | `protocol: carry sub-agent prompts for tile replay` | Merged PR #15 (`d7a4847`): required normalized prompt in live and replay metadata |
+| monorepo | ⚙️ | DeepSeek consumer replacement steps 1–5 below | Replaces oversized PR #1293; runtime policy unchanged |
+| adapter | 🌱 | `release: publish v0.1.3 for the merged consumer` | Next after the monorepo consumer merges: record its commit, tag, publish, and verify assets |
+| monorepo | ⚙️ | `deepseek: scoped stop for sub-agents` | Pending: consume interrupt, pin target/PATH floor 0.1.3, narrow initialization to v2, and test mixed modes |
+| monorepo | 🌱 | `docs: record DeepSeek sub-agent coverage` | Pending final E2E matrix and plan retirement |
+
+### Consumer replacement series
+
+PR #1293 reached 5,431 changed lines and is superseded at the user's request.
+Preserve its complete implementation at `948de715804c7120623f7ff379112f4d65c6adde`
+on `claude-inline-subtasks-deepseek-tiles`; extract the following five slices in
+order, with one open PR at a time. Do not rewrite or force-push the archived
+branch. Count additions plus deletions, including tests, fixtures, codegen, and
+plan updates, before publishing each slice. Target about 1,500 lines per PR.
+
+This replaces only the existing consumer step, not the completed original
+8-step series or its remaining harness follow-ups. The plan already landed;
+record this split with the first slice. The existing release, scoped-stop,
+regression-document reconciliation, and final coverage/retirement gates remain
+required. Adapter release preparation must wait for **all five** consumer
+slices to merge and record the final replay consumer's merge commit.
+
+1. `⚙️ [claude-inline-subtasks] acp: child lifecycle and request attribution [step 1/5]`
+   - About 650 production/test/doc lines plus this split bookkeeping.
+   - Shared live child identities, prompt ordering, subtree cleanup, and typed
+     permission attribution. No DeepSeek-v2 or replay callback consumption.
+   - Expected: correct ACP parentage and permission routing; no database change.
+     Verify ACP tests/analyzer and unchanged DeepSeek/Grok consumers.
+2. `🌿 [claude-inline-subtasks] deepseek: vendor protocol v2 fixtures [step 2/5]`
+   - 1,596 lines: four verbatim v2 files plus integrity tests. This small soft-cap
+     overage keeps the authoritative fixture bundle whole, not minified or
+     partially vendored solely to lower the displayed diff.
+   - Expected: integrity evidence only; no runtime, user-visible, or database
+     change. Verify hashes, frozen v1 bytes, and protocol integrity tests.
+3. `⚙️ [claude-inline-subtasks] deepseek: parse typed subagent protocol [step 3/5]`
+   - About 750–900 lines: API validation, DTOs, generated serializers, and
+     conformance coverage. Preserve live initialization gating until step 4.
+   - Expected: validated typed boundary data; no tiles or database change.
+     Regenerate from source, run conformance tests and DeepSeek analysis.
+4. `🚧 [claude-inline-subtasks] deepseek: live subagent tiles and children [step 4/5]`
+   - About 1,300–1,500 lines: event mapper, delegation tracker, live-only methods
+     of `DeepSeekSubagentMapper`, catalog/service composition, and live tests.
+     Update existing test constructors together; defer replay methods and
+     unrelated formatting churn to step 5.
+   - Expected: protocol-v2 live tiles and child sessions; no schema change.
+     Verify lifecycle/correlation/catalog regressions and DeepSeek analysis.
+5. `⚙️ [claude-inline-subtasks] deepseek: replay child tiles with stable identities [step 5/5]`
+   - About 800–1,100 lines: required shared replay callback and all call sites,
+     history projection, mapper replay methods, identity tests, and remaining
+     consumer regression/capability documentation.
+   - Expected: live/replayed tile convergence and ordered storage-safe history;
+     no schema migration. Verify ACP and DeepSeek replay tests and analysis.
+
+These are delivery boundaries for the reviewed design, not an architectural
+redesign: add no new state, compatibility layer, or abstraction to make a slice
+stand alone. Reuse the approved trackers and mapper ownership; preserve every
+review fix and check the assembled consumer against the archived source.
 
 ### Probe results (dsh 0.1.1-rc.2, 2026-09-03, details in `followups/deepseek-probe.md`)
 

--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -592,10 +592,12 @@ slices to merge and record the final replay consumer's merge commit.
    - Expected: live/replayed tile convergence and ordered storage-safe history;
      no schema migration. Verify ACP and DeepSeek replay tests and analysis.
 
-These are delivery boundaries for the reviewed design, not an architectural
-redesign: add no new state, compatibility layer, or abstraction to make a slice
-stand alone. Reuse the approved trackers and mapper ownership; preserve every
-review fix and check the assembled consumer against the archived source.
+These delivery boundaries preserve intended behavior and valid review fixes,
+not the archived implementation verbatim. The user authorizes meaningful
+simplification and correctness improvements within each slice. Keep ownership
+clear and the diff near its budget; do not add state, compatibility layers, or
+abstractions solely to make a slice stand alone. Verify the assembled consumer
+against the required behavior rather than requiring byte-for-byte source parity.
 
 ### Probe results (dsh 0.1.1-rc.2, 2026-09-03, details in `followups/deepseek-probe.md`)
 

--- a/.plan/active/claude-inline-subtasks/PLAN.md
+++ b/.plan/active/claude-inline-subtasks/PLAN.md
@@ -14,6 +14,12 @@
 - **Delivery:** eight PRs: plan, contract + client tile, Claude lifecycle,
   Claude child sessions, Claude live sub-agent streaming, scoped stop,
   regression docs, retirement
+- **DeepSeek consumer split (2026-09-04):** supersede oversized PR #1293 with
+  five sequential, approximately 1,500-line slices. Exact scopes, titles,
+  budgets, and the verbatim-fixture exception are in `HARNESS_FOLLOWUPS.md`;
+  progress is in `TRACKER.md`. Preserve the approved design and all review
+  fixes. Release preparation waits for every consumer slice to merge. Existing
+  regression reconciliation and final coverage/retirement gates remain intact.
 
 ## Goal
 

--- a/.plan/active/claude-inline-subtasks/PLAN.md
+++ b/.plan/active/claude-inline-subtasks/PLAN.md
@@ -17,8 +17,9 @@
 - **DeepSeek consumer split (2026-09-04):** supersede oversized PR #1293 with
   five sequential, approximately 1,500-line slices. Exact scopes, titles,
   budgets, and the verbatim-fixture exception are in `HARNESS_FOLLOWUPS.md`;
-  progress is in `TRACKER.md`. Preserve the approved design and all review
-  fixes. Release preparation waits for every consumer slice to merge. Existing
+  progress is in `TRACKER.md`. Preserve intended behavior and valid review
+  fixes; improve the implementation where worthwhile within each slice's budget.
+  Release preparation waits for every consumer slice to merge. Existing
   regression reconciliation and final coverage/retirement gates remain intact.
 
 ## Goal

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -9,9 +9,9 @@
   also made the scoped stop harness-neutral (OpenCode honors it; rejections
   declare `mainAgentOnlySupported`) and added `docs/HARNESS_CAPABILITIES.md`;
   the series is retired
-- **Next action:** deliver the harness follow-ups in `HARNESS_FOLLOWUPS.md`
-  (Codex, Grok Build, DeepSeek, Cursor) as parallel PR chains under this slug
-  without step counters; E2E testing happens after each merge
+- **Next action:** replace oversized DeepSeek PR #1293 with the five numbered
+  consumer slices in `HARNESS_FOLLOWUPS.md`, one open PR at a time. Preserve
+  remaining harness follow-ups and their E2E/retirement gates.
 - **Pinned facts source:** `PLAN.md` "Claude Code CLI 2.1.237 facts" plus the
   Step 3 capture below (CLI 2.1.257); the completed
   `claude-code-plugin/PROTOCOL.md` is historical and is not edited
@@ -151,12 +151,11 @@
 
 ## Harness Follow-Ups
 
-Designs live in `HARNESS_FOLLOWUPS.md`. The four chains are independent and
-run in parallel; the Grok chain introduces the shared ACP seams that the
-DeepSeek and Cursor chains reuse, so the DeepSeek tile PR lands after the
-Grok lifecycle PRs and the Cursor PR after the Grok scoped-stop PR. Live
-probes are recorded here as bounded facts before each chain's first
-implementation PR. E2E testing is performed after each PR merges.
+Designs live in `HARNESS_FOLLOWUPS.md`. Deliver one PR at a time. The Grok
+chain introduces shared ACP seams reused by DeepSeek and Cursor; DeepSeek
+consumer slices follow the merged Grok lifecycle work, and Cursor follows
+Grok scoped stop. Live probes remain recorded as bounded facts, and existing
+post-merge E2E gates are unchanged.
 
 | Done | Harness | Description | State |
 |---|---|---|---|
@@ -171,11 +170,13 @@ implementation PR. E2E testing is performed after each PR merges.
 | [ ] | Grok | `🌿 [claude-inline-subtasks] grok: child session history` | Not started |
 | [ ] | Grok | `⚙️ [claude-inline-subtasks] grok: scoped stop for sub-agents` | Not started |
 | [ ] | Grok | `🌱 [claude-inline-subtasks] docs: record Grok Build sub-agent coverage` | Not started |
-| [ ] | DeepSeek (adapter) | `⚙️ sessions: sub-agent lifecycle notifications and child transcripts` | [sesori-deepseek-acp #13](https://github.com/sesori-ai/sesori-deepseek-acp/pull/13) |
-| [ ] | DeepSeek (adapter) | `⚙️ sessions: per-child interrupt; release v0.1.3` | [sesori-deepseek-acp #14](https://github.com/sesori-ai/sesori-deepseek-acp/pull/14) |
-| [ ] | DeepSeek | `🚧 [claude-inline-subtasks] deepseek: inline subtask tiles and live child sessions` | Not started |
-| [ ] | DeepSeek | `⚙️ [claude-inline-subtasks] deepseek: scoped stop for sub-agents` | Not started |
-| [ ] | DeepSeek | `🌱 [claude-inline-subtasks] docs: record DeepSeek sub-agent coverage` | Not started |
+| [x] | DeepSeek (adapter) | `⚙️ sessions: sub-agent lifecycle notifications and child transcripts` | [sesori-deepseek-acp #13](https://github.com/sesori-ai/sesori-deepseek-acp/pull/13) merged at `0a85fb2` |
+| [x] | DeepSeek (adapter) | `⚙️ sessions: per-child interrupt; release v0.1.3` | [sesori-deepseek-acp #14](https://github.com/sesori-ai/sesori-deepseek-acp/pull/14) merged at `1f839c3`; package version staged, release pending |
+| [x] | DeepSeek (adapter) | `🌿 protocol: carry sub-agent prompts for tile replay` | [sesori-deepseek-acp #15](https://github.com/sesori-ai/sesori-deepseek-acp/pull/15) merged at `d7a4847` |
+| [ ] | DeepSeek | Consumer replacement steps 1–5 | PR #1293 superseded; fixed titles and budgets in `HARNESS_FOLLOWUPS.md` |
+| [ ] | DeepSeek (adapter) | `🌱 release: publish v0.1.3 for the merged consumer` | Wait for all five consumer slices |
+| [ ] | DeepSeek | `⚙️ [claude-inline-subtasks] deepseek: scoped stop for sub-agents` | Pending adapter v0.1.3 release |
+| [ ] | DeepSeek | `🌱 [claude-inline-subtasks] docs: record DeepSeek sub-agent coverage` | Pending final E2E matrix and plan retirement |
 | [ ] | Cursor | `⚙️ [claude-inline-subtasks] cursor: subtask tiles and stop confirmation for task subagents` | Not started |
 | [ ] | Cursor | `🌱 [claude-inline-subtasks] docs: record Cursor sub-agent coverage` | Not started |
 
@@ -534,3 +535,85 @@ A third follow-up `architecture-plan-review` on 2026-09-03 approved the Codex
 service-owned lifecycle flow and replay replacement, the proportional Grok
 denied-attempt replay limitation, and terminal DeepSeek settlement cleanup
 with no findings.
+
+A fourth follow-up `architecture-plan-review` on 2026-09-04 reconciled the
+DeepSeek design to the merged adapter contract and approved the sequence:
+prompt-contract correction, monorepo tiles/live children, release preparation,
+then scoped stop. The corrected design carries a bounded truthful prompt, has
+no settlement lifecycle or autonomous hold, and uses the enclosing standard
+update's tool-call id for replay correlation.
+
+The following DeepSeek review evidence describes the preserved full source at
+`948de715804c7120623f7ff379112f4d65c6adde`, not functionality already merged by
+an individual replacement slice.
+
+The DeepSeek tile implementation's `architecture-implementation-review`
+rejected one deferred scoped-stop addition: interrupt request/response DTOs and
+parsers had no production consumer in this change. They were removed and stay
+owned by the later scoped-stop PR; the complete protocol-v2 source fixture
+remains pinned as integrity evidence. An initial correctness review found
+Unicode-scalar validation and child project/parent attribution gaps; both were
+fixed with regressions, and its focused re-review passed with no findings.
+
+Fresh PR feedback then identified prompt echoes, nested parent/root accounting,
+cross-turn delegation correlation, dropped partial startup updates, and
+repeated history metadata decoding. The fixes retain direct parent and owning
+root separately and decode typed metadata once at the API boundary. A follow-up
+architecture implementation review required the new multi-turn correlation
+state to move from the event mapper into an injected
+`DeepSeekDelegationTracker`; the revised boundary was approved with no findings.
+
+A later review caught that rolling nested tile identities up to the root
+orphaned those tiles from both root and child message reads. Live and replay
+tiles now remain in the direct parent's transcript while activity alone rolls
+up to the root. The same review made parent deletion recursive, changed
+ambiguous cross-session tool-call correlation to fail closed, replaced the
+unbounded deferred notification list with one bounded merged snapshot, and
+moved optional replay-shape validation into the DTO factories shared by direct
+and history parsing.
+
+A subsequent Codex pass found that standard ACP permissions nest their tool-call ID,
+that a live child did not populate the plugin's separate directory cache, and
+that naively unioning deferred `content` with `rawOutput` lost chronological
+precedence. Server-request attribution now carries a typed ambiguous result all
+the way to cancellation, live descendant catalogs read the mapper's tracked
+root project, and the bounded snapshot makes the newest content representation
+authoritative.
+
+The next review found three additional ordering gaps—mixed replay parts,
+update-before-call delivery, and lifecycle frames racing the accepted user
+message—plus stale lifecycle resurrection after subtree deletion. Replay now
+splits into order-preserving runs with distinct deterministic message and part
+identities, identifiable reordered delegation updates enter the same bounded
+accumulator, lifecycle events share prompt-write
+ordering, and process-scoped tracker tombstones reject late session and child
+frames until connection reset.
+
+Archived full-source verification on 2026-09-04: protocol v2 vendoring and codegen
+completed; `dart analyze --fatal-infos` and 87 tests passed in
+`sesori_plugin_deepseek`; `dart analyze --fatal-infos` and 311 tests passed in
+`sesori_plugin_acp`; `dart analyze --fatal-infos` and 83 tests passed in
+`sesori_plugin_grok`; `git diff --check` passed; protocol-v1 fixture bytes and
+the DeepSeek runtime manifest remained unchanged.
+
+### PR #1293 replacement delivery
+
+User correction: the 5,431-line consumer PR exceeded the approximately
+1,500-line review target. Its branch and review fixes remain preserved; the
+five-slice breakdown is in `HARNESS_FOLLOWUPS.md`. No feature scope or release
+prerequisite is dropped, and no new architecture review is claimed for this
+packaging-only change.
+
+| Slice | Scope | State |
+|---|---|---|
+| 1/5 | Shared ACP live prerequisites | Prepared for PR; no DeepSeek-v2/replay consumer yet |
+| 2/5 | Verbatim protocol-v2 fixtures and integrity | Pending slice 1 merge |
+| 3/5 | Typed protocol boundary and conformance | Pending slice 2 merge |
+| 4/5 | Live lifecycle, correlation, catalogs | Pending slice 3 merge |
+| 5/5 | Replay callback, history, remaining consumer docs | Pending slice 4 merge |
+
+Slice 1 verification: ACP analyze + 310 tests, unchanged DeepSeek analyze +
+42 tests, and Grok analyze + 83 tests passed. The replay callback and its
+consumer changes are deliberately absent until slice 5. `git diff --check`
+passed. The complete first-slice diff, including plan bookkeeping and tests,
+is about 1,020 changed lines, below the 1,500-line soft cap.

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -626,3 +626,12 @@ git diff --numstat 4842614608fe05928690b9cfed4758f6e943de5a..f098f78191b84790f23
 
 The first revision is the opening head's merge base with `main`. This is an
 opening measurement, not a self-updating claim about subsequent review fixes.
+
+User-directed quality review: the archived implementation is not frozen.
+Preserve intended behavior and valid fixes while making worthwhile local
+improvements within the line budget. A fresh audit found that descendant
+permissions survived subtree deletion. The existing cleanup loop now cancels
+those requests before forgetting their tracker records; the regression failed
+before the fix and passes afterward. ACP analysis and all 311 tests passed.
+An ancestry-traversal rewrite was declined because it would introduce an
+unnecessary parent-before-child ordering assumption.

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -606,7 +606,7 @@ packaging-only change.
 
 | Slice | Scope | State |
 |---|---|---|
-| 1/5 | Shared ACP live prerequisites | Prepared for PR; no DeepSeek-v2/replay consumer yet |
+| 1/5 | Shared ACP live prerequisites | [PR #1298](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1298) open |
 | 2/5 | Verbatim protocol-v2 fixtures and integrity | Pending slice 1 merge |
 | 3/5 | Typed protocol boundary and conformance | Pending slice 2 merge |
 | 4/5 | Live lifecycle, correlation, catalogs | Pending slice 3 merge |
@@ -615,5 +615,14 @@ packaging-only change.
 Slice 1 verification: ACP analyze + 310 tests, unchanged DeepSeek analyze +
 42 tests, and Grok analyze + 83 tests passed. The replay callback and its
 consumer changes are deliberately absent until slice 5. `git diff --check`
-passed. The complete first-slice diff, including plan bookkeeping and tests,
-is about 1,020 changed lines, below the 1,500-line soft cap.
+passed. At opening head `f098f78191b84790f23db081115874cb26ae0722`, the complete
+first-slice diff was **1,028 changed lines**, including plan bookkeeping and
+tests, below the 1,500-line soft cap. Reproduce that fixed measurement with:
+
+```bash
+git diff --numstat 4842614608fe05928690b9cfed4758f6e943de5a..f098f78191b84790f23db081115874cb26ae0722 |
+  awk '{ added += $1; removed += $2 } END { print added + removed }'
+```
+
+The first revision is the opening head's merge base with `main`. This is an
+opening measurement, not a self-updating claim about subsequent review fixes.

--- a/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
@@ -149,6 +149,23 @@ class AcpApprovalRegistry({
   /// Routes one server request received by the owning plugin.
   void handleServerRequest({required AcpServerRequest request}) => handleRequest(request);
 
+  /// Rejects a request whose tool-call id matches more than one live session.
+  /// No active-turn fallback is safe because it could present and approve the
+  /// request under the wrong source context.
+  void rejectAmbiguousServerRequest({required AcpServerRequest request}) {
+    Log.w("[acp] server request has ambiguous tool-call session attribution; cancelling");
+    switch (request.method) {
+      case AcpMethods.sessionRequestPermission:
+        _respond(request.id, const {
+          "outcome": {"outcome": "cancelled"},
+        });
+      case AcpMethods.elicitationCreate:
+        _respond(request.id, const {"action": "cancel"});
+      default:
+        _respondError(request.id, -32602, "ambiguous tool-call session attribution");
+    }
+  }
+
   /// Responds to a server request with a result payload.
   void respond(Object acpId, Object? result) => _respond(acpId, result);
 

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -10,6 +10,14 @@ import "repositories/trackers/acp_child_session_tracker.dart";
 import "repositories/trackers/acp_content_tracker.dart";
 import "repositories/trackers/acp_tool_content_tracker.dart";
 
+sealed class const AcpToolCallSessionLookup();
+
+final class const AcpToolCallSessionNotFound() extends AcpToolCallSessionLookup;
+
+final class const AcpToolCallSessionAmbiguous() extends AcpToolCallSessionLookup;
+
+final class const AcpToolCallSessionFound({required final String sessionId}) extends AcpToolCallSessionLookup;
+
 /// A backend "halt notice": the agent ended a turn without doing the requested
 /// work and instead streamed a terminal notice telling the user to change
 /// something (account, plan, model, or settings). Cursor's account/plan gate
@@ -190,17 +198,28 @@ class AcpEventMapper({
   final Map<String, Map<String, _LiveTool>> _liveTools = {};
 
   /// Resolves the live session that owns [toolCallId], when a harness extension
-  /// omits `sessionId` but carries the originating tool call id.
-  String? sessionIdForToolCallId({required String? toolCallId}) {
-    if (toolCallId == null || toolCallId.isEmpty) return null;
-    for (final entry in _liveTools.entries) {
-      if (entry.value.containsKey(toolCallId)) return entry.key;
-    }
-    for (final entry in _spawnToolCalls.entries) {
-      if (entry.value.contains(toolCallId)) return entry.key;
-    }
-    return null;
+  /// omits `sessionId` but carries the originating tool call id. Duplicate ids
+  /// across concurrent sessions are ambiguous rather than insertion-ordered.
+  AcpToolCallSessionLookup lookupSessionForToolCallId({required String? toolCallId}) {
+    if (toolCallId == null || toolCallId.isEmpty) return const AcpToolCallSessionNotFound();
+    final sessionIds = <String>{
+      for (final entry in _liveTools.entries)
+        if (entry.value.containsKey(toolCallId)) entry.key,
+      for (final entry in _spawnToolCalls.entries)
+        if (entry.value.contains(toolCallId)) entry.key,
+    };
+    return switch (sessionIds.toList(growable: false)) {
+      [final sessionId] => AcpToolCallSessionFound(sessionId: sessionId),
+      [] => const AcpToolCallSessionNotFound(),
+      _ => const AcpToolCallSessionAmbiguous(),
+    };
   }
+
+  String? sessionIdForToolCallId({required String? toolCallId}) =>
+      switch (lookupSessionForToolCallId(toolCallId: toolCallId)) {
+        AcpToolCallSessionFound(:final sessionId) => sessionId,
+        AcpToolCallSessionNotFound() || AcpToolCallSessionAmbiguous() => null,
+      };
 
   /// sessionId -> current turn number, advanced by [beginTurn].
   final Map<String, int> _turnSeq = {};
@@ -299,8 +318,7 @@ class AcpEventMapper({
 
   int _turn(String sessionId) => _turnSeq[sessionId] ?? 1;
 
-  String _fallbackTurnMessageId(String sessionId) =>
-      _turnMessageIds[sessionId] ?? "$sessionId-t${_turn(sessionId)}";
+  String _fallbackTurnMessageId(String sessionId) => _turnMessageIds[sessionId] ?? "$sessionId-t${_turn(sessionId)}";
 
   static String initialUserMessageId(String sessionId) => "$sessionId-initial-user";
 
@@ -449,8 +467,9 @@ class AcpEventMapper({
           time: messageTime,
         );
       case "user_message_chunk":
-        // A child session's first user message is the prompt its parent gave
-        // it, which no client sent: it is the one source of the tile's prompt.
+        // When lifecycle omitted the launch prompt, a child session's first
+        // user message supplies it. Trackers whose start already carried the
+        // prompt ignore this echo and every later direct child prompt.
         if (childSessions.isChild(sessionId: sessionId)) {
           return _childPromptChunk(childSessionId: sessionId, update: update);
         }
@@ -568,6 +587,12 @@ class AcpEventMapper({
     );
   }
 
+  /// Whether [notification] must remain behind an accepted prompt whose frame
+  /// is still being written. Standard updates always do; a harness lifecycle
+  /// extension that can synchronously follow prompt receipt overrides this.
+  bool shouldBufferDuringPromptWrite({required AcpNotification notification}) =>
+      notification.method == AcpMethods.sessionUpdate;
+
   /// Hook for non-`session/update` notifications (harness extensions such as
   /// Cursor's `cursor/update_todos`). Base implementation drops them.
   List<BridgeSseEvent> mapExtension(AcpNotification notification) => const [];
@@ -585,13 +610,15 @@ class AcpEventMapper({
   List<BridgeSseEvent> mapChildSpawned({required String sessionId, required AcpChildSpawn spawn}) {
     // Same boundary rule as [map]: an id-less session event is undeliverable.
     if (sessionId.isEmpty || spawn.childSessionId.isEmpty) return const [];
-    return _childTileEvents(
-      childSessions.spawn(
-        sessionId: sessionId,
-        spawn: spawn,
-        directory: projectForSession(sessionId: childSessions.rootOf(sessionId: sessionId)),
-      ),
+    final directory = projectForSession(sessionId: childSessions.rootOf(sessionId: sessionId));
+    final result = childSessions.spawn(
+      sessionId: sessionId,
+      spawn: spawn,
+      directory: directory,
     );
+    if (result == null) return const [];
+    setSessionProject(spawn.childSessionId, directory);
+    return _childTileEvents(result);
   }
 
   /// Records the model a harness reports for a spawned child, so the child's
@@ -613,7 +640,7 @@ class AcpEventMapper({
 
   /// A tile's first render needs the assistant envelope it hangs from.
   List<BridgeSseEvent> _childTileEvents(AcpChildTileResult result) => [
-    if (result.opensMessage) _toolEnvelope(sessionId: result.rootSessionId, messageId: result.messageId, time: null),
+    if (result.opensMessage) _toolEnvelope(sessionId: result.renderSessionId, messageId: result.messageId, time: null),
     ...result.events,
   ];
 
@@ -699,9 +726,7 @@ class AcpEventMapper({
   }) {
     final identity = _chunkIdentity(
       sessionId: sessionId,
-      update: messageId == null
-          ? const <String, dynamic>{}
-          : <String, dynamic>{"messageId": messageId},
+      update: messageId == null ? const <String, dynamic>{} : <String, dynamic>{"messageId": messageId},
       role: _ChunkRole.assistant,
     );
     final tracker = (_contentTrackers[sessionId] ??= {}).putIfAbsent(
@@ -1215,7 +1240,7 @@ class AcpEventMapper({
       pluginId: pluginId,
       projectID: project,
       directory: project,
-      parentID: null,
+      parentID: childSessions.parentOf(sessionId: id),
       title: snapshot?.title,
       time: created == null && updated == null
           ? null
@@ -1329,7 +1354,10 @@ class AcpEventMapper({
   }
 }
 
-enum _ChunkRole() { user, assistant }
+enum _ChunkRole() {
+  user,
+  assistant,
+}
 
 /// Last-known metadata for one session, merged into the `session.updated`
 /// payload a `session_info_update` emits.
@@ -1340,10 +1368,10 @@ class _SessionSnapshot() {
 }
 
 class _TextPartAccumulator({
-    required final String partId,
-    required final String messageId,
-    required final PluginMessagePartType type,
-  }) {
+  required final String partId,
+  required final String messageId,
+  required final PluginMessagePartType type,
+}) {
   final StringBuffer text = StringBuffer();
   bool isStreaming = false;
 }
@@ -1351,13 +1379,13 @@ class _TextPartAccumulator({
 /// The last-rendered state of one live tool call, so a partial
 /// `tool_call_update` merges onto it instead of replacing it.
 class _LiveTool({
-    required final String tool,
-    required final String? title,
-    required final PluginToolStatus status,
-    required final AcpToolContentTracker contentTracker,
-    required final bool isFileMutation,
-    required var bool diffEmitted,
-    required final bool hasExplicitKind,
-    required final bool hasExplicitStatus,
-    required final PluginMessageTime? time,
-  });
+  required final String tool,
+  required final String? title,
+  required final PluginToolStatus status,
+  required final AcpToolContentTracker contentTracker,
+  required final bool isFileMutation,
+  required var bool diffEmitted,
+  required final bool hasExplicitKind,
+  required final bool hasExplicitStatus,
+  required final PluginMessageTime? time,
+});

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1804,9 +1804,10 @@ abstract class AcpPlugin({
     // for a deleted session. Provider/model state is cleared from its tracker
     // independently above.
     eventMapper.forgetSession(sessionId);
-    // A root's children streamed under their own ids, so their mapper and
-    // model caches go with the root.
+    // Descendants own their pending input and caches under their own ids;
+    // retire both before dropping their tracker records.
     for (final childId in childSessionTracker.childSessionIds(sessionId: sessionId)) {
+      _approvalRegistry?.cancelForSession(sessionId: childId);
       _sessionOptionsService.forgetSession(sessionId: childId);
       eventMapper.forgetSession(childId);
     }

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -373,13 +373,16 @@ abstract class AcpPlugin({
   /// (see `CursorApprovalRegistry`), so both wire shapes share one mapping path.
   void handleAgentNotification(AcpNotification notification) {
     final sid = notification.params["sessionId"];
+    if (sid is String && childSessionTracker.isDeleted(sessionId: sid)) return;
     if (sid is String && _suppressedSessions.contains(sid) && isResumeReplayNotification(notification)) {
       // Replay from an in-flight resume-load — drop so old history does not
       // re-stream into the live conversation or reconstruct stale live state.
       _suppressedReplayCounts[sid] = (_suppressedReplayCounts[sid] ?? 0) + 1;
       return;
     }
-    if (notification.method == AcpMethods.sessionUpdate && sid is String && _isPromptFrameWriting(sessionId: sid)) {
+    if (sid is String &&
+        eventMapper.shouldBufferDuringPromptWrite(notification: notification) &&
+        _isPromptFrameWriting(sessionId: sid)) {
       _promptWriteNotifications.putIfAbsent(sid, () => []).add(notification);
       return;
     }
@@ -390,18 +393,21 @@ abstract class AcpPlugin({
     final registry = _approvalRegistry;
     if (registry == null) return;
     final attribution = _serverRequestAttribution(request: request);
-    final sessionId = attribution.sessionId;
-    // Pin heuristic sessionless attribution at receipt: another concurrent turn
-    // can dispatch before this request leaves the prompt-write buffer. Preserve
-    // exact tool correlation so a harness mapper can resolve its owning turn.
-    final routedRequest = sessionId == null || attribution.fromTool
-        ? request
-        : _serverRequestWithSession(request: request, sessionId: sessionId);
-    if (sessionId != null && _isPromptFrameWriting(sessionId: sessionId)) {
-      _promptWriteServerRequests.putIfAbsent(sessionId, () => []).add(routedRequest);
-      return;
+    switch (attribution) {
+      case AcpToolCallSessionAmbiguous():
+        registry.rejectAmbiguousServerRequest(request: request);
+      case AcpToolCallSessionNotFound():
+        registry.handleServerRequest(request: request);
+      case AcpToolCallSessionFound(:final sessionId):
+        // Pin sessionless attribution at receipt: another concurrent turn can
+        // dispatch before this request leaves the prompt-write buffer.
+        final routedRequest = _serverRequestWithSession(request: request, sessionId: sessionId);
+        if (_isPromptFrameWriting(sessionId: sessionId)) {
+          _promptWriteServerRequests.putIfAbsent(sessionId, () => []).add(routedRequest);
+          return;
+        }
+        registry.handleServerRequest(request: routedRequest);
     }
-    registry.handleServerRequest(request: routedRequest);
   }
 
   AcpServerRequest _serverRequestWithSession({required AcpServerRequest request, required String sessionId}) {
@@ -414,28 +420,57 @@ abstract class AcpPlugin({
     );
   }
 
-  ({String? sessionId, bool fromTool}) _serverRequestAttribution({required AcpServerRequest request}) {
+  AcpToolCallSessionLookup _serverRequestAttribution({required AcpServerRequest request}) {
     final rawSessionId = request.params["sessionId"];
-    if (rawSessionId != null && rawSessionId is! String) return (sessionId: null, fromTool: false);
+    if (rawSessionId != null && rawSessionId is! String) return const AcpToolCallSessionNotFound();
     final explicit = rawSessionId is String ? rawSessionId.trim() : null;
-    if (explicit != null && explicit.isNotEmpty) return (sessionId: explicit, fromTool: false);
-    final toolSessionId = _serverRequestToolSessionId(request: request);
-    if (toolSessionId != null) return (sessionId: toolSessionId, fromTool: true);
-    return (sessionId: activeTurnSessionId, fromTool: false);
+    if (explicit != null && explicit.isNotEmpty) return AcpToolCallSessionFound(sessionId: explicit);
+    final toolLookup = _serverRequestToolSessionLookup(request: request);
+    if (toolLookup is! AcpToolCallSessionNotFound) return toolLookup;
+    final activeSessionId = activeTurnSessionId;
+    return activeSessionId == null
+        ? const AcpToolCallSessionNotFound()
+        : AcpToolCallSessionFound(sessionId: activeSessionId);
   }
 
-  String? _serverRequestToolSessionId({required AcpServerRequest request}) {
-    final rawToolCallId = request.params["toolCallId"];
-    if (rawToolCallId is! String || rawToolCallId.isEmpty) return null;
-    final mapped = eventMapper.sessionIdForToolCallId(toolCallId: rawToolCallId);
-    if (mapped != null) return mapped;
-    for (final entry in _promptWriteNotifications.entries) {
-      for (final notification in entry.value) {
-        final update = notification.params["update"];
-        if (update is Map && update["toolCallId"] == rawToolCallId) return entry.key;
+  AcpToolCallSessionLookup _serverRequestToolSessionLookup({required AcpServerRequest request}) {
+    final toolCallIds = <String>{};
+    final topLevelToolCallId = request.params["toolCallId"];
+    if (topLevelToolCallId is String && topLevelToolCallId.isNotEmpty) {
+      toolCallIds.add(topLevelToolCallId);
+    }
+    final toolCall = request.params["toolCall"];
+    if (toolCall is Map) {
+      final nestedToolCallId = toolCall["toolCallId"];
+      if (nestedToolCallId is String && nestedToolCallId.isNotEmpty) {
+        toolCallIds.add(nestedToolCallId);
       }
     }
-    return null;
+    if (toolCallIds.length > 1) return const AcpToolCallSessionAmbiguous();
+    if (toolCallIds.isEmpty) return const AcpToolCallSessionNotFound();
+    final toolCallId = toolCallIds.single;
+    final sessionIds = <String>{};
+    switch (eventMapper.lookupSessionForToolCallId(toolCallId: toolCallId)) {
+      case AcpToolCallSessionFound(:final sessionId):
+        sessionIds.add(sessionId);
+      case AcpToolCallSessionAmbiguous():
+        return const AcpToolCallSessionAmbiguous();
+      case AcpToolCallSessionNotFound():
+        break;
+    }
+    for (final entry in _promptWriteNotifications.entries) {
+      if (entry.value.any((notification) {
+        final update = notification.params["update"];
+        return update is Map && update["toolCallId"] == toolCallId;
+      })) {
+        sessionIds.add(entry.key);
+      }
+    }
+    return switch (sessionIds.toList(growable: false)) {
+      [final sessionId] => AcpToolCallSessionFound(sessionId: sessionId),
+      [] => const AcpToolCallSessionNotFound(),
+      _ => const AcpToolCallSessionAmbiguous(),
+    };
   }
 
   bool _isPromptFrameWriting({required String sessionId}) =>

--- a/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_child_session_tracker.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_child_session_tracker.dart
@@ -20,10 +20,10 @@ final class const AcpRunningChild({
   required final bool isBackground,
 });
 
-/// The events one lifecycle fact produced, plus the envelope the mapper must
-/// emit first when this is the tile's first render.
+/// The events one lifecycle fact produced, plus the direct-parent session
+/// where the mapper must render the tile envelope.
 final class const AcpChildTileResult({
-  required final String rootSessionId,
+  required final String renderSessionId,
   required final String messageId,
   required final bool opensMessage,
   required final List<BridgeSseEvent> events,
@@ -40,14 +40,19 @@ final class const AcpChildSessionTrackerChange({required final String rootSessio
 /// [forgetSession] and [clear].
 ///
 /// Every tile is keyed by the child session id the harness reports, never by
-/// a tool call, so one child is exactly one tile. Children are flattened under
-/// the root that owns them, so a nested spawn reported under a child id files
-/// under the same root. State survives turn boundaries because a background
-/// child outlives the turn that launched it.
+/// a tool call, so one child is exactly one tile. A tile belongs to the direct
+/// parent whose transcript launched it, while activity rolls up to the owning
+/// root. State survives turn boundaries because a background child outlives
+/// the turn that launched it.
 final class AcpChildSessionTracker() {
   /// Children per root, in spawn order.
   final Map<String, List<_Child>> _byRoot = {};
   final Map<String, _Child> _byChild = {};
+
+  /// Deleted roots and child subtrees for the current agent process. Late
+  /// lifecycle frames cannot recreate them; a process reset drains that old
+  /// event source and [clear] releases the tombstones.
+  final Set<String> _deletedSessionIds = {};
 
   /// Opaque backend-neutral work holds that keep a root active after a child
   /// terminal event and until its autonomous settlement turn completes. Each
@@ -69,39 +74,51 @@ final class AcpChildSessionTracker() {
     }
   }
 
+  /// Whether [sessionId] was deleted from the current agent process.
+  bool isDeleted({required String sessionId}) => _deletedSessionIds.contains(sessionId);
+
   /// Whether [sessionId] is a child this tracker announced.
   bool isChild({required String sessionId}) => _byChild.containsKey(sessionId);
 
   /// The root that owns [sessionId]: itself unless it is a known child.
   String rootOf({required String sessionId}) => _byChild[sessionId]?.rootSessionId ?? sessionId;
 
+  /// The direct parent reported for a known child.
+  String? parentOf({required String sessionId}) => _byChild[sessionId]?.parentSessionId;
+
   /// Records that [spawn] started under [sessionId] (the parent as the harness
   /// reports it) and emits the child session, its busy status, and, when the
-  /// prompt is already known, the tile. [directory] is the root's project
-  /// directory; children never carry their own.
-  AcpChildTileResult spawn({
+  /// prompt is already known, the tile. Returns null for a late lifecycle
+  /// frame targeting a deleted parent or child. [directory] is the root's
+  /// project directory; children never carry their own.
+  AcpChildTileResult? spawn({
     required String sessionId,
     required AcpChildSpawn spawn,
     required String directory,
   }) {
+    if (_deletedSessionIds.contains(sessionId) || _deletedSessionIds.contains(spawn.childSessionId)) {
+      return null;
+    }
     final root = rootOf(sessionId: sessionId);
     final existing = _byChild[spawn.childSessionId];
     if (existing != null) {
       return AcpChildTileResult(
-        rootSessionId: root,
+        renderSessionId: existing.parentSessionId,
         messageId: existing.messageId,
         opensMessage: false,
         events: const [],
       );
     }
-    final messageId = "$root-subagent-${spawn.childSessionId}";
+    final messageId = "$sessionId-subagent-${spawn.childSessionId}";
     final child = _Child(
       rootSessionId: root,
+      parentSessionId: sessionId,
       childSessionId: spawn.childSessionId,
       messageId: messageId,
       partId: "$messageId-subtask",
       description: spawn.description,
       agent: spawn.agent,
+      acceptsPromptChunks: spawn.prompt == null,
       isBackground: spawn.isBackground,
     );
     if (spawn.prompt case final prompt?) child.prompt.write(prompt);
@@ -110,7 +127,7 @@ final class AcpChildSessionTracker() {
     _notify(rootSessionId: root);
     final part = child.partOrNull();
     return AcpChildTileResult(
-      rootSessionId: root,
+      renderSessionId: sessionId,
       messageId: messageId,
       opensMessage: part != null,
       events: [
@@ -119,7 +136,7 @@ final class AcpChildSessionTracker() {
             id: spawn.childSessionId,
             projectID: directory,
             directory: directory,
-            parentID: root,
+            parentID: sessionId,
             title: spawn.description,
             time: null,
           ).toJson(),
@@ -134,12 +151,12 @@ final class AcpChildSessionTracker() {
   /// message streams under the child id; renders the tile once a prompt exists.
   AcpChildTileResult? appendPrompt({required String childSessionId, required String delta}) {
     final child = _byChild[childSessionId];
-    if (child == null || delta.isEmpty) return null;
+    if (child == null || !child.acceptsPromptChunks || delta.isEmpty) return null;
     final firstRender = child.prompt.isEmpty;
     child.prompt.write(delta);
     final part = child.partOrNull();
     return AcpChildTileResult(
-      rootSessionId: child.rootSessionId,
+      renderSessionId: child.parentSessionId,
       messageId: child.messageId,
       opensMessage: firstRender && part != null,
       events: [if (part != null) BridgeSseMessagePartUpdated(part: part)],
@@ -275,18 +292,19 @@ final class AcpChildSessionTracker() {
   /// Whether any root has child or autonomous settlement work.
   bool get hasActiveWork => hasBusyChildren || _rootHolds.values.any((holds) => holds.isNotEmpty);
 
-  /// The children of [sessionId] as sessions, for a harness whose listing
-  /// carries no parent marker. [directory] is the root's project directory.
+  /// The direct children of [sessionId] as sessions, for a harness whose
+  /// listing carries no parent marker. [directory] is the root's project.
   List<PluginSession> childSessions({required String sessionId, required String directory}) => [
-    for (final child in _byRoot[sessionId] ?? const <_Child>[])
-      PluginSession(
-        id: child.childSessionId,
-        projectID: directory,
-        directory: directory,
-        parentID: sessionId,
-        title: child.description,
-        time: null,
-      ),
+    for (final child in _byRoot[rootOf(sessionId: sessionId)] ?? const <_Child>[])
+      if (child.parentSessionId == sessionId)
+        PluginSession(
+          id: child.childSessionId,
+          projectID: directory,
+          directory: directory,
+          parentID: sessionId,
+          title: child.description,
+          time: null,
+        ),
   ];
 
   /// Statuses of every child this tracker announced, across roots.
@@ -295,9 +313,9 @@ final class AcpChildSessionTracker() {
       entry.key: entry.value.status.isTerminal ? const PluginSessionStatus.idle() : const PluginSessionStatus.busy(),
   };
 
-  /// Every child of [sessionId], running or finished.
+  /// Every descendant of [sessionId], running or finished.
   List<String> childSessionIds({required String sessionId}) => [
-    for (final child in _byRoot[sessionId] ?? const <_Child>[]) child.childSessionId,
+    for (final child in _descendantsOf(sessionId: sessionId)) child.childSessionId,
   ];
 
   /// The children of [sessionId] still running.
@@ -312,12 +330,14 @@ final class AcpChildSessionTracker() {
         AcpRunningChild(childSessionId: child.childSessionId, isBackground: child.isBackground),
   ];
 
-  /// Drops every record of a deleted root, or the single record of a deleted
-  /// child. Emits nothing: the session is gone.
+  /// Drops every record of a deleted root or child subtree. Emits nothing:
+  /// the sessions are gone.
   void forgetSession({required String sessionId}) {
+    _deletedSessionIds.add(sessionId);
     final removedRootHolds = _rootHolds.remove(sessionId);
     final children = _byRoot.remove(sessionId);
     if (children != null) {
+      _deletedSessionIds.addAll(children.map((child) => child.childSessionId));
       final hadActiveWork =
           children.any((child) => !child.status.isTerminal) || (removedRootHolds?.isNotEmpty ?? false);
       if (removedRootHolds?.isNotEmpty ?? false) _signalRootHoldChange(rootSessionId: sessionId);
@@ -327,7 +347,7 @@ final class AcpChildSessionTracker() {
       if (hadActiveWork) _notify(rootSessionId: sessionId);
       return;
     }
-    final child = _byChild.remove(sessionId);
+    final child = _byChild[sessionId];
     if (child == null) {
       if (removedRootHolds?.isNotEmpty ?? false) {
         _signalRootHoldChange(rootSessionId: sessionId);
@@ -335,23 +355,45 @@ final class AcpChildSessionTracker() {
       }
       return;
     }
+    final removedChildren = [child, ..._descendantsOf(sessionId: sessionId)];
+    final removedChildIds = {for (final removedChild in removedChildren) removedChild.childSessionId};
+    _deletedSessionIds.addAll(removedChildIds);
     final siblings = _byRoot[child.rootSessionId];
-    siblings?.remove(child);
+    siblings?.removeWhere((candidate) => removedChildIds.contains(candidate.childSessionId));
     if (siblings?.isEmpty ?? false) _byRoot.remove(child.rootSessionId);
+    removedChildIds.forEach(_byChild.remove);
     final siblingHolds = _rootHolds[child.rootSessionId];
     final holdCount = siblingHolds?.length ?? 0;
-    siblingHolds?.removeWhere((_, heldChildSessionId) => heldChildSessionId == sessionId);
+    siblingHolds?.removeWhere((_, heldChildSessionId) => removedChildIds.contains(heldChildSessionId));
     final removedChildHold = siblingHolds != null && siblingHolds.length != holdCount;
     if (siblingHolds?.isEmpty ?? false) _rootHolds.remove(child.rootSessionId);
     if (removedChildHold) _signalRootHoldChange(rootSessionId: child.rootSessionId);
-    if (!child.status.isTerminal || removedChildHold) {
+    if (removedChildren.any((removedChild) => !removedChild.status.isTerminal) || removedChildHold) {
       _notify(rootSessionId: child.rootSessionId);
     }
   }
 
+  List<_Child> _descendantsOf({required String sessionId}) {
+    final candidates = _byRoot[rootOf(sessionId: sessionId)] ?? const <_Child>[];
+    final descendants = <_Child>[];
+    final seen = <String>{};
+    var parentIds = <String>{sessionId};
+    while (parentIds.isNotEmpty) {
+      final nextParentIds = <String>{};
+      for (final child in candidates) {
+        if (parentIds.contains(child.parentSessionId) && seen.add(child.childSessionId)) {
+          descendants.add(child);
+          nextParentIds.add(child.childSessionId);
+        }
+      }
+      parentIds = nextParentIds;
+    }
+    return descendants;
+  }
+
   /// Drops every record: the agent process that hosted the children is gone.
   void clear() {
-    if (_byChild.isEmpty && _byRoot.isEmpty && _rootHolds.isEmpty) return;
+    if (_byChild.isEmpty && _byRoot.isEmpty && _rootHolds.isEmpty && _deletedSessionIds.isEmpty) return;
     final affectedRoots = <String>{
       for (final entry in _byRoot.entries)
         if (entry.value.any((child) => !child.status.isTerminal)) entry.key,
@@ -361,6 +403,7 @@ final class AcpChildSessionTracker() {
     _byRoot.clear();
     _byChild.clear();
     _rootHolds.clear();
+    _deletedSessionIds.clear();
     for (final rootSessionId in affectedRoots) {
       _signalRootHoldChange(rootSessionId: rootSessionId);
       _notify(rootSessionId: rootSessionId);
@@ -386,11 +429,13 @@ final class AcpChildSessionTracker() {
 
 final class _Child({
   required final String rootSessionId,
+  required final String parentSessionId,
   required final String childSessionId,
   required final String messageId,
   required final String partId,
   required final String? description,
   required final String? agent,
+  required final bool acceptsPromptChunks,
   required final bool isBackground,
 }) {
   final StringBuffer prompt = StringBuffer();
@@ -406,7 +451,7 @@ final class _Child({
     if (description == null || agent == null) return null;
     return PluginMessagePart.subtask(
       id: partId,
-      sessionID: rootSessionId,
+      sessionID: parentSessionId,
       messageID: messageId,
       prompt: prompt.toString(),
       description: description,

--- a/bridge/sesori_plugin_acp/test/acp_plugin_child_busy_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_child_busy_test.dart
@@ -364,6 +364,38 @@ void main() {
       expect(plugin.childSessionTracker.childStatuses, isEmpty);
     });
 
+    test("deleting a finished child cancels its descendant's pending permission", () async {
+      final sessionId = await connectAndCreateSession();
+      spawnChild(root: sessionId, childId: "child");
+      spawnChild(root: "child", childId: "grandchild");
+      await finishChild("child", status: PluginToolStatus.completed);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 501,
+        "method": "session/request_permission",
+        "params": {
+          "sessionId": "grandchild",
+          "toolCall": {"toolCallId": "call", "title": "Run", "kind": "execute"},
+          "options": [
+            {"optionId": "allow", "name": "Allow", "kind": "allow_once"},
+          ],
+        },
+      });
+      await pump();
+      expect(await plugin.getPendingPermissions(sessionId: "grandchild"), hasLength(1));
+      expect(plugin.currentWorkState, PluginWorkState.busy);
+
+      await plugin.deleteSession("child");
+      await pump();
+
+      expect(await plugin.getPendingPermissions(sessionId: "grandchild"), isEmpty);
+      final response = fake.written.singleWhere((frame) => frame["id"] == 501);
+      expect((response["result"] as Map)["outcome"], {"outcome": "cancelled"});
+      expect(emitted.whereType<BridgeSsePermissionReplied>().single.sessionID, "grandchild");
+      expect(plugin.childSessionTracker.childStatuses, isEmpty);
+      expect(plugin.currentWorkState, PluginWorkState.idle);
+    });
+
     test("deleting a child drops its descendant subtree from plugin state", () async {
       final sessionId = await connectAndCreateSession();
       spawnChild(root: sessionId, childId: "c1");

--- a/bridge/sesori_plugin_acp/test/acp_plugin_child_busy_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_child_busy_test.dart
@@ -93,7 +93,7 @@ void main() {
         ),
         directory: cwd,
       );
-      result.events.forEach(plugin.emitEvent);
+      result?.events.forEach(plugin.emitEvent);
     }
 
     /// The harness mapper's push: a child finished. Tracker-driven events reach
@@ -362,6 +362,39 @@ void main() {
       expect(rootIdles(sessionId), hasLength(1));
       expect(await plugin.getSessionStatuses(), {sessionId: const PluginSessionStatus.idle()});
       expect(plugin.childSessionTracker.childStatuses, isEmpty);
+    });
+
+    test("deleting a child drops its descendant subtree from plugin state", () async {
+      final sessionId = await connectAndCreateSession();
+      spawnChild(root: sessionId, childId: "c1");
+      spawnChild(root: "c1", childId: "c2");
+      expect((await plugin.getSessionStatuses()).keys, containsAll([sessionId, "c1", "c2"]));
+
+      await plugin.deleteSession("c1");
+      await pump();
+
+      expect(await plugin.getSessionStatuses(), {sessionId: const PluginSessionStatus.idle()});
+      expect(plugin.childSessionTracker.childStatuses, isEmpty);
+      expect(plugin.currentWorkState, PluginWorkState.idle);
+
+      emitted.clear();
+      plugin.handleAgentNotification(
+        const AcpNotification(
+          method: AcpMethods.sessionUpdate,
+          params: {
+            "sessionId": "c1",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": {"type": "text", "text": "late"},
+            },
+          },
+        ),
+      );
+      spawnChild(root: "c1", childId: "late-grandchild");
+      spawnChild(root: sessionId, childId: "c1");
+      await pump();
+      expect(plugin.childSessionTracker.childStatuses, isEmpty);
+      expect(emitted, isEmpty);
     });
 
     test("deleting the root drops its children from the statuses", () async {

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -66,6 +66,37 @@ class _TimestampingEventMapper({
       PluginMessageTime(created: createdAtMs, completed: null);
 }
 
+class _PromptOrderedChildMapper({
+  required super.launchDirectory,
+  required super.pluginId,
+  required super.configurationTracker,
+  required super.childSessions,
+}) extends AcpEventMapper {
+  static const childMethod = "test/subagent";
+
+  @override
+  bool shouldBufferDuringPromptWrite({required AcpNotification notification}) =>
+      notification.method == childMethod || super.shouldBufferDuringPromptWrite(notification: notification);
+
+  @override
+  List<BridgeSseEvent> mapExtension(AcpNotification notification) {
+    if (notification.method != childMethod) return super.mapExtension(notification);
+    final sessionId = notification.params["sessionId"];
+    final childSessionId = notification.params["childSessionId"];
+    if (sessionId is! String || childSessionId is! String) return const [];
+    return mapChildSpawned(
+      sessionId: sessionId,
+      spawn: AcpChildSpawn(
+        childSessionId: childSessionId,
+        description: "Child",
+        agent: pluginId,
+        prompt: "Inspect",
+        isBackground: true,
+      ),
+    );
+  }
+}
+
 class _FlushControlledAcpProcess() extends FakeAcpProcess {
   final _FlushControlledIOSink _controlledStdin = _FlushControlledIOSink();
 
@@ -447,6 +478,66 @@ void main() {
       respondTo(prompt, {"stopReason": "end_turn"});
     });
 
+    test("a prompt-ordered lifecycle extension stays behind its accepted user message", () async {
+      final configurationTracker = AcpSessionConfigurationTracker();
+      final commandTracker = AcpCommandTracker();
+      final childSessionTracker = AcpChildSessionTracker();
+      final mapper = _PromptOrderedChildMapper(
+        launchDirectory: cwd,
+        pluginId: "acp",
+        configurationTracker: configurationTracker,
+        childSessions: childSessionTracker,
+      );
+      final orderedPlugin = TestAcpPlugin(
+        id: "acp",
+        agentDisplayName: "ACP",
+        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+        launchDirectory: cwd,
+        childSessionTracker: childSessionTracker,
+        eventMapper: mapper,
+        commandTracker: commandTracker,
+        sessionOptionsService: AcpSessionOptionsService(
+          configurationTracker: configurationTracker,
+          commandTracker: commandTracker,
+          pluginId: "acp",
+          agentDisplayName: "ACP",
+        ),
+        processFactory: (_) async => fake,
+      );
+      await plugin.dispose();
+      plugin = orderedPlugin;
+      plugin.events.listen(emitted.add, onError: streamErrors.add);
+
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+      emitted.clear();
+      final flush = fake.holdNextFlush();
+      await sendPrompt(sessionId, "start a child");
+      final prompt = await waitForFrame("session/prompt");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": _PromptOrderedChildMapper.childMethod,
+        "params": {"sessionId": sessionId, "childSessionId": "child"},
+      });
+      await pump();
+      expect(emitted.whereType<BridgeSseSessionCreated>(), isEmpty);
+
+      flush.complete();
+      for (var index = 0; index < 20 && emitted.whereType<BridgeSseSessionCreated>().isEmpty; index++) {
+        await pump();
+      }
+
+      final userIndex = emitted.indexWhere(
+        (event) => event is BridgeSseMessageUpdated && event.info["role"] == "user",
+      );
+      final childIndex = emitted.indexWhere(
+        (event) => event is BridgeSseSessionCreated && event.info["id"] == "child",
+      );
+      expect(userIndex, greaterThanOrEqualTo(0));
+      expect(childIndex, greaterThan(userIndex));
+      respondTo(prompt, {"stopReason": "end_turn"});
+    });
+
     test("a buffered sessionless permission keeps its writing-turn attribution", () async {
       await connect();
       final firstSessionId = await createSession(cwd, "s1");
@@ -488,6 +579,98 @@ void main() {
       );
       respondTo(firstPrompt, {"stopReason": "end_turn"});
       respondTo(secondPrompt, {"stopReason": "end_turn"});
+    });
+
+    test("a nested permission uses its exact tool-call session instead of the active turn", () async {
+      await connect();
+      final firstSessionId = await createSession(cwd, "s1");
+      final secondSessionId = await createSession(cwd, "s2");
+      await sendPrompt(secondSessionId, "keep active");
+      final activePrompt = await waitForFrame("session/prompt");
+      plugin.handleAgentNotification(
+        AcpNotification(
+          method: AcpMethods.sessionUpdate,
+          params: {
+            "sessionId": firstSessionId,
+            "update": {
+              "sessionUpdate": "tool_call",
+              "toolCallId": "shared-shape",
+              "title": "Run command",
+              "kind": "execute",
+            },
+          },
+        ),
+      );
+      emitted.clear();
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 9001,
+        "method": AcpMethods.sessionRequestPermission,
+        "params": {
+          "toolCall": {"toolCallId": "shared-shape", "title": "Run command", "kind": "execute"},
+          "options": [
+            {"optionId": "reject", "name": "Reject", "kind": "reject_once"},
+          ],
+        },
+      });
+      for (var index = 0; index < 20 && emitted.whereType<BridgeSsePermissionAsked>().isEmpty; index++) {
+        await pump();
+      }
+
+      final permission = emitted.whereType<BridgeSsePermissionAsked>().single;
+      expect(permission.sessionID, firstSessionId);
+      await plugin.replyToPermission(
+        requestId: permission.requestID,
+        sessionId: firstSessionId,
+        reply: PluginPermissionReply.reject,
+      );
+      respondTo(activePrompt, {"stopReason": "end_turn"});
+    });
+
+    test("an ambiguous nested permission cannot fall back to the active turn", () async {
+      await connect();
+      final firstSessionId = await createSession(cwd, "s1");
+      final secondSessionId = await createSession(cwd, "s2");
+      await sendPrompt(secondSessionId, "keep active");
+      final activePrompt = await waitForFrame("session/prompt");
+      for (final sessionId in [firstSessionId, secondSessionId]) {
+        plugin.handleAgentNotification(
+          AcpNotification(
+            method: AcpMethods.sessionUpdate,
+            params: {
+              "sessionId": sessionId,
+              "update": {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "ambiguous",
+                "title": "Run command",
+                "kind": "execute",
+              },
+            },
+          ),
+        );
+      }
+      emitted.clear();
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 9002,
+        "method": AcpMethods.sessionRequestPermission,
+        "params": {
+          "toolCall": {"toolCallId": "ambiguous", "title": "Run command", "kind": "execute"},
+          "options": [
+            {"optionId": "reject", "name": "Reject", "kind": "reject_once"},
+          ],
+        },
+      });
+      for (var index = 0; index < 20 && !fake.written.any((frame) => frame["id"] == 9002); index++) {
+        await pump();
+      }
+
+      expect(emitted.whereType<BridgeSsePermissionAsked>(), isEmpty);
+      final response = fake.written.singleWhere((frame) => frame["id"] == 9002);
+      expect((response["result"] as Map)["outcome"], {"outcome": "cancelled"});
+      respondTo(activePrompt, {"stopReason": "end_turn"});
     });
 
     test("a queued prompt message uses its dispatch time", () async {

--- a/bridge/sesori_plugin_acp/test/repositories/trackers/acp_child_session_tracker_test.dart
+++ b/bridge/sesori_plugin_acp/test/repositories/trackers/acp_child_session_tracker_test.dart
@@ -34,8 +34,8 @@ void main() {
         sessionId: "root",
         spawn: _spawn(childId: "child"),
         directory: "/repo",
-      );
-      expect(result.rootSessionId, "root");
+      )!;
+      expect(result.renderSessionId, "root");
       expect(result.messageId, "root-subagent-child");
       expect(result.opensMessage, isFalse, reason: "no prompt yet: session events only");
       expect(result.events, hasLength(2));
@@ -72,10 +72,11 @@ void main() {
         sessionId: "root",
         spawn: _spawn(childId: "child", prompt: "p", isBackground: true),
         directory: "/r",
-      );
+      )!;
       expect(result.opensMessage, isTrue);
       expect(result.events, hasLength(3));
       expect(_subtaskPart(result.events[2]).prompt, "p");
+      expect(tracker.appendPrompt(childSessionId: "child", delta: "p"), isNull);
       expect(tracker.runningChildren(sessionId: "root").single.isBackground, isTrue);
     });
 
@@ -251,7 +252,7 @@ void main() {
       expect(failed.taskState?.output, isNull);
     });
 
-    test("a nested spawn under a child is flattened to the root", () {
+    test("a nested spawn retains its direct parent while activity rolls up to the root", () {
       tracker.spawn(
         sessionId: "root",
         spawn: _spawn(childId: "child"),
@@ -259,14 +260,83 @@ void main() {
       );
       final nested = tracker.spawn(
         sessionId: "child",
-        spawn: _spawn(childId: "grandchild"),
+        spawn: _spawn(childId: "grandchild", prompt: "nested"),
         directory: "/r",
-      );
-      expect(nested.rootSessionId, "root");
-      expect(shared.Session.fromJson((nested.events[0] as BridgeSseSessionCreated).info).parentID, "root");
+      )!;
+      expect(nested.renderSessionId, "child");
+      expect(shared.Session.fromJson((nested.events[0] as BridgeSseSessionCreated).info).parentID, "child");
+      final tile = _subtaskPart(nested.events.last);
+      expect(tile.id, "child-subagent-grandchild-subtask");
+      expect(tile.messageID, "child-subagent-grandchild");
+      expect(tile.sessionID, "child");
+      expect(tracker.childSessions(sessionId: "root", directory: "/r").map((session) => session.id), ["child"]);
+      expect(tracker.childSessions(sessionId: "child", directory: "/r").map((session) => session.id), [
+        "grandchild",
+      ]);
       expect(tracker.busyChildIds(sessionId: "root"), {"child", "grandchild"});
+      expect(tracker.parentOf(sessionId: "grandchild"), "child");
       expect(tracker.rootOf(sessionId: "grandchild"), "root");
       expect(tracker.rootOf(sessionId: "root"), "root");
+    });
+
+    test("forgetting a child removes its full descendant subtree", () {
+      tracker
+        ..spawn(
+          sessionId: "root",
+          spawn: _spawn(childId: "child"),
+          directory: "/r",
+        )
+        ..spawn(
+          sessionId: "child",
+          spawn: _spawn(childId: "grandchild"),
+          directory: "/r",
+        )
+        ..spawn(
+          sessionId: "grandchild",
+          spawn: _spawn(childId: "great-grandchild"),
+          directory: "/r",
+        )
+        ..spawn(
+          sessionId: "root",
+          spawn: _spawn(childId: "sibling"),
+          directory: "/r",
+        );
+
+      expect(tracker.childSessionIds(sessionId: "child"), ["grandchild", "great-grandchild"]);
+      tracker.forgetSession(sessionId: "child");
+
+      expect(tracker.childStatuses.keys, ["sibling"]);
+      expect(tracker.childSessions(sessionId: "root", directory: "/r").map((session) => session.id), ["sibling"]);
+      expect(tracker.busyChildIds(sessionId: "root"), {"sibling"});
+      expect(tracker.isChild(sessionId: "grandchild"), isFalse);
+      expect(tracker.isChild(sessionId: "great-grandchild"), isFalse);
+      expect(
+        tracker.spawn(
+          sessionId: "child",
+          spawn: _spawn(childId: "late-grandchild"),
+          directory: "/r",
+        ),
+        isNull,
+      );
+      expect(
+        tracker.spawn(
+          sessionId: "root",
+          spawn: _spawn(childId: "child"),
+          directory: "/r",
+        ),
+        isNull,
+      );
+
+      tracker.clear();
+      expect(
+        tracker.spawn(
+          sessionId: "root",
+          spawn: _spawn(childId: "child"),
+          directory: "/r",
+        ),
+        isNotNull,
+        reason: "a new process has drained the deleted process's late frames",
+      );
     });
 
     test("a repeated spawn for a known child is a no-op", () {
@@ -279,7 +349,7 @@ void main() {
         sessionId: "root",
         spawn: _spawn(childId: "child"),
         directory: "/r",
-      );
+      )!;
       expect(again.events, isEmpty);
       expect(again.opensMessage, isFalse);
       expect(tracker.childStatuses.keys, ["child"]);

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -194,6 +194,10 @@ state.
   explicit `session_info` names, uses file modification time for activity,
   preserves resolvable parent-session lineage, and never decodes transcript
   messages to derive titles.
+- Tracked ACP children retain their direct parent for navigation and inline
+  tiles while activity rolls up to the owning root. Deleting a tracked parent
+  clears its descendant state; process-scoped tombstones reject late lifecycle
+  starts and transcript updates until the old event source is drained.
 - DeepSeek explicit import enumerates only adapter-owned session headers below
   the isolated plugin state. It derives projects from normalized session `cwd`,
   preserves parent/child metadata, and never scans or imports normal

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -55,8 +55,11 @@ reaches the backend so the turn continues.
   phone-mediated unless an existing explicit bridge auto-approval rule applies.
   Abort, process exit, and disposal cancel pending Grok requests rather than
   broadening or silently approving them.
-- A sessionless backend request is attributed to the most recently dispatched
-  active turn, falling back to the last dispatched turn at its settlement
+- A sessionless ACP request first resolves its top-level or nested
+  `toolCall.toolCallId` against tracked calls. An exact match retains its session;
+  an ambiguous match cancels rather than falling back to another active turn.
+  Without tool-call attribution, a sessionless backend request uses the most
+  recently dispatched active turn, or the last dispatched turn at its settlement
   boundary. A backend requiring exact form correlation must serialize prompts
   process-wide so another session cannot become the attribution target. OMP
   supplies explicit session IDs on permissions and forms, so its independent

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -64,6 +64,9 @@ reaches the backend so the turn continues.
   process-wide so another session cannot become the attribution target. OMP
   supplies explicit session IDs on permissions and forms, so its independent
   session turns remain attributable while running concurrently.
+- Deleting a tracked ACP parent retires pending input for its full descendant
+  subtree, including a running grandchild of a finished child, so removed
+  sessions cannot leave unanswered requests holding the plugin busy.
 - Resolving a request retires it in the pending list, on every open surface, and
   in completion-notification suppression. Raising and resolving a request also
   refreshes the activity summary, so the session's awaiting-input state appears


### PR DESCRIPTION
## Complexity

⚙️ Moderate — shared ACP child lifecycle, deletion cleanup, and permission attribution across the tracker, mapper, and plugin.

## What

- Keep tracked child tiles under their direct parent while activity rolls up to the root.
- Cancel descendant pending input when deleting a subtree, clear its state, and reject late lifecycle/transcript frames until process reset.
- Preserve exact/ambiguous tool-call session attribution, including standard nested permission IDs; cancel ambiguous requests.
- Expose the narrow prompt-write ordering hook used by the later DeepSeek consumer.
- Record the five-slice replacement sequence and relevant regression behavior.

**Size: 1,089 changed lines, including tests and plan documentation**, down from #1293's 5,431. The opening diff was 1,028 lines; the tracker records its immutable comparison range. Full reviewed source remains on its original branch at `948de715804c7120623f7ff379112f4d65c6adde`.

## Why

Replace #1293 with focused, sequential PRs around the 1,500-line soft cap. This first slice is independently usable ACP behavior; DeepSeek protocol parsing, fixtures, live projection, and replay land separately.

## Risk and test focus

- Shared ACP child ancestry, cleanup, permission routing, and accepted-prompt ordering.
- Existing DeepSeek and Grok consumers must continue passing unchanged.
- No DeepSeek-v2 initialization, runtime pin change, scoped-stop consumption, or replay callback in this slice.
- No database/schema change. User-visible effects are corrected ACP child placement, stale-event suppression, and permission attribution.

## Expected result

ACP descendants retain correct parentage and deletion behavior; identifiable permissions reach the correct session and ambiguous requests fail closed. No new DeepSeek subagent feature is enabled yet.

Remaining slices: frozen v2 fixtures → typed protocol boundary → live tiles/children → replay identities. Adapter v0.1.3 release preparation waits for all five consumer slices to merge.

## Verification

- ACP: analyzer clean; 311 tests passed. New descendant-permission cleanup regression failed before the fix and passes afterward.
- Existing DeepSeek: analyzer clean; 42 tests passed.
- Grok: analyzer clean; 83 tests passed.
- `git diff --check` passed.
- Upstream merged normally; its changes are unrelated plan/docs files.
- Builds on the reviewed design, with a fresh correctness/simplicity audit and a localized descendant-permission cleanup fix. No new state, production classes, or ownership changes.
