### PR TITLE
⚙️ [periodic-cleanup] client: preserve streamed text across refresh [step 2/25]

### DIFF
--- a/.plan/active/periodic-cleanup/PLAN.md
+++ b/.plan/active/periodic-cleanup/PLAN.md
@@ -1,7 +1,7 @@
 # Periodic cleanup
 
-Status: proposed scope; investigation/planning requested, implementation scope
-acceptance pending. Plan PR: [#1295](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1295).
+Status: executing; implementation scope accepted by the user on 2026-09-05
+(step 1 merged as #1295). Plan PR: [#1295](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1295).
 Baseline: `480d82f090`. Date: 2026-09-04. Slug: `periodic-cleanup`.
 
 ## Goal, evidence, and scope
@@ -722,7 +722,8 @@ no packaging or shipped runtime artifact changes.
 - Repository-wide documentation maintenance and simplification of all regression
   guides, including removing pointless content: explicitly requested during
   consolidation. Steps 21–24 own it; no narrow historical-report-only scope.
-- Refactor implementation scope acceptance: pending; no production edits in step 1.
+- Refactor implementation scope: accepted 2026-09-05 when the user asked to
+  start working the plan; no production edits were made in step 1.
 - #1294 merged and owns selection reconciliation; source diff inspected, no
   additional variant cleanup scheduled. Revalidate the original diagnostics
   against rebased code when steps 2–3 begin.

--- a/.plan/active/periodic-cleanup/PLAN.md
+++ b/.plan/active/periodic-cleanup/PLAN.md
@@ -35,9 +35,9 @@ bus, or broad cubit/orchestrator rewrite.
 The source changes are substantial in aggregate: approximately 8,000–15,000 changed implementation/test/generated lines,
 plus roughly 3,000 historical-document deletions, across twenty-two implementation
 or cleanup PRs. The user explicitly authorized consolidating useful findings
-and closing #1296. That is authorization for this plan update; executing the
-refactor series remains a separate scope decision before step 2. The root
-AGENTS.md requires approval before a considerable refactor.
+and closing #1296, and on 2026-09-05 accepted executing the refactor series by
+asking to start working the plan. That acceptance is the approval the root
+AGENTS.md requires before a considerable refactor.
 Remain in the dedicated worktree. Do not create another worktree or working directory.
 
 ## Implementation contracts
@@ -58,8 +58,11 @@ and display the installed text. This is exact content coverage, not a length or
 completion heuristic: a snapshot containing `before-after` can replace buffered
 `before-` even with null completion time. If the part is absent, shorter or
 divergent, keep the buffer; it contains live content the snapshot has not shown
-it can replace. Use the current accumulator, including deltas received while
-fetching, rather than a stale saved value. Existing final-part/removal events
+it can replace. A fetched part that ends with the entire buffered value also
+covers it: after a reconnect outside the replay window the accumulator holds
+only the tail of a part, and the snapshot is the sole source of its prefix. Use
+the current accumulator, including deltas received while fetching, rather than
+a stale saved value. Existing final-part/removal events
 still retire buffers directly.
 
 Retirement alone is insufficient because a fetched part may still be growing.

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -2,13 +2,14 @@
 
 Authority: [PLAN.md](PLAN.md). Fixed proposed series: **25 steps**.
 The user authorized consolidating #1296, closing it, and broad documentation
-simplification. Refactor execution scope remains pending.
+simplification. Refactor execution was accepted on 2026-09-05 when the user
+asked to start working the plan; steps execute in order from step 2.
 [Source-step dispositions](CONSOLIDATION.md).
 
 | Step | Exact PR title | Status | PR |
 | --- | --- | --- | --- |
-| 1/25 | 🌱 [periodic-cleanup] docs: consolidate the repository cleanup plan [step 1/25] | In review | [#1295](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1295) |
-| 2/25 | ⚙️ [periodic-cleanup] client: preserve streamed text across refresh [step 2/25] | Proposed | — |
+| 1/25 | 🌱 [periodic-cleanup] docs: consolidate the repository cleanup plan [step 1/25] | Merged | [#1295](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1295) |
+| 2/25 | ⚙️ [periodic-cleanup] client: preserve streamed text across refresh [step 2/25] | In review | PR_PLACEHOLDER |
 | 3/25 | ⚙️ [periodic-cleanup] client: preserve live transcript during refresh [step 3/25] | Proposed | — |
 | 4/25 | ⚙️ [periodic-cleanup] bridge: remove unused session paths and tracker state [step 4/25] | Proposed | — |
 | 5/25 | 🚧 [periodic-cleanup] bridge: remove unused options cache metadata [step 5/25] | Proposed | — |
@@ -111,3 +112,17 @@ simplification. Refactor execution scope remains pending.
   approval or newly executed product tests. Prior diagnostic evidence is unchanged.
 - Validation: all 63 relative links, 25 exact titles, the contiguous 13-row
   verification matrix and Git whitespace checks pass.
+
+## Step 2 execution — 2026-09-05
+
+- Refresh retires a streaming accumulator only when the fetched same-ID
+  text/reasoning part starts with the whole buffered value; otherwise the buffer
+  survives. `appendDelta` takes a lazy base-text lookup so a new accumulator
+  seeds once from the installed part. `StreamingTextBuffer.clear` had no
+  remaining production caller and was removed.
+- Both audit diagnostics are promoted as cubit tests, parameterized over text and
+  reasoning with `completed: null` assistant messages: covering, extending,
+  shorter/absent, divergent, and final-part-during-reload cases.
+- Not added: per-harness Codex/Pi/Claude history fixtures in the client suite.
+  The cubit reads no harness-specific field; the null-completion assistant
+  fixture is the whole boundary it observes. Recorded here for step 25's matrix.

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -9,7 +9,7 @@ asked to start working the plan; steps execute in order from step 2.
 | Step | Exact PR title | Status | PR |
 | --- | --- | --- | --- |
 | 1/25 | 🌱 [periodic-cleanup] docs: consolidate the repository cleanup plan [step 1/25] | Merged | [#1295](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1295) |
-| 2/25 | ⚙️ [periodic-cleanup] client: preserve streamed text across refresh [step 2/25] | In review | PR_PLACEHOLDER |
+| 2/25 | ⚙️ [periodic-cleanup] client: preserve streamed text across refresh [step 2/25] | In review | [#1299](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1299) |
 | 3/25 | ⚙️ [periodic-cleanup] client: preserve live transcript during refresh [step 3/25] | Proposed | — |
 | 4/25 | ⚙️ [periodic-cleanup] bridge: remove unused session paths and tracker state [step 4/25] | Proposed | — |
 | 5/25 | 🚧 [periodic-cleanup] bridge: remove unused options cache metadata [step 5/25] | Proposed | — |

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -53,7 +53,8 @@ asked to start working the plan; steps execute in order from step 2.
   Diagnostic source files were restored; evidence patches were unchanged at
   consolidation. The later PR-feedback diagnostic revision is recorded below.
 - Implementation tests, live-plugin/platform retirement matrix: not run.
-- Scope decision: pending, including unversioned reconciliation limits in step 3.
+- Scope decision: accepted 2026-09-05 (see authority line), including the
+  unversioned reconciliation limits recorded in step 3.
 - Existing refresh diagnostic plan: linked handoff, not falsely retired.
 - Retirement: not eligible; requires all recorded matrix rows to pass.
 
@@ -116,8 +117,9 @@ asked to start working the plan; steps execute in order from step 2.
 ## Step 2 execution — 2026-09-05
 
 - Refresh retires a streaming accumulator only when the fetched same-ID
-  text/reasoning part starts with the whole buffered value; otherwise the buffer
-  survives. `appendDelta` takes a lazy base-text lookup so a new accumulator
+  text/reasoning part starts or ends with the whole buffered value; otherwise
+  the buffer survives. The suffix case covers a tail-only accumulator after a
+  reconnect outside the replay window (PR review finding). `appendDelta` takes a lazy base-text lookup so a new accumulator
   seeds once from the installed part. `StreamingTextBuffer.clear` had no
   remaining production caller and was removed.
 - Both audit diagnostics are promoted as cubit tests, parameterized over text and

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -541,8 +541,7 @@ class SessionDetailCubit(
           final derived = _deriveSnapshot(snapshot);
           final latestAssistant = derived.latestAssistant;
 
-          final streamingText = _streamingBuffer.snapshot();
-          _streamingBuffer.clear();
+          _retireStreamingPartsCoveredBy(messages: snapshot.messages);
 
           final refreshedChildSessions = derived.children;
 
@@ -582,7 +581,7 @@ class SessionDetailCubit(
               // refreshed page whenever the session moved on meanwhile.
               olderMessagesCursor: snapshot.olderMessagesCursor,
               isLoadingOlderMessages: false,
-              streamingText: streamingText,
+              streamingText: _streamingBuffer.snapshot(),
               sessionStatus: refreshedSessionStatus,
               pendingQuestions: _mapPendingQuestions(snapshot.pendingQuestions),
               pendingPermissions: _mapPendingPermissions(snapshot.pendingPermissions),
@@ -740,8 +739,8 @@ class SessionDetailCubit(
           _onMessageUpdated(info);
         case SesoriMessageRemoved(:final messageID):
           _onMessageRemoved(messageID);
-        case SesoriMessagePartDelta(:final partID, :final delta):
-          _onPartDelta(partId: partID, delta: delta);
+        case SesoriMessagePartDelta(:final messageID, :final partID, :final delta):
+          _onPartDelta(messageId: messageID, partId: partID, delta: delta);
         case SesoriMessagePartUpdated(:final part):
           _onPartUpdated(part);
         case SesoriMessagePartRemoved(:final messageID, :final partID):
@@ -1277,9 +1276,63 @@ class SessionDetailCubit(
   // Streaming text
   // ---------------------------------------------------------------------------
 
-  void _onPartDelta({required String partId, required String delta}) {
-    _streamingBuffer.appendDelta(partId: partId, delta: delta);
+  void _onPartDelta({required String messageId, required String partId, required String delta}) {
+    _streamingBuffer.appendDelta(
+      partId: partId,
+      delta: delta,
+      // A part whose earlier content arrived through a refresh snapshot keeps
+      // streaming from that content; the buffer asks only when it has no
+      // accumulator for the part.
+      baseText: () {
+        final current = state;
+        if (current is! SessionDetailLoaded) return null;
+        for (final message in current.messages) {
+          if (message.info.id != messageId) continue;
+          for (final part in message.parts) {
+            if (part.id == partId) return _streamedText(part);
+          }
+        }
+        return null;
+      },
+    );
   }
+
+  /// Drops streaming accumulators whose full text the incoming transcript
+  /// already contains, so the installed part is shown instead.
+  ///
+  /// History carries no universal completion signal (several backends load
+  /// messages with a null completion time), so coverage is decided by content:
+  /// only a same-ID text/reasoning part that starts with the entire buffered
+  /// value retires it. An absent, shorter or divergent part keeps the buffer,
+  /// which still holds live content the transcript has not shown it can replace.
+  void _retireStreamingPartsCoveredBy({required List<MessageWithParts> messages}) {
+    final buffered = _streamingBuffer.snapshot();
+    if (buffered.isEmpty) return;
+    for (final message in messages) {
+      for (final part in message.parts) {
+        final live = buffered[part.id];
+        if (live == null) continue;
+        final installed = _streamedText(part);
+        if (installed != null && installed.startsWith(live)) _streamingBuffer.removePart(part.id);
+      }
+    }
+  }
+
+  /// The content a streaming delta accumulates for [part], or null for part
+  /// kinds that never stream text.
+  static String? _streamedText(MessagePart part) => switch (part) {
+    MessagePartText(:final text) || MessagePartReasoning(:final text) => text,
+    MessagePartTool() ||
+    MessagePartSubtask() ||
+    MessagePartStepStart() ||
+    MessagePartStepFinish() ||
+    MessagePartFile() ||
+    MessagePartSnapshot() ||
+    MessagePartPatch() ||
+    MessagePartAgent() ||
+    MessagePartRetry() ||
+    MessagePartCompaction() => null,
+  };
 
   void _onPartUpdated(MessagePart part) {
     final current = state;

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -1302,9 +1302,12 @@ class SessionDetailCubit(
   ///
   /// History carries no universal completion signal (several backends load
   /// messages with a null completion time), so coverage is decided by content:
-  /// only a same-ID text/reasoning part that starts with the entire buffered
-  /// value retires it. An absent, shorter or divergent part keeps the buffer,
-  /// which still holds live content the transcript has not shown it can replace.
+  /// only a same-ID text/reasoning part that starts or ends with the entire
+  /// buffered value retires it. The suffix case is a reconnect outside the
+  /// replay window, where the accumulator holds only the tail of a part and
+  /// the snapshot is the sole source of its prefix. An absent, shorter or
+  /// divergent part keeps the buffer, which still holds live content the
+  /// transcript has not shown it can replace.
   void _retireStreamingPartsCoveredBy({required List<MessageWithParts> messages}) {
     final buffered = _streamingBuffer.snapshot();
     if (buffered.isEmpty) return;
@@ -1313,7 +1316,8 @@ class SessionDetailCubit(
         final live = buffered[part.id];
         if (live == null) continue;
         final installed = _streamedText(part);
-        if (installed != null && installed.startsWith(live)) _streamingBuffer.removePart(part.id);
+        if (installed == null) continue;
+        if (installed.startsWith(live) || installed.endsWith(live)) _streamingBuffer.removePart(part.id);
       }
     }
   }

--- a/client/module_core/lib/src/cubits/session_detail/streaming_text_buffer.dart
+++ b/client/module_core/lib/src/cubits/session_detail/streaming_text_buffer.dart
@@ -13,8 +13,23 @@ class StreamingTextBuffer({
   Timer? _timer;
 
   /// Append a text delta for [partId], scheduling a throttled flush.
-  void appendDelta({required String partId, required String delta}) {
-    _buffers.putIfAbsent(partId, StringBuffer.new).write(delta);
+  ///
+  /// A new accumulator is seeded from [baseText] before the delta is written,
+  /// so a part whose earlier content arrived through a snapshot continues
+  /// from that content rather than from the delta alone. [baseText] is only
+  /// consulted when no accumulator exists for [partId]; an existing
+  /// accumulator already holds everything shown for the part.
+  void appendDelta({
+    required String partId,
+    required String delta,
+    required String? Function() baseText,
+  }) {
+    final existing = _buffers[partId];
+    if (existing != null) {
+      existing.write(delta);
+    } else {
+      _buffers[partId] = StringBuffer(baseText() ?? "")..write(delta);
+    }
     _scheduleFlush();
   }
 
@@ -35,14 +50,6 @@ class StreamingTextBuffer({
 
   /// Returns the current accumulated text as an immutable snapshot.
   Map<String, String> snapshot() => _buffers.map((key, value) => MapEntry(key, value.toString()));
-
-  /// Clear all buffered parts and cancel any pending flush timer.
-  /// Unlike [dispose], the buffer remains usable for future [appendDelta] calls.
-  void clear() {
-    _timer?.cancel();
-    _timer = null;
-    _buffers.clear();
-  }
 
   /// Cancel any pending flush timer.
   void dispose() {

--- a/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
@@ -8,6 +8,7 @@ import "package:sesori_dart_core/src/capabilities/server_connection/models/conne
 import "package:sesori_dart_core/src/capabilities/server_connection/models/sse_event.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/server_connection_config.dart";
 import "package:sesori_dart_core/src/cubits/session_detail/session_detail_cubit.dart";
+import "package:sesori_dart_core/src/cubits/session_detail/session_detail_resolvers.dart";
 import "package:sesori_dart_core/src/cubits/session_detail/session_detail_state.dart";
 import "package:sesori_dart_core/src/foundation/models/composer/composer_attachment.dart";
 import "package:sesori_dart_core/src/foundation/models/composer/composer_draft.dart";
@@ -1365,6 +1366,129 @@ void main() {
       ]);
     });
 
+    group("streamed text across a silent refresh", () {
+      // History from several backends carries no completion time, so every
+      // refreshed message below is an assistant message with `completed: null`
+      // and the outcome must follow from part content alone.
+      for (final kind in _StreamedPartKind.values) {
+        Future<
+          ({
+            SessionDetailCubit cubit,
+            Completer<SessionDetailLoadResult> refresh,
+          })
+        >
+        startStreaming({required String delta}) async {
+          final mockLoadService = MockSessionDetailLoadService();
+          final refresh = Completer<SessionDetailLoadResult>();
+          when(
+            () => mockLoadService.load(
+              sessionId: _sessionId,
+              projectId: any(named: "projectId"),
+            ),
+          ).thenAnswer(
+            (_) async => SessionDetailLoadResult.loaded(
+              snapshot: _snapshot(messages: [_assistantMessage(parts: const [])]),
+            ),
+          );
+          when(
+            () => mockLoadService.reload(
+              sessionId: _sessionId,
+              projectId: any(named: "projectId"),
+            ),
+          ).thenAnswer((_) => refresh.future);
+          final cubit = createCubit(loadService: mockLoadService);
+          await _awaitLoaded(cubit);
+          sessionEvents.add(kind.delta(delta: delta));
+          await _awaitStreamingText(cubit, partId: _streamedPartId, text: delta);
+          mockConnectionService.emitDataMayBeStale();
+          await untilCalled(
+            () => mockLoadService.reload(
+              sessionId: _sessionId,
+              projectId: any(named: "projectId"),
+            ),
+          );
+          return (cubit: cubit, refresh: refresh);
+        }
+
+        Future<void> completeRefresh({
+          required SessionDetailCubit cubit,
+          required Completer<SessionDetailLoadResult> refresh,
+          required List<MessagePart> parts,
+        }) async {
+          refresh.complete(
+            SessionDetailLoadResult.loaded(
+              snapshot: _snapshot(messages: [_assistantMessage(parts: parts)]),
+            ),
+          );
+          await _awaitCondition(() => !(cubit.state as SessionDetailLoaded).isRefreshing);
+        }
+
+        test("${kind.name}: a snapshot covering the streamed text retires the buffer", () async {
+          final (:cubit, :refresh) = await startStreaming(delta: "before-");
+          await completeRefresh(
+            cubit: cubit,
+            refresh: refresh,
+            parts: [kind.part(content: "before-after")],
+          );
+
+          final state = cubit.state as SessionDetailLoaded;
+          expect(state.streamingText, isEmpty);
+          expect(
+            state.resolvePartContent(partId: _streamedPartId, messageId: _streamedMessageId),
+            (text: "before-after", isStreaming: false),
+          );
+        });
+
+        test("${kind.name}: a delta after retirement continues from the installed text", () async {
+          final (:cubit, :refresh) = await startStreaming(delta: "before-");
+          await completeRefresh(
+            cubit: cubit,
+            refresh: refresh,
+            parts: [kind.part(content: "before-middle")],
+          );
+
+          sessionEvents.add(kind.delta(delta: "after"));
+          await _awaitStreamingText(cubit, partId: _streamedPartId, text: "before-middleafter");
+        });
+
+        test("${kind.name}: a shorter or absent snapshot part keeps the streamed text", () async {
+          final (:cubit, :refresh) = await startStreaming(delta: "before-");
+          sessionEvents.add(kind.delta(delta: "during-"));
+          await _awaitStreamingText(cubit, partId: _streamedPartId, text: "before-during-");
+          await completeRefresh(
+            cubit: cubit,
+            refresh: refresh,
+            parts: [kind.part(content: "before-")],
+          );
+
+          expect((cubit.state as SessionDetailLoaded).streamingText, {_streamedPartId: "before-during-"});
+
+          sessionEvents.add(kind.delta(delta: "after"));
+          await _awaitStreamingText(cubit, partId: _streamedPartId, text: "before-during-after");
+        });
+
+        test("${kind.name}: a divergent snapshot part keeps the streamed text", () async {
+          final (:cubit, :refresh) = await startStreaming(delta: "before-");
+          await completeRefresh(
+            cubit: cubit,
+            refresh: refresh,
+            parts: [kind.part(content: "rewritten")],
+          );
+
+          expect((cubit.state as SessionDetailLoaded).streamingText, {_streamedPartId: "before-"});
+        });
+
+        test("${kind.name}: a final part event during the reload still retires the buffer", () async {
+          final (:cubit, :refresh) = await startStreaming(delta: "before-");
+          sessionEvents.add(SesoriMessagePartUpdated(part: kind.part(content: "before-final")));
+          await _awaitCondition(() => (cubit.state as SessionDetailLoaded).streamingText.isEmpty);
+          await completeRefresh(cubit: cubit, refresh: refresh, parts: const []);
+
+          expect((cubit.state as SessionDetailLoaded).streamingText, isEmpty);
+        });
+      }
+    });
+
     test("keeps a finalized part that arrives before its message envelope", () async {
       final mockLoadService = MockSessionDetailLoadService();
       when(
@@ -1806,4 +1930,77 @@ Future<void> _awaitCondition(bool Function() condition) async {
     await Future<void>.delayed(Duration.zero);
   }
   fail("Timed out waiting for condition");
+}
+
+const _streamedMessageId = "message-1";
+const _streamedPartId = "stream-part";
+
+/// Text and reasoning parts stream through the same buffer; each case runs for both.
+enum _StreamedPartKind() {
+  text,
+  reasoning;
+
+  MessagePart part({required String content}) => switch (this) {
+    _StreamedPartKind.text => MessagePart.text(
+      id: _streamedPartId,
+      sessionID: _sessionId,
+      messageID: _streamedMessageId,
+      text: content,
+    ),
+    _StreamedPartKind.reasoning => MessagePart.reasoning(
+      id: _streamedPartId,
+      sessionID: _sessionId,
+      messageID: _streamedMessageId,
+      text: content,
+    ),
+  };
+
+  SesoriMessagePartDelta delta({required String delta}) => SesoriMessagePartDelta(
+    sessionID: _sessionId,
+    messageID: _streamedMessageId,
+    partID: _streamedPartId,
+    field: name,
+    delta: delta,
+  );
+}
+
+MessageWithParts _assistantMessage({required List<MessagePart> parts}) => MessageWithParts(
+  info: const Message.assistant(
+    id: _streamedMessageId,
+    sessionID: _sessionId,
+    agent: "build",
+    modelID: null,
+    providerID: null,
+    time: MessageTime(created: 100, completed: null),
+  ),
+  parts: parts,
+);
+
+SessionDetailSnapshot _snapshot({required List<MessageWithParts> messages}) => SessionDetailSnapshot(
+  areOptionsStale: false,
+  bridgeQueuedPrompts: const [],
+  projectId: "project-1",
+  pluginId: "opencode",
+  supportsPromptAttachments: false,
+  messages: messages,
+  olderMessagesCursor: null,
+  pendingQuestions: const <PendingQuestion>[],
+  pendingPermissions: const <PendingPermission>[],
+  childSessions: const <Session>[],
+  statuses: const <String, SessionStatus>{},
+  agents: const <AgentInfo>[],
+  providerData: null,
+  commands: const <CommandInfo>[],
+  canonicalSessionTitle: null,
+  promptDefaults: null,
+  isRootSession: true,
+  isArchived: false,
+);
+
+Future<void> _awaitStreamingText(SessionDetailCubit cubit, {required String partId, required String text}) async {
+  await awaitState(
+    cubit: cubit,
+    predicate: (state) => state is SessionDetailLoaded && state.streamingText[partId] == text,
+    description: "streaming text '$text' for $partId",
+  );
 }

--- a/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
@@ -1467,6 +1467,24 @@ void main() {
           await _awaitStreamingText(cubit, partId: _streamedPartId, text: "before-during-after");
         });
 
+        test("${kind.name}: a snapshot ending with a tail-only buffer retires it and supplies the prefix", () async {
+          // A reconnect outside the replay window delivers deltas from the
+          // middle of a part; only the snapshot knows how it started.
+          final (:cubit, :refresh) = await startStreaming(delta: "-after");
+          await completeRefresh(
+            cubit: cubit,
+            refresh: refresh,
+            parts: [kind.part(content: "before-after")],
+          );
+
+          final state = cubit.state as SessionDetailLoaded;
+          expect(state.streamingText, isEmpty);
+          expect(
+            state.resolvePartContent(partId: _streamedPartId, messageId: _streamedMessageId),
+            (text: "before-after", isStreaming: false),
+          );
+        });
+
         test("${kind.name}: a divergent snapshot part keeps the streamed text", () async {
           final (:cubit, :refresh) = await startStreaming(delta: "before-");
           await completeRefresh(

--- a/client/module_core/test/cubits/session_detail/streaming_text_buffer_test.dart
+++ b/client/module_core/test/cubits/session_detail/streaming_text_buffer_test.dart
@@ -12,24 +12,46 @@ void main() {
 
     test("appendDelta accumulates text for a part", () {
       final buffer = StreamingTextBuffer(onFlush: () {});
-      buffer.appendDelta(partId: "p1", delta: "Hello");
-      buffer.appendDelta(partId: "p1", delta: " World");
+      buffer.appendDelta(partId: "p1", delta: "Hello", baseText: _noBase);
+      buffer.appendDelta(partId: "p1", delta: " World", baseText: _noBase);
       expect(buffer.snapshot(), {"p1": "Hello World"});
       buffer.dispose();
     });
 
     test("appendDelta handles multiple parts independently", () {
       final buffer = StreamingTextBuffer(onFlush: () {});
-      buffer.appendDelta(partId: "p1", delta: "a");
-      buffer.appendDelta(partId: "p2", delta: "b");
+      buffer.appendDelta(partId: "p1", delta: "a", baseText: _noBase);
+      buffer.appendDelta(partId: "p2", delta: "b", baseText: _noBase);
       expect(buffer.snapshot(), {"p1": "a", "p2": "b"});
+      buffer.dispose();
+    });
+
+    test("a new accumulator is seeded once from the base text", () {
+      var baseLookups = 0;
+      final buffer = StreamingTextBuffer(onFlush: () {});
+      String? base() {
+        baseLookups++;
+        return "before-middle";
+      }
+
+      buffer.appendDelta(partId: "p1", delta: "after", baseText: base);
+      buffer.appendDelta(partId: "p1", delta: "!", baseText: base);
+      expect(buffer.snapshot(), {"p1": "before-middleafter!"});
+      expect(baseLookups, 1, reason: "an existing accumulator must not rescan for a base");
+      buffer.dispose();
+    });
+
+    test("a null base text starts the accumulator from the delta alone", () {
+      final buffer = StreamingTextBuffer(onFlush: () {});
+      buffer.appendDelta(partId: "p1", delta: "after", baseText: _noBase);
+      expect(buffer.snapshot(), {"p1": "after"});
       buffer.dispose();
     });
 
     test("removePart clears a specific part", () {
       final buffer = StreamingTextBuffer(onFlush: () {});
-      buffer.appendDelta(partId: "p1", delta: "data");
-      buffer.appendDelta(partId: "p2", delta: "keep");
+      buffer.appendDelta(partId: "p1", delta: "data", baseText: _noBase);
+      buffer.appendDelta(partId: "p2", delta: "keep", baseText: _noBase);
       buffer.removePart("p1");
       expect(buffer.snapshot(), {"p2": "keep"});
       buffer.dispose();
@@ -37,7 +59,7 @@ void main() {
 
     test("removePart is a no-op for unknown part", () {
       final buffer = StreamingTextBuffer(onFlush: () {});
-      buffer.appendDelta(partId: "p1", delta: "data");
+      buffer.appendDelta(partId: "p1", delta: "data", baseText: _noBase);
       buffer.removePart("nonexistent");
       expect(buffer.snapshot(), {"p1": "data"});
       buffer.dispose();
@@ -51,7 +73,7 @@ void main() {
           throttle: const Duration(milliseconds: 50),
         );
 
-        buffer.appendDelta(partId: "p1", delta: "data");
+        buffer.appendDelta(partId: "p1", delta: "data", baseText: _noBase);
         expect(flushCount, 0);
 
         async.elapse(const Duration(milliseconds: 50));
@@ -69,9 +91,9 @@ void main() {
           throttle: const Duration(milliseconds: 50),
         );
 
-        buffer.appendDelta(partId: "p1", delta: "a");
-        buffer.appendDelta(partId: "p1", delta: "b");
-        buffer.appendDelta(partId: "p1", delta: "c");
+        buffer.appendDelta(partId: "p1", delta: "a", baseText: _noBase);
+        buffer.appendDelta(partId: "p1", delta: "b", baseText: _noBase);
+        buffer.appendDelta(partId: "p1", delta: "c", baseText: _noBase);
 
         async.elapse(const Duration(milliseconds: 50));
         expect(flushCount, 1);
@@ -89,11 +111,11 @@ void main() {
           throttle: const Duration(milliseconds: 50),
         );
 
-        buffer.appendDelta(partId: "p1", delta: "first");
+        buffer.appendDelta(partId: "p1", delta: "first", baseText: _noBase);
         async.elapse(const Duration(milliseconds: 50));
         expect(flushCount, 1);
 
-        buffer.appendDelta(partId: "p1", delta: " second");
+        buffer.appendDelta(partId: "p1", delta: " second", baseText: _noBase);
         async.elapse(const Duration(milliseconds: 50));
         expect(flushCount, 2);
 
@@ -109,41 +131,12 @@ void main() {
           throttle: const Duration(milliseconds: 50),
         );
 
-        buffer.appendDelta(partId: "p1", delta: "data");
+        buffer.appendDelta(partId: "p1", delta: "data", baseText: _noBase);
         buffer.dispose();
 
         async.elapse(const Duration(milliseconds: 100));
         expect(flushCount, 0);
       });
-    });
-
-    test("clear() removes all buffered parts and cancels pending timer", () {
-      fakeAsync((async) {
-        var flushCount = 0;
-        final buffer = StreamingTextBuffer(
-          onFlush: () => flushCount++,
-          throttle: const Duration(milliseconds: 50),
-        );
-
-        buffer.appendDelta(partId: "p1", delta: "data");
-        buffer.appendDelta(partId: "p2", delta: "more");
-        expect(buffer.snapshot(), {"p1": "data", "p2": "more"});
-
-        buffer.clear();
-        expect(buffer.snapshot(), isEmpty);
-
-        async.elapse(const Duration(milliseconds: 100));
-        expect(flushCount, 0);
-      });
-    });
-
-    test("clear() followed by snapshot() returns empty map", () {
-      final buffer = StreamingTextBuffer(onFlush: () {});
-      buffer.appendDelta(partId: "p1", delta: "text");
-      buffer.appendDelta(partId: "p2", delta: "more");
-      buffer.clear();
-      expect(buffer.snapshot(), isEmpty);
-      buffer.dispose();
     });
 
     test("flush interval stretches as the buffered text grows, capped at 300ms", () {
@@ -155,20 +148,20 @@ void main() {
         );
 
         // Small buffers flush at the base throttle.
-        buffer.appendDelta(partId: "p1", delta: "small");
+        buffer.appendDelta(partId: "p1", delta: "small", baseText: _noBase);
         async.elapse(const Duration(milliseconds: 50));
         expect(flushCount, 1);
 
         // Past the relaxed threshold (8 KiB) the next flush waits
         // proportionally longer than the base throttle (~16 KB → ~98ms).
-        buffer.appendDelta(partId: "p1", delta: "x" * 16000);
+        buffer.appendDelta(partId: "p1", delta: "x" * 16000, baseText: _noBase);
         async.elapse(const Duration(milliseconds: 50));
         expect(flushCount, 1);
         async.elapse(const Duration(milliseconds: 50));
         expect(flushCount, 2);
 
         // No matter how large the part grows, the interval caps at 300ms.
-        buffer.appendDelta(partId: "p1", delta: "x" * 1000000);
+        buffer.appendDelta(partId: "p1", delta: "x" * 1000000, baseText: _noBase);
         async.elapse(const Duration(milliseconds: 300));
         expect(flushCount, 3);
 
@@ -186,12 +179,12 @@ void main() {
 
         // The large part schedules the capped 300ms interval, then finalizes
         // before that timer fires.
-        buffer.appendDelta(partId: "p1", delta: "x" * 1000000);
+        buffer.appendDelta(partId: "p1", delta: "x" * 1000000, baseText: _noBase);
         buffer.removePart("p1");
 
         // The next (small) part must get its normal 50ms flush, not inherit
         // the stale 300ms timer.
-        buffer.appendDelta(partId: "p2", delta: "small");
+        buffer.appendDelta(partId: "p2", delta: "small", baseText: _noBase);
         async.elapse(const Duration(milliseconds: 50));
         expect(flushCount, 1);
         expect(buffer.snapshot(), {"p2": "small"});
@@ -208,7 +201,7 @@ void main() {
           throttle: const Duration(milliseconds: 50),
         );
 
-        buffer.appendDelta(partId: "p1", delta: "data");
+        buffer.appendDelta(partId: "p1", delta: "data", baseText: _noBase);
         buffer.removePart("p1");
 
         async.elapse(const Duration(milliseconds: 400));
@@ -226,8 +219,8 @@ void main() {
           throttle: const Duration(milliseconds: 50),
         );
 
-        buffer.appendDelta(partId: "p1", delta: "x" * 1000000);
-        buffer.appendDelta(partId: "p2", delta: "small");
+        buffer.appendDelta(partId: "p1", delta: "x" * 1000000, baseText: _noBase);
+        buffer.appendDelta(partId: "p2", delta: "small", baseText: _noBase);
         buffer.removePart("p1");
 
         async.elapse(const Duration(milliseconds: 50));
@@ -237,27 +230,7 @@ void main() {
         buffer.dispose();
       });
     });
-
-    test("appendDelta() after clear() works normally (buffer is reusable)", () {
-      fakeAsync((async) {
-        var flushCount = 0;
-        final buffer = StreamingTextBuffer(
-          onFlush: () => flushCount++,
-          throttle: const Duration(milliseconds: 50),
-        );
-
-        buffer.appendDelta(partId: "p1", delta: "first");
-        buffer.clear();
-        expect(buffer.snapshot(), isEmpty);
-
-        buffer.appendDelta(partId: "p2", delta: "second");
-        expect(buffer.snapshot(), {"p2": "second"});
-
-        async.elapse(const Duration(milliseconds: 50));
-        expect(flushCount, 1);
-
-        buffer.dispose();
-      });
-    });
   });
 }
+
+String? _noBase() => null;

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -77,6 +77,11 @@ reconnect or restart.
   the newest edge while detached.
 - After a reconnect inside the replay window, buffered events are delivered;
   after a longer gap, a refresh reconciles without losing finalized content.
+  Text or reasoning still streaming through a client refresh keeps its
+  accumulated content: the refreshed transcript replaces it only when the same
+  part's fetched text starts with everything streamed so far, and a later delta
+  continues from that fetched text. History supplies no completion signal for
+  every backend, so this is decided by content, never by timestamps or status.
   After a backend event-stream gap, that plugin's stored transcripts stay marked
   incomplete until a full re-sync; later captures do not mark them complete.
 - Binary and attachment payloads are never stored inline in database tables; they
@@ -154,6 +159,9 @@ rules where supported.
   disappears after a refresh or reopen.
 - Reasoning still says `Thinking...` after answer or tool output has started, or
   disappears after reopening because only its empty start snapshot was retained.
+- A refresh during a streaming answer drops the text streamed before it, so the
+  next delta renders alone, or shows a shorter fetched part over longer live
+  text.
 - A page boundary duplicates, drops, or reorders messages, or history ends early.
 - An id-less ACP reply reuses a pre-restart fallback identity and overwrites an
   earlier answer instead of remaining distinct.

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -79,7 +79,8 @@ reconnect or restart.
   after a longer gap, a refresh reconciles without losing finalized content.
   Text or reasoning still streaming through a client refresh keeps its
   accumulated content: the refreshed transcript replaces it only when the same
-  part's fetched text starts with everything streamed so far, and a later delta
+  part's fetched text starts or ends with everything streamed so far (the
+  latter after a reconnect that missed the part's beginning), and a later delta
   continues from that fetched text. History supplies no completion signal for
   every backend, so this is decided by content, never by timestamps or status.
   After a backend event-stream gap, that plugin's stored transcripts stay marked


### PR DESCRIPTION
## Complexity

⚙️ moderate — changes the internal streaming-buffer input contract and the refresh/accumulator coordination in `SessionDetailCubit`, with a parameterized test matrix over text and reasoning.

## What

- A silent refresh no longer clears the `StreamingTextBuffer`. It retires a buffered part only when the fetched same-ID text or reasoning part starts with the entire buffered value (exact content coverage). Absent, shorter or divergent fetched parts leave the buffer alone.
- `StreamingTextBuffer.appendDelta` takes a required lazy `baseText` lookup. When a delta creates a new accumulator, it is seeded once from the installed part so `before-middle` + delta `after` renders `before-middleafter`. An existing accumulator ignores the lookup, so there is no transcript scan per delta.
- `_onPartDelta` receives the event's existing `messageID` for that lookup. `StreamingTextBuffer.clear` had no remaining production caller and is removed.
- Promotes both audit diagnostics into cubit tests, parameterized over text and reasoning with `completed: null` assistant messages: covering snapshot, extending snapshot plus continued delta, shorter/absent snapshot, divergent snapshot, and a final-part event during the reload.
- Updates `docs/regression/session-history-and-recovery.md` and the plan tracker.

## Why

Step 2/25 of `.plan/active/periodic-cleanup`. The audit reproduced that a refresh mid-stream drops everything streamed before it, so the next delta renders alone (`before-` / refresh / `after` showed only `after`). History from Codex, Pi and Claude carries no completion timestamp, so retirement must be decided by content rather than a finality heuristic.

## Risk and test focus

Moderate, client-only. Impacted: session detail transcript rendering of streaming text and reasoning across resume/reconnect/stale refreshes for every backend. Most valuable checks: streaming a long answer on macOS desktop and a mobile platform, forcing a refresh (background/resume or reconnect) mid-stream, and confirming the streamed text keeps its prefix, finalizes cleanly, and does not stay labeled as streaming after the answer completes. Step 3 of the plan still owns preserving live part events received during the reload.

No database or wire-contract change.

## Expected result

- User-visible: text and reasoning streaming through a refresh keep their content; a later delta continues the visible text; a snapshot that already contains the streamed text replaces it without a duplicate or a stuck streaming label.
- Database/persisted data: none.
- Internal: `appendDelta` contract change, `clear()` removed, one new private retirement helper in the cubit.

## Verification

- `dart analyze` in `client/module_core`: no issues.
- `dart test` for `streaming_text_buffer_test.dart`, `session_detail_event_buffer_test.dart`, `session_detail_stale_test.dart`, `session_detail_cubit_test.dart`, `session_detail_reconnect_test.dart`, `session_detail_paging_test.dart`: pass.
- Architecture implementation review (sub-agent, branch vs `main`): approved, no findings.
- Not run: live client E2E; recorded for the step 25 matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
A silent refresh no longer drops text streamed mid-answer. The streaming buffer survives the refresh and retires only when the fetched same-ID text or reasoning part starts or ends with the whole buffered value; a later delta continues from the installed text.

- `StreamingTextBuffer.appendDelta` takes a required lazy `baseText` lookup that seeds a new accumulator once; existing accumulators never rescan.
- Retirement is decided by content, not completion timestamps, since several backends load history with `completed: null`; the suffix case covers a tail-only buffer after a reconnect outside the replay window.
- `StreamingTextBuffer.clear` is removed; `_onPartDelta` now passes the event's `messageID` for the base-text lookup.
- Adds parameterized tests over text and reasoning covering snapshots, extending snapshots plus a continued delta, shorter or absent snapshots, the tail-only suffix case, divergent snapshots, and a final-part event during reload.
- Updates `streaming_text_buffer_test.dart`, `session_detail_event_buffer_test.dart`, `docs/regression/session-history-and-recovery.md`, and the plan tracker.

Client-only; no database or wire-contract change. Step 2/25 of the periodic-cleanup plan.

<sup>Written for commit aded3a48a67a32ea61aba22121ba10c76d162147. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

