### PR TITLE
⚙️ Stamp Claude messages with the picker model id and effort

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_backend_catalog_dto.g.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_backend_catalog_dto.g.dart
@@ -6,11 +6,10 @@ part of 'claude_backend_catalog_dto.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_ClaudeBackendCatalogDto _$ClaudeBackendCatalogDtoFromJson(Map json) =>
-    _ClaudeBackendCatalogDto(
-      commands: _commandsOrEmpty(json['commands']),
-      models: _modelsOrEmpty(json['models']),
-    );
+_ClaudeBackendCatalogDto _$ClaudeBackendCatalogDtoFromJson(Map json) => _ClaudeBackendCatalogDto(
+  commands: _commandsOrEmpty(json['commands']),
+  models: _modelsOrEmpty(json['models']),
+);
 
 _ClaudeCommandDto _$ClaudeCommandDtoFromJson(Map json) => _ClaudeCommandDto(
   name: _stringOrNull(json['name']),

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_content_block_dto.g.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_content_block_dto.g.dart
@@ -6,11 +6,10 @@ part of 'claude_content_block_dto.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-ClaudeTextContentBlockDto _$ClaudeTextContentBlockDtoFromJson(Map json) =>
-    ClaudeTextContentBlockDto(
-      text: _stringOrNull(json['text']),
-      $type: json['type'] as String?,
-    );
+ClaudeTextContentBlockDto _$ClaudeTextContentBlockDtoFromJson(Map json) => ClaudeTextContentBlockDto(
+  text: _stringOrNull(json['text']),
+  $type: json['type'] as String?,
+);
 
 ClaudeThinkingContentBlockDto _$ClaudeThinkingContentBlockDtoFromJson(
   Map json,
@@ -20,17 +19,15 @@ ClaudeThinkingContentBlockDto _$ClaudeThinkingContentBlockDtoFromJson(
   $type: json['type'] as String?,
 );
 
-ClaudeRedactedThinkingContentBlockDto
-_$ClaudeRedactedThinkingContentBlockDtoFromJson(Map json) =>
+ClaudeRedactedThinkingContentBlockDto _$ClaudeRedactedThinkingContentBlockDtoFromJson(Map json) =>
     ClaudeRedactedThinkingContentBlockDto($type: json['type'] as String?);
 
-ClaudeToolUseContentBlockDto _$ClaudeToolUseContentBlockDtoFromJson(Map json) =>
-    ClaudeToolUseContentBlockDto(
-      id: _stringOrNull(json['id']),
-      name: _stringOrNull(json['name']),
-      input: json['input'],
-      $type: json['type'] as String?,
-    );
+ClaudeToolUseContentBlockDto _$ClaudeToolUseContentBlockDtoFromJson(Map json) => ClaudeToolUseContentBlockDto(
+  id: _stringOrNull(json['id']),
+  name: _stringOrNull(json['name']),
+  input: json['input'],
+  $type: json['type'] as String?,
+);
 
 ClaudeToolResultContentBlockDto _$ClaudeToolResultContentBlockDtoFromJson(
   Map json,
@@ -41,18 +38,16 @@ ClaudeToolResultContentBlockDto _$ClaudeToolResultContentBlockDtoFromJson(
   $type: json['type'] as String?,
 );
 
-ClaudeImageContentBlockDto _$ClaudeImageContentBlockDtoFromJson(Map json) =>
-    ClaudeImageContentBlockDto(
-      source: _imageSourceOrNull(json['source']),
-      $type: json['type'] as String?,
-    );
+ClaudeImageContentBlockDto _$ClaudeImageContentBlockDtoFromJson(Map json) => ClaudeImageContentBlockDto(
+  source: _imageSourceOrNull(json['source']),
+  $type: json['type'] as String?,
+);
 
 ClaudeUnknownContentBlockDto _$ClaudeUnknownContentBlockDtoFromJson(Map json) =>
     ClaudeUnknownContentBlockDto($type: json['type'] as String?);
 
-_ClaudeImageSourceDto _$ClaudeImageSourceDtoFromJson(Map json) =>
-    _ClaudeImageSourceDto(
-      type: _stringOrNull(json['type']),
-      mediaType: _stringOrNull(json['media_type']),
-      data: _stringOrNull(json['data']),
-    );
+_ClaudeImageSourceDto _$ClaudeImageSourceDtoFromJson(Map json) => _ClaudeImageSourceDto(
+  type: _stringOrNull(json['type']),
+  mediaType: _stringOrNull(json['media_type']),
+  data: _stringOrNull(json['data']),
+);

--- a/bridge/sesori_plugin_claude/lib/src/api/models/claude_transcript_record_dto.g.dart
+++ b/bridge/sesori_plugin_claude/lib/src/api/models/claude_transcript_record_dto.g.dart
@@ -6,31 +6,29 @@ part of 'claude_transcript_record_dto.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_ClaudeTranscriptRecordDto _$ClaudeTranscriptRecordDtoFromJson(Map json) =>
-    _ClaudeTranscriptRecordDto(
-      type: _stringOrNull(json['type']),
-      sessionId: _stringOrNull(json['sessionId']),
-      cwd: _stringOrNull(json['cwd']),
-      timestamp: _timestampOrNull(json['timestamp']),
-      isSidechain: _boolOrNull(json['isSidechain']),
-      agentId: _stringOrNull(json['agentId']),
-      gitBranch: _stringOrNull(json['gitBranch']),
-      version: _stringOrNull(json['version']),
-      aiTitle: _stringOrNull(json['aiTitle']),
-      uuid: _stringOrNull(json['uuid']),
-      isMeta: _boolOrNull(json['isMeta']),
-      isVisibleInTranscriptOnly: _boolOrNull(json['isVisibleInTranscriptOnly']),
-      isApiErrorMessage: _boolOrNull(json['isApiErrorMessage']),
-      apiErrorStatus: _intOrNull(json['apiErrorStatus']),
-      effort: _stringOrNull(json['effort']),
-      message: _messageOrNull(json['message']),
-      toolUseResult: ClaudeToolUseResult.parse(json['toolUseResult']),
-      originKind: _originKindOrNull(json['origin']),
-    );
+_ClaudeTranscriptRecordDto _$ClaudeTranscriptRecordDtoFromJson(Map json) => _ClaudeTranscriptRecordDto(
+  type: _stringOrNull(json['type']),
+  sessionId: _stringOrNull(json['sessionId']),
+  cwd: _stringOrNull(json['cwd']),
+  timestamp: _timestampOrNull(json['timestamp']),
+  isSidechain: _boolOrNull(json['isSidechain']),
+  agentId: _stringOrNull(json['agentId']),
+  gitBranch: _stringOrNull(json['gitBranch']),
+  version: _stringOrNull(json['version']),
+  aiTitle: _stringOrNull(json['aiTitle']),
+  uuid: _stringOrNull(json['uuid']),
+  isMeta: _boolOrNull(json['isMeta']),
+  isVisibleInTranscriptOnly: _boolOrNull(json['isVisibleInTranscriptOnly']),
+  isApiErrorMessage: _boolOrNull(json['isApiErrorMessage']),
+  apiErrorStatus: _intOrNull(json['apiErrorStatus']),
+  effort: _stringOrNull(json['effort']),
+  message: _messageOrNull(json['message']),
+  toolUseResult: ClaudeToolUseResult.parse(json['toolUseResult']),
+  originKind: _originKindOrNull(json['origin']),
+);
 
-_ClaudeTranscriptMessageDto _$ClaudeTranscriptMessageDtoFromJson(Map json) =>
-    _ClaudeTranscriptMessageDto(
-      id: _stringOrNull(json['id']),
-      model: _stringOrNull(json['model']),
-      content: json['content'],
-    );
+_ClaudeTranscriptMessageDto _$ClaudeTranscriptMessageDtoFromJson(Map json) => _ClaudeTranscriptMessageDto(
+  id: _stringOrNull(json['id']),
+  model: _stringOrNull(json['model']),
+  content: json['content'],
+);

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -12,10 +12,21 @@ import "repositories/trackers/claude_tool_tracker.dart";
 final class ClaudeEventDispatcher({
   required final ClaudeContentMapper _content,
   required final ClaudeToolTracker _tools,
+
+  /// Translates an API model name into the catalog's picker id; null keeps the
+  /// name as reported.
+  required final String? Function({required String apiModel}) _catalogModelId,
 }) {
   final Map<String, String> _messageIds = {};
   final Map<String, String> _announcedMessageIds = {};
+
+  /// The model the stream last reported per session, an API name such as
+  /// `claude-opus-5`. Used only when the turn declared no selection.
   final Map<String, String> _models = {};
+
+  /// What the turn was dispatched with, per session: the picker id and effort
+  /// the user chose, when known.
+  final Map<String, ({String? model, String? variant})> _turnSelections = {};
   final Map<String, Set<int>> _streamedBlocks = {};
   final Map<String, Map<int, PluginMessagePart>> _completedStreamedParts = {};
   final Map<String, Set<String>> _streamedMessageIds = {};
@@ -45,10 +56,27 @@ final class ClaudeEventDispatcher({
 
   String _rootOf(String sessionId) => _roots[sessionId] ?? sessionId;
 
-  void beginTurn({required String sessionId, required String directory}) {
+  /// [model] and [variant] are the picker id and effort the turn runs with,
+  /// null when the CLI decides; messages are stamped with them so the client
+  /// matches the catalog instead of a raw API name.
+  void beginTurn({
+    required String sessionId,
+    required String directory,
+    required String? model,
+    required String? variant,
+  }) {
     _directories[sessionId] = directory;
+    _turnSelections[sessionId] = (model: model, variant: variant);
     _resetTurn(sessionId: sessionId);
   }
+
+  String? _modelId({required String sessionId}) {
+    final model = _turnSelections[sessionId]?.model ?? _models[sessionId];
+    if (model == null) return null;
+    return _catalogModelId(apiModel: model) ?? model;
+  }
+
+  String? _variant({required String sessionId}) => _turnSelections[sessionId]?.variant;
 
   /// Clears completed-turn stream state.
   void completeTurn({required String sessionId}) => _resetTurn(sessionId: sessionId);
@@ -339,9 +367,9 @@ final class ClaudeEventDispatcher({
             id: messageId,
             sessionID: sessionId,
             agent: "claude",
-            modelID: _models[sessionId],
+            modelID: _modelId(sessionId: sessionId),
             providerID: "anthropic",
-            variant: null,
+            variant: _variant(sessionId: sessionId),
             errorName: error.name,
             errorMessage: error.message,
             time: _messageTime(message.timestamp),
@@ -543,9 +571,9 @@ final class ClaudeEventDispatcher({
           id: messageId,
           sessionID: sessionId,
           agent: "claude",
-          modelID: _models[sessionId],
+          modelID: _modelId(sessionId: sessionId),
           providerID: "anthropic",
-          variant: null,
+          variant: _variant(sessionId: sessionId),
           errorName: error.name,
           errorMessage: error.message,
           time: null,
@@ -562,9 +590,9 @@ final class ClaudeEventDispatcher({
     id: messageId,
     sessionID: sessionId,
     agent: "claude",
-    modelID: _models[sessionId],
+    modelID: _modelId(sessionId: sessionId),
     providerID: "anthropic",
-    variant: null,
+    variant: _variant(sessionId: sessionId),
     sender: PluginMessageSender.agent,
     time: time,
   );

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -70,6 +70,10 @@ final class ClaudeEventDispatcher({
     _resetTurn(sessionId: sessionId);
   }
 
+  /// The turn's model also goes through the resolver: a resumed session with
+  /// no Sesori selection records the API name the CLI reported as its applied
+  /// model, and a picker id never matches a `resolvedModel`, so the lookup is
+  /// a no-op for one and the fix for the other.
   String? _modelId({required String sessionId}) {
     final model = _turnSelections[sessionId]?.model ?? _models[sessionId];
     if (model == null) return null;
@@ -110,6 +114,7 @@ final class ClaudeEventDispatcher({
     _announcedMessageIds.remove(sessionId);
     _mappedApiErrorSessions.remove(sessionId);
     _models.remove(sessionId);
+    _turnSelections.remove(sessionId);
     _clearStreamedMessages(sessionId: sessionId);
     _tools.forgetSession(sessionId: sessionId);
   }

--- a/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
@@ -20,12 +20,17 @@ final class const ClaudeHistoryMapper({
   /// [agentId] selects child mode: a sub-agent transcript's records are
   /// sidechain records stamped with the **parent's** session id, so they are
   /// attributed by agent id instead of the root's session-id cross-check.
+  ///
+  /// [catalogModelId] translates a transcript's API model name into the
+  /// catalog's picker id; null keeps names as recorded.
   List<PluginMessageWithParts> map({
     required String sessionId,
     required String? agentId,
     required List<ClaudeTranscriptRecord> records,
     required Set<String> residentTaskToolUseIds,
+    required String? Function({required String apiModel})? catalogModelId,
   }) {
+    String? modelId(String? model) => model == null ? null : catalogModelId?.call(apiModel: model) ?? model;
     bool skip(ClaudeTranscriptAttributedRecord record) => switch (agentId) {
       null => (record.isSidechain ?? false) || (record.sessionId != null && record.sessionId != sessionId),
       final agentId => record.agentId != agentId,
@@ -175,9 +180,9 @@ final class const ClaudeHistoryMapper({
         case _UserHistoryMessage(:final message):
           messages.add(message);
         case _ApiErrorHistoryMessage():
-          messages.add(_buildApiError(entry: entry, sessionId: sessionId));
+          messages.add(_buildApiError(entry: entry, sessionId: sessionId, modelId: modelId));
         case _AssistantHistoryMessage():
-          final message = _buildAssistant(entry: entry, sessionId: sessionId, tasks: tasks);
+          final message = _buildAssistant(entry: entry, sessionId: sessionId, tasks: tasks, modelId: modelId);
           if (message != null) messages.add(message);
       }
     }
@@ -187,6 +192,7 @@ final class const ClaudeHistoryMapper({
   PluginMessageWithParts _buildApiError({
     required _ApiErrorHistoryMessage entry,
     required String sessionId,
+    required String? Function(String? model) modelId,
   }) {
     final error = mapClaudeApiError(
       blocks: _content.map(content: entry.content),
@@ -197,7 +203,7 @@ final class const ClaudeHistoryMapper({
         id: entry.id,
         sessionID: sessionId,
         agent: "claude",
-        modelID: entry.model,
+        modelID: modelId(entry.model),
         providerID: "anthropic",
         variant: null,
         errorName: error.name,
@@ -212,6 +218,7 @@ final class const ClaudeHistoryMapper({
     required _AssistantHistoryMessage entry,
     required String sessionId,
     required ClaudeToolTracker tasks,
+    required String? Function(String? model) modelId,
   }) {
     final mapped = _content.mapParts(
       content: entry.content,
@@ -248,7 +255,7 @@ final class const ClaudeHistoryMapper({
         id: entry.id,
         sessionID: sessionId,
         agent: "claude",
-        modelID: entry.model,
+        modelID: modelId(entry.model),
         providerID: "anthropic",
         variant: entry.variant,
         sender: PluginMessageSender.agent,

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -215,6 +215,7 @@ final class ClaudePlugin({
         agentId: ClaudeSubagentSessionId.agentIdOf(sessionId),
         records: await _transcripts.readTranscriptRecordsInIsolate(sessionId: sessionId),
         residentTaskToolUseIds: _eventDispatcher.residentTaskToolUseIds(sessionId: sessionId),
+        catalogModelId: _catalogService.cached?.catalogModelId,
       );
     } on Object catch (error) {
       throw PluginOperationException(
@@ -486,7 +487,12 @@ final class ClaudePlugin({
     _validateModel(model, operation: operation, staleOptions: false);
     final effort = _effort(variant, operation: operation, staleOptions: false);
     final permissionMode = _permissionMode(agent, operation: operation, staleOptions: false);
-    _eventDispatcher.beginTurn(sessionId: sessionId, directory: directory);
+    _eventDispatcher.beginTurn(
+      sessionId: sessionId,
+      directory: directory,
+      model: model?.modelID,
+      variant: effort?.wireValue,
+    );
     try {
       await _sessions.enqueueInitialTurn(
         sessionId: sessionId,
@@ -651,7 +657,15 @@ final class ClaudePlugin({
 
   void _handleTurnDispatched(ClaudeTurnDispatched event) {
     _unstartedSessions.remove(event.sessionId);
-    if (!event.isSteering) _eventDispatcher.beginTurn(sessionId: event.sessionId, directory: event.directory);
+    if (!event.isSteering) {
+      final applied = _processes.appliedSelection(sessionId: event.sessionId);
+      _eventDispatcher.beginTurn(
+        sessionId: event.sessionId,
+        directory: event.directory,
+        model: applied?.model,
+        variant: applied?.effort?.wireValue,
+      );
+    }
     final command = event.command;
     if (command == null) return;
     final visible = event.displayText;

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -209,13 +209,14 @@ final class ClaudePlugin({
       if (_createdSessions.containsKey(sessionId)) return const [];
       throw const PluginOperationException.notFound("getSessionMessages", message: "session not found");
     }
+    final catalog = await _catalogForHistory();
     try {
       return _history.map(
         sessionId: sessionId,
         agentId: ClaudeSubagentSessionId.agentIdOf(sessionId),
         records: await _transcripts.readTranscriptRecordsInIsolate(sessionId: sessionId),
         residentTaskToolUseIds: _eventDispatcher.residentTaskToolUseIds(sessionId: sessionId),
-        catalogModelId: _catalogService.cached?.catalogModelId,
+        catalogModelId: catalog?.catalogModelId,
       );
     } on Object catch (error) {
       throw PluginOperationException(
@@ -223,6 +224,17 @@ final class ClaudePlugin({
         message: "Claude history read failed",
         cause: error,
       );
+    }
+  }
+
+  /// The catalog that maps a transcript's API model names to picker ids. A
+  /// failed probe must not withhold history, so it degrades to raw names.
+  Future<ClaudeBackendCatalog?> _catalogForHistory() async {
+    try {
+      return await _catalogService.getCatalog(refresh: false);
+    } on Object catch (error, stack) {
+      Log.w("[claude] history keeps API model names: catalog unavailable", error, stack);
+      return null;
     }
   }
 

--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_backend_catalog_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_backend_catalog_repository.dart
@@ -8,7 +8,24 @@ final class const ClaudeBackendCatalog({
   required final List<PluginAgent> agents,
   required final PluginProvidersResult providers,
   required final List<PluginCommand> commands,
-});
+
+  /// Picker id per catalog `resolvedModel` (`claude-opus-5[1m]` → `opus[1m]`).
+  required final Map<String, String> modelIdsByResolvedModel,
+}) {
+  /// The picker id behind an API model name, or null when the catalog has no
+  /// such model. The stream reports `claude-opus-5` for both `opus` and
+  /// `opus[1m]`, so a bare match takes the first entry sharing the name.
+  String? catalogModelId({required String apiModel}) {
+    if (modelIdsByResolvedModel[apiModel] case final id?) return id;
+    final bare = _bareModel(apiModel);
+    for (final entry in modelIdsByResolvedModel.entries) {
+      if (_bareModel(entry.key) == bare) return entry.value;
+    }
+    return null;
+  }
+
+  static String _bareModel(String model) => model.replaceFirst(RegExp(r"\[[^\]]*\]$"), "");
+}
 
 /// Maps Claude's backend catalog into the backend-neutral plugin contract.
 final class const ClaudeBackendCatalogRepository() {
@@ -65,6 +82,11 @@ final class const ClaudeBackendCatalogRepository() {
       commands: List.unmodifiable([
         for (final command in dto.commands) ?_command(command),
       ]),
+      modelIdsByResolvedModel: Map.unmodifiable({
+        for (final model in dto.models)
+          if (_model(model) case final mapped? when model.resolvedModel?.trim().isNotEmpty ?? false)
+            model.resolvedModel!.trim(): mapped.id,
+      }),
     );
   }
 

--- a/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_claude/lib/src/runtime/claude_plugin_descriptor.dart
@@ -215,22 +215,24 @@ final class const ClaudePluginDescriptor({
       idleTimeoutChanges: host.pluginIdleTimeoutChanges,
     );
     const content = ClaudeContentMapper();
+    final catalogService = ClaudeCatalogService(
+      catalog: const ClaudeBackendCatalogRepository(),
+      processes: processes,
+      probeSessionId: _generateUuidV4(),
+      discoveryDirectory: host.stateDirectory,
+    );
     final plugin = ClaudePlugin(
       processes: processes,
       transcripts: ClaudeTranscriptCatalogRepository(
         transcriptApi: ClaudeTranscriptApi(environment: host.environment),
       ),
       sessions: sessions,
-      catalogService: ClaudeCatalogService(
-        catalog: const ClaudeBackendCatalogRepository(),
-        processes: processes,
-        probeSessionId: _generateUuidV4(),
-        discoveryDirectory: host.stateDirectory,
-      ),
+      catalogService: catalogService,
       approvals: approvals,
       eventDispatcher: ClaudeEventDispatcher(
         content: content,
         tools: ClaudeToolTracker(),
+        catalogModelId: ({required apiModel}) => catalogService.cached?.catalogModelId(apiModel: apiModel),
       ),
       history: const ClaudeHistoryMapper(content: content),
       eventBuffer: eventBuffer,

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_catalog_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_catalog_service.dart
@@ -17,6 +17,9 @@ final class ClaudeCatalogService({
   ClaudeBackendCatalog? _catalog;
   _CatalogFetch? _fetch;
 
+  /// The last discovered catalog, or null before the first probe completes.
+  ClaudeBackendCatalog? get cached => _catalog;
+
   Future<ClaudeBackendCatalog> getCatalog({required bool refresh}) {
     final cached = _catalog;
     if (!refresh && cached != null) {

--- a/bridge/sesori_plugin_claude/test/claude_backend_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_backend_catalog_repository_test.dart
@@ -65,6 +65,25 @@ void main() {
       );
     });
 
+    test("maps API model names back to picker ids, exactly or by bare name", () {
+      final catalog = repository.map(
+        handshake: {
+          "models": [
+            {"value": "default", "resolvedModel": "claude-opus-5[1m]"},
+            {"value": "opus[1m]", "resolvedModel": "claude-opus-5[1m]"},
+            {"value": "fable", "resolvedModel": "claude-fable-5-1"},
+            {"value": "haiku"},
+          ],
+        },
+      );
+
+      expect(catalog.catalogModelId(apiModel: "claude-fable-5-1"), "fable");
+      expect(catalog.catalogModelId(apiModel: "claude-opus-5[1m]"), "opus[1m]");
+      expect(catalog.catalogModelId(apiModel: "claude-opus-5"), "opus[1m]");
+      expect(catalog.catalogModelId(apiModel: "claude-haiku-5"), isNull);
+      expect(catalog.catalogModelId(apiModel: "opus[1m]"), isNull);
+    });
+
     test("filters malformed entries and falls back to the first model", () {
       final catalog = repository.map(
         handshake: {

--- a/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
@@ -8,7 +8,51 @@ void main() {
     late ClaudeEventDispatcher mapper;
 
     setUp(() {
-      mapper = ClaudeEventDispatcher(content: const ClaudeContentMapper(), tools: ClaudeToolTracker());
+      mapper = ClaudeEventDispatcher(
+        content: const ClaudeContentMapper(),
+        tools: ClaudeToolTracker(),
+        catalogModelId: ({required apiModel}) => null,
+      );
+    });
+
+    test("stamps messages with the turn's picker id and effort, mapping the stream model otherwise", () {
+      mapper = ClaudeEventDispatcher(
+        content: const ClaudeContentMapper(),
+        tools: ClaudeToolTracker(),
+        catalogModelId: ({required apiModel}) => apiModel == "claude-opus-5" ? "opus[1m]" : null,
+      );
+      Map<String, Object?> assistantAfterText({required String messageId}) {
+        _map(
+          mapper,
+          _stream(
+            "message_start",
+            event: {
+              "message": {"id": messageId, "model": "claude-opus-5"},
+            },
+          ),
+        );
+        final textStart = _map(
+          mapper,
+          _stream(
+            "content_block_start",
+            event: {
+              "index": 0,
+              "content_block": {"type": "text", "text": ""},
+            },
+          ),
+        );
+        return (textStart.first as BridgeSseMessageUpdated).info;
+      }
+
+      mapper.beginTurn(sessionId: "session-1", directory: "/tmp/project", model: "fable", variant: "high");
+      final selected = assistantAfterText(messageId: "msg-1");
+      expect(selected["modelID"], "fable");
+      expect(selected["variant"], "high");
+
+      mapper.beginTurn(sessionId: "session-1", directory: "/tmp/project", model: null, variant: null);
+      final mapped = assistantAfterText(messageId: "msg-2");
+      expect(mapped["modelID"], "opus[1m]");
+      expect(mapped["variant"], isNull);
     });
 
     test("creates an assistant when its first visible block starts", () {
@@ -143,7 +187,7 @@ void main() {
       expect(complete.whereType<BridgeSseMessagePartUpdated>(), isEmpty);
       expect(stopped.whereType<BridgeSseMessagePartUpdated>().single.part.text, "answer");
 
-      mapper.beginTurn(sessionId: "session-1", directory: "/tmp/project");
+      mapper.beginTurn(sessionId: "session-1", directory: "/tmp/project", model: null, variant: null);
       final replayed = _map(
         mapper,
         _assistant(
@@ -748,6 +792,7 @@ void main() {
               ),
             ],
             residentTaskToolUseIds: const {},
+            catalogModelId: null,
           )
           .single;
 
@@ -767,7 +812,7 @@ void main() {
           ],
         ),
       );
-      mapper.beginTurn(sessionId: "session-1", directory: "/tmp/project");
+      mapper.beginTurn(sessionId: "session-1", directory: "/tmp/project", model: null, variant: null);
       final staleDelta = _map(
         mapper,
         _stream(

--- a/bridge/sesori_plugin_claude/test/claude_history_mapper_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_history_mapper_test.dart
@@ -98,12 +98,22 @@ void main() {
         ],
       );
 
+      final records = await transcripts.readTranscriptRecordsInIsolate(sessionId: _sessionId);
       final messages = mapper.map(
         sessionId: _sessionId,
         agentId: null,
-        records: await transcripts.readTranscriptRecordsInIsolate(sessionId: _sessionId),
+        records: records,
         residentTaskToolUseIds: const {},
+        catalogModelId: null,
       );
+      final catalogMapped = mapper.map(
+        sessionId: _sessionId,
+        agentId: null,
+        records: records,
+        residentTaskToolUseIds: const {},
+        catalogModelId: ({required apiModel}) => apiModel == "claude-test-model" ? "test" : null,
+      );
+      expect((catalogMapped[1].info as PluginMessageAssistant).modelID, "test");
 
       expect(messages, hasLength(2));
       final user = messages[0];
@@ -181,6 +191,7 @@ IMPORTANT: Do NOT create new worktrees.
         agentId: null,
         records: await transcripts.readTranscriptRecordsInIsolate(sessionId: _sessionId),
         residentTaskToolUseIds: const {},
+        catalogModelId: null,
       );
 
       expect(messages.map((message) => message.parts.single.text), ["visible prompt", "/review visible args"]);
@@ -206,6 +217,7 @@ IMPORTANT: Do NOT create new worktrees.
         agentId: null,
         records: await transcripts.readTranscriptRecordsInIsolate(sessionId: _sessionId),
         residentTaskToolUseIds: const {},
+        catalogModelId: null,
       );
 
       expect((messages.single.info as PluginMessageAssistant).variant, isNull);
@@ -247,6 +259,7 @@ IMPORTANT: Do NOT create new worktrees.
           agentId: null,
           records: await transcripts.readTranscriptRecordsInIsolate(sessionId: _sessionId),
           residentTaskToolUseIds: const {},
+          catalogModelId: null,
         ),
         isEmpty,
       );
@@ -277,6 +290,7 @@ IMPORTANT: Do NOT create new worktrees.
           agentId: null,
           records: await transcripts.readTranscriptRecordsInIsolate(sessionId: _sessionId),
           residentTaskToolUseIds: const {},
+          catalogModelId: null,
         ),
         isEmpty,
       );
@@ -323,6 +337,7 @@ IMPORTANT: Do NOT create new worktrees.
         agentId: null,
         records: await transcripts.readTranscriptRecordsInIsolate(sessionId: _sessionId),
         residentTaskToolUseIds: const {},
+        catalogModelId: null,
       );
 
       expect(messages, hasLength(2));
@@ -356,6 +371,7 @@ IMPORTANT: Do NOT create new worktrees.
         agentId: null,
         records: await transcripts.readTranscriptRecordsInIsolate(sessionId: _sessionId),
         residentTaskToolUseIds: const {},
+        catalogModelId: null,
       );
 
       final error = messages.single.info as PluginMessageError;
@@ -407,6 +423,7 @@ IMPORTANT: Do NOT create new worktrees.
         agentId: null,
         records: await transcripts.readTranscriptRecordsInIsolate(sessionId: _sessionId),
         residentTaskToolUseIds: const {},
+        catalogModelId: null,
       );
 
       final part = messages.single.parts.single as PluginMessagePartSubtask;

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -924,7 +924,11 @@ final class _PluginHarness({final bool failInitialize = false, bool failTranscri
         discoveryDirectory: temporary.path,
       ),
       approvals: approvals,
-      eventDispatcher: ClaudeEventDispatcher(content: content, tools: ClaudeToolTracker()),
+      eventDispatcher: ClaudeEventDispatcher(
+        content: content,
+        tools: ClaudeToolTracker(),
+        catalogModelId: ({required apiModel}) => null,
+      ),
       history: const ClaudeHistoryMapper(content: content),
       eventBuffer: eventBuffer,
       clock: const _NeverIdleClock(),

--- a/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_session_service_test.dart
@@ -942,6 +942,7 @@ final class _ControlledClock() extends ServerClock {
     }
     _delays.clear();
   }
+
   void elapseAt({required int index}) {
     final delay = _delays[index];
     if (!delay.isCompleted) delay.complete();

--- a/bridge/sesori_plugin_claude/test/claude_subagent_child_sessions_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_subagent_child_sessions_test.dart
@@ -93,6 +93,7 @@ void main() {
         agentId: _agentId,
         records: records,
         residentTaskToolUseIds: const {},
+        catalogModelId: null,
       );
 
       expect(messages.map((message) => message.info.runtimeType.toString()), [
@@ -109,8 +110,12 @@ void main() {
     late ClaudeEventDispatcher dispatcher;
 
     setUp(() {
-      dispatcher = ClaudeEventDispatcher(content: const ClaudeContentMapper(), tools: ClaudeToolTracker());
-      dispatcher.beginTurn(sessionId: _root, directory: "/workspace");
+      dispatcher = ClaudeEventDispatcher(
+        content: const ClaudeContentMapper(),
+        tools: ClaudeToolTracker(),
+        catalogModelId: ({required apiModel}) => null,
+      );
+      dispatcher.beginTurn(sessionId: _root, directory: "/workspace", model: null, variant: null);
     });
 
     test("announces the child once and follows repeated running and terminal transitions", () {

--- a/bridge/sesori_plugin_claude/test/claude_subtask_lifecycle_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_subtask_lifecycle_test.dart
@@ -230,7 +230,13 @@ void main() {
   group("ClaudeEventDispatcher subtasks", () {
     late ClaudeEventDispatcher dispatcher;
 
-    setUp(() => dispatcher = ClaudeEventDispatcher(content: const ClaudeContentMapper(), tools: ClaudeToolTracker()));
+    setUp(
+      () => dispatcher = ClaudeEventDispatcher(
+        content: const ClaudeContentMapper(),
+        tools: ClaudeToolTracker(),
+        catalogModelId: ({required apiModel}) => null,
+      ),
+    );
 
     test("emits one subtask part through launch, turn end, and notification", () {
       final launch = _map(dispatcher, _agentAssistantFrame());
@@ -314,6 +320,7 @@ void main() {
           _notificationRecord(text: _notificationText),
         ],
         residentTaskToolUseIds: const {},
+        catalogModelId: null,
       );
 
       expect(messages, hasLength(1));
@@ -331,12 +338,14 @@ void main() {
         agentId: null,
         records: [_agentRecord(), _launchResultRecord()],
         residentTaskToolUseIds: const {},
+        catalogModelId: null,
       );
       final live = mapper.map(
         sessionId: _session,
         agentId: null,
         records: [_agentRecord(), _launchResultRecord()],
         residentTaskToolUseIds: const {_toolUseId},
+        catalogModelId: null,
       );
 
       expect((dead.single.parts.single as PluginMessagePartSubtask).taskState?.status, PluginToolStatus.cancelled);
@@ -353,6 +362,7 @@ void main() {
           _notificationRecord(text: _notificationText),
         ],
         residentTaskToolUseIds: const {_toolUseId},
+        catalogModelId: null,
       );
 
       final part = messages.single.parts.single as PluginMessagePartSubtask;
@@ -376,6 +386,7 @@ void main() {
           _notificationRecord(text: "<task-notification>malformed"),
         ],
         residentTaskToolUseIds: const {},
+        catalogModelId: null,
       );
 
       expect(messages, hasLength(1));

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -16,6 +16,11 @@ variant, and worktree mode, and creating the session with its first input.
 - Claude's catalog drops the CLI's own `default` model entry and names the
   selection instead: Opus is the default model and `high` the default effort, so
   every picker entry states what will actually run.
+- Claude stamps assistant and error messages with the picker id and effort the
+  turn ran with (`fable` / `high`), never the API name the stream reports
+  (`claude-fable-5-1`), so a reopened session keeps its model and variants
+  selected. Replayed transcripts map the API name through the catalog's
+  `resolvedModel`; a name the catalog does not know stays as recorded.
 - No picker offers an unnamed "Default" option. Plugins declare effort variants
   default-first, and a model that offers variants always has one selected: the
   agent's declared variant when valid, otherwise the first available. Selecting a


### PR DESCRIPTION
## Complexity
⚙️ Moderate: one catalog lookup, a turn-selection record in the dispatcher, and a resolver threaded into history replay. Claude plugin only.

## What
- `ClaudeBackendCatalog` keeps a `resolvedModel` → picker id map from the handshake and exposes `catalogModelId`, matching exactly first and then by bare name (the stream reports `claude-opus-5` for both `opus` and `opus[1m]`).
- `ClaudeEventDispatcher.beginTurn` now takes the turn's picker model id and effort. Assistant and error messages are stamped with those; when the turn declared none (CLI default), the stream model is mapped through the catalog, and an unknown name stays as reported.
- `ClaudeHistoryMapper.map` takes an optional resolver; replayed assistant and error messages map their API model name the same way. The effort already came from transcript records.
- Wiring: the descriptor hoists the catalog service so the dispatcher can consult its cached catalog; `getSessionMessages` loads the catalog (cached after the first probe) and passes its lookup, degrading to raw names if the probe fails.

## Why
The bridge derives a session's prompt defaults from the latest assistant message, and Claude stamped those with the raw API name (`claude-fable-5-1`) and `variant: null`. The client retains a transcript model it cannot match rather than validating it away, so a reopened session showed the raw name and no variants even though the user had picked Fable / high.

## Risk and test focus
- No wire or database change. Other plugins untouched.
- History replay awaits the catalog probe (cached after the first) so names map after a bridge restart too; a failed probe is logged and names stay raw rather than withholding history.
- Focus: reopen a Claude session started from Sesori (should show `Fable` and `high`), and open a session created in the terminal with no Sesori selection (should map to the catalog id via `resolvedModel`).

## Expected result
A reopened Claude session shows its picker model (Fable / Opus (1M context) / …) and effort selected, not `claude-fable-5-1` with an empty variant list.

## Verification
- `dart analyze` clean and all 300 `sesori_plugin_claude` tests pass, including new coverage for the catalog lookup, dispatcher stamping and fallback mapping, and history mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
