### PR TITLE
🌿 [claude-inline-subtasks] deepseek: vendor protocol v2 fixtures [step 2/5]

### DIFF
--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -606,8 +606,8 @@ packaging-only change.
 
 | Slice | Scope | State |
 |---|---|---|
-| 1/5 | Shared ACP live prerequisites | [PR #1298](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1298) open |
-| 2/5 | Verbatim protocol-v2 fixtures and integrity | Pending slice 1 merge |
+| 1/5 | Shared ACP live prerequisites | [PR #1298](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1298) merged at `59464ca14a` |
+| 2/5 | Verbatim protocol-v2 fixtures and integrity | Prepared on `claude-inline-subtasks-deepseek-fixtures` |
 | 3/5 | Typed protocol boundary and conformance | Pending slice 2 merge |
 | 4/5 | Live lifecycle, correlation, catalogs | Pending slice 3 merge |
 | 5/5 | Replay callback, history, remaining consumer docs | Pending slice 4 merge |
@@ -635,3 +635,10 @@ those requests before forgetting their tracker records; the regression failed
 before the fix and passes afterward. ACP analysis and all 311 tests passed.
 An ancestry-traversal rewrite was declined because it would introduce an
 unnecessary parent-before-child ordering assumption.
+
+Slice 2 verification: both protocol integrity tests passed. The schema and
+valid/invalid fixtures match adapter commit `d7a48471b` byte-for-byte and all
+three manifest SHA-256 values were independently checked. Protocol-v1 files and
+the runtime manifest are untouched; no v2 consumer or interrupt implementation
+lands here. The 1,596-line fixture/test slice retains the documented soft-cap
+exception for an indivisible verbatim bundle; tracker bookkeeping is additional.

--- a/bridge/sesori_plugin_deepseek/test/deepseek_protocol_integrity_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_protocol_integrity_test.dart
@@ -5,23 +5,29 @@ import "package:crypto/crypto.dart";
 import "package:test/test.dart";
 
 void main() {
-  test("vendored protocol files match the source manifest", () async {
-    final directory = Directory("test/fixtures/protocol/v1");
-    final manifest = jsonDecode(
-      await File("${directory.path}/source_manifest.json").readAsString(),
-    ) as Map<String, dynamic>;
+  const commits = {
+    1: "9731711f079dc0d7acf7e5eff29c81a3622bc4a0",
+    2: "d7a48471bf5339793beb0c9e1c1889e63f76ec92",
+  };
+  for (final entry in commits.entries) {
+    test("vendored protocol v${entry.key} files match the source manifest", () async {
+      final directory = Directory("test/fixtures/protocol/v${entry.key}");
+      final manifest = jsonDecode(
+        await File("${directory.path}/source_manifest.json").readAsString(),
+      ) as Map<String, dynamic>;
 
-    expect(manifest["repository"], "sesori-ai/sesori-deepseek-acp");
-    expect(manifest["commit"], "9731711f079dc0d7acf7e5eff29c81a3622bc4a0");
-    final expected = (manifest["files"] as Map).cast<String, String>();
-    expect(expected.keys.toSet(), {
-      "deepseek-acp.schema.json",
-      "valid.json",
-      "invalid.json",
+      expect(manifest["repository"], "sesori-ai/sesori-deepseek-acp");
+      expect(manifest["commit"], entry.value);
+      final expected = (manifest["files"] as Map).cast<String, String>();
+      expect(expected.keys.toSet(), {
+        "deepseek-acp.schema.json",
+        "valid.json",
+        "invalid.json",
+      });
+      for (final file in expected.entries) {
+        final bytes = await File("${directory.path}/${file.key}").readAsBytes();
+        expect(sha256.convert(bytes).toString(), file.value, reason: file.key);
+      }
     });
-    for (final entry in expected.entries) {
-      final bytes = await File("${directory.path}/${entry.key}").readAsBytes();
-      expect(sha256.convert(bytes).toString(), entry.value, reason: entry.key);
-    }
-  });
+  }
 }

--- a/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v2/deepseek-acp.schema.json
+++ b/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v2/deepseek-acp.schema.json
@@ -1,0 +1,835 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sesori.ai/protocol/v2/deepseek-acp.schema.json",
+  "title": "Sesori DeepSeek ACP extension protocol v2",
+  "$defs": {
+    "nonblank": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "pattern": "\\S"
+    },
+    "sessionId": {
+      "$ref": "#/$defs/nonblank"
+    },
+    "selectionId": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 512,
+      "pattern": "^v1(?:[A-Za-z0-9_-]{2,3}|(?:[A-Za-z0-9_-]{4})+(?:[A-Za-z0-9_-]{2,3})?)$"
+    },
+    "absolutePath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096,
+      "anyOf": [
+        {
+          "pattern": "^/"
+        },
+        {
+          "pattern": "^[A-Za-z]:[\\\\/]"
+        },
+        {
+          "pattern": "^\\\\\\\\"
+        }
+      ]
+    },
+    "initializeMetadata": {
+      "type": "object",
+      "required": [
+        "extensionProtocolVersion",
+        "adapterVersion",
+        "harnessVersion",
+        "persistenceOwner"
+      ],
+      "properties": {
+        "extensionProtocolVersion": {
+          "const": 2
+        },
+        "adapterVersion": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "\\S"
+        },
+        "harnessVersion": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "pattern": "\\S"
+        },
+        "persistenceOwner": {
+          "const": "sesori"
+        }
+      },
+      "additionalProperties": true
+    },
+    "promptMetadata": {
+      "type": "object",
+      "properties": {
+        "messageId": {
+          "$ref": "#/$defs/nonblank"
+        }
+      },
+      "additionalProperties": true
+    },
+    "catalogRequest": {
+      "type": "object",
+      "required": [
+        "cwd"
+      ],
+      "properties": {
+        "cwd": {
+          "$ref": "#/$defs/absolutePath"
+        }
+      },
+      "additionalProperties": false
+    },
+    "catalogResponse": {
+      "type": "object",
+      "required": [
+        "agent",
+        "providers",
+        "defaultSelectionId",
+        "commands",
+        "failures"
+      ],
+      "properties": {
+        "agent": {
+          "type": "object",
+          "required": [
+            "id",
+            "name",
+            "primary"
+          ],
+          "properties": {
+            "id": {
+              "const": "deepseek"
+            },
+            "name": {
+              "$ref": "#/$defs/nonblank"
+            },
+            "primary": {
+              "const": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "providers": {
+          "type": "array",
+          "maxItems": 64,
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "name",
+              "models"
+            ],
+            "properties": {
+              "id": {
+                "$ref": "#/$defs/nonblank"
+              },
+              "name": {
+                "$ref": "#/$defs/nonblank"
+              },
+              "models": {
+                "type": "array",
+                "maxItems": 256,
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "upstreamModelId",
+                    "name",
+                    "reasoningEfforts",
+                    "defaultReasoningEffort",
+                    "supportsImages"
+                  ],
+                  "properties": {
+                    "id": {
+                      "$ref": "#/$defs/selectionId"
+                    },
+                    "upstreamModelId": {
+                      "$ref": "#/$defs/nonblank"
+                    },
+                    "name": {
+                      "$ref": "#/$defs/nonblank"
+                    },
+                    "reasoningEfforts": {
+                      "type": "array",
+                      "maxItems": 16,
+                      "uniqueItems": true,
+                      "items": {
+                        "$ref": "#/$defs/nonblank"
+                      }
+                    },
+                    "defaultReasoningEffort": {
+                      "anyOf": [
+                        {
+                          "$ref": "#/$defs/nonblank"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "supportsImages": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "defaultSelectionId": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/selectionId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "commands": {
+          "type": "array",
+          "maxItems": 128,
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "description"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "pattern": "^[A-Za-z0-9_-]+$"
+              },
+              "description": {
+                "$ref": "#/$defs/nonblank"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "failures": {
+          "type": "array",
+          "maxItems": 64,
+          "items": {
+            "type": "object",
+            "required": [
+              "providerId",
+              "category",
+              "message"
+            ],
+            "properties": {
+              "providerId": {
+                "$ref": "#/$defs/nonblank"
+              },
+              "category": {
+                "$ref": "#/$defs/nonblank"
+              },
+              "message": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 512,
+                "pattern": "\\S"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "historyRequest": {
+      "type": "object",
+      "required": [
+        "sessionId"
+      ],
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "beforeSeq": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "maxMessages": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "default": 50
+        }
+      },
+      "additionalProperties": false
+    },
+    "sessionUpdateEnvelope": {
+      "type": "object",
+      "required": [
+        "sessionId",
+        "update"
+      ],
+      "properties": {
+        "_meta": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "sesori.ai/deepseek": {
+                  "type": "object",
+                  "properties": {
+                    "messageCreatedAt": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9007199254740991
+                    },
+                    "subagent": {
+                      "$ref": "#/$defs/subagentReplay"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              },
+              "additionalProperties": true
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "update": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    "historyResponse": {
+      "type": "object",
+      "required": [
+        "updates",
+        "hasMore"
+      ],
+      "properties": {
+        "updates": {
+          "type": "array",
+          "maxItems": 10000,
+          "items": {
+            "$ref": "#/$defs/sessionUpdateEnvelope"
+          }
+        },
+        "nextBeforeSeq": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "hasMore": {
+          "type": "boolean"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "nextBeforeSeq"
+          ],
+          "properties": {
+            "nextBeforeSeq": true,
+            "hasMore": {
+              "const": true
+            }
+          }
+        },
+        {
+          "properties": {
+            "nextBeforeSeq": false,
+            "hasMore": {
+              "const": false
+            }
+          }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "renameRequest": {
+      "type": "object",
+      "required": [
+        "sessionId",
+        "title"
+      ],
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "pattern": "\\S"
+        }
+      },
+      "additionalProperties": false
+    },
+    "renameResponse": {
+      "type": "object",
+      "required": [
+        "title"
+      ],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256,
+          "pattern": "\\S"
+        }
+      },
+      "additionalProperties": false
+    },
+    "question": {
+      "type": "object",
+      "required": [
+        "id",
+        "text"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/nonblank"
+        },
+        "text": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 2048,
+          "pattern": "\\S"
+        },
+        "header": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128,
+          "pattern": "\\S"
+        },
+        "detail": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 4096,
+          "pattern": "\\S"
+        },
+        "options": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 256,
+            "pattern": "\\S"
+          }
+        },
+        "multiSelect": {
+          "type": "boolean"
+        },
+        "intent": {
+          "const": "plan_review"
+        },
+        "approveLabel": {
+          "$ref": "#/$defs/nonblank"
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "intent": {
+              "const": "plan_review"
+            },
+            "approveLabel": {
+              "$ref": "#/$defs/nonblank"
+            },
+            "options": true
+          },
+          "required": [
+            "intent",
+            "approveLabel",
+            "options"
+          ]
+        },
+        {
+          "not": {
+            "anyOf": [
+              {
+                "required": [
+                  "intent"
+                ]
+              },
+              {
+                "required": [
+                  "approveLabel"
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "askUserQuestionRequest": {
+      "type": "object",
+      "required": [
+        "sessionId",
+        "questions"
+      ],
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "questions": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "$ref": "#/$defs/question"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "askUserQuestionResponse": {
+      "type": "object",
+      "required": [
+        "answers"
+      ],
+      "properties": {
+        "answers": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "type": "object",
+            "required": [
+              "questionId",
+              "selectedLabels"
+            ],
+            "properties": {
+              "questionId": {
+                "$ref": "#/$defs/nonblank"
+              },
+              "selectedLabels": {
+                "type": "array",
+                "maxItems": 32,
+                "uniqueItems": true,
+                "items": {
+                  "$ref": "#/$defs/nonblank"
+                }
+              },
+              "customAnswer": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 2048,
+                "pattern": "\\S"
+              }
+            },
+            "anyOf": [
+              {
+                "properties": {
+                  "selectedLabels": {
+                    "type": "array",
+                    "minItems": 1
+                  }
+                }
+              },
+              {
+                "required": [
+                  "customAnswer"
+                ],
+                "properties": {
+                  "customAnswer": true
+                }
+              }
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "sessionStatusRetry": {
+      "type": "object",
+      "required": [
+        "sessionId",
+        "kind",
+        "attempt"
+      ],
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "kind": {
+          "const": "retry"
+        },
+        "attempt": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      "additionalProperties": false
+    },
+    "sessionStatusCompactionStarted": {
+      "type": "object",
+      "required": [
+        "sessionId",
+        "kind"
+      ],
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "kind": {
+          "const": "compaction_started"
+        }
+      },
+      "additionalProperties": false
+    },
+    "sessionStatusCompactionCompleted": {
+      "type": "object",
+      "required": [
+        "sessionId",
+        "kind"
+      ],
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "kind": {
+          "const": "compaction_completed"
+        }
+      },
+      "additionalProperties": false
+    },
+    "sessionStatusWarning": {
+      "type": "object",
+      "required": [
+        "sessionId",
+        "kind",
+        "message"
+      ],
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "kind": {
+          "const": "warning"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512,
+          "pattern": "\\S"
+        }
+      },
+      "additionalProperties": false
+    },
+    "sessionStatusNotification": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/sessionStatusRetry"
+        },
+        {
+          "$ref": "#/$defs/sessionStatusCompactionStarted"
+        },
+        {
+          "$ref": "#/$defs/sessionStatusCompactionCompleted"
+        },
+        {
+          "$ref": "#/$defs/sessionStatusWarning"
+        }
+      ]
+    },
+    "subagentMode": {
+      "enum": [
+        "foreground",
+        "background"
+      ]
+    },
+    "subagentStopReason": {
+      "enum": [
+        "completed",
+        "aborted",
+        "error",
+        "max-tokens",
+        "refusal"
+      ]
+    },
+    "subagentPrompt": {
+      "description": "Trimmed tile presentation prompt, bounded to 32768 Unicode scalar values.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 32768,
+      "pattern": "\\S",
+      "allOf": [
+        {
+          "pattern": "^[^\\uD800-\\uDFFF]*$"
+        }
+      ]
+    },
+    "subagentSummary": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512,
+      "pattern": "\\S"
+    },
+    "subagentStarted": {
+      "type": "object",
+      "required": [
+        "kind",
+        "sessionId",
+        "childSessionId",
+        "toolCallId",
+        "label",
+        "prompt",
+        "mode"
+      ],
+      "properties": {
+        "kind": {
+          "const": "started"
+        },
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "childSessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "toolCallId": {
+          "$ref": "#/$defs/nonblank"
+        },
+        "label": {
+          "$ref": "#/$defs/nonblank"
+        },
+        "prompt": {
+          "$ref": "#/$defs/subagentPrompt"
+        },
+        "mode": {
+          "$ref": "#/$defs/subagentMode"
+        }
+      },
+      "additionalProperties": false
+    },
+    "subagentEnded": {
+      "type": "object",
+      "required": [
+        "kind",
+        "sessionId",
+        "childSessionId",
+        "stopReason"
+      ],
+      "properties": {
+        "kind": {
+          "const": "ended"
+        },
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "childSessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "stopReason": {
+          "$ref": "#/$defs/subagentStopReason"
+        },
+        "summary": {
+          "$ref": "#/$defs/subagentSummary"
+        }
+      },
+      "additionalProperties": false
+    },
+    "subagentNotification": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/subagentStarted"
+        },
+        {
+          "$ref": "#/$defs/subagentEnded"
+        }
+      ]
+    },
+    "subagentReplay": {
+      "type": "object",
+      "required": [
+        "label",
+        "prompt",
+        "mode"
+      ],
+      "properties": {
+        "label": {
+          "$ref": "#/$defs/nonblank"
+        },
+        "prompt": {
+          "$ref": "#/$defs/subagentPrompt"
+        },
+        "mode": {
+          "$ref": "#/$defs/subagentMode"
+        },
+        "childSessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "ended": {
+          "type": "object",
+          "required": [
+            "stopReason"
+          ],
+          "properties": {
+            "stopReason": {
+              "$ref": "#/$defs/subagentStopReason"
+            },
+            "summary": {
+              "$ref": "#/$defs/subagentSummary"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "subagentInterruptRequest": {
+      "type": "object",
+      "required": [
+        "sessionId",
+        "childSessionId"
+      ],
+      "properties": {
+        "sessionId": {
+          "$ref": "#/$defs/sessionId"
+        },
+        "childSessionId": {
+          "$ref": "#/$defs/sessionId"
+        }
+      },
+      "additionalProperties": false
+    },
+    "subagentInterruptResponse": {
+      "type": "object",
+      "required": [
+        "result"
+      ],
+      "properties": {
+        "result": {
+          "enum": [
+            "interrupted",
+            "not_cancellable",
+            "unknown_child"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v2/invalid.json
+++ b/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v2/invalid.json
@@ -1,0 +1,375 @@
+[
+  {
+    "definition": "initializeMetadata",
+    "value": {
+      "extensionProtocolVersion": 1,
+      "adapterVersion": "0.1.0",
+      "harnessVersion": "0.1.1",
+      "persistenceOwner": "sesori"
+    }
+  },
+  {
+    "definition": "promptMetadata",
+    "value": {
+      "messageId": ""
+    }
+  },
+  {
+    "definition": "catalogRequest",
+    "value": {
+      "cwd": "relative/project"
+    }
+  },
+  {
+    "definition": "catalogResponse",
+    "value": {
+      "agent": {
+        "id": "other",
+        "name": "DeepSeek",
+        "primary": true
+      },
+      "providers": [],
+      "defaultSelectionId": null,
+      "commands": [],
+      "failures": []
+    }
+  },
+  {
+    "definition": "catalogResponse",
+    "value": {
+      "agent": {
+        "id": "deepseek",
+        "name": "DeepSeek",
+        "primary": true
+      },
+      "providers": [],
+      "defaultSelectionId": "v1",
+      "commands": [],
+      "failures": []
+    }
+  },
+  {
+    "definition": "catalogResponse",
+    "value": {
+      "agent": {
+        "id": "deepseek",
+        "name": "DeepSeek",
+        "primary": true
+      },
+      "providers": [],
+      "defaultSelectionId": "v1payload+",
+      "commands": [],
+      "failures": []
+    }
+  },
+  {
+    "definition": "catalogResponse",
+    "value": {
+      "agent": {
+        "id": "deepseek",
+        "name": "DeepSeek",
+        "primary": true
+      },
+      "providers": [],
+      "defaultSelectionId": "v1A",
+      "commands": [],
+      "failures": []
+    }
+  },
+  {
+    "definition": "historyRequest",
+    "value": {
+      "sessionId": "session-1",
+      "maxMessages": 101
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [],
+      "hasMore": "yes"
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [],
+      "hasMore": true
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [],
+      "nextBeforeSeq": 1,
+      "hasMore": false
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [
+        {
+          "sessionId": "session-1",
+          "update": {
+            "sessionUpdate": "agent_message_chunk"
+          },
+          "_meta": {
+            "sesori.ai/deepseek": {
+              "messageCreatedAt": -1
+            }
+          }
+        }
+      ],
+      "hasMore": false
+    }
+  },
+  {
+    "definition": "renameRequest",
+    "value": {
+      "sessionId": "session-1",
+      "title": "   "
+    }
+  },
+  {
+    "definition": "renameResponse",
+    "value": {
+      "title": ""
+    }
+  },
+  {
+    "definition": "askUserQuestionRequest",
+    "value": {
+      "sessionId": "session-1",
+      "questions": []
+    }
+  },
+  {
+    "definition": "askUserQuestionRequest",
+    "value": {
+      "sessionId": "session-1",
+      "questions": [
+        {
+          "id": "plan-1",
+          "text": "Review the plan",
+          "intent": "plan_review"
+        }
+      ]
+    }
+  },
+  {
+    "definition": "askUserQuestionRequest",
+    "value": {
+      "sessionId": "session-1",
+      "questions": [
+        {
+          "id": "q1",
+          "text": "Choose an option",
+          "intent": "question",
+          "approveLabel": "Approve"
+        }
+      ]
+    }
+  },
+  {
+    "definition": "askUserQuestionRequest",
+    "value": {
+      "sessionId": "session-1",
+      "questions": [
+        {
+          "id": "plan-1",
+          "text": "Review the plan",
+          "intent": "plan_review",
+          "approveLabel": "Approve"
+        }
+      ]
+    }
+  },
+  {
+    "definition": "askUserQuestionResponse",
+    "value": {
+      "answers": [
+        {
+          "questionId": "q1",
+          "selectedLabels": [
+            "Alpha",
+            "Alpha"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "definition": "askUserQuestionResponse",
+    "value": {
+      "answers": [
+        {
+          "questionId": "q1",
+          "selectedLabels": []
+        }
+      ]
+    }
+  },
+  {
+    "definition": "sessionStatusNotification",
+    "value": {
+      "sessionId": "session-1",
+      "kind": "future_status"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "started",
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "label": "Probe child",
+      "prompt": "Synthetic child prompt",
+      "mode": "foreground"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "started",
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "toolCallId": "call-1",
+      "label": "Probe child",
+      "prompt": "Synthetic child prompt",
+      "mode": "detached"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "ended",
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "stopReason": "vanished"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "ended",
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "stopReason": "completed",
+      "summary": "   "
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [
+        {
+          "sessionId": "session-1",
+          "update": {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "call-1"
+          },
+          "_meta": {
+            "sesori.ai/deepseek": {
+              "subagent": {
+                "prompt": "Synthetic child prompt",
+                "mode": "background"
+              }
+            }
+          }
+        }
+      ],
+      "hasMore": false
+    }
+  },
+  {
+    "definition": "subagentInterruptRequest",
+    "value": {
+      "sessionId": "session-1"
+    }
+  },
+  {
+    "definition": "subagentInterruptRequest",
+    "value": {
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "force": true
+    }
+  },
+  {
+    "definition": "subagentInterruptResponse",
+    "value": {
+      "result": "killed"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "started",
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "toolCallId": "call-1",
+      "label": "Probe child",
+      "mode": "foreground"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "started",
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "toolCallId": "call-1",
+      "label": "Probe child",
+      "prompt": "   ",
+      "mode": "foreground"
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [
+        {
+          "sessionId": "session-1",
+          "update": {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "call-1"
+          },
+          "_meta": {
+            "sesori.ai/deepseek": {
+              "subagent": {
+                "label": "Probe child",
+                "mode": "background"
+              }
+            }
+          }
+        }
+      ],
+      "hasMore": false
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [
+        {
+          "sessionId": "session-1",
+          "update": {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "call-1"
+          },
+          "_meta": {
+            "sesori.ai/deepseek": {
+              "subagent": {
+                "label": "Probe child",
+                "prompt": "   ",
+                "mode": "background"
+              }
+            }
+          }
+        }
+      ],
+      "hasMore": false
+    }
+  }
+]

--- a/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v2/source_manifest.json
+++ b/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v2/source_manifest.json
@@ -1,0 +1,9 @@
+{
+  "repository": "sesori-ai/sesori-deepseek-acp",
+  "commit": "d7a48471bf5339793beb0c9e1c1889e63f76ec92",
+  "files": {
+    "deepseek-acp.schema.json": "0214eee120039d7d573ee6bf4c585f3501570dfc568ce872066b39715992b4dc",
+    "valid.json": "a88483d685dc38766e2be4e0dda9e8a2be374635664074e8f59ea76dc7401f5a",
+    "invalid.json": "bf8a6b368bd2a3aa87c5591fcac83b16d9ed052ff295c0bc04362d01c7de39f2"
+  }
+}

--- a/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v2/valid.json
+++ b/bridge/sesori_plugin_deepseek/test/fixtures/protocol/v2/valid.json
@@ -1,0 +1,337 @@
+[
+  {
+    "definition": "initializeMetadata",
+    "value": {
+      "extensionProtocolVersion": 2,
+      "adapterVersion": "0.1.0",
+      "harnessVersion": "0.1.1-rc.2",
+      "persistenceOwner": "sesori"
+    }
+  },
+  {
+    "definition": "initializeMetadata",
+    "value": {
+      "extensionProtocolVersion": 2,
+      "adapterVersion": "0.1.0",
+      "harnessVersion": "0.1.1-rc.2",
+      "persistenceOwner": "sesori",
+      "futureCapability": true
+    }
+  },
+  {
+    "definition": "promptMetadata",
+    "value": {
+      "messageId": "message-1"
+    }
+  },
+  {
+    "definition": "promptMetadata",
+    "value": {}
+  },
+  {
+    "definition": "catalogRequest",
+    "value": {
+      "cwd": "/synthetic/project"
+    }
+  },
+  {
+    "definition": "catalogRequest",
+    "value": {
+      "cwd": "C:\\synthetic\\project"
+    }
+  },
+  {
+    "definition": "catalogResponse",
+    "value": {
+      "agent": {
+        "id": "deepseek",
+        "name": "DeepSeek",
+        "primary": true
+      },
+      "providers": [
+        {
+          "id": "provider/alpha-\u03b1",
+          "name": "Synthetic Provider",
+          "models": [
+            {
+              "id": "v1c3ludGhldGlj",
+              "upstreamModelId": "model/alpha-\u03b1",
+              "name": "Synthetic Model",
+              "reasoningEfforts": [
+                "low",
+                "high"
+              ],
+              "defaultReasoningEffort": "low",
+              "supportsImages": true
+            }
+          ]
+        }
+      ],
+      "defaultSelectionId": "v1c3ludGhldGlj",
+      "commands": [
+        {
+          "name": "inspect",
+          "description": "Synthetic command"
+        }
+      ],
+      "failures": [
+        {
+          "providerId": "offline",
+          "category": "unavailable",
+          "message": "Synthetic provider unavailable"
+        }
+      ]
+    }
+  },
+  {
+    "definition": "historyRequest",
+    "value": {
+      "sessionId": "session-1",
+      "maxMessages": 50
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [
+        {
+          "sessionId": "session-1",
+          "update": {
+            "sessionUpdate": "agent_message_chunk"
+          },
+          "_meta": {
+            "sesori.ai/deepseek": {
+              "messageCreatedAt": 1787831943365
+            }
+          }
+        }
+      ],
+      "nextBeforeSeq": 12,
+      "hasMore": true
+    }
+  },
+  {
+    "definition": "renameRequest",
+    "value": {
+      "sessionId": "session-1",
+      "title": "Synthetic title"
+    }
+  },
+  {
+    "definition": "renameResponse",
+    "value": {
+      "title": "Synthetic title"
+    }
+  },
+  {
+    "definition": "askUserQuestionRequest",
+    "value": {
+      "sessionId": "session-1",
+      "questions": [
+        {
+          "id": "q1",
+          "text": "Choose synthetic option",
+          "options": [
+            "Alpha",
+            "Beta"
+          ],
+          "multiSelect": false
+        }
+      ]
+    }
+  },
+  {
+    "definition": "askUserQuestionResponse",
+    "value": {
+      "answers": [
+        {
+          "questionId": "q1",
+          "selectedLabels": [
+            "Alpha"
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "definition": "askUserQuestionResponse",
+    "value": {
+      "answers": [
+        {
+          "questionId": "q1",
+          "selectedLabels": [],
+          "customAnswer": "Synthetic custom answer"
+        }
+      ]
+    }
+  },
+  {
+    "definition": "askUserQuestionResponse",
+    "value": {
+      "answers": [
+        {
+          "questionId": "q1",
+          "selectedLabels": [
+            "Alpha"
+          ],
+          "customAnswer": "Synthetic additional answer"
+        }
+      ]
+    }
+  },
+  {
+    "definition": "askUserQuestionRequest",
+    "value": {
+      "sessionId": "session-1",
+      "questions": [
+        {
+          "id": "plan-1",
+          "text": "Review the plan",
+          "options": [
+            "Approve",
+            "Reject"
+          ],
+          "intent": "plan_review",
+          "approveLabel": "Approve"
+        }
+      ]
+    }
+  },
+  {
+    "definition": "sessionStatusNotification",
+    "value": {
+      "sessionId": "session-1",
+      "kind": "retry",
+      "attempt": 1,
+      "limit": 3
+    }
+  },
+  {
+    "definition": "sessionStatusNotification",
+    "value": {
+      "sessionId": "session-1",
+      "kind": "retry",
+      "attempt": 2
+    }
+  },
+  {
+    "definition": "sessionStatusNotification",
+    "value": {
+      "sessionId": "session-1",
+      "kind": "compaction_started"
+    }
+  },
+  {
+    "definition": "sessionStatusNotification",
+    "value": {
+      "sessionId": "session-1",
+      "kind": "compaction_completed"
+    }
+  },
+  {
+    "definition": "sessionStatusNotification",
+    "value": {
+      "sessionId": "session-1",
+      "kind": "warning",
+      "message": "Synthetic warning"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "started",
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "toolCallId": "call-1",
+      "label": "Probe child",
+      "prompt": "Synthetic prompt for child-1",
+      "mode": "foreground"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "started",
+      "sessionId": "session-1",
+      "childSessionId": "child-2",
+      "toolCallId": "call-2",
+      "label": "Probe child",
+      "prompt": "Synthetic prompt for child-2",
+      "mode": "background"
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "ended",
+      "sessionId": "session-1",
+      "childSessionId": "child-1",
+      "stopReason": "completed",
+      "summary": "Done."
+    }
+  },
+  {
+    "definition": "subagentNotification",
+    "value": {
+      "kind": "ended",
+      "sessionId": "session-1",
+      "childSessionId": "child-2",
+      "stopReason": "aborted"
+    }
+  },
+  {
+    "definition": "historyResponse",
+    "value": {
+      "updates": [
+        {
+          "sessionId": "session-1",
+          "update": {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "call-1"
+          },
+          "_meta": {
+            "sesori.ai/deepseek": {
+              "messageCreatedAt": 1,
+              "subagent": {
+                "label": "Probe child",
+                "prompt": "Synthetic child prompt",
+                "mode": "background",
+                "childSessionId": "child-1",
+                "ended": {
+                  "stopReason": "completed",
+                  "summary": "Done."
+                }
+              }
+            }
+          }
+        }
+      ],
+      "hasMore": false
+    }
+  },
+  {
+    "definition": "subagentInterruptRequest",
+    "value": {
+      "sessionId": "session-1",
+      "childSessionId": "child-1"
+    }
+  },
+  {
+    "definition": "subagentInterruptResponse",
+    "value": {
+      "result": "interrupted"
+    }
+  },
+  {
+    "definition": "subagentInterruptResponse",
+    "value": {
+      "result": "not_cancellable"
+    }
+  },
+  {
+    "definition": "subagentInterruptResponse",
+    "value": {
+      "result": "unknown_child"
+    }
+  }
+]


### PR DESCRIPTION
## Complexity

🌿 Straightforward — vendor one authoritative protocol bundle and extend the existing hash-integrity test to cover both versions.

## What

- Copy the DeepSeek protocol-v2 schema and valid/invalid fixtures verbatim from adapter commit `d7a48471bf5339793beb0c9e1c1889e63f76ec92`.
- Record source provenance and SHA-256 values.
- Check both v1 and v2 manifests; keep every v1 fixture byte unchanged.
- Record step 1 (#1298) merged and this slice's verification.

**Size: 1,607 changed lines**: 1,556 verbatim fixture/manifest lines, 40 integrity-test lines, and 11 tracker lines. This is the documented small exception to the ~1,500-line target so the authoritative bundle remains intact, not minified or partially copied.

## Why

Step 2/5 replaces the fixture portion of oversized #1293. Typed parsing and protocol consumption remain separate reviewable steps.

## Risk and test focus

Low: tests and evidence only. Verify source identity, hashes, and frozen-v1 integrity. The schema includes the native interrupt contract as evidence, but no interrupt consumer is added.

No user-visible behavior, database/schema, production code, or runtime-pin change. The adapter release still waits for all five consumer slices to merge.

## Expected result

Both vendored protocol versions pass integrity checks. Runtime behavior stays unchanged; step 3 can add typed protocol-v2 parsing against pinned evidence.

## Verification

- `dart test test/deepseek_protocol_integrity_test.dart` — 2 passed.
- Independently compared all three v2 files byte-for-byte against the native adapter Git source and checked every manifest SHA-256.
- Protocol-v1 fixture bytes and `deepseek_runtime_manifest.dart` unchanged.
- Dart formatting and `git diff --check` passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vendors the DeepSeek protocol-v2 schema and fixtures verbatim from the adapter commit and extends the hash-integrity test to verify both v1 and v2 bundles, so step 3 can parse protocol v2 against pinned evidence.

- The v2 schema, `valid.json`, and `invalid.json` are copied byte-for-byte from adapter commit `d7a48471b` with SHA-256 values recorded in a new `source_manifest.json`.
- The integrity test now iterates over both protocol versions, leaving all v1 fixture bytes and `deepseek_runtime_manifest.dart` unchanged.
- No production code, runtime pins, or user-visible behavior changes; the schema includes the native subagent interrupt contract as evidence only.

<sup>Written for commit 94b4fdc2d59189c0755ca9d053372f819cb3bae7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

