### PR TITLE
⚙️ [claude-inline-subtasks] deepseek: parse typed subagent protocol [step 3/5]

### DIFF
--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -607,8 +607,8 @@ packaging-only change.
 | Slice | Scope | State |
 |---|---|---|
 | 1/5 | Shared ACP live prerequisites | [PR #1298](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1298) merged at `59464ca14a` |
-| 2/5 | Verbatim protocol-v2 fixtures and integrity | Prepared on `claude-inline-subtasks-deepseek-fixtures` |
-| 3/5 | Typed protocol boundary and conformance | Pending slice 2 merge |
+| 2/5 | Verbatim protocol-v2 fixtures and integrity | [PR #1301](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1301) merged at `cde00fdf90` |
+| 3/5 | Typed protocol boundary and conformance | Prepared on `claude-inline-subtasks-deepseek-protocol` |
 | 4/5 | Live lifecycle, correlation, catalogs | Pending slice 3 merge |
 | 5/5 | Replay callback, history, remaining consumer docs | Pending slice 4 merge |
 
@@ -642,3 +642,11 @@ three manifest SHA-256 values were independently checked. Protocol-v1 files and
 the runtime manifest are untouched; no v2 consumer or interrupt implementation
 lands here. The 1,596-line fixture/test slice retains the documented soft-cap
 exception for an indivisible verbatim bundle; tracker bookkeeping is additional.
+
+Slice 3 verification: source-generated serializers, DeepSeek analysis, and all
+50 tests passed, including consumed v1/v2 conformance, Unicode bounds, malformed
+optional fields, and additive metadata retention. The terminal-summary shape
+check lives in its DTO factory, consistent with replay metadata; semantic checks
+remain in the API. Architecture implementation review approved with no findings.
+Initialization remains v1-only until slice 4 installs the live consumer. No
+fixture bytes, runtime pins, interrupt consumer, or live/replay projection changed.

--- a/bridge/sesori_plugin_deepseek/lib/src/api/deepseek_acp_api.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/deepseek_acp_api.dart
@@ -8,7 +8,8 @@ class const DeepSeekAcpApi({required final String pluginId}) {
   static const String renameMethod = "deepseek/session/rename";
   static const String askUserQuestionMethod = "deepseek/ask_user_question";
   static const String sessionStatusMethod = "deepseek/session/status";
-  static const String initializeMetadataKey = "sesori.ai/deepseek";
+  static const String subagentMethod = "deepseek/subagent";
+  static const String initializeMetadataKey = deepSeekExtensionMetadataKey;
   static const int extensionProtocolVersion = 1;
 
   // ignore: no_slop_linter/prefer_specific_type, ACP JSON object values are heterogeneous
@@ -148,6 +149,46 @@ class const DeepSeekAcpApi({required final String pluginId}) {
     return status;
   }
 
+  // ignore: no_slop_linter/prefer_specific_type, ACP JSON object values are heterogeneous
+  DeepSeekSubagentNotificationDto parseSubagentNotification(Map<String, dynamic> json) {
+    final notification = DeepSeekSubagentNotificationDto.fromJson(json);
+    if (!_validSubagentText(notification.sessionId, maxScalars: 256) ||
+        !_validSubagentText(notification.childSessionId, maxScalars: 256)) {
+      throw const FormatException("Invalid DeepSeek sub-agent notification");
+    }
+    switch (notification) {
+      case DeepSeekSubagentStartedDto(:final toolCallId, :final prompt, :final label, :final mode):
+        if (!_validSubagentText(toolCallId, maxScalars: 256) ||
+            !_validSubagentText(label, maxScalars: 256) ||
+            !_validSubagentPrompt(prompt) ||
+            mode == DeepSeekSubagentMode.unknown) {
+          throw const FormatException("Invalid DeepSeek sub-agent notification");
+        }
+      case DeepSeekSubagentEndedDto(:final stopReason, :final summary):
+        if (stopReason == DeepSeekSubagentStopReason.unknown || !_validSubagentSummary(summary)) {
+          throw const FormatException("Invalid DeepSeek sub-agent notification");
+        }
+    }
+    return notification;
+  }
+
+  // ignore: no_slop_linter/prefer_specific_type, ACP JSON object values are heterogeneous
+  DeepSeekSubagentReplayDto parseSubagentReplay(Map<String, dynamic> json) {
+    final replay = DeepSeekSubagentReplayDto.fromJson(json);
+    _validateSubagentReplay(replay);
+    return replay;
+  }
+
+  void _validateSubagentReplay(DeepSeekSubagentReplayDto replay) {
+    if (!_validSubagentText(replay.label, maxScalars: 256) ||
+        !_validSubagentPrompt(replay.prompt) ||
+        replay.mode == DeepSeekSubagentMode.unknown ||
+        !_validOptionalSubagentText(replay.childSessionId, maxScalars: 256) ||
+        !_validSubagentReplayEnd(replay.ended)) {
+      throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
+    }
+  }
+
   // ignore: no_slop_linter/prefer_specific_type, ACP response and JSON object values are heterogeneous
   static Map<String, dynamic> _json(Object? raw, {required String method}) {
     if (raw is! Map) throw FormatException("$method returned a non-object result");
@@ -155,7 +196,7 @@ class const DeepSeekAcpApi({required final String pluginId}) {
     return raw.cast<String, dynamic>();
   }
 
-  static void _validateHistoryResponse(DeepSeekHistoryResponseDto response, {required String? sessionId}) {
+  void _validateHistoryResponse(DeepSeekHistoryResponseDto response, {required String? sessionId}) {
     if (response.updates.length > 10000 ||
         response.updates.any(
           (update) =>
@@ -166,6 +207,45 @@ class const DeepSeekAcpApi({required final String pluginId}) {
     if (response case DeepSeekPaginatedHistoryResponseDto(nextBeforeSeq: final cursor) when cursor < 1) {
       throw const FormatException("Invalid DeepSeek history response");
     }
+    for (final update in response.updates) {
+      final deepSeek = update.metadata?.deepSeek;
+      final createdAt = deepSeek?.messageCreatedAt;
+      if (createdAt != null && (createdAt < 0 || createdAt > 9007199254740991)) {
+        throw const FormatException("Invalid DeepSeek history response");
+      }
+      final subagent = deepSeek?.subagent;
+      if (subagent != null) _validateSubagentReplay(subagent);
+    }
+  }
+
+  static bool _validSubagentReplayEnd(DeepSeekSubagentReplayEndedDto? ended) =>
+      ended == null || ended.stopReason != DeepSeekSubagentStopReason.unknown && _validSubagentSummary(ended.summary);
+
+  static bool _validSubagentSummary(String? value) => _validOptionalSubagentText(value, maxScalars: 512);
+
+  static bool _validSubagentPrompt(String value) =>
+      value == value.trim() && _validSubagentText(value, maxScalars: 32768);
+
+  static bool _validOptionalSubagentText(String? value, {required int maxScalars}) =>
+      value == null || _validSubagentText(value, maxScalars: maxScalars);
+
+  static bool _validSubagentText(String value, {required int maxScalars}) {
+    if (value.isEmpty || !value.contains(RegExp(r"\S"))) return false;
+    var scalars = 0;
+    final units = value.codeUnits;
+    for (var index = 0; index < units.length; index++) {
+      final unit = units[index];
+      if (unit >= 0xD800 && unit <= 0xDBFF) {
+        if (index + 1 >= units.length) return false;
+        final next = units[++index];
+        if (next < 0xDC00 || next > 0xDFFF) return false;
+      } else if (unit >= 0xDC00 && unit <= 0xDFFF) {
+        return false;
+      }
+      scalars++;
+      if (scalars > maxScalars) return false;
+    }
+    return true;
   }
 
   static bool _optionalNonblank(String? value, {required int maxLength}) =>

--- a/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.dart
@@ -2,6 +2,8 @@ import "package:json_annotation/json_annotation.dart";
 
 part "deepseek_protocol_dto.g.dart";
 
+const String deepSeekExtensionMetadataKey = "sesori.ai/deepseek";
+
 // ignore: no_slop_linter/prefer_specific_type, json_serializable converter input is heterogeneous
 int _integer(Object? value) {
   if (value is! int) throw const FormatException("Expected integer");
@@ -10,6 +12,22 @@ int _integer(Object? value) {
 
 // ignore: no_slop_linter/prefer_specific_type, json_serializable converter input is heterogeneous
 int? _nullableInteger(Object? value) => value == null ? null : _integer(value);
+
+enum DeepSeekSubagentMode() {
+  foreground,
+  background,
+  unknown,
+}
+
+enum DeepSeekSubagentStopReason() {
+  completed,
+  aborted,
+  error,
+  @JsonValue("max-tokens")
+  maxTokens,
+  refusal,
+  unknown,
+}
 
 @JsonSerializable()
 class const DeepSeekInitializeMetadataDto({
@@ -139,16 +157,141 @@ class const DeepSeekTerminalHistoryResponseDto({
   Map<String, dynamic> toJson() => _$DeepSeekTerminalHistoryResponseDtoToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class const DeepSeekSessionUpdateEnvelopeDto({
-  // ignore: no_slop_linter/prefer_specific_type, protocol metadata values are heterogeneous
-  @JsonKey(name: "_meta") required final Map<String, dynamic>? metadata,
+  @JsonKey(name: "_meta") required final DeepSeekEnvelopeMetadataDto? metadata,
   required final String sessionId,
   // ignore: no_slop_linter/prefer_specific_type, standard ACP update values are heterogeneous
   required final Map<String, dynamic> update,
 }) {
   factory fromJson(Map<String, dynamic> json) => _$DeepSeekSessionUpdateEnvelopeDtoFromJson(json);
   Map<String, dynamic> toJson() => _$DeepSeekSessionUpdateEnvelopeDtoToJson(this);
+}
+
+/// Typed view of DeepSeek's member inside the open ACP `_meta` container while
+/// retaining every original entry for shared and forward-compatible replay.
+class const DeepSeekEnvelopeMetadataDto({
+  // ignore: no_slop_linter/prefer_specific_type, protocol metadata values are heterogeneous
+  required final Map<String, dynamic> raw,
+  required final DeepSeekEnvelopeDeepSeekMetadataDto? deepSeek,
+}) {
+  factory fromJson(Map<String, dynamic> json) {
+    if (!json.containsKey(deepSeekExtensionMetadataKey)) {
+      return DeepSeekEnvelopeMetadataDto(raw: Map.unmodifiable(json), deepSeek: null);
+    }
+    final value = json[deepSeekExtensionMetadataKey];
+    // ignore: no_slop_linter/prefer_specific_type, protocol metadata values are heterogeneous
+    if (value is! Map<String, dynamic>) {
+      throw const FormatException("Invalid DeepSeek history metadata");
+    }
+    return DeepSeekEnvelopeMetadataDto(
+      raw: Map.unmodifiable(json),
+      deepSeek: DeepSeekEnvelopeDeepSeekMetadataDto.fromJson(value),
+    );
+  }
+
+  Map<String, dynamic> toJson() => raw;
+}
+
+@JsonSerializable(explicitToJson: true)
+class const DeepSeekEnvelopeDeepSeekMetadataDto({
+  @JsonKey(fromJson: _nullableInteger, includeIfNull: false) required final int? messageCreatedAt,
+  @JsonKey(includeIfNull: false) required final DeepSeekSubagentReplayDto? subagent,
+}) {
+  factory fromJson(Map<String, dynamic> json) {
+    if (json.containsKey("messageCreatedAt") && json["messageCreatedAt"] is! int) {
+      throw const FormatException("Invalid DeepSeek history metadata");
+    }
+    final subagent = json["subagent"];
+    // ignore: no_slop_linter/prefer_specific_type, protocol metadata values are heterogeneous
+    if (json.containsKey("subagent") && subagent is! Map<String, dynamic>) {
+      throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
+    }
+    return _$DeepSeekEnvelopeDeepSeekMetadataDtoFromJson(json);
+  }
+  Map<String, dynamic> toJson() => _$DeepSeekEnvelopeDeepSeekMetadataDtoToJson(this);
+}
+
+sealed class const DeepSeekSubagentNotificationDto() {
+  factory fromJson(Map<String, dynamic> json) => switch (json["kind"]) {
+    "started" => DeepSeekSubagentStartedDto.fromJson(json),
+    "ended" => DeepSeekSubagentEndedDto.fromJson(json),
+    _ => throw const FormatException("Invalid DeepSeek sub-agent notification"),
+  };
+  String get sessionId;
+  String get childSessionId;
+  Map<String, dynamic> toJson();
+}
+
+@JsonSerializable()
+class const DeepSeekSubagentStartedDto({
+  @override required final String sessionId,
+  @override required final String childSessionId,
+  required final String toolCallId,
+  required final String prompt,
+  required final String label,
+  @JsonKey(unknownEnumValue: DeepSeekSubagentMode.unknown) required final DeepSeekSubagentMode mode,
+}) extends DeepSeekSubagentNotificationDto {
+  factory fromJson(Map<String, dynamic> json) => _$DeepSeekSubagentStartedDtoFromJson(json);
+  @JsonKey(includeFromJson: false, includeToJson: true)
+  String get kind => "started";
+  @override
+  Map<String, dynamic> toJson() => _$DeepSeekSubagentStartedDtoToJson(this);
+}
+
+@JsonSerializable()
+class const DeepSeekSubagentEndedDto({
+  @override required final String sessionId,
+  @override required final String childSessionId,
+  @JsonKey(unknownEnumValue: DeepSeekSubagentStopReason.unknown) required final DeepSeekSubagentStopReason stopReason,
+  @JsonKey(includeIfNull: false) required final String? summary,
+}) extends DeepSeekSubagentNotificationDto {
+  factory fromJson(Map<String, dynamic> json) {
+    if (json.containsKey("summary") && json["summary"] is! String) {
+      throw const FormatException("Invalid DeepSeek sub-agent notification");
+    }
+    return _$DeepSeekSubagentEndedDtoFromJson(json);
+  }
+  @JsonKey(includeFromJson: false, includeToJson: true)
+  String get kind => "ended";
+  @override
+  Map<String, dynamic> toJson() => _$DeepSeekSubagentEndedDtoToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class const DeepSeekSubagentReplayDto({
+  required final String prompt,
+  required final String label,
+  @JsonKey(unknownEnumValue: DeepSeekSubagentMode.unknown) required final DeepSeekSubagentMode mode,
+  @JsonKey(includeIfNull: false) required final String? childSessionId,
+  @JsonKey(includeIfNull: false) required final DeepSeekSubagentReplayEndedDto? ended,
+}) {
+  factory fromJson(Map<String, dynamic> json) {
+    if (json.containsKey("childSessionId") && json["childSessionId"] is! String) {
+      throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
+    }
+    final ended = json["ended"];
+    // ignore: no_slop_linter/prefer_specific_type, protocol metadata values are heterogeneous
+    if (json.containsKey("ended") && ended is! Map<String, dynamic>) {
+      throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
+    }
+    return _$DeepSeekSubagentReplayDtoFromJson(json);
+  }
+  Map<String, dynamic> toJson() => _$DeepSeekSubagentReplayDtoToJson(this);
+}
+
+@JsonSerializable()
+class const DeepSeekSubagentReplayEndedDto({
+  @JsonKey(unknownEnumValue: DeepSeekSubagentStopReason.unknown) required final DeepSeekSubagentStopReason stopReason,
+  @JsonKey(includeIfNull: false) required final String? summary,
+}) {
+  factory fromJson(Map<String, dynamic> json) {
+    if (json.containsKey("summary") && json["summary"] is! String) {
+      throw const FormatException("Invalid DeepSeek sub-agent replay metadata");
+    }
+    return _$DeepSeekSubagentReplayEndedDtoFromJson(json);
+  }
+  Map<String, dynamic> toJson() => _$DeepSeekSubagentReplayEndedDtoToJson(this);
 }
 
 @JsonSerializable()

--- a/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.g.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.g.dart
@@ -220,7 +220,11 @@ Map<String, dynamic> _$DeepSeekTerminalHistoryResponseDtoToJson(
 DeepSeekSessionUpdateEnvelopeDto _$DeepSeekSessionUpdateEnvelopeDtoFromJson(
   Map json,
 ) => DeepSeekSessionUpdateEnvelopeDto(
-  metadata: (json['_meta'] as Map?)?.map((k, e) => MapEntry(k as String, e)),
+  metadata: json['_meta'] == null
+      ? null
+      : DeepSeekEnvelopeMetadataDto.fromJson(
+          Map<String, dynamic>.from(json['_meta'] as Map),
+        ),
   sessionId: json['sessionId'] as String,
   update: Map<String, dynamic>.from(json['update'] as Map),
 );
@@ -228,9 +232,135 @@ DeepSeekSessionUpdateEnvelopeDto _$DeepSeekSessionUpdateEnvelopeDtoFromJson(
 Map<String, dynamic> _$DeepSeekSessionUpdateEnvelopeDtoToJson(
   DeepSeekSessionUpdateEnvelopeDto instance,
 ) => <String, dynamic>{
-  '_meta': ?instance.metadata,
+  '_meta': ?instance.metadata?.toJson(),
   'sessionId': instance.sessionId,
   'update': instance.update,
+};
+
+DeepSeekEnvelopeDeepSeekMetadataDto
+_$DeepSeekEnvelopeDeepSeekMetadataDtoFromJson(Map json) =>
+    DeepSeekEnvelopeDeepSeekMetadataDto(
+      messageCreatedAt: _nullableInteger(json['messageCreatedAt']),
+      subagent: json['subagent'] == null
+          ? null
+          : DeepSeekSubagentReplayDto.fromJson(
+              Map<String, dynamic>.from(json['subagent'] as Map),
+            ),
+    );
+
+Map<String, dynamic> _$DeepSeekEnvelopeDeepSeekMetadataDtoToJson(
+  DeepSeekEnvelopeDeepSeekMetadataDto instance,
+) => <String, dynamic>{
+  'messageCreatedAt': ?instance.messageCreatedAt,
+  'subagent': ?instance.subagent?.toJson(),
+};
+
+DeepSeekSubagentStartedDto _$DeepSeekSubagentStartedDtoFromJson(Map json) =>
+    DeepSeekSubagentStartedDto(
+      sessionId: json['sessionId'] as String,
+      childSessionId: json['childSessionId'] as String,
+      toolCallId: json['toolCallId'] as String,
+      prompt: json['prompt'] as String,
+      label: json['label'] as String,
+      mode: $enumDecode(
+        _$DeepSeekSubagentModeEnumMap,
+        json['mode'],
+        unknownValue: DeepSeekSubagentMode.unknown,
+      ),
+    );
+
+Map<String, dynamic> _$DeepSeekSubagentStartedDtoToJson(
+  DeepSeekSubagentStartedDto instance,
+) => <String, dynamic>{
+  'sessionId': instance.sessionId,
+  'childSessionId': instance.childSessionId,
+  'toolCallId': instance.toolCallId,
+  'prompt': instance.prompt,
+  'label': instance.label,
+  'mode': _$DeepSeekSubagentModeEnumMap[instance.mode]!,
+  'kind': instance.kind,
+};
+
+const _$DeepSeekSubagentModeEnumMap = {
+  DeepSeekSubagentMode.foreground: 'foreground',
+  DeepSeekSubagentMode.background: 'background',
+  DeepSeekSubagentMode.unknown: 'unknown',
+};
+
+DeepSeekSubagentEndedDto _$DeepSeekSubagentEndedDtoFromJson(Map json) =>
+    DeepSeekSubagentEndedDto(
+      sessionId: json['sessionId'] as String,
+      childSessionId: json['childSessionId'] as String,
+      stopReason: $enumDecode(
+        _$DeepSeekSubagentStopReasonEnumMap,
+        json['stopReason'],
+        unknownValue: DeepSeekSubagentStopReason.unknown,
+      ),
+      summary: json['summary'] as String?,
+    );
+
+Map<String, dynamic> _$DeepSeekSubagentEndedDtoToJson(
+  DeepSeekSubagentEndedDto instance,
+) => <String, dynamic>{
+  'sessionId': instance.sessionId,
+  'childSessionId': instance.childSessionId,
+  'stopReason': _$DeepSeekSubagentStopReasonEnumMap[instance.stopReason]!,
+  'summary': ?instance.summary,
+  'kind': instance.kind,
+};
+
+const _$DeepSeekSubagentStopReasonEnumMap = {
+  DeepSeekSubagentStopReason.completed: 'completed',
+  DeepSeekSubagentStopReason.aborted: 'aborted',
+  DeepSeekSubagentStopReason.error: 'error',
+  DeepSeekSubagentStopReason.maxTokens: 'max-tokens',
+  DeepSeekSubagentStopReason.refusal: 'refusal',
+  DeepSeekSubagentStopReason.unknown: 'unknown',
+};
+
+DeepSeekSubagentReplayDto _$DeepSeekSubagentReplayDtoFromJson(Map json) =>
+    DeepSeekSubagentReplayDto(
+      prompt: json['prompt'] as String,
+      label: json['label'] as String,
+      mode: $enumDecode(
+        _$DeepSeekSubagentModeEnumMap,
+        json['mode'],
+        unknownValue: DeepSeekSubagentMode.unknown,
+      ),
+      childSessionId: json['childSessionId'] as String?,
+      ended: json['ended'] == null
+          ? null
+          : DeepSeekSubagentReplayEndedDto.fromJson(
+              Map<String, dynamic>.from(json['ended'] as Map),
+            ),
+    );
+
+Map<String, dynamic> _$DeepSeekSubagentReplayDtoToJson(
+  DeepSeekSubagentReplayDto instance,
+) => <String, dynamic>{
+  'prompt': instance.prompt,
+  'label': instance.label,
+  'mode': _$DeepSeekSubagentModeEnumMap[instance.mode]!,
+  'childSessionId': ?instance.childSessionId,
+  'ended': ?instance.ended?.toJson(),
+};
+
+DeepSeekSubagentReplayEndedDto _$DeepSeekSubagentReplayEndedDtoFromJson(
+  Map json,
+) => DeepSeekSubagentReplayEndedDto(
+  stopReason: $enumDecode(
+    _$DeepSeekSubagentStopReasonEnumMap,
+    json['stopReason'],
+    unknownValue: DeepSeekSubagentStopReason.unknown,
+  ),
+  summary: json['summary'] as String?,
+);
+
+Map<String, dynamic> _$DeepSeekSubagentReplayEndedDtoToJson(
+  DeepSeekSubagentReplayEndedDto instance,
+) => <String, dynamic>{
+  'stopReason': _$DeepSeekSubagentStopReasonEnumMap[instance.stopReason]!,
+  'summary': ?instance.summary,
 };
 
 DeepSeekRenameRequestDto _$DeepSeekRenameRequestDtoFromJson(Map json) =>

--- a/bridge/sesori_plugin_deepseek/test/deepseek_protocol_conformance_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_protocol_conformance_test.dart
@@ -4,48 +4,50 @@ import "dart:io";
 import "package:deepseek_plugin/src/api/deepseek_acp_api.dart";
 import "package:deepseek_plugin/src/api/models/deepseek_protocol_dto.dart";
 import "package:deepseek_plugin/src/deepseek_identity.dart";
-import "package:deepseek_plugin/src/deepseek_message_time_parser.dart";
 import "package:test/test.dart";
 
 void main() {
   const api = DeepSeekAcpApi(pluginId: DeepSeekIdentity.id);
-  final fixtureDirectory = Directory("test/fixtures/protocol/v1");
-  test("all valid runtime fixtures decode and encode through generated DTOs", () async {
-    final corpus = jsonDecode(await File("${fixtureDirectory.path}/valid.json").readAsString()) as List;
-    final definitions = <String>{};
-    for (final fixture in corpus.cast<Map<String, dynamic>>()) {
-      final definition = fixture["definition"] as String;
-      final value = (fixture["value"] as Map).cast<String, dynamic>();
-      definitions.add(definition);
-      expect(_decodeValid(api, definition, value), isA<Map<String, dynamic>>(), reason: definition);
-    }
-    expect(definitions, {
-      "initializeMetadata",
-      "promptMetadata",
-      "catalogRequest",
-      "catalogResponse",
-      "historyRequest",
-      "historyResponse",
-      "renameRequest",
-      "renameResponse",
-      "askUserQuestionRequest",
-      "askUserQuestionResponse",
-      "sessionStatusNotification",
+
+  for (final protocolVersion in const [1, 2]) {
+    final fixtureDirectory = Directory("test/fixtures/protocol/v$protocolVersion");
+    test("protocol v$protocolVersion consumed valid fixtures decode and encode through typed DTOs", () async {
+      final corpus = jsonDecode(await File("${fixtureDirectory.path}/valid.json").readAsString()) as List;
+      final expectedDefinitions = _definitionsFor(protocolVersion: protocolVersion);
+      final definitions = <String>{};
+      for (final fixture in corpus.cast<Map<String, dynamic>>()) {
+        final definition = fixture["definition"] as String;
+        // The complete source corpus also pins contracts whose consumer lands in a later PR.
+        if (!expectedDefinitions.contains(definition)) continue;
+        final value = (fixture["value"] as Map).cast<String, dynamic>();
+        definitions.add(definition);
+        expect(
+          _decode(api: api, definition: definition, value: value),
+          isA<Map<String, dynamic>>(),
+          reason: definition,
+        );
+      }
+      expect(definitions, expectedDefinitions);
     });
-  });
-  test("all invalid runtime fixtures are rejected", () async {
-    final corpus = jsonDecode(await File("${fixtureDirectory.path}/invalid.json").readAsString()) as List;
-    for (final fixture in corpus.cast<Map<String, dynamic>>()) {
-      final value = (fixture["value"] as Map).cast<String, dynamic>();
-      expect(
-        () => _rejectInvalid(api, fixture["definition"] as String, value),
-        throwsA(anything),
-        reason: fixture["definition"] as String,
-      );
-    }
-  });
+
+    test("protocol v$protocolVersion consumed invalid fixtures are rejected", () async {
+      final corpus = jsonDecode(await File("${fixtureDirectory.path}/invalid.json").readAsString()) as List;
+      final expectedDefinitions = _definitionsFor(protocolVersion: protocolVersion);
+      for (final fixture in corpus.cast<Map<String, dynamic>>()) {
+        final definition = fixture["definition"] as String;
+        if (!expectedDefinitions.contains(definition)) continue;
+        final value = (fixture["value"] as Map).cast<String, dynamic>();
+        expect(
+          () => _decode(api: api, definition: definition, value: value),
+          throwsA(anything),
+          reason: definition,
+        );
+      }
+    });
+  }
+
   test("catalog rejects bounded collection and entry violations", () async {
-    final corpus = jsonDecode(await File("${fixtureDirectory.path}/valid.json").readAsString()) as List;
+    final corpus = jsonDecode(await File("test/fixtures/protocol/v2/valid.json").readAsString()) as List;
     Map<String, dynamic> fixture(String definition) =>
         (corpus.cast<Map<String, dynamic>>().firstWhere(
                   (fixture) => fixture["definition"] == definition,
@@ -94,54 +96,238 @@ void main() {
     (questions["questions"] as List).add((questions["questions"] as List).first);
     expect(() => api.parseQuestionRequest(questions), throwsFormatException);
   });
+
+  test("initialization stays on v1 until the live v2 consumer is installed", () {
+    Map<String, dynamic> metadata({required int version}) => {
+      "extensionProtocolVersion": version,
+      "adapterVersion": "0.1.3",
+      "harnessVersion": "0.1.1-rc.2",
+      "persistenceOwner": "sesori",
+    };
+
+    expect(api.parseInitializeMetadata(metadata(version: 1)).extensionProtocolVersion, 1);
+    expect(() => api.parseInitializeMetadata(metadata(version: 2)), throwsFormatException);
+    expect(() => api.parseInitializeMetadata(metadata(version: 3)), throwsFormatException);
+  });
+
+  test("history preserves additive metadata while parsing typed DeepSeek fields", () {
+    final metadata = {
+      "shared/future": {"retained": true},
+      DeepSeekAcpApi.initializeMetadataKey: {
+        "messageCreatedAt": 1,
+        "futureField": "retained",
+        "subagent": {
+          "label": "Child",
+          "prompt": "Inspect",
+          "mode": "background",
+          "childSessionId": "child",
+        },
+      },
+    };
+    final response = api.parseHistoryResponse({
+      "updates": [
+        {
+          "sessionId": "root",
+          "update": {"sessionUpdate": "tool_call", "toolCallId": "call"},
+          "_meta": metadata,
+        },
+      ],
+      "hasMore": false,
+    }, sessionId: "root");
+
+    final encodedUpdate = (response.toJson()["updates"] as List).single as Map<String, dynamic>;
+    expect(encodedUpdate["_meta"], metadata);
+    expect(response.updates.single.metadata?.deepSeek?.subagent?.childSessionId, "child");
+  });
+
+  test("history validates typed DeepSeek metadata before repositories consume it", () {
+    expect(
+      () => api.parseHistoryResponse({
+        "updates": [
+          {
+            "sessionId": "root",
+            "update": {"sessionUpdate": "tool_call", "toolCallId": "call"},
+            "_meta": {
+              DeepSeekAcpApi.initializeMetadataKey: {
+                "subagent": {"label": "Child", "prompt": "Inspect", "mode": "detached"},
+              },
+            },
+          },
+        ],
+        "hasMore": false,
+      }, sessionId: "root"),
+      throwsFormatException,
+    );
+  });
+
+  test("sub-agent optional fields reject explicit null", () {
+    final invalidEnd = {
+      "kind": "ended",
+      "sessionId": "root",
+      "childSessionId": "child",
+      "stopReason": "completed",
+      "summary": null,
+    };
+    expect(() => api.parseSubagentNotification(invalidEnd), throwsFormatException);
+    expect(() => DeepSeekSubagentNotificationDto.fromJson(invalidEnd), throwsFormatException);
+    expect(() => DeepSeekSubagentEndedDto.fromJson(invalidEnd), throwsFormatException);
+    expect(
+      () => api.parseSubagentReplay({
+        "label": "Child",
+        "prompt": "Inspect",
+        "mode": "background",
+        "childSessionId": null,
+      }),
+      throwsFormatException,
+    );
+    expect(
+      () => api.parseSubagentReplay({
+        "label": "Child",
+        "prompt": "Inspect",
+        "mode": "background",
+        "ended": {"stopReason": "completed", "summary": null},
+      }),
+      throwsFormatException,
+    );
+    for (final subagent in [
+      {"label": "Child", "prompt": "Inspect", "mode": "background", "childSessionId": null},
+      {
+        "label": "Child",
+        "prompt": "Inspect",
+        "mode": "background",
+        "ended": {"stopReason": "completed", "summary": null},
+      },
+    ]) {
+      expect(
+        () => api.parseHistoryResponse({
+          "updates": [
+            {
+              "sessionId": "root",
+              "update": {"sessionUpdate": "tool_call", "toolCallId": "call"},
+              "_meta": {
+                DeepSeekAcpApi.initializeMetadataKey: {"subagent": subagent},
+              },
+            },
+          ],
+          "hasMore": false,
+        }, sessionId: "root"),
+        throwsFormatException,
+      );
+    }
+  });
+
+  test("sub-agent presentation fields validate Unicode scalar structure and bounds", () {
+    Map<String, dynamic> started({required String prompt, String label = "Child"}) => {
+      "kind": "started",
+      "sessionId": "root",
+      "childSessionId": "child",
+      "toolCallId": "call",
+      "label": label,
+      "prompt": prompt,
+      "mode": "foreground",
+    };
+    Map<String, dynamic> ended(String summary) => {
+      "kind": "ended",
+      "sessionId": "root",
+      "childSessionId": "child",
+      "stopReason": "completed",
+      "summary": summary,
+    };
+
+    expect(
+      api.parseSubagentNotification(started(prompt: List.filled(32768, "😀").join())),
+      isA<DeepSeekSubagentStartedDto>(),
+    );
+    expect(
+      api.parseSubagentNotification(started(prompt: "valid", label: List.filled(256, "😀").join())),
+      isA<DeepSeekSubagentStartedDto>(),
+    );
+    expect(
+      api.parseSubagentNotification(ended(List.filled(512, "😀").join())),
+      isA<DeepSeekSubagentEndedDto>(),
+    );
+    expect(
+      () => api.parseSubagentNotification(started(prompt: List.filled(32769, "😀").join())),
+      throwsFormatException,
+    );
+    expect(
+      () => api.parseSubagentNotification(started(prompt: "valid", label: List.filled(257, "😀").join())),
+      throwsFormatException,
+    );
+    expect(() => api.parseSubagentNotification(ended(List.filled(513, "😀").join())), throwsFormatException);
+    expect(() => api.parseSubagentNotification(ended("valid\uD800")), throwsFormatException);
+    expect(
+      () => api.parseSubagentReplay({
+        "label": "Child",
+        "prompt": "Inspect",
+        "mode": "background",
+        "ended": {"stopReason": "completed", "summary": "valid\uD800"},
+      }),
+      throwsFormatException,
+    );
+    expect(() => api.parseSubagentNotification(started(prompt: "valid\uD800")), throwsFormatException);
+    expect(() => api.parseSubagentNotification(started(prompt: " padded ")), throwsFormatException);
+  });
 }
 
-Map<String, dynamic> _decodeValid(DeepSeekAcpApi api, String definition, Map<String, dynamic> value) =>
-    switch (definition) {
-      "initializeMetadata" => api.parseInitializeMetadata(value).toJson(),
-      "promptMetadata" => api.parsePromptMetadata(value).toJson(),
-      "catalogRequest" => DeepSeekCatalogRequestDto.fromJson(value).toJson(),
-      "catalogResponse" => api.parseCatalogResponse(value).toJson(),
-      "historyRequest" => DeepSeekHistoryRequestDto.fromJson(value).toJson(),
-      "historyResponse" => DeepSeekHistoryResponseDto.fromJson(value).toJson(),
-      "renameRequest" => DeepSeekRenameRequestDto.fromJson(value).toJson(),
-      "renameResponse" => DeepSeekRenameResponseDto.fromJson(value).toJson(),
-      "askUserQuestionRequest" => api.parseQuestionRequest(value).toJson(),
-      "askUserQuestionResponse" => api.parseQuestionResponse(value).toJson(),
-      "sessionStatusNotification" => api.parseSessionStatus(value).toJson(),
-      _ => throw StateError("Unknown fixture definition $definition"),
-    };
-void _rejectInvalid(DeepSeekAcpApi api, String definition, Map<String, dynamic> value) {
-  switch (definition) {
-    case "initializeMetadata" ||
-        "promptMetadata" ||
-        "catalogResponse" ||
-        "askUserQuestionRequest" ||
-        "askUserQuestionResponse" ||
-        "sessionStatusNotification":
-      _decodeValid(api, definition, value);
-    case "historyResponse":
-      final response = DeepSeekHistoryResponseDto.fromJson(value);
-      for (final update in response.updates) {
-        if (update.metadata != null && const DeepSeekMessageTimeParser().parse(update.toJson()) == null) {
-          throw const FormatException("messageCreatedAt");
-        }
-      }
-    case "catalogRequest":
-      final request = DeepSeekCatalogRequestDto.fromJson(value);
-      if (!request.cwd.startsWith("/") && !RegExp(r"^[A-Za-z]:[\\/]").hasMatch(request.cwd)) {
-        throw const FormatException("cwd");
-      }
-    case "historyRequest":
-      final request = DeepSeekHistoryRequestDto.fromJson(value);
-      if (request.maxMessages < 1 || request.maxMessages > 100) throw const FormatException("maxMessages");
-    case "renameRequest":
-      final request = DeepSeekRenameRequestDto.fromJson(value);
-      if (!request.title.contains(RegExp(r"\S"))) throw const FormatException("title");
-    case "renameResponse":
-      final response = DeepSeekRenameResponseDto.fromJson(value);
-      if (!response.title.contains(RegExp(r"\S"))) throw const FormatException("title");
-    default:
-      throw StateError("Unknown fixture definition $definition");
+Set<String> _definitionsFor({required int protocolVersion}) => {
+  // V2 initialization is enabled alongside live lifecycle consumption, not by these DTOs alone.
+  if (protocolVersion == 1) "initializeMetadata",
+  "promptMetadata",
+  "catalogRequest",
+  "catalogResponse",
+  "historyRequest",
+  "historyResponse",
+  "renameRequest",
+  "renameResponse",
+  "askUserQuestionRequest",
+  "askUserQuestionResponse",
+  "sessionStatusNotification",
+  if (protocolVersion == 2) "subagentNotification",
+};
+
+Map<String, dynamic> _decode({
+  required DeepSeekAcpApi api,
+  required String definition,
+  required Map<String, dynamic> value,
+}) => switch (definition) {
+  "initializeMetadata" => api.parseInitializeMetadata(value).toJson(),
+  "promptMetadata" => api.parsePromptMetadata(value).toJson(),
+  "catalogRequest" => _catalogRequest(value),
+  "catalogResponse" => api.parseCatalogResponse(value).toJson(),
+  "historyRequest" => _historyRequest(value),
+  "historyResponse" => api.parseHistoryResponse(value, sessionId: null).toJson(),
+  "renameRequest" => _renameRequest(value),
+  "renameResponse" => _renameResponse(value),
+  "askUserQuestionRequest" => api.parseQuestionRequest(value).toJson(),
+  "askUserQuestionResponse" => api.parseQuestionResponse(value).toJson(),
+  "sessionStatusNotification" => api.parseSessionStatus(value).toJson(),
+  "subagentNotification" => api.parseSubagentNotification(value).toJson(),
+  _ => throw StateError("Unknown fixture definition $definition"),
+};
+
+Map<String, dynamic> _catalogRequest(Map<String, dynamic> value) {
+  final request = DeepSeekCatalogRequestDto.fromJson(value);
+  if (!request.cwd.startsWith("/") && !RegExp(r"^[A-Za-z]:[\\/]").hasMatch(request.cwd)) {
+    throw const FormatException("cwd");
   }
+  return request.toJson();
+}
+
+Map<String, dynamic> _historyRequest(Map<String, dynamic> value) {
+  final request = DeepSeekHistoryRequestDto.fromJson(value);
+  if (request.maxMessages < 1 || request.maxMessages > 100) throw const FormatException("maxMessages");
+  return request.toJson();
+}
+
+Map<String, dynamic> _renameRequest(Map<String, dynamic> value) {
+  final request = DeepSeekRenameRequestDto.fromJson(value);
+  if (!request.title.contains(RegExp(r"\S"))) throw const FormatException("title");
+  return request.toJson();
+}
+
+Map<String, dynamic> _renameResponse(Map<String, dynamic> value) {
+  final response = DeepSeekRenameResponseDto.fromJson(value);
+  if (!response.title.contains(RegExp(r"\S"))) throw const FormatException("title");
+  return response.toJson();
 }

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -24,7 +24,10 @@ reconnect or restart.
   process. It pages at complete message boundaries, returns at most 100 messages
   per page, rejects non-progressing or over-100-page traversal, and reuses the
   shared ACP replay collector. Direct user message IDs remain exact; assistant
-  IDs use the deterministic ACP projection.
+  IDs use the deterministic ACP projection. Known DeepSeek history metadata is
+  decoded once into typed fields and validated at the API boundary; malformed
+  timestamps or sub-agent metadata fail the read rather than reaching replay.
+  Unrecognized additive metadata remains intact when envelopes are serialized.
 - GitHub Copilot history uses standard ACP `session/load` on a dedicated
   short-lived connection. Replayed updates backfill the bridge transcript, while
   reopening a prior session after plugin, process, or bridge restart loads it


### PR DESCRIPTION
## Complexity

⚙️ Moderate — adds typed backend protocol variants and strict validation at the existing DeepSeek API boundary.

## What

- Parse started/ended sub-agent notifications and typed replay metadata, including mode and terminal-reason enums.
- Validate normalized prompts, Unicode scalar structure and bounds, optional-field shapes, and history timestamps.
- Decode known DeepSeek metadata once while preserving additive metadata during serialization.
- Generate serializers from their source declarations and test consumed v1/v2 fixture contracts.
- Keep initialization v1-only until step 4 installs the live consumer.

**Size: 736 changed lines**, including generated code, tests, and documentation. Step 3/5 of the replacement for #1293; follows merged #1298 and #1301.

## Why

Establish a tested typed boundary before adding live lifecycle and replay projection. Improve consistency over the archived implementation by putting the ended-summary shape check in its DTO factory, so direct and API decoding use the same check.

## Risk and test focus

- Highest risk: rejecting valid protocol data, accepting malformed optional fields, losing additive metadata, or mishandling Unicode scalar limits.
- Invalid known history metadata now fails at the API boundary rather than reaching replay.
- No database/schema change, runtime-pin change, scoped-stop consumer, new tiles, or child-session behavior. Released v1 initialization stays unchanged.

## Expected result

Consumed lifecycle/history shapes parse into typed plugin-local data and serialize with additive metadata intact. Invalid values fail before repository consumption. No protocol-v2 runtime is accepted and no subagent UI is enabled by this slice alone.

## Verification

- `dart run build_runner build --delete-conflicting-outputs` — passed.
- DeepSeek `dart analyze --fatal-infos` — clean.
- DeepSeek `dart test` — 50 passed.
- Architecture implementation review — approved, no findings.
- `git diff --check` — passed.
- Both fixture versions, runtime manifest, plugin/event mapper, and history projection unchanged.

Remaining: live lifecycle/catalogs → replay projection, then adapter release preparation using the final merged consumer commit.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typed parsing and validation for DeepSeek sub-agent protocol messages so malformed lifecycle and replay data fails at the API boundary instead of reaching downstream consumers.

- Parses started/ended sub-agent notifications and replay metadata into typed DTOs with mode and stop-reason enums.
- Validates Unicode scalar structure, prompt trimming and bounds, optional-field shapes, and history timestamps.
- Preserves additive metadata on history envelopes while decoding known DeepSeek fields once.
- Moves the ended-summary shape check into the DTO factory so direct and API decoding share the same validation.
- Keeps initialization v1-only; protocol-v2 runtime and sub-agent UI remain disabled until later slices.

**Migration**

No database, schema, or runtime-pin changes. Released v1 initialization behavior is unchanged.

<sup>Written for commit ddfb53b782ffc9d82e25de893469651355b5f089. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

