### PR TITLE
🌿 Fix relay disconnect warnings and session deletion navigation

### DIFF
--- a/client/app/lib/features/session_list/session_list_screen.dart
+++ b/client/app/lib/features/session_list/session_list_screen.dart
@@ -48,7 +48,10 @@ class const SessionListScreen({
 /// Leaves a deleted session's detail/diffs route when that session is still
 /// the current mobile location. In a narrow list route this is a no-op.
 void closeDeletedSessionRoute({required BuildContext context, required String sessionId}) {
-  final routeState = GoRouterState.of(context);
+  // Deletion can finish outside a route-local context. Inspect the current
+  // router location, including any navigation while the request was in flight.
+  // ignore: no_slop_linter/avoid_raw_go_router, reads current route state; navigation below uses the typed extension
+  final routeState = GoRouter.of(context).state;
   if (routeState.pathParameters[sessionIdPathParam] != sessionId) return;
 
   final projectId = routeState.pathParameters[projectIdPathParam];

--- a/client/app/test/features/session_list/session_deletion_navigation_test.dart
+++ b/client/app/test/features/session_list/session_deletion_navigation_test.dart
@@ -1,0 +1,47 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:go_router/go_router.dart";
+import "package:material_ui/material_ui.dart";
+import "package:sesori_mobile/features/session_list/session_list_screen.dart";
+
+void main() {
+  for (final suffix in ["", "/diffs"]) {
+    testWidgets("deletion closes the current session$suffix from a context outside its route", (tester) async {
+      final navigatorKey = GlobalKey<NavigatorState>();
+      final router = GoRouter(
+        navigatorKey: navigatorKey,
+        initialLocation: "/projects/p1/sessions/deleted$suffix?name=Project+One",
+        routes: [
+          GoRoute(
+            path: "/projects/:projectId/sessions",
+            builder: (_, _) => const SizedBox(),
+            routes: [
+              GoRoute(
+                path: ":sessionId",
+                builder: (_, _) => const SizedBox(),
+                routes: [GoRoute(path: "diffs", builder: (_, _) => const SizedBox())],
+              ),
+            ],
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      await tester.pumpAndSettle();
+      final context = navigatorKey.currentContext!;
+      expect(ModalRoute.of(context), isNull);
+
+      closeDeletedSessionRoute(context: context, sessionId: "another-session");
+      expect(router.state.pathParameters["sessionId"], "deleted");
+
+      closeDeletedSessionRoute(context: context, sessionId: "deleted");
+      await tester.pumpAndSettle();
+      expect(router.state.uri.path, "/projects/p1/sessions");
+      expect(router.state.uri.queryParameters["name"], "Project One");
+
+      closeDeletedSessionRoute(context: context, sessionId: "deleted");
+      await tester.pumpAndSettle();
+      expect(router.state.uri.path, "/projects/p1/sessions");
+      expect(tester.takeException(), isNull);
+    });
+  }
+}

--- a/client/desktop/lib/core/routing/desktop_router.dart
+++ b/client/desktop/lib/core/routing/desktop_router.dart
@@ -375,7 +375,9 @@ void _openSettings({required BuildContext context, required String currentPath})
 }
 
 void _closeDeletedSessionRoute({required BuildContext context, required String sessionId}) {
-  final routeState = GoRouterState.of(context);
+  // The list's context need not belong to the current detail route.
+  // ignore: no_slop_linter/avoid_raw_go_router, reads current route state inside the typed routing boundary
+  final routeState = GoRouter.of(context).state;
   if (routeState.pathParameters[sessionIdPathParam] != sessionId) {
     return;
   }

--- a/client/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/client/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -488,14 +488,8 @@ class RelayClient._({
     _disposed = true;
     _connectionState = RelayClientConnectionState.disconnecting;
 
-    final sseController = _sseController;
-    if (_sessionEncryptor != null && sseController != null && !sseController.isClosed) {
-      await _sendSseControlMessage(
-        message: const RelayMessage.sseUnsubscribe(),
-        context: "disconnecting",
-      );
-    }
-
+    // Socket teardown releases the bridge's SSE subscription through
+    // phone_disconnected; encrypted messages are no longer valid after disposal.
     await _teardownChannelOnly();
     await _closeSseController();
     await _closeBridgeStatusController();

--- a/client/module_core/test/capabilities/relay/relay_client_handshake_replay_test.dart
+++ b/client/module_core/test/capabilities/relay/relay_client_handshake_replay_test.dart
@@ -13,6 +13,49 @@ import "package:web_socket_channel/web_socket_channel.dart";
 class _MockRoomKeyStorage() extends Mock implements RoomKeyStorage;
 
 void main() {
+  test("disconnect closes an active SSE stream without encryption errors", () async {
+    final roomKey = Uint8List.fromList(List<int>.generate(32, (index) => index));
+    final roomKeyStorage = _MockRoomKeyStorage();
+    when(roomKeyStorage.getRoomKey).thenAnswer((_) async => roomKey);
+    final socket = _FakeWebSocket();
+    final client = RelayClient.withChannelConnector(
+      relayHost: "relay.example.com",
+      cryptoService: RelayCryptoService(),
+      roomKeyStorage: roomKeyStorage,
+      authToken: null,
+      channelConnector: (_) => socket.channel,
+      boundedJsonEncoder: null,
+      maxPlaintextMessageBytes: RelayProtocol.maxPlaintextMessageBytes,
+    );
+    final outgoing = StreamIterator<Object?>(socket.outgoing);
+    addTearDown(() async {
+      await outgoing.cancel();
+      await client.disconnect();
+      await socket.close();
+    });
+    final resumeReady = outgoing.moveNext();
+    final connectFuture = client.connect();
+    expect(await resumeReady.timeout(const Duration(seconds: 1)), isTrue);
+    final encryptor = RelayCryptoService().createSessionEncryptor(SecretKey(roomKey));
+    socket.serverSink.add(
+      await frame(utf8.encode(jsonEncode(const RelayMessage.resumeAck().toJson())), encryptor: encryptor),
+    );
+    await connectFuture.timeout(const Duration(seconds: 1));
+    final sseClosed = client.subscribeSse("/event").drain<void>();
+    expect(await outgoing.moveNext().timeout(const Duration(seconds: 1)), isTrue);
+
+    final socketClosed = outgoing.moveNext();
+    final logs = <String>[];
+    await runZoned(
+      client.disconnect,
+      zoneSpecification: ZoneSpecification(print: (_, _, _, line) => logs.add(line)),
+    );
+    await sseClosed.timeout(const Duration(seconds: 1));
+    expect(await socketClosed.timeout(const Duration(seconds: 1)), isFalse);
+    expect(client.connectionState, RelayClientConnectionState.disconnected);
+    expect(logs, isEmpty);
+  });
+
   test("replays resume when the bridge reconnects during handshake", () async {
     final roomKey = Uint8List.fromList(List<int>.generate(32, (index) => index));
     final roomKeyStorage = _MockRoomKeyStorage();

--- a/docs/regression/bridge-connectivity.md
+++ b/docs/regression/bridge-connectivity.md
@@ -25,6 +25,9 @@ explicit restart, and the connection states the app presents.
 - Ordered mutation and event lanes continue processing later work after one operation fails, and graceful shutdown drains work accepted before shutdown began.
 - Deliberate shutdown is not an outage; a handshake cancelled mid-flight closes at
   once and can never later authenticate.
+- Client relay disconnect closes active SSE streams and the socket without
+  attempting encrypted sends after disposal. The bridge releases the connection's
+  SSE subscription when it receives the phone-disconnected notification.
 - One live bridge per account holds the slot; a second start resolves ownership
   explicitly, and an explicit restart hands off to its successor cleanly.
 - Bridge registration uses a stable machine name. On macOS, transient

--- a/docs/regression/session-archiving-and-deletion.md
+++ b/docs/regression/session-archiving-and-deletion.md
@@ -63,6 +63,11 @@ entirely along with its transcript and, optionally, its worktree.
 - Archive and delete confirmation sheets identify the action, default worktree
   cleanup on only when a dedicated worktree exists, and keep deletion's confirm
   action visually destructive. Cancelling performs neither operation.
+- After successful deletion, mobile and desktop leave the deleted session's
+  current detail or diffs route for its project list, preserving the project
+  name. Deleting another session, or completing deletion after navigation to
+  another session, does not change the current route. The callback also works
+  from list contexts without a route-local `GoRouterState`.
 
 ## Regression Levels
 


### PR DESCRIPTION
## Complexity
🌿 Straightforward: two localized client fixes with regression coverage.

## What
- Remove the encrypted SSE unsubscribe attempted after relay-client disposal; socket teardown already releases the bridge subscription.
- Read the router's current state after successful session deletion on mobile and desktop, instead of requiring route state above the list context.
- Add regression coverage and update connectivity/deletion behavior documentation.

## Why
Reconnect cleanup logged `RelayClient is not ready for encrypted messages` because it marked the client disposed before sending. Successful deletion could then throw `There is no GoRouterState above the current context` during navigation. The older-client `session.options_updated` warning needs no change: current clients already support the event.

## Risk and test focus
Low risk, confined to teardown and post-deletion navigation. Verify active SSE streams close without encryption errors, deleted detail/diffs routes return to the project list with its name preserved, and deleting an unrelated session leaves navigation unchanged. No database or wire-contract changes.

## Expected result
Relay reconnect cleanup no longer emits the invalid encrypted-send warning. Successful session deletion exits the deleted session's current route without a route-context exception on mobile and desktop.

## Verification
- New relay and mobile navigation regression tests failed with the original reported errors before the fixes and passed afterward.
- Relay capability tests: 28 passed.
- Mobile deletion navigation and adaptive route matrix: 9 passed.
- Desktop routing tests: 5 passed.
- `dart analyze --fatal-infos` for `module_core`, mobile, and desktop.
- `git diff --check`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes relay disconnect warnings and session deletion navigation by removing the encrypted SSE unsubscribe attempt after client disposal and reading the router's current state after deletion.

**Bug Fixes**
- Reconnect cleanup no longer logs `RelayClient is not ready for encrypted messages`; socket teardown already releases the bridge subscription.
- Deletion now uses the current router state, so it works from list contexts and preserves the project name when returning to the project list.
- Adds regression tests covering active SSE stream teardown and deletion from contexts outside the route.
- No database or wire-contract changes; the older-client `session.options_updated` warning is unaffected.

<sup>Written for commit bb4b4d5f5e7949900c3103599d0100d83985fbf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

