### PR TITLE
⚙️ [periodic-cleanup] client: preserve live transcript during refresh [step 3/25]

### DIFF
--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -10,7 +10,7 @@ asked to start working the plan; steps execute in order from step 2.
 | --- | --- | --- | --- |
 | 1/25 | 🌱 [periodic-cleanup] docs: consolidate the repository cleanup plan [step 1/25] | Merged | [#1295](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1295) |
 | 2/25 | ⚙️ [periodic-cleanup] client: preserve streamed text across refresh [step 2/25] | In review | [#1299](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1299) |
-| 3/25 | ⚙️ [periodic-cleanup] client: preserve live transcript during refresh [step 3/25] | Proposed | — |
+| 3/25 | ⚙️ [periodic-cleanup] client: preserve live transcript during refresh [step 3/25] | In progress (local, awaiting step 2 merge) | — |
 | 4/25 | ⚙️ [periodic-cleanup] bridge: remove unused session paths and tracker state [step 4/25] | Proposed | — |
 | 5/25 | 🚧 [periodic-cleanup] bridge: remove unused options cache metadata [step 5/25] | Proposed | — |
 | 6/25 | ⚙️ [periodic-cleanup] plugins: keep session status events typed [step 6/25] | Proposed | — |

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -9,8 +9,8 @@ asked to start working the plan; steps execute in order from step 2.
 | Step | Exact PR title | Status | PR |
 | --- | --- | --- | --- |
 | 1/25 | 🌱 [periodic-cleanup] docs: consolidate the repository cleanup plan [step 1/25] | Merged | [#1295](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1295) |
-| 2/25 | ⚙️ [periodic-cleanup] client: preserve streamed text across refresh [step 2/25] | In review | [#1299](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1299) |
-| 3/25 | ⚙️ [periodic-cleanup] client: preserve live transcript during refresh [step 3/25] | In progress (local, awaiting step 2 merge) | — |
+| 2/25 | ⚙️ [periodic-cleanup] client: preserve streamed text across refresh [step 2/25] | Merged | [#1299](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1299) |
+| 3/25 | ⚙️ [periodic-cleanup] client: preserve live transcript during refresh [step 3/25] | In review | [#1303](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1303) |
 | 4/25 | ⚙️ [periodic-cleanup] bridge: remove unused session paths and tracker state [step 4/25] | Proposed | — |
 | 5/25 | 🚧 [periodic-cleanup] bridge: remove unused options cache metadata [step 5/25] | Proposed | — |
 | 6/25 | ⚙️ [periodic-cleanup] plugins: keep session status events typed [step 6/25] | Proposed | — |

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -29,6 +29,7 @@ import "../../services/project_viewing_service.dart";
 import "../../services/session_detail_load_service.dart";
 import "../../services/session_selection_calculator.dart";
 import "../../services/session_viewing_service.dart";
+import "../../services/transcript_snapshot_calculator.dart";
 import "deferred_part_event_buffer.dart";
 import "prompt_send_queue.dart";
 import "queued_session_submission.dart";
@@ -84,6 +85,7 @@ class SessionDetailCubit(
   final Duration eventRefreshMinInterval = const Duration(seconds: 5),
 }) extends Cubit<SessionDetailState> {
   static const SessionSelectionCalculator _selection = SessionSelectionCalculator();
+  static const TranscriptSnapshotCalculator _transcript = TranscriptSnapshotCalculator();
 
   /// Shown when a catalog offers no agent at all, so the composer still names
   /// something. Backends that advertise agents always replace it.
@@ -297,7 +299,9 @@ class SessionDetailCubit(
     final current = state;
     if (current is! SessionDetailLoaded) return;
     final cursor = current.olderMessagesCursor;
-    if (cursor == null || current.isLoadingOlderMessages) return;
+    // A refresh replaces the newest page, so a page requested against the
+    // outgoing transcript could only splice unrelated history onto it.
+    if (cursor == null || current.isLoadingOlderMessages || current.isRefreshing) return;
 
     final generation = _transcriptGeneration;
     final deferredPartEventSequence = _deferredPartEvents.latestSequence;
@@ -516,10 +520,17 @@ class SessionDetailCubit(
     final connectionGeneration = _connectionGeneration;
     final optionsGeneration = _optionsGeneration;
     final deferredPartEventSequence = _deferredPartEvents.latestSequence;
+    // The transcript as the fetch sees it; live changes received while the
+    // fetch is in flight are reconciled against it when the page lands.
+    final before = current.messages;
 
+    // An older page still in flight describes the transcript this refresh is
+    // about to replace, so it must not join the refreshed one.
+    _transcriptGeneration++;
     emit(
       current.copyWith(
         isRefreshing: true,
+        isLoadingOlderMessages: false,
         queuedMessages: _promptQueue.items,
         awaitingBridgeSubmissions: _promptQueue.awaitingBridge,
         sendingSubmission: _promptQueue.active,
@@ -539,14 +550,12 @@ class SessionDetailCubit(
         case SessionDetailLoadResultLoaded(:final snapshot):
           _waitingForConnection = false;
           final derived = _deriveSnapshot(snapshot);
-          final latestAssistant = derived.latestAssistant;
-
-          _retireStreamingPartsCoveredBy(messages: snapshot.messages);
-
           final refreshedChildSessions = derived.children;
 
           final latest = state;
           if (latest is! SessionDetailLoaded) return _SessionRefreshResult.closed;
+          final messages = _transcript.reconcile(before: before, live: latest.messages, fetched: snapshot.messages);
+          _retireStreamingPartsCoveredBy(messages: messages);
           final preservedSelectedAgent = latest.selectedAgent;
           final preservedSelectedAgentModel = latest.selectedAgentModel;
           final preservedStagedCommand = latest.stagedCommand;
@@ -560,21 +569,21 @@ class SessionDetailCubit(
             providers: availableProviders,
             model: preservedSelectedAgentModel,
           );
+          // Assistant metadata describes the transcript actually installed,
+          // not the raw fetched page a live assistant may have outrun.
+          final assistant = _assistantMetadata(messages: messages, agents: availableAgents);
           _reconcileStagedWithSnapshot(snapshot: snapshot, parkEpochAtFetch: parkEpochAtFetch);
 
           final refreshedSessionStatus = snapshot.statuses[_sessionId] ?? const SessionStatus.idle();
           final queue = _queueView(bridgePrompts: snapshot.bridgeQueuedPrompts);
 
-          // The transcript is being replaced wholesale, so any older-page
-          // request still in flight no longer joins onto it.
           _deferredPartEvents.discardForMessagesThrough(
             messageIds: snapshot.messages.map((message) => message.info.id),
             sequence: deferredPartEventSequence,
           );
-          _transcriptGeneration++;
           emit(
             latest.copyWith(
-              messages: snapshot.messages,
+              messages: messages,
               // A refresh re-reads the newest page, so previously paged-back
               // history is dropped and the cursor returns to that page's edge.
               // Keeping older pages would leave a gap between them and the
@@ -586,8 +595,8 @@ class SessionDetailCubit(
               pendingQuestions: _mapPendingQuestions(snapshot.pendingQuestions),
               pendingPermissions: _mapPendingPermissions(snapshot.pendingPermissions),
               bridgeQueuedPrompts: snapshot.bridgeQueuedPrompts,
-              agent: latestAssistant?.agent,
-              assistantAgentModel: derived.assistantAgentModel,
+              agent: assistant.latestAssistant?.agent,
+              assistantAgentModel: assistant.assistantAgentModel,
               children: refreshedChildSessions,
               childStatuses: derived.childStatuses,
               isArchived: snapshot.isArchived,
@@ -1115,8 +1124,7 @@ class SessionDetailCubit(
       messages[index] = messages[index].copyWith(info: message);
     } else {
       final entry = MessageWithParts(info: message, parts: const []);
-      final insertionIndex = _messageInsertionIndex(messages: messages, message: message);
-      messages.insert(insertionIndex, entry);
+      messages.insert(_transcript.insertionIndex(messages: messages, message: message), entry);
     }
 
     if (isClosed) return;
@@ -1239,20 +1247,6 @@ class SessionDetailCubit(
         sendingSubmission: queue.sendingSubmission,
       ),
     );
-  }
-
-  int _messageInsertionIndex({required List<MessageWithParts> messages, required Message message}) {
-    final created = message.time?.created;
-    if (created == null) return messages.length;
-    for (var index = 0; index < messages.length; index++) {
-      final existing = messages[index].info;
-      final existingCreated = existing.time?.created;
-      if (existingCreated == null) continue;
-      if (existingCreated > created) {
-        return index;
-      }
-    }
-    return messages.length;
   }
 
   void _onMessageRemoved(String messageId) {
@@ -2356,11 +2350,21 @@ class SessionDetailCubit(
   }
 
   _SnapshotDerivation _deriveSnapshot(SessionDetailSnapshot snapshot) {
-    final latestAssistant = _latestAssistantOrErrorMessage(snapshot.messages);
     final children = [...snapshot.childSessions];
     _sortChildrenByUpdatedDesc(children);
     final childIds = children.map((child) => child.id).toSet();
-    final agents = _selection.selectableAgents(agents: snapshot.agents);
+    return (
+      children: children,
+      childStatuses: Map.fromEntries(snapshot.statuses.entries.where((entry) => childIds.contains(entry.key))),
+      agents: _selection.selectableAgents(agents: snapshot.agents),
+      providers: snapshot.providerData?.items ?? <ProviderInfo>[],
+    );
+  }
+
+  /// The latest agent-authored assistant/error message of [messages] and the
+  /// model it ran on, resolved against the [agents] catalog in effect.
+  _AssistantMetadata _assistantMetadata({required List<MessageWithParts> messages, required List<AgentInfo> agents}) {
+    final latestAssistant = _latestAssistantOrErrorMessage(messages);
     final assistantAgentModel = switch (latestAssistant) {
       MessageAssistant(sender: MessageSender.agent, :final modelID, :final providerID) ||
       MessageError(
@@ -2369,25 +2373,19 @@ class SessionDetailCubit(
       ) => _resolveAgentModel(agents: agents, providerID: providerID, modelID: modelID),
       MessageAssistant() || MessageUser() || null => null,
     };
-    return (
-      latestAssistant: latestAssistant,
-      assistantAgentModel: assistantAgentModel,
-      children: children,
-      childStatuses: Map.fromEntries(snapshot.statuses.entries.where((entry) => childIds.contains(entry.key))),
-      agents: agents,
-      providers: snapshot.providerData?.items ?? <ProviderInfo>[],
-    );
+    return (latestAssistant: latestAssistant, assistantAgentModel: assistantAgentModel);
   }
 
   SessionDetailLoaded _buildLoadedState({required SessionDetailSnapshot snapshot, required int parkEpochAtFetch}) {
     _reconcileStagedWithSnapshot(snapshot: snapshot, parkEpochAtFetch: parkEpochAtFetch);
     final derived = _deriveSnapshot(snapshot);
-    final latestAssistant = derived.latestAssistant;
     final childSessions = derived.children;
     final agents = derived.agents;
     final providers = derived.providers;
 
-    final assistantAgentModel = derived.assistantAgentModel;
+    final assistant = _assistantMetadata(messages: snapshot.messages, agents: agents);
+    final latestAssistant = assistant.latestAssistant;
+    final assistantAgentModel = assistant.assistantAgentModel;
     // The transcript's own model is retained rather than validated: a session
     // imported from a terminal must not silently resume on a different provider
     // because a retained provider cache does not list what it ran on.
@@ -2499,9 +2497,9 @@ typedef _QueueView = ({
   QueuedSessionSubmission? sendingSubmission,
 });
 
+typedef _AssistantMetadata = ({Message? latestAssistant, AgentModel? assistantAgentModel});
+
 typedef _SnapshotDerivation = ({
-  Message? latestAssistant,
-  AgentModel? assistantAgentModel,
   List<Session> children,
   Map<String, SessionStatus> childStatuses,
   List<AgentInfo> agents,

--- a/client/module_core/lib/src/services/transcript_snapshot_calculator.dart
+++ b/client/module_core/lib/src/services/transcript_snapshot_calculator.dart
@@ -1,0 +1,100 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+/// Merges a freshly fetched transcript page with the live changes a session
+/// received while that fetch was in flight.
+///
+/// A silent refresh used to install the fetched page wholesale, which dropped
+/// every message and part event that arrived between the request and its
+/// response. This is the one owner of the before/live/fetched merge policy:
+/// the fetched page is the base, live changes observed since the fetch began
+/// are overlaid, and removals observed live are honored. Matching is by
+/// message and part ID; "changed" is value inequality against the transcript
+/// as it was when the fetch started.
+///
+/// Pure and stateless: three immutable lists in, one immutable list out. It
+/// cannot see history that happened entirely inside the fetch window and
+/// left no trace in either list, and it does not try to.
+class const TranscriptSnapshotCalculator() {
+  /// Reconciles [fetched] with the live transcript.
+  ///
+  /// [before] is the transcript when the fetch started, [live] the transcript
+  /// when the fetch completed, [fetched] the page the fetch returned.
+  ///
+  /// - Fetched messages keep their supplied order. One removed live since
+  ///   [before] is omitted.
+  /// - A matching message takes its live envelope only when that envelope
+  ///   changed since [before]; otherwise the fetched envelope stands. Its
+  ///   fetched parts stay in fetched order, live changes and additions overlay
+  ///   them, and parts removed live since [before] are dropped.
+  /// - A live message the page does not contain is kept when it was added or
+  ///   changed since [before]; it joins at [insertionIndex]. One the page
+  ///   omits without any live change is gone: the page is authoritative for
+  ///   what it did not see change.
+  List<MessageWithParts> reconcile({
+    required List<MessageWithParts> before,
+    required List<MessageWithParts> live,
+    required List<MessageWithParts> fetched,
+  }) {
+    final beforeById = {for (final message in before) message.info.id: message};
+    final liveById = {for (final message in live) message.info.id: message};
+
+    final result = <MessageWithParts>[];
+    for (final fetchedMessage in fetched) {
+      final id = fetchedMessage.info.id;
+      final beforeMessage = beforeById[id];
+      final liveMessage = liveById[id];
+      if (liveMessage == null) {
+        if (beforeMessage == null) result.add(fetchedMessage);
+        continue;
+      }
+      result.add(_reconcileMessage(before: beforeMessage, live: liveMessage, fetched: fetchedMessage));
+    }
+
+    final fetchedIds = {for (final message in fetched) message.info.id};
+    for (final liveMessage in live) {
+      final id = liveMessage.info.id;
+      if (fetchedIds.contains(id) || liveMessage == beforeById[id]) continue;
+      result.insert(insertionIndex(messages: result, message: liveMessage.info), liveMessage);
+    }
+    return result;
+  }
+
+  /// Where a live message joins [messages]: before the first message created
+  /// after it, or at the end when either side has no creation time.
+  int insertionIndex({required List<MessageWithParts> messages, required Message message}) {
+    final created = message.time?.created;
+    if (created == null) return messages.length;
+    for (var index = 0; index < messages.length; index++) {
+      final existingCreated = messages[index].info.time?.created;
+      if (existingCreated != null && existingCreated > created) return index;
+    }
+    return messages.length;
+  }
+
+  MessageWithParts _reconcileMessage({
+    required MessageWithParts? before,
+    required MessageWithParts live,
+    required MessageWithParts fetched,
+  }) {
+    final info = live.info == before?.info ? fetched.info : live.info;
+    final beforeParts = {for (final part in before?.parts ?? const <MessagePart>[]) part.id: part};
+    final liveParts = {for (final part in live.parts) part.id: part};
+
+    final parts = <MessagePart>[];
+    for (final fetchedPart in fetched.parts) {
+      final beforePart = beforeParts[fetchedPart.id];
+      final livePart = liveParts[fetchedPart.id];
+      if (livePart == null) {
+        if (beforePart == null) parts.add(fetchedPart);
+        continue;
+      }
+      parts.add(livePart == beforePart ? fetchedPart : livePart);
+    }
+    final fetchedIds = {for (final part in fetched.parts) part.id};
+    for (final livePart in live.parts) {
+      if (fetchedIds.contains(livePart.id) || livePart == beforeParts[livePart.id]) continue;
+      parts.add(livePart);
+    }
+    return MessageWithParts(info: info, parts: parts);
+  }
+}

--- a/client/module_core/lib/src/services/transcript_snapshot_calculator.dart
+++ b/client/module_core/lib/src/services/transcript_snapshot_calculator.dart
@@ -59,8 +59,10 @@ class const TranscriptSnapshotCalculator() {
     return result;
   }
 
-  /// Where a live message joins [messages]: before the first message created
-  /// after it, or at the end when either side has no creation time.
+  /// Where a live message joins [messages]: before the first timestamped
+  /// message created after it. Existing messages without a creation time are
+  /// skipped, and a message without one is appended at the end. This is the
+  /// ordering live insertion has always used, moved here unchanged.
   int insertionIndex({required List<MessageWithParts> messages, required Message message}) {
     final created = message.time?.created;
     if (created == null) return messages.length;

--- a/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
@@ -1366,6 +1366,165 @@ void main() {
       ]);
     });
 
+    group("live changes during a silent refresh", () {
+      Future<
+        ({
+          SessionDetailCubit cubit,
+          MockSessionDetailLoadService loadService,
+          Completer<SessionDetailLoadResult> refresh,
+        })
+      >
+      startRefresh({required SessionDetailSnapshot initial}) async {
+        final mockLoadService = MockSessionDetailLoadService();
+        final refresh = Completer<SessionDetailLoadResult>();
+        when(
+          () => mockLoadService.load(
+            sessionId: _sessionId,
+            projectId: any(named: "projectId"),
+          ),
+        ).thenAnswer((_) async => SessionDetailLoadResult.loaded(snapshot: initial));
+        when(
+          () => mockLoadService.reload(
+            sessionId: _sessionId,
+            projectId: any(named: "projectId"),
+          ),
+        ).thenAnswer((_) => refresh.future);
+        final cubit = createCubit(loadService: mockLoadService);
+        await _awaitLoaded(cubit);
+        mockConnectionService.emitDataMayBeStale();
+        await untilCalled(
+          () => mockLoadService.reload(
+            sessionId: _sessionId,
+            projectId: any(named: "projectId"),
+          ),
+        );
+        return (cubit: cubit, loadService: mockLoadService, refresh: refresh);
+      }
+
+      Future<SessionDetailLoaded> completeRefresh({
+        required SessionDetailCubit cubit,
+        required Completer<SessionDetailLoadResult> refresh,
+        required SessionDetailSnapshot snapshot,
+      }) async {
+        refresh.complete(SessionDetailLoadResult.loaded(snapshot: snapshot));
+        await _awaitCondition(() => !(cubit.state as SessionDetailLoaded).isRefreshing);
+        return cubit.state as SessionDetailLoaded;
+      }
+
+      test("a part received during the reload survives the fetched replacement of its sibling", () async {
+        final (:cubit, :refresh, loadService: _) = await startRefresh(
+          initial: _snapshot(
+            messages: [
+              _assistantMessage(parts: [_StreamedPartKind.text.part(content: "stale")]),
+            ],
+          ),
+        );
+
+        const livePart = MessagePart.text(
+          id: "part-during-refresh",
+          sessionID: _sessionId,
+          messageID: _streamedMessageId,
+          text: "live",
+        );
+        sessionEvents.add(const SesoriMessagePartUpdated(part: livePart));
+        await Future<void>.delayed(Duration.zero);
+
+        final state = await completeRefresh(
+          cubit: cubit,
+          refresh: refresh,
+          snapshot: _snapshot(
+            messages: [
+              _assistantMessage(parts: [_StreamedPartKind.text.part(content: "fresh snapshot")]),
+            ],
+          ),
+        );
+
+        expect(state.messages.single.parts.whereType<MessagePartText>().map((part) => (part.id, part.text)), [
+          (_streamedPartId, "fresh snapshot"),
+          ("part-during-refresh", "live"),
+        ]);
+      });
+
+      test("an assistant added during the reload sets the agent and model of the installed transcript", () async {
+        final (:cubit, :refresh, loadService: _) = await startRefresh(initial: _snapshot(messages: const []));
+
+        sessionEvents.add(
+          const SesoriMessageUpdated(
+            info: Message.assistant(
+              id: "assistant-live",
+              sessionID: _sessionId,
+              agent: "coder",
+              modelID: "live-model",
+              providerID: "provider",
+              time: MessageTime(created: 200, completed: null),
+            ),
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        final state = await completeRefresh(
+          cubit: cubit,
+          refresh: refresh,
+          snapshot: _snapshot(messages: const []),
+        );
+
+        expect(state.messages.map((message) => message.info.id), ["assistant-live"]);
+        expect(state.agent, "coder");
+        expect(
+          state.assistantAgentModel,
+          const AgentModel(providerID: "provider", modelID: "live-model", variant: null),
+        );
+      });
+
+      test("an assistant whose model changed during the reload outranks the fetched page", () async {
+        Message assistant({required String modelID}) => Message.assistant(
+          id: _streamedMessageId,
+          sessionID: _sessionId,
+          agent: "build",
+          modelID: modelID,
+          providerID: "provider",
+          time: const MessageTime(created: 100, completed: null),
+        );
+        final stale = _snapshot(
+          messages: [
+            MessageWithParts(
+              info: assistant(modelID: "old"),
+              parts: const [],
+            ),
+          ],
+        );
+        final (:cubit, :refresh, loadService: _) = await startRefresh(initial: stale);
+
+        sessionEvents.add(SesoriMessageUpdated(info: assistant(modelID: "new")));
+        await Future<void>.delayed(Duration.zero);
+
+        final state = await completeRefresh(cubit: cubit, refresh: refresh, snapshot: stale);
+
+        expect((state.messages.single.info as MessageAssistant).modelID, "new");
+        expect(state.assistantAgentModel, const AgentModel(providerID: "provider", modelID: "new", variant: null));
+      });
+
+      test("loading older messages is a no-op while a refresh is in flight", () async {
+        final (:cubit, :refresh, :loadService) = await startRefresh(
+          initial: _snapshot(messages: const [], olderMessagesCursor: 50),
+        );
+
+        await cubit.loadOlderMessages();
+
+        verifyNever(
+          () => loadService.loadOlderMessages(
+            sessionId: _sessionId,
+            before: any(named: "before"),
+          ),
+        );
+        await completeRefresh(
+          cubit: cubit,
+          refresh: refresh,
+          snapshot: _snapshot(messages: const []),
+        );
+      });
+    });
+
     group("streamed text across a silent refresh", () {
       // History from several backends carries no completion time, so every
       // refreshed message below is an assistant message with `completed: null`
@@ -1994,26 +2153,27 @@ MessageWithParts _assistantMessage({required List<MessagePart> parts}) => Messag
   parts: parts,
 );
 
-SessionDetailSnapshot _snapshot({required List<MessageWithParts> messages}) => SessionDetailSnapshot(
-  areOptionsStale: false,
-  bridgeQueuedPrompts: const [],
-  projectId: "project-1",
-  pluginId: "opencode",
-  supportsPromptAttachments: false,
-  messages: messages,
-  olderMessagesCursor: null,
-  pendingQuestions: const <PendingQuestion>[],
-  pendingPermissions: const <PendingPermission>[],
-  childSessions: const <Session>[],
-  statuses: const <String, SessionStatus>{},
-  agents: const <AgentInfo>[],
-  providerData: null,
-  commands: const <CommandInfo>[],
-  canonicalSessionTitle: null,
-  promptDefaults: null,
-  isRootSession: true,
-  isArchived: false,
-);
+SessionDetailSnapshot _snapshot({required List<MessageWithParts> messages, int? olderMessagesCursor}) =>
+    SessionDetailSnapshot(
+      areOptionsStale: false,
+      bridgeQueuedPrompts: const [],
+      projectId: "project-1",
+      pluginId: "opencode",
+      supportsPromptAttachments: false,
+      messages: messages,
+      olderMessagesCursor: olderMessagesCursor,
+      pendingQuestions: const <PendingQuestion>[],
+      pendingPermissions: const <PendingPermission>[],
+      childSessions: const <Session>[],
+      statuses: const <String, SessionStatus>{},
+      agents: const <AgentInfo>[],
+      providerData: null,
+      commands: const <CommandInfo>[],
+      canonicalSessionTitle: null,
+      promptDefaults: null,
+      isRootSession: true,
+      isArchived: false,
+    );
 
 Future<void> _awaitStreamingText(SessionDetailCubit cubit, {required String partId, required String text}) async {
   await awaitState(

--- a/client/module_core/test/services/transcript_snapshot_calculator_test.dart
+++ b/client/module_core/test/services/transcript_snapshot_calculator_test.dart
@@ -1,0 +1,187 @@
+import "package:sesori_dart_core/src/services/transcript_snapshot_calculator.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+const _sessionId = "session-1";
+
+Message _user({required String id, required int? created}) => Message.user(
+  id: id,
+  sessionID: _sessionId,
+  agent: "build",
+  time: created == null ? null : MessageTime(created: created, completed: null),
+  promptId: null,
+);
+
+Message _assistant({required String id, required int created, required String modelID}) => Message.assistant(
+  id: id,
+  sessionID: _sessionId,
+  agent: "build",
+  modelID: modelID,
+  providerID: "provider",
+  time: MessageTime(created: created, completed: null),
+);
+
+MessagePart _text({required String messageId, required String id, required String text}) =>
+    MessagePart.text(id: id, sessionID: _sessionId, messageID: messageId, text: text);
+
+MessageWithParts _message(Message info, {List<MessagePart> parts = const []}) =>
+    MessageWithParts(info: info, parts: parts);
+
+void main() {
+  const calculator = TranscriptSnapshotCalculator();
+  final user1 = _user(id: "m1", created: 100);
+  final user2 = _user(id: "m2", created: 200);
+  final user3 = _user(id: "m3", created: 300);
+
+  group("TranscriptSnapshotCalculator.reconcile", () {
+    test("an unchanged transcript installs the fetched page as-is", () {
+      final before = [_message(user1), _message(user2)];
+      final fetched = [
+        _message(
+          user1,
+          parts: [_text(messageId: "m1", id: "p1", text: "fresh")],
+        ),
+        _message(user2),
+      ];
+      expect(calculator.reconcile(before: before, live: before, fetched: fetched), fetched);
+    });
+
+    test("keeps both the fetched replacement of a part and a part added live during the fetch", () {
+      final stale = _text(messageId: "m1", id: "p-before", text: "stale");
+      final live = _text(messageId: "m1", id: "p-during", text: "live");
+      final fresh = _text(messageId: "m1", id: "p-before", text: "fresh snapshot");
+
+      final result = calculator.reconcile(
+        before: [
+          _message(user1, parts: [stale]),
+        ],
+        live: [
+          _message(user1, parts: [stale, live]),
+        ],
+        fetched: [
+          _message(user1, parts: [fresh]),
+        ],
+      );
+
+      expect(result, [
+        _message(user1, parts: [fresh, live]),
+      ]);
+    });
+
+    test("a message removed live is omitted even when the page still contains it", () {
+      final result = calculator.reconcile(
+        before: [_message(user1), _message(user2)],
+        live: [_message(user2)],
+        fetched: [_message(user1), _message(user2)],
+      );
+      expect(result, [_message(user2)]);
+    });
+
+    test("a message added live joins the page at its creation time", () {
+      final result = calculator.reconcile(
+        before: [_message(user1), _message(user3)],
+        live: [_message(user1), _message(user2), _message(user3)],
+        fetched: [_message(user1), _message(user3)],
+      );
+      expect(result, [_message(user1), _message(user2), _message(user3)]);
+    });
+
+    test("a message changed live is retained when the page omits it", () {
+      final changed = _message(_assistant(id: "a1", created: 150, modelID: "new"));
+      final result = calculator.reconcile(
+        before: [
+          _message(user1),
+          _message(_assistant(id: "a1", created: 150, modelID: "old")),
+        ],
+        live: [_message(user1), changed],
+        fetched: [_message(user1)],
+      );
+      expect(result, [_message(user1), changed]);
+    });
+
+    test("a message the page omits without any live change is gone", () {
+      final result = calculator.reconcile(
+        before: [_message(user1), _message(user2)],
+        live: [_message(user1), _message(user2)],
+        fetched: [_message(user2)],
+      );
+      expect(result, [_message(user2)]);
+    });
+
+    test("a changed live envelope keeps the fetched part list", () {
+      final beforeEnvelope = _assistant(id: "a1", created: 150, modelID: "old");
+      final liveEnvelope = _assistant(id: "a1", created: 150, modelID: "new");
+      final fetchedPart = _text(messageId: "a1", id: "p1", text: "answer");
+      final result = calculator.reconcile(
+        before: [_message(beforeEnvelope)],
+        live: [_message(liveEnvelope)],
+        fetched: [
+          _message(beforeEnvelope, parts: [fetchedPart]),
+        ],
+      );
+      expect(result, [
+        _message(liveEnvelope, parts: [fetchedPart]),
+      ]);
+    });
+
+    test("parts overlay independently: fetched-only kept, live change wins, live removal drops", () {
+      final kept = _text(messageId: "m1", id: "kept", text: "kept");
+      final changedBefore = _text(messageId: "m1", id: "changed", text: "old");
+      final changedLive = _text(messageId: "m1", id: "changed", text: "new");
+      final changedFetched = _text(messageId: "m1", id: "changed", text: "fetched");
+      final removed = _text(messageId: "m1", id: "removed", text: "removed");
+      final fetchedOnly = _text(messageId: "m1", id: "fetched-only", text: "fetched only");
+
+      final result = calculator.reconcile(
+        before: [
+          _message(user1, parts: [kept, changedBefore, removed]),
+        ],
+        live: [
+          _message(user1, parts: [kept, changedLive]),
+        ],
+        fetched: [
+          _message(user1, parts: [kept, changedFetched, removed, fetchedOnly]),
+        ],
+      );
+
+      expect(result, [
+        _message(user1, parts: [kept, changedLive, fetchedOnly]),
+      ]);
+    });
+
+    test("a part unchanged live but absent from the page is dropped", () {
+      final stale = _text(messageId: "m1", id: "stale", text: "stale");
+      final result = calculator.reconcile(
+        before: [
+          _message(user1, parts: [stale]),
+        ],
+        live: [
+          _message(user1, parts: [stale]),
+        ],
+        fetched: [_message(user1)],
+      );
+      expect(result, [_message(user1)]);
+    });
+  });
+
+  group("TranscriptSnapshotCalculator.insertionIndex", () {
+    test("inserts before the first later message and appends without a creation time", () {
+      final messages = [_message(user1), _message(user3)];
+      expect(calculator.insertionIndex(messages: messages, message: user2), 1);
+      expect(
+        calculator.insertionIndex(
+          messages: messages,
+          message: _user(id: "m4", created: 400),
+        ),
+        2,
+      );
+      expect(
+        calculator.insertionIndex(
+          messages: messages,
+          message: _user(id: "m5", created: null),
+        ),
+        2,
+      );
+    });
+  });
+}

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -85,6 +85,13 @@ reconnect or restart.
   every backend, so this is decided by content, never by timestamps or status.
   After a backend event-stream gap, that plugin's stored transcripts stay marked
   incomplete until a full re-sync; later captures do not mark them complete.
+- A client refresh reconciles the fetched page with the message and part events
+  that arrived while the fetch was in flight instead of replacing the transcript
+  wholesale: messages and parts added or changed live survive, removals seen
+  live are honored, and a fetched replacement of an older part still lands. The
+  agent and model shown for the session come from that installed transcript. An
+  older-history page cannot start during a refresh, and one already in flight is
+  dropped rather than spliced onto the refreshed transcript.
 - Binary and attachment payloads are never stored inline in database tables; they
   round-trip through spill storage and still render. A slow or stuck request
   never blocks unrelated requests, other plugins, key exchange, or reconnects.
@@ -163,6 +170,9 @@ rules where supported.
 - A refresh during a streaming answer drops the text streamed before it, so the
   next delta renders alone, or shows a shorter fetched part over longer live
   text.
+- A message or part that arrived while a refresh was fetching disappears when
+  the refresh lands, or the session's agent/model label lags behind an assistant
+  message already on screen.
 - A page boundary duplicates, drops, or reorders messages, or history ends early.
 - An id-less ACP reply reuses a pre-restart fallback identity and overwrites an
   earlier answer instead of remaining distinct.


### PR DESCRIPTION
## Complexity

⚙️ moderate — a new stateless service-layer calculator plus refresh, paging, and assistant-metadata coordination changes in `SessionDetailCubit`, with unit and cubit tests.

## What

- Adds `TranscriptSnapshotCalculator` under `client/module_core/lib/src/services/`, following `SessionSelectionCalculator`. `reconcile(before:, live:, fetched:)` starts from the fetched page in its order, overlays live message/part additions and changes observed since the fetch began, honors live removals, and drops what the page omits without any live change. `insertionIndex` moves here from the cubit so live insertion and reconciliation share one ordering policy.
- `_doSilentRefresh` captures the transcript at fetch start, advances `_transcriptGeneration` and clears `isLoadingOlderMessages` in the start emission, reconciles at completion, retires streaming buffers against the installed list, and derives the session's agent and model from that installed list using the effective agents catalog (options supersession rules unchanged).
- `loadOlderMessages` is a no-op while a refresh is in flight.
- Promotes the audit diagnostic "a part received during the reload survives the fetched replacement of its sibling" and adds cubit cases for a live assistant added during the fetch, a live model change the page predates, and the paging guard. Calculator unit tests cover unchanged, added, changed, and removed messages and parts, snapshot-only omissions, envelope-versus-part independence, and insertion ordering.
- Updates `docs/regression/session-history-and-recovery.md` and the plan tracker.

## Why

Step 3/25 of `.plan/active/periodic-cleanup`. The audit reproduced a refresh dropping a part that arrived while the fetch was in flight: the fetched page replaced the transcript wholesale. Reconciling observable changes fixes that without a versioned snapshot protocol.

## Risk and test focus

Moderate, client-only. Impacted: session detail transcript after resume/reconnect/stale refreshes for every backend, the agent/model label after refresh, and paging older history around a refresh. Most valuable checks: stream a turn on macOS desktop and a mobile platform, force a refresh mid-turn, and confirm no message or part disappears, none duplicates, the agent/model label matches the newest assistant message, and paging back after the refresh lands cleanly.

No database or wire-contract change.

## Expected result

- User-visible: messages and parts that arrive during a refresh stay on screen; a fetched replacement of an older part still lands; the agent/model label reflects the installed transcript; paging cannot start during a refresh.
- Database/persisted data: none.
- Internal: one new production class, one private helper split out of `_deriveSnapshot`, insertion ordering moved to the calculator.

## Verification

- `dart analyze` in `client/module_core`: no issues.
- `dart test` for the calculator suite and every `test/cubits/session_detail/` suite: 202 tests pass after rebasing onto the merged step 2.
- Architecture implementation review (sub-agent, commit vs its parent): approved, no findings.
- Not run: live client E2E; recorded for the step 25 matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves live transcript changes during a silent refresh so messages or parts that arrive while the fetch is in flight no longer disappear. Previously the fetched page replaced the transcript wholesale; now the fetched page is reconciled with the live transcript so additions, changes, and removals observed during the fetch survive.

**Behavior changes**
- A refresh now merges the fetched page with live changes, keeping messages and parts that arrived during the fetch.
- The agent and model label is derived from the reconciled transcript, not the raw fetched page.
- Loading older messages is blocked while a refresh is in flight, and in-flight older-page requests are dropped.

<sup>Written for commit 29c9b34245ae9292789bb0acc360eaa2ba47bcb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

